### PR TITLE
WT-147 Add undocumented bulk=unordered for LSM cursors.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -295,6 +295,7 @@ UnixLib
 Unmap
 UnmapViewOfFile
 Unmarshall
+Unordered
 Uryyb
 VARCHAR
 VLDB
@@ -949,6 +950,7 @@ unmarshall
 unmarshalled
 unmerged
 unmodify
+unordered
 unpackv
 unpadded
 unreferenced

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -487,6 +487,7 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 	int bitmap, bulk;
 	uint32_t flags;
 
+	bulk = 0;
 	flags = 0;
 
 	WT_RET(__wt_config_gets_def(session, cfg, "bulk", 0, &cval));
@@ -497,6 +498,15 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 		bulk = (cval.val != 0);
 	} else if (WT_STRING_MATCH("bitmap", cval.str, cval.len))
 		bitmap = bulk = 1;
+	else if (WT_STRING_MATCH("unordered", cval.str, cval.len))
+		/*
+		 * Unordered bulk insert is a special case used internally for
+		 * index creation on existing tables. It requires exclusive
+		 * access, but not the other bulk semantics. It primarily
+		 * exists to avoid some locking problems with LSM trees and
+		 * index creation.
+		 */
+		LF_SET(WT_DHANDLE_EXCLUSIVE);
 	else
 		WT_RET_MSG(session, EINVAL,
 		    "Value for 'bulk' must be a boolean or 'bitmap'");
@@ -508,11 +518,11 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 	/* Get the handle and lock it while the cursor is using it. */
 	if (WT_PREFIX_MATCH(uri, "file:")) {
 		/*
-		 * If we are opening a bulk cursor, get the handle while
-		 * holding the checkpoint lock.  This prevents a bulk cursor
-		 * open failing with EBUSY due to a database-wide checkpoint.
+		 * If we are opening exclusive, get the handle while holding
+		 * the checkpoint lock.  This prevents a bulk cursor open
+		 * failing with EBUSY due to a database-wide checkpoint.
 		 */
-		if (bulk)
+		if (LF_ISSET(WT_DHANDLE_EXCLUSIVE))
 			WT_WITH_CHECKPOINT_LOCK(session, ret =
 			    __wt_session_get_btree_ckpt(
 			    session, uri, cfg, flags));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -487,7 +487,7 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 	int bitmap, bulk;
 	uint32_t flags;
 
-	bulk = 0;
+	bitmap = bulk = 0;
 	flags = 0;
 
 	WT_RET(__wt_config_gets_def(session, cfg, "bulk", 0, &cval));
@@ -500,7 +500,7 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 		bitmap = bulk = 1;
 	else if (WT_STRING_MATCH("unordered", cval.str, cval.len))
 		/*
-		 * Unordered bulk insert is a special case used internally for
+		 * Unordered bulk insert is a special case used internally by
 		 * index creation on existing tables. It requires exclusive
 		 * access, but not the other bulk semantics. It primarily
 		 * exists to avoid some locking problems with LSM trees and

--- a/src/lsm/lsm_cursor_bulk.c
+++ b/src/lsm/lsm_cursor_bulk.c
@@ -90,16 +90,28 @@ __clsm_insert_bulk(WT_CURSOR *cursor)
 int
 __wt_clsm_open_bulk(WT_CURSOR_LSM *clsm, const char *cfg[])
 {
+	WT_CONFIG_ITEM cval;
 	WT_CURSOR *cursor, *bulk_cursor;
 	WT_LSM_TREE *lsm_tree;
 	WT_SESSION_IMPL *session;
+	int ordered;
 
 	bulk_cursor = NULL;
 	cursor = &clsm->iface;
 	lsm_tree = clsm->lsm_tree;
+	ordered = 1;	/* Default to ordered inserts */
 	session = (WT_SESSION_IMPL *)clsm->iface.session;
 
 	F_SET(clsm, WT_CLSM_BULK);
+
+	/*
+	 * Check for the undocumented unordered bulk flag, which is used when
+	 * doing index builds into LSM for existing trees.
+	 */
+	WT_RET(__wt_config_gets_def(session, cfg, "bulk", 0, &cval));
+	WT_ASSERT(session, cval.val != 0);
+	if (strncmp(cval.str, "unordered", strlen("unordered")) == 0)
+		ordered = 0;
 
 	/* Bulk cursors are limited to insert and close. */
 	__wt_cursor_set_notsup(cursor);
@@ -138,7 +150,8 @@ __wt_clsm_open_bulk(WT_CURSOR_LSM *clsm, const char *cfg[])
 	 * for bulk access.
 	 */
 	WT_RET(__wt_open_cursor(session,
-	    lsm_tree->chunk[0]->uri, &clsm->iface, cfg, &bulk_cursor));
+	    lsm_tree->chunk[0]->uri, &clsm->iface,
+	    ordered ? cfg : NULL, &bulk_cursor));
 	clsm->cursors[0] = bulk_cursor;
 	/* LSM cursors are always raw */
 	F_SET(bulk_cursor, WT_CURSTD_RAW);


### PR DESCRIPTION
The feature allows us to stop worrying about schema lock interactions when building LSM indexes on existing tables.