### PR TITLE
Track the per-page contribution to the cache's dirty byte count.

### DIFF
--- a/src/btree/bt_evict.c
+++ b/src/btree/bt_evict.c
@@ -470,8 +470,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, int syncop)
 			if (WT_PAGE_IS_ROOT(page))
 				btree->root_page = NULL;
 			if (__wt_page_is_modified(page))
-				__wt_cache_dirty_decr(
-				    session, page->memory_footprint);
+				__wt_cache_dirty_decr(session, page);
 			__wt_page_out(session, &page);
 			break;
 		WT_ILLEGAL_VALUE_ERR(session);

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -3935,22 +3935,8 @@ err:			__wt_scr_free(&tkey);
 	if (!r->upd_skipped) {
 		mod->disk_txn = r->max_txn;
 
-		/*
-		 * !!!
-		 * This code has a bug: the idea is to read the memory footprint
-		 * before attempting to "clean" the page, which is safe because
-		 * the atomic compare-and-swap is a read barrier so the read of
-		 * the memory footprint precedes the update of the page's write
-		 * generation.   Since it is possible to decrement the footprint
-		 * of the page without making the page "dirty" (for example
-		 * when freeing an obsolete update list), the footprint could
-		 * be decremented between read and swap, and we might attempt to
-		 * decrement more than the bytes held by the page.   Unlikely,
-		 * but technically possible.
-		 */
-		size = page->memory_footprint;
 		if (WT_ATOMIC_CAS(mod->write_gen, r->orig_write_gen, 0))
-			__wt_cache_dirty_decr(session, size);
+			__wt_cache_dirty_decr(session, page);
 	}
 
 	/* Record the most recent transaction ID we have *not* written. */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -351,6 +351,8 @@ struct __wt_page {
 	/* Memory attached to the page. */
 	uint32_t memory_footprint;
 
+	int64_t bytes_dirty;		/* Dirty bytes added to cache. */
+
 #define	WT_PAGE_INVALID		0	/* Invalid page */
 #define	WT_PAGE_BLOCK_MANAGER	1	/* Block-manager page */
 #define	WT_PAGE_COL_FIX		2	/* Col-store fixed-len leaf */


### PR DESCRIPTION
If this is non-zero when a page is being discarded, fix the cache's count.

refs #635, #699
