### PR TITLE
WT-2234: Coverity analysis warnings 

### DIFF
--- a/ext/extractors/csv/csv_extractor.c
+++ b/ext/extractors/csv/csv_extractor.c
@@ -97,8 +97,10 @@ csv_extract(WT_EXTRACTOR *extractor, WT_SESSION *session,
 		strncpy(copy, p, len);
 		copy[len] = '\0';
 		if (csv_extractor->format_isnum) {
-			if ((val = atoi(copy)) < 0)
+			if ((val = atoi(copy)) < 0) {
+				free(copy);
 				return (EINVAL);
+			}
 			result_cursor->set_key(result_cursor, val);
 		} else
 			result_cursor->set_key(result_cursor, copy);

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -22,8 +22,9 @@ __curjoin_entry_iter_init(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin,
 	WT_DECL_RET;
 	const char *raw_cfg[] = { WT_CONFIG_BASE(
 	    session, WT_SESSION_open_cursor), "raw", NULL };
+	/* Coverity needs cfg arrays to be sized at least 3. */
 	const char *def_cfg[] = { WT_CONFIG_BASE(
-	    session, WT_SESSION_open_cursor), NULL };
+	    session, WT_SESSION_open_cursor), NULL, NULL };
 	const char *uri, **config;
 	char *uribuf;
 	WT_CURSOR_JOIN_ITER *iter;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -22,9 +22,8 @@ __curjoin_entry_iter_init(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin,
 	WT_DECL_RET;
 	const char *raw_cfg[] = { WT_CONFIG_BASE(
 	    session, WT_SESSION_open_cursor), "raw", NULL };
-	/* Coverity needs cfg arrays to be sized at least 3. */
 	const char *def_cfg[] = { WT_CONFIG_BASE(
-	    session, WT_SESSION_open_cursor), NULL, NULL };
+	    session, WT_SESSION_open_cursor), NULL };
 	const char *uri, **config;
 	char *uribuf;
 	WT_CURSOR_JOIN_ITER *iter;


### PR DESCRIPTION
In __wt_config_gets_def() there is a conditional reference of cfg[2]. Presumably this means that cfg strings are de facto required to have at least 3 entries. If so, would never manifest as a runtime bug, but it's easy enough to satisfy Coverity.