### PR TITLE
Fix some issues with the recent changes to handle locking

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -53,39 +53,41 @@ __sweep(WT_SESSION_IMPL *session)
 			if (dhandle->session_ref != 0 ||
 			    now - dhandle->timeofdeath <= WT_DHANDLE_SWEEP_WAIT)
 				continue;
-
-			/*
-			 * We don't set WT_DHANDLE_EXCLUSIVE deliberately, we
-			 * want opens to block on us rather than returning an
-			 * EBUSY error to the application.
-			 */
-			ret = __wt_try_writelock(session, dhandle->rwlock);
-			if (ret == EBUSY) {
-				ret = 0;
-				continue;
-			}
-			WT_RET(ret);
-
-			WT_WITH_DHANDLE(session, dhandle,
-			    ret = __wt_conn_btree_sync_and_close(session, 0));
-			if (ret == EBUSY)
-				ret = 0;
-
-			WT_TRET(__wt_writeunlock(session, dhandle->rwlock));
-			WT_RET(ret);
 		}
 
 		/*
-		 * Attempt to discard the handle (the called function checks the
-		 * handle-open flag after acquiring appropriate locks, which is
-		 * why we don't do any special handling of EBUSY returns above,
-		 * that path never cleared the handle-open flag.
+		 * We don't set WT_DHANDLE_EXCLUSIVE deliberately, we want
+		 * opens to block on us rather than returning an EBUSY error to
+		 * the application.
+		 */
+		if ((ret =
+		    __wt_try_writelock(session, dhandle->rwlock)) == EBUSY)
+			continue;
+		WT_RET(ret);
+
+		/*
+		 * Check if the handle was reacquired by a session while we
+		 * waited.
+		 */
+		if (dhandle->session_ref != 0) {
+			WT_RET(__wt_writeunlock(session, dhandle->rwlock));
+			continue;
+		}
+
+		/*
+		 * Attempt to discard the handle (the called function re-checks
+		 * the handle-open flag, which is why we don't do any special
+		 * handling of EBUSY returns above, that path never cleared the
+		 * handle-open flag.
 		 */
 		WT_WITH_DHANDLE(session, dhandle,
-		    ret = __wt_conn_dhandle_discard_single(session, 0));
-		if (ret == EBUSY)
-			ret = 0;
-		WT_RET(ret);
+		    ret = __wt_conn_dhandle_discard_single(session));
+
+		/* If the handle wasn't discarded, drop our lock. */
+		if (ret != 0)
+			WT_TRET(__wt_writeunlock(session, dhandle->rwlock));
+
+		WT_RET_BUSY_OK(ret);
 	}
 	return (0);
 }

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -462,17 +462,15 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 		 * holding the checkpoint lock.  This prevents a bulk cursor
 		 * open failing with EBUSY due to a database-wide checkpoint.
 		 */
-		if (bulk) {
+		if (bulk)
 			__wt_spin_lock(
 			    session, &S2C(session)->checkpoint_lock);
-			ret = __wt_session_get_btree_ckpt(
-			    session, uri, cfg, flags);
+		ret = __wt_session_get_btree_ckpt(
+		    session, uri, cfg, flags);
+		if (bulk)
 			__wt_spin_unlock(
 			    session, &S2C(session)->checkpoint_lock);
-			WT_RET(ret);
-		} else
-			WT_RET(__wt_session_get_btree_ckpt(
-			    session, uri, cfg, flags));
+		WT_RET(ret);
 	} else
 		WT_RET(__wt_bad_object_type(session, uri));
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -244,7 +244,7 @@ extern int __wt_conn_btree_get(WT_SESSION_IMPL *session, const char *name, const
 extern int __wt_conn_btree_apply(WT_SESSION_IMPL *session, int apply_checkpoints, int (*func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[]);
 extern int __wt_conn_btree_apply_single(WT_SESSION_IMPL *session, const char *uri, const char *checkpoint, int (*func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[]);
 extern int __wt_conn_dhandle_close_all( WT_SESSION_IMPL *session, const char *name, int force);
-extern int __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final);
+extern int __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session);
 extern int __wt_conn_dhandle_discard(WT_SESSION_IMPL *session);
 extern int __wt_connection_init(WT_CONNECTION_IMPL *conn);
 extern int __wt_connection_destroy(WT_CONNECTION_IMPL *conn);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -356,6 +356,21 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session, uint32_t flags)
 }
 
 /*
+ * __session_dhandle_find --
+ *	Search for a data handle in the connection and add it to a session's
+ *	cache.  Since the data handle isn't locked, this must be called holding
+ *	the handle list lock, and we must increment the handle's reference
+ *	count before releasing it.
+ */
+static int
+__session_dhandle_find(WT_SESSION_IMPL *session,
+    const char *uri, const char *checkpoint, uint32_t flags)
+{
+	WT_RET(__wt_conn_dhandle_find(session, uri, checkpoint, flags));
+	return (__session_add_btree(session, NULL));
+}
+
+/*
  * __wt_session_get_btree --
  *	Get a btree handle for the given name, set session->dhandle.
  */
@@ -390,11 +405,11 @@ __wt_session_get_btree(WT_SESSION_IMPL *session,
 		session->dhandle = dhandle;
 	else {
 		/*
-		 * We didn't find a match in the session cache, now check the
-		 * shared handle list.
+		 * We didn't find a match in the session cache, now search the
+		 * shared handle list and cache any handle we find.
 		 */
 		WT_WITH_DHANDLE_LOCK(session, ret =
-		    __wt_conn_dhandle_find(session, uri, checkpoint, flags));
+		    __session_dhandle_find(session, uri, checkpoint, flags));
 		dhandle = (ret == 0) ? session->dhandle : NULL;
 		WT_RET_NOTFOUND_OK(ret);
 	}
@@ -422,16 +437,16 @@ __wt_session_get_btree(WT_SESSION_IMPL *session,
 		__wt_conn_btree_get(session, uri, checkpoint, cfg, flags)));
 	WT_RET(ret);
 
-done:	if (dhandle_cache == NULL) {
+	if (!LF_SET(WT_DHANDLE_HAVE_REF))
 		WT_RET(__session_add_btree(session, NULL));
-		/* Sweep the handle list to remove any dead handles. */
-		WT_RET(__session_dhandle_sweep(session, flags));
-	}
+
+	/* Sweep the handle list to remove any dead handles. */
+	WT_RET(__session_dhandle_sweep(session, flags));
 
 	WT_ASSERT(session, LF_ISSET(WT_DHANDLE_LOCK_ONLY) ||
 	    F_ISSET(session->dhandle, WT_DHANDLE_OPEN));
 
-	/* Increment the data-source's in-use counter. */
+done:	/* Increment the data-source's in-use counter. */
 	__wt_session_dhandle_incr_use(session);
 
 	WT_ASSERT(session, LF_ISSET(WT_DHANDLE_EXCLUSIVE) ==


### PR DESCRIPTION
1. bump the reference count before dropping the handle list lock.  Otherwise, a handle sweep could free the handle from under us in between.
2. hold the handle exclusive until sweep is finished with it.  Previously it could have been re-acquired in between, and the locking situation was unclear.

refs #1391, #1392
