### PR TITLE
MSVC & Clang Warning Cleanup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ AddOption("--enable-snappy", dest="snappy", type="string", nargs=1, action="stor
 
 env = Environment(
     CPPPATH = ["#/src/include/", "#/."],
-    CFLAGS = ["/Z7"],
+    CFLAGS = ["/Z7", "/wd4090"],
     LINKFLAGS = ["/DEBUG"],
 )
 
@@ -112,7 +112,6 @@ env.Program("wt", [
     "src/utilities/util_create.c",
     "src/utilities/util_drop.c",
     "src/utilities/util_dump.c",
-    "src/utilities/util_getopt.c",
     "src/utilities/util_list.c",
     "src/utilities/util_load.c",
     "src/utilities/util_loadtext.c",

--- a/src/include/intpack.i
+++ b/src/include/intpack.i
@@ -55,7 +55,7 @@
 	(i = (x == 0) ? (int)sizeof (x) : __builtin_clzll(x) >> 3)
 #elif defined(_MSC_VER)
 #define	WT_LEADING_ZEROS(x, i)						\
-	(i = (x == 0) ? (int)sizeof (x) : __lzcnt64(x) >> 3)
+	(i = (x == 0) ? (int)sizeof (x) : (int)__lzcnt64(x) >> 3)
 #else
 #define	WT_LEADING_ZEROS(x, i) do {					\
 	uint64_t __x = (x);						\
@@ -84,7 +84,7 @@ __wt_vpack_posint(uint8_t **pp, size_t maxlen, uint64_t x)
 	*p++ |= (len & 0xf);
 
 	for (shift = (len - 1) << 3; len != 0; --len, shift -= 8)
-		*p++ = (x >> shift);
+		*p++ = (uint8_t)(x >> shift);
 
 	*pp = p;
 	return (0);
@@ -114,7 +114,7 @@ __wt_vpack_negint(uint8_t **pp, size_t maxlen, uint64_t x)
 	*p++ |= (lz & 0xf);
 
 	for (shift = (len - 1) << 3; len != 0; shift -= 8, --len)
-		*p++ = (x >> shift);
+		*p++ = (uint8_t)(x >> shift);
 
 	*pp = p;
 	return (0);

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -6,50 +6,60 @@
  */
 #include <intrin.h>
 
+#ifndef _M_AMD64
+#error "Only x64 is supported with MSVC"
+#endif
+
 #define	inline __inline
 
 #define	WT_GCC_ATTRIBUTE(x)
 #define	WT_GCC_FUNC_ATTRIBUTE(x)
 
-#define	WT_ATOMIC_ADD(v, val, n, s)					\
+#define	WT_ATOMIC_ADD(v, val, n, s, t)					\
 	(WT_STATIC_ASSERT(sizeof(v) == (n)),				\
-	_InterlockedExchangeAdd ## s(&(v), val) + val)
-#define	WT_ATOMIC_CAS(v, old, new, n, s)				\
+	_InterlockedExchangeAdd ## s((t*)&(v), (t)(val)) + (val))
+#define	WT_ATOMIC_CAS(v, old, new, n, s, t)				\
 	(WT_STATIC_ASSERT(sizeof(v) == (n)),				\
-	_InterlockedCompareExchange ## s(&(v), new, old) == old)
-#define	WT_ATOMIC_CAS_VAL(v, old, new, n, s)				\
+	_InterlockedCompareExchange ## s				\
+	((t*)&(v), (t)(new), (t)(old)) == (t)(old))
+#define	WT_ATOMIC_CAS_VAL(v, old, new, n, s, t)				\
 	(WT_STATIC_ASSERT(sizeof(v) == (n)),				\
-	_InterlockedCompareExchange ## s(&(v), new, old))
-#define	WT_ATOMIC_STORE(v, val, n, s)					\
+	_InterlockedCompareExchange ## s((t*)&(v), (t)(new), (t)(old)))
+#define	WT_ATOMIC_STORE(v, val, n, s, t)				\
 	(WT_STATIC_ASSERT(sizeof(v) == (n)),				\
-	_InterlockedExchange ## s(&(v), val))
+	_InterlockedExchange ## s((t*)&(v), (t)(val)))
 #define	WT_ATOMIC_SUB(v, val, n, s, t)					\
 	(WT_STATIC_ASSERT(sizeof(v) == (n)),				\
-	_InterlockedExchangeAdd ## s(&(v), -(t) val) - val)
+	_InterlockedExchangeAdd ## s((t*)&(v), -(t) val) - (val))
 
-#define	WT_ATOMIC_ADD1(v, val)		WT_ATOMIC_ADD(v, val, 1, 8)
-#define	WT_ATOMIC_CAS1(v, old, new)	WT_ATOMIC_CAS(v, old, new, 1, 8)
-#define	WT_ATOMIC_CAS_VAL1(v, old, new)	WT_ATOMIC_CAS_VAL(v, old, new, 1, 8)
-#define	WT_ATOMIC_STORE1(v, val)	WT_ATOMIC_STORE(v, val, 1, 8)
-#define	WT_ATOMIC_SUB1(v, val)		WT_ATOMIC_SUB(v, val, 1, 8, int8_t)
+#define	WT_ATOMIC_ADD1(v, val)		WT_ATOMIC_ADD(v, val, 1, 8, char)
+#define	WT_ATOMIC_CAS1(v, old, new)	WT_ATOMIC_CAS(v, old, new, 1, 8, char)
+#define	WT_ATOMIC_CAS_VAL1(v, old, new) \
+	WT_ATOMIC_CAS_VAL(v, old, new, 1, 8, char)
+#define	WT_ATOMIC_STORE1(v, val)	WT_ATOMIC_STORE(v, val, 1, 8, char)
+#define	WT_ATOMIC_SUB1(v, val)		WT_ATOMIC_SUB(v, val, 1, 8, char)
 
-#define	WT_ATOMIC_ADD2(v, val)		WT_ATOMIC_ADD(v, val, 2, 16)
-#define	WT_ATOMIC_CAS2(v, old, new)	WT_ATOMIC_CAS(v, old, new, 2, 16)
-#define	WT_ATOMIC_CAS_VAL2(v, old, new)	WT_ATOMIC_CAS_VAL(v, old, new, 2, 16)
-#define	WT_ATOMIC_STORE2(v, val)	WT_ATOMIC_STORE(v, val, 2, 16)
-#define	WT_ATOMIC_SUB2(v, val)		WT_ATOMIC_SUB(v, val, 2, 16, int16_t)
+#define	WT_ATOMIC_ADD2(v, val)		WT_ATOMIC_ADD(v, val, 2, 16, short)
+#define	WT_ATOMIC_CAS2(v, old, new)	WT_ATOMIC_CAS(v, old, new, 2, 16, short)
+#define	WT_ATOMIC_CAS_VAL2(v, old, new)	\
+	WT_ATOMIC_CAS_VAL(v, old, new, 2, 16, short)
+#define	WT_ATOMIC_STORE2(v, val)	WT_ATOMIC_STORE(v, val, 2, 16, short)
+#define	WT_ATOMIC_SUB2(v, val)		WT_ATOMIC_SUB(v, val, 2, 16, short)
 
-#define	WT_ATOMIC_ADD4(v, val)		WT_ATOMIC_ADD(v, val, 4, )
-#define	WT_ATOMIC_CAS4(v, old, new)	WT_ATOMIC_CAS(v, old, new, 4, )
-#define	WT_ATOMIC_CAS_VAL4(v, old, new)	WT_ATOMIC_CAS_VAL(v, old, new, 4, )
-#define	WT_ATOMIC_STORE4(v, val)	WT_ATOMIC_STORE(v, val, 4, )
-#define	WT_ATOMIC_SUB4(v, val)		WT_ATOMIC_SUB(v, val, 4, , int32_t)
+#define	WT_ATOMIC_ADD4(v, val)		WT_ATOMIC_ADD(v, val, 4, , long)
+#define	WT_ATOMIC_CAS4(v, old, new)	WT_ATOMIC_CAS(v, old, new, 4, , long)
+#define	WT_ATOMIC_CAS_VAL4(v, old, new)	\
+	WT_ATOMIC_CAS_VAL(v, old, new, 4, , long)
+#define	WT_ATOMIC_STORE4(v, val)	WT_ATOMIC_STORE(v, val, 4, , long)
+#define	WT_ATOMIC_SUB4(v, val)		WT_ATOMIC_SUB(v, val, 4, , long)
 
-#define	WT_ATOMIC_ADD8(v, val)		WT_ATOMIC_ADD(v, val, 8, 64)
-#define	WT_ATOMIC_CAS8(v, old, new)	WT_ATOMIC_CAS(v, old, new, 8, 64)
-#define	WT_ATOMIC_CAS_VAL8(v, old, new)	WT_ATOMIC_CAS_VAL(v, old, new, 8, 64)
-#define	WT_ATOMIC_STORE8(v, val)	WT_ATOMIC_STORE(v, val, 8, 64)
-#define	WT_ATOMIC_SUB8(v, val)		WT_ATOMIC_SUB(v, val, 8, 64, int64_t)
+#define	WT_ATOMIC_ADD8(v, val)		WT_ATOMIC_ADD(v, val, 8, 64, __int64)
+#define	WT_ATOMIC_CAS8(v, old, new)	\
+	WT_ATOMIC_CAS(v, old, new, 8, 64, __int64)
+#define	WT_ATOMIC_CAS_VAL8(v, old, new)	\
+	WT_ATOMIC_CAS_VAL(v, old, new, 8, 64, __int64)
+#define	WT_ATOMIC_STORE8(v, val)	WT_ATOMIC_STORE(v, val, 8, 64, __int64)
+#define	WT_ATOMIC_SUB8(v, val)		WT_ATOMIC_SUB(v, val, 8, 64, __int64)
 
 static inline void WT_BARRIER(void) { _ReadWriteBarrier(); }
 static inline void WT_FULL_BARRIER(void) { _mm_mfence(); }

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -290,8 +290,7 @@ __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 
 #elif SPINLOCK_TYPE == SPINLOCK_MSVC
 
-#define	WT_DECL_SPINLOCK_ID(i)						\
-	static int i = WT_SPINLOCK_REGISTER
+#define	WT_DECL_SPINLOCK_ID(i)	
 #define	WT_SPINLOCK_REGISTER		-1
 #define	WT_SPINLOCK_REGISTER_FAILED	-2
 

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -284,7 +284,9 @@ struct __wt_update;
 
 #include "misc.h"
 #include "mutex.h"
+#ifndef _WIN32
 #include "posix.h"
+#endif
 
 #include "stat.h"			/* required by dhandle.h */
 #include "dhandle.h"			/* required by btree.h */

--- a/src/os_win/os_alloc.c
+++ b/src/os_win/os_alloc.c
@@ -108,8 +108,6 @@ int
 __wt_realloc_aligned(WT_SESSION_IMPL *session,
     size_t *bytes_allocated_ret, size_t bytes_to_allocate, void *retp)
 {
-	WT_DECL_RET;
-
 	/*
 	 * !!!
 	 * This function MUST handle a NULL WT_SESSION_IMPL handle.

--- a/src/os_win/os_dir.c
+++ b/src/os_win/os_dir.c
@@ -23,7 +23,7 @@ __wt_dirlist(WT_SESSION_IMPL *session, const char *dir, const char *prefix,
 	u_int count, dirsz;
 	int match;
 	char **entries, *path;
-	int pathlen;
+	size_t pathlen;
 
 	count = 0;
 	*dirlist = NULL;

--- a/src/os_win/os_ftruncate.c
+++ b/src/os_win/os_ftruncate.c
@@ -16,6 +16,7 @@ __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
 {
 	WT_DECL_RET;
 	LARGE_INTEGER largeint;
+	uint32_t lasterror;
 
 	largeint.QuadPart = len;
 
@@ -24,10 +25,15 @@ __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
 		WT_RET_MSG(session, __wt_errno(), "%s SetFilePointerEx error",
 		    fh->name);
 
-	if ((ret = SetEndOfFile(fh->filehandle)) != FALSE) {
+	ret = SetEndOfFile(fh->filehandle);
+	if (ret != FALSE) {
 		fh->size = fh->extend_size = len;
-		return (0);
 	}
 
-	WT_RET_MSG(session, __wt_errno(), "%s SetEndofFile error", fh->name);
+	lasterror = GetLastError();
+
+	if (lasterror = ERROR_USER_MAPPED_FILE)
+		return (EBUSY);
+
+	WT_RET_MSG(session, lasterror, "%s SetEndofFile error", fh->name);
 }

--- a/src/os_win/os_rename.c
+++ b/src/os_win/os_rename.c
@@ -17,7 +17,6 @@ __wt_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
 	WT_DECL_RET;
 	uint32_t lasterror;
 	char *from_path, *to_path;
-	int exists;
 
 	WT_RET(__wt_verbose(
 		session, WT_VERB_FILEOPS, "rename %s to %s", from, to));

--- a/src/os_win/os_rw.c
+++ b/src/os_win/os_rw.c
@@ -15,10 +15,9 @@ int
 __wt_read(
     WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void *buf)
 {
-	size_t chunk;
-	size_t nr;
+	DWORD chunk;
+	DWORD nr;
 	uint8_t *addr;
-	BOOL ret;
 	OVERLAPPED overlapped = { 0 };
 
 	nr = 0;
@@ -40,7 +39,7 @@ __wt_read(
 
 	/* Break reads larger than 1GB into 1GB chunks. */
 	for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
-		chunk = WT_MIN(len, WT_GIGABYTE);
+		chunk = (DWORD)WT_MIN(len, WT_GIGABYTE);
 		overlapped.Offset = UINT32_MAX & offset;
 		overlapped.OffsetHigh = UINT32_MAX & (offset >> 32);
 
@@ -61,8 +60,8 @@ int
 __wt_write(WT_SESSION_IMPL *session,
     WT_FH *fh, wt_off_t offset, size_t len, const void *buf)
 {
-	size_t chunk;
-	size_t nw;
+	DWORD chunk;
+	DWORD nw;
 	const uint8_t *addr;
 	OVERLAPPED overlapped = { 0 };
 
@@ -85,7 +84,7 @@ __wt_write(WT_SESSION_IMPL *session,
 
 	/* Break writes larger than 1GB into 1GB chunks. */
 	for (addr = buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {
-		chunk = WT_MIN(len, WT_GIGABYTE);
+		chunk = (DWORD)WT_MIN(len, WT_GIGABYTE);
 		overlapped.Offset = UINT32_MAX & offset;
 		overlapped.OffsetHigh = UINT32_MAX & (offset >> 32);
 

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -15,8 +15,6 @@ int
 __wt_thread_create(WT_SESSION_IMPL *session,
     pthread_t *tidret, void *(*func)(void *), void *arg)
 {
-	WT_DECL_RET;
-
 	/* Spawn a new thread of control. */
 	*tidret = CreateThread(NULL, 0, func, arg, 0, NULL);
 	if (*tidret != NULL)
@@ -45,7 +43,7 @@ __wt_thread_join(WT_SESSION_IMPL *session, pthread_t tid)
  *	Fill in a printable version of the process and thread IDs.
  */
 void
-__wt_thread_id(WT_SESSION_IMPL *session, char buf, size_t buflen)
+__wt_thread_id(WT_SESSION_IMPL *session, char* buf, size_t buflen)
 {
 	DWORD self;
 	size_t len;

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -30,7 +30,6 @@ __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
 int
 __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 {
-	WT_DECL_RET;
 	uint64_t ns100;
 
 	FILETIME time;
@@ -39,7 +38,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	ns100 = (((int64_t)time.dwHighDateTime << 32) + time.dwLowDateTime)
 	    - 116444736000000000LL;
 	tsp->tv_sec = ns100 / 10000000;
-	tsp->tv_nsec = ns100 * 100;
+	tsp->tv_nsec = (long)(ns100 * 100);
 
 	return (0);
 }
@@ -53,7 +52,7 @@ localtime_r(const time_t *timer, struct tm *result)
 {
 	errno_t err;
 
-	err = localtime_s(timer, result);
+	err = localtime_s(result, timer);
 	if (err != 0) {
 		__wt_err(NULL, err, "localtime_s");
 		return (NULL);

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -157,7 +157,7 @@ copy(const char *name, const char *directory)
 	 * We need to know this file was successfully written, it's a backup.
 	 */
 #ifdef _WIN32
-	if (FlushFileBuffers(_get_osfhandle(fd)) == 0) {
+	if (FlushFileBuffers((HANDLE)_get_osfhandle(ofd)) == 0) {
 		DWORD err = GetLastError();
 		ret = err;
 		goto writerr;


### PR DESCRIPTION
Ran the code through MSVC & Clang. It helped fine some bugs.

Implemented fallocate, and fixed ftruncate to handle mapped files by returning EBUSY.
