### PR TITLE
WT-2119: don't evict clean multiblock pages with overflow items during checkpoints.

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -405,6 +405,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 	WT_PAGE_INDEX *pindex;
 	WT_REF *ref, **refp;
 	uint32_t i;
+	bool overflow_keys;
 
 	btree = S2BT(session);
 	unpack = &_unpack;
@@ -419,6 +420,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 	 */
 	pindex = WT_INTL_INDEX_GET_SAFE(page);
 	refp = pindex->index;
+	overflow_keys = false;
 	WT_CELL_FOREACH(btree, dsk, cell, unpack, i) {
 		ref = *refp;
 		ref->home = page;
@@ -433,7 +435,12 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			__wt_ref_key_onpage_set(page, ref, unpack);
 			break;
 		case WT_CELL_KEY_OVFL:
-			/* Instantiate any overflow records. */
+			/*
+			 * Instantiate any overflow keys; WiredTiger depends on
+			 * this, assuming any overflow key is instantiated, and
+			 * any keys that aren't instantiated cannot be overflow
+			 * items.
+			 */
 			WT_ERR(__wt_dsk_cell_data_ref(
 			    session, page->type, unpack, current));
 
@@ -442,6 +449,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			    current->data, current->size, ref));
 
 			*sizep += sizeof(WT_IKEY) + current->size;
+			overflow_keys = true;
 			break;
 		case WT_CELL_ADDR_DEL:
 			/*
@@ -486,6 +494,13 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 		WT_ILLEGAL_VALUE_ERR(session);
 		}
 	}
+
+	/*
+	 * We track if an internal page has backing overflow keys, as overflow
+	 * keys limit the eviction we can do during a checkpoint.
+	 */
+	if (overflow_keys)
+		F_SET_ATOMIC(page, WT_PAGE_OVERFLOW_KEYS);
 
 err:	__wt_scr_free(session, &current);
 	return (ret);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -229,6 +229,10 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
 	WT_IKEY *ikey;
 	uint32_t cell_offset;
 
+	/* There's a per-page flag if there are any overflow keys at all. */
+	if (!F_ISSET_ATOMIC(page, WT_PAGE_OVERFLOW_KEYS))
+		return (0);
+
 	/*
 	 * A key being discarded (page split) or moved to a different page (page
 	 * deepening) may be an on-page overflow key.  Clear any reference to an

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -90,7 +90,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, int syncop)
 
 			WT_ASSERT(session,
 			    F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
-			    __wt_page_can_evict(session, page, false, NULL));
+			    __wt_page_can_evict(session, ref, false, NULL));
 			__wt_evict_page_clean_update(session, ref, 1);
 			break;
 		WT_ILLEGAL_VALUE_ERR(session);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1221,7 +1221,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 			page->read_gen = __wt_cache_read_gen_new(session);
 
 fast:		/* If the page can't be evicted, give up. */
-		if (!__wt_page_can_evict(session, page, true, NULL))
+		if (!__wt_page_can_evict(session, ref, true, NULL))
 			continue;
 
 		/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -344,7 +344,7 @@ __evict_review(
 		if (__wt_page_is_modified(page))
 			__wt_txn_update_oldest(session, true);
 
-		if (!__wt_page_can_evict(session, page, false, inmem_splitp))
+		if (!__wt_page_can_evict(session, ref, false, inmem_splitp))
 			return (EBUSY);
 
 		/*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -288,11 +288,9 @@ struct __wt_page_modify {
 		uint32_t cksum;
 	} *multi;
 	uint32_t multi_entries;		/* Multiple blocks element count */
-	bool	 multi_row_ovfl;	/* Row-store overflow key/values */
 	} m;
 #define	mod_multi		u1.m.multi
 #define	mod_multi_entries	u1.m.multi_entries
