### PR TITLE
WT-2006: s_copyright fixes

### DIFF
--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -9,14 +9,7 @@ c4=__wt.copyright.4
 
 check()
 {
-	# Skip files in which WiredTiger holds no rights. 3rdparty and
-	# node_modules are used by wtstats
-	if expr "$1" : '*3rdparty*' > /dev/null; then
-		return;
-	fi
-	if expr "$1" : '*node_modules*' > /dev/null; then
-		return;
-	fi
+	# Skip files in which WiredTiger holds no rights.
 	if `egrep "skip	$1" dist/s_copyright.list > /dev/null`; then
 		return;
 	fi
@@ -100,8 +93,8 @@ ENDOFTEXT
 	-e '/api\/leveldb\/hyperleveldb\//d' \
 	-e '/api\/leveldb\/leveldb\//d' \
 	-e '/api\/leveldb\/rocksdb\//d' \
-	-e '/test\/3rdparty\//d' \
-	-e '/tools\/wtperf_stats\/3rdparty\//d' \
+	-e '/\/3rdparty\//d' \
+	-e '/\/node_modules\//d' \
 	-e '/dist\/__/d' \
 	-e 's/^\.\///' |
     xargs -P 20 -n 1 -I{} sh dist/s_copyright {})

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -2,10 +2,56 @@
 
 # Check the copyrights.
 
