### PR TITLE
Use the eviction server to write pages with READGEN_OLDEST set.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -407,13 +407,14 @@ __evict_has_work(WT_SESSION_IMPL *session, uint32_t *flagsp)
 	    (cache->eviction_dirty_target * bytes_max) / 100)
 		/* Ignore clean pages unless the cache is too large */
 		LF_SET(WT_EVICT_PASS_DIRTY);
-	else if (F_ISSET(cache, WT_EVICT_EARLY_CANDIDATES)) {
+	else if (F_ISSET(cache, WT_EVICT_WOULD_BLOCK)) {
 		/*
-		 * Trickle out pages with oldest generation set regardless of
-		 * whether we have reached the eviction trigger.
+		 * Evict pages with oldest generation (which would otherwise
+		 * block application threads) set regardless of whether we have
+		 * reached the eviction trigger.
 		 */
-		LF_SET(WT_EVICT_PASS_TRICKLE);
-		F_CLR(cache, WT_EVICT_EARLY_CANDIDATES);
+		LF_SET(WT_EVICT_PASS_WOULD_BLOCK);
+		F_CLR(cache, WT_EVICT_WOULD_BLOCK);
 	}
 
 	if (F_ISSET(cache, WT_EVICT_STUCK))
@@ -1088,7 +1089,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp, uint32_t flags)
 		 * If we are only trickling out pages marked for definite
 		 * eviction, skip anything that isn't marked.
 		 */
-		if (LF_ISSET(WT_EVICT_PASS_TRICKLE) &&
+		if (LF_ISSET(WT_EVICT_PASS_WOULD_BLOCK) &&
 		    page->read_gen != WT_READGEN_OLDEST)
 			continue;
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -118,8 +118,8 @@ done:	session->excl_next = 0;
 		txn_state->snap_min = WT_TXN_NONE;
 
 	if ((inmem_split || (forced_eviction && ret == EBUSY)) &&
-	    !F_ISSET(S2C(session)->cache, WT_EVICT_EARLY_CANDIDATES)) {
-		F_SET(S2C(session)->cache, WT_EVICT_EARLY_CANDIDATES);
+	    !F_ISSET(S2C(session)->cache, WT_EVICT_WOULD_BLOCK)) {
+		F_SET(S2C(session)->cache, WT_EVICT_WOULD_BLOCK);
 		WT_TRET(__wt_evict_server_wake(session));
 	}
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -19,7 +19,7 @@
 #define	WT_EVICT_PASS_AGGRESSIVE	0x01
 #define	WT_EVICT_PASS_ALL		0x02
 #define	WT_EVICT_PASS_DIRTY		0x04
-#define	WT_EVICT_PASS_TRICKLE		0x08
+#define	WT_EVICT_PASS_WOULD_BLOCK	0x08
 
 /*
  * WT_EVICT_ENTRY --
@@ -34,7 +34,6 @@ struct __wt_evict_entry {
  * WT_EVICT_WORKER --
  *	Encapsulation of an eviction worker thread.
  */
-
 struct __wt_evict_worker {
 	WT_SESSION_IMPL *session;
 	u_int id;
@@ -114,8 +113,8 @@ struct __wt_cache {
 #define	WT_CACHE_POOL_RUN	0x02	/* Cache pool thread running */
 #define	WT_EVICT_ACTIVE		0x04	/* Eviction server is active */
 #define	WT_EVICT_CLEAR_WALKS	0x08	/* Clear eviction walks */
-#define	WT_EVICT_EARLY_CANDIDATES	0x10	/* Evict before trigger */
-#define	WT_EVICT_STUCK		0x20	/* Eviction server is stuck */
+#define	WT_EVICT_STUCK		0x10	/* Eviction server is stuck */
+#define	WT_EVICT_WOULD_BLOCK	0x20	/* Pages that would block apps */
 	uint32_t flags;
 };
 


### PR DESCRIPTION
Even before the eviction trigger has been reached. This should mean
that we clear those pages out of cache earlier, and hopefully will
save application threads from doing the evictions (at least sometimes).
