### PR TITLE
Snapshot resolve

### DIFF
--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -136,14 +136,29 @@ __wt_bm_close(WT_SESSION_IMPL *session)
  *	Write a buffer into a block, creating a snapshot.
  */
 int
-__wt_bm_snapshot(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_SNAPSHOT *snap)
+__wt_bm_snapshot(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_SNAPSHOT *snapbase)
 {
 	WT_BLOCK *block;
 
 	if ((block = session->btree->block) == NULL)
 		return (__bm_invalid(session));
 
-	return (__wt_block_snapshot(session, block, buf, snap));
+	return (__wt_block_snapshot(session, block, buf, snapbase));
+}
+
+/*
+ * __wt_bm_snapshot_resolve --
+ *	Resolve the snapshot.
+ */
+int
+__wt_bm_snapshot_resolve(WT_SESSION_IMPL *session, WT_SNAPSHOT *snapbase)
+{
+	WT_BLOCK *block;
+
+	if ((block = session->btree->block) == NULL)
+		return (__bm_invalid(session));
+
+	return (__wt_block_snapshot_resolve(session, block, snapbase));
 }
 
 /*

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -121,12 +121,13 @@ struct __wt_block_snapshot {
 	off_t	 root_offset;			/* The root */
 	uint32_t root_cksum, root_size;
 
-	WT_EXTLIST  alloc;			/* Extents allocated */
-	WT_EXTLIST  avail;			/* Extents available */
-	WT_EXTLIST  discard;			/* Extents discarded */
+	WT_EXTLIST alloc;			/* Extents allocated */
+	WT_EXTLIST avail;			/* Extents available */
+	WT_EXTLIST discard;			/* Extents discarded */
 
-	off_t	 file_size;			/* Snapshot file size */
-	uint64_t snapshot_size;			/* Snapshot contents */
+	off_t	   file_size;			/* Snapshot file size */
+	uint64_t   snapshot_size;		/* Snapshot byte count */
+	WT_EXTLIST snapshot_avail;		/* Snapshot free'd extents */
 
 	uint64_t write_gen;			/* Write generation */
 };
@@ -143,22 +144,23 @@ struct __wt_block {
 	uint32_t allocsize;		/* Allocation size */
 	int	 checksum;		/* If checksums configured */
 
-	WT_SPINLOCK	  live_lock;	/* Lock to protect the live snapshot. */
+	WT_SPINLOCK	  live_lock;	/* Lock to protect the live snapshot */
 	WT_BLOCK_SNAPSHOT live;		/* Live snapshot */
 	int		  live_load;	/* Live snapshot loaded */
 
 	WT_COMPRESSOR *compressor;	/* Page compressor */
 
-					/* Salvage support */
-	int	slvg;			/* If performing salvage. */
+				/* Salvage support */
+	int	slvg;			/* If performing salvage */
 	off_t	slvg_off;		/* Salvage file offset */
 
-	int	 verify;		/* Verification support */
-	off_t	 verify_size;		/* Snapshot's file size */
+				/* Verification support */
+	int	   verify;		/* If performing verification */
+	off_t	   verify_size;		/* Snapshot's file size */
 	WT_EXTLIST verify_alloc;	/* Verification allocation list */
-	uint32_t frags;			/* Maximum frags in the file */
-	uint8_t *fragfile;		/* Per-file frag tracking list */
-	uint8_t *fragsnap;		/* Per-snapshot frag tracking list */
+	uint32_t   frags;		/* Maximum frags in the file */
+	uint8_t   *fragfile;		/* Per-file frag tracking list */
+	uint8_t   *fragsnap;		/* Per-snapshot frag tracking list */
 };
 
 /*

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -144,31 +144,3 @@ struct __wt_salvage_cookie {
 
 	int	 done;				/* Ignore the rest */
 };
