### PR TITLE
Add a test case for statistics logging.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -598,7 +598,7 @@ methods = {
 		Config('wait', '0', r'''
 		seconds to wait between each write of the log records; setting
 		this value configures \c statistics and statistics logging''',
-		min='5', max='100000'),
+		min='1', max='100000'),
 		]),
 	Config('sync', 'true', r'''
 		flush files to stable storage when closing or writing

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -441,7 +441,7 @@ __wt_confchk_statistics_log_subconfigs[] = {
 	{ "path", "string", NULL, NULL },
 	{ "sources", "list", NULL, NULL },
 	{ "timestamp", "string", NULL, NULL },
-	{ "wait", "int", "min=5,max=100000", NULL },
+	{ "wait", "int", "min=1,max=100000", NULL },
 	{ NULL, NULL, NULL, NULL }
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1329,7 +1329,7 @@ struct __wt_connection {
  * \c "%b %d %H:%M:%S".}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to wait
  * between each write of the log records; setting this value configures \c
- * statistics and statistics logging., an integer between 5 and 100000; default
+ * statistics and statistics logging., an integer between 1 and 100000; default
  * \c 0.}
  * @config{ ),,}
  * @config{sync, flush files to stable storage when closing or writing

--- a/test/suite/test_stat_log01.py
+++ b/test/suite/test_stat_log01.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#
+# Public Domain 2008-2013 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import glob
+import os.path
+import time
+import helper, wiredtiger, wttest
+from wiredtiger import stat
+
+# test_stat_log01.py
+#    Statistics log
+class test_stat_log01(wttest.WiredTigerTestCase):
+    """
+    Test statistics log
+    """
+
+    # Tests need to setup the connection in their own way.
+    def setUpConnectionOpen(self, dir):
+        return None
+
+    def setUpSessionOpen(self, conn):
+        return None
+
+    def test_stats_log_default(self):
+        self.conn = wiredtiger.wiredtiger_open(None, "create,statistics_log=(wait=1)")
+        # Wait for the default interval, to ensure stats have been written.
+        time.sleep(2)
+        self.check_stats_file("WiredTigerStat")
+
+    def test_stats_log_name(self):
+        self.conn = wiredtiger.wiredtiger_open(None, "create,statistics_log=(wait=1,path=foo)")
+        # Wait for the default interval, to ensure stats have been written.
+        time.sleep(2)
+        self.check_stats_file("foo")
+
+    def check_stats_file(self, filename):
+        if filename == "WiredTigerStat":
+            files = glob.glob(filename + '.[0-9]*')
+            self.assertTrue(files)
+        else:
+            self.assertTrue(os.path.isfile(filename))
+
+if __name__ == '__main__':
+    wttest.run()
+


### PR DESCRIPTION
I bumped into a crash (that has been fixed) in statistics logging. I figured a Python test case would be useful.

While I was there.. Waiting 5 seconds (i.e the smallest logging interval) for each different test isn't practical in the test suite. I dropped the minimum to 1 second. I figured if I wanted it to be 1 second for this case, other people probably will too.
