### PR TITLE
Split sweep into two passes

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -745,7 +745,8 @@ __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, int final)
 	 * Kludge: interrupt the eviction server in case it is holding the
 	 * handle list lock.
 	 */
-	F_SET(S2C(session)->cache, WT_CACHE_CLEAR_WALKS);
+	if (!F_ISSET(session, WT_SESSION_HANDLE_LIST_LOCKED))
+		F_SET(S2C(session)->cache, WT_CACHE_CLEAR_WALKS);
 
 	/* Try to remove the handle, protected by the data handle lock. */
 	WT_WITH_DHANDLE_LOCK(session,


### PR DESCRIPTION
One pass walks the handle list without locking and finds candidate handles to close, and the second pass holding the handle list lock that removes dead handles.

refs #1814, #1811, #1808