### PR TITLE
WT-2025 Assert that cursors are positioned for inserts

### DIFF
--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -160,7 +160,7 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		 * The serial mutex acts as our memory barrier to flush these
 		 * writes before inserting them into the list.
 		 */
-		if (WT_SKIP_FIRST(ins_head) == NULL || recno == 0)
+		if (cbt->ins_stack[0] == NULL || recno == 0)
 			for (i = 0; i < skipdepth; i++) {
 				cbt->ins_stack[i] = &ins_head->head[i];
 				ins->next[i] = cbt->next_stack[i] = NULL;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -192,7 +192,7 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		 * The serial mutex acts as our memory barrier to flush these
 		 * writes before inserting them into the list.
 		 */
-		if (WT_SKIP_FIRST(ins_head) == NULL)
+		if (cbt->ins_stack[0] == NULL)
 			for (i = 0; i < skipdepth; i++) {
 				cbt->ins_stack[i] = &ins_head->head[i];
 				ins->next[i] = cbt->next_stack[i] = NULL;

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -187,6 +187,12 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, int reenter)
 	if (reenter)
 		WT_RET(__curfile_leave(cbt));
 
+	/*
+	 * Any old insert position is now invalid.  We rely on this being
+	 * cleared to detect if a new skiplist is installed after a search.
+	 */
+	cbt->ins_stack[0] = NULL;
+
 	/* If the transaction is idle, check that the cache isn't full. */
 	WT_RET(__wt_txn_idle_cache_check(session));
 

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -67,7 +67,7 @@ __insert_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head,
 
 	WT_UNUSED(session);
 
-        /* The cursor should be positioned. */
+	/* The cursor should be positioned. */
 	WT_ASSERT(session, ins_stack[0] != NULL);
 
 	/*

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -65,8 +65,6 @@ __insert_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head,
 {
 	u_int i;
 
-	WT_UNUSED(session);
-
 	/* The cursor should be positioned. */
 	WT_ASSERT(session, ins_stack[0] != NULL);
 
@@ -158,8 +156,8 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	    session, ins_head, ins_stack, new_ins, recnop, skipdepth);
 	WT_PAGE_UNLOCK(session, page);
 
-	/* Free unused memory on error. */
 	if (ret != 0) {
+		/* Free unused memory on error. */
 		__wt_free(session, new_ins);
 		return (ret);
 	}

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -67,6 +67,9 @@ __insert_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head,
 
 	WT_UNUSED(session);
 
+        /* The cursor should be positioned. */
+	WT_ASSERT(session, ins_stack[0] != NULL);
+
 	/*
 	 * Update the skiplist elements referencing the new WT_INSERT item.
 	 *
@@ -143,13 +146,6 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	WT_INSERT *new_ins = *new_insp;
 	WT_DECL_RET;
 
-	/* !!!
-	 * Test for an uninitialized cursor, ins_stack[0] is cleared as part of
-	 * initializing a cursor for a search.
-	 */
-	if (ins_stack[0] == NULL)
-		return (WT_RESTART);
-
 	/* Check for page write generation wrap. */
 	WT_RET(__page_write_gen_wrapped_check(page));
 
@@ -195,13 +191,6 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	WT_DECL_RET;
 	int simple;
 	u_int i;
-
-	/* !!!
-	 * Test for an uninitialized cursor, ins_stack[0] is cleared as part of
-	 * initializing a cursor for a search.
-	 */
-	if (ins_stack[0] == NULL)
-		return (WT_RESTART);
 
 	/* Check for page write generation wrap. */
 	WT_RET(__page_write_gen_wrapped_check(page));

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -47,6 +47,10 @@ __insert_simple_func(WT_SESSION_IMPL *session,
 	 * return success: the levels we updated are correct and sufficient.
 	 * Even though we don't get the benefit of the memory we allocated,
 	 * we can't roll back.
+	 *
+	 * All structure setup must be flushed before the structure is entered
+	 * into the list. We need a write barrier here, our callers depend on
+	 * it.
 	 */
 	for (i = 0; i < skipdepth; i++)
 		if (!WT_ATOMIC_CAS8(*ins_stack[i], new_ins->next[i], new_ins))
@@ -76,6 +80,10 @@ __insert_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head,
 	 * upper levels in the skiplist, return success: the levels we updated
 	 * are correct and sufficient. Even though we don't get the benefit of
 	 * the memory we allocated, we can't roll back.
+	 *
+	 * All structure setup must be flushed before the structure is entered
+	 * into the list. We need a write barrier here, our callers depend on
+	 * it.
 	 */
 	for (i = 0; i < skipdepth; i++) {
 		if (!WT_ATOMIC_CAS8(*ins_stack[i], new_ins->next[i], new_ins))
@@ -249,6 +257,10 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	*updp = NULL;
 
 	/*
+	 * All structure setup must be flushed before the structure is entered
+	 * into the list. We need a write barrier here, our callers depend on
+	 * it.
+	 *
 	 * Swap the update into place.  If that fails, a new update was added
 	 * after our search, we raced.  Check if our update is still permitted.
 	 */


### PR DESCRIPTION
Fix a possible race between two threads inserting into a clean page.