### PR TITLE
WT_EXTENSION_API.transaction_id_init: durable transaction IDs

### DIFF
--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -192,6 +192,14 @@ static int my_cursor_insert(WT_CURSOR *wtcursor)
 	}
 
 	{
+	/*! [WT_EXTENSION transaction ID init] */
+	uint64_t transaction_id_max;
+
+	ret = wt_api->transaction_id_init(wt_api, transaction_id_max);
+	/*! [WT_EXTENSION transaction ID init] */
+	}
+
+	{
 	/*! [WT_EXTENSION transaction oldest] */
 	uint64_t transaction_oldest;
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -117,6 +117,7 @@ __conn_get_extension_api(WT_CONNECTION *wt_conn)
 	conn->extension_api.struct_pack = __wt_ext_struct_pack;
 	conn->extension_api.struct_size = __wt_ext_struct_size;
 	conn->extension_api.struct_unpack = __wt_ext_struct_unpack;
+	conn->extension_api.transaction_id_init = __wt_ext_transaction_id_init;
 	conn->extension_api.transaction_id = __wt_ext_transaction_id;
 	conn->extension_api.transaction_isolation_level =
 	    __wt_ext_transaction_isolation_level;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1353,6 +1353,8 @@ extern int __wt_checkpoint_sync(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_checkpoint_close(WT_SESSION_IMPL *session, const char *cfg[]);
 extern uint64_t __wt_ext_transaction_id(WT_EXTENSION_API *wt_api,
     WT_SESSION *wt_session);
+extern int __wt_ext_transaction_id_init(WT_EXTENSION_API *wt_api,
+    uint64_t txnid);
 extern int __wt_ext_transaction_isolation_level( WT_EXTENSION_API *wt_api,
     WT_SESSION *wt_session);
 extern int __wt_ext_transaction_notify( WT_EXTENSION_API *wt_api,

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -27,7 +27,8 @@ struct __wt_txn_state {
 };
 
 struct __wt_txn_global {
-	volatile uint64_t current;	/* Current transaction ID. */
+#define	WT_TXN_INITIAL_ID	1	/* Initial transaction ID */
+	volatile uint64_t current;	/* Current transaction ID */
 
 	/*
 	 * The oldest transaction ID that is not yet visible to some

--- a/src/include/wiredtiger_ext.h
+++ b/src/include/wiredtiger_ext.h
@@ -372,6 +372,24 @@ struct __wt_extension_api {
 	    WT_SESSION *session);
 
 	/*!
+	 * Initialize the system transaction ID.
+	 *
+	 * WiredTiger transaction IDs are not durable, and are reset each time
+	 * the database is recovered.  This method ensures future WiredTiger
+	 * transactions have IDs greater than the ID specified, allowing data
+	 * sources to depend on ever-increasing transaction IDs across recovery.
+	 *
+	 * This method may only be called before any transactions are started.
+	 *
+	 * @param wt_api the extension handle
+	 * @param txnid the maximum transaction ID which is not to be reused
+	 * @errors
+	 *
+	 * @snippet ex_data_source.c WT_EXTENSION transaction ID init
+	 */
+	int (*transaction_id_init)(WT_EXTENSION_API *wt_api, uint64_t txnid);
+
+	/*!
 	 * Return the current transaction's isolation level; returns one of
 	 * ::WT_TXN_ISO_READ_COMMITTED, ::WT_TXN_ISO_READ_UNCOMMITTED, or
 	 * ::WT_TXN_ISO_SNAPSHOT.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -445,7 +445,7 @@ __wt_txn_global_init(WT_CONNECTION_IMPL *conn, const char *cfg[])
 	WT_UNUSED(cfg);
 	session = conn->default_session;
 	txn_global = &conn->txn_global;
-	txn_global->current = 1;
+	txn_global->current = WT_TXN_INITIAL_ID;
 
 	WT_RET(__wt_calloc_def(
 	    session, conn->session_size, &txn_global->states));


### PR DESCRIPTION
@michaelcahill, here are the changes we discussed to allow data sources to make transaction IDs durable.
