### PR TITLE
WT-2104 Write up commit and log_flush options.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -822,10 +822,10 @@ methods = {
 ]),
 'WT_SESSION.strerror' : Method([]),
 'WT_SESSION.transaction_sync' : Method([
-    Config('timeout_ms', '', r'''
+    Config('timeout_ms', '1200000', r'''
         maximum amount of time to wait for background sync to complete in
         milliseconds.  A value of zero disables the timeout and returns
-        immediately.  The default waits forever.''',
+        immediately.''',
         type='int'),
 ]),
 
@@ -882,7 +882,12 @@ methods = {
 'WT_SESSION.commit_transaction' : Method([
     Config('sync', '', r'''
         override whether to sync log records when the transaction commits,
-        inherited from ::wiredtiger_open \c transaction_sync''',
+        inherited from ::wiredtiger_open \c transaction_sync.
+        The \c background setting initiates a background
+        synchronization intended to be used with a later call to
+        WT_SESSION::transaction_sync.  The \c off setting does not
+        wait for record to be written or synchronized.  The
+        \c on setting forces log records to be written to the storage device''',
         choices=['background', 'off', 'on']),
 ]),
 'WT_SESSION.rollback_transaction' : Method([]),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -913,7 +913,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  NULL, 0
 	},
 	{ "WT_SESSION.transaction_sync",
-	  "timeout_ms=",
+	  "timeout_ms=1200000",
 	  confchk_WT_SESSION_transaction_sync, 1
 	},
 	{ "WT_SESSION.truncate",

--- a/src/docs/durability.dox
+++ b/src/docs/durability.dox
@@ -14,11 +14,9 @@ When logging is enabled, WiredTiger writes records to the log for each
 transaction.
 
 Transactions define which updates are made durable together; see
-@ref transactions for details.  By default, log records are flushed to
-disk by WT_SESSION::commit_transaction, ensuring that, once
-WT_SESSION::commit_transaction returns successfully, updates performed
-by the transaction will be included in the database state regardless of
-application or system failure.
+@ref transactions for details.  By default, log records are buffered in memory
+when written by WT_SESSION::commit_transaction.  See
+@ref durability_group_commit for information about durability options.
 
 When the transactional log is enabled, calling ::wiredtiger_open
 automatically performs a recovery step when opening the database that

--- a/src/docs/tune-durability.dox
+++ b/src/docs/tune-durability.dox
@@ -66,6 +66,40 @@ most durability guarantees).
 	logging configured; updates durable on application or system
 	failure}
 </table>
+
+The durability setting can also be controlled directly on a per-transaction
+basis via the WT_SESSION::commit_transaction method.
+The WT_SESSION::commit_transaction supports several durability modes with
+the \c sync configuration that override the connection level settings.
+
+If \c sync=on is configured then this commit operation will wait for its
+log records, and all earlier ones, to be durable on disk before returning.
+
+If \c sync=off is configured then this commit operation will write its
+records into the in-memory buffer and return immediately.
+
+If \c sync=background is configured then this commit operation will write
+its record to an in-memory buffer, and will return.  Prior to returning it
+will signal an internal WiredTiger worker thread to synchronize this log
+record.  The caller may then check the status of that background
+synchronization with the WT_SESSION::transaction_sync method.
+
+The durability of the write-ahead log can be controlled independently
+as well via the WT_SESSION::log_flush method.
+The WT_SESSION::log_flush supports several durability modes with
+the \c sync configuration that immediately act upon the log.
+
+If \c sync=on is configured then this flush will force the current
+log and all earlier records to be durable on disk before returning.
+
+If \c sync=off is configured then this flush operation will force the
+logging subsystem to write any outstanding in-memory buffers to the
+file system before returning.
+
+If \c sync=background is configured then this flush operation will force
+the signalling of a background synchronization operation.
+The caller may then check the status of that background
+synchronization with the WT_SESSION::transaction_sync method.
  */
 
 /*! @page tune_durability Commit-level durability

--- a/src/docs/tune-durability.dox
+++ b/src/docs/tune-durability.dox
@@ -73,7 +73,8 @@ The WT_SESSION::commit_transaction supports several durability modes with
 the \c sync configuration that override the connection level settings.
 
 If \c sync=on is configured then this commit operation will wait for its
-log records, and all earlier ones, to be durable on disk before returning.
+log records, and all earlier ones, to be durable to the extent specified
+by the \c transaction_sync=(method) setting before returning.
 
 If \c sync=off is configured then this commit operation will write its
 records into the in-memory buffer and return immediately.
@@ -91,6 +92,8 @@ the \c sync configuration that immediately act upon the log.
 
 If \c sync=on is configured then this flush will force the current
 log and all earlier records to be durable on disk before returning.
+This method call overrides the \c transaction_sync setting and
+forces the data out via \c fsync.
 
 If \c sync=off is configured then this flush operation will force the
 logging subsystem to write any outstanding in-memory buffers to the

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1460,8 +1460,13 @@ struct __wt_session {
 	 * @configstart{WT_SESSION.commit_transaction, see dist/api_data.py}
 	 * @config{sync, override whether to sync log records when the
 	 * transaction commits\, inherited from ::wiredtiger_open \c
-	 * transaction_sync., a string\, chosen from the following options: \c
-	 * "background"\, \c "off"\, \c "on"; default empty.}
+	 * transaction_sync.  The \c background setting initiates a background
+	 * synchronization intended to be used with a later call to
+	 * WT_SESSION::transaction_sync.  The \c off setting does not wait for
+	 * record to be written or synchronized.  The \c on setting forces log
+	 * records to be written to the storage device., a string\, chosen from
+	 * the following options: \c "background"\, \c "off"\, \c "on"; default
+	 * empty.}
 	 * @configend
 	 * @errors
 	 */
@@ -1570,8 +1575,7 @@ struct __wt_session {
 	 * @configstart{WT_SESSION.transaction_sync, see dist/api_data.py}
 	 * @config{timeout_ms, maximum amount of time to wait for background
 	 * sync to complete in milliseconds.  A value of zero disables the
-	 * timeout and returns immediately.  The default waits forever., an
-	 * integer; default \c .}
+	 * timeout and returns immediately., an integer; default \c 1200000.}
 	 * @configend
 	 * @errors
 	 */


### PR DESCRIPTION
Also add large default value for transaction_sync.

@keithbostic and @michaelcahill Please review these changes.  I added a large, real default value for the `transaction_sync` method.  I also wrote up the options for `commit_transaction` and `log_flush`.  They're a bit redundant.  Let me know if there is enough information about the `background` setting.