### PR TITLE
Remove lsm=(merge_threads) configuration option.

### DIFF
--- a/bench/wtperf/runners/evict-lsm.wtperf
+++ b/bench/wtperf/runners/evict-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: evict lsm configuration
 conn_config="cache_size=50M"
-table_config="lsm=(merge_threads=2),type=lsm,os_cache_dirty_max=16MB"
+table_config="type=lsm,os_cache_dirty_max=16MB"
 compact=true
 icount=10000000
 report_interval=5

--- a/bench/wtperf/runners/fruit-lsm.wtperf
+++ b/bench/wtperf/runners/fruit-lsm.wtperf
@@ -2,12 +2,12 @@
 # The configuration for the connection and table are from riak and the
 # specification of the data (count, size, threads) is from basho_bench.
 #
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600),log=(enabled=true),transaction_sync=(enabled=true,method=none),checkpoint=(wait=180)"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600),log=(enabled=true),transaction_sync=(enabled=true,method=none),checkpoint=(wait=180),lsm_manager=(worker_thread_max=12)"
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compact=true
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,leaf_item_max=4K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,leaf_item_max=4K,os_cache_dirty_max=16MB"
 icount=25000000
 key_sz=40
 value_sz=800

--- a/bench/wtperf/runners/fruit-short.wtperf
+++ b/bench/wtperf/runners/fruit-short.wtperf
@@ -6,7 +6,7 @@
 conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compact=true
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K"
 icount=25000000
 key_sz=40
 value_sz=800

--- a/bench/wtperf/runners/large-lsm.wtperf
+++ b/bench/wtperf/runners/large-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: large lsm configuration
 conn_config="cache_size=20G,mmap=false"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 compact=true
 compression="snappy"
 icount=250000000

--- a/bench/wtperf/runners/medium-lsm-async.wtperf
+++ b/bench/wtperf/runners/medium-lsm-async.wtperf
@@ -1,7 +1,7 @@
 # wtperf options file: medium lsm configuration using async operations
 conn_config="cache_size=1G"
 async_threads=10
-table_config="lsm=(chunk_size=100MB,merge_threads=2),type=lsm,os_cache_dirty_max=16MB"
+table_config="lsm=(chunk_size=100MB),type=lsm,os_cache_dirty_max=16MB"
 icount=50000000
 report_interval=5
 run_time=120

--- a/bench/wtperf/runners/medium-lsm-compact.wtperf
+++ b/bench/wtperf/runners/medium-lsm-compact.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: medium lsm configuration
 conn_config="cache_size=1G"
-table_config="lsm=(chunk_size=100MB,merge_threads=2,chunk_max=1TB),type=lsm,os_cache_dirty_max=16MB"
+table_config="lsm=(chunk_size=100MB,chunk_max=1TB),type=lsm,os_cache_dirty_max=16MB"
 icount=50000000
 populate_threads=1
 compact=true

--- a/bench/wtperf/runners/medium-lsm.wtperf
+++ b/bench/wtperf/runners/medium-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: medium lsm configuration
 conn_config="cache_size=1G"
-table_config="lsm=(chunk_size=100MB,merge_threads=2),type=lsm,os_cache_dirty_max=16MB"
+table_config="lsm=(chunk_size=100MB),type=lsm,os_cache_dirty_max=16MB"
 icount=50000000
 report_interval=5
 run_time=120

--- a/bench/wtperf/runners/medium-multi-lsm-noprefix.wtperf
+++ b/bench/wtperf/runners/medium-multi-lsm-noprefix.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: medium lsm configuration, with multiple tables.
-conn_config="cache_size=1G"
-table_config="lsm=(chunk_size=100MB,merge_threads=2,chunk_max=1TB),type=lsm,prefix_compression=false,os_cache_dirty_max=16MB"
+conn_config="cache_size=1G,lsm_manager=(worker_thread_max=8)"
+table_config="lsm=(chunk_size=100MB,chunk_max=1TB),type=lsm,prefix_compression=false,os_cache_dirty_max=16MB"
 icount=50000000
 populate_threads=1
 compact=true

--- a/bench/wtperf/runners/medium-multi-lsm.wtperf
+++ b/bench/wtperf/runners/medium-multi-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: medium lsm configuration, with multiple tables.
-conn_config="cache_size=1G"
-table_config="lsm=(chunk_size=100MB,merge_threads=2,chunk_max=1TB),type=lsm,os_cache_dirty_max=16MB"
+conn_config="cache_size=1G,lsm_manager=(worker_thread_max=8)"
+table_config="lsm=(chunk_size=100MB,chunk_max=1TB),type=lsm,os_cache_dirty_max=16MB"
 icount=50000000
 populate_threads=1
 compact=true

