### PR TITLE
Fix a bug where a custom extractor terminate was being called twice.

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2613,7 +2613,8 @@ struct __wt_collator {
 	    const char *uri, WT_CONFIG_ITEM *appcfg, WT_COLLATOR **customp);
 
 	/*!
-	 * If non-NULL, a callback performed when the database is closed.
+	 * If non-NULL a callback performed when the data source is closed
+	 * for customized extractors otherwise when the database is closed.
 	 *
 	 * The WT_COLLATOR::terminate callback is intended to allow cleanup,
 	 * the handle will not be subsequently accessed by WiredTiger.
@@ -3037,7 +3038,9 @@ struct __wt_extractor {
 	    const char *uri, WT_CONFIG_ITEM *appcfg, WT_EXTRACTOR **customp);
 
 	/*!
-	 * If non-NULL, a callback performed when the database is closed.
+	 * If non-NULL a callback performed when the index or column group
+	 * is closed for customized extractors otherwise when the database
+	 * is closed.
 	 *
 	 * The WT_EXTRACTOR::terminate callback is intended to allow cleanup,
 	 * the handle will not be subsequently accessed by WiredTiger.

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -139,9 +139,13 @@ __wt_schema_destroy_index(WT_SESSION_IMPL *session, WT_INDEX *idx)
 	WT_DECL_RET;
 
 	/* If there is a custom extractor configured, terminate it. */
-	if (idx->extractor != NULL && idx->extractor->terminate != NULL)
+	if (idx->extractor != NULL &&
+	    idx->extractor_owned && idx->extractor->terminate != NULL) {
 		WT_TRET(idx->extractor->terminate(
 		    idx->extractor, &session->iface));
+		idx->extractor = NULL;
+		idx->extractor_owned = 0;
+	}
 
 	__wt_free(session, idx->name);
 	__wt_free(session, idx->source);


### PR DESCRIPTION
Resolves issue #1503.

Clarify the custom extractor and collator terminate documentation while
I'm here.
