### PR TITLE
Calculate a merge generation for bulk loaded LSM chunks.

### DIFF
--- a/src/lsm/lsm_cursor_bulk.c
+++ b/src/lsm/lsm_cursor_bulk.c
@@ -17,11 +17,14 @@ __clsm_close_bulk(WT_CURSOR *cursor)
 {
 	WT_CURSOR_LSM *clsm;
 	WT_CURSOR *bulk_cursor;
+	WT_LSM_CHUNK *chunk;
 	WT_LSM_TREE *lsm_tree;
 	WT_SESSION_IMPL *session;
+	uint64_t avg_chunks, last_size;
 
 	clsm = (WT_CURSOR_LSM *)cursor;
 	lsm_tree = clsm->lsm_tree;
+	chunk = lsm_tree->chunk[0];
 	session = (WT_SESSION_IMPL *)clsm->iface.session;
 
 	/* Close the bulk cursor to ensure the chunk is written to disk. */
@@ -31,7 +34,16 @@ __clsm_close_bulk(WT_CURSOR *cursor)
 	clsm->nchunks = 0;
 
 	/* Set ondisk, and flush the metadata */
-	F_SET(lsm_tree->chunk[0], WT_LSM_CHUNK_ONDISK);
+	F_SET(chunk, WT_LSM_CHUNK_ONDISK);
+	/*
+	 * Setup a generation in our chunk, so that future LSM merges choose
+	 * reasonable sets of chunks.
+	 */
+	avg_chunks = (lsm_tree->merge_min + lsm_tree->merge_max) / 2;
+	for (last_size = avg_chunks * lsm_tree->chunk_size;
+	    last_size < chunk->size;
+	    last_size *= avg_chunks, ++chunk->generation) {}
+
 	WT_RET(__wt_lsm_meta_write(session, lsm_tree));
 	++lsm_tree->dsk_gen;
 
@@ -49,15 +61,18 @@ __clsm_insert_bulk(WT_CURSOR *cursor)
 {
 	WT_CURSOR *bulk_cursor;
 	WT_CURSOR_LSM *clsm;
+	WT_LSM_CHUNK *chunk;
 	WT_LSM_TREE *lsm_tree;
 	WT_SESSION_IMPL *session;
 
 	clsm = (WT_CURSOR_LSM *)cursor;
 	lsm_tree = clsm->lsm_tree;
+	chunk = lsm_tree->chunk[0];
 	session = (WT_SESSION_IMPL *)clsm->iface.session;
 
 	WT_ASSERT(session, lsm_tree->nchunks == 1 && clsm->nchunks == 1);
-	++lsm_tree->chunk[0]->count;
+	++chunk->count;
+	chunk->size += cursor->key.size + cursor->value.size;
 	bulk_cursor = *clsm->cursors;
 	bulk_cursor->set_key(bulk_cursor, &cursor->key);
 	bulk_cursor->set_value(bulk_cursor, &cursor->value);


### PR DESCRIPTION
Otherwise LSM tends to choose poor merges after a bulk load,
which leads to degraded performance.

Refs WT-1947