### PR TITLE
Fix include file paths in lang/{java,python}

### DIFF
--- a/lang/java/Makefile.am
+++ b/lang/java/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(top_srcdir)
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src/include
 
 JAVADEST = src/com/wiredtiger/db
 JAVADESTFULL = $(srcdir)/$(JAVADEST)

--- a/lang/python/setup.py
+++ b/lang/python/setup.py
@@ -36,7 +36,7 @@ if not 'ARCHFLAGS' in os.environ:
     os.environ['ARCHFLAGS'] = ''
 
 # Suppress warnings building SWIG generated code
-extra_cflags = [ '-w' ]
+extra_cflags = [ '-w', '-I../../src/include']
 
 dir = os.path.dirname(__file__)
 


### PR DESCRIPTION
@keithbostic noticed that an internal file that does `#include <3rdparty/...>` causes the python/java builds to fail. This is because the java `Makefile` and python `setup.py `did not have `-Isrc/include` on the build line. This commit this fixes that.

It probably worked up to now because the SWIG modules use `#include "src/include/wt_internal.h"` and the top level directory is on the build line and other include files are found directly on that directory. Blame the complexity of gcc/clang include rules for why including a file in a subdirectory behaves differently.