### PR TITLE
Manpage improvements

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -166,10 +166,12 @@ EOF
 	(cd ../docs && mkdir -p man/man1 &&
 	    mv man/man3/command_line.3 man/man1/wt.1 &&
 	    sed -i~ -e 's/command_line/wt/g' man/man1/wt.1 &&
+	    sed -i~ -e 's/Version Version/Version/g' man/man1/wt.1 &&
 	    rm -f man/man1/wt.1~ &&
 	    mv man/man3/basic_api.3 man/ && rm -f man/man3/* &&
 	    mv man/basic_api.3 man/man3/wiredtiger.3 &&
 	    sed -i~ -e 's/basic_api/WiredTiger/g' man/man3/wiredtiger.3 &&
+	    sed -i~ -e 's/Version Version/Version/g' man/man3/wiredtiger.3 &&
 	    rm -f man/man3/wiredtiger.3~)
 }
 

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -2,14 +2,14 @@
 
 WiredTiger includes a command line utility, \c wt.
 
-@section util_global_synopsis Synopsis
+@section util_global_synopsis SYNOPSIS
 <code>wt [-LRVv] [-C config] [-h directory] command [command-specific arguments]</code>
 
-@section util_global_description Description
+@section util_global_description DESCRIPTION
 The \c wt tool is a command-line utility that provides access to
 various pieces of the WiredTiger functionality.
 
-@section util_global_options Options
+@section util_global_options OPTIONS
 There are four global options:
 
 @par <code>-C config</code>


### PR DESCRIPTION
This removes a doubling of the word "Version" in the "wiredtiger" and "wt" manpages, and makes the section headers for the "wt" manpage more normal. I wanted to do the same for the wiredtiger manpage, but it'd be more disruptive to the structure of the docs they're generated from (so it remains a very weird looking manpage). Other options:
1) Remove the wiredtiger.3 manpage
2) Replace it with a pointer to generated docs in another format
3) Generate both manpages a more traditional way - I'm willing to do the work on this