### PR TITLE
WT-2164 Prevent another chunk checkpoint while the first is still in progress.

### DIFF
--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -96,6 +96,7 @@ struct __wt_lsm_chunk {
 
 	int8_t empty;			/* 1/0: checkpoint missing */
 	int8_t evicted;			/* 1/0: in-memory chunk was evicted */
+	int8_t flushing;		/* 1/0: chunk flush in progress */
 
 #define	WT_LSM_CHUNK_BLOOM	0x01
 #define	WT_LSM_CHUNK_MERGING	0x02

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -96,7 +96,7 @@ struct __wt_lsm_chunk {
 
 	int8_t empty;			/* 1/0: checkpoint missing */
 	int8_t evicted;			/* 1/0: in-memory chunk was evicted */
-	int8_t flushing;		/* 1/0: chunk flush in progress */
+	uint8_t flushing;		/* 1/0: chunk flush in progress */
 
 #define	WT_LSM_CHUNK_BLOOM	0x01
 #define	WT_LSM_CHUNK_MERGING	0x02

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -261,6 +261,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 {
 	WT_DECL_RET;
 	WT_TXN_ISOLATION saved_isolation;
+	bool flush_set;
 
 	/*
 	 * If the chunk is already checkpointed, make sure it is also evicted.
@@ -295,7 +296,11 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 		return (0);
 	}
 
-	WT_RET(__wt_verbose(session, WT_VERB_LSM, "LSM worker flushing %s",
+	if (!__wt_atomic_cas8(&chunk->flushing, 0, 1))
+		return (0);
+	flush_set = true;
+
+	WT_ERR(__wt_verbose(session, WT_VERB_LSM, "LSM worker flushing %s",
 	    chunk->uri));
 
 	/*
@@ -319,9 +324,9 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 		session->txn.isolation = saved_isolation;
 		WT_TRET(__wt_session_release_btree(session));
 	}
-	WT_RET(ret);
+	WT_ERR(ret);
 
-	WT_RET(__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s",
+	WT_ERR(__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s",
 	    chunk->uri));
 
 	WT_WITH_SCHEMA_LOCK(session,
@@ -329,17 +334,17 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	    __wt_checkpoint, NULL, NULL, 0));
 
 	if (ret != 0)
-		WT_RET_MSG(session, ret, "LSM checkpoint");
+		WT_ERR_MSG(session, ret, "LSM checkpoint");
 
 	/* Now the file is written, get the chunk size. */
-	WT_RET(__wt_lsm_tree_set_chunk_size(session, chunk));
+	WT_ERR(__wt_lsm_tree_set_chunk_size(session, chunk));
 
 	/* Update the flush timestamp to help track ongoing progress. */
-	WT_RET(__wt_epoch(session, &lsm_tree->last_flush_ts));
+	WT_ERR(__wt_epoch(session, &lsm_tree->last_flush_ts));
 	++lsm_tree->chunks_flushed;
 
 	/* Lock the tree, mark the chunk as on disk and update the metadata. */
-	WT_RET(__wt_lsm_tree_writelock(session, lsm_tree));
+	WT_ERR(__wt_lsm_tree_writelock(session, lsm_tree));
 	F_SET(chunk, WT_LSM_CHUNK_ONDISK);
 	ret = __wt_lsm_meta_write(session, lsm_tree);
 	++lsm_tree->dsk_gen;
@@ -348,8 +353,13 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	__wt_lsm_tree_throttle(session, lsm_tree, true);
 	WT_TRET(__wt_lsm_tree_writeunlock(session, lsm_tree));
 
+	if (!__wt_atomic_cas8(&chunk->flushing, 1, 0)) {
+		__wt_errx(session, "Could not reset flushing");
+		__wt_abort(session);
+	}
+	flush_set = false;
 	if (ret != 0)
-		WT_RET_MSG(session, ret, "LSM metadata write");
+		WT_ERR_MSG(session, ret, "LSM metadata write");
 
 	/*
 	 * Clear the no-eviction flag so the primary can be evicted and
@@ -357,24 +367,29 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	 * otherwise, accessing the leaf page during the checkpoint can trigger
 	 * forced eviction.
 	 */
-	WT_RET(__wt_session_get_btree(session, chunk->uri, NULL, NULL, 0));
+	WT_ERR(__wt_session_get_btree(session, chunk->uri, NULL, NULL, 0));
 	__wt_btree_evictable(session, true);
-	WT_RET(__wt_session_release_btree(session));
+	WT_ERR(__wt_session_release_btree(session));
 
 	/* Make sure we aren't pinning a transaction ID. */
 	__wt_txn_release_snapshot(session);
 
-	WT_RET(__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointed %s",
+	WT_ERR(__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointed %s",
 	    chunk->uri));
 
 	/* Schedule a bloom filter create for our newly flushed chunk. */
 	if (!FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OFF))
-		WT_RET(__wt_lsm_manager_push_entry(
+		WT_ERR(__wt_lsm_manager_push_entry(
 		    session, WT_LSM_WORK_BLOOM, 0, lsm_tree));
 	else
-		WT_RET(__wt_lsm_manager_push_entry(
+		WT_ERR(__wt_lsm_manager_push_entry(
 		    session, WT_LSM_WORK_MERGE, 0, lsm_tree));
-	return (0);
+err:	if (flush_set && !__wt_atomic_cas8(&chunk->flushing, 1, 0)) {
+		__wt_errx(session, "Could not reset flushing for chunk %s",
+		    chunk->uri);
+		return (__wt_panic(session));
+	}
+	return (ret);
 }
 
 /*


### PR DESCRIPTION
@agorrod Please review this change.  It avoids the bus error by not allowing two LSM workers to checkpoint the same chunk.