### PR TITLE
Revert "Make LZ4 default off in scons builds for now."

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ AddOption("--enable-attach", dest="attach", action="store_true", default=False,
 AddOption("--enable-diagnostic", dest="diagnostic", action="store_true", default=False,
           help="Configure WiredTiger to perform various run-time diagnostic tests. DO NOT configure this option in production environments.")
 
-AddOption("--enable-lz4", dest="lz4", type="string", nargs=1, action="store_true", default=False,
+AddOption("--enable-lz4", dest="lz4", type="string", nargs=1, action="store",
           help="Use LZ4 compression")
 
 AddOption("--enable-python", dest="lang-python", type="string", nargs=1, action="store",


### PR DESCRIPTION
LZ4 is not on by default in scons. It can only be enabled if a user specifies `--enable-lz4=<path_to_lz4_files>` where path_to_lz4_files contains these files

`<path_to_lz4_files>\include\lz4.h`
`<path_to_lz4_files>\lib\lz4.lib`