### PR TITLE
Add ability to turn verify and salvage off in test/format.

### DIFF
--- a/test/format/config.h
+++ b/test/format/config.h
@@ -251,6 +251,10 @@ static CONFIG c[] = {
 	  "the number of runs",
 	  C_IGNORE, 0, UINT_MAX, UINT_MAX, &g.c_runs, NULL },
 
+	{ "salvage",
+	  "verify integrity via salvage",			/* 100% */
+	  C_BOOL, 100, 1, 0, &g.c_salvage, NULL },
+
 	{ "split_pct",
 	  "page split size as a percentage of the maximum page size",
 	  0x0, 40, 85, 85, &g.c_split_pct, NULL },
@@ -278,6 +282,10 @@ static CONFIG c[] = {
 	{ "value_min",
 	  "minimum size of values",
 	  0x0, 0, 20, 4096, &g.c_value_min, NULL },
+
+	{ "verify",
+	  "to regularly verify during a run",			/* 100% */
+	  C_BOOL, 100, 1, 0, &g.c_verify, NULL },
 
 	{ "wiredtiger_config",
 	  "configuration string used to wiredtiger_open",

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -217,6 +217,7 @@ typedef struct {
 	uint32_t c_reverse;
 	uint32_t c_rows;
 	uint32_t c_runs;
+	uint32_t c_salvage;
 	uint32_t c_split_pct;
 	uint32_t c_statistics;
 	uint32_t c_statistics_server;
@@ -224,6 +225,7 @@ typedef struct {
 	uint32_t c_timer;
 	uint32_t c_value_max;
 	uint32_t c_value_min;
+	uint32_t c_verify;
 	uint32_t c_write_pct;
 
 #define	FIX				1	

--- a/test/format/salvage.c
+++ b/test/format/salvage.c
@@ -149,6 +149,9 @@ wts_salvage(void)
 	if (DATASOURCE("helium") || DATASOURCE("kvsbdb"))
 		return;
 
+	if (g.c_salvage == 0)
+		return;
+
 	/*
 	 * Save a copy of the interesting files so we can replay the salvage
 	 * step as necessary.

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -489,6 +489,9 @@ wts_verify(const char *tag)
 	WT_SESSION *session;
 	int ret;
 
+	if (g.c_verify == 0)
+		return;
+
 	conn = g.wts_conn;
 	track("verify", 0ULL, NULL);
 


### PR DESCRIPTION
This can be handy when reproducing failures that aren't uncovered
with verify/salvage, since it decreases the runtime for a single pass.