### PR TITLE
WT-2196 Fix size-only statistics when there are LSM tables.

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -422,9 +422,13 @@ int
 __wt_block_manager_size(
     WT_SESSION_IMPL *session, const char *filename, WT_DSRC_STATS *stats)
 {
+	WT_DECL_RET;
 	wt_off_t filesize;
 
-	WT_RET(__wt_filesize_name(session, filename, &filesize));
+	ret = __wt_filesize_name(session, filename, &filesize);
+	if (ret != 0)
+		WT_RET_MSG(session, ret, "%s: file size", filename);
+
 	stats->block_size = filesize;
 
 	return (0);

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -213,6 +213,7 @@ int
 __wt_lsm_tree_set_chunk_size(
     WT_SESSION_IMPL *session, WT_LSM_CHUNK *chunk)
 {
+	WT_DECL_RET;
 	wt_off_t size;
 	const char *filename;
 
@@ -220,7 +221,9 @@ __wt_lsm_tree_set_chunk_size(
 	if (!WT_PREFIX_SKIP(filename, "file:"))
 		WT_RET_MSG(session, EINVAL,
 		    "Expected a 'file:' URI: %s", chunk->uri);
-	WT_RET(__wt_filesize_name(session, filename, &size));
+	ret = __wt_filesize_name(session, filename, &size);
+	if (ret != 0)
+		WT_RET_MSG(session, ret, "%s: file size", filename);
 
 	chunk->size = (uint64_t)size;
 

--- a/src/os_posix/os_filesize.c
+++ b/src/os_posix/os_filesize.c
@@ -47,10 +47,9 @@ __wt_filesize_name(
 
 	__wt_free(session, path);
 
-	if (ret == 0) {
+	if (ret == 0)
 		*sizep = sb.st_size;
-		return (0);
-	}
 
-	WT_RET_MSG(session, ret, "%s: fstat", filename);
+	/* Some callers expect failure, so don't log an error message. */
+	return (ret);
 }

--- a/src/os_win/os_filesize.c
+++ b/src/os_win/os_filesize.c
@@ -47,11 +47,10 @@ __wt_filesize_name(
 
 	__wt_free(session, path);
 
-	if (ret != 0) {
+	if (ret != 0)
 		*sizep =
 		    ((int64_t)data.nFileSizeHigh << 32) | data.nFileSizeLow;
-		return (0);
-	}
 
-	WT_RET_MSG(session, __wt_errno(), "%s: GetFileAttributesEx", filename);
+	/* Some callers expect failure, so don't log an error message. */
+	return (ret);
 }

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -90,18 +90,19 @@ __curstat_size_only(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_buf_fmt(
 	    session, &namebuf, "%s.wt", uri + strlen("table:")));
 	/*
-	 * Get the size of the underlying file.  There is nothing stopping a
-	 * race with schema level table operations (for example drop) if there
-	 * is a race there will be an error message generated.
+	 * Get the size of the underlying file. This will fail for anything
+	 * other than simple tables (LSM for example) and will fail if there
+	 * are concurrent schema level operations (for example drop). That is
+	 * fine - failing here results in falling back to the slow path of
+	 * opening the handle.
 	 */
-	WT_ERR(__wt_filesize_name(session, namebuf.data, &filesize));
-
-	/* Setup and populate the statistics structure */
-	__wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
-	cst->u.dsrc_stats.block_size = filesize;
-	__wt_curstat_dsrc_final(cst);
-
-	*was_fast = true;
+	if (__wt_filesize_name(session, namebuf.data, &filesize) == 0) {
+		/* Setup and populate the statistics structure */
+		__wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
+		cst->u.dsrc_stats.block_size = filesize;
+		__wt_curstat_dsrc_final(cst);
+		*was_fast = true;
+	}
 
 err:	__wt_free(session, tableconf);
 	__wt_buf_free(session, &namebuf);


### PR DESCRIPTION
It used to generate an error message when attempting to open a
statistics=(size) cursor on an LSM tree.