### PR TITLE
New chunk_count_limit is an integer. #1658 #1652

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -92,7 +92,8 @@ lsm_config = [
             the maximum number of chunks to allow in an LSM tree. This
             option automatically times out old data. As new chunks are
             added old chunks will be removed. Enabling this option
-            disables LSM background merges'''),
+            disables LSM background merges''',
+            type='int'),
         Config('chunk_max', '5GB', r'''
             the maximum size a single chunk can be. Chunks larger than this
             size are not considered for further merges. This is a soft

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -203,7 +203,7 @@ static const WT_CONFIG_CHECK confchk_lsm_subconfigs[] = {
 	{ "bloom_config", "string", NULL, NULL },
 	{ "bloom_hash_count", "int", "min=2,max=100", NULL },
 	{ "bloom_oldest", "boolean", NULL, NULL },
-	{ "chunk_count_limit", "string", NULL, NULL },
+	{ "chunk_count_limit", "int", NULL, NULL },
 	{ "chunk_max", "int", "min=100MB,max=10TB", NULL },
 	{ "chunk_size", "int", "min=512K,max=500MB", NULL },
 	{ "merge_max", "int", "min=2,max=100", NULL },

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1097,7 +1097,7 @@ struct __wt_session {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_count_limit, the maximum number
 	 * of chunks to allow in an LSM tree.  This option automatically times
 	 * out old data.  As new chunks are added old chunks will be removed.
-	 * Enabling this option disables LSM background merges., a string;
+	 * Enabling this option disables LSM background merges., an integer;
 	 * default \c 0.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_max, the maximum
 	 * size a single chunk can be.  Chunks larger than this size are not


### PR DESCRIPTION
@agorrod When I looked at the change, it seemed odd that this was documented as a string type rather than an integer.  I explicitly set it to `type=int`.  Please review.