### PR TITLE
Windows Fixes

### DIFF
--- a/src/include/intpack.i
+++ b/src/include/intpack.i
@@ -54,8 +54,14 @@
 #define	WT_LEADING_ZEROS(x, i)						\
 	(i = (x == 0) ? (int)sizeof (x) : __builtin_clzll(x) >> 3)
 #elif defined(_MSC_VER)
-#define	WT_LEADING_ZEROS(x, i)						\
-	(i = (x == 0) ? (int)sizeof (x) : (int)__lzcnt64(x) >> 3)
+#define	WT_LEADING_ZEROS(x, i)	do {					\
+	if (x == 0) i = (int)sizeof(x);				\
+	else  { 							\
+		unsigned long __index;					\
+		_BitScanReverse64(&__index, x);				\
+		__index = 63 ^ __index;					\
+		i = (int)(__index >> 3); }				\
+	} while (0)
 #else
 #define	WT_LEADING_ZEROS(x, i) do {					\
 	uint64_t __x = (x);						\

--- a/src/os_win/os_filesize.c
+++ b/src/os_win/os_filesize.c
@@ -42,7 +42,7 @@ __wt_filesize_name(
 
 	WT_RET(__wt_filename(session, filename, &path));
 
-	ret = GetFileAttributesEx(filename, GetFileExInfoStandard, &data);
+	ret = GetFileAttributesEx(path, GetFileExInfoStandard, &data);
 
 	__wt_free(session, path);
 

--- a/src/os_win/os_open.c
+++ b/src/os_win/os_open.c
@@ -121,8 +121,9 @@ __wt_open(WT_SESSION_IMPL *session,
 	    OPEN_EXISTING,
 	    f,
 	    NULL);
-	WT_ERR_MSG(session, __wt_errno(),
-	    "open failed for secondary handle: %s", path);
+	if (filehandle == INVALID_HANDLE_VALUE)
+		WT_ERR_MSG(session, __wt_errno(),
+		    "open failed for secondary handle: %s", path);
 
 	WT_ERR(__wt_calloc(session, 1, sizeof(WT_FH), &fh));
 	WT_ERR(__wt_strdup(session, name, &fh->name));


### PR DESCRIPTION
- _aligned_malloc is required to be paired with _aligned_free which different then the POSIX so the CRT cannot support aligned memory allocation as wired tiger requires
- Fix WT_LEADING_ZEROS by copying the assembly copy of __builtin_clzll.
- Only test_compact.py, and test_backup03.py fail have the only unknown failures now
