### PR TITLE
Enhance forced eviction to allow multiple pages to be queued.

### DIFF
--- a/src/btree/bt_evict.c
+++ b/src/btree/bt_evict.c
@@ -10,6 +10,7 @@
 static void __evict_dirty_validate(WT_CONNECTION_IMPL *);
 static int  __evict_file(WT_SESSION_IMPL *, int);
 static int  __evict_file_request_walk(WT_SESSION_IMPL *);
+static int __evict_forced_pages(WT_SESSION_IMPL *);
 static void __evict_init_candidate(
     WT_SESSION_IMPL *, WT_EVICT_ENTRY *, WT_PAGE *);
 static int  __evict_lru(WT_SESSION_IMPL *, int);
@@ -95,8 +96,9 @@ __evict_list_clr(WT_SESSION_IMPL *session, WT_EVICT_ENTRY *e)
 		 * clear the locked state when removing it from the eviction
 		 * queue.
 		 */
-		(void)WT_ATOMIC_CAS(e->page->ref->state,
-		    WT_REF_EVICT_FORCE, WT_REF_MEM);
+		if (WT_ATOMIC_CAS(e->page->ref->state,
+		    WT_REF_EVICT_FORCE, WT_REF_MEM))
+			--S2C(session)->cache->force_entries;
 	}
 	e->page = NULL;
 	e->btree = WT_DEBUG_POINT;
@@ -159,7 +161,7 @@ __wt_evict_list_clr_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 /*
  * __wt_evict_forced_page --
- *	If a page matches the force criteria,try to add it to the eviction
+ *	If a page matches the force criteria try to add it to the eviction
  *	queue and trigger the eviction server.  Best effort only, so no error
  *	is returned if the page is busy.
  */
@@ -168,15 +170,12 @@ __wt_evict_forced_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
+	WT_EVICT_ENTRY *candidate;
 	WT_PAGE *top;
 	u_int levels;
 
 	conn = S2C(session);
 	cache = conn->cache;
-
-	/* Don't queue a page for forced eviction if we already have one. */
-	if (F_ISSET(cache, WT_EVICT_FORCE_PASS))
-		return;
 
 	/*
 	 * Check if the page we have been asked to forcefully evict is at the
@@ -192,6 +191,26 @@ __wt_evict_forced_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 		page = top;
 
 	/*
+	 * Find the first slot in the eviction queue that doesn't already
+	 * contain a forced eviction candidate. There is a possibility that
+	 * we will race here, and another forced candidate will be added to
+	 * the slot we have chosen. That's OK, the winner will replace the
+	 * prior candidate in the queue and it's WT_REF_EVICT_FORCE state will
+	 * be reset to WT_REF_MEM.
+	 */
+	for (candidate = cache->evict;
+	    candidate < cache->evict + cache->evict_entries &&
+	    candidate->page != NULL &&
+	    candidate->page->ref->state == WT_REF_EVICT_FORCE;
+	    candidate++) {}
+	/*
+	 * Nothing to do if the eviction list is already full of forced
+	 * eviction candidates.
+	 */
+	if (candidate == cache->evict + cache->evict_entries)
+		return;
+
+	/*
 	 * Try to lock the page.  If this succeeds, we're going to queue
 	 * it for forced eviction.  We don't go right to the EVICT_FORCED
 	 * state, because that is cleared by __wt_evict_list_clr_page.
@@ -204,8 +223,8 @@ __wt_evict_forced_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 	__wt_spin_lock(session, &cache->evict_lock);
 
-	/* Add the page to the head of the eviction queue. */
-	__evict_init_candidate(session, cache->evict, page);
+	/* Add the page to the eviction queue. */
+	__evict_init_candidate(session, candidate, page);
 
 	/* Set the location in the eviction queue to the new entry. */
 	cache->evict_current = cache->evict;
@@ -217,7 +236,7 @@ __wt_evict_forced_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 */
 	WT_PUBLISH(page->ref->state, WT_REF_EVICT_FORCE);
 
