### PR TITLE
Flip cache overhead to apply to the allocated bytes

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -325,13 +325,13 @@ connection_runtime_config = [
         min='1MB', max='10TB'),
     Config('cache_overhead', '8', r'''
         assume the heap allocator overhead is the specified percentage, and
-        adjust the cache size by that amount (for example, if the cache size is
-        100GB, a percentage of 10 means WiredTiger limits itself to allocating
-        90GB of memory).  This value is configurable because different heap
-        allocators have different overhead and different workloads will have
-        different heap allocation sizes and patterns, therefore applications
-        may need to adjust this value based on allocator choice and behavior
-        in measured workloads''',
+        adjust the cache usage by that amount (for example, if there is 10GB
+		of data in cache, a percentage of 10 means WiredTiger treats this as
+		11GB).  This value is configurable because different heap allocators
+		have different overhead and different workloads will have different
+		heap allocation sizes and patterns, therefore applications may need to
+		adjust this value based on allocator choice and behavior in measured
+		workloads''',
         min='0', max='30'),
     Config('checkpoint', '', r'''
         periodically checkpoint the database''',

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -326,12 +326,12 @@ connection_runtime_config = [
     Config('cache_overhead', '8', r'''
         assume the heap allocator overhead is the specified percentage, and
         adjust the cache usage by that amount (for example, if there is 10GB
-		of data in cache, a percentage of 10 means WiredTiger treats this as
-		11GB).  This value is configurable because different heap allocators
-		have different overhead and different workloads will have different
-		heap allocation sizes and patterns, therefore applications may need to
-		adjust this value based on allocator choice and behavior in measured
-		workloads''',
+        of data in cache, a percentage of 10 means WiredTiger treats this as
+        11GB).  This value is configurable because different heap allocators
+        have different overhead and different workloads will have different
+        heap allocation sizes and patterns, therefore applications may need to
+        adjust this value based on allocator choice and behavior in measured
+        workloads''',
         min='0', max='30'),
     Config('checkpoint', '', r'''
         periodically checkpoint the database''',

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -469,7 +469,8 @@ __evict_pass(WT_SESSION_IMPL *session)
 		 * Start a worker if we have capacity and we haven't reached
 		 * the eviction targets.
 		 */
-		if (LF_ISSET(WT_EVICT_PASS_ALL | WT_EVICT_PASS_DIRTY)) {
+		if (LF_ISSET(WT_EVICT_PASS_ALL | WT_EVICT_PASS_DIRTY) &&
+		    conn->evict_workers < conn->evict_workers_max) {
 			WT_RET(__wt_verbose(session, WT_VERB_EVICTSERVER,
 			    "Starting evict worker: %"PRIu32"\n",
 			    conn->evict_workers));

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -82,6 +82,8 @@ struct __wt_cache {
 	u_int eviction_target;		/* Percent to end eviction */
 	u_int eviction_dirty_target;    /* Percent to allow dirty */
 
+	u_int overhead_pct;	        /* Cache percent adjustment */
+
 	/*
 	 * LRU eviction list information.
 	 */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -227,7 +227,6 @@ struct __wt_connection_impl {
 	uint32_t   hazard_max;		/* Hazard array size */
 
 	WT_CACHE  *cache;		/* Page cache */
-	int	   cache_overhead;	/* Cache percent adjustment */
 	uint64_t   cache_size;		/* Configured cache size */
 
 	WT_TXN_GLOBAL txn_global;	/* Global transaction state */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1546,14 +1546,14 @@ struct __wt_connection {
 	 * integer between 1 and 20; default \c 2.}
 	 * @config{ ),,}
 	 * @config{cache_overhead, assume the heap allocator overhead is the
-	 * specified percentage\, and adjust the cache size by that amount (for
-	 * example\, if the cache size is 100GB\, a percentage of 10 means
-	 * WiredTiger limits itself to allocating 90GB of memory). This value is
-	 * configurable because different heap allocators have different
-	 * overhead and different workloads will have different heap allocation
-	 * sizes and patterns\, therefore applications may need to adjust this
-	 * value based on allocator choice and behavior in measured workloads.,
-	 * an integer between 0 and 30; default \c 8.}
+	 * specified percentage\, and adjust the cache usage by that amount (for
+	 * example\, if there is 10GB of data in cache\, a percentage of 10
+	 * means WiredTiger treats this as 11GB). This value is configurable
+	 * because different heap allocators have different overhead and
+	 * different workloads will have different heap allocation sizes and
+	 * patterns\, therefore applications may need to adjust this value based
+	 * on allocator choice and behavior in measured workloads., an integer
+	 * between 0 and 30; default \c 8.}
 	 * @config{cache_size, maximum heap memory to allocate for the cache.  A
 	 * database should configure either \c cache_size or \c shared_cache but
 	 * not both., an integer between 1MB and 10TB; default \c 100MB.}
@@ -1882,13 +1882,13 @@ struct __wt_connection {
  * should be used (4KB on Linux systems\, zero elsewhere)., an integer between
  * -1 and 1MB; default \c -1.}
  * @config{cache_overhead, assume the heap allocator overhead is the specified
- * percentage\, and adjust the cache size by that amount (for example\, if the
- * cache size is 100GB\, a percentage of 10 means WiredTiger limits itself to
- * allocating 90GB of memory). This value is configurable because different heap
- * allocators have different overhead and different workloads will have
- * different heap allocation sizes and patterns\, therefore applications may
- * need to adjust this value based on allocator choice and behavior in measured
- * workloads., an integer between 0 and 30; default \c 8.}
+ * percentage\, and adjust the cache usage by that amount (for example\, if
+ * there is 10GB of data in cache\, a percentage of 10 means WiredTiger treats
+ * this as 11GB). This value is configurable because different heap allocators
+ * have different overhead and different workloads will have different heap
+ * allocation sizes and patterns\, therefore applications may need to adjust
+ * this value based on allocator choice and behavior in measured workloads., an
+ * integer between 0 and 30; default \c 8.}
  * @config{cache_size, maximum heap memory to allocate for the cache.  A
  * database should configure either \c cache_size or \c shared_cache but not
  * both., an integer between 1MB and 10TB; default \c 100MB.}


### PR DESCRIPTION
Flip cache overhead to apply to the allocated bytes rather than the total size.  Include the overhead in stats so that tools (e.g., mongostat) report accurate cache full and dirty percentages.  This also makes eviction triggers and targets meaningful: with the default trigger of 95% and overhead 8%, eviction was previously never triggered until the cache was completely full.