--- a/bench/wtperf/runners/parallel-pop-lsm.wtperf
+++ b/bench/wtperf/runners/parallel-pop-lsm.wtperf
@@ -1,7 +1,7 @@
 # wtperf options file: Run populate thread multi-threaded and with groups
 # of operations in each transaction.
 conn_config="cache_size=200MB"
-table_config="lsm=(merge_threads=2),type=lsm,os_cache_dirty_max=16MB"
+table_config="type=lsm,os_cache_dirty_max=16MB"
 transaction_config="isolation=snapshot"
 icount=10000000
 report_interval=5

--- a/bench/wtperf/runners/test1-1b-lsm.wtperf
+++ b/bench/wtperf/runners/test1-1b-lsm.wtperf
@@ -3,11 +3,11 @@
 # specification of the data (count, size, threads) is from basho_bench.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=1000000000
 key_sz=40
 value_sz=1000

--- a/bench/wtperf/runners/test1-2b-lsm.wtperf
+++ b/bench/wtperf/runners/test1-2b-lsm.wtperf
@@ -3,11 +3,11 @@
 # specification of the data (count, size, threads) is from basho_bench.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB,merge_threads=4),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=2000000000
 key_sz=40
 value_sz=1000

--- a/bench/wtperf/runners/test1-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test1-500m-lsm.wtperf
@@ -3,11 +3,11 @@
 # specification of the data (count, size, threads) is from basho_bench.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=500000000
 key_sz=40
 value_sz=1000

--- a/bench/wtperf/runners/test1-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test1-50m-lsm.wtperf
@@ -6,7 +6,7 @@
 conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
 compact=true
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=50000000
 key_sz=40
 value_sz=1000

--- a/bench/wtperf/runners/test2-1b-lsm.wtperf
+++ b/bench/wtperf/runners/test2-1b-lsm.wtperf
@@ -8,7 +8,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test2-2b-lsm.wtperf
+++ b/bench/wtperf/runners/test2-2b-lsm.wtperf
@@ -4,11 +4,11 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB,merge_threads=4),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test2-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test2-500m-lsm.wtperf
@@ -4,11 +4,11 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 create=false
 compression="snappy"
 sess_config="isolation=snapshot
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test2-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test2-50m-lsm.wtperf
@@ -7,7 +7,7 @@
 conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test3-1b-lsm.wtperf
+++ b/bench/wtperf/runners/test3-1b-lsm.wtperf
@@ -4,11 +4,11 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=8)"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test3-2b-lsm.wtperf
+++ b/bench/wtperf/runners/test3-2b-lsm.wtperf
@@ -4,11 +4,11 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=8)"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB,merge_threads=4),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test3-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test3-500m-lsm.wtperf
@@ -4,11 +4,11 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=60)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=8)"
 create=false
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test3-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test3-50m-lsm.wtperf
@@ -4,10 +4,10 @@
 # This test assumes that a test1 populate already completed and exists.
 #
 #conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=30)"
-conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test4-1b-lsm.wtperf
+++ b/bench/wtperf/runners/test4-1b-lsm.wtperf
@@ -8,7 +8,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test4-2b-lsm.wtperf
+++ b/bench/wtperf/runners/test4-2b-lsm.wtperf
@@ -8,7 +8,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compression="snappy"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB,merge_threads=4),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=20GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test4-500m-lsm.wtperf
+++ b/bench/wtperf/runners/test4-500m-lsm.wtperf
@@ -8,7 +8,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 create=false
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB,merge_threads=3),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/test4-50m-lsm.wtperf
+++ b/bench/wtperf/runners/test4-50m-lsm.wtperf
@@ -7,7 +7,7 @@
 conn_config="cache_size=10G,checkpoint_sync=false,mmap=false,session_max=1024"
 create=false
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 key_sz=40
 value_sz=1000
 max_latency=2000

--- a/bench/wtperf/runners/update-large-lsm.wtperf
+++ b/bench/wtperf/runners/update-large-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: lsm with inserts/updates, in memory
-conn_config="cache_size=2G"
-table_config="lsm=(chunk_size=50MB,merge_threads=3),type=lsm,os_cache_dirty_max=16MB"
+conn_config="cache_size=2G,lsm_manager=(worker_thread_max=6)"
+table_config="lsm=(chunk_size=50MB),type=lsm,os_cache_dirty_max=16MB"
 icount=200000000
 report_interval=5
 run_time=1200

