### PR TITLE
fix durability support on OS X

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -118,6 +118,7 @@ FOREACH
 FREAD
 FREELIST
 FTRUNCATE
+FULLFSYNC
 Fasttrack
 Filesystems
 FindFirstFile
@@ -143,6 +144,7 @@ GetModuleHandleEx
 GetProcAddress
 Givargis
 Google
+HFS
 HHHH
 HHHHLL
 HHHLL
@@ -328,6 +330,7 @@ Timespec
 Timestamp
 TryCV
 TxnID
+UDF
 UID
 UIDs
 UINT

--- a/src/os_posix/os_fsync.c
+++ b/src/os_posix/os_fsync.c
@@ -8,6 +8,46 @@
 #include "wt_internal.h"
 
 /*
+ * __wt_handle_sync --
+ *	Flush a file handle.
+ */
+static int
+__wt_handle_sync(int fd)
+{
+	WT_DECL_RET;
+
+#if defined(F_FULLFSYNC)
+	/*
+	 * OS X fsync documentation:
+	 * "Note that while fsync() will flush all data from the host to the
+	 * drive (i.e. the "permanent storage device"), the drive itself may
+	 * not physically write the data to the platters for quite some time
+	 * and it may be written in an out-of-order sequence. For applications
+	 * that require tighter guarantees about the integrity of their data,
+	 * Mac OS X provides the F_FULLFSYNC fcntl. The F_FULLFSYNC fcntl asks
+	 * the drive to flush all buffered data to permanent storage."
+	 *
+	 * OS X F_FULLFSYNC fcntl documentation:
+	 * "This is currently implemented on HFS, MS-DOS (FAT), and Universal
+	 * Disk Format (UDF) file systems."
+	 */
+	WT_SYSCALL_RETRY(fcntl(fd, F_FULLFSYNC, 0), ret);
+	if (ret == 0)
+		return (0);
+	/*
+	 * Assume F_FULLFSYNC failed because the file system doesn't support it
+	 * and fallback to fsync.
+	 */
+#endif
+#if defined(HAVE_FDATASYNC)
+	WT_SYSCALL_RETRY(fdatasync(fd), ret);
+#else
+	WT_SYSCALL_RETRY(fsync(fd), ret);
+#endif
+	return (ret);
+}
+
+/*
  * __wt_directory_sync_fh --
  *	Flush a directory file handle.  We don't use __wt_fsync because
  *	most file systems don't require this step and we don't want to
@@ -19,10 +59,9 @@ __wt_directory_sync_fh(WT_SESSION_IMPL *session, WT_FH *fh)
 #ifdef __linux__
 	WT_DECL_RET;
 
-	WT_SYSCALL_RETRY(fsync(fh->fd), ret);
-	if (ret != 0)
-		WT_RET_MSG(session, ret, "%s: fsync", fh->name);
-	return (ret);
+	if ((ret = __wt_handle_sync(fh->fd)) == 0)
+		return (0);
+	WT_RET_MSG(session, ret, "%s: fsync", fh->name);
 #else
 	WT_UNUSED(session);
 	WT_UNUSED(fh);
@@ -59,8 +98,7 @@ __wt_directory_sync(WT_SESSION_IMPL *session, char *path)
 	if (ret != 0)
 		WT_RET_MSG(session, ret, "%s: open", path);
 
-	WT_SYSCALL_RETRY(fsync(fd), ret);
-	if (ret != 0)
+	if ((ret = __wt_handle_sync(fd)) != 0)
 		WT_ERR_MSG(session, ret, "%s: fsync", path);
 
 err:	WT_SYSCALL_RETRY(close(fd), tret);
@@ -86,15 +124,9 @@ __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh)
 
 	WT_RET(__wt_verbose(session, WT_VERB_FILEOPS, "%s: fsync", fh->name));
 
-#ifdef HAVE_FDATASYNC
-	WT_SYSCALL_RETRY(fdatasync(fh->fd), ret);
-#else
-	WT_SYSCALL_RETRY(fsync(fh->fd), ret);
-#endif
-	if (ret != 0)
-		WT_RET_MSG(session, ret, "%s fsync error", fh->name);
-
-	return (0);
+	if ((ret = __wt_handle_sync(fh->fd)) == 0)
+		return (0);
+	WT_RET_MSG(session, ret, "%s fsync error", fh->name);
 }
 
 /*
@@ -110,8 +142,9 @@ __wt_fsync_async(WT_SESSION_IMPL *session, WT_FH *fh)
 	WT_RET(__wt_verbose(
 	    session, WT_VERB_FILEOPS, "%s: sync_file_range", fh->name));
 
-	if ((ret = sync_file_range(fh->fd,
-	    (off64_t)0, (off64_t)0, SYNC_FILE_RANGE_WRITE)) == 0)
+	WT_SYSCALL_RETRY(sync_file_range(fh->fd,
+	    (off64_t)0, (off64_t)0, SYNC_FILE_RANGE_WRITE), ret);
+	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "%s: sync_file_range", fh->name);
 #else


### PR DESCRIPTION
OS X fsync isn't sufficient, use fcntl(F_FULLFSYNC) instead; note that F_FULLFSYNC isn't supported on all OS X filesystems, fallback to fsync if F_FULLFSYNC fails.
