### PR TITLE
WT-2217: change WT_CURSOR.insert to clear "set" key/value on return

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -246,17 +246,17 @@ __curfile_insert(WT_CURSOR *cursor)
 
 	/*
 	 * Insert is the one cursor operation that doesn't end with the cursor
-	 * pointing to an on-page item. The standard macro handles errors
-	 * correctly, but we need to leave the application cursor unchanged in
-	 * the case of success, except for column-store appends, where we are
-	 * returning a key.
+	 * pointing to an on-page item (except for column-store appends, where
+	 * we are returning a key). That is, the application's cursor continues
+	 * to reference the application's memory after a successful cursor call,
+	 * which isn't true anywhere else. We don't want to have to explain that
+	 * scoping corner case, so we reset the application's cursor so it can
+	 * free the referenced memory and continue on without risking subsequent
+	 * core dumps.
 	 */
 	if (ret == 0) {
-		if (!F_ISSET(cursor, WT_CURSTD_APPEND)) {
-			F_SET(cursor, WT_CURSTD_KEY_EXT);
+		if (!F_ISSET(cursor, WT_CURSTD_APPEND))
 			F_CLR(cursor, WT_CURSTD_KEY_INT);
-		}
-		F_SET(cursor, WT_CURSTD_VALUE_EXT);
 		F_CLR(cursor, WT_CURSTD_VALUE_INT);
 	}
 

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -530,7 +530,7 @@ __curtable_insert(WT_CURSOR *cursor)
 		 * for overwrite cursors, but for now we just reset the flags.
 		 */
 		F_SET(primary, WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
-		ret = __curtable_update(cursor);
+		WT_ERR(__curtable_update(cursor));
 
 		/*
 		 * WT_CURSOR.insert doesn't leave the cursor positioned, and the
@@ -539,16 +539,16 @@ __curtable_insert(WT_CURSOR *cursor)
 		 * file object cursor insert semantics).
 		 */
 		F_CLR(primary, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-		goto err;
-	}
-	WT_ERR(ret);
+	} else {
+		WT_ERR(ret);
 
-	for (i = 1; i < WT_COLGROUPS(ctable->table); i++, cp++) {
-		(*cp)->recno = primary->recno;
-		WT_ERR((*cp)->insert(*cp));
-	}
+		for (i = 1; i < WT_COLGROUPS(ctable->table); i++, cp++) {
+			(*cp)->recno = primary->recno;
+			WT_ERR((*cp)->insert(*cp));
+		}
 
-	WT_ERR(__apply_idx(ctable, offsetof(WT_CURSOR, insert), false));
+		WT_ERR(__apply_idx(ctable, offsetof(WT_CURSOR, insert), false));
+	}
 
 err:	CURSOR_UPDATE_API_END(session, ret);
 	return (ret);

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -520,26 +520,18 @@ __curtable_insert(WT_CURSOR *cursor)
 	if (ctable->table->nindices > 0)
 		F_CLR(primary, WT_CURSTD_OVERWRITE);
 	ret = primary->insert(primary);
-	F_SET(primary, flag_orig);
 
