### PR TITLE
Fix for checkpoints where the first checkpoint to delete is fake

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -303,9 +303,6 @@ __ckpt_process(
 	last_ckpt = NULL;
 	deleting = 0;
 	WT_CKPT_FOREACH(ckptbase, ckpt) {
-		if (F_ISSET(ckpt, WT_CKPT_FAKE))
-			continue;
-
 		/*
 		 * To delete a checkpoint, we'll need checkpoint information for
 		 * it and the subsequent checkpoint.  The test is tricky, load
@@ -342,6 +339,11 @@ __ckpt_process(
 		    session, 1, sizeof(WT_BLOCK_CKPT), &ckpt->bpriv));
 		ci = ckpt->bpriv;
 		WT_ERR(__wt_block_ckpt_init(session, block, ci, ckpt->name, 0));
+
+		/* Fake checkpoints don't have extents lists. */
+		if (F_ISSET(ckpt, WT_CKPT_FAKE))
+			continue;
+
 		WT_ERR(__wt_block_buffer_to_ckpt(
 		    session, block, ckpt->raw.data, ci));
 		WT_ERR(__wt_block_extlist_read(session, block, &ci->alloc));


### PR DESCRIPTION
Here is a test case:

``` python
import wiredtiger, wttest
from helper import key_populate, value_populate

class test_f(wttest.WiredTigerTestCase):
    uri = 'table:x'

    def test_f(self):
        self.session.create(self.uri, 'key_format=S,value_format=S')

        self.session.checkpoint('')
        curs1 = self.session.open_cursor(self.uri, None)
        for i in xrange(10):
            curs1.set_key(str(i) + "TEST_KEY")
            curs1.set_value("TEST_VAL")
            curs1.insert()
        curs1.close()

        curs1 = self.session.open_cursor(self.uri, None, 'checkpoint=WiredTigerCheckpoint')
        for i in xrange(10):
            curs1.set_key(str(i) + "TEST_KEY")
            self.assertEqual(curs1.search(), wiredtiger.WT_NOTFOUND)
        curs1.close()

        # Pin the original checkpoint
        sess2 = self.conn.open_session()
        curs2 = sess2.open_cursor(self.uri, None, 'checkpoint=WiredTigerCheckpoint')

        # Take a new checkpoint, make sure the data is there.
        self.session.checkpoint('')
        curs1 = self.session.open_cursor(self.uri, None, 'checkpoint=WiredTigerCheckpoint')
        for i in xrange(10):
            curs1.set_key(str(i) + "TEST_KEY")
            self.assertEqual(curs1.search(), 0)
        curs1.close()

        # Release the pinned cursor / session
        curs2.close()
        sess2.close()

        # Add more data
        curs3 = self.session.open_cursor(self.uri, None)
        for i in xrange(10, 20):
            curs3.set_key(str(i) + "TEST_KEY")
            curs3.set_value("TEST_VAL")
            curs3.insert()
        curs3.close()

        self.session.checkpoint('')

if __name__ == '__main__':
   wttest.run()
```
