### PR TITLE
Don't double-count the on-disk header size when setting split boundaries

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1988,13 +1988,10 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 		 * add whatever space remains in this page.
 		 */
 		if (inuse + r->split_size <= r->page_size)
-			r->space_avail =
-			    r->split_size - WT_PAGE_HEADER_BYTE_SIZE(btree);
+			r->space_avail = r->split_size;
 		else {
-			WT_ASSERT(session, r->page_size >=
-			    (WT_PAGE_HEADER_BYTE_SIZE(btree) + inuse));
-			r->space_avail = r->page_size -
-			    (WT_PAGE_HEADER_BYTE_SIZE(btree) + inuse);
+			WT_ASSERT(session, r->page_size >= inuse);
+			r->space_avail = r->page_size - inuse;
 
 			/* There are no further boundary points. */
 			r->bnd_state = SPLIT_MAX;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1988,7 +1988,8 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 		 * add whatever space remains in this page.
 		 */
 		if (inuse + r->split_size <= r->page_size)
-			r->space_avail = r->split_size;
+			r->space_avail =
+			    r->split_size - WT_PAGE_HEADER_BYTE_SIZE(btree);
 		else {
 			WT_ASSERT(session, r->page_size >= inuse);
 			r->space_avail = r->page_size - inuse;


### PR DESCRIPTION
refs #1655