### PR TITLE
Use hazard references to prevent child pages being evicted during reconciliation of their parent

### DIFF
--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -690,15 +690,36 @@ retry:	*updp = __wt_txn_read_skip(session, upd, &r->max_txn, &skip);
 }
 
 /*
+ * CHILD_RELEASE --
+ *	Macros to clean up during internal-page reconciliation, releasing the
+ * hazard pointer we're holding on child pages.
+ */
+#undef	CHILD_RELEASE
+#define	CHILD_RELEASE(session, hazard, child) do {			\
+	if (hazard) {							\
+		hazard = 0;						\
+		WT_TRET(__wt_page_release(session, child));		\
+	}								\
+} while (0)
+#undef	CHILD_RELEASE_ERR
+#define	CHILD_RELEASE_ERR(session, hazard, child) do {			\
+	CHILD_RELEASE(session, hazard, child);				\
+	WT_ERR(ret);							\
+} while (0)
+
+/*
  * __rec_child_modify --
  *	Return if the internal page's child references any modifications.
  */
 static int
 __rec_child_modify(WT_SESSION_IMPL *session,
-    WT_RECONCILE *r, WT_PAGE *page, WT_REF *ref, int *statep)
+    WT_RECONCILE *r, WT_PAGE *page, WT_REF *ref, int *hazardp, int *statep)
 {
 	WT_DECL_RET;
 	WT_PAGE_MODIFY *mod;
+
+	/* We may acquire a hazard pointer our caller must release. */
+	*hazardp = 0;
 
 #define	WT_CHILD_IGNORE		1		/* Deleted child: ignore */
 #define	WT_CHILD_MODIFIED	2		/* Modified child */
@@ -774,17 +795,15 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			    !F_ISSET(r, WT_EVICTION_SERVER_LOCKED));
 
 			/*
-			 * If called during checkpoint, try to grab a hazard
-			 * pointer so the child can't be evicted: it's an
-			 * in-memory case.
+			 * If called during checkpoint, acquire a hazard pointer
+			 * so the child isn't evicted, it's an in-memory case.
 			 */
