### PR TITLE
Add a "statistics=(size)" mode to statistics cursors

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -769,22 +769,22 @@ methods = {
         type='boolean', undoc=True),
     Config('statistics', '', r'''
         Specify the statistics to be gathered.  Choosing "all" gathers
-        statistics regardless of cost and may include traversing
-        on-disk files; "fast" gathers a subset of relatively
-        inexpensive statistics.  The selection must agree with the
-        database \c statistics configuration specified to
-        ::wiredtiger_open or WT_CONNECTION::reconfigure.  For example,
-        "all" or "fast" can be configured when the database is
-        configured with "all", but the cursor open will fail if "all"
-        is specified when the database is configured with "fast",
-        and the cursor open will fail in all cases when the database
-        is configured with "none".  If \c statistics is not configured,
-        the default configuration is the database configuration.
-        The "clear" configuration resets statistics after gathering
-        them, where appropriate (for example, a cache size statistic
-        is not cleared, while the count of cursor insert operations
-        will be cleared).  See @ref statistics for more information''',
-        type='list', choices=['all', 'fast', 'clear']),
+        statistics regardless of cost and may include traversing on-disk files;
+        "fast" gathers a subset of relatively inexpensive statistics.  The
+        selection must agree with the database \c statistics configuration
+        specified to ::wiredtiger_open or WT_CONNECTION::reconfigure.  For
+        example, "all" or "fast" can be configured when the database is
+        configured with "all", but the cursor open will fail if "all" is
+        specified when the database is configured with "fast", and the cursor
+        open will fail in all cases when the database is configured with
+        "none".  If "size" is configured, only the underlying size of the
+        object on disk is filled in and the object is not opened.  If \c
+        statistics is not configured, the default configuration is the database
+        configuration.  The "clear" configuration resets statistics after
+        gathering them, where appropriate (for example, a cache size statistic
+        is not cleared, while the count of cursor insert operations will be
+        cleared).  See @ref statistics for more information''',
+        type='list', choices=['all', 'fast', 'clear', 'size']),
     Config('target', '', r'''
         if non-empty, backup the list of objects; valid only for a
         backup data source''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -286,7 +286,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_open_cursor[] = {
 	{ "readonly", "boolean", NULL, NULL, NULL, 0 },
 	{ "skip_sort_check", "boolean", NULL, NULL, NULL, 0 },
 	{ "statistics", "list",
-	    NULL, "choices=[\"all\",\"fast\",\"clear\"]",
+	    NULL, "choices=[\"all\",\"fast\",\"clear\",\"size\"]",
 	    NULL, 0 },
 	{ "target", "list", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -286,6 +286,7 @@ struct __wt_connection_impl {
 #define	WT_CONN_STAT_FAST	0x04	/* "fast" statistics configured */
 #define	WT_CONN_STAT_NONE	0x08	/* don't gather statistics */
 #define	WT_CONN_STAT_ON_CLOSE	0x10	/* output statistics on close */
+#define	WT_CONN_STAT_SIZE	0x20	/* "size" statistics configured */
 	uint32_t stat_flags;
 
 	WT_CONNECTION_STATS stats;	/* Connection statistics */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -946,14 +946,16 @@ struct __wt_session {
 	 * configured when the database is configured with "all"\, but the
 	 * cursor open will fail if "all" is specified when the database is
 	 * configured with "fast"\, and the cursor open will fail in all cases
-	 * when the database is configured with "none". If \c statistics is not
+	 * when the database is configured with "none". If "size" is
+	 * configured\, only the underlying size of the object on disk is filled
+	 * in and the object is not opened.  If \c statistics is not
 	 * configured\, the default configuration is the database configuration.
 	 * The "clear" configuration resets statistics after gathering them\,
 	 * where appropriate (for example\, a cache size statistic is not
 	 * cleared\, while the count of cursor insert operations will be
 	 * cleared). See @ref statistics for more information., a list\, with
 	 * values chosen from the following options: \c "all"\, \c "fast"\, \c
-	 * "clear"; default empty.}
+	 * "clear"\, \c "size"; default empty.}
 	 * @config{target, if non-empty\, backup the list of objects; valid only
 	 * for a backup data source., a list of strings; default empty.}
 	 * @configend

--- a/src/lsm/lsm_stat.c
+++ b/src/lsm/lsm_stat.c
@@ -40,11 +40,12 @@ __curstat_lsm_init(
 	/* Propagate all, fast and/or clear to the cursors we open. */
 	if (!F_ISSET(cst, WT_CONN_STAT_NONE)) {
 		(void)snprintf(config, sizeof(config),
-		    "statistics=(%s%s%s)",
-		    F_ISSET(cst, WT_CONN_STAT_CLEAR) ? "clear," : "",
+		    "statistics=(%s%s%s%s)",
 		    F_ISSET(cst, WT_CONN_STAT_ALL) ? "all," : "",
+		    F_ISSET(cst, WT_CONN_STAT_CLEAR) ? "clear," : "",
 		    !F_ISSET(cst, WT_CONN_STAT_ALL) &&
-		    F_ISSET(cst, WT_CONN_STAT_FAST) ? "fast," : "");
+		    F_ISSET(cst, WT_CONN_STAT_FAST) ? "fast," : "",
+		    F_ISSET(cst, WT_CONN_STAT_SIZE) ? "size," : "");
 		cfg[1] = disk_cfg[1] = config;
 	}
 

--- a/test/suite/test_stat01.py
+++ b/test/suite/test_stat01.py
@@ -136,6 +136,12 @@ class test_stat01(wttest.WiredTigerTestCase):
         self.assertEqual(val, values[2])
         cursor.close()
 
+        cursor = self.session.open_cursor(
+            'statistics:' + self.uri, None, "statistics=(size)")
+        values = cursor[stat.dsrc.block_size]
+        self.assertNotEqual(values[2], 0)
+        cursor.close()
+
     # Test simple per-checkpoint statistics.
     def test_checkpoint_stats(self):
         for name in ('first', 'second', 'third'):


### PR DESCRIPTION
Add a "statistics=(size)" mode to statistics cursors that just gets the filesize without opening anything.

refs SERVER-17078