### PR TITLE
Allow dead handles to be closed even if open handle count doesn't

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -51,12 +51,12 @@ __sweep_mark(WT_SESSION_IMPL *session, int *dead_handlesp)
 }
 
 /*
- * __sweep_discard_expired --
- *	Close files that have no changes since the last checkpoint, until we
- *	have reached the configured minimum number of handles.
+ * __sweep_expire --
+ *	Mark trees dead if they are clean and haven't been accessed recently,
+ *	until we have reached the configured minimum number of handles.
  */
 static int
-__sweep_discard_expired(WT_SESSION_IMPL *session)
+__sweep_expire(WT_SESSION_IMPL *session)
 {
 	WT_BTREE *btree;
 	WT_CONNECTION_IMPL *conn;
@@ -252,7 +252,7 @@ __sweep_server(void *arg)
 		/* Close handles if we have reached the configured limit */
 		if (conn->open_file_count >= conn->sweep_handles_min) {
 			WT_WITH_DHANDLE_LOCK(session,
-			    ret = __sweep_discard_expired(session));
+			    ret = __sweep_expire(session));
 			WT_ERR(ret);
 		}
 

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -9,11 +9,12 @@
 #include "wt_internal.h"
 
 /*
- * __sweep_count --
- *	Count if there are dead handles.
+ * __sweep_mark --
+ *	Mark idle handles with a time of death, and note if we see dead
+ *	handles.
  */
 static int
-__sweep_count(WT_SESSION_IMPL *session, int *dead_handlesp)
+__sweep_mark(WT_SESSION_IMPL *session, int *dead_handlesp)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
@@ -50,11 +51,12 @@ __sweep_count(WT_SESSION_IMPL *session, int *dead_handlesp)
 }
 
 /*
- * __sweep_mark_dead --
- *	Mark any old files dead.
+ * __sweep_discard_expired --
+ *	Close files that have no changes since the last checkpoint, until we
+ *	have reached the configured minimum number of handles.
  */
 static int
-__sweep_mark_dead(WT_SESSION_IMPL *session)
+__sweep_discard_expired(WT_SESSION_IMPL *session)
 {
 	WT_BTREE *btree;
 	WT_CONNECTION_IMPL *conn;
@@ -229,7 +231,7 @@ __sweep_server(void *arg)
 	conn = S2C(session);
 
 	/*
-	 * Sweep for dead handles.
+	 * Sweep for dead and excess handles.
 	 */
 	while (F_ISSET(conn, WT_CONN_SERVER_RUN) &&
 	    F_ISSET(conn, WT_CONN_SERVER_SWEEP)) {
@@ -238,21 +240,21 @@ __sweep_server(void *arg)
 		    (uint64_t)conn->sweep_interval * WT_MILLION));
 
 		/*
-		 * Ignore in-use files once the open file count reaches the
-		 * minimum number of handles.
+		 * Mark handles with a time of death, and report whether any
+		 * handles are marked dead.
 		 */
-		if (conn->open_file_count < conn->sweep_handles_min)
+		WT_ERR(__sweep_mark(session, &dead_handles));
+
+		if (dead_handles == 0 &&
+		    conn->open_file_count < conn->sweep_handles_min)
 			continue;
 
-		/* Sweep the handles. */
-		WT_ERR(__sweep_count(session, &dead_handles));
-
-		if (dead_handles == 0)
-			continue;
-
-		WT_WITH_DHANDLE_LOCK(session,
-		    ret = __sweep_mark_dead(session));
-		WT_ERR(ret);
+		/* Close handles if we have reached the configured limit */
+		if (conn->open_file_count >= conn->sweep_handles_min) {
+			WT_WITH_DHANDLE_LOCK(session,
+			    ret = __sweep_discard_expired(session));
+			WT_ERR(ret);
+		}
 
 		WT_ERR(__sweep_flush(session));
 


### PR DESCRIPTION
exceed the minimum configured number.

Tidy some comments/naming/control flow in the sweep server at the
same time.