### PR TITLE
WT-2182: detect internal page split races.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -389,9 +389,6 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	 */
 	pindex = WT_INTL_INDEX_GET_SAFE(root);
 
-	/* Acquire a new split generation. */
-	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
-
 	/*
 	 * A prepending/appending workload will repeatedly deepen parts of the
 	 * tree that aren't changing, and appending workloads are not uncommon.
@@ -626,6 +623,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	 * fails, we don't roll back that change, because threads may already
 	 * be using the new index.
 	 */
+	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 	size = sizeof(WT_PAGE_INDEX) + pindex->entries * sizeof(WT_REF *);
 	WT_TRET(__split_safe_free(session, split_gen, false, pindex, size));
 	root_decr += size;
@@ -686,9 +684,6 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	 */
 	pindex = WT_INTL_INDEX_GET_SAFE(parent);
 	parent_entries = pindex->entries;
-
-	/* Acquire a new split generation. */
-	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 
 	/*
 	 * Remove any refs to deleted pages while we are splitting, we have
@@ -814,10 +809,12 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	    parent_entries, result_entries, result_entries - parent_entries));
 
 	/*
-	 * The new page index is in place, free the WT_REF we were splitting
-	 * and any deleted WT_REFs we found, modulo the usual safe free
-	 * semantics.
+	 * The new page index is in place, free the WT_REF we were splitting and
+	 * any deleted WT_REFs we found, modulo the usual safe free semantics.
+	 *
+	 * Acquire a new split generation.
 	 */
+	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 	for (i = 0; deleted_entries > 0 && i < parent_entries; ++i) {
 		next_ref = pindex->index[i];
 		if (next_ref->state != WT_REF_SPLIT)
@@ -937,9 +934,6 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	 * generation.
 	 */
 	pindex = WT_INTL_INDEX_GET_SAFE(page);
-
-	/* Acquire a new split generation. */
-	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 
 	/* Figure out how many child pages we're creating. */
 	moved_entries = pindex->entries;
@@ -1148,6 +1142,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	 * back that change, because threads may already be using the new parent
 	 * page.
 	 */
+	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 	size = sizeof(WT_PAGE_INDEX) + pindex->entries * sizeof(WT_REF *);
 	WT_TRET(__split_safe_free(session, split_gen, false, pindex, size));
 	page_decr += size;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1995,14 +1995,7 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
 	bool hazard;
 
 	WT_RET(__split_internal_lock(session, ref, &parent, &hazard));
-
-	/* If we give up on a reverse split, unlock the child. */
-	if ((ret =
-	    __split_parent(session, ref, NULL, 0, 0, false, true)) != 0) {
-		WT_ASSERT(session, ref->state == WT_REF_LOCKED);
-		ref->state = WT_REF_DELETED;
-	}
-
+	ret = __split_parent(session, ref, NULL, 0, 0, false, true);
 	WT_TRET(__split_internal_unlock(session, parent, hazard));
 	return (ret);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -791,6 +791,12 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	}
 
 	/*
+	 * Push out the changes: not required for correctness, but don't let
+	 * threads spin on incorrect page references longer than necessary.
+	 */
+	WT_FULL_BARRIER();
+
+	/*
 	 * A note on error handling: failures before we swapped the new page
 	 * index into the parent can be resolved by freeing allocated memory
 	 * because the original page is unchanged, we can continue to use it

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -22,7 +22,7 @@ __wt_col_search(WT_SESSION_IMPL *session,
 	WT_INSERT *ins;
 	WT_INSERT_HEAD *ins_head;
 	WT_PAGE *page;
-	WT_PAGE_INDEX *pindex;
+	WT_PAGE_INDEX *pindex, *parent_pindex;
 	WT_REF *current, *descent;
 	uint32_t base, indx, limit;
 	int depth;
@@ -37,10 +37,12 @@ __wt_col_search(WT_SESSION_IMPL *session,
 		goto leaf_only;
 	}
 
+restart_root:
 	/* Search the internal pages of the tree. */
 	current = &btree->root;
