### PR TITLE
Bulk skiptest

### DIFF
--- a/test/suite/test_bulk01.py
+++ b/test/suite/test_bulk01.py
@@ -105,11 +105,8 @@ class test_bulk_load_row_order(wttest.WiredTigerTestCase):
                 self.skipTest('requires a diagnostic build')
         except:
             pass
-        #if not self.conn.diagnostic_build():
-        #    self.skipTest('requires a diagnostic build')
-
-        # Close explicitly, there's going to be a fallure.
         else:
+            # Close explicitly, there's going to be a fallure.
             msg = '/are incorrectly sorted/'
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda: self.conn.close(), msg)


### PR DESCRIPTION
@michaelcahill Please review this branch.  We may want to throw it away.  When running bulk01 without diagnostic I see:

```
test_bulk01.test_bulk_load_row_order.test_bulk_load_row_order_nocheck ... skipped 'requires a diagnostic build'
test_bulk01.test_bulk_load_row_order.test_bulk_load_row_order_nocheck ... skipped 'requires a diagnostic build'

----------------------------------------------------------------------
Ran 26 tests in 0.134s

OK (skipped=2)
ERROR in test_bulk_load_row_order.2
ERROR in test_bulk_load_row_order.3
```

The reason is that `skipTest` raises an exception.  With this change we get rid of the exception, and its errors, but lose the fact that the tests were skipped:

```
test_bulk01.test_bulk_load_row_order.test_bulk_load_row_order_nocheck ... ok
test_bulk01.test_bulk_load_row_order.test_bulk_load_row_order_nocheck ... ok

----------------------------------------------------------------------
Ran 26 tests in 0.126s

OK
```

I think that is better than errors, but we do lose information.

An alternative I considered, but couldn't figure out how to make work was a decorator of the form:
`@unittest.skipUnless(conn.diagnostic_build(), 'reason')`
but there is no way to access a connection at that level, nor could I figure out where else to put diagnostic_build to make it globally accessible.
