### PR TITLE
Add optional insert throttling for LSM trees.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -94,6 +94,10 @@ format_meta = column_meta + [
 ]
 
 lsm_config = [
+	Config('lsm_auto_throttle', 'false', r'''
+		Throttle inserts into LSM tree if merge operations aren't keeping
+		up''',
+		type='boolean'),
 	Config('lsm_bloom', 'true', r'''
 		create bloom filters on LSM tree chunks as they are merged''',
 		type='boolean'),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -244,12 +244,12 @@ __wt_confdfl_session_create =
 	"colgroups=,collator=,columns=,dictionary=0,exclusive=0,format=btree,"
 	"huffman_key=,huffman_value=,internal_item_max=0,"
 	"internal_key_truncate=,internal_page_max=2KB,key_format=u,key_gap=10"
-	",leaf_item_max=0,leaf_page_max=1MB,lsm_bloom=,lsm_bloom_bit_count=8,"
-	"lsm_bloom_config=,lsm_bloom_hash_count=4,lsm_bloom_newest=0,"
-	"lsm_bloom_oldest=0,lsm_chunk_size=2MB,lsm_merge_max=15,"
-	"lsm_merge_threads=1,memory_page_max=5MB,os_cache_dirty_max=0,"
-	"os_cache_max=0,prefix_compression=,source=,split_pct=75,type=file,"
-	"value_format=u";
+	",leaf_item_max=0,leaf_page_max=1MB,lsm_auto_throttle=0,lsm_bloom=,"
+	"lsm_bloom_bit_count=8,lsm_bloom_config=,lsm_bloom_hash_count=4,"
+	"lsm_bloom_newest=0,lsm_bloom_oldest=0,lsm_chunk_size=2MB,"
+	"lsm_merge_max=15,lsm_merge_threads=1,memory_page_max=5MB,"
+	"os_cache_dirty_max=0,os_cache_max=0,prefix_compression=,source=,"
+	"split_pct=75,type=file,value_format=u";
 
 WT_CONFIG_CHECK
 __wt_confchk_session_create[] = {
@@ -274,6 +274,7 @@ __wt_confchk_session_create[] = {
 	{ "key_gap", "int", "min=0", NULL},
 	{ "leaf_item_max", "int", "min=0", NULL},
 	{ "leaf_page_max", "int", "min=512B,max=512MB", NULL},
+	{ "lsm_auto_throttle", "boolean", NULL, NULL},
 	{ "lsm_bloom", "boolean", NULL, NULL},
 	{ "lsm_bloom_bit_count", "int", "min=2,max=1000", NULL},
 	{ "lsm_bloom_config", "string", NULL, NULL},

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -67,6 +67,10 @@ struct __wt_lsm_tree {
 
 	WT_DSRC_STATS stats;		/* LSM statistics */
 
+	/* Variables to help with insert throttling */
+	uint64_t switch_count;	/* Number of new chunks since the last merge */
+	double merge_rate;	/* Proportion of inserts vs merged items */
+
 	uint64_t dsk_gen;
 
 	/* Configuration parameters */
@@ -105,6 +109,7 @@ struct __wt_lsm_tree {
 
 #define	WT_LSM_TREE_WORKING	0x01
 #define	WT_LSM_TREE_OPEN	0x02
+#define	WT_LSM_THROTTLE		0x04
 	uint32_t flags;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -693,6 +693,8 @@ struct __wt_session {
 	 * uncompressed data\, that is\, the limit is applied before any block
 	 * compression is done.,an integer between 512B and 512MB; default \c
 	 * 1MB.}
+	 * @config{lsm_auto_throttle, Throttle inserts into LSM tree if merge
+	 * operations aren't keeping up.,a boolean flag; default \c false.}
 	 * @config{lsm_bloom, create bloom filters on LSM tree chunks as they
 	 * are merged.,a boolean flag; default \c true.}
 	 * @config{lsm_bloom_bit_count, the number of bits used per item for LSM

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -55,7 +55,11 @@ __wt_lsm_meta_read(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		else if (WT_STRING_MATCH(
 		    "lsm_bloom_hash_count", ck.str, ck.len))
 			lsm_tree->bloom_hash_count = (uint32_t)cv.val;
-		else if (WT_STRING_MATCH("lsm_chunk_size", ck.str, ck.len))
+		else if (WT_STRING_MATCH(
+		    "lsm_auto_throttle", ck.str, ck.len)) {
+			if (cv.val != 0)
+				F_SET(lsm_tree, WT_LSM_THROTTLE);
+		} else if (WT_STRING_MATCH("lsm_chunk_size", ck.str, ck.len))
 			lsm_tree->chunk_size = (uint32_t)cv.val;
 		else if (WT_STRING_MATCH("lsm_merge_max", ck.str, ck.len))
 			lsm_tree->merge_max = (uint32_t)cv.val;
@@ -170,10 +174,12 @@ __wt_lsm_meta_write(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	    lsm_tree->key_format, lsm_tree->value_format));
 	WT_ERR(__wt_buf_catfmt(session, buf,
 	    ",last=%" PRIu32 ",lsm_chunk_size=%" PRIu64
+	    ",lsm_auto_throttle=%s"
 	    ",lsm_merge_max=%" PRIu32 ",lsm_merge_threads=%" PRIu32
 	    ",lsm_bloom=%" PRIu32
 	    ",lsm_bloom_bit_count=%" PRIu32 ",lsm_bloom_hash_count=%" PRIu32,
 	    lsm_tree->last, (uint64_t)lsm_tree->chunk_size,
+	    F_ISSET(lsm_tree, WT_LSM_THROTTLE) ? "true" : "false",
 	    lsm_tree->merge_max, lsm_tree->merge_threads, lsm_tree->bloom,
 	    lsm_tree->bloom_bit_count, lsm_tree->bloom_hash_count));
 	WT_ERR(__wt_buf_catfmt(session, buf, ",chunks=["));


### PR DESCRIPTION
Addresses issue #446.

An alternative implementation would be to add some statistics - probably those output in the new VERBOSE message. Adding statistics would facilitate applications implementing throttling (and save us guessing what a reasonable throttling policy is).
