### PR TITLE
Add force flag to checkpoint last chunk. #1200

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1010,8 +1010,9 @@ extern int __wt_lsm_tree_worker(WT_SESSION_IMPL *session,
     int *),
     const char *cfg[],
     uint32_t open_flags);
-extern int __wt_lsm_get_chunk_to_flush( WT_SESSION_IMPL *session,
+extern int __wt_lsm_get_chunk_to_flush(WT_SESSION_IMPL *session,
     WT_LSM_TREE *lsm_tree,
+    int force,
     WT_LSM_CHUNK **chunkp);
 extern int __wt_lsm_work_switch( WT_SESSION_IMPL *session,
     WT_LSM_WORK_UNIT **entryp,

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -88,6 +88,8 @@ struct __wt_lsm_chunk {
 #define	WT_LSM_WORK_FLUSH	0x04	/* Flush a chunk to disk */
 #define	WT_LSM_WORK_MERGE	0x08	/* Look for a tree merge */
 #define	WT_LSM_WORK_SWITCH	0x10	/* Switch to a new in memory chunk */
+#define	WT_LSM_WORK_FORCE	0x10000	/* Force last chunk flush */
+#define	WT_LSM_WORK_MASK	0xffff	/* Mask for work types */
 
 /*
  * WT_LSM_WORK_UNIT --

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -523,7 +523,7 @@ __wt_lsm_manager_push_entry(
 	(void)WT_ATOMIC_ADD(lsm_tree->queue_ref, 1);
 	WT_STAT_FAST_CONN_INCR(session, lsm_work_units_created);
 
-	switch (type) {
+	switch (type & WT_LSM_WORK_MASK) {
 	case WT_LSM_WORK_SWITCH:
 		__wt_spin_lock(session, &manager->switch_lock);
 		TAILQ_INSERT_TAIL(&manager->switchqh, entry, q);

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1058,7 +1058,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 
 	/* Make sure the in-memory chunk gets flushed but not switched. */
 	WT_ERR(__wt_lsm_manager_push_entry(
-	    session, WT_LSM_WORK_FLUSH, lsm_tree));
+	    session, WT_LSM_WORK_FLUSH | WT_LSM_WORK_FORCE, lsm_tree));
 
 	/* Wait for the work unit queues to drain. */
 	while (F_ISSET(lsm_tree, WT_LSM_TREE_ACTIVE)) {

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -66,10 +66,10 @@ err:	WT_TRET(__wt_lsm_tree_unlock(session, lsm_tree));
  *	Find and pin a chunk in the LSM tree that is likely to need flushing.
  */
 int
-__wt_lsm_get_chunk_to_flush(
-    WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LSM_CHUNK **chunkp)
+__wt_lsm_get_chunk_to_flush(WT_SESSION_IMPL *session,
+    WT_LSM_TREE *lsm_tree, int force, WT_LSM_CHUNK **chunkp)
 {
-	u_int i;
+	u_int i, end;
 
 	*chunkp = NULL;
 
@@ -78,7 +78,8 @@ __wt_lsm_get_chunk_to_flush(
 	if (!F_ISSET(lsm_tree, WT_LSM_TREE_ACTIVE))
 		return (__wt_lsm_tree_unlock(session, lsm_tree));
 
-	for (i = 0; i < lsm_tree->nchunks - 1; i++) {
+	end = force ? lsm_tree->nchunks : lsm_tree->nchunks - 1;
+	for (i = 0; i < end; i++) {
 		if (!F_ISSET(lsm_tree->chunk[i], WT_LSM_CHUNK_ONDISK)) {
 			(void)WT_ATOMIC_ADD(lsm_tree->chunk[i]->refcnt, 1);
 			*chunkp = lsm_tree->chunk[i];


### PR DESCRIPTION
@agorrod Here's a fix that recovers the performance for medium-lsm-compact.wtperf.  The problem, as described in #1200 was that the final chunk was not checkpointed.  This fix adds a force flag to the flush work unit that compact pushes onto the work queue and the force flag changes the end chunk looked for by the flush code.
