### PR TITLE
Inline strcmp calls in the standard cursor functions

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -304,7 +304,7 @@ struct __wt_cursor_table {
 #define	WT_CURSOR_PRIMARY(cursor)					\
 	(((WT_CURSOR_TABLE *)cursor)->cg_cursors[0])
 
-#define	WT_CURSOR_RECNO(cursor)	(strcmp((cursor)->key_format, "r") == 0)
+#define	WT_CURSOR_RECNO(cursor)	WT_STREQ((cursor)->key_format, "r")
 
 /*
  * WT_CURSOR_NEEDKEY, WT_CURSOR_NEEDVALUE --

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -153,6 +153,15 @@
 #define	WT_PREFIX_MATCH_LEN(str, len, pfx)				\
 	((len) >= strlen(pfx) && WT_PREFIX_MATCH(str, pfx))
 
+/*
+ * Check if a variable string equals a constant string.  Inline the common
+ * case for WiredTiger of a single byte string.  This is required because not
+ * all compilers optimize this case in strcmp (e.g., clang).
+ */
+#define	WT_STREQ(s, cs)							\
+	(sizeof (cs) == 2 ? (s)[0] == (cs)[0] && (s)[1] == '\0' :	\
+	strcmp(s, cs) == 0)
+
 /* Check if a string matches a prefix, and move past it. */
 #define	WT_PREFIX_SKIP(str, pfx)					\
 	((strncmp((str), (pfx), strlen(pfx)) == 0) ?			\


### PR DESCRIPTION
@michaelcahill, I noticed zoom was complaining that strcmp in get/set key was taking up a big chunk of time, and it turns out that clang isn't inlining the calls.  Here's a rework of that, ready to merge if you agree.

There are some minor cleanups along the way:
- always set `fmt` at the start of the function, based on `WT_CURSOR_RAW_OK`
- always check `S` first, then `u`, then `r`
