### PR TITLE
Async api

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -313,7 +313,7 @@ connection_runtime_config = [
             type='boolean'),
         Config('ops_max', '1024', r'''
             maximum number of expected simultaneous asynchronous
-                operations''', min='10', max='4096'),
+                operations''', min='1', max='4096'),
         Config('threads', '2', r'''
             the number of worker threads to service asynchronous
                 requests''',

--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -187,7 +187,7 @@ __async_config(WT_SESSION_IMPL *session,
 	 * Bound the minimum maximum operations at 10.
 	 */
 	WT_RET(__wt_config_gets(session, cfg, "async.ops_max", &cval));
-	conn->async_size = (uint32_t)MAX(cval.val, 10);
+	conn->async_size = (uint32_t)WT_MAX(cval.val, 10);
 
 	WT_RET(__wt_config_gets(session, cfg, "async.threads", &cval));
 	conn->async_workers = (uint32_t)cval.val;

--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -181,11 +181,13 @@ __async_config(WT_SESSION_IMPL *session,
 	*runp = cval.val != 0;
 
 	/*
-	 * Even if async is turned off, we want to parse and store the
-	 * default values so that reconfigure can just enable them.
+	 * Even if async is turned off, we want to parse and store the default
+	 * values so that reconfigure can just enable them.
+	 *
+	 * Bound the minimum maximum operations at 10.
 	 */
 	WT_RET(__wt_config_gets(session, cfg, "async.ops_max", &cval));
-	conn->async_size = (uint32_t)cval.val;
+	conn->async_size = (uint32_t)MAX(cval.val, 10);
 
 	WT_RET(__wt_config_gets(session, cfg, "async.threads", &cval));
 	conn->async_workers = (uint32_t)cval.val;

--- a/src/async/async_op.c
+++ b/src/async/async_op.c
@@ -267,11 +267,17 @@ __wt_async_op_enqueue(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op)
 
 	conn = S2C(session);
 	async = conn->async;
+
+	/*
+	 * If an application re-uses a WT_ASYNC_OP, we end up here with an
+	 * invalid object.
+	 */
+	if (op->state != WT_ASYNCOP_READY)
+		WT_RET_MSG(session, EINVAL,
+		    "application error: WT_ASYNC_OP already in use");
+
 	/*
 	 * Enqueue op at the tail of the work queue.
-	 */
-	WT_ASSERT(session, op->state == WT_ASYNCOP_READY);
-	/*
 	 * We get our slot in the ring buffer to use.
 	 */
 	my_alloc = WT_ATOMIC_ADD8(async->alloc_head, 1);

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -39,7 +39,7 @@ static const WT_CONFIG_CHECK confchk_connection_open_session[] = {
 
 static const WT_CONFIG_CHECK confchk_async_subconfigs[] = {
 	{ "enabled", "boolean", NULL, NULL },
-	{ "ops_max", "int", "min=10,max=4096", NULL },
+	{ "ops_max", "int", "min=1,max=4096", NULL },
 	{ "threads", "int", "min=1,max=20", NULL },
 	{ NULL, NULL, NULL, NULL }
 };

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1549,11 +1549,11 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, enable asynchronous
 	 * operation., a boolean flag; default \c false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;ops_max, maximum number of expected
-	 * simultaneous asynchronous operations., an integer between 10 and
-	 * 4096; default \c 1024.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the
-	 * number of worker threads to service asynchronous requests., an
-	 * integer between 1 and 20; default \c 2.}
+	 * simultaneous asynchronous operations., an integer between 1 and 4096;
+	 * default \c 1024.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number
+	 * of worker threads to service asynchronous requests., an integer
+	 * between 1 and 20; default \c 2.}
 	 * @config{ ),,}
 	 * @config{cache_overhead, assume the heap allocator overhead is the
 	 * specified percentage\, and adjust the cache usage by that amount (for
@@ -1883,7 +1883,7 @@ struct __wt_connection {
  * boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;ops_max,
  * maximum number of expected simultaneous asynchronous operations., an integer
- * between 10 and 4096; default \c 1024.}
+ * between 1 and 4096; default \c 1024.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number of worker threads to
  * service asynchronous requests., an integer between 1 and 20; default \c 2.}
  * @config{ ),,}

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -296,7 +296,6 @@ void	 config_file(const char *);
 void	 config_print(int);
 void	 config_setup(void);
 void	 config_single(const char *, int);
-void	 die(int, const char *, ...);
 void	 key_len_setup(void);
 void	 key_gen_setup(uint8_t **);
 void	 key_gen(uint8_t *, size_t *, uint64_t, int);
@@ -316,3 +315,9 @@ void	 wts_read_scan(void);
 void	 wts_salvage(void);
 void	 wts_stats(void);
 void	 wts_verify(const char *);
+
+void	 die(int, const char *, ...)
+#if defined(__GNUC__)
+__attribute__((__noreturn__))
+#endif
+;


### PR DESCRIPTION
@sueloverso, I've been meaning to futz a little with async operations (I've never written anything that used the API, and I wanted to take it out for a spin). Anyway, I changed test/format to do async operations along with cursor operations, and this branch has a couple of minor changes I made along the way, for your consideration.

@michaelcahill, I don't plan to push the actual changes to format to support asynchronous threads. If you see value in testing asynchronous operations in format, and you want those changes to live on, let me know.