### PR TITLE
Map ENOENT to WT_NOTFOUND in log cursors.

### DIFF
--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -238,8 +238,11 @@ __curlog_next(WT_CURSOR *cursor)
 	 */
 	if (cl->stepp == NULL || cl->stepp >= cl->stepp_end || !*cl->stepp) {
 		cl->txnid = 0;
-		WT_ERR(__wt_log_scan(session, cl->next_lsn, WT_LOGSCAN_ONE,
-		    __curlog_logrec, cl));
+		ret = __wt_log_scan(session, cl->next_lsn, WT_LOGSCAN_ONE,
+		    __curlog_logrec, cl);
+		if (ret == ENOENT)
+			ret = WT_NOTFOUND;
+		WT_ERR(ret);
 	}
 	WT_ASSERT(session, cl->logrec->data != NULL);
 	WT_ERR(__curlog_kv(session, cursor));
@@ -272,8 +275,11 @@ __curlog_search(WT_CURSOR *cursor)
 	 */
 	WT_ERR(__wt_cursor_get_key((WT_CURSOR *)cl,
 	    &key.file, &key.offset, &counter));
-	WT_ERR(__wt_log_scan(session, &key, WT_LOGSCAN_ONE,
-	    __curlog_logrec, cl));
+	ret = __wt_log_scan(session, &key, WT_LOGSCAN_ONE,
+	    __curlog_logrec, cl);
+	if (ret == ENOENT)
+		ret = WT_NOTFOUND;
+	WT_ERR(ret);
 	WT_ERR(__curlog_kv(session, cursor));
 	WT_STAT_FAST_CONN_INCR(session, cursor_search);
 	WT_STAT_FAST_DATA_INCR(session, cursor_search);


### PR DESCRIPTION
http://build.wiredtiger.com:8080/job/wiredtiger-test-format/4201/console

refs WT-1936