### PR TITLE
WT-2014 Checkpoint file fixes

### DIFF
--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -316,13 +316,10 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, int need_sync, int unroll)
 
 	/* If we're logging, make sure the metadata update was flushed. */
 	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED)) {
-		if (!FLD_ISSET(S2C(session)->txn_logsync,
-		    WT_LOG_DSYNC | WT_LOG_FSYNC)) {
-			WT_WITH_DHANDLE(session, session->meta_dhandle,
-			    ret = __wt_txn_checkpoint_log(session,
-			    0, WT_TXN_LOG_CKPT_SYNC, NULL));
-			WT_RET(ret);
-		}
+		WT_WITH_DHANDLE(session, session->meta_dhandle,
+		    ret = __wt_txn_checkpoint_log(session,
+		    0, WT_TXN_LOG_CKPT_SYNC, NULL));
+		WT_RET(ret);
 	} else {
 		WT_WITH_DHANDLE(session, session->meta_dhandle,
 		    ret = __wt_checkpoint(session, NULL));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1202,11 +1202,9 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, int final)
 	 * Turn on metadata tracking if:
 	 * * The session isn't already doing metadata tracking
 	 * * The file isn't bulk loadable
-	 * * The close isn't during connection close or the update is for the
-	 *   metadata file itself (when we need to track to ensure durability).
+	 * * The close isn't during connection close
 	 */
-	need_tracking = !WT_META_TRACKING(session) && !bulk &&
-	   (!final || WT_IS_METADATA(session->dhandle));
+	need_tracking = !WT_META_TRACKING(session) && !bulk && !final;
 
 	if (need_tracking)
 		WT_RET(__wt_meta_track_on(session));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -352,7 +352,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_TXN_STATE *txn_state;
 	void *saved_meta_next;
 	u_int i;
-	int full, fullckpt_logging, idle, tracking;
+	int full, idle, logging, tracking;
 	const char *txn_cfg[] = { WT_CONFIG_BASE(session,
 	    WT_SESSION_begin_transaction), "isolation=snapshot", NULL };
 
@@ -361,7 +361,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	txn_global = &conn->txn_global;
 	txn_state = WT_SESSION_TXN_STATE(session);
 	saved_isolation = session->isolation;
-	full = fullckpt_logging = idle = tracking = 0;
+	full = idle = logging= tracking = 0;
 
 	/* Ensure the metadata table is open before taking any locks. */
 	WT_RET(__wt_metadata_open(session));
@@ -373,8 +373,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_RET(__checkpoint_apply_all(session, cfg, NULL, &full));
 
 	/* Configure logging only if doing a full checkpoint. */
-	fullckpt_logging =
-	    full && FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED);
+	logging = FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED);
 
 	/*
 	 * Get a list of handles we want to flush; this may pull closed objects
@@ -424,7 +423,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	tracking = 1;
 
 	/* Tell logging that we are about to start a database checkpoint. */
-	if (fullckpt_logging)
+	if (full && logging)
 		WT_ERR(__wt_txn_checkpoint_log(
 		    session, full, WT_TXN_LOG_CKPT_PREPARE, NULL));
 
@@ -494,7 +493,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	txn_state->id = txn_state->snap_min = WT_TXN_NONE;
 
 	/* Tell logging that we have started a database checkpoint. */
-	if (fullckpt_logging)
+	if (full && logging)
 		WT_ERR(__wt_txn_checkpoint_log(
 		    session, full, WT_TXN_LOG_CKPT_START, NULL));
 
@@ -532,26 +531,44 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ERR(__wt_txn_commit(session, NULL));
 
 	/*
-	 * If any tree was dirty, we will have updated the metadata with the
-	 * new checkpoint information.  If the metadata is clean, all other
-	 * trees must have been clean.
-	 *
-	 * Disable metadata tracking during the metadata checkpoint.
-	 *
-	 * We don't lock old checkpoints in the metadata file: there is no way
-	 * to open one.  We are holding other handle locks, it is not safe to
-	 * lock conn->spinlock.
+	 * Checkpoint the metadata file if this is a system wide checkpoint or
+	 * logging is disabled. Otherwise ensure that the log file has been
+	 * flushed so that the checkpoint is stable on disk.
+	 * It is not OK to checkpoint the metadata if logging is enabled and
+	 * this isn't a full checkpoint since checkpointing the metadata
+	 * updates the start LSN for recovery.
 	 */
