### PR TITLE
Don't wait for a handle lock while holding the schema lock.

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -52,6 +52,7 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags)
 	enum { NOLOCK, READLOCK, WRITELOCK } locked;
 	WT_BTREE *btree;
 	WT_DATA_HANDLE *dhandle;
+	WT_DECL_RET;
 	uint32_t special_flags;
 
 	btree = S2BT(session);
@@ -85,7 +86,17 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags)
 		}
 	} else if (F_ISSET(btree, WT_BTREE_SPECIAL_FLAGS))
 		return (EBUSY);
-	else {
+	else if (F_ISSET(session, WT_SESSION_SCHEMA_LOCKED)) {
+		/*
+		 * Waiting on a handle lock whilst holding the schema lock
+		 * result in deadlocks.
+		 */
+		if ((ret = __wt_try_readlock(
+		    session, dhandle->rwlock)) == EBUSY)
+			return (ret);
+		WT_RET(ret);
+		locked = READLOCK;
+	} else {
 		WT_RET(__wt_readlock(session, dhandle->rwlock));
 		locked = READLOCK;
 	}


### PR DESCRIPTION
This change for __wt_session_get_btree mirrors a similar change made to
__conn_dhandle_open_lock recently.