### PR TITLE
Update the eviction server to not set stuck if it isn't full.

### DIFF
--- a/bench/wtperf/runners/parallel-pop-stress.wtperf
+++ b/bench/wtperf/runners/parallel-pop-stress.wtperf
@@ -1,0 +1,9 @@
+# wtperf options file: Run populate multi-threaded with a btree. This can
+# uncover conditions where pages are too busy for eviction to work as
+# expected
+conn_config="cache_size=1GB"
+table_config="type=file"
+icount=10000000
+report_interval=5
+populate_threads=20
+run_time=0

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -540,12 +540,18 @@ __evict_pass(WT_SESSION_IMPL *session)
 			 */
 			__wt_sleep(0, 1000 * (uint64_t)loop);
 			if (loop == 100) {
-				F_SET(cache, WT_CACHE_STUCK);
-				WT_STAT_FAST_CONN_INCR(
-				    session, cache_eviction_slow);
-				WT_RET(__wt_verbose(
-				    session, WT_VERB_EVICTSERVER,
-				    "unable to reach eviction goal"));
+				/*
+				 * Mark the cache as stuck if we need space
+				 * and aren't evicting any pages.
+				 */
+				if (!LF_ISSET(WT_EVICT_PASS_WOULD_BLOCK)) {
+					F_SET(cache, WT_CACHE_STUCK);
+					WT_STAT_FAST_CONN_INCR(
+					    session, cache_eviction_slow);
+					WT_RET(__wt_verbose(
+					    session, WT_VERB_EVICTSERVER,
+					    "unable to reach eviction goal"));
+				}
 				break;
 			}
 		} else {


### PR DESCRIPTION
When only looking for pages to force out, the cache isn't really stuck.
The trouble is that if we set stuck the eviction server doesn't clear walks
which can lead to it always holding a reference t othe page we (really) want
to evict.

Refs: #1777