### PR TITLE
Fix a bug in table create. A crash could cause recovery to break.

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -54,6 +54,12 @@ __wt_block_manager_create(
 	/* Write out the file's meta-data. */
 	ret = __wt_desc_init(session, fh, allocsize);
 
+	/*
+	 * Ensure the new file has made it to disk. Otherwise a crash
+	 * after log records exist for the file can lead to a recovery failure.
+	 */
+	WT_TRET(__wt_fsync(session, fh));
+
 	/* Close the file handle. */
 	WT_TRET(__wt_close(session, fh));
 


### PR DESCRIPTION
Refs SERVER-17204

The bug is that we weren't doing an fsync of the file after it was
created. Recovery assumes that if there are records for a particular
file, then it will exist on disk.