### PR TITLE
Use deflateCopy to copy zlib streams

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -542,6 +542,7 @@ decl
 decr
 decrement
 decrementing
+deflateCopy
 deflateEnd
 deflateInit
 defno


### PR DESCRIPTION
We need to copy zlib streams for rollback in case the compressed size is too large.  It is not safe to do that by simply making a copy of the structure: use `deflateCopy` instead.

refs SERVER-17713