### PR TITLE
Add MCI project definition

### DIFF
--- a/mciproject.yml
+++ b/mciproject.yml
@@ -1,0 +1,99 @@
+
+functions:
+  "fetch source" :
+    command: git.get_project
+    params:
+      directory: wiredtiger
+
+pre:
+  - command: shell.exec
+    params:
+      script: |
+        rm -rf "wiredtiger"
+post:
+  - command: shell.exec
+    params:
+      script: |
+        rm -rf "wiredtiger"
+
+tasks:
+  - name: compile-posix
+    commands:
+      - func: "fetch source"
+      - command: git.apply_patch
+        params:
+          directory: wiredtiger
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            ./build_posix/reconf
+            ${configure_env_vars|} ./configure --enable-diagnostic --enable-python --enable-zlib
+            ${make_command|make} ${smp_command|}
+            ${make_command|make} check
+
+            ${test_env_vars|} python ./test/suite/run.py -v 2
+  - name: compile-windows
+    commands:
+      - func: "fetch source"
+      - command: git.apply_patch
+        params:
+          directory: wiredtiger
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            scons.bat --enable-swig=c:\\swigwin-3.0.2\\swig.exe ${smp_command|}
+
+            ${test_env_vars|} python ./test/suite/run.py -v 2
+
+buildvariants:
+- name: ubuntu1404
+  display_name: Ubuntu 14.04
+  run_on:
+  - ubuntu1404-test
+  expansions:
+    test_env_vars: LD_LIBRARY_PATH=.libs
+    smp_command: -j$(grep -c ^processor /proc/cpuinfo)
+    configure_env_vars: CC=/opt/mongodbtoolchain/bin/gcc CXX=/opt/mongodbtoolchain/bin/g++
+  tasks:
+    - name: compile-posix
+
+- name: solaris
+  display_name: Solaris
+  run_on:
+  - solaris
+  expansions:
+    make_command: PATH=/opt/mongodbtoolchain/bin:$PATH gmake
+    test_env_vars: LD_LIBRARY_PATH=.libs
+    smp_command: -j$(kstat cpu | sort -u | grep -c "^module")
+    configure_env_vars: PATH=/opt/mongodbtoolchain/bin:$PATH CFLAGS="-m64"
+  tasks:
+    - name: compile-posix
+
+- name: windows-64
+  display_name: Windows 64-bit
+  run_on:
+  - windows-64-vs2013-compile
+  expansions:
+    smp_command: -j$(grep -c ^processor /proc/cpuinfo)
+  tasks:
+    - name: compile-windows
+
+- name: osx-108
+  display_name: OS X 10.8
+  run_on:
+  - osx-108
+  expansions:
+    smp_command: -j$(sysctl -n hw.logicalcpu)
+    configure_env_vars: PATH=/opt/local/bin:$PATH
+    make_command: PATH=/opt/local/bin:$PATH ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future make
+    test_env_vars: DYLD_LIBRARY_PATH=.libs
+  tasks:
+    - name: compile-posix

--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -1,3 +1,7 @@
+#
+# This file defines the tasks and platforms for WiredTiger in the
+# MongoDB continuous integration system (see https://mci.mongodb.com).
+#
 
 functions:
   "fetch source" :


### PR DESCRIPTION
This PR adds a MCI project file so we can add the wiredtiger develop branch into our CI system. The work is being tracked in https://jira.mongodb.org/browse/BUILD-479. Let me know if you have any questions or concerns.