### PR TITLE
Wrap calls to functions using pindex with WT_WITH_PAGE_INDEX.

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -782,7 +782,9 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
 
 	WT_RET(__cursor_func_init(cbt, 1));
 
-	WT_ERR(__wt_row_random(session, cbt));
+	WT_WITH_PAGE_INDEX(session,
+	    ret = __wt_row_random(session, cbt));
+	WT_ERR(ret);
 	if (__cursor_valid(cbt, &upd))
 		WT_ERR(__wt_kv_return(session, cbt, upd));
 	else

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -548,7 +548,9 @@ __debug_page(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 	session = ds->session;
 
 	/* Dump the page metadata. */
-	WT_RET(__debug_page_metadata(ds, page));
+	WT_WITH_PAGE_INDEX(session,
+	    ret = __debug_page_metadata(ds, page));
+	WT_RET(ret);
 
 	/* Dump the page. */
 	switch (page->type) {

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -99,10 +99,12 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 		WT_ERR(bm->checkpoint_load(bm, session,
 		    ckpt.raw.data, ckpt.raw.size,
 		    root_addr, &root_addr_size, readonly));
-		if (creation || root_addr_size == 0)
-			WT_ERR(__btree_tree_open_empty(
+		if (creation || root_addr_size == 0) {
+			WT_WITH_PAGE_INDEX(session,
+			    ret = __btree_tree_open_empty(
 			    session, creation, readonly));
-		else {
+			WT_ERR(ret);
+		} else {
 			WT_ERR(__wt_btree_tree_open(
 			    session, root_addr, root_addr_size));
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -294,12 +294,16 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 		switch (ss->page_type) {
 		case WT_PAGE_COL_FIX:
 		case WT_PAGE_COL_VAR:
-			WT_ERR(
-			    __slvg_col_build_internal(session, leaf_cnt, ss));
+			WT_WITH_PAGE_INDEX(session,
+			    ret = __slvg_col_build_internal(
+			    session, leaf_cnt, ss));
+			WT_ERR(ret);
 			break;
 		case WT_PAGE_ROW_LEAF:
-			WT_ERR(
-			    __slvg_row_build_internal(session, leaf_cnt, ss));
+			WT_WITH_PAGE_INDEX(session,
+			    ret = __slvg_row_build_internal(
+			    session, leaf_cnt, ss));
+			WT_ERR(ret);
 			break;
 		}
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -690,7 +690,9 @@ __split_multi_inmem(
 			recno = WT_INSERT_RECNO(skip->ins);
 
 			/* Search the page. */
-			WT_ERR(__wt_col_search(session, recno, ref, &cbt));
+			WT_WITH_PAGE_INDEX(session,
+			    ret = __wt_col_search(session, recno, ref, &cbt));
+			WT_ERR(ret);
 
 			/* Apply the modification. */
 			WT_ERR(__wt_col_modify(
@@ -714,7 +716,9 @@ __split_multi_inmem(
 			}
 
 			/* Search the page. */
-			WT_ERR(__wt_row_search(session, key, ref, &cbt, 1));
+			WT_WITH_PAGE_INDEX(session,
+			    ret = __wt_row_search(session, key, ref, &cbt, 1));
+			WT_ERR(ret);
 
 			/* Apply the modification. */
 			WT_ERR(
@@ -1364,8 +1368,10 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 	 * longer locked, so we cannot safely look at it.
 	 */
 	page = NULL;
-	if ((ret = __split_parent(session, ref, split_ref, 2,
-	    parent_decr, parent_incr, 0, 0, &split_gen)) != 0) {
+	WT_WITH_PAGE_INDEX(session,
+	    ret = __split_parent(session, ref, split_ref, 2,
+	    parent_decr, parent_incr, 0, 0, &split_gen));
+	if (ret != 0) {
 		/*
 		 * Move the insert list element back to the original page list.
 		 * For simplicity, the previous skip list pointers originally
@@ -1517,8 +1523,10 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 			    parent_decr, sizeof(WT_IKEY) + ikey->size);
 
 	/* Split into the parent. */
-	WT_ERR(__split_parent(session, ref, ref_new, new_entries,
+	WT_WITH_PAGE_INDEX(session,
+	    ret = __split_parent(session, ref, ref_new, new_entries,
 	    parent_decr, parent_incr, exclusive, 1, &split_gen));
+	WT_ERR(ret);
 
 	__wt_free(session, ref_new);
 

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -45,8 +45,11 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 
 	next_walk = NULL;
 	while ((ret =
-	    __wt_tree_walk(session, &next_walk, 0)) == 0 && next_walk != NULL)
-		WT_RET(__stat_page(session, next_walk->page, stats));
+	    __wt_tree_walk(session, &next_walk, 0)) == 0 && next_walk != NULL) {
+		WT_WITH_PAGE_INDEX(session,
+		    ret = __stat_page(session, next_walk->page, stats));
+		WT_RET(ret);
+	}
 	return (ret == WT_NOTFOUND ? 0 : ret);
 }
 

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -97,9 +97,10 @@ __clsm_enter_update(WT_CURSOR_LSM *clsm)
 
 	if (have_primary) {
 		WT_WITH_BTREE(session, ((WT_CURSOR_BTREE *)primary)->btree,
+		    WT_WITH_PAGE_INDEX(session,
 		    ovfl = __wt_btree_size_overflow(
 		    session, hard_limit ?
-		    2 * lsm_tree->chunk_size : lsm_tree->chunk_size));
+		    2 * lsm_tree->chunk_size : lsm_tree->chunk_size)));
 
 		/* If there was no overflow, we're done. */
 		if (!ovfl)


### PR DESCRIPTION
@michaelcahill Using your split-gen branch, I wrapped all the places I saw that were vulnerable with `WT_WITH_PAGE_INDEX`.