### PR TITLE
Add __wt_getenv to workaround caching in MSVC CRT's getenv implementation

### DIFF
--- a/build_win/filelist.win
+++ b/build_win/filelist.win
@@ -113,6 +113,7 @@ src/os_win/os_filesize.c
 src/os_win/os_flock.c
 src/os_win/os_fsync.c
 src/os_win/os_ftruncate.c
+src/os_win/os_getenv.c
 src/os_win/os_map.c
 src/os_win/os_mtx_cond.c
 src/os_win/os_once.c

--- a/dist/filelist
+++ b/dist/filelist
@@ -109,6 +109,7 @@ src/os_posix/os_filesize.c
 src/os_posix/os_flock.c
 src/os_posix/os_fsync.c
 src/os_posix/os_ftruncate.c
+src/os_posix/os_getenv.c
 src/os_posix/os_getline.c
 src/os_posix/os_getopt.c
 src/os_posix/os_map.c

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -138,6 +138,7 @@ GETTIMEOFDAY
 GIDs
 Gcc
 Geoff
+GetEnvironmentVariableA
 GetFileAttributesEx
 GetFileSizeEx
 GetLastError
@@ -639,6 +640,7 @@ func
 funcs
 gcc
 gdb
+getenv
 getfiles
 getid
 getline

--- a/dist/s_win
+++ b/dist/s_win
@@ -44,6 +44,7 @@ win_filelist()
 	    -e 's;os_posix/os_flock.c;os_win/os_flock.c;' \
 	    -e 's;os_posix/os_fsync.c;os_win/os_fsync.c;' \
 	    -e 's;os_posix/os_ftruncate.c;os_win/os_ftruncate.c;' \
+	    -e 's;os_posix/os_getenv.c;os_win/os_getenv.c;' \
 	    -e 's;os_posix/os_map.c;os_win/os_map.c;' \
 	    -e 's;os_posix/os_mtx_cond.c;os_win/os_mtx_cond.c;' \
 	    -e 's;os_posix/os_once.c;os_win/os_once.c;' \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -442,6 +442,7 @@ extern int __wt_directory_sync(WT_SESSION_IMPL *session, char *path);
 extern int __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh);
 extern int __wt_fsync_async(WT_SESSION_IMPL *session, WT_FH *fh);
 extern int __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len);
+extern int __wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **env);
 extern int __wt_getline(WT_SESSION_IMPL *session, WT_ITEM *buf, FILE *fp);
 extern int __wt_getopt( const char *progname, int nargc, char *const *nargv, const char *ostr);
 extern int __wt_mmap(WT_SESSION_IMPL *session, WT_FH *fh, void *mapp, size_t *lenp, void **mappingcookie);

--- a/src/os_posix/os_getenv.c
+++ b/src/os_posix/os_getenv.c
@@ -1,0 +1,26 @@
+/*-
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_getenv --
+ * 	Get a non-null environment variable
+ */
+int
+__wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **env)
+{
+	const char *temp;
+
+	*env = NULL;
+
+	if (((temp = getenv(variable)) != NULL) && strlen(temp) > 0) {
+		return (__wt_strdup(session, temp, env));
+	}
+
+	return (WT_NOTFOUND);
+}

--- a/src/os_win/os_getenv.c
+++ b/src/os_win/os_getenv.c
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_getenv --
+ * 	Get a non-null environment variable
+ */
+int
+__wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **env)
+{
+	WT_DECL_RET;
+	DWORD size;
+
+	*env = NULL;
+
+	size = GetEnvironmentVariableA(variable, NULL, 0);
+	if (size <= 1)
+		return (WT_NOTFOUND);
+
+	WT_RET(__wt_calloc(session, 1, size, env));
+
+	ret = GetEnvironmentVariableA(variable, *env, size);
+	/* We expect the number of bytes not including null terminator */
+	if ((ret + 1) != size)
+		WT_RET_MSG(session, __wt_errno(),
+		    "GetEnvironmentVariableA failed: %s", variable);
+
+	return (0);
+}


### PR DESCRIPTION
MSVC CRT's getenv caches the environment variables it returns after the first call. I had to switch to the Windows API to avoid the CRT caching.

Implemented __wt_getenv which now allocates memory, and updated callers.

Test: Mac OS X 10.10 & Windows 8.1 compile, and unit test suite runs
Also, adhoc tests for WIREDTIGER_CONFIG with wt.exe.
