### PR TITLE
Avoid EBUSY errors from truncate caused by checkpoints.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -605,9 +605,15 @@ __session_truncate(WT_SESSION *wt_session,
 				    "the truncate method should not specify any"
 				    "target after the log: URI prefix.");
 			ret = __wt_log_truncate_files(session, start, cfg);
-		} else
+		} else {
+			/* Wait for checkpoints to avoid EBUSY errors. */
+			__wt_spin_lock(session,
+			    &S2C(session)->checkpoint_lock);
 			WT_WITH_SCHEMA_LOCK(session,
 			    ret = __wt_schema_truncate(session, uri, cfg));
+			__wt_spin_unlock(session,
+			    &S2C(session)->checkpoint_lock);
+		}
 		goto done;
 	}
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -386,7 +386,9 @@ __wt_session_get_btree(WT_SESSION_IMPL *session,
 
 		/*
 		 * If the handle isn't available (or seems busy from our quick
-		 * check, fall through to the slow path.
+		 * check), fall through to the slow path, the sweep server
+		 * relies on there being a retry loop if an exclusive operation
+		 * such as verify conflicts with a sweep.
 		 */
 		if (ret != EBUSY && ret != WT_NOTFOUND)
 			return (ret);


### PR DESCRIPTION
refs #1643