### PR TITLE
Remove version numbering from the pkg-config file.

### DIFF
--- a/build_posix/wiredtiger.pc.in
+++ b/build_posix/wiredtiger.pc.in
@@ -7,5 +7,5 @@ Name: WiredTiger
 Description: The WiredTiger Data Engine
 Requires:
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lwiredtiger-@VERSION_NOPATCH@
-Cflags: -I${includedir}/wiredtiger-@VERSION_NOPATCH@
+Libs: -L${libdir} -lwiredtiger
+Cflags: -I${includedir}


### PR DESCRIPTION
We don't create include files that are named by version.  Programs linked using -lwiredtiger will follow the symlink to wiredtiger-a.b.c.so, so their referred library name is forever stamped as wiredtiger-a.b.c.so, which won't conflict even when we ship wiredtiger-a.b.d.so .
Refs #1458.

Note: jenkins job wiredtiger-configure-combinations has been adjusted to test building programs using pkg-config (under all tested configurations).