-			ret = __wt_page_in(session, page, ref,
-			    WT_READ_CACHE | WT_READ_NO_WAIT);
-			if (ret == WT_NOTFOUND) {
+			if ((ret = __wt_page_in(session, page, ref,
+			    WT_READ_CACHE | WT_READ_NO_WAIT)) == WT_NOTFOUND) {
 				ret = 0;
 				break;
 			}
-			WT_RET(ret);
+			*hazardp = 1;
 			goto in_memory;
 
 		case WT_REF_READING:
@@ -814,11 +833,9 @@ in_memory:
 	mod = ref->page->modify;
 	if (mod != NULL && mod->flags != 0)
 		*statep = WT_CHILD_MODIFIED;
-	else  {
-		if (!F_ISSET(r, WT_EVICTION_SERVER_LOCKED))
-			WT_TRET(__wt_page_release(session, ref->page));
-		if (ref->addr == NULL)
-			*statep = WT_CHILD_IGNORE;
+	else if (ref->addr == NULL) {
+		*statep = WT_CHILD_IGNORE;
+		CHILD_RELEASE(session, *hazardp, ref->page);
 	}
 
 done:	WT_HAVE_DIAGNOSTIC_YIELD;
@@ -2330,18 +2347,21 @@ static int
 __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 {
 	WT_ADDR *addr;
+	WT_CELL_UNPACK *unpack, _unpack;
 	WT_DECL_RET;
 	WT_KV *val;
-	WT_CELL_UNPACK *unpack, _unpack;
-	WT_PAGE *rp;
+	WT_PAGE *child;
 	WT_REF *ref;
 	uint32_t i;
-	int done, state;
+	int hazard, state;
 
 	WT_STAT_FAST_DATA_INCR(session, rec_page_merge);
 
-	val = &r->v;
 	unpack = &_unpack;
+	child = NULL;
+	hazard = 0;
+
+	val = &r->v;
 
 	/* For each entry in the page... */
 	WT_REF_FOREACH(page, ref, i) {
@@ -2353,12 +2373,12 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 * Deleted/split pages are merged into the parent and discarded.
 		 */
 		addr = NULL;
-		WT_RET(__rec_child_modify(session, r, page, ref, &state));
+		WT_ERR(
+		    __rec_child_modify(session, r, page, ref, &hazard, &state));
+		child = ref->page;
 		if (state) {
 			WT_ASSERT(session, state == WT_CHILD_MODIFIED);
-			rp = ref->page;
-			done = 0;
-			switch (F_ISSET(rp->modify, WT_PM_REC_MASK)) {
+			switch (F_ISSET(child->modify, WT_PM_REC_MASK)) {
 			case WT_PM_REC_EMPTY:
 				/*
 				 * Column-store pages are almost never empty, as
@@ -2366,26 +2386,22 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				 * name space.  The exceptions are pages created
 				 * when the tree is created, and never filled.
 				 */
-				done = 1;
-				break;
+				CHILD_RELEASE_ERR(session, hazard, child);
+				continue;
 			case WT_PM_REC_REPLACE:
-				addr = &rp->modify->u.replace;
+				addr = &child->modify->u.replace;
 				break;
 			case WT_PM_REC_SPLIT:
-				WT_TRET(__rec_col_merge(
-				    session, r, rp->modify->u.split));
-				done = 1;
-				break;
-			case WT_PM_REC_SPLIT_MERGE:
-				WT_TRET(__rec_col_merge(session, r, rp));
-				done = 1;
-				break;
-			}
-			if (!F_ISSET(r, WT_EVICTION_SERVER_LOCKED))
-				WT_TRET(__wt_page_release(session, rp));
-			WT_RET(ret);
-			if (done)
+				WT_ERR(__rec_col_merge(
+				    session, r, child->modify->u.split));
+				CHILD_RELEASE_ERR(session, hazard, child);
 				continue;
+			case WT_PM_REC_SPLIT_MERGE:
+				WT_ERR(__rec_col_merge(session, r, child));
+				CHILD_RELEASE_ERR(session, hazard, child);
+				continue;
+			WT_ILLEGAL_VALUE_ERR(session);
+			}
 		}
 
 		/*
@@ -2408,19 +2424,23 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		} else
 			__rec_cell_build_addr(r, addr->addr, addr->size,
 			    __rec_vtype(addr), ref->key.recno);
+		CHILD_RELEASE_ERR(session, hazard, child);
 
 		/* Boundary: split or write the page. */
 		while (val->len > r->space_avail)
 			if (r->raw_compression)
-				WT_RET(__rec_split_raw(session, r));
+				WT_ERR(__rec_split_raw(session, r));
 			else
-				WT_RET(__rec_split(session, r));
+				WT_ERR(__rec_split(session, r));
 
 		/* Copy the value onto the page. */
 		__rec_copy_incr(session, r, val);
 	}
 
 	return (0);
+
+err:	CHILD_RELEASE(session, hazard, child);
+	return (ret);
 }
 
 /*
@@ -3020,15 +3040,17 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	WT_DECL_RET;
 	WT_IKEY *ikey;
 	WT_KV *key, *val;
-	WT_PAGE *rp;
+	WT_PAGE *child;
 	WT_REF *ref;
 	size_t size;
 	uint32_t i;
 	u_int vtype;
-	int done, onpage_ovfl, ovfl_key, state;
+	int hazard, onpage_ovfl, ovfl_key, state;
 	const void *p;
 
 	btree = S2BT(session);
+	child = NULL;
+	hazard = 0;
 
 	key = &r->k;
 	kpack = &_kpack;
@@ -3078,7 +3100,11 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 			onpage_ovfl = kpack->ovfl == 1 ? 1 : 0;
 		}
 
-		WT_RET(__rec_child_modify(session, r, page, ref, &state));
+		WT_ERR(
+		    __rec_child_modify(session, r, page, ref, &hazard, &state));
+		addr = ref->addr;
+		child = ref->page;
+		vtype = 0;
 
 		/* Deleted child we don't have to write. */
 		if (state == WT_CHILD_IGNORE) {
@@ -3090,15 +3116,17 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 			 * reusing this key in this reconciliation is unlikely.
 			 */
 			if (onpage_ovfl)
-				WT_RET(__wt_ovfl_onpage_add(
+				WT_ERR(__wt_ovfl_onpage_add(
 				    session, page, kpack->data, kpack->size));
+			CHILD_RELEASE_ERR(session, hazard, child);
 			continue;
 		}
 
 		addr = ref->addr;
 
 		/* Deleted child requiring a proxy cell. */
-		vtype = (state == WT_CHILD_PROXY) ? WT_CELL_ADDR_DEL : 0;
+		if (state == WT_CHILD_PROXY)
+			vtype = WT_CELL_ADDR_DEL;
 
 		/*
 		 * Modified child.
@@ -3109,10 +3137,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 * prevent eviction.  Release it when we're done.
 		 */
 		if (state == WT_CHILD_MODIFIED) {
-			rp = ref->page;
-			done = 0;
-
-			switch (F_ISSET(rp->modify, WT_PM_REC_MASK)) {
+			switch (F_ISSET(child->modify, WT_PM_REC_MASK)) {
 			case WT_PM_REC_EMPTY:
 				/*
 				 * Overflow keys referencing empty pages are no
@@ -3123,17 +3148,17 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				 * reconciliation is unlikely.
 				 */
 				if (onpage_ovfl)
-					WT_TRET(__wt_ovfl_onpage_add(
+					WT_ERR(__wt_ovfl_onpage_add(
 					    session, page,
 					    kpack->data, kpack->size));
-				done = 1;
-				break;
+				CHILD_RELEASE_ERR(session, hazard, child);
+				continue;
 			case WT_PM_REC_REPLACE:
 				/*
 				 * If the page is replaced, the page's modify
 				 * structure has the page's address.
 				 */
-				addr = &rp->modify->u.replace;
+				addr = &child->modify->u.replace;
 				break;
 			case WT_PM_REC_SPLIT:
 			case WT_PM_REC_SPLIT_MERGE:
@@ -3147,22 +3172,17 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				 * reconciliation is unlikely.
 				 */
 				if (onpage_ovfl)
-					WT_TRET(__wt_ovfl_onpage_add(
+					WT_ERR(__wt_ovfl_onpage_add(
 					    session, page,
 					    kpack->data, kpack->size));
 
-				WT_TRET(__rec_row_merge(session, r,
-				    F_ISSET(rp->modify, WT_PM_REC_SPLIT_MERGE) ?
-				    rp : rp->modify->u.split));
-				done = 1;
-				break;
-			WT_ILLEGAL_VALUE(session);
-			}
-			if (!F_ISSET(r, WT_EVICTION_SERVER_LOCKED))
-				WT_TRET(__wt_page_release(session, rp));
-			WT_RET(ret);
-			if (done)
+				WT_ERR(__rec_row_merge(session, r, F_ISSET(
+				    child->modify, WT_PM_REC_SPLIT_MERGE) ?
+				    child : child->modify->u.split));
+				CHILD_RELEASE_ERR(session, hazard, child);
 				continue;
+			WT_ILLEGAL_VALUE_ERR(session);
+			}
 		}
 
 		/*
@@ -3185,6 +3205,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				vtype = vpack->raw;
 		}
 		__rec_cell_build_addr(r, p, size, vtype, 0);
+		CHILD_RELEASE_ERR(session, hazard, child);
 
 		/*
 		 * If the key is an overflow key, check to see if we've entered
@@ -3208,7 +3229,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 			ovfl_key = 1;
 		} else {
 			__wt_ref_key(page, ref, &p, &size);
-			WT_RET(__rec_cell_build_int_key(
+			WT_ERR(__rec_cell_build_int_key(
 			    session, r, p, r->cell_zero ? 1 : size, &ovfl_key));
 		}
 		r->cell_zero = 0;
@@ -3218,7 +3239,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 */
 		while (key->len + val->len > r->space_avail) {
 			if (r->raw_compression) {
-				WT_RET(__rec_split_raw(session, r));
+				WT_ERR(__rec_split_raw(session, r));
 				continue;
 			}
 
@@ -3229,11 +3250,11 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 			 * about to promote it.
 			 */
 			if (onpage_ovfl) {
-				WT_RET(__wt_buf_set(session,
+				WT_ERR(__wt_buf_set(session,
 				    r->cur, WT_IKEY_DATA(ikey), ikey->size));
 				onpage_ovfl = 0;
 			}
-			WT_RET(__rec_split(session, r));
+			WT_ERR(__rec_split(session, r));
 		}
 
 		/* Copy the key and value onto the page. */
@@ -3246,6 +3267,9 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
 	/* Write the remnant page. */
 	return (__rec_split_finish(session, r));
+
+err:	CHILD_RELEASE(session, hazard, child);
+	return (ret);
 }
 
 /*
@@ -3259,15 +3283,18 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	WT_CELL_UNPACK *vpack, _vpack;
 	WT_DECL_RET;
 	WT_KV *key, *val;
-	WT_PAGE *rp;
+	WT_PAGE *child;
 	WT_REF *ref;
 	size_t size;
 	uint32_t i;
 	u_int vtype;
-	int done, ovfl_key, state;
+	int hazard, ovfl_key, state;
 	const void *p;
 
 	WT_STAT_FAST_DATA_INCR(session, rec_page_merge);
+
+	child = NULL;
+	hazard = 0;
 
 	key = &r->k;
 	val = &r->v;
@@ -3275,9 +3302,11 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
 	/* For each entry in the in-memory page... */
 	WT_REF_FOREACH(page, ref, i) {
-		vtype = 0;
-		WT_RET(__rec_child_modify(session, r, page, ref, &state));
+		WT_ERR(
+		    __rec_child_modify(session, r, page, ref, &hazard, &state));
 		addr = ref->addr;
+		child = ref->page;
+		vtype = 0;
 
 		/* Deleted child we don't have to write. */
 		if (state == WT_CHILD_IGNORE)
@@ -3293,33 +3322,26 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 * Deleted/split pages are merged into the parent and discarded.
 		 */
 		if (state == WT_CHILD_MODIFIED) {
-			rp = ref->page;
-			done = 0;
-			switch (F_ISSET(rp->modify, WT_PM_REC_MASK)) {
+			switch (F_ISSET(child->modify, WT_PM_REC_MASK)) {
 			case WT_PM_REC_EMPTY:
-				done = 1;
-				break;
+				CHILD_RELEASE_ERR(session, hazard, child);
+				continue;
 			case WT_PM_REC_REPLACE:
 				/*
 				 * If the page is replaced, the page's modify
 				 * structure has the page's address.
 				 */
-				addr = &rp->modify->u.replace;
+				addr = &child->modify->u.replace;
 				break;
 			case WT_PM_REC_SPLIT:
 			case WT_PM_REC_SPLIT_MERGE:
-				WT_TRET(__rec_row_merge(session, r,
-				    F_ISSET(rp->modify, WT_PM_REC_SPLIT_MERGE) ?
-				    rp : rp->modify->u.split));
-				done = 1;
-				break;
-			WT_ILLEGAL_VALUE(session);
-			}
-			if (!F_ISSET(r, WT_EVICTION_SERVER_LOCKED))
-				WT_TRET(__wt_page_release(session, rp));
-			WT_RET(ret);
-			if (done)
+				WT_ERR(__rec_row_merge(session, r, F_ISSET(
+				    child->modify, WT_PM_REC_SPLIT_MERGE) ?
+				    child : child->modify->u.split));
+				CHILD_RELEASE_ERR(session, hazard, child);
 				continue;
+			WT_ILLEGAL_VALUE_ERR(session);
+			}
 		}
 
 		/*
@@ -3342,13 +3364,14 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				vtype = vpack->raw;
 		}
 		__rec_cell_build_addr(r, p, size, vtype, 0);
+		CHILD_RELEASE_ERR(session, hazard, child);
 
 		/*
 		 * Build the key cell.
 		 * Truncate any 0th key, internal pages don't need 0th keys.
 		 */
 		__wt_ref_key(page, ref, &p, &size);
-		WT_RET(__rec_cell_build_int_key(
+		WT_ERR(__rec_cell_build_int_key(
 		    session, r, p, r->cell_zero ? 1 : size, &ovfl_key));
 		r->cell_zero = 0;
 
@@ -3357,10 +3380,10 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 */
 		while (key->len + val->len > r->space_avail) {
 			if (r->raw_compression) {
-				WT_RET(__rec_split_raw(session, r));
+				WT_ERR(__rec_split_raw(session, r));
 				continue;
 			}
-			WT_RET(__rec_split(session, r));
+			WT_ERR(__rec_split(session, r));
 		}
 
 		/* Copy the key and value onto the page. */
@@ -3372,6 +3395,9 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	}
 
 	return (0);
+
+err:	CHILD_RELEASE(session, hazard, child);
+	return (ret);
 }
 
 /*


### PR DESCRIPTION
It used to be that the `WT_REF_EVICT_WALK` state implicitly prevented eviction from underneath an internal page that is being reconciled.  Now that all threads just use hazard references to prevent pages going away, reconciliation should do the same when examining the child page of an internal page.

refs #896, #898, #899
