### PR TITLE
WT-2127 Back out some of a change to split internal pages sooner.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -211,7 +211,8 @@ __split_should_deepen(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * splitting into parent pages can become large enough to result
 	 * in slow operations.
 	 */
-	if (pindex->entries > btree->split_deepen_min_child)
+	if (!__wt_ref_is_root(ref) &&
+	    pindex->entries > btree->split_deepen_min_child)
 		return (true);
 
 	return (false);


### PR DESCRIPTION
We aren't doing an awesome job of balancing trees built via append
workloads, especially when splitting the root. Avoid splitting the
root until it grows large.

The work in WT-2182 should help with our tree shape.