### PR TITLE
more simplification of forced-eviction from page-in function

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -89,7 +89,7 @@ __wt_page_in_func(
 			    force_attempts < 10 &&
 			    __wt_eviction_force_check(session, page)) {
 				++force_attempts;
-				WT_RET(__wt_eviction_force(session, page));
+				WT_RET(__wt_page_release(session, page));
 				break;
 			}
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -522,7 +522,6 @@ struct __wt_page {
 #define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
 #define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
 #define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
-#define	WT_PAGE_EVICT_FORCE	0x10	/* Page being forcibly evicted */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 };
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -755,22 +755,10 @@ __wt_eviction_force_check(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (page->modify == NULL)
 		return (0);
 
-	return (1);
-}
-
-/*
- * __wt_eviction_force --
- *	Forcefully evict a page, if possible.
- */
-static inline int
-__wt_eviction_force(WT_SESSION_IMPL *session, WT_PAGE *page)
-{
-	if (!F_ISSET_ATOMIC(page, WT_PAGE_EVICT_FORCE)) {
-		F_SET_ATOMIC(page, WT_PAGE_EVICT_FORCE);
-		WT_RET(__wt_evict_server_wake(session));
-	}
+	/* Trigger eviction on the next page release. */
 	page->read_gen = WT_READGEN_OLDEST;
-	return (__wt_page_release(session, page));
+
+	return (1);
 }
 
 /*


### PR DESCRIPTION
@agorrod, this change gets rid of the WT_PAGE_EVICT_FORCE flag entirely (its only effect, AFAICT, is to wake up the eviction server once per forced page eviction).

If you don't like this change, feel free to discard it.  (I'm pushing it to you, you have a better sense of what's needed in eviction than I do.)
