### PR TITLE
WT-2013 Add gcc asm definitions for ARM64

### DIFF
--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -169,6 +169,19 @@
 #define	WT_READ_BARRIER()	WT_FULL_BARRIER()
 #define	WT_WRITE_BARRIER()	WT_FULL_BARRIER()
 
+#elif defined(__aarch64__)
+#define WT_PAUSE() __asm__ volatile("yield" ::: "memory")
+
+#define WT_FULL_BARRIER() do {                          \
+          __asm__ volatile ("dsb sy" ::: "memory");     \
+      } while (0)
+#define WT_READ_BARRIER() do {                          \
+          __asm__ volatile ("dsb ld" ::: "memory");     \
+      } while (0)
+#define WT_WRITE_BARRIER() do {                         \
+          __asm__ volatile ("dsb st" ::: "memory");     \
+      } while (0)
+
 #else
 #error "No write barrier implementation for this hardware"
 #endif


### PR DESCRIPTION
Developed by analogy, particularly with:

http://lxr.free-electrons.com/source/arch/x86/include/asm/barrier.h
http://lxr.free-electrons.com/source/arch/arm64/include/asm/barrier.h

and

http://lxr.free-electrons.com/source/arch/x86/include/asm/processor.h#L692
http://lxr.free-electrons.com/source/arch/arm64/include/asm/processor.h#L130

Interestingly, linux doesn't seem to use sleep on x86.