### PR TITLE
Fix a typo, add what will be a description section for pydoc

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -31,10 +31,16 @@
  *	The SWIG interface file defining the wiredtiger python API.
  */
 %define DOCSTRING
-"@defgroup wt_python WiredTiger Python API
-Python wrappers aroung the WiredTiger C API.
-@{
-@cond IGNORE"
+"Python wrappers around the WiredTiger C API
+
+This provides an API similar to the C API, with the following modifications:
+  - Many C functions are exposed as OO methods. See the Python examples and test suite
+  - Errors are handled in a Pythonic way; wrap calls in try/except blocks
+  - Cursors have extra accessor methods and iterators that are higher-level than the C API
+  - Statistics cursors behave a little differently and are best handled using the C-like functions
+  - C Constants starting with WT_STAT_DSRC are instead exposed under wiredtiger.stat.dsrc
+  - C Constants starting with WT_STAT_CONN are instead exposed under wiredtiger.stat.conn
+"
 %enddef
 
 %module(docstring=DOCSTRING) wiredtiger


### PR DESCRIPTION
Starting to make "pydoc wiredtiger" give better results.