### PR TITLE
Remove pockets of case-sensitivity for configuration strings.

### DIFF
--- a/src/btree/bt_huffman.c
+++ b/src/btree/bt_huffman.c
@@ -129,7 +129,7 @@ static int __wt_huffman_read(WT_SESSION_IMPL *,
     WT_CONFIG_ITEM *, struct __wt_huffman_table **, u_int *, u_int *);
 
 #define	WT_HUFFMAN_CONFIG_VALID(str, len)				\
-	(WT_STRING_CASE_MATCH("english", (str), (len)) ||		\
+	(WT_STRING_MATCH("english", (str), (len)) ||			\
 	    WT_PREFIX_MATCH((str), "utf8") || WT_PREFIX_MATCH((str), "utf16"))
 
 /*
@@ -193,7 +193,7 @@ __wt_btree_huffman_open(WT_SESSION_IMPL *session)
 
 	if (key_conf.len == 0) {
 		;
-	} else if (strncasecmp(key_conf.str, "english", key_conf.len) == 0) {
+	} else if (strncmp(key_conf.str, "english", key_conf.len) == 0) {
 		struct __wt_huffman_table
 		    copy[WT_ELEMENTS(__wt_huffman_nytenglish)];
 
@@ -204,7 +204,7 @@ __wt_btree_huffman_open(WT_SESSION_IMPL *session)
 		    1, &btree->huffman_key));
 
 		/* Check for a shared key/value table. */
-		if (value_conf.len != 0 && strncasecmp(
+		if (value_conf.len != 0 && strncmp(
 		    value_conf.str, "english", value_conf.len) == 0) {
 			btree->huffman_value = btree->huffman_key;
 			return (0);
@@ -228,8 +228,7 @@ __wt_btree_huffman_open(WT_SESSION_IMPL *session)
 
 	if (value_conf.len == 0) {
 		;
-	} else if (
-	    strncasecmp(value_conf.str, "english", value_conf.len) == 0) {
+	} else if (strncmp(value_conf.str, "english", value_conf.len) == 0) {
 		struct __wt_huffman_table
 		    copy[WT_ELEMENTS(__wt_huffman_nytenglish)];
 
@@ -277,7 +276,7 @@ __wt_huffman_read(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *ip,
 	 * UTF-8 table is 256 bytes, with a range of 0-255.
 	 * UTF-16 is 128KB (2 * 65536) bytes, with a range of 0-65535.
 	 */
-	if (strncasecmp(ip->str, "utf8", 4) == 0) {
+	if (strncmp(ip->str, "utf8", 4) == 0) {
 		entries = UINT8_MAX;
 		*numbytesp = 1;
 		WT_ERR(__wt_calloc_def(session, entries, &table));
@@ -287,7 +286,7 @@ __wt_huffman_read(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *ip,
 			    "no Huffman table file name specified");
 		WT_ERR(__wt_calloc_def(session, ip->len, &file));
 		memcpy(file, ip->str + 4, ip->len - 4);
-	} else if (strncasecmp(ip->str, "utf16", 5) == 0) {
+	} else if (strncmp(ip->str, "utf16", 5) == 0) {
 		entries = UINT16_MAX;
 		*numbytesp = 2;
 		WT_ERR(__wt_calloc_def(session, entries, &table));

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -500,11 +500,10 @@ __config_process_value(WT_CONFIG *conf, WT_CONFIG_ITEM *value)
 		return (0);
 
 	if (value->type == WT_CONFIG_ITEM_ID) {
-		if (WT_STRING_CASE_MATCH("false", value->str, value->len)) {
+		if (WT_STRING_MATCH("false", value->str, value->len)) {
 			value->type = WT_CONFIG_ITEM_BOOL;
 			value->val = 0;
-		} else if (
-		    WT_STRING_CASE_MATCH("true", value->str, value->len)) {
+		} else if (WT_STRING_MATCH("true", value->str, value->len)) {
 			value->type = WT_CONFIG_ITEM_BOOL;
 			value->val = 1;
 		}
@@ -593,12 +592,11 @@ __config_getraw(
 		if (k.type != WT_CONFIG_ITEM_STRING &&
 		    k.type != WT_CONFIG_ITEM_ID)
 			continue;
-		if (k.len == key->len &&
-		    strncasecmp(key->str, k.str, k.len) == 0) {
+		if (k.len == key->len && strncmp(key->str, k.str, k.len) == 0) {
 			*value = v;
 			found = 1;
 		} else if (k.len < key->len && key->str[k.len] == '.' &&
-		    strncasecmp(key->str, k.str, k.len) == 0) {
+		    strncmp(key->str, k.str, k.len) == 0) {
 			subk.str = key->str + k.len + 1;
 			subk.len = (key->len - k.len) - 1;
 			WT_RET(__wt_config_initn(
@@ -665,7 +663,7 @@ __wt_config_gets_none(WT_SESSION_IMPL *session,
     const char **cfg, const char *key, WT_CONFIG_ITEM *value)
 {
 	WT_RET(__wt_config_gets(session, cfg, key, value));
-	if (WT_STRING_CASE_MATCH("none", value->str, value->len))
+	if (WT_STRING_MATCH("none", value->str, value->len))
 		value->len = 0;
 	return (0);
 }
@@ -710,7 +708,7 @@ __wt_config_getones_none(WT_SESSION_IMPL *session,
     const char *config, const char *key, WT_CONFIG_ITEM *value)
 {
 	WT_RET(__wt_config_getones(session, config, key, value));
-	if (WT_STRING_CASE_MATCH("none", value->str, value->len))
+	if (WT_STRING_MATCH("none", value->str, value->len))
 		value->len = 0;
 	return (0);
 }

--- a/src/docs/config-strings.dox
+++ b/src/docs/config-strings.dox
@@ -19,6 +19,9 @@ expression do not require quotes:
     [-_0-9A-Za-z./][^\\t\\r\\n :=,\\])}]*
 </pre>
 
+Configuration strings are case-sensitive (for example, "true" is a
+valid boolean value, but "True" is not).
+
 More complex keys and values can be specified by quoting them with double
 quotes.
 

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -409,6 +409,7 @@ substring
 superset
 sys
 sz
+tRuE
 tablename
 tcl
 tcmalloc

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -1,5 +1,19 @@
 /*! @page upgrading Upgrading WiredTiger applications
 
+@section version_252 Upgrading to Version 2.5.2
+
+<dl>
+<dt>Configuration string case-sensitivity</dt>
+<dd>
+In previous WiredTiger releases, there were several cases where configuration
+strings were treated in a case-sensitive manner (for example, it was possible
+to specify "True", "true" or even "tRuE" as a boolean value). For consistency,
+in this release all WiredTiger configuration strings are case-sensitive, and
+only "true" will be accepted.
+
+</dd>
+</dl>
+
 @section version_251 Upgrading to Version 2.5.1
 
 <dl>

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -182,10 +182,6 @@
 #define	WT_STRING_MATCH(str, bytes, len)				\
 	(((const char *)str)[0] == ((const char *)bytes)[0] &&		\
 	    strncmp(str, bytes, len) == 0 && (str)[(len)] == '\0')
-#define	WT_STRING_CASE_MATCH(str, bytes, len)				\
-	(tolower(((const char *)str)[0]) ==				\
-	    tolower(((const char *)bytes)[0]) &&			\
-	    strncasecmp(str, bytes, len) == 0 && (str)[(len)] == '\0')
 
 /*
  * Macro that produces a string literal that isn't wrapped in quotes, to avoid

--- a/src/include/os_windows.h
+++ b/src/include/os_windows.h
@@ -20,8 +20,6 @@ struct timespec {
 	long   tv_nsec;		/* nanoseconds */
 };
 
-#define	strncasecmp _strnicmp
-
 /*
  * Windows Portability stuff
  * These are POSIX types which Windows lacks

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -41,7 +41,7 @@ __wt_lsm_meta_read(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 			    cv.str, cv.len, &lsm_tree->value_format));
 		} else if (WT_STRING_MATCH("collator", ck.str, ck.len)) {
 			if (cv.len == 0 ||
-			    WT_STRING_CASE_MATCH("none", cv.str, cv.len))
+			    WT_STRING_MATCH("none", cv.str, cv.len))
 				continue;
 			/*
 			 * Extract the application-supplied metadata (if any)

--- a/test/suite/test_huffman01.py
+++ b/test/suite/test_huffman01.py
@@ -43,14 +43,12 @@ class test_huffman01(wttest.WiredTigerTestCase, suite_subprocess):
     huffkey = [
         ('none', dict(huffkey='huffman_key=none',kfile=None)),
         ('english', dict(huffkey='huffman_key=english',kfile=None)),
-        ('English', dict(huffkey='huffman_key=English',kfile=None)),
         ('utf8', dict(huffkey='huffman_key=utf8t8file',kfile='t8file')),
         ('utf16', dict(huffkey='huffman_key=utf16t16file',kfile='t16file')),
     ]
     huffval = [
         ('none', dict(huffval=',huffman_value=none',vfile=None)),
         ('english', dict(huffval=',huffman_value=english',vfile=None)),
-        ('English', dict(huffval=',huffman_value=English',vfile=None)),
         ('utf8', dict(huffval=',huffman_value=utf8t8file',vfile='t8file')),
         ('utf16', dict(huffval=',huffman_value=utf16t16file',vfile='t16file')),
     ]


### PR DESCRIPTION
@michaelcahill, we talked about getting case-sensitivity consistency for WiredTiger configuration strings, and you indicated you'd prefer being globally case-sensitive rather than case-insensitive.

Here are the changes to remove the relatively few places where we did case-sensitive comparisons of configuration strings.

Obviously, this raises portability questions, but those won't get better if we wait to make this change, and since we just recently modified the Huffman configuration code, it seems like making the change now is the right thing to do.