### PR TITLE
WT-1926 Make WiredTiger work correctly with SWIG version 3

### DIFF
--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -98,7 +98,7 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Check that a URI doesn't exist, both the meta-data and the file names.
     def confirmPathDoesNotExist(self, uri):
-        conn = wiredtiger.wiredtiger_open(self.dir)
+        conn = wiredtiger.wiredtiger_open(self.dir, None)
         session = conn.open_session()
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: session.open_cursor(uri, None, None))

--- a/test/suite/test_backup03.py
+++ b/test/suite/test_backup03.py
@@ -102,7 +102,7 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Check that a URI doesn't exist, both the meta-data and the file names.
     def confirmPathDoesNotExist(self, uri):
-        conn = wiredtiger.wiredtiger_open(self.dir)
+        conn = wiredtiger.wiredtiger_open(self.dir, None)
         session = conn.open_session()
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: session.open_cursor(uri, None, None))

--- a/test/suite/test_bulk02.py
+++ b/test/suite/test_bulk02.py
@@ -104,7 +104,7 @@ class test_bulkload_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.backup(backupdir, session)
 
         # Open the target directory, and confirm the object has no contents.
-        conn = wiredtiger.wiredtiger_open(backupdir)
+        conn = wiredtiger.wiredtiger_open(backupdir, None)
         session = conn.open_session()
         cursor = session.open_cursor(self.uri, None, None)
         self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)

--- a/test/suite/test_dump.py
+++ b/test/suite/test_dump.py
@@ -109,7 +109,7 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(['-h', self.dir, 'load', '-f', 'dump.out'])
 
         # Check the contents
-        conn = wiredtiger.wiredtiger_open(self.dir)
+        conn = wiredtiger.wiredtiger_open(self.dir, None)
         session = conn.open_session()
         cursor = session.open_cursor(uri, None, None)
         self.populate_check(self, cursor, self.nentries)
@@ -119,7 +119,7 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(['-h', self.dir, 'load', '-f', 'dump.out'])
 
         # Check the contents, they shouldn't have changed.
-        conn = wiredtiger.wiredtiger_open(self.dir)
+        conn = wiredtiger.wiredtiger_open(self.dir, None)
         session = conn.open_session()
         cursor = session.open_cursor(uri, None, None)
         self.populate_check(self, cursor, self.nentries)

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -70,7 +70,7 @@ class backup_thread(threading.Thread):
 
             cursor.close()
 
-            bkp_conn = wiredtiger.wiredtiger_open(self.backup_dir)
+            bkp_conn = wiredtiger.wiredtiger_open(self.backup_dir, None)
             bkp_session = bkp_conn.open_session()
             # Verify that the backup was OK.
             uris = list()


### PR DESCRIPTION
@ddanderson Can you review these changes to the test suite?  Several calls to wiredtiger.wiredtiger_open only had one arg and python was unhappy about that on my Mac.