### PR TITLE
If the session-level attempt to lock a handle gets EBUSY, fall back to the slow path

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -383,7 +383,13 @@ __wt_session_get_btree(WT_SESSION_IMPL *session,
 		/* Try to lock the handle; if this succeeds, we're done. */
 		if ((ret = __wt_session_lock_dhandle(session, flags)) == 0)
 			goto done;
-		WT_RET_NOTFOUND_OK(ret);
+
+		/*
+		 * If the handle isn't available (or seems busy from our quick
+		 * check, fall through to the slow path.
+		 */
+		if (ret != EBUSY && ret != WT_NOTFOUND)
+			return (ret);
 
 		/* We found the data handle, don't try to get it again. */
 		LF_SET(WT_DHANDLE_HAVE_REF);


### PR DESCRIPTION
The sweep server relies on there being a retry loop if an exclusive operation such as verify conflicts with a sweep.

refs #1404