### PR TITLE
TC Malloc for WT

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,6 +34,9 @@ AddOption("--enable-python", dest="lang-python", type="string", nargs=1, action=
 AddOption("--enable-snappy", dest="snappy", type="string", nargs=1, action="store",
           help="Use snappy compression")
 
+AddOption("--enable-tcmalloc", dest="tcmalloc", type="string", nargs=1, action="store",
+          help="Use TCMalloc for memory allocation")
+
 AddOption("--enable-verbose", dest="verbose", action="store_true", default=False,
           help="Configure WiredTiger to support the verbose configuration string to wiredtiger_open")
 
@@ -113,6 +116,7 @@ useZlib = GetOption("zlib")
 useSnappy = GetOption("snappy")
 useLz4 = GetOption("lz4")
 useBdb = GetOption("bdb")
+useTcmalloc = GetOption("tcmalloc")
 wtlibs = []
 
 conf = Configure(env)
@@ -155,6 +159,16 @@ if useBdb:
     conf.env.Append(LIBPATH=[useBdb+ "/lib"])
     if not conf.CheckCHeader('db.h'):
         print 'db.h must be installed!'
+        Exit(1)
+
+if useTcmalloc:
+    conf.env.Append(CPPPATH=[useTcmalloc + "/include"])
+    conf.env.Append(LIBPATH=[useTcmalloc + "/lib"])
+    if conf.CheckCHeader('gperftools/tcmalloc.h'):
+        wtlibs.append("libtcmalloc_minimal")
+        conf.env.Append(CPPDEFINES=['HAVE_LIBTCMALLOC'])
+    else:
+        print 'tcmalloc.h must be installed!'
         Exit(1)
 
 env = conf.Finish()

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -202,6 +202,25 @@ if test "$wt_cv_enable_lz4" = "yes"; then
 fi
 AM_CONDITIONAL([LZ4], [test "$wt_cv_enable_lz4" = "yes"])
 
+AC_MSG_CHECKING(if --enable-tcmalloc option specified)
+AC_ARG_ENABLE(tcmalloc,
+	[AS_HELP_STRING([--enable-tcmalloc],
+	    [Build the WT with tcmalloc.])], r=$enableval, r=no)
+case "$r" in
+no)	wt_cv_enable_tcmalloc=no;;
+*)	wt_cv_enable_tcmalloc=yes;;
+esac
+AC_MSG_RESULT($wt_cv_enable_tcmalloc)
+if test "$wt_cv_enable_tcmalloc" = "yes"; then
+	AC_LANG_PUSH([C++])
+	AC_CHECK_HEADER(google/tcmalloc.h,,
+	    [AC_MSG_ERROR([--enable-tcmalloc requires tcmalloc.h])])
+	AC_LANG_POP([C++])
+	AC_CHECK_LIB(tcmalloc, tc_calloc,,
+	    [AC_MSG_ERROR([--enable-tcmalloc requires tcmalloc library])])
+fi
+AM_CONDITIONAL([TCMalloc], [test "$wt_cv_enable_tcmalloc" = "yes"])
+
 AH_TEMPLATE(SPINLOCK_TYPE, [Spinlock type from mutex.h.])
 AC_MSG_CHECKING(if --with-spinlock option specified)
 AC_ARG_WITH(spinlock,

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -70,6 +70,9 @@
 /* Define to 1 if you have the `snappy' library (-lsnappy). */
 /* #undef HAVE_LIBSNAPPY */
 
+/* Define to 1 if you have the `tcmalloc' library (-ltcmalloc). */
+/* #undef HAVE_LIBTCMALLOC */
+
 /* Define to 1 if you have the `z' library (-lz). */
 /* #undef HAVE_LIBZ */
 

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -162,6 +162,7 @@ LockFile
 Lookup
 MALLOC
 MEM
+MEMALIGN
 MERCHANTABILITY
 MSVC
 MUTEX
@@ -243,6 +244,7 @@ Spinlocks
 Split's
 Stoica
 TAILQ
+TCMalloc
 TODO
 TORTIOUS
 TXN

--- a/src/os_posix/os_alloc.c
+++ b/src/os_posix/os_alloc.c
@@ -9,6 +9,27 @@
 #include "wt_internal.h"
 
 /*
+ * On systems with poor default allocators for allocations greater than 16 KB,
+ * we provide an option to use TCMalloc explicitly.
+ * This is important on Windows which does not have a builtin mechanism
+ * to replace C run-time memory management functions with alternatives.
+ */
+#ifdef HAVE_LIBTCMALLOC
+#include <gperftools/tcmalloc.h>
+
+/*
+ * Define HAVE_POSIX_MEMALIGN explicitly since TCMalloc supports it
+ */
+#define	HAVE_POSIX_MEMALIGN 1
+
+#define	calloc			tc_calloc
+#define	realloc 		tc_realloc
+#define	posix_memalign 		tc_posix_memalign
+#define	free 			tc_free
+
+#endif
+
+/*
  * There's no malloc interface, WiredTiger never calls malloc.
  *
  * The problem is an application might allocate memory, write secret stuff in

--- a/src/os_win/os_fallocate.c
+++ b/src/os_win/os_fallocate.c
@@ -39,5 +39,10 @@ int
 __wt_fallocate(
     WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, wt_off_t len)
 {
+	WT_UNUSED(session);
+	WT_UNUSED(fh);
+	WT_UNUSED(offset);
+	WT_UNUSED(len);
+
 	return (ENOTSUP);
 }


### PR DESCRIPTION
After considerable investigation, the default Windows allocator takes a critical section for allocators >= 16 KB which significantly impacts performance as compared to an alternate malloc implementation. I have added support for TCMalloc because it is what MongoDB vendors. This has shown improvement on several workloads for MongoDB. I did not investigate JEMalloc.

See  Jira WT-1904, SERVER-18079 for performance investigations.