### PR TITLE
The checkpoint ID is volatile, cache it so we don't keep reading it.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -202,13 +202,13 @@ __txn_refresh(WT_SESSION_IMPL *session, const int get_snapshot)
 	    (!get_snapshot || oldest_id - prev_oldest_id > 100) &&
 	    WT_ATOMIC_CAS4(txn_global->scan_count, 1, -1)) {
 		WT_ORDERED_READ(session_cnt, conn->session_cnt);
+		ckpt_id = txn_global->checkpoint_id;
 		for (i = 0, s = txn_global->states; i < session_cnt; i++, s++) {
 			/*
 			 * Skip the checkpoint transaction; it is never read
 			 * from.
 			 */
-			if (txn_global->checkpoint_id != WT_TXN_NONE &&
-			    s->id == txn_global->checkpoint_id)
+			if (ckpt_id != WT_TXN_NONE && ckpt_id == s->id)
 				continue;
 
 			if ((id = s->id) != WT_TXN_NONE &&

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -80,7 +80,7 @@ __txn_refresh(WT_SESSION_IMPL *session, const int get_snapshot)
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_STATE *s, *txn_state;
-	uint64_t current_id, id, oldest_id;
+	uint64_t ckpt_id, current_id, id, oldest_id;
 	uint64_t prev_oldest_id, snap_min;
 	uint32_t i, n, oldest_session, session_cnt;
 	int32_t count;
@@ -123,10 +123,10 @@ __txn_refresh(WT_SESSION_IMPL *session, const int get_snapshot)
 
 	/* Walk the array of concurrent transactions. */
 	WT_ORDERED_READ(session_cnt, conn->session_cnt);
+	ckpt_id = txn_global->checkpoint_id;
 	for (i = n = 0, s = txn_global->states; i < session_cnt; i++, s++) {
 		/* Skip the checkpoint transaction; it is never read from. */
-		if (txn_global->checkpoint_id != WT_TXN_NONE &&
-		    s->id == txn_global->checkpoint_id)
+		if (ckpt_id != WT_TXN_NONE && ckpt_id == s->id)
 			continue;
 
 		/*


### PR DESCRIPTION
@michaelcahill, this instruction is about 5% of the in-memory wtperf run-time.

I'm guessing this change might not be safe, so I put it on a separate branch to make it easy to discard.

