### PR TITLE
Start tuning the WT_SESSION_IMPL cache of WT_EXT and WT_SIZE structures.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -672,6 +672,7 @@ poptable
 posint
 posix
 pre
+prealloc
 preload
 prepended
 presize

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -46,8 +46,6 @@ connection_stats = [
 	Stat('block_byte_map_read', 'block manager: mapped bytes read'),
 	Stat('block_byte_read', 'block manager: bytes read'),
 	Stat('block_byte_write', 'block manager: bytes written'),
-	Stat('block_locked_allocation',
-	    'block manager: memory allocations while locked'),
 	Stat('block_map_read', 'block manager: mapped blocks read'),
 	Stat('block_preload', 'block manager: blocks pre-loaded'),
 	Stat('block_read', 'block manager: blocks read'),

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -199,6 +199,7 @@ __wt_block_checkpoint(WT_SESSION_IMPL *session,
     WT_BLOCK *block, WT_ITEM *buf, WT_CKPT *ckptbase, int data_cksum)
 {
 	WT_BLOCK_CKPT *ci;
+	WT_DECL_RET;
 
 	ci = &block->live;
 	ci->version = WT_BM_CHECKPOINT_VERSION;
@@ -224,11 +225,15 @@ __wt_block_checkpoint(WT_SESSION_IMPL *session,
 	 * Checkpoints are potentially reading/writing/merging lots of blocks,
 	 * pre-allocate structures for this thread's use.
 	 */
-	WT_RET(__wt_block_ext_alloc(session, NULL, 100));
-	WT_RET(__wt_block_size_alloc(session, NULL, 10));
+	WT_RET(__wt_block_ext_prealloc(session, 250));
 
 	/* Process the checkpoint list, deleting and updating as required. */
-	return (__ckpt_process(session, block, ckptbase));
+	ret = __ckpt_process(session, block, ckptbase);
+
+	/* Discard any excessive memory we've allocated. */
+	WT_TRET(__wt_block_ext_discard(session, 250));
+
+	return (ret);
 }
 
 /*

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -169,7 +169,7 @@ __block_ext_insert(WT_SESSION_IMPL *session, WT_EXTLIST *el, WT_EXT *ext)
 	__block_size_srch(el->sz, ext->size, sstack);
 	szp = *sstack[0];
 	if (szp == NULL || szp->size != ext->size) {
-		WT_RET(__wt_block_size_alloc(session, &szp, 1));
+		WT_RET(__wt_block_size_alloc(session, &szp));
 		szp->size = ext->size;
 		szp->depth = ext->depth;
 		for (i = 0; i < ext->depth; ++i) {
@@ -211,7 +211,7 @@ __block_off_insert(
 {
 	WT_EXT *ext;
 
-	WT_RET(__wt_block_ext_alloc(session, &ext, 1));
+	WT_RET(__wt_block_ext_alloc(session, &ext));
 	ext->off = off;
 	ext->size = size;
 
@@ -550,8 +550,7 @@ __wt_block_free(WT_SESSION_IMPL *session,
 #ifdef HAVE_DIAGNOSTIC
 	WT_RET(__wt_block_misplaced(session, block, "free", offset, size, 1));
 #endif
-	WT_RET(__wt_block_ext_alloc(session, NULL, 5));
-	WT_RET(__wt_block_size_alloc(session, NULL, 2));
+	WT_RET(__wt_block_ext_prealloc(session, 5));
 	__wt_spin_lock(session, &block->live_lock);
 	ret = __wt_block_off_free(session, block, offset, (off_t)size);
 	__wt_spin_unlock(session, &block->live_lock);

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -11,16 +11,12 @@
  * Per session handle cached block manager information.
  */
 typedef struct {
-#define	WT_BLOCK_MGR_CACHE_EXT_MAX	100
 	WT_EXT  *ext_cache;			/* List of WT_EXT handles */
 	u_int    ext_cache_cnt;			/* Count */
 
-#define	WT_BLOCK_MGR_CACHE_SIZE_MAX	10
 	WT_SIZE *sz_cache;			/* List of WT_SIZE handles */
 	u_int    sz_cache_cnt;			/* Count */
 } WT_BLOCK_MGR_SESSION;
-
-static int __block_manager_session_cleanup(WT_SESSION_IMPL *);
 
 /*
  * __block_ext_alloc --
@@ -44,46 +40,44 @@ __block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp)
 
 /*
  * __wt_block_ext_alloc --
- *	Allocate WT_EXT structures.
+ *	Return a WT_EXT structure for use.
  */
 int
-__wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp, u_int max)
+__wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp)
 {
 	WT_BLOCK_MGR_SESSION *bms;
-	WT_EXT *ext;
 
 	bms = session->block_manager;
 
-	/* First, return a WT_EXT structure for use from a cached list. */
+	/* Return a WT_EXT structure for use from a cached list. */
 	if (extp != NULL && bms != NULL && bms->ext_cache != NULL) {
 		(*extp) = bms->ext_cache;
 		bms->ext_cache = bms->ext_cache->next[0];
 
 		/*
 		 * The count is advisory to minimize our exposure to bugs, but
-		 * don't let it go negative, that would lead to never caching
-		 * a WT_EXT structure again, we'd always believe there are too
-		 * many cached.
+		 * don't let it go negative.
 		 */
 		if (bms->ext_cache_cnt > 0)
 			--bms->ext_cache_cnt;
 		return (0);
 	}
 
-	/* Second, allocating a WT_EXT structure for use. */
-	if (extp != NULL) {
-		WT_STAT_FAST_CONN_INCR(session, block_locked_allocation);
-		return (__block_ext_alloc(session, extp));
-	}
+	return (__block_ext_alloc(session, extp));
+}
 
