### PR TITLE
Prioritize errors so system errors aren't lost. #388

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -66,12 +66,14 @@
 /* Set "ret" if not already set. */
 #define	WT_TRET(a) do {							\
 	int __ret;							\
-	if ((__ret = (a)) != 0 && ret == 0)				\
+	if ((__ret = (a)) != 0 &&					\
+	    (ret == 0 || ret == WT_DUPLICATE_KEY || ret == WT_NOTFOUND))\
 		ret = __ret;						\
 } while (0)
 #define	WT_TRET_NOTFOUND_OK(a) do {					\
 	int __ret;							\
-	if ((__ret = (a)) != 0 && __ret != WT_NOTFOUND && ret == 0)	\
+	if ((__ret = (a)) != 0 && __ret != WT_NOTFOUND &&		\
+	    (ret == 0 || ret == WT_DUPLICATE_KEY || ret == WT_NOTFOUND))\
 		ret = __ret;						\
 } while (0)
 


### PR DESCRIPTION
Check for non-fatal errors that could mask system errors in WT_TRET and WT_TRET_NOTFOUND_OK.
