### PR TITLE
Fix a bug in checkpoint, where it could get an EBUSY return.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -542,11 +542,6 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session,
  * __wt_conn_btree_apply_single_ckpt --
  *	Decode any checkpoint information from the configuration string then
  *	call btree apply single.
- *	TODO: This is based on __wt_session_get_btree_ckpt, which has retry
- *	      logic around ebusy returns. I don't think we want that here -
- *	      since the primary use case is when applying a function to a
- *	      list of handles provided to a checkpoint (in fact, I think we'd
- *	      end up stuck in a loop).
  */
 int
 __wt_conn_btree_apply_single_ckpt(WT_SESSION_IMPL *session,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -221,6 +221,7 @@ extern int __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *name, co
 extern int __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, int force);
 extern int __wt_conn_btree_get(WT_SESSION_IMPL *session, const char *name, const char *ckpt, const char *cfg[], uint32_t flags);
 extern int __wt_conn_btree_apply(WT_SESSION_IMPL *session, int apply_checkpoints, const char *uri, int (*func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[]);
+extern int __wt_conn_btree_apply_single_ckpt(WT_SESSION_IMPL *session, const char *uri, int (*func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[]);
 extern int __wt_conn_btree_apply_single(WT_SESSION_IMPL *session, const char *uri, const char *checkpoint, int (*func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[]);
 extern int __wt_conn_dhandle_close_all( WT_SESSION_IMPL *session, const char *name, int force);
 extern int __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final);


### PR DESCRIPTION
The case that could return EBUSY was when checkpointing with a
specific target, while that target was open exclusively or for a bulk
load.

Refs #1404 #1589