### PR TITLE
WT-2008 Fix a bug in recovery where a file create went missing.

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -100,11 +100,10 @@ __wt_block_manager_create(
 	WT_TRET(__wt_close(session, &fh));
 
 	/*
-	 * If checkpoint syncing is enabled, some filesystems require that we
-	 * sync the directory to be confident that the file will appear.
+	 * Some filesystems require that we sync the directory to be confident
+	 * that the file will appear.
 	 */
-	if (ret == 0 && F_ISSET(S2C(session), WT_CONN_CKPT_SYNC) &&
-	    (ret = __wt_filename(session, filename, &path)) == 0) {
+	if (ret == 0 && (ret = __wt_filename(session, filename, &path)) == 0) {
 		ret = __wt_directory_sync(session, path);
 		__wt_free(session, path);
 	}


### PR DESCRIPTION
The problem was that a hard system crash could cause a file to not
be created, even though it had been synced. The solution is to do a
directory sync each time a new file is created.