### PR TITLE
Add size specific atomics for 1, 4 & 8 byte atomic operations

### DIFF
--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -150,15 +150,15 @@ retry:
 	 * If we can set the state then the op entry is ours.
 	 * Start the next search at the next entry after this one.
 	 */
-	if (!WT_ATOMIC_CAS(op->state, WT_ASYNCOP_FREE, WT_ASYNCOP_READY)) {
+	if (!WT_ATOMIC_CAS4(op->state, WT_ASYNCOP_FREE, WT_ASYNCOP_READY)) {
 		WT_STAT_FAST_CONN_INCR(session, async_alloc_race);
 		goto retry;
 	}
 	WT_STAT_FAST_CONN_INCRV(session, async_alloc_view, view);
 	WT_RET(__async_get_format(conn, uri, config, op));
-	op->unique_id = WT_ATOMIC_ADD(async->op_id, 1);
+	op->unique_id = WT_ATOMIC_ADD8(async->op_id, 1);
 	op->optype = WT_AOP_NONE;
-	(void)WT_ATOMIC_STORE(async->ops_index, (i + 1) % conn->async_size);
+	(void)WT_ATOMIC_STORE4(async->ops_index, (i + 1) % conn->async_size);
 	*opp = op;
 	return (0);
 }
@@ -511,7 +511,7 @@ retry:
 		 */
 		__wt_sleep(0, 100000);
 
