### PR TITLE
If we get part way through a btree open then fail, make sure the checkpoint is unloaded

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -133,16 +133,13 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 {
 	WT_BM *bm;
 	WT_BTREE *btree;
-	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 
-	dhandle = session->dhandle;
 	btree = S2BT(session);
 
 	if ((bm = btree->bm) != NULL) {
 		/* Unload the checkpoint, unless it's a special command. */
-		if (F_ISSET(dhandle, WT_DHANDLE_OPEN) &&
-		    !F_ISSET(btree,
+		if (!F_ISSET(btree,
 		    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY))
 			WT_TRET(bm->checkpoint_unload(bm, session));
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -330,9 +330,6 @@ __wt_conn_btree_open(
 
 	if (0) {
 err:		F_CLR(btree, WT_BTREE_SPECIAL_FLAGS);
-		/* If the open failed, close the handle. */
-		if (F_ISSET(dhandle, WT_DHANDLE_OPEN))
-			WT_TRET(__wt_conn_btree_sync_and_close(session, 0, 0));
 	}
 
 	return (ret);


### PR DESCRIPTION
Hopefully this will fix a hard-to-reproduce leak found recently by valgrind.

refs WT-1598