### PR TITLE
WT-1989 Log scalability

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -241,6 +241,7 @@ connection_stats = [
     LogStat('log_writes', 'log write operations'),
     LogStat('log_write_lsn', 'log server thread advances write LSN'),
 
+    LogStat('log_slot_coalesced', 'written slots coalesced'),
     LogStat('log_slot_consolidated', 'logging bytes consolidated'),
     LogStat('log_slot_closes', 'consolidated slot closures'),
     LogStat('log_slot_joins', 'consolidated slot joins'),

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -405,14 +405,13 @@ __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i)
 	WT_LOG_WRLSN_ENTRY written[WT_SLOT_POOL];
 	WT_LOGSLOT *coalescing, *slot;
 	size_t written_i;
-	uint32_t i, max_i, save_i;
+	uint32_t i, save_i;
 
 	conn = S2C(session);
 	log = conn->log;
 	coalescing = NULL;
 	written_i = 0;
 	i = 0;
-	max_i = WT_MIN(log->max_used + 1, WT_SLOT_POOL - 1);
 	if (free_i != NULL)
 		*free_i = WT_SLOT_POOL;
 
@@ -420,7 +419,7 @@ __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i)
 	 * Walk the array once saving any slots that are in the
 	 * WT_LOG_SLOT_WRITTEN state.
 	 */
-	while (i <= max_i) {
+	while (i < WT_SLOT_POOL) {
 		save_i = i;
 		slot = &log->slot_pool[i++];
 		if (free_i != NULL && *free_i == WT_SLOT_POOL &&
@@ -498,17 +497,6 @@ __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i)
 				*free_i = save_i;
 		}
 	}
