### PR TITLE
SERVER-18829 Have pages start in the middle of the LRU queue for eviction

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -183,7 +183,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			    page->read_gen != WT_READGEN_OLDEST &&
 			    page->read_gen < __wt_cache_read_gen(session))
 				page->read_gen =
-				    __wt_cache_read_gen_set(session);
+				    __wt_cache_read_gen_bump(session);
 skip_evict:
 			/*
 			 * Check if we need an autocommit transaction.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -824,9 +824,6 @@ __evict_lru_walk(WT_SESSION_IMPL *session, uint32_t flags)
 
 	cache->evict_entries = entries;
 
-	/* Track the oldest read generation we have in the queue. */
-	cache->read_gen_oldest = cache->evict[0].ref->page->read_gen;
-
 	if (entries == 0) {
 		/*
 		 * If there are no entries, there cannot be any candidates.
@@ -840,6 +837,9 @@ __evict_lru_walk(WT_SESSION_IMPL *session, uint32_t flags)
 	}
 
 	WT_ASSERT(session, cache->evict[0].ref != NULL);
+
+	/* Track the oldest read generation we have in the queue. */
+	cache->read_gen_oldest = cache->evict[0].ref->page->read_gen;
 
 	if (LF_ISSET(WT_EVICT_PASS_AGGRESSIVE | WT_EVICT_PASS_WOULD_BLOCK))
 		/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -485,6 +485,14 @@ __evict_pass(WT_SESSION_IMPL *session)
 			    session, cache->evict_waiter_cond));
 		}
 
+		/*
+		 * Increment the shared read generation.  We do this
+		 * occasionally even if eviction is not currently required, so
+		 * that pages have some relative read generation when the
+		 * eviction server does need to do some work.
+		 */
+		__wt_cache_read_gen_incr(session);
+
 		WT_RET(__evict_has_work(session, &flags));
 		if (flags == 0)
 			break;
@@ -816,6 +824,9 @@ __evict_lru_walk(WT_SESSION_IMPL *session, uint32_t flags)
 
 	cache->evict_entries = entries;
 
+	/* Track the oldest read generation we have in the queue. */
+	cache->read_gen_oldest = cache->evict[0].ref->page->read_gen;
+
 	if (entries == 0) {
 		/*
 		 * If there are no entries, there cannot be any candidates.
@@ -923,9 +934,6 @@ __evict_walk(WT_SESSION_IMPL *session, uint32_t flags)
 	dhandle = NULL;
 	incr = dhandle_locked = 0;
 	retries = 0;
-
-	/* Increment the shared read generation. */
-	__wt_cache_read_gen_incr(session);
 
 	/*
 	 * Update the oldest ID: we use it to decide whether pages are
@@ -1213,15 +1221,11 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp, uint32_t flags)
 			continue;
 
 		/*
-		 * If this page has never been considered for eviction,
-		 * set its read generation to a little bit in the
-		 * future and move on, give readers a chance to start
-		 * updating the read generation.
+		 * If this page has never been considered for eviction, set its
+		 * read generation to somewhere in the middle of the LRU list.
 		 */
-		if (page->read_gen == WT_READGEN_NOTSET) {
-			page->read_gen = __wt_cache_read_gen_set(session);
-			continue;
-		}
+		if (page->read_gen == WT_READGEN_NOTSET)
+			page->read_gen = __wt_cache_read_gen_new(session);
 
 fast:		/* If the page can't be evicted, give up. */
 		if (!__wt_page_can_evict(session, page, 1, NULL))
@@ -1414,7 +1418,7 @@ __wt_evict_lru_page(WT_SESSION_IMPL *session, int is_server)
 	 */
 	page = ref->page;
 	if (page->read_gen != WT_READGEN_OLDEST)
-		page->read_gen = __wt_cache_read_gen_set(session);
+		page->read_gen = __wt_cache_read_gen_bump(session);
 
 	/*
 	 * If we are evicting in a dead tree, don't write dirty pages.

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -71,6 +71,8 @@ struct __wt_cache {
 	 * Read information.
 	 */
 	uint64_t   read_gen;		/* Page read generation (LRU) */
+	uint64_t   read_gen_oldest;	/* The oldest read generation that
+					   eviction knows about */
 
 	/*
 	 * Eviction thread information.

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -27,11 +27,11 @@ __wt_cache_read_gen_incr(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_cache_read_gen_set --
- *      Get the read generation to store in a page.
+ * __wt_cache_read_gen_bump --
+ *      Get the read generation to keep a page in memory.
  */
 static inline uint64_t
-__wt_cache_read_gen_set(WT_SESSION_IMPL *session)
+__wt_cache_read_gen_bump(WT_SESSION_IMPL *session)
 {
 	/*
 	 * We return read-generations from the future (where "the future" is
@@ -43,6 +43,19 @@ __wt_cache_read_gen_set(WT_SESSION_IMPL *session)
 	 * immediately after each update we have to make.
 	 */
 	return (__wt_cache_read_gen(session) + WT_READGEN_STEP);
+}
+
+/*
+ * __wt_cache_read_gen_new --
+ *      Get the read generation for a new page in memory.
+ */
+static inline uint64_t
+__wt_cache_read_gen_new(WT_SESSION_IMPL *session)
+{
+	WT_CACHE *cache;
+
+	cache = S2C(session)->cache;
+	return (__wt_cache_read_gen(session) + cache->read_gen_oldest) / 2;
 }
 
 /*


### PR DESCRIPTION
Also make sure that when eviction first needs to run, it can find some pages to
evict.