### PR TITLE
Doc fixes and modification. #397

### DIFF
--- a/src/docs/architecture.dox
+++ b/src/docs/architecture.dox
@@ -26,7 +26,7 @@ WiredTiger's design is focused on a few core principles:
 @section multi_core Multi-core scaling
 
 WiredTiger scales on modern, multi-CPU architectures.  Using a variety of
-programming techniques such as hazard references, lock-free algorithms, fast
+programming techniques such as hazard pointers, lock-free algorithms, fast
 latching and message passing, WiredTiger performs more work per CPU core than
 alternative engines.
 

--- a/src/docs/config-strings.dox
+++ b/src/docs/config-strings.dox
@@ -65,7 +65,7 @@ For example, in Python, code might look as follows:
 @todo improve the example
 
 Open a connection to a database, creating it if it does not exist and set a
-cache size of 10MB, then open a session in the database:
+cache size of 500MB, then open a session in the database:
 
 @snippet ex_config.c configure cache size
 

--- a/src/docs/cursors.dox
+++ b/src/docs/cursors.dox
@@ -20,7 +20,7 @@ WT_SESSION::commit_transaction, or discarded by calling
 WT_SESSION::rollback_transaction.
 
 If no transaction is active, cursor reads are performed at the isolation
-level of the session, set with the \c isolation key to
+level of the session, set with the \c isolation configuration key to
 WT_CONNECTION::open_session and successful updates are automatically
 committed before the update operation completes.
 
@@ -35,7 +35,7 @@ cursors in a session read from a stable snapshot while any cursor in the
 session remains positioned.
 
 Cursor positions do not survive transaction boundaries.  When a
-transaction is started with the WT_SESSION:begin_transaction or ended
+transaction is started with the WT_SESSION::begin_transaction or ended
 with either WT_SESSION::commit_transaction or
 WT_SESSION::rollback_transaction, all open cursors are reset, as if the
 WT_CURSOR::reset method was called.  The cursor reset discards any
@@ -51,23 +51,28 @@ See @ref transactions for more information.
 
 @section cursor_types Cursor types
 
-The following are some of common builtin cursor types:
+The following are some of the common builtin cursor types:
 
 <table>
-  @hrow{URI, Type}
+  @hrow{URI, Type, Notes}
+   @row{<tt>backup:</tt>,
+hot backup cursor, See also: @ref hot_backup}
    @row{<tt>colgroup:\<tablename\>.\<columnset\></tt>,
-column group cursor}
-  @row{<tt>table:\<tablename\></tt>,
-table cursor (key=table key\, value=table value)}
+column group cursor,}
+   @row{<tt>config:[\<uri\>]</tt>,
+object configuration cursor (key=config string\,
+value=config value),}
   @row{<tt>file:\<filename\></tt>,
-file cursor (key=file key\, value=file value)}
+file cursor (key=file key\, value=file value),}
   @row{<tt>index:\<tablename\>.\<indexname\></tt>,
-index cursor (key=index key\, value=table value)}
+index cursor (key=index key\, value=table value),}
   @row{<tt>lsm:\<name\></tt>,
-LSM cursor (key=LSM key\, value=LSM value), see @ref lsm}
+LSM cursor (key=LSM key\, value=LSM value), See also: @ref lsm}
   @row{<tt>statistics:[file</tt><tt>:\<filename\>]</tt>,
-  database or file statistics (key=(int)\,
-  value=(string)description\, (string)value\, (uint64_t)value)}
+database or file statistics (key=(int)\,
+value=(string)description\, (string)value\, (uint64_t)value),}
+  @row{<tt>table:\<tablename\></tt>,
+table cursor (key=table key\, value=table value),}
 </table>
 
 See @subpage data_sources for the full list.
@@ -99,7 +104,7 @@ WT_CURSOR::set_key and WT_CURSOR::set_value in raw mode, the WT_ITEM
 should be equivalent to calling ::wiredtiger_struct_pack for the
 cursor's \c key_format or \c value_format, respectively.
 
-@section cursor_random Random lookup
+@section cursor_rand Random lookup
 
 Cursors can be configured to return pseudo-random records from row-store
 objects.  See @subpage cursor_random for details.

--- a/src/docs/data_sources.dox
+++ b/src/docs/data_sources.dox
@@ -24,8 +24,6 @@ column group cursor,}
    @row{<tt>config:[\<uri\>]</tt>,
 object configuration cursor (key=config string\,
 value=config value),}
