### PR TITLE
WT-2016: wt_rwlock_t union packing

### DIFF
--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -32,7 +32,9 @@ typedef union {			/* Read/write lock */
 	WiredTiger read/write locks require modification for big-endian systems.
 #else
 	uint64_t u;
-	uint32_t us;
+	struct {
+		uint32_t us;
+	} i;
 	struct {
 		uint16_t writers;
 		uint16_t readers;

--- a/src/os_posix/os_mtx_rw.c
+++ b/src/os_posix/os_mtx_rw.c
@@ -216,7 +216,7 @@ __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 	++copy.s.writers;
 	++copy.s.readers;
 
-	l->us = copy.us;
+	l->i.us = copy.i.us;
 	return (0);
 }
 


### PR DESCRIPTION
@keithbostic Here is a really trivial change to nest the `us` member in a struct in the union. I need this so that I can add padding into the struct for big-endian systems.