### PR TITLE
Make sure there is no forced eviction during checkpoints

### DIFF
--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -115,7 +115,7 @@ struct __wt_btree {
 	uint64_t evict_priority;	/* Relative priority of cached pages */
 	u_int    evict_walk_period;	/* Skip this many LRU walks */
 	u_int    evict_walk_skips;	/* Number of walks skipped */
-	volatile uint32_t lru_count;	/* Count of threads in LRU eviction */
+	volatile uint32_t evict_busy;	/* Count of threads in eviction */
 
 	int checkpointing;		/* Checkpoint in progress */
 


### PR DESCRIPTION
We were checking that forced eviction didn't start after a checkpoint, but not that forced eviction had completed when a checkpoint started.
