### PR TITLE
WT-2149 Fix the order of creation of the lookaside table

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2034,9 +2034,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_turtle_init(session));
 	WT_ERR(__wt_metadata_open(session));
 
-	/* Create the lookaside table. */
-	WT_ERR(__wt_las_create(session));
-
 	/* Start the worker threads and run recovery. */
 	WT_ERR(__wt_connection_workers(session, cfg));
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -678,11 +678,15 @@ __wt_conn_dhandle_discard(WT_SESSION_IMPL *session)
 	conn = S2C(session);
 
 	/*
-	 * Close open data handles: first, everything but the metadata file
-	 * (as closing a normal file may open and write the metadata file),
-	 * then the metadata file.  This function isn't called often, and I
-	 * don't want to "know" anything about the metadata file's position on
-	 * the list, so we do it the hard way.
+	 * Empty the session cache: any data handles created in a connection
+	 * method may be cached here, and we're about to close them.
+	 */
+	__wt_session_close_cache(session);
+
+	/*
+	 * Close open data handles: first, everything but the metadata file (as
+	 * closing a normal file may open and write the metadata file), then
+	 * the metadata file.
 	 */
 restart:
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -318,7 +318,7 @@ extern int __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, const c
 extern int __wt_evict_file(WT_SESSION_IMPL *session, int syncop);
 extern void __wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref);
 extern int __wt_evict_server_wake(WT_SESSION_IMPL *session);
-extern int __wt_evict_create(WT_SESSION_IMPL *session);
+extern int __wt_evict_create(WT_SESSION_IMPL *session, bool with_las);
 extern int __wt_evict_destroy(WT_SESSION_IMPL *session);
 extern int __wt_evict_file_exclusive_on(WT_SESSION_IMPL *session, bool *evict_resetp);
 extern void __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -412,11 +412,12 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	WT_RECOVERY r;
 	struct WT_RECOVERY_FILE *metafile;
 	char *config;
-	bool needs_rec, was_backup;
+	bool eviction_started, needs_rec, was_backup;
 
 	conn = S2C(session);
 	WT_CLEAR(r);
 	WT_INIT_LSN(&r.ckpt_lsn);
+	eviction_started = false;
 	was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
 
 	/* We need a real session for recovery. */
@@ -494,6 +495,15 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	 */
 	if (needs_rec && FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_ERR))
 		WT_ERR(WT_RUN_RECOVERY);
+
+	/*
+	 * Recovery can touch more data than fits in cache, so it relies on
+	 * regular eviction to manage paging.  Start eviction threads for
+	 * recovery without LAS cursors.
+	 */
+	WT_ERR(__wt_evict_create(session, false));
+	eviction_started = true;
+
 	/*
 	 * Always run recovery even if it was a clean shutdown.
 	 * We can consider skipping it in the future.
@@ -522,6 +532,15 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 err:	WT_TRET(__recovery_free(&r));
 	__wt_free(session, config);
+
+	/*
+	 * Destroy the eviction threads that were started in support of
+	 * recovery.  They will be restarted once the lookaside table is
+	 * created.
+	 */
+	if (eviction_started)
+		WT_TRET(__wt_evict_destroy(session));
+
 	WT_TRET(session->iface.close(&session->iface, NULL));
 
 	return (ret);


### PR DESCRIPTION
The lookaside table has to be created after recovery has completed because it needs a file ID and otherwise recovery could overwrite its entry in the metadata.  However, recovery needs eviction threads running because recovery could touch more data than fits in cache.

Resolve this ordering problem by having recovery start a special set of eviction threads without lookaside table cursors.  Once it is done, they are shut down, the lookaside table can be created, and a new set of eviction threads started.