### PR TITLE
Add fix for C2054 to lz4_compress

### DIFF
--- a/ext/compressors/lz4/lz4_compress.c
+++ b/ext/compressors/lz4/lz4_compress.c
@@ -39,6 +39,9 @@
  * is being built into the WiredTiger library.
  */
 #include "wiredtiger_config.h"
+#ifdef _MSC_VER
+#define	inline __inline
+#endif
 
 /* Local compressor structure. */
 typedef struct {


### PR DESCRIPTION
The new LZ4 code will not compile under windows as we are missing an override of "inline" to avoid C2054 errors.

@agorrod and @markbenvenuto can you have a look at this? The logic here is the same as for zlib.