### PR TITLE
Add a table_count_idle option to wtperf.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -589,9 +589,10 @@ config_sanity(CONFIG *cfg)
 		fprintf(stderr, "interval value longer than the run-time\n");
 		return (EINVAL);
 	}
-	if (cfg->table_count < 1 || cfg->table_count > 99) {
+	/* The maximum is here to keep file name construction simple. */
+	if (cfg->table_count < 1 || cfg->table_count > 99999) {
 		fprintf(stderr,
-		    "invalid table count, less than 1 or greater than 99\n");
+		    "invalid table count, less than 1 or greater than 99999\n");
 		return (EINVAL);
 	}
 	if (cfg->database_count < 1 || cfg->database_count > 99) {

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -380,7 +380,7 @@ worker(void *arg)
 	CONFIG_THREAD *thread;
 	TRACK *trk;
 	WT_CONNECTION *conn;
-	WT_CURSOR **cursors, *cursor;
+	WT_CURSOR **cursors, *cursor, *tmp_cursor;
 	WT_SESSION *session;
 	int64_t ops, ops_per_txn, throttle_ops;
 	size_t i;
@@ -388,6 +388,7 @@ worker(void *arg)
 	uint8_t *op, *op_end;
 	int measure_latency, ret;
 	char *value_buf, *key_buf, *value;
+	char buf[512];
 
 	thread = (CONFIG_THREAD *)arg;
 	cfg = thread->cfg;
@@ -409,6 +410,16 @@ worker(void *arg)
 		lprintf(cfg, ENOMEM, 0,
 		    "worker: couldn't allocate cursor array");
 		goto err;
+	}
+	for (i = 0; i < cfg->table_count_idle; i++) {
+		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], i);
+		if ((ret = session->open_cursor(
+		    session, buf, NULL, NULL, &tmp_cursor)) != 0) {
+			lprintf(cfg, ret, 0,
+			    "Error opening idle table %s", buf);
+			goto err;
+		}
+		tmp_cursor->close(tmp_cursor);
 	}
 	for (i = 0; i < cfg->table_count; i++) {
 		if ((ret = session->open_cursor(session,
@@ -1602,20 +1613,18 @@ create_uris(CONFIG *cfg)
 		goto err;
 	}
 	for (i = 0; i < cfg->table_count; i++) {
-		uri = cfg->uris[i] = calloc(base_uri_len + 3, 1);
+		uri = cfg->uris[i] = calloc(base_uri_len + 5, 1);
 		if (uri == NULL) {
 			ret = ENOMEM;
 			goto err;
 		}
-		memcpy(uri, cfg->base_uri, base_uri_len);
 		/*
 		 * If there is only one table, just use base name.
 		 */
-		if (cfg->table_count > 1) {
-			uri[base_uri_len] = uri[base_uri_len + 1] = '0';
-			uri[base_uri_len] = '0' + (i / 10);
-			uri[base_uri_len + 1] = '0' + (i % 10);
-		}
+		if (cfg->table_count == 1)
+			memcpy(uri, cfg->base_uri, base_uri_len);
+		else
+			sprintf(uri, "%s%05d", cfg->base_uri, i);
 	}
 err:	if (ret != 0 && cfg->uris != NULL) {
 		for (i = 0; i < cfg->table_count; i++)
@@ -1632,6 +1641,7 @@ create_tables(CONFIG *cfg)
 	WT_SESSION *session;
 	size_t i;
 	int ret;
+	char buf[512];
 
 	if (cfg->create == 0)
 		return (0);
@@ -1641,6 +1651,16 @@ create_tables(CONFIG *cfg)
 		lprintf(cfg, ret, 0,
 		    "Error opening a session on %s", cfg->home);
 		return (ret);
+	}
+
+	for (i = 0; i < cfg->table_count_idle; i++) {
+		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], i);
+		if ((ret = session->create(
+		    session, buf, cfg->table_config)) != 0) {
+			lprintf(cfg, ret, 0,
+			    "Error creating idle table %s", buf);
+			return (ret);
+		}
 	}
 
 	for (i = 0; i < cfg->table_count; i++)

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -412,7 +412,7 @@ worker(void *arg)
 		goto err;
 	}
 	for (i = 0; i < cfg->table_count_idle; i++) {
-		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], i);
+		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], (int)i);
 		if ((ret = session->open_cursor(
 		    session, buf, NULL, NULL, &tmp_cursor)) != 0) {
 			lprintf(cfg, ret, 0,
@@ -1654,7 +1654,7 @@ create_tables(CONFIG *cfg)
 	}
 
 	for (i = 0; i < cfg->table_count_idle; i++) {
-		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], i);
+		snprintf(buf, 512, "%s_idle%05d", cfg->uris[0], (int)i);
 		if ((ret = session->create(
 		    session, buf, cfg->table_config)) != 0) {
 			lprintf(cfg, ret, 0,

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -419,7 +419,11 @@ worker(void *arg)
 			    "Error opening idle table %s", buf);
 			goto err;
 		}
-		tmp_cursor->close(tmp_cursor);
+		if ((ret = tmp_cursor->close(tmp_cursor)) != 0) {
+			lprintf(cfg, ret, 0,
+			    "Error closing idle table %s", buf);
+			goto err;
+		}
 	}
 	for (i = 0; i < cfg->table_count; i++) {
 		if ((ret = session->open_cursor(session,

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -145,7 +145,10 @@ DEF_OPT_AS_CONFIG_STRING(table_config,
     "table configuration string")
 DEF_OPT_AS_UINT32(table_count, 1,
     "number of tables to run operations over. Keys are divided evenly "
-    "over the tables. Default 1, maximum 99.")
+    "over the tables. Cursors are held open on all tables. Default 1, maximum "
+    "99999.")
+DEF_OPT_AS_UINT32(table_count_idle, 0,
+    "number of tables to create, that won't be populated. Default 0.")
 DEF_OPT_AS_STRING(threads, "", "workload configuration: each 'count' "
     "entry is the total number of threads, and the 'insert', 'read' and "
     "'update' entries are the ratios of insert, read and update operations "

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -210,7 +210,10 @@ session configuration string
 table configuration string
 @par table_count (unsigned int, default=1)
 number of tables to run operations over. Keys are divided evenly over
-the tables. Default 1, maximum 99.
+the tables. Cursors are held open on all tables. Default 1, maximum
+99999.
+@par table_count_idle (unsigned int, default=0)
+number of tables to create, that won't be populated. Default 0.
 @par threads (string, default=)
 workload configuration: each 'count' entry is the total number of
 threads, and the 'insert', 'read' and 'update' entries are the ratios


### PR DESCRIPTION
The option causes wtperf to create table_count_idle tables before
populate, and to open/close a cursor on each of those tables at
the start of the workload phase.