### PR TITLE
Add insertion-sort to sort snapshots

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -126,6 +126,33 @@
 #define	FLD_ISSET(field, mask)	((field) & ((uint32_t)(mask)))
 #define	FLD_SET(field, mask)	((field) |= ((uint32_t)(mask)))
 
+/*
+ * Insertion sort, for sorting small sets of values.
+ *
+ * The "compare_lt" argument is a function or macro that returns true when
+ * its first argument is less than its second argument.
+ */
+#define	WT_INSERTION_SORT(arrayp, n, value_type, compare_lt) do {	\
+	value_type __v;							\
+	int __i, __j, __n = (int)(n);					\
+	if (__n == 2) {							\
+		__v = (arrayp)[1];					\
+		if (compare_lt(__v, (arrayp)[0])) {			\
+			(arrayp)[1] = (arrayp)[0];			\
+			(arrayp)[0] = __v;				\
+		}							\
+	}								\
+	if (__n > 2) {							\
+		for (__i = 1; __i < __n; ++__i) {			\
+			__v = (arrayp)[__i];				\
+			for (__j = __i - 1; __j >= 0 &&			\
+			    compare_lt(__v, (arrayp)[__j]); --__j)	\
+				(arrayp)[__j + 1] = (arrayp)[__j];	\
+			(arrayp)[__j + 1] = __v;			\
+		}							\
+	}								\
+} while (0)
+
 /* Verbose messages. */
 #ifdef HAVE_VERBOSE
 #define	WT_VERBOSE_ISSET(session, f)					\

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -31,11 +31,38 @@ static void
 __txn_sort_snapshot(WT_SESSION_IMPL *session, uint32_t n, uint64_t snap_max)
 {
 	WT_TXN *txn;
+	int i, j;
+	uint64_t v;
 
 	txn = &session->txn;
 
-	if (n > 1)
+	switch (n) {
+	case 0: case 1:
+		break;
+	case 2:
+		v = txn->snapshot[1];
+		if (TXNID_LT(v, txn->snapshot[0])) {
+			txn->snapshot[1] = txn->snapshot[0];
+			txn->snapshot[0] = v;
+		}
+		break;
+	case 3: case 4: case 5: case 6: case 7: case 8: case 9: case 10:
+		/*
+		 * Insertion sort for small numbers of items.
+		 */
+		for (i = 1; i < (int)n; ++i) {
+			v = txn->snapshot[i];
+			for (j = i - 1; j >= 0 &&
+			    TXNID_LT(v, txn->snapshot[j]); --j)
+				txn->snapshot[j + 1] = txn->snapshot[j];
+			txn->snapshot[j + 1] = v;
+		}
+		break;
+	default:
 		qsort(txn->snapshot, n, sizeof(uint64_t), __wt_txnid_cmp);
+		break;
+	}
+
 	txn->snapshot_count = n;
 	txn->snap_max = snap_max;
 	txn->snap_min = (n > 0 && TXNID_LE(txn->snapshot[0], snap_max)) ?


### PR DESCRIPTION
@michaelcahill, we're spending cycles calling qsort() on typically small numbers of items, so I inlined the case where we have 2 items (wtperf's common case), and less than 11 items. A good implementation of qsort will simply do an insertion sort on small numbers of items anyway, but that still requires the qsort setup and then repeated calls to the qsort callback function.