### PR TITLE
WT-2007 Backport static log buffer fix.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -215,7 +215,6 @@ connection_stats = [
     ##########################################
     # Logging statistics
     ##########################################
-    LogStat('log_buffer_grow', 'log buffer size increases'),
     LogStat('log_buffer_size', 'total log buffer size', 'no_clear,no_scale'),
     LogStat('log_bytes_payload', 'log bytes of payload data'),
     LogStat('log_bytes_written', 'log bytes written'),

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -363,7 +363,6 @@ extern int __wt_log_slot_notify(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_log_slot_wait(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int64_t __wt_log_slot_release(WT_LOGSLOT *slot, uint64_t size);
 extern int __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
-extern int __wt_log_slot_grow_buffers(WT_SESSION_IMPL *session, size_t newsize);
 extern int __wt_clsm_request_switch(WT_CURSOR_LSM *clsm);
 extern int __wt_clsm_await_switch(WT_CURSOR_LSM *clsm);
 extern int __wt_clsm_init_merge( WT_CURSOR *cursor, u_int start_chunk, uint32_t start_id, u_int nchunks);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -12,7 +12,7 @@
 
 /* Logging subsystem declarations. */
 #define	LOG_ALIGN		128
-#define	WT_LOG_SLOT_BUF_INIT_SIZE	64 * 1024
+#define	WT_LOG_SLOT_BUF_SIZE	256 * 1024
 
 #define	WT_INIT_LSN(l)	do {						\
 	(l)->file = 1;							\
@@ -91,11 +91,10 @@ typedef WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) struct {
 	WT_ITEM slot_buf;		/* Buffer for grouped writes */
 	int32_t	slot_churn;		/* Active slots are scarce. */
 
-#define	SLOT_BUF_GROW	0x01			/* Grow buffer on release */
-#define	SLOT_BUFFERED	0x02			/* Buffer writes */
-#define	SLOT_CLOSEFH	0x04			/* Close old fh on release */
-#define	SLOT_SYNC	0x08			/* Needs sync on release */
-#define	SLOT_SYNC_DIR	0x10			/* Directory sync on release */
+#define	SLOT_BUFFERED	0x01			/* Buffer writes */
+#define	SLOT_CLOSEFH	0x02			/* Close old fh on release */
+#define	SLOT_SYNC	0x04			/* Needs sync on release */
+#define	SLOT_SYNC_DIR	0x08			/* Directory sync on release */
 	uint32_t flags;			/* Flags */
 } WT_LOGSLOT;
 
@@ -160,6 +159,7 @@ typedef struct {
 	uint32_t	 pool_index;		/* Global pool index */
 	WT_LOGSLOT	*slot_array[SLOT_ACTIVE];	/* Active slots */
 	WT_LOGSLOT	 slot_pool[SLOT_POOL];	/* Pool of all slots */
+	wt_off_t	 slot_buf_size;		/* Buffer size for slots */
 
 #define	WT_LOG_FORCE_CONSOLIDATE	0x01	/* Disable direct writes */
 	uint32_t	 flags;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -203,7 +203,6 @@ struct __wt_connection_stats {
 	WT_STATS dh_session_handles;
 	WT_STATS dh_session_sweeps;
 	WT_STATS file_open;
-	WT_STATS log_buffer_grow;
 	WT_STATS log_buffer_size;
 	WT_STATS log_bytes_payload;
 	WT_STATS log_bytes_written;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -222,19 +222,19 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 	txn->isolation = session->isolation;
 	txn->txn_logsync = S2C(session)->txn_logsync;
 
-        if (cfg != NULL)
-                WT_RET(__wt_txn_config(session, cfg));
+	if (cfg != NULL)
+		WT_RET(__wt_txn_config(session, cfg));
 
 	F_SET(txn, TXN_RUNNING);
 	if (txn->isolation == TXN_ISO_SNAPSHOT) {
 		if (session->ncursors > 0)
 			WT_RET(__wt_session_copy_values(session));
 
-                /*
-                 * We're about to allocate a snapshot: if we need to block for
-                 * eviction, it's better to do it beforehand.
-                 */
-                WT_RET(__wt_cache_full_check(session));
+		/*
+		 * We're about to allocate a snapshot: if we need to block for
+		 * eviction, it's better to do it beforehand.
+		 */
+		WT_RET(__wt_cache_full_check(session));
 		__wt_txn_get_snapshot(session);
 	}
 	return (0);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3345,150 +3345,148 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_DH_SESSION_SWEEPS			1069
 /*! connection: files currently open */
 #define	WT_STAT_CONN_FILE_OPEN				1070
-/*! log: log buffer size increases */
-#define	WT_STAT_CONN_LOG_BUFFER_GROW			1071
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1072
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1071
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1073
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1072
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1074
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1073
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1075
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1074
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1076
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1075
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1077
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1076
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1078
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1077
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1079
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1078
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1080
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1079
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1081
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1080
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1082
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1081
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1083
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1082
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1084
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1083
 /*! log: log read operations */
-#define	WT_STAT_CONN_LOG_READS				1085
+#define	WT_STAT_CONN_LOG_READS				1084
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1086
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1085
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1087
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1086
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1088
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1087
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1089
+#define	WT_STAT_CONN_LOG_SCANS				1088
 /*! log: consolidated slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1090
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1089
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1091
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1090
 /*! log: consolidated slot joins */
-#define	WT_STAT_CONN_LOG_SLOT_JOINS			1092
+#define	WT_STAT_CONN_LOG_SLOT_JOINS			1091
 /*! log: consolidated slot join races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1093
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1092
 /*! log: slots selected for switching that were unavailable */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_FAILS		1094
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_FAILS		1093
 /*! log: record size exceeded maximum */
-#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			1095
+#define	WT_STAT_CONN_LOG_SLOT_TOOBIG			1094
 /*! log: failed to find a slot large enough for record */
-#define	WT_STAT_CONN_LOG_SLOT_TOOSMALL			1096
+#define	WT_STAT_CONN_LOG_SLOT_TOOSMALL			1095
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1097
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1096
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1098
+#define	WT_STAT_CONN_LOG_SYNC				1097
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1099
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1098
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1100
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1099
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1101
+#define	WT_STAT_CONN_LOG_WRITES				1100
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1102
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1101
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1103
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1102
 /*! LSM: rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			1104
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			1103
 /*! LSM: application work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1105
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1104
 /*! LSM: merge work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1106
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1105
 /*! LSM: tree queue hit maximum */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1107
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1106
 /*! LSM: switch work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1108
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1107
 /*! LSM: tree maintenance operations scheduled */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1109
+#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1108
 /*! LSM: tree maintenance operations discarded */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1110
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1109
 /*! LSM: tree maintenance operations executed */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1111
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1110
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1112
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1111
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1113
+#define	WT_STAT_CONN_MEMORY_FREE			1112
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1114
+#define	WT_STAT_CONN_MEMORY_GROW			1113
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1115
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1114
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1116
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1115
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1117
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1116
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1118
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1117
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1119
+#define	WT_STAT_CONN_PAGE_SLEEP				1118
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1120
+#define	WT_STAT_CONN_READ_IO				1119
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1121
+#define	WT_STAT_CONN_REC_PAGES				1120
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1122
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1121
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1123
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1122
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1124
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1123
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1125
+#define	WT_STAT_CONN_RWLOCK_READ			1124
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1126
+#define	WT_STAT_CONN_RWLOCK_WRITE			1125
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1127
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1126
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1128
+#define	WT_STAT_CONN_SESSION_OPEN			1127
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1129
+#define	WT_STAT_CONN_TXN_BEGIN				1128
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1130
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1129
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1131
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1130
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1132
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1131
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1133
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1132
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1134
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1133
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1135
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1134
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1136
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1135
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1137
+#define	WT_STAT_CONN_TXN_COMMIT				1136
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1138
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1137
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1139
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1138
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1140
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1139
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1141
+#define	WT_STAT_CONN_TXN_ROLLBACK			1140
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1142
+#define	WT_STAT_CONN_WRITE_IO				1141
 
 /*!
  * @}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1820,11 +1820,6 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 		    session, record, lsnp, flags)) == EAGAIN)
 			;
 		WT_ERR(ret);
-		/*
-		 * Increase the buffer size of any slots we can get access
-		 * to, so future consolidations are likely to succeed.
-		 */
-		WT_ERR(__wt_log_slot_grow_buffers(session, 4 * rdup_len));
 		return (0);
 	}
 	WT_ERR(ret);

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -54,13 +54,17 @@ __wt_log_slot_init(WT_SESSION_IMPL *session)
 	 * Allocate memory for buffers now that the arrays are setup. Split
 	 * this out to make error handling simpler.
 	 */
+	/*
+	 * Cap the slot buffer to the log file size.
+	 */
+	log->slot_buf_size = WT_MIN(conn->log_file_max, WT_LOG_SLOT_BUF_SIZE);
 	for (i = 0; i < SLOT_POOL; i++) {
 		WT_ERR(__wt_buf_init(session,
-		    &log->slot_pool[i].slot_buf, WT_LOG_SLOT_BUF_INIT_SIZE));
+		    &log->slot_pool[i].slot_buf, log->slot_buf_size));
 		F_SET(&log->slot_pool[i], SLOT_INIT_FLAGS);
 	}
 	WT_STAT_FAST_CONN_INCRV(session,
-	    log_buffer_size, WT_LOG_SLOT_BUF_INIT_SIZE * SLOT_POOL);
+	    log_buffer_size, log->slot_buf_size * SLOT_POOL);
 	if (0) {
 err:		while (--i >= 0)
 			__wt_buf_free(session, &log->slot_pool[i].slot_buf);
@@ -101,11 +105,16 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize,
 	WT_LOG *log;
 	WT_LOGSLOT *slot;
 	int64_t cur_state, new_state, old_state;
-	uint32_t allocated_slot, slot_grow_attempts;
+	uint32_t allocated_slot, slot_attempts;
 
 	conn = S2C(session);
 	log = conn->log;
-	slot_grow_attempts = 0;
+	slot_attempts = 0;
+
+	if (mysize >= (uint64_t)log->slot_buf_size) {
+		WT_STAT_FAST_CONN_INCR(session, log_slot_toobig);
+		return (ENOMEM);
+	}
 find_slot:
 	allocated_slot = __wt_random(session->rnd) % SLOT_ACTIVE;
 	slot = log->slot_array[allocated_slot];
@@ -131,12 +140,11 @@ join_slot:
 		goto find_slot;
 	}
 	/*
-	 * If the slot buffer isn't big enough to hold this update, mark
-	 * the slot for a buffer size increase and find another slot.
+	 * If the slot buffer isn't big enough to hold this update, try
+	 * to find another slot.
 	 */
 	if (new_state > (int64_t)slot->slot_buf.memsize) {
-		F_SET(slot, SLOT_BUF_GROW);
-		if (++slot_grow_attempts > 5) {
+		if (++slot_attempts > 5) {
 			WT_STAT_FAST_CONN_INCR(session, log_slot_toosmall);
 			return (ENOMEM);
 		}
@@ -297,24 +305,7 @@ __wt_log_slot_release(WT_LOGSLOT *slot, uint64_t size)
 int
 __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
 {
-	WT_DECL_RET;
-
-	ret = 0;
-	/*
-	 * Grow the buffer if needed before returning it to the pool.
-	 */
-	if (F_ISSET(slot, SLOT_BUF_GROW)) {
-		WT_STAT_FAST_CONN_INCR(session, log_buffer_grow);
-		WT_STAT_FAST_CONN_INCRV(session,
-		    log_buffer_size, slot->slot_buf.memsize);
-		WT_ERR(__wt_buf_grow(session,
-		    &slot->slot_buf, slot->slot_buf.memsize * 2));
-	}
-err:
-	/*
-	 * No matter if there is an error, we always want to free
-	 * the slot back to the pool.
-	 */
+	WT_UNUSED(session);
 	/*
 	 * Make sure flags don't get retained between uses.
 	 * We have to reset them them here because multiple threads may
@@ -322,65 +313,5 @@ err:
 	 */
 	slot->flags = SLOT_INIT_FLAGS;
 	slot->slot_state = WT_LOG_SLOT_FREE;
-	return (ret);
-}
-
-/*
- * __wt_log_slot_grow_buffers --
- *	Increase the buffer size of all available slots in the buffer pool.
- *	Go to some lengths to include active (but unused) slots to handle
- *	the case where all log write record sizes exceed the size of the
- *	active buffer.
- */
-int
-__wt_log_slot_grow_buffers(WT_SESSION_IMPL *session, size_t newsize)
-{
-	WT_CONNECTION_IMPL *conn;
-	WT_DECL_RET;
-	WT_LOG *log;
-	WT_LOGSLOT *slot;
-	int64_t orig_state;
-	uint64_t old_size, total_growth;
-	int i;
-
-	conn = S2C(session);
-	log = conn->log;
-	total_growth = 0;
-	WT_STAT_FAST_CONN_INCR(session, log_buffer_grow);
-	/*
-	 * Take the log slot lock to prevent other threads growing buffers
-	 * at the same time. Could tighten the scope of this lock, or have
-	 * a separate lock if there is contention.
-	 */
-	__wt_spin_lock(session, &log->log_slot_lock);
-	for (i = 0; i < SLOT_POOL; i++) {
-		slot = &log->slot_pool[i];
-		/* Avoid atomic operations if they won't succeed. */
-		if (slot->slot_state != WT_LOG_SLOT_FREE &&
-		    slot->slot_state != WT_LOG_SLOT_READY)
-			continue;
-		/* Don't keep growing unrelated buffers. */
-		if (slot->slot_buf.memsize > (10 * newsize) &&
-		    !F_ISSET(slot, SLOT_BUF_GROW))
-			continue;
-		orig_state = WT_ATOMIC_CAS_VAL8(
-		    slot->slot_state, WT_LOG_SLOT_FREE, WT_LOG_SLOT_PENDING);
-		if (orig_state != WT_LOG_SLOT_FREE) {
-			orig_state = WT_ATOMIC_CAS_VAL8(slot->slot_state,
-			    WT_LOG_SLOT_READY, WT_LOG_SLOT_PENDING);
-			if (orig_state != WT_LOG_SLOT_READY)
-				continue;
-		}
-
-		/* We have a slot - now go ahead and grow the buffer. */
-		old_size = slot->slot_buf.memsize;
-		F_CLR(slot, SLOT_BUF_GROW);
-		WT_ERR(__wt_buf_grow(session, &slot->slot_buf,
-		    WT_MAX(slot->slot_buf.memsize * 2, newsize)));
-		slot->slot_state = orig_state;
-		total_growth += slot->slot_buf.memsize - old_size;
-	}
-err:	__wt_spin_unlock(session, &log->log_slot_lock);
-	WT_STAT_FAST_CONN_INCRV(session, log_buffer_size, total_growth);
-	return (ret);
+	return (0);
 }

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1535,7 +1535,7 @@ __wt_clsm_open(WT_SESSION_IMPL *session,
 		    "bulk-load is only supported on newly created LSM trees");
 	WT_ASSERT(session, !bulk || lsm_tree->exclusive);
 	/* Flag any errors from the tree get. */
-	WT_RET(ret);
+	WT_ERR(ret);
 
 	WT_ERR(__wt_calloc_one(session, &clsm));
 

--- a/src/lsm/lsm_cursor_bulk.c
+++ b/src/lsm/lsm_cursor_bulk.c
@@ -128,4 +128,3 @@ __wt_clsm_open_bulk(WT_CURSOR_LSM *clsm, const char *cfg[])
 
 	return (0);
 }
-

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -447,7 +447,6 @@ __wt_stat_init_connection_stats(WT_CONNECTION_STATS *stats)
 	stats->log_slot_joins.desc = "log: consolidated slot joins";
 	stats->log_slot_toosmall.desc =
 	    "log: failed to find a slot large enough for record";
-	stats->log_buffer_grow.desc = "log: log buffer size increases";
 	stats->log_bytes_payload.desc = "log: log bytes of payload data";
 	stats->log_bytes_written.desc = "log: log bytes written";
 	stats->log_reads.desc = "log: log read operations";
@@ -622,7 +621,6 @@ __wt_stat_refresh_connection_stats(void *stats_arg)
 	stats->log_slot_transitions.v = 0;
 	stats->log_slot_joins.v = 0;
 	stats->log_slot_toosmall.v = 0;
-	stats->log_buffer_grow.v = 0;
 	stats->log_bytes_payload.v = 0;
 	stats->log_bytes_written.v = 0;
 	stats->log_reads.v = 0;


### PR DESCRIPTION
@michaelcahill Please review this backport of the fix in WT-2007.  This addresses ENOMEM errors from logging during a commit transaction call.  There are a couple things to note here:
1.  I backported the removal of the `log_buffer_grow` statistic field.  I don't know if there is a requirement that it continue to exist in the 3.0 branch.  Keeping it would mean we'd see the message about an unused statistic field (but reduces the size of the diff by a lot since half the changes are auto-generated statistic stuff).
2.  Building on this branch, `s_all` modified `txn.i` and `lsm_cursor_bulk.c` for whitespace, etc. but I did not include those in my commit.