### PR TITLE
Disable fallocate on Windows

### DIFF
--- a/src/os_win/os_fallocate.c
+++ b/src/os_win/os_fallocate.c
@@ -17,7 +17,12 @@ __wt_fallocate_config(WT_SESSION_IMPL *session, WT_FH *fh)
 {
 	WT_UNUSED(session);
 
-	fh->fallocate_available = WT_FALLOCATE_AVAILABLE;
+	/*
+	 * fallocate on Windows is implemented using SetEndOfFile which can
+	 * also truncate the file. WiredTiger expects fallocate to ignore
+	 * requests to truncate the file which Windows does not do.
+	 */
+	fh->fallocate_available = WT_FALLOCATE_NOT_AVAILABLE;
 
 	/*
 	 * We use a separate handle for file size changes, so there's no need
@@ -34,33 +39,5 @@ int
 __wt_fallocate(
     WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, wt_off_t len)
 {
-	WT_DECL_RET;
-	LARGE_INTEGER largeint;
-	wt_off_t size;
-
-	WT_RET(__wt_verbose(
-	    session, WT_VERB_FILEOPS, "%s: fallocate", fh->name));
-
-	WT_RET(__wt_filesize(session, fh, &size));
-
-	/*
-	 * If the new size is smaller then the current size,
-	 * then there is nothing to do since fallocate ignores
-	 * truncation requests.
-	 */
-	if ((offset + len) <= size) {
-		return (0);
-	}
-
-	largeint.QuadPart = offset + len;
-
-	if ((ret = SetFilePointerEx(
-	    fh->filehandle_secondary, largeint, NULL, FILE_BEGIN)) == FALSE)
-		WT_RET_MSG(session,
-		    __wt_errno(), "%s SetFilePointerEx error", fh->name);
-
-	if ((ret = SetEndOfFile(fh->filehandle_secondary)) != FALSE)
-		return (0);
-
-	WT_RET_MSG(session, __wt_errno(), "%s SetEndOfFile error", fh->name);
+	return (ENOTSUP);
 }


### PR DESCRIPTION
 Since SetEndofFile does not ignore truncation requests like POSIX fallocate, after discussions with @keithbostic, we decided it was best to disable fallocate on Windows.

With #1873, and the change, I was able to get ~700 successful runs of test/format.