### PR TITLE
Update LSM error handling for drop, rename and truncate.

### DIFF
--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -374,10 +374,10 @@ __lsm_free_chunks(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		__wt_free(session, lsm_tree->old_chunks[i]);
 		++lsm_tree->old_avail;
 	}
-	if (locked) {
-err:		WT_TRET(__wt_lsm_meta_write(session, lsm_tree));
+err:	if (progress)
+		WT_TRET(__wt_lsm_meta_write(session, lsm_tree));
+	if (locked)
 		WT_TRET(__wt_rwunlock(session, lsm_tree->rwlock));
-	}
 
 	/* Returning non-zero means there is no work to do. */
 	if (!progress)


### PR DESCRIPTION
Hi Michael,

I've made some changes to the error handling. I think they are definite improvements. I've got two remaining concerns, I wanted to check in to ensure they are valid before I chase them down (hence the pull request).

1) Should drop and rename be updating the WT_CONNECTION::lsmqh queue? If so, would that belong in the lsm_dsrc.c:__lsm_drop and lsm_dsrc.c:__lsm_rename functions?
2) I'm concerned about the state of things if a call to __lsm_tree_close (or any subsequent calls in the schema level functions) fails. At that stage, I suspect we really want to free any resources we can and remove the LSM tree from the connection list (so a new one can be created). Alternatively, do we need a call to __lsm_tree_start_worker in the error handling code?
