### PR TITLE
Specify a key-format to simplify creating lookaside table records.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -34,7 +34,7 @@ __wt_las_remove_block(WT_SESSION_IMPL *session,
 	las_addr->size = addr_size;
 	las_key->size = 0;
 	cursor->set_key(
-	    cursor, btree_id, &las_addr, (uint64_t)0, (uint32_t)0, las_key);
+	    cursor, btree_id, las_addr, (uint64_t)0, (uint32_t)0, las_key);
 	if ((ret = cursor->search_near(cursor, &exact)) == 0 && exact < 0)
 		ret = cursor->next(cursor);
 	for (; ret == 0; ret = cursor->next(cursor)) {

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -113,7 +113,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session,
 	uint64_t current_recno, las_counter, las_txnid, recno, upd_txnid;
 	uint32_t las_id, upd_size;
 	int exact, reset_evict;
-	const void *p;
+	const uint8_t *p;
 
 	cursor = NULL;
 	page = ref->page;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -337,8 +337,12 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		 * calling cursor.remove, cursor.remove can discard our hazard
 		 * pointer and the page could be evicted from underneath us.
 		 */
-		if (cnt == 1)
+		if (cnt == 1) {
 			WT_ERR(__wt_cursor_get_raw_key(cursor, key));
+			if (!WT_DATA_IN_ITEM(key))
+				WT_ERR(__wt_buf_set(
+				    session, key, key->data, key->size));
+		}
 
 		WT_ERR(cursor->get_key(cursor,
 		    &las_id, las_addr, &las_txnid, &las_counter, las_key));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3258,7 +3258,7 @@ __rec_update_las(WT_SESSION_IMPL *session,
 	uint64_t las_counter;
 	uint32_t i, slot;
 	int reset_evict;
-	void *p;
+	uint8_t *p;
 
 	cursor = NULL;
 	WT_CLEAR(las_addr);


### PR DESCRIPTION
@michaelcahill, I haven't tested this extensively yet, but this is the direction I'm heading (it seems to run, fwiw).

This removes the flag byte from the beginning of the lookaside table records, I don't see any way to support multiple formats in that table.