### PR TITLE
WT-2189 Make F_SET (and F_CLR) into a void expression.

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -460,7 +460,7 @@ __evict_review(
 	WT_ASSERT(session,
 	    LF_ISSET(WT_EVICT_UPDATE_RESTORE) || !__wt_page_is_modified(page));
 	WT_ASSERT(session,
-	    LF_SET(WT_EVICT_LOOKASIDE) ||
+	    LF_ISSET(WT_EVICT_LOOKASIDE) ||
 	    __wt_page_is_modified(page) ||
 	    __wt_txn_visible_all(session, page->modify->rec_max_txn));
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -120,11 +120,11 @@
  * hex constant might be a negative integer), and to ensure the hex constant is
  * the correct size before applying the bitwise not operator.
  */
-#define	FLD_CLR(field, mask)	        ((field) &= ~((uint32_t)(mask)))
+#define	FLD_CLR(field, mask)	        ((void)((field) &= ~(uint32_t)(mask)))
 #define	FLD_MASK(field, mask)	        ((field) & (uint32_t)(mask))
 #define	FLD_ISSET(field, mask)	        (FLD_MASK(field, mask) != 0)
 #define	FLD64_ISSET(field, mask)	(((field) & (uint64_t)(mask)) != 0)
-#define	FLD_SET(field, mask)	        ((field) |= ((uint32_t)(mask)))
+#define	FLD_SET(field, mask)	        ((void)((field) |= (uint32_t)(mask)))
 
 #define	F_CLR(p, mask)		        FLD_CLR((p)->flags, mask)
 #define	F_ISSET(p, mask)	        FLD_ISSET((p)->flags, mask)


### PR DESCRIPTION
That way it can't accidentally be used in place of F_ISSET.