### PR TITLE
WT-2167 Switch recovery to using an internal session.

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -421,8 +421,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
 
 	/* We need a real session for recovery. */
-	WT_RET(__wt_open_session(conn, NULL, NULL, true, &session));
-	F_SET(session, WT_SESSION_NO_LOGGING);
+	WT_RET(__wt_open_internal_session(conn, "txn-recover",
+	    false, WT_SESSION_NO_LOGGING, &session));
 	r.session = session;
 
 	WT_ERR(__wt_metadata_search(session, WT_METAFILE_URI, &config));


### PR DESCRIPTION
It used to open and close a session handle that wasn't marked
internal. No functional change since recovery closes the handle
when it is done and the primary difference between internal and
non-internal sessions is during connection close.