### PR TITLE
Return keys from all operations: don't keep pointing to the application's key.

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -485,7 +485,7 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
 	WT_ERR(btree->type == BTREE_ROW ?
 	    __wt_row_random(session, cbt) : ENOTSUP);
 	ret = cbt->compare == 0 ?
-	    __wt_kv_return(session, cbt, 1) : WT_NOTFOUND;
+	    __wt_kv_return(session, cbt) : WT_NOTFOUND;
 
 err:	__cursor_func_resolve(cbt, ret);
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -155,7 +155,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 		} else
 			ret = WT_NOTFOUND;
 	} else
-		ret = __wt_kv_return(session, cbt, 0);
+		ret = __wt_kv_return(session, cbt);
 
 err:	__cursor_func_resolve(cbt, ret);
 
@@ -211,7 +211,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exact)
 		*exact = 0;
 	} else if (!__cursor_invalid(cbt)) {
 		*exact = cbt->compare;
-		ret = __wt_kv_return(session, cbt, cbt->compare == 0 ? 0 : 1);
+		ret = __wt_kv_return(session, cbt);
 	} else if ((ret = __wt_btcur_next(cbt)) != WT_NOTFOUND)
 		*exact = 1;
 	else {
@@ -220,8 +220,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exact)
 		    __wt_col_search(session, cbt, 0));
 		if (!__cursor_invalid(cbt)) {
 			*exact = cbt->compare;
-			ret = __wt_kv_return(
-			    session, cbt, cbt->compare == 0 ? 0 : 1);
+			ret = __wt_kv_return(session, cbt);
 		} else if ((ret = __wt_btcur_prev(cbt)) != WT_NOTFOUND)
 			*exact = -1;
 	}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -317,9 +317,7 @@ extern int __wt_page_inmem(WT_SESSION_IMPL *session,
 extern int __wt_cache_read(WT_SESSION_IMPL *session,
     WT_PAGE *parent,
     WT_REF *ref);
-extern int __wt_kv_return(WT_SESSION_IMPL *session,
-    WT_CURSOR_BTREE *cbt,
-    int key_ret);
+extern int __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt);
 extern int __wt_bt_salvage( WT_SESSION_IMPL *session,
     WT_CKPT *ckptbase,
     const char *cfg[]);


### PR DESCRIPTION
Keith, can you please review this change to always return keys?  In particular, are there common cases where this will introduce copying that could be avoided?
