### PR TITLE
Fix a deadlock in LSM with schema operations.

### DIFF
--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -125,11 +125,17 @@ struct __wt_table {
 	WT_CONNECTION_IMPL *__conn = S2C(session);		\
 	int __handle_locked =					\
 		F_ISSET(session, WT_SESSION_HANDLE_LIST_LOCKED);\
+	int __table_locked =					\
+		F_ISSET(session, WT_SESSION_TABLE_LOCKED);	\
 	int __schema_locked =					\
 		F_ISSET(session, WT_SESSION_SCHEMA_LOCKED);	\
 	if (__handle_locked) {					\
 		F_CLR(session, WT_SESSION_HANDLE_LIST_LOCKED);	\
 		__wt_spin_unlock(session, &__conn->dhandle_lock);\
+	}							\
+	if (__table_locked) {					\
+		F_CLR(session, WT_SESSION_TABLE_LOCKED);	\
+		__wt_spin_unlock(session, &__conn->table_lock);\
 	}							\
 	if (__schema_locked) {					\
 		F_CLR(session, WT_SESSION_SCHEMA_LOCKED);	\
@@ -139,6 +145,10 @@ struct __wt_table {
 	if (__schema_locked) {					\
 		__wt_spin_lock(session, &__conn->schema_lock);	\
 		F_SET(session, WT_SESSION_SCHEMA_LOCKED);	\
+	}							\
+	if (__table_locked) {					\
+		__wt_spin_lock(session, &__conn->table_lock);	\
+		F_SET(session, WT_SESSION_TABLE_LOCKED);	\
 	}							\
 	if (__handle_locked) {					\
 		__wt_spin_lock(session, &__conn->dhandle_lock);	\


### PR DESCRIPTION
There is special code in LSM to co-ordinate schema operations on
tables (drop, rename, etc). The code does a dance dropping and
acquiring locks, to allow utility operations to drain for the tree
while waiting for it to close.

We were doing the dance with the schema and dhandle list locks. We
needed to include the table lock, or parallel cursor opens could block:

The cursor open is waiting for the table lock:
__wt_spin_lock src/include/mutex.i:175
__schema_add_table src/schema/schema_list.c:26
__wt_schema_get_table src/schema/schema_list.c:98
__wt_curtable_open src/third_party/wiredtiger/src/cursor/cur_table.c:875
__wt_open_cursor src/session/session_api.c:240

The LSM table drop is waiting for the schema lock:
__wt_spin_lock src/include/mutex.i:175
__lsm_tree_close src/lsm/lsm_tree.c:107
__wt_lsm_tree_drop src/lsm/lsm_tree.c:943
__wt_schema_drop src/schema/schema_drop.c:174
__drop_table src/schema/schema_drop.c:124
__wt_schema_drop src/schema/schema_drop.c:176
__session_drop src/session/session_api.c:528