### PR TITLE
Fix a race on shutdown in LSM.

### DIFF
--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -658,6 +658,14 @@ __wt_lsm_manager_push_entry(WT_SESSION_IMPL *session,
 	manager = &S2C(session)->lsm_manager;
 
 	/*
+	 * Don't allow any work units unless a tree is active, this avoids
+	 * races on shutdown between clearing out queues and pushing new
+	 * work units.
+	 */
+	if (!F_ISSET(lsm_tree, WT_LSM_TREE_ACTIVE))
+		return (0);
+
+	/*
 	 * Don't add merges or bloom filter creates if merges
 	 * or bloom filters are disabled in the tree.
 	 */

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -27,6 +27,13 @@ __lsm_tree_discard(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, int final)
 
 	WT_UNUSED(final);	/* Only used in diagnostic builds */
 
+	/*
+	 * The work unit queue should be empty, but it's worth checking
+	 * since work units use a different locking scheme to regular tree
+	 * operations.
+	 */
+	WT_ASSERT(session, lsm_tree->queue_ref == 0);
+
 	/* We may be destroying an lsm_tree before it was added. */
 	if (F_ISSET(lsm_tree, WT_LSM_TREE_OPEN)) {
 		WT_ASSERT(session, final ||


### PR DESCRIPTION
A worker thread could push a new work unit during shutdown, which
could lead to a work unit being processed after the underlying tree
was freed.

refs WT-1935