### PR TITLE
WT-2034 Fine tune weighting of operations in shared cache balancing.

### DIFF
--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -30,8 +30,8 @@
  * Constants that control how much influence different metrics have on
  * the pressure calculation.
  */
-#define	WT_CACHE_POOL_APP_EVICT_MULTIPLIER	10
-#define	WT_CACHE_POOL_APP_WAIT_MULTIPLIER	50
+#define	WT_CACHE_POOL_APP_EVICT_MULTIPLIER	3
+#define	WT_CACHE_POOL_APP_WAIT_MULTIPLIER	6
 #define	WT_CACHE_POOL_READ_MULTIPLIER	1
 
 static int __cache_pool_adjust(


### PR DESCRIPTION
Update the code to be less aggressive towards application evictions
and application stalls. Being so aggressive led to unfair treatment
of read only workloads, and also more jitter in allocations over time.