### PR TITLE
Avoid obsolete update checks during long-running transactions

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -179,17 +179,20 @@ struct __wt_page_modify {
 	 */
 	uint64_t disk_snap_min;
 
-	/* The largest transaction ID seen on the page by reconciliation. */
-	uint64_t rec_max_txn;
-
 	/* The first unwritten transaction ID (approximate). */
 	uint64_t first_dirty_txn;
 
-	/* The largest update transaction ID (approximate). */
-	uint64_t update_txn;
-
 	/* In-memory split transaction ID. */
 	uint64_t inmem_split_txn;
+
+	/* Avoid checking for obsolete updates during checkpoints. */
+	uint64_t obsolete_check_txn;
+
+	/* The largest transaction ID seen on the page by reconciliation. */
+	uint64_t rec_max_txn;
+
+	/* The largest update transaction ID (approximate). */
+	uint64_t update_txn;
 
 	/* Dirty bytes added to the cache. */
 	size_t bytes_dirty;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -174,7 +174,7 @@ extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern int __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, WT_ITEM *value, WT_UPDATE *upd, int is_remove);
 extern int __wt_row_insert_alloc(WT_SESSION_IMPL *session, WT_ITEM *key, u_int skipdepth, WT_INSERT **insp, size_t *ins_sizep);
 extern int __wt_update_alloc( WT_SESSION_IMPL *session, WT_ITEM *value, WT_UPDATE **updp, size_t *sizep);
-extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_UPDATE *upd);
+extern WT_UPDATE *__wt_update_obsolete_check( WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
 extern void __wt_update_obsolete_free( WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
 extern int __wt_search_insert( WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key);
 extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt, int insert);


### PR DESCRIPTION
There can potentially be long chains of updates that cannot be freed: there is no point repeatedly scanning them.

refs WT-1913