### PR TITLE
Don't do a pass over the page index looking for deleted entries unless we found some in our initial pass.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -931,16 +931,19 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	complete = 1;
 
 	/*
-	 * Now that the new page is in place it's OK to free any deleted
-	 * refs we encountered modulo the regular safe free semantics.
+	 * The new page index is in place, free any deleted WT_REFs we found,
+	 * modulo the usual safe free semantics. Ignore the WT_REF we're
+	 * replacing, our caller is responsible for freeing it.
 	 */
-	for (i = 0; i < parent_entries; ++i) {
-		next_ref = pindex->index[i];
-		/* If we set the ref to split to mark it for delete */
-		if (next_ref != ref && next_ref->state == WT_REF_SPLIT) {
+	if (deleted_entries)
+		for (i = 0; i < parent_entries; ++i) {
+			next_ref = pindex->index[i];
+			if (next_ref == ref || next_ref->state != WT_REF_SPLIT)
+				continue;
+
 			/*
-			 * We're discarding a deleted reference.
-			 * Free any resources it holds.
+			 * We set the WT_REF to split, discard it, freeing any
+			 * resources it holds.
 			 */
 			if (parent->type == WT_PAGE_ROW_INT) {
 				WT_TRET(__split_ovfl_key_cleanup(
@@ -970,7 +973,6 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 			    session, split_gen, 0, next_ref, sizeof(WT_REF)));
 			parent_decr += sizeof(WT_REF);
 		}
-	}
 
 	/*
 	 * We can't free the previous page index, there may be threads using it.


### PR DESCRIPTION
@agorrod, would you please check me on this one? It seems to me we can skip a pass over the page index in the common case. Sorry about the re-format, but I had to shuffle things a little to avoid getting really deep clauses.