### PR TITLE
WT-2146 Do quick searches based on search key size

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -215,12 +215,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 	WT_RET(__wt_struct_confchk(session, &cval));
 	if (WT_STRING_MATCH("r", cval.str, cval.len))
 		btree->type = BTREE_COL_VAR;
-	else {
+	else
 		btree->type = BTREE_ROW;
-		if (WT_STRING_MATCH("Q", cval.str, cval.len) ||
-		    WT_STRING_MATCH("q", cval.str, cval.len))
-			btree->qsearch = 1;
-	}
 	WT_RET(__wt_strndup(session, cval.str, cval.len, &btree->key_format));
 
 	WT_RET(__wt_config_gets(session, cfg, "value_format", &cval));

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -236,14 +236,15 @@ restart:	page = current->page;
 		 */
 		base = 1;
 		limit = pindex->entries - 1;
-		if (btree->qsearch)
+		if (collator == NULL &&
+		    srch_key->size <= WT_COMPARE_SHORT_MAXLEN)
 			for (; limit != 0; limit >>= 1) {
 				indx = base + (limit >> 1);
 				descent = pindex->index[indx];
 				__wt_ref_key(
 				    page, descent, &item->data, &item->size);
 
-				cmp = __wt_lex_qcompare(srch_key, item);
+				cmp = __wt_lex_compare_short(srch_key, item);
 				if (cmp > 0) {
 					base = indx + 1;
 					--limit;
@@ -377,14 +378,14 @@ leaf_only:
 	 */
 	base = 0;
 	limit = page->pg_row_entries;
-	if (btree->qsearch)
+	if (collator == NULL && srch_key->size <= WT_COMPARE_SHORT_MAXLEN)
 		for (; limit != 0; limit >>= 1) {
 			indx = base + (limit >> 1);
 			rip = page->pg_row_d + indx;
 			WT_ERR(
 			    __wt_row_leaf_key(session, page, rip, item, true));
 
-			cmp = __wt_lex_qcompare(srch_key, item);
+			cmp = __wt_lex_compare_short(srch_key, item);
 			if (cmp > 0) {
 				base = indx + 1;
 				--limit;

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -74,7 +74,6 @@ struct __wt_btree {
 	const char *key_format;		/* Key format */
 	const char *value_format;	/* Value format */
 	uint8_t bitcnt;			/* Fixed-length field size in bits */
-	bool	qsearch;		/* Key is a packed uint64_t */
 
 	WT_COLLATOR *collator;		/* Row-store comparator */
 	int collator_owned;		/* The collator needs to be freed */

--- a/src/include/btree_cmp.i
+++ b/src/include/btree_cmp.i
@@ -84,8 +84,8 @@ __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 }
 
 /*
- * __wt_lex_qcompare --
- *	Lexicographic comparison routine for record number keys.
+ * __wt_lex_compare_short --
+ *	Lexicographic comparison routine for short keys.
  *
  * Returns:
  *	< 0 if user_item is lexicographically < tree_item
@@ -96,7 +96,7 @@ __wt_lex_compare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
  * the application is looking at when we call its comparison function.
  */
 static inline int
-__wt_lex_qcompare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
+__wt_lex_compare_short(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 {
 	size_t len, usz, tsz;
 	const uint8_t *userp, *treep;
@@ -112,6 +112,7 @@ __wt_lex_qcompare(const WT_ITEM *user_item, const WT_ITEM *tree_item)
 	 * The maximum packed uint64_t is 9B, catch row-store objects using
 	 * packed record numbers as keys.
 	 */
+#define	WT_COMPARE_SHORT_MAXLEN 9
 #undef	WT_COMPARE_SHORT
 #define	WT_COMPARE_SHORT(n)						\
 	case n:								\


### PR DESCRIPTION
This makes the branch more generally applicable, rather than being a special case for one type of key.  It was just as fast in my testing.

I tried several variations on the core of #2223 but didn't find any way to make it faster, and my attempts to simplify it made it slower.

@keithbostic, if you're happy with this change, can you please merge it, then merge #2223?