### PR TITLE
Forced eviction tweak

### DIFF
--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -81,7 +81,8 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, int op)
 	 */
 	if (cbt->compare == 0 && cbt->ins != NULL) {
 		/* Make sure the update can proceed. */
-		WT_ERR(__wt_update_check(session, old_upd = cbt->ins->upd));
+		WT_ERR(__wt_update_check(
+		    session, page, old_upd = cbt->ins->upd));
 
 		/* Allocate the WT_UPDATE structure and transaction ID. */
 		WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size));
@@ -98,7 +99,7 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, int op)
 			__wt_update_obsolete_free(session, page, upd_obsolete);
 	} else {
 		/* Make sure the update can proceed. */
-		WT_ERR(__wt_update_check(session, NULL));
+		WT_ERR(__wt_update_check(session, page, NULL));
 
 		/* There may be no insert list, allocate as necessary. */
 		new_inshead_size = new_inslist_size = 0;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -141,6 +141,9 @@ struct __wt_page_modify {
 	 */
 	uint64_t disk_snap_min;
 
+	/* The largest transaction ID to modify the page. */
+	uint64_t last_txn;
+
 	/* The largest transaction ID written to disk, for clean pages. */
 	uint64_t disk_txn;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -444,7 +444,9 @@ extern int __wt_row_insert_alloc(WT_SESSION_IMPL *session,
     WT_INSERT **insp,
     size_t *ins_sizep);
 extern int __wt_insert_serial_func(WT_SESSION_IMPL *session, void *args);
-extern int __wt_update_check(WT_SESSION_IMPL *session, WT_UPDATE *next);
+extern int __wt_update_check(WT_SESSION_IMPL *session,
+    WT_PAGE *page,
+    WT_UPDATE *next);
 extern int __wt_update_alloc(WT_SESSION_IMPL *session,
     WT_ITEM *value,
     WT_UPDATE **updp,


### PR DESCRIPTION
@agorrod, this is the only idea I've had, and it isn't perfect.

It attempt to evict any page that hasn't yet been modified by the current transaction.  There are likely to be a lot of failures, because the page may contain recent updates that some running transaction needs to read.  OTOH, if I tighten up the forced eviction check to only try pages with globally visible changes, I don't think it will ever try...
