### PR TITLE
Add a WT_SIZE structure cache to the WT_SESSION_IMPL handle.

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -222,9 +222,10 @@ __wt_block_checkpoint(WT_SESSION_IMPL *session,
 
 	/*
 	 * Checkpoints are potentially reading/writing/merging lots of blocks,
-	 * pre-allocate a bunch of WT_EXT structures for this thread's use.
+	 * pre-allocate structures for this thread's use.
 	 */
 	WT_RET(__wt_block_ext_alloc(session, NULL, 100));
+	WT_RET(__wt_block_size_alloc(session, NULL, 10));
 
 	/* Process the checkpoint list, deleting and updating as required. */
 	return (__ckpt_process(session, block, ckptbase));

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -163,21 +163,19 @@ __block_ext_insert(WT_SESSION_IMPL *session, WT_EXTLIST *el, WT_EXT *ext)
 	u_int i;
 
 	/*
-	 * If we are inserting a new size onto the size skiplist, we'll need
-	 * a new WT_EXT structure for that skiplist.
+	 * If we are inserting a new size onto the size skiplist, we'll need a
+	 * new WT_SIZE structure for that skiplist.
 	 */
 	__block_size_srch(el->sz, ext->size, sstack);
 	szp = *sstack[0];
 	if (szp == NULL || szp->size != ext->size) {
-		WT_RET(__wt_calloc(session, 1,
-		    sizeof(WT_SIZE) + ext->depth * sizeof(WT_SIZE *), &szp));
+		WT_RET(__wt_block_size_alloc(session, &szp, 1));
 		szp->size = ext->size;
 		szp->depth = ext->depth;
 		for (i = 0; i < ext->depth; ++i) {
 			szp->next[i] = *sstack[i];
 			*sstack[i] = szp;
 		}
-		WT_STAT_FAST_CONN_INCR(session, block_locked_allocation);
 	}
 
 	/* Insert the new WT_EXT structure into the offset skiplist. */
@@ -321,7 +319,7 @@ __block_off_remove(
 	if (szp->off[0] == NULL) {
 		for (i = 0; i < szp->depth; ++i)
 			*sstack[i] = szp->next[i];
-		__wt_free(session, szp);
+		__wt_block_size_free(session, szp);
 	}
 
 	--el->entries;
@@ -553,6 +551,7 @@ __wt_block_free(WT_SESSION_IMPL *session,
 	WT_RET(__wt_block_misplaced(session, block, "free", offset, size, 1));
 #endif
 	WT_RET(__wt_block_ext_alloc(session, NULL, 5));
+	WT_RET(__wt_block_size_alloc(session, NULL, 2));
 	__wt_spin_lock(session, &block->live_lock);
 	ret = __wt_block_off_free(session, block, offset, (off_t)size);
 	__wt_spin_unlock(session, &block->live_lock);

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -11,39 +11,16 @@
  * Per session handle cached block manager information.
  */
 typedef struct {
-	WT_EXT *ext_cache;			/* List of WT_EXT handles */
-	u_int   ext_cache_cnt;			/* Count */
+#define	WT_BLOCK_MGR_CACHE_EXT_MAX	100
+	WT_EXT  *ext_cache;			/* List of WT_EXT handles */
+	u_int    ext_cache_cnt;			/* Count */
+
+#define	WT_BLOCK_MGR_CACHE_SIZE_MAX	10
+	WT_SIZE *sz_cache;			/* List of WT_SIZE handles */
+	u_int    sz_cache_cnt;			/* Count */
 } WT_BLOCK_MGR_SESSION;
 
-/*
- * __block_manager_session_cleanup --
- *	Clean up the session handle's block manager information.
- */
-static int
-__block_manager_session_cleanup(WT_SESSION_IMPL *session)
-{
-	WT_BLOCK_MGR_SESSION *bms;
-	WT_DECL_RET;
-	WT_EXT *ext, *next;
-
-	if ((bms = session->block_manager) == NULL)
-		return (0);
-
-	for (ext = bms->ext_cache;
-	    ext != NULL; ext = next, --bms->ext_cache_cnt) {
-		next = ext->next[0];
-		__wt_free(session, ext);
-	}
-
-	if (bms->ext_cache_cnt != 0) {
-		ret = WT_ERROR;
-		__wt_errx(session,
-		    "incorrect count in session handle's block manager cache");
-	}
-	__wt_free(session, session->block_manager);
-
-	return (ret);
-}
+static int __block_manager_session_cleanup(WT_SESSION_IMPL *);
 
 /*
  * __block_ext_alloc --
@@ -85,7 +62,7 @@ __wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp, u_int max)
 		/*
 		 * The count is advisory to minimize our exposure to bugs, but
 		 * don't let it go negative, that would lead to never caching
-		 * a WT_EXT structure  again, we'd always believe there are too
+		 * a WT_EXT structure again, we'd always believe there are too
 		 * many cached.
 		 */
 		if (bms->ext_cache_cnt > 0)
@@ -107,20 +84,18 @@ __wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp, u_int max)
 		session->block_manager_cleanup =
 		    __block_manager_session_cleanup;
 	}
-	if (bms->ext_cache_cnt >= max)
-		return (0);
-	do {
+	for (; bms->ext_cache_cnt < max; ++bms->ext_cache_cnt) {
 		WT_RET(__block_ext_alloc(session, &ext));
 
 		ext->next[0] = bms->ext_cache;
 		bms->ext_cache = ext;
-	} while (++bms->ext_cache_cnt < max);
+	}
 	return (0);
 }
 
 /*
  * __wt_block_ext_free --
- *	Add an EXT structure to the cached list, or free it if enough cached.
+ *	Add an WT_EXT structure to the cached list, or free if enough cached.
  */
 void
 __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
