### PR TITLE
WT-1967: don't dirty the tree/page when instantiating lookaside table records

### DIFF
--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -36,6 +36,15 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	upd = upd_arg;
 	append = logged = 0;
 
+	/*
+	 * If we don't yet have a modify structure, allocate one; a requirement
+	 * even if not modifying the page because column-store stores key/value
+	 * pairs that don't appear on the page in the page-modify structure, so
+	 * when re-instantiating update lists from the lookaside table we might
+	 * need the page-modify structure.
+	 */
+	WT_RET(__wt_page_modify_init(session, page));
+
 	/* This code expects a remove to have a NULL value. */
 	if (is_remove) {
 		if (btree->type == BTREE_COL_FIX) {

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -58,9 +58,6 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 			append = 1;
 	}
 
-	/* If we don't yet have a modify structure, we'll need one. */
-	WT_RET(__wt_page_modify_init(session, page));
-
 	/*
 	 * Delete, insert or update a column-store entry.
 	 *

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -43,7 +43,7 @@ __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 /*
  * __wt_row_modify --
- *	Row-store insert, update and delete.
+ *	Row-store page insert, update and delete.
  */
 int
 __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
@@ -67,9 +67,6 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	/* This code expects a remove to have a NULL value. */
 	if (is_remove)
 		value = NULL;
-
-	/* If we don't yet have a modify structure, we'll need one. */
-	WT_RET(__wt_page_modify_init(session, page));
 
 	/*
 	 * Modify: allocate an update array as necessary, build a WT_UPDATE

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -402,6 +402,12 @@ static inline void
 __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
 	/*
+	 * Pages in the lookaside table are updated in the service of checkpoint
+	 * handles, and dirtying the page or tree leads to tears.
+	 */
+	WT_ASSERT(session, session->dhandle->checkpoint == NULL);
+
+	/*
 	 * Mark the tree dirty (even if the page is already marked dirty), newly
 	 * created pages to support "empty" files are dirty, but the file isn't
 	 * marked dirty until there's a real change needing to be written. Test


### PR DESCRIPTION
@michaelcahill, this change fixes some sporadic errors we've been seeing, generally I see it as an eviction server panic or `write operation on read-only checkpoint handle` error.

In short, we can't allow instantiating lookaside table records on a page being read into the cache dirty the tree/page, because if it's a checkpoint handle, we're never going to be able to write it, and it eventually all goes south during close or eviction.

I'm putting this on a branch, it needs review.