### PR TITLE
WT-2102 Combine the switch and force_write functions.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -338,6 +338,7 @@ extern int __wt_log_allocfile( WT_SESSION_IMPL *session, uint32_t lognum, const 
 extern int __wt_log_remove(WT_SESSION_IMPL *session, const char *file_prefix, uint32_t lognum);
 extern int __wt_log_open(WT_SESSION_IMPL *session);
 extern int __wt_log_close(WT_SESSION_IMPL *session);
+extern int __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *freep);
 extern int __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags, int (*func)(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, WT_LSN *next_lsnp, void *cookie, int firstrecord), void *cookie);
 extern int __wt_log_force_write(WT_SESSION_IMPL *session, int retry);
 extern int __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t flags);
@@ -367,8 +368,7 @@ extern int __wt_logop_row_truncate_print( WT_SESSION_IMPL *session, const uint8_
 extern int __wt_txn_op_printlog( WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, FILE *out);
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_log_slot_close( WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *releasep, int forced);
-extern int __wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot);
-extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot);
+extern int __wt_log_slot_switch( WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int retry, int forced);
 extern int __wt_log_slot_new(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_init(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_destroy(WT_SESSION_IMPL *session);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -542,7 +542,7 @@ __log_file_header(
 	/*
 	 * We may recursively call __wt_log_acquire to allocate log space for
 	 * the log descriptor record.  Call __log_fill to write it, but we
-	 * do not need to call __log_release because we're not waiting for
+	 * do not need to call __wt_log_release because we're not waiting for
 	 * any earlier operations to complete.
 	 */
 	if (prealloc) {
@@ -1170,11 +1170,11 @@ err:
 }
 
 /*
- * __log_release --
+ * __wt_log_release --
  *	Release a log slot.
  */
-static int
-__log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *freep)
+int
+__wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, int *freep)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
@@ -1624,40 +1624,6 @@ err:	WT_STAT_FAST_CONN_INCR(session, log_scans);
 }
 
 /*
- * __log_force_write_internal --
- *	Force a switch and release and write of the current slot.
- *	Must be called with the slot lock held.
- */
-static int
-__log_force_write_internal(WT_SESSION_IMPL *session)
-{
-	WT_DECL_RET;
-	WT_LOG *log;
-	WT_LOGSLOT *slot;
-	int free_slot, release;
-
-	log = S2C(session)->log;
-	slot = log->active_slot;
-	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SLOT));
-	/*
-	 * If closing the slot returns WT_NOTFOUND, it means that someone else
-	 * is processing the slot change: we're done.  If we get EBUSY (or any
-	 * other error), return that so the caller can decide what to do.
-	 */
-	ret = __wt_log_slot_close(session, slot, &release, 1);
-	if (ret == WT_NOTFOUND)
-		return (0);
-	WT_RET(ret);
-	if (release) {
-		WT_RET(__log_release(session, slot, &free_slot));
-		if (free_slot)
-			__wt_log_slot_free(session, slot);
-	}
-	WT_RET(__wt_log_slot_new(session));
-	return (0);
-}
-
-/*
  * __wt_log_force_write --
  *	Force a switch and release and write of the current slot.
  *	Wrapper function that takes the lock.
@@ -1665,14 +1631,13 @@ __log_force_write_internal(WT_SESSION_IMPL *session)
 int
 __wt_log_force_write(WT_SESSION_IMPL *session, int retry)
 {
-	WT_DECL_RET;
+	WT_LOG *log;
+	WT_MYSLOT myslot;
 
-	do {
-		WT_WITH_SLOT_LOCK(session, S2C(session)->log,
-		    ret = __log_force_write_internal(session));
-	} while (retry && ret == EBUSY);
-
-	return (ret);
+	log = S2C(session)->log;
+	memset(&myslot, 0, sizeof(myslot));
+	myslot.slot = log->active_slot;
+	return (__wt_log_slot_switch(session, &myslot, retry, 1));
 }
 
 /*
@@ -1866,7 +1831,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	ret = 0;
 	if (myslot.end_offset >= WT_LOG_SLOT_BUF_MAX ||
 	    F_ISSET(&myslot, WT_MYSLOT_UNBUFFERED) || force)
-		ret = __wt_log_slot_switch(session, &myslot);
+		ret = __wt_log_slot_switch(session, &myslot, 1, 0);
 	if (ret == 0)
 		ret = __log_fill(session, &myslot, 0, record, &lsn);
 	release_size = __wt_log_slot_release(
@@ -1880,7 +1845,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 		myslot.slot->slot_error = ret;
 	WT_ASSERT(session, ret == 0);
 	if (WT_LOG_SLOT_DONE(release_size)) {
-		WT_ERR(__log_release(session, myslot.slot, &free_slot));
+		WT_ERR(__wt_log_release(session, myslot.slot, &free_slot));
 		if (free_slot)
 			__wt_log_slot_free(session, myslot.slot);
 	} else if (force) {

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -100,22 +100,21 @@ retry:
 }
 
 /*
- * __wt_log_slot_switch_internal --
+ * __log_slot_switch_internal --
  *	Switch out the current slot and set up a new one.
  */