-  @row{<tt>table:\<tablename\></tt>,
-table cursor (key=table key\, value=table value),}
   @row{<tt>file:\<filename\></tt>,
 file cursor (key=file key\, value=file value),}
   @row{<tt>index:\<tablename\>.\<indexname\></tt>,
@@ -35,8 +33,10 @@ join cursor, @notyet{join cursors}}
   @row{<tt>lsm:\<name\></tt>,
 LSM cursor (key=LSM key\, value=LSM value), See also: @ref lsm}
   @row{<tt>statistics:[file</tt><tt>:\<filename\>]</tt>,
-  database or file statistics (key=(int)\,
-  value=(string)description\, (string)value\, (uint64_t)value),}
+database or file statistics (key=(int)\,
+value=(string)description\, (string)value\, (uint64_t)value),}
+  @row{<tt>table:\<tablename\></tt>,
+table cursor (key=table key\, value=table value),}
 </table>
 
 @subsection data_files Raw Files

--- a/src/docs/threads.dox
+++ b/src/docs/threads.dox
@@ -13,7 +13,7 @@ session.
 WT_SESSION and WT_CURSOR methods may be accessed by different threads
 serially (for example, a pool of threads managed by the application with
 a set of shared session or cursor handles).  There is no thread-local
-state in WiredTiger, but no built-in synchronization of session or
+state in WiredTiger, and no built-in synchronization of session or
 cursor handles, either, so if multiple threads access a session or
 cursor handle, access must be serialized by the application.
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -501,20 +501,25 @@ struct __wt_session {
 	 *  @row{<tt>colgroup:\<tablename\>.\<columnset\></tt>,
 	 *	column group cursor,
 	 *	table key\, column group value(s)}
-	 *  @row{<tt>table:\<tablename\></tt>,
-	 *	table cursor,
-	 *	table key\, table value(s)}
+	 *  @row{<tt>config:</tt>,
+	 *	object configuration cursor (key=config string\,
+	 *	value=config value}
 	 *  @row{<tt>file:\<filename\></tt>,
 	 *	file cursor,
 	 *	file key\, file value(s)}
 	 *  @row{<tt>index:\<tablename\>.\<indexname\></tt>,
 	 *	index cursor,
 	 *	key=index key\, value=table value(s)}
+	 *  @row{<tt>lsm:\<name\></tt>,
+	 *	LSM cursor (key=LSM key\, value=LSM value), See also: @ref lsm}
 	 *  @row{<tt>statistics:[file</tt><tt>:\<filename\>]</tt>,
 	 *	database or file statistics cursor,
 	 *	key=<code>int id</code>\, value=(<code>string description\,
 	 *	string value\, uint64_t value</code>)\,
 	 *	see @ref data_statistics for details}
+	 *  @row{<tt>table:\<tablename\></tt>,
+	 *	table cursor,
+	 *	table key\, table value(s)}
 	 *  </table>
 	 * @param to_dup a cursor to duplicate
 	 * @param session the session handle
@@ -873,7 +878,7 @@ struct __wt_session {
 	 *
 	 * All open cursors are reset.
 	 *
-	 * WT_SESSION::transaction_begin will fail if a transaction is already
+	 * WT_SESSION::begin_transaction will fail if a transaction is already
 	 * in progress in the session.
 	 *
 	 * @snippet ex_all.c transaction commit/rollback


### PR DESCRIPTION
This is a first set of doc mods that fix some minor things.  Most of the changes should be obvious.

Here are a few that may be noteworthy.  The cursor uri tables (3 copies!) were different from each other.  I brought them up to date.  It appears that the one in data_sources.dox is "the master" although I probably would have expected the master to be in wiredtiger.in.  I also moved table: alphabetically.

I changed hazard reference to hazard pointer because when I tried searching for that, it does not search well (Google tries very hard to make it harvard reference) and hazard pointer immediately is fruitful.

For cursor_rand, apparently having both a section and subpage with the same name doesn't really work and the section wins, so it was a link to itself.

Things I did not fix:
1.  Why does the TOC have  Data Sources -> Cursor Operations?  I couldn't figure out how/why that is there.
2.  Cursor random is given unusual prominence given its specialized nature.
3.  The cursor_ops page never discusses get_value or retrieving values.
The WT_CURSOR page for get_value() does not discuss the varargs.
Is the varargs discussed somewhere?  It is shown on the data_sources page.
