### PR TITLE
WT-2187 Add flag for flushing a slot

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -152,8 +152,9 @@ struct WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) __wt_logslot {
 	WT_ITEM  slot_buf;		/* Buffer for grouped writes */
 
 #define	WT_SLOT_CLOSEFH		0x01		/* Close old fh on release */
-#define	WT_SLOT_SYNC		0x02		/* Needs sync on release */
-#define	WT_SLOT_SYNC_DIR	0x04		/* Directory sync on release */
+#define	WT_SLOT_FLUSH		0x02		/* Wait for write */
+#define	WT_SLOT_SYNC		0x04		/* Needs sync on release */
+#define	WT_SLOT_SYNC_DIR	0x08		/* Directory sync on release */
 	uint32_t flags;			/* Flags */
 };
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1312,6 +1312,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 		 */
 		if (F_ISSET(session, WT_SESSION_LOCKED_SLOT))
 			__wt_spin_unlock(session, &log->log_slot_lock);
+		WT_ERR(__wt_cond_signal(session, conn->log_wrlsn_cond));
 		if (++yield_count < 1000)
 			__wt_yield();
 		else

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -429,6 +429,8 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize,
 		WT_STAT_FAST_CONN_INCR(session, log_slot_joins);
 	if (LF_ISSET(WT_LOG_DSYNC | WT_LOG_FSYNC))
 		F_SET(slot, WT_SLOT_SYNC_DIR);
+	if (LF_ISSET(WT_LOG_FLUSH))
+		F_SET(slot, WT_SLOT_FLUSH);
 	if (LF_ISSET(WT_LOG_FSYNC))
 		F_SET(slot, WT_SLOT_SYNC);
 	if (F_ISSET(myslot, WT_MYSLOT_UNBUFFERED)) {


### PR DESCRIPTION
so that we locally handle write_lsn rather than waiting for a worker thread, similar to sync.

@michaelcahill Please review this change for the performance issue reported with write-no-sync.  With this change, I see the current logging code perform the same (one populate thread) or 50% faster (8 threads).