### PR TITLE
WT-1975 Wait for sync_lsn of earlier log files to complete for forced sync.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -318,6 +318,8 @@ __log_file_server(void *arg)
 			__wt_spin_lock(session, &log->log_sync_lock);
 			locked = 1;
 			WT_ERR(__wt_close(session, &close_fh));
+			WT_ASSERT(session,
+			    WT_LOG_CMP(&close_end_lsn, &log->sync_lsn) >= 0);
 			log->sync_lsn = close_end_lsn;
 			WT_ERR(__wt_cond_signal(session, log->log_sync_cond));
 			locked = 0;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -71,6 +71,19 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 
 	log = S2C(session)->log;
 
+	/*
+	 * We need to wait for the previous log file to get written
+	 * to disk before we sync out the current one and advance
+	 * the LSN.  Signal the worker thread because we know the
+	 * LSN has moved into a later log file and there should be a
+	 * log file ready to close.
+	 */
+	while (log->sync_lsn.file < min_lsn->file) {
+		WT_ERR(__wt_cond_signal(session,
+		    S2C(session)->log_file_cond));
+		WT_ERR(__wt_cond_wait(
+		    session, log->log_sync_cond, 10000));
+	}
 	__wt_spin_lock(session, &log->log_sync_lock);
 	WT_ASSERT(session, log->log_dir_fh != NULL);
 	/*


### PR DESCRIPTION
@michaelcahill Please review this fix.  As I was not able to repro the failure, I found this by code inspection.