-	/* Third, pre-allocating WT_EXT structures for later use. */
-	if (bms == NULL) {
-		WT_RET(__wt_calloc(session,
-		    1, sizeof(WT_BLOCK_MGR_SESSION), &session->block_manager));
-		bms = session->block_manager;
-		session->block_manager_cleanup =
-		    __block_manager_session_cleanup;
-	}
+/*
+ * __block_ext_prealloc --
+ *	Pre-allocate WT_EXT structures.
+ */
+static int
+__block_ext_prealloc(WT_SESSION_IMPL *session, u_int max)
+{
+	WT_BLOCK_MGR_SESSION *bms;
+	WT_EXT *ext;
+
+	bms = session->block_manager;
+
 	for (; bms->ext_cache_cnt < max; ++bms->ext_cache_cnt) {
 		WT_RET(__block_ext_alloc(session, &ext));
 
@@ -95,16 +89,14 @@ __wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp, u_int max)
 
 /*
  * __wt_block_ext_free --
- *	Add an WT_EXT structure to the cached list, or free if enough cached.
+ *	Add a WT_EXT structure to the cached list.
  */
 void
 __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
 {
 	WT_BLOCK_MGR_SESSION *bms;
 
-	bms = session->block_manager;
-
-	if (bms == NULL || bms->ext_cache_cnt >= WT_BLOCK_MGR_CACHE_EXT_MAX)
+	if ((bms = session->block_manager) == NULL)
 		__wt_free(session, ext);
 	else {
 		ext->next[0] = bms->ext_cache;
@@ -115,20 +107,31 @@ __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
 }
 
 /*
- * __block_ext_cleanup --
- *	Cleanup the WT_EXT structure cache.
+ * __block_ext_discard --
+ *	Discard some or all of the WT_EXT structure cache.
  */
 static int
-__block_ext_cleanup(WT_SESSION_IMPL *session, WT_BLOCK_MGR_SESSION *bms)
+__block_ext_discard(WT_SESSION_IMPL *session, u_int max)
 {
+	WT_BLOCK_MGR_SESSION *bms;
 	WT_EXT *ext, *next;
 
-	for (ext = bms->ext_cache;
-	    ext != NULL; ext = next, --bms->ext_cache_cnt) {
+	bms = session->block_manager;
+	if (max != 0 && bms->ext_cache_cnt <= max)
+		return (0);
+
+	for (ext = bms->ext_cache; ext != NULL;) {
 		next = ext->next[0];
 		__wt_free(session, ext);
+		ext = next;
+
+		--bms->ext_cache_cnt;
+		if (max != 0 && bms->ext_cache_cnt <= max)
+			break;
 	}
-	if (bms->ext_cache_cnt != 0)
+	bms->ext_cache = ext;
+
+	if (max == 0 && bms->ext_cache_cnt != 0)
 		WT_RET_MSG(session, WT_ERROR,
 		    "incorrect count in session handle's block manager cache");
 	return (0);
@@ -146,46 +149,44 @@ __block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp)
 
 /*
  * __wt_block_size_alloc --
- *	Allocate WT_SIZE structures.
+ *	Return a WT_SIZE structure for use.
  */
 int
-__wt_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp, u_int max)
+__wt_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp)
 {
 	WT_BLOCK_MGR_SESSION *bms;
-	WT_SIZE *sz;
 
 	bms = session->block_manager;
 
-	/* First, return a WT_SIZE structure for use from a cached list. */
+	/* Return a WT_SIZE structure for use from a cached list. */
 	if (szp != NULL && bms != NULL && bms->sz_cache != NULL) {
 		(*szp) = bms->sz_cache;
 		bms->sz_cache = bms->sz_cache->next[0];
 
 		/*
 		 * The count is advisory to minimize our exposure to bugs, but
-		 * don't let it go negative, that would lead to never caching
-		 * a WT_SIZE structure again, we'd always believe there are too
-		 * many cached.
+		 * don't let it go negative.
 		 */
 		if (bms->sz_cache_cnt > 0)
 			--bms->sz_cache_cnt;
 		return (0);
 	}
 
-	/* Second, allocating a WT_SIZE structure for use. */
-	if (szp != NULL) {
-		WT_STAT_FAST_CONN_INCR(session, block_locked_allocation);
-		return (__block_size_alloc(session, szp));
-	}
+	return (__block_size_alloc(session, szp));
+}
 
-	/* Third, pre-allocating WT_SIZE structures for later use. */
-	if (bms == NULL) {
-		WT_RET(__wt_calloc(session,
-		    1, sizeof(WT_BLOCK_MGR_SESSION), &session->block_manager));
-		bms = session->block_manager;
-		session->block_manager_cleanup =
-		    __block_manager_session_cleanup;
-	}
+/*
+ * __block_size_prealloc --
+ *	Pre-allocate WT_SIZE structures.
+ */
+static int
+__block_size_prealloc(WT_SESSION_IMPL *session, u_int max)
+{
+	WT_BLOCK_MGR_SESSION *bms;
+	WT_SIZE *sz;
+
+	bms = session->block_manager;
+
 	for (; bms->sz_cache_cnt < max; ++bms->sz_cache_cnt) {
 		WT_RET(__block_size_alloc(session, &sz));
 
@@ -197,16 +198,14 @@ __wt_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp, u_int max)
 
 /*
  * __wt_block_size_free --
- *	Add an WT_SIZE structure to the cached list, or free if enough cached.
+ *	Add a WT_SIZE structure to the cached list.
  */
 void
 __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz)
 {
 	WT_BLOCK_MGR_SESSION *bms;
 
-	bms = session->block_manager;
-
-	if (bms == NULL || bms->sz_cache_cnt >= WT_BLOCK_MGR_CACHE_SIZE_MAX)
+	if ((bms = session->block_manager) == NULL)
 		__wt_free(session, sz);
 	else {
 		sz->next[0] = bms->sz_cache;
@@ -217,19 +216,31 @@ __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz)
 }
 
 /*
- * __block_size_cleanup --
- *	Cleanup the WT_SIZE structure cache.
+ * __block_size_discard --
+ *	Discard some or all of the WT_SIZE structure cache.
  */
 static int
-__block_size_cleanup(WT_SESSION_IMPL *session, WT_BLOCK_MGR_SESSION *bms)
+__block_size_discard(WT_SESSION_IMPL *session, u_int max)
 {
+	WT_BLOCK_MGR_SESSION *bms;
 	WT_SIZE *sz, *nsz;
 
-	for (sz = bms->sz_cache; sz != NULL; sz = nsz, --bms->sz_cache_cnt) {
+	bms = session->block_manager;
+	if (max != 0 && bms->sz_cache_cnt <= max)
+		return (0);
+
+	for (sz = bms->sz_cache; sz != NULL;) {
 		nsz = sz->next[0];
 		__wt_free(session, sz);
+		sz = nsz;
+
+		--bms->sz_cache_cnt;
+		if (max != 0 && bms->sz_cache_cnt <= max)
+			break;
 	}
-	if (bms->sz_cache_cnt != 0)
+	bms->sz_cache = sz;
+
+	if (max == 0 && bms->sz_cache_cnt != 0)
 		WT_RET_MSG(session, WT_ERROR,
 		    "incorrect count in session handle's block manager cache");
 	return (0);
@@ -247,10 +258,40 @@ __block_manager_session_cleanup(WT_SESSION_IMPL *session)
 	if (session->block_manager == NULL)
 		return (0);
 
-	WT_TRET(__block_ext_cleanup(session, session->block_manager));
-	WT_TRET(__block_size_cleanup(session, session->block_manager));
+	WT_TRET(__block_ext_discard(session, 0));
+	WT_TRET(__block_size_discard(session, 0));
 
 	__wt_free(session, session->block_manager);
 
 	return (ret);
+}
+
+/*
+ * __wt_block_ext_prealloc --
+ *	Pre-allocate WT_EXT and WT_SIZE structures.
+ */
+int
+__wt_block_ext_prealloc(WT_SESSION_IMPL *session, u_int max)
+{
+	if (session->block_manager == NULL) {
+		WT_RET(__wt_calloc(session, 1,
+		    sizeof(WT_BLOCK_MGR_SESSION), &session->block_manager));
+		session->block_manager_cleanup =
+		    __block_manager_session_cleanup;
+	}
+	WT_RET(__block_ext_prealloc(session, max));
+	WT_RET(__block_size_prealloc(session, max));
+	return (0);
+}
+
+/*
+ * __wt_block_ext_discard --
+ *	Discard WT_EXT and WT_SIZE structures after checkpoint runs.
+ */
+int
+__wt_block_ext_discard(WT_SESSION_IMPL *session, u_int max)
+{
+	WT_RET(__block_ext_discard(session, max));
+	WT_RET(__block_size_discard(session, max));
+	return (0);
 }

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -127,8 +127,7 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 	    buf->mem, data_cksum ? align_size : WT_BLOCK_COMPRESS_SKIP);
 
 	if (!locked) {
-		WT_RET(__wt_block_ext_alloc(session, NULL, 5));
-		WT_RET(__wt_block_size_alloc(session, NULL, 2));
+		WT_RET(__wt_block_ext_prealloc(session, 5));
 		__wt_spin_lock(session, &block->live_lock);
 	}
 	ret = __wt_block_alloc(session, block, &offset, (off_t)align_size);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -162,14 +162,12 @@ extern int __wt_block_read_off(WT_SESSION_IMPL *session,
     off_t offset,
     uint32_t size,
     uint32_t cksum);
-extern int __wt_block_ext_alloc(WT_SESSION_IMPL *session,
-    WT_EXT **extp,
-    u_int max);
+extern int __wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp);
 extern void __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
