### PR TITLE
WT-1967: Add support for a long-running, isolation=snapshot, reader thread

### DIFF
--- a/test/format/Makefile.am
+++ b/test/format/Makefile.am
@@ -8,7 +8,7 @@ endif
 noinst_PROGRAMS = t
 noinst_SCRIPTS = s_dumpcmp
 t_SOURCES =\
-	config.h format.h backup.c bulk.c compact.c config.c ops.c \
+	config.h format.h backup.c bulk.c compact.c config.c lrt.c ops.c \
 	salvage.c t.c util.c wts.c
 
 if HAVE_BERKELEY_DB

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -211,6 +211,10 @@ static CONFIG c[] = {
 	  "if log file pre-allocation configured",		/* 50% */
 	  C_BOOL, 50, 0, 0, &g.c_logging_prealloc, NULL },
 
+	{ "long_running_txn",
+	  "if a long-running transaction configured",		/* 0% */
+	  C_BOOL, 0, 0, 0, &g.c_long_running_txn, NULL },
+
 	{ "lsm_worker_threads",
 	  "the number of LSM worker threads",
 	  0x0, 3, 4, 20, &g.c_lsm_worker_threads, NULL },

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -207,6 +207,7 @@ typedef struct {
 	uint32_t c_logging_archive;
 	char	*c_logging_compression;
 	uint32_t c_logging_prealloc;
+	uint32_t c_long_running_txn;
 	uint32_t c_lsm_worker_threads;
 	uint32_t c_merge_max;
 	uint32_t c_mmap;
@@ -314,6 +315,7 @@ void	 key_gen(uint8_t *, size_t *, uint64_t);
 void	 key_gen_insert(uint64_t *, uint8_t *, size_t *, uint64_t);
 void	 key_gen_setup(uint8_t **);
 void	 key_len_setup(void);
+void	*lrt(void *);
 void	 path_setup(const char *);
 uint32_t rng(uint64_t *);
 void	 track(const char *, uint64_t, TINFO *);

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -1,0 +1,86 @@
+/*-
+ * Public Domain 2014-2015 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "format.h"
+
+/*
+ * lrt --
+ *	Start a long-running transaction.
+ */
+void *
+lrt(void *arg)
+{
+	WT_CONNECTION *conn;
+	WT_CURSOR *cursor;
+	WT_SESSION *session;
+	u_int period;
+	int pinned, ret;
+
+	(void)(arg);
+
+	/* Open a session and cursor. */
+	conn = g.wts_conn;
+	if ((ret = conn->open_session(
+	    conn, NULL, "isolation=snapshot", &session)) != 0)
+		die(ret, "connection.open_session");
+	if ((ret = session->open_cursor(
+	    session, g.uri, NULL, NULL, &cursor)) != 0)
+		die(ret, "session.open_cursor");
+
+	for (pinned = 0;;) {
+		/*
+		 * If we have an open cursor, reset it, releasing our pin, else
+		 * position the cursor, creating a snapshot.
+		 */
+		if (pinned) {
+			if ((ret = cursor->reset(cursor)) != 0)
+				die(ret, "cursor.reset");
+			pinned = 0;
+		} else {
+			if ((ret = cursor->next(cursor)) != 0)
+				die(ret, "cursor.reset");
+			pinned = 1;
+		}
+
+		/* Sleep for some number of seconds. */
+		period = mmrand(NULL, 1, 10);
+
+		/* Sleep for short periods so we don't make the run wait. */
+		while (period > 0 && !g.workers_finished) {
+			--period;
+			sleep(1);
+		}
+		if (g.workers_finished)
+			break;
+	}
+
+	if ((ret = session->close(session, NULL)) != 0)
+		die(ret, "session.close");
+
+	return (NULL);
+}

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -54,7 +54,7 @@ wts_ops(int lastrun)
 	TINFO *tinfo, total;
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	pthread_t backup_tid, compact_tid;
+	pthread_t backup_tid, compact_tid, lrt_tid;
 	int64_t fourths, thread_ops;
 	uint32_t i;
 	int ret, running;
@@ -114,13 +114,19 @@ wts_ops(int lastrun)
 			die(ret, "pthread_create");
 	}
 
-	/* If a multi-threaded run, start backup and compaction threads. */
+	/*
+	 * If a multi-threaded run, start optional backup, compaction and
+	 * long-running reader threads.
+	 */
 	if (g.c_backups &&
 	    (ret = pthread_create(&backup_tid, NULL, backup, NULL)) != 0)
 		die(ret, "pthread_create: backup");
 	if (g.c_compact &&
 	    (ret = pthread_create(&compact_tid, NULL, compact, NULL)) != 0)
 		die(ret, "pthread_create: compaction");
+	if (!SINGLETHREADED && g.c_long_running_txn &&
+	    (ret = pthread_create(&lrt_tid, NULL, lrt, NULL)) != 0)
+		die(ret, "pthread_create: long-running reader");
 
 	/* Spin on the threads, calculating the totals. */
 	for (;;) {
@@ -174,12 +180,14 @@ wts_ops(int lastrun)
 	}
 	free(tinfo);
 
-	/* Wait for the backup, compaction thread. */
+	/* Wait for the backup, compaction, long-running reader threads. */
 	g.workers_finished = 1;
 	if (g.c_backups)
 		(void)pthread_join(backup_tid, NULL);
 	if (g.c_compact)
 		(void)pthread_join(compact_tid, NULL);
+	if (!SINGLETHREADED && g.c_long_running_txn)
+		(void)pthread_join(lrt_tid, NULL);
 
 	if (g.logging != 0) {
 		(void)g.wt_api->msg_printf(g.wt_api, session,


### PR DESCRIPTION
WT-1967: Add support for a long-running, isolation=snapshot, reader.

@agorrod, if you want to see the long-running reader in action, this branch can do that.

Here's the CONFIG:
```
cache=2
checkpoints=0
compression=none
data_source=file
file_type=row
internal_page_max=9
leaf_page_max=9
logging=0
long_running_txn=1
ops=1000000
rows=10000
runs=1
salvage=0
threads=2
verify=0
write_pct=80
```
Do a quick mod like this:
```
diff --git a/test/format/lrt.c b/test/format/lrt.c
index a00a4e0..3b9b856 100644
--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -69,6 +69,8 @@ lrt(void *arg)
 
                /* Sleep for some number of seconds. */
                period = mmrand(NULL, 1, 10);
+               fprintf(stderr, "\n" "%s " "%u" "\n",
+                   pinned ? "pinned" : "unpinned", period);
 
                /* Sleep for short periods so we don't make the run wait. */
                while (period > 0 && !g.workers_finished) {
```
and run format, the whole thing freezes up whenever the reading cursor is set.

If you like this change, feel free to merge it into develop -- I've defaulted `long_running_txn` to 0% for now, so it won't affect any runs where we aren't specifically configuring for it.