### PR TITLE
Fix LSM search_near landing on a deleted record

### DIFF
--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -392,8 +392,9 @@ __clsm_open_cursors(
 	c = &clsm->iface;
 	session = (WT_SESSION_IMPL *)c->session;
 	txn = &session->txn;
-	lsm_tree = clsm->lsm_tree;
 	chunk = NULL;
+	locked = 0;
+	lsm_tree = clsm->lsm_tree;
 
 	/*
 	 * Ensure that any snapshot update has cursors on the right set of


### PR DESCRIPTION
If an LSM search-near operation lands on a deleted item, make a copy of the key before stepping to the next record.

refs WT-1891