### PR TITLE
track the tree's max-txn-ID in reconciliation, where the page's max-txn-ID is set.

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -109,17 +109,6 @@ __sync_file(WT_SESSION_IMPL *session, int syncop)
 		/* Write all dirty in-cache pages. */
 		flags |= WT_READ_NO_EVICT;
 		for (walk = NULL;;) {
-			/*
-			 * If we have a page, and it was ever modified, track
-			 * the highest transaction ID in the tree.  We do this
-			 * here because we want the value after reconciling
-			 * dirty pages.
-			 */
-			if (walk != NULL && walk->page != NULL &&
-			    (mod = walk->page->modify) != NULL &&
-			    WT_TXNID_LT(btree->rec_max_txn, mod->rec_max_txn))
-				btree->rec_max_txn = mod->rec_max_txn;
-
 			WT_ERR(__wt_tree_walk(session, &walk, NULL, flags));
 			if (walk == NULL)
 				break;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -5096,7 +5096,13 @@ err:			__wt_scr_free(session, &tkey);
 		btree->modified = 1;
 		WT_FULL_BARRIER();
 	} else {
+		/*
+		 * Set the highest transaction ID for the page, and track the
+		 * highest transaction ID for the tree.
+		 */
 		mod->rec_max_txn = r->max_txn;
+		if (WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
+			btree->rec_max_txn = r->max_txn;
 
 		if (WT_ATOMIC_CAS4(mod->write_gen, r->orig_write_gen, 0))
 			__wt_cache_dirty_decr(session, page);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -5081,14 +5081,6 @@ err:			__wt_scr_free(session, &tkey);
 	 * be set before a subsequent checkpoint reads it, and because the
 	 * current checkpoint is waiting on this reconciliation to complete,
 	 * there's no risk of that happening).
-	 *
-	 * Otherwise, if no updates were skipped, we have a new maximum
-	 * transaction written for the page (used to decide if a clean page can
-	 * be evicted).  The page only might be clean; if the write generation
-	 * is unchanged since reconciliation started, clear it and update cache
-	 * dirty statistics, if the write generation changed, then the page has
-	 * been written since we started reconciliation, it cannot be
-	 * discarded.
 	 */
 	if (r->leave_dirty) {
 		mod->first_dirty_txn = r->skipped_txn;
@@ -5097,13 +5089,29 @@ err:			__wt_scr_free(session, &tkey);
 		WT_FULL_BARRIER();
 	} else {
 		/*
-		 * Set the highest transaction ID for the page, and track the
-		 * highest transaction ID for the tree.
+		 * If no updates were skipped, we have a new maximum transaction
+		 * written for the page (used to decide if a clean page can be
+		 * evicted). Set the highest transaction ID for the page.
+		 *
+		 * Track the highest transaction ID for the tree (used to decide
+		 * if it's safe to discard all of the pages in the tree without
+		 * further checking). Reconciliation in the service of eviction
+		 * is multi-threaded, only update the tree's maximum transaction
+		 * ID when doing a checkpoint. That's sufficient, we only care
+		 * about the highest transaction ID of any update currently in
+		 * the tree, and checkpoint visits every dirty page in the tree.
 		 */
 		mod->rec_max_txn = r->max_txn;
-		if (WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
+		if (!F_ISSET(r, WT_EVICTING) &&
+		    !WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
 			btree->rec_max_txn = r->max_txn;
 
+		/*
+		 * The page only might be clean; if the write generation is
+		 * unchanged since reconciliation started, it's clean. If the
+		 * write generation changed, the page has been written since
+		 * we started reconciliation and remains dirty.
+		 */
 		if (WT_ATOMIC_CAS4(mod->write_gen, r->orig_write_gen, 0))
 			__wt_cache_dirty_decr(session, page);
 	}


### PR DESCRIPTION
@michaelcahill, I was staring at this code this morning, and it seemed like it would be easier (safer?) to set the tree's maximum transaction ID when we set/update the page's maximum transaction ID.

The "safer" part may be a misunderstanding on my part: the WT_BTREE.rec_max_txn field is used by sweep and close, but it's only set as part of the checkpoint operation.

But what if, by the time we get to checkpoint (WT_SYNC_CHECKPOINT), there aren't any leaf pages to write. Is it possible we won't update the tree's maximum transaction ID, since internal pages don't have a maximum transaction ID?