### PR TITLE
Typos.  Fix WT_ATOMIC_CAS in _lint case to be more accurate.

### DIFF
--- a/src/conn/conn_btree.c
+++ b/src/conn/conn_btree.c
@@ -77,7 +77,7 @@ __conn_btree_open_lock(WT_SESSION_IMPL *session, uint32_t flags)
  * __conn_btree_get --
  *	Find an open btree file handle, otherwise create a new one and link it
  *	into the connection's list.  If successful, it returns with either
- *	(a) an open handle, read locked (if WT_BTREE_EXCLUSIVE is set); or
+ *	(a) an open handle, read locked (if WT_BTREE_EXCLUSIVE is not set); or
  *	(b) an open handle, write locked (if WT_BTREE_EXCLUSIVE is set), or
  *	(c) a closed handle, write locked.
  */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -472,7 +472,7 @@ __wt_page_hazard_check(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 	/*
 	 * No lock is required because the session array is fixed size, but it
-	 * it may contain inactive entries.  We must review any active session
+	 * may contain inactive entries.  We must review any active session
 	 * that might contain a hazard pointer, so insert a barrier before
 	 * reading the active session count.  That way, no matter what sessions
 	 * come or go, we'll check the slots for all of the sessions that could

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -72,7 +72,7 @@
 #if defined(_lint)
 #define	WT_ATOMIC_ADD(v, val)	((v) += (val), (v))
 #define	WT_ATOMIC_CAS(v, oldv, newv)					\
-	((v) == (oldv) || (v) == (newv) ? 1 : 0)
+	((v) == (oldv) && (v) = (newv) ? 1 : 0)
 #define	WT_ATOMIC_SUB(v, val)	((v) -= (val), (v))
 #define	WT_FULL_BARRIER()
 #define	WT_READ_BARRIER()

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -88,7 +88,7 @@ __wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, int *busyp
 		 * page to be evicted and a different page read into the same
 		 * memory, so the pointer hasn't changed but the contents have.
 		 * That's OK, we found this page using the tree's key space,
-		 * whatever page we find here is the page page for us to use.)
+		 * whatever page we find here is the page for us to use.)
 		 */
 		if (ref->page == hp->page &&
 		    (ref->state == WT_REF_MEM ||


### PR DESCRIPTION
Fix a few typos.  Corrected WT_ATOMIC_CAS for _lint.
