### PR TITLE
Mongo eviction whitespace, minor cleanup.

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -32,14 +32,11 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 		return (0);
 
 	/* Leaf pages only. */
-	if (page->type != WT_PAGE_COL_FIX &&
-	    page->type != WT_PAGE_COL_VAR &&
-	    page->type != WT_PAGE_ROW_LEAF)
+	if (WT_PAGE_IS_INTERNAL(page))
 		return (0);
 
 	/* Eviction may be turned off. */
-	if (LF_ISSET(WT_READ_NO_EVICT) ||
-	    F_ISSET(btree, WT_BTREE_NO_EVICTION))
+	if (LF_ISSET(WT_READ_NO_EVICT) || F_ISSET(btree, WT_BTREE_NO_EVICTION))
 		return (0);
 
 	/*
@@ -53,10 +50,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 	__wt_page_evict_soon(page);
 
 	/* If eviction cannot succeed, don't try. */
-	if (!__wt_page_can_evict(session, page, 1))
-		return (0);
-
-	return (1);
+	return (__wt_page_can_evict(session, page, 1));
 }
 
 /*


### PR DESCRIPTION
@michaelcahill, feel free to discard anything you don't like, it's all semantic sugar.