-int
-__wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
+static int
+__log_slot_switch_internal(
+    WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int forced)
 {
 	WT_DECL_RET;
 	WT_LOG *log;
-	int release;
-#ifdef HAVE_DIAGNOSTIC
-	int64_t r, state;
-	int32_t j;
-#endif
+	WT_LOGSLOT *slot;
+	int free_slot, release;
 
 	log = S2C(session)->log;
 	release = 0;
+	slot = myslot->slot;
 
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SLOT));
 
@@ -123,7 +122,7 @@ __wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
 	 * If someone else raced us to closing this specific slot, we're
 	 * done here.
 	 */
-	if (myslot->slot != log->active_slot)
+	if (slot != log->active_slot)
 		return (0);
 
 	/*
@@ -133,31 +132,24 @@ __wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
 	 * someone else and we need to try setting up a new slot again.
 	 */
 	if (!F_ISSET(myslot, WT_MYSLOT_CLOSE)) {
-		ret = __wt_log_slot_close(session, myslot->slot, &release, 0);
+		ret = __wt_log_slot_close(
+		    session, slot, &release, forced);
 		if (ret == WT_NOTFOUND)
 			return (0);
+		WT_RET(ret);
+		if (release) {
+			WT_RET(__wt_log_release(session, slot, &free_slot));
+			if (free_slot)
+				__wt_log_slot_free(session, slot);
+		}
 	}
-
-	/*
-	 * Only mainline callers use switch.  Our size should be in join
-	 * and we have not yet released, so we should never think release
-	 * should be done now.
-	 */
-	WT_ASSERT(session, release == 0);
-	WT_ASSERT(session, ret == 0);
-
 	/*
 	 * Set that we have closed this slot because we may call in here
 	 * multiple times if we retry creating a new slot.
 	 */
 	F_SET(myslot, WT_MYSLOT_CLOSE);
-#ifdef HAVE_DIAGNOSTIC
-	state = myslot->slot->slot_state;
-	j = WT_LOG_SLOT_JOINED(state);
-	r = WT_LOG_SLOT_RELEASED(state);
-	WT_ASSERT(session, j > r);
-#endif
 	WT_RET(__wt_log_slot_new(session));
+	F_CLR(myslot, WT_MYSLOT_CLOSE);
 	return (0);
 }
 
@@ -166,7 +158,8 @@ __wt_log_slot_switch_internal(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
  *	Switch out the current slot and set up a new one.
  */
 int
-__wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
+__wt_log_slot_switch(
+    WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int retry, int forced)
 {
 	WT_DECL_RET;
 	WT_LOG *log;
@@ -177,15 +170,15 @@ __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot)
 	 * compiler does not like it combined directly with the while loop
 	 * here.
 	 */
-	WT_WITH_SLOT_LOCK(session, log,
-	    ret = __wt_log_slot_switch_internal(session, myslot));
-	while (ret == EBUSY) {
-		WT_STAT_FAST_CONN_INCR(session, log_slot_switch_busy);
-		__wt_yield();
+	do {
 		WT_WITH_SLOT_LOCK(session, log,
-		    ret = __wt_log_slot_switch_internal(session, myslot));
-	}
-	WT_ASSERT(session, ret == 0);
+		    ret = __log_slot_switch_internal(
+		    session, myslot, forced));
+		if (ret == EBUSY) {
+			WT_STAT_FAST_CONN_INCR(session, log_slot_switch_busy);
+			__wt_yield();
+		}
+	} while (F_ISSET(myslot, WT_MYSLOT_CLOSE) || (retry && ret == EBUSY));
 	return (ret);
 }
 


### PR DESCRIPTION
All paths check whether they have closed the slot and need to retry
creating a new slot if they get EBUSY.

@michaelcahill Please review this.  This solves the hang and it is better to have a single function doing this work.