### PR TITLE
WT-2170 Add a macro perform an operation at an isolation level.

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -443,6 +443,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 	} else if ((ret = __wt_btcur_next(cbt, false)) != WT_NOTFOUND)
 		exact = 1;
 	else {
+		WT_ERR(__cursor_func_init(cbt, true));
 		WT_ERR(btree->type == BTREE_ROW ?
 		    __cursor_row_search(session, cbt, NULL, true) :
 		    __cursor_col_search(session, cbt, NULL));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -152,6 +152,8 @@ __sync_file(WT_SESSION_IMPL *session, int syncop)
 				leaf_bytes += page->memory_footprint;
 				++leaf_pages;
 			}
+			if (txn->isolation == WT_ISO_READ_COMMITTED)
+				__wt_txn_get_snapshot(session);
 			WT_ERR(__wt_reconcile(session, walk, NULL, 0));
 		}
 		break;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -565,9 +565,9 @@ extern int __wt_schema_colgroup_name(WT_SESSION_IMPL *session, WT_TABLE *table, 
 extern int __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table);
 extern int __wt_schema_open_index(WT_SESSION_IMPL *session, WT_TABLE *table, const char *idxname, size_t len, WT_INDEX **indexp);
 extern int __wt_schema_open_indices(WT_SESSION_IMPL *session, WT_TABLE *table);
-extern int __wt_schema_open_table(WT_SESSION_IMPL *session, const char *name, size_t namelen, bool ok_incomplete, WT_TABLE **tablep);
 extern int __wt_schema_get_colgroup(WT_SESSION_IMPL *session, const char *uri, bool quiet, WT_TABLE **tablep, WT_COLGROUP **colgroupp);
 extern int __wt_schema_get_index(WT_SESSION_IMPL *session, const char *uri, bool quiet, WT_TABLE **tablep, WT_INDEX **indexp);
+extern int __wt_schema_open_table(WT_SESSION_IMPL *session, const char *name, size_t namelen, bool ok_incomplete, WT_TABLE **tablep);
 extern int __wt_schema_colcheck(WT_SESSION_IMPL *session, const char *key_format, const char *value_format, WT_CONFIG_ITEM *colconf, u_int *kcolsp, u_int *vcolsp);
 extern int __wt_table_check(WT_SESSION_IMPL *session, WT_TABLE *table);
 extern int __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns, size_t len, bool value_only, WT_ITEM *plan);

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -222,9 +222,6 @@ __wt_metadata_search(
 	if (__metadata_turtle(key))
 		return (__wt_turtle_read(session, key, valuep));
 
-	WT_RET(__wt_metadata_cursor(session, NULL, &cursor));
-	cursor->set_key(cursor, key);
-
 	/*
 	 * All metadata reads are at read-uncommitted isolation.  That's
 	 * because once a schema-level operation completes, subsequent
@@ -233,6 +230,8 @@ __wt_metadata_search(
 	 * Metadata updates use non-transactional techniques (such as the
 	 * schema and metadata locks) to protect access to in-flight updates.
 	 */
+	WT_RET(__wt_metadata_cursor(session, NULL, &cursor));
+	cursor->set_key(cursor, key);
 	WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED,
 	    ret = cursor->search(cursor));
 	WT_ERR(ret);

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -275,7 +275,8 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 		WT_RET(ret);
 	} else {
 		WT_WITH_DHANDLE(session, session->meta_dhandle,
-		    ret = __wt_checkpoint(session, NULL));
+		    WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_COMMITTED,
+			ret = __wt_checkpoint(session, NULL)));
 		WT_RET(ret);
 		WT_WITH_DHANDLE(session, session->meta_dhandle,
 		    ret = __wt_checkpoint_sync(session, NULL));


### PR DESCRIPTION
Lock down visibility checks so we never try to use a snapshot without one being allocated.