### PR TITLE
Change timing to allow archive thread to complete on tests that do archive.

### DIFF
--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -161,10 +161,9 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             try:
                 self.check(backup_conn.open_session(), None, committed)
             finally:
-                # Yield so that the archive thread gets a chance to run
-                # before we close the connection.  time.sleep(0) is not
-                # guaranteed to force a context switch.  So use a small time.
-                time.sleep(0.01)
+                # Sleep long enough so that the archive thread is guaranteed
+                # to run before we close the connection.
+                time.sleep(1.0)
                 backup_conn.close()
             count += 1
         #
@@ -255,8 +254,11 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             self.check_all(current, committed)
 
         # Check the log state after the entire op completes
-        # and run recovery.
-        self.check_log(committed)
+        # and run recovery.  check_log() takes over a second
+        # to run, so we don't want to run it for all scenarios;
+        # rather, we run it about 100 times overall.
+        if self.scenario_number % (len(test_txn02.scenarios) / 100 + 1) == 0:
+            self.check_log(committed)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -141,10 +141,9 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
             try:
                  self.check(backup_conn.open_session(), None, committed)
             finally:
-                 # Let other threads like archive run before closing.
-                 # time.sleep(0) is not guaranteed to force a context switch.
-                 # Use a small timeout.
-                time.sleep(0.01)
+                # Sleep long enough so that the archive thread is guaranteed
+                # to run before we close the connection.
+                time.sleep(1.0)
                 backup_conn.close()
             count += 1
         #
@@ -234,7 +233,8 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Check the log state after the entire op completes
         # and run recovery.
-        self.check_log(committed)
+        if self.scenario_number % (len(test_txn05.scenarios) / 100 + 1) == 0:
+            self.check_log(committed)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Since this can make each test run substantially longer, reduce the number of tests that are doing archive from ~4000 to something under 100. Refs #1452.
