### PR TITLE
If we have no config, explicitly check for flushing and clear txn_logsync

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -240,8 +240,8 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 
 	if (cfg != NULL)
 		WT_RET(__wt_txn_config(session, cfg));
-        else if (!FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH))
-                txn->txn_logsync = 0;
+	else if (!FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH))
+		txn->txn_logsync = 0;
 
 	/*
 	 * Allocate a snapshot if required. Named snapshot transactions already

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -240,6 +240,8 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 
 	if (cfg != NULL)
 		WT_RET(__wt_txn_config(session, cfg));
+        else if (!FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH))
+                txn->txn_logsync = 0;
 
 	/*
 	 * Allocate a snapshot if required. Named snapshot transactions already

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -240,7 +240,14 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 
 	if (cfg != NULL)
 		WT_RET(__wt_txn_config(session, cfg));
-	else if (!FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH))
+
+	/*
+	 * If the flush flag is not set, then either the connection-wide
+	 * transaction sync is disabled (the default), or this transaction was
+	 * configured with sync=false.  Either way, if we are not flushing,
+	 * clear all flags that cause the log write to flush.
+	 */
+	if (!FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH))
 		txn->txn_logsync = 0;
 
 	/*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -335,14 +335,12 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 	 * be overridden by an explicit "sync" setting for this transaction.
 	 *
 	 * !!! This is an unusual use of the config code: the "default" value
-	 * we pass in is inherited from the connection.  If flush is not set in
-	 * the connection-wide flag and not overridden here, we end up clearing
-	 * all flags.
+	 * we pass in is inherited from the connection.
 	 */
 	WT_RET(__wt_config_gets_def(session, cfg, "sync",
 	    FLD_ISSET(txn->txn_logsync, WT_LOG_FLUSH) ? 1 : 0, &cval));
 	if (!cval.val)
-		txn->txn_logsync = 0;
+		FLD_CLR(txn->txn_logsync, WT_LOG_FLUSH);
 
 	WT_RET(__wt_config_gets_def(session, cfg, "snapshot", 0, &cval));
 	if (cval.len > 0)


### PR DESCRIPTION
refs  WT-1949

@michaelcahill Although this is a tiny diff, please carefully review.  I explain what is happening in the Jira ticket.  This feels a tiny bit hacky to me, but some of that is due to how the config code assumes the inheritance from the connection, and changes defaults based on that.