### PR TITLE
wtperf failure: accessing a freed page

### DIFF
--- a/src/btree/bt_evict.c
+++ b/src/btree/bt_evict.c
@@ -778,6 +778,7 @@ __evict_init_candidate(
 	u_int slot;
 
 	cache = S2C(session)->cache;
+	WT_ASSERT(session, page->ref->state == WT_REF_EVICT_WALK);
 
 	/* Keep track of the maximum slot we are using. */
 	slot = (u_int)(evict - cache->evict);


### PR DESCRIPTION
I'm running a script over the wtperf configs and the 3rd iteration of evict-lsm took a segv.

```
(gdb) bt
#0  0x00000000004432c5 in __wt_tree_walk (session=0xd17060, 
    pagep=0x7fb9401c3358, flags=16) at ../src/btree/bt_walk.c:242
#1  0x0000000000431ff6 in __evict_walk_file (session=0xd17060, 
    slotp=0x7fb9f041bd5c, clean=1) at ../src/btree/bt_evict.c:826
#2  0x0000000000431ac5 in __evict_walk (session=0xd17060, 
    entriesp=0x7fb9f041bdc0, clean=1) at ../src/btree/bt_evict.c:750
#3  0x00000000004316a6 in __evict_lru (session=0xd17060, clean=1)
    at ../src/btree/bt_evict.c:631
#4  0x0000000000430bb3 in __evict_worker (session=0xd17060)
    at ../src/btree/bt_evict.c:252
#5  0x00000000004307cc in __wt_cache_evict_server (arg=0xd17060)
    at ../src/btree/bt_evict.c:160
#6  0x00007fb9f10e4c6b in start_thread () from /lib64/libpthread.so.0
#7  0x00007fb9f0a1d5ed in clone () from /lib64/libc.so.6

241                     if ((prev && slot == 0) ||
242                         (!prev && slot == page->entries - 1)) {

(gdb) p *page
Cannot access memory at address 0x7f9239e9e4819bd6
```

Not sure how reproducible it is, but clearly doesn't happen every time since the other 2 iterations passed. 
