### PR TITLE
SERVER-21619 Don't do internal page splits after a tree is marked DEAD.

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -77,7 +77,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		}
 
 		(void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
-		ret = __wt_evict(session, ref, 0);
+		ret = __wt_evict(session, ref, false);
 		(void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);
 		WT_RET_BUSY_OK(ret);
 	}

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -60,8 +60,7 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 	 * - a page queued for eviction, or
 	 * - a locked page.
 	 */
-	WT_ASSERT(session, !__wt_page_is_modified(page) ||
-	    F_ISSET(session->dhandle, WT_DHANDLE_DEAD));
+	WT_ASSERT(session, !__wt_page_is_modified(page));
 	WT_ASSERT(session, !F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU));
 	WT_ASSERT(session, !__wt_fair_islocked(session, &page->page_lock));
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -326,7 +326,7 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 	 */
 	if (ss->root_ref.page != NULL) {
 		btree->ckpt = ckptbase;
-		ret = __wt_evict(session, &ss->root_ref, 1);
+		ret = __wt_evict(session, &ss->root_ref, true);
 		ss->root_ref.page = NULL;
 		btree->ckpt = NULL;
 	}
@@ -1304,7 +1304,7 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, 1);
+		ret = __wt_evict(session, ref, true);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));
@@ -2030,7 +2030,7 @@ __slvg_row_build_leaf(
 	 */
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, 1);
+		ret = __wt_evict(session, ref, true);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -76,22 +76,16 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			/*
 			 * Evict the page.
 			 */
-			WT_ERR(__wt_evict(session, ref, 1));
+			WT_ERR(__wt_evict(session, ref, true));
 			break;
 		case WT_SYNC_DISCARD:
 			/*
-			 * Dead handles may reference dirty pages; clean the
-			 * page, both to keep statistics correct, and to let
-			 * the page-discard function assert no dirty page is
-			 * ever discarded.
+			 * Discard the page regardless of whether it is dirty.
 			 */
-			if (F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
-				__wt_page_modify_clear(session, page);
-
 			WT_ASSERT(session,
 			    F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
 			    __wt_page_can_evict(session, ref, false, NULL));
-			__wt_evict_page_clean_update(session, ref, 1);
+			__wt_evict_page_clean_update(session, ref, true);
 			break;
 		WT_ILLEGAL_VALUE_ERR(session);
 		}

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1454,17 +1454,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	if (page->read_gen != WT_READGEN_OLDEST)
 		page->read_gen = __wt_cache_read_gen_bump(session);
 
-	/*
-	 * If we are evicting in a dead tree, don't write dirty pages.
-	 *
-	 * Force pages clean to keep statistics correct and to let the
-	 * page-discard function assert that no dirty pages are ever
-	 * discarded.
-	 */
-	if (F_ISSET(btree->dhandle, WT_DHANDLE_DEAD))
-		__wt_page_modify_clear(session, page);
-
-	WT_WITH_BTREE(session, btree, ret = __wt_evict(session, ref, 0));
+	WT_WITH_BTREE(session, btree, ret = __wt_evict(session, ref, false));
 
 	(void)__wt_atomic_subv32(&btree->evict_busy, 1);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -55,7 +55,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	WT_DECL_RET;
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
-	bool forced_eviction, inmem_split;
+	bool clean_page, forced_eviction, inmem_split, tree_dead;
 
 	conn = S2C(session);
 
@@ -65,6 +65,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	page = ref->page;
 	forced_eviction = page->read_gen == WT_READGEN_OLDEST;
 	inmem_split = false;
+	tree_dead = F_ISSET(session->dhandle, WT_DHANDLE_DEAD);
 
 	WT_RET(__wt_verbose(session, WT_VERB_EVICT,
 	    "page %p (%s)", page, __wt_page_type_string(page->type)));
@@ -105,24 +106,26 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	if (page->memory_footprint > conn->cache->evict_max_page_size)
 		conn->cache->evict_max_page_size = page->memory_footprint;
 
-	/* Update the reference and discard the page. */
-	if ((mod == NULL || mod->rec_result == 0) &&
-	    !F_ISSET(conn, WT_CONN_IN_MEMORY)) {
-		if (__wt_ref_is_root(ref))
-			__wt_ref_out(session, ref);
-		else
-			WT_ERR(__wt_evict_page_clean_update(
-			    session, ref, closing));
+	/* Figure out whether reconciliation was done on the page */
+	clean_page = mod == NULL || mod->rec_result == 0;
 
+	/* Update the reference and discard the page. */
+	if (__wt_ref_is_root(ref))
+		__wt_ref_out(session, ref);
+	else if (tree_dead || (clean_page && !F_ISSET(conn, WT_CONN_IN_MEMORY)))
+		/*
+		 * Pages that belong to dead trees never write back to disk
+		 * and can't support page splits.
+		 */
+		WT_ERR(__wt_evict_page_clean_update(
+		    session, ref, tree_dead || closing));
+	else
+		WT_ERR(__evict_page_dirty_update(session, ref, closing));
+
+	if (clean_page) {
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_clean);
 		WT_STAT_FAST_DATA_INCR(session, cache_eviction_clean);
 	} else {
-		if (__wt_ref_is_root(ref))
-			__wt_ref_out(session, ref);
-		else
-			WT_ERR(__evict_page_dirty_update(
-			    session, ref, closing));
-
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_dirty);
 		WT_STAT_FAST_DATA_INCR(session, cache_eviction_dirty);
 	}
@@ -398,6 +401,13 @@ __evict_review(
 		    ret = __evict_child_check(session, ref));
 		WT_RET(ret);
 	}
+
+	/*
+	 * It is always OK to evict pages from dead trees if they don't have
+	 * children.
+	 */
+	if (F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
+		return (0);
 
 	/*
 	 * Retrieve the modified state of the page. This must happen after the

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -330,6 +330,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
 	uint64_t last_running;
 
+	WT_ASSERT(session, !F_ISSET(session->dhandle, WT_DHANDLE_DEAD));
+
 	last_running = 0;
 	if (page->modify->write_gen == 0)
 		last_running = S2C(session)->txn_global.last_running;

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1164,7 +1164,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 	(void)__wt_atomic_addv32(&btree->evict_busy, 1);
 
 	too_big = page->memory_footprint > btree->maxmempage;
-	if ((ret = __wt_evict(session, ref, 0)) == 0) {
+	if ((ret = __wt_evict(session, ref, false)) == 0) {
 		if (too_big)
 			WT_STAT_FAST_CONN_INCR(session, cache_eviction_force);
 		else


### PR DESCRIPTION
It leads to problems where eviction attempts to write back to a file after the block manager is already closed.