### PR TITLE
WT-2202: release of the "current" page is wrong.

### DIFF
--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -487,7 +487,13 @@ leaf_match:	cbt->compare = 0;
 
 	return (0);
 
-err:	if (leaf == NULL)
+err:	/*
+	 * Release the current page if the search started at the root. If the
+	 * search didn't start at the root we should never have gone looking
+	 * beyond the start page.
+	 */
+	WT_ASSERT(session, leaf == NULL || leaf == current);
+	if (leaf == NULL)
 		WT_TRET(__wt_page_release(session, current, 0));
 	return (ret);
 }

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -487,7 +487,7 @@ leaf_match:	cbt->compare = 0;
 
 	return (0);
 
-err:	if (leaf != NULL)
+err:	if (current != leaf)
 		WT_TRET(__wt_page_release(session, current, 0));
 	return (ret);
 }

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -487,7 +487,7 @@ leaf_match:	cbt->compare = 0;
 
 	return (0);
 
-err:	if (current != leaf)
+err:	if (leaf == NULL)
 		WT_TRET(__wt_page_release(session, current, 0));
 	return (ret);
 }


### PR DESCRIPTION
We're releasing the "current" page if (leaf != NULL), and that's wrong, we should only release the current page if no leaf-page WT_REF was specified.  The test could be (leaf == NULL), but I think (leaf != current) is a little more obvious.

@agorrod, @michaelcahill, would one of you please do a review? Thanks!