### PR TITLE
Support snapshots in LSM via update checks, rather than actual updates.

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -404,16 +404,6 @@ retry:	WT_RET(__cursor_func_init(cbt, 1));
 		    cbt->compare == 0 && !__cursor_invalid(cbt))
 			WT_ERR(WT_DUPLICATE_KEY);
 
-		/*
-		 * If we are only interested in conflict checking do it now.
-		 * A conflict can only exist if there was an exact match.
-		 */
-		if (F_ISSET(cbt, WT_CBT_CONFLICT_CHECK)) {
-			if (cbt->compare != 0)
-				return (0);
-			return (__wt_txn_update_check(session, cbt->ins->upd));
-		}
-
 		ret = __cursor_row_modify(session, cbt, 0);
 		break;
 	WT_ILLEGAL_VALUE_ERR(session);
@@ -424,6 +414,50 @@ err:	if (ret == WT_RESTART)
 	/* Insert doesn't maintain a position across calls, clear resources. */
 	if (ret == 0)
 		WT_TRET(__curfile_leave(cbt));
+	if (ret != 0)
+		WT_TRET(__cursor_error_resolve(cbt));
+	return (ret);
+}
+
+/*
+ * __wt_btcur_update_check --
+ *	Check whether an update would conflict.
+ *
+ *	This can be used to replace WT_CURSOR::insert or WT_CURSOR::update, so
+ *	they only check for conflicts without updating the tree.  It is used to
+ *	maintain snapshot isolation for transactions that span multiple chunks
+ *	in an LSM tree.
+ */
+int
+__wt_btcur_update_check(WT_CURSOR_BTREE *cbt)
+{
+	WT_BTREE *btree;
+	WT_CURSOR *cursor;
+	WT_DECL_RET;
+	WT_SESSION_IMPL *session;
+
+	cursor = &cbt->iface;
+	btree = cbt->btree;
+	session = (WT_SESSION_IMPL *)cursor->session;
+
+retry:	WT_RET(__cursor_func_init(cbt, 1));
+
+	switch (btree->type) {
+	case BTREE_ROW:
+		WT_ERR(__cursor_row_search(session, cbt, 1));
+
+		/*
+		 * We are only interested in checking for conflicts.
+		 */
+		if (cbt->compare == 0 && cbt->ins != NULL)
+			ret = __wt_txn_update_check(session, cbt->ins->upd);
+		break;
+	WT_ILLEGAL_VALUE_ERR(session);
+	}
+
+err:	if (ret == WT_RESTART)
+		goto retry;
+	WT_TRET(__curfile_leave(cbt));
 	if (ret != 0)
 		WT_TRET(__cursor_error_resolve(cbt));
 	return (ret);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -266,6 +266,29 @@ err:	CURSOR_UPDATE_API_END(session, ret);
 }
 
 /*
+ * __wt_curfile_update_check --
+ *	WT_CURSOR->update_check method for the btree cursor type.
+ */
+int
+__wt_curfile_update_check(WT_CURSOR *cursor)
+{
+	WT_CURSOR_BTREE *cbt;
+	WT_DECL_RET;
+	WT_SESSION_IMPL *session;
+
+	cbt = (WT_CURSOR_BTREE *)cursor;
+	CURSOR_UPDATE_API_CALL(cursor, session, update, cbt->btree);
+
+	WT_CURSOR_NEEDKEY(cursor);
+
+	WT_BTREE_CURSOR_SAVE_AND_RESTORE(
+	    cursor, __wt_btcur_update_check(cbt), ret);
+
+err:	CURSOR_UPDATE_API_END(session, ret);
+	return (ret);
+}
+
+/*
  * __curfile_remove --
  *	WT_CURSOR->remove method for the btree cursor type.
  */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -172,7 +172,6 @@ struct __wt_cursor_btree {
 #define	WT_CBT_ITERATE_PREV	0x08	/* Prev iteration configuration */
 #define	WT_CBT_MAX_RECORD	0x10	/* Col-store: past end-of-table */
 #define	WT_CBT_SEARCH_SMALLEST	0x20	/* Row-store: small-key insert list */
-#define	WT_CBT_CONFLICT_CHECK	0x40	/* Only check for conflicts */
 	uint8_t flags;
 };
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -269,6 +269,7 @@ extern int __wt_btcur_reset(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_search(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp);
 extern int __wt_btcur_insert(WT_CURSOR_BTREE *cbt);
+extern int __wt_btcur_update_check(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_remove(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_update(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_compare(WT_CURSOR_BTREE *a_arg,
@@ -666,6 +667,7 @@ extern int __wt_curds_create( WT_SESSION_IMPL *session,
 extern int __wt_curdump_create(WT_CURSOR *child,
     WT_CURSOR *owner,
     WT_CURSOR **cursorp);
+extern int __wt_curfile_update_check(WT_CURSOR *cursor);
 extern int __wt_curfile_create(WT_SESSION_IMPL *session,
     WT_CURSOR *owner,
     const char *cfg[],


### PR DESCRIPTION
The current code inserts updates into old chunks, in order to check for
conflicts with snapshot transactions. It's enough to do the conflict check
without actually updating, and doing a check saves some mess with tracking
when it's OK to checkpoint non-primary chunks.