-	/*
-	 * Walk slots again to update max slot used.
-	 */
-	while (log->slot_pool[max_i].slot_state == WT_LOG_SLOT_FREE &&
-	    max_i != 0)
-		--max_i;
-#if 0
-	if (free_i != NULL && *free_i != WT_SLOT_POOL)
-		max_i = WT_MAX(*free_i, max_i);
-#endif
-	log->max_used = max_i;
 	return (0);
 }
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -392,6 +392,127 @@ typedef struct {
 	(entry1).lsn.offset < (entry2).lsn.offset))
 
 /*
+ * __wt_log_wrlsn --
+ *	Process written log slots and attempt to coalesce them if the LSNs
+ *	are contiguous.  Returns 1 if slots were freed, 0 if no slots were
+ *	freed in the progress arg.  Must be called with the log slot lock held.
+ */
+int
+__wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_LOG *log;
+	WT_LOG_WRLSN_ENTRY written[WT_SLOT_POOL];
+	WT_LOGSLOT *coalescing, *slot;
+	size_t written_i;
+	uint32_t i, max_i, save_i;
+
+	conn = S2C(session);
+	log = conn->log;
+	coalescing = NULL;
+	written_i = 0;
+	i = 0;
+	max_i = WT_MIN(log->max_used + 1, WT_SLOT_POOL - 1);
+	if (free_i != NULL)
+		*free_i = WT_SLOT_POOL;
+
+	/*
+	 * Walk the array once saving any slots that are in the
+	 * WT_LOG_SLOT_WRITTEN state.
+	 */
+	while (i <= max_i) {
+		save_i = i;
+		slot = &log->slot_pool[i++];
+		if (free_i != NULL && *free_i == WT_SLOT_POOL &&
+		    slot->slot_state == WT_LOG_SLOT_FREE)
+			*free_i = save_i;
+		if (slot->slot_state != WT_LOG_SLOT_WRITTEN)
+			continue;
+		written[written_i].slot_index = save_i;
+		written[written_i++].lsn = slot->slot_release_lsn;
+	}
+	/*
+	 * If we found any written slots process them.  We sort them
+	 * based on the release LSN, and then look for them in order.
+	 */
+	if (written_i > 0) {
+		WT_INSERTION_SORT(written, written_i,
+		    WT_LOG_WRLSN_ENTRY, WT_WRLSN_ENTRY_CMP_LT);
+
+		/*
+		 * We know the written array is sorted by LSN.  Go
+		 * through them either advancing write_lsn or coalesce
+		 * contiguous ranges of written slots.
+		 */
+		for (i = 0; i < written_i; i++) {
+			slot = &log->slot_pool[written[i].slot_index];
+			if (coalescing != NULL) {
+				if (WT_LOG_CMP(&coalescing->slot_end_lsn,
+				    &written[i].lsn) != 0) {
+					coalescing = slot;
+					continue;
+				}
+				/*
+				 * If we get here we have a slot to coalesce
+				 * and free.
+				 */
+				coalescing->slot_end_lsn = slot->slot_end_lsn;
+				WT_STAT_FAST_CONN_INCR(
+				    session, log_slot_coalesced);
+				/*
+				 * Copy the flag for later closing.
+				 */
+				if (F_ISSET(slot, WT_SLOT_CLOSEFH))
+					F_SET(coalescing, WT_SLOT_CLOSEFH);
+			} else {
+				/*
+				 * If this written slot is not the next LSN,
+				 * try to start coalescing with later slots.
+				 */
+				if (WT_LOG_CMP(
+				    &log->write_lsn, &written[i].lsn) != 0) {
+					coalescing = slot;
+					continue;
+				}
+				/*
+				 * If we get here we have a slot to process.
+				 * Advance the LSN and process the slot.
+				 */
+				WT_ASSERT(session, WT_LOG_CMP(&written[i].lsn,
+				    &slot->slot_release_lsn) == 0);
+				log->write_start_lsn = slot->slot_start_lsn;
+				log->write_lsn = slot->slot_end_lsn;
+				WT_RET(__wt_cond_signal(
+				    session, log->log_write_cond));
+				WT_STAT_FAST_CONN_INCR(session, log_write_lsn);
+				/*
+				 * Signal the close thread if needed.
+				 */
+				if (F_ISSET(slot, WT_SLOT_CLOSEFH))
+					WT_RET(__wt_cond_signal(
+					    session, conn->log_file_cond));
+			}
+			WT_RET(__wt_log_slot_free(session, slot));
+			if (free_i != NULL && *free_i == WT_SLOT_POOL &&
+			    slot->slot_state == WT_LOG_SLOT_FREE)
+				*free_i = save_i;
+		}
+	}
+	/*
+	 * Walk slots again to update max slot used.
+	 */
+	while (log->slot_pool[max_i].slot_state == WT_LOG_SLOT_FREE &&
+	    max_i != 0)
+		--max_i;
+#if 0
+	if (free_i != NULL && *free_i != WT_SLOT_POOL)
+		max_i = WT_MAX(*free_i, max_i);
+#endif
+	log->max_used = max_i;
+	return (0);
+}
+
+/*
  * __log_wrlsn_server --
  *	The log wrlsn server thread.
  */
@@ -401,91 +522,27 @@ __log_wrlsn_server(void *arg)
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_LOG *log;
-	WT_LOG_WRLSN_ENTRY written[WT_SLOT_POOL];
-	WT_LOGSLOT *slot;
 	WT_SESSION_IMPL *session;
-	size_t written_i;
-	uint32_t i, save_i;
-	int yield;
+	int locked;
 
 	session = arg;
 	conn = S2C(session);
 	log = conn->log;