-	for (depth = 2;; ++depth) {
-restart:	page = current->page;
+	for (depth = 2, pindex = NULL;; ++depth) {
+		parent_pindex = pindex;
+restart_page:	page = current->page;
 		if (page->type != WT_PAGE_COL_INT)
 			break;
 
@@ -51,8 +53,19 @@ restart:	page = current->page;
 		descent = pindex->index[base - 1];
 
 		/* Fast path appends. */
-		if (recno >= descent->key.recno)
+		if (recno >= descent->key.recno) {
+			/*
+			 * If on the last slot (the key is larger than any key
+			 * on the page), check for an internal page split race.
+			 */
+			if (parent_pindex != NULL &&
+			    __wt_split_intl_race(
+			    session, current->home, parent_pindex)) {
+				WT_RET(__wt_page_release(session, current, 0));
+				goto restart_root;
+			}
 			goto descend;
+		}
 
 		/* Binary search of internal pages. */
 		for (base = 0,
@@ -95,7 +108,7 @@ descend:	/*
 			current = descent;
 			break;
 		case WT_RESTART:
-			goto restart;
+			goto restart_page;
 		default:
 			return (ret);
 		}

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -312,9 +312,10 @@ restart_page:	page = current->page;
 append:			if (parent_pindex != NULL &&
 			    __wt_split_intl_race(
 			    session, current->home, parent_pindex)) {
-				ret = __wt_page_release(session, current, 0);
-				current = NULL;
-				WT_ERR(ret);
+				if ((ret = __wt_page_release(
+				    session, current, 0)) != 0)
+					return (ret);
+
 				goto restart_root;
 			}
 		}
@@ -505,7 +506,7 @@ leaf_match:	cbt->compare = 0;
 
 	return (0);
 
-err:	if (current != NULL && leaf == NULL)
+err:	if (leaf != NULL)
 		WT_TRET(__wt_page_release(session, current, 0));
 	return (ret);
 }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -179,9 +179,14 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		 * something is busy, be sure that the page still ends up
 		 * marked deleted.
 		 */
-		if (ndeleted > pindex->entries / 10 && pindex->entries > 1 &&
-		    (ret = __wt_split_reverse(session, ref)) != EBUSY)
-			return (ret);
+		if (ndeleted > pindex->entries / 10 && pindex->entries > 1) {
+			if ((ret = __wt_split_reverse(session, ref)) == 0)
+				return (ret);
+			WT_RET_BUSY_OK(ret);
+
+			/* If a reverse split fails, unlock the child. */
+			WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+		}
 	}
 
 	WT_PUBLISH(ref->state, WT_REF_DELETED);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1389,13 +1389,18 @@ __wt_split_intl_race(
 	 * A place to hang this comment...
 	 *
 	 * There's a page-split race when we walk the tree: if we're splitting
-	 * an internal page into its parent we update the parent's page index
+	 * an internal page into its parent, we update the parent's page index
 	 * and then update the page being split, and it's not an atomic update.
 	 * A thread could read the parent page's original page index, and then
 	 * read the page's replacement index. Because internal page splits work
 	 * by replacing the original page with the initial part of the original
-	 * page, the result of the race is we will have a key that's past the
+	 * page, the result of this race is we will have a key that's past the
 	 * end of the current page, and the parent's page index will have moved.
+	 *
+	 * It's also possible a thread could read the parent page's replacement
+	 * page index, and then read the page's original index. Because internal
+	 * splits work by truncating the original page, the original page's old
+	 * content is compatible, this isn't a problem and we ignore this race.
 	 */
 	WT_INTL_INDEX_GET(session, parent, pindex);
 	return (pindex != saved_pindex);


### PR DESCRIPTION
@agorrod, this makes the race I was seeing (append-only workload, column-store), much less likely to hit, but it still occasionally hits.