### PR TITLE
WT-2007 Only grow log slot buffers to  a maximum size.

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -13,6 +13,7 @@
 /* Logging subsystem declarations. */
 #define	WT_LOG_ALIGN			128
 #define	WT_LOG_SLOT_BUF_INIT_SIZE	64 * 1024
+#define	WT_LOG_SLOT_BUF_MAX_SIZE	256 * 1024
 
 #define	WT_INIT_LSN(l)	do {						\
 	(l)->file = 1;							\


### PR DESCRIPTION
@agorrod Here is a branch that implements a simple maximum size.  I chose 256K as the maximum size which uses 32Mb of memory for log slot buffers.  This is the smallest code change.  Please compare this to the other pull request.