### PR TITLE
remove page-deleted count check from cursor-leave calls

### DIFF
--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -116,15 +116,6 @@ __curfile_leave(WT_CURSOR_BTREE *cbt)
 	}
 
 	/*
-	 * If we were scanning and saw a lot of deleted records on this page,
-	 * try to evict the page when we release it.
-	 */
-	if (cbt->ref != NULL &&
-	    cbt->page_deleted_count > WT_BTREE_DELETE_THRESHOLD)
-		__wt_page_evict_soon(cbt->ref->page);
-	cbt->page_deleted_count = 0;
-
-	/*
 	 * Release any page references we're holding.  This can trigger
 	 * eviction (e.g., forced eviction of big pages), so it is important to
 	 * do it after releasing our snapshot above.


### PR DESCRIPTION
@michaelcahill, I might be missing something, but is there any reason to check for deleted records found in page scan in the standard cursor-leave functions?

We have the explicit checks every time a cursor scan reaches the end of a page, so I'm not sure what scenario this would target. FTR, you added both tests (abc6cfb).