### PR TITLE
Remove call to instantiate a deleted overflow key during reconciliation.

### DIFF
--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -3458,15 +3458,21 @@ __rec_row_leaf(WT_SESSION_IMPL *session,
 				 * blocks.  Don't worry about reuse, reusing
 				 * keys from a row-store page reconciliation
 				 * seems unlikely enough to ignore.
-				 *
-				 * Keys are part of the name-space though, we
-				 * can't remove them from the in-memory tree;
-				 * assert the key was instantiated, otherwise
-				 * we might try and look it up.
 				 */
 				__wt_cell_unpack(cell, unpack);
 				if (unpack->ovfl) {
-					WT_ASSERT(session, ikey != NULL);
+					/*
+					 * Keys are part of the name-space, we
+					 * can't remove them from the in-memory
+					 * tree; if an overflow key was deleted
+					 * without being instantiated (for
+					 * example, cursor-based trunction, do
+					 * it now.
+					 */
+					if (ikey == NULL)
+						WT_ERR(__wt_row_leaf_key_work(
+						    session,
+						    page, rip, NULL, 1));
 
 					/*
 					 * Acquire the overflow lock to avoid


### PR DESCRIPTION
I don't believe it's possible for a key/value pair to be deleted without instantiating the key, which makes this call to __wt_row_leaf_key_work unnecessary; assert the fact.

@michaelcahill: this call went in as part of #310, and there's wording there https://github.com/wiredtiger/wiredtiger/issues/310#issuecomment-9075481:

> Truncate is key to this failure: it's the only way, in the current engine, to modify a key/value pair without caching the key's value in memory.

I reviewed truncate, and I don't believe truncate can ever delete a row without instantiating its key.   If you agree (and can't think of any other path where we can remove a row without instantiating the key), I think we should make this change.
