### PR TITLE
Track how many bytes match in each lexical comparison and don't check prefix bytes we know will match.

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -5,6 +5,7 @@ __bit_nclr
 __wt_bloom_drop
 __wt_bloom_get
 __wt_btree_lex_compare
+__wt_btree_lex_compare_skip
 __wt_cache_dump
 __wt_config_getone
 __wt_debug_addr

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -617,6 +617,46 @@ __wt_btree_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 	    (k1), (k2), &(cmp)))
 
 /*
+ * __wt_btree_lex_compare_skip --
+ *	Lexicographic comparison routine, but skipping leading bytes.
+ *
+ * Returns:
+ *	< 0 if user_item is lexicographically < tree_item
+ *	= 0 if user_item is lexicographically = tree_item
+ *	> 0 if user_item is lexicographically > tree_item
+ *
+ * We use the names "user" and "tree" so it's clear which the application is
+ * looking at when we call its comparison func.
+ */
+static inline int
+__wt_btree_lex_compare_skip(
+    const WT_ITEM *user_item, const WT_ITEM *tree_item, uint32_t *matchp)
+{
+	const uint8_t *userp, *treep;
+	uint32_t len, usz, tsz;
+
+	usz = user_item->size;
+	tsz = tree_item->size;
+	len = WT_MIN(usz, tsz) - *matchp;
+
+	for (userp = (uint8_t *)user_item->data + *matchp,
+	    treep = (uint8_t *)tree_item->data + *matchp;
+	    len > 0;
+	    --len, ++userp, ++treep, ++*matchp)
+		if (*userp != *treep)
+			return (*userp < *treep ? -1 : 1);
+
+	/* Contents are equal up to the smallest length. */
+	return ((usz == tsz) ? 0 : (usz < tsz) ? -1 : 1);
+}
+
+#define	WT_BTREE_CMP_SKIP(s, bt, k1, k2, cmp, matchp)			\
+	(((bt)->collator == NULL) ?					\
+	(((cmp) = __wt_btree_lex_compare_skip((k1), (k2), matchp)), 0) :\
+	(bt)->collator->compare((bt)->collator, &(s)->iface,		\
+	    (k1), (k2), &(cmp)))
+
+/*
  * __wt_btree_mergeable --
  *      Determines whether the given page is a candidate for merging.
  */


### PR DESCRIPTION
@michaelcahill, @agorrod:

A change that went into Berkeley DB awhile back was to track how many bytes matched when searching through keys on a page, that is, if you're searching through a page for the user key "abXXX", where every key on the page has the prefix "ab", you quickly figure it out and start future comparisons 2 bytes into the strings.

I wrote a test program that loads 5M records in sorted order, where the key is a 0-padded 10 character integer, preceded by some number of prefix bytes.  So, the keys are 0000000001 to 0005000000, and then I add some number of prefix bytes, which would make the keys be something like abc0000000001 to abc0005000000.  (Since all of the keys have at least 3 leading 0's, there are always 3 matching bytes.)

The timed phase of the program is a WT_CURSOR.search call for every key in the table.

Results from pixiebob:

```
 0 additional prefix bytes: old  5.88, new 5.83 (0.85%)
 5 additional prefix bytes: old  6.52, new 6.42 (1.53%)
10 additional prefix bytes: old  6.96, new 6.81 (2.16%)
20 additional prefix bytes: old  7.92, new 7.67 (3.16%)
25 additional prefix bytes: old  8.57, new 8.22 (4.08%)
50 additional prefix bytes: old 10.77, new 9.91 (7.99%)
```

Obviously, it's no big deal if there aren't strings of prefix bytes, if someone stores URL's in a table, this will pay off.

What I think is happening is that by starting the search further into the string we're avoiding some number of memory fetches -- I can't imagine the number of comparisons we make matters.

Probabilistically, even starting the search a few bytes into the string should mean we average fewer memory fetches to find the mismatched bytes, but I'm not sure if that's always true, based on what the compiler and/or hardware are doing with byte alignment.  (I also asked @fedorova if she could shed some light here.)

I'm inclined to pull this change into the tree, because it's really cheap (3 new uint32_t variables, and a couple of additions/subtractions and a comparison or two in each loop iteration), I don't think it will slow the loop down even when it's not gaining us performance.    Sasha may have something useful to say there as well.

We could probably figure out if this optimization will win on a page-by-page basis, when we read pages into memory, but I didn't look at that in any detail.
