### PR TITLE
Sync the log directory when creating log files, not its parent

### DIFF
--- a/src/os_posix/os_open.c
+++ b/src/os_posix/os_open.c
@@ -16,16 +16,9 @@ static int
 __open_directory(WT_SESSION_IMPL *session, char *path, int *fd)
 {
 	WT_DECL_RET;
-	char *dir;
 
-	if ((dir = strrchr(path, '/')) == NULL)
-		path = (char *)".";
-	else
-		*dir = '\0';
 	WT_SYSCALL_RETRY(((*fd =
 	    open(path, O_RDONLY, 0444)) == -1 ? 1 : 0), ret);
-	if (dir != NULL)
-		*dir = '/';
 	if (ret != 0)
 		WT_RET_MSG(session, ret, "%s: open_directory", path);
 	return (ret);


### PR DESCRIPTION
The logging code is the only caller of `__wt_open` with `WT_FILE_TYPE_DIRECTORY` and it passes in the correct path, but `__open_directory` was stripping the last component.

refs WT-1941