### PR TITLE
Introduce new typedefs for pthread typedefs in platform agnostic code

### DIFF
--- a/src/include/async.h
+++ b/src/include/async.h
@@ -100,7 +100,7 @@ struct __wt_async {
 #define	WT_ASYNC_MAX_WORKERS	20
 	WT_SESSION_IMPL		*worker_sessions[WT_ASYNC_MAX_WORKERS];
 					/* Async worker threads */
-	pthread_t		 worker_tids[WT_ASYNC_MAX_WORKERS];
+	_wt_thread_t		 worker_tids[WT_ASYNC_MAX_WORKERS];
 
 	uint32_t		 flags;	/* Currently unused. */
 };

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -37,7 +37,7 @@ struct __wt_evict_entry {
 struct __wt_evict_worker {
 	WT_SESSION_IMPL *session;
 	u_int id;
-	pthread_t tid;
+	_wt_thread_t tid;
 #define	WT_EVICT_WORKER_RUN	0x01
 	uint32_t flags;
 };
@@ -104,7 +104,7 @@ struct __wt_cache {
 	uint32_t cp_skip_count;		/* Post change stabilization */
 	uint64_t cp_reserved;		/* Base size for this cache */
 	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */
-	pthread_t cp_tid;		/* Thread ID for cache pool manager */
+	_wt_thread_t cp_tid;		/* Thread ID for cache pool manager */
 
 	/*
 	 * Flags.

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -157,7 +157,7 @@ struct __wt_connection_impl {
 	int hot_backup;
 
 	WT_SESSION_IMPL *ckpt_session;	/* Checkpoint thread session */
-	pthread_t	 ckpt_tid;	/* Checkpoint thread */
+	_wt_thread_t	 ckpt_tid;	/* Checkpoint thread */
 	int		 ckpt_tid_set;	/* Checkpoint thread set */
 	WT_CONDVAR	*ckpt_cond;	/* Checkpoint wait mutex */
 	const char	*ckpt_config;	/* Checkpoint configuration */
@@ -208,7 +208,7 @@ struct __wt_connection_impl {
 	WT_LSM_MANAGER	lsm_manager;	/* LSM worker thread information */
 
 	WT_SESSION_IMPL *evict_session; /* Eviction server sessions */
-	pthread_t	 evict_tid;	/* Eviction server thread ID */
+	_wt_thread_t	 evict_tid;	/* Eviction server thread ID */
 	int		 evict_tid_set;	/* Eviction server thread ID set */
 
 	uint32_t	 evict_workers_max;/* Max eviction workers */
@@ -217,7 +217,7 @@ struct __wt_connection_impl {
 	WT_EVICT_WORKER	*evict_workctx;	/* Eviction worker context */
 
 	WT_SESSION_IMPL *stat_session;	/* Statistics log session */
-	pthread_t	 stat_tid;	/* Statistics log thread */
+	_wt_thread_t	 stat_tid;	/* Statistics log thread */
 	int		 stat_tid_set;	/* Statistics log thread set */
 	WT_CONDVAR	*stat_cond;	/* Statistics log wait mutex */
 	const char	*stat_format;	/* Statistics log timestamp format */
@@ -231,7 +231,7 @@ struct __wt_connection_impl {
 	int		 archive;	/* Global archive configuration */
 	WT_CONDVAR	*arch_cond;	/* Log archive wait mutex */
 	WT_SESSION_IMPL *arch_session;	/* Log archive session */
-	pthread_t	 arch_tid;	/* Log archive thread */
+	_wt_thread_t	 arch_tid;	/* Log archive thread */
 	int		 arch_tid_set;	/* Log archive thread set */
 	WT_LOG		*log;		/* Logging structure */
 	wt_off_t	 log_file_max;	/* Log file max size */
@@ -239,7 +239,7 @@ struct __wt_connection_impl {
 	uint32_t	txn_logsync;	/* Log sync configuration */
 
 	WT_SESSION_IMPL *sweep_session;	/* Handle sweep session */
-	pthread_t	 sweep_tid;	/* Handle sweep thread */
+	_wt_thread_t	 sweep_tid;	/* Handle sweep thread */
 	int		 sweep_tid_set;	/* Handle sweep thread set */
 	WT_CONDVAR	*sweep_cond;	/* Handle sweep wait mutex */
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -473,8 +473,8 @@ extern int __wt_read( WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size
 extern int __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, const void *buf);
 extern void __wt_sleep(long seconds, long micro_seconds);
 extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base);
-extern int __wt_thread_create(WT_SESSION_IMPL *session, pthread_t *tidret, void *(*func)(void *), void *arg);
-extern int __wt_thread_join(WT_SESSION_IMPL *session, pthread_t tid);
+extern int __wt_thread_create(WT_SESSION_IMPL *session, _wt_thread_t *tidret, void *(*func)(void *), void *arg);
+extern int __wt_thread_join(WT_SESSION_IMPL *session, _wt_thread_t tid);
 extern void __wt_thread_id(WT_SESSION_IMPL *session, char *buf, size_t buflen);
 extern int __wt_seconds(WT_SESSION_IMPL *session, time_t *timep);
 extern int __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp);

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -22,7 +22,7 @@ struct __wt_lsm_worker_cookie {
 struct __wt_lsm_worker_args {
 	WT_SESSION_IMPL	*session;	/* Session */
 	WT_CONDVAR	*work_cond;	/* Owned by the manager */
-	pthread_t	tid;		/* Thread id */
+	_wt_thread_t	tid;		/* Thread id */
 	u_int		id;		/* My manager slot id */
 	uint32_t	type;		/* Types of operations handled */
 #define	WT_LSM_WORKER_RUN	0x01

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -14,8 +14,8 @@
 struct __wt_condvar {
 	const char *name;		/* Mutex name for debugging */
 
-	pthread_mutex_t mtx;		/* Mutex */
-	pthread_cond_t  cond;		/* Condition variable */
+	_wt_mutex_t mtx;		/* Mutex */
+	_wt_cond_t  cond;		/* Condition variable */
 
 	int waiters;			/* Numbers of waiters, or
 					   -1 if signalled with no waiters. */
@@ -30,10 +30,10 @@ struct __wt_condvar {
 struct __wt_rwlock {
 	const char *name;		/* Lock name for debugging */
 
-	pthread_rwlock_t rwlock;	/* Read/write lock */
+	_wt_rwlock_t rwlock;		/* Read/write lock */
 
 #ifdef _WIN32
-    uint32_t exclusive_locked;
+	uint32_t exclusive_locked;
 #endif
 };
 
@@ -61,7 +61,7 @@ typedef volatile int
 	SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX_LOGGING
 
 typedef struct {
-	pthread_mutex_t lock;
+	_wt_mutex_t lock;
 
 	uint64_t counter;		/* Statistics: counter */
 

--- a/src/include/os_windows.h
+++ b/src/include/os_windows.h
@@ -6,17 +6,16 @@
  */
 
 /*
- * Windows does not support Posix Threads
- * WT needs it so we mock it up with the Windows concurrency primitives
+ * Define WT threading and concurrency primitives
  * Assumes Windows 7+/2008 R2+
  */
-typedef CRITICAL_SECTION  pthread_mutex_t;
+typedef CRITICAL_SECTION  _wt_mutex_t;
 
-typedef CONDITION_VARIABLE pthread_cond_t;
+typedef CONDITION_VARIABLE _wt_cond_t;
 
-typedef SRWLOCK pthread_rwlock_t;
+typedef SRWLOCK _wt_rwlock_t;
 
-typedef HANDLE pthread_t;
+typedef HANDLE _wt_thread_t;
 
 /* Timespec is a POSIX structure not defined in Windows */
 struct timespec {

--- a/src/include/posix.h
+++ b/src/include/posix.h
@@ -18,3 +18,14 @@
 
 /* Define O_BINARY for Posix systems */
 #define	O_BINARY 	0
+
+/*
+ * Define WT threading and concurrency primitives
+ */
+typedef pthread_mutex_t  _wt_mutex_t;
+
+typedef pthread_cond_t _wt_cond_t;
+
+typedef pthread_rwlock_t _wt_rwlock_t;
+
+typedef pthread_t _wt_thread_t;

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -276,13 +276,12 @@ struct __wt_update;
 
 #ifdef _WIN32
 #include "os_windows.h"
+#else
+#include "posix.h"
 #endif
 
 #include "misc.h"
 #include "mutex.h"
-#ifndef _WIN32
-#include "posix.h"
-#endif
 
 #include "stat.h"			/* required by dhandle.h */
 #include "dhandle.h"			/* required by btree.h */

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -13,7 +13,7 @@
  */
 int
 __wt_thread_create(WT_SESSION_IMPL *session,
-    pthread_t *tidret, void *(*func)(void *), void *arg)
+    _wt_thread_t *tidret, void *(*func)(void *), void *arg)
 {
 	WT_DECL_RET;
 
@@ -28,7 +28,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
  *	Wait for a thread of control to exit.
  */
 int
-__wt_thread_join(WT_SESSION_IMPL *session, pthread_t tid)
+__wt_thread_join(WT_SESSION_IMPL *session, _wt_thread_t tid)
 {
 	WT_DECL_RET;
 

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -13,7 +13,7 @@
  */
 int
 __wt_thread_create(WT_SESSION_IMPL *session,
-    pthread_t *tidret, void *(*func)(void *), void *arg)
+    _wt_thread_t *tidret, void *(*func)(void *), void *arg)
 {
 	/* Spawn a new thread of control. */
 	*tidret = CreateThread(NULL, 0, func, arg, 0, NULL);
@@ -28,7 +28,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
  *	Wait for a thread of control to exit.
  */
 int
-__wt_thread_join(WT_SESSION_IMPL *session, pthread_t tid)
+__wt_thread_join(WT_SESSION_IMPL *session, _wt_thread_t tid)
 {
 	WT_DECL_RET;
 


### PR DESCRIPTION
Currently the Windows port creates typedefs for pthread typedefs instead of WT using platform agnostic typedefs for its platform agnostic code.
