### PR TITLE
Avoid second pass over row-store leaf pages when they're read.

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -222,7 +222,7 @@ __wt_page_inmem(
 		/*
 		 * Column-store leaf page entries map one-to-one to the number
 		 * of physical entries on the page (each physical entry is a
-		 * data item).
+		 * value item).
 		 */
 		alloc_entries = dsk->u.entries;
 		break;
@@ -236,11 +236,17 @@ __wt_page_inmem(
 		break;
 	case WT_PAGE_ROW_LEAF:
 		/*
-		 * Row-store leaf page entries map in an indeterminate way to
-		 * the physical entries on the page, we have to walk the page
-		 * to figure it out.
+		 * If the "no empty values" flag is set, row-store leaf page
+		 * entries map one-to-one to the number of physical entries
+		 * on the page (each physical entry is a key or value item).
+		 * If that flag is not set, there are more keys than values,
+		 * we have to walk the page to figure it out.
 		 */
-		WT_RET(__inmem_row_leaf_entries(session, dsk, &alloc_entries));
+		if (F_ISSET(dsk, WT_PAGE_NO_EMPTY_VALUES))
+			alloc_entries = dsk->u.entries / 2;
+		else
+			WT_RET(__inmem_row_leaf_entries(
+			    session, dsk, &alloc_entries));
 		break;
 	WT_ILLEGAL_VALUE(session);
 	}
@@ -571,14 +577,6 @@ __inmem_row_leaf_entries(
 		WT_ILLEGAL_VALUE(session);
 		}
 	}
-
-	/*
-	 * We use the fact that cells exactly fill a page to detect the case of
-	 * a row-store leaf page where the last cell is a key (that is, there's
-	 * no subsequent value cell).  Assert that to be true, the bug would be
-	 * difficult to find/diagnose in the field.
-	 */
-	WT_ASSERT(session, cell == (WT_CELL *)((uint8_t *)dsk + dsk->mem_size));
 
 	*nindxp = nindx;
 	return (0);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -39,6 +39,7 @@ struct __wt_page_header {
 	uint8_t type;			/* 24: page type */
 
 #define	WT_PAGE_COMPRESSED	0x01	/* Page is compressed on disk */
+#define	WT_PAGE_NO_EMPTY_VALUES	0x02	/* Page has no zero-length values */
 	uint8_t flags;			/* 25: flags */
 
 	/*


### PR DESCRIPTION
@michaelcahill, @sue: this change avoids the second pass when reading in row-store leaf pages, as long as there aren't any zero-length values on the page.

Michael: we could do a bit better and avoid the second pass in all cases, but I think it would cost us 4B in the page header, I don't see any way to do it without growing that structure.  Let me know what you think, if we should just grow that structure.
