### PR TITLE
Initial changes to get some basho_bench/riak like tests running in wtperf.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -491,6 +491,8 @@ config_print(CONFIG *cfg)
 	printf("\tHome: %s\n", cfg->home);
 	printf("\tTable name: %s\n", cfg->table_name);
 	printf("\tConnection configuration: %s\n", cfg->conn_config);
+	if (cfg->sess_config != NULL)
+		printf("\tSession configuration: %s\n", cfg->sess_config);
 
 	printf("\t%s table: %s\n",
 	    cfg->create ? "Creating new" : "Using existing",

--- a/bench/wtperf/misc.c
+++ b/bench/wtperf/misc.c
@@ -54,7 +54,7 @@ setup_log_file(CONFIG *cfg)
 		return (enomem(cfg));
 
 	sprintf(fname, "%s/%s.stat", cfg->home, cfg->table_name);
-	cfg->logf = fopen(fname, "w");
+	cfg->logf = fopen(fname, "a");
 	free(fname);
 
 	if (cfg->logf == NULL) {

--- a/bench/wtperf/runners/fruit-lsm.wtperf
+++ b/bench/wtperf/runners/fruit-lsm.wtperf
@@ -1,0 +1,18 @@
+# wtperf options file: simulate riak and its test1 and test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+compact=true
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+icount=25000000
+key_sz=40
+value_sz=800
+pareto=true
+populate_threads=100
+report_interval=10
+random_value=true
+run_time=18000
+sample_interval=10
+threads=((count=250,read=6,update=1))

--- a/bench/wtperf/runners/test1-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test1-500m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test1 and test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+conn_config="cache_size=21B,checkpoint_sync=false,mmap=false,session_max=1024"
+compact=true
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+icount=500000000
+key_sz=40
+value_sz=1000
+populate_threads=100
+report_interval=10
+random_value=true
+sample_interval=10

--- a/bench/wtperf/runners/test1-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test1-50m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test1 and test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
+compact=true
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+icount=50000000
+key_sz=40
+value_sz=1000
+populate_threads=10
+report_interval=10
+random_value=true
+sample_interval=10

--- a/bench/wtperf/runners/test2-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test2-500m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+report_interval=10
+run_time=14400
+sample_interval=10
+threads=((count=100,reads=4,updates=1))

--- a/bench/wtperf/runners/test2-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test2-50m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+report_interval=10
+run_time=1440
+sample_interval=10
+threads=((count=10,reads=4,updates=1))

--- a/bench/wtperf/runners/test3-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test3-500m-lsm.wtperf
@@ -1,0 +1,16 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+pareto=true
+report_interval=10
+run_time=14400
+sample_interval=10
+threads=((count=100,reads=1,updates=1))

--- a/bench/wtperf/runners/test3-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test3-50m-lsm.wtperf
@@ -1,0 +1,16 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+pareto=true
+report_interval=10
+run_time=1440
+sample_interval=10
+threads=((count=10,reads=1,updates=1))

--- a/bench/wtperf/runners/test4-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test4-500m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+report_interval=10
+run_time=14400
+sample_interval=10
+threads=((count=100,reads=1))

--- a/bench/wtperf/runners/test4-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test4-50m-lsm.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: simulate riak and its test2 configuration
+# The configuration for the connection and table are from riak and the
+# specification of the data (count, size, threads) is from basho_bench.
+# This test assumes that a test1 populate already completed and exists.
+#conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
+create=false
+conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
+sess_config="isolation=snapshot"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm"
+key_sz=40
+value_sz=1000
+report_interval=10
+run_time=1440
+sample_interval=10
+threads=((count=10,reads=1))

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -84,7 +84,6 @@ DEF_OPT_AS_CONFIG_STRING(conn_config, "create",
 DEF_OPT_AS_BOOL(compact, 0, "post-populate compact for LSM merging activity")
 DEF_OPT_AS_BOOL(create, 1,
     "do population phase; false to use existing database")
-DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(icount, 5000, "number of records to initially populate")
 DEF_OPT_AS_BOOL(insert_rmw, 0,
     "execute a read prior to each insert in workload phase")
@@ -97,7 +96,8 @@ DEF_OPT_AS_UINT32(populate_threads, 1,
     "number of populate threads, 1 for bulk load")
 DEF_OPT_AS_UINT32(random_range, 0,
     "if non zero choose a value from within this range as the key for "
-    "operations")
+    "insert operations")
+DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
 DEF_OPT_AS_UINT32(report_interval, 2,
     "output throughput information every interval seconds, 0 to disable")
 DEF_OPT_AS_UINT32(run_ops, 0,
@@ -109,22 +109,25 @@ DEF_OPT_AS_UINT32(sample_interval, 0,
 DEF_OPT_AS_UINT32(sample_rate, 50,
     "how often the latency of operations is measured. One for every operation,"
     "two for every second operation, three for every third operation etc.")
+DEF_OPT_AS_CONFIG_STRING(sess_config, "", "session configuration string")
 DEF_OPT_AS_CONFIG_STRING(table_config,
     "key_format=S,value_format=S,type=lsm,exclusive=true,"
     "leaf_page_max=4kb,internal_page_max=64kb,allocation_size=4kb,",
     "table configuration string")
-DEF_OPT_AS_STRING(threads, "", "worker thread configuration: each 'count' "
+DEF_OPT_AS_STRING(threads, "", "workload configuration: each 'count' "
     "entry is the total number of threads, and the 'insert', 'read' and "
     "'update' entries are the ratios of insert, read and update operations "
     "done by each worker thread; multiple workload configurations may be "
     "specified; for example, a more complex threads configuration might be "
     "'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))' "
     "which would create 2 threads doing nothing but reads and 8 threads "
-    "each doing 50% inserts and 25% reads and updates")
+    "each doing 50% inserts and 25% reads and updates.  Allowed"
+    "configuration values are 'count', 'reads', 'inserts', 'updates'")
 DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
     "transaction configuration string, relevant when populate_opts_per_txn "
     "is nonzero")
 DEF_OPT_AS_STRING(table_name, "test", "table name")
+DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(verbose, 1, "verbosity")
 
 #undef DEF_OPT_AS_BOOL


### PR DESCRIPTION
Here's a small set of changes to get riak-like tests running in wtperf.  There are a couple minor things:
1.  Right now populate is blazingly fast compared to riak because we only doing inserts instead of empty read followed by an update, and also because populate is sequential, and riak is not.  It seems the random populate does not guarantee a full keyspace.  We may want more of a random shuffle instead.  For instance, the fruit config finished populating 25M items in 160 seconds rather than 45 minutes.
2.  When running tests 2, 3, 4 after running test 1, I append to the existing test.stat.  @keithbostic I do not do the same for the latency log file, 'monitor' because having separate latency charts for each seems best.  For now, the script I run just moves the 'monitor' file aside after the test completes.
3.  It isn't clear we really need the random_value config, but given the bug found and different behaviors of random data versus all the same data, it seemed reasonable.
