### PR TITLE
Revert "Avoid a deadlock between the sweep server and a checkpoint."

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -727,8 +727,7 @@ __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final)
 {
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	int need_dhandle_lock, tret;
-	WT_DECL_SPINLOCK_ID(id);			/* Must appear last */
+	int tret;
 
 	dhandle = session->dhandle;
 
@@ -748,30 +747,9 @@ __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final)
 	 */
 	F_SET(S2C(session)->cache, WT_CACHE_CLEAR_WALKS);
 
-	/*
-	 * Try to remove the handle, protected by the data handle lock.
-	 *
-	 * If we need the handle list lock and it is busy, give up unless we
-	 * are closing: we already have an exclusive lock on the handle and
-	 * waiting here could deadlock (e.g., with a checkpoint gathering
-	 * the list of handles to operate on).
-	 */
-	need_dhandle_lock = !F_ISSET(session, WT_SESSION_HANDLE_LIST_LOCKED);
-	if (need_dhandle_lock) {
-		if (final)
-			__wt_spin_lock(session, &S2C(session)->dhandle_lock);
-		else
-			WT_RET(__wt_spin_trylock(
-			    session, &S2C(session)->dhandle_lock, &id));
-		F_SET(session, WT_SESSION_HANDLE_LIST_LOCKED);
-	}
-
-	WT_TRET(__conn_dhandle_remove(session, final));
-
-	if (need_dhandle_lock) {
-		F_CLR(session, WT_SESSION_HANDLE_LIST_LOCKED);
-		__wt_spin_unlock(session, &S2C(session)->dhandle_lock);
-	}
+	/* Try to remove the handle, protected by the data handle lock. */
+	WT_WITH_DHANDLE_LOCK(session,
+	    WT_TRET(__conn_dhandle_remove(session, final)));
 
 	/*
 	 * After successfully removing the handle, clean it up.


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#1808

The change looks solid to me, but appears to be causing Jenkins failures. I can't reproduce them locally. Revert for now.