### PR TITLE
In recovery, track the maximum file ID in the metadata

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -47,10 +47,6 @@ __recovery_cursor(WT_SESSION_IMPL *session, WT_RECOVERY *r,
 
 	c = NULL;
 
-	/* Track the largest file ID we have seen. */
-	if (id > r->max_fileid)
-		r->max_fileid = id;
-
 	/*
 	 * Metadata operations have an id of 0.  Match operations based
 	 * on the id and the current pass of recovery for metadata.
@@ -312,6 +308,10 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 
 	WT_RET(__wt_config_getones(r->session, config, "id", &cval));
 	fileid = (uint32_t)cval.val;
+
+	/* Track the largest file ID we have seen. */
+	if (fileid > r->max_fileid)
+		r->max_fileid = fileid;
 
 	if (r->nfiles <= fileid) {
 		WT_RET(__wt_realloc_def(


### PR DESCRIPTION
... regardless of whether there are any updates to roll forward.

Previously, we tracked the largest file ID that was updated in the logs being rolled forward.  It was usually the case that the most recently created file was also the most recently updated, so that calculation usually worked and wasn't detected until the repro in SERVER-17142 that created tables, did a clean shutdown and restart, then created more tables and did a dirty shutdown and restart, which was rolling forward updates into the wrong tables.

refs SERVER-17142, SERVER-17131(?)