### PR TITLE
Update handle sweep timing. #1460

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -124,8 +124,8 @@ __sweep_server(void *arg)
 	    F_ISSET(conn, WT_CONN_SERVER_SWEEP)) {
 
 		/* Wait until the next event. */
-		WT_ERR(
-		    __wt_cond_wait(session, conn->sweep_cond, 30 * WT_MILLION));
+		WT_ERR(__wt_cond_wait(session,
+		    conn->sweep_cond, WT_DHANDLE_SWEEP_PERIOD * WT_MILLION));
 
 		/* Sweep the handles. */
 		WT_ERR(__sweep(session));

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -67,8 +67,8 @@ struct __wt_session_impl {
 	 */
 					/* Session handle reference list */
 	SLIST_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
-#define	WT_DHANDLE_SWEEP_WAIT	60	/* Wait before discarding */
-#define	WT_DHANDLE_SWEEP_PERIOD	20	/* Only sweep every 20 seconds */
+#define	WT_DHANDLE_SWEEP_WAIT	10	/* Wait before discarding */
+#define	WT_DHANDLE_SWEEP_PERIOD	5	/* Only sweep every 20 seconds */
 	time_t last_sweep;		/* Last sweep for dead handles */
 
 	WT_CURSOR *cursor;		/* Current cursor */


### PR DESCRIPTION
- Have session and connection sweeps wait the same amount of time.
- Reduce handle keep-alive from 60 to 10 seconds
- Reduce sweep wait period to 5 seconds
