### PR TITLE
Fix a race between reconciliation and freeing obsolete updates on a page.

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -521,7 +521,8 @@ struct __wt_page {
 #define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
 #define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
 #define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
-#define	WT_PAGE_SPLITTING	0x10	/* An internal page is growing. */
+#define	WT_PAGE_SCANNING	0x10	/* Obsolete updates are being scanned */
+#define	WT_PAGE_SPLITTING	0x20	/* An internal page is growing. */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 };
 

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -112,6 +112,7 @@ static inline int
 __update_serial_func(WT_SESSION_IMPL *session,
     WT_PAGE *page, WT_UPDATE **upd_entry, WT_UPDATE *upd)
 {
+	WT_DECL_RET;
 	WT_UPDATE *obsolete;
 	WT_DECL_SPINLOCK_ID(id);			/* Must appear last */
 
@@ -130,13 +131,17 @@ __update_serial_func(WT_SESSION_IMPL *session,
 	 * If there are WT_UPDATE structures to review, we're evicting pages,
 	 * and no other thread holds the page's spinlock, discard obsolete
 	 * WT_UPDATE structures.  Serialization is needed so only one thread
-	 * does the obsolete check at a time.
+	 * does the obsolete check at a time, and also to protect updates from
+	 * disappearing under reconciliation.
 	 */
 	if (upd->next != NULL &&
-	    F_ISSET(S2C(session)->cache, WT_EVICT_ACTIVE) &&
-	    WT_PAGE_TRYLOCK(session, page, &id) == 0) {
+	    F_ISSET(S2C(session)->cache, WT_EVICT_ACTIVE)) {
+		F_CAS_ATOMIC(page, WT_PAGE_SCANNING, ret);
+		/* If we can't lock it, don't scan, that's okay. */
+		if (ret != 0)
+			return (0);
 		obsolete = __wt_update_obsolete_check(session, upd->next);
-		WT_PAGE_UNLOCK(session, page);
+		F_CLR_ATOMIC(page, WT_PAGE_SCANNING);
 		if (obsolete != NULL)
 			__wt_update_obsolete_free(session, page, obsolete);
 	}


### PR DESCRIPTION
Now that reconciliation scans to the end of update lists, it is not safe for it to run concurrently with freeing obsolete updates.  Use an atomic page flag rather than a mutex to protect access: there is no real need to block update operations if there is contention, this is just trimming old memory.