-	F_SET(cache, WT_EVICT_FORCE_PASS);
+	cache->force_entries++;
 	__wt_spin_unlock(session, &cache->evict_lock);
 
 	WT_CSTAT_INCR(session, cache_eviction_force);
@@ -343,11 +362,9 @@ err:		WT_PANIC_ERR(session, ret, "eviction server error");
 static int
 __evict_worker(WT_SESSION_IMPL *session)
 {
-	WT_BTREE *force_btree;
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
-	WT_PAGE *force_page;
 	uint64_t bytes_inuse, bytes_max, dirty_inuse;
 	int clean, loop;
 
@@ -356,7 +373,6 @@ __evict_worker(WT_SESSION_IMPL *session)
 
 	/* Evict pages from the cache. */
 	for (loop = 0;; loop++) {
-		force_page = NULL;
 
 		/*
 		 * Block out concurrent eviction while we are handling requests.
@@ -367,31 +383,9 @@ __evict_worker(WT_SESSION_IMPL *session)
 		while (ret == 0 && cache->sync_complete != cache->sync_request)
 			ret = __evict_file_request_walk(session);
 
-		/*
-		 * If we've been awoken for forced eviction, just try to evict
-		 * the first page in the queue: don't do a walk and sort first.
-		 */
-		force_btree = NULL;
-		force_page = NULL;
-		if (ret == 0 && F_ISSET(cache, WT_EVICT_FORCE_PASS)) {
-			if (cache->evict->page != NULL &&
-			    WT_ATOMIC_CAS(cache->evict->page->ref->state,
-			    WT_REF_EVICT_FORCE, WT_REF_LOCKED)) {
-				force_btree = cache->evict->btree;
-				force_page = cache->evict->page;
-				__evict_list_clr(session, cache->evict);
-			}
-			F_CLR(cache, WT_EVICT_FORCE_PASS);
-		}
-
 		__wt_spin_unlock(session, &cache->evict_lock);
 		WT_RET(ret);
-
-		if (force_page != NULL) {
-			WT_SET_BTREE_IN_SESSION(session, force_btree);
-			(void)__evict_page(session, force_page);
-			WT_CLEAR_BTREE_IN_SESSION(session);
-		}
+		WT_RET(__evict_forced_pages(session));
 
 		/*
 		 * Keep evicting until we hit the target cache usage and the
@@ -445,6 +439,81 @@ __evict_worker(WT_SESSION_IMPL *session)
 			loop = 0;
 	}
 	return (0);
+}
+
+/*
+ * __evict_forced_pages --
+ *	Find and evict any pages added for forced eviction.
+ */
+static int
+__evict_forced_pages(WT_SESSION_IMPL *session)
+{
+	WT_BTREE *force_btree;
+	WT_CACHE *cache;
+	WT_DECL_RET;
+	WT_EVICT_ENTRY *candidate, *force_candidates;
+	WT_PAGE *force_page;
+	uint32_t curr_entry, force_entries;
+
+	cache = S2C(session)->cache;
+	/*
+	 * Short circuit if there are no forced entries. If the count drops to
+	 * zero between this test and acquiring the lock - we'll do a small
+	 * amount of additional work.
+	 */
+	if (cache->force_entries == 0)
+		return (0);
+
+	__wt_spin_lock(session, &cache->evict_lock);
+
+	/*
+	 * Try to evict any pages marked as forced. Gather the set of
+	 * candidates into an array, but don't evict until we've released the
+	 * eviction lock.
+	 * TODO: We could stash this array in the cache handle, and resize if
+	 * necessary, but this isn't a common code path, so that optimization
+	 * isn't worth it at the moment.
+	 */
+	force_btree = NULL;
+	force_page = NULL;
+	if ((ret = __wt_calloc_def(session,
+	    cache->force_entries, &force_candidates)) != 0) {
+		__wt_spin_unlock(session, &cache->evict_lock);
+		return (ret);
+	}
+
+	for (candidate = cache->evict, force_entries = 0;
+	    candidate->page != NULL &&
+	    cache->force_entries != force_entries;
+	    candidate++) {
+		if (!WT_ATOMIC_CAS(candidate->page->ref->state,
+		    WT_REF_EVICT_FORCE, WT_REF_LOCKED))
+			continue;
+		force_candidates[force_entries].btree =
+		    candidate->btree;
+		force_candidates[force_entries].page =
+		    candidate->page;
+		force_entries++;
+		__evict_list_clr(session, candidate);
+	}
+	WT_ASSERT(session,
+	    force_entries == cache->force_entries);
+	cache->force_entries = 0;
+
+	__wt_spin_unlock(session, &cache->evict_lock);
+	WT_ERR(ret);
+
+	/* Evict force pages now that we've released the lock. */
+	for (curr_entry = 0; curr_entry < force_entries; curr_entry++) {
+		WT_SET_BTREE_IN_SESSION(session,
+		    force_candidates[curr_entry].btree);
+		(void)__evict_page(session,
+		    force_candidates[curr_entry].page);
+		WT_CLEAR_BTREE_IN_SESSION(session);
+	}
+
+err:	__wt_free(session, force_candidates);
+	return (ret);
 }
 
 /*
@@ -1112,6 +1181,7 @@ __evict_get_page(
 	WT_CACHE *cache;
 	WT_EVICT_ENTRY *evict;
 	WT_REF *ref;
+	int was_force;
 	uint32_t candidates;
 
 	cache = S2C(session)->cache;
@@ -1185,12 +1255,15 @@ __evict_get_page(
 		 * on, and having reconciliation be able to use a single
 		 * locked state simplifies that code.
 		 */
+		was_force = 0;
 		if (!WT_ATOMIC_CAS(ref->state, WT_REF_MEM, WT_REF_LOCKED) &&
-		    !WT_ATOMIC_CAS(
-		    ref->state, WT_REF_EVICT_FORCE, WT_REF_LOCKED)) {
+		    !(was_force = WT_ATOMIC_CAS(ref->state,
+		    WT_REF_EVICT_FORCE, WT_REF_LOCKED))) {
 			__evict_list_clr(session, evict);
 			continue;
 		}
+		if (was_force)
+			--S2C(session)->cache->force_entries;
 
 		/*
 		 * Increment the LRU count in the btree handle to prevent it

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -56,6 +56,7 @@ struct __wt_cache {
 	uint32_t evict_entries;		/* LRU list eviction slots */
 	uint32_t evict_candidates;	/* LRU list pages to evict */
 	u_int    evict_file_next;	/* LRU: next file to search */
+	uint32_t force_entries;		/* Forced eviction page count */
 
 	/*
 	 * Sync/flush request information.
@@ -74,9 +75,8 @@ struct __wt_cache {
 	/*
 	 * Flags.
 	 */
-#define	WT_EVICT_FORCE_PASS	0x01	/* Ignore the eviction trigger */
-#define	WT_EVICT_NO_PROGRESS	0x02	/* Check if pages are being evicted */
-#define	WT_EVICT_STUCK		0x04	/* Eviction server is stuck */
+#define	WT_EVICT_NO_PROGRESS	0x01	/* Check if pages are being evicted */
+#define	WT_EVICT_STUCK		0x02	/* Eviction server is stuck */
 	uint32_t flags;
 };
 


### PR DESCRIPTION
This implementation creates a queue of forced pages during the eviction pass (but shares the regular eviction queue).

It'd be possible to do the following instead:
- Section off a part of the regular eviction queue for forced candidates
- Create a separate queue for forced candidates

Given that having pages queued for forced eviction is relatively infrequent, allocating a queue (array) when we have forced eviction candidates and the eviction server isn't regularly running seems like a reasonable compromise for keeping the code a bit simpler.

Refs issue #491
