### PR TITLE
Change WT_SESSION.verify to not error on leaked blocks, by default.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -834,6 +834,11 @@ methods = {
     Config('dump_shape', 'false', r'''
         Display the shape of the tree after verification,
         using the application's message handler, intended for debugging''',
+        type='boolean'),
+    Config('strict', 'false', r'''
+        Treat any verification problem as an error; by default, verify will
+        warn, but not fail, in the case of errors that won't affect future
+        behavior (for example, a leaked block)''',
         type='boolean')
 ]),
 

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -302,9 +302,10 @@ __bm_salvage_end(WT_BM *bm, WT_SESSION_IMPL *session)
  *	Start a block manager verify.
  */
 static int
-__bm_verify_start(WT_BM *bm, WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
+__bm_verify_start(WT_BM *bm,
+    WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 {
-	return (__wt_block_verify_start(session, bm->block, ckptbase));
+	return (__wt_block_verify_start(session, bm->block, ckptbase, cfg));
 }
 
 /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -23,7 +23,7 @@ typedef struct {
 #define	WT_VRFY_DUMP(vs)						\
 	((vs)->dump_address ||						\
 	    (vs)->dump_blocks || (vs)->dump_pages || (vs)->dump_shape)
-	int dump_address;			/* Debugging hooks */
+	int dump_address;			/* Configure: dump special */
 	int dump_blocks;
 	int dump_pages;
 	int dump_shape;
@@ -183,7 +183,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
 	    __wt_meta_ckptlist_get(session, btree->dhandle->name, &ckptbase));
 
 	/* Inform the underlying block manager we're verifying. */
-	WT_ERR(bm->verify_start(bm, session, ckptbase));
+	WT_ERR(bm->verify_start(bm, session, ckptbase, cfg));
 	bm_start = 1;
 
 	/* Loop through the file's checkpoints, verifying each one. */

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -336,6 +336,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_verify[] = {
 	{ "dump_offsets", "list", NULL, NULL, NULL, 0 },
 	{ "dump_pages", "boolean", NULL, NULL, NULL, 0 },
 	{ "dump_shape", "boolean", NULL, NULL, NULL, 0 },
+	{ "strict", "boolean", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -909,8 +910,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "WT_SESSION.verify",
 	  "dump_address=0,dump_blocks=0,dump_offsets=,dump_pages=0,"
-	  "dump_shape=0",
-	  confchk_WT_SESSION_verify, 5
+	  "dump_shape=0,strict=0",
+	  confchk_WT_SESSION_verify, 6
 	},
 	{ "colgroup.meta",
 	  "app_metadata=,collator=,columns=,source=,type=file",

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -1,5 +1,23 @@
 /*! @page upgrading Upgrading WiredTiger applications
 
+@section version_262 Upgrading to Version 2.6.2
+
+<dl>
+<dt>WT_SESSION.verify</dt>
+<dd>
+The WT_SESSION.verify method in this release has a new configuration
+option, \c strict. By default, with \c strict set to \c false,
+WT_SESSION.verify will no longer return an error for problems that do
+not impact the future use of the object (for example, if a leaked block
+were detected, the application can continue to run).  WT_SESSION.verify
+will continue to output an error message whenever an error is detected,
+only the final return value is affected.  This change allows
+applications to verify objects and continue if at all possible.
+Applications in development should configure \c strict to \c true in
+order to terminate the application whenever an error is detected.
+</dd>
+
+</dl><hr>
 @section version_261 Upgrading to Version 2.6.1
 
 <dl>

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -185,7 +185,8 @@ struct __wt_bm {
 	int (*sync)(WT_BM *, WT_SESSION_IMPL *, int);
 	int (*verify_addr)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
 	int (*verify_end)(WT_BM *, WT_SESSION_IMPL *);
-	int (*verify_start)(WT_BM *, WT_SESSION_IMPL *, WT_CKPT *);
+	int (*verify_start)
+	    (WT_BM *, WT_SESSION_IMPL *, WT_CKPT *, const char *[]);
 	int (*write) (WT_BM *,
 	    WT_SESSION_IMPL *, WT_ITEM *, uint8_t *, size_t *, int);
 	int (*write_size)(WT_BM *, WT_SESSION_IMPL *, size_t *);
@@ -246,6 +247,7 @@ struct __wt_block {
 
 				/* Verification support */
 	int	   verify;		/* If performing verification */
+	int	   verify_strict;	/* Fail hard on any error */
 	wt_off_t   verify_size;		/* Checkpoint's file size */
 	WT_EXTLIST verify_alloc;	/* Verification allocation list */
 	uint64_t   frags;		/* Maximum frags in the file */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -65,7 +65,7 @@ extern int __wt_block_salvage_end(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_offset_invalid(WT_BLOCK *block, wt_off_t offset, uint32_t size);
 extern int __wt_block_salvage_next(WT_SESSION_IMPL *session, WT_BLOCK *block, uint8_t *addr, size_t *addr_sizep, int *eofp);
 extern int __wt_block_salvage_valid(WT_SESSION_IMPL *session, WT_BLOCK *block, uint8_t *addr, size_t addr_size, int valid);
-extern int __wt_block_verify_start( WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase);
+extern int __wt_block_verify_start(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase, const char *cfg[]);
 extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_verify_ckpt_load( WT_SESSION_IMPL *session, WT_BLOCK *block, WT_BLOCK_CKPT *ci);
 extern int __wt_verify_ckpt_unload(WT_SESSION_IMPL *session, WT_BLOCK *block);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1360,6 +1360,10 @@ struct __wt_session {
 	 * @config{dump_shape, Display the shape of the tree after
 	 * verification\, using the application's message handler\, intended for
 	 * debugging., a boolean flag; default \c false.}
+	 * @config{strict, Treat any verification problem as an error; by
+	 * default\, verify will warn\, but not fail\, in the case of errors
+	 * that won't affect future behavior (for example\, a leaked block)., a
+	 * boolean flag; default \c false.}
 	 * @configend
 	 * @ebusy_errors
 	 */

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -499,7 +499,7 @@ wts_verify(const char *tag)
 		    "=============== verify start ===============");
 
 	/* Session operations for LSM can return EBUSY. */
-	ret = session->verify(session, g.uri, NULL);
+	ret = session->verify(session, g.uri, "strict");
 	if (ret != 0 && !(ret == EBUSY && DATASOURCE("lsm")))
 		die(ret, "session.verify: %s: %s", g.uri, tag);
 


### PR DESCRIPTION
Reference WT-1959.