### PR TITLE
fallocate should ignore requests to truncate the file

### DIFF
--- a/src/os_win/os_fallocate.c
+++ b/src/os_win/os_fallocate.c
@@ -36,9 +36,21 @@ __wt_fallocate(
 {
 	WT_DECL_RET;
 	LARGE_INTEGER largeint;
+	wt_off_t size;
 
 	WT_RET(__wt_verbose(
 	    session, WT_VERB_FILEOPS, "%s: fallocate", fh->name));
+
+	WT_RET(__wt_filesize(session, fh, &size));
+
+	/*
+	 * If the new size is smaller then the current size,
+	 * then there is nothing to do since fallocate ignores
+	 * truncation requests.
+	 */
+	if ((offset + len) <= size) {
+		return (0);
+	}
 
 	largeint.QuadPart = offset + len;
 


### PR DESCRIPTION
The Windows fallocate call will now ignore requests to truncate the file by checking if the new requested size is less than the current size of the file.