### PR TITLE
Grab the table list lock while building the list of handles to checkpoint

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -341,9 +341,10 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * into the session cache, but we're going to do that eventually anyway.
 	 */
 	WT_WITH_SCHEMA_LOCK(session,
-	    WT_WITH_DHANDLE_LOCK(session,
-		ret = __checkpoint_apply_all(
-		session, cfg, __wt_checkpoint_list, NULL)));
+	    WT_WITH_TABLE_LOCK(session,
+		WT_WITH_DHANDLE_LOCK(session,
+		    ret = __checkpoint_apply_all(
+		    session, cfg, __wt_checkpoint_list, NULL))));
 	WT_ERR(ret);
 
 	/*


### PR DESCRIPTION
This avoids a potential deadlock during compact operations and/or checkpoints with a target list (and an assertion about lock ordering in diagnostic builds).

Note that nested locking is not ideal: the medium-term fix here is #1598.

refs #1589