### PR TITLE
Switch to holding the checkpoint lock when opening a bulk cursor.

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -459,13 +459,16 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 	if (WT_PREFIX_MATCH(uri, "file:")) {
 		/*
 		 * If we are opening a bulk cursor, get the handle while
-		 * holding the schema lock.  This prevents a bulk cursor open
-		 * failing with EBUSY due to a database-wide checkpoint.
+		 * holding the checkpoint lock.  This prevents a bulk cursor
+		 * open failing with EBUSY due to a database-wide checkpoint.
 		 */
 		if (bulk) {
-			WT_WITH_SCHEMA_LOCK(session,
-			    ret = __wt_session_get_btree_ckpt(
-			    session, uri, cfg, flags));
+			__wt_spin_lock(
+			    session, &S2C(session)->checkpoint_lock);
+			ret = __wt_session_get_btree_ckpt(
+			    session, uri, cfg, flags);
+			__wt_spin_unlock(
+			    session, &S2C(session)->checkpoint_lock);
 			WT_RET(ret);
 		} else
 			WT_RET(__wt_session_get_btree_ckpt(


### PR DESCRIPTION
This avoids a spurious EBUSY without adding more complexity to checkpoints.

refs #1397
