### PR TITLE
Oracle Solaris fixes

### DIFF
--- a/build_posix/makemake
+++ b/build_posix/makemake
@@ -26,7 +26,7 @@ sed -n '/END SUBDIRS/,/BEGIN SOURCES/p' Make.base
 echo
 echo "libwiredtiger_la_LDFLAGS = -release @VERSION@"
 echo "libwiredtiger_la_SOURCES=\\"
-sed -e '/^[a-z]/! d' \
+sed -e '/^[a-z]/!d' \
     -e 's/.*/	& \\/' \
     -e '$s/ \\$//' < ../dist/filelist
 

--- a/dist/s_prototypes
+++ b/dist/s_prototypes
@@ -10,7 +10,7 @@ cat <<EOF
 
 EOF
 
-for i in `sed -e '/^[a-z]/! d' filelist`; do
+for i in `sed -e '/^[a-z]/!d' filelist`; do
 	sed -n \
 	    -e '/^__wt_[a-z]/!{' \
 		-e h \

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -23,7 +23,7 @@ build() {
 	egrep -h '^[ 	]*(struct|union)[	 ]*__.*[	 ]*{' $l | \
 	    sed -e 's/^[	 ]*//' -e 's/[	 ]*{.*//' | sort | \
 	while read t n; do
-		upper=`echo $n | sed -e 's/^__//' | tr a-z A-Z`
+		upper=`echo $n | sed -e 's/^__//' | tr [a-z] [A-Z]`
 		echo "$t $n;"
 		echo "    typedef $t $n $upper;"
 	done


### PR DESCRIPTION
Small fixes to enable building on Oracle Solaris 11.2

sed does not allow a space between ! and d
tr requires square brackets around the arguments

Have validated the fixes on MacOS 10.9, and Oracle Solaris 11.2.
