### PR TITLE
Overflow key delete race.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -156,7 +156,7 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 	__wt_btree_huffman_close(session);
 
 	/* Destroy locks. */
-	WT_TRET(__wt_rwlock_destroy(session, &btree->val_ovfl_lock));
+	WT_TRET(__wt_rwlock_destroy(session, &btree->ovfl_lock));
 
 	/* Free allocated memory. */
 	__wt_free(session, btree->key_format);
@@ -306,7 +306,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 
 	/* Overflow lock. */
 	WT_RET(__wt_rwlock_alloc(
-	    session, "btree overflow lock", &btree->val_ovfl_lock));
+	    session, "btree overflow lock", &btree->ovfl_lock));
 
 	__wt_stat_init_dsrc_stats(&btree->dhandle->stats);
 

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -62,11 +62,11 @@ __wt_ovfl_read(WT_SESSION_IMPL *session,
 	 *
 	 * Re-test the cell's value inside the lock.
 	 */
-	WT_RET(__wt_readlock(session, S2BT(session)->val_ovfl_lock));
+	WT_RET(__wt_readlock(session, S2BT(session)->ovfl_lock));
 	ret = __wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM ?
 	    __wt_ovfl_txnc_search(page, unpack->data, unpack->size, store) :
 	    __ovfl_read(session, unpack->data, unpack->size, store);
-	WT_TRET(__wt_rwunlock(session, S2BT(session)->val_ovfl_lock));
+	WT_TRET(__wt_rwunlock(session, S2BT(session)->ovfl_lock));
 	return (ret);
 }
 
@@ -209,7 +209,7 @@ __wt_ovfl_cache(WT_SESSION_IMPL *session,
 	WT_ILLEGAL_VALUE(session);
 	}
 
-	WT_RET(__wt_writelock(session, S2BT(session)->val_ovfl_lock));
+	WT_RET(__wt_writelock(session, S2BT(session)->ovfl_lock));
 	if (__wt_cell_type_raw(unpack->cell) != WT_CELL_VALUE_OVFL_RM) {
 		/*
 		 * If there's no globally visible update, there's a reader in
@@ -227,7 +227,7 @@ __wt_ovfl_cache(WT_SESSION_IMPL *session,
 		 */
 		__wt_cell_type_reset(unpack->cell, WT_CELL_VALUE_OVFL_RM);
 	}
-err:	WT_TRET(__wt_rwunlock(session, S2BT(session)->val_ovfl_lock));
+err:	WT_TRET(__wt_rwunlock(session, S2BT(session)->ovfl_lock));
 
 	return (ret);
 }

--- a/src/btree/rec_track.c
+++ b/src/btree/rec_track.c
@@ -971,9 +971,9 @@ __wt_ovfl_track_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
 		WT_RET(__ovfl_reuse_wrapup(session, page));
 
 	if (mod->ovfl_track->ovfl_txnc[0] != NULL) {
-		WT_RET(__wt_writelock(session, S2BT(session)->val_ovfl_lock));
+		WT_RET(__wt_writelock(session, S2BT(session)->ovfl_lock));
 		ret = __ovfl_txnc_wrapup(session, page);
-		WT_TRET(__wt_rwunlock(session, S2BT(session)->val_ovfl_lock));
+		WT_TRET(__wt_rwunlock(session, S2BT(session)->ovfl_lock));
 	}
 	return (0);
 }
@@ -999,9 +999,9 @@ __wt_ovfl_track_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
 		WT_RET(__ovfl_reuse_wrapup_err(session, page));
 
 	if (mod->ovfl_track->ovfl_txnc[0] != NULL) {
-		WT_RET(__wt_writelock(session, S2BT(session)->val_ovfl_lock));
+		WT_RET(__wt_writelock(session, S2BT(session)->ovfl_lock));
 		ret = __ovfl_txnc_wrapup(session, page);
-		WT_TRET(__wt_rwunlock(session, S2BT(session)->val_ovfl_lock));
+		WT_TRET(__wt_rwunlock(session, S2BT(session)->ovfl_lock));
 	}
 	return (0);
 }

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -3482,9 +3482,9 @@ __rec_row_leaf(WT_SESSION_IMPL *session,
 					 * checking for key instantiation.
 					 */
 					WT_ERR(__wt_writelock(session,
-					    S2BT(session)->val_ovfl_lock));
+					    S2BT(session)->ovfl_lock));
 					WT_ERR(__wt_rwunlock(session,
-					    S2BT(session)->val_ovfl_lock));
+					    S2BT(session)->ovfl_lock));
 
 					WT_ERR(__wt_ovfl_onpage_add(
 					    session, page,

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -247,17 +247,17 @@ off_page:		ikey = key;
 			 */
 			if (slot_offset == 0) {
 				WT_ERR(__wt_readlock(
-				    session, S2BT(session)->val_ovfl_lock));
+				    session, S2BT(session)->ovfl_lock));
 				key = WT_ROW_KEY_COPY(rip);
 				if (__wt_off_page(page, key)) {
 					WT_ERR(__wt_rwunlock(session,
-					    S2BT(session)->val_ovfl_lock));
+					    S2BT(session)->ovfl_lock));
 					goto off_page;
 				}
 				ret = __wt_dsk_cell_data_ref(
 				    session, WT_PAGE_ROW_LEAF, unpack, retb);
 				WT_TRET(__wt_rwunlock(session,
-				    S2BT(session)->val_ovfl_lock));
+				    S2BT(session)->ovfl_lock));
 				WT_ERR(ret);
 				break;
 			}

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -92,7 +92,7 @@ struct __wt_btree {
 	u_int prefix_compression_min;	/* Reconcile: prefix compression min */
 	int   split_pct;		/* Reconcile: split page percent */
 	WT_COMPRESSOR *compressor;	/* Reconcile: page compressor */
-	WT_RWLOCK *val_ovfl_lock;	/* Reconcile: overflow value lock */
+	WT_RWLOCK *ovfl_lock;		/* Reconcile: overflow lock */
 
 	uint64_t last_recno;		/* Column-store last record number */
 


### PR DESCRIPTION
Don't let reconciliation delete overflow keys out from under readers instantiating them.  #789
