### PR TITLE
Enable test/fops for Windows, and add to CI

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -338,11 +338,12 @@ t = env.Program("t_huge",
     LIBS=[wtlib] + wtlibs)
 Default(t)
 
-#env.Program("t_fops",
-    #["test/fops/file.c",
-    #"test/fops/fops.c",
-    #"test/fops/t.c"],
-    #LIBS=[wtlib])
+t = env.Program("t_fops",
+    ["test/fops/file.c",
+    "test/fops/fops.c",
+    "test/fops/t.c"],
+    LIBS=[wtlib, shim] + wtlibs)
+Default(t)
 
 if useBdb:
     benv = env.Clone()

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -113,7 +113,7 @@ main(int argc, char *argv[])
 		return (usage());
 
 	/* Use line buffering on stdout so status updates aren't buffered. */
-	(void)setvbuf(stdout, NULL, _IOLBF, 0);
+	(void)setvbuf(stdout, NULL, _IOLBF, 32);
 
 	/* Clean up on signal. */
 	(void)signal(SIGINT, onint);
@@ -156,7 +156,14 @@ wt_startup(char *config_open)
 	int ret;
 	char config_buf[128];
 
-	if ((ret = system("rm -rf WT_TEST && mkdir WT_TEST")) != 0)
+#undef	CMD
+#ifdef _WIN32
+#define	CMD "rd /s /q WT_TEST & mkdir WT_TEST"
+#else
+#define	CMD "rm -rf WT_TEST && mkdir WT_TEST"
+#endif
+
+	if ((ret = system(CMD)) != 0)
 		die(ret, "directory cleanup call failed");
 
 	snprintf(config_buf, sizeof(config_buf),
@@ -192,7 +199,13 @@ shutdown(void)
 {
 	int ret;
 
-	if ((ret = system("rm -rf WT_TEST")) != 0)
+#undef	CMD
+#ifdef _WIN32
+#define	CMD "if exist WT_TEST rd /s /q WT_TEST"
+#else
+#define	CMD "rm -rf WT_TEST"
+#endif
+	if ((ret = system(CMD)) != 0)
 		die(ret, "directory cleanup call failed");
 }
 

--- a/test/fops/thread.h
+++ b/test/fops/thread.h
@@ -27,16 +27,26 @@
  */
 
 #include <sys/types.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include <errno.h>
 #include <inttypes.h>
+#ifndef _WIN32
 #include <pthread.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
+#ifdef _WIN32
+#include "windows_shim.h"
+#endif
 
 #include <wiredtiger.h>
 

--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -72,6 +72,23 @@ tasks:
 
             scons.bat ${smp_command|} "CFLAGS=/Gv /wd4090 /wd4996 /we4047 /we4024 /TC /we4100" wiredtiger.dll libwiredtiger.lib
 
+  - name: fops-windows
+    commands:
+      - func: "fetch source"
+      - command: git.apply_patch
+        params:
+          directory: wiredtiger
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            scons.bat --enable-python=c:\\swigwin-3.0.2\\swig.exe ${smp_command|}
+
+            cmd.exe /c t_fops.exe
+
 buildvariants:
 - name: ubuntu1404
   display_name: Ubuntu 14.04
@@ -99,12 +116,13 @@ buildvariants:
 - name: windows-64
   display_name: Windows 64-bit
   run_on:
-  - windows-64-vs2013-compile
+  - windows-64-vs2013-test
   expansions:
     smp_command: -j$(grep -c ^processor /proc/cpuinfo)
   tasks:
     - name: compile-windows
     - name: compile-windows-alt
+    - name: fops-windows
 
 - name: osx-108
   display_name: OS X 10.8

--- a/test/windows/windows_shim.c
+++ b/test/windows/windows_shim.c
@@ -56,6 +56,23 @@ usleep(useconds_t useconds)
 	return (0);
 }
 
+int gettimeofday(struct timeval* tp, void* tzp)
+{
+	uint64_t ns100;
+	FILETIME time;
+
+	tzp = tzp;
+
+	GetSystemTimeAsFileTime(&time);
+
+	ns100 = (((int64_t)time.dwHighDateTime << 32) + time.dwLowDateTime)
+	    - 116444736000000000LL;
+	tp->tv_sec = ns100 / 10000000;
+	tp->tv_usec = (long)((ns100 % 10000000) / 10);
+
+	return (0);
+}
+
 int
 pthread_rwlock_destroy(pthread_rwlock_t *lock)
 {

--- a/test/windows/windows_shim.h
+++ b/test/windows/windows_shim.h
@@ -60,6 +60,16 @@ _Check_return_opt_ int __cdecl _wt_snprintf(
 #define	mkdir(path, mode) _mkdir(path)
 
 /*
+ * Emulate <sys/time.h>
+ */
+struct timeval {
+	time_t tv_sec;
+	int64_t tv_usec;
+};
+
+int gettimeofday(struct timeval* tp, void* tzp);
+
+/*
  * Emulate <sched.h>
  */
 int sched_yield(void);


### PR DESCRIPTION
Added Windows shim for gettimeofday

fops is added to CI system. Also, used cheaper test machines.

BTW, on Windows, setvbuf does not accept 0 as a valid value.

(New pull request because I forgot to run s_all on this branch, and force pushing the previous PR closed it.)
