### PR TITLE
Skip test_priv01.py on Windows since it is Unix specific

### DIFF
--- a/test/suite/test_priv01.py
+++ b/test/suite/test_priv01.py
@@ -48,6 +48,7 @@ class test_priv01(wttest.WiredTigerTestCase):
     def setUp(self):
         if os.name == 'nt':
             self.skipTest('Unix specific test skipped on Windows')
+        super(test_priv01, self).setUp()
 
     # Each test needs to set up its connection in its own way,
     # so override these methods to do nothing


### PR DESCRIPTION
Since Windows does not support POSIX style privileges, I am skipping this test on Windows.

Let me know if there are any issues.
