### PR TITLE
Defend against row-search calls using a returned key

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -261,12 +261,12 @@ new_page:	/* Find the matching WT_COL slot. */
 				continue;
 			}
 			WT_RET(__wt_page_cell_data_ref(
-			    session, page, &unpack, &cbt->tmp));
+			    session, page, &unpack, cbt->tmp));
 
 			cbt->cip_saved = cip;
 		}
-		val->data = cbt->tmp.data;
-		val->size = cbt->tmp.size;
+		val->data = cbt->tmp->data;
+		val->size = cbt->tmp->size;
 		return (0);
 	}
 	/* NOTREACHED */

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -398,12 +398,12 @@ new_page:	if (cbt->recno < page->pg_var_recno)
 				continue;
 			}
 			WT_RET(__wt_page_cell_data_ref(
-			    session, page, &unpack, &cbt->tmp));
+			    session, page, &unpack, cbt->tmp));
 
 			cbt->cip_saved = cip;
 		}
-		val->data = cbt->tmp.data;
-		val->size = cbt->tmp.size;
+		val->data = cbt->tmp->data;
+		val->size = cbt->tmp->size;
 		return (0);
 	}
 	/* NOTREACHED */

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1135,7 +1135,7 @@ err:	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED))
 void
 __wt_btcur_open(WT_CURSOR_BTREE *cbt)
 {
-	cbt->search_key = &cbt->_search_key;
+	cbt->row_key = &cbt->_row_key;
 	cbt->tmp = &cbt->_tmp;
 }
 
@@ -1152,7 +1152,7 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt)
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
 	ret = __curfile_leave(cbt);
-	__wt_buf_free(session, &cbt->_search_key);
+	__wt_buf_free(session, &cbt->_row_key);
 	__wt_buf_free(session, &cbt->_tmp);
 
 	return (ret);

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1129,6 +1129,17 @@ err:	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED))
 }
 
 /*
+ * __wt_btcur_open --
+ *	Open a btree cursor.
+ */
+void
+__wt_btcur_open(WT_CURSOR_BTREE *cbt)
+{
+	cbt->search_key = &cbt->_search_key;
+	cbt->tmp = &cbt->_tmp;
+}
+
+/*
  * __wt_btcur_close --
  *	Close a btree cursor.
  */
@@ -1141,8 +1152,8 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt)
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
 	ret = __curfile_leave(cbt);
-	__wt_buf_free(session, &cbt->search_key);
-	__wt_buf_free(session, &cbt->tmp);
+	__wt_buf_free(session, &cbt->_search_key);
+	__wt_buf_free(session, &cbt->_tmp);
 
 	return (ret);
 }

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -91,12 +91,12 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 			 * the search key during any subsequent search that used
 			 * the temporary buffer.
 			 */
-			tmp = cbt->search_key;
-			cbt->search_key = cbt->tmp;
+			tmp = cbt->row_key;
+			cbt->row_key = cbt->tmp;
 			cbt->tmp = tmp;
 
-			cursor->key.data = cbt->search_key->data;
-			cursor->key.size = cbt->search_key->size;
+			cursor->key.data = cbt->row_key->data;
+			cursor->key.size = cbt->row_key->size;
 		} else
 			WT_RET(__wt_row_leaf_key(
 			    session, page, rip, &cursor->key, 0));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -19,6 +19,7 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	WT_CELL *cell;
 	WT_CELL_UNPACK unpack;
 	WT_CURSOR *cursor;
+	WT_ITEM *tmp;
 	WT_PAGE *page;
 	WT_ROW *rip;
 	uint8_t v;
