### PR TITLE
Use Standard C type uint64_t for zlib

### DIFF
--- a/ext/compressors/zlib/zlib_compress.c
+++ b/ext/compressors/zlib/zlib_compress.c
@@ -158,7 +158,7 @@ zlib_compress(WT_COMPRESSOR *compressor, WT_SESSION *session,
  *	Find the slot containing the target offset (binary search).
  */
 static inline uint32_t
-zlib_find_slot(u_long target, uint32_t *offsets, uint32_t slots)
+zlib_find_slot(uint64_t target, uint32_t *offsets, uint32_t slots)
 {
 	uint32_t base, indx, limit;
 


### PR DESCRIPTION
Use the Standard C type uint64_t for zlib_compress.c instead of the posix type u_long.