### PR TITLE
Create a os shim for one-time initialization

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -112,6 +112,7 @@ src/os_posix/os_ftruncate.c
 src/os_posix/os_getline.c
 src/os_posix/os_map.c
 src/os_posix/os_mtx.c
+src/os_posix/os_once.c
 src/os_posix/os_open.c
 src/os_posix/os_priv.c
 src/os_posix/os_remove.c

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -454,6 +454,7 @@ extern int __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock);
 extern int __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock);
 extern int __wt_rwunlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock);
 extern int __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK **rwlockp);
+extern int __wt_once(void (*init_routine)(void));
 extern int __wt_open(WT_SESSION_IMPL *session, const char *name, int ok_create, int exclusive, int dio_type, WT_FH **fhp);
 extern int __wt_close(WT_SESSION_IMPL *session, WT_FH *fh);
 extern int __wt_has_priv(void);

--- a/src/os_posix/os_once.c
+++ b/src/os_posix/os_once.c
@@ -1,0 +1,26 @@
+/*-
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *  All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_once --
+ *  One-time initialization per process.
+ */
+int
+__wt_once(void (*init_routine)(void))
+{
+	static pthread_once_t once_control = PTHREAD_ONCE_INIT;
+
+	/*
+	 * Do per-process initialization once, before anything else, but only
+	 * once.  I don't know how heavy_weight pthread_once might be, so I'm
+	 * front-ending it with a local static and only using pthread_once to
+	 * avoid a race.
+	 */
+	return pthread_once(&once_control, init_routine);
+}

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -33,11 +33,11 @@ __system_is_little_endian(void)
 }
 
 /*
- * __wt_pthread_once --
+ * __wt_global_once --
  *	Global initialization, run once.
  */
 static void
-__wt_pthread_once(void)
+__wt_global_once(void)
 {
 	WT_DECL_RET;
 
@@ -64,7 +64,6 @@ __wt_pthread_once(void)
 int
 __wt_library_init(void)
 {
-	static pthread_once_t once_control = PTHREAD_ONCE_INIT;
 	static int first = 1;
 	WT_DECL_RET;
 
@@ -77,7 +76,7 @@ __wt_library_init(void)
 	 * avoid a race.
 	 */
 	if (first) {
-		if ((ret = pthread_once(&once_control, __wt_pthread_once)) != 0)
+		if ((ret = __wt_once(__wt_global_once)) != 0)
 			__wt_pthread_once_failed = ret;
 		first = 0;
 	}


### PR DESCRIPTION
I created a shim for one-time initialization to remove global.c's dependency on pthread.

The only downside of this implementation is that you cannot support multiple different one time init functions (i.e., _wt_global_once) in a process since pthread_once_t is a static of __wt_once. Let me know is this is an unsuitable design limitation.

Tested on MacOS.
