### PR TITLE
Use the event handler to capture stderr, stdout for python.

### DIFF
--- a/test/suite/test_reconfig.py
+++ b/test/suite/test_reconfig.py
@@ -38,7 +38,16 @@ class test_reconfig(wttest.WiredTigerTestCase):
         self.conn.reconfigure("statistics=true")
 
     def test_reconfig_verbose(self):
-        self.conn.reconfigure("verbose=[mutex]")
+        # we know the verbose output format may change in the future,
+        # so we just match on a string that's likely to endure.
+        with self.expectedStdoutPattern('mutex: '):
+            self.conn.reconfigure("verbose=[mutex]")
+            # Reopening the connection allows the initial connection
+            # to completely close and all its threads to finish.
+            # If we don't do this, some trailing threads give additional
+            # output after we make our 'expectedStdoutPattern' check,
+            # and cause the test to fail.
+            self.reopen_conn()
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -85,12 +85,13 @@ class backup_thread(threading.Thread):
                         self, sess, uris, "checkpoint=WiredTigerCheckpoint"):
                 print "Error: checkpoint tables differ."
             else:
-                print "Checkpoint tables match"
+                wttest.WiredTigerTestCase.printVerbose(
+                    3, "Checkpoint tables match")
 
             if not compare_tables(self, bkp_session, uris):
                 print "Error: backup tables differ."
             else:
-                print "Backup tables match"
+                wttest.WiredTigerTestCase.printVerbose(3, "Backup tables match")
             bkp_conn.close()
 
         sess.close()


### PR DESCRIPTION
Cleaned up test suite infrastructure a bit using this.
Any verbose messages from the infrastructure itself do not get captured.
refs #649

test_reconfig.py needed special treatment.  Verbose output from
threads is not necessarily flushed until the connection is closed;
we reopen the connection to force the flush so that the test should
pass on all platforms.
refs #698
