### PR TITLE
WT-2182: fixes for splitting up the tree.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -311,7 +311,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 		/*
 		 * Row-store keys: if it's not yet instantiated, instantiate it.
 		 * If already instantiated, check for overflow cleanup (overflow
-		 * keys are always instantiated.
+		 * keys are always instantiated).
 		 */
 		if ((ikey = __wt_ref_key_instantiated(ref)) == NULL) {
 			__wt_ref_key(from_home, ref, &key, &size);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1044,8 +1044,8 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	 * We're not acquiring hazard pointers on these pages, they cannot be
 	 * evicted because of the eviction transaction value set above.
 	 */
-	for (alloc_refp = alloc_index->index,
-	    i = 0; i < alloc_index->entries; ++alloc_refp, ++i) {
+	for (alloc_refp = alloc_index->index + 1,
+	    i = 1; i < alloc_index->entries; ++alloc_refp, ++i) {
 		ref = *alloc_refp;
 		WT_ASSERT(session, ref->home == parent);
 		if (ref->state != WT_REF_MEM)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -353,11 +353,11 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 }
 
 /*
- * __split_child_txn_set --
+ * __split_child_no_evict --
  *	Ensure the newly created child isn't evicted for now.
  */
 static void
-__split_child_txn_set(WT_PAGE *child)
+__split_child_no_evict(WT_PAGE *child)
 {
 	/*
 	 * Once the split is live, newly created internal pages might be evicted
@@ -561,7 +561,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 		__wt_page_modify_set(session, child);
 
 		/* Ensure the newly created page isn't evicted for now. */
-		__split_child_txn_set(child);
+		__split_child_no_evict(child);
 
 		/*
 		 * The newly allocated child's page index references the same
@@ -1024,7 +1024,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 		__wt_page_modify_set(session, child);
 
 		/* Ensure the newly created page isn't evicted for now. */
-		__split_child_txn_set(child);
+		__split_child_no_evict(child);
 
 		/*
 		 * The newly allocated child's page index references the same

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -567,7 +567,8 @@ struct __wt_page {
 #define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
 #define	WT_PAGE_OVERFLOW_KEYS	0x10	/* Page has overflow keys */
 #define	WT_PAGE_SPLIT_INSERT	0x20	/* A leaf page was split for append */
-#define	WT_PAGE_UPDATE_IGNORE	0x40	/* Ignore updates on page discard */
+#define	WT_PAGE_SPLIT_BLOCK	0x40	/* Split blocking eviction and splits */
+#define	WT_PAGE_UPDATE_IGNORE	0x80	/* Ignore updates on page discard */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 
 	uint8_t unused[2];		/* Unused padding */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1110,7 +1110,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session,
 	 * transaction value is globally visible.
 	 */
 	if (check_splits && WT_PAGE_IS_INTERNAL(page) &&
-	    !__wt_txn_visible_all(session, mod->mod_split_txn))
+	    (F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_BLOCK) ||
+	    !__wt_txn_visible_all(session, mod->mod_split_txn)))
 		return (false);
 
 	/*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1101,13 +1101,13 @@ __wt_page_can_evict(WT_SESSION_IMPL *session,
 		return (false);
 
 	/*
-	 * If the tree was deepened, there's a requirement that newly created
-	 * internal pages not be evicted until all threads are known to have
-	 * exited the original page index array, because evicting an internal
-	 * page discards its WT_REF array, and a thread traversing the original
-	 * page index array might see a freed WT_REF.  During the split we set
-	 * a transaction value, once that's globally visible, we know we can
-	 * evict the created page.
+	 * If a split created new internal pages, those newly created internal
+	 * pages cannot be evicted until all threads are known to have exited
+	 * the original parent page's index, because evicting an internal page
+	 * discards its WT_REF array, and a thread traversing the original
+	 * parent page index might see a freed WT_REF. During the split we set
+	 * a transaction value, we can evict the created page as soon as that
+	 * transaction value is globally visible.
 	 */
 	if (check_splits && WT_PAGE_IS_INTERNAL(page) &&
 	    !__wt_txn_visible_all(session, mod->mod_split_txn))


### PR DESCRIPTION
@michaelcahill, this branch is for your review.

I stared at the code that fixes up the moved WT_REF structures today, and found what I think are 3 problems:

* setting WT_PAGE_MODIFY.mod_split_txn as the page is created, see 7dded31,
* only fixing up moved WT_REF's that are in the WT_REF_MEM state when we look at them, see 9464fe3,
* allowing newly created internal pages to split before we fix up the WT_REFs we moved there, see 9464fe3.

I might be wrong on any or all of these, of course, but I hoped coding up an approach to fixing them would help me fully understand the problems and give you something concrete to look at. I put big honkin' comments all over the place.
