### PR TITLE
Add a __setitem__ to cursors in the Python API

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -358,12 +358,12 @@ retry:
 	$action
 	if (result != 0 && result != EBUSY)
 		SWIG_ERROR_IF_NOT_SET(result);
-        else if (result == EBUSY) {
+	else if (result == EBUSY) {
 		SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-                __wt_sleep(0, 10000);
+		__wt_sleep(0, 10000);
 		SWIG_PYTHON_THREAD_END_ALLOW;
-                goto retry;
-        }
+		goto retry;
+	}
 }
 %enddef
 
@@ -745,8 +745,8 @@ typedef int int_void;
 		}
 		else {
 			ret = $self->equals($self, other, &cmp);
-                        if (ret == 0)
-                                ret = cmp;
+			if (ret == 0)
+				ret = cmp;
 		}
 		return (ret);
 	}
@@ -842,12 +842,25 @@ typedef int int_void;
 			self._iterable = IterableCursor(self)
 		return self._iterable
 
+	def __delitem__(self, key):
+		'''Python convenience for removing'''
+		self.set_key(key)
+		if self.remove() != 0:
+			raise KeyError
+
 	def __getitem__(self, key):
 		'''Python convenience for searching'''
 		self.set_key(key)
 		if self.search() != 0:
 			raise KeyError
 		return self.get_value()
+
+	def __setitem__(self, key, value):
+		'''Python convenience for inserting'''
+		self.set_key(key)
+		self.set_value(value)
+		if self.insert() != 0:
+			raise KeyError
 %}
 };
 
@@ -870,17 +883,17 @@ typedef int int_void;
 %{
 int diagnostic_build() {
 #ifdef HAVE_DIAGNOSTIC
-        return 1;
+	return 1;
 #else
-        return 0;
+	return 0;
 #endif
 }
 
 int verbose_build() {
 #ifdef HAVE_VERBOSE
-        return 1;
+	return 1;
 #else
-        return 0;
+	return 0;
 #endif
 }
 %}
@@ -1127,8 +1140,8 @@ pythonAsyncCallback(WT_ASYNC_CALLBACK *cb, WT_ASYNC_OP *asyncop, int opret,
 	int ret, t_ret;
 	PY_CALLBACK *pcb;
 	PyObject *arglist, *notify_method, *pyresult;
-        WT_ASYNC_OP_IMPL *op;
-        WT_SESSION_IMPL *session;
+	WT_ASYNC_OP_IMPL *op;
+	WT_SESSION_IMPL *session;
 
 	/*
 	 * Ensure the global interpreter lock is held since we'll be
@@ -1136,8 +1149,8 @@ pythonAsyncCallback(WT_ASYNC_CALLBACK *cb, WT_ASYNC_OP *asyncop, int opret,
 	 */
 	SWIG_PYTHON_THREAD_BEGIN_BLOCK;
 
-        op = (WT_ASYNC_OP_IMPL *)asyncop;
-        session = O2S(op);
+	op = (WT_ASYNC_OP_IMPL *)asyncop;
+	session = O2S(op);
 	pcb = (PY_CALLBACK *)asyncop->c.lang_private;
 	asyncop->c.lang_private = NULL;
 	ret = 0;
@@ -1172,10 +1185,10 @@ err:		__wt_err(session, ret, "python async callback error");
 	}
 	__wt_free(session, pcb);
 
-        if (ret == 0 && (opret == 0 || opret == WT_NOTFOUND))
-	        return (0);
-        else
-                return (1);
+	if (ret == 0 && (opret == 0 || opret == WT_NOTFOUND))
+		return (0);
+	else
+		return (1);
 }
 
 static WT_ASYNC_CALLBACK pyApiAsyncCallback = { pythonAsyncCallback };

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -134,9 +134,7 @@ def simple_populate(self, uri, config, rows):
     self.session.create(uri, 'value_format=S,' + config)
     cursor = self.session.open_cursor(uri, None)
     for i in range(1, rows + 1):
-        cursor.set_key(key_populate(cursor, i))
-        cursor.set_value(value_populate(cursor, i))
-        cursor.insert()
+        cursor[key_populate(cursor, i)] = value_populate(cursor, i)
     cursor.close()
 
 def simple_populate_check_cursor(self, cursor, rows):
@@ -206,10 +204,8 @@ def complex_populate_type(self, uri, config, rows, type):
         indxname + ':indx6', 'columns=(column3,column5,column4)' + ',' + type)
     cursor = self.session.open_cursor(uri, None)
     for i in range(1, rows + 1):
-        cursor.set_key(key_populate(cursor, i))
         v = complex_value_populate(cursor, i)
-        cursor.set_value(v[0], v[1], v[2], v[3])
-        cursor.insert()
+        cursor[key_populate(cursor, i)] = (v[0], v[1], v[2], v[3])
     cursor.close()
 
 def complex_populate_colgroup_name(self, uri):

--- a/test/suite/test_backup04.py
+++ b/test/suite/test_backup04.py
@@ -71,20 +71,14 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
         self.pr('populate: ' + uri + ' with ' + str(rows) + ' rows')
         cursor = self.session.open_cursor(uri, None)
         for i in range(1, rows + 1):
-            cursor.set_key(key_populate(cursor, i))
-            my_data = str(i) + ':' + 'a' * dsize
-            cursor.set_value(my_data)
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = str(i) + ':' + 'a' * dsize
         cursor.close()
 
     def update(self, uri, dsize, upd, rows):
         self.pr('update: ' + uri + ' with ' + str(rows) + ' rows')
         cursor = self.session.open_cursor(uri, None)
         for i in range(1, rows + 1):
-            cursor.set_key(key_populate(cursor, i))
-            my_data = str(i) + ':' + upd * dsize
-            cursor.set_value(my_data)
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = str(i) + ':' + upd * dsize
         cursor.close()
 
     # Compare the original and backed-up files using the wt dump command.

