### PR TITLE
Python: include WT_NOTFOUND as an error returned from CURSOR->compare.

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -363,8 +363,17 @@ retry:
 }
 %enddef
 
-/* Cursor compare can return any of -1, 0, 1 or WT_NOTFOUND. */
+/* Cursor compare can return any of -1, 0, 1. */
 %define COMPARE_OK(m)
+%exception m {
+	$action
+	if (result < -1 || result > 1)
+		SWIG_ERROR_IF_NOT_SET(result);
+}
+%enddef
+
+/* Cursor compare can return any of -1, 0, 1 or WT_NOTFOUND. */
+%define COMPARE_NOTFOUND_OK(m)
 %exception m {
 	$action
 	if ((result < -1 || result > 1) && result != WT_NOTFOUND)
@@ -381,7 +390,7 @@ NOTFOUND_OK(__wt_cursor::search)
 NOTFOUND_OK(__wt_cursor::update)
 
 COMPARE_OK(__wt_cursor::compare)
-COMPARE_OK(__wt_cursor::search_near)
+COMPARE_NOTFOUND_OK(__wt_cursor::search_near)
 
 /* Lastly, some methods need no (additional) error checking. */
 %exception __wt_connection::get_home;


### PR DESCRIPTION
This code in wiredtiger.i looks wrong:

```
/* Cursor compare can return any of -1, 0, 1 or WT_NOTFOUND. */
%define COMPARE_OK(m)
%exception m {
        $action
        if ((result < -1 || result > 1) && result != WT_NOTFOUND)
                SWIG_ERROR_IF_NOT_SET(result);
}
%enddef
```
I don't think compare can return WT_NOTFOUND -- but, COMPARE_OK is used for search-near, too, not just compare.