### PR TITLE
Fix Windows os_dir.c, and os_ftruncate.c. Correctly enable hardware chksum

### DIFF
--- a/src/os_win/os_ftruncate.c
+++ b/src/os_win/os_ftruncate.c
@@ -28,6 +28,7 @@ __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
 	ret = SetEndOfFile(fh->filehandle);
 	if (ret != FALSE) {
 		fh->size = fh->extend_size = len;
+		return (0);
 	}
 
 	lasterror = GetLastError();

--- a/src/support/cksum.c
+++ b/src/support/cksum.c
@@ -1291,7 +1291,7 @@ __wt_cksum_init(void)
 	else
 		__wt_cksum_func = __wt_cksum_sw;
 
-#elif defined(_M_AMD64aaa)
+#elif defined(_M_AMD64)
 	int cpuInfo[4];
 
 	__cpuid(cpuInfo, 1);


### PR DESCRIPTION
Fix Windows os_dir.c. @michaelcahill was correct that this function was not returning the correct list of files. I need to append *. I used a WT_ITEM for the buffer. Let me know if you would like me to change it.

Fix missing return in os_ftruncate.c.
Correctly enable hardware chksum. I had disabled debugging a chksum error which had nothing to do with the chksum code.
