### PR TITLE
Scons Improvements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,7 @@
 # -*- mode: python; -*-
 import re
 import os
+import sys
 import textwrap
 import distutils.sysconfig
 
@@ -242,6 +243,12 @@ wtbin = env.Program("wt", [
 
 # Python SWIG wrapper for WiredTiger
 if GetOption("lang-python"):
+    # Check that this version of python is 64-bit
+    #
+    if sys.maxsize < 2**32:
+        print "The Python Interpreter must be 64-bit in order to build the python bindings"
+        Exit(1)
+
     pythonEnv = env.Clone()
     pythonEnv.Append(SWIGFLAGS=[
             "-python",

--- a/SConstruct
+++ b/SConstruct
@@ -33,6 +33,9 @@ AddOption("--enable-verbose", dest="verbose", action="store_true", default=False
 AddOption("--enable-zlib", dest="zlib", type="string", nargs=1, action="store",
           help="Use zlib compression")
 
+AddOption("--prefix", dest="prefix", type="string", nargs=1, action="store", default="package",
+          help="Install directory")
+
 AddOption("--with-berkeley-db", dest="bdb", type="string", nargs=1, action="store",
           help="Berkeley DB install path, ie, /usr/local")
 
@@ -172,7 +175,7 @@ replacements = {
     '@wiredtiger_includes_decl@': wiredtiger_includes
 }
 
-env.Substfile(
+wtheader = env.Substfile(
     target='wiredtiger.h',
     source=[
         'src/include/wiredtiger.in',
@@ -348,3 +351,11 @@ for ex in examples:
     else:
         env.Program(ex, "examples/c/" + ex + ".c", LIBS=[wtdll[1]] + wtlibs)
 
+# Install Target
+#
+prefix = GetOption("prefix")
+env.Alias("install", env.Install(os.path.join(prefix, "bin"), wtbin))
+env.Alias("install", env.Install(os.path.join(prefix, "bin"), wtdll[0])) # Just the dll
+env.Alias("install", env.Install(os.path.join(prefix, "include"), wtheader))
+env.Alias("install", env.Install(os.path.join(prefix, "lib"), wtdll[1])) # Just the import lib
+env.Alias("install", env.Install(os.path.join(prefix, "lib"), wtlib))

--- a/SConstruct
+++ b/SConstruct
@@ -85,6 +85,8 @@ env = Environment(
     SWIG=swig_binary
 )
 
+env['STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME'] = 1
+
 useZlib = GetOption("zlib")
 useSnappy = GetOption("snappy")
 useBdb = GetOption("bdb")

--- a/build_win/wiredtiger.def
+++ b/build_win/wiredtiger.def
@@ -1,0 +1,21 @@
+LIBRARY WIREDTIGER
+EXPORTS
+    wiredtiger_config_parser_open
+    wiredtiger_open
+    wiredtiger_pack_close
+    wiredtiger_pack_int
+    wiredtiger_pack_item
+    wiredtiger_pack_start
+    wiredtiger_pack_str
+    wiredtiger_pack_uint
+    wiredtiger_strerror
+    wiredtiger_strerror_r
+    wiredtiger_struct_pack
+    wiredtiger_struct_size
+    wiredtiger_struct_unpack
+    wiredtiger_unpack_int
+    wiredtiger_unpack_item
+    wiredtiger_unpack_start
+    wiredtiger_unpack_str
+    wiredtiger_unpack_uint
+    wiredtiger_version

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -36,7 +36,9 @@ extern "C" {
 #include <io.h>
 #endif
 #include <limits.h>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <pthread.h>
 #endif
 #ifdef HAVE_PTHREAD_NP_H

--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -53,7 +53,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            scons.bat --enable-swig=c:\\swigwin-3.0.2\\swig.exe ${smp_command|}
+            scons.bat --enable-python=c:\\swigwin-3.0.2\\swig.exe ${smp_command|}
 
             ${test_env_vars|} python ./test/suite/run.py -v 2
 

--- a/test/windows/windows_shim.h
+++ b/test/windows/windows_shim.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <direct.h>
 #include <io.h>
+#include <process.h>
 
 #define	inline __inline
 
@@ -66,8 +67,6 @@ int sched_yield(void);
 /*
  * Emulate <unistd.h>
  */
-#define	getpid GetCurrentProcessId
-
 typedef uint32_t useconds_t;
 
 int


### PR DESCRIPTION
This is a set of improvements to the Windows build that @keithbostic asked for
1. Add various build flags to bring Windows build closer to parity like attach, diagnostic, and verbose.
2. Renamed --enable-swig to --enable-python and update MCI config.
3. Add a DLL, and linked some examples against it. @keithbostic Check the list of exported functions to see if they what you want
4. Ensure python is 64-bit
5. Add "*scons check*" for unit tests, and "*scons install*" targets