### PR TITLE
Use a prime number as the hash table size

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -232,6 +232,7 @@ STAILQ
 STRUCT
 Scalability
 Scalable
+Sedgewick
 Seigh
 SetEndOfFile
 SetFilePointerEx

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -124,6 +124,12 @@ struct __wt_named_extractor {
 } while (0)
 
 /*
+ * Default hash table size; use a prime number of buckets rather than assuming
+ * a good hash (Reference Sedgewick, Algorithms in C, "Hash Functions").
+ */
+#define	WT_HASH_ARRAY_SIZE	509
+
+/*
  * WT_CONNECTION_IMPL --
  *	Implementation of WT_CONNECTION
  */
@@ -184,7 +190,6 @@ struct __wt_connection_impl {
 	 * URI.
 	 */
 					/* Locked: data handle hash array */
-#define	WT_HASH_ARRAY_SIZE	512
 	SLIST_HEAD(__wt_dhhash, __wt_data_handle) dhhash[WT_HASH_ARRAY_SIZE];
 					/* Locked: data handle list */
 	SLIST_HEAD(__wt_dhandle_lh, __wt_data_handle) dhlh;


### PR DESCRIPTION
Reference WT-1914.