### PR TITLE
Add a "soft update" of the oldest ID from application threads

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -49,6 +49,9 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 	/* Trigger eviction on the next page release. */
 	__wt_page_evict_soon(page);
 
+	/* Bump the oldest ID, we're about to do some visibility checks. */
+	__wt_txn_update_oldest(session, 0);
+
 	/* If eviction cannot succeed, don't try. */
 	return (
 	    __wt_page_can_evict(session, page, WT_EVICT_CHECK_SPLITS, NULL));

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -92,7 +92,7 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
 	 * transaction ID will catch up with the current ID.
 	 */
 	for (;;) {
-		__wt_txn_update_oldest(session);
+		__wt_txn_update_oldest(session, 1);
 		if (txn_global->oldest_id == txn_global->current)
 			break;
 		__wt_yield();

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -27,7 +27,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, int syncop)
 	WT_RET(__wt_evict_file_exclusive_on(session, &evict_reset));
 
 	/* Make sure the oldest transaction ID is up-to-date. */
-	__wt_txn_update_oldest(session);
+	__wt_txn_update_oldest(session, 1);
 
 	/* Walk the tree, discarding pages. */
 	next_ref = NULL;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -681,7 +681,7 @@ __wt_evict_page(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * before evicting, using a special "eviction" isolation level, where
 	 * only globally visible updates can be evicted.
 	 */
-	__wt_txn_update_oldest(session);
+	__wt_txn_update_oldest(session, 1);
 	txn = &session->txn;
 	saved_iso = txn->isolation;
 	txn->isolation = TXN_ISO_EVICTION;
@@ -941,7 +941,7 @@ __evict_walk(WT_SESSION_IMPL *session, uint32_t flags)
 	 * after a long-running transaction (such as a checkpoint) completes,
 	 * we may never start evicting again.
 	 */
-	__wt_txn_update_oldest(session);
+	__wt_txn_update_oldest(session, 1);
 
 	if (cache->evict_current == NULL)
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_queue_empty);
@@ -1523,7 +1523,7 @@ __wt_cache_wait(WT_SESSION_IMPL *session, int full)
 		 * are not busy.
 		 */
 		if (busy) {
-			__wt_txn_update_oldest(session);
+			__wt_txn_update_oldest(session, 0);
 			if (txn_state->id == txn_global->oldest_id ||
 			    txn_state->snap_min == txn_global->oldest_id)
 				return (0);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -655,7 +655,7 @@ extern void __wt_stat_refresh_connection_stats(void *stats_arg);
 extern int WT_CDECL __wt_txnid_cmp(const void *v1, const void *v2);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);
-extern void __wt_txn_update_oldest(WT_SESSION_IMPL *session);
+extern void __wt_txn_update_oldest(WT_SESSION_IMPL *session, int force);
 extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]);
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]);

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -281,7 +281,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	}
 
 	/* Stop if a running transaction needs the chunk. */
-	__wt_txn_update_oldest(session);
+	__wt_txn_update_oldest(session, 1);
 	if (chunk->switch_txn == WT_TXN_NONE ||
 	    !__wt_txn_visible_all(session, chunk->switch_txn)) {
 		WT_RET(__wt_verbose(session, WT_VERB_LSM,

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -387,7 +387,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * This is particularly important for compact, so that all dirty pages
 	 * can be fully written.
 	 */
-	__wt_txn_update_oldest(session);
+	__wt_txn_update_oldest(session, 1);
 
 	/* Flush data-sources before we start the checkpoint. */
 	WT_ERR(__checkpoint_data_source(session, cfg));
@@ -1107,7 +1107,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, int final)
 	 * for active readers.
 	 */
 	if (!btree->modified && !bulk) {
-		__wt_txn_update_oldest(session);
+		__wt_txn_update_oldest(session, 1);
 		return (__wt_txn_visible_all(session, btree->rec_max_txn) ?
 		    __wt_cache_op(session, NULL, WT_SYNC_DISCARD) : EBUSY);
 	}


### PR DESCRIPTION
In case eviction isn't running (e.g., during forced eviction checks).

refs WT-1907