### PR TITLE
Add a forced eviction mode that uses a new page state

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -781,6 +781,9 @@ __debug_ref(WT_DBG *ds, WT_REF *ref, WT_PAGE *page)
 	case WT_REF_DELETED:
 		__dmsg(ds, "deleted");
 		break;
+	case WT_REF_EVICT_FORCE:
+		__dmsg(ds, "evict-force %p", ref->page);
+		break;
 	case WT_REF_EVICT_WALK:
 		__dmsg(ds, "evict-walk %p", ref->page);
 		break;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -42,6 +42,7 @@ __wt_page_in_func(
 			WT_RET(__wt_cache_full_check(session));
 			WT_RET(__wt_cache_read(session, parent, ref));
 			continue;
+		case WT_REF_EVICT_FORCE:
 		case WT_REF_LOCKED:
 		case WT_REF_READING:
 			/*

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -284,8 +284,9 @@ retry:				if (!WT_ATOMIC_CAS(ref->state,
 				 * that the page will be read back in to cache.
 				 */
 				while (LF_ISSET(WT_TREE_WAIT) &&
-				    (ref->state == WT_REF_LOCKED ||
-				     ref->state == WT_REF_READING))
+				    (ref->state == WT_REF_EVICT_FORCE ||
+				    ref->state == WT_REF_LOCKED ||
+				    ref->state == WT_REF_READING))
 					__wt_yield();
 				if (ref->state == WT_REF_DELETED ||
 				    ref->state == WT_REF_DISK)

--- a/src/btree/rec_evict.c
+++ b/src/btree/rec_evict.c
@@ -273,6 +273,7 @@ __rec_review(WT_SESSION_IMPL *session,
 				    session, ref, ref->page, exclusive, 0));
 				break;
 			case WT_REF_EVICT_WALK:		/* Walk point */
+			case WT_REF_EVICT_FORCE:	/* Forced evict */
 			case WT_REF_LOCKED:		/* Being evicted */
 			case WT_REF_READING:		/* Being read */
 				return (EBUSY);
@@ -462,7 +463,8 @@ __rec_excl_clear(WT_SESSION_IMPL *session)
 		if ((ref = session->excl[i]) == NULL)
 			break;
 		WT_ASSERT(session,
-		    ref->state == WT_REF_LOCKED && ref->page != NULL);
+		    (ref->state == WT_REF_LOCKED ||
+		     ref->state == WT_REF_EVICT_FORCE) && ref->page != NULL);
 		ref->state = WT_REF_MEM;
 	}
 }

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -323,6 +323,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 
 			WT_HAVE_DIAGNOSTIC_YIELD;
 			return (ret);
+		case WT_REF_EVICT_FORCE:
 		case WT_REF_LOCKED:
 			/*
 			 * If being called by the eviction server, the page was

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -308,7 +308,6 @@ struct __wt_page {
 
 #define	WT_PAGE_BUILD_KEYS	0x01	/* Keys have been built in memory */
 #define	WT_PAGE_EVICT_LRU	0x02	/* Page is on the LRU queue */
-#define	WT_PAGE_EVICT_LOCKED	0x04	/* Page was locked when queued */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 };
 
@@ -337,6 +336,11 @@ struct __wt_page {
  *	The page is on disk, but has been deleted from the tree; we can delete
  * row-store leaf pages without reading them if they don't reference overflow
  * items.
+ *
+ * WT_REF_EVICT_FORCE:
+ *	An application thread has selected this page for eviction. No other
+ * hazard references should be granted. If eviction fails, the eviction server
+ * should set the state back to WT_REF_MEM.
  *
  * WT_REF_EVICT_WALK:
  *	The next page to be walked for LRU eviction.  This page is available for
@@ -375,6 +379,7 @@ struct __wt_page {
 enum __wt_page_state {
 	WT_REF_DISK=0,			/* Page is on disk */
 	WT_REF_DELETED,			/* Page is on disk, but deleted */
+	WT_REF_EVICT_FORCE,		/* Page is ready for forced eviction */
 	WT_REF_EVICT_WALK,		/* Next page for LRU eviction */
 	WT_REF_LOCKED,			/* Page being evicted */
 	WT_REF_MEM,			/* Page is in cache and valid */


### PR DESCRIPTION
instead of re-using the locked state and tracking other information in
the eviction server.
