### PR TITLE
Build fixes

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -73,7 +73,6 @@ AM_TYPES
 
 AC_PROG_INSTALL
 
-AC_CHECK_HEADERS([pthread_np.h])
 AC_CHECK_LIB(pthread, pthread_create)
 AC_CHECK_LIB(dl, dlopen)
 AC_CHECK_LIB(rt, sched_yield)

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -73,6 +73,7 @@ AM_TYPES
 
 AC_PROG_INSTALL
 
+AC_CHECK_HEADERS([x86intrin.h])
 AC_CHECK_LIB(pthread, pthread_create)
 AC_CHECK_LIB(dl, dlopen)
 AC_CHECK_LIB(rt, sched_yield)

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -88,9 +88,6 @@
 /* Define to 1 if you have the `posix_memalign' function. */
 /* #undef HAVE_POSIX_MEMALIGN */
 
-/* Define to 1 if you have the <pthread_np.h> header file. */
-/* #undef HAVE_PTHREAD_NP_H */
-
 /* Build the LevelDB API with RocksDB support. */
 /* #undef HAVE_ROCKSDB */
 

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -121,6 +121,9 @@
 /* Enable verbose message configuration. */
 /* #undef HAVE_VERBOSE */
 
+/* Define to 1 if you have the <x86intrin.h> header file. */
+#define HAVE_X86INTRIN_H 1
+
 /* Spinlock type from mutex.h. */
 #define SPINLOCK_TYPE SPINLOCK_MSVC
 

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -879,6 +879,7 @@ valuep
 valuev
 vanishingly
 variable's
+vectorized
 versa
 vfprintf
 vpack

--- a/src/include/btree_cmp.i
+++ b/src/include/btree_cmp.i
@@ -29,9 +29,6 @@ static inline int
 __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 {
 	size_t len, usz, tsz;
-#ifdef HAVE_X86INTRIN_H
-	size_t remain;
-#endif
 	const uint8_t *userp, *treep;
 
 	usz = user_item->size;
@@ -44,6 +41,7 @@ __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 #ifdef HAVE_X86INTRIN_H
 	/* Use vector instructions if we'll execute at least 2 of them. */
 	if (len >= WT_VECTOR_SIZE * 2) {
+		size_t remain;
 		__m128i res_eq, u, t;
 
 		remain = len % WT_VECTOR_SIZE;
@@ -117,9 +115,6 @@ __wt_lex_compare_skip(
     const WT_ITEM *user_item, const WT_ITEM *tree_item, size_t *matchp)
 {
 	size_t len, usz, tsz;
-#ifdef HAVE_X86INTRIN_H
-	size_t remain;
-#endif
 	const uint8_t *userp, *treep;
 
 	usz = user_item->size;
@@ -132,6 +127,7 @@ __wt_lex_compare_skip(
 #ifdef HAVE_X86INTRIN_H
 	/* Use vector instructions if we'll execute at least 2 of them. */
 	if (len >= WT_VECTOR_SIZE * 2) {
+		size_t remain;
 		__m128i res_eq, u, t;
 
 		remain = len % WT_VECTOR_SIZE;

--- a/src/include/btree_cmp.i
+++ b/src/include/btree_cmp.i
@@ -28,7 +28,10 @@
 static inline int
 __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 {
-	size_t len, remain, usz, tsz;
+	size_t len, usz, tsz;
+#ifdef HAVE_X86INTRIN_H
+	size_t remain;
+#endif
 	const uint8_t *userp, *treep;
 
 	usz = user_item->size;
@@ -113,7 +116,10 @@ static inline int
 __wt_lex_compare_skip(
     const WT_ITEM *user_item, const WT_ITEM *tree_item, size_t *matchp)
 {
-	size_t len, remain, usz, tsz;
+	size_t len, usz, tsz;
+#ifdef HAVE_X86INTRIN_H
+	size_t remain;
+#endif
 	const uint8_t *userp, *treep;
 
 	usz = user_item->size;

--- a/src/include/btree_cmp.i
+++ b/src/include/btree_cmp.i
@@ -6,18 +6,8 @@
  * See the file LICENSE for redistribution information.
  */
 
-#if defined(_MSC_VER)
-#include <intrin.h>
-#define	HAVE_VECTOR_INSTR
-#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-/*
- * Don't include <x86intrin.h>, older versions of gcc don't have it.
- */
-#include <emmintrin.h>
-#define	HAVE_VECTOR_INSTR
-#endif
-
-#ifdef	HAVE_VECTOR_INSTR
+#ifdef HAVE_X86INTRIN_H
+#include <x86intrin.h>
 						/* 16B alignment */
 #define	WT_ALIGNED_16(p)	(((uintptr_t)(p) & 0x0f) == 0)
 #define	WT_VECTOR_SIZE		16		/* chunk size */
@@ -48,7 +38,7 @@ __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 	userp = user_item->data;
 	treep = tree_item->data;
 
-#ifdef HAVE_VECTOR_INSTR
+#ifdef HAVE_X86INTRIN_H
 	/* Use vector instructions if we'll execute at least 2 of them. */
 	if (len >= WT_VECTOR_SIZE * 2) {
 		__m128i res_eq, u, t;
@@ -133,7 +123,7 @@ __wt_lex_compare_skip(
 	userp = (uint8_t *)user_item->data + *matchp;
 	treep = (uint8_t *)tree_item->data + *matchp;
 
-#ifdef HAVE_VECTOR_INSTR
+#ifdef HAVE_X86INTRIN_H
 	/* Use vector instructions if we'll execute at least 2 of them. */
 	if (len >= WT_VECTOR_SIZE * 2) {
 		__m128i res_eq, u, t;

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -41,9 +41,6 @@ extern "C" {
 #else
 #include <pthread.h>
 #endif
-#ifdef HAVE_PTHREAD_NP_H
-#include <pthread_np.h>
-#endif
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
Changes to remove the `pthread_np.h` include file from WiredTiger's build, and use the `x86intrin.h` include file to configure the vectorization instructions.

@sueloverso, would you please confirm this build works on your laptop, and if it does, merge it?

@agorrod, @michaelcahill: I added `pthread_np.h` to the build in commit 562ae1f, to support the use of `pthread_timedjoin_np`, as far as I can tell, we no longer use any pthread_XXX_np functions.