### PR TITLE
WT-2170 Restore visible_all semantics if we try to check visibility without a snapshot

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -32,9 +32,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, int syncop)
 	/* Make sure the oldest transaction ID is up-to-date. */
 	__wt_txn_update_oldest(session, true);
 
-	if (txn->isolation == WT_ISO_READ_COMMITTED)
-		__wt_txn_get_snapshot(session);
-
 	/* Walk the tree, discarding pages. */
 	next_ref = NULL;
 	WT_ERR(__wt_tree_walk(session, &next_ref, NULL,
@@ -64,10 +61,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, int syncop)
 		 */
 		if (syncop == WT_SYNC_CLOSE && __wt_page_is_modified(page))
 			WT_ERR(__wt_reconcile(session, ref, NULL, WT_EVICTING));
-
-		/* Update our snapshot for each new page. */
-		if (txn->isolation == WT_ISO_READ_COMMITTED)
-			__wt_txn_get_snapshot(session);
 
 		/*
 		 * We can't evict the page just returned to us (it marks our

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -192,10 +192,11 @@ __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id)
 		return (true);
 
 	/*
-	 * A visibility check that is not read-uncommitted must have an
-	 * active snapshot.
+	 * If we don't have a transactional snapshot, only make stable updates
+	 * visible.
 	 */
-	WT_ASSERT(session, F_ISSET(txn, WT_TXN_HAS_SNAPSHOT));
+	if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
+		return (__wt_txn_visible_all(session, id));
 
 	/* Transactions see their own changes. */
 	if (id == txn->id)


### PR DESCRIPTION
There are various internal checks (e.g., checking tombstone visibility during tree walks, and during eviction of dirty trees prior to an exclusive operation like drop) where we don't have a transactional snapshot, but the isolation level may be set read-committed or higher.  The isolation level is irrelevant to these checks: we used to have a special "eviction" isolation level to avoid these issues.

This change restores that semantic: if we attempt a visibilty check without a snapshot, fall back to only making stable updates visible.