### PR TITLE
WT-1989 Use size_t for the log slot size in memory.

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -160,7 +160,7 @@ typedef struct {
 #define	WT_SLOT_POOL	128
 	WT_LOGSLOT	*slot_array[WT_SLOT_ACTIVE];	/* Active slots */
 	WT_LOGSLOT	 slot_pool[WT_SLOT_POOL];	/* Pool of all slots */
-	wt_off_t	 slot_buf_size;		/* Buffer size for slots */
+	size_t		 slot_buf_size;		/* Buffer size for slots */
 
 #define	WT_LOG_FORCE_CONSOLIDATE	0x01	/* Disable direct writes */
 	uint32_t	 flags;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -53,11 +53,11 @@ __wt_log_slot_init(WT_SESSION_IMPL *session)
 	/*
 	 * Allocate memory for buffers now that the arrays are setup. Split
 	 * this out to make error handling simpler.
-	 */
-	/*
+	 *
 	 * Cap the slot buffer to the log file size.
 	 */
-	log->slot_buf_size = WT_MIN(conn->log_file_max, WT_LOG_SLOT_BUF_SIZE);
+	log->slot_buf_size =
+	    WT_MIN((size_t)conn->log_file_max, WT_LOG_SLOT_BUF_SIZE);
 	for (i = 0; i < WT_SLOT_POOL; i++) {
 		WT_ERR(__wt_buf_init(session,
 		    &log->slot_pool[i].slot_buf, log->slot_buf_size));


### PR DESCRIPTION
Fixes:
log/log_slot.c:62:3: error: conversion to 'size_t' from 'wt_off_t' may change the sign of the result [-Werror=sign-conversion]