### PR TITLE
WT-2012 Fix a bug updating the oldest ID

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -309,7 +309,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, int force)
 		/* Make sure the ID doesn't move past any named snapshots. */
 		WT_ASSERT(session,
 		    (id = txn_global->nsnap_oldest_id) == WT_TXN_NONE ||
-		    WT_TXNID_LT(id, oldest_id));
+		    !WT_TXNID_LT(id, oldest_id));
 
 		if (WT_TXNID_LT(txn_global->oldest_id, oldest_id))
 			txn_global->oldest_id = oldest_id;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -307,6 +307,12 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, int force)
 			    WT_TXNID_LT(id, oldest_id))
 				oldest_id = id;
 		}
+
+		/* The oldest ID can't move past any named snapshots. */
+		if ((id = txn_global->nsnap_oldest_id) != WT_TXN_NONE &&
+		    WT_TXNID_LT(id, oldest_id))
+			oldest_id = id;
+
 		if (WT_TXNID_LT(txn_global->oldest_id, oldest_id))
 			txn_global->oldest_id = oldest_id;
 		txn_global->scan_count = 0;


### PR DESCRIPTION
We weren't checking that the oldest ID doesn't move past the oldest named snapshot ID.

Found by inspection.