### PR TITLE
SERVER-19989 Add a write barrier before handles become public

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -119,6 +119,8 @@ struct __wt_named_extractor {
  * main queue and the hashed queue.
  */
 #define	WT_CONN_DHANDLE_INSERT(conn, dhandle, bucket) do {		\
+	/* Don't allow readers to see a partially constructed handle. */\
+	WT_WRITE_BARRIER();						\
 	TAILQ_INSERT_HEAD(&(conn)->dhqh, dhandle, q);			\
 	TAILQ_INSERT_HEAD(&(conn)->dhhash[bucket], dhandle, hashq);	\
 	++conn->dhandle_count;						\
@@ -135,6 +137,8 @@ struct __wt_named_extractor {
  * main queue and the hashed queue.
  */
 #define	WT_CONN_BLOCK_INSERT(conn, block, bucket) do {			\
+	/* Don't allow readers to see a partially constructed handle. */\
+	WT_WRITE_BARRIER();						\
 	TAILQ_INSERT_HEAD(&(conn)->blockqh, block, q);			\
 	TAILQ_INSERT_HEAD(&(conn)->blockhash[bucket], block, hashq);	\
 } while (0)
@@ -149,6 +153,8 @@ struct __wt_named_extractor {
  * main queue and the hashed queue.
  */
 #define	WT_CONN_FILE_INSERT(conn, fh, bucket) do {			\
+	/* Don't allow readers to see a partially constructed handle. */\
+	WT_WRITE_BARRIER();						\
 	TAILQ_INSERT_HEAD(&(conn)->fhqh, fh, q);			\
 	TAILQ_INSERT_HEAD(&(conn)->fhhash[bucket], fh, hashq);		\
 } while (0)

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -377,7 +377,8 @@ __wt_txn_id_check(WT_SESSION_IMPL *session)
 		do {
 			txn_state->id = txn->id = txn_global->current;
 		} while (!WT_ATOMIC_CAS8(
-		    txn_global->current, txn->id, txn->id + 1));
+		    txn_global->current, txn->id, txn->id + 1) ||
+			WT_TXNID_LT(txn->id, txn_global->last_running));
 
 		/*
 		 * If we have used 64-bits of transaction IDs, there is nothing

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -377,8 +377,7 @@ __wt_txn_id_check(WT_SESSION_IMPL *session)
 		do {
 			txn_state->id = txn->id = txn_global->current;
 		} while (!WT_ATOMIC_CAS8(
-		    txn_global->current, txn->id, txn->id + 1) ||
-			WT_TXNID_LT(txn->id, txn_global->last_running));
+		    txn_global->current, txn->id, txn->id + 1));
 
 		/*
 		 * If we have used 64-bits of transaction IDs, there is nothing

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -182,9 +182,6 @@ __wt_txn_get_snapshot(WT_SESSION_IMPL *session)
 	WT_ASSERT(session, prev_oldest_id == txn_global->oldest_id);
 	txn_state->snap_min = snap_min;
 
-	if (WT_TXNID_LT(txn_global->last_running + 100, snap_min))
-		txn_global->last_running = snap_min;
-
 	WT_ASSERT(session, txn_global->scan_count > 0);
 	(void)WT_ATOMIC_SUB4(txn_global->scan_count, 1);
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -182,6 +182,9 @@ __wt_txn_get_snapshot(WT_SESSION_IMPL *session)
 	WT_ASSERT(session, prev_oldest_id == txn_global->oldest_id);
 	txn_state->snap_min = snap_min;
 
+	if (WT_TXNID_LT(txn_global->last_running + 100, snap_min))
+		txn_global->last_running = snap_min;
+
 	WT_ASSERT(session, txn_global->scan_count > 0);
 	(void)WT_ATOMIC_SUB4(txn_global->scan_count, 1);
 


### PR DESCRIPTION
There are readers of the handle list that don't acquire the mutex: add a write barrier before handles are inserted.