### PR TITLE
SERVER-21585 Don't use the lookaside file until the cache is stuck full.

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -473,7 +473,8 @@ __evict_review(
 			LF_SET(WT_EVICT_IN_MEMORY | WT_EVICT_UPDATE_RESTORE);
 		else if (page->read_gen == WT_READGEN_OLDEST)
 			LF_SET(WT_EVICT_UPDATE_RESTORE);
-		else if (__wt_eviction_aggressive(session))
+		else if (F_ISSET(session, WT_SESSION_INTERNAL) &&
+		    F_ISSET(S2C(session)->cache, WT_CACHE_STUCK))
 			LF_SET(WT_EVICT_LOOKASIDE);
 	}
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -131,17 +131,6 @@ __wt_session_can_wait(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_eviction_aggressive --
- *	Return if the eviction server is running in aggressive mode.
- */
-static inline bool
-__wt_eviction_aggressive(WT_SESSION_IMPL *session)
-{
-	return (FLD_ISSET(
-	    S2C(session)->cache->state, WT_EVICT_PASS_AGGRESSIVE));
-}
-
-/*
  * __wt_eviction_dirty_target --
  *	Return if the eviction server is running to reduce the number of dirty
  * pages (versus running to discard pages from the cache).


### PR DESCRIPTION
Also only write into the lookaside file from internal (aka eviction) threads, so application threads don't pay the performance cost.

It is possible that the cache stuck check is too restrictive, but using only the eviction aggressive flag can result in writing a lot of content to the lookaside file when pages can still be evicted.