### PR TITLE
Strip out the "log=(recover=)" configuration from the base configuration file.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1721,8 +1721,8 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 	 * to be stripped out from the base configuration file; do that now, and
 	 * merge the rest to be written.
 	 */
-	WT_ERR(__wt_config_merge(session,
-	    cfg + 1, "create=,encryption=(secretkey=)", &base_config));
+	WT_ERR(__wt_config_merge(session, cfg + 1,
+	    "create=,encryption=(secretkey=),log=(recover=)", &base_config));
 	WT_ERR(__wt_config_init(session, &parser, base_config));
 	while ((ret = __wt_config_next(&parser, &k, &v)) == 0) {
 		/* Fix quoting for non-trivial settings. */


### PR DESCRIPTION
@sueloverso, for your review.

I don't see any easy way to create a configuration string to do this work, but it's only in one place, so it's probably OK to inline it?