### PR TITLE
Fix a bug in handle close, where we could fail to clear WT_DHANDLE_OPEN.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -170,6 +170,8 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 
 	btree->bulk_load_ok = 0;
 
+	F_CLR(btree, WT_BTREE_SPECIAL_FLAGS);
+
 	return (ret);
 }
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -188,7 +188,7 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, int final, int force)
 	 * invalid if the mapping is closed.
 	 */
 	if (!F_ISSET(btree,
-            WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY)) {
+	    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY)) {
 		if (force && (btree->bm == NULL || btree->bm->map == NULL))  {
 			WT_ERR(__conn_dhandle_mark_dead(session));
 			marked_dead = 1;


### PR DESCRIPTION
Specifically if closing a checkpoint handle. This manifested by a
segfault opening a handle for a merge in LSM.

Refs WT-1915