### PR TITLE
WT-2191: in memory disk image no longer the same as saved updates

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -164,7 +164,7 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 				break;
 			}
 			__wt_free(session, multi->supd);
-			__wt_free(session, multi->supd_dsk);
+			__wt_free(session, multi->disk_image);
 			__wt_free(session, multi->addr.addr);
 		}
 		__wt_free(session, mod->mod_multi);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -841,7 +841,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	/* Any parent reference is filled in by our caller. */
 	ref->home = NULL;
 
-	if (multi->supd == NULL && multi->supd_dsk == NULL) {
+	if (multi->supd_dsk == NULL) {
 		/*
 		 * Copy the address: we could simply take the buffer, but that
 		 * would complicate error handling, freeing the reference array

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -717,9 +717,9 @@ __split_multi_inmem(
 	 * allocated page on error, when discarding the allocated WT_REF.
 	 */
 	WT_RET(__wt_page_inmem(session, ref,
-	    multi->supd_dsk, ((WT_PAGE_HEADER *)multi->supd_dsk)->mem_size,
+	    multi->disk_image, ((WT_PAGE_HEADER *)multi->disk_image)->mem_size,
 	    WT_PAGE_DISK_ALLOC, &page));
-	multi->supd_dsk = NULL;
+	multi->disk_image = NULL;
 
 	if (orig->type == WT_PAGE_ROW_LEAF)
 		WT_RET(__wt_scr_alloc(session, 0, &key));
@@ -841,7 +841,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	/* Any parent reference is filled in by our caller. */
 	ref->home = NULL;
 
-	if (multi->supd_dsk == NULL) {
+	if (multi->disk_image == NULL) {
 		/*
 		 * Copy the address: we could simply take the buffer, but that
 		 * would complicate error handling, freeing the reference array

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -261,7 +261,9 @@ struct __wt_page_modify {
 		} key;
 
 		/*
-		 * Eviction, but block wasn't written: unresolved updates and
+		 * Eviction, but the block wasn't written: either an in-memory
+		 * configuration or unresolved updates prevented the write.
+		 * There may be a list of unresolved updates, there's always an
 		 * associated disk image.
 		 *
 		 * Saved updates are either a WT_INSERT, or a row-store leaf
@@ -274,7 +276,7 @@ struct __wt_page_modify {
 			uint64_t   onpage_txn;
 		} *supd;
 		uint32_t supd_entries;
-		void	*supd_dsk;
+		void	*disk_image;
 
 		/*
 		 * Block was written: address, size and checksum.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3222,16 +3222,17 @@ supd_check_complete:
 	}
 
 	/*
-	 * If using the save/restore eviction path and we had to skip updates in
-	 * order to build this disk image, we can't actually write it. Instead,
-	 * we will re-instantiate the page using the disk image and the list of
-	 * updates we skipped.
-	 *
-	 * With an in-memory database, we always take this path.
+	 * If configured for an in-memory database, or using the save/restore
+	 * eviction path and we had to skip updates in order to build this disk
+	 * image, we can't actually write it. Instead, we will re-instantiate
+	 * the page using the disk image and any list of updates we skipped.
 	 */
-	if ((F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && bnd->supd != NULL) ||
-	    F_ISSET(r, WT_EVICT_IN_MEMORY)) {
-		r->cache_write_restore = true;
+	if (F_ISSET(r, WT_EVICT_IN_MEMORY) ||
+	    (F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && bnd->supd != NULL)) {
+
+		/* Statistics tracking that we used update/restore. */
+		if (F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && bnd->supd != NULL)
+			r->cache_write_restore = true;
 
 		/*
 		 * If the buffer is compressed (raw compression was configured),

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -5292,7 +5292,7 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
 			__wt_free(session, multi->key.ikey);
 			break;
 		}
-		if (multi->supd == NULL && multi->supd_dsk == NULL) {
+		if (multi->supd_dsk == NULL) {
 			if (multi->addr.reuse)
 				multi->addr.addr = NULL;
 			else {
@@ -5642,7 +5642,7 @@ __rec_split_row(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		WT_RET(__wt_row_ikey_alloc(session, 0,
 		    bnd->key.data, bnd->key.size, &multi->key.ikey));
 
-		if (bnd->supd != NULL || F_ISSET(r, WT_EVICT_IN_MEMORY)) {
+		if (bnd->dsk != NULL) {
 			multi->supd = bnd->supd;
 			multi->supd_entries = bnd->supd_next;
 			bnd->supd = NULL;
@@ -5682,7 +5682,7 @@ __rec_split_col(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	    bnd = r->bnd, i = 0; i < r->bnd_next; ++multi, ++bnd, ++i) {
 		multi->key.recno = bnd->recno;
 
-		if (bnd->supd != NULL || F_ISSET(r, WT_EVICT_IN_MEMORY)) {
+		if (bnd->dsk != NULL) {
 			multi->supd = bnd->supd;
 			multi->supd_entries = bnd->supd_next;
 			bnd->supd = NULL;


### PR DESCRIPTION
@agorrod, @michaelcahill, I think this is ready for review and merge.

956cc66 is the fix, 0818fc3 is a general naming change.