### PR TITLE
WT-2044: Fix Windows wtperf.exe build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -454,6 +454,7 @@ t = env.Program("wtperf", [
     "bench/wtperf/misc.c",
     "bench/wtperf/track.c",
     "bench/wtperf/wtperf.c",
+    "bench/wtperf/wtperf_truncate.c",
     ],
     LIBS=[wtlib, shim]  + wtlibs)
 Default(t)


### PR DESCRIPTION
Add missing file in SConstruct.