### PR TITLE
WT-2104 Change log_printf to be synchronous.

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1238,7 +1238,7 @@ struct __wt_session {
 	/*!
 	 * Insert a ::WT_LOGREC_MESSAGE type record in the database log files
 	 * (the database must be configured for logging when this method is
-	 * called).
+	 * called).  The record is written synchronously.
 	 *
 	 * @param session the session handle
 	 * @param fmt a printf format specifier

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1979,7 +1979,7 @@ __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap)
 	    "log_printf: %s", (char *)logrec->data + logrec->size));
 
 	logrec->size += len;
-	WT_ERR(__wt_log_write(session, logrec, NULL, 0));
+	WT_ERR(__wt_log_write(session, logrec, NULL, WT_LOG_FSYNC));
 err:	__wt_scr_free(session, &logrec);
 	return (ret);
 }


### PR DESCRIPTION
@keithbostic and @michaelcahill  Here is a simple set of changes to accomplish a synchronous flushing of the log via log_printf.  Feel free to toss if you don't like it.  I confirmed by turning on statistics and adding a couple more log_printf calls in ex_log.c and watch the log sync stat go up.