### PR TITLE
Don't leak blocks when reconciliation fails after resetting on-page overflow cells.

### DIFF
--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -156,7 +156,6 @@ int
 __wt_ovfl_cache(WT_SESSION_IMPL *session,
     WT_PAGE *page, void *cookie, WT_CELL_UNPACK *vpack)
 {
-	WT_DECL_RET;
 	int visible;
 
 	/*
@@ -183,9 +182,9 @@ __wt_ovfl_cache(WT_SESSION_IMPL *session,
 	 *     - the reader wakes up and reads the wrong value
 	 *
 	 * Use a read/write lock and the on-page cell to fix the problem: hold
-	 * a write lock when creating the cached copy and resetting the on-page
-	 * cell type from WT_CELL_VALUE_OVFL to WT_CELL_VALUE_OVFL_RM and hold
-	 * a read lock when reading an overflow item.
+	 * a write lock when changing the cell type from WT_CELL_VALUE_OVFL to
+	 * WT_CELL_VALUE_OVFL_RM and hold a read lock when reading an overflow
+	 * item.
 	 *
 	 * The read/write lock is per btree, but it could be per page or even
 	 * per overflow item.  We don't do any of that because overflow values
@@ -205,36 +204,70 @@ __wt_ovfl_cache(WT_SESSION_IMPL *session,
 	WT_ILLEGAL_VALUE(session);
 	}
 
-	WT_RET(__wt_writelock(session, S2BT(session)->ovfl_lock));
-	if (__wt_cell_type_raw(vpack->cell) != WT_CELL_VALUE_OVFL_RM) {
-		/*
-		 * If there's no globally visible update, there's a reader in
-		 * the system that might try and read the old value, cache it.
-		 */
-		if (!visible) {
-			WT_ERR(__ovfl_cache(session, page, vpack));
-			WT_STAT_FAST_DATA_INCR(session, cache_overflow_value);
-		}
-
-		/*
-		 * Queue the underlying overflow value's blocks to be freed when
-		 * reconciliation completes.  We're using the on-page structure,
-		 * not the reuse structure because we don't always have the
-		 * value itself, only the block address, and it's unclear reuse
-		 * is probable.
-		 */
-		WT_ERR(__wt_ovfl_discard_add(
-		    session, page, vpack->data, vpack->size));
-
-		/*
-		 * Reset the page's cell type regardless of whether or not we
-		 * cached a copy and a thread might read it: we don't want to
-		 * redo this process during every reconciliation of this page.
-		 */
-		__wt_cell_type_reset(session,
-		    vpack->cell, WT_CELL_VALUE_OVFL, WT_CELL_VALUE_OVFL_RM);
+	/*
+	 * If there's no globally visible update, there's a reader in the system
+	 * that might try and read the old value, cache it.
+	 */
+	if (!visible) {
+		WT_RET(__ovfl_cache(session, page, vpack));
+		WT_STAT_FAST_DATA_INCR(session, cache_overflow_value);
 	}
-err:	WT_TRET(__wt_rwunlock(session, S2BT(session)->ovfl_lock));
+
+	/*
+	 * Queue the on-page cell to be set to WT_CELL_VALUE_OVFL_RM and the
+	 * underlying overflow value's blocks to be freed when reconciliation
+	 * completes.
+	 */
+	return (__wt_ovfl_discard_add(session, page, vpack->cell));
+}
+
+/*
+ * __wt_ovfl_discard --
+ *	Discard an on-page overflow value, and reset the page's cell.
+ */
+int
+__wt_ovfl_discard(WT_SESSION_IMPL *session, WT_CELL *cell)
+{
+	WT_BM *bm;
+	WT_BTREE *btree;
+	WT_CELL_UNPACK *unpack, _unpack;
+	WT_DECL_RET;
+
+	btree = S2BT(session);
+	bm = btree->bm;
+	unpack = &_unpack;
+
+	__wt_cell_unpack(cell, unpack);
+
+	/*
+	 * Finally remove overflow key/value objects, called when reconciliation
+	 * finishes after successfully writing a page.
+	 *
+	 * Keys must have already been instantiated and value objects must have
+	 * already been cached (if they're can still potentially be read by any
+	 * running transaction).
+	 *
+	 * Acquire the overflow lock to avoid racing with a thread reading the
+	 * backing overflow blocks.
+	 */
+	WT_RET(__wt_writelock(session, btree->ovfl_lock));
+
+	switch (unpack->raw) {
+	case WT_CELL_KEY_OVFL:
+		__wt_cell_type_reset(session,
+		    unpack->cell, WT_CELL_KEY_OVFL, WT_CELL_KEY_OVFL_RM);
+		break;
+	case WT_CELL_VALUE_OVFL:
+		__wt_cell_type_reset(session,
+		    unpack->cell, WT_CELL_VALUE_OVFL, WT_CELL_VALUE_OVFL_RM);
+		break;
+	WT_ILLEGAL_VALUE(session);
+	}
+
+	WT_TRET(__wt_rwunlock(session, btree->ovfl_lock));
+
+	/* Free the backing disk blocks. */
+	WT_TRET(bm->free(bm, session, unpack->data, unpack->size));
 
 	return (ret);
 }

