### PR TITLE
txn-release resets txn->isolation

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -397,11 +397,15 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 		__wt_split_stash_discard(session);
 
 	/*
-	 * Reset the transaction state to not running and release the snapshot.
+	 * Release any snapshot.
 	 */
 	__wt_txn_release_snapshot(session);
-	txn->isolation = session->isolation;
-	/* Ensure the transaction flags are cleared on exit */
+
+	/*
+	 * Clear the transaction flags: the one we care about is WT_TXN_RUNNING
+	 * which ensures we don't look at this transaction again, but clearing
+	 * them all is fine.
+	 */
 	txn->flags = 0;
 }
 


### PR DESCRIPTION
@agorrod, I had a branch lying around from when we were talking about 7b6fe6a.

The one change I had that didn't get in was removing where we're clearing `txn->isolation` in `__wt_txn_release`.

Since the session's isolation can change at any time, resetting here can't be meaningful, so I think it should go.