### PR TITLE
Minor cleanups to page-release.

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1136,10 +1136,10 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * between.
 	 */
 	locked = WT_ATOMIC_CAS4(ref->state, WT_REF_MEM, WT_REF_LOCKED);
-	WT_TRET(__wt_hazard_clear(session, page));
-	if (!locked) {
-		WT_TRET(EBUSY);
-		return (ret);
+	if ((ret = __wt_hazard_clear(session, page)) != 0 || !locked) {
+		if (locked)
+			ref->state = WT_REF_MEM;
+		return (ret == 0 ? EBUSY : ret);
 	}
 
 	(void)WT_ATOMIC_ADD4(btree->evict_busy, 1);
@@ -1156,9 +1156,9 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 			 */
 			WT_STAT_FAST_CONN_INCR(
 			    session, cache_eviction_force_delete);
-	} else {
+	} else
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_force_fail);
-	}
+
 	(void)WT_ATOMIC_SUB4(btree->evict_busy, 1);
 
 	return (ret);
@@ -1180,7 +1180,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * Discard our hazard pointer.  Ignore pages we don't have and the root
 	 * page, which sticks in memory, regardless.
 	 */
-	if (ref == NULL || __wt_ref_is_root(ref))
+	if (ref == NULL || ref->page == NULL || __wt_ref_is_root(ref))
 		return (0);
 
 	/*
@@ -1205,8 +1205,8 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	page = ref->page;
 	if (F_ISSET(btree, WT_BTREE_NO_EVICTION) ||
 	    LF_ISSET(WT_READ_NO_EVICT) ||
-	    page->read_gen != WT_READGEN_OLDEST || !__wt_page_can_evict(
-	    session, page, WT_EVICT_CHECK_SPLITS, NULL))
+	    page->read_gen != WT_READGEN_OLDEST ||
+	    !__wt_page_can_evict(session, page, WT_EVICT_CHECK_SPLITS, NULL))
 		return (__wt_hazard_clear(session, page));
 
 	WT_RET_BUSY_OK(__wt_page_release_evict(session, ref));


### PR DESCRIPTION
@michaelcahill, I took a look today at clearing WT_REF.page during page release -- in short, it's not going to happen, there's too much sync and eviction code that knows hazard pointers aren't necessary once the WT_REF is locked or the file is single-threaded, and expect WT_REF.page to be available.

I did make the change so there's no chance a software bug will release a non-existent hazard pointer after WT_REF.page has been cleared.

And, a couple of trivial cleanups I spotted along the way, both for your review.