### PR TITLE
Release Python's global lock (GIL) during sleep.

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -339,7 +339,9 @@ retry:
 	if (result != 0 && result != EBUSY)
 		SWIG_ERROR_IF_NOT_SET(result);
         else if (result == EBUSY) {
+		SWIG_PYTHON_THREAD_BEGIN_ALLOW;
                 __wt_sleep(0, 10000);
+		SWIG_PYTHON_THREAD_END_ALLOW;
                 goto retry;
         }
 }


### PR DESCRIPTION
This should fix the deadlock issue seen during test_async.py by Mark Benvenuto and Jonathan Reams.