### PR TITLE
Always cache the last key returned for use in scans.

### DIFF
--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -196,8 +196,8 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 			goto slow;
 		__wt_cell_unpack((WT_CELL *)ikey, unpack);
 		if (unpack->type == WT_CELL_KEY && unpack->prefix == 0) {
-			kb->data = cbt->tmp.data = unpack->data;
-			kb->size = cbt->tmp.size = unpack->size;
+			cbt->tmp.data = unpack->data;
+			cbt->tmp.size = unpack->size;
 		} else if (unpack->type == WT_CELL_KEY &&
 		    cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {
 			/*
@@ -221,8 +221,6 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 			memcpy((uint8_t *)cbt->tmp.data +
 			    unpack->prefix, unpack->data, unpack->size);
 			cbt->tmp.size = unpack->prefix + unpack->size;
-			kb->data = cbt->tmp.data;
-			kb->size = cbt->tmp.size;
 		} else {
 			/*
 			 * __wt_row_leaf_key_work instead of __wt_row_leaf_key:
@@ -230,9 +228,9 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 			 */
 slow:			WT_RET(__wt_row_leaf_key_work(
 			    session, cbt->page, rip, &cbt->tmp, 0));
-			kb->data = cbt->tmp.data;
-			kb->size = cbt->tmp.size;
 		}
+		kb->data = cbt->tmp.data;
+		kb->size = cbt->tmp.size;
 		cbt->rip_saved = rip;
 	}
 


### PR DESCRIPTION
Otherwise, we can do huge amounts of unnecessary work in __cursor_row_slot_return when scanning some pages.  This change speeds up test_backup03 by over 20% (by speeding up "wt dump").
