### PR TITLE
Fix huffman config and add huffman tests. #1536

### DIFF
--- a/src/btree/bt_huffman.c
+++ b/src/btree/bt_huffman.c
@@ -128,10 +128,9 @@ static const struct __wt_huffman_table __wt_huffman_nytenglish[] = {
 static int __wt_huffman_read(WT_SESSION_IMPL *,
     WT_CONFIG_ITEM *, struct __wt_huffman_table **, u_int *, u_int *);
 
-#define	HUFF_CONFIG_VALID(str, len)					\
+#define	WT_HUFFMAN_CONFIG_VALID(str, len)				\
 	(WT_STRING_CASE_MATCH("english", (str), (len)) ||		\
-	    WT_PREFIX_MATCH((str), "utf8") ||				\
-	    WT_PREFIX_MATCH((str), "utf16"))
+	    WT_PREFIX_MATCH((str), "utf8") || WT_PREFIX_MATCH((str), "utf16"))
 
 /*
  * __btree_huffman_config --
@@ -142,13 +141,13 @@ __btree_huffman_config(WT_SESSION_IMPL *session,
     WT_CONFIG_ITEM *key_conf, WT_CONFIG_ITEM *value_conf)
 {
 	if (key_conf->len != 0 &&
-	    !HUFF_CONFIG_VALID(key_conf->str, key_conf->len))
-		WT_RET_MSG(session, EINVAL,
-		    "illegal Huffman key setting");
+	    !WT_HUFFMAN_CONFIG_VALID(key_conf->str, key_conf->len))
+		WT_RET_MSG(
+		    session, EINVAL, "illegal Huffman key configuration");
 	if (value_conf->len != 0 &&
-	    !HUFF_CONFIG_VALID(value_conf->str, value_conf->len))
-		WT_RET_MSG(session, EINVAL,
-		    "illegal Huffman value setting");
+	    !WT_HUFFMAN_CONFIG_VALID(value_conf->str, value_conf->len))
+		WT_RET_MSG(
+		    session, EINVAL, "illegal Huffman value configuration");
 	return (0);
 
 }

--- a/src/btree/bt_huffman.c
+++ b/src/btree/bt_huffman.c
@@ -128,6 +128,31 @@ static const struct __wt_huffman_table __wt_huffman_nytenglish[] = {
 static int __wt_huffman_read(WT_SESSION_IMPL *,
     WT_CONFIG_ITEM *, struct __wt_huffman_table **, u_int *, u_int *);
 
+#define	HUFF_CONFIG_VALID(str, len)					\
+	(WT_STRING_CASE_MATCH("english", (str), (len)) ||		\
+	    WT_PREFIX_MATCH((str), "utf8") ||				\
+	    WT_PREFIX_MATCH((str), "utf16"))
+
+/*
+ * __btree_huffman_config --
+ *	Verify the key or value strings passed in.
+ */
+static int
+__btree_huffman_config(WT_SESSION_IMPL *session,
+    WT_CONFIG_ITEM *key_conf, WT_CONFIG_ITEM *value_conf)
+{
+	if (key_conf->len != 0 &&
+	    !HUFF_CONFIG_VALID(key_conf->str, key_conf->len))
+		WT_RET_MSG(session, EINVAL,
+		    "illegal Huffman key setting");
+	if (value_conf->len != 0 &&
+	    !HUFF_CONFIG_VALID(value_conf->str, value_conf->len))
+		WT_RET_MSG(session, EINVAL,
+		    "illegal Huffman value setting");
+	return (0);
+
+}
+
 /*
  * __wt_btree_huffman_open --
  *	Configure Huffman encoding for the tree.
@@ -150,6 +175,7 @@ __wt_btree_huffman_open(WT_SESSION_IMPL *session)
 	    __wt_config_gets_none(session, cfg, "huffman_value", &value_conf));
 	if (key_conf.len == 0 && value_conf.len == 0)
 		return (0);
+	WT_RET(__btree_huffman_config(session, &key_conf, &value_conf));
 
 	switch (btree->type) {		/* Check file type compatibility. */
 	case BTREE_COL_FIX:
@@ -311,6 +337,8 @@ __wt_huffman_read(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *ip,
 		tp->frequency = (uint32_t)frequency;
 	}
 
+	if (ret == EOF)
+		ret = 0;
 	*entriesp = lineno - 1;
 	*tablep = table;
 

