### PR TITLE
WT-2241 Use a lock to protect transaction ID allocation.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -70,7 +70,7 @@ struct WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) __wt_txn_state {
 };
 
 struct __wt_txn_global {
-	uint64_t alloc;			/* Transaction ID to allocate. */
+	WT_SPINLOCK id_lock;
 	volatile uint64_t current;	/* Current transaction ID. */
 
 	/* The oldest running transaction ID (may race). */


### PR DESCRIPTION
We still need to make sure that transaction IDs are published in the state
table before the current ID is incremented so that snapshot reads don't see
uncommitted updates.  However, a lock simplifies the code and performs better
in testing than the initial fix.