-
-/*
- * WT_SNAPSHOT --
- *	Encapsulation of snapshot information, shared with the block manager.
- */
-#define	WT_INTERNAL_SNAPSHOT	"WiredTigerInternalSnapshot"
-#define	WT_SNAPSHOT_FOREACH(snapbase, snap)				\
-	for ((snap) = (snapbase); (snap)->name != NULL; ++(snap))
-
-struct __wt_snapshot {
-	char	*name;				/* Name or NULL */
-
-	WT_ITEM  addr;				/* Snapshot cookie string */
-	WT_ITEM  raw;				/* Snapshot cookie raw */
-
-	int64_t	 order;				/* Snapshot order */
-
-	uintmax_t sec;				/* Timestamp */
-
-	uint64_t snapshot_size;			/* Snapshot size */
-
-	void	*bpriv;				/* Block manager's private */
-
-#define	WT_SNAP_ADD	0x01			/* Snapshot to be added */
-#define	WT_SNAP_DELETE	0x02			/* Snapshot to be deleted */
-#define	WT_SNAP_UPDATE	0x04			/* Snapshot requires update */
-	uint32_t flags;
-};

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -64,9 +64,10 @@ extern int __wt_block_insert_ext( WT_SESSION_IMPL *session,
 extern int __wt_block_extlist_read( WT_SESSION_IMPL *session,
     WT_BLOCK *block,
     WT_EXTLIST *el);
-extern int __wt_block_extlist_write( WT_SESSION_IMPL *session,
+extern int __wt_block_extlist_write(WT_SESSION_IMPL *session,
     WT_BLOCK *block,
-    WT_EXTLIST *el);
+    WT_EXTLIST *el,
+    WT_EXTLIST *additional);
 extern int __wt_block_extlist_truncate( WT_SESSION_IMPL *session,
     WT_BLOCK *block,
     WT_EXTLIST *el);
@@ -94,7 +95,9 @@ extern int __wt_bm_open(WT_SESSION_IMPL *session,
 extern int __wt_bm_close(WT_SESSION_IMPL *session);
 extern int __wt_bm_snapshot(WT_SESSION_IMPL *session,
     WT_ITEM *buf,
-    WT_SNAPSHOT *snap);
+    WT_SNAPSHOT *snapbase);
+extern int __wt_bm_snapshot_resolve(WT_SESSION_IMPL *session,
+    WT_SNAPSHOT *snapbase);
 extern int __wt_bm_snapshot_load(WT_SESSION_IMPL *session,
     WT_ITEM *buf,
     const uint8_t *addr,
@@ -175,6 +178,9 @@ extern int __wt_block_snapshot_unload(WT_SESSION_IMPL *session,
 extern int __wt_block_snapshot(WT_SESSION_IMPL *session,
     WT_BLOCK *block,
     WT_ITEM *buf,
+    WT_SNAPSHOT *snapbase);
+extern int __wt_block_snapshot_resolve( WT_SESSION_IMPL *session,
+    WT_BLOCK *block,
     WT_SNAPSHOT *snapbase);
 extern int __wt_block_verify_start( WT_SESSION_IMPL *session,
     WT_BLOCK *block,

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -12,3 +12,32 @@
 
 #define	WT_METADATA_VERSION	"WiredTiger version"	/* Version keys */
 #define	WT_METADATA_VERSION_STR	"WiredTiger version string"
+
+/*
+ * WT_SNAPSHOT --
+ *	Encapsulation of snapshot information, shared by the metadata, the
+ * btree engine, and the block manager.
+ */
+#define	WT_INTERNAL_SNAPSHOT	"WiredTigerInternalSnapshot"
+#define	WT_SNAPSHOT_FOREACH(snapbase, snap)				\
+	for ((snap) = (snapbase); (snap)->name != NULL; ++(snap))
+
+struct __wt_snapshot {
+	char	*name;				/* Name or NULL */
+
+	WT_ITEM  addr;				/* Snapshot cookie string */
+	WT_ITEM  raw;				/* Snapshot cookie raw */
+
+	int64_t	 order;				/* Snapshot order */
+
+	uintmax_t sec;				/* Timestamp */
+
+	uint64_t snapshot_size;			/* Snapshot size */
+
+	void	*bpriv;				/* Block manager private */
+
+#define	WT_SNAP_ADD	0x01			/* Snapshot to be added */
+#define	WT_SNAP_DELETE	0x02			/* Snapshot to be deleted */
+#define	WT_SNAP_UPDATE	0x04			/* Snapshot requires update */
+	uint32_t flags;
+};

--- a/src/session/session_snapshot.c
+++ b/src/session/session_snapshot.c
@@ -244,8 +244,10 @@ nomatch:		WT_ERR_MSG(session,
 		if (force)
 			WT_ERR_MSG(session,
 			    EINVAL, "cache flush failed to create a snapshot");
-	} else
+	} else {
 		WT_ERR(__wt_meta_snaplist_set(session, btree->name, snapbase));
+		WT_ERR(__wt_bm_snapshot_resolve(session, snapbase));
+	}
 
 err:	__wt_meta_snaplist_free(session, snapbase);
 	__wt_rwunlock(session, btree->snaplock);


### PR DESCRIPTION
Extents free'd up by deleting snapshots cannot immediately be made available for re-allocation, if we allocate a block but then crash before updating the metadata's snapshot information, we might overwrite a block referenced by a snapshot in the system.  Closes #226.
