### PR TITLE
AC_TRY_RUN is obsolete.

### DIFF
--- a/build_posix/aclocal/ax_func_posix_memalign.m4
+++ b/build_posix/aclocal/ax_func_posix_memalign.m4
@@ -27,7 +27,7 @@
 AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
 [AC_CACHE_CHECK([for working posix_memalign],
   [ax_cv_func_posix_memalign_works],
-  [AC_TRY_RUN([
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 
 int
@@ -39,7 +39,7 @@ main ()
    * the size word. */
   exit (posix_memalign (&buffer, sizeof(void *), 123) != 0);
 }
-    ],
+    ]])],
     [ax_cv_func_posix_memalign_works=yes],
     [ax_cv_func_posix_memalign_works=no],
     [ax_cv_func_posix_memalign_works=no])])


### PR DESCRIPTION
@michaelcahill, did you have a test you ran to integrate the AX_FUNC_POSIX_MEMALIGN macro, could we re-run that test?