### PR TITLE
Add name_hash and hash bucket queues for fh and block. #1634

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -83,9 +83,11 @@ __block_destroy(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	uint64_t bucket;
 
 	conn = S2C(session);
-	TAILQ_REMOVE(&conn->blockqh, block, q);
+	bucket = block->name_hash % WT_HASH_ARRAY_SIZE;
+	WT_CONN_BLOCK_REMOVE(conn, block, bucket);
 
 	if (block->name != NULL)
 		__wt_free(session, block->name);
@@ -113,27 +115,31 @@ __wt_block_open(WT_SESSION_IMPL *session,
 	WT_CONFIG_ITEM cval;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	uint64_t bucket, hash;
 
 	WT_TRET(__wt_verbose(session, WT_VERB_BLOCK, "open: %s", filename));
 
 	conn = S2C(session);
 	*blockp = NULL;
-
+	hash = __wt_hash_city64(filename, strlen(filename));
+	bucket = hash % WT_HASH_ARRAY_SIZE;
 	__wt_spin_lock(session, &conn->block_lock);
-	TAILQ_FOREACH(block, &conn->blockqh, q)
+	TAILQ_FOREACH(block, &conn->blockhash[bucket], hashq) {
 		if (strcmp(filename, block->name) == 0) {
 			++block->ref;
 			*blockp = block;
 			__wt_spin_unlock(session, &conn->block_lock);
 			return (0);
 		}
+	}
 
 	/* Basic structure allocation, initialization. */
 	WT_ERR(__wt_calloc_one(session, &block));
 	block->ref = 1;
-	TAILQ_INSERT_HEAD(&conn->blockqh, block, q);
+	WT_CONN_BLOCK_INSERT(conn, block, bucket);
 
 	WT_ERR(__wt_strdup(session, filename, &block->name));
+	block->name_hash = hash;
 	block->allocsize = allocsize;
 
 	WT_ERR(__wt_config_gets(session, cfg, "block_allocation", &cval));

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,8 +20,11 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
 
 	session = conn->default_session;
 
-	for (i = 0; i < WT_HASH_ARRAY_SIZE; i++)
+	for (i = 0; i < WT_HASH_ARRAY_SIZE; i++) {
 		SLIST_INIT(&conn->dhhash[i]);	/* Data handle hash lists */
+		TAILQ_INIT(&conn->fhhash[i]);	/* File handle hash lists */
+		TAILQ_INIT(&conn->blockhash[i]);/* Block handle hash lists */
+	}
 
 	SLIST_INIT(&conn->dhlh);		/* Data handle list */
 	TAILQ_INIT(&conn->dlhqh);		/* Library list */

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -209,11 +209,13 @@ struct __wt_bm {
  */
 struct __wt_block {
 	const char *name;		/* Name */
+	uint64_t name_hash;		/* Hash of name */
 
 	/* A list of block manager handles, sharing a file descriptor. */
 	uint32_t ref;			/* References */
 	WT_FH	*fh;			/* Backing file handle */
 	TAILQ_ENTRY(__wt_block) q;	/* Linked list of handles */
+	TAILQ_ENTRY(__wt_block) hashq;	/* Hashed list of handles */
 
 	/* Configuration information, set when the file is opened. */
 	int	 allocfirst;		/* Allocation is first-fit */

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -45,7 +45,9 @@
 
 struct __wt_fh {
 	char	*name;				/* File name */
+	uint64_t name_hash;			/* Hash of name */
 	TAILQ_ENTRY(__wt_fh) q;			/* List of open handles */
+	TAILQ_ENTRY(__wt_fh) hashq;		/* Hashed list of handles */
 
 	u_int	ref;				/* Reference count */
 

--- a/src/os_posix/os_open.c
+++ b/src/os_posix/os_open.c
@@ -43,6 +43,7 @@ __wt_open(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	WT_FH *fh, *tfh;
 	mode_t mode;
+	uint64_t bucket, hash;
 	int direct_io, f, fd, matched;
 	char *path;
 
@@ -56,14 +57,17 @@ __wt_open(WT_SESSION_IMPL *session,
 
 	/* Increment the reference count if we already have the file open. */
 	matched = 0;
+	hash = __wt_hash_city64(name, strlen(name));
+	bucket = hash % WT_HASH_ARRAY_SIZE;
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(tfh, &conn->fhqh, q)
+	TAILQ_FOREACH(tfh, &conn->fhhash[bucket], q) {
 		if (strcmp(name, tfh->name) == 0) {
 			++tfh->ref;
 			*fhp = tfh;
 			matched = 1;
 			break;
 		}
+	}
 	__wt_spin_unlock(session, &conn->fh_lock);
 	if (matched)
 		return (0);
@@ -148,6 +152,7 @@ setupfh:
 
 	WT_ERR(__wt_calloc_one(session, &fh));
 	WT_ERR(__wt_strdup(session, name, &fh->name));
+	fh->name_hash = hash;
 	fh->fd = fd;
 	fh->ref = 1;
 	fh->direct_io = direct_io;
@@ -169,15 +174,16 @@ setupfh:
 	 */
 	matched = 0;
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(tfh, &conn->fhqh, q)
+	TAILQ_FOREACH(tfh, &conn->fhhash[bucket], q) {
 		if (strcmp(name, tfh->name) == 0) {
 			++tfh->ref;
 			*fhp = tfh;
 			matched = 1;
 			break;
 		}
+	}
 	if (!matched) {
-		TAILQ_INSERT_TAIL(&conn->fhqh, fh, q);
+		WT_CONN_FILE_INSERT(conn, fh, bucket);
 		WT_STAT_FAST_CONN_INCR(session, file_open);
 
 		*fhp = fh;
@@ -205,8 +211,10 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH *fh)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	uint64_t bucket;
 
 	conn = S2C(session);
+	bucket = fh->name_hash % WT_HASH_ARRAY_SIZE;
 
 	__wt_spin_lock(session, &conn->fh_lock);
 	if (fh == NULL || fh->ref == 0 || --fh->ref > 0) {
@@ -215,7 +223,7 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH *fh)
 	}
 
 	/* Remove from the list. */
-	TAILQ_REMOVE(&conn->fhqh, fh, q);
+	WT_CONN_FILE_REMOVE(conn, fh, bucket);
 	WT_STAT_FAST_CONN_DECR(session, file_open);
 
 	__wt_spin_unlock(session, &conn->fh_lock);

--- a/src/os_posix/os_remove.c
+++ b/src/os_posix/os_remove.c
@@ -22,7 +22,8 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 
 	conn = S2C(session);
 	fh = NULL;
-	bucket = __wt_hash_city64(name, strlen(name));
+	bucket = __wt_hash_city64(name, strlen(name)) %
+	    WT_HASH_ARRAY_SIZE;
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher

--- a/src/os_posix/os_remove.c
+++ b/src/os_posix/os_remove.c
@@ -22,8 +22,7 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 
 	conn = S2C(session);
 	fh = NULL;
-	bucket = __wt_hash_city64(name, strlen(name)) %
-	    WT_HASH_ARRAY_SIZE;
+	bucket = __wt_hash_city64(name, strlen(name)) % WT_HASH_ARRAY_SIZE;
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher

--- a/src/os_posix/os_remove.c
+++ b/src/os_posix/os_remove.c
@@ -18,16 +18,18 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 #ifdef HAVE_DIAGNOSTIC
 	WT_CONNECTION_IMPL *conn;
 	WT_FH *fh;
+	uint64_t bucket;
 
 	conn = S2C(session);
 	fh = NULL;
+	bucket = __wt_hash_city64(name, strlen(name));
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher
 	 * level should have closed it before removing.
 	 */
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(fh, &conn->fhqh, q) {
+	TAILQ_FOREACH(fh, &conn->fhhash[bucket], q) {
 		if (strcmp(name, fh->name) == 0)
 			break;
 	}

--- a/src/os_win/os_open.c
+++ b/src/os_win/os_open.c
@@ -21,6 +21,7 @@ __wt_open(WT_SESSION_IMPL *session,
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_FH *fh, *tfh;
+	uint64_t bucket, hash;
 	int direct_io, f, matched, share_mode;
 	char *path;
 
@@ -30,13 +31,15 @@ __wt_open(WT_SESSION_IMPL *session,
 	filehandle = INVALID_HANDLE_VALUE;
 	filehandle_secondary = INVALID_HANDLE_VALUE;
 	direct_io = 0;
+	hash = __wt_hash_city64(name, strlen(name));
+	bucket = hash % WT_HASH_ARRAY_SIZE;
 
 	WT_RET(__wt_verbose(session, WT_VERB_FILEOPS, "%s: open", name));
 
 	/* Increment the reference count if we already have the file open. */
 	matched = 0;
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(tfh, &conn->fhqh, q)
+	TAILQ_FOREACH(tfh, &conn->fhhash[bucket], q)
 		if (strcmp(name, tfh->name) == 0) {
 			++tfh->ref;
 			*fhp = tfh;
@@ -133,6 +136,7 @@ __wt_open(WT_SESSION_IMPL *session,
 setupfh:
 	WT_ERR(__wt_calloc_one(session, &fh));
 	WT_ERR(__wt_strdup(session, name, &fh->name));
+	fh->name_hash = hash;
 	fh->filehandle = filehandle;
 	fh->filehandle_secondary = filehandle_secondary;
 	fh->ref = 1;
@@ -156,7 +160,7 @@ setupfh:
 	 */
 	matched = 0;
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(tfh, &conn->fhqh, q)
+	TAILQ_FOREACH(tfh, &conn->fhhash[bucket], q)
 		if (strcmp(name, tfh->name) == 0) {
 			++tfh->ref;
 			*fhp = tfh;
@@ -164,7 +168,7 @@ setupfh:
 			break;
 		}
 	if (!matched) {
-		TAILQ_INSERT_TAIL(&conn->fhqh, fh, q);
+		WT_CONN_FILE_INSERT(conn, fh, bucket);
 		WT_STAT_FAST_CONN_INCR(session, file_open);
 
 		*fhp = fh;
@@ -194,8 +198,10 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH *fh)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	uint64_t bucket;
 
 	conn = S2C(session);
+	bucket = fh->name_hash % WT_HASH_ARRAY_SIZE;
 
 	__wt_spin_lock(session, &conn->fh_lock);
 	if (fh == NULL || fh->ref == 0 || --fh->ref > 0) {
@@ -204,7 +210,7 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH *fh)
 	}
 
 	/* Remove from the list. */
-	TAILQ_REMOVE(&conn->fhqh, fh, q);
+	WT_CONN_FILE_REMOVE(conn, fh, bucket);
 	WT_STAT_FAST_CONN_DECR(session, file_open);
 
 	__wt_spin_unlock(session, &conn->fh_lock);

--- a/src/os_win/os_remove.c
+++ b/src/os_win/os_remove.c
@@ -22,7 +22,8 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 
 	conn = S2C(session);
 	fh = NULL;
-	bucket = __wt_hash_city64(name, strlen(name));
+	bucket = __wt_hash_city64(name, strlen(name)) %
+	    WT_HASH_ARRAY_SIZE;
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher

--- a/src/os_win/os_remove.c
+++ b/src/os_win/os_remove.c
@@ -22,8 +22,7 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 
 	conn = S2C(session);
 	fh = NULL;
-	bucket = __wt_hash_city64(name, strlen(name)) %
-	    WT_HASH_ARRAY_SIZE;
+	bucket = __wt_hash_city64(name, strlen(name)) % WT_HASH_ARRAY_SIZE;
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher

--- a/src/os_win/os_remove.c
+++ b/src/os_win/os_remove.c
@@ -18,16 +18,18 @@ __remove_file_check(WT_SESSION_IMPL *session, const char *name)
 #ifdef HAVE_DIAGNOSTIC
 	WT_CONNECTION_IMPL *conn;
 	WT_FH *fh;
+	uint64_t bucket;
 
 	conn = S2C(session);
 	fh = NULL;
+	bucket = __wt_hash_city64(name, strlen(name));
 
 	/*
 	 * Check if the file is open: it's an error if it is, since a higher
 	 * level should have closed it before removing.
 	 */
 	__wt_spin_lock(session, &conn->fh_lock);
-	TAILQ_FOREACH(fh, &conn->fhqh, q) {
+	TAILQ_FOREACH(fh, &conn->fhhash[bucket], q) {
 		if (strcmp(name, fh->name) == 0)
 			break;
 	}


### PR DESCRIPTION
Using hash buckets for the file handle and block lists saves us about 1.5-2.0 seconds off the test.  It was about 15.6 seconds and is now 13.6-14.0 seconds.