### PR TITLE
fix test_salvage.py on Windows

### DIFF
--- a/test/suite/test_salvage.py
+++ b/test/suite/test_salvage.py
@@ -120,8 +120,9 @@ class test_salvage(wttest.WiredTigerTestCase, suite_subprocess):
         found = matchpos = 0
         match = self.unique
         matchlen = len(match)
+        flen = os.fstat(fp.fileno()).st_size
         c = fp.read(1)
-        while c:
+        while fp.tell() != flen:
             if match[matchpos] == c:
                 matchpos += 1
                 if matchpos == matchlen:


### PR DESCRIPTION
Use file size to check for EOF instead of depending on return from file.read.

Verified test passes on Windows 8.1, OmniOS, and MacOS X 10.10
