### PR TITLE
WT-2153 Fix bug. Now we always need to start the log_server thread.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -83,10 +83,8 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	 * If pre-allocation is configured, set the initial number to one.
 	 * We'll adapt as load dictates.
 	 */
-	if (cval.val != 0) {
-		FLD_SET(conn->log_flags, WT_CONN_LOG_PREALLOC);
+	if (cval.val != 0)
 		conn->log_prealloc = 1;
-	}
 	WT_RET(__wt_config_gets_def(session, cfg, "log.recover", 0, &cval));
 	if (cval.len != 0  && WT_STRING_MATCH("error", cval.str, cval.len))
 		FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_ERR);
@@ -811,11 +809,6 @@ __wt_logmgr_open(WT_SESSION_IMPL *session)
 	WT_RET(__wt_thread_create(conn->log_wrlsn_session,
 	    &conn->log_wrlsn_tid, __log_wrlsn_server, conn->log_wrlsn_session));
 	conn->log_wrlsn_tid_set = true;
-
-	/* If no log thread services are configured, we're done. */ 
-	if (!FLD_ISSET(conn->log_flags,
-	    (WT_CONN_LOG_ARCHIVE | WT_CONN_LOG_PREALLOC)))
-		return (0);
 
 	/*
 	 * If a log server thread exists, the user may have reconfigured

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -339,9 +339,8 @@ struct __wt_connection_impl {
 #define	WT_CONN_LOG_ARCHIVE	0x01	/* Archive is enabled */
 #define	WT_CONN_LOG_ENABLED	0x02	/* Logging is enabled */
 #define	WT_CONN_LOG_EXISTED	0x04	/* Log files found */
-#define	WT_CONN_LOG_PREALLOC	0x08	/* Pre-allocation is enabled */
-#define	WT_CONN_LOG_RECOVER_DONE	0x10	/* Recovery completed */
-#define	WT_CONN_LOG_RECOVER_ERR	0x20	/* Error if recovery required */
+#define	WT_CONN_LOG_RECOVER_DONE	0x08	/* Recovery completed */
+#define	WT_CONN_LOG_RECOVER_ERR	0x10	/* Error if recovery required */
 	uint32_t	 log_flags;	/* Global logging configuration */
 	WT_CONDVAR	*log_cond;	/* Log server wait mutex */
 	WT_SESSION_IMPL *log_session;	/* Log server session */


### PR DESCRIPTION
@michaelcahill Please review this bug fix.  I found it when adding tests for reconfiguration in PR #2229.  But it is a bug on its own and deserved its own ticket.