### PR TITLE
Some optimizations for __wt_config_gets_defno, for #279

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -449,16 +449,16 @@ extern int __wt_config_gets(WT_SESSION_IMPL *session,
     const char **cfg,
     const char *key,
     WT_CONFIG_ITEM *value);
-extern int __wt_config_gets_defno(WT_SESSION_IMPL *session,
-    const char **cfg,
-    const char *key,
-    WT_CONFIG_ITEM *value);
 extern  int __wt_config_getone(WT_SESSION_IMPL *session,
-    const char *cfg,
+    const char *config,
     WT_CONFIG_ITEM *key,
     WT_CONFIG_ITEM *value);
 extern  int __wt_config_getones(WT_SESSION_IMPL *session,
-    const char *cfg,
+    const char *config,
+    const char *key,
+    WT_CONFIG_ITEM *value);
+extern int __wt_config_gets_defno(WT_SESSION_IMPL *session,
+    const char **cfg,
     const char *key,
     WT_CONFIG_ITEM *value);
 extern  int __wt_config_subgetraw(WT_SESSION_IMPL *session,


### PR DESCRIPTION
If we're dealing with a simple stack of config strings, just parse the application string rather than the full list of defaults.
