### PR TITLE
Don't translate errno. #443.

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -489,7 +489,7 @@ __backup_file_create(WT_SESSION_IMPL *session, FILE **fpp)
 
 	/* Open the hot backup file. */
 	WT_RET(__wt_filename(session, WT_METADATA_BACKUP, &path));
-	WT_ERR_TEST((*fpp = fopen(path, "w")) == NULL, WT_NOTFOUND);
+	WT_ERR_TEST((*fpp = fopen(path, "w")) == NULL, __wt_errno());
 
 err:	__wt_free(session, path);
 	return (ret);

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -69,7 +69,7 @@ __wt_meta_turtle_read(
 
 	/* Open the turtle file. */
 	WT_RET(__wt_filename(session, WT_METADATA_TURTLE, &path));
-	WT_ERR_TEST((fp = fopen(path, "r")) == NULL, WT_NOTFOUND);
+	WT_ERR_TEST((fp = fopen(path, "r")) == NULL, __wt_errno());
 
 	/* Search for the key. */
 	WT_ERR(__wt_scr_alloc(session, 512, &buf));


### PR DESCRIPTION
Apply Keith's diff to remove the translation of errno into WT_NOTFOUND.
