### PR TITLE
Windows - Implement a custom version of snprintf

### DIFF
--- a/dist/filelist.win
+++ b/dist/filelist.win
@@ -125,6 +125,7 @@ src/os_win/os_rw.c
 src/os_win/os_sleep.c
 src/os_win/os_thread.c
 src/os_win/os_time.c
+src/os_win/os_snprintf.c
 src/os_win/os_vsnprintf.c
 src/os_win/os_yield.c
 src/packing/pack_api.c

--- a/src/include/os_windows.h
+++ b/src/include/os_windows.h
@@ -30,9 +30,14 @@ typedef uint32_t	u_int;
 typedef unsigned char	u_char;
 typedef unsigned long	u_long;
 
-/* < VS 2013 is not C99 compat */
+/* <= VS 2013 is not C99 compat */
 #if _MSC_VER < 1900
-#define	snprintf _snprintf
+#define	snprintf _wt_snprintf
+
+_Check_return_opt_ int __cdecl _wt_snprintf(
+    _Out_writes_(_MaxCount) char * _DstBuf,
+    _In_ size_t _MaxCount,
+    _In_z_ _Printf_format_string_ const char * _Format, ...);
 #endif
 
 /*

--- a/src/os_win/os_snprintf.c
+++ b/src/os_win/os_snprintf.c
@@ -1,0 +1,23 @@
+/*-
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+_Check_return_opt_ int __cdecl _wt_snprintf(
+    _Out_writes_(_MaxCount) char * _DstBuf,
+    _In_ size_t _MaxCount,
+    _In_z_ _Printf_format_string_ const char * _Format, ...)
+{
+	va_list args;
+	WT_DECL_RET;
+
+	va_start(args, _Format);
+	ret = _wt_vsnprintf(_DstBuf, _MaxCount, _Format, args);
+	va_end(args);
+
+	return (ret);
+}

--- a/src/os_win/os_vsnprintf.c
+++ b/src/os_win/os_vsnprintf.c
@@ -7,8 +7,6 @@
 
 #include "wt_internal.h"
 
-#undef vsnprintf
-
 _Check_return_opt_ int __cdecl _wt_vsnprintf(
     _Out_writes_(_MaxCount) char * _DstBuf,
     _In_ size_t _MaxCount,
@@ -17,12 +15,23 @@ _Check_return_opt_ int __cdecl _wt_vsnprintf(
 {
 	int len;
 
-	len = (size_t)vsnprintf(_DstBuf, _MaxCount, _Format, _ArgList);
+	/*
+	 * WiredTiger will call with length 0 to get the needed buffer size
+	 * We call the count only version in this case since vsnprintf_s assumes
+	 * length is greater than zero or else it triggers the invalid_parameter
+	 * handler.
+	 */
+	if (_MaxCount == 0) {
+		return _vscprintf(_Format, _ArgList);
+	}
+
+	len = (size_t)_vsnprintf_s(
+		_DstBuf, _MaxCount, _TRUNCATE, _Format, _ArgList);
 
 	/*
 	 * The MSVC implementation returns -1 on truncation instead of what
-	 * it would have written.  We could iteratively grow the buffer, or
-	 * just ask us how big a buffer they would like.
+	 * it would have written.  We could let callers iteratively grow the
+	 * buffer, or just ask us how big a buffer they would like.
 	 */
 	if (len == -1)
 		len = _vscprintf(_Format, _ArgList) + 1;

--- a/test/windows/windows_shim.h
+++ b/test/windows/windows_shim.h
@@ -43,7 +43,14 @@ typedef int u_int;
 #define	X_OK R_OK
 
 /* snprintf does not exist on <= VS 2013 */
-#define	snprintf _snprintf
+#if _MSC_VER < 1900
+#define	snprintf _wt_snprintf
+
+_Check_return_opt_ int __cdecl _wt_snprintf(
+    _Out_writes_(_MaxCount) char * _DstBuf,
+    _In_ size_t _MaxCount,
+    _In_z_ _Printf_format_string_ const char * _Format, ...);
+#endif
 
 /*
  * Emulate <sys/stat.h>


### PR DESCRIPTION
Windows needs to match the truncation behavior of C99 standard snprintf until MSVC supports snprintf.

The Windows CRT function _snprintf does not truncate strings. I have updated _wt_vsnprintf to truncate, and created a wt wrapper called _wt_snprintf.

This became an issue while testing wtperf, and I saw an issue in the config.c configuration parser.
