### PR TITLE
Database creation

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1718,7 +1718,7 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 			--v.str;
 			v.len += 2;
 		}
-		WT_ERR(fprintf(fp,
+		WT_ERR(__wt_fprintf(fp,
 		    "%.*s=%.*s\n", (int)k.len, k.str, (int)v.len, v.str));
 	}
 	WT_ERR_NOTFOUND_OK(ret);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1417,10 +1417,6 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 	 * WiredTiger file and system utilities on Windows can't copy locked
 	 * files.
 	 *
-	 * For this reason, we don't use the lock file's existence to decide if
-	 * we're creating the database or not, use the WiredTiger file instead,
-	 * it has existed in every version of WiredTiger.
-	 *
 	 * Additionally, avoid an upgrade race: a 2.3.1 release process might
 	 * have the WiredTiger file locked, and we're going to create the lock
 	 * file and lock it instead. For this reason, first acquire a lock on

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1485,7 +1485,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 	 * file. If the turtle file doesn't exist, it's a create.
 	 */
 	WT_ERR(__wt_exist(session, WT_METADATA_TURTLE, &exist));
-	conn->is_new = exist ? 1 : 0;
+	conn->is_new = exist ? 0 : 1;
 
 	if (conn->is_new) {
 		len = (size_t)snprintf(buf, sizeof(buf),

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1975,15 +1975,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	    (WT_CONFIG_ARG *)enc_cfg, &conn->kencryptor));
 
 	/*
-	 * Check on the turtle and metadata files, creating them if necessary
-	 * (which avoids application threads racing to create the metadata file
-	 * later).  Once the metadata file exists, get a reference to it in
-	 * the connection's session.
-	 */
-	WT_ERR(__wt_turtle_init(session));
-	WT_ERR(__wt_metadata_open(session));
-
-	/*
 	 * Configuration completed; optionally write the base configuration file
 	 * if it doesn't already exist.
 	 *
@@ -1996,6 +1987,15 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_config_merge(session,
 	    cfg + 1, "create=,encryption=(secretkey=)", &base_merge));
 	WT_ERR(__conn_write_base_config(session, cfg, base_merge));
+
+	/*
+	 * Check on the turtle and metadata files, creating them if necessary
+	 * (which avoids application threads racing to create the metadata file
+	 * later).  Once the metadata file exists, get a reference to it in
+	 * the connection's session.
+	 */
+	WT_ERR(__wt_turtle_init(session));
+	WT_ERR(__wt_metadata_open(session));
 
 	/*
 	 * Start the worker threads last.

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1679,13 +1679,13 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_RET(__wt_fopen(session,
 	    WT_BASECONFIG_SET, WT_FHANDLE_WRITE, 0, &fp));
 
-	fprintf(fp, "%s\n\n",
+	WT_ERR(__wt_fprintf(fp, "%s\n\n",
 	    "# Do not modify this file.\n"
 	    "#\n"
 	    "# WiredTiger created this file when the database was created,\n"
 	    "# to store persistent database settings.  Instead of changing\n"
 	    "# these settings, set a WIREDTIGER_CONFIG environment variable\n"
-	    "# or create a WiredTiger.config file to override them.");
+	    "# or create a WiredTiger.config file to override them."));
 
 	/*
 	 * The base configuration file contains all changes to default settings
@@ -1718,8 +1718,8 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 			--v.str;
 			v.len += 2;
 		}
-		fprintf(fp,
-		    "%.*s=%.*s\n", (int)k.len, k.str, (int)v.len, v.str);
+		WT_ERR(fprintf(fp,
+		    "%.*s=%.*s\n", (int)k.len, k.str, (int)v.len, v.str));
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -263,7 +263,6 @@ __backup_start(
 			WT_ERR(__backup_list_append(
 			    session, cb, WT_USERCONFIG));
 		WT_ERR(__backup_list_append(session, cb, WT_WIREDTIGER));
-		WT_ERR(__backup_list_append(session, cb, WT_SINGLETHREAD));
 	}
 
 err:	/* Close the hot backup file. */

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -263,6 +263,7 @@ __backup_start(
 			WT_ERR(__backup_list_append(
 			    session, cb, WT_USERCONFIG));
 		WT_ERR(__backup_list_append(session, cb, WT_WIREDTIGER));
+		WT_ERR(__backup_list_append(session, cb, WT_SINGLETHREAD));
 	}
 
 err:	/* Close the hot backup file. */

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -175,10 +175,10 @@ __wt_turtle_init(WT_SESSION_IMPL *session)
 	 * creation doesn't fully complete, we won't have a turtle file and we
 	 * will repeat the process until we succeed.
 	 *
-	 * Incremental backups can occur only run recovery is run and it becomes
-	 * live.  So if there is a turtle file and an incremental backup file
-	 * that is an error.  Otherwise, if there's already a turtle file,
-	 * we're done.
+	 * Incremental backups can occur only if recovery is run and it becomes
+	 * live. So, if there is a turtle file and an incremental backup file,
+	 * that is an error.  Otherwise, if there's already a turtle file, we're
+	 * done.
 	 */
 	WT_RET(__wt_exist(session, WT_INCREMENTAL_BACKUP, &exist_incr));
 	WT_RET(__wt_exist(session, WT_METADATA_TURTLE, &exist));

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -187,23 +187,23 @@ __wt_turtle_init(WT_SESSION_IMPL *session)
 			WT_RET_MSG(session, EINVAL,
 			    "Incremental backup after running recovery "
 			    "is not allowed.");
-		return (0);
+	} else {
+		if (exist_incr)
+			F_SET(S2C(session), WT_CONN_WAS_BACKUP);
+
+		/* Create the metadata file. */
+		WT_RET(__metadata_init(session));
+
+		/* Load any hot-backup information. */
+		WT_RET(__metadata_load_hot_backup(session));
+
+		/* Create any bulk-loaded file stubs. */
+		WT_RET(__metadata_load_bulk(session));
+
+		/* Create the turtle file. */
+		WT_RET(__metadata_config(session, &metaconf));
+		WT_ERR(__wt_turtle_update(session, WT_METAFILE_URI, metaconf));
 	}