-#define	mod_multi_row_ovfl	u1.m.multi_row_ovfl
 	} u1;
 
 	/*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -577,8 +577,9 @@ struct __wt_page {
 #define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
 #define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
 #define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
-#define	WT_PAGE_RECONCILIATION	0x10	/* Page reconciliation lock */
-#define	WT_PAGE_SPLIT_INSERT	0x20	/* A leaf page was split for append */
+#define	WT_PAGE_OVERFLOW_KEYS	0x10	/* Page has overflow keys */
+#define	WT_PAGE_RECONCILIATION	0x20	/* Page reconciliation lock */
+#define	WT_PAGE_SPLIT_INSERT	0x40	/* A leaf page was split for append */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 
 	/*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1035,9 +1035,10 @@ __wt_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  */
 static inline bool
 __wt_page_can_evict(WT_SESSION_IMPL *session,
-    WT_PAGE *page, bool check_splits, bool *inmem_splitp)
+    WT_REF *ref, bool check_splits, bool *inmem_splitp)
 {
 	WT_BTREE *btree;
+	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
 	WT_TXN_GLOBAL *txn_global;
 
@@ -1045,6 +1046,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session,
 		*inmem_splitp = false;
 
 	btree = S2BT(session);
+	page = ref->page;
 	mod = page->modify;
 
 	/* Pages that have never been modified can always be evicted. */
@@ -1075,6 +1077,16 @@ __wt_page_can_evict(WT_SESSION_IMPL *session,
 		WT_STAT_FAST_DATA_INCR(session, cache_eviction_checkpoint);
 		return (false);
 	}
+
+	/*
+	 * We can't evict clean, multiblock row-store pages where the parent's
+	 * key for the page is an overflow item, because the split into the
+	 * parent frees the backing blocks for any no-longer-used overflow keys,
+	 * which will corrupt the checkpoint's block management.
+	 */
+	if (btree->checkpointing &&
+	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
+		return (false);
 
 	/*
 	 * If the tree was deepened, there's a requirement that newly created
@@ -1196,7 +1208,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	    LF_ISSET(WT_READ_NO_EVICT) ||
 	    F_ISSET(session, WT_SESSION_NO_EVICTION) ||
 	    F_ISSET(btree, WT_BTREE_NO_EVICTION) ||
-	    !__wt_page_can_evict(session, page, true, NULL))
+	    !__wt_page_can_evict(session, ref, true, NULL))
 		return (__wt_hazard_clear(session, page));
 
 	WT_RET_BUSY_OK(__wt_page_release_evict(session, ref));

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1077,16 +1077,6 @@ __wt_page_can_evict(WT_SESSION_IMPL *session,
 	}
 
 	/*
-	 * We can't evict clean, multiblock row-store pages with overflow keys
-	 * when the file is being checkpointed: the split into the parent frees
-	 * the backing blocks for no-longer-used overflow keys, corrupting the
-	 * checkpoint's block management.
-	 */
-	if (btree->checkpointing &&
-	    mod->rec_result == WT_PM_REC_MULTIBLOCK && mod->mod_multi_row_ovfl)
-		return (false);
-
-	/*
 	 * If the tree was deepened, there's a requirement that newly created
 	 * internal pages not be evicted until all threads are known to have
 	 * exited the original page index array, because evicting an internal

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -4564,6 +4564,10 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	vpack = &_vpack;
 	WT_CLEAR(*vpack);	/* -Wuninitialized */
 
+	ikey = NULL;		/* -Wuninitialized */
+	cell = NULL;
+	key_onpage_ovfl = false;
+
 	WT_RET(__rec_split_init(session, r, page, 0ULL, btree->maxintlpage));
 
 	/*
@@ -4593,17 +4597,20 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		 * things up.
 		 *
 		 * Note the cell reference and unpacked key cell are available
-		 * only in the case of an instantiated, off-page key.
+		 * only in the case of an instantiated, off-page key, we don't
+		 * bother setting them if that's not possible.
 		 */
-		ikey = __wt_ref_key_instantiated(ref);
-		if (ikey == NULL || ikey->cell_offset == 0) {
+		if (F_ISSET_ATOMIC(page, WT_PAGE_OVERFLOW_KEYS)) {
 			cell = NULL;
 			key_onpage_ovfl = false;
-		} else {
-			cell = WT_PAGE_REF_OFFSET(page, ikey->cell_offset);
-			__wt_cell_unpack(cell, kpack);
-			key_onpage_ovfl =
-			    kpack->ovfl && kpack->raw != WT_CELL_KEY_OVFL_RM;
+			ikey = __wt_ref_key_instantiated(ref);
+			if (ikey != NULL && ikey->cell_offset != 0) {
+				cell =
+				    WT_PAGE_REF_OFFSET(page, ikey->cell_offset);
+				__wt_cell_unpack(cell, kpack);
+				key_onpage_ovfl = kpack->ovfl &&
+				    kpack->raw != WT_CELL_KEY_OVFL_RM;
+			}
 		}
 
 		WT_ERR(__rec_child_modify(session, r, ref, &hazard, &state));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -5667,15 +5667,6 @@ __rec_split_row(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	}
 	mod->mod_multi_entries = r->bnd_next;
 
-	/*
-	 * We can't evict clean, multiblock row-store pages with overflow keys
-	 * when the file is being checkpointed: the split into the parent frees
-	 * the backing blocks for no-longer-used overflow keys, corrupting the
-	 * checkpoint's block management. Column-store pages have no overflow
-	 * keys, so they're not a problem, track overflow items for row-store.
-	 */
-	mod->mod_multi_row_ovfl = r->ovfl_items;
-
 	return (0);
 }
 


### PR DESCRIPTION
Another approach: track if an internal page has any on-page overflow keys.

@michaelcahill, for your review.