### PR TITLE
Restore default transaction_sync values. #1585 #1586

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -547,12 +547,12 @@ common_wiredtiger_open = [
     Config('transaction_sync', '', r'''
         how to sync log records when the transaction commits''',
         type='category', subconfig=[
-        Config('enabled', 'true', r'''
+        Config('enabled', 'false', r'''
             whether to sync the log on every commit by default, can
         be overridden by the \c sync setting to
         WT_SESSION::begin_transaction''',
             type='boolean'),
-        Config('method', 'none', r'''
+        Config('method', 'fsync', r'''
             the method used to ensure log records are stable on disk,
         see @ref tune_durability for more information''',
             choices=['dsync', 'fsync', 'none']),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -684,8 +684,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",name=,reserve=0,size=500MB),statistics=none,"
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=,method=),use_environment_priv=0,"
-	  "verbose=",
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=",
 	  confchk_wiredtiger_open
 	},
 	{ "wiredtiger_open_all",
@@ -702,8 +702,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",name=,reserve=0,size=500MB),statistics=none,"
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=,method=),use_environment_priv=0,"
-	  "verbose=,version=(major=0,minor=0)",
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_all
 	},
 	{ "wiredtiger_open_basecfg",
@@ -719,8 +719,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=,"
-	  "method=),verbose=,version=(major=0,minor=0)",
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg
 	},
 	{ "wiredtiger_open_usercfg",
@@ -736,8 +736,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=,"
-	  "method=),verbose=",
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg
 	},
 	{ NULL, NULL, NULL }

--- a/src/docs/tune-durability.dox
+++ b/src/docs/tune-durability.dox
@@ -11,24 +11,23 @@ required for this feature.
 
 /*! @class doc_tune_durability_flush_config
 
-By default, log records are written to the operating system before
-WT_SESSION::commit_transaction returns, ensuring durability at the
-application level.  The durability guarantees can be stricter to increase
-durability guarantees.
+By default, log records are written to an in-memory buffer before
+WT_SESSION::commit_transaction returns, giving highest performance but
+not ensuring durability.  The durability guarantees can be stricter but
+will impact performance.
 
 If \c transaction_sync=(enabled=false) is configured to ::wiredtiger_open,
 log records may be buffered in memory, and only flushed to disk by
-checkpoints or calls to WT_SESSION::begin_transaction with \c sync=true.
-(Note that any call to WT_SESSION::begin_transaction with \c sync=true
-will flush the log records for all committed transactions, not just the
-transaction where the configuration is set.)  This provides the minimal
-guarantees, but will be significantly faster than other configurations.
+checkpoints, when log files switch or calls to WT_SESSION::begin_transaction
+with \c sync=true.  (Note that any call to WT_SESSION::begin_transaction
+with \c sync=true will flush the log records for all committed transactions,
+not just the transaction where the configuration is set.)  This provides the
+minimal guarantees, but will be significantly faster than other configurations.
 
 If \c transaction_sync=(enabled=true), \c transaction_sync=(method)
 further configures the method used to flush log records to disk.  By
-default, the configured value is \c none, which calls the operating
-system's \c write call as each commit completes, but does not
-flush to disk.
+default, the configured value is \c fsync, which calls the operating
+system's \c fsync call (of \c fdatasync if available) as each commit completes.
 
 If the value is set to \c dsync, the \c O_DSYNC or \c O_SYNC
 flag to the operating system's \c open call will be specified when the
@@ -37,8 +36,10 @@ configurations are the same, and in our experience the \c open flags are
 slower, this configuration is only included for systems where that may
 not be the case.)
 
-If the value is set to \c fsync, the operating system's \c fsync call
-(or \c fdatasync if available) will be called as each commit completes.
+If the value is set to \c none, the operating system's \c write call
+will be called as each commit completes but does not flush to disk.
+This setting gives durability at the application level but not at
+the system level.
 
 When a log file fills and the system moves to the next log file, the
 previous log file will always be flushed to disk prior to close.  So

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2023,11 +2023,11 @@ struct __wt_connection {
  * commits., a set of related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether to sync the log on every
  * commit by default\, can be overridden by the \c sync setting to
- * WT_SESSION::begin_transaction., a boolean flag; default \c true.}
+ * WT_SESSION::begin_transaction., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;method, the method used to ensure log records
  * are stable on disk\, see @ref tune_durability for more information., a
  * string\, chosen from the following options: \c "dsync"\, \c "fsync"\, \c
- * "none"; default \c none.}
+ * "none"; default \c fsync.}
  * @config{ ),,}
  * @config{use_environment_priv, use the \c WIREDTIGER_CONFIG and \c
  * WIREDTIGER_HOME environment variables regardless of whether or not the


### PR DESCRIPTION
@michaelcahill This restores the old defaults of in-memory buffering instead of write-no-sync.  Please review.  It restores the performance of the `log_append.wtperf` workload also.