### PR TITLE
Make explicit calls ascii versions of Windows functions

### DIFF
--- a/src/os_win/os_dir.c
+++ b/src/os_win/os_dir.c
@@ -52,7 +52,7 @@ __wt_dirlist(WT_SESSION_IMPL *session, const char *dir, const char *prefix,
 	    pathbuf->data, LF_ISSET(WT_DIRLIST_INCLUDE) ? "include" : "exclude",
 	    prefix == NULL ? "all" : prefix));
 
-	findhandle = FindFirstFile(pathbuf->data, &finddata);
+	findhandle = FindFirstFileA(pathbuf->data, &finddata);
 
 	if (INVALID_HANDLE_VALUE == findhandle)
 		WT_ERR_MSG(session, __wt_errno(), "%s: FindFirstFile",
@@ -85,7 +85,7 @@ __wt_dirlist(WT_SESSION_IMPL *session, const char *dir, const char *prefix,
 				WT_ERR(__wt_strdup(session,
 				    finddata.cFileName, &entries[count - 1]));
 			}
-		} while (FindNextFile(findhandle, &finddata) != 0);
+		} while (FindNextFileA(findhandle, &finddata) != 0);
 	}
 
 	if (count > 0)

--- a/src/os_win/os_dlopen.c
+++ b/src/os_win/os_dlopen.c
@@ -22,7 +22,7 @@ __wt_dlopen(WT_SESSION_IMPL *session, const char *path, WT_DLH **dlhp)
 
 	/* NULL means load from the current binary */
 	if (path == NULL) {
-		ret = GetModuleHandleEx(0, NULL, &dlh->handle);
+		ret = GetModuleHandleExA(0, NULL, &dlh->handle);
 		if (ret == FALSE)
 			WT_ERR_MSG(session,
 			    __wt_errno(), "GetModuleHandleEx(%s): %s", path, 0);

--- a/src/os_win/os_exist.c
+++ b/src/os_win/os_exist.c
@@ -19,7 +19,7 @@ __wt_exist(WT_SESSION_IMPL *session, const char *filename, int *existp)
 
 	WT_RET(__wt_filename(session, filename, &path));
 
-	ret = GetFileAttributes(path);
+	ret = GetFileAttributesA(path);
 
 	__wt_free(session, path);
 

--- a/src/os_win/os_filesize.c
+++ b/src/os_win/os_filesize.c
@@ -42,7 +42,7 @@ __wt_filesize_name(
 
 	WT_RET(__wt_filename(session, filename, &path));
 
-	ret = GetFileAttributesEx(path, GetFileExInfoStandard, &data);
+	ret = GetFileAttributesExA(path, GetFileExInfoStandard, &data);
 
 	__wt_free(session, path);
 

--- a/src/os_win/os_map.c
+++ b/src/os_win/os_map.c
@@ -27,7 +27,7 @@ __wt_mmap(WT_SESSION_IMPL *session, WT_FH *fh, void *mapp, size_t *lenp,
 	 */
 	orig_size = (size_t)fh->size;
 	*mappingcookie =
-	    CreateFileMapping(fh->filehandle, NULL, PAGE_READONLY, 0, 0, NULL);
+	    CreateFileMappingA(fh->filehandle, NULL, PAGE_READONLY, 0, 0, NULL);
 	if (*mappingcookie == NULL)
 		WT_RET_MSG(session, __wt_errno(),
 			"%s CreateFileMapping error: failed to map %"

--- a/src/os_win/os_open.c
+++ b/src/os_win/os_open.c
@@ -84,7 +84,7 @@ __wt_open(WT_SESSION_IMPL *session,
 	    dio_type == WT_FILE_TYPE_CHECKPOINT)
 		f |= FILE_FLAG_RANDOM_ACCESS;
 
-	filehandle = CreateFile(path,
+	filehandle = CreateFileA(path,
 				(GENERIC_READ | GENERIC_WRITE),
 				share_mode,
 				NULL,
@@ -93,7 +93,7 @@ __wt_open(WT_SESSION_IMPL *session,
 				NULL);
 	if (filehandle == INVALID_HANDLE_VALUE) {
 		if (GetLastError() == ERROR_FILE_EXISTS && ok_create)
-			filehandle = CreateFile(path,
+			filehandle = CreateFileA(path,
 						(GENERIC_READ | GENERIC_WRITE),
 						share_mode,
 						NULL,
@@ -114,7 +114,7 @@ __wt_open(WT_SESSION_IMPL *session,
 	 * concurrently with reads on the file. Writes would also move the file
 	 * pointer.
 	 */
-	filehandle_secondary = CreateFile(path,
+	filehandle_secondary = CreateFileA(path,
 	    (GENERIC_READ | GENERIC_WRITE),
 	    share_mode,
 	    NULL,

--- a/src/os_win/os_remove.c
+++ b/src/os_win/os_remove.c
@@ -56,7 +56,7 @@ __wt_remove(WT_SESSION_IMPL *session, const char *name)
 
 	WT_RET(__wt_filename(session, name, &path));
 
-	if ((ret = DeleteFile(path)) == FALSE)
+	if ((ret = DeleteFileA(path)) == FALSE)
 		lasterror = __wt_errno();
 
 	__wt_free(session, path);

--- a/src/os_win/os_rename.c
+++ b/src/os_win/os_rename.c
@@ -30,14 +30,14 @@ __wt_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
 	 * Check if file exists since Windows does not override the file if
 	 * it exists.
 	 */
-	if ((ret = GetFileAttributes(to_path)) != INVALID_FILE_ATTRIBUTES) {
-		if ((ret = DeleteFile(to_path)) == FALSE) {
+	if ((ret = GetFileAttributesA(to_path)) != INVALID_FILE_ATTRIBUTES) {
+		if ((ret = DeleteFileA(to_path)) == FALSE) {
 			lasterror = GetLastError();
 			goto err;
 		}
 	}
 
-	if ((MoveFile(from_path, to_path)) == FALSE)
+	if ((MoveFileA(from_path, to_path)) == FALSE)
 		lasterror = GetLastError();
 
 err:


### PR DESCRIPTION
Windows API allows you to choose whether to call the ASCII, or Unicode versions of their APIs. You can either call the API with A or W if you want to be explicit or let preprocessor defines dictate which version is chosen.

Currently, WT is uses the naked API calls like CreateFile which can either become CreateFileA or CreateFileW depending on preprocessor defines. With change, I have chosen to explicitly call the ascii versions to be clear. 
