### PR TITLE
Fix incorrect assert in Windows error handling

### DIFF
--- a/src/os_win/os_errno.c
+++ b/src/os_win/os_errno.c
@@ -22,7 +22,7 @@ __wt_map_error_to_windows_error(int error) {
 	   Also validate he do not get any COM errors
 	   (which are negative integers)
 	*/
-	WT_ASSERT(NULL, error > 0 && error > -(windows_error_offset));
+	WT_ASSERT(NULL, error < 0);
 
 	return (error + -(windows_error_offset));
 }
@@ -96,7 +96,7 @@ __wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)
 		    snprintf(errbuf, errlen, "%s", buf) > 0)
 			return (errbuf);
 		if (lasterror != 0 && session != NULL &&
-		    __wt_buf_set(session, &session->err, buf, strlen(buf)) == 0)
+		    __wt_buf_fmt(session, &session->err, "%s", buf) == 0)
 			return (session->err.data);
 	}
 


### PR DESCRIPTION
This assert was wrong when I shifted the WIndows error range. It should just be < 0.

Also fixed an issue where a buffer was not correctly null-terminated by switching from `__wt_buf_set` to  `__wt_buf_fmt` during this testing.

Tests:
Windows build
Adhoc fault injection into __wt_read to ensure it is printed correctly.