### PR TITLE
WT-1966 Change how the shared cache assigns priority to participants.

### DIFF
--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -455,7 +455,7 @@ __cache_pool_assess(WT_SESSION_IMPL *session, uint64_t *phighest)
 	WT_CACHE_POOL *cp;
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *entry;
-	uint64_t entries, highest, new;
+	uint64_t entries, highest, tmp;
 
 	cp = __wt_process.cache_pool;
 	entries = 0;
@@ -468,25 +468,26 @@ __cache_pool_assess(WT_SESSION_IMPL *session, uint64_t *phighest)
 			continue;
 		cache = entry->cache;
 		++entries;
-		new = cache->bytes_read;
+		/* Copy the value out so it doesn't change underneath us */
+		tmp = cache->bytes_read;
 		/* Handle wrapping of eviction requests. */
-		if (new >= cache->cp_saved_read)
-			cache->cp_pass_read = new - cache->cp_saved_read;
+		if (tmp >= cache->cp_saved_read)
+			cache->cp_pass_read = tmp - cache->cp_saved_read;
 		else
-			cache->cp_pass_read = new;
-		cache->cp_saved_read = new;
+			cache->cp_pass_read = tmp;
+		cache->cp_saved_read = tmp;
 
 		/* Update the application eviction count information */
-		new = cache->cp_saved_app_evicts;
+		tmp = cache->cp_saved_app_evicts;
 		cache->cp_pass_app_evicts =
-		    new - cache->cp_pass_app_evicts;
-		cache->cp_saved_app_evicts = new;
+		    tmp - cache->cp_pass_app_evicts;
+		cache->cp_saved_app_evicts = tmp;
 
 		/* Update the eviction wait information */
-		new = cache->cp_saved_app_waits;
+		tmp = cache->cp_saved_app_waits;
 		cache->cp_pass_app_waits =
-		    new - cache->cp_pass_app_waits;
-		cache->cp_saved_app_waits = new;
+		    tmp - cache->cp_pass_app_waits;
+		cache->cp_saved_app_waits = tmp;
 
 		/* Calculate the weighted pressure for this member */
 		cache->cp_pass_pressure =

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1494,6 +1494,7 @@ __wt_cache_wait(WT_SESSION_IMPL *session, int full)
 
 		switch (ret = __wt_evict_lru_page(session, 0)) {
 		case 0:
+			cache->app_evicts++;
 			if (--count == 0)
 				return (0);
 			break;
@@ -1533,6 +1534,7 @@ __wt_cache_wait(WT_SESSION_IMPL *session, int full)
 		WT_RET(__wt_cond_wait(session,
 		    S2C(session)->cache->evict_waiter_cond, 100000));
 
+		cache->app_waits++;
 		/* Check if things have changed so that we are busy. */
 		if (!busy && txn_state->snap_min != WT_TXN_NONE &&
 		    txn_global->current != txn_global->oldest_id)

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -65,6 +65,9 @@ struct __wt_cache {
 	uint64_t pages_dirty;
 	uint64_t bytes_read;		/* Bytes read into memory */
 
+	uint64_t app_evicts;		/* Pages evicted by user threads */
+	uint64_t app_waits;		/* User threads waited for cache */
+
 	uint64_t evict_max_page_size;	/* Largest page seen at eviction */
 
 	/*
@@ -105,8 +108,13 @@ struct __wt_cache {
 	/*
 	 * Cache pool information.
 	 */
-	uint64_t cp_saved_read;		/* Read count from last pass */
-	uint64_t cp_current_read;	/* Read count from current pass */
+	uint64_t cp_saved_app_evicts;	/* User eviction count at last review */
+	uint64_t cp_saved_app_waits;	/* User wait count at last review */
+	uint64_t cp_saved_read;		/* Read count at last review */
+	uint64_t cp_pass_app_evicts;	/* User eviction count from this pass */
+	uint64_t cp_pass_app_waits;	/* User wait count from this pass */
+	uint64_t cp_pass_pressure;	/* Calculated pressure from this pass */
+	uint64_t cp_pass_read;		/* Read count from this pass */
 	uint32_t cp_skip_count;		/* Post change stabilization */
 	uint64_t cp_reserved;		/* Base size for this cache */
 	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -108,17 +108,15 @@ struct __wt_cache {
 	/*
 	 * Cache pool information.
 	 */
+	uint64_t cp_pass_pressure;	/* Calculated pressure from this pass */
+	uint64_t cp_reserved;		/* Base size for this cache */
+	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */
+	uint32_t cp_skip_count;		/* Post change stabilization */
+	wt_thread_t cp_tid;		/* Thread ID for cache pool manager */
+	/* State seen at the last pass of the shared cache manager */
 	uint64_t cp_saved_app_evicts;	/* User eviction count at last review */
 	uint64_t cp_saved_app_waits;	/* User wait count at last review */
 	uint64_t cp_saved_read;		/* Read count at last review */
-	uint64_t cp_pass_app_evicts;	/* User eviction count from this pass */
-	uint64_t cp_pass_app_waits;	/* User wait count from this pass */
-	uint64_t cp_pass_pressure;	/* Calculated pressure from this pass */
-	uint64_t cp_pass_read;		/* Read count from this pass */
-	uint32_t cp_skip_count;		/* Post change stabilization */
-	uint64_t cp_reserved;		/* Base size for this cache */
-	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */
-	wt_thread_t cp_tid;		/* Thread ID for cache pool manager */
 
 	/*
 	 * Flags.


### PR DESCRIPTION
The old code implicitly assumed at least 10 members. The new
code uses a pressure based on a percentage of the most active
member.

refs WT-1966