### PR TITLE
Cursor.random

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -132,6 +132,10 @@ cursor_ops(WT_SESSION *session)
 	ret = cursor->prev(cursor);
 	/*! [Return the previous record] */
 
+	/*! [Return a random record] */
+	ret = cursor->random(cursor);
+	/*! [Return a random record] */
+
 	/*! [Reset the cursor] */
 	ret = cursor->reset(cursor);
 	/*! [Reset the cursor] */

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -99,6 +99,35 @@ __cursor_invalid(WT_CURSOR_BTREE *cbt)
 }
 
 /*
+ * __wt_btcur_random --
+ *	Move to the first record of a random page in the tree.
+ */
+int
+__wt_btcur_random(WT_CURSOR_BTREE *cbt)
+{
+	WT_BTREE *btree;
+	WT_CURSOR *cursor;
+	WT_DECL_RET;
+	WT_SESSION_IMPL *session;
+
+	btree = cbt->btree;
+	cursor = &cbt->iface;
+	session = (WT_SESSION_IMPL *)cursor->session;
+	WT_BSTAT_INCR(session, cursor_read);
+
+	__cursor_func_init(cbt, 1);
+
+	WT_ERR(btree->type == BTREE_ROW ?
+	    __wt_row_random(session, cbt) : ENOTSUP);
+	ret = cbt->compare == 0 ?
+	    __wt_kv_return(session, cbt, 1) : WT_NOTFOUND;
+
+err:	__cursor_func_resolve(cbt, ret);
+
+	return (ret);
+}
+
+/*
  * __wt_btcur_reset --
  *	Invalidate the cursor position.
  */

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -278,3 +278,70 @@ retry:		ikey = WT_ROW_KEY_COPY(rip);
 err:	__wt_page_release(session, page);
 	return (ret);
 }
