### PR TITLE
WT-2131 Switch all WT_PAGE_RECONCILIATION locks to fair locks.

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -55,20 +55,12 @@ __compact_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		 * The page's modification information can change underfoot if
 		 * the page is being reconciled, serialize with reconciliation.
 		 */
-		if (WT_PAGE_IS_INTERNAL(page))
-			WT_RET(__wt_fair_lock(
-			    session, &page->pg_intl_split_lock));
-		else
-			F_CAS_ATOMIC_WAIT(page, WT_PAGE_RECONCILIATION);
+		WT_RET(__wt_fair_lock(session, &page->page_lock));
 
 		ret = bm->compact_page_skip(bm, session,
 		    mod->mod_replace.addr, mod->mod_replace.size, skipp);
 
-		if (WT_PAGE_IS_INTERNAL(page))
-			WT_TRET(__wt_fair_unlock(
-			    session, &page->pg_intl_split_lock));
-		else
-			F_CLR_ATOMIC(page, WT_PAGE_RECONCILIATION);
+		WT_TRET(__wt_fair_unlock(session, &page->page_lock));
 		WT_RET(ret);
 	}
 	return (0);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -645,10 +645,13 @@ __debug_page_metadata(WT_DBG *ds, WT_PAGE *page)
 		__dmsg(ds, ", disk-mapped");
 	if (F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU))
 		__dmsg(ds, ", evict-lru");
-	if (F_ISSET_ATOMIC(page, WT_PAGE_RECONCILIATION))
-		__dmsg(ds, ", reconciliation");
 	if (F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_INSERT))
 		__dmsg(ds, ", split-insert");
+
+	if (__wt_fair_trylock(session, &page->page_lock) != 0)
+		__dmsg(ds, ", locked");
+	else
+		WT_RET(__wt_fair_unlock(session, &page->page_lock));
 
 	if (mod != NULL)
 		switch (mod->rec_result) {

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -55,7 +55,11 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 	 */
 	WT_ASSERT(session, !__wt_page_is_modified(page));
 	WT_ASSERT(session, !F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU));
-	WT_ASSERT(session, !F_ISSET_ATOMIC(page, WT_PAGE_RECONCILIATION));
+	/*
+	 * This will leave the page lock held - but that doesn't matter - we
+	 * are about to free the memory anyway.
+	 */
+	WT_ASSERT(session, __wt_fair_trylock(session, &page->page_lock) == 0);
 
 #ifdef HAVE_DIAGNOSTIC
 	{

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -449,18 +449,12 @@ struct __wt_page {
 			 */
 			uint32_t deepen_split_append;
 			uint32_t deepen_split_last;
-			/*
-			 * Used to protect and fairly co-ordinate splits into
-			 * this page.
-			 */
-			WT_FAIR_LOCK split_lock;
 		} intl;
 #undef	pg_intl_recno
 #define	pg_intl_recno			u.intl.recno
 #define	pg_intl_parent_ref		u.intl.parent_ref
 #define	pg_intl_deepen_split_append	u.intl.deepen_split_append
 #define	pg_intl_deepen_split_last	u.intl.deepen_split_last
-#define	pg_intl_split_lock		u.intl.split_lock
 
 	/*
 	 * Macros to copy/set the index because the name is obscured to ensure
@@ -585,8 +579,7 @@ struct __wt_page {
 #define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
 #define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
 #define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
-#define	WT_PAGE_RECONCILIATION	0x10	/* Page reconciliation lock */
-#define	WT_PAGE_SPLIT_INSERT	0x20	/* A leaf page was split for append */
+#define	WT_PAGE_SPLIT_INSERT	0x10	/* A leaf page was split for append */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 
 	/*
@@ -609,6 +602,12 @@ struct __wt_page {
 #define	WT_READGEN_OLDEST	1
 #define	WT_READGEN_STEP		100
 	uint64_t read_gen;
+
+	/*
+	 * Used to protect and co-ordinate splits for internal pages and
+	 * reconciliation for all pages.
+	 */
+	WT_FAIR_LOCK page_lock;
 
 	size_t memory_footprint;	/* Memory attached to the page */
 

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -50,16 +50,6 @@
 	    &(p)->flags_atomic, __orig, __orig | (uint8_t)(mask)));	\
 } while (0)
 
