### PR TITLE
Add a read barrier to __wt_log_slot_join to avoid a hang.

### DIFF
--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -109,7 +109,7 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize,
 find_slot:
 	allocated_slot = WT_SLOT_ACTIVE == 1 ? 0 :
 	    __wt_random(session->rnd) % WT_SLOT_ACTIVE;
-	WT_READ_BARRIER();
+	WT_BARRIER();
 	slot = log->slot_array[allocated_slot];
 	old_state = slot->slot_state;
 join_slot:

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -109,6 +109,7 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize,
 find_slot:
 	allocated_slot = WT_SLOT_ACTIVE == 1 ? 0 :
 	    __wt_random(session->rnd) % WT_SLOT_ACTIVE;
+	WT_READ_BARRIER();
 	slot = log->slot_array[allocated_slot];
 	old_state = slot->slot_state;
 join_slot:


### PR DESCRIPTION
Otherwise the compiler can decide not to refresh a local variable
and we never see a state update.

refs WT-1938