### PR TITLE
Only skip metadata checkpoint if we really skipped it, not force.

### DIFF
--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -148,8 +148,9 @@ struct __wt_btree {
 #define	WT_BTREE_IN_MEMORY	0x00200	/* Cache-resident object */
 #define	WT_BTREE_NO_EVICTION	0x00400	/* Disable eviction */
 #define	WT_BTREE_SALVAGE	0x00800	/* Handle is for salvage */
-#define	WT_BTREE_UPGRADE	0x01000	/* Handle is for upgrade */
-#define	WT_BTREE_VERIFY		0x02000	/* Handle is for verify */
+#define	WT_BTREE_SKIP_CKPT	0x01000	/* Handle skipped checkpoint */
+#define	WT_BTREE_UPGRADE	0x02000	/* Handle is for upgrade */
+#define	WT_BTREE_VERIFY		0x04000	/* Handle is for verify */
 	uint32_t flags;
 };
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -315,6 +315,7 @@ extern void __wt_cache_dump(WT_SESSION_IMPL *session);
 extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags);
 extern void __wt_evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref);
 extern int __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);
+extern int __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn);
 extern int __wt_log_needs_recovery(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn, int *rec);
 extern void __wt_log_written_reset(WT_SESSION_IMPL *session);
 extern int __wt_log_get_all_files(WT_SESSION_IMPL *session, char ***filesp, u_int *countp, uint32_t *maxid, int active_only);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -34,6 +34,50 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn)
 }
 
 /*
+ * __wt_log_force_sync --
+ *	Force a sync of the log and files.
+ */
+int
+__wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+	WT_LOG *log;
+
+	conn = S2C(session);
+	log = conn->log;
+	__wt_spin_lock(session, &log->log_sync_lock);
+	WT_ASSERT(session, log->log_dir_fh != NULL);
+	/*
+	 * Sync the directory if the log file entry hasn't been written
+	 * into the directory.
+	 */
+	if (log->sync_dir_lsn.file < min_lsn->file) {
+		WT_ERR(__wt_verbose(session, WT_VERB_LOG,
+		    "log_force_sync: sync directory %s",
+		    log->log_dir_fh->name));
+		WT_ERR(__wt_directory_sync_fh(session, log->log_dir_fh));
+		log->sync_dir_lsn = *min_lsn;
+		WT_STAT_FAST_CONN_INCR(session, log_sync_dir);
+	}
+	/*
+	 * Sync the log file if needed.
+	 */
+	if (WT_LOG_CMP(&log->sync_lsn, min_lsn) < 0) {
+		WT_ERR(__wt_verbose(session, WT_VERB_LOG,
+		    "log_force_sync: sync to LSN %d/%lu",
+		    min_lsn->file, min_lsn->offset));
+		WT_ERR(__wt_fsync(session, log->log_fh));
+		log->sync_lsn = *min_lsn;
+		WT_STAT_FAST_CONN_INCR(session, log_sync);
+		WT_ERR(__wt_cond_signal(session, log->log_sync_cond));
+	}
+err:
+	__wt_spin_unlock(session, &log->log_sync_lock);
+	return (ret);
+}
+
+/*
  * __wt_log_needs_recovery --
  *	Return 0 if we encounter a clean shutdown and 1 if recovery
  *	must be run in the given variable.

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -303,6 +303,12 @@ __wt_txn_checkpoint_log(
 	case WT_TXN_LOG_CKPT_PREPARE:
 		txn->full_ckpt = 1;
 		*ckpt_lsn = S2C(session)->log->write_start_lsn;
+		/*
+		 * We need to make sure that the log records in the checkpoint
+		 * LSN are on disk.  In particular to make sure that the
+		 * current log file exists.
+		 */
+		WT_ERR(__wt_log_force_sync(session, ckpt_lsn));
 		break;
 
 	case WT_TXN_LOG_CKPT_START:


### PR DESCRIPTION
WT-1944
@michaelcahill I have put the flag back in to only skip idle checkpoints if it was actually skipped, not just based on the modified flag.  Your change in changeset ff56ae5dd686c is causing the second issue in WT-1944.  That change is too broad.  The symptom is that repeated runs of recovery are not forcing a metadata update even though the recovery code uses "force=1".  The change you put in loses the "force" setting and we never updated the metadata, and its checkpoint LSN never advanced.  Please review again.  If you don't like this approach we can discuss alternatives.