### PR TITLE
Use the configured collator when index cursor need to compare keys.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -20,6 +20,10 @@ class Config:
 common_meta = [
     Config('app_metadata', '', r'''
         application-owned metadata for this object'''),
+    Config('collator', 'none', r'''
+        configure custom collation for keys.  Permitted values are
+        \c "none" or a custom collator name created with
+        WT_CONNECTION::add_collator'''),
     Config('columns', '', r'''
         list of the column names.  Comma-separated list of the form
         <code>(column[,...])</code>.  For tables, the number of entries
@@ -148,10 +152,6 @@ file_config = format_meta + [
         applications which can rely on decompression to fail if a block
         has been corrupted''',
         choices=['on', 'off', 'uncompressed']),
-    Config('collator', 'none', r'''
-        configure custom collation for keys.  Permitted values are
-        \c "none" or a custom collator name created with
-        WT_CONNECTION::add_collator'''),
     Config('dictionary', '0', r'''
         the maximum number of unique values remembered in the Btree
         row-store leaf page value dictionary; see

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -4,6 +4,7 @@
 
 static const WT_CONFIG_CHECK confchk_colgroup_meta[] = {
 	{ "app_metadata", "string", NULL, NULL },
+	{ "collator", "string", NULL, NULL },
 	{ "columns", "list", NULL, NULL },
 	{ "source", "string", NULL, NULL },
 	{ "type", "string", NULL, NULL },
@@ -170,6 +171,7 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
 
 static const WT_CONFIG_CHECK confchk_index_meta[] = {
 	{ "app_metadata", "string", NULL, NULL },
+	{ "collator", "string", NULL, NULL },
 	{ "columns", "list", NULL, NULL },
 	{ "extractor", "string", NULL, NULL },
 	{ "immutable", "boolean", NULL, NULL },
@@ -314,6 +316,7 @@ static const WT_CONFIG_CHECK confchk_session_verify[] = {
 static const WT_CONFIG_CHECK confchk_table_meta[] = {
 	{ "app_metadata", "string", NULL, NULL },
 	{ "colgroups", "list", NULL, NULL },
+	{ "collator", "string", NULL, NULL },
 	{ "columns", "list", NULL, NULL },
 	{ "key_format", "format", NULL, NULL },
 	{ "value_format", "format", NULL, NULL },
@@ -543,7 +546,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 
 static const WT_CONFIG_ENTRY config_entries[] = {
 	{ "colgroup.meta",
-	  "app_metadata=,columns=,source=,type=file",
+	  "app_metadata=,collator=,columns=,source=,type=file",
 	  confchk_colgroup_meta
 	},
 	{ "connection.add_collator",
@@ -616,8 +619,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  confchk_file_meta
 	},
 	{ "index.meta",
-	  "app_metadata=,columns=,extractor=,immutable=0,index_key_columns="
-	  ",key_format=u,source=,type=file,value_format=u",
+	  "app_metadata=,collator=,columns=,extractor=,immutable=0,"
+	  "index_key_columns=,key_format=u,source=,type=file,value_format=u",
 	  confchk_index_meta
 	},
 	{ "session.begin_transaction",
@@ -704,7 +707,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  confchk_session_verify
 	},
 	{ "table.meta",
-	  "app_metadata=,colgroups=,columns=,key_format=u,value_format=u",
+	  "app_metadata=,colgroups=,collator=,columns=,key_format=u,"
+	  "value_format=u",
 	  confchk_table_meta
 	},
 	{ "wiredtiger_open",

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -28,6 +28,9 @@ struct __wt_index {
 
 	WT_CONFIG_ITEM colconf;		/* List of columns from config */
 
+	WT_COLLATOR *collator;		/* Custom collator */
+	int collator_owned;		/* Collator is owned by this index */
+
 	WT_EXTRACTOR *extractor;	/* Custom key extractor */
 	int extractor_owned;		/* Extractor is owned by this index */
 

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -139,6 +139,15 @@ __wt_schema_destroy_index(WT_SESSION_IMPL *session, WT_INDEX *idx)
 {
 	WT_DECL_RET;
 
+	/* If there is a custom collator configured, terminate it. */
+	if (idx->collator != NULL &&
+	    idx->collator_owned && idx->collator->terminate != NULL) {
+		WT_TRET(idx->collator->terminate(
+		    idx->collator, &session->iface));
+		idx->collator = NULL;
+		idx->collator_owned = 0;
+	}
+
 	/* If there is a custom extractor configured, terminate it. */
 	if (idx->extractor != NULL &&
 	    idx->extractor_owned && idx->extractor->terminate != NULL) {

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -148,8 +148,8 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 		F_SET(idx, WT_INDEX_IMMUTABLE);
 
 	/*
-	 * Compatibility: we didn't always collator info in index metadata.
-	 * Cope if it isn't found.
+	 * Compatibility: we didn't always maintain collator information in
+	 * index metadata, cope when it isn't found.
 	 */
 	WT_CLEAR(cval);
 	WT_ERR_NOTFOUND_OK(__wt_config_getones(

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -130,7 +130,7 @@ static int
 __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 {
 	WT_CONFIG colconf;
-	WT_CONFIG_ITEM ckey, cval;
+	WT_CONFIG_ITEM ckey, cval, metadata;
 	WT_DECL_ITEM(buf);
 	WT_DECL_ITEM(plan);
 	WT_DECL_RET;
@@ -146,6 +146,22 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 	WT_ERR(__wt_config_getones(session, idx->config, "immutable", &cval));
 	if (cval.val)
 		F_SET(idx, WT_INDEX_IMMUTABLE);
+
+	/*
+	 * Compatibility: we didn't always collator info in index metadata.
+	 * Cope if it isn't found.
+	 */
+	WT_CLEAR(cval);
+	WT_ERR_NOTFOUND_OK(__wt_config_getones(
+	    session, idx->config, "collator", &cval));
+	if (cval.len != 0) {
+		WT_CLEAR(metadata);
+		WT_ERR_NOTFOUND_OK(__wt_config_getones(
+		    session, idx->config, "app_metadata", &metadata));
+		WT_ERR(__wt_collator_config(
+		    session, idx->name, &cval, &metadata,
+		    &idx->collator, &idx->collator_owned));
+	}
 
 	WT_ERR(__wt_extractor_config(
 	    session, idx->config, &idx->extractor, &idx->extractor_owned));


### PR DESCRIPTION
While in the area, add support for WT_CURSOR::compare and WT_CURSOR::equal to index cursors.

refs #1714