-#define	F_CAS_ATOMIC_WAIT(p, mask) do {					\
-	int __ret;							\
-	for (;;) {							\
-		F_CAS_ATOMIC(p, mask, __ret);				\
-		if (__ret == 0)						\
-			break;						\
-		__wt_yield();						\
-	}								\
-} while (0)
-
 #define	F_CLR_ATOMIC(p, mask)	do {					\
 	uint8_t __orig;							\
 	do {								\

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -56,8 +56,15 @@ struct __wt_rwlock {
  * necessary. Implements a ticket-based back off spin lock.
  */
 struct __wt_fair_lock {
-	uint16_t owner;		/* Ticket number for current owner */
-	uint16_t waiter;	/* Ticket number of last allocated */
+	union {
+		uint32_t lock;  /* Used when needing to atomically switch */
+		struct {
+			uint16_t owner;	/* Ticket number for current owner */
+			uint16_t waiter;/* Ticket number of last allocated */
+		} s;
+	} u;
+#define	fair_lock_owner u.s.owner
+#define	fair_lock_waiter u.s.waiter
 };
 
 /*

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -54,13 +54,15 @@ struct __wt_rwlock {
 /*
  * A light weight lock that can be used to replace spinlocks if fairness is
  * necessary. Implements a ticket-based back off spin lock.
+ * The fields are available as a union to allow for atomically setting
+ * the state of the entire lock.
  */
 struct __wt_fair_lock {
 	union {
-		uint32_t lock;  /* Used when needing to atomically switch */
+		uint32_t lock;
 		struct {
-			uint16_t owner;	/* Ticket number for current owner */
-			uint16_t waiter;/* Ticket number of last allocated */
+			uint16_t owner;		/* Ticket for current owner */
+			uint16_t waiter;	/* Last allocated ticket */
 		} s;
 	} u;
 #define	fair_lock_owner u.s.owner

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -316,12 +316,11 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	}
 
 	/* If we can't lock it, don't scan, that's okay. */
-	F_CAS_ATOMIC(page, WT_PAGE_RECONCILIATION, ret);
-	if (ret != 0)
+	if (__wt_fair_trylock(session, &page->page_lock) != 0)
 		return (0);
 
 	obsolete = __wt_update_obsolete_check(session, page, upd->next);
-	F_CLR_ATOMIC(page, WT_PAGE_RECONCILIATION);
+	WT_RET(__wt_fair_unlock(session, &page->page_lock));
 	if (obsolete != NULL)
 		__wt_update_obsolete_free(session, page, obsolete);
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -394,10 +394,7 @@ __wt_reconcile(WT_SESSION_IMPL *session,
 	 *    In-memory splits: reconciliation of an internal page cannot handle
 	 * a child page splitting during the reconciliation.
 	 */
-	if (WT_PAGE_IS_INTERNAL(page))
-		WT_RET(__wt_fair_lock(session, &page->pg_intl_split_lock));
-	else
-		F_CAS_ATOMIC_WAIT(page, WT_PAGE_RECONCILIATION);
+	WT_RET(__wt_fair_lock(session, &page->page_lock));
 
 	/* Reconcile the page. */
 	switch (page->type) {
@@ -435,10 +432,7 @@ __wt_reconcile(WT_SESSION_IMPL *session,
 		WT_TRET(__rec_write_wrapup_err(session, r, page));
 
 	/* Release the reconciliation lock. */
-	if (WT_PAGE_IS_INTERNAL(page))
-		WT_TRET(__wt_fair_unlock(session, &page->pg_intl_split_lock));
-	else
-		F_CLR_ATOMIC(page, WT_PAGE_RECONCILIATION);
+	WT_TRET(__wt_fair_unlock(session, &page->page_lock));
 
 	/* Update statistics. */
 	WT_STAT_FAST_CONN_INCR(session, rec_pages);


### PR DESCRIPTION
The main purpose is to keep a single lock for all page operations.