### PR TITLE
WT-2194: Java close callbacks should handle cursors that Java code did not open.

### DIFF
--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -395,15 +395,20 @@ javaCloseHandler(WT_EVENT_HANDLER *handler, WT_SESSION *session,
 	WT_CURSOR *cursor)
 {
 	int ret;
+	JAVA_CALLBACK *jcb;
 
 	WT_UNUSED(handler);
 
-	if (cursor != NULL)
-		ret = cursorCloseHandler(NULL, session, (JAVA_CALLBACK *)
-		    cursor->lang_private);
-	else
-		ret = closeHandler(NULL, session, (JAVA_CALLBACK *)
-		    ((WT_SESSION_IMPL *)session)->lang_private);
+	ret = 0;
+	if (cursor != NULL) {
+		if ((jcb = (JAVA_CALLBACK *)cursor->lang_private) != NULL) {
+			ret = cursorCloseHandler(NULL, session, jcb);
+			cursor->lang_private = NULL;
+		}
+	} else if ((jcb = ((WT_SESSION_IMPL *)session)->lang_private) != NULL) {
+		ret = closeHandler(NULL, session, jcb);
+		((WT_SESSION_IMPL *)session)->lang_private = NULL;
+	}
 	return (ret);
 }
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -147,7 +147,8 @@ __session_close(WT_SESSION *wt_session, const char *config)
 		 * Notify the user that we are closing the cursor handle
 		 * via the registered close callback.
 		 */
-		if (session->event_handler->handle_close != NULL)
+		if (session->event_handler->handle_close != NULL &&
+		    !WT_STREQ(cursor->uri, WT_LAS_URI))
 			WT_TRET(session->event_handler->handle_close(
 			    session->event_handler, wt_session, cursor));
 		WT_TRET(cursor->close(cursor));


### PR DESCRIPTION
This can now happen, as WiredTigerLAS.wt is opened internally.