### PR TITLE
If we have an empty page with skipped updates after reconciliation, don't write the image

### DIFF
--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -153,6 +153,7 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 	 * verify the image.  Always check the in-memory length for accuracy.
 	 */
 	dsk = buf->mem;
+	WT_ASSERT(session, dsk->u.entries != 0);
 	if (compressed) {
 		WT_ERR(__wt_scr_alloc(session, dsk->mem_size, &tmp));
 

--- a/src/btree/rec_write.c
+++ b/src/btree/rec_write.c
@@ -2487,7 +2487,7 @@ __rec_split_finish_std(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	 * the parent's reconciliation.  A page with skipped updates isn't truly
 	 * empty, continue on.
 	 */
-	if (r->entries == 0 && r->skip == NULL)
+	if (r->entries == 0 && r->skip_next == 0)
 		return (0);
 
 	/* Set the boundary reference and increment the count. */
@@ -2514,10 +2514,10 @@ static int
 __rec_split_finish(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 {
 	/* We're done reconciling - write the final page */
-	if (r->raw_compression) {
+	if (r->raw_compression && r->entries != 0) {
 		while (r->entries != 0)
 			WT_RET(__rec_split_raw_worker(session, r, 1));
-	} else if (r->entries != 0)
+	} else
 		WT_RET(__rec_split_finish_std(session, r));
 
 	return (0);


### PR DESCRIPTION
refs #1335