-c1=__wt.1$$
-c2=__wt.2$$
-c3=__wt.3$$
-c4=__wt.4$$
+c1=__wt.copyright.1
+c2=__wt.copyright.2
+c3=__wt.copyright.3
+c4=__wt.copyright.4
+
+check()
+{
+	# Skip files in which WiredTiger holds no rights. 3rdparty and
+	# node_modules are used by wtstats
+	if expr "$1" : '*3rdparty*' > /dev/null; then
+		return;
+	fi
+	if expr "$1" : '*node_modules*' > /dev/null; then
+		return;
+	fi
+	if `egrep "skip	$1" dist/s_copyright.list > /dev/null`; then
+		return;
+	fi
+
+	# It's okay if the file doesn't exist: we may be running in a release
+	# tree with some files removed.
+	test -f $1 || return
+
+	# Check for a correct copyright header.
+	if `sed -e 2,5p -e 6q -e d $1 | diff - dist/$c1 > /dev/null` ; then
+		return;
+	fi
+	if `sed -e 2,4p -e 5q -e d $1 | diff - dist/$c2 > /dev/null` ; then
+		return;
+	fi
+	if `sed -e 3,6p -e 7q -e d $1 | diff - dist/$c3 > /dev/null` ; then
+		return;
+	fi
+	if `sed -e 3,5p -e 6q -e d $1 | diff - dist/$c4 > /dev/null` ; then
+		return;
+	fi
+	if `sed -e 1,3p -e 4q -e d $1 | diff - dist/$c4 > /dev/null` ; then
+		return;
+	fi
+
+	echo "$1: copyright information is incorrect"
+	exit 1
+}
+
+# s_copyright is re-entrant, calling itself with individual file names.
+# Any single argument call is a file name, check its copyright.
+if [ $# -ne 0 ]; then
+	check $1
+	exit 0
+fi
 
 trap 'rm -f $c1 $c2 $c3 $c4; exit 0' 0 1 2 3 13 15
 
@@ -42,86 +88,39 @@ cat > $c4 <<ENDOFTEXT
 # This is free and unencumbered software released into the public domain.
 ENDOFTEXT
 
-check()
+# Search for files, skipping some well-known 3rd party directories.
+(cd .. && find [a-z]* -name '*.[chi]' \
+	-o -name '*.cxx' \
+	-o -name '*.in' \
+	-o -name '*.java' \
+	-o -name '*.py' |
+    sed	-e '/Makefile.in/d' \
+	-e '/^build_posix\//d' \
+	-e '/api\/leveldb\/basho\//d' \
+	-e '/api\/leveldb\/hyperleveldb\//d' \
+	-e '/api\/leveldb\/leveldb\//d' \
+	-e '/api\/leveldb\/rocksdb\//d' \
+	-e '/test\/3rdparty\//d' \
+	-e '/tools\/wtperf_stats\/3rdparty\//d' \
+	-e '/dist\/__/d' \
+	-e 's/^\.\///' |
+    xargs -P 20 -n 1 -I{} sh dist/s_copyright {})
+
+# A few special cases: LICENSE, documentation, wt utility, some of which have
+# more than one copyright notice in the file. For files that have only a single
+# copyright notice, we give it to MongoDB, from 2008 to now.
+string1="Copyright \(c\) 2014-$year MongoDB, Inc."
+string2="Copyright \(c\) 2008-$year MongoDB, Inc."
+string3="printf.*Copyright \(c\) 2008-$year MongoDB, Inc."
+special_copyright()
 {
-	# Skip files in which WiredTiger holds no rights. 3rdparty and
-	# node_modules are used by wtstats
-	if expr "$1" : '*3rdparty*' > /dev/null; then
-		return;
+	cnt=`egrep "$3" ../$1 | wc -l`
+	if test $cnt -ne $2; then
+		echo "$1: copyright information is incorrect"
 	fi
-	if expr "$1" : '*node_modules*' > /dev/null; then
-		return;
-	fi
-	if `egrep "skip	$1" dist/s_copyright.list > /dev/null`; then
-		return;
-	fi
-
-	# It's okay if the file doesn't exist: we may be running in a release
-	# tree with some files removed.
-	test -f $1 || return
-
-	# Check for a correct copyright header.
-	if `sed -e 2,5p -e 6q -e d $1 | diff - $c1 > /dev/null` ; then
-		return;
-	fi
-	if `sed -e 2,4p -e 5q -e d $1 | diff - $c2 > /dev/null` ; then
-		return;
-	fi
-	if `sed -e 3,6p -e 7q -e d $1 | diff - $c3 > /dev/null` ; then
-		return;
-	fi
-	if `sed -e 3,5p -e 6q -e d $1 | diff - $c4 > /dev/null` ; then
-		return;
-	fi
-	if `sed -e 1,3p -e 4q -e d $1 | diff - $c4 > /dev/null` ; then
-		return;
-	fi
-
-	echo "$1: copyright information is incorrect"
 }
 
-if [ $# -ne 1 ]; then
-	# Search for files, skipping some well-known 3rd party directories.
-	(cd .. && find [a-z]* -name '*.[chi]' \
-		-o -name '*.cxx' \
-		-o -name '*.in' \
-		-o -name '*.java' \
-		-o -name '*.py' |
-	    sed	-e '/Makefile.in/d' \
-		-e '/^build_posix\//d' \
-		-e '/api\/leveldb\/basho\//d' \
-		-e '/api\/leveldb\/hyperleveldb\//d' \
-		-e '/api\/leveldb\/leveldb\//d' \
-		-e '/api\/leveldb\/rocksdb\//d' \
-		-e '/test\/3rdparty\//d' \
-		-e '/tools\/wtperf_stats\/3rdparty\//d' \
-		-e '/dist\/__/d' \
-		-e 's/^\.\///' |
-	    xargs -P 20 -n 1 -I{} sh dist/s_copyright {})
-
-	# A few special cases: LICENSE, documentation, wt utility, some of
-	# which have more than one copyright notice in the file. For files that
-	# have only a single copyright notice, we give it to MongoDB, from 2008
-	# to now.
-	string1="Copyright \(c\) 2014-$year MongoDB, Inc."
-	string2="Copyright \(c\) 2008-$year MongoDB, Inc."
-	string3="printf.*Copyright \(c\) 2008-$year MongoDB, Inc."
-	special_copyright()
-	{
-		cnt=`egrep "$3" ../$1 | wc -l`
-		if test $cnt -ne $2; then
-			echo "$1: copyright information is incorrect"
-		fi
-	}
-
-	special_copyright LICENSE 1 "$string1"
-	special_copyright src/docs/build-javadoc.sh 1 "$string2"
-	special_copyright src/docs/style/footer.html 2 "$string2"
-	special_copyright src/utilities/util_cpyright.c 1 "$string3"
-else
-	# s_copyright is re-entrant. It calls itself with individual file
-	# names. Any single arg call is a file name - check it's copyright.
-	# Run the check from the dist directory, but ensure trap starts in
-	# the right place to cleanup temporary files.
-	check $1
-fi
+special_copyright LICENSE 1 "$string1"
+special_copyright src/docs/build-javadoc.sh 1 "$string2"
+special_copyright src/docs/style/footer.html 2 "$string2"
+special_copyright src/utilities/util_cpyright.c 1 "$string3"

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -46,10 +46,10 @@ check()
 {
 	# Skip files in which WiredTiger holds no rights. 3rdparty and
 	# node_modules are used by wtstats
-	if `egrep "3rdparty" <<< $1 > /dev/null`; then
+	if expr "$1" : '*3rdparty*' > /dev/null; then
 		return;
 	fi
-	if `egrep "node_modules" <<< $1 > /dev/null`; then
+	if expr "$1" : '*node_modules*' > /dev/null; then
 		return;
 	fi
 	if `egrep "skip	$1" s_copyright.list > /dev/null`; then

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -52,28 +52,28 @@ check()
 	if expr "$1" : '*node_modules*' > /dev/null; then
 		return;
 	fi
-	if `egrep "skip	$1" s_copyright.list > /dev/null`; then
+	if `egrep "skip	$1" dist/s_copyright.list > /dev/null`; then
 		return;
 	fi
 
 	# It's okay if the file doesn't exist: we may be running in a release
 	# tree with some files removed.
-	test -f ../$i || return
+	test -f $1 || return
 
 	# Check for a correct copyright header.
-	if `sed -e 2,5p -e 6q -e d ../$1 | diff - $c1 > /dev/null` ; then
+	if `sed -e 2,5p -e 6q -e d $1 | diff - $c1 > /dev/null` ; then
 		return;
 	fi
-	if `sed -e 2,4p -e 5q -e d ../$1 | diff - $c2 > /dev/null` ; then
+	if `sed -e 2,4p -e 5q -e d $1 | diff - $c2 > /dev/null` ; then
 		return;
 	fi
-	if `sed -e 3,6p -e 7q -e d ../$1 | diff - $c3 > /dev/null` ; then
+	if `sed -e 3,6p -e 7q -e d $1 | diff - $c3 > /dev/null` ; then
 		return;
 	fi
-	if `sed -e 3,5p -e 6q -e d ../$1 | diff - $c4 > /dev/null` ; then
+	if `sed -e 3,5p -e 6q -e d $1 | diff - $c4 > /dev/null` ; then
 		return;
 	fi
-	if `sed -e 1,3p -e 4q -e d ../$1 | diff - $c4 > /dev/null` ; then
+	if `sed -e 1,3p -e 4q -e d $1 | diff - $c4 > /dev/null` ; then
 		return;
 	fi
 
@@ -97,7 +97,7 @@ if [ $# -ne 1 ]; then
 		-e '/tools\/wtperf_stats\/3rdparty\//d' \
 		-e '/dist\/__/d' \
 		-e 's/^\.\///' |
-	    xargs -P 20 -n 1 -I{} sh ./dist/s_copyright {})
+	    xargs -P 20 -n 1 -I{} sh dist/s_copyright {})
 
 	# A few special cases: LICENSE, documentation, wt utility, some of
 	# which have more than one copyright notice in the file. For files that
@@ -123,5 +123,5 @@ else
 	# names. Any single arg call is a file name - check it's copyright.
 	# Run the check from the dist directory, but ensure trap starts in
 	# the right place to cleanup temporary files.
-	(cd dist && check $1)
+	check $1
 fi


### PR DESCRIPTION
WT-2006

@agorrod, for your review.

`s_copyright` wasn't running on FreeBSD, and checking it over I think I found some problems.

Note, the final commit isn't a bug fix, but it reworks the script so we only create a single copy of the copyright template files.

One thing I didn't change: in the check() function, there's this code:
```
        # Skip files in which WiredTiger holds no rights. 3rdparty and
        # node_modules are used by wtstats
        if expr "$1" : '*3rdparty*' > /dev/null; then
                return;
        fi
        if expr "$1" : '*node_modules*' > /dev/null; then
                return;
        fi
```

There's already code in the parent find that uses sed to remove directories from the copyright list we check:
```
# Search for files, skipping some well-known 3rd party directories.
(cd .. && find [a-z]* -name '*.[chi]' \
        -o -name '*.cxx' \
        -o -name '*.in' \
        -o -name '*.java' \
        -o -name '*.py' |
    sed -e '/Makefile.in/d' \
        -e '/^build_posix\//d' \
        -e '/api\/leveldb\/basho\//d' \
        -e '/api\/leveldb\/hyperleveldb\//d' \
        -e '/api\/leveldb\/leveldb\//d' \
        -e '/api\/leveldb\/rocksdb\//d' \
        -e '/test\/3rdparty\//d' \
        -e '/tools\/wtperf_stats\/3rdparty\//d' \
        -e '/dist\/__/d' \
        -e 's/^\.\///' |
    xargs -P 20 -n 1 -I{} sh dist/s_copyright {})
```

Would it be simpler to put the `3rdparty` and `node_modules` checks with the others, so all the checks are in one place (and it's going to be faster to do that, instead of checking every individual file name for a match).