### PR TITLE
WT-2075 When closing a slot, detect, return and handle different values.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -262,6 +262,7 @@ connection_stats = [
     LogStat('log_slot_consolidated', 'logging bytes consolidated'),
     LogStat('log_slot_joins', 'consolidated slot joins'),
     LogStat('log_slot_races', 'consolidated slot join races'),
+    LogStat('log_slot_switch_busy', 'busy returns attempting to switch slots'),
     LogStat('log_slot_transitions', 'consolidated slot join transitions'),
     LogStat('log_slot_unbuffered', 'consolidated slot unbuffered writes'),
     LogStat('log_sync', 'log sync operations'),

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -591,8 +591,7 @@ __log_wrlsn_server(void *arg)
 	 * On close we need to do this one more time because there could
 	 * be straggling log writes that need to be written.
 	 */
-	while (__wt_log_force_write(session) == EBUSY)
-		__wt_yield();
+	WT_ERR(__wt_log_force_write(session, 1));
 	WT_ERR(__wt_log_wrlsn(session));
 	if (0) {
 err:		__wt_err(session, ret, "log wrlsn server error");
@@ -644,7 +643,7 @@ __log_server(void *arg)
 		 * and a buffer may need to wait for the write_lsn to advance
 		 * in the case of a synchronous buffer.  We end up with a hang.
 		 */
-		WT_ERR_BUSY_OK(__wt_log_force_write(session));
+		WT_ERR_BUSY_OK(__wt_log_force_write(session, 0));
 
 		/*
 		 * We don't want to archive or pre-allocate files as often as

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -591,7 +591,8 @@ __log_wrlsn_server(void *arg)
 	 * On close we need to do this one more time because there could
 	 * be straggling log writes that need to be written.
 	 */
-	WT_ERR(__wt_log_force_write(session, 0));
+	while (__wt_log_force_write(session) == EBUSY)
+		__wt_yield();
 	WT_ERR(__wt_log_wrlsn(session));
 	if (0) {
 err:		__wt_err(session, ret, "log wrlsn server error");
@@ -643,7 +644,7 @@ __log_server(void *arg)
 		 * and a buffer may need to wait for the write_lsn to advance
 		 * in the case of a synchronous buffer.  We end up with a hang.
 		 */
-		WT_ERR(__wt_log_force_write(session, 1));
+		WT_ERR_BUSY_OK(__wt_log_force_write(session));
 
 		/*
 		 * We don't want to archive or pre-allocate files as often as

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -396,7 +396,7 @@ __wt_curlog_open(WT_SESSION_IMPL *session,
 	 * The user may be trying to read a log record they just wrote.
 	 * Log records may be buffered, so force out any now.
 	 */
-	WT_ERR(__wt_log_force_write(session, 1));
+	WT_ERR_BUSY_OK(__wt_log_force_write(session));
 
 	/* Log cursors block archiving. */
 	WT_ERR(__wt_readlock(session, log->log_archive_lock));

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -396,7 +396,7 @@ __wt_curlog_open(WT_SESSION_IMPL *session,
 	 * The user may be trying to read a log record they just wrote.
 	 * Log records may be buffered, so force out any now.
 	 */
-	WT_ERR_BUSY_OK(__wt_log_force_write(session));
+	WT_ERR(__wt_log_force_write(session, 1));
 
 	/* Log cursors block archiving. */
 	WT_ERR(__wt_readlock(session, log->log_archive_lock));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -367,11 +367,12 @@ extern int __wt_logop_row_truncate_print( WT_SESSION_IMPL *session, const uint8_
 extern int __wt_txn_op_printlog( WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, FILE *out);
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_log_slot_close( WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *releasep, int forced);
-extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
+extern int __wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot);
+extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot);
 extern int __wt_log_slot_new(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_init(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_destroy(WT_SESSION_IMPL *session);
-extern void __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT_MYSLOT *myslotp);
+extern void __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT_MYSLOT *myslot);
 extern int64_t __wt_log_slot_release(WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int64_t size);
 extern void __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_clsm_request_switch(WT_CURSOR_LSM *clsm);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -339,7 +339,7 @@ extern int __wt_log_remove(WT_SESSION_IMPL *session, const char *file_prefix, ui
 extern int __wt_log_open(WT_SESSION_IMPL *session);
 extern int __wt_log_close(WT_SESSION_IMPL *session);
 extern int __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags, int (*func)(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, WT_LSN *next_lsnp, void *cookie, int firstrecord), void *cookie);
-extern int __wt_log_force_write(WT_SESSION_IMPL *session, int new_slot);
+extern int __wt_log_force_write(WT_SESSION_IMPL *session);
 extern int __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t flags);
 extern int __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap);
 extern int __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp);