--- a/test/suite/test_base03.py
+++ b/test/suite/test_base03.py
@@ -66,9 +66,7 @@ class test_base03(wttest.WiredTigerTestCase):
         self.pr('creating cursor')
         cursor = self.session.open_cursor('table:' + self.table_name1, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key('key' + str(i))
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor['key' + str(i)] = 'value' + str(i)
 
         i = 0
         cursor.reset()
@@ -89,9 +87,7 @@ class test_base03(wttest.WiredTigerTestCase):
         self.pr('creating cursor')
         cursor = self.session.open_cursor('table:' + self.table_name2, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key('key' + str(i))
-            cursor.set_value(i)
-            cursor.insert()
+            cursor['key' + str(i)] = i
 
         i = 0
         cursor.reset()
@@ -115,9 +111,7 @@ class test_base03(wttest.WiredTigerTestCase):
         self.pr('creating cursor')
         cursor = self.session.open_cursor('table:' + self.table_name3, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(i)
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor[i] = 'value' + str(i)
 
         i = 0
         cursor.reset()
@@ -141,9 +135,7 @@ class test_base03(wttest.WiredTigerTestCase):
         self.pr('stepping')
         for i in range(0, self.nentries):
             self.pr('put %d -> %d' % (i, i))
-            cursor.set_key(i)
-            cursor.set_value(i)
-            cursor.insert()
+            cursor[i] = i
 
         i = 0
         cursor.reset()

--- a/test/suite/test_base04.py
+++ b/test/suite/test_base04.py
@@ -63,9 +63,7 @@ class test_base04(wttest.WiredTigerTestCase):
     def insert(self, key, value):
         self.pr('insert')
         cursor = self.cursor()
-        cursor.set_key(key)
-        cursor.set_value(value)
-        cursor.insert()
+        cursor[key] = value
         cursor.close()
         if self.reconcile:
             self.reopen_conn()

--- a/test/suite/test_base05.py
+++ b/test/suite/test_base05.py
@@ -168,9 +168,7 @@ class test_base05(wttest.WiredTigerTestCase):
             numbers[i] = i
             key = self.mixed_string(i)
             value = self.mixed_string(i+1)
-            cursor.set_key(key)
-            cursor.set_value(value)
-            cursor.insert()
+            cursor[key] = value
 
         # quick spot check to make sure searches work
         for divisor in [3, 5, 7]:
@@ -212,9 +210,7 @@ class test_base05(wttest.WiredTigerTestCase):
                 key = val = unicode(strlist[i])
             else:
                 key = val = strlist[i]
-            cursor.set_key(key)
-            cursor.set_value(val)
-            cursor.insert()
+            cursor[key] = val
 
         for i in range(0, len(strlist)):
             if convert:

--- a/test/suite/test_bug001.py
+++ b/test/suite/test_bug001.py
@@ -43,13 +43,9 @@ class test_bug001(wttest.WiredTigerTestCase):
         r = initial
         for i in range(0, middle):
             r += 1
-            cursor.set_key(r)
-            cursor.set_value(0xab)
-            cursor.insert()
+            cursor[r] = 0xab
         r += trailing
-        cursor.set_key(r + 1)
-        cursor.set_value(0xbb)
-        cursor.insert()
+        cursor[r + 1] = 0xbb
         return (cursor)
 
     # Test a bug where cursor movement inside implicit records failed.

--- a/test/suite/test_bug004.py
+++ b/test/suite/test_bug004.py
@@ -50,9 +50,8 @@ class test_bug004(wttest.WiredTigerTestCase):
         self.session.create(self.uri, self.config)
         c1 = self.session.open_cursor(self.uri, None)
         for i in range(1, self.nentries):
-            c1.set_key(key_populate(c1, i) + 'abcdef' * 100)
-            c1.set_value(value_populate(c1, i) + 'abcdef' * 100)
-            c1.insert()
+            c1[key_populate(c1, i) + 'abcdef' * 100] = \
+                value_populate(c1, i) + 'abcdef' * 100
         c1.close()
 
         # Verify the object, force it to disk, and verify the on-disk version.

--- a/test/suite/test_bug005.py
+++ b/test/suite/test_bug005.py
@@ -43,9 +43,7 @@ class test_bug005(wttest.WiredTigerTestCase):
         self.session.create(self.uri, 'value_format=S,key_format=S')
         cursor = self.session.open_cursor(self.uri, None)
         for i in range(1, 1000):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
         cursor.close()
 
         # Verify the object, force it to disk, and verify the on-disk version.

--- a/test/suite/test_bug006.py
+++ b/test/suite/test_bug006.py
@@ -47,9 +47,7 @@ class test_bug006(wttest.WiredTigerTestCase):
         self.session.create(uri, 'value_format=S,key_format=S')
         cursor = self.session.open_cursor(uri, None)
         for i in range(1, 1000):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Table operations should fail, the cursor is open.
         self.assertRaises(

--- a/test/suite/test_bug008.py
+++ b/test/suite/test_bug008.py
@@ -55,9 +55,7 @@ class test_bug008(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         cursor = self.session.open_cursor(uri, None)
         for i in range(100, 140):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Open a separate session and cursor.
         s = self.conn.open_session()
@@ -113,18 +111,14 @@ class test_bug008(wttest.WiredTigerTestCase):
         # Add some additional visible records.
         cursor = self.session.open_cursor(uri, None)
         for i in range(100, 120):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
         cursor.close()
 
         # Begin a transaction, and add some additional records.
         self.session.begin_transaction()
         cursor = self.session.open_cursor(uri, None)
         for i in range(120, 140):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Open a separate session and cursor.
         s = self.conn.open_session()

--- a/test/suite/test_bug009.py
+++ b/test/suite/test_bug009.py
@@ -55,13 +55,8 @@ class test_bug009(wttest.WiredTigerTestCase):
         # Insert two items with keys that will be prefix compressed and data
         # items sized so that the compression size difference tips the
         # size over a page boundary.
-        cursor.set_key('fill_2__b_27')
-        cursor.set_value(2294 * '0')
-        cursor.insert()
-
-        cursor.set_key('fill_2__b_28')
-        cursor.set_value(3022 * '0')
-        cursor.insert()
+        cursor['fill_2__b_27'] = '0' * 2294
+        cursor['fill_2__b_28'] = '0' * 3022
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug010.py
+++ b/test/suite/test_bug010.py
@@ -59,9 +59,7 @@ class test_bug010(wttest.WiredTigerTestCase):
             self.session.create(self.uri + str(i),
             'key_format=S,value_format=i')
             c = self.session.open_cursor(self.uri + str(i), None)
-            c.set_key('a')
-            c.set_value(0)
-            c.insert()
+            c['a'] = 0
             c.close()
 
         self.session.checkpoint()
@@ -79,9 +77,7 @@ class test_bug010(wttest.WiredTigerTestCase):
                 expected_val += 1
                 for i in range(0, self.num_tables):
                     c = self.session.open_cursor(self.uri + str(i), None)
-                    c.set_key('a')
-                    c.set_value(expected_val)
-                    c.insert()
+                    c['a'] = expected_val
                     c.close()
             finally:
                 done.set()

--- a/test/suite/test_bulk01.py
+++ b/test/suite/test_bulk01.py
@@ -61,9 +61,7 @@ class test_bulk_load(wttest.WiredTigerTestCase):
             'key_format=' + self.keyfmt + ',value_format=' + self.valfmt)
         cursor = self.session.open_cursor(uri, None, "bulk")
         for i in range(1, 100):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
         cursor.close()
 
 
@@ -81,9 +79,8 @@ class test_bulk_load_row_order(wttest.WiredTigerTestCase):
         uri = self.type + self.name
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri, None, "bulk")
-        cursor.set_key(key_populate(cursor, 10))
-        cursor.set_value(value_populate(cursor, 10))
-        cursor.insert()
+        cursor[key_populate(cursor, 10)] = value_populate(cursor, 10)
+
         cursor.set_key(key_populate(cursor, 1))
         cursor.set_value(value_populate(cursor, 1))
         msg = '/compares smaller than previously inserted key/'
@@ -94,12 +91,8 @@ class test_bulk_load_row_order(wttest.WiredTigerTestCase):
         uri = self.type + self.name
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri, None, "bulk,skip_sort_check")
-        cursor.set_key(key_populate(cursor, 10))
-        cursor.set_value(value_populate(cursor, 10))
-        cursor.insert()
-        cursor.set_key(key_populate(cursor, 1))
-        cursor.set_value(value_populate(cursor, 1))
-        cursor.insert()
+        cursor[key_populate(cursor, 10)] = value_populate(cursor, 10)
+        cursor[key_populate(cursor, 1)] = value_populate(cursor, 1)
 
         if not wiredtiger.diagnostic_build():
             self.skipTest('requires a diagnostic build')
@@ -123,9 +116,7 @@ class test_bulk_load_not_empty(wttest.WiredTigerTestCase):
         uri = self.type + self.name
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri, None)
-        cursor.set_key(key_populate(cursor, 1))
-        cursor.set_value(value_populate(cursor, 1))
-        cursor.insert()
+        cursor[key_populate(cursor, 1)] = value_populate(cursor, 1)
         # Close the insert cursor, else we'll get EBUSY.
         cursor.close()
         msg = '/bulk-load is only supported on newly created objects/'
@@ -136,9 +127,7 @@ class test_bulk_load_not_empty(wttest.WiredTigerTestCase):
         uri = self.type + self.name
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri, None)
-        cursor.set_key(key_populate(cursor, 1))
-        cursor.set_value(value_populate(cursor, 1))
-        cursor.insert()
+        cursor[key_populate(cursor, 1)] = value_populate(cursor, 1)
         # Don't close the insert cursor, we want EBUSY.
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(uri, None, "bulk"))