--- a/src/btree/rec_evict.c
+++ b/src/btree/rec_evict.c
@@ -761,8 +761,7 @@ __rec_split_evict(WT_SESSION_IMPL *session, WT_REF *parent_ref, WT_PAGE *page)
 	/*
 	 * The key for the original page may be an onpage overflow key, and we
 	 * just lost track of it as the parent's index no longer references the
-	 * WT_REF pointing to it.  Add it to the parent's tracking list and it
-	 * will be discarded the next time the parent is reconciled.
+	 * WT_REF pointing to it.  Discard it now, including the backing blocks.
 	 */
 	switch (parent->type) {
 	case WT_PAGE_ROW_INT:
@@ -772,8 +771,7 @@ __rec_split_evict(WT_SESSION_IMPL *session, WT_REF *parent_ref, WT_PAGE *page)
 			cell = WT_PAGE_REF_OFFSET(parent, ikey->cell_offset);
 			__wt_cell_unpack(cell, kpack);
 			if (kpack->ovfl && kpack->raw != WT_CELL_KEY_OVFL_RM)
-				WT_ERR(__wt_ovfl_discard_add(
-				    session, parent, kpack->data, kpack->size));
+				WT_ERR(__wt_ovfl_discard(session, cell));
 		}
 		break;
 	}

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -228,29 +228,6 @@ __wt_update_alloc(
 }
 
 /*
- * __wt_update_alloc_simple --
- *	Allocate a WT_UPDATE structure and associated value and fill it in (used
- * by a couple of places that need a simple linked lists with associated data).
- */
-int
-__wt_update_alloc_simple(
-    WT_SESSION_IMPL *session, const void *data, size_t size, WT_UPDATE **updp)
-{
-	WT_UPDATE *upd;
-
-	/*
-	 * Allocate the WT_UPDATE structure and room for the data, then copy
-	 * the data into place.
-	 */
-	WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE) + size, &upd));
-	upd->size = WT_STORE_SIZE(size);
-	memcpy(WT_UPDATE_DATA(upd), data, size);
-
-	*updp = upd;
-	return (0);
-}
-
-/*
  * __wt_update_obsolete_check --
  *	Check for obsolete updates.
  */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -291,7 +291,9 @@ struct __wt_page_modify {
 		 * structure has pretty much exactly what we need, so use it
 		 * instead of inventing something new.
 		 */
-		WT_UPDATE *discard;
+		WT_CELL **discard;
+		size_t	  discard_entries;
+		size_t	  discard_allocated;
 	} *ovfl_track;
 
 	uint64_t bytes_dirty;		/* Dirty bytes added to cache. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -335,6 +335,7 @@ extern int __wt_ovfl_cache(WT_SESSION_IMPL *session,
     WT_PAGE *page,
     void *cookie,
     WT_CELL_UNPACK *vpack);
+extern int __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_CELL *cell);
 extern int
 __wt_page_in_func(
  WT_SESSION_IMPL *session, WT_PAGE *parent, WT_REF *ref, uint32_t flags
@@ -406,8 +407,7 @@ extern int __wt_merge_tree(WT_SESSION_IMPL *session, WT_PAGE *top);
 extern int __wt_split_page_inmem(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session,
     WT_PAGE *page,
-    const uint8_t *addr_arg,
-    size_t addr_size);
+    WT_CELL *cell);
 extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern int __wt_ovfl_reuse_search(WT_SESSION_IMPL *session,
     WT_PAGE *page,
@@ -480,10 +480,6 @@ extern int __wt_update_alloc( WT_SESSION_IMPL *session,
     WT_ITEM *value,
     WT_UPDATE **updp,
     size_t *sizep);
-extern int __wt_update_alloc_simple( WT_SESSION_IMPL *session,
-    const void *data,
-    size_t size,
-    WT_UPDATE **updp);
 extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session,
     WT_UPDATE *upd);
 extern void __wt_update_obsolete_free( WT_SESSION_IMPL *session,


### PR DESCRIPTION
@michaelcahill -- this is a cleanup, delaying changing on-page cells from "overflow" to "removed overflow" until we're actually removing the blocks at the end of a successful reconciliation.
