### PR TITLE
Update the split deepen sanity check.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -623,10 +623,10 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
 	 * When a page is forced to split, we want at least 50 entries on its
 	 * parent.
 	 *
-	 * Don't let pages grow to more than a quaert of the cache size, else,
-	 * with too-small caches, we can end up in a situation where nothing
-	 * can be evicted.  Take care getting the cache size: with a shared
-	 * cache, it may not have been set.
+	 * Don't let pages grow larger than a quarter of the cache, with too-
+	 * small caches, we can end up in a situation where nothing can be
+	 * evicted.  Take care getting the cache size: with a shared cache,
+	 * it may not have been set.
 	 */
 	WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
 	btree->maxmempage =

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -623,8 +623,8 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
 	 * When a page is forced to split, we want at least 50 entries on its
 	 * parent.
 	 *
-	 * Don't let pages grow to more than half the cache size.  Otherwise,
-	 * with very small caches, we can end up in a situation where nothing
+	 * Don't let pages grow to more than a quaert of the cache size, else,
+	 * with too-small caches, we can end up in a situation where nothing
 	 * can be evicted.  Take care getting the cache size: with a shared
 	 * cache, it may not have been set.
 	 */


### PR DESCRIPTION
Allow a page that it using more than 1/4 of the cache to be split.

Refs #1759