### PR TITLE
SERVER-19954 Don't scan tracked handles during checkpoints.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -446,7 +446,6 @@ extern int __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key);
 extern int __wt_metadata_search( WT_SESSION_IMPL *session, const char *key, char **valuep);
 extern void __wt_meta_track_discard(WT_SESSION_IMPL *session);
 extern int __wt_meta_track_on(WT_SESSION_IMPL *session);
-extern int __wt_meta_track_find_handle( WT_SESSION_IMPL *session, const char *name, const char *checkpoint);
 extern int __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll);
 extern int __wt_meta_track_sub_on(WT_SESSION_IMPL *session);
 extern int __wt_meta_track_sub_off(WT_SESSION_IMPL *session);

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -223,35 +223,6 @@ __meta_track_unroll(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
 }
 
 /*
- * __wt_meta_track_find_handle --
- *	Check if we have already seen a handle.
- */
-int
-__wt_meta_track_find_handle(
-    WT_SESSION_IMPL *session, const char *name, const char *checkpoint)
-{
-	WT_META_TRACK *trk, *trk_orig;
-
-	WT_ASSERT(session,
-	    WT_META_TRACKING(session) && session->meta_track_nest > 0);
-
-	trk_orig = session->meta_track;
-	trk = session->meta_track_next;
-
-	while (--trk >= trk_orig) {
-		if (trk->op != WT_ST_LOCK)
-			continue;
-		if (strcmp(trk->dhandle->name, name) == 0 &&
-		    ((trk->dhandle->checkpoint == NULL && checkpoint == NULL) ||
-		    (trk->dhandle->checkpoint != NULL &&
-		    strcmp(trk->dhandle->checkpoint, checkpoint) == 0)))
-			return (0);
-	}
-
-	return (WT_NOTFOUND);
-}
-
-/*
  * __wt_meta_track_off --
  *	Turn off metadata operation tracking, unrolling on error.
  */

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -541,14 +541,6 @@ __wt_session_lock_checkpoint(WT_SESSION_IMPL *session, const char *checkpoint)
 	saved_dhandle = session->dhandle;
 
 	/*
-	 * If we already have the checkpoint locked, don't attempt to lock
-	 * it again.
-	 */
-	if ((ret = __wt_meta_track_find_handle(
-	    session, saved_dhandle->name, checkpoint)) != WT_NOTFOUND)
-		return (ret);
-
-	/*
 	 * Get the checkpoint handle exclusive, so no one else can access it
 	 * while we are creating the new checkpoint.
 	 */


### PR DESCRIPTION
The change in WT-147 to allow a session to lock the same handle exclusive multiple times makes this unnecessary.