### PR TITLE
Support zero-length data items in LSM

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -712,6 +712,7 @@ posix
 pre
 prealloc
 preload
+prepend
 prepended
 prepending
 presize

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -155,9 +155,8 @@ value_gen(uint8_t *val, size_t *sizep, uint64_t keyno)
 	/*
 	 * WiredTiger doesn't store zero-length data items in row-store files,
 	 * test that by inserting a zero-length data item every so often.
-	 * LSM doesn't support zero length items.
 	 */
-	if (keyno % 63 == 0 && !DATASOURCE("lsm")) {
+	if (keyno % 63 == 0) {
 		val[0] = '\0';
 		*sizep = 0;
 		return;


### PR DESCRIPTION
I'm putting this one into the system, but it's not ready to merge.

It's a hack, but it mostly works.  I think there's something I don't understand about how LSM cursors get used -- I think LSM cursors are being called from somewhere outside of the application level, but I'm not seeing where.

Reference #540.
