### PR TITLE
SERVER-18899 followup to abstract copying a WT home directory into a function.

### DIFF
--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -97,11 +97,11 @@ def confirm_empty(self, uri):
     cursor.close()
 
 # copy a WT home directory
-def copy_live_wiredtiger_home(olddir, newdir, aligned=True):
+def copy_wiredtiger_home(olddir, newdir, aligned=True):
     # unaligned copy requires 'dd', which may not be available on Windows
     if not aligned and os.name == "nt":
         raise AssertionError(
-            'copy_live_wiredtiger_home: unaligned copy impossible on Windows')
+            'copy_wiredtiger_home: unaligned copy impossible on Windows')
     shutil.rmtree(newdir, ignore_errors=True)
     os.mkdir(newdir)
     for fname in os.listdir(olddir):

--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -37,7 +37,7 @@ import fnmatch, os, shutil, time
 from suite_subprocess import suite_subprocess
 from wiredtiger import wiredtiger_open
 from wtscenario import multiply_scenarios, number_scenarios, prune_scenarios
-from helper import copy_live_wiredtiger_home
+from helper import copy_wiredtiger_home
 import wttest
 
 class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
@@ -61,7 +61,7 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
         # With the connection still open, copy files to new directory.
         # Half the time use an unaligned copy.
         aligned = (i % (self.freq * 2) != 0) or os.name == "nt"
-        copy_live_wiredtiger_home(olddir, newdir, aligned)
+        copy_wiredtiger_home(olddir, newdir, aligned)
 
         # Now simulate fsyncUnlock by closing the backup cursor.
         cbkup.close()

--- a/test/suite/test_durability01.py
+++ b/test/suite/test_durability01.py
@@ -32,7 +32,7 @@
 #
 
 import fnmatch, os, shutil, time
-from helper import copy_live_wiredtiger_home
+from helper import copy_wiredtiger_home
 from suite_subprocess import suite_subprocess
 from wiredtiger import wiredtiger_open
 from wtscenario import multiply_scenarios, number_scenarios, prune_scenarios
@@ -45,7 +45,7 @@ class test_durability01(wttest.WiredTigerTestCase, suite_subprocess):
     def check_crash_restart(self, olddir, newdir):
         ''' Simulate a crash from olddir and restart in newdir. '''
         # with the connection still open, copy files to new directory
-        copy_live_wiredtiger_home(olddir, newdir)
+        copy_wiredtiger_home(olddir, newdir)
 
         # Open the new directory
         conn = self.setUpConnectionOpen(newdir)


### PR DESCRIPTION
This commit makes a small change, but the main function is to put the correct JIRA ticket into the comment stream (the previous commit used a bad ticket id in the comment).

@sueloverso, can you review?  This is the best I can do to fix the errant comment comment reference.  When develop is merged into master, perhaps the previous commit can be squashed into this one.