-	yield = 0;
+	locked = 0;
 	while (F_ISSET(conn, WT_CONN_LOG_SERVER_RUN)) {
-		/*
-		 * No need to use the log_slot_lock because the slot pool
-		 * is statically allocated and any slot in the
-		 * WT_LOG_SLOT_WRITTEN state is exclusively ours for now.
-		 */
-		i = 0;
-		written_i = 0;
-		/*
-		 * Walk the array once saving any slots that are in the
-		 * WT_LOG_SLOT_WRITTEN state.
-		 */
-		while (i < WT_SLOT_POOL) {
-			save_i = i;
-			slot = &log->slot_pool[i++];
-			if (slot->slot_state != WT_LOG_SLOT_WRITTEN)
-				continue;
-			written[written_i].slot_index = save_i;
-			written[written_i++].lsn = slot->slot_release_lsn;
-		}
-		/*
-		 * If we found any written slots process them.  We sort them
-		 * based on the release LSN, and then look for them in order.
-		 */
-		if (written_i > 0) {
-			yield = 0;
-			WT_INSERTION_SORT(written, written_i,
-			    WT_LOG_WRLSN_ENTRY, WT_WRLSN_ENTRY_CMP_LT);
-
-			/*
-			 * We know the written array is sorted by LSN.  Go
-			 * through them either advancing write_lsn or stop
-			 * as soon as one is not in order.
-			 */
-			for (i = 0; i < written_i; i++) {
-				if (WT_LOG_CMP(&log->write_lsn,
-				    &written[i].lsn) != 0)
-					break;
-				/*
-				 * If we get here we have a slot to process.
-				 * Advance the LSN and process the slot.
-				 */
-				slot = &log->slot_pool[written[i].slot_index];
-				WT_ASSERT(session, WT_LOG_CMP(&written[i].lsn,
-				    &slot->slot_release_lsn) == 0);
-				log->write_start_lsn = slot->slot_start_lsn;
-				log->write_lsn = slot->slot_end_lsn;
-				WT_ERR(__wt_cond_signal(session,
-				    log->log_write_cond));
-				WT_STAT_FAST_CONN_INCR(session, log_write_lsn);
-
-				/*
-				 * Signal the close thread if needed.
-				 */
-				if (F_ISSET(slot, WT_SLOT_CLOSEFH))
-					WT_ERR(__wt_cond_signal(session,
-					    conn->log_file_cond));
-				WT_ERR(__wt_log_slot_free(session, slot));
-			}
-		}
-		/*
-		 * If we saw a later write, we always want to yield because
-		 * we know something is in progress.
-		 */
-		if (yield++ < 1000)
-			__wt_yield();
-		else
-			/* Wait until the next event. */
-			WT_ERR(__wt_cond_wait(session,
-			    conn->log_wrlsn_cond, 100000));
+		__wt_spin_lock(session, &log->log_slot_lock);
+		locked = 1;
+		WT_ERR(__wt_log_wrlsn(session, NULL));
+		locked = 0;
+		__wt_spin_unlock(session, &log->log_slot_lock);
+		WT_ERR(__wt_cond_wait(session,
+		    conn->log_wrlsn_cond, 1000));
 	}
-
-	if (0)
+	if (0) {
 err:		__wt_err(session, ret, "log wrlsn server error");
+	}
+	if (locked)
+		__wt_spin_unlock(session, &log->log_slot_lock);
 	return (WT_THREAD_RET_VALUE);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -237,6 +237,7 @@ extern int __wt_conn_dhandle_discard(WT_SESSION_IMPL *session);
 extern int __wt_connection_init(WT_CONNECTION_IMPL *conn);
 extern int __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern int __wt_log_truncate_files( WT_SESSION_IMPL *session, WT_CURSOR *cursor, const char *cfg[]);
