### PR TITLE
Fix when reconciliation of large page results in a single, small page.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -162,9 +162,6 @@ connection_stats = [
     Stat('rec_pages', 'reconciliation: page reconciliation calls'),
     Stat('rec_pages_eviction',
         'reconciliation: page reconciliation calls for eviction'),
-    Stat('rec_skipped_update',
-        'reconciliation: reconciliation failed because an update' +
-        ' could not be included'),
     Stat('rec_split_stashed_bytes',
         'reconciliation: split bytes currently awaiting free',
         'no_clear,no_scale'),

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -2011,30 +2011,6 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 }
 
 /*
- * __rec_skipped_update_chk --
- *	Return if a skipped update makes this a waste of time.
- */
-static inline int
-__rec_skipped_update_chk(WT_SESSION_IMPL *session, WT_RECONCILE *r)
-{
-	/*
-	 * If we're doing an eviction, and we skipped an update, it only pays
-	 * off to continue if we're writing multiple blocks, that is, we'll be
-	 * able to evict something.  This should be unlikely (why did eviction
-	 * choose a recently written, small block), but it's possible.  Our
-	 * caller is responsible for calling us at the right moment, when all
-	 * of the rows have been reviewed and we're about to finalize a write.
-	 */
-	if (F_ISSET(r, WT_SKIP_UPDATE_RESTORE) &&
-	    r->bnd_next == 0 && r->leave_dirty) {
-		WT_STAT_FAST_CONN_INCR(session, rec_skipped_update);
-		WT_STAT_FAST_DATA_INCR(session, rec_skipped_update);
-		return (EBUSY);
-	}
-	return (0);
-}
-
-/*
  * __rec_split_raw_worker --
  *	Handle the raw compression page reconciliation bookkeeping.
  */
@@ -2393,10 +2369,6 @@ no_slots:
 		return (0);
 	}
 
-	/* Check if a skipped update makes this a waste of time. */
-	if (last_block)
-		WT_RET(__rec_skipped_update_chk(session, r));
-
 	/* We have a block, update the boundary counter. */
 	++r->bnd_next;
 
@@ -2501,20 +2473,21 @@ __rec_split_finish_std(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		WT_RET(__rec_split_bnd_grow(session, r));
 		break;
 	case SPLIT_TRACKING_RAW:
+		/*
+		 * We were configured for raw compression, but never actually
+		 * wrote anything.
+		 */
+		break;
 	WT_ILLEGAL_VALUE(session);
 	}
 
-	/* Check if a skipped update makes this a waste of time. */
-	WT_RET(__rec_skipped_update_chk(session, r));
-
 	/*
 	 * We only arrive here with no entries to write if the page was entirely
-	 * empty; if the page was empty, we merge it into its parent during the
-	 * parent's reconciliation.  This check is done after checking skipped
-	 * updates, we could have a page that's empty only because we skipped
-	 * all of the updates.
+	 * empty, and if the page is empty, we merge it into its parent during
+	 * the parent's reconciliation.  A page with skipped updates isn't truly
+	 * empty, continue on.
 	 */
-	if (r->entries == 0)
+	if (r->entries == 0 && r->skip == NULL)
 		return (0);
 
 	/* Set the boundary reference and increment the count. */
@@ -2534,34 +2507,21 @@ __rec_split_finish_std(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 }
 
 /*
- * __rec_split_finish_raw --
- *	Finish processing page, raw compression version.
- */
-static inline int
-__rec_split_finish_raw(WT_SESSION_IMPL *session, WT_RECONCILE *r)
-{
-	/* Check if a skipped update makes this a waste of time. */
-	if (r->entries == 0)
-		WT_RET(__rec_skipped_update_chk(session, r));
-
-	while (r->entries != 0)
-		WT_RET(__rec_split_raw_worker(session, r, 1));
-	return (0);
-}
-
-/*
  * __rec_split_finish --
  *	Finish processing a page.
  */
