### PR TITLE
WT-2085 Run some of the log_server threads operations more frequently

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -611,18 +611,17 @@ __log_server(void *arg)
 	WT_LOG *log;
 	WT_SESSION_IMPL *session;
 	uint64_t count, freq_per_sec, wait_time;
-	u_int arch_lock;
-	int signalled;
+	int arch_lock, signalled;
 
 	session = arg;
 	conn = S2C(session);
 	log = conn->log;
-	arch_lock = 0;
+	arch_lock = signalled = 0;
+
 	/*
 	 * Set this to the number of times per second we want to force out the
 	 * log slot buffer.
 	 */
-	signalled = 0;
 	count = 0;
 	freq_per_sec = 20;
 	wait_time = WT_MILLION / freq_per_sec;

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -670,7 +670,8 @@ __log_server(void *arg)
 					    session, log->log_archive_lock));
 					arch_lock = 0;
 				} else
-					WT_ERR(__wt_verbose(session, WT_VERB_LOG,
+					WT_ERR(
+					    __wt_verbose(session, WT_VERB_LOG,
 					    "log_archive: Blocked due to open "
 					    "log cursor holding archive lock"));
 			}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -486,6 +486,7 @@ extern int __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t siz
 extern int __wt_mmap_discard(WT_SESSION_IMPL *session, void *p, size_t size);
 extern int __wt_munmap(WT_SESSION_IMPL *session, WT_FH *fh, void *map, size_t len, void **mappingcookie);
 extern int __wt_cond_alloc(WT_SESSION_IMPL *session, const char *name, int is_signalled, WT_CONDVAR **condp);
+extern int __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, int *signalled);
 extern int __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs);
 extern int __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond);
 extern int __wt_cond_destroy(WT_SESSION_IMPL *session, WT_CONDVAR **condp);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -486,8 +486,7 @@ extern int __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t siz
 extern int __wt_mmap_discard(WT_SESSION_IMPL *session, void *p, size_t size);
 extern int __wt_munmap(WT_SESSION_IMPL *session, WT_FH *fh, void *map, size_t len, void **mappingcookie);
 extern int __wt_cond_alloc(WT_SESSION_IMPL *session, const char *name, int is_signalled, WT_CONDVAR **condp);
-extern int __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, int *signalled);
-extern int __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs);
+extern int __wt_cond_wait_signal( WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, int *signalled);
 extern int __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond);
 extern int __wt_cond_destroy(WT_SESSION_IMPL *session, WT_CONDVAR **condp);
 extern int __wt_rwlock_alloc( WT_SESSION_IMPL *session, WT_RWLOCK **rwlockp, const char *name);

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -7,6 +7,18 @@
  */
 
 /*
+ * __wt_cond_wait --
+ *	Wait on a mutex, optionally timing out.
+ */
+static inline int
+__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
+{
+	int notused;
+
+	return (__wt_cond_wait_signal(session, cond, usecs, &notused));
+}
+
+/*
  * __wt_strdup --
  *	ANSI strdup function.
  */

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -46,8 +46,8 @@ err:	__wt_free(session, cond);
  *	before the time out period expires, let the caller know.
  */
 int
-__wt_cond_wait_signal(WT_SESSION_IMPL *session,
-    WT_CONDVAR *cond, uint64_t usecs, int *signalled)
+__wt_cond_wait_signal(
+    WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, int *signalled)
 {
 	struct timespec ts;
 	WT_DECL_RET;
@@ -56,8 +56,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session,
 	locked = 0;
 
 	/* Fast path if already signalled. */
-	if (signalled != NULL)
-		*signalled = 1;
+	*signalled = 1;
 	if (__wt_atomic_addi32(&cond->waiters, 1) == 0)
 		return (0);
 
@@ -93,8 +92,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session,
 	    ret == ETIME ||
 #endif
 	    ret == ETIMEDOUT) {
-		if (signalled != NULL)
-			*signalled = 0;
+		*signalled = 0;
 		ret = 0;
 	}
 
@@ -105,16 +103,6 @@ err:	if (locked)
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "pthread_cond_wait");
-}
-
-/*
- * __wt_cond_wait --
- *	Wait on a mutex, optionally timing out.
- */
-int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
-{
-	return (__wt_cond_wait_signal(session, cond, usecs, NULL));
 }
 
 /*

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -41,11 +41,13 @@ err:	__wt_free(session, cond);
 }
 
 /*
- * __wt_cond_wait --
- *	Wait on a mutex, optionally timing out.
+ * __wt_cond_wait_signal --
+ *	Wait on a mutex, optionally timing out.  If we get it
+ *	before the time out period expires, let the caller know.
  */
 int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
