### PR TITLE
Export a function to get the oldest transaction ID

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -89,13 +89,12 @@ __wt_txn_modify_ref(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
- * __wt_txn_visible_all --
- *	Check if a given transaction ID is "globally visible".	This is, if
- *	all sessions in the system will see the transaction ID including the
- *	ID that belongs to a running checkpoint.
+ * __wt_txn_oldest_id --
+ *	Return the oldest transaction ID that has to be kept for the current
+ *	tree.
  */
-static inline int
-__wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id)
+static inline uint64_t
+__wt_txn_oldest_id(WT_SESSION_IMPL *session)
 {
 	WT_BTREE *btree;
 	WT_TXN_GLOBAL *txn_global;
@@ -124,6 +123,22 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id)
 		 * oldest ID in the system.
 		 */
 		oldest_id = checkpoint_snap_min;
+
+	return (oldest_id);
+}
+
+/*
+ * __wt_txn_visible_all --
+ *	Check if a given transaction ID is "globally visible".	This is, if
+ *	all sessions in the system will see the transaction ID including the
+ *	ID that belongs to a running checkpoint.
+ */
+static inline int
+__wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id)
+{
+	uint64_t oldest_id;
+
+	oldest_id = __wt_txn_oldest_id(session);
 
 	return (WT_TXNID_LT(id, oldest_id));
 }

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -711,7 +711,7 @@ __ovfl_txnc_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * visibility check could give different results as the global ID moves
 	 * forward.
 	 */
-	oldest_txn = S2C(session)->txn_global.oldest_id;
+	oldest_txn = __wt_txn_oldest_id(session);
 
 	/*
 	 * Discard any transaction-cache records with transaction IDs earlier


### PR DESCRIPTION
Export a function to get the oldest transaction ID that needs to be tracked for a given tree.  Managing cached overflow items was using the oldest transaction ID, but the meaning of that field changed.

This fixes a bug that was introduced by WT-1745, that requires a combination of many overflow values, eviction and checkpoints, but can lead to unexpected WT_NOTFOUND errors during reconciliation.