### PR TITLE
Don't create bloom filters on the oldest chunk unless configured.

### DIFF
--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1227,8 +1227,8 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, int *skip)
 	 * already created a bloom filter for it or we are configured not to.
 	 */
 	if (lsm_tree->nchunks == 1 &&
-	    (FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OLDEST) &&
-	    F_ISSET(lsm_tree->chunk[0], WT_LSM_CHUNK_BLOOM) ||
+	    ((FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OLDEST) &&
+	    F_ISSET(lsm_tree->chunk[0], WT_LSM_CHUNK_BLOOM)) ||
 	    !FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OLDEST))) {
 		__wt_lsm_tree_release(session, lsm_tree);
 		return (0);

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -215,6 +215,10 @@ __wt_lsm_work_bloom(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		    chunk->count == 0)
 			continue;
 
+		/* Never create a bloom filter on the oldest chunk */
+		if (chunk == lsm_tree->chunk[0] &&
+		    !FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OLDEST))
+			continue;
 		/*
 		 * See if we win the race to switch on the "busy" flag and
 		 * recheck that the chunk still needs a Bloom filter.


### PR DESCRIPTION
The recent bulk load change meant that we sometimes created a bloom
filter on the oldest chunk when running compact.

Caused performance to drop by 50% in wtperf medium lsm compact job.