### PR TITLE
Force a checkpoint at the end of recovery so that the checkpoint LSN

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -469,7 +469,7 @@ err:	if (ret == 0)
 		 * so that the next open is fast and keep the metadata
 		 * up to date with the checkpoint LSN and archiving.
 		 */
-		session->iface.checkpoint(session, "force=1");
+		session->iface.checkpoint(&session->iface, "force=1");
 	WT_TRET(__recovery_free(&r));
 	__wt_free(session, config);
 	WT_TRET(session->iface.close(&session->iface, NULL));


### PR DESCRIPTION
in the metadata matches the checkpoint record in the log. #1115 

@michaelcahill Here is one solution to fixing the issue.  I ended up forcing a checkpoint at the end of recovery instead of just writing the checkpoint log record.  That keeps the metadata checkpoint LSN in sync with what is actually in the log.  The alternative of closing the files at the end of recovery was a much larger and involved change that I abandoned.
