### PR TITLE
For wt printlog, make operations into a JSON array.

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -260,7 +260,7 @@ __wt_logop_%(name)s_print(
 \t%(arg_init)sWT_RET(__wt_logop_%(name)s_unpack(
 \t    session, pp, end%(arg_addrs)s));
 
-\tfprintf(out, "    \\"optype\\": \\"%(name)s\\",\\n");
+\tfprintf(out, " \\"optype\\": \\"%(name)s\\",\\n");
 \t%(print_args)s
 \t%(arg_fini)sreturn (0);
 }
@@ -274,10 +274,10 @@ __wt_logop_%(name)s_print(
     if has_escape(optype.fields) else ''),
     'arg_addrs' : ''.join(', &%s' % f[1] for f in optype.fields),
     'print_args' : '\n\t'.join(
-        '%sfprintf(out, "    \\"%s\\": \\"%s\\",\\n",%s);' %
+        '%sfprintf(out, "        \\"%s\\": \\"%s\\",\\n",%s);' %
         (printf_setup(f), f[1], printf_fmt(f), printf_arg(f))
         for f in optype.fields[:-1]) + str(
-        '\n\t%sfprintf(out, "    \\"%s\\": \\"%s\\"",%s);' %
+        '\n\t%sfprintf(out, "        \\"%s\\": \\"%s\\"",%s);' %
         (printf_setup(last_field), last_field[1],
             printf_fmt(last_field), printf_arg(last_field))),
 })

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -130,11 +130,11 @@ __wt_logop_col_put_print(
 	WT_RET(__wt_logop_col_put_unpack(
 	    session, pp, end, &fileid, &recno, &value));
 
-	fprintf(out, "    \"optype\": \"col_put\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
-	fprintf(out, "    \"recno\": \"%" PRIu64 "\",\n", recno);
+	fprintf(out, " \"optype\": \"col_put\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, "        \"recno\": \"%" PRIu64 "\",\n", recno);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &value));
-	fprintf(out, "    \"value\": \"%s\"", escaped);
+	fprintf(out, "        \"value\": \"%s\"", escaped);
 	__wt_free(session, escaped);
 	return (0);
 }
@@ -189,9 +189,9 @@ __wt_logop_col_remove_print(
 	WT_RET(__wt_logop_col_remove_unpack(
 	    session, pp, end, &fileid, &recno));
 
-	fprintf(out, "    \"optype\": \"col_remove\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
-	fprintf(out, "    \"recno\": \"%" PRIu64 "\"", recno);
+	fprintf(out, " \"optype\": \"col_remove\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, "        \"recno\": \"%" PRIu64 "\"", recno);
 	return (0);
 }
 
@@ -246,10 +246,10 @@ __wt_logop_col_truncate_print(
 	WT_RET(__wt_logop_col_truncate_unpack(
 	    session, pp, end, &fileid, &start, &stop));
 
-	fprintf(out, "    \"optype\": \"col_truncate\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
-	fprintf(out, "    \"start\": \"%" PRIu64 "\",\n", start);
-	fprintf(out, "    \"stop\": \"%" PRIu64 "\"", stop);
+	fprintf(out, " \"optype\": \"col_truncate\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, "        \"start\": \"%" PRIu64 "\",\n", start);
+	fprintf(out, "        \"stop\": \"%" PRIu64 "\"", stop);
 	return (0);
 }
 
@@ -306,12 +306,12 @@ __wt_logop_row_put_print(
 	WT_RET(__wt_logop_row_put_unpack(
 	    session, pp, end, &fileid, &key, &value));
 
-	fprintf(out, "    \"optype\": \"row_put\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, " \"optype\": \"row_put\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &key));
-	fprintf(out, "    \"key\": \"%s\",\n", escaped);
+	fprintf(out, "        \"key\": \"%s\",\n", escaped);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &value));
-	fprintf(out, "    \"value\": \"%s\"", escaped);
+	fprintf(out, "        \"value\": \"%s\"", escaped);
 	__wt_free(session, escaped);
 	return (0);
 }
@@ -368,10 +368,10 @@ __wt_logop_row_remove_print(
 	WT_RET(__wt_logop_row_remove_unpack(
 	    session, pp, end, &fileid, &key));
 
-	fprintf(out, "    \"optype\": \"row_remove\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, " \"optype\": \"row_remove\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &key));
-	fprintf(out, "    \"key\": \"%s\"", escaped);
+	fprintf(out, "        \"key\": \"%s\"", escaped);
 	__wt_free(session, escaped);
 	return (0);
 }
@@ -430,13 +430,13 @@ __wt_logop_row_truncate_print(
 	WT_RET(__wt_logop_row_truncate_unpack(
 	    session, pp, end, &fileid, &start, &stop, &mode));
 
-	fprintf(out, "    \"optype\": \"row_truncate\",\n");
-	fprintf(out, "    \"fileid\": \"%" PRIu32 "\",\n", fileid);
+	fprintf(out, " \"optype\": \"row_truncate\",\n");
+	fprintf(out, "        \"fileid\": \"%" PRIu32 "\",\n", fileid);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &start));
-	fprintf(out, "    \"start\": \"%s\",\n", escaped);
+	fprintf(out, "        \"start\": \"%s\",\n", escaped);
 	WT_RET(__logrec_jsonify_str(session, &escaped, &stop));
-	fprintf(out, "    \"stop\": \"%s\",\n", escaped);
-	fprintf(out, "    \"mode\": \"%" PRIu32 "\"", mode);
+	fprintf(out, "        \"stop\": \"%s\",\n", escaped);
+	fprintf(out, "        \"mode\": \"%" PRIu32 "\"", mode);
 	__wt_free(session, escaped);
 	return (0);
 }

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -70,18 +70,21 @@ __txn_commit_printlog(
 	int firstrecord;
 
 	firstrecord = 1;
+	fprintf(out, "    \"ops\": [\n");
 
 	/* The logging subsystem zero-pads records. */
 	while (*pp < end && **pp) {
 		if (!firstrecord)
 			fprintf(out, ",\n");
+		fprintf(out, "      {");
 
 		firstrecord = 0;
 
 		WT_RET(__wt_txn_op_printlog(session, pp, end, out));
+		fprintf(out, "\n      }");
 	}
 
-	fprintf(out, "\n");
+	fprintf(out, "\n    ]\n");
 
 	return (0);
 }


### PR DESCRIPTION
Without that, any tool that parses JSON is almost certain to merge successive values of repeated fields.
Refs #1438.