### PR TITLE
Enhance checkpoints when LSM trees are present.

### DIFF
--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -60,6 +60,7 @@ struct __wt_data_handle {
 #define	WT_DHANDLE_EXCLUSIVE	        0x04	/* Need exclusive access */
 #define	WT_DHANDLE_HAVE_REF		0x08	/* Already have ref */
 #define	WT_DHANDLE_LOCK_ONLY	        0x10	/* Handle only used as a lock */
-#define	WT_DHANDLE_OPEN		        0x20	/* Handle is open */
+#define	WT_DHANDLE_LSM		        0x20	/* Handle only used as a lock */
+#define	WT_DHANDLE_OPEN		        0x40	/* Handle is open */
 	uint32_t flags;
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -982,6 +982,8 @@ extern int __wt_lsm_tree_unlock( WT_SESSION_IMPL *session,
 extern int __wt_lsm_compact(WT_SESSION_IMPL *session,
     const char *name,
     int *skip);
+extern int __wt_lsm_tree_checkpoint(WT_SESSION_IMPL *session,
+    WT_LSM_TREE *lsm_tree);
 extern int __wt_lsm_tree_worker(WT_SESSION_IMPL *session,
     const char *uri,
     int (*file_func)(WT_SESSION_IMPL *,
@@ -991,7 +993,18 @@ extern int __wt_lsm_tree_worker(WT_SESSION_IMPL *session,
     int *),
     const char *cfg[],
     uint32_t open_flags);
+extern int __wt_lsm_copy_chunks(WT_SESSION_IMPL *session,
+    WT_LSM_TREE *lsm_tree,
+    WT_LSM_WORKER_COOKIE *cookie,
+    int old_chunks);
+extern void __wt_lsm_unpin_chunks(WT_SESSION_IMPL *session,
+    WT_LSM_WORKER_COOKIE *cookie);
 extern void *__wt_lsm_merge_worker(void *vargs);
+extern int __wt_lsm_checkpoint_chunks( WT_SESSION_IMPL *session,
+    WT_LSM_TREE *lsm_tree,
+    WT_LSM_WORKER_COOKIE *cookie,
+    int for_checkpoint,
+    int *checkpointed_all);
 extern void *__wt_lsm_checkpoint_worker(void *arg);
 extern int __wt_meta_btree_apply(WT_SESSION_IMPL *session,
     int (*func)(WT_SESSION_IMPL *,


### PR DESCRIPTION
Don't do checkpoints of chunks from an LSM tree, implement an LSM tree
specific checkpoint operation.

Refs #1107

Not yet ready for review.