+__wt_cond_wait_signal(WT_SESSION_IMPL *session,
+    WT_CONDVAR *cond, uint64_t usecs, int *signalled)
 {
 	struct timespec ts;
 	WT_DECL_RET;
@@ -54,6 +56,8 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 	locked = 0;
 
 	/* Fast path if already signalled. */
+	if (signalled != NULL)
+		*signalled = 1;
 	if (__wt_atomic_addi32(&cond->waiters, 1) == 0)
 		return (0);
 
@@ -88,8 +92,11 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 #ifdef ETIME
 	    ret == ETIME ||
 #endif
-	    ret == ETIMEDOUT)
+	    ret == ETIMEDOUT) {
+		if (signalled != NULL)
+			*signalled = 0;
 		ret = 0;
+	}
 
 	(void)__wt_atomic_subi32(&cond->waiters, 1);
 
@@ -98,6 +105,16 @@ err:	if (locked)
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "pthread_cond_wait");
+}
+
+/*
+ * __wt_cond_wait --
+ *	Wait on a mutex, optionally timing out.
+ */
+int
+__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
+{
+	return (__wt_cond_wait_signal(session, cond, usecs, NULL));
 }
 
 /*

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -42,7 +42,7 @@ __wt_cond_alloc(WT_SESSION_IMPL *session,
  *	before the time out period expires, let the caller know.
  */
 int
-__wt_cond_wait_isngal(WT_SESSION_IMPL *session,
+__wt_cond_wait_signal(WT_SESSION_IMPL *session,
     WT_CONDVAR *cond, uint64_t usecs, int *signalled)
 {
 	DWORD milliseconds;

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -37,11 +37,13 @@ __wt_cond_alloc(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_cond_wait --
- *	Wait on a mutex, optionally timing out.
+ * __wt_cond_wait_signal --
+ *	Wait on a mutex, optionally timing out.  If we get it
+ *	before the time out period expires, let the caller know.
  */
 int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
+__wt_cond_wait_isngal(WT_SESSION_IMPL *session,
+    WT_CONDVAR *cond, uint64_t usecs, int *signalled)
 {
 	DWORD milliseconds;
 	WT_DECL_RET;
@@ -51,6 +53,8 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 	locked = 0;
 
 	/* Fast path if already signalled. */
+	if (signalled != NULL)
+		*signalled = 1;
 	if (__wt_atomic_addi32(&cond->waiters, 1) == 0)
 		return (0);
 
@@ -93,6 +97,8 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 
 	if (ret == 0) {
 		if (GetLastError() == ERROR_TIMEOUT) {
+			if (signalled != NULL)
+				*signalled = 0;
 			ret = 1;
 		}
 	}
@@ -104,6 +110,16 @@ __wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
 	if (ret != 0)
 		return (0);
 	WT_RET_MSG(session, ret, "SleepConditionVariableCS");
+}
+
+/*
+ * __wt_cond_wait --
+ *	Wait on a mutex, optionally timing out.
+ */
+int
+__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
+{
+	return (__wt_cond_wait_signal(session, cond, usecs, NULL));
 }
 
 /*

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -42,8 +42,8 @@ __wt_cond_alloc(WT_SESSION_IMPL *session,
  *	before the time out period expires, let the caller know.
  */
 int
-__wt_cond_wait_signal(WT_SESSION_IMPL *session,
-    WT_CONDVAR *cond, uint64_t usecs, int *signalled)
+__wt_cond_wait_signal(
+    WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, int *signalled)
 {
 	DWORD milliseconds;
 	WT_DECL_RET;
@@ -53,8 +53,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session,
 	locked = 0;
 
 	/* Fast path if already signalled. */
-	if (signalled != NULL)
-		*signalled = 1;
+	*signalled = 1;
 	if (__wt_atomic_addi32(&cond->waiters, 1) == 0)
 		return (0);
 
@@ -97,8 +96,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session,
 
 	if (ret == 0) {
 		if (GetLastError() == ERROR_TIMEOUT) {
-			if (signalled != NULL)
-				*signalled = 0;
+			*signalled = 0;
 			ret = 1;
 		}
 	}
@@ -110,16 +108,6 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session,
 	if (ret != 0)
 		return (0);
 	WT_RET_MSG(session, ret, "SleepConditionVariableCS");
-}
-
-/*
- * __wt_cond_wait --
- *	Wait on a mutex, optionally timing out.
- */
-int
-__wt_cond_wait(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs)
-{
-	return (__wt_cond_wait_signal(session, cond, usecs, NULL));
 }
 
 /*


### PR DESCRIPTION
than others.  In particular, flush the log slot 20x per second.

@keithbostic Would you please review?  I added a new API for waiting on conditions.  This change allows the log slot to be forced out more frequently than other operations in the same worker thread rather than having to create a new thread.