### PR TITLE
Use reads to measure cache pressure with shared caches

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -285,6 +285,7 @@ err:			if ((pindex = WT_INTL_INDEX_COPY(page)) != NULL) {
 
 	/* Increment the cache statistics. */
 	__wt_cache_page_inmem_incr(session, page, size);
+	(void)WT_ATOMIC_ADD8(cache->bytes_read, size);
 	(void)WT_ATOMIC_ADD8(cache->pages_inmem, 1);
 
 	*pagep = page;

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -448,15 +448,15 @@ __cache_pool_assess(WT_SESSION_IMPL *session, uint64_t *phighest)
 			continue;
 		cache = entry->cache;
 		++entries;
-		new = cache->bytes_evict;
+		new = cache->bytes_read;
 		/* Handle wrapping of eviction requests. */
-		if (new >= cache->cp_saved_evict)
-			cache->cp_current_evict = new - cache->cp_saved_evict;
+		if (new >= cache->cp_saved_read)
+			cache->cp_current_read = new - cache->cp_saved_read;
 		else
-			cache->cp_current_evict = new;
-		cache->cp_saved_evict = new;
-		if (cache->cp_current_evict > highest)
-			highest = cache->cp_current_evict;
+			cache->cp_current_read = new;
+		cache->cp_saved_read = new;
+		if (cache->cp_current_read > highest)
+			highest = cache->cp_current_read;
 	}
 	WT_RET(__wt_verbose(session, WT_VERB_SHARED_CACHE,
 	    "Highest eviction count: %" PRIu64 ", entries: %" PRIu64,
@@ -501,7 +501,7 @@ __cache_pool_adjust(WT_SESSION_IMPL *session,
 		reserved = cache->cp_reserved;
 		adjusted = 0;
 
-		read_pressure = cache->cp_current_evict / highest;
+		read_pressure = cache->cp_current_read / highest;
 		WT_RET(__wt_verbose(session, WT_VERB_SHARED_CACHE,
 		    "\t%" PRIu64 ", %" PRIu64 ", %" PRIu32,
 		    entry->cache_size, read_pressure, cache->cp_skip_count));

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -229,7 +229,6 @@ __wt_page_refp(WT_SESSION_IMPL *session,
 	 * but the index's value is always valid, even if it's not up-to-date.
 	 */
 retry:	pindex = WT_INTL_INDEX_COPY(ref->home);
-        WT_HAVE_DIAGNOSTIC_YIELD;
 
 	/*
 	 * Use the page's reference hint: it should be correct unless the page

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -229,6 +229,7 @@ __wt_page_refp(WT_SESSION_IMPL *session,
 	 * but the index's value is always valid, even if it's not up-to-date.
 	 */
 retry:	pindex = WT_INTL_INDEX_COPY(ref->home);
+        WT_HAVE_DIAGNOSTIC_YIELD;
 
 	/*
 	 * Use the page's reference hint: it should be correct unless the page

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -60,6 +60,7 @@ struct __wt_cache {
 	uint64_t pages_evict;
 	uint64_t bytes_dirty;		/* Bytes/pages currently dirty */
 	uint64_t pages_dirty;
+	uint64_t bytes_read;		/* Bytes read into memory */
 
 	uint64_t evict_max_page_size;	/* Largest page seen at eviction */
 
@@ -102,8 +103,8 @@ struct __wt_cache {
 	/*
 	 * Cache pool information.
 	 */
-	uint64_t cp_saved_evict;	/* Evict count from last pass */
-	uint64_t cp_current_evict;	/* Evict count from current pass */
+	uint64_t cp_saved_read;		/* Read count from last pass */
+	uint64_t cp_current_read;	/* Read count from current pass */
 	uint32_t cp_skip_count;		/* Post change stabilization */
 	uint64_t cp_reserved;		/* Base size for this cache */
 	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */


### PR DESCRIPTION
We previously tracked writes, which were skewed by checkpoints.

refs #1569