### PR TITLE
SERVER-17471: Use uint64_t instead of long since long is compiler specific

### DIFF
--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -18,8 +18,8 @@ __async_op_dequeue(WT_CONNECTION_IMPL *conn, WT_SESSION_IMPL *session,
     WT_ASYNC_OP_IMPL **op)
 {
 	WT_ASYNC *async;
-	long sleep_usec;
 	uint64_t cur_tail, last_consume, my_consume, my_slot, prev_slot;
+	uint64_t sleep_usec;
 	uint32_t tries;
 
 	async = conn->async;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -460,7 +460,7 @@ extern int __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t siz
 extern int __wt_mmap_discard(WT_SESSION_IMPL *session, void *p, size_t size);
 extern int __wt_munmap(WT_SESSION_IMPL *session, WT_FH *fh, void *map, size_t len, void **mappingcookie);
 extern int __wt_cond_alloc(WT_SESSION_IMPL *session, const char *name, int is_signalled, WT_CONDVAR **condp);
-extern int __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs);
+extern int __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs);
 extern int __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond);
 extern int __wt_cond_destroy(WT_SESSION_IMPL *session, WT_CONDVAR **condp);
 extern int __wt_rwlock_alloc( WT_SESSION_IMPL *session, WT_RWLOCK **rwlockp, const char *name);
@@ -481,7 +481,7 @@ extern int __wt_remove(WT_SESSION_IMPL *session, const char *name);
 extern int __wt_rename(WT_SESSION_IMPL *session, const char *from, const char *to);
 extern int __wt_read( WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void *buf);
 extern int __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, const void *buf);
-extern void __wt_sleep(long seconds, long micro_seconds);
+extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds);
 extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base);
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, void *(*func)(void *), void *arg);
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid);

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -45,7 +45,7 @@ err:	__wt_free(session, cond);
  *	Wait on a mutex, optionally timing out.
  */
 int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs)
+__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 {
 	struct timespec ts;
 	WT_DECL_RET;

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -52,7 +52,6 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 	int locked;
 
 	locked = 0;
-	WT_ASSERT(session, usecs >= 0);
 
 	/* Fast path if already signalled. */
 	if (WT_ATOMIC_ADD4(cond->waiters, 1) == 0)

--- a/src/os_posix/os_sleep.c
+++ b/src/os_posix/os_sleep.c
@@ -13,7 +13,7 @@
  *	Pause the thread of control.
  */
 void
-__wt_sleep(long seconds, long micro_seconds)
+__wt_sleep(uint64_t seconds, uint64_t micro_seconds)
 {
 	struct timeval t;
 

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -41,11 +41,13 @@ __wt_cond_alloc(WT_SESSION_IMPL *session,
  *	Wait on a mutex, optionally timing out.
  */
 int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs)
+__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 {
 	WT_DECL_RET;
+	uint64_t milliseconds64;
 	int locked;
-	int milliseconds;
+	int lasterror;
+	DWORD milliseconds;
 	locked = 0;
 	WT_ASSERT(session, usecs >= 0);
 
@@ -67,13 +69,23 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, long usecs)
 	locked = 1;
 
 	if (usecs > 0) {
-		milliseconds = usecs / 1000;
+		milliseconds64 = usecs / 1000;
+
+		/*
+		 * Check for 32-bit unsigned integer overflow
+		 * INFINITE is max unsigned int on Windows
+		 */
+		if (milliseconds64 >= INFINITE)
+			milliseconds64 = INFINITE - 1;
+		milliseconds = milliseconds64;
+
 		/*
 		 * 0 would mean the CV sleep becomes a TryCV which we do not
 		 * want
 		 */
 		if (milliseconds == 0)
 			milliseconds = 1;
+
 		ret = SleepConditionVariableCS(
 		    &cond->cond, &cond->mtx, milliseconds);
 	} else

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -49,7 +49,6 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 	int lasterror;
 	DWORD milliseconds;
 	locked = 0;
-	WT_ASSERT(session, usecs >= 0);
 
 	/* Fast path if already signalled. */
 	if (WT_ATOMIC_ADD4(cond->waiters, 1) == 0)

--- a/src/os_win/os_sleep.c
+++ b/src/os_win/os_sleep.c
@@ -13,7 +13,7 @@
  *	Pause the thread of control.
  */
 void
-__wt_sleep(long seconds, long micro_seconds)
+__wt_sleep(uint64_t seconds, uint64_t micro_seconds)
 {
 	Sleep(seconds * 1000 + micro_seconds / 1000);
 }


### PR DESCRIPTION
Change the usage of long to uint64_t since long is platform specific. Also, fix the __wt_cond_wait code to ensure we handle integer overflow when converting from 64-bit to 32-bit types.