### PR TITLE
Don't free the disk image twice on error.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -370,18 +370,21 @@ __wt_btree_tree_open(
 	 */
 	WT_CLEAR(dsk);
 
-	/* Read the page, then build the in-memory version of the page. */
+	/*
+	 * Read the page, then build the in-memory version of the page. Clear
+	 * any local reference to an allocated copy of the disk image on return,
+	 * the page steals it.
+	 */
 	WT_ERR(__wt_bt_read(session, &dsk, addr, addr_size));
 	WT_ERR(__wt_page_inmem(session, NULL, dsk.data,
 	    WT_DATA_IN_ITEM(&dsk) ?
 	    WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED , &page));
+	dsk.mem = NULL;
 
 	/* Finish initializing the root, root reference links. */
 	__wt_root_ref_init(&btree->root, page, btree->type != BTREE_ROW);
 
-	if (0) {
-err:		__wt_buf_free(session, &dsk);
-	}
+err:	__wt_buf_free(session, &dsk);
 	return (ret);
 }
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -55,13 +55,16 @@ __wt_cache_read(WT_SESSION_IMPL *session, WT_REF *ref)
 		WT_ERR(__wt_btree_new_leaf_page(session, &page));
 		ref->page = page;
 	} else {
-		/* Read the backing disk page. */
+		/*
+		 * Read the page, then build the in-memory version of the page.
+		 * Clear any local reference to an allocated copy of the disk
+		 * image on return, the page steals it.
+		 */
 		WT_ERR(__wt_bt_read(session, &tmp, addr, addr_size));
-
-		/* Build the in-memory version of the page. */
 		WT_ERR(__wt_page_inmem(session, ref, tmp.data,
 		    WT_DATA_IN_ITEM(&tmp) ?
 		    WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page));
+		tmp.mem = NULL;
 
 		/* If the page was deleted, instantiate that information. */
 		if (previous_state == WT_REF_DELETED)


### PR DESCRIPTION
@agorrod, I think that if `__wt_delete_page_instantiate` fails in `__wt_cache_read`, we'll free the allocated disk image twice, and no good will come from that. Would you please take a look and see if I've missed anything?