-	if (exist_incr)
-		F_SET(S2C(session), WT_CONN_WAS_BACKUP);
-
-	/* Create the metadata file. */
-	WT_RET(__metadata_init(session));
-
-	/* Load any hot-backup information. */
-	WT_RET(__metadata_load_hot_backup(session));
-
-	/* Create any bulk-loaded file stubs. */
-	WT_RET(__metadata_load_bulk(session));
-
-	/* Create the turtle file. */
-	WT_RET(__metadata_config(session, &metaconf));
-	WT_ERR(__wt_turtle_update(session, WT_METAFILE_URI, metaconf));
 
 	/* Remove the backup files, we'll never read them again. */
 	WT_ERR(__wt_backup_file_remove(session));


### PR DESCRIPTION
@michaelcahill, this is a set of changes around database creation. The bug fixes are:

1. WT-1943, don't write the base configuration file if not also creating the database.
2. Don't create the lock file unless also creating the database, so mis-typing a home directory to the `wt` command or other WiredTiger application doesn't litter a random directory with a lock file (this necessitated an additional change, backups now have to copy the lock file to the backup directory).
3. Change "is-new" to test for the final result of database initialization (the creation/rename of the turtle file) instead of the creation of the WiredTiger lock file, so that if we crash in the middle of the process, a subsequent open doesn't incorrectly NOT set is-new.

Some comments:

* By not creating the WiredTiger lock file (and changing backup cursors to copy it instead), we could potentially have a problem with using a newer release to open a backup directory created with an older release because the lock file won't exist and the open will fail. The workaround is to create a lock file by hand, and I don't think the problem is worth worrying about.

* I can't spot a path where the WiredTiger turtle file won't exist once the database is "created", please confirm that. It's a gaping hole in this approach if it's not true. (We should have created a "creation is done" file at the end of the initial creation and used that instead; we could still switch to that approach I suppose, but obviously that leads to an upgrade problem.)