### PR TITLE
Don't checkpoint dead handles

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -486,6 +486,7 @@ __wt_conn_btree_apply_single(WT_SESSION_IMPL *session,
 	bucket = hash % WT_HASH_ARRAY_SIZE;
 	SLIST_FOREACH(dhandle, &conn->dhhash[bucket], hashl)
 		if (F_ISSET(dhandle, WT_DHANDLE_OPEN) &&
+		    !F_ISSET(dhandle, WT_DHANDLE_DEAD) &&
 		    (hash == dhandle->name_hash &&
 		     strcmp(uri, dhandle->name) == 0) &&
 		    ((dhandle->checkpoint == NULL && checkpoint == NULL) ||
@@ -500,7 +501,8 @@ __wt_conn_btree_apply_single(WT_SESSION_IMPL *session,
 			 * still open.
 			 */
 			__wt_spin_lock(session, &dhandle->close_lock);
-			if (F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+			if (F_ISSET(dhandle, WT_DHANDLE_OPEN) &&
+			    !F_ISSET(dhandle, WT_DHANDLE_DEAD)) {
 				WT_WITH_DHANDLE(session, dhandle,
 				    ret = func(session, cfg));
 			}

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -58,7 +58,7 @@ obj_bulk(void)
 }
 
 void
-obj_bulk_unique(void)
+obj_bulk_unique(int force)
 {
 	WT_CURSOR *c;
 	WT_SESSION *session;
@@ -86,7 +86,8 @@ obj_bulk_unique(void)
 	if ((ret = c->close(c)) != 0)
 		testutil_die(ret, "cursor.close");
 
-	while ((ret = session->drop(session, new_uri, NULL)) != 0)
+	while ((ret = session->drop(
+	    session, new_uri, force ? "force" : NULL)) != 0)
 		if (ret != EBUSY)
 			testutil_die(ret, "session.drop: %s", new_uri);
 
@@ -134,7 +135,7 @@ obj_create(void)
 }
 
 void
-obj_create_unique(void)
+obj_create_unique(int force)
 {
 	WT_SESSION *session;
 	int ret;
@@ -154,7 +155,8 @@ obj_create_unique(void)
 		testutil_die(ret, "session.create");
 
 	sched_yield();
-	while ((ret = session->drop(session, new_uri, NULL)) != 0)
+	while ((ret = session->drop(
+	    session, new_uri, force ? "force" : NULL)) != 0)
 		if (ret != EBUSY)
 			testutil_die(ret, "session.drop: %s", new_uri);
 
@@ -163,7 +165,7 @@ obj_create_unique(void)
 }
 
 void
-obj_drop(void)
+obj_drop(int force)
 {
 	WT_SESSION *session;
 	int ret;
@@ -171,7 +173,7 @@ obj_drop(void)
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		testutil_die(ret, "conn.session");
 
-	if ((ret = session->drop(session, uri, NULL)) != 0)
+	if ((ret = session->drop(session, uri, force ? "force" : NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.drop");
 

--- a/test/fops/fops.c
+++ b/test/fops/fops.c
@@ -123,7 +123,7 @@ fop(void *arg)
 			break;
 		case 3:
 			++s->drop;
-			obj_drop();
+			obj_drop(__wt_random(rnd) & 1);
 			break;
 		case 4:
 			++s->ckpt;
@@ -139,11 +139,11 @@ fop(void *arg)
 			break;
 		case 7:
 			++s->bulk_unique;
-			obj_bulk_unique();
+			obj_bulk_unique(__wt_random(rnd) & 1);
 			break;
 		case 8:
 			++s->create_unique;
-			obj_create_unique();
+			obj_create_unique(__wt_random(rnd) & 1);
 			break;
 		}
 

--- a/test/fops/thread.h
+++ b/test/fops/thread.h
@@ -57,11 +57,11 @@ extern pthread_rwlock_t single;			/* Single-thread */
 
 int  fop_start(u_int);
 void obj_bulk(void);
-void obj_bulk_unique(void);
+void obj_bulk_unique(int);
 void obj_checkpoint(void);
 void obj_create(void);
-void obj_create_unique(void);
+void obj_create_unique(int);
 void obj_cursor(void);
-void obj_drop(void);
+void obj_drop(int);
 void obj_upgrade(void);
 void obj_verify(void);


### PR DESCRIPTION
We've seen failures that look like this:

```
2015-05-15T06:30:02.354+0000 E STORAGE  WiredTiger (2) [1431671402:354440][6611:0x2b3e7dfe7940], checkpoint-server: checkpoint server error: No such file or directory
2015-05-15T06:30:02.354+0000 E STORAGE  WiredTiger (-31804) [1431671402:354533][6611:0x2b3e7dfe7940], checkpoint-server: the process must exit and restart: WT_PANIC: WiredTiger library panic
```

This branch enhances `test/fops` to randomly do forced drops to exercise this path (it quickly reproduced the failure), plus adds the fix.