### PR TITLE
WT-2200 Change WiredTiger caching strategy on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -167,6 +167,7 @@ if useTcmalloc:
     if conf.CheckCHeader('gperftools/tcmalloc.h'):
         wtlibs.append("libtcmalloc_minimal")
         conf.env.Append(CPPDEFINES=['HAVE_LIBTCMALLOC'])
+        conf.env.Append(CPPDEFINES=['HAVE_POSIX_MEMALIGN'])
     else:
         print 'tcmalloc.h must be installed!'
         Exit(1)

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -594,7 +594,8 @@ wiredtiger_open_common = connection_runtime_config + [
         checkpoints''',
         type='boolean'),
     Config('direct_io', '', r'''
-        Use \c O_DIRECT to access files.  Options are given as a list,
+        Use \c O_DIRECT on Posix systems, and FILE_FLAG_NO_BUFFERING on Windows
+        to access files.  Options are given as a list,
         such as <code>"direct_io=[data]"</code>.  Configuring
         \c direct_io requires care, see @ref
         tuning_system_buffer_cache_direct_io for important warnings.
@@ -602,7 +603,8 @@ wiredtiger_open_common = connection_runtime_config + [
         \c O_DIRECT, including \c "log" will cause WiredTiger log files
         to use \c O_DIRECT, and including \c "checkpoint" will cause
         WiredTiger data files opened at a checkpoint (i.e: read only) to
-        use \c O_DIRECT''',
+        use \c O_DIRECT. It should be combined with write_through to get the
+        equivalent of O_DIRECT on Windows.''',
         type='list', choices=['checkpoint', 'data', 'log']),
     Config('encryption', '', r'''
         configure an encryptor for system wide metadata and logs.
@@ -674,6 +676,19 @@ wiredtiger_open_common = connection_runtime_config + [
             @ref tune_durability for more information''',
             choices=['dsync', 'fsync', 'none']),
         ]),
+    Config('write_through', '', r'''
+        Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to files.
+        Options are given as a list,
+        such as <code>"write_through=[data]"</code>.  Configuring
+        \c write_through requires care, see @ref
+        tuning_system_buffer_cache_direct_io for important warnings.
+        Including \c "data" will cause WiredTiger data files to use
+        \c FILE_FLAG_WRITE_THROUGH, including \c "log" will cause WiredTiger log
+        files to use \c FILE_FLAG_WRITE_THROUGH, and including \c "checkpoint"
+        will cause WiredTiger data files opened at a checkpoint (i.e: read only)
+        to use \c FILE_FLAG_WRITE_THROUGH. It should be combined with
+        direct_io to get the equivalent of O_DIRECT on Windows.''',
+        type='list', choices=['checkpoint', 'data', 'log']),
 ]
 
 wiredtiger_open = wiredtiger_open_common + [

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -594,17 +594,16 @@ wiredtiger_open_common = connection_runtime_config + [
         checkpoints''',
         type='boolean'),
     Config('direct_io', '', r'''
-        Use \c O_DIRECT on Posix systems, and FILE_FLAG_NO_BUFFERING on Windows
-        to access files.  Options are given as a list,
-        such as <code>"direct_io=[data]"</code>.  Configuring
-        \c direct_io requires care, see @ref
-        tuning_system_buffer_cache_direct_io for important warnings.
-        Including \c "data" will cause WiredTiger data files to use
-        \c O_DIRECT, including \c "log" will cause WiredTiger log files
-        to use \c O_DIRECT, and including \c "checkpoint" will cause
-        WiredTiger data files opened at a checkpoint (i.e: read only) to
-        use \c O_DIRECT. It should be combined with write_through to get the
-        equivalent of O_DIRECT on Windows.''',
+        Use \c O_DIRECT on POSIX systems, and \c FILE_FLAG_NO_BUFFERING on
+        Windows to access files.  Options are given as a list, such as
+        <code>"direct_io=[data]"</code>.  Configuring \c direct_io requires
+        care, see @ref tuning_system_buffer_cache_direct_io for important
+        warnings.  Including \c "data" will cause WiredTiger data files to use
+        direct I/O, including \c "log" will cause WiredTiger log files to use
+        direct I/O, and including \c "checkpoint" will cause WiredTiger data
+        files opened at a checkpoint (i.e: read only) to use direct I/O.
+        \c direct_io should be combined with \c write_through to get the
+        equivalent of \c O_DIRECT on Windows.''',
         type='list', choices=['checkpoint', 'data', 'log']),
     Config('encryption', '', r'''
         configure an encryptor for system wide metadata and logs.
@@ -677,18 +676,16 @@ wiredtiger_open_common = connection_runtime_config + [
             choices=['dsync', 'fsync', 'none']),
         ]),
     Config('write_through', '', r'''
-        Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to files.
-        Options are given as a list,
-        such as <code>"write_through=[data]"</code>.  Configuring
-        \c write_through requires care, see @ref
-        tuning_system_buffer_cache_direct_io for important warnings.
-        Including \c "data" will cause WiredTiger data files to use
-        \c FILE_FLAG_WRITE_THROUGH, including \c "log" will cause WiredTiger log
-        files to use \c FILE_FLAG_WRITE_THROUGH, and including \c "checkpoint"
-        will cause WiredTiger data files opened at a checkpoint (i.e: read only)
-        to use \c FILE_FLAG_WRITE_THROUGH. It should be combined with
-        direct_io to get the equivalent of O_DIRECT on Windows.''',
-        type='list', choices=['checkpoint', 'data', 'log']),
+        Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to files.  Ignored
+        on non-Windows systems.  Options are given as a list, such as
+        <code>"write_through=[data]"</code>.  Configuring \c write_through
+        requires care, see @ref tuning_system_buffer_cache_direct_io for
+        important warnings.  Including \c "data" will cause WiredTiger data
+        files to write through cache, including \c "log" will cause WiredTiger
+        log files to write through cache. \c write_through should be combined
+        with \c direct_io to get the equivalent of POSIX \c O_DIRECT on
+        Windows.''',
+        type='list', choices=['data', 'log']),
 ]
 
 wiredtiger_open = wiredtiger_open_common + [

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -552,6 +552,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	    "\"split\",\"temporary\",\"transaction\",\"verify\",\"version\","
 	    "\"write\"]",
 	    NULL, 0 },
