### PR TITLE
Fix use of 'compressed' flag for printlog.

### DIFF
--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -430,7 +430,7 @@ __txn_printlog(
 	p = LOG_SKIP_HEADER(rawrec->data);
 	end = (const uint8_t *)rawrec->data + rawrec->size;
 	logrec = (WT_LOG_RECORD *)rawrec->data;
-	compressed = F_ISSET(rawrec, WT_LOG_RECORD_COMPRESSED);
+	compressed = F_ISSET(logrec, WT_LOG_RECORD_COMPRESSED);
 
 	/* First, peek at the log record type. */
 	WT_RET(__wt_logrec_read(session, &p, end, &rectype));

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -242,5 +242,10 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             self.assertEqual(cwrites > 0, True)
             self.assertEqual((cfails > 0 or csmall > 0), True)
 
+        #
+        # Run printlog and make sure it exits with zero status.
+        #
+        self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Also added printlog call to test case for log compression.
Refs #1472.
