### PR TITLE
Fix backup on Windows by using O_BINARY

### DIFF
--- a/src/include/posix.h
+++ b/src/include/posix.h
@@ -15,3 +15,6 @@
 #ifndef	LLONG_MIN
 #define	LLONG_MIN	(-0x7fffffffffffffffLL - 1)
 #endif
+
+/* Define O_BINARY for Posix systems */
+#define	O_BINARY 	0

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -127,13 +127,14 @@ copy(const char *name, const char *directory)
 	/* Open the read file. */
 	if (snprintf(cbuf, CBUF_LEN, "%s/%s", home, name) >= CBUF_LEN)
 		goto memerr;
-	if ((ifd = open(cbuf, O_RDONLY, 0)) < 0)
+	if ((ifd = open(cbuf, O_BINARY | O_RDONLY, 0)) < 0)
 		goto readerr;
 
 	/* Open the write file. */
 	if (snprintf(cbuf, CBUF_LEN, "%s/%s", directory, name) >= CBUF_LEN)
 		goto memerr;
-	if ((ofd = open(cbuf, O_CREAT | O_WRONLY | O_TRUNC, 0666)) < 0)
+	if ((ofd = open(
+	    cbuf, O_BINARY | O_CREAT | O_WRONLY | O_TRUNC, 0666)) < 0)
 		goto writerr;
 
 	/* Copy the file. */


### PR DESCRIPTION
Use Binary mode for reading & writing files on Windows instead of text mode.

For reference
http://msdn.microsoft.com/en-us/library/ktss1a9b.aspx

Built on Mac OS 10.9