-	if (!WT_ATOMIC_CAS(async->flush_state, WT_ASYNC_FLUSH_NONE,
+	if (!WT_ATOMIC_CAS4(async->flush_state, WT_ASYNC_FLUSH_NONE,
 	    WT_ASYNC_FLUSH_IN_PROGRESS))
 		goto retry;
 	/*
@@ -521,7 +521,7 @@ retry:
 	 * things off the work queue with the lock.
 	 */
 	async->flush_count = 0;
-	(void)WT_ATOMIC_ADD(async->flush_gen, 1);
+	(void)WT_ATOMIC_ADD8(async->flush_gen, 1);
 	WT_ASSERT(session, async->flush_op.state == WT_ASYNCOP_FREE);
 	async->flush_op.state = WT_ASYNCOP_READY;
 	WT_ERR(__wt_async_op_enqueue(session, &async->flush_op));

--- a/src/async/async_op.c
+++ b/src/async/async_op.c
@@ -273,7 +273,7 @@ __wt_async_op_enqueue(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op)
 	/*
 	 * We get our slot in the ring buffer to use.
 	 */
-	my_alloc = WT_ATOMIC_ADD(async->alloc_head, 1);
+	my_alloc = WT_ATOMIC_ADD8(async->alloc_head, 1);
 	my_slot = my_alloc % async->async_qsize;
 
 	/*
@@ -293,7 +293,7 @@ __wt_async_op_enqueue(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op)
 #endif
 	WT_PUBLISH(async->async_queue[my_slot], op);
 	op->state = WT_ASYNCOP_ENQUEUED;
-	if (WT_ATOMIC_ADD(async->cur_queue, 1) > async->max_queue)
+	if (WT_ATOMIC_ADD4(async->cur_queue, 1) > async->max_queue)
 		WT_PUBLISH(async->max_queue, async->cur_queue);
 	/*
 	 * Multiple threads may be adding ops to the queue.  We need to wait

--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -67,7 +67,7 @@ retry:
 	 * a race, try again.
 	 */
 	my_consume = last_consume + 1;
-	if (!WT_ATOMIC_CAS(async->alloc_tail, last_consume, my_consume))
+	if (!WT_ATOMIC_CAS8(async->alloc_tail, last_consume, my_consume))
 		goto retry;
 	/*
 	 * This item of work is ours to process.  Clear it out of the
@@ -75,12 +75,12 @@ retry:
 	 */
 	my_slot = my_consume % async->async_qsize;
 	prev_slot = last_consume % async->async_qsize;
-	*op = WT_ATOMIC_STORE(async->async_queue[my_slot], NULL);
+	*op = WT_ATOMIC_STORE8(async->async_queue[my_slot], NULL);
 
 	WT_ASSERT(session, async->cur_queue > 0);
 	WT_ASSERT(session, *op != NULL);
 	WT_ASSERT(session, (*op)->state == WT_ASYNCOP_ENQUEUED);
-	(void)WT_ATOMIC_SUB(async->cur_queue, 1);
+	(void)WT_ATOMIC_SUB4(async->cur_queue, 1);
 	(*op)->state = WT_ASYNCOP_WORKING;
 
 	if (*op == &async->flush_op)
@@ -318,7 +318,7 @@ __wt_async_worker(void *arg)
 			 * the queue.
 			 */
 			WT_ORDERED_READ(flush_gen, async->flush_gen);
-			if (WT_ATOMIC_ADD(async->flush_count, 1) ==
+			if (WT_ATOMIC_ADD4(async->flush_count, 1) ==
 			    conn->async_workers) {
 				/*
 				 * We're last.  All workers accounted for so

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -78,7 +78,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, int *skipp)
 	 * unclear optimizing for overlapping range deletes is worth the effort.
 	 */
 	if (ref->state != WT_REF_DISK ||
-	    !WT_ATOMIC_CAS(ref->state, WT_REF_DISK, WT_REF_LOCKED))
+	    !WT_ATOMIC_CAS4(ref->state, WT_REF_DISK, WT_REF_LOCKED))
 		return (0);
 
 	/*
@@ -161,7 +161,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 			 * If the page is still "deleted", it's as we left it,
 			 * reset the state.
 			 */
-			if (WT_ATOMIC_CAS(
+			if (WT_ATOMIC_CAS4(
 			    ref->state, WT_REF_DELETED, WT_REF_DISK))
 				return;
 			break;
@@ -224,7 +224,7 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * the page could switch to an in-memory state at any time.  Lock down
 	 * the structure, just to be safe.
 	 */
-	if (!WT_ATOMIC_CAS(ref->state, WT_REF_DELETED, WT_REF_LOCKED))
+	if (!WT_ATOMIC_CAS4(ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 		return (0);
 
 	skip = ref->page_del == NULL ||

--- a/src/btree/bt_evict.c
+++ b/src/btree/bt_evict.c
@@ -69,7 +69,7 @@ __evict_list_clear(WT_SESSION_IMPL *session, WT_EVICT_ENTRY *e)
 	if (e->ref != NULL) {
 		WT_ASSERT(session,
 		    F_ISSET_ATOMIC(e->ref->page, WT_PAGE_EVICT_LRU));
-		F_CLR_ATOMIC(e->ref->page, WT_PAGE_EVICT_LRU);
+		F_CLR_ATOMIC1(e->ref->page, WT_PAGE_EVICT_LRU);
 	}
 	e->ref = NULL;
 	e->btree = WT_DEBUG_POINT;
@@ -953,7 +953,7 @@ __evict_init_candidate(
 	evict->btree = S2BT(session);
 
 	/* Mark the page on the list */
-	F_SET_ATOMIC(ref->page, WT_PAGE_EVICT_LRU);
+	F_SET_ATOMIC1(ref->page, WT_PAGE_EVICT_LRU);
 }
 
 /*
@@ -1157,7 +1157,7 @@ __evict_get_ref(
 		 * multiple attempts to evict it.  For pages that are already
 		 * being evicted, this operation will fail and we will move on.
 		 */
-		if (!WT_ATOMIC_CAS(
+		if (!WT_ATOMIC_CAS4(
 		    evict->ref->state, WT_REF_MEM, WT_REF_LOCKED)) {
 			__evict_list_clear(session, evict);
 			continue;
@@ -1167,7 +1167,7 @@ __evict_get_ref(
 		 * Increment the busy count in the btree handle to prevent it
 		 * from being closed under us.
 		 */
-		(void)WT_ATOMIC_ADD(evict->btree->evict_busy, 1);
+		(void)WT_ATOMIC_ADD4(evict->btree->evict_busy, 1);
 
 		*btreep = evict->btree;
 		*refp = evict->ref;
@@ -1219,7 +1219,7 @@ __wt_evict_lru_page(WT_SESSION_IMPL *session, int is_app)
 
 	WT_WITH_BTREE(session, btree, ret = __wt_evict_page(session, ref));
 
-	(void)WT_ATOMIC_SUB(btree->evict_busy, 1);
+	(void)WT_ATOMIC_SUB4(btree->evict_busy, 1);
 
 	WT_RET(ret);
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -255,7 +255,7 @@ err:			if ((pindex = WT_INTL_INDEX_COPY(page)) != NULL) {
 
 	/* Increment the cache statistics. */
 	__wt_cache_page_inmem_incr(session, page, size);
-	(void)WT_ATOMIC_ADD(cache->pages_inmem, 1);
+	(void)WT_ATOMIC_ADD8(cache->pages_inmem, 1);
 
 	*pagep = page;
 	return (0);
@@ -330,7 +330,7 @@ __wt_page_inmem(WT_SESSION_IMPL *session,
 	WT_RET(__wt_page_alloc(
 	    session, dsk->type, dsk->recno, alloc_entries, 1, &page));
 	page->dsk = dsk;
-	F_SET_ATOMIC(page, flags);
+	F_SET_ATOMIC1(page, flags);
 
 	/*
 	 * Track the memory allocated to build this page so we can update the

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -34,9 +34,9 @@ __wt_cache_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * WT_REF_LOCKED, for deleted pages.  If successful, we've won the
 	 * race, read the page.
 	 */
-	if (WT_ATOMIC_CAS(ref->state, WT_REF_DISK, WT_REF_READING))
+	if (WT_ATOMIC_CAS4(ref->state, WT_REF_DISK, WT_REF_READING))
 		previous_state = WT_REF_DISK;
-	else if (WT_ATOMIC_CAS(ref->state, WT_REF_DELETED, WT_REF_LOCKED))
+	else if (WT_ATOMIC_CAS4(ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 		previous_state = WT_REF_DELETED;
 	else
 		return (0);

--- a/src/btree/rec_evict.c
+++ b/src/btree/rec_evict.c
@@ -449,7 +449,7 @@ __hazard_exclusive(WT_SESSION_IMPL *session, WT_REF *ref, int top)
 	 * already be in the locked state, lock child pages in memory.
 	 * If another thread already has this page, give up.
 	 */
-	if (!top && !WT_ATOMIC_CAS(ref->state, WT_REF_MEM, WT_REF_LOCKED))
+	if (!top && !WT_ATOMIC_CAS4(ref->state, WT_REF_MEM, WT_REF_LOCKED))
 		return (EBUSY);	/* We couldn't change the state. */
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED);
 

--- a/src/btree/rec_split.c
+++ b/src/btree/rec_split.c
@@ -67,7 +67,7 @@ __split_stash_add(WT_SESSION_IMPL *session, void *p, size_t len)
 	    session->split_stash_cnt + 1, &session->split_stash));
 
 	stash = session->split_stash + session->split_stash_cnt++;
-	stash->split_gen = WT_ATOMIC_ADD(S2C(session)->split_gen, 1);
+	stash->split_gen = WT_ATOMIC_ADD8(S2C(session)->split_gen, 1);
 	stash->p = p;
 	stash->len = len;
 
@@ -861,11 +861,11 @@ __wt_split_evict(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 	 */
 	for (;;) {
 		parent = ref->home;
-		F_CAS_ATOMIC(parent, WT_PAGE_SPLITTING, ret);
+		F_CAS_ATOMIC1(parent, WT_PAGE_SPLITTING, ret);
 		if (ret == 0) {
 			if (parent == ref->home)
 				break;
-			F_CLR_ATOMIC(parent, WT_PAGE_SPLITTING);
+			F_CLR_ATOMIC1(parent, WT_PAGE_SPLITTING);
 			continue;
 		}
 		__wt_yield();
@@ -1018,7 +1018,7 @@ __wt_split_evict(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 		ret = __split_deepen(session, parent);
 
 err:	if (locked)
-		F_CLR_ATOMIC(parent, WT_PAGE_SPLITTING);
+		F_CLR_ATOMIC1(parent, WT_PAGE_SPLITTING);
 
 	if (hazard)
 		WT_TRET(__wt_hazard_clear(session, parent));

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -384,7 +384,7 @@ __wt_rec_write(WT_SESSION_IMPL *session,
 		WT_PAGE_LOCK(session, page);
 	} else
 		for (;;) {
-			F_CAS_ATOMIC(page, WT_PAGE_SCANNING, ret);
+			F_CAS_ATOMIC1(page, WT_PAGE_SCANNING, ret);
 			if (ret == 0)
 				break;
 			__wt_yield();
@@ -423,7 +423,7 @@ __wt_rec_write(WT_SESSION_IMPL *session,
 	if (locked)
 		WT_PAGE_UNLOCK(session, page);
 	else
-		F_CLR_ATOMIC(page, WT_PAGE_SCANNING);
+		F_CLR_ATOMIC1(page, WT_PAGE_SCANNING);
 
 	/*
 	 * Clean up the boundary structures: some workloads result in millions
@@ -1051,7 +1051,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			 * to see if the delete is visible to us.  Lock down the
 			 * structure.
 			 */
-			if (!WT_ATOMIC_CAS(
+			if (!WT_ATOMIC_CAS4(
 			    ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 				break;
 			ret = __rec_child_deleted(session, r, ref, statep);
@@ -4913,7 +4913,7 @@ err:			__wt_scr_free(&tkey);
 	if (!r->leave_dirty) {
 		mod->rec_max_txn = r->max_txn;
 
-		if (WT_ATOMIC_CAS(mod->write_gen, r->orig_write_gen, 0))
+		if (WT_ATOMIC_CAS4(mod->write_gen, r->orig_write_gen, 0))
 			__wt_cache_dirty_decr(session, page);
 	}
 

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -26,7 +26,7 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
 	btree = S2BT(session);
 
 	if (page->pg_row_entries == 0) {		/* Just checking... */
-		F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
+		F_SET_ATOMIC1(page, WT_PAGE_BUILD_KEYS);
 		return (0);
 	}
 
@@ -62,7 +62,7 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
 			WT_ERR(__wt_row_leaf_key_work(
 			    session, page, rip, key, 1));
 
-	F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
+	F_SET_ATOMIC1(page, WT_PAGE_BUILD_KEYS);
 
 err:	__wt_scr_free(&key);
 	__wt_scr_free(&tmp);
@@ -447,7 +447,7 @@ next:		switch (direction) {
 			 * update the page's memory footprint, on failure, free
 			 * the allocated memory.
 			 */
-			if (WT_ATOMIC_CAS(WT_ROW_KEY_COPY(rip), copy, ikey))
+			if (WT_ATOMIC_CAS8(WT_ROW_KEY_COPY(rip), copy, ikey))
 				__wt_cache_page_inmem_incr(session,
 				    page, sizeof(WT_IKEY) + ikey->size);
 			else

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -278,7 +278,7 @@ __wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 	 */
 	if (first != NULL &&
 	    (next = first->next) != NULL &&
-	    WT_ATOMIC_CAS(first->next, next, NULL))
+	    WT_ATOMIC_CAS8(first->next, next, NULL))
 		return (next);
 
 	return (NULL);

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -243,7 +243,7 @@ __wt_conn_cache_pool_open(WT_SESSION_IMPL *session)
 	 * in each connection saves having a complex election process when
 	 * the active connection shuts down.
 	 */
-	F_SET_ATOMIC(cp, WT_CACHE_POOL_ACTIVE);
+	F_SET_ATOMIC4(cp, WT_CACHE_POOL_ACTIVE);
 	F_SET(cache, WT_CACHE_POOL_RUN);
 	WT_RET(__wt_thread_create(session, &cache->cp_tid,
 	    __wt_cache_pool_server, cache->cp_session));
@@ -334,7 +334,7 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
 
 	if (--cp->refs == 0) {
 		WT_ASSERT(session, TAILQ_EMPTY(&cp->cache_pool_qh));
-		F_CLR_ATOMIC(cp, WT_CACHE_POOL_ACTIVE);
+		F_CLR_ATOMIC4(cp, WT_CACHE_POOL_ACTIVE);
 	}
 
 	if (!F_ISSET_ATOMIC(cp, WT_CACHE_POOL_ACTIVE)) {
@@ -366,7 +366,7 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
 
 		/* Notify other participants if we were managing */
 		if (F_ISSET(cache, WT_CACHE_POOL_MANAGER)) {
-			F_CLR_ATOMIC(cp, WT_CACHE_POOL_MANAGED);
+			F_CLR_ATOMIC4(cp, WT_CACHE_POOL_MANAGED);
 			WT_TRET(__wt_verbose(session, WT_VERB_SHARED_CACHE,
 			    "Shutting down shared cache manager connection"));
 		}
@@ -617,7 +617,7 @@ __wt_cache_pool_server(void *arg)
 			break;
 
 		/* Try to become the managing thread */
-		F_CAS_ATOMIC(cp, WT_CACHE_POOL_MANAGED, ret);
+		F_CAS_ATOMIC4(cp, WT_CACHE_POOL_MANAGED, ret);
 		if (ret == 0) {
 			F_SET(cache, WT_CACHE_POOL_MANAGER);
 			WT_ERR(__wt_verbose(session, WT_VERB_SHARED_CACHE,

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -104,7 +104,7 @@ __conn_dhandle_get(WT_SESSION_IMPL *session,
 		    strcmp(ckpt, dhandle->checkpoint) == 0))) {
 			WT_RET(__conn_dhandle_open_lock(
 			    session, dhandle, flags));
-			(void)WT_ATOMIC_ADD(dhandle->session_ref, 1);
+			(void)WT_ATOMIC_ADD4(dhandle->session_ref, 1);
 			session->dhandle = dhandle;
 			return (0);
 		}
@@ -503,7 +503,7 @@ err:	session->dhandle = saved_dhandle;
 void
 __wt_conn_btree_close(WT_SESSION_IMPL *session)
 {
-	(void)WT_ATOMIC_SUB(session->dhandle->session_ref, 1);
+	(void)WT_ATOMIC_SUB4(session->dhandle->session_ref, 1);
 }
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -911,7 +911,7 @@ struct __wt_insert {
 #define	WT_PAGE_ALLOC_AND_SWAP(s, page, dest, v, count)	do {		\
 	if (((v) = (dest)) == NULL) {					\
 		WT_ERR(__wt_calloc_def(s, count, &(v)));		\
-		if (WT_ATOMIC_CAS(dest, NULL, v))			\
+		if (WT_ATOMIC_CAS8(dest, NULL, v))			\
 			__wt_cache_page_inmem_incr(			\
 			    s, page, (count) * sizeof(*(v)));		\
 		else							\

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -45,11 +45,11 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
 	size += WT_ALLOC_OVERHEAD;
 
 	cache = S2C(session)->cache;
-	(void)WT_ATOMIC_ADD(cache->bytes_inmem, size);
-	(void)WT_ATOMIC_ADD(page->memory_footprint, size);
+	(void)WT_ATOMIC_ADD8(cache->bytes_inmem, size);
+	(void)WT_ATOMIC_ADD8(page->memory_footprint, size);
 	if (__wt_page_is_modified(page)) {
-		(void)WT_ATOMIC_ADD(cache->bytes_dirty, size);
-		(void)WT_ATOMIC_ADD(page->modify->bytes_dirty, size);
+		(void)WT_ATOMIC_ADD8(cache->bytes_dirty, size);
+		(void)WT_ATOMIC_ADD8(page->modify->bytes_dirty, size);
 	}
 }
 
@@ -65,11 +65,11 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
 	size += WT_ALLOC_OVERHEAD;
 
 	cache = S2C(session)->cache;
-	(void)WT_ATOMIC_SUB(cache->bytes_inmem, size);
-	(void)WT_ATOMIC_SUB(page->memory_footprint, size);
+	(void)WT_ATOMIC_SUB8(cache->bytes_inmem, size);
+	(void)WT_ATOMIC_SUB8(page->memory_footprint, size);
 	if (__wt_page_is_modified(page)) {
-		(void)WT_ATOMIC_SUB(cache->bytes_dirty, size);
-		(void)WT_ATOMIC_SUB(page->modify->bytes_dirty, size);
+		(void)WT_ATOMIC_SUB8(cache->bytes_dirty, size);
+		(void)WT_ATOMIC_SUB8(page->modify->bytes_dirty, size);
 	}
 }
 
@@ -84,15 +84,15 @@ __wt_cache_dirty_incr(WT_SESSION_IMPL *session, WT_PAGE *page)
 	size_t size;
 
 	cache = S2C(session)->cache;
-	(void)WT_ATOMIC_ADD(cache->pages_dirty, 1);
+	(void)WT_ATOMIC_ADD8(cache->pages_dirty, 1);
 
 	/*
 	 * Take care to read the memory_footprint once in case we are racing
 	 * with updates.
 	 */
 	size = page->memory_footprint;
-	(void)WT_ATOMIC_ADD(cache->bytes_dirty, size);
-	(void)WT_ATOMIC_ADD(page->modify->bytes_dirty, size);
+	(void)WT_ATOMIC_ADD8(cache->bytes_dirty, size);
+	(void)WT_ATOMIC_ADD8(page->modify->bytes_dirty, size);
 }
 
 /*
@@ -113,7 +113,7 @@ __wt_cache_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 		   "negative");
 		cache->pages_dirty = 0;
 	} else
-		(void)WT_ATOMIC_SUB(cache->pages_dirty, 1);
+		(void)WT_ATOMIC_SUB8(cache->pages_dirty, 1);
 
 	/*
 	 * It is possible to decrement the footprint of the page without making
@@ -131,8 +131,8 @@ __wt_cache_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * the page is evicted.
 	 */
 	size = WT_MIN(page->memory_footprint, cache->bytes_dirty);
-	(void)WT_ATOMIC_SUB(cache->bytes_dirty, size);
-	(void)WT_ATOMIC_SUB(page->modify->bytes_dirty, size);
+	(void)WT_ATOMIC_SUB8(cache->bytes_dirty, size);
+	(void)WT_ATOMIC_SUB8(page->modify->bytes_dirty, size);
 }
 
 /*
@@ -154,13 +154,13 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * we can fix the global stats.
 	 */
 	if (mod != NULL && mod->bytes_dirty != 0)
-		(void)WT_ATOMIC_SUB(cache->bytes_dirty, mod->bytes_dirty);
+		(void)WT_ATOMIC_SUB8(cache->bytes_dirty, mod->bytes_dirty);
 
 	WT_ASSERT(session, page->memory_footprint != 0);
-	(void)WT_ATOMIC_ADD(cache->bytes_evict, page->memory_footprint);
+	(void)WT_ATOMIC_ADD8(cache->bytes_evict, page->memory_footprint);
 	page->memory_footprint = 0;
 
-	(void)WT_ATOMIC_ADD(cache->pages_evict, 1);
+	(void)WT_ATOMIC_ADD8(cache->pages_evict, 1);
 }
 
 /*
@@ -308,7 +308,7 @@ __wt_page_modify_init(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * footprint, else discard the modify structure, another thread did the
 	 * work.
 	 */
-	if (WT_ATOMIC_CAS(page->modify, NULL, modify))
+	if (WT_ATOMIC_CAS8(page->modify, NULL, modify))
 		__wt_cache_page_inmem_incr(session, page, sizeof(*modify));
 	else
 		__wt_free(session, modify);
@@ -337,7 +337,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * Every time the page transitions from clean to dirty, update the cache
 	 * and transactional information.
 	 */
-	if (WT_ATOMIC_ADD(page->modify->write_gen, 1) == 1) {
+	if (WT_ATOMIC_ADD4(page->modify->write_gen, 1) == 1) {
 		__wt_cache_dirty_incr(session, page);
 
 		/*
@@ -964,12 +964,12 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * reference without first locking the page, it could be evicted in
 	 * between.
 	 */
-	locked = WT_ATOMIC_CAS(ref->state, WT_REF_MEM, WT_REF_LOCKED);
+	locked = WT_ATOMIC_CAS4(ref->state, WT_REF_MEM, WT_REF_LOCKED);
 	WT_TRET(__wt_hazard_clear(session, page));
 	if (!locked)
 		return (ret);
 
-	(void)WT_ATOMIC_ADD(btree->evict_busy, 1);
+	(void)WT_ATOMIC_ADD4(btree->evict_busy, 1);
 	if ((ret = __wt_evict_page(session, ref)) == 0)
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_force);
 	else {
@@ -977,7 +977,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 		if (ret == EBUSY)
 			ret = 0;
 	}
-	(void)WT_ATOMIC_SUB(btree->evict_busy, 1);
+	(void)WT_ATOMIC_SUB4(btree->evict_busy, 1);
 
 	return (ret);
 }

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -71,15 +71,37 @@
  */
 #if defined(__GNUC__)
 
-#define	WT_ATOMIC_ADD(v, val)						\
+#define	WT_ATOMIC_ADD1(v, val)						\
 	__sync_add_and_fetch(&(v), val)
-#define	WT_ATOMIC_CAS(v, oldv, newv)					\
+#define	WT_ATOMIC_CAS1(v, oldv, newv)					\
 	__sync_bool_compare_and_swap(&(v), oldv, newv)
-#define	WT_ATOMIC_CAS_VAL(v, oldv, newv)				\
+#define	WT_ATOMIC_CAS_VAL1(v, oldv, newv)				\
 	__sync_val_compare_and_swap(&(v), oldv, newv)
-#define	WT_ATOMIC_STORE(v, val)						\
+#define	WT_ATOMIC_STORE1(v, val)						\
 	__sync_lock_test_and_set(&(v), val)
-#define	WT_ATOMIC_SUB(v, val)						\
+#define	WT_ATOMIC_SUB1(v, val)						\
+	__sync_sub_and_fetch(&(v), val)
+
+#define	WT_ATOMIC_ADD4(v, val)						\
+	__sync_add_and_fetch(&(v), val)
+#define	WT_ATOMIC_CAS4(v, oldv, newv)					\
+	__sync_bool_compare_and_swap(&(v), oldv, newv)
+#define	WT_ATOMIC_CAS_VAL4(v, oldv, newv)				\
+	__sync_val_compare_and_swap(&(v), oldv, newv)
+#define	WT_ATOMIC_STORE4(v, val)						\
+	__sync_lock_test_and_set(&(v), val)
+#define	WT_ATOMIC_SUB4(v, val)						\
+	__sync_sub_and_fetch(&(v), val)
+
+#define	WT_ATOMIC_ADD8(v, val)						\
+	__sync_add_and_fetch(&(v), val)
+#define	WT_ATOMIC_CAS8(v, oldv, newv)					\
+	__sync_bool_compare_and_swap(&(v), oldv, newv)
+#define	WT_ATOMIC_CAS_VAL8(v, oldv, newv)				\
+	__sync_val_compare_and_swap(&(v), oldv, newv)
+#define	WT_ATOMIC_STORE8(v, val)						\
+	__sync_lock_test_and_set(&(v), val)
+#define	WT_ATOMIC_SUB8(v, val)						\
 	__sync_sub_and_fetch(&(v), val)
 
 /* Compile read-write barrier */
@@ -111,13 +133,29 @@
 
 #elif defined(_lint)
 
-#define	WT_ATOMIC_ADD(v, val)			((v) += (val), (v))
-#define	WT_ATOMIC_CAS(v, oldv, newv)					\
+#define	WT_ATOMIC_ADD1(v, val)			((v) += (val), (v))
+#define	WT_ATOMIC_CAS1(v, oldv, newv)					\
     ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
-#define	WT_ATOMIC_CAS_VAL(v, oldv, newv)				\
+#define	WT_ATOMIC_CAS_VAL1(v, oldv, newv)				\
     ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
-#define	WT_ATOMIC_STORE(v, val)			((v) = (val))
-#define	WT_ATOMIC_SUB(v, val)			((v) -= (val), (v))
+#define	WT_ATOMIC_STORE1(v, val)			((v) = (val))
+#define	WT_ATOMIC_SUB1(v, val)			((v) -= (val), (v))
+
+#define	WT_ATOMIC_ADD4(v, val)			((v) += (val), (v))
+#define	WT_ATOMIC_CAS4(v, oldv, newv)					\
+    ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
+#define	WT_ATOMIC_CAS_VAL4(v, oldv, newv)				\
+    ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
+#define	WT_ATOMIC_STORE4(v, val)			((v) = (val))
+#define	WT_ATOMIC_SUB4(v, val)			((v) -= (val), (v))
+
+#define	WT_ATOMIC_ADD8(v, val)			((v) += (val), (v))
+#define	WT_ATOMIC_CAS8(v, oldv, newv)					\
+    ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
+#define	WT_ATOMIC_CAS_VAL8(v, oldv, newv)				\
+    ((v) = ((v) == (oldv) ? (newv) : (oldv)), (v) == (oldv))
+#define	WT_ATOMIC_STORE8(v, val)			((v) = (val))
+#define	WT_ATOMIC_SUB8(v, val)			((v) -= (val), (v))
 
 static inline void WT_BARRIER(void) { return; }
 static inline void WT_FULL_BARRIER(void) { return; }
@@ -167,34 +205,47 @@ static inline void WT_WRITE_BARRIER(void) { return; }
 
 #define	F_ISSET_ATOMIC(p, mask)	((p)->flags_atomic & (uint32_t)(mask))
 
-#define	F_SET_ATOMIC(p, mask)	do {					\
-	uint32_t __orig;						\
+#define	F_SET_ATOMIC_BASE(p, mask, type, func)	do {					\
+	type __orig;						\
 	do {								\
 		__orig = (p)->flags_atomic;				\
-	} while (!WT_ATOMIC_CAS((p)->flags_atomic,			\
-	    __orig, __orig | (uint32_t)(mask)));			\
+	} while (!func((p)->flags_atomic,			\
+	    __orig, __orig | (type)(mask)));			\
 } while (0)
 
-#define	F_CAS_ATOMIC(p, mask, ret)	do {				\
-	uint32_t __orig;						\
+#define	F_CAS_ATOMIC_BASE(p, mask, ret, type, func)	do {				\
+	type __orig;						\
 	ret = 0;							\
 	do {								\
 		__orig = (p)->flags_atomic;				\
-		if ((__orig & (uint32_t)(mask)) != 0) {			\
+		if ((__orig & (type)(mask)) != 0) {			\
 			ret = EBUSY;					\
 			break;						\
 		}							\
-	} while (!WT_ATOMIC_CAS((p)->flags_atomic,			\
-	    __orig, __orig | (uint32_t)(mask)));			\
+	} while (!func((p)->flags_atomic,			\
+	    __orig, __orig | (type)(mask)));			\
 } while (0)
 
-#define	F_CLR_ATOMIC(p, mask)	do {					\
-	uint32_t __orig;						\
+#define	F_CLR_ATOMIC_BASE(p, mask, type, func)	do {					\
+	type __orig;						\
 	do {								\
 		__orig = (p)->flags_atomic;				\
-	} while (!WT_ATOMIC_CAS((p)->flags_atomic,			\
-	    __orig, __orig & ~(uint32_t)(mask)));			\
+	} while (!func((p)->flags_atomic,			\
+	    __orig, __orig & ~(type)(mask)));			\
 } while (0)
+
+#define F_SET_ATOMIC1(p, mask)      F_SET_ATOMIC_BASE(p, mask, uint8_t, WT_ATOMIC_CAS1)
+
+#define F_CAS_ATOMIC1(p, mask, ret) F_CAS_ATOMIC_BASE(p, mask, ret, uint8_t, WT_ATOMIC_CAS1)
+
+#define F_CLR_ATOMIC1(p, mask)      F_CLR_ATOMIC_BASE(p, mask, uint8_t, WT_ATOMIC_CAS1)
+
+#define F_SET_ATOMIC4(p, mask)      F_SET_ATOMIC_BASE(p, mask, uint32_t, WT_ATOMIC_CAS4)
+
+#define F_CAS_ATOMIC4(p, mask, ret) F_CAS_ATOMIC_BASE(p, mask, ret, uint32_t, WT_ATOMIC_CAS4)
+
+#define F_CLR_ATOMIC4(p, mask)      F_CLR_ATOMIC_BASE(p, mask, uint32_t, WT_ATOMIC_CAS4)
+
 #endif
 
 #define	WT_CACHE_LINE_ALIGNMENT	64	/* Cache line alignment */

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -122,7 +122,7 @@ __update_serial_func(WT_SESSION_IMPL *session,
 	 * and if it is, do a full-barrier to ensure the update's next pointer
 	 * is set before we update the linked list and try again.
 	 */
-	while (!WT_ATOMIC_CAS(*upd_entry, upd->next, upd)) {
+	while (!WT_ATOMIC_CAS8(*upd_entry, upd->next, upd)) {
 		WT_RET(__wt_txn_update_check(session, upd->next = *upd_entry));
 		WT_WRITE_BARRIER();
 	}
@@ -136,12 +136,12 @@ __update_serial_func(WT_SESSION_IMPL *session,
 	 */
 	if (upd->next != NULL &&
 	    F_ISSET(S2C(session)->cache, WT_EVICT_ACTIVE)) {
-		F_CAS_ATOMIC(page, WT_PAGE_SCANNING, ret);
+		F_CAS_ATOMIC1(page, WT_PAGE_SCANNING, ret);
 		/* If we can't lock it, don't scan, that's okay. */
 		if (ret != 0)
 			return (0);
 		obsolete = __wt_update_obsolete_check(session, upd->next);
-		F_CLR_ATOMIC(page, WT_PAGE_SCANNING);
+		F_CLR_ATOMIC1(page, WT_PAGE_SCANNING);
 		if (obsolete != NULL)
 			__wt_update_obsolete_free(session, page, obsolete);
 	}

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -16,11 +16,11 @@ struct __wt_stats {
 #define	WT_STAT(stats, fld)						\
 	((stats)->fld.v)
 #define	WT_STAT_ATOMIC_DECRV(stats, fld, value) do {			\
-	(void)WT_ATOMIC_SUB(WT_STAT(stats, fld), (value));		\
+	(void)WT_ATOMIC_SUB8(WT_STAT(stats, fld), (value));		\
 } while (0)
 #define	WT_STAT_ATOMIC_DECR(stats, fld) WT_STAT_ATOMIC_DECRV(stats, fld, 1)
 #define	WT_STAT_ATOMIC_INCRV(stats, fld, value) do {			\
-	(void)WT_ATOMIC_ADD(WT_STAT(stats, fld), (value));		\
+	(void)WT_ATOMIC_ADD8(WT_STAT(stats, fld), (value));		\
 } while (0)
 #define	WT_STAT_ATOMIC_INCR(stats, fld) WT_ATOMIC_ADD(WT_STAT(stats, fld), 1)
 #define	WT_STAT_DECRV(stats, fld, value) do {				\

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -208,7 +208,7 @@ __wt_txn_new_id(WT_SESSION_IMPL *session)
 	 * global current ID, so we want post-increment semantics.  Our atomic
 	 * add primitive does pre-increment, so adjust the result here.
 	 */
-	return WT_ATOMIC_ADD(S2C(session)->txn_global.current, 1) - 1;
+	return WT_ATOMIC_ADD8(S2C(session)->txn_global.current, 1) - 1;
 }
 
 /*
@@ -254,7 +254,7 @@ __wt_txn_id_check(WT_SESSION_IMPL *session)
 		 */
 		do {
 			txn_state->id = txn->id = txn_global->current;
-		} while (!WT_ATOMIC_CAS(
+		} while (!WT_ATOMIC_CAS8(
 		    txn_global->current, txn->id, txn->id + 1));
 
 		/*

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -141,7 +141,7 @@ join_slot:
 		}
 		goto find_slot;
 	}
-	cur_state = WT_ATOMIC_CAS_VAL(slot->slot_state, old_state, new_state);
+	cur_state = WT_ATOMIC_CAS_VAL8(slot->slot_state, old_state, new_state);
 	/*
 	 * We lost a race to add our size into this slot.  Check the state
 	 * and try again.
@@ -222,7 +222,7 @@ retry:
 	newslot->slot_state = WT_LOG_SLOT_READY;
 	newslot->slot_index = slot->slot_index;
 	log->slot_array[newslot->slot_index] = &log->slot_pool[pool_i];
-	old_state = WT_ATOMIC_STORE(slot->slot_state, WT_LOG_SLOT_PENDING);
+	old_state = WT_ATOMIC_STORE8(slot->slot_state, WT_LOG_SLOT_PENDING);
 	slot->slot_group_size = (uint64_t)(old_state - WT_LOG_SLOT_READY);
 	/*
 	 * Note that this statistic may be much bigger than in reality,
@@ -278,7 +278,7 @@ __wt_log_slot_release(WT_LOGSLOT *slot, uint64_t size)
 	 * Add my size into the state.  When it reaches WT_LOG_SLOT_DONE
 	 * all participatory threads have completed copying their piece.
 	 */
-	newsize = WT_ATOMIC_ADD(slot->slot_state, (int64_t)size);
+	newsize = WT_ATOMIC_ADD8(slot->slot_state, (int64_t)size);
 	return (newsize);
 }
 
@@ -331,10 +331,10 @@ __wt_log_slot_grow_buffers(WT_SESSION_IMPL *session, size_t newsize)
 		if (slot->slot_buf.memsize > (10 * newsize) &&
 		    !F_ISSET(slot, SLOT_BUF_GROW))
 			continue;
-		orig_state = WT_ATOMIC_CAS_VAL(
+		orig_state = WT_ATOMIC_CAS_VAL8(
 		    slot->slot_state, WT_LOG_SLOT_FREE, WT_LOG_SLOT_PENDING);
 		if (orig_state != WT_LOG_SLOT_FREE) {
-			orig_state = WT_ATOMIC_CAS_VAL(slot->slot_state,
+			orig_state = WT_ATOMIC_CAS_VAL8(slot->slot_state,
 			    WT_LOG_SLOT_READY, WT_LOG_SLOT_PENDING);
 			if (orig_state != WT_LOG_SLOT_READY)
 				continue;

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -223,7 +223,7 @@ __wt_lsm_manager_free_work_unit(
 	if (entry != NULL) {
 		WT_ASSERT(session, entry->lsm_tree->queue_ref > 0);
 
-		(void)WT_ATOMIC_SUB(entry->lsm_tree->queue_ref, 1);
+		(void)WT_ATOMIC_SUB4(entry->lsm_tree->queue_ref, 1);
 		__wt_free(session, entry);
 	}
 }
@@ -648,7 +648,7 @@ __wt_lsm_manager_push_entry(WT_SESSION_IMPL *session,
 	entry->type = type;
 	entry->flags = flags;
 	entry->lsm_tree = lsm_tree;
-	(void)WT_ATOMIC_ADD(lsm_tree->queue_ref, 1);
+	(void)WT_ATOMIC_ADD4(lsm_tree->queue_ref, 1);
 	WT_STAT_FAST_CONN_INCR(session, lsm_work_units_created);
 
 	if (type == WT_LSM_WORK_SWITCH)

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -249,7 +249,7 @@ __wt_lsm_merge(
 		return (WT_NOTFOUND);
 
 	/* Allocate an ID for the merge. */
-	dest_id = WT_ATOMIC_ADD(lsm_tree->last, 1);
+	dest_id = WT_ATOMIC_ADD4(lsm_tree->last, 1);
 
 	/*
 	 * We only want to do the chunk loop if we're running with verbose,

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -118,7 +118,7 @@ __wt_lsm_tree_close_all(WT_SESSION_IMPL *session)
 		 * is no need to decrement the reference count since destroy
 		 * is unconditional.
 		 */
-		(void)WT_ATOMIC_ADD(lsm_tree->refcnt, 1);
+		(void)WT_ATOMIC_ADD4(lsm_tree->refcnt, 1);
 		WT_TRET(__lsm_tree_close(session, lsm_tree));
 		WT_TRET(__lsm_tree_discard(session, lsm_tree));
 	}
@@ -426,7 +426,7 @@ __lsm_tree_open(
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_SCHEMA_LOCKED));
 
 	/* Start the LSM manager thread if it isn't running. */
-	if (WT_ATOMIC_CAS(conn->lsm_manager.lsm_workers, 0, 1))
+	if (WT_ATOMIC_CAS4(conn->lsm_manager.lsm_workers, 0, 1))
 		WT_RET(__wt_lsm_manager_start(session));
 
 	/* Make sure no one beat us to it. */
@@ -507,13 +507,13 @@ __wt_lsm_tree_get(WT_SESSION_IMPL *session,
 			    return (EBUSY);
 
 			if (exclusive) {
-				F_SET_ATOMIC(lsm_tree, WT_LSM_TREE_EXCLUSIVE);
-				if (!WT_ATOMIC_CAS(lsm_tree->refcnt, 0, 1)) {
+				F_SET_ATOMIC4(lsm_tree, WT_LSM_TREE_EXCLUSIVE);
+				if (!WT_ATOMIC_CAS4(lsm_tree->refcnt, 0, 1)) {
 					F_CLR(lsm_tree, WT_LSM_TREE_EXCLUSIVE);
 					return (EBUSY);
 				}
 			} else
-				(void)WT_ATOMIC_ADD(lsm_tree->refcnt, 1);
+				(void)WT_ATOMIC_ADD4(lsm_tree->refcnt, 1);
 
 			/*
 			 * If we got a reference, but an exclusive reference
@@ -521,7 +521,7 @@ __wt_lsm_tree_get(WT_SESSION_IMPL *session,
 			 */
 			if (!exclusive &&
 			    F_ISSET_ATOMIC(lsm_tree, WT_LSM_TREE_EXCLUSIVE)) {
-				(void)WT_ATOMIC_SUB(lsm_tree->refcnt, 1);
+				(void)WT_ATOMIC_SUB4(lsm_tree->refcnt, 1);
 				return (EBUSY);
 			}
 			*treep = lsm_tree;
@@ -540,8 +540,8 @@ void
 __wt_lsm_tree_release(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 {
 	WT_ASSERT(session, lsm_tree->refcnt > 0);
-	(void)WT_ATOMIC_SUB(lsm_tree->refcnt, 1);
-	F_CLR_ATOMIC(lsm_tree, WT_LSM_TREE_EXCLUSIVE);
+	(void)WT_ATOMIC_SUB4(lsm_tree->refcnt, 1);
+	F_CLR_ATOMIC4(lsm_tree, WT_LSM_TREE_EXCLUSIVE);
 }
 
 /* How aggressively to ramp up or down throttle due to level 0 merging */
@@ -735,7 +735,7 @@ __wt_lsm_tree_switch(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	/* Update the throttle time. */
 	__wt_lsm_tree_throttle(session, lsm_tree, 0);
 
-	new_id = WT_ATOMIC_ADD(lsm_tree->last, 1);
+	new_id = WT_ATOMIC_ADD4(lsm_tree->last, 1);
 
 	WT_ERR(__wt_realloc_def(session, &lsm_tree->chunk_alloc,
 	    nchunks + 1, &lsm_tree->chunk));
@@ -925,7 +925,7 @@ __wt_lsm_tree_truncate(
 
 	/* Create the new chunk. */
 	WT_ERR(__wt_calloc_def(session, 1, &chunk));
-	chunk->id = WT_ATOMIC_ADD(lsm_tree->last, 1);
+	chunk->id = WT_ATOMIC_ADD4(lsm_tree->last, 1);
 	WT_ERR(__wt_lsm_tree_setup_chunk(session, lsm_tree, chunk));
 
 	/* Mark all chunks old. */
@@ -1064,7 +1064,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 		 * If we have a chunk, we want to look for it to be on-disk.
 		 * So we need to add a reference to keep it available.
 		 */
-		(void)WT_ATOMIC_ADD(chunk->refcnt, 1);
+		(void)WT_ATOMIC_ADD4(chunk->refcnt, 1);
 		ref = 1;
 	}
 
@@ -1110,7 +1110,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 				    "Compact flush done %s chunk %u.  "
 				    "Start compacting",
 				    name, chunk->id));
-				(void)WT_ATOMIC_SUB(chunk->refcnt, 1);
+				(void)WT_ATOMIC_SUB4(chunk->refcnt, 1);
 				flushing = ref = 0;
 				compacting = 1;
 				F_SET(lsm_tree, WT_LSM_TREE_COMPACTING);
@@ -1160,7 +1160,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 err:
 	/* Ensure anything we set is cleared. */
 	if (ref)
-		(void)WT_ATOMIC_SUB(chunk->refcnt, 1);
+		(void)WT_ATOMIC_SUB4(chunk->refcnt, 1);
 	if (compacting) {
 		F_CLR(lsm_tree, WT_LSM_TREE_COMPACTING);
 		lsm_tree->merge_aggressiveness = 0;

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -52,7 +52,7 @@ __lsm_copy_chunks(WT_SESSION_IMPL *session,
 	 * it's safe.
 	 */
 	for (i = 0; i < nchunks; i++)
-		(void)WT_ATOMIC_ADD(cookie->chunk_array[i]->refcnt, 1);
+		(void)WT_ATOMIC_ADD4(cookie->chunk_array[i]->refcnt, 1);
 
 err:	WT_TRET(__wt_lsm_tree_unlock(session, lsm_tree));
 
@@ -86,7 +86,7 @@ __wt_lsm_get_chunk_to_flush(WT_SESSION_IMPL *session,
 	end = force ? lsm_tree->nchunks : lsm_tree->nchunks - 1;
 	for (i = 0; i < end; i++) {
 		if (!F_ISSET(lsm_tree->chunk[i], WT_LSM_CHUNK_ONDISK)) {
-			(void)WT_ATOMIC_ADD(lsm_tree->chunk[i]->refcnt, 1);
+			(void)WT_ATOMIC_ADD4(lsm_tree->chunk[i]->refcnt, 1);
 			WT_RET(__wt_verbose(session, WT_VERB_LSM,
 			    "Flush%s: return chunk %u of %u: %s",
 			    force ? " w/ force" : "", i, end - 1,
@@ -115,7 +115,7 @@ __lsm_unpin_chunks(WT_SESSION_IMPL *session, WT_LSM_WORKER_COOKIE *cookie)
 		if (cookie->chunk_array[i] == NULL)
 			continue;
 		WT_ASSERT(session, cookie->chunk_array[i]->refcnt > 0);
-		(void)WT_ATOMIC_SUB(cookie->chunk_array[i]->refcnt, 1);
+		(void)WT_ATOMIC_SUB4(cookie->chunk_array[i]->refcnt, 1);
 	}
 	/* Ensure subsequent calls don't double decrement. */
 	cookie->nchunks = 0;
@@ -186,7 +186,7 @@ __wt_lsm_work_bloom(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		 * See if we win the race to switch on the "busy" flag and
 		 * recheck that the chunk still needs a Bloom filter.
 		 */
-		if (WT_ATOMIC_CAS(chunk->bloom_busy, 0, 1)) {
+		if (WT_ATOMIC_CAS4(chunk->bloom_busy, 0, 1)) {
 			if (!F_ISSET(chunk, WT_LSM_CHUNK_BLOOM)) {
 				ret = __lsm_bloom_create(
 				    session, lsm_tree, chunk, (u_int)i);
@@ -504,7 +504,7 @@ __wt_lsm_free_chunks(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	 * Make sure only a single thread is freeing the old chunk array
 	 * at any time.
 	 */
-	if (!WT_ATOMIC_CAS(lsm_tree->freeing_old_chunks, 0, 1))
+	if (!WT_ATOMIC_CAS4(lsm_tree->freeing_old_chunks, 0, 1))
 		return (0);
 	/*
 	 * Take a copy of the current state of the LSM tree and look for chunks

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -64,7 +64,7 @@ __lsm_worker_general_op(
 			ret = __wt_lsm_checkpoint_chunk(
 			    session, entry->lsm_tree, chunk);
 			WT_ASSERT(session, chunk->refcnt > 0);
-			(void)WT_ATOMIC_SUB(chunk->refcnt, 1);
+			(void)WT_ATOMIC_SUB4(chunk->refcnt, 1);
 			WT_ERR(ret);
 		}
 	} else if (entry->type == WT_LSM_WORK_DROP)

--- a/src/os_posix/os_mtx.c
+++ b/src/os_posix/os_mtx.c
@@ -54,7 +54,7 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs)
 	WT_ASSERT(session, usecs >= 0);
 
 	/* Fast path if already signalled. */
-	if (WT_ATOMIC_ADD(cond->waiters, 1) == 0)
+	if (WT_ATOMIC_ADD4(cond->waiters, 1) == 0)
 		return (0);
 
 	/*
@@ -89,7 +89,7 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs)
 	    ret == ETIMEDOUT)
 		ret = 0;
 
-	(void)WT_ATOMIC_SUB(cond->waiters, 1);
+	(void)WT_ATOMIC_SUB4(cond->waiters, 1);
 
 err:	if (locked)
 		WT_TRET(pthread_mutex_unlock(&cond->mtx));
@@ -122,7 +122,7 @@ __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond)
 	if (cond->waiters == -1)
 		return (0);
 
-	if (cond->waiters > 0 || !WT_ATOMIC_CAS(cond->waiters, 0, -1)) {
+	if (cond->waiters > 0 || !WT_ATOMIC_CAS4(cond->waiters, 0, -1)) {
 		WT_ERR(pthread_mutex_lock(&cond->mtx));
 		locked = 1;
 		WT_ERR(pthread_cond_broadcast(&cond->cond));

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -18,7 +18,7 @@ __wt_session_dhandle_incr_use(WT_SESSION_IMPL *session)
 
 	dhandle = session->dhandle;
 
-	(void)WT_ATOMIC_ADD(dhandle->session_inuse, 1);
+	(void)WT_ATOMIC_ADD4(dhandle->session_inuse, 1);
 }
 
 /*
@@ -38,7 +38,7 @@ __wt_session_dhandle_decr_use(WT_SESSION_IMPL *session)
 	 * the last reference, set the time-of-death timestamp.
 	 */
 	WT_ASSERT(session, dhandle->session_inuse > 0);
-	if (WT_ATOMIC_SUB(dhandle->session_inuse, 1) == 0)
+	if (WT_ATOMIC_SUB4(dhandle->session_inuse, 1) == 0)
 		WT_TRET(__wt_seconds(session, &dhandle->timeofdeath));
 	return (0);
 }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -131,7 +131,7 @@ __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot, int pin_reads)
 		if ((count = txn_global->scan_count) < 0)
 			WT_PAUSE();
 	} while (count < 0 ||
-	    !WT_ATOMIC_CAS(txn_global->scan_count, count, count + 1));
+	    !WT_ATOMIC_CAS4(txn_global->scan_count, count, count + 1));
 
 	/* The oldest ID cannot change until the scan count goes to zero. */
 	prev_oldest_id = txn_global->oldest_id;
@@ -212,7 +212,7 @@ __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot, int pin_reads)
 	 */
 	if (TXNID_LT(prev_oldest_id, oldest_id) &&
 	    (!get_snapshot || oldest_id - prev_oldest_id > 100) &&
-	    WT_ATOMIC_CAS(txn_global->scan_count, 1, -1)) {
+	    WT_ATOMIC_CAS4(txn_global->scan_count, 1, -1)) {
 		WT_ORDERED_READ(session_cnt, conn->session_cnt);
 		for (i = 0, s = txn_global->states; i < session_cnt; i++, s++) {
 			if ((id = s->id) != WT_TXN_NONE &&
@@ -227,7 +227,7 @@ __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot, int pin_reads)
 		txn_global->scan_count = 0;
 	} else {
 		WT_ASSERT(session, txn_global->scan_count > 0);
-		(void)WT_ATOMIC_SUB(txn_global->scan_count, 1);
+		(void)WT_ATOMIC_SUB4(txn_global->scan_count, 1);
 	}
 
 	if (get_snapshot)


### PR DESCRIPTION
Some compilers use size specific intrinsics for atomics instead of GCC/Clang's automatic size derivation.

I added macros for 1, 4, and 8 byte atomics. I did not find any use of 2 byte atomics so I did not add any at this time. I could add them for uniformity.