@@ -129,7 +104,7 @@ __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
 
 	bms = session->block_manager;
 
-	if (bms == NULL || bms->ext_cache_cnt > 100)
+	if (bms == NULL || bms->ext_cache_cnt >= WT_BLOCK_MGR_CACHE_EXT_MAX)
 		__wt_free(session, ext);
 	else {
 		ext->next[0] = bms->ext_cache;
@@ -137,4 +112,145 @@ __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
 
 		++bms->ext_cache_cnt;
 	}
+}
+
+/*
+ * __block_ext_cleanup --
+ *	Cleanup the WT_EXT structure cache.
+ */
+static int
+__block_ext_cleanup(WT_SESSION_IMPL *session, WT_BLOCK_MGR_SESSION *bms)
+{
+	WT_EXT *ext, *next;
+
+	for (ext = bms->ext_cache;
+	    ext != NULL; ext = next, --bms->ext_cache_cnt) {
+		next = ext->next[0];
+		__wt_free(session, ext);
+	}
+	if (bms->ext_cache_cnt != 0)
+		WT_RET_MSG(session, WT_ERROR,
+		    "incorrect count in session handle's block manager cache");
+	return (0);
+}
+
+/*
+ * __block_size_alloc --
+ *	Allocate a new WT_SIZE structure.
+ */
+static int
+__block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp)
+{
+	return (__wt_calloc(session, 1, sizeof(WT_SIZE), szp));
+}
+
+/*
+ * __wt_block_size_alloc --
+ *	Allocate WT_SIZE structures.
+ */
+int
+__wt_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp, u_int max)
+{
+	WT_BLOCK_MGR_SESSION *bms;
+	WT_SIZE *sz;
+
+	bms = session->block_manager;
+
+	/* First, return a WT_SIZE structure for use from a cached list. */
+	if (szp != NULL && bms != NULL && bms->sz_cache != NULL) {
+		(*szp) = bms->sz_cache;
+		bms->sz_cache = bms->sz_cache->next[0];
+
+		/*
+		 * The count is advisory to minimize our exposure to bugs, but
+		 * don't let it go negative, that would lead to never caching
+		 * a WT_SIZE structure again, we'd always believe there are too
+		 * many cached.
+		 */
+		if (bms->sz_cache_cnt > 0)
+			--bms->sz_cache_cnt;
+		return (0);
+	}
+
+	/* Second, allocating a WT_SIZE structure for use. */
+	if (szp != NULL) {
+		WT_STAT_FAST_CONN_INCR(session, block_locked_allocation);
+		return (__block_size_alloc(session, szp));
+	}
+
+	/* Third, pre-allocating WT_SIZE structures for later use. */
+	if (bms == NULL) {
+		WT_RET(__wt_calloc(session,
+		    1, sizeof(WT_BLOCK_MGR_SESSION), &session->block_manager));
+		bms = session->block_manager;
+		session->block_manager_cleanup =
+		    __block_manager_session_cleanup;
+	}
+	for (; bms->sz_cache_cnt < max; ++bms->sz_cache_cnt) {
+		WT_RET(__block_size_alloc(session, &sz));
+
+		sz->next[0] = bms->sz_cache;
+		bms->sz_cache = sz;
+	}
+	return (0);
+}
+
+/*
+ * __wt_block_size_free --
+ *	Add an WT_SIZE structure to the cached list, or free if enough cached.
+ */
+void
+__wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz)
+{
+	WT_BLOCK_MGR_SESSION *bms;
+
+	bms = session->block_manager;
+
+	if (bms == NULL || bms->sz_cache_cnt >= WT_BLOCK_MGR_CACHE_SIZE_MAX)
+		__wt_free(session, sz);
+	else {
+		sz->next[0] = bms->sz_cache;
+		bms->sz_cache = sz;
+
+		++bms->sz_cache_cnt;
+	}
+}
+
+/*
+ * __block_size_cleanup --
+ *	Cleanup the WT_SIZE structure cache.
+ */
+static int
+__block_size_cleanup(WT_SESSION_IMPL *session, WT_BLOCK_MGR_SESSION *bms)
+{
+	WT_SIZE *sz, *nsz;
+
+	for (sz = bms->sz_cache; sz != NULL; sz = nsz, --bms->sz_cache_cnt) {
+		nsz = sz->next[0];
+		__wt_free(session, sz);
+	}
+	if (bms->sz_cache_cnt != 0)
+		WT_RET_MSG(session, WT_ERROR,
+		    "incorrect count in session handle's block manager cache");
+	return (0);
+}
+
+/*
+ * __block_manager_session_cleanup --
+ *	Clean up the session handle's block manager information.
+ */
+static int
+__block_manager_session_cleanup(WT_SESSION_IMPL *session)
+{
+	WT_DECL_RET;
+
+	if (session->block_manager == NULL)
+		return (0);
+
+	WT_TRET(__block_ext_cleanup(session, session->block_manager));
+	WT_TRET(__block_size_cleanup(session, session->block_manager));
+
+	__wt_free(session, session->block_manager);
+
+	return (ret);
 }

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -128,6 +128,7 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 
 	if (!locked) {
 		WT_RET(__wt_block_ext_alloc(session, NULL, 5));
+		WT_RET(__wt_block_size_alloc(session, NULL, 2));
 		__wt_spin_lock(session, &block->live_lock);
 	}
 	ret = __wt_block_alloc(session, block, &offset, (off_t)align_size);

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -86,8 +86,12 @@ struct __wt_size {
 
 	WT_EXT	*off[WT_SKIP_MAXDEPTH];		/* Per-size offset skiplist */
 
-	/* Variable-length array, sized by the number of skiplist elements. */
-	WT_SIZE *next[0];			/* Size skiplist */
+	/*
+	 * We don't use a variable-length array for the size skiplist, we want
+	 * to be able to use any cached WT_SIZE structure as the head of a list,
+	 * and we don't know the related WT_EXT structure's depth.
+	 */
+	WT_SIZE *next[WT_SKIP_MAXDEPTH];	/* Size skiplist */
 };
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -166,6 +166,10 @@ extern int __wt_block_ext_alloc(WT_SESSION_IMPL *session,
     WT_EXT **extp,
     u_int max);
 extern void __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
+extern int __wt_block_size_alloc(WT_SESSION_IMPL *session,
+    WT_SIZE **szp,
+    u_int max);
+extern void __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz);
 extern int __wt_block_salvage_start(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_salvage_end(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_salvage_next(WT_SESSION_IMPL *session,


### PR DESCRIPTION
Create a cache of WT_SIZE structures in the WT_SESSION_IMPL handle so we (hopefully) never call malloc while holding the block manager's live lock, and minimize modifying the WT_BLOCK structure's cache lines.

@michaelcahill, here's the parallel change to cache WT_SIZE structures in the same way we're now caching WT_EXT structures.
