### PR TITLE
64  bit bitstring API

### DIFF
--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -439,7 +439,7 @@ static int
 __verify_filefrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 	WT_DECL_RET;
-	uint32_t first, last;
+	uint64_t first, last;
 
 	/*
 	 * Check for file fragments we haven't verified -- every time we find
@@ -518,7 +518,7 @@ static int
 __verify_ckptfrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 	WT_DECL_RET;
-	uint32_t first, last;
+	uint64_t first, last;
 
 	/*
 	 * Check for checkpoint fragments we haven't verified -- every time we

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -12,7 +12,7 @@ static int __err_cell_type(
 	WT_SESSION_IMPL *, uint32_t, const char *, uint8_t, uint8_t);
 static int __err_eof(WT_SESSION_IMPL *, uint32_t, const char *);
 static int __verify_dsk_chunk(
-	WT_SESSION_IMPL *, const char *, WT_PAGE_HEADER *, uint32_t);
+	WT_SESSION_IMPL *, const char *, WT_PAGE_HEADER *, uint64_t);
 static int __verify_dsk_col_fix(
 	WT_SESSION_IMPL *, const char *, WT_PAGE_HEADER *);
 static int __verify_dsk_col_int(
@@ -407,7 +407,7 @@ __verify_dsk_col_fix(
     WT_SESSION_IMPL *session, const char *addr, WT_PAGE_HEADER *dsk)
 {
 	WT_BTREE *btree;
-	uint32_t datalen;
+	uint64_t datalen;
 
 	btree = session->btree;
 
@@ -506,7 +506,7 @@ match_err:			WT_RET_VRFY(session,
  */
 static int
 __verify_dsk_chunk(WT_SESSION_IMPL *session,
-    const char *addr, WT_PAGE_HEADER *dsk, uint32_t datalen)
+    const char *addr, WT_PAGE_HEADER *dsk, uint64_t datalen)
 {
 	WT_BTREE *btree;
 	uint8_t *p, *end;

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -458,7 +458,7 @@ __wt_rec_destroy(WT_SESSION_IMPL *session)
  *	Update the memory tracking structure for a set of new entries.
  */
 static inline void
-__rec_incr(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, uint32_t size)
+__rec_incr(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, uint64_t size)
 {
 	/*
 	 * The buffer code is fragile and prone to off-by-one errors -- check
@@ -469,7 +469,7 @@ __rec_incr(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, uint32_t size)
 	    WT_BLOCK_FITS(r->first_free, size, r->dsk.mem, r->page_size));
 
 	r->entries += v;
-	r->space_avail -= size;
+	r->space_avail -= (uint32_t)size;
 	r->first_free += size;
 }
 

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -47,7 +47,8 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * Allocate a bit array and figure out the set of "interesting" keys,
 	 * marking up the array.
 	 */
-	WT_RET(__wt_scr_alloc(session, __bitstr_size(page->entries), &tmp));
+	WT_RET(__wt_scr_alloc(
+	    session, (uint32_t)__bitstr_size(page->entries), &tmp));
 
 	__inmem_row_leaf_slots(tmp->mem, 0, page->entries, btree->key_gap);
 

--- a/src/include/bitstring.i
+++ b/src/include/bitstring.i
@@ -69,8 +69,8 @@
  * __bitstr_size --
  *	Return the bytes in a bitstring of nbits.
  */
-static inline uint32_t
-__bitstr_size(uint32_t nbits)
+static inline uint64_t
+__bitstr_size(uint64_t nbits)
 {
 	return (((nbits) + 7) >> 3);
 }
@@ -80,7 +80,7 @@ __bitstr_size(uint32_t nbits)
  *	Allocate a bitstring.
  */
 static inline int
-__bit_alloc(WT_SESSION_IMPL *session, uint32_t nbits, void *retp)
+__bit_alloc(WT_SESSION_IMPL *session, uint64_t nbits, void *retp)
 {
 	return (__wt_calloc(
 	    session, (size_t)__bitstr_size(nbits), sizeof(uint8_t), retp));
@@ -91,7 +91,7 @@ __bit_alloc(WT_SESSION_IMPL *session, uint32_t nbits, void *retp)
  *	Test one bit in name.
  */
 static inline int
-__bit_test(uint8_t *bitf, uint32_t bit)
+__bit_test(uint8_t *bitf, uint64_t bit)
 {
 	return (bitf[__bit_byte(bit)] & __bit_mask(bit) ? 1 : 0);
 }
@@ -101,7 +101,7 @@ __bit_test(uint8_t *bitf, uint32_t bit)
  *	Set one bit in name.
  */
 static inline void
-__bit_set(uint8_t *bitf, uint32_t bit)
+__bit_set(uint8_t *bitf, uint64_t bit)
 {
 	bitf[__bit_byte(bit)] |= __bit_mask(bit);
 }
@@ -111,7 +111,7 @@ __bit_set(uint8_t *bitf, uint32_t bit)
  *	Clear one bit in name.
  */
 static inline void
-__bit_clear(uint8_t *bitf, uint32_t bit)
+__bit_clear(uint8_t *bitf, uint64_t bit)
 {
 	bitf[__bit_byte(bit)] &= ~__bit_mask(bit);
 }
@@ -121,9 +121,9 @@ __bit_clear(uint8_t *bitf, uint32_t bit)
  *	Clear bits start-to-stop in name.
  */
 static inline void
-__bit_nclr(uint8_t *bitf, uint32_t start, uint32_t stop)
+__bit_nclr(uint8_t *bitf, uint64_t start, uint64_t stop)
 {
-	uint32_t startbyte, stopbyte;
+	uint64_t startbyte, stopbyte;
 
 	startbyte = __bit_byte(start);
 	stopbyte = __bit_byte(stop);
@@ -145,9 +145,9 @@ __bit_nclr(uint8_t *bitf, uint32_t start, uint32_t stop)
  *	Set bits start-to-stop in name.
  */
 static inline void
-__bit_nset(uint8_t *bitf, uint32_t start, uint32_t stop)
+__bit_nset(uint8_t *bitf, uint64_t start, uint64_t stop)
 {
-	uint32_t startbyte, stopbyte;
+	uint64_t startbyte, stopbyte;
 
 	startbyte = __bit_byte(start);
 	stopbyte = __bit_byte(stop);
@@ -167,10 +167,10 @@ __bit_nset(uint8_t *bitf, uint32_t start, uint32_t stop)
  *	Find first clear bit in name, return 0 on success, -1 on no bit clear.
  */
 static inline int
-__bit_ffc(uint8_t *bitf, uint32_t nbits, uint32_t *retp)
+__bit_ffc(uint8_t *bitf, uint64_t nbits, uint64_t *retp)
 {
 	uint8_t lb;
-	uint32_t byte, stopbyte, value;
+	uint64_t byte, stopbyte, value;
 
 	value = 0;		/* -Wuninitialized */
 
@@ -198,10 +198,10 @@ __bit_ffc(uint8_t *bitf, uint32_t nbits, uint32_t *retp)
  *	Find first set bit in name, return 0 on success, -1 on no bit set.
  */
 static inline int
-__bit_ffs(uint8_t *bitf, uint32_t nbits, uint32_t *retp)
+__bit_ffs(uint8_t *bitf, uint64_t nbits, uint64_t *retp)
 {
 	uint8_t lb;
-	uint32_t byte, stopbyte, value;
+	uint64_t byte, stopbyte, value;
 
 	value = 0;
 	if (nbits == 0)
@@ -228,10 +228,10 @@ __bit_ffs(uint8_t *bitf, uint32_t nbits, uint32_t *retp)
  *	Return a fixed-length column store bit-field value.
  */
 static inline uint8_t
-__bit_getv(uint8_t *bitf, uint32_t entry, uint8_t width)
+__bit_getv(uint8_t *bitf, uint64_t entry, uint8_t width)
 {
 	uint8_t value;
-	uint32_t bit;
+	uint64_t bit;
 
 #define	__BIT_GET(len, mask)						\
 	case len:							\
@@ -270,7 +270,7 @@ static inline uint8_t
 __bit_getv_recno(WT_PAGE *page, uint64_t recno, uint8_t width)
 {
 	return (__bit_getv(page->u.col_fix.bitf,
-	    (uint32_t)(recno - page->u.col_fix.recno), width));
+	    recno - page->u.col_fix.recno, width));
 }
 
 /*
@@ -278,9 +278,9 @@ __bit_getv_recno(WT_PAGE *page, uint64_t recno, uint8_t width)
  *	Set a fixed-length column store bit-field value.
  */
 static inline void
-__bit_setv(uint8_t *bitf, uint32_t entry, uint8_t width, uint8_t value)
+__bit_setv(uint8_t *bitf, uint64_t entry, uint8_t width, uint8_t value)
 {
-	uint32_t bit;
+	uint64_t bit;
 
 #define	__BIT_SET(len, mask)						\
 	case len:							\
@@ -320,5 +320,5 @@ static inline void
 __bit_setv_recno(WT_PAGE *page, uint64_t recno, uint8_t width, uint8_t value)
 {
 	return (__bit_setv(page->u.col_fix.bitf,
-	    (uint32_t)(recno - page->u.col_fix.recno), width, value));
+	    recno - page->u.col_fix.recno, width, value));
 }


### PR DESCRIPTION
Hi Keith,

I updated the bitstring implementation to support 64 bit string lengths. The change seems pretty simple, but it touches code I'm nervous about (in btree). Could you do a review and pull if it's OK?

Also, while I was doing this I came came across the gcc __builtin_ffs, which turns into a single processor instruction. Should we think about using that in the _bit_ffs implementation?

Thanks,
Alex
