### PR TITLE
Update API documentation to tell explain session usage.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -319,8 +319,9 @@ connection_runtime_config = [
             maximum number of expected simultaneous asynchronous
                 operations''', min='1', max='4096'),
         Config('threads', '2', r'''
-            the number of worker threads to service asynchronous
-                requests''',
+            the number of worker threads to service asynchronous requests.
+            Each worker thread uses a session from the configured
+            session_max.''',
                 min='1', max='20'), # !!! Must match WT_ASYNC_MAX_WORKERS
             ]),
     Config('cache_size', '100MB', r'''
@@ -338,7 +339,8 @@ connection_runtime_config = [
         workloads''',
         min='0', max='30'),
     Config('checkpoint', '', r'''
-        periodically checkpoint the database''',
+        periodically checkpoint the database. Enabling the checkpoint server
+        uses a session from the configured session_max''',
         type='category', subconfig=[
         Config('name', '"WiredTigerCheckpoint"', r'''
             the checkpoint name'''),
@@ -382,11 +384,14 @@ connection_runtime_config = [
             inactive and close them''', min=1, max=100000),
         ]),
     Config('lsm_manager', '', r'''
-        configure database wide options for LSM tree management''',
+        configure database wide options for LSM tree management. The LSM
+        manager is started automatically the first time an LSM tree is opened.
+        The LSM manager uses a session from the configured session_max.''',
         type='category', subconfig=[
         Config('worker_thread_max', '4', r'''
             Configure a set of threads to manage merging LSM trees in
-            the database.''',
+            the database. Each worker thread uses a session handle from
+            the configured session_max''',
             min='3',     # !!! Must match WT_LSM_MIN_WORKERS
             max='20'),     # !!! Must match WT_LSM_MAX_WORKERS
         Config('merge', 'true', r'''
@@ -402,7 +407,8 @@ connection_runtime_config = [
             Config('threads_max', '1', r'''
                 maximum number of threads WiredTiger will start to help evict
                 pages from cache. The number of threads started will vary
-                depending on the current eviction load''',
+                depending on the current eviction load. Each eviction worker
+                thread uses a session from the configured session_max''',
                 min=1, max=20),
             Config('threads_min', '1', r'''
                 minimum number of threads WiredTiger will start to help evict
@@ -412,7 +418,8 @@ connection_runtime_config = [
             ]),
     Config('shared_cache', '', r'''
         shared cache configuration options. A database should configure
-        either a cache_size or a shared_cache not both''',
+        either a cache_size or a shared_cache not both. Enabling a
+        shared cache uses a session from the configured session_max''',
         type='category', subconfig=[
         Config('chunk', '10MB', r'''
             the granularity that a shared cache is redistributed''',
@@ -445,7 +452,9 @@ connection_runtime_config = [
         type='list', choices=['all', 'fast', 'none', 'clear']),
     Config('statistics_log', '', r'''
         log any statistics the database is configured to maintain,
-        to a file.  See @ref statistics for more information''',
+        to a file.  See @ref statistics for more information. Enabling
+        the statistics log server uses a session from the configured
+        session_max''',
         type='category', subconfig=[
         Config('on_close', 'false', r'''log statistics on database close''',
             type='boolean'),
@@ -545,7 +554,8 @@ common_wiredtiger_open = [
         handle''',
         min='15'),
     Config('log', '', r'''
-        enable logging''',
+        enable logging. Enabling logging uses three sessions from the
+        configured session_max''',
         type='category', subconfig=[
         Config('archive', 'true', r'''
             automatically archive unneeded log files''',

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1555,7 +1555,8 @@ struct __wt_connection {
 	 * simultaneous asynchronous operations., an integer between 1 and 4096;
 	 * default \c 1024.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number
-	 * of worker threads to service asynchronous requests., an integer
+	 * of worker threads to service asynchronous requests.  Each worker
+	 * thread uses a session from the configured session_max., an integer
 	 * between 1 and 20; default \c 2.}
 	 * @config{ ),,}
 	 * @config{cache_overhead, assume the heap allocator overhead is the
@@ -1570,8 +1571,9 @@ struct __wt_connection {
 	 * @config{cache_size, maximum heap memory to allocate for the cache.  A
 	 * database should configure either \c cache_size or \c shared_cache but
 	 * not both., an integer between 1MB and 10TB; default \c 100MB.}
-	 * @config{checkpoint = (, periodically checkpoint the database., a set
-	 * of related configuration options defined below.}
+	 * @config{checkpoint = (, periodically checkpoint the database.
+	 * Enabling the checkpoint server uses a session from the configured
+	 * session_max., a set of related configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_size, wait for this amount of log
 	 * record bytes to be written to the log between each checkpoint.  A
 	 * database can configure both log_size and wait to set an upper bound
@@ -1590,7 +1592,8 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of
 	 * threads WiredTiger will start to help evict pages from cache.  The
 	 * number of threads started will vary depending on the current eviction
-	 * load., an integer between 1 and 20; default \c 1.}
+	 * load.  Each eviction worker thread uses a session from the configured
+	 * session_max., an integer between 1 and 20; default \c 1.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of
 	 * threads WiredTiger will start to help evict pages from cache.  The
 	 * number of threads currently running will vary depending on the
@@ -1620,16 +1623,21 @@ struct __wt_connection {
 	 * them., an integer between 1 and 100000; default \c 10.}
 	 * @config{ ),,}
 	 * @config{lsm_manager = (, configure database wide options for LSM tree
-	 * management., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge, merge LSM chunks where
-	 * possible., a boolean flag; default \c true.}
+	 * management.  The LSM manager is started automatically the first time
+	 * an LSM tree is opened.  The LSM manager uses a session from the
+	 * configured session_max., a set of related configuration options
+	 * defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge, merge LSM
+	 * chunks where possible., a boolean flag; default \c true.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;worker_thread_max, Configure a set of
-	 * threads to manage merging LSM trees in the database., an integer
-	 * between 3 and 20; default \c 4.}
+	 * threads to manage merging LSM trees in the database.  Each worker
+	 * thread uses a session handle from the configured session_max., an
+	 * integer between 3 and 20; default \c 4.}
 	 * @config{ ),,}
 	 * @config{shared_cache = (, shared cache configuration options.  A
 	 * database should configure either a cache_size or a shared_cache not
-	 * both., a set of related configuration options defined below.}
+	 * both.  Enabling a shared cache uses a session from the configured
+	 * session_max., a set of related configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared
 	 * cache is redistributed., an integer between 1MB and 10TB; default \c
 	 * 10MB.}
@@ -1660,9 +1668,11 @@ struct __wt_connection {
 	 * \c "none"\, \c "clear"; default \c none.}
 	 * @config{statistics_log = (, log any statistics the database is
 	 * configured to maintain\, to a file.  See @ref statistics for more
-	 * information., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;on_close, log statistics on database
-	 * close., a boolean flag; default \c false.}
+	 * information.  Enabling the statistics log server uses a session from
+	 * the configured session_max., a set of related configuration options
+	 * defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;on_close, log
+	 * statistics on database close., a boolean flag; default \c false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the pathname to a file into
 	 * which the log records are written\, may contain ISO C standard
 	 * strftime conversion specifications.  If the value is not an absolute
@@ -1900,8 +1910,10 @@ struct __wt_connection {
  * maximum number of expected simultaneous asynchronous operations., an integer
  * between 1 and 4096; default \c 1024.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number of worker threads to
- * service asynchronous requests., an integer between 1 and 20; default \c 2.}
- * @config{ ),,}
+ * service asynchronous requests.  Each worker thread uses a session from the
+ * configured session_max., an integer between 1 and 20; default \c 2.}
+ * @config{
+ * ),,}
  * @config{buffer_alignment, in-memory alignment (in bytes) for buffers used for
  * I/O. The default value of -1 indicates a platform-specific alignment value
  * should be used (4KB on Linux systems when direct I/O is configured\, zero
@@ -1917,7 +1929,8 @@ struct __wt_connection {
  * @config{cache_size, maximum heap memory to allocate for the cache.  A
  * database should configure either \c cache_size or \c shared_cache but not
  * both., an integer between 1MB and 10TB; default \c 100MB.}
- * @config{checkpoint = (, periodically checkpoint the database., a set of
+ * @config{checkpoint = (, periodically checkpoint the database.  Enabling the
+ * checkpoint server uses a session from the configured session_max., a set of
  * related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_size, wait for this amount of log record
  * bytes to be written to the log between each checkpoint.  A database can
@@ -1952,13 +1965,15 @@ struct __wt_connection {
  * configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads
  * WiredTiger will start to help evict pages from cache.  The number of threads
- * started will vary depending on the current eviction load., an integer between
- * 1 and 20; default \c 1.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum
- * number of threads WiredTiger will start to help evict pages from cache.  The
- * number of threads currently running will vary depending on the current
- * eviction load., an integer between 1 and 20; default \c 1.}
- * @config{ ),,}
+ * started will vary depending on the current eviction load.  Each eviction
+ * worker thread uses a session from the configured session_max., an integer
+ * between 1 and 20; default \c 1.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min,
+ * minimum number of threads WiredTiger will start to help evict pages from
+ * cache.  The number of threads currently running will vary depending on the
+ * current eviction load., an integer between 1 and 20; default \c 1.}
+ * @config{
+ * ),,}
  * @config{eviction_dirty_target, continue evicting until the cache has less
  * dirty memory than the value\, as a percentage of the total cache size.  Dirty
  * pages will only be evicted if the cache is full enough to trigger eviction.,
@@ -1995,10 +2010,11 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{hazard_max, maximum number of simultaneous hazard pointers per
  * session handle., an integer greater than or equal to 15; default \c 1000.}
- * @config{log = (, enable logging., a set of related configuration options
- * defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;archive, automatically
- * archive unneeded log files., a boolean flag; default \c true.}
+ * @config{log = (, enable logging.  Enabling logging uses three sessions from
+ * the configured session_max., a set of related configuration options defined
+ * below.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;archive, automatically archive
+ * unneeded log files., a boolean flag; default \c true.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for log
  * records.  Permitted values are \c "none" or custom compression engine name
  * created with WT_CONNECTION::add_compressor.  If WiredTiger has builtin
@@ -2019,11 +2035,14 @@ struct __wt_connection {
  * chosen from the following options: \c "error"\, \c "on"; default \c on.}
  * @config{ ),,}
  * @config{lsm_manager = (, configure database wide options for LSM tree
- * management., a set of related configuration options defined below.}
+ * management.  The LSM manager is started automatically the first time an LSM
+ * tree is opened.  The LSM manager uses a session from the configured
+ * session_max., a set of related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge, merge LSM chunks where possible., a
  * boolean flag; default \c true.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;worker_thread_max, Configure a set of threads
- * to manage merging LSM trees in the database., an integer between 3 and 20;
+ * to manage merging LSM trees in the database.  Each worker thread uses a
+ * session handle from the configured session_max., an integer between 3 and 20;
  * default \c 4.}
  * @config{ ),,}
  * @config{mmap, Use memory mapping to access files when possible., a boolean
@@ -2035,7 +2054,8 @@ struct __wt_connection {
  * @config{session_max, maximum expected number of sessions (including server
  * threads)., an integer greater than or equal to 1; default \c 100.}
  * @config{shared_cache = (, shared cache configuration options.  A database
- * should configure either a cache_size or a shared_cache not both., a set of
+ * should configure either a cache_size or a shared_cache not both.  Enabling a
+ * shared cache uses a session from the configured session_max., a set of
  * related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared cache is
  * redistributed., an integer between 1MB and 10TB; default \c 10MB.}
@@ -2063,8 +2083,9 @@ struct __wt_connection {
  * list\, with values chosen from the following options: \c "all"\, \c "fast"\,
  * \c "none"\, \c "clear"; default \c none.}
  * @config{statistics_log = (, log any statistics the database is configured to
- * maintain\, to a file.  See @ref statistics for more information., a set of
- * related configuration options defined below.}
+ * maintain\, to a file.  See @ref statistics for more information.  Enabling
+ * the statistics log server uses a session from the configured session_max., a
+ * set of related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;on_close, log statistics on database close.,
  * a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the


### PR DESCRIPTION
This allows users to account for internal WiredTiger session handle usage. We already allocate additional handles for those we use unconditionally. This allows users to do specific calculations based
on their session_max setting.