### PR TITLE
Fix microsecond to millisecond conversion if small value given. #1764

### DIFF
--- a/src/os_win/os_sleep.c
+++ b/src/os_win/os_sleep.c
@@ -15,5 +15,12 @@
 void
 __wt_sleep(uint64_t seconds, uint64_t micro_seconds)
 {
+	/*
+	 * If the caller wants a small pause, set to our
+	 * smallest granularity.
+	 */
+	if (seconds == 0 &&
+	    micro_seconds != 0 && micro_seconds < 1000)
+		micro_seconds = 1000;
 	Sleep(seconds * 1000 + micro_seconds / 1000);
 }


### PR DESCRIPTION
@markbenvenuto and @keithbostic can you review this change?  Mark, please compile to make sure I didn't mess anything up.  It seems that sleep with a 0 value has special meaning that does not seem to be what we intend with a small timeout value. 
https://msdn.microsoft.com/en-us/library/windows/desktop/ms686298%28v=vs.85%29.aspx

Or if I'm off-base we can just toss this branch.