### PR TITLE
Add encryption and log compression to stress testing

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -31,7 +31,7 @@
 
 static void	   config_checksum(void);
 static void	   config_compression(const char *);
-static void	   config_encryption();
+static void	   config_encryption(void);
 static const char *config_file_type(u_int);
 static CONFIG	  *config_find(const char *, size_t);
 static int	   config_is_perm(const char *);

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -273,7 +273,7 @@ config_compression(const char *conf_name)
  *	Encryption configuration.
  */
 static void
-config_encryption()
+config_encryption(void)
 {
 	const char *cstr;
 

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -131,6 +131,10 @@ static CONFIG c[] = {
 	  "if values are dictionary compressed",		/* 20% */
 	  C_BOOL, 20, 0, 0, &g.c_dictionary, NULL },
 
+	{ "encryption",
+	  "type of encryption (none | rotn-7)",
+	  C_IGNORE|C_STRING, 0, 0, 0, NULL, &g.c_encryption },
+
 	{ "evict_max",
 	  "the maximum number of eviction workers",
 	  0x0, 0, 5, 100, &g.c_evict_max, NULL },

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -192,6 +192,11 @@ static CONFIG c[] = {
 	  "if logging configured",				/* 30% */
 	  C_BOOL, 30, 0, 0, &g.c_logging, NULL },
 
+	{ "logging_compression",
+	  "type of logging compression "
+	  "(none | bzip | bzip-raw | lzo | snappy | zlib | zlib-noraw)",
+	  C_IGNORE|C_STRING, 1, 7, 7, NULL, &g.c_logging_compression },
+
 	{ "logging_archive",
 	  "if log file archival configured",			/* 50% */
 	  C_BOOL, 50, 0, 0, &g.c_logging_archive, NULL },

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -79,6 +79,9 @@ extern WT_EXTENSION_API *wt_api;
 #define	REVERSE_PATH							\
 	EXTPATH "collators/reverse/.libs/libwiredtiger_reverse_collator.so"
 
+#define	ROTN_PATH							\
+	EXTPATH "encryptors/rotn/.libs/libwiredtiger_rotn.so"
+
 #define	KVS_BDB_PATH							\
 	EXTPATH "test/kvs_bdb/.libs/libwiredtiger_kvs_bdb.so"
 #define	HELIUM_PATH							\
@@ -181,6 +184,7 @@ typedef struct {
 	char	*c_checksum;
 	uint32_t c_chunk_size;
 	char	*c_compression;
+	char	*c_encryption;
 	char	*c_config_open;
 	uint32_t c_data_extend;
 	char	*c_data_source;
@@ -244,6 +248,10 @@ typedef struct {
 #define	COMPRESS_ZLIB_NO_RAW		9
 	u_int c_compression_flag;		/* Compression flag value */
 	u_int c_logging_compression_flag;	/* Log compression flag value */
+
+#define	ENCRYPT_NONE			1
+#define	ENCRYPT_ROTN_7			2
+	u_int c_encryption_flag;		/* Encryption flag value */
 
 #define	ISOLATION_RANDOM		1
 #define	ISOLATION_READ_UNCOMMITTED	2

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -202,6 +202,7 @@ typedef struct {
 	uint32_t c_leak_memory;
 	uint32_t c_logging;
 	uint32_t c_logging_archive;
+	char	*c_logging_compression;
 	uint32_t c_logging_prealloc;
 	uint32_t c_lsm_worker_threads;
 	uint32_t c_merge_max;
@@ -242,6 +243,7 @@ typedef struct {
 #define	COMPRESS_ZLIB			8
 #define	COMPRESS_ZLIB_NO_RAW		9
 	u_int c_compression_flag;		/* Compression flag value */
+	u_int c_logging_compression_flag;	/* Log compression flag value */
 
 #define	ISOLATION_RANDOM		1
 #define	ISOLATION_READ_UNCOMMITTED	2


### PR DESCRIPTION
Stress testing had block compression, this change adds log compression, with some refactoring.  Likewise, overall 'system' encryption is added.