### PR TITLE
WT-2126: __split_deepen() doesn't really need to panic

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -405,7 +405,7 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent)
 	uint64_t split_gen;
 	uint32_t children, chunk, i, j, moved_entries, new_entries, remain;
 	uint32_t skip_leading, slots;
-	bool panic;
+	bool complete;
 	void *p;
 
 	WT_STAT_FAST_CONN_INCR(session, cache_eviction_deepen);
@@ -414,7 +414,7 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent)
 	btree = S2BT(session);
 	alloc_index = NULL;
 	parent_incr = parent_decr = 0;
-	panic = false;
+	complete = false;
 
 	/*
 	 * Our caller is holding the parent page locked to single-thread splits,
@@ -559,21 +559,21 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent)
 	/*
 	 * Confirm the parent page's index hasn't moved, then update it, which
 	 * makes the split visible to threads descending the tree. From this
-	 * point on, we're committed to the split.  If subsequent work fails,
-	 * we have to panic because we may have threads of control using the
-	 * new page index we swap in.
+	 * point on, we're committed to the split.
 	 *
 	 * A note on error handling: until this point, there's no problem with
 	 * unwinding on error.  We allocated a new page index, a new set of
 	 * WT_REFs and a new set of child pages -- if an error occurred, the
 	 * parent remained unchanged, although it may have an incorrect memory
 	 * footprint.  From now on we've modified the parent page, attention
-	 * needs to be paid.
+	 * needs to be paid. However, subsequent failures are relatively benign,
+	 * the split is OK and complete. For that reason, we ignore errors past
+	 * this point unless there's a panic.
 	 */
 	WT_ASSERT(session, WT_INTL_INDEX_GET_SAFE(parent) == pindex);
 	WT_INTL_INDEX_SET(parent, alloc_index);
 	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
-	panic = true;
+	complete = true;
 
 #ifdef HAVE_DIAGNOSTIC
 	WT_WITH_PAGE_INDEX(session,
@@ -657,7 +657,7 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent)
 	 * be using the new index.
 	 */
 	size = sizeof(WT_PAGE_INDEX) + pindex->entries * sizeof(WT_REF *);
-	WT_ERR(__split_safe_free(session, split_gen, 0, pindex, size));
+	WT_TRET(__split_safe_free(session, split_gen, 0, pindex, size));
 	parent_decr += size;
 
 	/*
@@ -666,22 +666,24 @@ __split_deepen(WT_SESSION_IMPL *session, WT_PAGE *parent)
 	__wt_cache_page_inmem_incr(session, parent, parent_incr);
 	__wt_cache_page_inmem_decr(session, parent, parent_decr);
 
-	if (0) {
-err:		/*
-		 * If panic is set, we saw an error after opening up the tree
-		 * to descent through the parent page's new index.  There is
-		 * nothing we can do, the tree is inconsistent and there are
-		 * threads potentially active in both versions of the tree.
-		 */
-		if (panic) {
-			__wt_err(session, ret,
-			    "failure after splitting a parent page to deepen "
-			    "the tree, unable to recover");
-			ret = __wt_panic(session);
-		} else
-			__wt_free_ref_index(session, parent, alloc_index, true);
-	}
-	return (ret);
+err:	/*
+	 * If complete is true, we saw an error after opening up the tree to
+	 * descent through the parent page's new index. There is nothing we
+	 * can do, there are threads potentially active in both versions of
+	 * the tree.
+	 *
+	 * A note on error handling: if we completed the split, return success,
+	 * nothing really bad can have happened, and our caller has to proceed
+	 * with the split.
+	 */
+	if (!complete)
+		__wt_free_ref_index(session, parent, alloc_index, true);
+
+	if (ret != 0 && ret != WT_PANIC)
+		__wt_err(session, ret,
+		    "ignoring not-fatal error during parent page split to "
+		    "deepen the tree");
+	return (ret == WT_PANIC || !complete ? ret : 0);
 }
 
 /*
@@ -1175,20 +1177,21 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref,
 	    __split_should_deepen(session, parent_ref))
 		ret = __split_deepen(session, parent);
 
-err:	if (!complete)
+err:	/*
+	 * A note on error handling: if we completed the split, return success,
+	 * nothing really bad can have happened, and our caller has to proceed
+	 * with the split.
+	 */
+	if (!complete) {
 		for (i = 0; i < parent_entries; ++i) {
 			next_ref = pindex->index[i];
 			if (next_ref->state == WT_REF_SPLIT)
 				next_ref->state = WT_REF_DELETED;
 		}
 
-	__wt_free_ref_index(session, NULL, alloc_index, false);
+		__wt_free_ref_index(session, NULL, alloc_index, false);
+	}
 
-	/*
-	 * A note on error handling: if we completed the split, return success,
-	 * nothing really bad can have happened, and our caller has to proceed
-	 * with the split.
-	 */
 	if (ret != 0 && ret != WT_PANIC)
 		__wt_err(session, ret,
 		    "ignoring not-fatal error during parent page split");


### PR DESCRIPTION
@michaelcahill, I'm open to going the other way, doing a panic in both `__split_parent` and `__split_deepen`. It's unclear how long we're going to run after this failure anyway.

Maybe we should just quit when malloc fails? That would simplify a lot of error handling, and once we're out of memory we're almost certainly taking rarely tested error paths, nothing good is going to happen.