-	session->isolation = txn->isolation = WT_ISO_READ_UNCOMMITTED;
-	saved_meta_next = session->meta_track_next;
-	session->meta_track_next = NULL;
-	WT_WITH_DHANDLE(session,
-	    session->meta_dhandle, ret = __wt_checkpoint(session, cfg));
-	session->meta_track_next = saved_meta_next;
-	WT_ERR(ret);
+	if (full || !logging) { 
+		/*
+		 * If any tree was dirty, we will have updated the metadata
+		 * with the new checkpoint information.  If the metadata is
+		 * clean, all other trees must have been clean.
+		 *
+		 * Disable metadata tracking during the metadata checkpoint.
+		 *
+		 * We don't lock old checkpoints in the metadata file: there is
+		 * no way to open one.  We are holding other handle locks, it
+		 * is not safe to lock conn->spinlock.
+		 */
+		session->isolation = txn->isolation = WT_ISO_READ_UNCOMMITTED;
+		saved_meta_next = session->meta_track_next;
+		session->meta_track_next = NULL;
+		WT_WITH_DHANDLE(session,
+		    session->meta_dhandle, ret = __wt_checkpoint(session, cfg));
+		session->meta_track_next = saved_meta_next;
+		WT_ERR(ret);
 
-	WT_ERR(__checkpoint_verbose_track(session,
-	    "metadata sync completed", &verb_timer));
+		WT_ERR(__checkpoint_verbose_track(session,
+		    "metadata sync completed", &verb_timer));
+	} else if (logging)
+		/*
+		 * Ensure the log file is synced so that recovery finds the
+		 * correct checkpoint in the metadata for the files in which we
+		 * just created checkpoints.
+		 */
+		WT_WITH_DHANDLE(session, session->meta_dhandle,
+		    ret = __wt_txn_checkpoint_log(session,
+		    0, WT_TXN_LOG_CKPT_SYNC, NULL));
 
 	if (full) {
 		WT_ERR(__wt_epoch(session, &stop));
@@ -590,7 +607,7 @@ err:	/*
 	 * Tell logging that we have finished a database checkpoint.  Do not
 	 * write a log record if the database was idle.
 	 */
-	if (fullckpt_logging) {
+	if (full && logging) {
 		if (ret == 0 &&
 		    F_ISSET((WT_BTREE *)session->meta_dhandle->handle,
 		    WT_BTREE_SKIP_CKPT))

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1186,7 +1186,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, int final)
 	/*
 	 * Turn on metadata tracking if:
 	 * - The session is not already doing metadata tracking.
-	 * - The file is not empty or being bulk loaded.
+	 * - The file was bulk loaded.
 	 * - The close is not during connection close.
 	 */
 	need_tracking = !WT_META_TRACKING(session) && !bulk && !final;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -560,7 +560,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
 		WT_ERR(__checkpoint_verbose_track(session,
 		    "metadata sync completed", &verb_timer));
-	} else if (logging)
+	} else
 		/*
 		 * Ensure the log file is synced so that recovery finds the
 		 * correct checkpoint in the metadata for the files in which we

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -538,7 +538,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * this isn't a full checkpoint since checkpointing the metadata
 	 * updates the start LSN for recovery.
 	 */
-	if (full || !logging) { 
+	if (full || !logging) {
 		/*
 		 * If any tree was dirty, we will have updated the metadata
 		 * with the new checkpoint information.  If the metadata is


### PR DESCRIPTION
For WT-2014 and WT-2009, which came from durability testing with MongoDB.