### PR TITLE
WT-2057: Strip the verbose configuration as part of writing the base configuration file.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1724,7 +1724,8 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 	    "encryption=(secretkey=),"
 	    "exclusive=,"
 	    "log=(recover=),"
-	    "use_environment_priv=,", &base_config));
+	    "use_environment_priv=,"
+	    "verbose=,", &base_config));
 	WT_ERR(__wt_config_init(session, &parser, base_config));
 	while ((ret = __wt_config_next(&parser, &k, &v)) == 0) {
 		/* Fix quoting for non-trivial settings. */


### PR DESCRIPTION
WT-2057: The verbose configuration is being written to the base configuration file, which means all subsequent runs (including wt command runs), inherit the verbose flags from the initial run.

Strip the verbose configuration as part of writing the base configuration file.

@michaelcahill, ready for review & merge.