### PR TITLE
WT-2101 Don't update the logging ckpt_lsn on clean shutdown.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -145,10 +145,9 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
 		for (i = 0; i < logcount; i++) {
 			WT_ERR(__wt_log_extract_lognum(
 			    session, logfiles[i], &lognum));
-			if (lognum < min_lognum) {
+			if (lognum < min_lognum)
 				WT_ERR(__wt_log_remove(
 				    session, WT_LOG_FILENAME, lognum));
-			}
 		}
 	}
 	WT_ERR(__wt_readunlock(session, conn->hot_backup_lock));

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -358,9 +358,13 @@ __wt_txn_checkpoint_log(
 		/*
 		 * If this full checkpoint completed successfully and there is
 		 * no hot backup in progress, tell the logging subsystem the
-		 * checkpoint LSN so that it can archive.
+		 * checkpoint LSN so that it can archive.  Do not update the
+		 * logging checkpoint LSN if this is during a clean connection
+		 * close, only during a full checkpoint.  A clean close may not
+		 * update any metadata LSN and we do not want to archive in
+		 * that case.
 		 */
-		if (!S2C(session)->hot_backup)
+		if (!S2C(session)->hot_backup && txn->full_ckpt)
 			WT_ERR(__wt_log_ckpt(session, ckpt_lsn));
 
 		/* FALLTHROUGH */


### PR DESCRIPTION
It can race with archive.  Metadata LSNs may not be updated on clean shutdown.

@michaelcahill Please review.  This fixes the missing file errors with `test_txn11`.  Also a minor KNF I saw along the way.