--- a/bench/wtperf/runners/update-lsm.wtperf
+++ b/bench/wtperf/runners/update-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: lsm with inserts/updates, in memory
-conn_config="cache_size=1G"
-table_config="lsm=(chunk_size=20MB,merge_threads=2),type=lsm,os_cache_dirty_max=16MB"
+conn_config="cache_size=1G,lsm_manager=(worker_thread_max=6)"
+table_config="lsm=(chunk_size=20MB),type=lsm,os_cache_dirty_max=16MB"
 icount=5000000
 report_interval=5
 run_time=120

--- a/bench/wtperf/runners/voxer-10k-short.wtperf
+++ b/bench/wtperf/runners/voxer-10k-short.wtperf
@@ -7,7 +7,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=15000
 key_sz=40
 value_sz=10000

--- a/bench/wtperf/runners/voxer-10k.wtperf
+++ b/bench/wtperf/runners/voxer-10k.wtperf
@@ -7,7 +7,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=15000
 key_sz=40
 value_sz=10000

--- a/bench/wtperf/runners/voxer-130k-short.wtperf
+++ b/bench/wtperf/runners/voxer-130k-short.wtperf
@@ -3,11 +3,11 @@
 # specification of the data (count, size, threads) is from basho_bench.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=15000
 key_sz=40
 value_sz=130000

--- a/bench/wtperf/runners/voxer-130k.wtperf
+++ b/bench/wtperf/runners/voxer-130k.wtperf
@@ -3,11 +3,11 @@
 # specification of the data (count, size, threads) is from basho_bench.
 #
 #conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,statistics=(fast,clear),statistics_log=(wait=600)"
-conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024"
+conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,session_max=1024,lsm_manager=(worker_thread_max=6)"
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB,merge_threads=2),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=15000
 key_sz=40
 value_sz=130000

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -138,9 +138,6 @@ lsm_config = [
 	        the minimum number of chunks to include in a merge operation. If
 	        set to 0 or 1 half the value of merge_max is used''',
 	        max='100'),
-	    Config('merge_threads', '2', r'''
-	        the number of threads to perform merge operations''',
-	        min='1', max='10'), # !!! max must match WT_LSM_MAX_WORKERS
 	]),
 ]
 

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -191,7 +191,6 @@ static const WT_CONFIG_CHECK confchk_lsm_subconfigs[] = {
 	{ "chunk_size", "int", "min=512K,max=500MB", NULL },
 	{ "merge_max", "int", "min=2,max=100", NULL },
 	{ "merge_min", "int", "max=100", NULL },
-	{ "merge_threads", "int", "min=1,max=10", NULL },
 	{ NULL, NULL, NULL, NULL }
 };
 
@@ -450,7 +449,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "key_gap=10,leaf_item_max=0,leaf_page_max=32KB,"
 	  "lsm=(auto_throttle=,bloom=,bloom_bit_count=16,bloom_config=,"
 	  "bloom_hash_count=8,bloom_oldest=0,chunk_max=5GB,chunk_size=10MB,"
-	  "merge_max=15,merge_min=0,merge_threads=2),memory_page_max=5MB,"
+	  "merge_max=15,merge_min=0),memory_page_max=5MB,"
 	  "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=0,"
 	  "prefix_compression_min=4,source=,split_pct=75,type=file,"
 	  "value_format=u",

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -96,6 +96,7 @@ basecfg
 basho
 bdb
 bdbmap
+benchmarking
 bigram
 bindir
 bitstring

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -46,6 +46,13 @@ mutexes to non-adaptive pthread mutexes. Installations can explicitly
 select adaptive pthread mutexes by specifying
 \c --with-spinlock=pthread_adaptive at configuration time.
 </dd>
+<dt>LSM merge threads option change</dt>
+<dd>
+The WT_SESSION::create \c lsm=(merge_threads) configuration option has been
+replaced by the W::wiredtiger_open \c lsm_manager=(worker_thread_max) option.
+The new version specifies a set of LSM threads that are shared across all
+LSM trees in a database, the older configuration was per LSM table.
+</dd>
 </dl>
 
 @section version_231 Upgrading to Version 2.3.1

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -164,7 +164,6 @@ struct __wt_lsm_tree {
 	uint64_t chunk_size;
 	uint64_t chunk_max;
 	u_int merge_min, merge_max;
-	u_int merge_threads;
 
 	u_int merge_idle;		/* Count of idle merge threads */
 
@@ -172,14 +171,6 @@ struct __wt_lsm_tree {
 #define	WT_LSM_BLOOM_OFF				0x00000002
 #define	WT_LSM_BLOOM_OLDEST				0x00000004
 	uint32_t bloom;			/* Bloom creation policy */
-
-#define	WT_LSM_MAX_WORKERS	10
-					/* Passed to thread_create */
-	WT_SESSION_IMPL *worker_sessions[WT_LSM_MAX_WORKERS];
-					/* LSM worker thread(s) */
-	pthread_t worker_tids[WT_LSM_MAX_WORKERS];
-	WT_SESSION_IMPL *ckpt_session;	/* For checkpoint worker */
-	pthread_t ckpt_tid;		/* LSM checkpoint worker thread */
 
 	WT_LSM_CHUNK **chunk;		/* Array of active LSM chunks */
 	size_t chunk_alloc;		/* Space allocated for chunks */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1060,9 +1060,6 @@ struct __wt_session {
 	 * chunks to include in a merge operation.  If set to 0 or 1 half the
 	 * value of merge_max is used., an integer no more than 100; default \c
 	 * 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge_threads, the number of
-	 * threads to perform merge operations., an integer between 1 and 10;
-	 * default \c 2.}
 	 * @config{ ),,}
 	 * @config{memory_page_max, the maximum size a page can grow to in
 	 * memory before being reconciled to disk.  The specified size will be

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -80,8 +80,6 @@ __wt_lsm_meta_read(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 			lsm_tree->merge_max = (uint32_t)cv.val;
 		else if (WT_STRING_MATCH("merge_min", ck.str, ck.len))
 			lsm_tree->merge_min = (uint32_t)cv.val;
-		else if (WT_STRING_MATCH("merge_threads", ck.str, ck.len))
-			lsm_tree->merge_threads = (uint32_t)cv.val;
 		else if (WT_STRING_MATCH("last", ck.str, ck.len))
 			lsm_tree->last = (u_int)cv.val;
 		else if (WT_STRING_MATCH("chunks", ck.str, ck.len)) {
@@ -191,14 +189,12 @@ __wt_lsm_meta_write(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	    ",auto_throttle=%" PRIu32
 	    ",merge_max=%" PRIu32
 	    ",merge_min=%" PRIu32
-	    ",merge_threads=%" PRIu32
 	    ",bloom=%" PRIu32
 	    ",bloom_bit_count=%" PRIu32
 	    ",bloom_hash_count=%" PRIu32,
 	    lsm_tree->last, lsm_tree->chunk_max, lsm_tree->chunk_size,
 	    F_ISSET(lsm_tree, WT_LSM_TREE_THROTTLE) ? 1 : 0,
-	    lsm_tree->merge_max, lsm_tree->merge_min,
-	    lsm_tree->merge_threads, lsm_tree->bloom,
+	    lsm_tree->merge_max, lsm_tree->merge_min, lsm_tree->bloom,
 	    lsm_tree->bloom_bit_count, lsm_tree->bloom_hash_count));
 	WT_ERR(__wt_buf_catfmt(session, buf, ",chunks=["));
 	for (i = 0; i < lsm_tree->nchunks; i++) {

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -202,7 +202,7 @@ static CONFIG c[] = {
 
 	{ "merge_threads",
 	  "the number of threads to perform merge operations",
-	  0x0, 1, 4, 10, &g.c_merge_threads, NULL },
+	  0x0, 3, 4, 20, &g.c_merge_threads, NULL },
 
 	{ "mmap",
 	  "configure for mmap operations",			/* 90% */

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -92,12 +92,14 @@ wts_open(const char *home, int set_api, WT_CONNECTION **connp)
 	if (snprintf(config, sizeof(config),
 	    "create,"
 	    "checkpoint_sync=false,cache_size=%" PRIu32 "MB,"
-	    "buffer_alignment=512,error_prefix=\"%s\","
+	    "buffer_alignment=512,lsm_manager=(worker_thread_max=%" PRIu32
+	    "),error_prefix=\"%s\","
 	    "%s,%s,%s,%s,%s"
 	    "extensions="
 	    "[\"%s\", \"%s\", \"%s\", \"%s\", \"%s\", \"%s\"],"
 	    "%s,%s",
 	    g.c_cache,
+	    g.c_merge_threads,
 	    g.progname,
 	    g.c_data_extend ? "file_extend=(data=8MB)" : "",
 	    g.c_logging ? "log=(enabled=true)" : "",
@@ -321,8 +323,6 @@ wts_create(void)
 		    "bloom_oldest=%s,", g.c_bloom_oldest ? "true" : "false");
 		p += snprintf(p, (size_t)(end - p),
 		    "merge_max=%" PRIu32 ",", g.c_merge_max);
-		p += snprintf(p, (size_t)(end - p),
-		    "merge_threads=%" PRIu32 ",", g.c_merge_threads);
 		p += snprintf(p, (size_t)(end - p), ",)");
 	}
 


### PR DESCRIPTION
It's been replaced by lsm_manager=(worker_thread_max). Update
all places it was used in our tree, and add note to upgrade doc.
