### PR TITLE
Add a WT_SESSION.app_private field for applications to use in callbacks taking a WT_SESSION handle.

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -745,6 +745,18 @@ struct __wt_session {
 	/*! The connection for this session. */
 	WT_CONNECTION *connection;
 
+	/*
+	 * Don't expose app_private to non-C language bindings - they have
+	 * their own way to attach data to an operation.
+	 */
+#if !defined(SWIG)
+	/*!
+	 * A location for applications to store information that will be
+	 * available in callbacks taking a WT_SESSION handle.
+	 */
+	void *app_private;
+#endif
+
 	/*!
 	 * Close the session handle.
 	 *

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -953,6 +953,7 @@ __wt_open_session(WT_CONNECTION_IMPL *conn,
 {
 	static const WT_SESSION stds = {
 		NULL,
+		NULL,
 		__session_close,
 		__session_reconfigure,
 		__session_open_cursor,


### PR DESCRIPTION
@michaelcahill, is there anything else needed?

Reference #1423.
