### PR TITLE
Move the statistics=(size) support into the block manager

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -388,7 +388,7 @@ err:	__wt_scr_free(session, &buf);
 
 /*
  * __wt_block_stat --
- *	Block statistics
+ *	Set the statistics for a live block handle.
  */
 void
 __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats)
@@ -408,4 +408,20 @@ __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats)
 	WT_STAT_SET(stats, block_reuse_bytes, block->live.avail.bytes);
 	WT_STAT_SET(stats, block_size, block->fh->size);
 	__wt_spin_unlock(session, &block->live_lock);
+}
+
+/*
+ * __wt_block_manager_size --
+ *	Set the size statistic for a file.
+ */
+int
+__wt_block_manager_size(
+    WT_SESSION_IMPL *session, const char *filename, WT_DSRC_STATS *stats)
+{
+	wt_off_t filesize;
+
+	WT_RET(__wt_filesize_name(session, filename, &filesize));
+	WT_STAT_SET(stats, block_size, filesize);
+
+	return (0);
 }

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -373,7 +373,6 @@ __curstat_file_init(WT_SESSION_IMPL *session,
 {
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	wt_off_t filesize;
 	const char *filename;
 
 	/*

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -374,21 +374,19 @@ __curstat_file_init(WT_SESSION_IMPL *session,
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 	wt_off_t filesize;
+	const char *filename;
 
 	/*
 	 * If we are only getting the size of the file, we don't need to open
 	 * the tree.
 	 */
 	if (F_ISSET(cst, WT_CONN_STAT_SIZE)) {
-		if (!WT_PREFIX_SKIP(uri, "file:"))
-			WT_RET_MSG(session, EINVAL,
-			    "incorrect URI %s passed to file-specific call",
-			    uri);
-
-		WT_RET(__wt_filesize_name(session, uri, &filesize));
-
+		filename = uri;
+		if (!WT_PREFIX_SKIP(filename, "file:"))
+			return (EINVAL);
 		__wt_stat_init_dsrc_stats(&cst->u.dsrc_stats);
-		cst->u.dsrc_stats.block_size.v = (uint64_t)filesize;
+		WT_RET(__wt_block_manager_size(
+		    session, filename, &cst->u.dsrc_stats));
 		__wt_curstat_dsrc_final(cst);
 		return (0);
 	}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -50,6 +50,7 @@ extern int __wt_block_open(WT_SESSION_IMPL *session, const char *filename, const
 extern int __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_desc_init(WT_SESSION_IMPL *session, WT_FH *fh, uint32_t allocsize);
 extern void __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats);
+extern int __wt_block_manager_size( WT_SESSION_IMPL *session, const char *filename, WT_DSRC_STATS *stats);
 extern int __wt_bm_preload(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);
 extern int __wt_bm_read(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, size_t addr_size);
 extern int __wt_block_read_off_blind( WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_off_t offset);


### PR DESCRIPTION
@michaelcahill, I think this work should be in the block manager, for clarity.

Thoughts?