### PR TITLE
WT-1985. Integer packing and other fixes for Java

### DIFF
--- a/lang/java/Makefile.am
+++ b/lang/java/Makefile.am
@@ -49,6 +49,8 @@ JAVA_JUNIT = \
 		$(JAVATEST)/CursorTest02.java \
 		$(JAVATEST)/ExceptionTest.java \
 		$(JAVATEST)/PackTest.java \
+		$(JAVATEST)/PackTest02.java \
+		$(JAVATEST)/PackTest03.java \
 		$(JAVATEST)/WiredTigerSuite.java
 
 dist_java_JAVA = $(JAVA_SRC) @JAVA_JUNIT@

--- a/lang/java/src/com/wiredtiger/db/PackFormatInputStream.java
+++ b/lang/java/src/com/wiredtiger/db/PackFormatInputStream.java
@@ -180,5 +180,12 @@ public class PackFormatInputStream {
         }
         return valueLen;
     }
-}
 
+    /**
+     * Return whether there is an explicit length indicated in the format
+     * string.
+     */
+    protected boolean hasLength() {
+        return (getIntFromFormat(false) > 0);
+    }
+}

--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -299,6 +299,7 @@ WT_CLASS(struct __wt_async_op, WT_ASYNC_OP, op)
 %ignore __wt_cursor::set_value;
 %ignore __wt_cursor::insert;
 %ignore __wt_cursor::remove;
+%ignore __wt_cursor::reset;
 %ignore __wt_cursor::search;
 %ignore __wt_cursor::search_near;
 %ignore __wt_cursor::update;
@@ -1138,6 +1139,11 @@ WT_ASYNC_CALLBACK javaApiAsyncHandler = {javaAsyncHandler};
 		return $self->remove($self);
 	}
 
+	%javamethodmodifiers reset_wrap "protected";
+	int reset_wrap() {
+		return $self->reset($self);
+	}
+
 	%javamethodmodifiers search_wrap "protected";
 	int search_wrap(WT_ITEM *k) {
 		$self->set_key($self, k);
@@ -1702,6 +1708,21 @@ WT_ASYNC_CALLBACK javaApiAsyncHandler = {javaAsyncHandler};
 		valuePacker.reset();
 		keyUnpacker = initKeyUnpacker(ret == 0);
 		valueUnpacker = initValueUnpacker(ret == 0);
+		return ret;
+	}
+
+	/**
+	 * Reset a cursor.
+	 *
+	 * \return The status of the operation.
+	 */
+	public int reset()
+	throws WiredTigerException {
+		int ret = reset_wrap();
+		keyPacker.reset();
+		valuePacker.reset();
+		keyUnpacker = null;
+		valueUnpacker = null;
 		return ret;
 	}
 

--- a/lang/python/wiredtiger/packing.py
+++ b/lang/python/wiredtiger/packing.py
@@ -97,7 +97,8 @@ def unpack(fmt, s):
                     size = len(s)
                 else:
                     # Note: 'U' is used internally, and may be exposed to us.
-                    # It indicates that the size is always stored.
+                    # It indicates that the size is always stored unless there
+                    # is a size in the format.
                     size, s = unpack_int(s)
             result.append(s[:size])
             if f == 'S' and not havesize:

--- a/test/java/com/wiredtiger/test/ExceptionTest.java
+++ b/test/java/com/wiredtiger/test/ExceptionTest.java
@@ -156,6 +156,7 @@ public class ExceptionTest {
                 sess2.close("");
         }
         Assert.assertEquals(caught, true);
