### PR TITLE
Zlib replace saved stream with restart

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -544,6 +544,7 @@ decrement
 decrementing
 deflateEnd
 deflateInit
+deflateReset
 defno
 del
 delfmt

--- a/ext/compressors/zlib/zlib_compress.c
+++ b/ext/compressors/zlib/zlib_compress.c
@@ -143,7 +143,7 @@ zlib_compress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 	zs.avail_out = (uint32_t)dst_len;
 	if (deflate(&zs, Z_FINISH) == Z_STREAM_END) {
 		*compression_failed = 0;
-		*result_lenp = zs.total_out;
+		*result_lenp = (size_t)zs.total_out;
 	} else
 		*compression_failed = 1;
 
@@ -158,7 +158,7 @@ zlib_compress(WT_COMPRESSOR *compressor, WT_SESSION *session,
  *	Find the slot containing the target offset (binary search).
  */
 static inline uint32_t
-zlib_find_slot(uint32_t target, uint32_t *offsets, uint32_t slots)
+zlib_find_slot(u_long target, uint32_t *offsets, uint32_t slots)
 {
 	uint32_t base, indx, limit;
 
@@ -210,7 +210,7 @@ zlib_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 	while ((ret = inflate(&zs, Z_FINISH)) == Z_OK)
 		;
 	if (ret == Z_STREAM_END) {
-		*result_lenp = zs.total_out;
+		*result_lenp = (size_t)zs.total_out;
 		ret = Z_OK;
 	}
 
@@ -334,7 +334,7 @@ rollback:	if ((ret = deflateReset(&zs)) != Z_OK)
 
 	if (last_slot > 0) {
 		*result_slotsp = last_slot;
-		*result_lenp = zs.total_out;
+		*result_lenp = (size_t)zs.total_out;
 	} else {
 		/* We didn't manage to compress anything: don't retry. */
 		*result_slotsp = 0;


### PR DESCRIPTION
@michaelcahill, to test this, add code to force rollbacks and turn on the debugging code that compares the compressed result against the original source, then test/format will hit it pretty quickly.
```
--- a/ext/compressors/zlib/zlib_compress.c
+++ b/ext/compressors/zlib/zlib_compress.c
@@ -236,7 +236,7 @@ zlib_compress_raw(WT_COMPRESSOR *compressor, WT_SESSION *session,
        ZLIB_OPAQUE opaque;
        z_stream zs;
        uint32_t curr_slot, last_slot;
-       int ret;
+       int ret, rbcnt;
 
        curr_slot = last_slot = 0;
        (void)split_pct;
@@ -277,6 +277,7 @@ zlib_compress_raw(WT_COMPRESSOR *compressor, WT_SESSION *session,
         * page results in forced eviction based on in-memory size, even though
         * the data fits into a single on-disk block.
         */
+       rbcnt = 1;
        while (zs.avail_out > 0 && zs.total_in <= zs.total_out * 20) {
                /* Find the slot we will try to compress up to. */
                if ((curr_slot = zlib_find_slot(
@@ -290,7 +291,7 @@ zlib_compress_raw(WT_COMPRESSOR *compressor, WT_SESSION *session,
                                    compressor, session, "deflate", ret));
 
                /* Roll back if the last deflate didn't complete. */
-               if (zs.avail_in > 0)
+               if (zs.avail_in > 0 || ++rbcnt > 10)
                        goto rollback;
 
                last_slot = curr_slot;
@@ -341,7 +342,7 @@ rollback:   if ((ret = deflateReset(&zs)) != Z_OK)
                *result_lenp = 1;
        }
 
-#if 0
+#if 1
        /* Decompress the result and confirm it matches the original source. */
        if (last_slot > 0) {
                void *decomp;
```