+	{ "write_through", "list",
+	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -629,6 +632,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	    "\"write\"]",
 	    NULL, 0 },
 	{ "version", "string", NULL, NULL, NULL, 0 },
+	{ "write_through", "list",
+	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -701,6 +707,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	    "\"write\"]",
 	    NULL, 0 },
 	{ "version", "string", NULL, NULL, NULL, 0 },
+	{ "write_through", "list",
+	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -771,6 +780,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	    "\"reconcile\",\"recovery\",\"salvage\",\"shared_cache\","
 	    "\"split\",\"temporary\",\"transaction\",\"verify\",\"version\","
 	    "\"write\"]",
+	    NULL, 0 },
+	{ "write_through", "list",
+	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -984,8 +996,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
-	  ",verbose=",
-	  confchk_wiredtiger_open, 35
+	  ",verbose=,write_through=",
+	  confchk_wiredtiger_open, 36
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=0,ops_max=1024,threads=2),buffer_alignment=-1,"
@@ -1005,8 +1017,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "transaction_sync=(enabled=0,method=fsync),use_environment_priv=0"
-	  ",verbose=,version=(major=0,minor=0)",
-	  confchk_wiredtiger_open_all, 36
+	  ",verbose=,version=(major=0,minor=0),write_through=",
+	  confchk_wiredtiger_open_all, 37
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=0,ops_max=1024,threads=2),buffer_alignment=-1,"
@@ -1025,8 +1037,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "transaction_sync=(enabled=0,method=fsync),verbose=,"
-	  "version=(major=0,minor=0)",
-	  confchk_wiredtiger_open_basecfg, 31
+	  "version=(major=0,minor=0),write_through=",
+	  confchk_wiredtiger_open_basecfg, 32
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=0,ops_max=1024,threads=2),buffer_alignment=-1,"
@@ -1044,8 +1056,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
 	  "statistics_log=(on_close=0,path=\"WiredTigerStat.%d.%H\","
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=0,method=fsync),verbose=",
-	  confchk_wiredtiger_open_usercfg, 30
+	  "transaction_sync=(enabled=0,method=fsync),verbose=,"
+	  "write_through=",
+	  confchk_wiredtiger_open_usercfg, 31
 	},
 	{ NULL, NULL, NULL, 0 }
 };

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -553,7 +553,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	    "\"write\"]",
 	    NULL, 0 },
 	{ "write_through", "list",
-	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, "choices=[\"data\",\"log\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -633,7 +633,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	    NULL, 0 },
 	{ "version", "string", NULL, NULL, NULL, 0 },
 	{ "write_through", "list",
-	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, "choices=[\"data\",\"log\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -708,7 +708,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	    NULL, 0 },
 	{ "version", "string", NULL, NULL, NULL, 0 },
 	{ "write_through", "list",
-	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, "choices=[\"data\",\"log\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -782,7 +782,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	    "\"write\"]",
 	    NULL, 0 },
 	{ "write_through", "list",
-	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
+	    NULL, "choices=[\"data\",\"log\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1947,6 +1947,16 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 			goto err;
 	}
 
+	WT_ERR(__wt_config_gets(session, cfg, "write_through", &cval));
+	for (ft = file_types; ft->name != NULL; ft++) {
+		ret = __wt_config_subgets(session, &cval, ft->name, &sval);
+		if (ret == 0) {
+			if (sval.val)
+				FLD_SET(conn->write_through, ft->flag);
+		} else if (ret != WT_NOTFOUND)
+			goto err;
+	}
+
 	/*
 	 * If buffer alignment is not configured, use zero unless direct I/O is
 	 * also configured, in which case use the build-time default.

--- a/src/docs/tune-system-buffer-cache.dox
+++ b/src/docs/tune-system-buffer-cache.dox
@@ -17,6 +17,17 @@ for WiredTiger's data files:
 
 @snippet ex_all.c Configure direct_io for data files
 
+On Windows, the "direct_io" configuration string controls whether the operating
+system cache is used to buffer reads, and writes to disk, i.e.,
+FILE_FLAG_NO_BUFFERING. When "direct_io" is off, Windows will use free RAM to
+cache access to files. This may had adverse effects because Windows may page out
+the WiredTiger buffer cache instead of its file cache. An additional
+configuration string "write_through" controls whether the disk is allowed to
+cache the writes. Enabling this flag increases write latency as the drive must
+ensure all writes are persisted to disk, but it ensures write durability. To get
+the equivalent of \c O_DIRECT on Windows, "direct_io", and "write_through" must
+be both set.
+
 Direct I/O implies a writing thread waits for the write to complete
 (which is a slower operation than writing into the system buffer cache),
 and configuring direct I/O is likely to decrease overall application
@@ -36,11 +47,11 @@ should also specify \c O_DIRECT when configuring their file access.  A
 standard Linux system utility that supports \c O_DIRECT is the \c dd
 utility, when using the \c iflag=direct command-line option.
 
-Additionally, many Linux systems require specific alignment for buffers
-used for I/O when direct I/O is configured, and using the wrong
+Additionally, Windows, and many Linux systems require specific alignment for
+buffers used for I/O when direct I/O is configured, and using the wrong
 alignment can cause data loss or corruption.  When direct I/O is
-configured on Linux systems, WiredTiger aligns I/O buffers to 4KB; if
-different alignment is required by your system, the \c buffer_alignment
+configured on Windows, and Linux systems, WiredTiger aligns I/O buffers to 4KB;
+if different alignment is required by your system, the \c buffer_alignment
 configuration to the wiredtiger_open call should be configured to the
 correct value.
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -412,7 +412,9 @@ struct __wt_connection_impl {
 	wt_off_t data_extend_len;	/* file_extend data length */
 	wt_off_t log_extend_len;	/* file_extend log length */
 
-	uint32_t direct_io;		/* O_DIRECT file type flags */
+	/* O_DIRECT/FILE_FLAG_NO_BUFFERING file type flags */
+	uint32_t direct_io;
+	uint32_t write_through;		/* FILE_FLAG_WRITE_THROUGH type flags */
 	bool	 mmap;			/* mmap configuration */
 	uint32_t verbose;
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2130,17 +2130,17 @@ struct __wt_connection {
  * true.}
  * @config{create, create the database if it does not exist., a boolean flag;
  * default \c false.}
- * @config{direct_io, Use \c O_DIRECT on Posix systems\, and
+ * @config{direct_io, Use \c O_DIRECT on POSIX systems\, and \c
  * FILE_FLAG_NO_BUFFERING on Windows to access files.  Options are given as a
  * list\, such as <code>"direct_io=[data]"</code>. Configuring \c direct_io
  * requires care\, see @ref tuning_system_buffer_cache_direct_io for important
- * warnings.  Including \c "data" will cause WiredTiger data files to use \c
- * O_DIRECT\, including \c "log" will cause WiredTiger log files to use \c
- * O_DIRECT\, and including \c "checkpoint" will cause WiredTiger data files
- * opened at a checkpoint (i.e: read only) to use \c O_DIRECT. It should be
- * combined with write_through to get the equivalent of O_DIRECT on Windows., a
- * list\, with values chosen from the following options: \c "checkpoint"\, \c
- * "data"\, \c "log"; default empty.}
+ * warnings.  Including \c "data" will cause WiredTiger data files to use direct
+ * I/O\, including \c "log" will cause WiredTiger log files to use direct I/O\,
+ * and including \c "checkpoint" will cause WiredTiger data files opened at a
+ * checkpoint (i.e: read only) to use direct I/O. \c direct_io should be
+ * combined with \c write_through to get the equivalent of \c O_DIRECT on
+ * Windows., a list\, with values chosen from the following options: \c
+ * "checkpoint"\, \c "data"\, \c "log"; default empty.}
  * @config{encryption = (, configure an encryptor for system wide metadata and
  * logs.  If a system wide encryptor is set\, it is also used for encrypting
  * data files and tables\, unless encryption configuration is explicitly set for
@@ -2342,16 +2342,14 @@ struct __wt_connection {
  * "shared_cache"\, \c "split"\, \c "temporary"\, \c "transaction"\, \c
  * "verify"\, \c "version"\, \c "write"; default empty.}
  * @config{write_through, Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to
- * files.  Options are given as a list\, such as
- * <code>"write_through=[data]"</code>. Configuring \c write_through requires
+ * files.  Ignored on non-Windows systems.  Options are given as a list\, such
+ * as <code>"write_through=[data]"</code>. Configuring \c write_through requires
  * care\, see @ref tuning_system_buffer_cache_direct_io for important warnings.
- * Including \c "data" will cause WiredTiger data files to use \c
- * FILE_FLAG_WRITE_THROUGH\, including \c "log" will cause WiredTiger log files
- * to use \c FILE_FLAG_WRITE_THROUGH\, and including \c "checkpoint" will cause
- * WiredTiger data files opened at a checkpoint (i.e: read only) to use \c
- * FILE_FLAG_WRITE_THROUGH. It should be combined with direct_io to get the
- * equivalent of O_DIRECT on Windows., a list\, with values chosen from the
- * following options: \c "checkpoint"\, \c "data"\, \c "log"; default empty.}
+ * Including \c "data" will cause WiredTiger data files to write through cache\,
+ * including \c "log" will cause WiredTiger log files to write through cache It
+ * should be combined with direct_io to get the equivalent of POSIX \c O_DIRECT
+ * on Windows., a list\, with values chosen from the following options: \c
+ * "data"\, \c "log"; default empty.}
  * @configend
  * Additionally, if files named \c WiredTiger.config or \c WiredTiger.basecfg
  * appear in the WiredTiger home directory, they are read for configuration

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2346,10 +2346,10 @@ struct __wt_connection {
  * as <code>"write_through=[data]"</code>. Configuring \c write_through requires
  * care\, see @ref tuning_system_buffer_cache_direct_io for important warnings.
  * Including \c "data" will cause WiredTiger data files to write through cache\,
- * including \c "log" will cause WiredTiger log files to write through cache It
- * should be combined with direct_io to get the equivalent of POSIX \c O_DIRECT
- * on Windows., a list\, with values chosen from the following options: \c
- * "data"\, \c "log"; default empty.}
+ * including \c "log" will cause WiredTiger log files to write through cache.
+ * \c write_through should be combined with \c direct_io to get the equivalent
+ * of POSIX \c O_DIRECT on Windows., a list\, with values chosen from the
+ * following options: \c "data"\, \c "log"; default empty.}
  * @configend
  * Additionally, if files named \c WiredTiger.config or \c WiredTiger.basecfg
  * appear in the WiredTiger home directory, they are read for configuration

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2130,15 +2130,17 @@ struct __wt_connection {
  * true.}
  * @config{create, create the database if it does not exist., a boolean flag;
  * default \c false.}
- * @config{direct_io, Use \c O_DIRECT to access files.  Options are given as a
+ * @config{direct_io, Use \c O_DIRECT on Posix systems\, and
+ * FILE_FLAG_NO_BUFFERING on Windows to access files.  Options are given as a
  * list\, such as <code>"direct_io=[data]"</code>. Configuring \c direct_io
  * requires care\, see @ref tuning_system_buffer_cache_direct_io for important
  * warnings.  Including \c "data" will cause WiredTiger data files to use \c
  * O_DIRECT\, including \c "log" will cause WiredTiger log files to use \c
  * O_DIRECT\, and including \c "checkpoint" will cause WiredTiger data files
- * opened at a checkpoint (i.e: read only) to use \c O_DIRECT., a list\, with
- * values chosen from the following options: \c "checkpoint"\, \c "data"\, \c
- * "log"; default empty.}
+ * opened at a checkpoint (i.e: read only) to use \c O_DIRECT. It should be
+ * combined with write_through to get the equivalent of O_DIRECT on Windows., a
+ * list\, with values chosen from the following options: \c "checkpoint"\, \c
+ * "data"\, \c "log"; default empty.}
  * @config{encryption = (, configure an encryptor for system wide metadata and
  * logs.  If a system wide encryptor is set\, it is also used for encrypting
  * data files and tables\, unless encryption configuration is explicitly set for
@@ -2339,6 +2341,17 @@ struct __wt_connection {
  * "overflow"\, \c "read"\, \c "reconcile"\, \c "recovery"\, \c "salvage"\, \c
  * "shared_cache"\, \c "split"\, \c "temporary"\, \c "transaction"\, \c
  * "verify"\, \c "version"\, \c "write"; default empty.}
+ * @config{write_through, Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to
+ * files.  Options are given as a list\, such as
+ * <code>"write_through=[data]"</code>. Configuring \c write_through requires
+ * care\, see @ref tuning_system_buffer_cache_direct_io for important warnings.
+ * Including \c "data" will cause WiredTiger data files to use \c
+ * FILE_FLAG_WRITE_THROUGH\, including \c "log" will cause WiredTiger log files
+ * to use \c FILE_FLAG_WRITE_THROUGH\, and including \c "checkpoint" will cause
+ * WiredTiger data files opened at a checkpoint (i.e: read only) to use \c
+ * FILE_FLAG_WRITE_THROUGH. It should be combined with direct_io to get the
+ * equivalent of O_DIRECT on Windows., a list\, with values chosen from the
+ * following options: \c "checkpoint"\, \c "data"\, \c "log"; default empty.}
  * @configend
  * Additionally, if files named \c WiredTiger.config or \c WiredTiger.basecfg
  * appear in the WiredTiger home directory, they are read for configuration

--- a/src/os_win/os_open.c
+++ b/src/os_win/os_open.c
@@ -78,9 +78,18 @@ __wt_open(WT_SESSION_IMPL *session,
 	} else
 		dwCreationDisposition = OPEN_EXISTING;
 
+	/*
+	 * direct_io means no OS file caching. This requires aligned buffer
+	 * allocations like O_DIRECT.
+	 */
 	if (dio_type && FLD_ISSET(conn->direct_io, dio_type)) {
-		f |= FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH;
+		f |= FILE_FLAG_NO_BUFFERING;
 		direct_io = true;
+	}
+
+	/* FILE_FLAG_WRITE_THROUGH does not require aligned buffers */
+	if (dio_type && FLD_ISSET(conn->write_through, dio_type)) {
+		f |= FILE_FLAG_WRITE_THROUGH;
 	}
 
 	if (dio_type == WT_FILE_TYPE_LOG &&


### PR DESCRIPTION
This change splits out `direct_io` into two options on Windows. `direct_io` now controls OS buffering while `write_through` controls disk buffering. This allows consumers like MongoDB to have fine grain control over how they write to disk.

I updated the documentation to reflect the new options.

Lastly, I now define `HAVE_POSIX_MEMALIGN` since TCMalloc provides it.

**Note:** I have aligned the python and text to 80 columns. I was not sure if it was supposed to be 80 or some other limit.