### PR TITLE
test/format for Windows

### DIFF
--- a/src/os_win/os_fallocate.c
+++ b/src/os_win/os_fallocate.c
@@ -48,7 +48,6 @@ __wt_fallocate(
 		    __wt_errno(), "%s SetFilePointerEx error", fh->name);
 
 	if ((ret = SetEndOfFile(fh->filehandle_secondary)) != FALSE) {
-		fh->size = fh->extend_size = len;
 		return (0);
 	}
 

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -397,7 +397,7 @@ void
 config_single(const char *s, int perm)
 {
 	CONFIG *cp;
-	u_long v;
+	uint64_t v;
 	char *p;
 	const char *ep;
 

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -299,7 +299,7 @@ path_setup(const char *home)
 	 */
 #undef	CMD
 #ifdef _WIN32
-#define	CMD	"cd %s && del /s /q * && rd /s /q KVS"
+#define	CMD	"cd %s && del /s /q * >:nul && rd /s /q KVS"
 #else
 #define	CMD	"cd %s > /dev/null && rm -rf `ls | sed /rand/d`"
 #endif
@@ -311,7 +311,7 @@ path_setup(const char *home)
 	/* Backup directory initialize command, remove and re-create it. */
 #undef	CMD
 #ifdef _WIN32
-#define	CMD	"del /s && mkdir %s"
+#define	CMD	"del /s /q >:nul && mkdir %s"
 #else
 #define	CMD	"rm -rf %s && mkdir %s"
 #endif
@@ -330,9 +330,9 @@ path_setup(const char *home)
 #undef	CMD
 #ifdef _WIN32
 #define	CMD								\
-	"cd %s "							\
+	"cd %s && "							\
 	"rd /q /s slvg.copy & mkdir slvg.copy && "			\
-	"copy WiredTiger* slvg.copy\\ && copy wt* slvg.copy\\"
+	"copy WiredTiger* slvg.copy\\ >:nul && copy wt* slvg.copy\\ >:nul"
 #else
 #define	CMD								\
 	"cd %s > /dev/null && "						\

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -424,6 +424,7 @@ wts_dump(const char *tag, int dump_bdb)
 	if (DATASOURCE("helium") || DATASOURCE("kvsbdb"))
 		return;
 
+#ifndef _WIN32
 	track("dump files and compare", 0ULL, NULL);
 
 	len = strlen(g.home) + strlen(BERKELEY_DB_PATH) + strlen(g.uri) + 100;
@@ -441,6 +442,7 @@ wts_dump(const char *tag, int dump_bdb)
 	if ((ret = system(cmd)) != 0)
 		die(ret, "%s: dump comparison failed", tag);
 	free(cmd);
+#endif
 }
 
 void


### PR DESCRIPTION
- Fixed an issue where fallocate was setting fh->size (incorrectly copied from ftruncate implementation)
- Send delete and copy output to :nul (aka /dev/null)
- Skip BDB verification for now