--- a/test/suite/test_huffman01.py
+++ b/test/suite/test_huffman01.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2015 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+from suite_subprocess import suite_subprocess
+from wtscenario import multiply_scenarios, number_scenarios
+import wiredtiger, wttest
+
+# test_huffman01.py
+#    Huffman key and value configurations
+# Basic smoke-test of huffman key and value settings.
+class test_huffman01(wttest.WiredTigerTestCase, suite_subprocess):
+    """
+    Test basic operations
+    """
+    table_name = 'table:test_huff'
+
+    huffkey = [
+        ('none', dict(huffkey='huffman_key=none',kfile=None)),
+        ('english', dict(huffkey='huffman_key=english',kfile=None)),
+        ('English', dict(huffkey='huffman_key=English',kfile=None)),
+        ('utf8', dict(huffkey='huffman_key=utf8t8file',kfile='t8file')),
+        ('utf16', dict(huffkey='huffman_key=utf16t16file',kfile='t16file')),
+    ]
+    huffval = [
+        ('none', dict(huffval=',huffman_value=none',vfile=None)),
+        ('english', dict(huffval=',huffman_value=english',vfile=None)),
+        ('English', dict(huffval=',huffman_value=English',vfile=None)),
+        ('utf8', dict(huffval=',huffman_value=utf8t8file',vfile='t8file')),
+        ('utf16', dict(huffval=',huffman_value=utf16t16file',vfile='t16file')),
+    ]
+    scenarios = number_scenarios(multiply_scenarios('.', huffkey, huffval))
+
+    def test_huffman(self):
+        dir = self.conn.get_home()
+        if self.kfile != None:
+            # For the UTF settings write some made-up frequency information.
+            f = open(dir + '/' + self.kfile, 'w')
+            f.write('48 546233\n49 460946\n')
+            f.close()
+        # if self.vfile != None and not os.path.exists(self.vfile):
+        if self.vfile != None:
+            f = open(dir + '/' + self.vfile, 'w')
+            # For the UTF settings write some made-up frequency information.
+            f.write('50 546233\n51 460946\n')
+            f.close()
+        config=self.huffkey + self.huffval
+        self.session.create(self.table_name, config)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_huffman02.py
+++ b/test/suite/test_huffman02.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2015 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+from suite_subprocess import suite_subprocess
+from wtscenario import multiply_scenarios, number_scenarios
+import wiredtiger, wttest
+
+# test_huffman02.py
+#    Huffman key and value configurations with bad settings
+class test_huffman02(wttest.WiredTigerTestCase, suite_subprocess):
+    """
+    Test basic operations
+    """
+    table_name = 'table:test_huff'
+
+    huffkey = [
+        ('none', dict(huffkey='huffman_key=none',kfile=None)),
+        ('english', dict(huffkey='huffman_key=english',kfile=None)),
+        ('bad', dict(huffkey='huffman_key=bad',kfile=None)),
+    ]
+    huffval = [
+        ('bad', dict(huffval=',huffman_value=bad',kfile=None)),
+    ]
+    scenarios = number_scenarios(multiply_scenarios('.', huffkey, huffval))
+
+    def test_huffman(self):
+        gotException = False
+        expectMessage = 'illegal Huffman'
+        config=self.huffkey + self.huffval
+        with self.expectedStderrPattern(expectMessage):
+            try:
+                self.pr('expect an error message...')
+                self.session.create(self.table_name, config)
+            except wiredtiger.WiredTigerError as e:
+                gotException = True
+                self.pr('got expected exception: ' + str(e))
+                self.assertTrue(str(e).find('nvalid argument') >= 0)
+        self.assertTrue(gotException, 'expected exception')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_huffman02.py
+++ b/test/suite/test_huffman02.py
@@ -40,12 +40,12 @@ class test_huffman02(wttest.WiredTigerTestCase, suite_subprocess):
     table_name = 'table:test_huff'
 
     huffkey = [
-        ('none', dict(huffkey='huffman_key=none',kfile=None)),
-        ('english', dict(huffkey='huffman_key=english',kfile=None)),
-        ('bad', dict(huffkey='huffman_key=bad',kfile=None)),
+        ('none', dict(huffkey='huffman_key=none')),
+        ('english', dict(huffkey='huffman_key=english')),
+        ('bad', dict(huffkey='huffman_key=bad')),
     ]
     huffval = [
-        ('bad', dict(huffval=',huffman_value=bad',kfile=None)),
+        ('bad', dict(huffval=',huffman_value=bad')),
     ]
     scenarios = number_scenarios(multiply_scenarios('.', huffkey, huffval))
 


### PR DESCRIPTION
@keithbostic  Please review these changes for huffman.  I added a test for all the valid huffman config settings as well as invalid ones.

There was one minor bug fix to reset `ret` after reading the utf file.

One outstanding issue is I found in my test that I could not use hex in the frequency file as shown in the docs.  SCNu64 does not read hex.  You'll notice `test_huffman01.py` writes decimal.  We can fix the documentation or assume the values are hex, fix the code and document that requirement.
http://source.wiredtiger.com/2.5.0/huffman.html