-static inline int
+static int
 __rec_split_finish(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 {
 	/*
 	 * We're done reconciling a page.
 	 */
-	return (r->raw_compression ?
-	    __rec_split_finish_raw(session, r) :
-	    __rec_split_finish_std(session, r));
+	if (r->entries == 0 || !r->raw_compression)
+		return (__rec_split_finish_std(session, r));
+
+	while (r->entries != 0)
+		WT_RET(__rec_split_raw_worker(session, r, 1));
+	return (0);
 }
 
 /*
@@ -2674,9 +2634,10 @@ __rec_split_write(WT_SESSION_IMPL *session,
 	/* Set the zero-length value flag in the page header. */
 	if (dsk->type == WT_PAGE_ROW_LEAF) {
 		F_CLR(dsk, WT_PAGE_EMPTY_V_ALL | WT_PAGE_EMPTY_V_NONE);
-		if (r->all_empty_value)
+
+		if (r->entries != 0 && r->all_empty_value)
 			F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
-		if (!r->any_empty_value)
+		if (r->entries != 0 && !r->any_empty_value)
 			F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
 	}
 
@@ -4677,6 +4638,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	WT_BM *bm;
 	WT_BOUNDARY *bnd;
 	WT_BTREE *btree;
+	WT_MULTI *multi;
 	WT_PAGE_MODIFY *mod;
 	WT_REF *ref;
 	size_t addr_size;
@@ -4783,13 +4745,28 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 * Because WiredTiger's pages grow without splitting, we're
 		 * replacing a single page with another single page most of
 		 * the time.
-		 *
-		 * We should not be saving/restoring changes for this page in
-		 * this case, we should have returned failure before writing
-		 * any blocks.
 		 */
 		bnd = &r->bnd[0];
-		WT_ASSERT(session, bnd->skip == NULL);
+
+		/*
+		 * If we're saving/restoring changes for this page, there's
+		 * nothing to write. Allocate, then initialize the array of
+		 * replacement blocks.
+		 */
+		if (bnd->skip != NULL) {
+			WT_RET(__wt_calloc_def(
+			    session, r->bnd_next, &mod->mod_multi));
+			multi = mod->mod_multi;
+			multi->skip = bnd->skip;
+			multi->skip_entries = bnd->skip_next;
+			bnd->skip = NULL;
+			multi->skip_dsk = bnd->dsk;
+			bnd->dsk = NULL;
+			mod->mod_multi_entries = 1;
+
+			F_SET(mod, WT_PM_REC_MULTIBLOCK);
+			break;
+		}
 
 		/*
 		 * If this is a root page, then we don't have an address and we
@@ -4992,8 +4969,7 @@ __rec_split_row(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	}
 
 	/* Allocate, then initialize the array of replacement blocks. */
-	WT_RET(__wt_calloc(
-	    session, r->bnd_next, sizeof(WT_MULTI), &mod->mod_multi));
+	WT_RET(__wt_calloc_def(session, r->bnd_next, &mod->mod_multi));
 
 	for (multi = mod->mod_multi,
 	    bnd = r->bnd, i = 0; i < r->bnd_next; ++multi, ++bnd, ++i) {
@@ -5034,8 +5010,7 @@ __rec_split_col(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	mod = page->modify;
 
 	/* Allocate, then initialize the array of replacement blocks. */
-	WT_RET(__wt_calloc(
-	    session, r->bnd_next, sizeof(WT_MULTI), &mod->mod_multi));
+	WT_RET(__wt_calloc_def(session, r->bnd_next, &mod->mod_multi));
 
 	for (multi = mod->mod_multi,
 	    bnd = r->bnd, i = 0; i < r->bnd_next; ++multi, ++bnd, ++i) {

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -221,7 +221,6 @@ struct __wt_connection_stats {
 	WT_STATS read_io;
 	WT_STATS rec_pages;
 	WT_STATS rec_pages_eviction;
-	WT_STATS rec_skipped_update;
 	WT_STATS rec_split_stashed_bytes;
 	WT_STATS rec_split_stashed_objects;
 	WT_STATS rwlock_read;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3205,37 +3205,34 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_REC_PAGES				1092
 /*! reconciliation: page reconciliation calls for eviction */
 #define	WT_STAT_CONN_REC_PAGES_EVICTION			1093
-/*! reconciliation: reconciliation failed because an update could not be
- * included */
-#define	WT_STAT_CONN_REC_SKIPPED_UPDATE			1094
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1095
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1094
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1096
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1095
 /*! conn: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1097
+#define	WT_STAT_CONN_RWLOCK_READ			1096
 /*! conn: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1098
+#define	WT_STAT_CONN_RWLOCK_WRITE			1097
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1099
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1098
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1100
+#define	WT_STAT_CONN_SESSION_OPEN			1099
 /*! txn: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1101
+#define	WT_STAT_CONN_TXN_BEGIN				1100
 /*! txn: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1102
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1101
 /*! txn: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1103
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1102
 /*! txn: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1104
+#define	WT_STAT_CONN_TXN_COMMIT				1103
 /*! txn: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1105
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1104
 /*! txn: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1106
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1105
 /*! txn: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1107
+#define	WT_STAT_CONN_TXN_ROLLBACK			1106
 /*! conn: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1108
+#define	WT_STAT_CONN_WRITE_IO				1107
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -446,8 +446,6 @@ __wt_stat_init_connection_stats(WT_CONNECTION_STATS *stats)
 	stats->rec_pages.desc = "reconciliation: page reconciliation calls";
 	stats->rec_pages_eviction.desc =
 	    "reconciliation: page reconciliation calls for eviction";
-	stats->rec_skipped_update.desc =
-	    "reconciliation: reconciliation failed because an update could not be included";
 	stats->rec_split_stashed_bytes.desc =
 	    "reconciliation: split bytes currently awaiting free";
 	stats->rec_split_stashed_objects.desc =
@@ -562,7 +560,6 @@ __wt_stat_refresh_connection_stats(void *stats_arg)
 	stats->read_io.v = 0;
 	stats->rec_pages.v = 0;
 	stats->rec_pages_eviction.v = 0;
-	stats->rec_skipped_update.v = 0;
 	stats->rwlock_read.v = 0;
 	stats->rwlock_write.v = 0;
 	stats->txn_begin.v = 0;


### PR DESCRIPTION
In the case of a workload where we're forcibly evicting a large page, but most of the page is discarded during reconciliation and the page doesn't split into multiple chunks, we were quitting, leaving the page in place.  Instead, instantiate the page and swap it into place to replace the previous version. Reference #1317.

@michaelcahill, I think this is ready for review.