@@ -366,7 +366,7 @@ extern int __wt_logop_row_truncate_unpack( WT_SESSION_IMPL *session, const uint8
 extern int __wt_logop_row_truncate_print( WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, FILE *out);
 extern int __wt_txn_op_printlog( WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, FILE *out);
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
-extern void __wt_log_slot_close(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *releasep);
+extern int __wt_log_slot_close( WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *releasep, int forced);
 extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_log_slot_new(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_init(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -339,7 +339,7 @@ extern int __wt_log_remove(WT_SESSION_IMPL *session, const char *file_prefix, ui
 extern int __wt_log_open(WT_SESSION_IMPL *session);
 extern int __wt_log_close(WT_SESSION_IMPL *session);
 extern int __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags, int (*func)(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, WT_LSN *next_lsnp, void *cookie, int firstrecord), void *cookie);
-extern int __wt_log_force_write(WT_SESSION_IMPL *session);
+extern int __wt_log_force_write(WT_SESSION_IMPL *session, int retry);
 extern int __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t flags);
 extern int __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap);
 extern int __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -127,9 +127,11 @@
     (FLD64_ISSET((uint64_t)state, WT_LOG_SLOT_CLOSE) &&			\
     !FLD64_ISSET((uint64_t)state, WT_LOG_SLOT_RESERVED)))
 /* Slot is in use, all data copied into buffer */
