### PR TITLE
Move server thread waits to the beginning of their loops

### DIFF
--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -83,6 +83,14 @@ __ckpt_server(void *arg)
 
 	while (F_ISSET(conn, WT_CONN_SERVER_RUN) &&
 	    F_ISSET(conn, WT_CONN_SERVER_CHECKPOINT)) {
+		/*
+		 * Wait...
+		 * NOTE: If the user only configured logsize, then usecs
+		 * will be 0 and this wait won't return until signalled.
+		 */
+		WT_ERR(
+		    __wt_cond_wait(session, conn->ckpt_cond, conn->ckpt_usecs));
+
 		/* Checkpoint the database. */
 		WT_ERR(wt_session->checkpoint(wt_session, conn->ckpt_config));
 
@@ -99,14 +107,6 @@ __ckpt_server(void *arg)
 			 */
 			WT_ERR(__wt_cond_wait(session, conn->ckpt_cond, 1));
 		}
-
-		/*
-		 * Wait...
-		 * NOTE: If the user only configured logsize, then usecs
-		 * will be 0 and this wait won't return until signalled.
-		 */
-		WT_ERR(
-		    __wt_cond_wait(session, conn->ckpt_cond, conn->ckpt_usecs));
 	}
 
 	if (0) {

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -406,12 +406,12 @@ __statlog_server(void *arg)
 
 	while (F_ISSET(conn, WT_CONN_SERVER_RUN) &&
 	    F_ISSET(conn, WT_CONN_SERVER_STATISTICS)) {
-		if (!FLD_ISSET(conn->stat_flags, WT_CONN_STAT_NONE))
-			WT_ERR(__statlog_log_one(session, &path, &tmp));
-
 		/* Wait until the next event. */
 		WT_ERR(
 		    __wt_cond_wait(session, conn->stat_cond, conn->stat_usecs));
+
+		if (!FLD_ISSET(conn->stat_flags, WT_CONN_STAT_NONE))
+			WT_ERR(__statlog_log_one(session, &path, &tmp));
 	}
 
 	if (0) {

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -118,7 +118,6 @@ __sweep_server(void *arg)
 	 */
 	while (F_ISSET(conn, WT_CONN_SERVER_RUN) &&
 	    F_ISSET(conn, WT_CONN_SERVER_SWEEP)) {
-
 		/* Wait until the next event. */
 		WT_ERR(__wt_cond_wait(session,
 		    conn->sweep_cond, WT_DHANDLE_SWEEP_PERIOD * WT_MILLION));


### PR DESCRIPTION
Check that we're still running before waiting.  This makes more sense to me, but also fixes a problem introduced recently where the checkpoint server could hang on shutdown if the signal from the closing thread got lost.