### PR TITLE
Several optimizations to large page eviction:

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -634,7 +634,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
 	    WT_MAX((uint64_t)cval.val, 50 * (uint64_t)btree->maxleafpage);
 	cache_size = S2C(session)->cache_size;
 	if (cache_size > 0)
-		btree->maxmempage = WT_MIN(btree->maxmempage, cache_size / 2);
+		btree->maxmempage = WT_MIN(btree->maxmempage, cache_size / 4);
 
 	/*
 	 * Get the split percentage (reconciliation splits pages into smaller

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -165,6 +165,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			if (oldgen && page->read_gen == WT_READGEN_NOTSET)
 				__wt_page_evict_soon(page);
 			else if (!LF_ISSET(WT_READ_NO_GEN) &&
+			    page->read_gen != WT_READGEN_OLDEST &&
 			    page->read_gen < __wt_cache_read_gen(session))
 				page->read_gen =
 				    __wt_cache_read_gen_set(session);

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -738,7 +738,7 @@ __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final)
 	 * Kludge: interrupt the eviction server in case it is holding the
 	 * handle list lock.
 	 */
-	F_SET(S2C(session)->cache, WT_EVICT_CLEAR_WALKS);
+	F_SET(S2C(session)->cache, WT_CACHE_CLEAR_WALKS);
 
 	/* Try to remove the handle, protected by the data handle lock. */
 	WT_WITH_DHANDLE_LOCK(session,

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -802,7 +802,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session, uint32_t flags)
 
 	WT_ASSERT(session, cache->evict[0].ref != NULL);
 
-	if (LF_ISSET(WT_EVICT_PASS_WOULD_BLOCK))
+	if (LF_ISSET(WT_EVICT_PASS_AGGRESSIVE | WT_EVICT_PASS_WOULD_BLOCK))
 		/*
 		 * Take all candidates if we only gathered pages with an oldest
 		 * read generation set.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1110,8 +1110,8 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp, uint32_t flags)
 	    cache->evict + cache->evict_slots);
 	enough = internal_pages = restarts = 0;
 
-	walk_flags =
-	    WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT;
+	walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT |
+	    WT_READ_NO_GEN | WT_READ_NO_WAIT | WT_READ_PREV;
 
 	/*
 	 * Get some more eviction candidate pages.

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -130,8 +130,8 @@ done:	session->excl_next = 0;
 		txn_state->snap_min = WT_TXN_NONE;
 
 	if ((inmem_split || (forced_eviction && ret == EBUSY)) &&
-	    !F_ISSET(conn->cache, WT_EVICT_WOULD_BLOCK)) {
-		F_SET(conn->cache, WT_EVICT_WOULD_BLOCK);
+	    !F_ISSET(conn->cache, WT_CACHE_WOULD_BLOCK)) {
+		F_SET(conn->cache, WT_CACHE_WOULD_BLOCK);
 		WT_TRET(__wt_evict_server_wake(session));
 	}
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -949,7 +949,6 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 {
 	WT_BTREE *btree;
 	WT_PAGE_MODIFY *mod;
-        WT_REF *bt_evict_ref;
 
 	btree = S2BT(session);
 	mod = page->modify;
@@ -959,8 +958,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 		return (1);
 
         /* Skip pages that are already being evicted. */
-        if ((bt_evict_ref = btree->evict_ref) != NULL &&
-            bt_evict_ref->page == page)
+        if (F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU))
                 return (0);
 
 	/*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -949,6 +949,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 {
 	WT_BTREE *btree;
 	WT_PAGE_MODIFY *mod;
+        WT_REF *bt_evict_ref;
 
 	btree = S2BT(session);
 	mod = page->modify;
@@ -956,6 +957,11 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 	/* Pages that have never been modified can always be evicted. */
 	if (mod == NULL)
 		return (1);
+
+        /* Skip pages that are already being evicted. */
+        if ((bt_evict_ref = btree->evict_ref) != NULL &&
+            bt_evict_ref->page == page)
+                return (0);
 
 	/*
 	 * If the tree was deepened, there's a requirement that newly created

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -118,9 +118,10 @@ struct __wt_cache {
 	 */
 #define	WT_CACHE_POOL_MANAGER	0x01	/* The active cache pool manager */
 #define	WT_CACHE_POOL_RUN	0x02	/* Cache pool thread running */
-#define	WT_EVICT_CLEAR_WALKS	0x04	/* Clear eviction walks */
-#define	WT_EVICT_STUCK		0x08	/* Eviction server is stuck */
-#define	WT_EVICT_WOULD_BLOCK	0x10	/* Pages that would block apps */
+#define	WT_CACHE_CLEAR_WALKS	0x04	/* Clear eviction walks */
+#define	WT_CACHE_STUCK		0x08	/* Eviction server is stuck */
+#define	WT_CACHE_WALK_REVERSE	0x10	/* Scan backwards for candidates */
+#define	WT_CACHE_WOULD_BLOCK	0x20	/* Pages that would block apps */
 	uint32_t flags;
 };
 


### PR DESCRIPTION
* Don't update the read generation on page in if it's set to oldest.
* Clear the walk positions before the eviction server sleeps.
* If only looking for pages that would block add them all to the queue.
* If evicting dirty pages use the worker threads, not the server.