### PR TITLE
Clear all transaction flags on release, not a subset.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -396,8 +396,8 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 	 */
 	__wt_txn_release_snapshot(session);
 	txn->isolation = session->isolation;
-	F_CLR(txn, WT_TXN_ERROR | WT_TXN_HAS_ID |
-	    WT_TXN_NAMED_SNAPSHOT | WT_TXN_READONLY | WT_TXN_RUNNING);
+	/* Ensure the transaction flags are cleared on exit */
+	txn->flags = 0;
 }
 
 /*


### PR DESCRIPTION
Release is the last thing a transaction does - so all state should
be cleared upon release.