### PR TITLE
WT-2151 Add zero fill config

### DIFF
--- a/bench/wtperf/runners/log-append-zero.wtperf
+++ b/bench/wtperf/runners/log-append-zero.wtperf
@@ -1,0 +1,8 @@
+# wtperf options file: Test a log file with a multi-threaded
+# append workload.
+conn_config="cache_size=1G,log=(enabled=true,file_max=20MB,zero_fill=true),checkpoint=(log_size=1G)"
+table_config="type=file"
+icount=50000000
+report_interval=5
+run_time=0
+populate_threads=8

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -642,6 +642,9 @@ common_wiredtiger_open = [
             run recovery or error if recovery needs to run after an
             unclean shutdown.''',
             choices=['error','on']),
+        Config('zero_fill', 'false', r'''
+            manually write zeroes into log files''',
+            type='boolean'),
         ]),
     Config('mmap', 'true', r'''
         Use memory mapping to access files when possible''',

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -272,6 +272,7 @@ connection_stats = [
     LogStat('log_sync_dir', 'log sync_dir operations'),
     LogStat('log_write_lsn', 'log server thread advances write LSN'),
     LogStat('log_writes', 'log write operations'),
+    LogStat('log_zero_fills', 'log files manually zero-filled'),
 
     ##########################################
     # Reconciliation statistics

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -463,6 +463,7 @@ static const WT_CONFIG_CHECK
 	{ "recover", "string",
 	    NULL, "choices=[\"error\",\"on\"]",
 	    NULL, 0 },
+	{ "zero_fill", "boolean", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -517,7 +518,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 7 },
+	    confchk_wiredtiger_open_log_subconfigs, 8 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -592,7 +593,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 7 },
+	    confchk_wiredtiger_open_log_subconfigs, 8 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -665,7 +666,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 7 },
+	    confchk_wiredtiger_open_log_subconfigs, 8 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -737,7 +738,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 7 },
+	    confchk_wiredtiger_open_log_subconfigs, 8 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -969,13 +970,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,file_manager=(close_handle_minimum=250,"
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
-	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
-	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=",
+	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=",
 	  confchk_wiredtiger_open, 34
 	},
 	{ "wiredtiger_open_all",
@@ -989,14 +991,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,file_manager=(close_handle_minimum=250,"
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
-	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
-	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),use_environment_priv=0,verbose=,version=(major=0,"
-	  "minor=0)",
+	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
+	  ",verbose=,version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_all, 35
 	},
 	{ "wiredtiger_open_basecfg",
@@ -1009,13 +1011,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
-	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
-	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),verbose=,version=(major=0,minor=0)",
+	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),verbose=,"
+	  "version=(major=0,minor=0)",
 	  confchk_wiredtiger_open_basecfg, 31
 	},
 	{ "wiredtiger_open_usercfg",
@@ -1028,13 +1031,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
-	  "prealloc=,recover=on),lsm_manager=(merge=,worker_thread_max=4),"
-	  "lsm_merge=,mmap=,multiprocess=0,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(on_close=0"
-	  ",path=\"WiredTigerStat.%d.%H\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
-	  ",method=fsync),verbose=",
+	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
+	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
+	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=0,method=fsync),verbose=",
 	  confchk_wiredtiger_open_usercfg, 30
 	},
 	{ NULL, NULL, NULL, 0 }

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -74,6 +74,10 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	if (cval.val != 0)
 		FLD_SET(conn->log_flags, WT_CONN_LOG_ARCHIVE);
 
+	WT_RET(__wt_config_gets(session, cfg, "log.zero_fill", &cval));
+	if (cval.val != 0)
+		FLD_SET(conn->log_flags, WT_CONN_LOG_ZERO_FILL);
+
 	WT_RET(__wt_config_gets(session, cfg, "log.file_max", &cval));
 	conn->log_file_max = (wt_off_t)cval.val;
 	WT_STAT_FAST_CONN_SET(session, log_max_filesize, conn->log_file_max);
@@ -85,7 +89,7 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	 */
 	if (cval.val != 0) {
 		FLD_SET(conn->log_flags, WT_CONN_LOG_PREALLOC);
-		conn->log_prealloc = 1;
+		conn->log_prealloc = 5;
 	}
 	WT_RET(__wt_config_gets_def(session, cfg, "log.recover", 0, &cval));
 	if (cval.len != 0  && WT_STRING_MATCH("error", cval.str, cval.len))

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -342,6 +342,7 @@ struct __wt_connection_impl {
 #define	WT_CONN_LOG_PREALLOC	0x08	/* Pre-allocation is enabled */
 #define	WT_CONN_LOG_RECOVER_DONE	0x10	/* Recovery completed */
 #define	WT_CONN_LOG_RECOVER_ERR	0x20	/* Error if recovery required */
+#define	WT_CONN_LOG_ZERO_FILL	0x40	/* Manually zero files */
 	uint32_t	 log_flags;	/* Global logging configuration */
 	WT_CONDVAR	*log_cond;	/* Log server wait mutex */
 	WT_SESSION_IMPL *log_session;	/* Log server session */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -338,6 +338,7 @@ struct __wt_connection_stats {
 	int64_t log_sync_dir;
 	int64_t log_write_lsn;
 	int64_t log_writes;
+	int64_t log_zero_fills;
 	int64_t lsm_checkpoint_throttle;
 	int64_t lsm_merge_throttle;
 	int64_t lsm_rows_merged;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2212,6 +2212,8 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery
  * or error if recovery needs to run after an unclean shutdown., a string\,
  * chosen from the following options: \c "error"\, \c "on"; default \c on.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log
+ * files., a boolean flag; default \c false.}
  * @config{ ),,}
  * @config{lsm_manager = (, configure database wide options for LSM tree
  * management.  The LSM manager is started automatically the first time an LSM

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3795,90 +3795,92 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LOG_WRITE_LSN			1109
 /*! log: log write operations */
 #define	WT_STAT_CONN_LOG_WRITES				1110
+/*! log: log files manually zero-filled */
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1111
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1111
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1112
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1112
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1113
 /*! LSM: rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			1113
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			1114
 /*! LSM: application work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1114
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1115
 /*! LSM: merge work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1115
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1116
 /*! LSM: tree queue hit maximum */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1116
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1117
 /*! LSM: switch work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1117
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1118
 /*! LSM: tree maintenance operations scheduled */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1118
+#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1119
 /*! LSM: tree maintenance operations discarded */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1119
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1120
 /*! LSM: tree maintenance operations executed */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1120
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1121
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1121
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1122
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1122
+#define	WT_STAT_CONN_MEMORY_FREE			1123
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1123
+#define	WT_STAT_CONN_MEMORY_GROW			1124
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1124
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1125
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1125
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1126
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1126
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1127
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1127
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1128
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1128
+#define	WT_STAT_CONN_PAGE_SLEEP				1129
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1129
+#define	WT_STAT_CONN_READ_IO				1130
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1130
+#define	WT_STAT_CONN_REC_PAGES				1131
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1131
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1132
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1132
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1133
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1133
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1134
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1134
+#define	WT_STAT_CONN_RWLOCK_READ			1135
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1135
+#define	WT_STAT_CONN_RWLOCK_WRITE			1136
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1136
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1137
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1137
+#define	WT_STAT_CONN_SESSION_OPEN			1138
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1138
+#define	WT_STAT_CONN_TXN_BEGIN				1139
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1139
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1140
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1140
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1141
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1141
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1142
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1142
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1143
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1143
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1144
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1144
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1145
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1145
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1146
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1146
+#define	WT_STAT_CONN_TXN_COMMIT				1147
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1147
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1148
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1148
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1149
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1149
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1150
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1150
+#define	WT_STAT_CONN_TXN_ROLLBACK			1151
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1151
+#define	WT_STAT_CONN_TXN_SYNC				1152
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1152
+#define	WT_STAT_CONN_WRITE_IO				1153
 
 /*!
  * @}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -386,6 +386,7 @@ __log_zero(WT_SESSION_IMPL *session,
 		bufsz = conn->log_file_max;
 	WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
 	memset(zerobuf->mem, 0, zerobuf->size);
+	WT_STAT_FAST_CONN_INCR(session, log_zero_fills);
 
 	/*
 	 * Read in a chunk starting at the end of the file.  Keep going until
@@ -435,7 +436,7 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
 	 * manually.  Otherwise use either fallocate or ftruncate to create
 	 * and zero the log file based on what is available.
 	 */
-	if (F_ISSET(conn, WT_CONN_LOG_ZERO_FILL))
+	if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ZERO_FILL))
 		ret = __log_zero(session, fh,
 		    WT_LOG_FIRST_RECORD, conn->log_file_max);
 	else if (fh->fallocate_available == WT_FALLOCATE_NOT_AVAILABLE ||

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -357,6 +357,66 @@ __wt_log_extract_lognum(
 }
 
 /*
+ * __log_zero --
+ *	Zero a log file.
+ */
+static int
+__log_zero(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t start_off, wt_off_t len)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_ITEM(zerobuf);
+	WT_DECL_RET;
+	WT_LOG *log;
+	wt_off_t off, partial;
+	uint32_t allocsize, bufsz, wrlen;
+
+	conn = S2C(session);
+	log = conn->log;
+	allocsize = log->allocsize;
+	zerobuf = NULL;
+	if (allocsize < WT_MEGABYTE)
+		bufsz = WT_MEGABYTE;
+	else
+		bufsz = allocsize;
+	/*
+	 * If they're using smaller log files, cap it at the file size.
+	 */
+	if (conn->log_file_max < bufsz)
+		bufsz = conn->log_file_max;
+	WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
+	memset(zerobuf->mem, 0, zerobuf->size);
+
+	/*
+	 * Read in a chunk starting at the end of the file.  Keep going until
+	 * we reach the beginning or we find a chunk that contains any non-zero
+	 * bytes.  Compare against a known zero byte chunk.
+	 */
+	off = start_off;
+	while (off < len) {
+		/*
+		 * Typically we start to zero the file after the log header
+		 * and the bufsz is a sector-aligned size.  So we want to
+		 * align our writes when we can.
+		 */
+		partial = off % (wt_off_t)bufsz;
+		if (partial != 0)
+			wrlen = bufsz - partial;
+		else
+			wrlen = bufsz;
+		/*
+		 * Check if we're writing a partial amount at the end too.
+		 */
+		if (len - off < bufsz)
+			wrlen = len - off;
+		WT_ERR(__wt_write(session, fh, off, wrlen, zerobuf->mem));
+		off += wrlen;
+	}
+err:	__wt_scr_free(session, &zerobuf);
+	return (ret);
+}
+
+/*
  * __log_prealloc --
  *	Pre-allocate a log file.
  */
@@ -370,7 +430,15 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
 	conn = S2C(session);
 	log = conn->log;
 	ret = 0;
-	if (fh->fallocate_available == WT_FALLOCATE_NOT_AVAILABLE ||
+	/*
+	 * If the user configured zero filling, pre-allocate the log file
+	 * manually.  Otherwise use either fallocate or ftruncate to create
+	 * and zero the log file based on what is available.
+	 */
+	if (F_ISSET(conn, WT_CONN_LOG_ZERO_FILL))
+		ret = __log_zero(session, fh,
+		    WT_LOG_FIRST_RECORD, conn->log_file_max);
+	else if (fh->fallocate_available == WT_FALLOCATE_NOT_AVAILABLE ||
 	    (ret = __wt_fallocate(session, fh,
 	    WT_LOG_FIRST_RECORD, conn->log_file_max)) == ENOTSUP)
 		ret = __wt_ftruncate(session, fh,

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -595,6 +595,7 @@ static const char * const __stats_connection_desc[] = {
 	"log: log sync_dir operations",
 	"log: log server thread advances write LSN",
 	"log: log write operations",
+	"log: log files manually zero-filled",
 	"LSM: sleep for LSM checkpoint throttle",
 	"LSM: sleep for LSM merge throttle",
 	"LSM: rows merged in an LSM tree",
@@ -760,6 +761,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->log_slot_unbuffered = 0;
 	stats->log_bytes_payload = 0;
 	stats->log_bytes_written = 0;
+	stats->log_zero_fills = 0;
 	stats->log_flush = 0;
 	stats->log_compress_writes = 0;
 	stats->log_compress_write_fails = 0;
@@ -944,6 +946,7 @@ __wt_stat_connection_aggregate(
 	to->log_slot_unbuffered += WT_STAT_READ(from, log_slot_unbuffered);
 	to->log_bytes_payload += WT_STAT_READ(from, log_bytes_payload);
 	to->log_bytes_written += WT_STAT_READ(from, log_bytes_written);
+	to->log_zero_fills += WT_STAT_READ(from, log_zero_fills);
 	to->log_flush += WT_STAT_READ(from, log_flush);
 	to->log_compress_writes += WT_STAT_READ(from, log_compress_writes);
 	to->log_compress_write_fails +=


### PR DESCRIPTION
@michaelcahill Please review the change for zero-filling logs via a configuration knob.  I'm seeing mixed results on performance.  I see no performance difference on the AWS SSD or my Mac laptop.  On my AWS HDD box I saw no difference running to the HDD file system with small (20Mb) log files.  When I ran to the HDD box with 100Mb files or when I ran to the local disk, I saw about an 80% performance hit.

I also added a log-append-zero workload and I'll add it to the logging jobs once this is merged and plot it against the normal log-append workload.

Of course the trick will be having someone know when they need to configure this.