+
+/*
+ * __wt_row_random --
+ *	Return a random key from a row-store tree.
+ */
+int
+__wt_row_random(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+{
+	WT_BTREE *btree;
+	WT_DECL_RET;
+	WT_INSERT *p, *t;
+	WT_PAGE *page;
+	WT_REF *ref;
+
+	__cursor_search_clear(cbt);
+
+	btree = session->btree;
+
+	/* Walk the internal pages of the tree. */
+	for (page = btree->root_page; page->type == WT_PAGE_ROW_INT;) {
+		ref = page->u.intl.t + __wt_random() % page->entries;
+
+		/* Swap the parent page for the child page. */
+		WT_ERR(__wt_page_in(session, page, ref));
+		__wt_page_release(session, page);
+		page = ref->page;
+	}
+
+	cbt->page = page;
+	cbt->compare = 0;
+
+	if (page->entries != 0) {
+		/*
+		 * The use case for this call is finding a place to split the
+		 * tree.  Cheat (it's not like this is "random", anyway), and
+		 * make things easier by returning the first key on the page.
+		 * If the caller is attempting to split a newly created tree,
+		 * or a tree with just one big page, that's not going to work,
+		 * check for that.
+		 */
+		cbt->slot =
+		    btree-> root_page->entries < 2 ?
+		    __wt_random() % page->entries : 0;
+		return (0);
+	}
+
+	/*
+	 * If the tree is new (and not empty), it might have a large insert
+	 * list, pick the key in the middle of that insert list.
+	 */
+	F_SET(cbt, WT_CBT_SEARCH_SMALLEST);
+	if ((cbt->ins_head = WT_ROW_INSERT_SMALLEST(page)) == NULL)
+		return (WT_NOTFOUND);
+	for (p = t = WT_SKIP_FIRST(cbt->ins_head);;) {
+		if ((p = WT_SKIP_NEXT(p)) == NULL)
+			break;
+		if ((p = WT_SKIP_NEXT(p)) == NULL)
+			break;
+		t = WT_SKIP_NEXT(t);
+	}
+	cbt->ins = t;
+
+	return (0);
+
+err:	__wt_page_release(session, page);
+	return (ret);
+}

--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -45,8 +45,9 @@ __wt_curconfig_open(WT_SESSION_IMPL *session,
 		__wt_cursor_notsup,	/* update */
 		__wt_cursor_notsup,	/* remove */
 		__curconfig_close,
-		(int (*)		/* config */
+		(int (*)		/* reconfigure */
 		    (WT_CURSOR *, const char *))__wt_cursor_notsup,
+		__wt_cursor_notsup,	/* random */
 		{ NULL, NULL },		/* TAILQ_ENTRY q */
 		0,			/* recno key */
 		{ 0 },                  /* recno raw buffer */

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -310,8 +310,9 @@ __wt_curdump_create(WT_CURSOR *child, WT_CURSOR *owner, WT_CURSOR **cursorp)
 		__curdump_update,
 		__curdump_remove,
 		__curdump_close,
-		(int (*)		/* config */
+		(int (*)		/* reconfigure */
 		    (WT_CURSOR *, const char *))__wt_cursor_notsup,
+		__wt_cursor_notsup,	/* random */
 		{ NULL, NULL },		/* TAILQ_ENTRY q */
 		0,			/* recno key */
 		{ 0 },                  /* recno raw buffer */

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -356,8 +356,9 @@ __wt_curindex_open(WT_SESSION_IMPL *session,
 		__wt_cursor_notsup,	/* update */
 		__wt_cursor_notsup,	/* remove */
 		__curindex_close,
-		(int (*)		/* config */
+		(int (*)		/* reconfigure */
 		    (WT_CURSOR *, const char *))__wt_cursor_notsup,
+		__wt_cursor_notsup,	/* random */
 		{ NULL, NULL },		/* TAILQ_ENTRY q */
 		0,			/* recno key */
 		{ 0 },                  /* recno raw buffer */

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -318,8 +318,9 @@ __wt_curstat_open(WT_SESSION_IMPL *session,
 		__wt_cursor_notsup,	/* update */
 		__wt_cursor_notsup,	/* remove */
 		__curstat_close,
-		(int (*)		/* config */
+		(int (*)		/* reconfigure */
 		    (WT_CURSOR *, const char *))__wt_cursor_notsup,
+		__wt_cursor_notsup,	/* random */
 		{ NULL, NULL },		/* TAILQ_ENTRY q */
 		0,			/* recno key */
 		{ 0 },                  /* recno raw buffer */

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -483,9 +483,9 @@ __wt_cursor_init(WT_CURSOR *cursor,
 	/* Checkpoint cursors are read-only. */
 	WT_RET(__wt_config_gets(session, cfg, "checkpoint", &cval));
 	if (cval.len != 0) {
-		cursor->insert = (int (*)(WT_CURSOR *))__wt_cursor_notsup;
-		cursor->update = (int (*)(WT_CURSOR *))__wt_cursor_notsup;
-		cursor->remove = (int (*)(WT_CURSOR *))__wt_cursor_notsup;
+		cursor->insert = __wt_cursor_notsup;
+		cursor->update = __wt_cursor_notsup;
+		cursor->remove = __wt_cursor_notsup;
 	}
 
 	/*

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -529,6 +529,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 		__curtable_remove,
 		__curtable_close,
 		NULL,
+		__wt_cursor_notsup,	/* random */
 		{ NULL, NULL },		/* TAILQ_ENTRY q */
 		0,			/* recno key */
 		{ 0 },                  /* raw recno buffer */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -239,6 +239,7 @@ extern int __wt_cell_unpack_copy( WT_SESSION_IMPL *session,
 extern void __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt, int next);
 extern int __wt_btcur_next(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_prev(WT_CURSOR_BTREE *cbt);
+extern int __wt_btcur_random(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_reset(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_search(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exact);
@@ -421,6 +422,7 @@ extern WT_INSERT *__wt_search_insert(WT_SESSION_IMPL *session,
 extern int __wt_row_search(WT_SESSION_IMPL *session,
     WT_CURSOR_BTREE *cbt,
     int is_modify);
+extern int __wt_row_random(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt);
 extern int __wt_config_initn( WT_SESSION_IMPL *session,
     WT_CONFIG *conf,
     const char *str,

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -388,6 +388,20 @@ struct __wt_cursor {
 	 */
 	int __F(reconfigure)(WT_CURSOR *cursor, const char *config);
 
+	/*! @name Specialized functionality
+	 * @{
+	 */
+	/*! Move to a random record (only supported for row-store files
+	 * or tables with a primary row-store key).
+	 *
+	 * @snippet ex_all.c Return a random record
+	 *
+	 * @param cursor the cursor handle
+	 * @errors
+	 */
+	int __F(random)(WT_CURSOR *cursor);
+	/*! @} */
+
 	/*
 	 * Protected fields, only to be used by cursor implementations.
 	 */


### PR DESCRIPTION
Michael, I took a run at WT_CURSOR::random today, would you please take a look?

Specific comments:
- I created a new "specialized functions" area in the cursor method documentation instead of including this call in the standard list.  I hate to leave it undocumented, but I also hate to put it in the middle of the normal calls.
- I didn't implement it for col-store files, I can't imagine any use for it there.
- I didn't implement it for table cursors -- can you give me a hint on how to do that?   (Presumably, we do the cursor lookup on the primary key, but I don't see any obvious templates for doing that, and my first couple of attempts ended in tears.)

This should close #143.
