### PR TITLE
WT-2155 Remove last use of F_CAS_ATOMIC and the associated macro.

### DIFF
--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -151,7 +151,8 @@ struct __wt_cache_pool {
 	/* Locked: List of connections participating in the cache pool. */
 	TAILQ_HEAD(__wt_cache_pool_qh, __wt_connection_impl) cache_pool_qh;
 
-#define	WT_CACHE_POOL_MANAGED	0x01	/* Cache pool has a manager thread */
-#define	WT_CACHE_POOL_ACTIVE	0x02	/* Cache pool is active */
-	uint8_t flags_atomic;
+	uint8_t pool_managed;		/* Cache pool has a manager thread */
+
+#define	WT_CACHE_POOL_ACTIVE	0x01	/* Cache pool is active */
+	uint8_t flags;
 };

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -37,19 +37,6 @@
 	    &(p)->flags_atomic, __orig, __orig | (uint8_t)(mask)));	\
 } while (0)
 
-#define	F_CAS_ATOMIC(p, mask, ret) do {					\
-	uint8_t __orig;							\
-	ret = 0;							\
-	do {								\
-		__orig = (p)->flags_atomic;				\
-		if ((__orig & (uint8_t)(mask)) != 0) {			\
-			ret = EBUSY;					\
-			break;						\
-		}							\
-	} while (!__wt_atomic_cas8(					\
-	    &(p)->flags_atomic, __orig, __orig | (uint8_t)(mask)));	\
-} while (0)
-
 #define	F_CLR_ATOMIC(p, mask)	do {					\
 	uint8_t __orig;							\
 	do {								\


### PR DESCRIPTION
It's not trivial to remove all atomic flags primitives, since the page flags rely on them. This part of the change is simple, so it might as well be done quickly.