-	if (ret == WT_DUPLICATE_KEY && F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
-		/*
-		 * !!!
-		 * WT_CURSOR.insert clears the set internally/externally flags
-		 * but doesn't touch the items. We could make a copy each time
-		 * for overwrite cursors, but for now we just reset the flags.
-		 */
-		F_SET(primary, WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
+	/*
+	 * !!!
+	 * WT_CURSOR.insert clears the set internally/externally flags
+	 * but doesn't touch the items. We could make a copy each time
+	 * for overwrite cursors, but for now we just reset the flags.
+	 */
+	F_SET(primary, flag_orig | WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
+
+	if (ret == WT_DUPLICATE_KEY && F_ISSET(cursor, WT_CURSTD_OVERWRITE))
 		WT_ERR(__curtable_update(cursor));
-
-		/*
-		 * WT_CURSOR.insert doesn't leave the cursor positioned, and the
-		 * application may want to free the memory used to configure the
-		 * insert; don't read that memory again (matching the underlying
-		 * file object cursor insert semantics).
-		 */
-		F_CLR(primary, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-	} else {
+	else {
 		WT_ERR(ret);
 
 		for (i = 1; i < WT_COLGROUPS(ctable->table); i++, cp++) {
@@ -550,7 +542,16 @@ __curtable_insert(WT_CURSOR *cursor)
 		WT_ERR(__apply_idx(ctable, offsetof(WT_CURSOR, insert), false));
 	}
 
+	/*
+	 * WT_CURSOR.insert doesn't leave the cursor positioned, and the
+	 * application may want to free the memory used to configure the
+	 * insert; don't read that memory again (matching the underlying
+	 * file object cursor insert semantics).
+	 */
+	F_CLR(primary, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+
 err:	CURSOR_UPDATE_API_END(session, ret);
+
 	return (ret);
 }
 

--- a/src/docs/cursor-ops.dox
+++ b/src/docs/cursor-ops.dox
@@ -123,28 +123,27 @@ When applications pass a pointer (either to a WT_ITEM or a string), to
 WT_CURSOR::set_key or WT_CURSOR::set_value, WiredTiger does not copy the
 memory referenced by the pointer. For this reason, the application must
 keep the referenced memory unchanged and valid until the next operation
-that successfully positions the cursor, or the cursor is reset or closed
-(discarding its resources).  The operations that position the cursor are
-WT_CURSOR::remove, WT_CURSOR::search, WT_CURSOR::search_near and
-WT_CURSOR::update, but <b>do not include</b> WT_CURSOR::insert. This
-means an application calling WT_CURSOR::insert, then subsequently
-calling another cursor operation without re-setting the key/value
-between the two calls, must keep the memory valid across both cursor
-calls.
+that successfully positions the cursor, modifies the underlying data,
+or the cursor is reset or closed (discarding its resources).  The
+operations that position the cursor are WT_CURSOR::next, WT_CURSOR::prev,
+WT_CURSOR::search and WT_CURSOR::search_near; the operations that modify
+the underlying data are WT_CURSOR::insert, WT_CURSOR::update and
+WT_CURSOR::remove.
 
 If a cursor operation fails (for example, due to a ::WT_ROLLBACK error),
 it may be retried without calling WT_CURSOR::set_key or
 WT_CURSOR::set_value again.  That is, the cursor may still reference the
-application-supplied memory until it is successfully positioned, closed
-or reset.
+application-supplied memory until the cursor is successfully positioned,
+underlying data is modified, or the cursor is closed or reset.
 
 @m_if{c}
 Any pointers returned by WT_CURSOR::get_key or WT_CURSOR::get_value are
-only valid until the cursor is re-positioned, closed or reset. These
-pointers may reference private WiredTiger data structures that may not
-be modified or freed by the application.  If a longer scope is required,
-the application must make a copy of the memory before the cursor is
-positioned, closed or reset.
+only valid until a subsequent cursor call that successfully positions
+the cursor, modifies the underlying data, or the cursor is reset or
+closed. These pointers may reference private WiredTiger data structures
+that may not be modified or freed by the application.  If a longer scope
+is required, the application must make a copy of the memory before the
+cursor is re-used, closed or reset.
 
 The comments in this example code explain when the application can safely
 modify memory passed to WT_CURSOR::set_key or WT_CURSOR::set_value:

--- a/src/docs/cursor-ops.dox
+++ b/src/docs/cursor-ops.dox
@@ -119,24 +119,32 @@ for the backup, config and statistics cursor types.
 
 @section cursor_memory_scoping Cursor key/value memory scoping
 
-When applications pass pointers to WT_CURSOR::set_key or WT_CURSOR::set_value,
-which can be a WT_ITEM or a string, the application is required to keep
-the memory valid until the next operation that successfully positions
-the cursor.  These operations are WT_CURSOR::remove, WT_CURSOR::search,
-WT_CURSOR::search_near and WT_CURSOR::update, but <b>do not include</b>
-WT_CURSOR::insert, as it does not position the cursor.
+When applications pass a pointer (either to a WT_ITEM or a string), to
+WT_CURSOR::set_key or WT_CURSOR::set_value, WiredTiger does not copy the
+memory referenced by the pointer. For this reason, the application must
+keep the referenced memory unchanged and valid until the next operation
+that successfully positions the cursor, or the cursor is reset or closed
+(discarding its resources).  The operations that position the cursor are
+WT_CURSOR::remove, WT_CURSOR::search, WT_CURSOR::search_near and
+WT_CURSOR::update, but <b>do not include</b> WT_CURSOR::insert. This
+means an application calling WT_CURSOR::insert, then subsequently
+calling another cursor operation without re-setting the key/value
+between the two calls, must keep the memory valid across both cursor
+calls.
 
-If such an operation fails (for example, due to a ::WT_ROLLBACK error),
+If a cursor operation fails (for example, due to a ::WT_ROLLBACK error),
 it may be retried without calling WT_CURSOR::set_key or
 WT_CURSOR::set_value again.  That is, the cursor may still reference the
-application-supplied memory until it is successfully positioned.
+application-supplied memory until it is successfully positioned, closed
+or reset.
 
 @m_if{c}
-Any pointers returned by WT_CURSOR::get_key or WT_CURSOR::get_value are only
-valid until the cursor is positioned.  These pointers may reference private
-WiredTiger data structures that must not be modified or freed by the
-application.  If a longer scope is required, the application must make a copy
-of the memory before the cursor is positioned.
+Any pointers returned by WT_CURSOR::get_key or WT_CURSOR::get_value are
+only valid until the cursor is re-positioned, closed or reset. These
+pointers may reference private WiredTiger data structures that may not
+be modified or freed by the application.  If a longer scope is required,
+the application must make a copy of the memory before the cursor is
+positioned, closed or reset.
 
 The comments in this example code explain when the application can safely
 modify memory passed to WT_CURSOR::set_key or WT_CURSOR::set_value:

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -11,7 +11,21 @@ was relying on this behavior, a connection will be opened with different
 settings after upgrading, which could lead to errors or unexpected behavior.
 </dd>
 
-<dl>
+<dt>Change to WT_CURSOR::insert</dt>
+<dd>
+The WT_CURSOR::insert method in this release has slightly different semantics
+with respect to referencing application memory. In previous releases,
+WT_CURSOR::insert continued to reference application-memory specified to
+either WT_CURSOR::set_key or WT_CURSOR::set_value after a successful return,
+which could potentially lead to a core dump if the application freed that
+memory before a subsequent call to a WT_CURSOR:: method without an intermediate
+WT_CURSOR::set_key or WT_CURSOR::set_value call. In the 2.6.2 release,
+WT_CURSOR::insert behaves like the other cursor methods and does not reference
+application memory after a successful return. Applications depending on the
+previous semantic will require modifications to set the cursor's key and/or
+value after a successful WT_CURSOR::insert call.
+</dd>
+
 <dt>WT_SESSION.verify</dt>
 <dd>
 The WT_SESSION.verify method in this release has a new configuration

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1381,6 +1381,14 @@ __clsm_insert(WT_CURSOR *cursor)
 	WT_ERR(__clsm_deleted_encode(session, &cursor->value, &value, &buf));
 	ret = __clsm_put(session, clsm, &cursor->key, &value, false);
 
+	/*
+	 * WT_CURSOR.insert doesn't leave the cursor positioned, and the
+	 * application may want to free the memory used to configure the
+	 * insert; don't read that memory again (matching the underlying
+	 * file object cursor insert semantics).
+	 */
+	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+
 err:	__wt_scr_free(session, &buf);
 	__clsm_leave(clsm);
 	CURSOR_UPDATE_API_END(session, ret);

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1379,7 +1379,7 @@ __clsm_insert(WT_CURSOR *cursor)
 	}
 
 	WT_ERR(__clsm_deleted_encode(session, &cursor->value, &value, &buf));
-	ret = __clsm_put(session, clsm, &cursor->key, &value, false);
+	WT_ERR(__clsm_put(session, clsm, &cursor->key, &value, false));
 
 	/*
 	 * WT_CURSOR.insert doesn't leave the cursor positioned, and the

--- a/test/huge/huge.c
+++ b/test/huge/huge.c
@@ -139,8 +139,8 @@ run(CONFIG *cp, int bigkey, size_t bytes)
 		cursor->set_key(cursor, "key001");
 	cursor->set_value(cursor, big);
 
-	/* Insert the record. */
-	if ((ret = cursor->insert(cursor)) != 0)
+	/* Insert the record (use update, insert discards the key). */
+	if ((ret = cursor->update(cursor)) != 0)
 		testutil_die(ret, "WT_CURSOR.insert");
 
 	/* Retrieve the record and check it. */

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -178,10 +178,10 @@ def simple_populate_check(self, uri, rows):
 
 # Return the value stored in a complex object.
 def complex_value_populate(cursor, i):
-    return (str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%26],
+    return [str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%26],
         i,
         str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%23],
-        str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%18])
+        str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%18]]
 
 # Return the number of column groups used
 def complex_populate_colgroup_count():