--- a/test/suite/test_bulk02.py
+++ b/test/suite/test_bulk02.py
@@ -57,9 +57,7 @@ class test_bulkload_checkpoint(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(self.uri, None, 'bulk')
         for i in range(1, 10):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Checkpoint a few times (to test the drop code).
         for i in range(1, 5):
@@ -117,9 +115,7 @@ class test_bulkload_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(self.uri, None, 'bulk')
         for i in range(1, 10):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Test without a checkpoint, with an unnamed checkpoint, with a named
         # checkpoint.

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -59,9 +59,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(self.uri, None, "overwrite")
         start, stop = self.checkpoints[name][0]
         for i in range(start, stop+1):
-            cursor.set_key("%010d KEY------" % i)
-            cursor.set_value("%010d VALUE "% i + name)
-            self.assertEqual(cursor.insert(), 0)
+            cursor["%010d KEY------" % i] = ("%010d VALUE " % i) + name
         cursor.close()
         self.checkpoints[name] = (self.checkpoints[name][0], 1)
 
@@ -214,9 +212,7 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
 
     def update(self, uri, value):
         cursor = self.session.open_cursor(uri, None, "overwrite")
-        cursor.set_key(key_populate(cursor, 10))
-        cursor.set_value(value)
-        cursor.insert()
+        cursor[key_populate(cursor, 10)] = value
         cursor.close()
 
     def check(self, uri, value):
@@ -293,9 +289,7 @@ class test_checkpoint_last(wttest.WiredTigerTestCase):
         for value in ('FIRST', 'SECOND', 'THIRD', 'FOURTH', 'FIFTH'):
             # Update the object.
             cursor = self.session.open_cursor(uri, None, "overwrite")
-            cursor.set_key(key_populate(cursor, 10))
-            cursor.set_value(value)
-            cursor.insert()
+            cursor[key_populate(cursor, 10)] = value
             cursor.close()
 
             # Checkpoint the object.
@@ -397,9 +391,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None)
-        cursor.set_key("key")
-        cursor.set_value("value")
-        cursor.insert()
+        cursor["key"] = "value"
         self.session.checkpoint()
 
         cursor = self.session.open_cursor(self.uri, None, "checkpoint=ckpt")
