### PR TITLE
Row search simplify

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -42,6 +42,7 @@ CAS
 CELL's
 CELLs
 CHECKKEY
+CHK
 CKPT
 CMP
 CONCAT
@@ -582,6 +583,7 @@ keycmp
 keyv
 kv
 kvraw
+kvret
 kvs
 kvsbdb
 lang

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -413,8 +413,9 @@ __btcur_search_col(WT_CURSOR_BTREE *cbt)
 			cbt->v = 0;
 			cursor->value.data = &cbt->v;
 			cursor->value.size = 1;
-		} else
-			ret = WT_NOTFOUND;
+			return (0);
+		}
+		ret = WT_NOTFOUND;
 	}
 
 err:	WT_TRET(__cursor_reset(cbt));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -9,125 +9,155 @@
 #include "wt_internal.h"
 
 /*
- * __wt_kv_return --
- *	Return a page referenced key/value pair to the application.
+ * __wt_kvret_fix --
+ *	Return a fixed-length column store key/value pair to the application.
  */
 int
-__wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+__wt_kvret_fix(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 {
 	WT_BTREE *btree;
+	WT_CURSOR *cursor;
+	WT_PAGE *page;
+	WT_SESSION_IMPL *session;
+	uint8_t v;
+
+	page = cbt->ref->page;
+	cursor = &cbt->iface;
+	session = (WT_SESSION_IMPL *)cursor->session;
+	btree = S2BT(session);
+
+	/*
+	 * The interface cursor's record has usually been set, but that
+	 * isn't universally true, specifically, cursor.search_near may
+	 * call here without first setting the interface cursor.
+	 */
+	cursor->recno = cbt->recno;
+
+	/* If the cursor references a WT_UPDATE item, return it. */
+	if (upd != NULL) {
+		cursor->value.data = WT_UPDATE_DATA(upd);
+		cursor->value.size = upd->size;
+		return (0);
+	}
+
+	/* Take the value from the original page. */
+	v = __bit_getv_recno(page, cbt->iface.recno, btree->bitcnt);
+	return (__wt_buf_set(session, &cursor->value, &v, 1));
+}
+
+/*
+ * __wt_kvret_var --
+ *	Return a variable-length column store key/value pair to the application.
+ */
+int
+__wt_kvret_var(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+{
+	WT_CELL *cell;
+	WT_CELL_UNPACK unpack;
+	WT_CURSOR *cursor;
+	WT_PAGE *page;
+	WT_SESSION_IMPL *session;
+
+	page = cbt->ref->page;
+	cursor = &cbt->iface;
+	session = (WT_SESSION_IMPL *)cursor->session;
+
+	/*
+	 * The interface cursor's record has usually been set, but that
+	 * isn't universally true, specifically, cursor.search_near may
+	 * call here without first setting the interface cursor.
+	 */
+	cursor->recno = cbt->recno;
+
+	/* If the cursor references a WT_UPDATE item, return it. */
+	if (upd != NULL) {
+		cursor->value.data = WT_UPDATE_DATA(upd);
+		cursor->value.size = upd->size;
+		return (0);
+	}
+
+	/*
+	 * Take the value from the original page cell, unpack it and expand
+	 * it as necessary.
+	 */
+	cell = WT_COL_PTR(page, &page->pg_var_d[cbt->slot]);
+	__wt_cell_unpack(cell, &unpack);
+	return (
+	    __wt_page_cell_data_ref(session, page, &unpack, &cursor->value));
+}
+
+/*
+ * __wt_kvret_row --
+ *	Return a row-store key/value pair to the application.
+ */
+int
+__wt_kvret_row(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+{
 	WT_CELL *cell;
 	WT_CELL_UNPACK unpack;
 	WT_CURSOR *cursor;
 	WT_ITEM *tmp;
 	WT_PAGE *page;
 	WT_ROW *rip;
-	uint8_t v;
-
-	btree = S2BT(session);
+	WT_SESSION_IMPL *session;
 
 	page = cbt->ref->page;
 	cursor = &cbt->iface;
+	session = (WT_SESSION_IMPL *)cursor->session;
 
-	switch (page->type) {
-	case WT_PAGE_COL_FIX:
+	rip = &page->pg_row_d[cbt->slot];
+
+	/*
+	 * If the cursor references a WT_INSERT item, take its key.
+	 * Else, if we have an exact match, we copied the key in the
+	 * search function, take it from there.
+	 * If we don't have an exact match, take the key from the
+	 * original page.
+	 */
+	if (cbt->ins != NULL) {
+		cursor->key.data = WT_INSERT_KEY(cbt->ins);
+		cursor->key.size = WT_INSERT_KEY_SIZE(cbt->ins);
+	} else if (cbt->compare == 0) {
 		/*
-		 * The interface cursor's record has usually been set, but that
-		 * isn't universally true, specifically, cursor.search_near may
-		 * call here without first setting the interface cursor.
+		 * If not in an insert list and there's an exact match,
+		 * the row-store search function built the key we want
+		 * to return in the cursor's temporary buffer. Swap the
+		 * cursor's search-key and temporary buffers so we can
+		 * return it (it's unsafe to return the temporary buffer
+		 * itself because our caller might do another search in
+		 * this table using the key we return, and we'd corrupt
+		 * the search key during any subsequent search that used
+		 * the temporary buffer.
 		 */
-		cursor->recno = cbt->recno;
+		tmp = cbt->row_key;
+		cbt->row_key = cbt->tmp;
+		cbt->tmp = tmp;
 
-		/* If the cursor references a WT_UPDATE item, return it. */
-		if (upd != NULL) {
-			cursor->value.data = WT_UPDATE_DATA(upd);
-			cursor->value.size = upd->size;
-			return (0);
-		}
+		cursor->key.data = cbt->row_key->data;
+		cursor->key.size = cbt->row_key->size;
+	} else
+		WT_RET(__wt_row_leaf_key(session, page, rip, &cursor->key, 0));
 
-		/* Take the value from the original page. */
-		v = __bit_getv_recno(page, cbt->iface.recno, btree->bitcnt);
-		return (__wt_buf_set(session, &cursor->value, &v, 1));
-	case WT_PAGE_COL_VAR:
-		/*
-		 * The interface cursor's record has usually been set, but that
-		 * isn't universally true, specifically, cursor.search_near may
-		 * call here without first setting the interface cursor.
-		 */
-		cursor->recno = cbt->recno;
-
-		/* If the cursor references a WT_UPDATE item, return it. */
-		if (upd != NULL) {
-			cursor->value.data = WT_UPDATE_DATA(upd);
-			cursor->value.size = upd->size;
-			return (0);
-		}
-
-		/* Take the value from the original page cell. */
-		cell = WT_COL_PTR(page, &page->pg_var_d[cbt->slot]);
-		break;
-	case WT_PAGE_ROW_LEAF:
-		rip = &page->pg_row_d[cbt->slot];
-
-		/*
-		 * If the cursor references a WT_INSERT item, take its key.
-		 * Else, if we have an exact match, we copied the key in the
-		 * search function, take it from there.
-		 * If we don't have an exact match, take the key from the
-		 * original page.
-		 */
-		if (cbt->ins != NULL) {
-			cursor->key.data = WT_INSERT_KEY(cbt->ins);
-			cursor->key.size = WT_INSERT_KEY_SIZE(cbt->ins);
-		} else if (cbt->compare == 0) {
-			/*
-			 * If not in an insert list and there's an exact match,
-			 * the row-store search function built the key we want
-			 * to return in the cursor's temporary buffer. Swap the
-			 * cursor's search-key and temporary buffers so we can
-			 * return it (it's unsafe to return the temporary buffer
-			 * itself because our caller might do another search in
-			 * this table using the key we return, and we'd corrupt
-			 * the search key during any subsequent search that used
-			 * the temporary buffer.
-			 */
-			tmp = cbt->row_key;
-			cbt->row_key = cbt->tmp;
-			cbt->tmp = tmp;
-
-			cursor->key.data = cbt->row_key->data;
-			cursor->key.size = cbt->row_key->size;
-		} else
-			WT_RET(__wt_row_leaf_key(
-			    session, page, rip, &cursor->key, 0));
-
-		/* If the cursor references a WT_UPDATE item, return it. */
-		if (upd != NULL) {
-			cursor->value.data = WT_UPDATE_DATA(upd);
-			cursor->value.size = upd->size;
-			return (0);
-		}
-
-		/* Simple values have their location encoded in the WT_ROW. */
-		if (__wt_row_leaf_value(page, rip, &cursor->value))
-			return (0);
-
-		/*
-		 * Take the value from the original page cell (which may be
-		 * empty).
-		 */
-		if ((cell =
-		    __wt_row_leaf_value_cell(page, rip, NULL)) == NULL) {
-			cursor->value.size = 0;
-			return (0);
-		}
-		break;
-	WT_ILLEGAL_VALUE(session);
+	/* If the cursor references a WT_UPDATE item, return it. */
+	if (upd != NULL) {
+		cursor->value.data = WT_UPDATE_DATA(upd);
+		cursor->value.size = upd->size;
+		return (0);
 	}
 
-	/* The value is an on-page cell, unpack and expand it as necessary. */
-	__wt_cell_unpack(cell, &unpack);
-	WT_RET(__wt_page_cell_data_ref(session, page, &unpack, &cursor->value));
+	/* Simple values have their location encoded in the WT_ROW. */
+	if (__wt_row_leaf_value(page, rip, &cursor->value))
+		return (0);
 
-	return (0);
+	/*
+	 * Take the value from the original page cell (which may be empty),
+	 * otherwise unpack it and expand it as necessary.
+	 */
+	if ((cell = __wt_row_leaf_value_cell(page, rip, NULL)) == NULL) {
+		cursor->value.size = 0;
+		return (0);
+	}
+	__wt_cell_unpack(cell, &unpack);
+	return (
+	    __wt_page_cell_data_ref(session, page, &unpack, &cursor->value));
 }

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -197,7 +197,7 @@ __curfile_search(WT_CURSOR *cursor)
 	WT_CURSOR_NEEDKEY(cursor);
 	WT_CURSOR_NOVALUE(cursor);
 
-	WT_BTREE_CURSOR_SAVE_AND_RESTORE(cursor, __wt_btcur_search(cbt), ret);
+	WT_BTREE_CURSOR_SAVE_AND_RESTORE(cursor, cbt->search(cbt), ret);
 
 err:	API_END_RET(session, ret);
 }

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -79,8 +79,7 @@ struct __wt_cursor_backup {
 struct __wt_cursor_btree {
 	WT_CURSOR iface;
 
-	WT_BTREE *btree;		/* Enclosing btree and fast functions */
-	int (*search)(WT_CURSOR_BTREE *);
+	WT_BTREE *btree;		/* Enclosing btree */
 
 	/*
 	 * The following fields are set by the search functions as a precursor
@@ -183,6 +182,13 @@ struct __wt_cursor_btree {
 	 * functions, used to avoid a data copy in the WT_CURSOR.update call.
 	 */
 	WT_UPDATE *modify_update;
+
+	/*
+	 * There a couple of calls we figure out on a per-type basis (row- or
+	 * column-store, for example), and cache in the cursor.
+	 */
+	int (*kvret)(WT_CURSOR_BTREE *, WT_UPDATE *);
+	int (*search)(WT_CURSOR_BTREE *);
 
 	/*
 	 * Fixed-length column-store items are a single byte, and it's simpler

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -79,7 +79,8 @@ struct __wt_cursor_backup {
 struct __wt_cursor_btree {
 	WT_CURSOR iface;
 
-	WT_BTREE *btree;		/* Enclosing btree */
+	WT_BTREE *btree;		/* Enclosing btree and fast functions */
+	int (*search)(WT_CURSOR_BTREE *);
 
 	/*
 	 * The following fields are set by the search functions as a precursor

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -146,7 +146,9 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 extern int __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint64_t recno, uint32_t alloc_entries, int alloc_refs, WT_PAGE **pagep);
 extern int __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, size_t memsize, uint32_t flags, WT_PAGE **pagep);
 extern int __wt_cache_read(WT_SESSION_IMPL *session, WT_REF *ref);
-extern int __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
+extern int __wt_kvret_fix(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
+extern int __wt_kvret_var(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
+extern int __wt_kvret_row(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
 extern int __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[]);
 extern void __wt_split_stash_discard(WT_SESSION_IMPL *session);
 extern void __wt_split_stash_discard_all( WT_SESSION_IMPL *session_safe, WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -90,7 +90,6 @@ extern void __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt, int next);
 extern int __wt_btcur_next(WT_CURSOR_BTREE *cbt, int truncating);
 extern int __wt_btcur_prev(WT_CURSOR_BTREE *cbt, int truncating);
 extern int __wt_btcur_reset(WT_CURSOR_BTREE *cbt);
-extern int __wt_btcur_search(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp);
 extern int __wt_btcur_insert(WT_CURSOR_BTREE *cbt);
 extern int __wt_btcur_update_check(WT_CURSOR_BTREE *cbt);


### PR DESCRIPTION
@michaelcahill, I made a change I've been thinking about for awhile, splitting up the object types in the Btree cursor code and removing some of the `btree->type == BTREE_ROW` branches in the code, I thought it might make a difference.

The following branch gets me about 4% improvement in the row-store cursor lookup path (pixiebob, clang 3.3 with -O3, running a microbenchmark doing 100M WT_CURSOR.set_key and WT_CURSOR.search pairs).

I can't get too excited about 4% -- I think it depends if you think this architecture is at least as clean, understandable and maintainable as the old one? If you like the old structure better, I'm happy to discard the branch, otherwise, I'm happy to take the 4%.

Obviously, we could keep going down this path (split up fixed-length vs. variable length column store, for example), this was just an experiment in making row-store searches faster.