### PR TITLE
Fix configure checks for posix_memalign

### DIFF
--- a/build_posix/aclocal/ax_func_posix_memalign.m4
+++ b/build_posix/aclocal/ax_func_posix_memalign.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_func_posix_memalign.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_FUNC_POSIX_MEMALIGN
+#
+# DESCRIPTION
+#
+#   Some versions of posix_memalign (notably glibc 2.2.5) incorrectly apply
+#   their power-of-two check to the size argument, not the alignment
+#   argument. AX_FUNC_POSIX_MEMALIGN defines HAVE_POSIX_MEMALIGN if the
+#   power-of-two check is correctly applied to the alignment argument.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Scott Pakin <pakin@uiuc.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
+[AC_CACHE_CHECK([for working posix_memalign],
+  [ax_cv_func_posix_memalign_works],
+  [AC_TRY_RUN([
+#include <stdlib.h>
+
+int
+main ()
+{
+  void *buffer;
+
+  /* Some versions of glibc incorrectly perform the alignment check on
+   * the size word. */
+  exit (posix_memalign (&buffer, sizeof(void *), 123) != 0);
+}
+    ],
+    [ax_cv_func_posix_memalign_works=yes],
+    [ax_cv_func_posix_memalign_works=no],
+    [ax_cv_func_posix_memalign_works=no])])
+if test "$ax_cv_func_posix_memalign_works" = "yes" ; then
+  AC_DEFINE([HAVE_POSIX_MEMALIGN], [1],
+    [Define to 1 if `posix_memalign' works.])
+fi
+])

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -80,11 +80,15 @@ AC_CHECK_LIB(rt, sched_yield)
 
 AC_CHECK_FUNCS([\
 	clock_gettime fallocate fcntl fread_unlocked ftruncate gettimeofday\
-	posix_fadvise posix_fallocate posix_madvise posix_memalign\
+	posix_fadvise posix_fallocate posix_madvise\
 	strtouq sync_file_range])
 
 # OS X wrongly reports that it has fdatasync
 AS_CASE([$host_os], [darwin*], [], [AC_CHECK_FUNCS([fdatasync])])
+
+# Check for posix_memalign explicitly: it is a builtin in some compilers and
+# the generic declaration in AC_CHECK_FUNCS is incompatible.
+AX_FUNC_POSIX_MEMALIGN
 
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
Add code from the autoconf archive to detect `posix_memalign` instead of relying on AC_CHECK_FUNCS.

refs WT-1951