### PR TITLE
WT-2068 Put live_open usage under HAVE_DIAGNOSTIC and an assert.

### DIFF
--- a/src/include/block.h
+++ b/src/include/block.h
@@ -238,7 +238,9 @@ struct __wt_block {
 	 */
 	WT_SPINLOCK	live_lock;	/* Live checkpoint lock */
 	WT_BLOCK_CKPT	live;		/* Live checkpoint */
+#ifdef HAVE_DIAGNOSTIC
 	bool		live_open;	/* Live system is open */
+#endif
 	bool		ckpt_inprogress;/* Live checkpoint in progress */
 
 				/* Compaction support */


### PR DESCRIPTION
@keithbostic and @michaelcahill - after thinking about this for a while, I still feel that this code really should be under HAVE_DIAGNOSTIC and an assertion.  I have not heard that we want to move away from that for things like this.  But this seems cleaner to me.  I made it a sub-branch off Keith's so it can be tossed if you want.

I definitely think we want some form of this because it quickly uncovered WT-2068 and we may need it again as we come up with a fix.