### PR TITLE
Split __wt_txn_begin into two parts

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -656,7 +656,7 @@ extern int WT_CDECL __wt_txnid_cmp(const void *v1, const void *v2);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_update_oldest(WT_SESSION_IMPL *session);
 extern void __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot);
-extern int __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[]);
+extern int __wt_txn_begin_config(WT_SESSION_IMPL *session, const char *cfg[]);
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -656,7 +656,7 @@ extern int WT_CDECL __wt_txnid_cmp(const void *v1, const void *v2);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_update_oldest(WT_SESSION_IMPL *session);
 extern void __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot);
-extern int __wt_txn_begin_config(WT_SESSION_IMPL *session, const char *cfg[]);
+extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]);
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -204,9 +204,35 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 }
 
 /*
+ * __wt_txn_begin --
+ *	Begin a transaction.
+ */
+static inline int
+__wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
+{
+	WT_TXN *txn;
+
+	txn = &session->txn;
+	txn->isolation = session->isolation;
+	txn->txn_logsync = S2C(session)->txn_logsync;
+
+	if (cfg != NULL)
+		WT_RET(__wt_txn_begin_config(session, cfg));
+
+	if (txn->isolation == TXN_ISO_SNAPSHOT) {
+		if (session->ncursors > 0)
+			WT_RET(__wt_session_copy_values(session));
+		__wt_txn_refresh(session, 1);
+	}
+
+	F_SET(txn, TXN_RUNNING);
+	return (0);
+}
+
+/*
  * __wt_txn_autocommit_check --
  *	If an auto-commit transaction is required, start one.
-*/
+ */
 static inline int
 __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
 {

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -217,7 +217,7 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 	txn->txn_logsync = S2C(session)->txn_logsync;
 
 	if (cfg != NULL)
-		WT_RET(__wt_txn_begin_config(session, cfg));
+		WT_RET(__wt_txn_config(session, cfg));
 
 	if (txn->isolation == TXN_ISO_SNAPSHOT) {
 		if (session->ncursors > 0)

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -261,11 +261,11 @@ __wt_txn_refresh(WT_SESSION_IMPL *session, int get_snapshot)
 }
 
 /*
- * __wt_txn_begin_config --
- *	Begin a transaction based on a specified configuration.
+ * __wt_txn_config --
+ *	Configure a transaction.
  */
 int
-__wt_txn_begin_config(WT_SESSION_IMPL *session, const char *cfg[])
+__wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 {
 	WT_CONFIG_ITEM cval;
 	WT_TXN *txn;


### PR DESCRIPTION
@michaelcahill, would you please review this change?

Some of my zoom profiles show us spending time in `__wt_config_gets_def` when creating auto-commit transactions, and it's pretty easy to avoid.

There's one subtle change here, I moved the `F_SET(txn, TXN_RUNNING);` code after the handling of `txn->isolation == TXN_ISO_SNAPSHOT`.

It looked safe and I think it's cleaner, but I wanted to call it out in case there was something I missed (in which case, I think it needs a comment).