### PR TITLE
WT-1967 fix an "uninitialized variable" warning.

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -92,7 +92,8 @@
 		return (__wt_illegal_value(session, NULL))
 #define	WT_ILLEGAL_VALUE_ERR(session)					\
 	default:							\
-		WT_ERR(__wt_illegal_value(session, NULL))
+		ret = __wt_illegal_value(session, NULL);		\
+		goto err
 #define	WT_ILLEGAL_VALUE_SET(session)					\
 	default:							\
 		ret = __wt_illegal_value(session, NULL);		\


### PR DESCRIPTION
../src/reconcile/rec_write.c: In function '__rec_split_write':
../src/reconcile/rec_write.c:3252: warning: 'upd' may be used uninitialized in this function

Make it really obvious to dumb compilers that we're not going to continue after an illegal value.