### PR TITLE
Reset eol if we continue.  Return NOTFOUND if checksum mismatch. #1840

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1370,6 +1370,7 @@ advance:
 			WT_ERR(__log_openfile(
 			    session, 0, &log_fh, WT_LOG_FILENAME, rd_lsn.file));
 			WT_ERR(__log_filesize(session, log_fh, &log_size));
+			eol = 0;
 			continue;
 		}
 		/*
@@ -1432,6 +1433,12 @@ advance:
 			 */
 			if (log != NULL)
 				log->trunc_lsn = rd_lsn;
+			/*
+			 * If the user asked for a specific LSN and it is not
+			 * a valid LSN, return WT_NOTFOUND.
+			 */
+			if (LF_ISSET(WT_LOGSCAN_ONE))
+				ret = WT_NOTFOUND;
 			break;
 		}
 

--- a/test/suite/test_cursor07.py
+++ b/test/suite/test_cursor07.py
@@ -40,7 +40,9 @@ class test_cursor07(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = "100K"
     tablename = 'test_cursor07'
     uri = 'table:' + tablename
-    nkeys = 5
+    #  A large number of keys will force a log file change which will
+    # test that scenario for log cursors.
+    nkeys = 7000
 
     scenarios = check_scenarios([
         ('regular', dict(reopen=False)),


### PR DESCRIPTION
@michaelcahill Please review.  The fix specifically for the test failure is reseting `eol` if we read the next log file.  I also added a fix so that if a checksum doesn't match and we asked specifically for a record we return `WT_NOTFOUND` (the case of a log cursor setting an invalid LSN and calling search()).  I also bumped up the keys in `test_cursor07.py` that showed the problem.