### PR TITLE
test/format failure: illegal cell and page type combination

### DIFF
--- a/src/btree/bt_evict.c
+++ b/src/btree/bt_evict.c
@@ -359,7 +359,7 @@ __wt_evict_page(WT_SESSION_IMPL *session, WT_PAGE *page)
 		    txn->snapshot != saved_txn.snapshot);
 		__wt_txn_destroy(session);
 	} else
-		__wt_txn_release_snapshot(session);
+		__wt_txn_release_evict_snapshot(session);
 
 	*txn = saved_txn;
 	return (ret);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1327,6 +1327,7 @@ extern void __wt_stat_aggregate_dsrc_stats(void *child, void *parent);
 extern void __wt_stat_init_connection_stats(WT_CONNECTION_STATS *stats);
 extern void __wt_stat_clear_connection_stats(void *stats_arg);
 extern int __wt_txnid_cmp(const void *v1, const void *v2);
+extern void __wt_txn_release_evict_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_refresh_force(WT_SESSION_IMPL *session);
 extern void __wt_txn_refresh(WT_SESSION_IMPL *session,

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -35,8 +35,8 @@ struct __wt_txn_global {
 	 */
 	volatile uint64_t oldest_id;
 
-	volatile uint32_t gen;		/* Completed transaction generation */
-	volatile uint32_t scan_gen;	/* Snapshot scan generation */
+	/* Count of scanning threads, or -1 for exclusive access. */
+	volatile int32_t scan_count;
 
 	WT_TXN_STATE *states;		/* Per-session transaction states */
 };
@@ -64,8 +64,6 @@ struct __wt_txn {
 
 	/* Saved global state, to avoid repeating scans. */
 	uint64_t last_id;
-	uint32_t last_gen;
-	uint32_t last_scan_gen;
 
 	/*
 	 * Arrays of txn IDs in WT_UPDATE or WT_REF structures created or

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -43,6 +43,19 @@ __txn_sort_snapshot(WT_SESSION_IMPL *session, uint32_t n, uint64_t id)
 }
 
 /*
+ * __wt_txn_release_evict_snapshot --
+ *	Release the snapshot in the current transaction without sanity checks.
+ */
+void
+__wt_txn_release_evict_snapshot(WT_SESSION_IMPL *session)
+{
+	WT_TXN_STATE *txn_state;
+
+	txn_state = &S2C(session)->txn_global.states[session->id];
+	txn_state->snap_min = WT_TXN_NONE;
+}
+
+/*
  * __wt_txn_release_snapshot --
  *	Release the snapshot in the current transaction.
  */
@@ -52,6 +65,8 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
 	WT_TXN_STATE *txn_state;
 
 	txn_state = &S2C(session)->txn_global.states[session->id];
+	WT_ASSERT(session, txn_state->snap_min == WT_TXN_NONE ||
+	    !__wt_txn_visible_all(session, txn_state->snap_min));
 	txn_state->snap_min = WT_TXN_NONE;
 }
 
@@ -87,94 +102,100 @@ __wt_txn_refresh(WT_SESSION_IMPL *session, uint64_t max_id, int get_snapshot)
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_STATE *s, *txn_state;
-	uint64_t current_id, id, snap_min, oldest_id;
+	uint64_t current_id, id, snap_min, oldest_id, prev_oldest_id;
 	uint32_t i, n, session_cnt;
+	int32_t count;
 
 	conn = S2C(session);
 	txn = &session->txn;
 	txn_global = &conn->txn_global;
 	txn_state = &txn_global->states[session->id];
 
+	/* For pure read-only workloads, use the last cached snapshot. */
 	if (get_snapshot &&
 	    txn->id == max_id &&
-	    txn->last_id == txn_global->current &&
-	    txn->last_gen == txn_global->gen &&
-	    TXNID_LE(txn_global->oldest_id, txn->snap_min)) {
+	    txn->snapshot_count == 0 &&
+	    txn->snap_min == txn_global->current + 1) {
 		/* If nothing has changed since last time, we're done. */
 		txn_state->snap_min = txn->snap_min;
 		return;
 	}
 
+	/*
+	 * We're going to scan.  Increment the count of scanners to prevent the
+	 * oldest ID from moving forwards.  Spin if the count is negative,
+	 * which indicates that some thread is moving the oldest ID forwards.
+	 */
 	do {
-		/* Take a copy of the current generation numbers. */
-		txn->last_scan_gen = txn_global->scan_gen;
-		txn->last_gen = txn_global->gen;
-		txn->last_id = current_id = txn_global->current;
-		snap_min = current_id + 1;
+		count = txn_global->scan_count;
+		if (count < 0)
+			WT_PAUSE();
+	} while (count < 0 ||
+	    !WT_ATOMIC_CAS(txn_global->scan_count, count, count + 1));
 
+	/* The oldest ID cannot change until the scan count goes to zero. */
+	prev_oldest_id = txn_global->oldest_id;
+	current_id = txn_global->current;
+	snap_min = current_id + 1;
+
+	/* If the maximum ID is constrained, so is the oldest. */
+	oldest_id = (max_id != WT_TXN_NONE) ? max_id : snap_min;
+
+	/* Copy the array of concurrent transactions. */
+	WT_ORDERED_READ(session_cnt, conn->session_cnt);
+	for (i = n = 0, s = txn_global->states; i < session_cnt; i++, s++) {
 		/*
-		 * Constrain the oldest ID we calculate to be less than the
-		 * specified value.
+		 * Ignore the ID if we are committing (indicated by max_id
+		 * being set): it is about to be released.
 		 */
-		oldest_id = (max_id != WT_TXN_NONE) ? max_id : snap_min;
+		if ((id = s->id) != WT_TXN_NONE && id + 1 != max_id) {
+			txn->snapshot[n++] = id;
+			if (TXNID_LT(id, snap_min))
+				snap_min = id;
+		}
+		/*
+		 * Ignore the session's own snap_min if we are in the process
+		 * of updating it.
+		 */
+		if (get_snapshot && s == txn_state)
+			continue;
+		if ((id = s->snap_min) != WT_TXN_NONE &&
+		    TXNID_LT(id, oldest_id))
+			oldest_id = id;
+	}
 
-		/* Copy the array of concurrent transactions. */
+	if (TXNID_LT(snap_min, oldest_id))
+		oldest_id = snap_min;
+
+	if (get_snapshot) {
+		WT_ASSERT(session, TXNID_LE(prev_oldest_id, snap_min));
+		txn_state->snap_min = snap_min;
+	}
+
+	/*
+	 * Update the oldest ID if we have a newer ID and we can get exclusive
+	 * access.  Once we get exclusive access, do another pass to make sure
+	 * nobody else is using an earlier ID.
+	 */
+	if (max_id == WT_TXN_NONE &&
+	    TXNID_LT(prev_oldest_id, oldest_id) &&
+	    WT_ATOMIC_CAS(txn_global->scan_count, 1, -1)) {
 		WT_ORDERED_READ(session_cnt, conn->session_cnt);
-		for (i = n = 0, s = txn_global->states;
-		    i < session_cnt;
-		    i++, s++) {
-			/*
-			 * Ignore the ID if we are committing (indicated by
-			 * max_id being set): it is about to be released.
-			 */
-			if ((id = s->id) != WT_TXN_NONE && id + 1 != max_id) {
-				txn->snapshot[n++] = id;
-				if (TXNID_LT(id, snap_min))
-					snap_min = id;
-			}
-			/*
-			 * Ignore the session's own snap_min if we are in the
-			 * process of updating it.
-			 */
-			if (get_snapshot && s == txn_state)
-				continue;
+		for (i = 0, s = txn_global->states; i < session_cnt; i++, s++) {
+			if ((id = s->id) != WT_TXN_NONE &&
+			    TXNID_LT(id, oldest_id))
+				oldest_id = id;
 			if ((id = s->snap_min) != WT_TXN_NONE &&
 			    TXNID_LT(id, oldest_id))
 				oldest_id = id;
 		}
-
-		if (TXNID_LT(snap_min, oldest_id))
-			oldest_id = snap_min;
-
-		/*
-		 * Ensure the snapshot reads are scheduled before re-checking
-		 * the global generation.
-		 */
-		WT_READ_BARRIER();
-
-		/*
-		 * When getting an ordinary snapshot, it is sufficient to
-		 * unconditionally bump the scan generation.  Otherwise, we're
-		 * trying to update the oldest ID, so require that the scan
-		 * generation has not changed while we have been scanning.
-		 */
-		if (get_snapshot) {
-			txn_state->snap_min = snap_min;
-			WT_ATOMIC_ADD(txn_global->scan_gen, 1);
-		}
-	} while (TXNID_LT(snap_min, txn_global->oldest_id) ||
-	    (!get_snapshot && !WT_ATOMIC_CAS(txn_global->scan_gen,
-		txn->last_scan_gen, txn->last_scan_gen + 1)));
-
-	++txn->last_scan_gen;
-
-	/* Update the oldest ID if another thread hasn't beat us to it. */
-	do {
-		id = txn_global->oldest_id;
-	} while ((!get_snapshot ||
-	    txn->last_scan_gen == txn_global->scan_gen) &&
-	    TXNID_LT(id, oldest_id) &&
-	    !WT_ATOMIC_CAS(txn_global->oldest_id, id, oldest_id));
+		if (TXNID_LT(txn_global->oldest_id, oldest_id))
+			txn_global->oldest_id = oldest_id;
+		txn_global->scan_count = 0;
+	} else {
+		WT_ASSERT(session, txn_global->scan_count > 0);
+		(void)WT_ATOMIC_SUB(txn_global->scan_count, 1);
+	}
 
 	if (get_snapshot)
 		__txn_sort_snapshot(session, n, current_id + 1);
@@ -312,9 +333,6 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 	txn->isolation = session->isolation;
 	txn->force_evict_attempts = 0;
 	F_CLR(txn, TXN_ERROR | TXN_OLDEST | TXN_RUNNING);
-
-	/* Update the global generation number. */
-	++txn_global->gen;
 }
 
 /*


### PR DESCRIPTION
Just saw an interesting test/format failure that I'd like to chase further:

```
270: table, variable-length column-store                                     
t, file:wt.wt, session.checkpoint: illegal cell and page type combination: cell 8 on page at [write-check] is a value/ovfl,rm cell on a row-store leaf page
t, session.checkpoint: table:wt: WT_ERROR: non-specific WiredTiger error
t: session.compact: WT_ERROR: non-specific WiredTiger error
############################################
#  RUN PARAMETERS
############################################
# bitcnt not applicable to this run
cache=40
compression=snappy
data_extend=0
data_source=table
delete_pct=7
dictionary=1
file_type=row-store
hot_backups=0
huffman_key=0
huffman_value=0
insert_pct=34
internal_key_truncation=0
internal_page_max=13
key_gap=16
key_max=64
key_min=12
leaf_page_max=12
ops=5000
prefix=1
repeat_data_pct=49
reverse=0
rows=100
runs=0
split_pct=52
threads=20
value_max=256
value_min=19
# wiredtiger_config not applicable to this run
write_pct=45
```
