### PR TITLE
WT-2065 Add a quota to shared cache configuration.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -449,13 +449,16 @@ connection_runtime_config = [
         Config('chunk', '10MB', r'''
             the granularity that a shared cache is redistributed''',
             min='1MB', max='10TB'),
+        Config('name', 'none', r'''
+            the name of a cache that is shared between databases or
+            \c "none" when no shared cache is configured'''),
+        Config('quota', '0', r'''
+            maximum amount of cache this database is allowed to
+            be allocated. Defaults to the entire pool''', type='int'),
         Config('reserve', '0', r'''
             amount of cache this database is guaranteed to have
             available from the shared cache. This setting is per
             database. Defaults to the chunk size''', type='int'),
-        Config('name', 'none', r'''
-            the name of a cache that is shared between databases or
-            \c "none" when no shared cache is configured'''),
         Config('size', '500MB', r'''
             maximum memory to allocate for the shared cache. Setting
             this will update the value if one is already set''',

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -453,8 +453,9 @@ connection_runtime_config = [
             the name of a cache that is shared between databases or
             \c "none" when no shared cache is configured'''),
         Config('quota', '0', r'''
-            maximum amount of cache this database is allowed to
-            be allocated. Defaults to the entire pool''', type='int'),
+            maximum size of cache this database can be allocated from the
+            shared cache. Defaults to the entire shared cache size''',
+			type='int'),
         Config('reserve', '0', r'''
             amount of cache this database is guaranteed to have
             available from the shared cache. This setting is per

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -76,6 +76,7 @@ static const WT_CONFIG_CHECK
     confchk_wiredtiger_open_shared_cache_subconfigs[] = {
 	{ "chunk", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "name", "string", NULL, NULL, NULL, 0 },
+	{ "quota", "int", NULL, NULL, NULL, 0 },
 	{ "reserve", "int", NULL, NULL, NULL, 0 },
 	{ "size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
@@ -121,7 +122,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	{ "lsm_merge", "boolean", NULL, NULL, NULL, 0 },
 	{ "shared_cache", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_shared_cache_subconfigs, 4 },
+	    confchk_wiredtiger_open_shared_cache_subconfigs, 5 },
 	{ "statistics", "list",
 	    NULL, "choices=[\"all\",\"fast\",\"none\",\"clear\"]",
 	    NULL, 0 },
@@ -520,7 +521,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
 	{ "shared_cache", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_shared_cache_subconfigs, 4 },
+	    confchk_wiredtiger_open_shared_cache_subconfigs, 5 },
 	{ "statistics", "list",
 	    NULL, "choices=[\"all\",\"fast\",\"none\",\"clear\"]",
 	    NULL, 0 },
@@ -595,7 +596,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
 	{ "shared_cache", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_shared_cache_subconfigs, 4 },
+	    confchk_wiredtiger_open_shared_cache_subconfigs, 5 },
 	{ "statistics", "list",
 	    NULL, "choices=[\"all\",\"fast\",\"none\",\"clear\"]",
 	    NULL, 0 },
@@ -668,7 +669,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
 	{ "shared_cache", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_shared_cache_subconfigs, 4 },
+	    confchk_wiredtiger_open_shared_cache_subconfigs, 5 },
 	{ "statistics", "list",
 	    NULL, "choices=[\"all\",\"fast\",\"none\",\"clear\"]",
 	    NULL, 0 },
@@ -740,7 +741,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
 	{ "shared_cache", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_shared_cache_subconfigs, 4 },
+	    confchk_wiredtiger_open_shared_cache_subconfigs, 5 },
 	{ "statistics", "list",
 	    NULL, "choices=[\"all\",\"fast\",\"none\",\"clear\"]",
 	    NULL, 0 },
@@ -807,8 +808,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "eviction_dirty_trigger=95,eviction_target=80,eviction_trigger=95"
 	  ",file_manager=(close_handle_minimum=250,close_idle_time=30,"
 	  "close_scan_interval=10),lsm_manager=(merge=,worker_thread_max=4)"
-	  ",lsm_merge=,shared_cache=(chunk=10MB,name=,reserve=0,size=500MB)"
-	  ",statistics=none,statistics_log=(on_close=0,"
+	  ",lsm_merge=,shared_cache=(chunk=10MB,name=,quota=0,reserve=0,"
+	  "size=500MB),statistics=none,statistics_log=(on_close=0,"
 	  "path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),verbose=",
 	  confchk_WT_CONNECTION_reconfigure, 17
@@ -959,9 +960,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
 	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
 	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,reserve=0"
-	  ",size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),use_environment_priv=0,verbose=",
 	  confchk_wiredtiger_open, 34
@@ -979,9 +980,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
 	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
 	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,reserve=0"
-	  ",size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),use_environment_priv=0,verbose=,version=(major=0,"
 	  "minor=0)",
@@ -999,9 +1000,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
 	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
 	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,reserve=0"
-	  ",size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg, 31
@@ -1018,9 +1019,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
 	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
 	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,reserve=0"
-	  ",size=500MB),statistics=none,statistics_log=(on_close=0,"
-	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
+	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
+	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
 	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
 	  ",method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg, 30

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -651,7 +651,8 @@ __cache_pool_adjust(WT_SESSION_IMPL *session,
 		 *  - the pool is less than half distributed
 		 */
 		} else if (!pool_full &&
-		    entry->cache_size < cache->cp_quota &&
+		    (cache->cp_quota == 0 ||
+		    entry->cache_size < cache->cp_quota) &&
 		    __wt_cache_bytes_inuse(cache) >=
 		    (entry->cache_size * cache->eviction_target) / 100 &&
 		    (pressure > bump_threshold ||

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -109,6 +109,7 @@ struct __wt_cache {
 	 * Cache pool information.
 	 */
 	uint64_t cp_pass_pressure;	/* Calculated pressure from this pass */
+	uint64_t cp_quota;		/* Maximum size for this cache */
 	uint64_t cp_reserved;		/* Base size for this cache */
 	WT_SESSION_IMPL *cp_session;	/* May be used for cache management */
 	uint32_t cp_skip_count;		/* Post change stabilization */
@@ -140,6 +141,7 @@ struct __wt_cache_pool {
 	const char *name;
 	uint64_t size;
 	uint64_t chunk;
+	uint64_t quota;
 	uint64_t currently_used;
 	uint32_t refs;		/* Reference count for structure. */
 	/* Locked: List of connections participating in the cache pool. */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1750,14 +1750,16 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that
 	 * is shared between databases or \c "none" when no shared cache is
 	 * configured., a string; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this
-	 * database is guaranteed to have available from the shared cache.  This
-	 * setting is per database.  Defaults to the chunk size., an integer;
-	 * default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
-	 * to allocate for the shared cache.  Setting this will update the value
-	 * if one is already set., an integer between 1MB and 10TB; default \c
-	 * 500MB.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum amount of cache this
+	 * database is allowed to be allocated.  Defaults to the entire pool.,
+	 * an integer; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve,
+	 * amount of cache this database is guaranteed to have available from
+	 * the shared cache.  This setting is per database.  Defaults to the
+	 * chunk size., an integer; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate for
+	 * the shared cache.  Setting this will update the value if one is
+	 * already set., an integer between 1MB and 10TB; default \c 500MB.}
 	 * @config{ ),,}
 	 * @config{statistics, Maintain database statistics\, which may impact
 	 * performance.  Choosing "all" maintains all statistics regardless of
@@ -2216,14 +2218,18 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is shared
  * between databases or \c "none" when no shared cache is configured., a string;
  * default \c none.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache
- * this database is guaranteed to have available from the shared cache.  This
- * setting is per database.  Defaults to the chunk size., an integer; default \c
- * 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate for the
- * shared cache.  Setting this will update the value if one is already set., an
- * integer between 1MB and 10TB; default \c 500MB.}
- * @config{ ),,}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum amount of
+ * cache this database is allowed to be allocated.  Defaults to the entire
+ * pool., an integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve,
+ * amount of cache this database is guaranteed to have available from the shared
+ * cache.  This setting is per database.  Defaults to the chunk size., an
+ * integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
+ * to allocate for the shared cache.  Setting this will update the value if one
+ * is already set., an integer between 1MB and 10TB; default \c 500MB.}
+ * @config{
+ * ),,}
  * @config{statistics, Maintain database statistics\, which may impact
  * performance.  Choosing "all" maintains all statistics regardless of cost\,
  * "fast" maintains a subset of statistics that are relatively inexpensive\,

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1750,16 +1750,17 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that
 	 * is shared between databases or \c "none" when no shared cache is
 	 * configured., a string; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum amount of cache this
-	 * database is allowed to be allocated.  Defaults to the entire pool.,
-	 * an integer; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve,
-	 * amount of cache this database is guaranteed to have available from
-	 * the shared cache.  This setting is per database.  Defaults to the
-	 * chunk size., an integer; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate for
-	 * the shared cache.  Setting this will update the value if one is
-	 * already set., an integer between 1MB and 10TB; default \c 500MB.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this
+	 * database can be allocated from the shared cache.  Defaults to the
+	 * entire shared cache size., an integer; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this
+	 * database is guaranteed to have available from the shared cache.  This
+	 * setting is per database.  Defaults to the chunk size., an integer;
+	 * default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
+	 * to allocate for the shared cache.  Setting this will update the value
+	 * if one is already set., an integer between 1MB and 10TB; default \c
+	 * 500MB.}
 	 * @config{ ),,}
 	 * @config{statistics, Maintain database statistics\, which may impact
 	 * performance.  Choosing "all" maintains all statistics regardless of
@@ -2218,18 +2219,16 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is shared
  * between databases or \c "none" when no shared cache is configured., a string;
  * default \c none.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum amount of
- * cache this database is allowed to be allocated.  Defaults to the entire
- * pool., an integer; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve,
- * amount of cache this database is guaranteed to have available from the shared
- * cache.  This setting is per database.  Defaults to the chunk size., an
- * integer; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
- * to allocate for the shared cache.  Setting this will update the value if one
- * is already set., an integer between 1MB and 10TB; default \c 500MB.}
- * @config{
- * ),,}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of
+ * cache this database can be allocated from the shared cache.  Defaults to the
+ * entire shared cache size., an integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is
+ * guaranteed to have available from the shared cache.  This setting is per
+ * database.  Defaults to the chunk size., an integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate for the
+ * shared cache.  Setting this will update the value if one is already set., an
+ * integer between 1MB and 10TB; default \c 500MB.}
+ * @config{ ),,}
  * @config{statistics, Maintain database statistics\, which may impact
  * performance.  Choosing "all" maintains all statistics regardless of cost\,
  * "fast" maintains a subset of statistics that are relatively inexpensive\,


### PR DESCRIPTION
That provides the ability to limit how much cache a single participant in a shared cache can be allocated.