### PR TITLE
Row key ref

### DIFF
--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -69,8 +69,8 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 		 * or the page if the key was never updated.
 		 */
 		if (cbt->ins == NULL) {
-			WT_RET(__wt_row_key_ref(
-			    session, page, rip, &cursor->key, 0));
+			WT_RET(
+			    __wt_row_key(session, page, rip, &cursor->key, 0));
 			upd = WT_ROW_UPDATE(page, rip);
 		} else {
 			cursor->key.data = WT_INSERT_KEY(cbt->ins);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -515,9 +515,9 @@ __slvg_trk_leaf(WT_SESSION_IMPL *session, WT_PAGE_HEADER *dsk,
 		 * it's probably a great place to start.
 		 */
 		WT_ERR(__wt_page_inmem(session, NULL, NULL, dsk, &page));
-		WT_ERR(__wt_row_key(session,
+		WT_ERR(__wt_row_key_copy(session,
 		    page, &page->u.row.d[0], &trk->row_start));
-		WT_ERR(__wt_row_key(session,
+		WT_ERR(__wt_row_key_copy(session,
 		    page, &page->u.row.d[page->entries - 1], &trk->row_stop));
 
 		if (WT_VERBOSE_ISSET(session, salvage)) {
@@ -1559,7 +1559,7 @@ __slvg_row_trk_update_start(
 	 */
 	WT_ERR(__wt_scr_alloc(session, 0, &key));
 	WT_ROW_FOREACH(page, rip, i) {
-		WT_ERR(__wt_row_key_ref(session, page, rip, key, 0));
+		WT_ERR(__wt_row_key(session, page, rip, key, 0));
 		WT_ERR(WT_BTREE_CMP(session, btree, key, stop, cmp));
 		if (cmp > 0) {
 			found = 1;
@@ -1723,7 +1723,7 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session,
 	skip_start = skip_stop = 0;
 	if (F_ISSET(trk, WT_TRACK_CHECK_START))
 		WT_ROW_FOREACH(page, rip, i) {
-			WT_ERR(__wt_row_key_ref(session, page, rip, key, 0));
+			WT_ERR(__wt_row_key(session, page, rip, key, 0));
 
 			/*
 			 * >= is correct: see the comment above.
@@ -1746,7 +1746,7 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session,
 		}
 	if (F_ISSET(trk, WT_TRACK_CHECK_STOP))
 		WT_ROW_FOREACH_REVERSE(page, rip, i) {
-			WT_ERR(__wt_row_key_ref(session, page, rip, key, 0));
+			WT_ERR(__wt_row_key(session, page, rip, key, 0));
 
 			/*
 			 * < is correct: see the comment above.
@@ -1782,7 +1782,7 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session,
 	 * a copy from the page.
 	 */
 	rip = page->u.row.d + skip_start;
-	WT_ERR(__wt_row_key_ref(session, page, rip, key, 0));
+	WT_ERR(__wt_row_key(session, page, rip, key, 0));
 	WT_ERR(
 	    __wt_row_ikey_alloc(session, 0, key->data, key->size, &ref->u.key));
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -433,7 +433,8 @@ __verify_row_leaf_key_order(
 	 * are all empty entries).
 	 */
 	if (vs->max_addr->size != 0) {
-		WT_RET(__wt_row_key(session, page, page->u.row.d, vs->tmp1));
+		WT_RET(
+		    __wt_row_key_copy(session, page, page->u.row.d, vs->tmp1));
 
 		/*
 		 * Compare the key against the largest key we've seen so far.
@@ -457,7 +458,7 @@ __verify_row_leaf_key_order(
 	}
 
 	/* Update the largest key we've seen to the last key on this page. */
-	WT_RET(__wt_row_key(session,
+	WT_RET(__wt_row_key_copy(session,
 	    page, page->u.row.d + (page->entries - 1), vs->max_key));
 	(void)__wt_page_addr_string(session, vs->max_addr, page);
 

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -2696,8 +2696,8 @@ __rec_row_leaf(
 				    unpack->data, unpack->size);
 				tmpkey->size = unpack->prefix + unpack->size;
 			} else
-				WT_ERR(
-				    __wt_row_key(session, page, rip, tmpkey));
+				WT_ERR(__wt_row_key_copy(
+				    session, page, rip, tmpkey));
 
 			WT_ERR(__rec_cell_build_key(
 			    session, tmpkey->data, tmpkey->size, 0, &ovfl_key));

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -54,7 +54,7 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
 	/* Instantiate the keys. */
 	for (rip = page->u.row.d, i = 0; i < page->entries; ++rip, ++i)
 		if (__bit_test(tmp->mem, i))
-			WT_ERR(__wt_row_key(session, page, rip, NULL));
+			WT_ERR(__wt_row_key_copy(session, page, rip, NULL));
 
 	F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
 
@@ -97,12 +97,12 @@ __inmem_row_leaf_slots(
 }
 
 /*
- * __wt_row_key --
+ * __wt_row_key_copy --
  *	Copy an on-page key into a return buffer, or, if no return buffer
  * is specified, instantiate the key into the in-memory page.
  */
 int
-__wt_row_key(
+__wt_row_key_copy(
     WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip_arg, WT_ITEM *retb)
 {
 	enum { FORWARD, BACKWARD } direction;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -172,7 +172,7 @@ __wt_row_search(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, int is_modify)
 		indx = base + (limit >> 1);
 		rip = page->u.row.d + indx;
 
-		WT_ERR(__wt_row_key_ref(session, page, rip, item, 1));
+		WT_ERR(__wt_row_key(session, page, rip, item, 1));
 		WT_ERR(WT_BTREE_CMP(session, btree, srch_key, item, cmp));
 		if (cmp == 0)
 			break;

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -205,11 +205,11 @@ __wt_off_page(WT_PAGE *page, const void *p)
 }
 
 /*
- * __wt_row_key_ref --
+ * __wt_row_key --
  *	Set a buffer to reference a key as cheaply as possible.
  */
 static inline int
-__wt_row_key_ref(WT_SESSION_IMPL *session,
+__wt_row_key(WT_SESSION_IMPL *session,
     WT_PAGE *page, WT_ROW *rip, WT_ITEM *key, int instantiate)
 {
 	WT_BTREE *btree;
@@ -244,7 +244,7 @@ retry:	ikey = WT_ROW_KEY_COPY(rip);
 	 * If we're instantiating the key on the page, do that, and then look
 	 * it up again, else, we have a copy and we can return.
 	 */
-	WT_RET(__wt_row_key(session, page, rip, instantiate ? NULL : key));
+	WT_RET(__wt_row_key_copy(session, page, rip, instantiate ? NULL : key));
 	if (instantiate)
 		goto retry;
 	return (0);

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -123,11 +123,12 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip)
 		kb->size = ikey->size;
 	} else {
 		/*
-		 * If the key is simple and on-page, just reference it.
-		 * Else, if the key is simple, prefix-compressed and on-page,
-		 * and we have the previous expanded key in the cursor buffer,
-		 * build the key quickly.
-		 * Else, instantiate the key and do it all  the hard way.
+		 * Get a reference to the key, ideally without doing a copy.  If
+		 * the key is simple and on-page, just reference it; if the key
+		 * is simple, on-page and prefix-compressed, and we have the
+		 * previous expanded key in the cursor buffer, build the key
+		 * here.  Else, call the underlying routines to do it the hard
+		 * way.
 		 */
 		if (btree->huffman_key != NULL)
 			goto slow;
@@ -163,7 +164,7 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip)
 			kb->size = cbt->tmp.size;
 			cbt->rip_saved = rip;
 		} else
-slow:			WT_RET(__wt_row_key(session, cbt->page, rip, kb));
+slow:			WT_RET(__wt_row_key_copy(session, cbt->page, rip, kb));
 	}
 
 	/*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -385,7 +385,7 @@ extern int __wt_rec_row_bulk_insert(WT_CURSOR_BULK *cbulk);
 extern int __wt_rec_col_fix_bulk_insert(WT_CURSOR_BULK *cbulk);
 extern int __wt_rec_col_var_bulk_insert(WT_CURSOR_BULK *cbulk);
 extern int __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page);
-extern int __wt_row_key( WT_SESSION_IMPL *session,
+extern int __wt_row_key_copy( WT_SESSION_IMPL *session,
     WT_PAGE *page,
     WT_ROW *rip_arg,
     WT_ITEM *retb);


### PR DESCRIPTION
Michael, I suggest we merge the places where we have fast-track code for getting a reference to a key into a function.

This change does that (I merged your changes separately so you can create a patch for the master more easily).

The significant change in this diff is replacing the code in __wt_kv_return() and __wt_row_search() with a new inline function named __wt_row_key_ref(), that tries to fast-track getting a reference to the key, and falls back to __wt_row_key() if there's no fast-track path available.

I replaced a bunch of code in salvage to use the new routine, too, obviously that's less interesting.

There are no bug fixes or performance improvements in this change, it's purely semantic sugar to move a bunch of code into a common function.