@@ -414,9 +406,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None)
-        cursor.set_key("key")
-        cursor.set_value("value")
-        cursor.insert()
+        cursor["key"] = "value"
         self.session.checkpoint('name=ckpt')
 
         cursor = self.session.open_cursor(

--- a/test/suite/test_config02.py
+++ b/test/suite/test_config02.py
@@ -51,9 +51,7 @@ class test_config02(wttest.WiredTigerTestCase):
         self.session.create("table:" + self.table_name1, create_args)
         cursor = self.session.open_cursor('table:' + self.table_name1, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(str(1000000 + i))
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor[str(1000000 + i)] = 'value' + str(i)
         i = 0
         cursor.reset()
         for key, value in cursor:

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -58,9 +58,7 @@ class test_config04(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(
             'table:' + self.table_name1, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(str(1000000 + i))
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor[str(1000000 + i)] = 'value' + str(i)
         i = 0
         cursor.reset()
         for key, value in cursor:

--- a/test/suite/test_config05.py
+++ b/test/suite/test_config05.py
@@ -58,9 +58,7 @@ class test_config05(wttest.WiredTigerTestCase):
         session.create("table:" + self.table_name1, create_args)
         cursor = session.open_cursor('table:' + self.table_name1, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(str(1000000 + i))
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor[str(1000000 + i)] = 'value' + str(i)
         cursor.close()
 
     def verify_entries(self, session):

--- a/test/suite/test_cursor01.py
+++ b/test/suite/test_cursor01.py
@@ -101,9 +101,7 @@ class test_cursor01(wttest.WiredTigerTestCase):
         self.assertCursorHasNoKeyValue(cursor)
 
         for i in range(0, self.nentries):
-            cursor.set_key(self.genkey(i))
-            cursor.set_value(self.genvalue(i))
-            cursor.insert()
+            cursor[self.genkey(i)] = self.genvalue(i)
 
         return cursor
 

--- a/test/suite/test_cursor04.py
+++ b/test/suite/test_cursor04.py
@@ -125,9 +125,7 @@ class test_cursor04(wttest.WiredTigerTestCase):
 
         # 0. Populate the key space
         for i in range(0, self.nentries):
-            cursor.set_key(self.genkey(i))
-            cursor.set_value(self.genvalue(i))
-            cursor.insert()
+            cursor[self.genkey(i)] = self.genvalue(i)
 
         # 1. Calling search for a value that exists
         self.assertEqual(cursor[self.genkey(5)], self.genvalue(5))

--- a/test/suite/test_cursor05.py
+++ b/test/suite/test_cursor05.py
@@ -41,9 +41,7 @@ class test_cursor05(wttest.WiredTigerTestCase):
         """ Populate the given number of entries. """
         cursor = self.session.open_cursor('table:main', None, None)
         for i in range(0, count):
-            cursor.set_key(i, 'key' + str(i))
-            cursor.set_value('val' + str(i), i, 'val' + str(i), i)
-            cursor.insert()
+            cursor[(i, 'key' + str(i))] = ('val' + str(i), i, 'val' + str(i), i)
         cursor.close()
 
     def check_iterate_forward(self, cursor, expectcount):

--- a/test/suite/test_cursor07.py
+++ b/test/suite/test_cursor07.py
@@ -75,9 +75,7 @@ class test_cursor07(wttest.WiredTigerTestCase, suite_subprocess):
 
         self.session.begin_transaction()
         for k in range(self.nkeys):
-            c.set_key(k)
-            c.set_value(value)
-            c.insert()
+            c[k] = value
         self.session.commit_transaction()
         c.close()
 

--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -64,10 +64,8 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         uri = self.type + 'random'
         self.session.create(uri, 'key_format=' + self.fmt + ',value_format=S')
         cursor = self.session.open_cursor(uri, None)
-        cursor.set_key('AAA')
-        cursor.set_value('BBB')
-        cursor.insert()
-        cursor.close
+        cursor['AAA'] = 'BBB'
+        cursor.close()
         cursor = self.session.open_cursor(uri, None, "next_random=true")
         for i in range(1,5):
             cursor.next()
@@ -149,9 +147,7 @@ class test_cursor_random_invisible(wttest.WiredTigerTestCase):
         # Start a transaction.
         self.session.begin_transaction()
         for i in range(1, 100):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Open another session, the updates won't yet be visible, we shouldn't
         # find anything at all.
@@ -165,16 +161,12 @@ class test_cursor_random_invisible(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None)
 
         # Insert a single leading record.
-        cursor.set_key(key_populate(cursor, 1))
-        cursor.set_value(value_populate(cursor, 1))
-        cursor.insert()
+        cursor[key_populate(cursor, 1)] = value_populate(cursor, 1)
 
         # Start a transaction.
         self.session.begin_transaction()
         for i in range(2, 100):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Open another session, the updates won't yet be visible, we should
         # return the only possible record.
@@ -189,16 +181,12 @@ class test_cursor_random_invisible(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None)
 
         # Insert a single leading record.
-        cursor.set_key(key_populate(cursor, 99))
-        cursor.set_value(value_populate(cursor, 99))
-        cursor.insert()
+        cursor[key_populate(cursor, 99)] = value_populate(cursor, 99)
 
         # Start a transaction.
         self.session.begin_transaction()
         for i in range(2, 100):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value_populate(cursor, i))
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value_populate(cursor, i)
 
         # Open another session, the updates won't yet be visible, we should
         # return the only possible record.

--- a/test/suite/test_cursor_tracker.py
+++ b/test/suite/test_cursor_tracker.py
@@ -156,12 +156,8 @@ class TestCursorTracker(wttest.WiredTigerTestCase):
             for i in range(npairs):
                 wtkey = self.encode_key(i << 32)
                 wtval = self.encode_value(i << 32)
-                self.traceapi('cursor.set_key(' + str(wtkey) + ')')
-                cursor.set_key(wtkey)
-                self.traceapi('cursor.set_value(' + str(wtval) + ')')
-                cursor.set_value(wtval)
-                self.traceapi('cursor.insert()')
-                cursor.insert()
+                self.traceapi('cursor[' + str(wtkey) + '] = ' + str(wtval))
+                cursor[wtkey] = wtval
             cursor.close()
             self.pr('reopening the connection')
             self.conn.close()
@@ -316,12 +312,8 @@ class TestCursorTracker(wttest.WiredTigerTestCase):
         self.setpos(pos, True)
         wtkey = self.encode_key(bits)
         wtval = self.encode_value(bits)
-        self.traceapi('cursor.set_key(' + str(wtkey) + ')')
-        cursor.set_key(wtkey)
-        self.traceapi('cursor.set_value(' + str(wtval) + ')')
-        cursor.set_value(wtval)
-        self.traceapi('cursor.insert()')
-        cursor.insert()
+        self.traceapi('cursor[' + str(wtkey) + '] = ' + str(wtval))
+        cursor[wtkey] = wtval
 
     def cur_remove_here(self, cursor):
         # TODO: handle the exception case

--- a/test/suite/test_drop_create.py
+++ b/test/suite/test_drop_create.py
@@ -63,9 +63,7 @@ class test_drop_create(wttest.WiredTigerTestCase):
         # Create a table with the same name, but a different schema
         self.assertEqual(s.create("table:test", 'key_format=S,value_format=l,columns=(k,v)'), 0)
         c2 = s2.open_cursor("table:test", None, None)
-        c2.set_key("Hi")
-        c2.set_value(1)
-        c2.insert()
+        c2["Hi"] = 1
         self.assertEqual(s.close(), 0)
         self.assertEqual(s2.close(), 0)
 

--- a/test/suite/test_durability01.py
+++ b/test/suite/test_durability01.py
@@ -73,9 +73,7 @@ class test_durability01(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create(self.uri, self.create_params)
         for i in range(100):
             c = self.session.open_cursor(self.uri)
-            c.set_key(i)
-            c.set_value(i)
-            c.insert()
+            c[i] = i
             c.close()
             if i % 5 == 0:
                 self.session.checkpoint()

--- a/test/suite/test_empty.py
+++ b/test/suite/test_empty.py
@@ -64,10 +64,9 @@ class test_empty(wttest.WiredTigerTestCase):
         # Add a few records to the object and remove them.
         cursor = self.session.open_cursor(uri, None, None)
         for i in range(1,5):
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value("XXX")
-            cursor.insert()
-            cursor.remove()
+            key = key_populate(cursor, i)
+            cursor[key] = "XXX"
+            del cursor[key]
 
         # Perform a checkpoint (we shouldn't write any underlying pages because
         # of a checkpoint, either).

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -42,18 +42,14 @@ class test_jsondump02(wttest.WiredTigerTestCase):
     def set_kv(self, uri, key, val):
         cursor = self.session.open_cursor(uri, None, None)
         try:
-            cursor.set_key(key)
-            cursor.set_value(val)
-            cursor.insert()
+            cursor[key] = val
         finally:
             cursor.close()
 
     def set_kv2(self, uri, key, val1, val2):
         cursor = self.session.open_cursor(uri, None, None)
         try:
-            cursor.set_key(key)
-            cursor.set_value(val1, val2)
-            cursor.insert()
+            cursor[key] = (val1, val2)
         finally:
             cursor.close()
 
@@ -61,11 +57,10 @@ class test_jsondump02(wttest.WiredTigerTestCase):
     def populate_squarecube(self, uri):
         cursor = self.session.open_cursor(uri, None, None)
         for i in range(1, 5):
-            cursor.set_key(i, 'key' + str(i))
             square = i * i
             cube = square * i
-            cursor.set_value('val' + str(square), square, 'val' + str(cube), cube)
-            cursor.insert()
+            cursor[(i, 'key' + str(i))] = \
+                ('val' + str(square), square, 'val' + str(cube), cube)
         cursor.close()
 
     # Check the result of using a JSON cursor on the URI.
@@ -86,9 +81,7 @@ class test_jsondump02(wttest.WiredTigerTestCase):
         try:
             for insert in inserts:
                 #tty_pr('Insert: ' + str(insert))
-                cursor.set_key(insert[0])
-                cursor.set_value(insert[1])
-                cursor.insert()
+                cursor[insert[0]] = insert[1]
         finally:
             cursor.close()
         

--- a/test/suite/test_lsm02.py
+++ b/test/suite/test_lsm02.py
@@ -36,9 +36,7 @@ class test_lsm02(wttest.WiredTigerTestCase):
 
     def add_key(self, uri, key, value):
         cursor = self.session.open_cursor(uri, None, None)
-        cursor.set_key(key)
-        cursor.set_value(value)
-        cursor.insert()
+        cursor[key] = value
         cursor.close()
 
     def verify_key_exists(self, uri, key, value):

--- a/test/suite/test_perf001.py
+++ b/test/suite/test_perf001.py
@@ -51,12 +51,7 @@ class test_perf001(wttest.WiredTigerTestCase):
         self.pr(`conn`)
         return conn
 
-    def insert_one(self, c, k1, v1, v2):
-        c.set_key(k1)
-        c.set_value(v1, v2)
-        self.assertEqual(c.insert(), 0)
-
-    def test_performance_of_indeces(self):
+    def test_performance_of_indices(self):
         uri = 'table:' + self.table_name
         create_args = 'key_format=i,value_format=ii,columns=(a,c,d),type=' + self.tabletype
         self.session.create(uri, create_args)
@@ -72,7 +67,7 @@ class test_perf001(wttest.WiredTigerTestCase):
                 end_time = clock()
                 self.assertTrue(end_time - start_time < 5)
                 start_time = end_time
-            self.insert_one(c, i, int(time()), random.randint(1,5))
+            c[i] = (int(time()), random.randint(1,5))
         c.close()
 
 if __name__ == '__main__':

--- a/test/suite/test_priv01.py
+++ b/test/suite/test_priv01.py
@@ -67,9 +67,7 @@ class test_priv01(wttest.WiredTigerTestCase):
         self.session.create("table:" + self.table_name1, create_args)
         cursor = self.session.open_cursor('table:' + self.table_name1, None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(str(1000000 + i))
-            cursor.set_value('value' + str(i))
-            cursor.insert()
+            cursor[str(1000000 + i)] = 'value' + str(i)
         i = 0
         cursor.reset()
         for key, value in cursor:

--- a/test/suite/test_salvage.py
+++ b/test/suite/test_salvage.py
@@ -50,9 +50,7 @@ class test_salvage(wttest.WiredTigerTestCase, suite_subprocess):
                 val = self.unique + '0'
             else:
                 val = key + key
-            cursor.set_key(key)
-            cursor.set_value(val)
-            cursor.insert()
+            cursor[key] = val
         cursor.close()
 
     def check_populate(self, tablename):

--- a/test/suite/test_schema01.py
+++ b/test/suite/test_schema01.py
@@ -84,9 +84,7 @@ class test_schema01(wttest.WiredTigerTestCase):
             c = self.cursor('overwrite')
             try:
                 for record in pop_data:
-                    c.set_key(record[0])
-                    c.set_value(*record[1:])
-                    c.insert()
+                    c[record[0]] = record[1:]
             finally:
                 c.close()
 

--- a/test/suite/test_schema02.py
+++ b/test/suite/test_schema02.py
@@ -167,11 +167,10 @@ class test_schema02(wttest.WiredTigerTestCase):
     def populate(self):
         cursor = self.session.open_cursor('table:main', None, None)
         for i in range(0, self.nentries):
-            cursor.set_key(i, 'key' + str(i))
             square = i * i
             cube = square * i
-            cursor.set_value('val' + str(square), square, 'val' + str(cube), cube)
-            cursor.insert()
+            cursor[(i, 'key' + str(i))] = \
+                ('val' + str(square), square, 'val' + str(cube), cube)
         cursor.close()
         
     def check_entries(self):

--- a/test/suite/test_shared_cache01.py
+++ b/test/suite/test_shared_cache01.py
@@ -46,9 +46,7 @@ class test_shared_cache01(wttest.WiredTigerTestCase):
     def add_records(self, session, start, stop):
         cursor = session.open_cursor(self.uri, None, "overwrite")
         for i in range(start, stop+1):
-            cursor.set_key("%010d KEY------" % i)
-            cursor.set_value("%010d VALUE "% i + self.data_str)
-            self.assertEqual(cursor.insert(), 0)
+            cursor["%010d KEY------" % i] = ("%010d VALUE " % i) + self.data_str
         cursor.close()
 
     # Disable default setup/shutdown steps - connections are managed manually.

--- a/test/suite/test_shared_cache02.py
+++ b/test/suite/test_shared_cache02.py
@@ -46,9 +46,7 @@ class test_shared_cache02(wttest.WiredTigerTestCase):
     def add_records(self, session, start, stop):
         cursor = session.open_cursor(self.uri, None, "overwrite")
         for i in range(start, stop+1):
-            cursor.set_key("%010d KEY------" % i)
-            cursor.set_value("%010d VALUE "% i + self.data_str)
-            self.assertEqual(cursor.insert(), 0)
+            cursor["%010d KEY------" % i] = ("%010d VALUE " % i) + self.data_str
         cursor.close()
 
     # Disable default setup/shutdown steps - connections are managed manually.

--- a/test/suite/test_split.py
+++ b/test/suite/test_split.py
@@ -52,9 +52,7 @@ class test_split(wttest.WiredTigerTestCase):
         # Create a 4KB page (more than 3KB): 40 records w / 10 byte keys
         # and 81 byte values.
         for i in range(40):
-            cursor.set_key('%09d' % i)
-            cursor.set_value(8 * ('%010d' % i))
-            cursor.insert()
+            cursor['%09d' % i] = 8 * ('%010d' % i)
 
         # Stabilize
         self.reopen_conn()
@@ -66,9 +64,7 @@ class test_split(wttest.WiredTigerTestCase):
         # Now append a few records so we're definitely (a little) over 4KB
         cursor = self.session.open_cursor(self.uri, None)
         for i in range(50,55):
-            cursor.set_key('%09d' % i)
-            cursor.set_value(8 * ('%010d' % i))
-            cursor.insert()
+            cursor['%09d' % i] = 8 * ('%010d' % i)
 
         # Stabilize
         self.reopen_conn()
@@ -80,9 +76,7 @@ class test_split(wttest.WiredTigerTestCase):
         # Now insert some more records in between
         cursor = self.session.open_cursor(self.uri, None)
         for i in range(40,45):
-            cursor.set_key('%09d' % i)
-            cursor.set_value(8 * ('%010d' % i))
-            cursor.insert()
+            cursor['%09d' % i] = 8 * ('%010d' % i)
 
         # Stabilize
         self.reopen_conn()

--- a/test/suite/test_stat01.py
+++ b/test/suite/test_stat01.py
@@ -117,9 +117,7 @@ class test_stat01(wttest.WiredTigerTestCase):
         value = ""
         for i in range(1, self.nentries):
             value = value + 1000 * "a"
-            cursor.set_key(key_populate(cursor, i))
-            cursor.set_value(value)
-            cursor.insert()
+            cursor[key_populate(cursor, i)] = value
         cursor.close()
 
         # Force the object to disk, otherwise we can't check the overflow count.

--- a/test/suite/test_stat04.py
+++ b/test/suite/test_stat04.py
@@ -95,9 +95,7 @@ class test_stat04(wttest.WiredTigerTestCase, suite_subprocess):
         for i in range(0, self.nentries):
             if count % 50 == 0:
                 self.checkcount(uri, count)
-            cursor.set_key(self.genkey(i))
-            cursor.set_value(self.genvalue(i))
-            cursor.insert()
+            cursor[self.genkey(i)] = self.genvalue(i)
             count += 1
         # Remove a number of entries, at each step checking that stats match.
         for i in range(0, self.nentries / 37):

--- a/test/suite/test_sweep01.py
+++ b/test/suite/test_sweep01.py
@@ -86,10 +86,8 @@ class test_sweep01(wttest.WiredTigerTestCase, suite_subprocess):
             # print "Creating %s with config '%s'" % (uri, self.create_params)
             self.session.create(uri, self.create_params)
             c = self.session.open_cursor(uri, None)
-            c.set_value(1)
             for k in range(self.numkv):
-                c.set_key(k+1)
-                c.insert()
+                c[k+1] = 1
             c.close()
             if f % 20 == 0:
                 time.sleep(1)
@@ -123,9 +121,7 @@ class test_sweep01(wttest.WiredTigerTestCase, suite_subprocess):
         sleep = 0
         while sleep < 12:
             k = k+1
-            c.set_key(k)
-            c.set_value(1)
-            c.insert()
+            c[k] = 1
             sleep += 2
             time.sleep(2)
         c.close()

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -346,9 +346,7 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
                 for i in range(start + 1, stop + 1):
                     k = key_populate(cursor, i)
                     v = value_populate(cursor, i)
-                    cursor.set_key(k)
-                    cursor.set_value(v)
-                    cursor.insert()
+                    cursor[k] = v
                     expected[k] = [v]
                 cursor.close()
 
@@ -370,9 +368,7 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
                     start += 1
                     k = key_populate(cursor, start)
                     v = value_populate(cursor, start)
-                    cursor.set_key(k)
-                    cursor.set_value(v)
-                    cursor.insert()
+                    cursor[k] = v
                     expected[k] = [v]
 
                 # Optionally insert trailing skipped records.
@@ -386,9 +382,7 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
                     stop += 1
                     k = key_populate(cursor, stop)
                     v = value_populate(cursor, stop)
-                    cursor.set_key(k)
-                    cursor.set_value(v)
-                    cursor.insert()
+                    cursor[k] = v
                     expected[k] = [v]
                 cursor.close()
 

--- a/test/suite/test_truncate03.py
+++ b/test/suite/test_truncate03.py
@@ -113,9 +113,7 @@ class test_truncate_address_deleted(wttest.WiredTigerTestCase):
         for i in range(3000, 7000, 137):
             k = key_populate(cursor, i)
             v = 'changed value: ' + str(i)
-            cursor.set_key(k)
-            cursor.set_value(v)
-            self.assertEqual(cursor.insert(), 0)
+            cursor[k] = v
         for i in range(3000, 7000, 137):
             k = key_populate(cursor, i)
             v = 'changed value: ' + str(i)

--- a/test/suite/test_txn01.py
+++ b/test/suite/test_txn01.py
@@ -154,14 +154,10 @@ class test_read_committed_default(wttest.WiredTigerTestCase):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(self.uri, None)
         self.session.begin_transaction()
-        cursor.set_key('key: aaa')
-        cursor.set_value('value: aaa')
-        cursor.insert()
+        cursor['key: aaa'] = 'value: aaa'
         self.session.commit_transaction()
         self.session.begin_transaction()
-        cursor.set_key('key: bbb')
-        cursor.set_value('value: bbb')
-        cursor.insert()
+        cursor['key: bbb'] = 'value: bbb'
 
         s = self.conn.open_session()
         cursor = s.open_cursor(self.uri, None)

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -204,15 +204,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         # Set up the table with entries for 1, 2, 10 and 11.
         # We use the overwrite config so insert can update as needed.
         c = self.session.open_cursor(self.uri, None, 'overwrite')
-        c.set_value(1)
-        c.set_key(1)
-        c.insert()
-        c.set_key(2)
-        c.insert()
-        c.set_key(10)
-        c.insert()
-        c.set_key(11)
-        c.insert()
+        c[1] = c[2] = c[10] = c[11] = 1
         current = {1:1, 2:1, 10:1, 11:1}
         committed = current.copy()
 
@@ -238,13 +230,8 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             k1 = k + 1
             # print '%d: %s(%d)[%s]' % (i, ok[0], ok[1], txn)
             if op == 'insert' or op == 'update':
-                c.set_value(i + 2)
-                c.set_key(k)
-                c.insert()
-                c.set_key(k1)
-                c.insert()
-                current[k] = i + 2
-                current[k1] = i + 2
+                c[k] = c[k1] = i + 2
+                current[k] = current[k1] = i + 2
             elif op == 'remove':
                 c.set_key(k)
                 c.remove()

--- a/test/suite/test_txn03.py
+++ b/test/suite/test_txn03.py
@@ -59,23 +59,17 @@ class test_txn03(wttest.WiredTigerTestCase):
         # Set up the table with entries for 1 and 10
         # We use the overwrite config so insert can update as needed.
         c = self.session.open_cursor(self.uri1, None, 'overwrite')
-        c.set_value(self.data_str1)
-        c.set_key(self.key_str)
-        c.insert()
+        c[self.key_str] = self.data_str1
         c.close()
         c = self.session.open_cursor(self.uri2, None, 'overwrite')
-        c.set_value(self.data_str1)
-        c.set_key(self.key_str)
-        c.insert()
+        c[self.key_str] = self.data_str1
         c.close()
 
         # Update the first table - this update should be visible in the
         # new session.
         self.session.begin_transaction()
         c = self.session.open_cursor(self.uri1, None, 'overwrite')
-        c.set_value(self.data_str2)
-        c.set_key(self.key_str)
-        c.insert()
+        c[self.key_str] = self.data_str2
         self.session.commit_transaction()
         c.close()
 
@@ -88,9 +82,7 @@ class test_txn03(wttest.WiredTigerTestCase):
         # Make an update in the first session.
         self.session.begin_transaction()
         c = self.session.open_cursor(self.uri2, None, 'overwrite')
-        c.set_value(self.data_str2)
-        c.set_key(self.key_str)
-        c.insert()
+        c[self.key_str] = self.data_str2
         self.session.commit_transaction()
         c.close()
 

--- a/test/suite/test_txn04.py
+++ b/test/suite/test_txn04.py
@@ -139,10 +139,8 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
         # We then truncate starting or ending in various places.
         # We use the overwrite config so insert can update as needed.
         current = {1:1, 2:1, 3:1, 4:1, 5:1}
-        c.set_value(1)
         for k in current:
-            c.set_key(k)
-            c.insert()
+            c[k] = 1
         committed = current.copy()
 
         ops = (self.op1, )
@@ -163,9 +161,7 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
             
             # print '%d: %s(%d)[%s]' % (i, ok[0], ok[1], txn)
             if op == 'insert' or op == 'update':
-                c.set_value(i + 2)
-                c.set_key(k)
-                c.insert()
+                c[k] = i + 2
                 current[k] = i + 2
             elif op == 'remove':
                 c.set_key(k)

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -170,10 +170,8 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         # We then truncate starting or ending in various places.
         c = self.session.open_cursor(self.uri, None)
         current = {1:1, 2:1, 3:1, 4:1, 5:1}
-        c.set_value(1)
         for k in current:
-            c.set_key(k)
-            c.insert()
+            c[k] = 1
         committed = current.copy()
 
         ops = (self.op1, )

--- a/test/suite/test_txn06.py
+++ b/test/suite/test_txn06.py
@@ -55,9 +55,7 @@ class test_txn06(wttest.WiredTigerTestCase, suite_subprocess):
         c_src = self.session.open_cursor(self.source_uri)
         c = self.session.open_cursor(self.uri)
         for k, v in c_src:
-            c.set_key(k)
-            c.set_value(v)
-            c.insert()
+            c[k] = v
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -160,10 +160,8 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             # Choose large compressible values for the string cases.
             value = 'abc' * 1000000
         current = {1:value, 2:value, 3:value, 4:value, 5:value}
-        c.set_value(value)
         for k in current:
-            c.set_key(k)
-            c.insert()
+            c[k] = value
         committed = current.copy()
 
         ops = (self.op1, )

--- a/test/suite/test_txn08.py
+++ b/test/suite/test_txn08.py
@@ -72,9 +72,7 @@ class test_txn08(wttest.WiredTigerTestCase, suite_subprocess):
 
         self.session.begin_transaction()
         for k in range(5):
-            c.set_key(k)
-            c.set_value(value)
-            c.insert()
+            c[k] = value
 
         self.session.commit_transaction()
 

--- a/test/suite/test_txn09.py
+++ b/test/suite/test_txn09.py
@@ -128,15 +128,7 @@ class test_txn09(wttest.WiredTigerTestCase, suite_subprocess):
         # Set up the table with entries for 1, 2, 10 and 11.
         # We use the overwrite config so insert can update as needed.
         c = self.session.open_cursor(self.uri, None, 'overwrite')
-        c.set_value(1)
-        c.set_key(1)
-        c.insert()
-        c.set_key(2)
-        c.insert()
-        c.set_key(10)
-        c.insert()
-        c.set_key(11)
-        c.insert()
+        c[1] = c[2] = c[10] = c[11] = 1
         current = {1:1, 2:1, 10:1, 11:1}
         committed = current.copy()
 
@@ -160,18 +152,11 @@ class test_txn09(wttest.WiredTigerTestCase, suite_subprocess):
             k1 = k + 1
             # print '%d: %s(%d)[%s]' % (i, ok[0], ok[1], txn)
             if op == 'insert' or op == 'update':
-                c.set_value(i + 2)
-                c.set_key(k)
-                c.insert()
-                c.set_key(k1)
-                c.insert()
-                current[k] = i + 2
-                current[k1] = i + 2
+                c[k] = c[k1] = i + 2
+                current[k] = current[k1] = i + 2
             elif op == 'remove':
-                c.set_key(k)
-                c.remove()
-                c.set_key(k1)
-                c.remove()
+                del c[k]
+                del c[k1]
                 if k in current:
                     del current[k]
                 if k1 in current:

--- a/test/suite/test_txn10.py
+++ b/test/suite/test_txn10.py
@@ -80,9 +80,7 @@ class test_txn10(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create(self.t2, self.create_params)
         c = self.session.open_cursor(self.t2, None, None)
         for i in range(10000):
-            c.set_key(i)
-            c.set_value(i+1)
-            c.insert()
+            c[i] = i + 1
         c.close()
         self.simulate_crash_restart(".", "RESTART")
         c = self.session.open_cursor(self.t2, None, None)

--- a/test/suite/test_util01.py
+++ b/test/suite/test_util01.py
@@ -145,9 +145,7 @@ class test_util01(wttest.WiredTigerTestCase, suite_subprocess):
             for i in range(0, self.nentries):
                 key = self.get_key(i)
                 value = self.get_value(i)
-                cursor.set_key(key)
-                cursor.set_value(value)
-                cursor.insert()
+                cursor[key] = value
                 expectout.write(self.dumpstr(key, hexoutput))
                 expectout.write(self.dumpstr(value, hexoutput))
         cursor.close()

--- a/test/suite/test_util02.py
+++ b/test/suite/test_util02.py
@@ -128,11 +128,7 @@ class test_util02(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create('table:' + self.tablename, params)
         cursor = self.session.open_cursor('table:' + self.tablename, None, None)
         for i in range(0, self.nentries):
-            key = self.get_key(i)
-            value = self.get_value(i)
-            cursor.set_key(key)
-            cursor.set_value(value)
-            cursor.insert()
+            cursor[self.get_key(i)] = self.get_value(i)
         cursor.close()
 
         dumpargs = ["dump"]

--- a/test/suite/test_util07.py
+++ b/test/suite/test_util07.py
@@ -45,9 +45,7 @@ class test_util07(wttest.WiredTigerTestCase, suite_subprocess):
         for i in range(0, self.nentries):
             key = 'KEY' + str(i)
             val = 'VAL' + str(i)
-            cursor.set_key(key)
-            cursor.set_value(val)
-            cursor.insert()
+            cursor[key] = val
         cursor.close()
 
     def close_conn(self):

--- a/test/suite/test_util11.py
+++ b/test/suite/test_util11.py
@@ -41,9 +41,7 @@ class test_util11(wttest.WiredTigerTestCase, suite_subprocess):
         Insert some simple entries into the table
         """
         cursor = self.session.open_cursor('table:' + tablename, None, None)
-        cursor.set_key('SOMEKEY')
-        cursor.set_value('SOMEVALUE')
-        cursor.insert()
+        cursor['SOMEKEY'] = 'SOMEVALUE'
         cursor.close()
 
     def test_list_none(self):

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -44,10 +44,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         key = ''
         for i in range(0, self.nentries):
             key += str(i)
-            val = key + key
-            cursor.set_key(key)
-            cursor.set_value(val)
-            cursor.insert()
+            cursor[key] = key + key
         cursor.close()
 
     def check_populate(self, tablename):

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -126,9 +126,7 @@ class op_thread(threading.Thread):
                 if op == 'gi': # Group insert a number of tables.
                     sess.begin_transaction()
                     for next_cur in cursors:
-                        next_cur.set_key(key)
-                        next_cur.set_value(value)
-                        next_cur.insert()
+                        next_cur[key] = value
                     sess.commit_transaction()
                 if op == 'gu': # Group update a number of tables.
                     sess.begin_transaction()
@@ -139,9 +137,7 @@ class op_thread(threading.Thread):
                         next_cur.reset()
                     sess.commit_transaction()
                 if op == 'i': # Insert an item
-                    c.set_key(key)
-                    c.set_value(value)
-                    c.insert()
+                    c[key] = value
                 elif op == 'b': # Bounce the session handle.
                     c.close()
                     sess.close()
@@ -159,9 +155,7 @@ class op_thread(threading.Thread):
                         "key_format=" + self.key_fmt + ",value_format=S")
                     try:
                         c2 = sess.open_cursor(self.uris[0] + str(key), None, None)
-                        c2.set_key(key)
-                        c2.set_value(value)
-                        c2.insert()
+                        c2[key] = value
                         c2.close()
                     except wiredtiger.WiredTigerError as e:
                         # These operations can fail, if the drop in another


### PR DESCRIPTION
Remove lots of boilerplate c.set_key ... c.set_value ... c.insert code.