### PR TITLE
WT-2111: coverity complaint

### DIFF
--- a/dist/s_label
+++ b/dist/s_label
@@ -45,6 +45,22 @@ for f in `find bench examples ext src test -name '*.[ci]'`; do
 	}
 done
 
+# Jumps inside va_start/va_end pairs.
+for f in `find bench examples ext src test -name '*.[ci]'`; do
+	file_parse $f |
+	egrep 'va_start.*(WT_RET|goto).*va_end' |
+	sed 's/:.*//' > $t
+	file_parse $f |
+	egrep -v 'va_start.*WT_ERR.*[^a-z_]err:	va_end' |
+	egrep 'va_start.*WT_ERR.*va_end' |
+	sed 's/:.*//' >> $t
+
+	test -s $t && {
+		echo "$f: va_end of va_start/va_end pair can be skipped"
+		sed 's/^/function @ line:/' < $t
+	}
+done
+
 # Early exits from critical loops.
 for f in `find bench examples ext src test -name '*.[ci]'`; do
 	sed -n -e '/API_CALL.*;$/,/API_END.*;/{=;p;}' \

--- a/dist/s_label
+++ b/dist/s_label
@@ -23,7 +23,7 @@ file_parse()
 # where there's a jump to the error label after the error label.
 for f in `find bench examples ext src test -name '*.[ci]'`; do
 	file_parse $f |
-	egrep '(WT_ERR|WT_ERR_MSG|WT_ERR_NOTFOUND_OK|WT_ERR_TEST|WT_ILLEGAL_VALUE_ERR)\(.*(WT_ASSERT_RET|WT_ILLEGAL_VALUE|WT_RET|WT_RET_MSG|WT_RET_NOTFOUND_OK|WT_RET_TEST|WT_VERBOSE_RET|WT_VERBOSE_RETVAL)\(.*err:|[^a-z_]err:.*(WT_ERR|WT_ERR_MSG|WT_ERR_NOTFOUND_OK|WT_ERR_TEST|WT_ILLEGAL_VALUE_ERR)\(' |
+	egrep '(WT_ERR|WT_ILLEGAL_VALUE_ERR)\(.*(WT_ILLEGAL_VALUE|WT_RET)\(.*err:|[^a-z_]err:.*(WT_ERR|WT_ILLEGAL_VALUE_ERR)\(' |
 	sed 's/:.*//' > $t
 
 	test -s $t && {

--- a/examples/c/ex_sync.c
+++ b/examples/c/ex_sync.c
@@ -135,7 +135,7 @@ main(void)
 		cursor->set_value(cursor, v);
 		ret = cursor->insert(cursor);
 	}
-	session->log_flush(session, "sync=sync");
+	ret = session->log_flush(session, "sync=sync");
 
 	for (i = 0; i < MAX_KEYS; i++, record_count++) {
 		snprintf(k, sizeof(k), "key%d", record_count);
@@ -145,8 +145,8 @@ main(void)
 		ret = cursor->insert(cursor);
 	}
 	ret = cursor->close(cursor);
-	session->log_flush(session, "sync=write");
-	session->log_flush(session, "sync=sync");
+	ret = session->log_flush(session, "sync=write");
+	ret = session->log_flush(session, "sync=sync");
 
 	ret = wt_conn->close(wt_conn, NULL);
 	return (ret);

--- a/src/async/async_op.c
+++ b/src/async/async_op.c
@@ -67,7 +67,6 @@ static void
 __async_set_value(WT_ASYNC_OP *asyncop, ...)
 {
 	WT_CURSOR *c;
-	WT_DECL_RET;
 	va_list ap;
 
 	c = &asyncop->c;

--- a/src/async/async_op.c
+++ b/src/async/async_op.c
@@ -31,18 +31,16 @@ static void
 __async_set_key(WT_ASYNC_OP *asyncop, ...)
 {
 	WT_CURSOR *c;
-	WT_DECL_RET;
 	va_list ap;
 
 	c = &asyncop->c;
 	va_start(ap, asyncop);
 	__wt_cursor_set_keyv(c, c->flags, ap);
 	if (!WT_DATA_IN_ITEM(&c->key) && !WT_CURSOR_RECNO(c))
-		WT_ERR(__wt_buf_set(O2S((WT_ASYNC_OP_IMPL *)asyncop), &c->key,
-		    c->key.data, c->key.size));
+		c->saved_err = __wt_buf_set(
+		    O2S((WT_ASYNC_OP_IMPL *)asyncop),
+		    &c->key, c->key.data, c->key.size);
 	va_end(ap);
-	if (0)
-err:		c->saved_err = ret;
 }
 
 /*
@@ -77,11 +75,10 @@ __async_set_value(WT_ASYNC_OP *asyncop, ...)
 	__wt_cursor_set_valuev(c, ap);
 	/* Copy the data, if it is pointing at data elsewhere. */
 	if (!WT_DATA_IN_ITEM(&c->value))
-		WT_ERR(__wt_buf_set(O2S((WT_ASYNC_OP_IMPL *)asyncop),
-		    &c->value, c->value.data, c->value.size));
+		c->saved_err = __wt_buf_set(
+		    O2S((WT_ASYNC_OP_IMPL *)asyncop),
+		    &c->value, c->value.data, c->value.size);
 	va_end(ap);
-	if (0)
-err:		c->saved_err = ret;
 }
 
 /*


### PR DESCRIPTION
@sueloverso, would you please do the review and merge on this one?

One note, it looked to me like it was OK to simply set `WT_CURSOR.saved_err` (potentially clearing it), in this case.