### PR TITLE
Fix some LSM latency issues

### DIFF
--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -1,8 +1,8 @@
 /*! @page upgrading Upgrading WiredTiger applications
 
 @section version_221 Upgrading to Version 2.2.1
-<dl>
 
+<dl>
 <dt>::wiredtiger_open configuration parsing order changed</dt>
 <dd>
 In the 2.2.1 release, the order that configuration strings are
@@ -24,7 +24,16 @@ variable may need to change.  The old order:
 <li> user configuration file \c Wiredtiger.config</li>
 <li> user environment variable \c WIREDTIGER_CONFIG</li>
 </ol>
+
 </dd>
+<dt>\c os_cache_dirty_max off for LSM</dt>
+<dd>
+In some earlier versions of WiredTiger, creating an LSM table automatically
+configured \c os_cache_dirty_max, causing additional system calls that slowed
+some workloads.  Applications that benefit from this setting should set it
+explicitly in WT_SESSION::create.
+</dd>
+</dl>
 
 @section version_220 Upgrading to Version 2.2.0
 <dl>
@@ -41,6 +50,7 @@ that benefit from prefix compression will need to explicitly set
 In the 2.2.0 release it is now necessary to include \c --enable-verbose
 in the configure command to be able to use verbose messages.
 </dd>
+</dl>
 
 @section version_212 Upgrading to Version 2.1.2
 <dl>
@@ -54,6 +64,7 @@ the pool being shared.
 We are now also enforcing that only one of \c cache_size and \c shared_cache
 are specified in the ::wiredtiger_open configuration string.
 </dd>
+</dl>
 
 @section version_211 Upgrading to Version 2.1.1
 <dl>
@@ -69,6 +80,7 @@ WT_EXTENSION_API::config_parser_open method, which can be used to parse
 configuration strings. See the WT_CONFIG_PARSER documentation for
 examples on how to use the updated API.
 </dd>
+</dl>
 
 @section version_21 Upgrading to Version 2.1
 <dl>
@@ -99,6 +111,7 @@ explicit "fsync" calls than by enabling "dsync" on a file handle.
 Applications that don't execute concurrent transactions may see better
 throughput with transaction_sync set to "dsync".
 </dd>
+</dl>
 
 @section version_20 Upgrading to Version 2.0
 <dl>
@@ -119,6 +132,7 @@ details of the updated syntax: lsm_auto_throttle, lsm_bloom, lsm_bloom_config,
 lsm_bloom_bit_count, lsm_bloom_hash_count, lsm_bloom_oldest, lsm_chunk_max,
 lsm_chunk_size, lsm_merge_max and lsm_merge_threads.
 </dd>
+</dl>
 
 @section version_166 Upgrading to Version 1.6.6
 <dl>
@@ -200,6 +214,7 @@ Additionally add a WT_SESSION parameter into the existing
 WT_EVENT_HANDLER::handle_error, WT_EVENT_HANDLER::handle_message and
 WT_EVENT_HANDLER::handle_progress callback functions.
 </dd>
+</dl>
 
 @section version_165 Upgrading to Version 1.6.5
 <dl>
@@ -226,9 +241,8 @@ correct behavior.
 <dd>
 The \c sync configuration key to ::wiredtiger_open has been renamed \c checkpoint_sync.
 </dd>
-
 </dl>
-<hr>
+
 @section version_164 Upgrading to Version 1.6.4
 <dl>
 
@@ -249,9 +263,8 @@ add the \c -n option to their command line configuration; applications
 previously using the \c -o option on their command line configurations
 should remove it.
 </dd>
-
 </dl>
-<hr>
+
 @section version_163 Upgrading to Version 1.6.3
 <dl>
 
@@ -288,12 +301,11 @@ The \c transactional configuration key has been removed from
 ::wiredtiger_open.  Any application setting it should simply remove it,
 no change in application behavior is needed.
 </dd>
-
 </dl>
-<hr>
-@section version_162 Upgrading to Version 1.6.2
-<dl>
 
+@section version_162 Upgrading to Version 1.6.2
+
+<dl>
 <dt>Table of WiredTiger extension methods</dt>
 <dd>
 New functionality was added to the list of WiredTiger extension methods;
@@ -315,12 +327,11 @@ checksum, by default.  Applications using compression insufficient for
 the purposes of corrupted block identification should change their file
 checksum configuration to \c on.
 </dd>
-
 </dl>
-<hr>
-@section version_161 Upgrading to Version 1.6.1
-<dl>
 
+@section version_161 Upgrading to Version 1.6.1
+
+<dl>
 <dt>Default page sizes</dt>
 <dd>
 In the 1.6.1 release, the default for the WT_SESSION::create configuration
@@ -344,23 +355,21 @@ In the 1.6.1 release, the \c split_pct argument to the
 WT_COMPRESSOR::compress_raw function changed type from \c u_int to \c int,
 applications may require modification to avoid compiler warnings.
 </dd>
-
 </dl>
-<hr>
-@section version_160 Upgrading to Version 1.6.0
-<dl>
 
+@section version_160 Upgrading to Version 1.6.0
+
+<dl>
 <dt>File format changes</dt>
 <dd>
 The underlying file formats changed in the 1.6.0 release; tables and files
 should be dumped and re-loaded into a new database.
 </dd>
-
 </dl>
-<hr>
-@section version_153 Upgrading to Version 1.5.3
-<dl>
 
+@section version_153 Upgrading to Version 1.5.3
+
+<dl>
 <dt>Configuration strings</dt>
 <dd>
 An undocumented feature where configuration string case was ignored has
@@ -426,24 +435,22 @@ The \c exclusive argument to the WT_DATA_SOURCE::create method has been
 removed; applications may require modifications to resolve compile errors.
 </ul>
 </dd>
-
 </dl>
-<hr>
-@section version_143 Upgrading to Version 1.4.3
-<dl>
 
+@section version_143 Upgrading to Version 1.4.3
+
+<dl>
 <dt>Statistics</dt>
 <dd>
 WiredTiger statistics are no longer maintained by default; to configure
 statistics, use the \c statistics configuration string to the
 ::wiredtiger_open function.
 </dd>
-
 </dl>
-<hr>
-@section version_139 Upgrading to Version 1.3.9
-<dl>
 
+@section version_139 Upgrading to Version 1.3.9
+
+<dl>
 <dt>Compression</dt>
 <dd>
 A new member, WT_COMPRESSOR::compress_raw, was added to the WT_COMPRESSOR
@@ -465,24 +472,22 @@ string \c uncompressed.
 The underlying file formats changed in the 1.3.9 release; tables and files
 should be dumped and re-loaded into a new database.
 </dd>
-
 </dl>
-<hr>
-@section version_138 Upgrading to Version 1.3.8
-<dl>
 
+@section version_138 Upgrading to Version 1.3.8
+
+<dl>
 <dt>Statistics keys</dt>
 <dd>
 The @ref statistics_keys "statistics key constants" have been renamed to use
 all capitals, and use consistent prefixes to distinguish between connection
 statistics and statistics for data sources.
 </dd>
-
 </dl>
-<hr>
-@section version_136 Upgrading to Version 1.3.6
-<dl>
 
+@section version_136 Upgrading to Version 1.3.6
+
+<dl>
 <dt>Installed library names</dt>
 <dd>
 The installed WiredTiger extension library names changed to limit
@@ -516,23 +521,21 @@ The built-in compression name arguments to the WT_SESSION:create
 @row{Snappy compression, "snappy_compress", "snappy"}
 </table>
 </dd>
-
 </dl>
-<hr>
-@section version_135 Upgrading to Version 1.3.5
-<dl>
 
+@section version_135 Upgrading to Version 1.3.5
+
+<dl>
 <dt>File format changes</dt>
 <dd>
 The underlying file formats changed in the 1.3.5 release; tables and files
 should be dumped and re-loaded into a new database.
 </dd>
-
 </dl>
-<hr>
-@section version_13 Upgrading to Version 1.3
-<dl>
 
+@section version_13 Upgrading to Version 1.3
+
+<dl>
 <dt>Checkpoint and Snapshot</dt>
 <dd>
 The checkpoint functionality supported by WT_SESSION::checkpoint and the
@@ -623,8 +626,6 @@ returns a cursor comparison status (less than 0, equal to 0, or greater than
 The underlying file formats changed in the 1.3 release; tables and files
 should be dumped and re-loaded into a new database.
 </dd>
-
 </dl>
-<hr>
 
 */

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -294,6 +294,15 @@ __wt_lsm_merge(
 		if (insert_count % LSM_MERGE_CHECK_INTERVAL == 0) {
 			if (!F_ISSET(lsm_tree, WT_LSM_TREE_WORKING))
 				WT_ERR(EINTR);
+			/*
+			 * Help out with switching chunks in case the
+			 * checkpoint worker is busy.
+			 */
+			if (F_ISSET(lsm_tree, WT_LSM_TREE_NEED_SWITCH)) {
+				WT_WITH_SCHEMA_LOCK(session, ret =
+				    __wt_lsm_tree_switch(session, lsm_tree));
+				WT_ERR(ret);
+			}
 			WT_STAT_FAST_CONN_INCRV(session,
 			    lsm_rows_merged, LSM_MERGE_CHECK_INTERVAL);
 			++lsm_tree->merge_progressing;

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -415,23 +415,16 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 	WT_ASSERT(session, lsm_tree->merge_threads <= WT_LSM_MAX_WORKERS);
 
 	/*
-	 * Set up the config for each chunk.  If possible, avoid high latencies
-	 * from fsync by flushing the cache every 8MB (will be overridden by
-	 * any application setting).
+	 * Set up the config for each chunk.
 	 *
-	 * Also make the memory_page_max double the chunk size, so application
+	 * Make the memory_page_max double the chunk size, so application
 	 * threads don't immediately try to force evict the chunk when the
 	 * worker thread clears the NO_EVICTION flag.
 	 */
-	tmpconfig = "";
-#ifdef HAVE_SYNC_FILE_RANGE
-	if (!S2C(session)->direct_io)
-		tmpconfig = "os_cache_dirty_max=8MB,";
-#endif
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	WT_ERR(__wt_buf_fmt(session, buf,
-	    "%s%s,key_format=u,value_format=u,memory_page_max=%" PRIu64,
-	    tmpconfig, config, 2 * lsm_tree->chunk_max));
+	    "%s,key_format=u,value_format=u,memory_page_max=%" PRIu64,
+	    config, 2 * lsm_tree->chunk_max));
 	WT_ERR(__wt_strndup(
 	    session, buf->data, buf->size, &lsm_tree->file_config));
 


### PR DESCRIPTION
- have merge threads periodically check whether the tree needs to be switched in case the checkpoint thread is blocked; and
- don't turn on os_cache_dirty_max by default for LSM.
