### PR TITLE
Revert change to not evict in the server thread if application threads wait

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1137,7 +1137,6 @@ extern int __wt_cond_alloc(WT_SESSION_IMPL *session,
 extern int __wt_cond_wait(WT_SESSION_IMPL *session,
     WT_CONDVAR *cond,
     long usecs);
-extern int __wt_cond_has_waiters(WT_SESSION_IMPL *session, WT_CONDVAR *cond);
 extern int __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond);
 extern int __wt_cond_destroy(WT_SESSION_IMPL *session, WT_CONDVAR **condp);
 extern int __wt_rwlock_alloc( WT_SESSION_IMPL *session,

--- a/src/os_posix/os_mtx.c
+++ b/src/os_posix/os_mtx.c
@@ -111,22 +111,6 @@ err:	if (locked)
 }
 
 /*
- * __wt_cond_has_waiters --
- *	Indicates if threads are waiting.
- */
-int
-__wt_cond_has_waiters(WT_SESSION_IMPL *session, WT_CONDVAR *cond)
-{
-	WT_UNUSED(session);
-
-	/* Fast path if already signalled. */
-	if (cond->waiters == -1)
-		return (0);
-
-	return (1);
-}
-
-/*
  * __wt_cond_signal --
  *	Signal a waiting thread.
  */


### PR DESCRIPTION
It makes a read-heavy multi-threaded workload slower.

References #1098 
