### PR TITLE
Python testing: prepend third party libraries we supply to the front of the os.path list.

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -60,7 +60,7 @@ sys.path.append(os.path.join(wt_disttop, 'lang', 'python'))
 for d in os.listdir(wt_3rdpartydir):
     for subdir in ('lib', 'python', ''):
         if os.path.exists(os.path.join(wt_3rdpartydir, d, subdir)):
-            sys.path.append(os.path.join(wt_3rdpartydir, d, subdir))
+            sys.path.insert(1, os.path.join(wt_3rdpartydir, d, subdir))
             break
 
 import wttest

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -434,14 +434,7 @@ class WiredTigerTestCase(unittest.TestCase):
 def runsuite(suite, parallel):
     suite_to_run = suite
     if parallel > 1:
-        try:
-            from concurrencytest import ConcurrentTestSuite, fork_for_tests
-        except ImportError:
-            print ('ERROR: additional python modules must be installed\n' +
-                   '       to use the "--parallel N" option.  Consult\n' +
-                   '       the WiredTiger HOWTO:RunTheTestSuite wiki page.\n')
-            raise
-
+        from concurrencytest import ConcurrentTestSuite, fork_for_tests
         if not WiredTigerTestCase._globalSetup:
             WiredTigerTestCase.globalSetup()
         WiredTigerTestCase._concurrent = True


### PR DESCRIPTION
This way, we'll reliably get our versions of third party libraries.  Refs #1394.