+        teardown();
     }
 
     private void setup(String uriparam, String keyFormat, String valueFormat) {

--- a/test/java/com/wiredtiger/test/PackTest.java
+++ b/test/java/com/wiredtiger/test/PackTest.java
@@ -188,10 +188,10 @@ public class PackTest {
     throws WiredTigerPackingException {
         // Verify that we can pack and unpack single signed longs.
         for (long i:testers) {
-            PackOutputStream packer = new PackOutputStream("Q");
+            PackOutputStream packer = new PackOutputStream("q");
             packer.addLong(i);
             PackInputStream unpacker =
-                new PackInputStream("Q", packer.getValue());
+                new PackInputStream("q", packer.getValue());
             long unpacked = unpacker.getLong();
             if (i != unpacked)
                 System.out.println(
@@ -209,11 +209,11 @@ public class PackTest {
             long val1 = testers[i];
             long val2 = testers[i+1];
 
-            PackOutputStream packer = new PackOutputStream("QQ");
+            PackOutputStream packer = new PackOutputStream("qq");
             packer.addLong(val1);
             packer.addLong(val2);
             PackInputStream unpacker =
-                new PackInputStream("QQ", packer.getValue());
+                new PackInputStream("qq", packer.getValue());
             long unpacked = unpacker.getLong();
             if (val1 != unpacked) {
                 System.out.println(i + " did not match " + unpacked);

--- a/test/java/com/wiredtiger/test/PackTest02.java
+++ b/test/java/com/wiredtiger/test/PackTest02.java
@@ -1,0 +1,253 @@
+/*-
+ * Public Domain 2014-2015 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.wiredtiger.test;
+
+import java.util.Arrays;
+import com.wiredtiger.db.Connection;
+import com.wiredtiger.db.Cursor;
+import com.wiredtiger.db.Session;
+import com.wiredtiger.db.WiredTigerException;
+import com.wiredtiger.db.WiredTigerPackingException;
+import com.wiredtiger.db.wiredtiger;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+public class PackTest02 {
+
+    public static final String TEST_NAME = "PackTest02";
+
+    private Connection connection;
+    private Session session;
+
+    // Compare two byte arrays, assert if different
+    void compareByteArrays(byte[] a1, byte[] a2) {
+        //printByteArray(a1, a1.length);
+        //printByteArray(a2, a2.length);
+        if (a1.length != a2.length) {
+            System.err.println("Length differ");
+        }
+        assertEquals(a1.length, a2.length);
+        for (int i = 0; i < a1.length; i++) {
+            if (a1[i] != a2[i])
+                System.err.println("DIFFER at " + i);
+            assertEquals(a1[i], a2[i]);
+        }
+    }
+
+    // Add either a set of keys or a set of values to the
+    // cursor at the current position.
+    boolean addKeyValues(Cursor cursor, Object[] args, boolean iskey) {
+        for (Object arg : args) {
+            if (arg instanceof Integer) {
+                if (iskey)
+                    cursor.putKeyInt((Integer)arg);
+                else
+                    cursor.putValueInt((Integer)arg);
+            }
+            else if (arg instanceof String) {
+                if (iskey)
+                    cursor.putKeyString((String)arg);
+                else
+                    cursor.putValueString((String)arg);
+            }
+            else if (arg instanceof byte[]) {
+                if (iskey)
+                    cursor.putKeyByteArray((byte[])arg);
+                else
+                    cursor.putValueByteArray((byte[])arg);
+            }
+            else
+                throw new IllegalArgumentException("unknown type");
+        }
+        return true;
+    }
+    
+    // Check that either a set of keys or a set of values match
+    // the given expected values.  Assert when different.
+    boolean checkKeyValues(Cursor cursor, Object[] args, boolean iskey) {
+        for (Object arg : args) {
+            if (arg instanceof Integer) {
+                if (iskey)
+                    assertEquals(arg, cursor.getKeyInt());
+                else
+                    assertEquals(arg, cursor.getValueInt());
+            }
+            else if (arg instanceof String) {
+                if (iskey)
+                    assertEquals(arg, cursor.getKeyString());
+                else
+                    assertEquals(arg, cursor.getValueString());
+            }
+            else if (arg instanceof byte[]) {
+                if (iskey)
+                    compareByteArrays((byte[])arg, cursor.getKeyByteArray());
+                else
+                    compareByteArrays((byte[])arg, cursor.getValueByteArray());
+            }
+            else
+                throw new IllegalArgumentException("unknown type");
+        }
+        return true;
+    }
+
+    // Helper function to make an array out of variable args
+    Object[] makeArray(Object... args)
+    {
+        return args;
+    }
+
+    // Use checkCompare for the common case that what
+    // we store is what we expect.
+    boolean check(String fmt, Object... args)
+    {
+        return checkCompare(fmt, args, args);
+    }
+
+    // Create a table with 'fmt' as the value, and also a
+    // reverse index.  Store the given arguments as values,
+    // make sure we can retrieve them from the main table
+    // and the index.  We compare the result using compareArgs,
+    // these may be different from what we store due to padding.
+    boolean checkCompare(String fmt, Object[] storeArgs, Object[] compareArgs)
+        throws WiredTigerException {
+        String uri = "table:" + TEST_NAME + "-" + fmt;
+        String idx_uri = "index:" + TEST_NAME + "-" + fmt + ":inverse";
+        int nargs = storeArgs.length;
+        String colnames = "";
+        for (int i = 0; i < nargs; i++) {
+            if (i > 0)
+                colnames += ",";
+            colnames += "v" + i;
+        }
+        session.create(uri, "columns=(k," + colnames + ")," +
+                       "key_format=i,value_format=" + fmt);
+        session.create(idx_uri, "columns=(" + colnames + ")");
+        Cursor forw = session.open_cursor(uri, null, null);
+        Cursor forw_idx = session.open_cursor(idx_uri + "(k)", null, null);
+
+        forw.putKeyInt(1234);
+        if (!addKeyValues(forw, storeArgs, false))
+            return false;
+        forw.insert();
+
+        forw.putKeyInt(1234);
+        assertEquals(0, forw.search());
+        if (!checkKeyValues(forw, compareArgs, false))
+            return false;
+
+        if (!addKeyValues(forw_idx, storeArgs, true))
+            return false;
+        assertEquals(0, forw_idx.search());
+
+        Integer expected[] = { 1234 };
+
+        if (!checkKeyValues(forw_idx, expected, false))
+            return false;
+
+        forw.close();
+        forw_idx.close();
+        session.drop(idx_uri, null);
+        session.drop(uri, null);
+        return true;
+    }
+
+    // A debug helper method
+    private void printByteArray(byte[] bytes, int len) {
+        for (int i = 0; i < len; i++) {
+            System.out.println(String.format(
+                                   "\t%8s", Integer.toBinaryString(
+                                       bytes[i] & 0xff)).replace(' ', '0'));
+        }
+    }
+
+    private void setup() {
+        connection = wiredtiger.open("WT_HOME", "create");
+        session = connection.open_session(null);
+    }
+
+    private void teardown() {
+        session.close(null);
+        connection.close(null);
+    }
+
+    @Test
+    public void packTest()
+    throws WiredTigerPackingException {
+
+        // Do a test of packing, based on test suite's test_pack.py
+
+        String a10 = "aaaaaaaaaa";
+        String a42 = a10 + a10 + a10 + a10 + "aa";
+        byte[] b10 =
+            { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42 };
+        byte[] b20 =
+            { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+              0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42 };
+        byte[] b1 = { 0x4 };
+        byte[] b3 = { 0x4, 0x0, 0x0 };
+
+        setup();
+        check("iii", 0, 101, -99);
+        check("3i", 0, 101, -99);
+        check("iS", 42, "forty two");
+        check("S", "abc");
+        check("9S", "aaaaaaaaa");
+        check("9sS", "forty two", "spam egg");
+        check("42s", a42);
+        check("42sS", a42, "something");
+        check("S42s", "something", a42);
+        // nul terminated string with padding
+        check("10sS", "aaaaa\0\0\0\0\0", "something");
+        check("S10s", "something", "aaaaa\0\0\0\0\0");
+        check("u", b20);
+        check("uu", b10, b10);
+        // input 1 byte for a 3 byte format, extra null bytes will be stored
+        checkCompare("3u", makeArray(b1), makeArray(b3));
+        checkCompare("3uu", makeArray(b1, b10), makeArray(b3, b10));
+        checkCompare("u3u", makeArray(b10, b1), makeArray(b10, b3));
+
+        check("s", "4");
+        check("1s", "4");
+        check("2s", "42");
+        teardown();
+    }
+
+    public static void main(String[] args) {
+        PackTest02 tester = new PackTest02();
+        try {
+            tester.packTest();
+        } catch (WiredTigerPackingException wtpe) {
+            System.err.println("Packing exception: " + wtpe);
+        }
+    }
+}

--- a/test/java/com/wiredtiger/test/PackTest03.java
+++ b/test/java/com/wiredtiger/test/PackTest03.java
@@ -1,0 +1,228 @@
+/*-
+ * Public Domain 2014-2015 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.wiredtiger.test;
+
+import com.wiredtiger.db.PackOutputStream;
+import com.wiredtiger.db.PackInputStream;
+import com.wiredtiger.db.WiredTigerPackingException;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+public class PackTest03 {
+
+    public interface PackingAdaptor {
+        public void addval(PackOutputStream packer, long val);
+        public long getval(PackInputStream unpacker);
+    }
+    public static class Scenario {
+        public Scenario(String format, long low, long high, int nbits,
+                        PackingAdaptor a) {
+            this.format = format;
+            this.low = low;
+            this.high = high;
+            this.nbits = nbits;
+            if (format.equals("Q"))
+                this.mask = -1L;
+            else if (low == 0) // unsigned
+                this.mask = (1L << nbits) - 1;
+            else // signed - preserve the sign and lose one of the lower bits
+                this.mask = (1L << (nbits - 1)) - 1;
+            this.adaptor = a;
+        }
+        public String format;
+        public long low;
+        public long high;
+        public int nbits;
+        public long mask;
+        public PackingAdaptor adaptor;
+    }
+    public static final Scenario scenarios[] = {
+        new Scenario("b", -128, 127, 8, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addByte((byte)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getByte();
+                }
+            }),
+        new Scenario("B", 0, 255, 8, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addByte((byte)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getByte();
+                }
+            }),
+        new Scenario("h", -32768, 32767, 16, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addShort((short)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getShort();
+                }
+            }),
+        /*
+         * Note: high should be 65535, there's not currently a way to insert
+         * unsigned shorts between 2^15 and 2^16.
+         */
+        new Scenario("H", 0, 32767, 16, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addShort((short)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getShort();
+                }
+            }),
+        new Scenario("i", -2147483648, 2147483647, 32, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addInt((int)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getInt();
+                }
+            }),
+        /*
+         * Note: high should be 4294967295L, there's not currently a way to
+         * insert unsigned ints between 2^31 and 2^32.
+         */
+        new Scenario("I", 0, 2147483647L, 32, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addInt((int)val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getInt();
+                }
+            }),
+        new Scenario("q", -9223372036854775808L,
+                     9223372036854775807L, 64, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addLong(val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getLong();
+                }
+            }),
+
+        /* 'unsigned long' numbers larger than 2^63 cannot be
+         * expressed in Java (except indirectly as negative numbers).
+         */
+        new Scenario("Q", 0, -1L, 64, new PackingAdaptor() {
+                public void addval(PackOutputStream packer, long val) {
+                    packer.addLong(val); }
+                public long getval(PackInputStream unpacker) {
+                    return unpacker.getLong();
+                }
+            }),
+    };
+
+    void tryPackSingle(Scenario scen, long value)
+    throws WiredTigerPackingException {
+        if ((value < scen.low || value > scen.high) && scen.low < scen.high)
+            throw new IllegalArgumentException("value out of range: " + value);
+        
+        PackOutputStream packer = new PackOutputStream(scen.format);
+        scen.adaptor.addval(packer, value);
+        byte[] bytes = packer.getValue();
+        PackInputStream unpacker =
+            new PackInputStream(scen.format, packer.getValue());
+        //long unpacked = scen.adaptor.getval(unpacker) & scen.mask;
+        long unpacked = scen.adaptor.getval(unpacker);
+        if (scen.low < 0 && unpacked < 0) {
+            unpacked = (unpacked & scen.mask) | ~scen.mask;
+        }
+        else {
+            unpacked = unpacked & scen.mask;
+        }
+        if (value != unpacked) {
+            String arg = "ERROR: format " + scen.format + ": wanted=" +
+                value + " did not match got=" + unpacked;
+            System.out.println(arg);
+            throw new IllegalArgumentException(arg);
+        }
+    }
+
+    void tryPackRange(Scenario scen, long lowRange, long highRange)
+    throws WiredTigerPackingException {
+        if (lowRange < scen.low)
+            lowRange = scen.low;
+        if (highRange > scen.high && scen.high != -1L)
+            highRange = scen.high;
+        for (long val = lowRange; val <= highRange; val++) {
+            try {
+                tryPackSingle(scen, val);
+            }
+            catch (Exception ex) {
+                System.out.println("EXCEPTION: format " + scen.format +
+                                   ": value: " + val + ": " + ex);
+                throw ex;
+            }
+            // watch for long overflow
+            if (val == Long.MAX_VALUE)
+                break;
+        }
+    }
+
+    // A debug helper method
+    private void printByteArray(byte[] bytes, int len) {
+        for (int i = 0; i < len; i++) {
+            System.out.println(String.format(
+                                   "\t%8s", Integer.toBinaryString(
+                                       bytes[i] & 0xff)).replace(' ', '0'));
+        }
+    }
+
+    @Test
+    public void packUnpackRanges()
+    throws WiredTigerPackingException {
+        // Do a comprehensive test of packing for various formats.
+        // Based on test suite's test_intpack.py
+        long imin = Integer.MIN_VALUE;
+        long imax = Integer.MAX_VALUE;
+        long e32 = 1L << 32;
+        long lmin = Long.MIN_VALUE;
+        long lmax = Long.MAX_VALUE;
+
+        for (int scenidx = 0; scenidx < scenarios.length; scenidx++) {
+            Scenario scen = scenarios[scenidx];
+            tryPackRange(scen, -100000, 100000);
+            tryPackRange(scen, imin - 100, imin + 100);
+            tryPackRange(scen, imax - 100, imax + 100);
+            tryPackRange(scen, -e32 - 100, -e32 + 100);
+            tryPackRange(scen, e32 - 100, e32 + 100);
+            tryPackRange(scen, lmin, lmin + 100);
+            tryPackRange(scen, lmax - 100, lmax);
+        }
+    }
+
+    public static void main(String[] args) {
+        PackTest03 tester = new PackTest03();
+        try {
+            tester.packUnpackRanges();
+        } catch (WiredTigerPackingException wtpe) {
+            System.err.println("Packing exception: " + wtpe);
+        }
+    }
+}

--- a/test/java/com/wiredtiger/test/WiredTigerSuite.java
+++ b/test/java/com/wiredtiger/test/WiredTigerSuite.java
@@ -38,7 +38,9 @@ import org.junit.runners.Suite;
     CursorTest.class,
     CursorTest02.class,
     ExceptionTest.class,
-    PackTest.class
+    PackTest.class,
+    PackTest02.class,
+    PackTest03.class
 })
 
 public class WiredTigerSuite {


### PR DESCRIPTION
This set of commits adds more extensive packing tests (PackTest02, PackTest03) for Java and fixes various problems that came up in resolving the new tests:

* The basic PackTest does positive/negative numbers, so needs to use 'q' (signed format).
* Fixed bugs in packing/unpacking bytearrays: we must be aware of 'U' format; when length is provided in format, use it; do padding.
* Fixed signed checking for getInt/Long/Short.
* Added special case encoding for 8256 (to match Python and C), this is the original problem reported in WT-1985.
* Fixed bugs in packing strings: embedded nulls; use length when provided.  Logic copied from packing.py.
* Java's Cursor.reset() more completely resets the cursor - removes the state of any incompletely packed/unpacked items.