### PR TITLE
Remove references to Value from LevelDB. It's not present in 1.13.

### DIFF
--- a/api/leveldb/leveldb_wt.cc
+++ b/api/leveldb/leveldb_wt.cc
@@ -24,8 +24,6 @@ using leveldb::Status;
 namespace leveldb {
 class ReplayIterator;
 }
-#else
-using leveldb::Value;
 #endif
 
 #define	WT_URI	"table:data"
@@ -286,9 +284,6 @@ public:
 	virtual Status GetReplayIterator(const std::string& timestamp,
 					   leveldb::ReplayIterator** iter) { return Status::NotSupported("sorry!"); }
 	virtual void ReleaseReplayIterator(leveldb::ReplayIterator* iter) {}
-#else
-	virtual Status Get(const ReadOptions& options,
-		     const Slice& key, Value* value);
 #endif
 
 	virtual Iterator* NewIterator(const ReadOptions& options);
@@ -494,28 +489,6 @@ DbImpl::Get(const ReadOptions& options,
 	*value = std::string((const char *)item.data, item.size);
 	return Status::OK();
 }
-
-#ifndef HAVE_HYPERLEVELDB
-Status
-DbImpl::Get(const ReadOptions& options,
-	     const Slice& key, Value* value)
-{
-	WT_CURSOR *cursor = getCursor();
-	WT_ITEM item;
-
-	item.data = key.data();
-	item.size = key.size();
-	cursor->set_key(cursor, &item);
-	int ret = cursor->search(cursor);
-	if (ret == WT_NOTFOUND)
-		return Status::NotFound("DB::Get key not found");
-	assert(ret == 0);
-	ret = cursor->get_value(cursor, &item);
-	assert(ret == 0);
-	value->assign((const char *)item.data, item.size);
-	return Status::OK();
-}
-#endif
 
 // Return a heap-allocated iterator over the contents of the database.
 // The result of NewIterator() is initially invalid (caller must


### PR DESCRIPTION
@michaelcahill When I tried to build the LevelDB API against 1.13, I saw the following:

```
../../../api/leveldb/leveldb_wt.cc:28:16: error: 'leveldb::Value' has not been declared
 using leveldb::Value;
                ^
../../../api/leveldb/leveldb_wt.cc:291:26: error: 'Value' has not been declared
        const Slice& key, Value* value);
                          ^
../../../api/leveldb/leveldb_wt.cc:501:25: error: 'Value' has not been declared
       const Slice& key, Value* value)
                         ^
../../../api/leveldb/leveldb_wt.cc: In member function 'virtual leveldb::Status DbImpl::Get(const leveldb::ReadOptions&, const leveldb::Slice&, int*)':
../../../api/leveldb/leveldb_wt.cc:515:9: error: request for member 'assign' in '* value', which is of non-class type 'int'
  value->assign((const char *)item.data, item.size);
         ^
```

I checked in the leveldb/db.h on my system (1.13) and `leveldb::Value` doesn't appear. Am I missing something?
