### PR TITLE
Cache a maximum of 2MB per session for scratch buffers

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -541,6 +541,9 @@ common_wiredtiger_open = [
         maximum expected number of sessions (including server
         threads)''',
         min='1'),
+    Config('session_scratch_max', '2MB', r'''
+        maximum memory to cache in each session''',
+        type='int', undoc=True),
     Config('transaction_sync', '', r'''
         how to sync log records when the transaction commits''',
         type='category', subconfig=[

--- a/dist/log.py
+++ b/dist/log.py
@@ -125,8 +125,7 @@ __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 void
 __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp)
 {
-\tWT_UNUSED(session);
-\t__wt_scr_free(logrecp);
+\t__wt_scr_free(session, logrecp);
 }
 
 int

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -155,7 +155,7 @@ err:		/*
 	if (checkpoint && ci != NULL)
 		__wt_block_ckpt_destroy(session, ci);
 
-	__wt_scr_free(&tmp);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -658,7 +658,7 @@ err:	if (locked)
 		if ((ci = ckpt->bpriv) != NULL)
 			__wt_block_ckpt_destroy(session, ci);
 
-	__wt_scr_free(&tmp);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -742,7 +742,7 @@ __ckpt_update(WT_SESSION_IMPL *session,
 		    block->name, ckpt->name, (const char *)tmp->data));
 	}
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1200,7 +1200,7 @@ corrupted:		WT_PANIC_RET(session, WT_ERROR,
 	if (WT_VERBOSE_ISSET(session, WT_VERB_BLOCK))
 		WT_ERR(__block_extlist_dump(session, "read extlist", el, 0));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -1296,7 +1296,7 @@ __wt_block_extlist_write(WT_SESSION_IMPL *session,
 	    "%s written %" PRIdMAX "/%" PRIu32,
 	    el->name, (intmax_t)el->offset, el->size));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -255,7 +255,7 @@ __wt_desc_init(WT_SESSION_IMPL *session, WT_FH *fh, uint32_t allocsize)
 
 	ret = __wt_write(session, fh, (wt_off_t)0, (size_t)allocsize, desc);
 
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -313,7 +313,7 @@ __desc_read(WT_SESSION_IMPL *session, WT_BLOCK *block)
 		    WT_BLOCK_MAJOR_VERSION, WT_BLOCK_MINOR_VERSION,
 		    desc->majorv, desc->minorv);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -44,7 +44,7 @@ __wt_bm_preload(WT_BM *bm,
 			WT_RET(__wt_scr_alloc(session, size, &tmp));
 			ret = __wt_block_read_off(
 			    session, block, tmp, offset, size, cksum);
-			__wt_scr_free(&tmp);
+			__wt_scr_free(session, &tmp);
 			WT_RET(ret);
 		}
 	}

--- a/src/block/block_slvg.c
+++ b/src/block/block_slvg.c
@@ -155,7 +155,7 @@ __wt_block_salvage_next(WT_SESSION_IMPL *session,
 	*addr_sizep = WT_PTRDIFF(endp, addr);
 
 done:
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -119,7 +119,7 @@ __dmsg_wrapup(WT_DBG *ds)
 	session = ds->session;
 	msg = ds->msg;
 
-	__wt_scr_free(&ds->tmp);
+	__wt_scr_free(session, &ds->tmp);
 
 	/*
 	 * Discard the buffer -- it shouldn't have anything in it, but might
@@ -128,7 +128,7 @@ __dmsg_wrapup(WT_DBG *ds)
 	if (msg != NULL) {
 		if (msg->size != 0)
 			(void)__wt_msg(session, "%s", (char *)msg->mem);
-		__wt_scr_free(&ds->msg);
+		__wt_scr_free(session, &ds->msg);
 	}
 
 	/* Close any file we opened. */
@@ -208,7 +208,7 @@ __wt_debug_addr_print(
 	WT_RET(__wt_scr_alloc(session, 128, &buf));
 	fprintf(stderr, "%s\n",
 	    __wt_addr_string(session, addr, addr_size, buf));
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 
 	return (0);
 }
@@ -231,7 +231,7 @@ __wt_debug_addr(WT_SESSION_IMPL *session,
 	WT_ERR(bm->read(bm, session, buf, addr, addr_size));
 	ret = __wt_debug_disk(session, buf->mem, ofile);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -258,7 +258,7 @@ __wt_debug_offset_blind(
 	    session, S2BT(session)->bm->block, buf, offset));
 	ret = __wt_debug_disk(session, buf->mem, ofile);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -296,7 +296,7 @@ __wt_debug_offset(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_bt_read(session, buf, addr, WT_PTRDIFF(endp, addr)));
 	ret = __wt_debug_disk(session, buf->mem, ofile);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -856,7 +856,7 @@ __debug_page_row_leaf(WT_DBG *ds, WT_PAGE *page)
 			__debug_row_skip(ds, insert);
 	}
 
-err:	__wt_scr_free(&key);
+err:	__wt_scr_free(session, &key);
 	return (ret);
 }
 
@@ -1024,7 +1024,7 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 addr:		WT_RET(__wt_scr_alloc(session, 128, &buf));
 		__dmsg(ds, ", %s %s", type,
 		    __wt_addr_string(session, unpack->data, unpack->size, buf));
-		__wt_scr_free(&buf);
+		__wt_scr_free(session, &buf);
 		WT_RET(ret);
 		break;
 	}
@@ -1083,7 +1083,7 @@ __debug_cell_data(WT_DBG *ds,
 		    __wt_page_cell_data_ref(session, page, unpack, buf);
 		if (ret == 0)
 			__debug_item(ds, tag, buf->data, buf->size);
-		__wt_scr_free(&buf);
+		__wt_scr_free(session, &buf);
 		break;
 	WT_ILLEGAL_VALUE(session);
 	}

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -117,7 +117,7 @@ __wt_bt_read(WT_SESSION_IMPL *session,
 	WT_STAT_FAST_CONN_INCRV(session, cache_bytes_read, dsk->mem_size);
 	WT_STAT_FAST_DATA_INCRV(session, cache_bytes_read, dsk->mem_size);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -174,7 +174,7 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 		ip = buf;
 	}
 	WT_ERR(__wt_verify_dsk(session, "[write-check]", ip));
-	__wt_scr_free(&tmp);
+	__wt_scr_free(session, &tmp);
 #endif
 
 	/*
@@ -299,6 +299,6 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 	WT_STAT_FAST_CONN_INCRV(session, cache_bytes_write, dsk->mem_size);
 	WT_STAT_FAST_DATA_INCRV(session, cache_bytes_write, dsk->mem_size);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -142,7 +142,7 @@ __ovfl_cache(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK *unpack)
 	WT_ERR(__wt_ovfl_txnc_add(
 	    session, page, addr, addr_size, tmp->data, tmp->size));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -643,7 +643,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 		}
 	}
 
-err:	__wt_scr_free(&current);
+err:	__wt_scr_free(session, &current);
 	return (ret);
 }
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -342,8 +342,8 @@ err:	WT_TRET(bm->salvage_end(bm, session));
 	WT_TRET(__slvg_cleanup(session, ss));
 
 	/* Discard temporary buffers. */
-	__wt_scr_free(&ss->tmp1);
-	__wt_scr_free(&ss->tmp2);
+	__wt_scr_free(session, &ss->tmp1);
+	__wt_scr_free(session, &ss->tmp2);
 
 	/* Wrap up reporting. */
 	WT_TRET(__wt_progress(session, NULL, ss->fcnt));
@@ -472,8 +472,8 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
 		}
 	}
 
-err:	__wt_scr_free(&as);
-	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &as);
+	__wt_scr_free(session, &buf);
 
 	return (ret);
 }
@@ -1786,8 +1786,8 @@ __slvg_row_trk_update_start(
 
 err:	if (page != NULL)
 		__wt_page_out(session, &page);
-	__wt_scr_free(&dsk);
-	__wt_scr_free(&key);
+	__wt_scr_free(session, &dsk);
+	__wt_scr_free(session, &key);
 
 	return (ret);
 }
@@ -2024,7 +2024,7 @@ __slvg_row_build_leaf(
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));
 	}
-	__wt_scr_free(&key);
+	__wt_scr_free(session, &key);
 
 	return (ret);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -725,7 +725,7 @@ __split_multi_inmem(
 err:	/* Free any resources that may have been cached in the cursor. */
 	WT_TRET(__wt_btcur_close(&cbt));
 
-	__wt_scr_free(&key);
+	__wt_scr_free(session, &key);
 	return (ret);
 }
 
@@ -1108,7 +1108,7 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 
 	WT_ERR(__wt_row_ikey(
 	    session, 0, key->data, key->size, &child->key.ikey));
-	__wt_scr_free(&key);
+	__wt_scr_free(session, &key);
 
 	/*
 	 * The second page in the split is a new WT_REF/page pair.
@@ -1318,7 +1318,7 @@ err:	if (split_ref[0] != NULL) {
 	}
 	if (right != NULL)
 		__wt_page_out(session, &right);
-	__wt_scr_free(&key);
+	__wt_scr_free(session, &key);
 	return (ret);
 }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -147,10 +147,10 @@ err:	/* Inform the underlying block manager we're done. */
 	WT_TRET(__wt_progress(session, NULL, vs->fcnt));
 
 	/* Free allocated memory. */
-	__wt_scr_free(&vs->max_key);
-	__wt_scr_free(&vs->max_addr);
-	__wt_scr_free(&vs->tmp1);
-	__wt_scr_free(&vs->tmp2);
+	__wt_scr_free(session, &vs->max_key);
+	__wt_scr_free(session, &vs->max_addr);
+	__wt_scr_free(session, &vs->tmp1);
+	__wt_scr_free(session, &vs->tmp2);
 
 	return (ret);
 }

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -454,9 +454,9 @@ eof:		ret = __err_eof(session, cell_num, addr);
 err:		if (ret == 0)
 			ret = WT_ERROR;
 	}
-	__wt_scr_free(&current);
-	__wt_scr_free(&last_pfx);
-	__wt_scr_free(&last_ovfl);
+	__wt_scr_free(session, &current);
+	__wt_scr_free(session, &last_pfx);
+	__wt_scr_free(session, &last_ovfl);
 	return (ret);
 }
 

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -65,8 +65,8 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 	F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
 
-err:	__wt_scr_free(&key);
-	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &key);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -457,7 +457,7 @@ next:		switch (direction) {
 	}
 
 done:
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -73,7 +73,7 @@ __wt_config_collapse(
 		--tmp->size;
 	ret = __wt_strndup(session, tmp->data, tmp->size, config_ret);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -197,8 +197,8 @@ __config_merge_scan(WT_SESSION_IMPL *session,
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 
-err:	__wt_scr_free(&kb);
-	__wt_scr_free(&vb);
+err:	__wt_scr_free(session, &kb);
+	__wt_scr_free(session, &vb);
 	return (ret);
 }
 
@@ -306,7 +306,7 @@ __config_merge_format(
 
 	ret = __wt_strndup(session, build->data, build->size, config_ret);
 
-err:	__wt_scr_free(&build);
+err:	__wt_scr_free(session, &build);
 	return (ret);
 }
 

--- a/src/config/config_concat.c
+++ b/src/config/config_concat.c
@@ -67,6 +67,6 @@ __wt_config_concat(
 		--tmp->size;
 	ret = __wt_strndup(session, tmp->data, tmp->size, config_ret);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -345,6 +345,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "mmap", "boolean", NULL, NULL },
 	{ "multiprocess", "boolean", NULL, NULL },
 	{ "session_max", "int", "min=1", NULL },
+	{ "session_scratch_max", "int", NULL, NULL },
 	{ "shared_cache", "category", NULL,
 	     confchk_shared_cache_subconfigs },
 	{ "statistics", "list",
@@ -393,6 +394,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "mmap", "boolean", NULL, NULL },
 	{ "multiprocess", "boolean", NULL, NULL },
 	{ "session_max", "int", "min=1", NULL },
+	{ "session_scratch_max", "int", NULL, NULL },
 	{ "shared_cache", "category", NULL,
 	     confchk_shared_cache_subconfigs },
 	{ "statistics", "list",
@@ -439,6 +441,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "mmap", "boolean", NULL, NULL },
 	{ "multiprocess", "boolean", NULL, NULL },
 	{ "session_max", "int", "min=1", NULL },
+	{ "session_scratch_max", "int", NULL, NULL },
 	{ "shared_cache", "category", NULL,
 	     confchk_shared_cache_subconfigs },
 	{ "statistics", "list",
@@ -484,6 +487,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "mmap", "boolean", NULL, NULL },
 	{ "multiprocess", "boolean", NULL, NULL },
 	{ "session_max", "int", "min=1", NULL },
+	{ "session_scratch_max", "int", NULL, NULL },
 	{ "shared_cache", "category", NULL,
 	     confchk_shared_cache_subconfigs },
 	{ "statistics", "list",
@@ -666,11 +670,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,hazard_max=1000,log=(archive=,compressor=,enabled=0"
 	  ",file_max=100MB,path=,prealloc=),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
-	  "session_max=100,shared_cache=(chunk=10MB,name=,reserve=0,"
-	  "size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=",
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=",
 	  confchk_wiredtiger_open
 	},
 	{ "wiredtiger_open_all",
@@ -683,12 +688,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,hazard_max=1000,log=(archive=,compressor=,enabled=0"
 	  ",file_max=100MB,path=,prealloc=),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
-	  "session_max=100,shared_cache=(chunk=10MB,name=,reserve=0,"
-	  "size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=,version=(major=0,"
-	  "minor=0)",
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_all
 	},
 	{ "wiredtiger_open_basecfg",
@@ -700,9 +705,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "extensions=,file_extend=,hazard_max=1000,log=(archive=,"
 	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=),"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,name=,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(on_close=0,"
+	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg
@@ -716,9 +722,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "extensions=,file_extend=,hazard_max=1000,log=(archive=,"
 	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=),"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,shared_cache=(chunk=10MB,name=,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(on_close=0,"
+	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -264,8 +264,8 @@ __conn_load_extensions(WT_SESSION_IMPL *session, const char *cfg[])
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 
-err:	__wt_scr_free(&expath);
-	__wt_scr_free(&exconfig);
+err:	__wt_scr_free(session, &expath);
+	__wt_scr_free(session, &exconfig);
 
 	return (ret);
 }
@@ -1576,6 +1576,9 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 
 	WT_ERR(__wt_config_gets(session, cfg, "session_max", &cval));
 	conn->session_size = (uint32_t)cval.val + WT_NUM_INTERNAL_SESSIONS;
+
+	WT_ERR(__wt_config_gets(session, cfg, "session_scratch_max", &cval));
+	conn->session_scratch_max = (size_t)cval.val;
 
 	WT_ERR(__wt_config_gets(session, cfg, "checkpoint_sync", &cval));
 	if (cval.val)

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -61,7 +61,7 @@ __ckpt_server_config(WT_SESSION_IMPL *session, const char **cfg, int *startp)
 		conn->ckpt_config = p;
 	}
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -181,7 +181,7 @@ __statlog_dump(WT_SESSION_IMPL *session, const char *name, int conn_stats)
 		break;
 	}
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -372,7 +372,7 @@ __wt_statlog_log_one(WT_SESSION_IMPL *session)
 	WT_RET(__wt_scr_alloc(session, strlen(conn->stat_path) + 128, &tmp));
 	WT_ERR(__statlog_log_one(session, NULL, tmp));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -448,7 +448,7 @@ __backup_uri(WT_SESSION_IMPL *session,
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -127,8 +127,8 @@ __bulk_row_keycmp_err(WT_CURSOR_BULK *cbulk)
 	    (int)a->size, (const char *)a->data,
 	    (int)b->size, (const char *)b->data);
 
-err:	__wt_scr_free(&a);
-	__wt_scr_free(&b);
+err:	__wt_scr_free(session, &a);
+	__wt_scr_free(session, &b);
 	return (ret);
 }
 

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -443,6 +443,6 @@ err:		WT_TRET(__curindex_close(cursor));
 		*cursorp = NULL;
 	}
 
-	__wt_scr_free(&tmp);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -292,9 +292,9 @@ __curlog_close(WT_CURSOR *cursor)
 	WT_TRET(__curlog_reset(cursor));
 	__wt_free(session, cl->cur_lsn);
 	__wt_free(session, cl->next_lsn);
-	__wt_scr_free(&cl->logrec);
-	__wt_scr_free(&cl->opkey);
-	__wt_scr_free(&cl->opvalue);
+	__wt_scr_free(session, &cl->logrec);
+	__wt_scr_free(session, &cl->opkey);
+	__wt_scr_free(session, &cl->opvalue);
 	WT_TRET(__wt_cursor_close(cursor));
 
 err:	API_END_RET(session, ret);
@@ -363,9 +363,9 @@ err:		if (F_ISSET(cursor, WT_CURSTD_OPEN))
 		else {
 			__wt_free(session, cl->cur_lsn);
 			__wt_free(session, cl->next_lsn);
-			__wt_scr_free(&cl->logrec);
-			__wt_scr_free(&cl->opkey);
-			__wt_scr_free(&cl->opvalue);
+			__wt_scr_free(session, &cl->logrec);
+			__wt_scr_free(session, &cl->opkey);
+			__wt_scr_free(session, &cl->opvalue);
 			/*
 			 * NOTE:  We cannot get on the error path with the
 			 * readlock held.  No need to unlock it unless that

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -580,7 +580,7 @@ __curtable_update(WT_CURSOR *cursor)
 		WT_ERR(__apply_idx(ctable, offsetof(WT_CURSOR, insert), 1));
 
 err:	CURSOR_UPDATE_API_END(session, ret);
-	__wt_scr_free(&value_copy);
+	__wt_scr_free(session, &value_copy);
 	return (ret);
 }
 
@@ -689,7 +689,7 @@ __wt_table_range_truncate(WT_CURSOR_TABLE *start, WT_CURSOR_TABLE *stop)
 		    (start == NULL) ? NULL : start->cg_cursors[i],
 		    (stop == NULL) ? NULL : stop->cg_cursors[i]));
 
-err:	__wt_scr_free(&key);
+err:	__wt_scr_free(session, &key);
 	return (ret);
 }
 
@@ -957,6 +957,6 @@ err:		WT_TRET(__curtable_close(cursor));
 		*cursorp = NULL;
 	}
 
-	__wt_scr_free(&tmp);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }

--- a/src/include/buf.i
+++ b/src/include/buf.i
@@ -120,12 +120,19 @@ __wt_buf_free(WT_SESSION_IMPL *session, WT_ITEM *buf)
  *	Release a scratch buffer.
  */
 static inline void
-__wt_scr_free(WT_ITEM **bufp)
+__wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp)
 {
 	WT_ITEM *buf;
 
 	if ((buf = *bufp) != NULL) {
 		*bufp = NULL;
+
+		if (session->scratch_cached + buf->memsize >=
+		    S2C(session)->session_scratch_max) {
+			__wt_free(session, buf->mem);
+			buf->memsize = 0;
+		} else
+                        session->scratch_cached += buf->memsize;
 
 		buf->data = NULL;
 		buf->size = 0;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -187,6 +187,8 @@ struct __wt_connection_impl {
 	uint32_t	 session_size;	/* Session array size */
 	uint32_t	 session_cnt;	/* Session count */
 
+	size_t     session_scratch_max;	/* Max scratch memory per session */
+
 	/*
 	 * WiredTiger allocates space for a fixed number of hazard pointers
 	 * in each thread of control.

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -97,6 +97,7 @@ struct __wt_session_impl {
 
 	WT_ITEM	**scratch;		/* Temporary memory for any function */
 	u_int	scratch_alloc;		/* Currently allocated */
+	size_t scratch_cached;		/* Scratch bytes cached */
 #ifdef HAVE_DIAGNOSTIC
 	/*
 	 * It's hard to figure out from where a buffer was allocated after it's

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -416,7 +416,7 @@ __log_file_header(
 	if (end_lsn != NULL)
 		*end_lsn = tmp.slot_end_lsn;
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -441,7 +441,7 @@ __log_openfile(WT_SESSION_IMPL *session,
 	 * XXX - if we are not creating the file, we should verify the
 	 * log file header record for the magic number and versions here.
 	 */
-err:	__wt_scr_free(&path);
+err:	__wt_scr_free(session, &path);
 	return (ret);
 }
 
@@ -489,8 +489,8 @@ __log_alloc_prealloc(WT_SESSION_IMPL *session, uint32_t to_num)
 	 */
 	WT_ERR(__wt_rename(session, from_path->data, to_path->data));
 
-err:	__wt_scr_free(&from_path);
-	__wt_scr_free(&to_path);
+err:	__wt_scr_free(session, &from_path);
+	__wt_scr_free(session, &to_path);
 	if (logfiles != NULL)
 		__wt_log_files_free(session, logfiles, logcount);
 	return (ret);
@@ -613,8 +613,8 @@ __wt_log_allocfile(
 	 */
 	WT_ERR(__wt_rename(session, from_path->data, to_path->data));
 
-err:	__wt_scr_free(&from_path);
-	__wt_scr_free(&to_path);
+err:	__wt_scr_free(session, &from_path);
+	__wt_scr_free(session, &to_path);
 	if (log_fh != NULL)
 		WT_TRET(__wt_close(session, log_fh));
 	return (ret);
@@ -636,7 +636,7 @@ __wt_log_remove(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_verbose(session, WT_VERB_LOG,
 	    "log_remove: remove log %s", (char *)path->data));
 	WT_ERR(__wt_remove(session, path->data));
-err:	__wt_scr_free(&path);
+err:	__wt_scr_free(session, &path);
 	return (ret);
 }
 
@@ -1076,7 +1076,7 @@ __wt_log_read(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 		*uncitem = swap;
 	}
 
-err:	__wt_scr_free(&uncitem);
+err:	__wt_scr_free(session, &uncitem);
 	return (ret);
 }
 
@@ -1367,7 +1367,7 @@ advance:
 				    &uncitem));
 				WT_ERR((*func)(session, uncitem, &rd_lsn,
 				    cookie, firstrecord));
-				__wt_scr_free(&uncitem);
+				__wt_scr_free(session, &uncitem);
 			} else
 				WT_ERR((*func)(session, &buf, &rd_lsn, cookie,
 				    firstrecord));
@@ -1390,7 +1390,7 @@ err:	WT_STAT_FAST_CONN_INCR(session, log_scans);
 	if (logfiles != NULL)
 		__wt_log_files_free(session, logfiles, logcount);
 	__wt_buf_free(session, &buf);
-	__wt_scr_free(&uncitem);
+	__wt_scr_free(session, &uncitem);
 	/*
 	 * If the caller wants one record and it is at the end of log,
 	 * return WT_NOTFOUND.
@@ -1539,7 +1539,7 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	}
 	ret = __log_write_internal(session, ip, lsnp, flags);
 
-err:	__wt_scr_free(&citem);
+err:	__wt_scr_free(session, &citem);
 	return (ret);
 }
 
@@ -1717,6 +1717,6 @@ __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap)
 
 	logrec->size += len;
 	WT_ERR(__wt_log_write(session, logrec, NULL, 0));
-err:	__wt_scr_free(&logrec);
+err:	__wt_scr_free(session, &logrec);
 	return (ret);
 }

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -18,8 +18,7 @@ __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 void
 __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp)
 {
-	WT_UNUSED(session);
-	__wt_scr_free(logrecp);
+	__wt_scr_free(session, logrecp);
 }
 
 int

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1315,7 +1315,7 @@ __clsm_insert(WT_CURSOR *cursor)
 	WT_ERR(__clsm_deleted_encode(session, &cursor->value, &value, &buf));
 	ret = __clsm_put(session, clsm, &cursor->key, &value, 0);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	WT_TRET(__clsm_leave(clsm));
 	CURSOR_UPDATE_API_END(session, ret);
 	return (ret);
@@ -1348,7 +1348,7 @@ __clsm_update(WT_CURSOR *cursor)
 		ret = __clsm_put(session, clsm, &cursor->key, &value, 1);
 	}
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	WT_TRET(__clsm_leave(clsm));
 	CURSOR_UPDATE_API_END(session, ret);
 	return (ret);

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -235,6 +235,6 @@ __wt_lsm_meta_write(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	ret = __wt_metadata_update(session, lsm_tree->name, buf->data);
 	WT_ERR(ret);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }

--- a/src/lsm/lsm_stat.c
+++ b/src/lsm/lsm_stat.c
@@ -140,7 +140,7 @@ __curstat_lsm_init(
 err:	if (locked)
 		WT_TRET(__wt_lsm_tree_readunlock(session, lsm_tree));
 	__wt_lsm_tree_release(session, lsm_tree);
-	__wt_scr_free(&uribuf);
+	__wt_scr_free(session, &uribuf);
 
 	return (ret);
 }

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -172,7 +172,7 @@ __wt_lsm_tree_bloom_name(WT_SESSION_IMPL *session,
 	    session, tmp, "file:%s-%06" PRIu32 ".bf", lsm_tree->filename, id));
 	WT_ERR(__wt_strndup(session, tmp->data, tmp->size, retp));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -192,7 +192,7 @@ __wt_lsm_tree_chunk_name(WT_SESSION_IMPL *session,
 	    session, tmp, "file:%s-%06" PRIu32 ".lsm", lsm_tree->filename, id));
 	WT_ERR(__wt_strndup(session, tmp->data, tmp->size, retp));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -429,7 +429,7 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 	if (0) {
 err:		WT_TRET(__lsm_tree_discard(session, lsm_tree, 0));
 	}
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
 

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -300,7 +300,7 @@ __wt_meta_ckptlist_get(
 err:		__wt_meta_ckptlist_free(session, ckptbase);
 	}
 	__wt_free(session, config);
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 
 	return (ret);
 }
@@ -454,7 +454,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 		    ckptlsn->file, (uintmax_t)ckptlsn->offset));
 	WT_ERR(__ckpt_set(session, fname, buf->mem));
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -38,7 +38,7 @@ __metadata_config(WT_SESSION_IMPL *session, char **metaconfp)
 	if (0) {
 err:		__wt_free(session, metaconf);
 	}
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -101,8 +101,8 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session)
 
 err:	if (fp != NULL)
 		WT_TRET(fclose(fp) == 0 ? 0 : __wt_errno());
-	__wt_scr_free(&key);
-	__wt_scr_free(&value);
+	__wt_scr_free(session, &key);
+	__wt_scr_free(session, &value);
 	return (ret);
 }
 
@@ -276,7 +276,7 @@ __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
 
 err:	if (fp != NULL)
 		WT_TRET(fclose(fp) == 0 ? 0 : __wt_errno());
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -332,6 +332,6 @@ err:		WT_TRET(__wt_remove(session, WT_METADATA_TURTLE_SET));
 
 	if  (fh != NULL)
 		WT_TRET(__wt_close(session, fh));
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }

--- a/src/os_win/os_dir.c
+++ b/src/os_win/os_dir.c
@@ -97,7 +97,7 @@ err:
 	if (findhandle != INVALID_HANDLE_VALUE)
 		(void)FindClose(findhandle);
 	__wt_free(session, path);
-	__wt_scr_free(&pathbuf);
+	__wt_scr_free(session, &pathbuf);
 
 	if (ret == 0)
 		return (0);

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -49,7 +49,7 @@ __ovfl_discard_verbose(
 	    page,
 	    __wt_addr_string(session, unpack->data, unpack->size, tmp)));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -189,7 +189,7 @@ __ovfl_reuse_verbose(WT_SESSION_IMPL *session,
 	    F_ISSET(reuse, WT_OVFL_REUSE_JUST_ADDED) ? "just-added" : "",
 	    WT_MIN(reuse->value_size, 40), (char *)WT_OVFL_REUSE_VALUE(reuse)));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -580,7 +580,7 @@ __ovfl_txnc_verbose(WT_SESSION_IMPL *session,
 	    txnc->current,
 	    WT_MIN(txnc->value_size, 40), (char *)WT_OVFL_TXNC_VALUE(txnc)));
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1880,7 +1880,7 @@ __rec_split_row_promote(
 		}
 	ret = __wt_buf_set(session, key, r->cur->data, size);
 
-err:	__wt_scr_free(&update);
+err:	__wt_scr_free(session, &update);
 	return (ret);
 }
 
@@ -2503,7 +2503,7 @@ __rec_raw_decompress(
 	WT_ASSERT(session, __wt_verify_dsk_image(
 	    session, "[raw evict split]", tmp->data, dsk->mem_size, 0) == 0);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -2673,7 +2673,7 @@ __rec_split_fixup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	r->space_avail =
 	    r->split_size - (WT_PAGE_HEADER_BYTE_SIZE(btree) + len);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -2862,7 +2862,7 @@ skip_check_complete:
 	bnd->addr.size = (uint8_t)addr_size;
 
 done:
-err:	__wt_scr_free(&key);
+err:	__wt_scr_free(session, &key);
 	return (ret);
 }
 
@@ -3916,7 +3916,7 @@ compare:		/*
 	/* Write the remnant page. */
 	ret = __rec_split_finish(session, r);
 
-err:	__wt_scr_free(&orig);
+err:	__wt_scr_free(session, &orig);
 	return (ret);
 }
 
@@ -4565,8 +4565,8 @@ leaf_insert:	/* Write any K/V pairs inserted into the page after this key. */
 	/* Write the remnant page. */
 	ret = __rec_split_finish(session, r);
 
-err:	__wt_scr_free(&tmpkey);
-	__wt_scr_free(&tmpval);
+err:	__wt_scr_free(session, &tmpkey);
+	__wt_scr_free(session, &tmpval);
 	return (ret);
 }
 
@@ -4920,7 +4920,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 					break;
 				WT_ILLEGAL_VALUE_ERR(session);
 				}
-err:			__wt_scr_free(&tkey);
+err:			__wt_scr_free(session, &tkey);
 			WT_RET(ret);
 		}
 		if (r->bnd_next > r->bnd_next_max) {
@@ -5403,7 +5403,7 @@ __rec_cell_build_ovfl(WT_SESSION_IMPL *session,
 	kv->cell_len = __wt_cell_pack_ovfl(&kv->cell, type, rle, kv->buf.size);
 	kv->len = kv->cell_len + kv->buf.size;
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -123,7 +123,7 @@ __create_file(WT_SESSION_IMPL *session,
 	else
 		WT_ERR(__wt_session_release_btree(session));
 
-err:	__wt_scr_free(&val);
+err:	__wt_scr_free(session, &val);
 	__wt_free(session, fileconf);
 	return (ret);
 }

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -114,7 +114,7 @@ __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
 
 	table->cg_complete = 1;
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	if (colgroup != NULL)
 		__wt_schema_destroy_colgroup(session, colgroup);
 	if (cgconfig != NULL)
@@ -242,8 +242,8 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 	    table, table->colconf.str, table->colconf.len, 1, plan));
 	WT_ERR(__wt_strndup(session, plan->data, plan->size, &idx->value_plan));
 
-err:	__wt_scr_free(&buf);
-	__wt_scr_free(&plan);
+err:	__wt_scr_free(session, &buf);
+	__wt_scr_free(session, &plan);
 	return (ret);
 }
 
@@ -343,7 +343,7 @@ __wt_schema_open_index(WT_SESSION_IMPL *session,
 		table->idx_complete = 1;
 	}
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	if (idx != NULL)
 		WT_TRET(__wt_schema_destroy_index(session, idx));
 	if (cursor != NULL)
@@ -463,7 +463,7 @@ err:		if (table != NULL)
 		WT_TRET(cursor->close(cursor));
 
 	__wt_free(session, tablename);
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
 

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -164,10 +164,10 @@ __rename_tree(WT_SESSION_IMPL *session,
 	/* Rename the file. */
 	WT_ERR(__wt_schema_rename(session, os->data, ns->data, cfg));
 
-err:	__wt_scr_free(&nn);
-	__wt_scr_free(&ns);
-	__wt_scr_free(&nv);
-	__wt_scr_free(&os);
+err:	__wt_scr_free(session, &nn);
+	__wt_scr_free(session, &ns);
+	__wt_scr_free(session, &nv);
+	__wt_scr_free(session, &os);
 	__wt_free(session, value);
 	table->name = olduri;
 	return (ret);

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -26,7 +26,7 @@ __wt_curstat_colgroup_init(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", colgroup->source));
 	ret = __wt_curstat_init(session, buf->data, cfg, cst);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -48,7 +48,7 @@ __wt_curstat_index_init(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", idx->source));
 	ret = __wt_curstat_init(session, buf->data, cfg, cst);
 
-err:	__wt_scr_free(&buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 
@@ -110,6 +110,6 @@ __wt_curstat_table_init(WT_SESSION_IMPL *session,
 
 err:	__wt_schema_release_table(session, table);
 
-	__wt_scr_free(&buf);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -80,6 +80,6 @@ __wt_name_check(WT_SESSION_IMPL *session, const char *str, size_t len)
 
 	ret = __wt_str_name_check(session, tmp->data);
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -195,7 +195,7 @@ __compact_file(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 		WT_ERR(__session_compact_check_timeout(session, start_time));
 	}
 
-err:	__wt_scr_free(&t);
+err:	__wt_scr_free(session, &t);
 	return (ret);
 }
 

--- a/src/support/huffman.c
+++ b/src/support/huffman.c
@@ -687,7 +687,7 @@ __wt_huffman_encode(WT_SESSION_IMPL *session, void *huffman_arg,
 	    max_len, outlen);
 #endif
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 
 }
@@ -810,7 +810,7 @@ __wt_huffman_decode(WT_SESSION_IMPL *session, void *huffman_arg,
 	    max_len, outlen);
 #endif
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -180,8 +180,7 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
 		 * or the largest buffer if none are large enough.
 		 */
 		if (best == NULL ||
-		    ((*best)->memsize < size &&
-		    buf->memsize > (*best)->memsize) ||
+		    (buf->memsize <= size && buf->memsize > (*best)->memsize) ||
 		    (buf->memsize >= size && buf->memsize < (*best)->memsize))
 			best = p;
 
@@ -210,7 +209,7 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
 	}
 
 	/*
-	 * If slot is non-NULL, we found an empty slot, try and allocate a
+	 * If slot is non-NULL, we found an empty slot, try to allocate a
 	 * buffer.
 	 */
 	if (best == NULL) {
@@ -224,6 +223,7 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
 	}
 
 	/* Grow the buffer as necessary and return. */
+	session->scratch_cached -= (*best)->memsize;
 	WT_ERR(__wt_buf_init(session, *best, size));
 	F_SET(*best, WT_ITEM_INUSE);
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -163,7 +163,7 @@ __checkpoint_apply_all(WT_SESSION_IMPL *session, const char *cfg[],
 	if (fullp != NULL)
 		*fullp = !target_list;
 
-err:	__wt_scr_free(&tmp);
+err:	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -348,7 +348,7 @@ __wt_txn_checkpoint_log(
 		/* Cleanup any allocated resources */
 		WT_INIT_LSN(ckpt_lsn);
 		txn->ckpt_nsnapshot = 0;
-		__wt_scr_free(&txn->ckpt_snapshot);
+		__wt_scr_free(session, &txn->ckpt_snapshot);
 		txn->full_ckpt = 0;
 		break;
 	}


### PR DESCRIPTION
 (configurable via an undocumented "session_scratch_max" config).

SERVER-16623