### PR TITLE
WT-2215 Use 32-bit LSN file and offsets.  Set LSNs as a 64-bit value.

### DIFF
--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -389,16 +389,15 @@ simple_walk_log(WT_SESSION *session)
 {
 	WT_CURSOR *cursor;
 	WT_ITEM logrec_key, logrec_value;
-	WT_LSN lsn;
 	uint64_t txnid;
-	uint32_t fileid, opcount, optype, rectype;
+	uint32_t fileid, log_file, log_offset, opcount, optype, rectype;
 	int found, ret;
 
 	ret = session->open_cursor(session, "log:", NULL, NULL, &cursor);
 
 	found = 0;
 	while ((ret = cursor->next(cursor)) == 0) {
-		ret = cursor->get_key(cursor, &lsn.file, &lsn.offset, &opcount);
+		ret = cursor->get_key(cursor, &log_file, &log_offset, &opcount);
 		ret = cursor->get_value(cursor, &txnid,
 		    &rectype, &optype, &fileid, &logrec_key, &logrec_value);
 

--- a/examples/c/ex_log.c
+++ b/examples/c/ex_log.c
@@ -108,15 +108,15 @@ compare_tables(WT_SESSION *session, WT_SESSION *sess_copy)
 
 /*! [log cursor walk] */
 static void
-print_record(WT_LSN *lsn, uint32_t opcount,
+print_record(uint32_t log_file, uint32_t log_offset, uint32_t opcount,
    uint32_t rectype, uint32_t optype, uint64_t txnid, uint32_t fileid,
    WT_ITEM *key, WT_ITEM *value)
 {
 	printf(
-	    "LSN [%" PRIu32 "][%" PRIu64 "].%" PRIu32
+	    "LSN [%" PRIu32 "][%" PRIu32 "].%" PRIu32
 	    ": record type %" PRIu32 " optype %" PRIu32
 	    " txnid %" PRIu64 " fileid %" PRIu32,
-	    lsn->file, (uint64_t)lsn->offset, opcount,
+	    log_file, log_offset, opcount,
 	    rectype, optype, txnid, fileid);
 	printf(" key size %zu value size %zu\n", key->size, value->size);
 	if (rectype == WT_LOGREC_MESSAGE)
@@ -131,10 +131,9 @@ static int
 simple_walk_log(WT_SESSION *session, int count_min)
 {
 	WT_CURSOR *cursor;
-	WT_LSN lsn;
 	WT_ITEM logrec_key, logrec_value;
 	uint64_t txnid;
-	uint32_t fileid, opcount, optype, rectype;
+	uint32_t fileid, log_file, log_offset, opcount, optype, rectype;
 	int count, ret;
 
 	/*! [log cursor open] */
@@ -145,14 +144,14 @@ simple_walk_log(WT_SESSION *session, int count_min)
 	while ((ret = cursor->next(cursor)) == 0) {
 		count++;
 		/*! [log cursor get_key] */
-		ret = cursor->get_key(cursor, &lsn.file, &lsn.offset, &opcount);
+		ret = cursor->get_key(cursor, &log_file, &log_offset, &opcount);
 		/*! [log cursor get_key] */
 		/*! [log cursor get_value] */
 		ret = cursor->get_value(cursor, &txnid,
 		    &rectype, &optype, &fileid, &logrec_key, &logrec_value);
 		/*! [log cursor get_value] */
 
-		print_record(&lsn, opcount,
+		print_record(log_file, log_offset, opcount,
 		    rectype, optype, txnid, fileid, &logrec_key, &logrec_value);
 	}
 	if (ret == WT_NOTFOUND)
@@ -173,11 +172,11 @@ walk_log(WT_SESSION *session)
 {
 	WT_CONNECTION *wt_conn2;
 	WT_CURSOR *cursor, *cursor2;
-	WT_LSN lsn, lsnsave;
 	WT_ITEM logrec_key, logrec_value;
 	WT_SESSION *session2;
 	uint64_t txnid;
 	uint32_t fileid, opcount, optype, rectype;
+	uint32_t log_file, log_offset, save_file, save_offset;
 	int first, i, in_txn, ret;
 
 	ret = setup_copy(&wt_conn2, &session2);
@@ -186,21 +185,25 @@ walk_log(WT_SESSION *session)
 	i = 0;
 	in_txn = 0;
 	txnid = 0;
-	memset(&lsnsave, 0, sizeof(lsnsave));
+	save_file = 0;
+	save_offset = 0;
 	while ((ret = cursor->next(cursor)) == 0) {
-		ret = cursor->get_key(cursor, &lsn.file, &lsn.offset, &opcount);
+		ret = cursor->get_key(cursor,
+		    &log_file, &log_offset, &opcount);
 		/*
 		 * Save one of the LSNs we get back to search for it
 		 * later.  Pick a later one because we want to walk from
 		 * that LSN to the end (where the multi-step transaction
 		 * was performed).  Just choose the record that is MAX_KEYS.
 		 */
-		if (++i == MAX_KEYS)
-			lsnsave = lsn;
+		if (++i == MAX_KEYS) {
+			save_file = log_file;
+			save_offset = log_offset;
+		}
 		ret = cursor->get_value(cursor, &txnid, &rectype,
 		    &optype, &fileid, &logrec_key, &logrec_value);
 
-		print_record(&lsn, opcount,
+		print_record(log_file, log_offset, opcount,
 		    rectype, optype, txnid, fileid, &logrec_key, &logrec_value);
 
 		/*
@@ -245,7 +248,7 @@ walk_log(WT_SESSION *session)
 
 	ret = cursor->reset(cursor);
 	/*! [log cursor set_key] */
-	cursor->set_key(cursor, lsnsave.file, lsnsave.offset, 0);
+	cursor->set_key(cursor, save_file, save_offset, 0);
 	/*! [log cursor set_key] */
 	/*! [log cursor search] */
 	ret = cursor->search(cursor);
@@ -256,11 +259,11 @@ walk_log(WT_SESSION *session)
 	 */
 	first = 1;
 	while ((ret = cursor->get_key(cursor,
-	    &lsn.file, &lsn.offset, &opcount)) == 0) {
+	    &log_file, &log_offset, &opcount)) == 0) {
 		if (first) {
 			first = 0;
-			if (lsnsave.file != lsn.file ||
-			    lsnsave.offset != lsn.offset) {
+			if (save_file != log_file ||
+			    save_offset != log_offset) {
 				fprintf(stderr,
 				    "search returned the wrong LSN\n");
 				exit (1);
@@ -269,7 +272,7 @@ walk_log(WT_SESSION *session)
 		ret = cursor->get_value(cursor, &txnid, &rectype,
 		    &optype, &fileid, &logrec_key, &logrec_value);
 
-		print_record(&lsn, opcount,
+		print_record(log_file, log_offset, opcount,
 		    rectype, optype, txnid, fileid, &logrec_key, &logrec_value);
 
 		ret = cursor->next(cursor);

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -180,9 +180,10 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
 	 * disk and the checkpoint LSN.
 	 */
 	if (backup_file != 0)
-		min_lognum = WT_MIN(log->ckpt_lsn.file, backup_file);
+		min_lognum = WT_MIN(WT_LSN_FILE(&log->ckpt_lsn), backup_file);
 	else
-		min_lognum = WT_MIN(log->ckpt_lsn.file, log->sync_lsn.file);
+		min_lognum = WT_MIN(
+		    WT_LSN_FILE(&log->ckpt_lsn), WT_LSN_FILE(&log->sync_lsn));
 	WT_RET(__wt_verbose(session, WT_VERB_LOG,
 	    "log_archive: archive to log number %" PRIu32, min_lognum));
 
@@ -218,8 +219,7 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
 	 * Indicate what is our new earliest LSN.  It is the start
 	 * of the log file containing the last checkpoint.
 	 */
-	log->first_lsn.file = min_lognum;
-	log->first_lsn.offset = 0;
+	WT_SET_LSN(&log->first_lsn, min_lognum, 0);
 
 	if (0)
 err:		__wt_err(session, ret, "log archive server error");
@@ -317,7 +317,7 @@ __wt_log_truncate_files(
 	backup_file = 0;
 	if (cursor != NULL)
 		backup_file = WT_CURSOR_BACKUP_ID(cursor);
-	WT_ASSERT(session, backup_file <= log->alloc_lsn.file);
+	WT_ASSERT(session, backup_file <= WT_LSN_FILE(&log->alloc_lsn));
 	WT_RET(__wt_verbose(session, WT_VERB_LOG,
 	    "log_truncate_files: Archive once up to %" PRIu32,
 	    backup_file));
@@ -367,7 +367,7 @@ __log_file_server(void *arg)
 			 * could see mismatched settings.  If we do, yield
 			 * until it is set.  This should rarely happen.
 			 */
-			while (log->log_close_lsn.file < filenum)
+			while (WT_LSN_FILE(&log->log_close_lsn) < filenum)
 				__wt_yield();
 
 			if (__wt_log_cmp(
@@ -398,10 +398,10 @@ __log_file_server(void *arg)
 				 * actual data and has minimal pre-allocated
 				 * zeroed space.
 				 */
-				WT_ERR(__wt_ftruncate(
-				    session, close_fh, close_end_lsn.offset));
-				close_end_lsn.file++;
-				close_end_lsn.offset = 0;
+				WT_ERR(__wt_ftruncate(session,
+				    close_fh, WT_LSN_OFFSET(&close_end_lsn)));
+				WT_SET_LSN(&close_end_lsn,
+				    WT_LSN_FILE(&close_end_lsn) + 1, 0);
 				__wt_spin_lock(session, &log->log_sync_lock);
 				locked = true;
 				WT_ERR(__wt_close(session, &close_fh));
@@ -440,9 +440,10 @@ __log_file_server(void *arg)
 				 * this worker thread process that older file
 				 * immediately.
 				 */
-				if ((log->sync_lsn.file <
-				    log->bg_sync_lsn.file) ||
-				    (log->sync_lsn.file < min_lsn.file))
+				if ((WT_LSN_FILE(&log->sync_lsn) <
+				    WT_LSN_FILE(&log->bg_sync_lsn)) ||
+				    WT_LSN_FILE(&log->sync_lsn) <
+				    WT_LSN_FILE(&min_lsn))
 					continue;
 				WT_ERR(__wt_fsync(session, log->log_fh));
 				__wt_spin_lock(session, &log->log_sync_lock);
@@ -454,7 +455,8 @@ __log_file_server(void *arg)
 				if (__wt_log_cmp(
 				    &log->sync_lsn, &min_lsn) <= 0) {
 					WT_ASSERT(session,
-					    min_lsn.file == log->sync_lsn.file);
+					    WT_LSN_FILE(&min_lsn) ==
+					    WT_LSN_FILE(&log->sync_lsn));
 					log->sync_lsn = min_lsn;
 					WT_ERR(__wt_cond_signal(
 					    session, log->log_sync_cond));
@@ -500,9 +502,7 @@ typedef struct {
  *	Return comparison of a written slot pair by LSN.
  */
 #define	WT_WRLSN_ENTRY_CMP_LT(entry1, entry2)				\
-	((entry1).lsn.file < (entry2).lsn.file ||			\
-	((entry1).lsn.file == (entry2).lsn.file &&			\
-	(entry1).lsn.offset < (entry2).lsn.offset))
+	((entry1).lsn.file_offset < (entry2).lsn.file_offset)
 
 /*
  * __wt_log_wrlsn --
@@ -539,7 +539,8 @@ restart:
 		save_i = i;
 		slot = &log->slot_pool[i++];
 		WT_ASSERT(session, slot->slot_state != 0 ||
-		    slot->slot_release_lsn.file >= log->write_lsn.file);
+		    WT_LSN_FILE(&slot->slot_release_lsn) >=
+		    WT_LSN_FILE(&log->write_lsn));
 		if (slot->slot_state != WT_LOG_SLOT_WRITTEN)
 			continue;
 		written[written_i].slot_index = save_i;
@@ -627,10 +628,10 @@ restart:
 				 * the checkpoint LSN is close to the end of
 				 * the record.
 				 */
-				if (slot->slot_start_lsn.offset !=
+				if (WT_LSN_OFFSET(&slot->slot_start_lsn) !=
 				    slot->slot_last_offset)
-					slot->slot_start_lsn.offset =
-					    slot->slot_last_offset;
+					WT_SET_LSN_OFFSET(&slot->slot_start_lsn,
+					    slot->slot_last_offset);
 				log->write_start_lsn = slot->slot_start_lsn;
 				log->write_lsn = slot->slot_end_lsn;
 				WT_ERR(__wt_cond_signal(

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -187,13 +187,14 @@ __curlog_kv(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 	if (FLD_ISSET(cursor->flags, WT_CURSTD_RAW)) {
 		memset(&item, 0, sizeof(item));
 		WT_RET(wiredtiger_struct_size((WT_SESSION *)session,
-		    &item.size, WT_LOGC_KEY_FORMAT, cl->cur_lsn->file,
-		    cl->cur_lsn->offset, key_count));
+		    &item.size, WT_LOGC_KEY_FORMAT, WT_LSN_FILE(cl->cur_lsn),
+		    WT_LSN_OFFSET(cl->cur_lsn), key_count));
 		WT_RET(__wt_realloc(session, NULL, item.size, &cl->packed_key));
 		item.data = cl->packed_key;
 		WT_RET(wiredtiger_struct_pack((WT_SESSION *)session,
 		    cl->packed_key, item.size, WT_LOGC_KEY_FORMAT,
-		    cl->cur_lsn->file, cl->cur_lsn->offset, key_count));
+		    WT_LSN_FILE(cl->cur_lsn),
+		    WT_LSN_OFFSET(cl->cur_lsn), key_count));
 		__wt_cursor_set_key(cursor, &item);
 
 		WT_RET(wiredtiger_struct_size((WT_SESSION *)session,
@@ -208,8 +209,8 @@ __curlog_kv(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 		    cl->opvalue));
 		__wt_cursor_set_value(cursor, &item);
 	} else {
-		__wt_cursor_set_key(cursor, cl->cur_lsn->file,
-		    cl->cur_lsn->offset, key_count);
+		__wt_cursor_set_key(cursor, WT_LSN_FILE(cl->cur_lsn),
+		    WT_LSN_OFFSET(cl->cur_lsn), key_count);
 		__wt_cursor_set_value(cursor, cl->txnid, cl->rectype, optype,
 		    fileid, cl->opkey, cl->opvalue);
 	}
@@ -264,7 +265,7 @@ __curlog_search(WT_CURSOR *cursor)
 	WT_DECL_RET;
 	WT_LSN key;
 	WT_SESSION_IMPL *session;
-	uint32_t counter;
+	uint32_t counter, lsn_file, lsn_offset;
 
 	cl = (WT_CURSOR_LOG *)cursor;
 
@@ -274,7 +275,8 @@ __curlog_search(WT_CURSOR *cursor)
 	 * !!! We are ignoring the counter and only searching based on the LSN.
 	 */
 	WT_ERR(__wt_cursor_get_key((WT_CURSOR *)cl,
-	    &key.file, &key.offset, &counter));
+	    &lsn_file, &lsn_offset, &counter));
+	WT_SET_LSN(&key, lsn_file, lsn_offset);
 	ret = __wt_log_scan(session, &key, WT_LOGSCAN_ONE,
 	    __curlog_logrec, cl);
 	if (ret == ENOENT)

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -358,7 +358,7 @@ struct __wt_connection_impl {
 	bool		 log_wrlsn_tid_set;/* Log write lsn thread set */
 	WT_LOG		*log;		/* Logging structure */
 	WT_COMPRESSOR	*log_compressor;/* Logging compressor */
-	wt_off_t	 log_file_max;	/* Log file max size */
+	uint32_t	 log_file_max;	/* Log file max size */
 	const char	*log_path;	/* Logging path format */
 	uint32_t	 log_prealloc;	/* Log file pre-allocation */
 	uint32_t	 txn_logsync;	/* Log sync configuration */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -376,7 +376,7 @@ extern int __wt_log_slot_switch( WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bo
 extern int __wt_log_slot_new(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_init(WT_SESSION_IMPL *session);
 extern int __wt_log_slot_destroy(WT_SESSION_IMPL *session);
-extern void __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT_MYSLOT *myslot);
+extern void __wt_log_slot_join(WT_SESSION_IMPL *session, uint32_t mysize, uint32_t flags, WT_MYSLOT *myslot);
 extern int64_t __wt_log_slot_release(WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int64_t size);
 extern void __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_clsm_request_switch(WT_CURSOR_LSM *clsm);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -5,6 +5,13 @@
  *
  * See the file LICENSE for redistribution information.
  */
+/*
+ * WT_LSN --
+ *	A log sequence number, representing a position in the transaction log.
+ */
+struct __wt_lsn {
+	uint64_t file_offset;
+};
 
 #define	WT_LOG_FILENAME	"WiredTigerLog"		/* Log file name */
 #define	WT_LOG_PREPNAME	"WiredTigerPreplog"	/* Log pre-allocated name */
@@ -13,32 +20,43 @@
 /* Logging subsystem declarations. */
 #define	WT_LOG_ALIGN			128
 
+/*
+ * Atomically set the two components of the LSN.
+ */
+#define	WT_LSN_FILE(l)		(uint32_t)((l)->file_offset >> 32)
+#define	WT_LSN_OFFSET(l)	(uint32_t)((l)->file_offset)
+#define	WT_SET_LSN(l, f, o) (l)->file_offset = (((uint64_t)(f) << 32) + (o))
+#define	WT_SET_LSN_FILE(l, f)	WT_SET_LSN((l), (f), WT_LSN_OFFSET(l))
+#define	WT_SET_LSN_OFFSET(l, o)	WT_SET_LSN((l), WT_LSN_FILE(l), (o))
+
 #define	WT_INIT_LSN(l)	do {						\
-	(l)->file = 1;							\
-	(l)->offset = 0;						\
+	WT_SET_LSN((l), 1, 0);						\
 } while (0)
 
 #define	WT_MAX_LSN(l)	do {						\
-	(l)->file = UINT32_MAX;						\
-	(l)->offset = INT64_MAX;					\
+	WT_SET_LSN((l), UINT32_MAX, INT32_MAX);			\
 } while (0)
 
 #define	WT_ZERO_LSN(l)	do {						\
-	(l)->file = 0;							\
-	(l)->offset = 0;						\
+	WT_SET_LSN((l), 0, 0);						\
 } while (0)
 
-#define	WT_IS_INIT_LSN(l)						\
-	((l)->file == 1 && (l)->offset == 0)
+/*
+ * Initialize LSN is (1,0).  We only need to shift the 1 for comparison.
+ */
+#define	WT_IS_INIT_LSN(l)	((l)->file_offset == ((uint64_t)1 << 32))
+/*
+ * XXX Original tested INT32_MAX.
+ */
 #define	WT_IS_MAX_LSN(l)						\
-	((l)->file == UINT32_MAX && (l)->offset == INT64_MAX)
+	(WT_LSN_FILE(l) == UINT32_MAX && WT_LSN_OFFSET(l) == INT32_MAX)
 
 /*
  * Both of the macros below need to change if the content of __wt_lsn
  * ever changes.  The value is the following:
  * txnid, record type, operation type, file id, operation key, operation value
  */
-#define	WT_LOGC_KEY_FORMAT	WT_UNCHECKED_STRING(IqI)
+#define	WT_LOGC_KEY_FORMAT	WT_UNCHECKED_STRING(IiI)
 #define	WT_LOGC_VALUE_FORMAT	WT_UNCHECKED_STRING(qIIIuu)
 
 #define	WT_LOG_SKIP_HEADER(data)					\
@@ -143,8 +161,8 @@ struct WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) __wt_logslot {
 	volatile int64_t slot_state;	/* Slot state */
 	int64_t	 slot_unbuffered;	/* Unbuffered data in this slot */
 	int32_t	 slot_error;		/* Error value */
-	wt_off_t slot_start_offset;	/* Starting file offset */
-	wt_off_t slot_last_offset;	/* Last record offset */
+	uint32_t slot_start_offset;	/* Starting file offset */
+	uint32_t slot_last_offset;	/* Last record offset */
 	WT_LSN	 slot_release_lsn;	/* Slot release LSN */
 	WT_LSN	 slot_start_lsn;	/* Slot starting LSN */
 	WT_LSN	 slot_end_lsn;		/* Slot ending LSN */
@@ -168,8 +186,8 @@ struct WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) __wt_logslot {
 
 struct __wt_myslot {
 	WT_LOGSLOT	*slot;		/* Slot I'm using */
-	wt_off_t	 end_offset;	/* My end offset in buffer */
-	wt_off_t	 offset;	/* Slot buffer offset */
+	uint32_t	 end_offset;	/* My end offset in buffer */
+	uint32_t	 offset;	/* Slot buffer offset */
 #define	WT_MYSLOT_CLOSE		0x01	/* This thread is closing the slot */
 #define	WT_MYSLOT_UNBUFFERED	0x02	/* Write directly */
 	uint32_t flags;			/* Flags */

--- a/src/include/log.i
+++ b/src/include/log.i
@@ -16,25 +16,14 @@ static inline int __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2);
 static inline int
 __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2)
 {
-	WT_LSN l1, l2;
+	uint64_t l1, l2;
 
 	/*
-	 * Read LSNs into local variables so that we only read each field
-	 * once and all comparisons are on the same values.
+	 * Read LSNs into local variables so that we only read them
+	 * once and all comparisons are on the same value.
 	 */
-	l1 = *(volatile WT_LSN *)lsn1;
-	l2 = *(volatile WT_LSN *)lsn2;
+	l1 = ((volatile WT_LSN *)lsn1)->file_offset;
+	l2 = ((volatile WT_LSN *)lsn2)->file_offset;
 
-	/*
-	 * If the file numbers are different we don't need to compare the
-	 * offset.
-	 */
-	if (l1.file != l2.file)
-		return (l1.file < l2.file ? -1 : 1);
-	/*
-	 * If the file numbers are the same, compare the offset.
-	 */
-	if (l1.offset != l2.offset)
-	    return (l1.offset < l2.offset ? -1 : 1);
-	return (0);
+	return (l1 < l2 ? -1 : (l1 > l2 ? 1 : 0));
 }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -72,7 +72,6 @@ struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
 struct __wt_extension_api;  typedef struct __wt_extension_api WT_EXTENSION_API;
 struct __wt_extractor;	    typedef struct __wt_extractor WT_EXTRACTOR;
 struct __wt_item;	    typedef struct __wt_item WT_ITEM;
-struct __wt_lsn;	    typedef struct __wt_lsn WT_LSN;
 struct __wt_session;	    typedef struct __wt_session WT_SESSION;
 
 #if defined(SWIGJAVA)
@@ -124,22 +123,6 @@ struct __wt_item {
 	/*! Managed memory size (internal use). */
 	size_t memsize;
 #endif
-};
-
-/*
- * We rely on this structure being aligned at 64 bits by the compiler,
- * if we were paranoid we could add an unused field to ensure the padding
- * is correct.
- *
- * NOTE:  If you change the contents of this structure you must also update
- * the macros in log.h.
- */
-/*!
- * A log sequence number, representing a position in the transaction log.
- */
-struct __wt_lsn {
-	uint32_t        file;           /*!< Log file number */
-	wt_off_t        offset;         /*!< Log file offset */
 };
 
 /*!

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -206,6 +206,8 @@ struct __wt_lsm_worker_args;
     typedef struct __wt_lsm_worker_args WT_LSM_WORKER_ARGS;
 struct __wt_lsm_worker_cookie;
     typedef struct __wt_lsm_worker_cookie WT_LSM_WORKER_COOKIE;
+struct __wt_lsn;
+    typedef struct __wt_lsn WT_LSN;
 struct __wt_multi;
     typedef struct __wt_multi WT_MULTI;
 struct __wt_myslot;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -105,7 +105,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 	 * LSN has moved into a later log file and there should be a
 	 * log file ready to close.
 	 */
-	while (log->sync_lsn.file < min_lsn->file) {
+	while (WT_LSN_FILE(&log->sync_lsn) < WT_LSN_FILE(min_lsn)) {
 		WT_ERR(__wt_cond_signal(session,
 		    S2C(session)->log_file_cond));
 		WT_ERR(__wt_cond_wait(session, log->log_sync_cond, 10000));
@@ -116,10 +116,11 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 	 * Sync the directory if the log file entry hasn't been written
 	 * into the directory.
 	 */
-	if (log->sync_dir_lsn.file < min_lsn->file) {
+	if (WT_LSN_FILE(&log->sync_dir_lsn) < WT_LSN_FILE(min_lsn)) {
 		WT_ERR(__wt_verbose(session, WT_VERB_LOG,
 		    "log_force_sync: sync directory %s to LSN %d/%lu",
-		    log->log_dir_fh->name, min_lsn->file, min_lsn->offset));
+		    log->log_dir_fh->name,
+		    WT_LSN_FILE(min_lsn), WT_LSN_OFFSET(min_lsn)));
 		WT_ERR(__wt_directory_sync_fh(session, log->log_dir_fh));
 		log->sync_dir_lsn = *min_lsn;
 		WT_STAT_FAST_CONN_INCR(session, log_sync_dir);
@@ -130,7 +131,8 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 	if (__wt_log_cmp(&log->sync_lsn, min_lsn) < 0) {
 		WT_ERR(__wt_verbose(session, WT_VERB_LOG,
 		    "log_force_sync: sync %s to LSN %d/%lu",
-		    log->log_fh->name, min_lsn->file, min_lsn->offset));
+		    log->log_fh->name,
+		    WT_LSN_FILE(min_lsn), WT_LSN_OFFSET(min_lsn)));
 		WT_ERR(__wt_fsync(session, log->log_fh));
 		log->sync_lsn = *min_lsn;
 		WT_STAT_FAST_CONN_INCR(session, log_sync);
@@ -174,7 +176,7 @@ __wt_log_needs_recovery(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn, bool *recp)
 	 * we can skip recovery.
 	 */
 	WT_RET(__wt_curlog_open(session, "log:", NULL, &c));
-	c->set_key(c, ckp_lsn->file, ckp_lsn->offset, 0);
+	c->set_key(c, WT_LSN_FILE(ckp_lsn), WT_LSN_OFFSET(ckp_lsn), 0);
 	if ((ret = c->search(c)) == 0) {
 		while ((ret = c->next(c)) == 0) {
 			/*
@@ -278,7 +280,7 @@ __wt_log_get_all_files(WT_SESSION_IMPL *session,
 	/* Filter out any files that are below the checkpoint LSN. */
 	for (max = 0, i = 0; i < count; ) {
 		WT_ERR(__wt_log_extract_lognum(session, files[i], &id));
-		if (active_only && id < log->ckpt_lsn.file) {
+		if (active_only && id < WT_LSN_FILE(&log->ckpt_lsn)) {
 			__wt_free(session, files[i]);
 			files[i] = files[count - 1];
 			files[--count] = NULL;
@@ -362,7 +364,7 @@ __wt_log_extract_lognum(
  */
 static int
 __log_zero(WT_SESSION_IMPL *session,
-    WT_FH *fh, wt_off_t start_off, wt_off_t len)
+    WT_FH *fh, uint32_t start_off, uint32_t len)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_ITEM(zerobuf);
@@ -382,7 +384,7 @@ __log_zero(WT_SESSION_IMPL *session,
 	 * If they're using smaller log files, cap it at the file size.
 	 */
 	if (conn->log_file_max < bufsz)
-		bufsz = (uint32_t)conn->log_file_max;
+		bufsz = conn->log_file_max;
 	WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
 	memset(zerobuf->mem, 0, zerobuf->memsize);
 	WT_STAT_FAST_CONN_INCR(session, log_zero_fills);
@@ -392,8 +394,8 @@ __log_zero(WT_SESSION_IMPL *session,
 	 * we reach the beginning or we find a chunk that contains any non-zero
 	 * bytes.  Compare against a known zero byte chunk.
 	 */
-	off = (uint32_t)start_off;
-	while (off < (uint32_t)len) {
+	off = start_off;
+	while (off < len) {
 		/*
 		 * Typically we start to zero the file after the log header
 		 * and the bufsz is a sector-aligned size.  So we want to
@@ -407,8 +409,8 @@ __log_zero(WT_SESSION_IMPL *session,
 		/*
 		 * Check if we're writing a partial amount at the end too.
 		 */
-		if ((uint32_t)len - off < bufsz)
-			wrlen = (uint32_t)len - off;
+		if (len - off < bufsz)
+			wrlen = len - off;
 		WT_ERR(__wt_write(session,
 		    fh, (wt_off_t)off, wrlen, zerobuf->mem));
 		off += wrlen;
@@ -459,8 +461,8 @@ __log_size_fit(WT_SESSION_IMPL *session, WT_LSN *lsn, uint64_t recsize)
 
 	conn = S2C(session);
 	log = conn->log;
-	return (lsn->offset == WT_LOG_FIRST_RECORD ||
-	    lsn->offset + (wt_off_t)recsize < conn->log_file_max);
+	return (WT_LSN_OFFSET(lsn) == WT_LOG_FIRST_RECORD ||
+	    WT_LSN_OFFSET(lsn) + (wt_off_t)recsize < conn->log_file_max);
 }
 
 /*
@@ -559,7 +561,8 @@ __log_fill(WT_SESSION_IMPL *session,
 	WT_STAT_FAST_CONN_INCRV(session, log_bytes_written, logrec->len);
 	if (lsnp != NULL) {
 		*lsnp = myslot->slot->slot_start_lsn;
-		lsnp->offset += (wt_off_t)myslot->offset;
+		WT_SET_LSN_OFFSET(lsnp,
+		    WT_LSN_OFFSET(lsnp) + (wt_off_t)myslot->offset);
 	}
 err:
 	if (ret != 0 && myslot->slot->slot_error == 0)
@@ -829,8 +832,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 * We need to setup the LSNs.  Set the end LSN and alloc LSN to
 	 * the end of the header.
 	 */
-	log->alloc_lsn.file = log->fileid;
-	log->alloc_lsn.offset = WT_LOG_FIRST_RECORD;
+	WT_SET_LSN(&log->alloc_lsn, log->fileid, WT_LOG_FIRST_RECORD);
 	end_lsn = log->alloc_lsn;
 
 	/*
@@ -890,13 +892,13 @@ __wt_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WT_LOGSLOT *slot)
 	 * Pre-allocate on the first real write into the log file, if it
 	 * was just created (i.e. not pre-allocated).
 	 */
-	if (log->alloc_lsn.offset == WT_LOG_FIRST_RECORD && created_log)
+	if (WT_LSN_OFFSET(&log->alloc_lsn) == WT_LOG_FIRST_RECORD
+	    && created_log)
 		WT_RET(__log_prealloc(session, log->log_fh));
 	/*
 	 * Initialize the slot for activation.
 	 */
 	__wt_log_slot_activate(session, slot);
-
 	return (0);
 }
 
@@ -931,8 +933,9 @@ __log_truncate(WT_SESSION_IMPL *session,
 	/*
 	 * Truncate the log file to the given LSN.
 	 */
-	WT_ERR(__log_openfile(session, false, &log_fh, file_prefix, lsn->file));
-	WT_ERR(__wt_ftruncate(session, log_fh, lsn->offset));
+	WT_ERR(__log_openfile(session,
+	    false, &log_fh, file_prefix, WT_LSN_FILE(lsn)));
+	WT_ERR(__wt_ftruncate(session, log_fh, WT_LSN_OFFSET(lsn)));
 	WT_ERR(__wt_fsync(session, log_fh));
 	WT_ERR(__wt_close(session, &log_fh));
 
@@ -946,7 +949,8 @@ __log_truncate(WT_SESSION_IMPL *session,
 	    WT_LOG_FILENAME, &logfiles, &logcount));
 	for (i = 0; i < logcount; i++) {
 		WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
-		if (lognum > lsn->file && lognum < log->trunc_lsn.file) {
+		if (lognum > WT_LSN_FILE(lsn) &&
+		    lognum < WT_LSN_FILE(&log->trunc_lsn)) {
 			WT_ERR(__log_openfile(session,
 			    false, &log_fh, file_prefix, lognum));
 			/*
@@ -1111,10 +1115,8 @@ __wt_log_open(WT_SESSION_IMPL *session)
 	if (firstlog == UINT32_MAX) {
 		WT_ASSERT(session, logcount == 0);
 		WT_INIT_LSN(&log->first_lsn);
-	} else {
-		log->first_lsn.file = firstlog;
-		log->first_lsn.offset = 0;
-	}
+	} else
+		WT_SET_LSN(&log->first_lsn, firstlog, 0);
 
 	/*
 	 * Start logging at the beginning of the next log file, no matter
@@ -1346,7 +1348,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 		 * sync operations.  The most recent one will set the LSN to the
 		 * beginning of our file.
 		 */
-		if (log->sync_lsn.file < slot->slot_end_lsn.file ||
+		if (WT_LSN_FILE(&log->sync_lsn) <
+		    WT_LSN_FILE(&slot->slot_end_lsn) ||
 		    __wt_spin_trylock(session, &log->log_sync_lock) != 0) {
 			WT_ERR(__wt_cond_wait(
 			    session, log->log_sync_cond, 10000));
@@ -1366,12 +1369,14 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 		 * now if needed.
 		 */
 		if (F_ISSET(slot, WT_SLOT_SYNC_DIR) &&
-		    (log->sync_dir_lsn.file < sync_lsn.file)) {
+		    WT_LSN_FILE(&log->sync_dir_lsn) <
+		    WT_LSN_FILE(&sync_lsn)) {
 			WT_ASSERT(session, log->log_dir_fh != NULL);
 			WT_ERR(__wt_verbose(session, WT_VERB_LOG,
 			    "log_release: sync directory %s to LSN %d/%lu",
 			    log->log_dir_fh->name,
-			    sync_lsn.file, sync_lsn.offset));
+			    WT_LSN_FILE(&sync_lsn),
+			    WT_LSN_OFFSET(&sync_lsn)));
 			WT_ERR(__wt_directory_sync_fh(
 			    session, log->log_dir_fh));
 			log->sync_dir_lsn = sync_lsn;
@@ -1385,7 +1390,9 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 		    __wt_log_cmp(&log->sync_lsn, &slot->slot_end_lsn) < 0) {
 			WT_ERR(__wt_verbose(session, WT_VERB_LOG,
 			    "log_release: sync log %s to LSN %d/%lu",
-			    log->log_fh->name, sync_lsn.file, sync_lsn.offset));
+			    log->log_fh->name,
+			    WT_LSN_FILE(&sync_lsn),
+			    WT_LSN_OFFSET(&sync_lsn)));
 			WT_STAT_FAST_CONN_INCR(session, log_sync);
 			WT_ERR(__wt_fsync(session, log->log_fh));
 			log->sync_lsn = sync_lsn;
@@ -1449,8 +1456,9 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 
 	if (LF_ISSET(WT_LOGSCAN_RECOVER))
 		WT_RET(__wt_verbose(session, WT_VERB_LOG,
-		    "__wt_log_scan truncating to %u/%" PRIuMAX,
-		    log->trunc_lsn.file, (uintmax_t)log->trunc_lsn.offset));
+		    "__wt_log_scan truncating to %u/%u",
+		    WT_LSN_FILE(&log->trunc_lsn),
+		    WT_LSN_OFFSET(&log->trunc_lsn)));
 
 	if (log != NULL) {
 		allocsize = log->allocsize;
@@ -1468,8 +1476,8 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 			    "choose either a start LSN or a start flag");
 
 			/* Offsets must be on allocation boundaries. */
-			if (lsnp->offset % allocsize != 0 ||
-			    lsnp->file > log->fileid)
+			if (WT_LSN_OFFSET(lsnp) % allocsize != 0 ||
+			    WT_LSN_FILE(lsnp) > log->fileid)
 				return (WT_NOTFOUND);
 
 			/*
@@ -1509,14 +1517,13 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 			lastlog = WT_MAX(lastlog, lognum);
 			firstlog = WT_MIN(firstlog, lognum);
 		}
-		start_lsn.file = firstlog;
-		end_lsn.file = lastlog;
-		start_lsn.offset = end_lsn.offset = 0;
+		WT_SET_LSN(&start_lsn, firstlog, 0);
+		WT_SET_LSN(&end_lsn, lastlog, 0);
 		__wt_log_files_free(session, logfiles, logcount);
 		logfiles = NULL;
 	}
 	WT_ERR(__log_openfile(
-	    session, false, &log_fh, WT_LOG_FILENAME, start_lsn.file));
+	    session, false, &log_fh, WT_LOG_FILENAME, WT_LSN_FILE(&start_lsn)));
 	WT_ERR(__wt_filesize(session, log_fh, &log_size));
 	rd_lsn = start_lsn;
 
@@ -1524,7 +1531,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	WT_ERR(__wt_scr_alloc(session, 0, &decryptitem));
 	WT_ERR(__wt_scr_alloc(session, 0, &uncitem));
 	for (;;) {
-		if (rd_lsn.offset + allocsize > log_size) {
+		if (WT_LSN_OFFSET(&rd_lsn) + allocsize > log_size) {
 advance:
 			/*
 			 * If we read the last record, go to the next file.
@@ -1538,16 +1545,16 @@ advance:
 			if (LF_ISSET(WT_LOGSCAN_RECOVER))
 				WT_ERR(__log_truncate(session,
 				    &rd_lsn, WT_LOG_FILENAME, 1));
-			rd_lsn.file++;
-			rd_lsn.offset = 0;
+			WT_SET_LSN(&rd_lsn, WT_LSN_FILE(&rd_lsn) + 1, 0);
 			/*
 			 * Avoid an error message when we reach end of log
 			 * by checking here.
 			 */
-			if (rd_lsn.file > end_lsn.file)
+			if (WT_LSN_FILE(&rd_lsn) > WT_LSN_FILE(&end_lsn))
 				break;
 			WT_ERR(__log_openfile(session,
-			    false, &log_fh, WT_LOG_FILENAME, rd_lsn.file));
+			    false, &log_fh, WT_LOG_FILENAME,
+			    WT_LSN_FILE(&rd_lsn)));
 			WT_ERR(__wt_filesize(session, log_fh, &log_size));
 			eol = false;
 			continue;
@@ -1556,8 +1563,9 @@ advance:
 		 * Read the minimum allocation size a record could be.
 		 */
 		WT_ASSERT(session, buf->memsize >= allocsize);
-		WT_ERR(__wt_read(session,
-		    log_fh, rd_lsn.offset, (size_t)allocsize, buf->mem));
+		WT_ERR(__wt_read(session, log_fh,
+		    (wt_off_t)WT_LSN_OFFSET(&rd_lsn),
+		    (size_t)allocsize, buf->mem));
 		/*
 		 * First 4 bytes is the real record length.  See if we
 		 * need to read more than the allocation size.  We expect
@@ -1577,8 +1585,8 @@ advance:
 		 * and remove any later log files that may exist.
 		 */
 		if (reclen == 0) {
-			WT_ERR(__log_has_hole(
-			    session, log_fh, rd_lsn.offset, &eol));
+			WT_ERR(__log_has_hole(session,
+			    log_fh, WT_LSN_OFFSET(&rd_lsn), &eol));
 			if (eol)
 				/* Found a hole. This LSN is the end. */
 				break;
@@ -1592,15 +1600,16 @@ advance:
 			 * The log file end could be the middle of this
 			 * log record.
 			 */
-			if (rd_lsn.offset + rdup_len > log_size)
+			if (WT_LSN_OFFSET(&rd_lsn) + rdup_len > log_size)
 				goto advance;
 			/*
 			 * We need to round up and read in the full padded
 			 * record, especially for direct I/O.
 			 */
 			WT_ERR(__wt_buf_grow(session, buf, rdup_len));
-			WT_ERR(__wt_read(session,
-			    log_fh, rd_lsn.offset, (size_t)rdup_len, buf->mem));
+			WT_ERR(__wt_read(session, log_fh,
+			    (wt_off_t)WT_LSN_OFFSET(&rd_lsn),
+			    (size_t)rdup_len, buf->mem));
 			WT_STAT_FAST_CONN_INCR(session, log_scan_rereads);
 		}
 		/*
@@ -1636,8 +1645,9 @@ advance:
 		 */
 		WT_STAT_FAST_CONN_INCR(session, log_scan_records);
 		next_lsn = rd_lsn;
-		next_lsn.offset += (wt_off_t)rdup_len;
-		if (rd_lsn.offset != 0) {
+		WT_SET_LSN_OFFSET(&next_lsn,
+		    WT_LSN_OFFSET(&next_lsn) + rdup_len);
+		if (WT_LSN_OFFSET(&rd_lsn) != 0) {
 			/*
 			 * We need to manage the different buffers here.
 			 * Buf is the buffer this function uses to read from
@@ -2054,7 +2064,8 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
 		WT_RET(__wt_log_flush_lsn(session, &lsn, false));
 
 	WT_RET(__wt_verbose(session, WT_VERB_LOG,
-	    "log_flush: flags %d LSN %d/%lu", flags, lsn.file, lsn.offset));
+	    "log_flush: flags %d LSN %d/%lu",
+	    flags, WT_LSN_FILE(&lsn), WT_LSN_OFFSET(&lsn)));
 	/*
 	 * If the user wants write-no-sync, there is nothing more to do.
 	 * If the user wants background sync, set the LSN and we're done.

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -450,8 +450,8 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_buf_catfmt(session, buf, ")"));
 	if (ckptlsn != NULL)
 		WT_ERR(__wt_buf_catfmt(session, buf,
-		    ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
-		    ckptlsn->file, (uintmax_t)ckptlsn->offset));
+		    ",checkpoint_lsn=(%" PRIu32 ",%" PRIu32 ")",
+		    WT_LSN_FILE(ckptlsn), WT_LSN_OFFSET(ckptlsn)));
 	WT_ERR(__ckpt_set(session, fname, buf->mem));
 
 err:	__wt_scr_free(session, &buf);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -91,9 +91,9 @@ __recovery_cursor(WT_SESSION_IMPL *session, WT_RECOVERY *r,
 	WT_ERR(__recovery_cursor(					\
 	    (session), (r), (lsnp), (fileid), false, (cp)));		\
 	WT_ERR(__wt_verbose((session), WT_VERB_RECOVERY,		\
-	    "%s op %d to file %d at LSN %u/%" PRIuMAX,			\
+	    "%s op %d to file %d at LSN %u/%u",				\
 	    (cursor == NULL) ? "Skipping" : "Applying",			\
-	    optype, fileid, lsnp->file, (uintmax_t)lsnp->offset));	\
+	    optype, fileid, WT_LSN_FILE(lsnp), WT_LSN_OFFSET(lsnp)));	\
 	if (cursor == NULL)						\
 		break
 
@@ -303,8 +303,7 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 {
 	WT_CONFIG_ITEM cval;
 	WT_LSN lsn;
-	intmax_t offset;
-	uint32_t fileid;
+	uint32_t fileid, lsn_file, lsn_offset;
 
 	WT_RET(__wt_config_getones(r->session, config, "id", &cval));
 	fileid = (uint32_t)cval.val;
@@ -326,8 +325,8 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 	if (cval.type != WT_CONFIG_ITEM_STRUCT)
 		WT_INIT_LSN(&lsn);
 	else if (sscanf(cval.str,
-	    "(%" SCNu32 ",%" SCNdMAX ")", &lsn.file, &offset) == 2)
-		lsn.offset = offset;
+	    "(%" SCNu32 ",%" SCNu32 ")", &lsn_file, &lsn_offset) == 2)
+		WT_SET_LSN(&lsn, lsn_file, lsn_offset);
 	else
 		WT_RET_MSG(r->session, EINVAL,
 		    "Failed to parse checkpoint LSN '%.*s'",
@@ -335,8 +334,8 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 	r->files[fileid].ckpt_lsn = lsn;
 
 	WT_RET(__wt_verbose(r->session, WT_VERB_RECOVERY,
-	    "Recovering %s with id %u @ (%" PRIu32 ", %" PRIu64 ")",
-	    uri, fileid, lsn.file, lsn.offset));
+	    "Recovering %s with id %u @ (%" PRIu32 ", %" PRIu32 ")",
+	    uri, fileid, WT_LSN_FILE(&lsn), WT_LSN_OFFSET(&lsn)));
 
 	return (0);
 
@@ -485,8 +484,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	 */
 	r.metadata_only = false;
 	WT_ERR(__wt_verbose(session, WT_VERB_RECOVERY,
-	    "Main recovery loop: starting at %u/%" PRIuMAX,
-	    r.ckpt_lsn.file, (uintmax_t)r.ckpt_lsn.offset));
+	    "Main recovery loop: starting at %u/%u",
+	    WT_LSN_FILE(&r.ckpt_lsn), WT_LSN_OFFSET(&r.ckpt_lsn)));
 	WT_ERR(__wt_log_needs_recovery(session, &r.ckpt_lsn, &needs_rec));
 	/*
 	 * Check if the database was shut down cleanly.  If not


### PR DESCRIPTION
@michaelcahill Please review this set of changes to make LSNs a single 64 bit value that we can atomically update.  I created macros to set and get the file and offset part of that value.