### PR TITLE
WT-147. For dynamic index creation, solve a locking issue with LSM

### DIFF
--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -59,14 +59,15 @@ struct __wt_cursor_lsm {
 
 #define	WT_CLSM_ACTIVE		0x001   /* Incremented the session count */
 #define	WT_CLSM_BULK		0x002   /* Open for snapshot isolation */
-#define	WT_CLSM_ITERATE_NEXT    0x004   /* Forward iteration */
-#define	WT_CLSM_ITERATE_PREV    0x008   /* Backward iteration */
-#define	WT_CLSM_MERGE           0x010   /* Merge cursor, don't update */
-#define	WT_CLSM_MINOR_MERGE	0x020   /* Minor merge, include tombstones */
-#define	WT_CLSM_MULTIPLE        0x040   /* Multiple cursors have values for the
+#define	WT_CLSM_SCHEMA_LOCK_FILL 0x004	/* Schema locked while index filled */
+#define	WT_CLSM_ITERATE_NEXT    0x008   /* Forward iteration */
+#define	WT_CLSM_ITERATE_PREV    0x010   /* Backward iteration */
+#define	WT_CLSM_MERGE           0x020   /* Merge cursor, don't update */
+#define	WT_CLSM_MINOR_MERGE	0x040   /* Minor merge, include tombstones */
+#define	WT_CLSM_MULTIPLE        0x080   /* Multiple cursors have values for the
 					   current key */
-#define	WT_CLSM_OPEN_READ	0x080   /* Open for reads */
-#define	WT_CLSM_OPEN_SNAPSHOT	0x100   /* Open for snapshot isolation */
+#define	WT_CLSM_OPEN_READ	0x100   /* Open for reads */
+#define	WT_CLSM_OPEN_SNAPSHOT	0x200   /* Open for snapshot isolation */
 	uint32_t flags;
 };
 
@@ -227,10 +228,11 @@ struct __wt_lsm_tree {
 #define	WT_LSM_TREE_ACTIVE		0x01	/* Workers are active */
 #define	WT_LSM_TREE_AGGRESSIVE_TIMER	0x02	/* Timer for merge aggression */
 #define	WT_LSM_TREE_COMPACTING		0x04	/* Tree being compacted */
-#define	WT_LSM_TREE_MERGES		0x08	/* Tree should run merges */
-#define	WT_LSM_TREE_NEED_SWITCH		0x10	/* New chunk needs creating */
-#define	WT_LSM_TREE_OPEN		0x20	/* The tree is open */
-#define	WT_LSM_TREE_THROTTLE		0x40	/* Throttle updates */
+#define	WT_LSM_TREE_SCHEMA_LOCK_FILL	0x08	/* Index is being filled */
+#define	WT_LSM_TREE_MERGES		0x10	/* Tree should run merges */
+#define	WT_LSM_TREE_NEED_SWITCH		0x20	/* New chunk needs creating */
+#define	WT_LSM_TREE_OPEN		0x40	/* The tree is open */
+#define	WT_LSM_TREE_THROTTLE		0x80	/* Throttle updates */
 	uint32_t flags;
 };
 

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -45,6 +45,8 @@ __wt_clsm_request_switch(WT_CURSOR_LSM *clsm)
 		    (clsm->dsk_gen == lsm_tree->dsk_gen &&
 		    !F_ISSET(lsm_tree, WT_LSM_TREE_NEED_SWITCH))) {
 			F_SET(lsm_tree, WT_LSM_TREE_NEED_SWITCH);
+			if (F_ISSET(clsm, WT_CLSM_SCHEMA_LOCK_FILL))
+				F_SET(lsm_tree, WT_LSM_TREE_SCHEMA_LOCK_FILL);
 			ret = __wt_lsm_manager_push_entry(
 			    session, WT_LSM_WORK_SWITCH, 0, lsm_tree);
 		}

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -856,7 +856,7 @@ __wt_lsm_tree_switch(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	WT_ERR(__wt_lsm_tree_setup_chunk(session, lsm_tree, chunk));
 
 	WT_ERR(__wt_lsm_meta_write(session, lsm_tree));
-	F_CLR(lsm_tree, WT_LSM_TREE_NEED_SWITCH);
+	F_CLR(lsm_tree, WT_LSM_TREE_NEED_SWITCH | WT_LSM_TREE_SCHEMA_LOCK_FILL);
 	++lsm_tree->dsk_gen;
 
 	lsm_tree->modified = 1;

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -161,13 +161,21 @@ __wt_lsm_work_switch(
 {
 	WT_DECL_RET;
 	WT_LSM_WORK_UNIT *entry;
+	u_int32_t borrowed_lock;
 
 	/* We've become responsible for freeing the work unit. */
 	entry = *entryp;
 	*ran = 0;
 	*entryp = NULL;
+	borrowed_lock = 0;
 
 	if (F_ISSET(entry->lsm_tree, WT_LSM_TREE_NEED_SWITCH)) {
+		/* Application thread has the schema locked while we switch */
+		if (F_ISSET(entry->lsm_tree, WT_LSM_TREE_SCHEMA_LOCK_FILL) &&
+		    !F_ISSET(session, WT_SESSION_LOCKED_SCHEMA)) {
+			borrowed_lock = WT_SESSION_LOCKED_SCHEMA;
+			F_SET(session, WT_SESSION_LOCKED_SCHEMA);
+		}
 		WT_WITH_SCHEMA_LOCK(session,
 		    ret = __wt_lsm_tree_switch(session, entry->lsm_tree));
 		/* Failing to complete the switch is fine */
@@ -179,7 +187,8 @@ __wt_lsm_work_switch(
 		} else
 			*ran = 1;
 	}
-err:	__wt_lsm_manager_free_work_unit(session, entry);
+err:	F_CLR(session, borrowed_lock);
+	__wt_lsm_manager_free_work_unit(session, entry);
 	return (ret);
 }
 

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -161,7 +161,7 @@ __wt_lsm_work_switch(
 {
 	WT_DECL_RET;
 	WT_LSM_WORK_UNIT *entry;
-	u_int32_t borrowed_lock;
+	uint32_t borrowed_lock;
 
 	/* We've become responsible for freeing the work unit. */
 	entry = *entryp;


### PR DESCRIPTION
From @ddanderson (replacing #2127 with a pull request merging into the original branch):

This branch was built upon index-create, which does dynamic index creation.

For dynamic index creation, solve a locking issue with LSM. The issue is that the application thread is holding the schema lock while we are filling the index. If the index is LSM, then a different LSM thread wants to split the file eventually, but it needs the schema lock to do that.

Coordinate the locking by tagging the LSM cursor with a special flag: "I'm holding the schema lock while filling this lsm: cursor". That in turn sets a flag on the LSM file, so when the LSM worker thread comes along, it pretends it's already holding the schema lock - it's being held on its behalf by the app thread.