### PR TITLE
Fixup LSM drop:

### DIFF
--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -482,10 +482,10 @@ __lsm_drop_file(WT_SESSION_IMPL *session, const char *uri)
 		ret = __wt_remove(session, uri + strlen("file:"));
 	WT_RET(__wt_verbose(session, WT_VERB_LSM, "Dropped %s", uri));
 
-	if (ret == EBUSY || ret == ENOENT) {
+	if (ret == EBUSY || ret == ENOENT)
 		WT_RET(__wt_verbose(session, WT_VERB_LSM,
 		    "LSM worker drop of %s failed with %d", uri, ret));
-	}
+	
 	return (ret);
 }
 


### PR DESCRIPTION
- If a bloom drop succeeded but the chunk drop failed, we could skip the
  metadata update. Which would lead to a confused LSM tree after restart.
- Handle the case where an LSM tree is missing obsolete files more gracefully.
