### PR TITLE
Return if another thread already is in compact.

### DIFF
--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1022,6 +1022,12 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 		WT_RET_MSG(session, EINVAL,
 		    "LSM compaction requires active merge threads");
 
+	/*
+	 * If another thread started compacting this tree, we're done.
+	 */
+	if (F_ISSET(lsm_tree, WT_LSM_TREE_COMPACTING))
+		return (0);
+
 	WT_RET(__wt_seconds(session, &begin));
 
 	F_SET(lsm_tree, WT_LSM_TREE_COMPACTING);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -140,7 +140,7 @@ __session_compact_check_timeout(
 
 /*
  * __compact_file --
- *
+ *	Function to alternate between checkpoints and compaction calls.
  */
 static int
 __compact_file(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
@@ -200,7 +200,6 @@ err:	__wt_scr_free(&t);
 
 /*
  * __wt_session_compact --
- *	Function to alternate between checkpoints and compaction calls.
  */
 int
 __wt_session_compact(


### PR DESCRIPTION
@agorrod please review this.  In thinking about riak calling compact yesterday, I discovered that if multiple threads call compact on the same URI, all of them end up in the library a long time.  If that is by design, then ignore this.  But it seems that if one thread already gave merging the kickstart, the only thing this one is doing is hanging around and sleeping.  However, the one thing I'm not sure of is returning 0 immediately as that may imply to the caller that all compacting is complete.  But the use case I had in mind in riak was more "fire and forget" just to kick off merging.
