### PR TITLE
Ignore empty child pages in column stores

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -982,7 +982,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 	 */
 	if (btree->checkpointing &&
 	    (__wt_page_is_modified(page) ||
-            F_ISSET(mod, WT_PM_REC_MULTIBLOCK))) {
+	    F_ISSET(mod, WT_PM_REC_MULTIBLOCK))) {
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_checkpoint);
 		WT_STAT_FAST_DATA_INCR(session, cache_eviction_checkpoint);
 		return (0);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3237,15 +3237,11 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		WT_ERR(__rec_child_modify(session, r, ref, &hazard, &state));
 		addr = NULL;
 		child = ref->page;
-		if (state != 0) {
-			/*
-			 * Currently the only non-zero returned stated possible
-			 * for a column-store page is child-modified (all other
-			 * states are part of the fast-truncate support, which
-			 * is row-store only).
-			 */
-			WT_ASSERT(session, state == WT_CHILD_MODIFIED);
-
+		if (state == WT_CHILD_IGNORE) {
+			CHILD_RELEASE_ERR(session, hazard, ref);
+			continue;
+		}
+		if (state == WT_CHILD_MODIFIED) {
 			switch (F_ISSET(child->modify, WT_PM_REC_MASK)) {
 			case WT_PM_REC_EMPTY:
 				/*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3237,10 +3237,17 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		WT_ERR(__rec_child_modify(session, r, ref, &hazard, &state));
 		addr = NULL;
 		child = ref->page;
+
+		/* Deleted child we don't have to write. */
 		if (state == WT_CHILD_IGNORE) {
 			CHILD_RELEASE_ERR(session, hazard, ref);
 			continue;
 		}
+
+		/*
+		 * Modified child.  Empty pages are merged into the parent and
+		 * discarded.
+		 */
 		if (state == WT_CHILD_MODIFIED) {
 			switch (F_ISSET(child->modify, WT_PM_REC_MASK)) {
 			case WT_PM_REC_EMPTY:

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3261,7 +3261,9 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				break;
 			WT_ILLEGAL_VALUE_ERR(session);
 			}
-		}
+		} else
+			/* No other states are expected for column stores. */
+			WT_ASSERT(session, state == 0);
 
 		/*
 		 * Build the value cell.  The child page address is in one of 3


### PR DESCRIPTION
When reconciling column store internal pages, deal with the "ignore" case.