### PR TITLE
Fix memory leak: WT_TABLE.nindices wasn't being incremented in all cases.

### DIFF
--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -312,8 +312,7 @@ __wt_schema_open_index(WT_SESSION_IMPL *session,
 			memmove(&table->indices[i + 1], &table->indices[i],
 			    (table->nindices - i) * sizeof(WT_INDEX *));
 			table->indices[i] = NULL;
-			if (!match)
-				++table->nindices;
+			++table->nindices;
 		}
 
 		if (!match)
@@ -329,7 +328,12 @@ __wt_schema_open_index(WT_SESSION_IMPL *session,
 			table->indices[i] = idx;
 			idx = NULL;
 
-			++table->nindices;
+			/*
+			 * If the slot is bigger than anything else we've seen,
+			 * bump the number of indices.
+			 */
+			if (i >= table->nindices)
+				table->nindices = i + 1;
 		}
 
 		/* If we were looking for a single index, we're done. */

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -312,7 +312,8 @@ __wt_schema_open_index(WT_SESSION_IMPL *session,
 			memmove(&table->indices[i + 1], &table->indices[i],
 			    (table->nindices - i) * sizeof(WT_INDEX *));
 			table->indices[i] = NULL;
-			++table->nindices;
+			if (!match)
+				++table->nindices;
 		}
 
 		if (!match)
@@ -327,6 +328,8 @@ __wt_schema_open_index(WT_SESSION_IMPL *session,
 
 			table->indices[i] = idx;
 			idx = NULL;
+
+			++table->nindices;
 		}
 
 		/* If we were looking for a single index, we're done. */


### PR DESCRIPTION
Fix memory leak: WT_TABLE.nindices wasn't being incremented in all cases, reference #1474.

@michaelcahill, this one is probably yours to review.  This fixes the test case in #1474, and passes the test suite, but I'm not 100% sure it's correct. Basically, the test case results in our opening an index but not incrementing `table->nindices`, resulting in failure to discard the index when the table is closed.