### PR TITLE
Avoid EBUSY returns to verify and salvage caused by checkpoints

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -547,6 +547,7 @@ __session_salvage(WT_SESSION *wt_session, const char *uri, const char *config)
 	session = (WT_SESSION_IMPL *)wt_session;
 
 	SESSION_API_CALL(session, salvage, config, cfg);
+	/* Block out checkpoints to avoid spurious EBUSY errors. */
 	__wt_spin_lock(session, &S2C(session)->checkpoint_lock);
 	WT_WITH_SCHEMA_LOCK(session,
 	    ret = __wt_schema_worker(session, uri, __wt_salvage,
@@ -684,6 +685,7 @@ __session_upgrade(WT_SESSION *wt_session, const char *uri, const char *config)
 	session = (WT_SESSION_IMPL *)wt_session;
 
 	SESSION_API_CALL(session, upgrade, config, cfg);
+	/* Block out checkpoints to avoid spurious EBUSY errors. */
 	__wt_spin_lock(session, &S2C(session)->checkpoint_lock);
 	WT_WITH_SCHEMA_LOCK(session,
 	    ret = __wt_schema_worker(session, uri, __wt_upgrade,
@@ -706,6 +708,7 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
 	session = (WT_SESSION_IMPL *)wt_session;
 
 	SESSION_API_CALL(session, verify, config, cfg);
+	/* Block out checkpoints to avoid spurious EBUSY errors. */
 	__wt_spin_lock(session, &S2C(session)->checkpoint_lock);
 	WT_WITH_SCHEMA_LOCK(session,
 	    ret = __wt_schema_worker(session, uri, __wt_verify,


### PR DESCRIPTION
  The "fix" involves blocking checkpoints while salvage or verify are in progress.

refs #1404, SERVER-16457
