### PR TITLE
Use "none" for configurations in documentation but store empty defaults....

### DIFF
--- a/dist/api_config.py
+++ b/dist/api_config.py
@@ -188,6 +188,8 @@ def get_default(c):
     t = gettype(c)
     if c.default == 'false':
         return '0'
+    elif t == 'string' and c.default == 'none':
+        return ''
     elif t == 'category':
         return '(%s)' % (','.join('%s=%s' % (subc.name, get_default(subc))
             for subc in sorted(c.subconfig)))

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -124,7 +124,7 @@ file_config = format_meta + [
         items, and the default value of 4KB is a good choice absent
         requirements from the operating system or storage device''',
         min='512B', max='128MB'),
-    Config('block_compressor', '', r'''
+    Config('block_compressor', 'none', r'''
         configure a compressor for file blocks.  Permitted values are
         \c "none" or custom compression engine name created with
         WT_CONNECTION::add_compressor.  If WiredTiger has builtin support
@@ -142,7 +142,7 @@ file_config = format_meta + [
         applications which can rely on decompression to fail if a block
         has been corrupted''',
         choices=['on', 'off', 'uncompressed']),
-    Config('collator', '', r'''
+    Config('collator', 'none', r'''
         configure custom collation for keys.  Permitted values are
         \c "none" or a custom collator name created with
         WT_CONNECTION::add_collator'''),
@@ -154,11 +154,11 @@ file_config = format_meta + [
     Config('format', 'btree', r'''
         the file format''',
         choices=['btree']),
-    Config('huffman_key', '', r'''
+    Config('huffman_key', 'none', r'''
         configure Huffman encoding for keys.  Permitted values are
         \c "none", \c "english", \c "utf8<file>" or \c "utf16<file>".
         See @ref huffman for more information'''),
-    Config('huffman_value', '', r'''
+    Config('huffman_value', 'none', r'''
         configure Huffman encoding for values.  Permitted values are
         \c "none", \c "english", \c "utf8<file>" or \c "utf16<file>".
         See @ref huffman for more information'''),
@@ -273,7 +273,7 @@ table_only_config = [
 ]
 
 index_only_config = [
-    Config('extractor', '', r'''
+    Config('extractor', 'none', r'''
         configure custom extractor for indices.  Permitted values are
         \c "none" or an extractor name created with
         WT_CONNECTION::add_extractor'''),
@@ -510,7 +510,7 @@ common_wiredtiger_open = [
         Config('archive', 'true', r'''
             automatically archive unneeded log files''',
             type='boolean'),
-        Config('compressor', '', r'''
+        Config('compressor', 'none', r'''
             configure a compressor for log records.  Permitted values are
             \c "none" or \c "bzip2", \c "snappy" or custom compression
             engine \c "name" created with WT_CONNECTION::add_compressor.

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -547,7 +547,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "error_prefix=,eviction=(threads_max=1,threads_min=1),"
 	  "eviction_dirty_target=80,eviction_target=80,eviction_trigger=95,"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,"
-	  "shared_cache=(chunk=10MB,name=none,reserve=0,size=500MB),"
+	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),verbose=",
@@ -666,7 +666,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,hazard_max=1000,log=(archive=,compressor=,enabled=0"
 	  ",file_max=100MB,path=,prealloc=),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
-	  "session_max=100,shared_cache=(chunk=10MB,name=none,reserve=0,"
+	  "session_max=100,shared_cache=(chunk=10MB,name=,reserve=0,"
 	  "size=500MB),statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
@@ -683,7 +683,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,hazard_max=1000,log=(archive=,compressor=,enabled=0"
 	  ",file_max=100MB,path=,prealloc=),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
-	  "session_max=100,shared_cache=(chunk=10MB,name=none,reserve=0,"
+	  "session_max=100,shared_cache=(chunk=10MB,name=,reserve=0,"
 	  "size=500MB),statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
@@ -700,12 +700,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "extensions=,file_extend=,hazard_max=1000,log=(archive=,"
 	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=),"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,"
-	  "name=none,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
-	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=0,method=fsync),verbose=,"
-	  "version=(major=0,minor=0)",
+	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,name=,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg
 	},
 	{ "wiredtiger_open_usercfg",
@@ -717,11 +716,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "extensions=,file_extend=,hazard_max=1000,log=(archive=,"
 	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=),"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,"
-	  "name=none,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
-	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=0,method=fsync),verbose=",
+	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,name=,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg
 	},
 	{ NULL, NULL, NULL }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -946,7 +946,7 @@ struct __wt_session {
 	 * created with WT_CONNECTION::add_compressor.  If WiredTiger has
 	 * builtin support for \c "snappy" or \c "zlib" compression\, these
 	 * names are also available.  See @ref compression for more
-	 * information., a string; default empty.}
+	 * information., a string; default \c none.}
 	 * @config{cache_resident, do not ever evict the object's pages; see
 	 * @ref tuning_cache_resident for more information., a boolean flag;
 	 * default \c false.}
@@ -966,7 +966,7 @@ struct __wt_session {
 	 * strings; default empty.}
 	 * @config{collator, configure custom collation for keys.  Permitted
 	 * values are \c "none" or a custom collator name created with
-	 * WT_CONNECTION::add_collator., a string; default empty.}
+	 * WT_CONNECTION::add_collator., a string; default \c none.}
 	 * @config{columns, list of the column names.  Comma-separated list of
 	 * the form <code>(column[\,...])</code>. For tables\, the number of
 	 * entries must match the total number of values in \c key_format and \c
@@ -982,17 +982,17 @@ struct __wt_session {
 	 * specified configuration., a boolean flag; default \c false.}
 	 * @config{extractor, configure custom extractor for indices.  Permitted
 	 * values are \c "none" or an extractor name created with
-	 * WT_CONNECTION::add_extractor., a string; default empty.}
+	 * WT_CONNECTION::add_extractor., a string; default \c none.}
 	 * @config{format, the file format., a string\, chosen from the
 	 * following options: \c "btree"; default \c btree.}
 	 * @config{huffman_key, configure Huffman encoding for keys.  Permitted
 	 * values are \c "none"\, \c "english"\, \c "utf8<file>" or \c
 	 * "utf16<file>". See @ref huffman for more information., a string;
-	 * default empty.}
+	 * default \c none.}
 	 * @config{huffman_value, configure Huffman encoding for values.
 	 * Permitted values are \c "none"\, \c "english"\, \c "utf8<file>" or \c
 	 * "utf16<file>". See @ref huffman for more information., a string;
-	 * default empty.}
+	 * default \c none.}
 	 * @config{immutable, configure the index to be immutable - that is an
 	 * index is not changed by any update to a record in the table., a
 	 * boolean flag; default \c false.}
@@ -1905,7 +1905,7 @@ struct __wt_connection {
  * records.  Permitted values are \c "none" or \c "bzip2"\, \c "snappy" or
  * custom compression engine \c "name" created with
  * WT_CONNECTION::add_compressor.  See @ref compression for more information., a
- * string; default empty.}
+ * string; default \c none.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, enable
  * logging subsystem., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;file_max, the maximum size of log files., an


### PR DESCRIPTION
This is both more efficient than storing "none" and backwards compatible.

refs #1417