-extern int __wt_block_size_alloc(WT_SESSION_IMPL *session,
-    WT_SIZE **szp,
-    u_int max);
+extern int __wt_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp);
 extern void __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz);
+extern int __wt_block_ext_prealloc(WT_SESSION_IMPL *session, u_int max);
+extern int __wt_block_ext_discard(WT_SESSION_IMPL *session, u_int max);
 extern int __wt_block_salvage_start(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_salvage_end(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_salvage_next(WT_SESSION_IMPL *session,

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -211,7 +211,6 @@ struct __wt_connection_stats {
 	WT_STATS block_byte_map_read;
 	WT_STATS block_byte_read;
 	WT_STATS block_byte_write;
-	WT_STATS block_locked_allocation;
 	WT_STATS block_map_read;
 	WT_STATS block_preload;
 	WT_STATS block_read;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2401,156 +2401,154 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_BLOCK_BYTE_READ			1
 /*! block manager: bytes written */
 #define	WT_STAT_CONN_BLOCK_BYTE_WRITE			2
-/*! block manager: memory allocations while locked */
-#define	WT_STAT_CONN_BLOCK_LOCKED_ALLOCATION		3
 /*! block manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			4
+#define	WT_STAT_CONN_BLOCK_MAP_READ			3
 /*! block manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			5
+#define	WT_STAT_CONN_BLOCK_PRELOAD			4
 /*! block manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				6
+#define	WT_STAT_CONN_BLOCK_READ				5
 /*! block manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			7
+#define	WT_STAT_CONN_BLOCK_WRITE			6
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			8
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			7
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			9
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			8
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			10
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			9
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			11
+#define	WT_STAT_CONN_CACHE_BYTES_READ			10
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			12
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			11
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		13
+#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		12
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		14
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		13
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		15
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		14
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		16
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		15
 /*! cache: pages evicted because they exceeded the in memory maximum */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		17
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		16
 /*! cache: failed eviction of pages that exceeded the in memory maximum */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		18
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		17
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		19
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		18
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		20
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		19
 /*! cache: internal page merge operations completed */
-#define	WT_STAT_CONN_CACHE_EVICTION_MERGE		21
+#define	WT_STAT_CONN_CACHE_EVICTION_MERGE		20
 /*! cache: internal page merge attempts that could not complete */
-#define	WT_STAT_CONN_CACHE_EVICTION_MERGE_FAIL		22
+#define	WT_STAT_CONN_CACHE_EVICTION_MERGE_FAIL		21
 /*! cache: internal levels merged */
-#define	WT_STAT_CONN_CACHE_EVICTION_MERGE_LEVELS	23
+#define	WT_STAT_CONN_CACHE_EVICTION_MERGE_LEVELS	22
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		24
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		23
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		25
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		24
 /*! pages split because they were unable to be evicted */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			26
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			25
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			27
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			26
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			28
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			27
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				29
+#define	WT_STAT_CONN_CACHE_READ				28
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			30
+#define	WT_STAT_CONN_CACHE_WRITE			29
 /*! pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				31
+#define	WT_STAT_CONN_COND_WAIT				30
 /*! cursor creation */
-#define	WT_STAT_CONN_CURSOR_CREATE			32
+#define	WT_STAT_CONN_CURSOR_CREATE			31
 /*! Btree cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			33
+#define	WT_STAT_CONN_CURSOR_INSERT			32
 /*! Btree cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			34
+#define	WT_STAT_CONN_CURSOR_NEXT			33
 /*! Btree cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			35
+#define	WT_STAT_CONN_CURSOR_PREV			34
 /*! Btree cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			36
+#define	WT_STAT_CONN_CURSOR_REMOVE			35
 /*! Btree cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			37
+#define	WT_STAT_CONN_CURSOR_RESET			36
 /*! Btree cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			38
+#define	WT_STAT_CONN_CURSOR_SEARCH			37
 /*! Btree cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			39
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			38
 /*! Btree cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			40
+#define	WT_STAT_CONN_CURSOR_UPDATE			39
 /*! dhandle: connection dhandles swept */
-#define	WT_STAT_CONN_DH_CONN_HANDLES			41
+#define	WT_STAT_CONN_DH_CONN_HANDLES			40
 /*! dhandle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			42
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			41
 /*! dhandle: sweeps conflicting with evict */
-#define	WT_STAT_CONN_DH_SWEEP_EVICT			43
+#define	WT_STAT_CONN_DH_SWEEP_EVICT			42
 /*! dhandle: number of sweep attempts */
-#define	WT_STAT_CONN_DH_SWEEPS				44
+#define	WT_STAT_CONN_DH_SWEEPS				43
 /*! files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				45
+#define	WT_STAT_CONN_FILE_OPEN				44
 /*! log: user provided log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_USER			46
+#define	WT_STAT_CONN_LOG_BYTES_USER			45
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			47
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			46
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			48
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			47
 /*! log: log read operations */
-#define	WT_STAT_CONN_LOG_READS				49
+#define	WT_STAT_CONN_LOG_READS				48
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			50
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			49
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			51
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			50
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				52
+#define	WT_STAT_CONN_LOG_SCANS				51
 /*! log: consolidated slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			53
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			52
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		54
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		53
 /*! log: consolidated slot joins */
-#define	WT_STAT_CONN_LOG_SLOT_JOINS			55
+#define	WT_STAT_CONN_LOG_SLOT_JOINS			54
 /*! log: consolidated slot join races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			56
+#define	WT_STAT_CONN_LOG_SLOT_RACES			55
 /*! log: record size exceeded maximum */
-#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			57
+#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			56
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		58
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		57
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				59
+#define	WT_STAT_CONN_LOG_SYNC				58
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				60
+#define	WT_STAT_CONN_LOG_WRITES				59
 /*! rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			61
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			60
 /*! memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			62
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			61
 /*! memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			63
+#define	WT_STAT_CONN_MEMORY_FREE			62
 /*! memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			64
+#define	WT_STAT_CONN_MEMORY_GROW			63
 /*! total read I/Os */
-#define	WT_STAT_CONN_READ_IO				65
+#define	WT_STAT_CONN_READ_IO				64
 /*! page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				66
+#define	WT_STAT_CONN_REC_PAGES				65
 /*! page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			67
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			66
 /*! reconciliation failed because an update could not be included */
-#define	WT_STAT_CONN_REC_SKIPPED_UPDATE			68
+#define	WT_STAT_CONN_REC_SKIPPED_UPDATE			67
 /*! pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			69
+#define	WT_STAT_CONN_RWLOCK_READ			68
 /*! pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			70
+#define	WT_STAT_CONN_RWLOCK_WRITE			69
 /*! open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		71
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		70
 /*! transactions */
-#define	WT_STAT_CONN_TXN_BEGIN				72
+#define	WT_STAT_CONN_TXN_BEGIN				71
 /*! transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			73
+#define	WT_STAT_CONN_TXN_CHECKPOINT			72
 /*! transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				74
+#define	WT_STAT_CONN_TXN_COMMIT				73
 /*! transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			75
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			74
 /*! transactions rolled-back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			76
+#define	WT_STAT_CONN_TXN_ROLLBACK			75
 /*! total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				77
+#define	WT_STAT_CONN_WRITE_IO				76
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -311,8 +311,6 @@ __wt_stat_init_connection_stats(WT_CONNECTION_STATS *stats)
 	stats->block_byte_map_read.desc = "block manager: mapped bytes read";
 	stats->block_byte_read.desc = "block manager: bytes read";
 	stats->block_byte_write.desc = "block manager: bytes written";
-	stats->block_locked_allocation.desc =
-	    "block manager: memory allocations while locked";
 	stats->block_map_read.desc = "block manager: mapped blocks read";
 	stats->block_preload.desc = "block manager: blocks pre-loaded";
 	stats->block_read.desc = "block manager: blocks read";
@@ -417,7 +415,6 @@ __wt_stat_refresh_connection_stats(void *stats_arg)
 	stats->block_byte_map_read.v = 0;
 	stats->block_byte_read.v = 0;
 	stats->block_byte_write.v = 0;
-	stats->block_locked_allocation.v = 0;
 	stats->block_map_read.v = 0;
 	stats->block_preload.v = 0;
 	stats->block_read.v = 0;


### PR DESCRIPTION
@michaelcahill:

Increase the pre-alloc of WT_EXT/WT_SIZE structures from 5/2 to 5/5 in the write/free paths, and from 100/10 to 250/250 in the checkpoint path.

Turn off cache limits: checkpoints can take tens of thousands of WT_EXT structures and hundreds of WT_SIZE structures, we want to cache everything until the checkpoint completes.  Add a cleanup call after the checkpoint so we don't tie down megabytes of memory between checkpoints.

Split the previous pre-allocate function into two parts, it's simpler as a function to pre-allocate entries and a separate function to take an entry for use.

Remove the tracking of "memory allocations while locked"; there are extent lists we read while not holding any locks, and they can be really, really large requiring the allocation of tens of thousands of WT_EXT structures, they make the statistic meaningless.
