### PR TITLE
log.c typo

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -847,7 +847,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 		}
 		rdup_len = __wt_rduppo2(reclen, allocsize);
 		if (reclen > allocsize) {
-			WT_ERR(__wt_buf_grow(session, &buf, rdup_len));
+			WT_ERR(__wt_buf_grow(session, &buf, reclen));
 			WT_ERR(__wt_read(session,
 			    log_fh, rd_lsn.offset, (size_t)reclen, buf.mem));
 			WT_STAT_FAST_CONN_INCR(session, log_scan_rereads);


### PR DESCRIPTION
@sueloverso, I think this is a typo, but wanted you to check me.

The reason I was looking at this code was the rework from uint32_t to size_t -- basically rdup_len and reclen are declared uint32_t's, but should probably be size_t?  I looked around but couldn't convince myself that size_t was that much better, so I left it alone, but we are calling functions that now take size_t with uint32_t args.