@@ -79,8 +80,23 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 			cursor->key.data = WT_INSERT_KEY(cbt->ins);
 			cursor->key.size = WT_INSERT_KEY_SIZE(cbt->ins);
 		} else if (cbt->compare == 0) {
-			cursor->key.data = cbt->search_key.data;
-			cursor->key.size = cbt->search_key.size;
+			/*
+			 * If not in an insert list and there's an exact match,
+			 * the row-store search function built the key we want
+			 * to return in the cursor's temporary buffer. Swap the
+			 * cursor's search-key and temporary buffers so we can
+			 * return it (it's unsafe to return the temporary buffer
+			 * itself because our caller might do another search in
+			 * this table using the key we return, and we'd corrupt
+			 * the search key during any subsequent search that used
+			 * the temporary buffer.
+			 */
+			tmp = cbt->search_key;
+			cbt->search_key = cbt->tmp;
+			cbt->tmp = tmp;
+
+			cursor->key.data = cbt->search_key->data;
+			cursor->key.size = cbt->search_key->size;
 		} else
 			WT_RET(__wt_row_leaf_key(
 			    session, page, rip, &cursor->key, 0));

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -658,6 +658,7 @@ __split_multi_inmem(
 	WT_CLEAR(cbt);
 	cbt.iface.session = &session->iface;
 	cbt.btree = S2BT(session);
+	__wt_btcur_open(&cbt);
 
 	/*
 	 * We can find unresolved updates when attempting to evict a page, which

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -153,7 +153,7 @@ __wt_row_search(WT_SESSION_IMPL *session,
 
 	btree = S2BT(session);
 	collator = btree->collator;
-	item = &cbt->search_key;
+	item = cbt->tmp;
 
 	__cursor_pos_clear(cbt);
 
@@ -523,7 +523,7 @@ restart:
 		    __wt_random(session->rnd) % page->pg_row_entries : 0;
 
 		return (__wt_row_leaf_key(session,
-		    page, page->pg_row_d + cbt->slot, &cbt->search_key, 0));
+		    page, page->pg_row_d + cbt->slot, cbt->search_key, 0));
 	}
 
 	/*

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -523,7 +523,7 @@ restart:
 		    __wt_random(session->rnd) % page->pg_row_entries : 0;
 
 		return (__wt_row_leaf_key(session,
-		    page, page->pg_row_d + cbt->slot, cbt->search_key, 0));
+		    page, page->pg_row_d + cbt->slot, cbt->tmp, 0));
 	}
 
 	/*

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -432,8 +432,8 @@ __wt_curfile_create(WT_SESSION_IMPL *session,
 	cursor->internal_uri = btree->dhandle->name;
 	cursor->key_format = btree->key_format;
 	cursor->value_format = btree->value_format;
-
 	cbt->btree = btree;
+
 	if (bulk) {
 		F_SET(cursor, WT_CURSTD_BULK);
 
@@ -456,6 +456,9 @@ __wt_curfile_create(WT_SESSION_IMPL *session,
 		cursor->next = __curfile_next_random;
 		cursor->reset = __curfile_reset;
 	}
+
+	/* Underlying btree initialization. */
+	__wt_btcur_open(cbt);
 
 	/* __wt_cursor_init is last so we don't have to clean up on error. */
 	WT_ERR(__wt_cursor_init(

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -112,14 +112,16 @@ struct __wt_cursor_btree {
 	int	compare;
 
 	/*
-	 * A key from a binary search of a row-store leaf page; if we find an
-	 * exact match on a row-store leaf page, keep a copy of key we built
-	 * during the search to avoid doing the additional work of getting the
-	 * key again for return to the application. Note, this only applies to
-	 * exact matches when searching disk-image structures, so it's not, for
-	 * example, a key from an insert list.
+	 * A key returned from a binary search or cursor movement on a row-store
+	 * page; if we find an exact match on a row-store leaf page in a search
+	 * operation, keep a copy of key we built during the search to avoid
+	 * doing the additional work of getting the key again for return to the
+	 * application. Note, this only applies to exact matches when searching
+	 * disk-image structures, so it's not, for example, a key from an insert
+	 * list. Additionally, this structure is used to build keys when moving
+	 * a cursor through a row-store leaf page.
 	 */
-	WT_ITEM *search_key, _search_key;
+	WT_ITEM *row_key, _row_key;
 
 	/*
 	 * It's relatively expensive to calculate the last record on a variable-
@@ -170,9 +172,8 @@ struct __wt_cursor_btree {
 	 * to the next cursor position, we re-use the unpacked value we stored
 	 * here the first time we hit the value).
 	 *
-	 * A temporary buffer for building overflow and prefix-compressed keys
-	 * when stepping a cursor through row-store files, and building on-page
-	 * keys when searching row-store files.
+	 * A temporary buffer for building on-page keys when searching row-store
+	 * files.
 	 */
 	WT_ITEM *tmp, _tmp;
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -112,12 +112,14 @@ struct __wt_cursor_btree {
 	int	compare;
 
 	/*
-	 * The key value from a binary search of a row-store files; we keep a
-	 * copy of the last key we retrieved in the search, it avoids having
-	 * doing the additional work of getting the key again for return to
-	 * the application.
+	 * A key from a binary search of a row-store leaf page; if we find an
+	 * exact match on a row-store leaf page, keep a copy of key we built
+	 * during the search to avoid doing the additional work of getting the
+	 * key again for return to the application. Note, this only applies to
+	 * exact matches when searching disk-image structures, so it's not, for
+	 * example, a key from an insert list.
 	 */
-	WT_ITEM search_key;
+	WT_ITEM *search_key, _search_key;
 
 	/*
 	 * It's relatively expensive to calculate the last record on a variable-
@@ -163,9 +165,16 @@ struct __wt_cursor_btree {
 	WT_ROW *rip_saved;		/* Last-returned key reference */
 
 	/*
-	 * A temporary buffer for caching RLE values for column-store files.
+	 * A temporary buffer for caching RLE values for column-store files (if
+	 * RLE is non-zero, then we don't unpack the value every time we move
+	 * to the next cursor position, we re-use the unpacked value we stored
+	 * here the first time we hit the value).
+	 *
+	 * A temporary buffer for building overflow and prefix-compressed keys
+	 * when stepping a cursor through row-store files, and building on-page
+	 * keys when searching row-store files.
 	 */
-	WT_ITEM tmp;
+	WT_ITEM *tmp, _tmp;
 
 	/*
 	 * The update structure allocated by the row- and column-store modify

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -264,7 +264,7 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 	__wt_cell_unpack(cell, unpack);
 	if (unpack->type == WT_CELL_KEY &&
 	    cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {
-		WT_ASSERT(session, cbt->tmp.size >= unpack->prefix);
+		WT_ASSERT(session, cbt->tmp->size >= unpack->prefix);
 
 		/*
 		 * Grow the buffer as necessary as well as ensure data has been
@@ -274,22 +274,21 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 		 * Don't grow the buffer unnecessarily or copy data we don't
 		 * need, truncate the item's data length to the prefix bytes.
 		 */
-		cbt->tmp.size = unpack->prefix;
+		cbt->tmp->size = unpack->prefix;
 		WT_RET(__wt_buf_grow(
-		    session, &cbt->tmp, cbt->tmp.size + unpack->size));
-		memcpy((uint8_t *)cbt->tmp.data + cbt->tmp.size,
+		    session, cbt->tmp, cbt->tmp->size + unpack->size));
+		memcpy((uint8_t *)cbt->tmp->data + cbt->tmp->size,
 		    unpack->data, unpack->size);
-		cbt->tmp.size += unpack->size;
+		cbt->tmp->size += unpack->size;
 	} else {
 		/*
 		 * Call __wt_row_leaf_key_work instead of __wt_row_leaf_key: we
 		 * already did __wt_row_leaf_key's fast-path checks inline.
 		 */
-slow:		WT_RET(
-		    __wt_row_leaf_key_work(session, page, rip, &cbt->tmp, 0));
+slow:		WT_RET(__wt_row_leaf_key_work(session, page, rip, cbt->tmp, 0));
 	}
-	kb->data = cbt->tmp.data;
-	kb->size = cbt->tmp.size;
+	kb->data = cbt->tmp->data;
+	kb->size = cbt->tmp->size;
 	cbt->rip_saved = rip;
 
 value:

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -264,7 +264,7 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 	__wt_cell_unpack(cell, unpack);
 	if (unpack->type == WT_CELL_KEY &&
 	    cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {
-		WT_ASSERT(session, cbt->tmp->size >= unpack->prefix);
+		WT_ASSERT(session, cbt->row_key->size >= unpack->prefix);
 
 		/*
 		 * Grow the buffer as necessary as well as ensure data has been
@@ -274,21 +274,22 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 		 * Don't grow the buffer unnecessarily or copy data we don't
 		 * need, truncate the item's data length to the prefix bytes.
 		 */
-		cbt->tmp->size = unpack->prefix;
+		cbt->row_key->size = unpack->prefix;
 		WT_RET(__wt_buf_grow(
-		    session, cbt->tmp, cbt->tmp->size + unpack->size));
-		memcpy((uint8_t *)cbt->tmp->data + cbt->tmp->size,
+		    session, cbt->row_key, cbt->row_key->size + unpack->size));
+		memcpy((uint8_t *)cbt->row_key->data + cbt->row_key->size,
 		    unpack->data, unpack->size);
-		cbt->tmp->size += unpack->size;
+		cbt->row_key->size += unpack->size;
 	} else {
 		/*
 		 * Call __wt_row_leaf_key_work instead of __wt_row_leaf_key: we
 		 * already did __wt_row_leaf_key's fast-path checks inline.
 		 */
-slow:		WT_RET(__wt_row_leaf_key_work(session, page, rip, cbt->tmp, 0));
+slow:		WT_RET(__wt_row_leaf_key_work(
+		    session, page, rip, cbt->row_key, 0));
 	}
-	kb->data = cbt->tmp->data;
-	kb->size = cbt->tmp->size;
+	kb->data = cbt->row_key->data;
+	kb->size = cbt->row_key->size;
 	cbt->rip_saved = rip;
 
 value:

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -100,6 +100,7 @@ extern int __wt_btcur_next_random(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_compare(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *cmpp);
 extern int __wt_btcur_equals( WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *equalp);
 extern int __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop);
+extern void __wt_btcur_open(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_close(WT_CURSOR_BTREE *cbt);
 extern int __wt_debug_set_verbose(WT_SESSION_IMPL *session, const char *v);
 extern int __wt_debug_addr_print( WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);


### PR DESCRIPTION
@michaelcahill, here's the fix for #1887.

It may be worth looking at why LSM is doing this and there may be an improvement to make there: I think this failure only happens if a search is repeated, that is, a search on a key returns an exact match, and the search is repeated without resetting the key (so I think the cursor is guaranteed to end up in the same location).