### PR TITLE
Add an assert to the split free method.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -148,7 +148,7 @@ __split_safe_free(WT_SESSION_IMPL *session,
     uint64_t split_gen, int exclusive, void *p, size_t s)
 {
 	/* We should only call safe free if we aren't pinning the memory. */
-	WT_ASSERT(session, session->split_gen == 0);
+	WT_ASSERT(session, session->split_gen != split_gen);
 
 	/*
 	 * We have swapped something in a page: if we don't have exclusive

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -147,6 +147,9 @@ static int
 __split_safe_free(WT_SESSION_IMPL *session,
     uint64_t split_gen, int exclusive, void *p, size_t s)
 {
+	/* We should only call safe free if we aren't pinning the memory. */
+	WT_ASSERT(session, split_gen != session->split_gen);
+
 	/*
 	 * We have swapped something in a page: if we don't have exclusive
 	 * access, check whether there are other threads in the same tree.

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -148,7 +148,7 @@ __split_safe_free(WT_SESSION_IMPL *session,
     uint64_t split_gen, int exclusive, void *p, size_t s)
 {
 	/* We should only call safe free if we aren't pinning the memory. */
-	WT_ASSERT(session, split_gen != session->split_gen);
+	WT_ASSERT(session, session->split_gen == 0);
 
 	/*
 	 * We have swapped something in a page: if we don't have exclusive


### PR DESCRIPTION
It doesn't make sense for us to call split free while blocking it from freeing the memory immediately ourselves.