+#define	WT_LOG_SLOT_INPROGRESS(state)					\
+    (WT_LOG_SLOT_RELEASED(state) != WT_LOG_SLOT_JOINED(state))
 #define	WT_LOG_SLOT_DONE(state)						\
     (WT_LOG_SLOT_CLOSED(state) &&					\
-    (WT_LOG_SLOT_RELEASED(state) == WT_LOG_SLOT_JOINED(state)))
+    !WT_LOG_SLOT_INPROGRESS(state))
 /* Slot is in use, more threads may join this slot */
 #define	WT_LOG_SLOT_OPEN(state)						\
     (WT_LOG_SLOT_ACTIVE(state) &&					\

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -169,7 +169,8 @@ struct __wt_myslot {
 	WT_LOGSLOT	*slot;		/* Slot I'm using */
 	wt_off_t	 end_offset;	/* My end offset in buffer */
 	wt_off_t	 offset;	/* Slot buffer offset */
-#define	WT_MYSLOT_UNBUFFERED	0x01	/* Write directly */
+#define	WT_MYSLOT_CLOSE		0x01	/* This thread is closing the slot */
+#define	WT_MYSLOT_UNBUFFERED	0x02	/* Write directly */
 	uint32_t flags;			/* Flags */
 };
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -329,6 +329,7 @@ struct __wt_connection_stats {
 	int64_t log_slot_consolidated;
 	int64_t log_slot_joins;
 	int64_t log_slot_races;
+	int64_t log_slot_switch_busy;
 	int64_t log_slot_transitions;
 	int64_t log_slot_unbuffered;
 	int64_t log_sync;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3753,102 +3753,104 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LOG_SLOT_JOINS			1100
 /*! log: consolidated slot join races */
 #define	WT_STAT_CONN_LOG_SLOT_RACES			1101
+/*! log: busy returns attempting to switch slots */
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1102
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1102
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1103
 /*! log: consolidated slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1103
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1104
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1104
+#define	WT_STAT_CONN_LOG_SYNC				1105
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1105
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1106
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1106
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1107
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1107
+#define	WT_STAT_CONN_LOG_WRITES				1108
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1108
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1109
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1109
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1110
 /*! LSM: rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			1110
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			1111
 /*! LSM: application work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1111
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1112
 /*! LSM: merge work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1112
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1113
 /*! LSM: tree queue hit maximum */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1113
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1114
 /*! LSM: switch work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1114
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1115
 /*! LSM: tree maintenance operations scheduled */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1115
+#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1116
 /*! LSM: tree maintenance operations discarded */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1116
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1117
 /*! LSM: tree maintenance operations executed */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1117
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1118
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1118
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1119
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1119
+#define	WT_STAT_CONN_MEMORY_FREE			1120
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1120
+#define	WT_STAT_CONN_MEMORY_GROW			1121
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1121
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1122
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1122
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1123
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1123
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1124
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1124
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1125
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1125
+#define	WT_STAT_CONN_PAGE_SLEEP				1126
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1126
+#define	WT_STAT_CONN_READ_IO				1127
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1127
+#define	WT_STAT_CONN_REC_PAGES				1128
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1128
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1129
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1129
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1130
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1130
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1131
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1131
+#define	WT_STAT_CONN_RWLOCK_READ			1132
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1132
+#define	WT_STAT_CONN_RWLOCK_WRITE			1133
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1133
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1134
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1134
+#define	WT_STAT_CONN_SESSION_OPEN			1135
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1135
+#define	WT_STAT_CONN_TXN_BEGIN				1136
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1136
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1137
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1137
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1138
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1138
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1139
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1139
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1140
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1140
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1141
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1141
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1142
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1142
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1143
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1143
+#define	WT_STAT_CONN_TXN_COMMIT				1144
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1144
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1145
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1145
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1146
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1146
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1147
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1147
+#define	WT_STAT_CONN_TXN_ROLLBACK			1148
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1148
+#define	WT_STAT_CONN_TXN_SYNC				1149
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1149
+#define	WT_STAT_CONN_WRITE_IO				1150
 
 /*!
  * @}

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -100,7 +100,7 @@ retry:
 }
 
 /*
- * __wt_log_slot_switch --
+ * __wt_log_slot_switch_internal --
  *	Switch out the current slot and set up a new one.
  */
 int

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -586,6 +586,7 @@ static const char * const __stats_connection_desc[] = {
 	"log: logging bytes consolidated",
 	"log: consolidated slot joins",
 	"log: consolidated slot join races",
+	"log: busy returns attempting to switch slots",
 	"log: consolidated slot join transitions",
 	"log: consolidated slot unbuffered writes",
 	"log: log sync operations",
@@ -749,6 +750,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->dh_sweeps = 0;
 	stats->dh_session_handles = 0;
 	stats->dh_session_sweeps = 0;
+	stats->log_slot_switch_busy = 0;
 	stats->log_slot_closes = 0;
 	stats->log_slot_races = 0;
 	stats->log_slot_transitions = 0;
@@ -930,6 +932,7 @@ __wt_stat_connection_aggregate(
 	to->dh_sweeps += WT_STAT_READ(from, dh_sweeps);
 	to->dh_session_handles += WT_STAT_READ(from, dh_session_handles);
 	to->dh_session_sweeps += WT_STAT_READ(from, dh_session_sweeps);
+	to->log_slot_switch_busy += WT_STAT_READ(from, log_slot_switch_busy);
 	to->log_slot_closes += WT_STAT_READ(from, log_slot_closes);
 	to->log_slot_races += WT_STAT_READ(from, log_slot_races);
 	to->log_slot_transitions += WT_STAT_READ(from, log_slot_transitions);


### PR DESCRIPTION
This avoids hangs when rapidly filling log files so that in progress
writes can actually finish.

@michaelcahill Please review this branch to solve the hang with many threads and very few records per log file.  There are a couple things of note:
1.  Performance generally is a bit better than currently because by detecting these different conditions, there actually is less slot churn.
2.  Please consider the places where I used `*_BUSY_OK` and if it would be otherwise appropriate to loop/wait for a forced write to complete.  In particular, log cursors could still see a written log record still buffered if it happens when another thread is in the middle of its write.