### PR TITLE
WT-2164 Have LSM enable metadata tracking prior to checkpointing a chunk.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -59,6 +59,7 @@ CSV
 CURSORs
 CURSTD
 CallsCustDate
+Checkpointing
 Checksum
 Checksums
 CityHash

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -324,9 +324,16 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	WT_RET(__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s",
 	    chunk->uri));
 
+	/*
+	 * Turn on metadata tracking to ensure the checkpoint gets the
+	 * necessary handle locks.
+	 */
+	WT_RET(__wt_meta_track_on(session));
 	WT_WITH_SCHEMA_LOCK(session,
 	    ret = __wt_schema_worker(session, chunk->uri,
 	    __wt_checkpoint, NULL, NULL, 0));
+
+	WT_TRET(__wt_meta_track_off(session, false, ret != 0));
 
 	if (ret != 0)
 		WT_RET_MSG(session, ret, "LSM checkpoint");


### PR DESCRIPTION

Otherwise insufficient locks are held to keep checkpoint handles alive.

Also add assertions into checkpoint to avoid running into this again
in the future.