### PR TITLE
Add some wtperf workloads that turn logging on.

### DIFF
--- a/bench/wtperf/runners/log-append.wtperf
+++ b/bench/wtperf/runners/log-append.wtperf
@@ -1,0 +1,8 @@
+# wtperf options file: Test a log file with a multi-threaded
+# append workload.
+conn_config="cache_size=1G,log=(enabled=true,file_max=20MB),checkpoint=(log_size=1G)"
+table_config="type=file"
+icount=50000000
+report_interval=5
+run_time=0
+populate_threads=8

--- a/bench/wtperf/runners/log-nockpt.wtperf
+++ b/bench/wtperf/runners/log-nockpt.wtperf
@@ -1,0 +1,12 @@
+# wtperf options file: Test performance with a log file enabled.
+# Set the log file reasonably small to catch log-swtich bottle
+# necks.
+conn_config="cache_size=1G,log=(enabled=true,file_max=20MB)"
+table_config="type=file"
+icount=50000
+report_interval=5
+run_time=40
+populate_threads=1
+random_range=50000000
+threads=((count=8,inserts=1))
+

--- a/bench/wtperf/runners/log.wtperf
+++ b/bench/wtperf/runners/log.wtperf
@@ -1,0 +1,11 @@
+# wtperf options file: Test performance with a log file enabled.
+# Set the log file reasonably small to catch log-swtich bottle
+# necks.
+conn_config="cache_size=1G,log=(enabled=true,file_max=20MB),checkpoint=(log_size=1G)"
+table_config="type=file"
+icount=50000
+report_interval=5
+run_time=120
+populate_threads=1
+random_range=50000000
+threads=((count=8,inserts=1))


### PR DESCRIPTION
@sueloverso Could you take a look at these workloads please? This is related to #1414, it would be nice to figure out if there is a performance drop caused by the log subsystem.

It occurred to me that maybe we should play with value sizes as well. Maybe a larger one would be better?
