### PR TITLE
Remove unused statistics config.  Other minor doc edits. #397

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -388,9 +388,6 @@ methods = {
 		ignore the encodings for the key and value, manage data as if
 		the formats were \c "u".  See @ref cursor_raw for details''',
 		type='boolean'),
-	Config('statistics', 'false', r'''
-		configure the cursor for statistics''',
-		type='boolean'),
 	Config('statistics_clear', 'false', r'''
 		reset statistics counters when the cursor is closed; valid
 		only for statistics cursors''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -319,8 +319,7 @@ __wt_confchk_session_log_printf[] = {
 const char *
 __wt_confdfl_session_open_cursor =
 	"append=0,bulk=0,checkpoint=,dump=,next_random=0,no_cache=0,"
-	"overwrite=0,raw=0,statistics=0,statistics_clear=0,statistics_fast=0,"
-	"target=";
+	"overwrite=0,raw=0,statistics_clear=0,statistics_fast=0,target=";
 
 WT_CONFIG_CHECK
 __wt_confchk_session_open_cursor[] = {
@@ -332,7 +331,6 @@ __wt_confchk_session_open_cursor[] = {
 	{ "no_cache", "boolean", NULL, NULL},
 	{ "overwrite", "boolean", NULL, NULL},
 	{ "raw", "boolean", NULL, NULL},
-	{ "statistics", "boolean", NULL, NULL},
 	{ "statistics_clear", "boolean", NULL, NULL},
 	{ "statistics_fast", "boolean", NULL, NULL},
 	{ "target", "list", NULL, NULL},

--- a/src/docs/config-file.dox
+++ b/src/docs/config-file.dox
@@ -25,7 +25,7 @@ and the newline character are discarded.
 <li>Any text between double-quote pairs (<b><tt>"</tt></b>) is left
 untouched, including newline and white-space characters.   Backslash
 characters escape double-quote characters: a backslash escaped
-double-quote character can neither start or end a quoted string.
+double-quote character can neither start nor end a quoted string.
 
 <li>Comments are discarded.  If the first non-white-space character
 following an unquoted and unescaped newline character is a hash mark

--- a/src/docs/cursor-ops.dox
+++ b/src/docs/cursor-ops.dox
@@ -109,6 +109,7 @@ will not be cleared by an error.
 Applications that cannot re-position the cursor after failure must
 duplicate the cursor by calling WT_SESSION::open_cursor and passing the
 cursor as the \c to_dup parameter before calling a cursor method that will
-attempt to re-position the cursor.
+attempt to re-position the cursor.  Cursor duplication is not supported
+for the backup, config and statistics cursor types.
 
  */

--- a/src/docs/cursors.dox
+++ b/src/docs/cursors.dox
@@ -60,7 +60,7 @@ hot backup cursor, See also: @ref hot_backup}
    @row{<tt>colgroup:\<tablename\>.\<columnset\></tt>,
 column group cursor,}
    @row{<tt>config:[\<uri\>]</tt>,
-object configuration cursor (key=config string\,
+object configuration cursor, (key=config string\,
 value=config value),}
   @row{<tt>file:\<filename\></tt>,
 file cursor (key=file key\, value=file value),}

--- a/src/docs/namespace.dox
+++ b/src/docs/namespace.dox
@@ -11,7 +11,7 @@ WiredTiger's public function names begin with the string "wiredtiger".
 WiredTiger's public \c \#define and structure \c typedef declarations
 begin with the string "WT_".
 
-WiredTiger's private function names begin with the string "__wt__".
+WiredTiger's private function names begin with the string "__wt_".
 
 @section filename File system name space
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -314,7 +314,7 @@ struct __wt_cursor {
 	 * must be set; if the record already exists, the key's value will be
 	 * updated, otherwise, the record will be inserted.
 	 *
-	 * In a cursor with record number keys was configured with "append",
+	 * If a cursor with record number keys was configured with "append",
 	 * the value must be set; a new record will be appended and the record
 	 * number set as the cursor key value.
 	 *
@@ -366,7 +366,7 @@ struct __wt_cursor {
 	/*! Close the cursor.
 	 *
 	 * This releases the resources associated with the cursor handle.
-	 * Cursors are closed implicitly by ending the enclosing transaction or
+	 * Cursors are closed implicitly by ending the enclosing connection or
 	 * closing the session in which they were opened.
 	 *
 	 * @snippet ex_all.c Close the cursor
@@ -501,9 +501,9 @@ struct __wt_session {
 	 *  @row{<tt>colgroup:\<tablename\>.\<columnset\></tt>,
 	 *	column group cursor,
 	 *	table key\, column group value(s)}
-	 *  @row{<tt>config:</tt>,
-	 *	object configuration cursor (key=config string\,
-	 *	value=config value}
+	 *  @row{<tt>config:[\<uri\>]</tt>,
+	 *	object configuration cursor, (key=config string\,
+	 *	value=config value),}
 	 *  @row{<tt>file:\<filename\></tt>,
 	 *	file cursor,
 	 *	file key\, file value(s)}
@@ -522,7 +522,6 @@ struct __wt_session {
 	 *	table key\, table value(s)}
 	 *  </table>
 	 * @param to_dup a cursor to duplicate
-	 * @param session the session handle
 	 * @configstart{session.open_cursor, see dist/api_data.py}
 	 * @config{append, append the value as a new record\, creating a new
 	 * record number key; valid only for cursors with record number keys.,a
@@ -559,8 +558,6 @@ struct __wt_session {
 	 * @config{raw, ignore the encodings for the key and value\, manage data
 	 * as if the formats were \c "u".  See @ref cursor_raw for details.,a
 	 * boolean flag; default \c false.}
-	 * @config{statistics, configure the cursor for statistics.,a boolean
-	 * flag; default \c false.}
 	 * @config{statistics_clear, reset statistics counters when the cursor
 	 * is closed; valid only for statistics cursors.,a boolean flag; default
 	 * \c false.}


### PR DESCRIPTION
I removed the unused statistics config type from everywhere and have a few minor corrections.
This is probably the end of my doc survey changes.  The only thing left that I really want, but
not sure what it should really say is a description of the cursor::get_value varargs.
