### PR TITLE
Change the sort of the log's slot array from qsort to insertion sort

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -43,6 +43,7 @@ CELL's
 CELLs
 CHECKKEY
 CKPT
+CMP
 CONCAT
 CONFIG
 CPUs
@@ -275,6 +276,7 @@ Vo
 Vv
 VxWorks
 WIREDTIGER
+WRLSN
 WakeAllConditionVariable
 Wconditional
 WeakHashLen

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -344,18 +344,13 @@ typedef struct {
 } WT_LOG_WRLSN_ENTRY;
 
 /*
- * __log_wrlsn_cmp --
- *	The log wrlsn comparison function for qsort.
+ * WT_WRLSN_ENTRY_CMP_LT --
+ *	Return comparison of a written slot pair by LSN.
  */
-static int WT_CDECL
-__log_wrlsn_cmp(const void *a, const void *b)
-{
-	WT_LOG_WRLSN_ENTRY *ae, *be;
-
-	ae = (WT_LOG_WRLSN_ENTRY *)a;
-	be = (WT_LOG_WRLSN_ENTRY *)b;
-	return (LOG_CMP(&ae->lsn, &be->lsn));
-}
+#define	WT_WRLSN_ENTRY_CMP_LT(entry1, entry2)				\
+	((entry1).lsn.file < (entry2).lsn.file ||			\
+	((entry1).lsn.file == (entry2).lsn.file &&			\
+	(entry1).lsn.offset < (entry2).lsn.offset))
 
 /*
  * __log_wrlsn_server --
@@ -404,8 +399,9 @@ __log_wrlsn_server(void *arg)
 		 */
 		if (written_i > 0) {
 			yield = 0;
-			qsort(written, written_i, sizeof(WT_LOG_WRLSN_ENTRY),
-			    __log_wrlsn_cmp);
+			WT_INSERTION_SORT(written, written_i,
+			    WT_LOG_WRLSN_ENTRY, WT_WRLSN_ENTRY_CMP_LT);
+
 			/*
 			 * We know the written array is sorted by LSN.  Go
 			 * through them either advancing write_lsn or stop


### PR DESCRIPTION
@sueloverso, if @michaelcahill takes the `sort-snapshot-insertion` branch, here are the changes (entirely untested!) to switch the log slot sort from qsort to insertion sort.