### PR TITLE
Eviction config cleanup

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -393,6 +393,18 @@ connection_runtime_config = [
                 trigger eviction when the cache is using this much memory, as a
                 percentage of the total cache size''',
                 min=10, max=99),
+            Config('walk_base', '300', r'''
+                pages retained across eviction file visits''',
+                min=1, undoc=True),
+            Config('walk_base_incr', '100', r'''
+                pages added in each group of eviction file visits''',
+                min=1, undoc=True),
+            Config('walk_queue_per_file', '10', r'''
+                pages queued for eviction from each file per visit''',
+                min=1, undoc=True),
+            Config('walk_visit_per_file', '100', r'''
+                pages from each file visited''',
+                min=1, undoc=True),
             ]),
     Config('file_manager', '', r'''
         control how file handles are managed''',

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -356,19 +356,44 @@ connection_runtime_config = [
         ]),
     Config('error_prefix', '', r'''
         prefix string for error messages'''),
-    Config('eviction_dirty_target', '80', r'''
-        continue evicting until the cache has less dirty memory than the
-        value, as a percentage of the total cache size. Dirty pages will
-        only be evicted if the cache is full enough to trigger eviction''',
-        min=10, max=99),
-    Config('eviction_target', '80', r'''
-        continue evicting until the cache has less total memory than the
-        value, as a percentage of the total cache size. Must be less than
-        \c eviction_trigger''',
-        min=10, max=99),
-    Config('eviction_trigger', '95', r'''
-        trigger eviction when the cache is using this much memory, as a
-        percentage of the total cache size''', min=10, max=99),
+    Config('eviction_dirty_target', '0', r'''
+        deprecated for eviction.dirty_target''',
+        min=10, max=99, undoc=True),
+    Config('eviction_target', '0', r'''
+        deprecated for eviction.target''',
+        min=10, max=99, undoc=True),
+    Config('eviction_trigger', '0', r'''
+        deprecated for eviction.trigger''',
+        min=10, max=99, undoc=True),
+    Config('eviction', '', r'''
+        eviction configuration options.''',
+        type='category', subconfig=[
+            Config('dirty_target', '80', r'''
+                continue evicting until the cache has less dirty memory than
+                the value, as a percentage of the total cache size. Dirty pages
+                will only be evicted if the cache is full enough to trigger
+                eviction''',
+                min=10, max=99),
+            Config('target', '80', r'''
+                continue evicting until the cache has less total memory than
+                the value, as a percentage of the total cache size. Must be
+                less than \c eviction_trigger''',
+                min=10, max=99),
+            Config('threads_max', '1', r'''
+                maximum number of threads WiredTiger will start to help evict
+                pages from cache. The number of threads started will vary
+                depending on the current eviction load''',
+                min=1, max=20),
+            Config('threads_min', '1', r'''
+                minimum number of threads WiredTiger will start to help evict
+                pages from cache. The number of threads currently running will
+                vary depending on the current eviction load''',
+                min=1, max=20),
+            Config('trigger', '95', r'''
+                trigger eviction when the cache is using this much memory, as a
+                percentage of the total cache size''',
+                min=10, max=99),
+            ]),
     Config('file_manager', '', r'''
         control how file handles are managed''',
         type='category', subconfig=[
@@ -394,20 +419,6 @@ connection_runtime_config = [
     Config('lsm_merge', 'true', r'''
         merge LSM chunks where possible (deprecated)''',
         type='boolean', undoc=True),
-    Config('eviction', '', r'''
-        eviction configuration options.''',
-        type='category', subconfig=[
-            Config('threads_max', '1', r'''
-                maximum number of threads WiredTiger will start to help evict
-                pages from cache. The number of threads started will vary
-                depending on the current eviction load''',
-                min=1, max=20),
-            Config('threads_min', '1', r'''
-                minimum number of threads WiredTiger will start to help evict
-                pages from cache. The number of threads currently running will
-                vary depending on the current eviction load''',
-                min=1, max=20),
-            ]),
     Config('shared_cache', '', r'''
         shared cache configuration options. A database should configure
         either a cache_size or a shared_cache not both''',

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -165,7 +165,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			if (oldgen && page->read_gen == WT_READGEN_NOTSET)
 				__wt_page_evict_soon(page);
 			else if (!LF_ISSET(WT_READ_NO_GEN) &&
-			    page->read_gen != WT_READGEN_OLDEST &&
+			    page->read_gen != WT_READGEN_EVICT_NOW &&
 			    page->read_gen < __wt_cache_read_gen(session))
 				page->read_gen =
 				    __wt_cache_read_gen_set(session);

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -54,8 +54,11 @@ static const WT_CONFIG_CHECK confchk_checkpoint_subconfigs[] = {
 };
 
 static const WT_CONFIG_CHECK confchk_eviction_subconfigs[] = {
+	{ "dirty_target", "int", NULL, "min=10,max=99", NULL },
+	{ "target", "int", NULL, "min=10,max=99", NULL },
 	{ "threads_max", "int", NULL, "min=1,max=20", NULL },
 	{ "threads_min", "int", NULL, "min=1,max=20", NULL },
+	{ "trigger", "int", NULL, "min=10,max=99", NULL },
 	{ NULL, NULL, NULL, NULL, NULL }
 };
 
@@ -660,12 +663,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=0,ops_max=1024,threads=2),cache_overhead=8,"
 	  "cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),error_prefix=,"
-	  "eviction=(threads_max=1,threads_min=1),eviction_dirty_target=80,"
-	  "eviction_target=80,eviction_trigger=95,"
-	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
-	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,"
-	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
-	  "statistics=none,statistics_log=(on_close=0,"
+	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
+	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
+	  "eviction_trigger=0,file_manager=(close_idle_time=30,"
+	  "close_scan_interval=10),lsm_manager=(merge=,worker_thread_max=4)"
+	  ",lsm_merge=,shared_cache=(chunk=10MB,name=,reserve=0,size=500MB)"
+	  ",statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),verbose=",
 	  confchk_connection_reconfigure
@@ -790,18 +793,19 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "config_base=,create=0,direct_io=,error_prefix=,"
-	  "eviction=(threads_max=1,threads_min=1),eviction_dirty_target=80,"
-	  "eviction_target=80,eviction_trigger=95,exclusive=0,extensions=,"
-	  "file_extend=,file_manager=(close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=,"
-	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=,recover=on)"
-	  ",lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
-	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
-	  "statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=",
+	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
+	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
+	  "eviction_trigger=0,exclusive=0,extensions=,file_extend=,"
+	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
+	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
+	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=",
 	  confchk_wiredtiger_open
 	},
 	{ "wiredtiger_open_all",
@@ -809,55 +813,56 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "config_base=,create=0,direct_io=,error_prefix=,"
-	  "eviction=(threads_max=1,threads_min=1),eviction_dirty_target=80,"
-	  "eviction_target=80,eviction_trigger=95,exclusive=0,extensions=,"
-	  "file_extend=,file_manager=(close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=,"
-	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=,recover=on)"
-	  ",lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
-	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
-	  "statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=,version=(major=0,"
-	  "minor=0)",
+	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
+	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
+	  "eviction_trigger=0,exclusive=0,extensions=,file_extend=,"
+	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
+	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
+	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_all
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=0,ops_max=1024,threads=2),buffer_alignment=-1,"
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
-	  "direct_io=,error_prefix=,eviction=(threads_max=1,threads_min=1),"
-	  "eviction_dirty_target=80,eviction_target=80,eviction_trigger=95,"
-	  "extensions=,file_extend=,file_manager=(close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=,"
-	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=,recover=on)"
-	  ",lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
-	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
-	  "statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),verbose=,version=(major=0,minor=0)",
+	  "direct_io=,error_prefix=,eviction=(dirty_target=80,target=80,"
+	  "threads_max=1,threads_min=1,trigger=95),eviction_dirty_target=0,"
+	  "eviction_target=0,eviction_trigger=0,extensions=,file_extend=,"
+	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
+	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
+	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),verbose=,"
+	  "version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=0,ops_max=1024,threads=2),buffer_alignment=-1,"
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
-	  "direct_io=,error_prefix=,eviction=(threads_max=1,threads_min=1),"
-	  "eviction_dirty_target=80,eviction_target=80,eviction_trigger=95,"
-	  "extensions=,file_extend=,file_manager=(close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=,"
-	  "compressor=,enabled=0,file_max=100MB,path=,prealloc=,recover=on)"
-	  ",lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,mmap=,"
-	  "multiprocess=0,session_max=100,session_scratch_max=2MB,"
-	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
-	  "statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),verbose=",
+	  "direct_io=,error_prefix=,eviction=(dirty_target=80,target=80,"
+	  "threads_max=1,threads_min=1,trigger=95),eviction_dirty_target=0,"
+	  "eviction_target=0,eviction_trigger=0,extensions=,file_extend=,"
+	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
+	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
+	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg
 	},
 	{ NULL, NULL, NULL }

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -59,6 +59,10 @@ static const WT_CONFIG_CHECK confchk_eviction_subconfigs[] = {
 	{ "threads_max", "int", NULL, "min=1,max=20", NULL },
 	{ "threads_min", "int", NULL, "min=1,max=20", NULL },
 	{ "trigger", "int", NULL, "min=10,max=99", NULL },
+	{ "walk_base", "int", NULL, "min=1", NULL },
+	{ "walk_base_incr", "int", NULL, "min=1", NULL },
+	{ "walk_queue_per_file", "int", NULL, "min=1", NULL },
+	{ "walk_visit_per_file", "int", NULL, "min=1", NULL },
 	{ NULL, NULL, NULL, NULL, NULL }
 };
 
@@ -664,11 +668,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),error_prefix=,"
 	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
-	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
-	  "eviction_trigger=0,file_manager=(close_idle_time=30,"
-	  "close_scan_interval=10),lsm_manager=(merge=,worker_thread_max=4)"
-	  ",lsm_merge=,shared_cache=(chunk=10MB,name=,reserve=0,size=500MB)"
-	  ",statistics=none,statistics_log=(on_close=0,"
+	  "trigger=95,walk_base=300,walk_base_incr=100,"
+	  "walk_queue_per_file=10,walk_visit_per_file=100),"
+	  "eviction_dirty_target=0,eviction_target=0,eviction_trigger=0,"
+	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
+	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,"
+	  "shared_cache=(chunk=10MB,name=,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),verbose=",
 	  confchk_connection_reconfigure
@@ -794,8 +800,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "config_base=,create=0,direct_io=,error_prefix=,"
 	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
-	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
-	  "eviction_trigger=0,exclusive=0,extensions=,file_extend=,"
+	  "trigger=95,walk_base=300,walk_base_incr=100,"
+	  "walk_queue_per_file=10,walk_visit_per_file=100),"
+	  "eviction_dirty_target=0,eviction_target=0,eviction_trigger=0,"
+	  "exclusive=0,extensions=,file_extend=,"
 	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
 	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
 	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
@@ -814,8 +822,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "config_base=,create=0,direct_io=,error_prefix=,"
 	  "eviction=(dirty_target=80,target=80,threads_max=1,threads_min=1,"
-	  "trigger=95),eviction_dirty_target=0,eviction_target=0,"
-	  "eviction_trigger=0,exclusive=0,extensions=,file_extend=,"
+	  "trigger=95,walk_base=300,walk_base_incr=100,"
+	  "walk_queue_per_file=10,walk_visit_per_file=100),"
+	  "eviction_dirty_target=0,eviction_target=0,eviction_trigger=0,"
+	  "exclusive=0,extensions=,file_extend=,"
 	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
 	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
 	  "file_max=100MB,path=,prealloc=,recover=on),lsm_manager=(merge=,"
@@ -833,7 +843,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "direct_io=,error_prefix=,eviction=(dirty_target=80,target=80,"
-	  "threads_max=1,threads_min=1,trigger=95),eviction_dirty_target=0,"
+	  "threads_max=1,threads_min=1,trigger=95,walk_base=300,"
+	  "walk_base_incr=100,walk_queue_per_file=10,"
+	  "walk_visit_per_file=100),eviction_dirty_target=0,"
 	  "eviction_target=0,eviction_trigger=0,extensions=,file_extend=,"
 	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
 	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"
@@ -852,7 +864,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
 	  "name=\"WiredTigerCheckpoint\",wait=0),checkpoint_sync=,"
 	  "direct_io=,error_prefix=,eviction=(dirty_target=80,target=80,"
-	  "threads_max=1,threads_min=1,trigger=95),eviction_dirty_target=0,"
+	  "threads_max=1,threads_min=1,trigger=95,walk_base=300,"
+	  "walk_base_incr=100,walk_queue_per_file=10,"
+	  "walk_visit_per_file=100),eviction_dirty_target=0,"
 	  "eviction_target=0,eviction_trigger=0,extensions=,file_extend=,"
 	  "file_manager=(close_idle_time=30,close_scan_interval=10),"
 	  "hazard_max=1000,log=(archive=,compressor=,enabled=0,"

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -46,19 +46,19 @@ __cache_config_local(WT_SESSION_IMPL *session, int shared, const char *cfg[])
 	if (cval.val == 0)
 		WT_RET(__wt_config_gets(
 		    session, cfg, "eviction.target", &cval));
-	cache->eviction_target = (u_int)cval.val;
+	cache->evict_target = (u_int)cval.val;
 
 	WT_RET(__wt_config_gets(session, cfg, "eviction_trigger", &cval));
 	if (cval.val == 0)
 		WT_RET(__wt_config_gets(
 		    session, cfg, "eviction.trigger", &cval));
-	cache->eviction_trigger = (u_int)cval.val;
+	cache->evict_trigger = (u_int)cval.val;
 
 	WT_RET(__wt_config_gets(session, cfg, "eviction_dirty_target", &cval));
 	if (cval.val == 0)
 		WT_RET(__wt_config_gets(
 		    session, cfg, "eviction.dirty_target", &cval));
-	cache->eviction_dirty_target = (u_int)cval.val;
+	cache->evict_dirty_target = (u_int)cval.val;
 
 	WT_RET(__wt_config_gets(session, cfg, "eviction.threads_max", &cval));
 	evict_workers_max = (uint32_t)cval.val - 1;
@@ -163,7 +163,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	 * The target size must be lower than the trigger size or we will never
 	 * get any work done.
 	 */
-	if (cache->eviction_target >= cache->eviction_trigger)
+	if (cache->evict_target >= cache->evict_trigger)
 		WT_ERR_MSG(session, EINVAL,
 		    "eviction target must be lower than the eviction trigger");
 

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -73,6 +73,21 @@ __cache_config_local(WT_SESSION_IMPL *session, int shared, const char *cfg[])
 	conn->evict_workers_max = evict_workers_max;
 	conn->evict_workers_min = evict_workers_min;
 
+	WT_RET(__wt_config_gets(session, cfg, "eviction.walk_base", &cval));
+	cache->evict_walk_base = (u_int)cval.val;
+
+	WT_RET(__wt_config_gets(
+	    session, cfg, "eviction.walk_base_incr", &cval));
+	cache->evict_walk_base_incr = (u_int)cval.val;
+
+	WT_RET(__wt_config_gets(
+	    session, cfg, "eviction.walk_queue_per_file", &cval));
+	cache->evict_walk_queue_per_file = (u_int)cval.val;
+
+	WT_RET(__wt_config_gets(
+	    session, cfg, "eviction.walk_visit_per_file", &cval));
+	cache->evict_walk_visit_per_file = (u_int)cval.val;
+
 	return (0);
 }
 
@@ -160,7 +175,8 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ERR(__wt_spin_init(session, &cache->evict_walk_lock, "cache walk"));
 
 	/* Allocate the LRU eviction queue. */
-	cache->evict_slots = WT_EVICT_WALK_BASE + WT_EVICT_WALK_INCR;
+	cache->evict_slots =
+	    cache->evict_walk_base + cache->evict_walk_base_incr;
 	WT_ERR(__wt_calloc_def(session, cache->evict_slots, &cache->evict));
 
 	/*

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -558,7 +558,7 @@ __cache_pool_adjust(WT_SESSION_IMPL *session,
 		} else if (highest > 1 &&
 		    entry->cache_size < cp->size &&
 		     cache->bytes_inmem >=
-		     (entry->cache_size * cache->eviction_target) / 100 &&
+		     (entry->cache_size * cache->evict_target) / 100 &&
 		     cp->currently_used < cp->size &&
 		     read_pressure > bump_threshold) {
 			grew = 1;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1124,14 +1124,16 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp, uint32_t flags)
 	WT_REF *ref;
 	uint64_t pages_walked;
 	uint32_t walk_flags;
-	int enough, internal_pages, modified, restarts;
+	u_int internal_pages;
+	int enough, modified, restarts;
 
 	btree = S2BT(session);
 	cache = S2C(session)->cache;
 	start = cache->evict + *slotp;
 	end = WT_MIN(start + cache->evict_walk_queue_per_file,
 	    cache->evict + cache->evict_slots);
-	enough = internal_pages = restarts = 0;
+	internal_pages = 0;
+	enough = restarts = 0;
 
 	walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT |
 	    WT_READ_NO_GEN | WT_READ_NO_WAIT;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -445,10 +445,9 @@ __evict_has_work(WT_SESSION_IMPL *session, uint32_t *flagsp)
 	bytes_max = conn->cache_size;
 
 	/* Check to see if the eviction server should run. */
-	if (bytes_inuse > (cache->eviction_target * bytes_max) / 100)
+	if (bytes_inuse > (cache->evict_target * bytes_max) / 100)
 		LF_SET(WT_EVICT_PASS_ALL);
-	else if (dirty_inuse >
-	    (cache->eviction_dirty_target * bytes_max) / 100)
+	else if (dirty_inuse > (cache->evict_dirty_target * bytes_max) / 100)
 		/* Ignore clean pages unless the cache is too large */
 		LF_SET(WT_EVICT_PASS_DIRTY);
 	else if (F_ISSET(cache, WT_CACHE_WOULD_BLOCK)) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -37,7 +37,7 @@ __evict_read_gen(const WT_EVICT_ENTRY *entry)
 
 	/* Any empty page (leaf or internal), is a good choice. */
 	if (__wt_page_is_empty(page))
-		return (WT_READGEN_OLDEST);
+		return (WT_READGEN_EVICT_NOW);
 
 	/*
 	 * Skew the read generation for internal pages, we prefer to evict leaf
@@ -1190,7 +1190,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp, uint32_t flags)
 		 * eviction, skip anything that isn't marked.
 		 */
 		if (LF_ISSET(WT_EVICT_PASS_WOULD_BLOCK) &&
-		    page->read_gen != WT_READGEN_OLDEST)
+		    page->read_gen != WT_READGEN_EVICT_NOW)
 			continue;
 
 		/* Limit internal pages to 50% unless we get aggressive. */
@@ -1263,7 +1263,7 @@ fast:		/* If the page can't be evicted, give up. */
 	 * as quickly as possible.
 	 */
 	if ((ref = btree->evict_ref) != NULL && (__wt_ref_is_root(ref) ||
-	    ref->page->read_gen == WT_READGEN_OLDEST)) {
+	    ref->page->read_gen == WT_READGEN_EVICT_NOW)) {
 		btree->evict_ref = NULL;
 		__wt_page_release(session, ref, 0);
 	}
@@ -1401,7 +1401,7 @@ __wt_evict_lru_page(WT_SESSION_IMPL *session, int is_server)
 	 * look at it.
 	 */
 	page = ref->page;
-	if (page->read_gen != WT_READGEN_OLDEST)
+	if (page->read_gen != WT_READGEN_EVICT_NOW)
 		page->read_gen = __wt_cache_read_gen_set(session);
 
 	WT_WITH_BTREE(session, btree, ret = __wt_evict_page(session, ref));

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -60,7 +60,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, int exclusive)
 	conn = S2C(session);
 
 	page = ref->page;
-	forced_eviction = (page->read_gen == WT_READGEN_OLDEST);
+	forced_eviction = page->read_gen == WT_READGEN_EVICT_NOW;
 	inmem_split = 0;
 
 	WT_RET(__wt_verbose(session, WT_VERB_EVICT,
@@ -355,7 +355,7 @@ __evict_review(
 		if (exclusive)
 			LF_SET(WT_SKIP_UPDATE_ERR);
 		else if (!WT_PAGE_IS_INTERNAL(page) &&
-		    page->read_gen == WT_READGEN_OLDEST)
+		    page->read_gen == WT_READGEN_EVICT_NOW)
 			LF_SET(WT_SKIP_UPDATE_RESTORE);
 		WT_RET(__wt_reconcile(session, ref, NULL, flags));
 		WT_ASSERT(session,

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -552,7 +552,7 @@ struct __wt_page {
 	 * frequently, it is set to a future point.
 	 */
 #define	WT_READGEN_NOTSET	0
-#define	WT_READGEN_OLDEST	1
+#define	WT_READGEN_EVICT_NOW	1
 #define	WT_READGEN_STEP		100
 	uint64_t read_gen;
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -265,7 +265,7 @@ __wt_update_list_memsize(WT_UPDATE *upd)
 static inline void
 __wt_page_evict_soon(WT_PAGE *page)
 {
-	page->read_gen = WT_READGEN_OLDEST;
+	page->read_gen = WT_READGEN_EVICT_NOW;
 }
 
 /*
@@ -1016,7 +1016,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_PAGE *page, int check_splits)
 	 * internal page acquires hazard pointers on child pages it reads, and
 	 * is blocked by the exclusive lock.
 	 */
-	if (page->read_gen != WT_READGEN_OLDEST &&
+	if (page->read_gen != WT_READGEN_EVICT_NOW &&
 	    !__wt_txn_visible_all(session, __wt_page_is_modified(page) ?
 	    mod->update_txn : mod->rec_max_txn))
 		return (0);
@@ -1112,7 +1112,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * it contains an update that isn't stable.  Also skip forced eviction
 	 * if we just did an in-memory split.
 	 */
-	if (page->read_gen != WT_READGEN_OLDEST ||
+	if (page->read_gen != WT_READGEN_EVICT_NOW ||
 	    LF_ISSET(WT_READ_NO_EVICT) ||
 	    F_ISSET(btree, WT_BTREE_NO_EVICTION) ||
 	    !__wt_page_can_evict(session, page, 1))

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -6,17 +6,9 @@
  * See the file LICENSE for redistribution information.
  */
 
-/*
- * Tuning constants: I hesitate to call this tuning, but we want to review some
- * number of pages from each file's in-memory tree for each page we evict.
- */
 #define	WT_EVICT_INT_SKEW  (1<<20)	/* Prefer leaf pages over internal
 					   pages by this many increments of the
 					   read generation. */
-#define	WT_EVICT_WALK_PER_FILE	 10	/* Pages to queue per file */
-#define	WT_EVICT_MAX_PER_FILE	100	/* Max pages to visit per file */
-#define	WT_EVICT_WALK_BASE	300	/* Pages tracked across file visits */
-#define	WT_EVICT_WALK_INCR	100	/* Pages added each walk */
 
 #define	WT_EVICT_PASS_AGGRESSIVE	0x01
 #define	WT_EVICT_PASS_ALL		0x02
@@ -81,9 +73,13 @@ struct __wt_cache {
 	/* Condition signalled when the eviction server populates the queue */
 	WT_CONDVAR *evict_waiter_cond;
 
-	u_int eviction_trigger;		/* Percent to trigger eviction */
-	u_int eviction_target;		/* Percent to end eviction */
+	u_int evict_walk_base;		/* Pages tracked across file visits */
+	u_int evict_walk_base_incr;	/* Pages added each walk */
+	u_int evict_walk_queue_per_file;/* Pages to queue per file visit */
+	u_int evict_walk_visit_per_file;/* Max pages to visit per file */
 	u_int eviction_dirty_target;    /* Percent to allow dirty */
+	u_int eviction_target;		/* Percent to end eviction */
+	u_int eviction_trigger;		/* Percent to trigger eviction */
 
 	u_int overhead_pct;	        /* Cache percent adjustment */
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -65,6 +65,17 @@ struct __wt_cache {
 	uint64_t   read_gen;		/* Page read generation (LRU) */
 
 	/*
+	 * Configuration
+	 */
+	u_int evict_dirty_target;	/* Percent to allow dirty */
+	u_int evict_target;		/* Percent to end eviction */
+	u_int evict_trigger;		/* Percent to trigger eviction */
+	u_int evict_walk_base;		/* Pages tracked across file visits */
+	u_int evict_walk_base_incr;	/* Pages added each walk */
+	u_int evict_walk_queue_per_file;/* Pages to queue per file visit */
+	u_int evict_walk_visit_per_file;/* Max pages to visit per file */
+
+	/*
 	 * Eviction thread information.
 	 */
 	WT_CONDVAR *evict_cond;		/* Eviction server condition */
@@ -72,14 +83,6 @@ struct __wt_cache {
 	WT_SPINLOCK evict_walk_lock;	/* Eviction walk location */
 	/* Condition signalled when the eviction server populates the queue */
 	WT_CONDVAR *evict_waiter_cond;
-
-	u_int evict_walk_base;		/* Pages tracked across file visits */
-	u_int evict_walk_base_incr;	/* Pages added each walk */
-	u_int evict_walk_queue_per_file;/* Pages to queue per file visit */
-	u_int evict_walk_visit_per_file;/* Max pages to visit per file */
-	u_int eviction_dirty_target;    /* Percent to allow dirty */
-	u_int eviction_target;		/* Percent to end eviction */
-	u_int eviction_trigger;		/* Percent to trigger eviction */
 
 	u_int overhead_pct;	        /* Cache percent adjustment */
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -119,9 +119,8 @@ __wt_eviction_check(WT_SESSION_IMPL *session, int *fullp, int wake)
 	*fullp = (int)((100 * bytes_inuse) / bytes_max);
 
 	/* Wake eviction when we're over the trigger cache size. */
-	if (wake &&
-	    (bytes_inuse > (cache->eviction_trigger * bytes_max) / 100 ||
-	    dirty_inuse > (cache->eviction_dirty_target * bytes_max) / 100))
+	if (wake && (bytes_inuse > (cache->evict_trigger * bytes_max) / 100 ||
+	    dirty_inuse > (cache->evict_dirty_target * bytes_max) / 100))
 		WT_RET(__wt_evict_server_wake(session));
 
 	return (0);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1587,6 +1587,15 @@ struct __wt_connection {
 	 * default empty.}
 	 * @config{eviction = (, eviction configuration options., a set of
 	 * related configuration options defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;dirty_target, continue evicting until
+	 * the cache has less dirty memory than the value\, as a percentage of
+	 * the total cache size.  Dirty pages will only be evicted if the cache
+	 * is full enough to trigger eviction., an integer between 10 and 99;
+	 * default \c 80.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;target, continue
+	 * evicting until the cache has less total memory than the value\, as a
+	 * percentage of the total cache size.  Must be less than \c
+	 * eviction_trigger., an integer between 10 and 99; default \c 80.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of
 	 * threads WiredTiger will start to help evict pages from cache.  The
 	 * number of threads started will vary depending on the current eviction
@@ -1595,18 +1604,10 @@ struct __wt_connection {
 	 * threads WiredTiger will start to help evict pages from cache.  The
 	 * number of threads currently running will vary depending on the
 	 * current eviction load., an integer between 1 and 20; default \c 1.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;trigger, trigger eviction when the
+	 * cache is using this much memory\, as a percentage of the total cache
+	 * size., an integer between 10 and 99; default \c 95.}
 	 * @config{ ),,}
-	 * @config{eviction_dirty_target, continue evicting until the cache has
-	 * less dirty memory than the value\, as a percentage of the total cache
-	 * size.  Dirty pages will only be evicted if the cache is full enough
-	 * to trigger eviction., an integer between 10 and 99; default \c 80.}
-	 * @config{eviction_target, continue evicting until the cache has less
-	 * total memory than the value\, as a percentage of the total cache
-	 * size.  Must be less than \c eviction_trigger., an integer between 10
-	 * and 99; default \c 80.}
-	 * @config{eviction_trigger, trigger eviction when the cache is using
-	 * this much memory\, as a percentage of the total cache size., an
-	 * integer between 10 and 99; default \c 95.}
 	 * @config{file_manager = (, control how file handles are managed., a
 	 * set of related configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_idle_time, amount of time in
@@ -1947,25 +1948,26 @@ struct __wt_connection {
  * empty.}
  * @config{eviction = (, eviction configuration options., a set of related
  * configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads
- * WiredTiger will start to help evict pages from cache.  The number of threads
- * started will vary depending on the current eviction load., an integer between
- * 1 and 20; default \c 1.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum
- * number of threads WiredTiger will start to help evict pages from cache.  The
- * number of threads currently running will vary depending on the current
- * eviction load., an integer between 1 and 20; default \c 1.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;dirty_target, continue evicting until the
+ * cache has less dirty memory than the value\, as a percentage of the total
+ * cache size.  Dirty pages will only be evicted if the cache is full enough to
+ * trigger eviction., an integer between 10 and 99; default \c 80.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;target, continue evicting until the cache has
+ * less total memory than the value\, as a percentage of the total cache size.
+ * Must be less than \c eviction_trigger., an integer between 10 and 99; default
+ * \c 80.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of
+ * threads WiredTiger will start to help evict pages from cache.  The number of
+ * threads started will vary depending on the current eviction load., an integer
+ * between 1 and 20; default \c 1.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min,
+ * minimum number of threads WiredTiger will start to help evict pages from
+ * cache.  The number of threads currently running will vary depending on the
+ * current eviction load., an integer between 1 and 20; default \c 1.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;trigger, trigger eviction when the cache is
+ * using this much memory\, as a percentage of the total cache size., an integer
+ * between 10 and 99; default \c 95.}
  * @config{ ),,}
- * @config{eviction_dirty_target, continue evicting until the cache has less
- * dirty memory than the value\, as a percentage of the total cache size.  Dirty
- * pages will only be evicted if the cache is full enough to trigger eviction.,
- * an integer between 10 and 99; default \c 80.}
- * @config{eviction_target, continue evicting until the cache has less total
- * memory than the value\, as a percentage of the total cache size.  Must be
- * less than \c eviction_trigger., an integer between 10 and 99; default \c 80.}
- * @config{eviction_trigger, trigger eviction when the cache is using this much
- * memory\, as a percentage of the total cache size., an integer between 10 and
- * 99; default \c 95.}
  * @config{exclusive, fail if the database already exists\, generally used with
  * the \c create option., a boolean flag; default \c false.}
  * @config{extensions, list of shared library extensions to load (using dlopen).

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1607,6 +1607,18 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;trigger, trigger eviction when the
 	 * cache is using this much memory\, as a percentage of the total cache
 	 * size., an integer between 10 and 99; default \c 95.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_base, pages retained across
+	 * eviction file visits., an integer greater than or equal to 1; default
+	 * \c 300.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_base_incr, pages added
+	 * in each group of eviction file visits., an integer greater than or
+	 * equal to 1; default \c 100.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_queue_per_file, pages queued for
+	 * eviction from each file per visit., an integer greater than or equal
+	 * to 1; default \c 10.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_visit_per_file, pages from each
+	 * file visited., an integer greater than or equal to 1; default \c
+	 * 100.}
 	 * @config{ ),,}
 	 * @config{file_manager = (, control how file handles are managed., a
 	 * set of related configuration options defined below.}
@@ -1967,6 +1979,18 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;trigger, trigger eviction when the cache is
  * using this much memory\, as a percentage of the total cache size., an integer
  * between 10 and 99; default \c 95.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_base,
+ * pages retained across eviction file visits., an integer greater than or equal
+ * to 1; default \c 300.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_base_incr, pages
+ * added in each group of eviction file visits., an integer greater than or
+ * equal to 1; default \c 100.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_queue_per_file, pages queued for
+ * eviction from each file per visit., an integer greater than or equal to 1;
+ * default \c 10.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;walk_visit_per_file, pages
+ * from each file visited., an integer greater than or equal to 1; default \c
+ * 100.}
  * @config{ ),,}
  * @config{exclusive, fail if the database already exists\, generally used with
  * the \c create option., a boolean flag; default \c false.}

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -135,21 +135,46 @@ class test_config04(wttest.WiredTigerTestCase):
             lambda: wiredtiger.wiredtiger_open('.', configstr),
             "/Value too large for key 'cache_size' the maximum is/")
 
+    # Test a variety of eviction configurations, mixing old and new syntax.
     def test_eviction(self):
+        self.common_test('eviction=(target=84,trigger=94)')
+	self.close_conn()
+        self.common_test('eviction=(target=84),eviction_trigger=94')
+	self.close_conn()
+        self.common_test('eviction_target=84,eviction=(trigger=94)')
+	self.close_conn()
         self.common_test('eviction_target=84,eviction_trigger=94')
-        # Note
+	self.close_conn()
 
+    # Test a variety of eviction configurations, mixing old and new syntax.
     def test_eviction_bad(self):
+	msg = "/eviction target must be lower than the eviction trigger/"
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            wiredtiger.wiredtiger_open('.', 'create,eviction_target=91,' +
-                                       'eviction_trigger=81'),
-            "/eviction target must be lower than the eviction trigger/")
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction_target=91,eviction_trigger=81'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction=(target=91),eviction_trigger=81'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction_target=91,eviction=(trigger=81)'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction=(target=91,trigger=81)'), msg)
 
-    def test_eviction_bad2(self):
+	# Test with equal values.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            wiredtiger.wiredtiger_open('.', 'create,eviction_target=86,' +
-                                       'eviction_trigger=86'),
-            "/eviction target must be lower than the eviction trigger/")
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction_target=86,eviction_trigger=86'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction=(target=86),eviction_trigger=86'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction_target=86,eviction=(trigger=86)'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            wiredtiger.wiredtiger_open('.',
+                'create,eviction=(target=86,trigger=86)'), msg)
 
     def test_hazard_max(self):
         # Note: There isn't any direct way to know that this was set.

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -138,17 +138,17 @@ class test_config04(wttest.WiredTigerTestCase):
     # Test a variety of eviction configurations, mixing old and new syntax.
     def test_eviction(self):
         self.common_test('eviction=(target=84,trigger=94)')
-	self.close_conn()
+        self.close_conn()
         self.common_test('eviction=(target=84),eviction_trigger=94')
-	self.close_conn()
+        self.close_conn()
         self.common_test('eviction_target=84,eviction=(trigger=94)')
-	self.close_conn()
+        self.close_conn()
         self.common_test('eviction_target=84,eviction_trigger=94')
-	self.close_conn()
+        self.close_conn()
 
     # Test a variety of eviction configurations, mixing old and new syntax.
     def test_eviction_bad(self):
-	msg = "/eviction target must be lower than the eviction trigger/"
+        msg = "/eviction target must be lower than the eviction trigger/"
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             wiredtiger.wiredtiger_open('.',
                 'create,eviction_target=91,eviction_trigger=81'), msg)
@@ -162,7 +162,7 @@ class test_config04(wttest.WiredTigerTestCase):
             wiredtiger.wiredtiger_open('.',
                 'create,eviction=(target=91,trigger=81)'), msg)
 
-	# Test with equal values.
+        # Test with equal values.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             wiredtiger.wiredtiger_open('.',
                 'create,eviction_target=86,eviction_trigger=86'), msg)


### PR DESCRIPTION
@michaelcahill, @agorrod -- this branch has the changes for #1686 (move the big eviction configuration knobs into the configuration file as undocumented values), and #1217 (push the existing eviction configuration knobs into the eviction sub configuration group), if you agree with these changes, I believe we can close both of those issues.