### PR TITLE
Don't cache an ikey before winning the race to split into a parent.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -515,6 +515,7 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent, uint32_t children)
 	 * footprint.  From now on we've modified the parent page, attention
 	 * needs to be paid.
 	 */
+	WT_ASSERT(session, WT_INTL_INDEX_COPY(parent) == pindex);
 	WT_INTL_INDEX_SET(parent, alloc_index);
 	split_gen = WT_ATOMIC_ADD8(S2C(session)->split_gen, 1);
 	panic = 1;
@@ -787,7 +788,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 static int
 __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
     uint32_t new_entries, size_t parent_decr, size_t parent_incr,
-    int exclusive, int ref_discard, uint64_t *split_genp)
+    int exclusive, uint64_t *split_genp)
 {
 	WT_DECL_RET;
 	WT_IKEY *ikey;
@@ -849,9 +850,10 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	 * Remove any refs to deleted pages while we are splitting, we have
 	 * the internal page locked down, and are copying the refs into a new
 	 * array anyway.  Switch them to the special split state, so that any
-	 * reading thread will restart.
+	 * reading thread will restart.  Include the ref we are splitting in
+	 * the count to be deleted.
 	 */
-	for (i = 0, deleted_entries = 0; i < parent_entries; ++i) {
+	for (i = 0, deleted_entries = 1; i < parent_entries; ++i) {
 		next_ref = pindex->index[i];
 		WT_ASSERT(session, next_ref->state != WT_REF_SPLIT);
 		if (next_ref->state == WT_REF_DELETED &&
@@ -863,10 +865,9 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 
 	/*
 	 * The final entry count consists of: The original count, plus any
-	 * new pages, less any refs we are removing because they only
-	 * contained deleted items, less 1 for the page being replaced.
+	 * new pages, less any refs we are removing.
 	 */
-	result_entries = (parent_entries + new_entries) - (deleted_entries + 1);
+	result_entries = (parent_entries + new_entries) - deleted_entries;
 
 	/*
 	 * Allocate and initialize a new page index array for the parent, then
@@ -901,6 +902,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	 * Update the parent page's index: this update makes the split visible
 	 * to threads descending the tree.
 	 */
+	WT_ASSERT(session, WT_INTL_INDEX_COPY(parent) == pindex);
 	WT_INTL_INDEX_SET(parent, alloc_index);
 	split_gen = *split_genp = WT_ATOMIC_ADD8(S2C(session)->split_gen, 1);
 	alloc_index = NULL;
@@ -929,14 +931,20 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	 */
 	complete = 1;
 
+	WT_ERR(__wt_verbose(session, WT_VERB_SPLIT,
+	    "%s split into parent %" PRIu32 " -> %" PRIu32
+	    " (%" PRIu32 ")",
+	    __wt_page_type_string(ref->page->type), parent_entries,
+	    result_entries, result_entries - parent_entries));
+
 	/*
-	 * The new page index is in place, free any deleted WT_REFs we found,
-	 * modulo the usual safe free semantics. Ignore the WT_REF we're
-	 * replacing, our caller is responsible for freeing it.
+	 * The new page index is in place, free the WT_REF we were splitting
+	 * and any deleted WT_REFs we found, modulo the usual safe free
+	 * semantics.
 	 */
 	for (i = 0; deleted_entries > 0 && i < parent_entries; ++i) {
 		next_ref = pindex->index[i];
-		if (next_ref == ref || next_ref->state != WT_REF_SPLIT)
+		if (next_ref->state != WT_REF_SPLIT)
 			continue;
 		--deleted_entries;
 
@@ -972,6 +980,9 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 		parent_decr += sizeof(WT_REF);
 	}
 
+	/* We freed the reference that was split in the loop above. */
+	ref = NULL;
+
 	/*
 	 * We can't free the previous page index, there may be threads using it.
 	 * Add it to the session discard list, to be freed when it's safe.
@@ -981,29 +992,10 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	parent_decr += size;
 
 	/*
-	 * Row-store trees where the old version of the page is being discarded:
-	 * the previous parent page's key for this child page may have been an
-	 * on-page overflow key.  In that case, if the key hasn't been deleted,
-	 * delete it now, including its backing blocks.  We are exchanging the
-	 * WT_REF that referenced it for the split page WT_REFs and their keys,
-	 * and there's no longer any reference to it.  Done after completing the
-	 * split (if we failed, we'd leak the underlying blocks, but the parent
-	 * page would be unaffected).
-	 */
-	if (ref_discard && parent->type == WT_PAGE_ROW_INT)
-		WT_TRET(__split_ovfl_key_cleanup(session, parent, ref));
-
-	/*
 	 * Adjust the parent's memory footprint.
 	 */
 	__wt_cache_page_inmem_incr(session, parent, parent_incr);
 	__wt_cache_page_inmem_decr(session, parent, parent_decr);
-
-	WT_ERR(__wt_verbose(session, WT_VERB_SPLIT,
-	    "%s split into parent %" PRIu32 " -> %" PRIu32
-	    " (%" PRIu32 ")",
-	    __wt_page_type_string(ref->page->type), parent_entries,
-	    result_entries, result_entries - parent_entries));
 
 	/*
 	 * Simple page splits trickle up the tree, that is, as leaf pages grow
@@ -1071,7 +1063,6 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
-	WT_IKEY *ikey;
 	WT_DECL_ITEM(key);
 	WT_INSERT *ins, **insp, *moved_ins, *prev_ins;
 	WT_INSERT_HEAD *ins_head;
@@ -1085,7 +1076,6 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 
 	btree = S2BT(session);
 	page = ref->page;
-	ikey = NULL;
 	right = NULL;
 	page_decr = parent_decr = parent_incr = right_incr = 0;
 
@@ -1197,16 +1187,6 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 	    child));
 	parent_incr +=
 	    sizeof(WT_REF) + sizeof(WT_IKEY) + WT_INSERT_KEY_SIZE(moved_ins);
-
-	/*
-	 * After the split, we're going to discard the WT_REF, account for the
-	 * change in memory footprint.  Row store pages have keys that may be
-	 * instantiated, check for that.
-	 */
-	parent_decr += sizeof(WT_REF);
-	if (page->type == WT_PAGE_ROW_LEAF || page->type == WT_PAGE_ROW_INT)
-		if ((ikey = __wt_ref_key_instantiated(ref)) != NULL)
-			parent_decr += sizeof(WT_IKEY) + ikey->size;
 
 	/* The new page is dirty by definition. */
 	WT_ERR(__wt_page_modify_init(session, right));
@@ -1339,7 +1319,7 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 	 */
 	page = NULL;
 	if ((ret = __split_parent(session, ref, split_ref, 2,
-	    parent_decr, parent_incr, 0, 0, &split_gen)) != 0) {
+	    parent_decr, parent_incr, 0, &split_gen)) != 0) {
 		/*
 		 * Move the insert list element back to the original page list.
 		 * For simplicity, the previous skip list pointers originally
@@ -1367,17 +1347,6 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref, int *splitp)
 
 	WT_STAT_FAST_CONN_INCR(session, cache_inmem_split);
 	WT_STAT_FAST_DATA_INCR(session, cache_inmem_split);
-
-	/*
-	 * We may not be able to immediately free the page's original WT_REF
-	 * structure and instantiated key, there may be threads using them.
-	 * Add them to the session discard list, to be freed once we know it's
-	 * safe.
-	 */
-	 if (ikey != NULL)
-		WT_TRET(__split_safe_free(
-		    session, split_gen, 0, ikey, sizeof(WT_IKEY) + ikey->size));
-	WT_TRET(__split_safe_free(session, split_gen, 0, ref, sizeof(WT_REF)));
 
 	/*
 	 * A note on error handling: if we completed the split, return success,
@@ -1454,7 +1423,6 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref)
 int
 __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 {
-	WT_IKEY *ikey;
 	WT_DECL_RET;
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
@@ -1467,7 +1435,6 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 	mod = page->modify;
 	new_entries = mod->mod_multi_entries;
 
-	ikey = NULL;
 	parent_decr = parent_incr = 0;
 
 	/*
@@ -1479,19 +1446,9 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 		WT_ERR(__wt_multi_to_ref(session,
 		    page, &mod->mod_multi[i], &ref_new[i], &parent_incr));
 
-	/*
-	 * After the split, we're going to discard the WT_REF, account for the
-	 * change in memory footprint.  Row store pages have keys that may be
-	 * instantiated, check for that.
-	 */
-	parent_decr += sizeof(WT_REF);
-	if (page->type == WT_PAGE_ROW_LEAF || page->type == WT_PAGE_ROW_INT)
-		if ((ikey = __wt_ref_key_instantiated(ref)) != NULL)
-			parent_decr += sizeof(WT_IKEY) + ikey->size;
-
 	/* Split into the parent. */
 	WT_ERR(__split_parent(session, ref, ref_new, new_entries,
-	    parent_decr, parent_incr, exclusive, 1, &split_gen));
+	    parent_decr, parent_incr, exclusive, &split_gen));
 
 	WT_STAT_FAST_CONN_INCR(session, cache_eviction_split);
 	WT_STAT_FAST_DATA_INCR(session, cache_eviction_split);
@@ -1508,19 +1465,7 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 		 mod->write_gen = 0;
 		 __wt_cache_dirty_decr(session, page);
 	}
-	__wt_ref_out(session, ref);
-
-	/*
-	 * We may not be able to immediately free the page's original WT_REF
-	 * structure and instantiated key, there may be threads using them.
-	 * Add them to the session discard list, to be freed once we know it's
-	 * safe.
-	 */
-	if (ikey != NULL)
-		WT_TRET(__split_safe_free(session, split_gen, exclusive,
-		    ikey, sizeof(WT_IKEY) + ikey->size));
-	WT_TRET(__split_safe_free(session, split_gen, exclusive,
-	    ref, sizeof(WT_REF)));
+	__wt_page_out(session, &page);
 
 	/*
 	 * A note on error handling: if we completed the split, return success,


### PR DESCRIPTION
refs #1582