@@ -223,7 +223,8 @@ def complex_populate_type(self, uri, config, rows, type):
         indxname + ':indx4', 'columns=(column2,column4)' + ',' + type)
     cursor = self.session.open_cursor(uri, None)
     for i in range(1, rows + 1):
-        cursor[key_populate(cursor, i)] = complex_value_populate(cursor, i)
+        cursor[key_populate(cursor, i)] = \
+                tuple(complex_value_populate(cursor, i))
     cursor.close()
     # add some indices after populating
     self.session.create(

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -178,10 +178,10 @@ def simple_populate_check(self, uri, rows):
 
 # Return the value stored in a complex object.
 def complex_value_populate(cursor, i):
-    return [str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%26],
+    return (str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%26],
         i,
         str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%23],
-        str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%18]]
+        str(i) + ': abcdefghijklmnopqrstuvwxyz'[0:i%18])
 
 # Return the number of column groups used
 def complex_populate_colgroup_count():
@@ -223,8 +223,7 @@ def complex_populate_type(self, uri, config, rows, type):
         indxname + ':indx4', 'columns=(column2,column4)' + ',' + type)
     cursor = self.session.open_cursor(uri, None)
     for i in range(1, rows + 1):
-        v = complex_value_populate(cursor, i)
-        cursor[key_populate(cursor, i)] = (v[0], v[1], v[2], v[3])
+        cursor[key_populate(cursor, i)] = complex_value_populate(cursor, i)
     cursor.close()
     # add some indices after populating
     self.session.create(

--- a/test/suite/test_autoclose.py
+++ b/test/suite/test_autoclose.py
@@ -107,7 +107,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         self.table_name = 'test_autoclose_c4.wt'
         self.create_table()
         inscursor = self.cursor_ss(self.table_name, 'key1', 'value1')
-        inscursor.insert()
+        inscursor.update()
         inscursor2 = self.session.open_cursor(None, inscursor, None)
         self.session.truncate(None, inscursor, inscursor2, '')
         inscursor.close()
@@ -122,7 +122,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         self.create_table()
 
         inscursor = self.cursor_ss(self.table_name, 'key1', 'value1')
-        inscursor.insert()
+        inscursor.update()
         inscursor2 = self.session.open_cursor(None, inscursor, None)
         inscursor.compare(inscursor2)
 

--- a/test/suite/test_bug009.py
+++ b/test/suite/test_bug009.py
@@ -33,9 +33,6 @@
 
 import wiredtiger, wttest
 from wiredtiger import stat
-from helper import confirm_empty,\
-    key_populate, value_populate, simple_populate,\
-    complex_populate, complex_value_populate
 from wtscenario import multiply_scenarios, number_scenarios
 
 class test_bug009(wttest.WiredTigerTestCase):

--- a/test/suite/test_cursor06.py
+++ b/test/suite/test_cursor06.py
@@ -60,7 +60,7 @@ class test_cursor06(wttest.WiredTigerTestCase):
     def set_kv(self, cursor):
         cursor.set_key(key_populate(cursor, 10))
         if self.complex:
-            cursor.set_value(complex_value_populate(cursor, 10))
+            cursor.set_value(tuple(complex_value_populate(cursor, 10)))
         else:
             cursor.set_value(value_populate(cursor, 10))
 

--- a/test/suite/test_cursor09.py
+++ b/test/suite/test_cursor09.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2015 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper import key_populate, value_populate, simple_populate
+from helper import complex_populate, complex_value_populate
+from wtscenario import check_scenarios
+
+# test_cursor09.py
+#    JIRA WT-2217: insert resets key/value "set".
+class test_cursor09(wttest.WiredTigerTestCase):
+
+    scenarios = check_scenarios([
+        ('file-r', dict(type='file:',keyfmt='r',complex=0)),
+        ('file-S', dict(type='file:',keyfmt='S',complex=0)),
+        ('lsm-S', dict(type='lsm:',keyfmt='S',complex=0)),
+        ('table-r', dict(type='table:',keyfmt='r',complex=0)),
+        ('table-S', dict(type='table:',keyfmt='S',complex=0)),
+        ('table-r-complex', dict(type='table:',keyfmt='r',complex=1)),
+        ('table-S-complex', dict(type='table:',keyfmt='S',complex=1)),
+    ])
+
+    def pop(self, uri):
+        if self.complex == 1:
+            complex_populate(self, uri, 'key_format=' + self.keyfmt, 100)
+        else:
+            simple_populate(self, uri, 'key_format=' + self.keyfmt, 100)
+
+    def set_kv(self, cursor):
+        cursor.set_key(key_populate(cursor, 10))
+        if self.complex == 1:
+            v = complex_value_populate(cursor, 10)
+            cursor.set_value(v[0], v[1], v[2], v[3])
+        else:
+            cursor.set_value(value_populate(cursor, 10))
+
+    # WT_CURSOR.insert doesn't leave the cursor positioned, verify any
+    # subsequent cursor operation fails with a "key not set" message.
+    def test_cursor09(self):
+        uri = self.type + 'cursor09'
+        self.pop(uri)
+        cursor = self.session.open_cursor(uri, None, None)
+        self.set_kv(cursor)
+        cursor.insert()
+        msg = '/requires key be set/'
+        self.assertRaisesWithMessage(
+            wiredtiger.WiredTigerError, cursor.search, msg)
+
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_cursor09.py
+++ b/test/suite/test_cursor09.py
@@ -62,7 +62,7 @@ class test_cursor09(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(uri, None, None)
         cursor[key_populate(cursor, 10)] = \
-            complex_value_populate(cursor, 10) if self.complex \
+            tuple(complex_value_populate(cursor, 10)) if self.complex \
             else value_populate(cursor, 10)
         msg = '/requires key be set/'
         self.assertRaisesWithMessage(

--- a/test/suite/test_stat03.py
+++ b/test/suite/test_stat03.py
@@ -83,8 +83,7 @@ class test_stat_cursor_reset(wttest.WiredTigerTestCase):
         if self.pop == simple_populate:
             c.set_value(value_populate(c, 200))
         else:
-            v = complex_value_populate(c, 200)
-            c.set_value(v[0], v[1], v[2], v[3])
+            c.set_value(tuple(complex_value_populate(c, 200)))
         c.insert()
 
         # Test that cursor reset re-loads the values.

--- a/test/suite/test_stat05.py
+++ b/test/suite/test_stat05.py
@@ -81,7 +81,7 @@ class test_stat_cursor_config(wttest.WiredTigerTestCase):
                 cursor[key_populate(cursor, i)] = value_populate(cursor, i)
             else:
                 cursor[key_populate(cursor, i)] = \
-                        complex_value_populate(cursor, i)
+                        tuple(complex_value_populate(cursor, i))
         cursor.close()
         self.openAndWalkStatCursor()
 

--- a/test/suite/test_stat05.py
+++ b/test/suite/test_stat05.py
@@ -80,8 +80,8 @@ class test_stat_cursor_config(wttest.WiredTigerTestCase):
             if self.pop == simple_populate:
                 cursor[key_populate(cursor, i)] = value_populate(cursor, i)
             else:
-                v = complex_value_populate(cursor, i)
-                cursor[key_populate(cursor, i)] = (v[0], v[1], v[2], v[3])
+                cursor[key_populate(cursor, i)] = \
+                        complex_value_populate(cursor, i)
         cursor.close()
         self.openAndWalkStatCursor()
 


### PR DESCRIPTION
Wording changes to clarify when applications can discard memory passed to set-key/set-value.

@michaelcahill, some minor cursor wording changes to clarify when application-memory is used.

One suggestion that came out of the discussion was we could change `WT_CURSOR.insert` to unset the key/value, so not only would the cursor not be positioned after insert returned, it would also not have a set key/value.

I think it's unlikely for an insert cursor to be intentionally re-used without also doing a fresh set-key/set-value call, so I don't think the change would impact real applications and clearing the key/value would mean we'd get a clean error message instead of dropping core.

If you like that idea, let me know and I'll open a ticket and get it done.