### PR TITLE
Ignore unknown extractors during WT_SESSION.create.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -616,8 +616,7 @@ __extractor_confchk(
 	WT_CONNECTION_IMPL *conn;
 	WT_NAMED_EXTRACTOR *nextractor;
 
-	if (extractorp != NULL)
-		*extractorp = NULL;
+	*extractorp = NULL;
 
 	if (cname->len == 0 || WT_STRING_MATCH("none", cname->str, cname->len))
 		return (0);
@@ -625,22 +624,11 @@ __extractor_confchk(
 	conn = S2C(session);
 	TAILQ_FOREACH(nextractor, &conn->extractorqh, q)
 		if (WT_STRING_MATCH(nextractor->name, cname->str, cname->len)) {
-			if (extractorp != NULL)
-				*extractorp = nextractor->extractor;
+			*extractorp = nextractor->extractor;
 			return (0);
 		}
 	WT_RET_MSG(session, EINVAL,
 	    "unknown extractor '%.*s'", (int)cname->len, cname->str);
-}
-
-/*
- * __wt_extractor_confchk --
- *     Check for a valid custom extractor (public).
- */
-int
-__wt_extractor_confchk(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cname)
-{
-	return (__extractor_confchk(session, cname, NULL));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -210,7 +210,6 @@ extern int __wt_conn_remove_compressor(WT_SESSION_IMPL *session);
 extern int __wt_conn_remove_data_source(WT_SESSION_IMPL *session);
 extern int __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_CONFIG_ITEM *keyid, WT_CONFIG_ARG *cfg_arg, WT_KEYED_ENCRYPTOR **kencryptorp);
 extern int __wt_conn_remove_encryptor(WT_SESSION_IMPL *session);
-extern int __wt_extractor_confchk(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cname);
 extern int __wt_extractor_config(WT_SESSION_IMPL *session, const char *config, WT_EXTRACTOR **extractorp, int *ownp);
 extern int __wt_conn_remove_extractor(WT_SESSION_IMPL *session);
 extern int __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[]);

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -477,6 +477,10 @@ __create_index(WT_SESSION_IMPL *session,
 		goto err;
 	}
 
+	/* Make sure that the configuration is valid. */
+	WT_ERR(__wt_schema_open_index(
+	    session, table, idxname, strlen(idxname), NULL));
+
 err:	__wt_free(session, idxconf);
 	__wt_free(session, sourceconf);
 	__wt_buf_free(session, &confbuf);

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -373,10 +373,6 @@ __create_index(WT_SESSION_IMPL *session,
 	if (__wt_config_getones_none(
 	    session, config, "extractor", &cval) == 0 && cval.len != 0) {
 		have_extractor = 1;
-
-		/* Confirm the extractor exists. */
-		WT_ERR(__wt_extractor_confchk(session, &cval));
-
 		/* Custom extractors must supply a key format. */
 		if ((ret = __wt_config_getones(
 		    session, config, "key_format", &kval)) != 0)

--- a/test/suite/test_bug012.py
+++ b/test/suite/test_bug012.py
@@ -29,7 +29,6 @@
 import wiredtiger, wttest
 from helper import complex_populate
 
-
 # test_bug012.py
 class test_bug012(wttest.WiredTigerTestCase):
 
@@ -77,10 +76,9 @@ class test_bug012(wttest.WiredTigerTestCase):
     def test_illegal_extractor(self):
         complex_populate(self, 'table:A', 'key_format=S', 10)
         msg = '/unknown extractor/'
-        self.session.create('index:A:xyzzy',
-            'key_format=S,columns=(column2),extractor="xyzzy"')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            self.session.open_cursor('index:A:xyzzy', None, None), msg)
+            self.session.create('index:A:xyzzy',
+            'key_format=S,columns=(column2),extractor="xyzzy"'), msg)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug012.py
+++ b/test/suite/test_bug012.py
@@ -77,9 +77,10 @@ class test_bug012(wttest.WiredTigerTestCase):
     def test_illegal_extractor(self):
         complex_populate(self, 'table:A', 'key_format=S', 10)
         msg = '/unknown extractor/'
+        self.session.create('index:A:xyzzy',
+            'key_format=S,columns=(column2),extractor="xyzzy"')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            self.session.create('index:A:xyzzy',
-            'key_format=S,columns=(column2),extractor="xyzzy"'), msg)
+            self.session.open_cursor('index:A:xyzzy', None, None), msg)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@michaelcahill, you said:

> the usual pattern is to create the object, including setting the metadata, then try to open it (which does the validation). If the open fails, the create is rolled back.

This backs out a change to detect unknown extractors during WT_SESSION.create.