### PR TITLE
Fix test/checkpoint skipping dirty pages

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -717,10 +717,11 @@ __split_multi_inmem(
 	/*
 	 * We modified the page above, which will have set the first dirty
 	 * transaction to the last transaction current running.  However, the
-	 * updates we installed may be older than that.  Inherit the first
-	 * dirty transaction from the original page.
+	 * updates we installed may be older than that.  Set the first dirty
+	 * transaction to an impossibly old value so this page is never skipped
+	 * in a checkpoint.
 	 */
-	page->modify->first_dirty_txn = orig->modify->first_dirty_txn;
+	page->modify->first_dirty_txn = WT_TXN_FIRST;
 
 err:	/* Free any resources that may have been cached in the cursor. */
 	WT_TRET(__wt_btcur_close(&cbt));
@@ -1137,10 +1138,11 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 	/*
 	 * We modified the page above, which will have set the first dirty
 	 * transaction to the last transaction current running.  However, the
-	 * updates we installed may be older than that.  Inherit the first
-	 * dirty transaction from the original page.
+	 * updates we installed may be older than that.  Set the first dirty
+	 * transaction to an impossibly old value so this page is never skipped
+	 * in a checkpoint.
 	 */
-	right->modify->first_dirty_txn = page->modify->first_dirty_txn;
+	right->modify->first_dirty_txn = WT_TXN_FIRST;
 
 	/*
 	 * Calculate how much memory we're moving: figure out how deep the skip

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -7,6 +7,7 @@
  */
 
 #define	WT_TXN_NONE	0		/* No txn running in a session. */
+#define	WT_TXN_FIRST	1		/* First transaction to run. */
 #define	WT_TXN_ABORTED	UINT64_MAX	/* Update rolled back, ignore. */
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -531,9 +531,8 @@ __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
 	conn = S2C(session);
 
 	txn_global = &conn->txn_global;
-	txn_global->current = 1;
-	txn_global->oldest_id = 1;
-	txn_global->last_running = 1;
+	txn_global->current = txn_global->last_running =
+	    txn_global->oldest_id = WT_TXN_FIRST;
 
 	WT_RET(__wt_calloc_def(
 	    session, conn->session_size, &txn_global->states));


### PR DESCRIPTION
When restoring updates that could not be evicted, mark pages with the oldest possible first dirty transaction.  This guarantees that such pages can never be skipped by a checkpoint.

refs #1521