### PR TITLE
Close Thread Handle after thread join on Windows

### DIFF
--- a/src/os_win/os_map.c
+++ b/src/os_win/os_map.c
@@ -99,7 +99,10 @@ __wt_munmap(WT_SESSION_IMPL *session, WT_FH *fh, void *map, size_t len,
 		    fh->name, len);
 	}
 
-	CloseHandle(*mappingcookie);
+	if (CloseHandle(*mappingcookie) == 0) {
+		WT_RET_MSG(session, __wt_errno(),
+		    "CloseHandle: MapViewOfFile: %s", fh->name);
+	}
 
 	*mappingcookie = 0;
 

--- a/src/os_win/os_open.c
+++ b/src/os_win/os_open.c
@@ -214,13 +214,13 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH *fh)
 	 * windows since it is not possible to sync a directory
 	 */
 	if (fh->filehandle != INVALID_HANDLE_VALUE &&
-	    !CloseHandle(fh->filehandle) != 0) {
+	    CloseHandle(fh->filehandle) == 0) {
 		ret = __wt_errno();
 		__wt_err(session, ret, "CloseHandle: %s", fh->name);
 	}
 
 	if (fh->filehandle_secondary != INVALID_HANDLE_VALUE &&
-	    !CloseHandle(fh->filehandle_secondary) != 0) {
+	    CloseHandle(fh->filehandle_secondary) == 0) {
 		ret = __wt_errno();
 		__wt_err(session, ret, "CloseHandle: secondary: %s", fh->name);
 	}

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -33,10 +33,15 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid)
 {
 	WT_DECL_RET;
 
-	if ((ret = WaitForSingleObject(tid, INFINITE)) == WAIT_OBJECT_0)
-		return (0);
+	if ((ret = WaitForSingleObject(tid, INFINITE)) != WAIT_OBJECT_0)
+		/*
+		 * If we fail to wait, we will leak handles so do not continue
+		 */
+		WT_PANIC_RET(session, WT_PANIC, "Wait for thread join failed");
 
-	WT_RET_MSG(session, ret, "WaitForSingleObject");
+	CloseHandle(tid);
+
+	return (0);
 }
 
 /*

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -37,9 +37,13 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid)
 		/*
 		 * If we fail to wait, we will leak handles so do not continue
 		 */
-		WT_PANIC_RET(session, WT_PANIC, "Wait for thread join failed");
+		WT_PANIC_RET(session, ret == WAIT_FAILED ? __wt_errno() : ret,
+		    "Wait for thread join failed");
 
-	CloseHandle(tid);
+	if (CloseHandle(tid) == 0) {
+		WT_RET_MSG(session, __wt_errno(),
+		    "CloseHandle: thread join");
+	}
 
 	return (0);
 }


### PR DESCRIPTION
On Windows after a thread exits, there is still one last remaining reference to the thread handle, and a program is required to call CloseHandle to free the last reference otherwise there is handle leak. The last reference allows thread creators to check on the status of thread, etc.

Fixes SERVER-17025