+extern int __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i);
 extern int __wt_logmgr_create(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_logmgr_open(WT_SESSION_IMPL *session);
 extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -237,7 +237,7 @@ extern int __wt_conn_dhandle_discard(WT_SESSION_IMPL *session);
 extern int __wt_connection_init(WT_CONNECTION_IMPL *conn);
 extern int __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern int __wt_log_truncate_files( WT_SESSION_IMPL *session, WT_CURSOR *cursor, const char *cfg[]);
-extern int __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i);
+extern int __wt_log_wrlsn(WT_SESSION_IMPL *session, uint32_t *free_i, int *yield);
 extern int __wt_logmgr_create(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_logmgr_open(WT_SESSION_IMPL *session);
 extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -158,8 +158,6 @@ typedef struct {
 	 */
 #define	WT_SLOT_ACTIVE	1
 #define	WT_SLOT_POOL	128
-	uint32_t	 max_used;		/* Largest slot in use */
-	uint32_t	 pool_index;		/* Global pool index */
 	WT_LOGSLOT	*slot_array[WT_SLOT_ACTIVE];	/* Active slots */
 	WT_LOGSLOT	 slot_pool[WT_SLOT_POOL];	/* Pool of all slots */
 	wt_off_t	 slot_buf_size;		/* Buffer size for slots */

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -158,10 +158,11 @@ typedef struct {
 	 */
 #define	WT_SLOT_ACTIVE	1
 #define	WT_SLOT_POOL	128
+	uint32_t	 max_used;		/* Largest slot in use */
 	uint32_t	 pool_index;		/* Global pool index */
 	WT_LOGSLOT	*slot_array[WT_SLOT_ACTIVE];	/* Active slots */
 	WT_LOGSLOT	 slot_pool[WT_SLOT_POOL];	/* Pool of all slots */
-	uint32_t	 slot_buf_size;		/* Buffer size for slots */
+	wt_off_t	 slot_buf_size;		/* Buffer size for slots */
 
 #define	WT_LOG_FORCE_CONSOLIDATE	0x01	/* Disable direct writes */
 	uint32_t	 flags;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -221,6 +221,7 @@ struct __wt_connection_stats {
 	WT_STATS log_scan_rereads;
 	WT_STATS log_scans;
 	WT_STATS log_slot_closes;
+	WT_STATS log_slot_coalesced;
 	WT_STATS log_slot_consolidated;
 	WT_STATS log_slot_joins;
 	WT_STATS log_slot_races;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3720,112 +3720,114 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LOG_SCANS				1087
 /*! log: consolidated slot closures */
 #define	WT_STAT_CONN_LOG_SLOT_CLOSES			1088
+/*! log: written slots coalesced */
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1089
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1089
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1090
 /*! log: consolidated slot joins */
-#define	WT_STAT_CONN_LOG_SLOT_JOINS			1090
+#define	WT_STAT_CONN_LOG_SLOT_JOINS			1091
 /*! log: consolidated slot join races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1091
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1092
 /*! log: slots selected for switching that were unavailable */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_FAILS		1092
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_FAILS		1093
 /*! log: record size exceeded maximum */
-#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			1093
+#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			1094
 /*! log: failed to find a slot large enough for record */
-#define	WT_STAT_CONN_LOG_SLOT_TOOSMALL			1094
+#define	WT_STAT_CONN_LOG_SLOT_TOOSMALL			1095
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1095
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1096
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1096
+#define	WT_STAT_CONN_LOG_SYNC				1097
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1097
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1098
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1098
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1099
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1099
+#define	WT_STAT_CONN_LOG_WRITES				1100
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1100
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1101
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1101
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1102
 /*! LSM: rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			1102
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			1103
 /*! LSM: application work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1103
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1104
 /*! LSM: merge work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1104
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1105
 /*! LSM: tree queue hit maximum */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1105
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1106
 /*! LSM: switch work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1106
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1107
 /*! LSM: tree maintenance operations scheduled */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1107
+#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1108
 /*! LSM: tree maintenance operations discarded */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1108
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1109
 /*! LSM: tree maintenance operations executed */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1109
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1110
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1110
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1111
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1111
+#define	WT_STAT_CONN_MEMORY_FREE			1112
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1112
+#define	WT_STAT_CONN_MEMORY_GROW			1113
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1113
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1114
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1114
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1115
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1115
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1116
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1116
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1117
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1117
+#define	WT_STAT_CONN_PAGE_SLEEP				1118
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1118
+#define	WT_STAT_CONN_READ_IO				1119
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1119
+#define	WT_STAT_CONN_REC_PAGES				1120
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1120
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1121
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1121
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1122
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1122
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1123
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1123
+#define	WT_STAT_CONN_RWLOCK_READ			1124
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1124
+#define	WT_STAT_CONN_RWLOCK_WRITE			1125
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1125
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1126
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1126
+#define	WT_STAT_CONN_SESSION_OPEN			1127
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1127
+#define	WT_STAT_CONN_TXN_BEGIN				1128
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1128
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1129
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1129
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1130
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1130
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1131
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1131
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1132
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1132
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1133
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1133
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1134
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1134
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1135
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1135
+#define	WT_STAT_CONN_TXN_COMMIT				1136
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1136
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1137
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1137
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1138
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1138
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1139
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1139
+#define	WT_STAT_CONN_TXN_ROLLBACK			1140
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1140
+#define	WT_STAT_CONN_TXN_SYNC				1141
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1141
+#define	WT_STAT_CONN_WRITE_IO				1142
 
 /*!
  * @}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1217,6 +1217,7 @@ __wt_log_newfile(WT_SESSION_IMPL *session, int conn_create, int *created)
 	 */
 	while (log->log_close_fh != NULL) {
 		WT_STAT_FAST_CONN_INCR(session, log_close_yields);
+		WT_RET(__wt_log_wrlsn(session, NULL));
 		__wt_yield();
 	}
 	log->log_close_fh = log->log_fh;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1217,7 +1217,7 @@ __wt_log_newfile(WT_SESSION_IMPL *session, int conn_create, int *created)
 	 */
 	while (log->log_close_fh != NULL) {
 		WT_STAT_FAST_CONN_INCR(session, log_close_yields);
-		WT_RET(__wt_log_wrlsn(session, NULL));
+		WT_RET(__wt_log_wrlsn(session, NULL, NULL));
 		__wt_yield();
 	}
 	log->log_close_fh = log->log_fh;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -191,7 +191,7 @@ join_slot:
  * __log_slot_find_free --
  * 	Find and return a free log slot.
  */
-int
+static int
 __log_slot_find_free(WT_SESSION_IMPL *session, WT_LOGSLOT **slot)
 {
 	WT_CONNECTION_IMPL *conn;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -207,10 +207,10 @@ __log_slot_find_free(WT_SESSION_IMPL *session, WT_LOGSLOT **slot)
 	 * work and let it give us the index of a free slot along
 	 * the way.
 	 */
-	WT_RET(__wt_log_wrlsn(session, &pool_i));
+	WT_RET(__wt_log_wrlsn(session, &pool_i, NULL));
 	while (pool_i == WT_SLOT_POOL) {
 		__wt_yield();
-		WT_RET(__wt_log_wrlsn(session, &pool_i));
+		WT_RET(__wt_log_wrlsn(session, &pool_i, NULL));
 	}
 	*slot = &log->slot_pool[pool_i];
 	WT_ASSERT(session, (*slot)->slot_state == WT_LOG_SLOT_FREE);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -490,6 +490,7 @@ __wt_stat_init_connection_stats(WT_CONNECTION_STATS *stats)
 	    "log: total in-memory size of compressed records";
 	stats->log_buffer_size.desc = "log: total log buffer size";
 	stats->log_compress_len.desc = "log: total size of compressed records";
+	stats->log_slot_coalesced.desc = "log: written slots coalesced";
 	stats->log_close_yields.desc =
 	    "log: yields waiting for previous log file close";
 	stats->lsm_work_queue_app.desc =
@@ -650,6 +651,7 @@ __wt_stat_refresh_connection_stats(void *stats_arg)
 	stats->log_slot_switch_fails.v = 0;
 	stats->log_compress_mem.v = 0;
 	stats->log_compress_len.v = 0;
+	stats->log_slot_coalesced.v = 0;
 	stats->log_close_yields.v = 0;
 	stats->lsm_rows_merged.v = 0;
 	stats->lsm_checkpoint_throttle.v = 0;


### PR DESCRIPTION
@michaelcahill Please review this diff. It is essentially the "patch2" with a few changes.  With this patch, compared to develop I see the following performance (ops/sec) running Bruce's workload (on the AWS SSD).

Client threads:|Dev|Branch|difference
--------------------|---|-----|---------------
8 | 109 | 92 | -16%
16 | 125 | 151 | +21%
24 | 117 | 143 | +22%
32 | 121 | 126 | +4%
64 | 120 | 111 | -8%