### PR TITLE
TXN_API_END_RETRY cleanup.

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -76,7 +76,7 @@
 		}							\
 	}								\
 	break;								\
-} while (ret == 0)
+} while (1)
 
 /* End a transactional API call, retry on deadlock. */
 #define	TXN_API_END(s, ret)	TXN_API_END_RETRY(s, ret, 1)


### PR DESCRIPTION
@michaelcahill, Coverity complains about the `ret == 0` test at the end of the TXN_API_END_RETRY macro in half-a-dozen places in the code.

I'm pretty sure we don't need the `ret == 0`, I think the only path to the loop's test is the `ret = 0; continue` statement above it, but please check me.