### PR TITLE
Minor handle cleanup/restructuring

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -204,7 +204,7 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session)
 
 	if (!F_ISSET(btree,
 	    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY))
-		ret = __wt_checkpoint_close(session, NULL);
+		ret = __wt_checkpoint_close(session);
 
 	WT_TRET(__wt_btree_close(session));
 	F_CLR(dhandle, WT_DHANDLE_OPEN);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1359,7 +1359,7 @@ extern int __wt_checkpoint(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_checkpoint_write_leaves(WT_SESSION_IMPL *session,
     const char *cfg[]);
 extern int __wt_checkpoint_sync(WT_SESSION_IMPL *session, const char *cfg[]);
-extern int __wt_checkpoint_close(WT_SESSION_IMPL *session, const char *cfg[]);
+extern int __wt_checkpoint_close(WT_SESSION_IMPL *session);
 extern uint64_t __wt_ext_transaction_id(WT_EXTENSION_API *wt_api,
     WT_SESSION *wt_session);
 extern int __wt_ext_transaction_isolation_level( WT_EXTENSION_API *wt_api,

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -430,16 +430,6 @@ __checkpoint_worker(
 	track_ckpt = 1;
 
 	/*
-	 * Checkpoint handles are read-only by definition and don't participate
-	 * in checkpoints.   Closing one discards its blocks, otherwise there's
-	 * no work to do.
-	 */
-	if (dhandle->checkpoint != NULL)
-		return (is_checkpoint ? 0 :
-		    __wt_bt_cache_op(
-		    session, NULL, WT_SYNC_DISCARD_NOWRITE));
-
-	/*
 	 * If closing a file that's never been modified, discard its blocks.
 	 * If checkpoint of a file that's never been modified, we may still
 	 * have to checkpoint it, we'll test again once we understand the
@@ -764,6 +754,9 @@ skip:	__wt_meta_ckptlist_free(session, ckptbase);
 int
 __wt_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 {
+	/* Should not be called with a checkpoint handle. */
+	WT_ASSERT(session, session->dhandle->checkpoint == NULL);
+
 	return (__checkpoint_worker(session, cfg, 1));
 }
 
@@ -776,10 +769,12 @@ __wt_checkpoint_write_leaves(WT_SESSION_IMPL *session, const char *cfg[])
 {
 	WT_UNUSED(cfg);
 
-	if (S2BT(session)->modified)
-		WT_RET(__wt_bt_cache_op(session, NULL, WT_SYNC_WRITE_LEAVES));
+	/* Should not be called with a checkpoint handle. */
+	WT_ASSERT(session, session->dhandle->checkpoint == NULL);
 
-	return (0);
+	/* May not have been modified, in which case don't do the traversal. */
+	return (S2BT(session)->modified ?
+	    __wt_bt_cache_op(session, NULL, WT_SYNC_WRITE_LEAVES) : 0);
 }
 
 /*
@@ -789,26 +784,42 @@ __wt_checkpoint_write_leaves(WT_SESSION_IMPL *session, const char *cfg[])
 int
 __wt_checkpoint_sync(WT_SESSION_IMPL *session, const char *cfg[])
 {
-	WT_BTREE *btree;
+	WT_BM *bm;
 
 	WT_UNUSED(cfg);
-	btree = S2BT(session);
 
-	/* Only sync ordinary handles: checkpoint handles are read-only. */
-	if (btree->dhandle->checkpoint == NULL && btree->bm != NULL)
-		return (btree->bm->sync(btree->bm, session));
-	return (0);
+	bm = S2BT(session)->bm;
+
+	/* Should not be called with a checkpoint handle. */
+	WT_ASSERT(session, session->dhandle->checkpoint == NULL);
+
+	/* Should have an underlying block manager reference. */
+	WT_ASSERT(session, bm != NULL);
+
+	return (bm->sync(bm, session));
 }
 
 /*
  * __wt_checkpoint_close --
- *	Checkpoint a file as part of a close.
+ *	Checkpoint a single file as part of closing the handle.
  */
 int
-__wt_checkpoint_close(WT_SESSION_IMPL *session, const char *cfg[])
+__wt_checkpoint_close(WT_SESSION_IMPL *session)
 {
-	WT_RET(__checkpoint_worker(session, cfg, 0));
+	/*
+	 * Checkpoint handles are read-only: closing one discards its blocks,
+	 * otherwise there's no work to do.
+	 */
+	if (session->dhandle->checkpoint != NULL)
+		return (
+		    __wt_bt_cache_op(session, NULL, WT_SYNC_DISCARD_NOWRITE));
+
+	/*
+	 * Otherwise, checkpoint the file and optionally flush the writes to
+	 * stable storage.
+	 */
+	WT_RET(__checkpoint_worker(session, NULL, 0));
 	if (F_ISSET(S2C(session), WT_CONN_CKPT_SYNC))
-		WT_RET(__wt_checkpoint_sync(session, cfg));
+		WT_RET(__wt_checkpoint_sync(session, NULL));
 	return (0);
 }


### PR DESCRIPTION
@michaelcahill: staring at this code last night, I did some cleanup.

Unless I'm missing something, the only function that should ever be passed a checkpoint handle is `__wt_checkpoint_close`, in the WiredTiger handle close path, and the right thing to do is to deal with checkpoint handles there and nowhere else.   This change is basically a bunch of asserts that we never see checkpoint handles except in that function.
