### PR TITLE
WT-2244 - Trigger in-memory splits sooner.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -697,6 +697,13 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
 	}
 
 	/*
+	 * Try in-memory splits once we hit 80% of the maximum in-memory page
+	 * size.  This gives multi-threaded append workloads a better chance of
+	 * not stalling.
+	 */
+	btree->splitmempage = 8 * btree->maxmempage / 10;
+
+	/*
 	 * Get the split percentage (reconciliation splits pages into smaller
 	 * than the maximum page size chunks so we don't split every time a
 	 * new entry is added). Determine how large newly split pages will be.

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -331,7 +331,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	__wt_txn_update_oldest(session, false);
 
 	/* If eviction cannot succeed, don't try. */
-	return (__wt_page_can_evict(session, ref, true, NULL));
+	return (__wt_page_can_evict(session, ref, NULL));
 }
 
 /*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -322,7 +322,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	if (page->memory_footprint < btree->splitmempage)
 		return (0);
 	else if (page->memory_footprint < btree->maxmempage)
-		return (__wt_page_can_split(session, page));
+		return (__wt_leaf_page_can_split(session, page));
 
 	/* Trigger eviction on the next page release. */
 	__wt_page_evict_soon(page);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -307,10 +307,6 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	btree = S2BT(session);
 	page = ref->page;
 
-	/* Pages are usually small enough, check that first. */
-	if (page->memory_footprint < btree->maxmempage)
-		return (0);
-
 	/* Leaf pages only. */
 	if (WT_PAGE_IS_INTERNAL(page))
 		return (0);
@@ -321,6 +317,12 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	 */
 	if (page->modify == NULL)
 		return (0);
+
+	/* Pages are usually small enough, check that first. */
+	if (page->memory_footprint < btree->splitmempage)
+		return (0);
+	else if (page->memory_footprint < btree->maxmempage)
+		return (__wt_page_can_split(session, page));
 
 	/* Trigger eviction on the next page release. */
 	__wt_page_evict_soon(page);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1634,7 +1634,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 *
 	 * Note this page has already been through an in-memory split.
 	 */
-	WT_ASSERT(session, __wt_page_can_split(session, page));
+	WT_ASSERT(session, __wt_leaf_page_can_split(session, page));
 	WT_ASSERT(session, __wt_page_is_modified(page));
 	F_SET_ATOMIC(page, WT_PAGE_SPLIT_INSERT);
 

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -84,7 +84,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 */
 			WT_ASSERT(session,
 			    F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
-			    __wt_page_can_evict(session, ref, false, NULL));
+			    __wt_page_can_evict(session, ref, NULL));
 			__wt_evict_page_clean_update(session, ref, true);
 			break;
 		WT_ILLEGAL_VALUE_ERR(session);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1169,7 +1169,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 	uint64_t pages_walked;
 	uint32_t walk_flags;
 	int internal_pages, restarts;
-	bool enough, modified;
+	bool enough, modified, would_split;
 
 	conn = S2C(session);
 	btree = S2BT(session);
@@ -1254,8 +1254,14 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 			page->read_gen = __wt_cache_read_gen_new(session);
 
 fast:		/* If the page can't be evicted, give up. */
-		if (!__wt_page_can_evict(session, ref, true, NULL))
+		if (!__wt_page_can_evict(session, ref, true, &would_split))
 			continue;
+
+		/*
+		 * Note: take care with ordering: if we detected that
+		 * the page is modified above, we expect mod != NULL.
+		 */
+		mod = page->modify;
 
 		/*
 		 * Additional tests if eviction is likely to succeed.
@@ -1270,32 +1276,26 @@ fast:		/* If the page can't be evicted, give up. */
 		if (!FLD_ISSET(cache->state,
 		    WT_EVICT_PASS_AGGRESSIVE | WT_EVICT_PASS_WOULD_BLOCK)) {
 			/*
-			 * Note: take care with ordering: if we detected that
-			 * the page is modified above, we expect mod != NULL.
-			 */
-			mod = page->modify;
-
-			/*
 			 * If the page is clean but has modifications that
 			 * appear too new to evict, skip it.
 			 */
 			if (!modified && mod != NULL &&
 			    !__wt_txn_visible_all(session, mod->rec_max_txn))
 				continue;
-
-			/*
-			 * If the oldest transaction hasn't changed since the
-			 * last time this page was written, it's unlikely we
-			 * can make progress.  Similarly, if the most recent
-			 * update on the page is not yet globally visible,
-			 * eviction will fail.  These heuristics attempt to
-			 * avoid repeated attempts to evict the same page.
-			 */
-			if (modified &&
-			    (mod->disk_snap_min == conn->txn_global.oldest_id ||
-			    !__wt_txn_visible_all(session, mod->update_txn)))
-				continue;
 		}
+
+		/*
+		 * If the oldest transaction hasn't changed since the last time
+		 * this page was written, it's unlikely we can make progress.
+		 * Similarly, if the most recent update on the page is not yet
+		 * globally visible, eviction will fail.  These heuristics
+		 * attempt to avoid repeated attempts to evict the same page.
+		 */
+		if (modified && !would_split &&
+		    !FLD_ISSET(cache->state, WT_CACHE_STUCK) &&
+		    (mod->last_oldest_id == __wt_txn_oldest_id(session) ||
+		    !__wt_txn_visible_all(session, mod->update_txn)))
+			continue;
 
 		WT_ASSERT(session, evict->ref == NULL);
 		__evict_init_candidate(session, evict, ref);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1254,7 +1254,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 			page->read_gen = __wt_cache_read_gen_new(session);
 
 fast:		/* If the page can't be evicted, give up. */
-		if (!__wt_page_can_evict(session, ref, true, &would_split))
+		if (!__wt_page_can_evict(session, ref, &would_split))
 			continue;
 
 		/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -434,7 +434,7 @@ __evict_review(
 		if (modified)
 			__wt_txn_update_oldest(session, true);
 
-		if (!__wt_page_can_evict(session, ref, false, inmem_splitp))
+		if (!__wt_page_can_evict(session, ref, inmem_splitp))
 			return (EBUSY);
 
 		/*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -198,14 +198,6 @@ struct __wt_ovfl_txnc {
  *	When a page is modified, there's additional information to maintain.
  */
 struct __wt_page_modify {
-	/*
-	 * Track the highest transaction ID at which the page was written to
-	 * disk.  This can be used to avoid trying to write the page multiple
-	 * times if a snapshot is keeping old versions pinned (e.g., in a
-	 * checkpoint).
-	 */
-	uint64_t disk_snap_min;
-
 	/* The first unwritten transaction ID (approximate). */
 	uint64_t first_dirty_txn;
 
@@ -221,10 +213,8 @@ struct __wt_page_modify {
 	/* The largest update transaction ID (approximate). */
 	uint64_t update_txn;
 
-#ifdef HAVE_DIAGNOSTIC
 	/* Check that transaction time moves forward. */
 	uint64_t last_oldest_id;
-#endif
 
 	/* Dirty bytes added to the cache. */
 	size_t bytes_dirty;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -201,9 +201,6 @@ struct __wt_page_modify {
 	/* The first unwritten transaction ID (approximate). */
 	uint64_t first_dirty_txn;
 
-	/* In-memory split transaction ID. */
-	uint64_t inmem_split_txn;
-
 	/* Avoid checking for obsolete updates during checkpoints. */
 	uint64_t obsolete_check_txn;
 
@@ -303,17 +300,8 @@ struct __wt_page_modify {
 		 * so they can be discarded when no longer needed.
 		 */
 		WT_PAGE *root_split;	/* Linked list of root split pages */
-
-		/*
-		 * When we deepen the tree, newly created internal pages cannot
-		 * be evicted until all threads have exited the original page
-		 * index structure.  We set a transaction value during the split
-		 * that's checked during eviction.
-		 */
-		uint64_t split_txn;	/* Split eviction transaction value */
 	} intl;
 #define	mod_root_split		u2.intl.root_split
-#define	mod_split_txn		u2.intl.split_txn
 	struct {
 		/*
 		 * Appended items to column-stores: there is only a single one

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -88,7 +88,8 @@ struct __wt_btree {
 	uint32_t maxleafpage;		/* Leaf page max size */
 	uint32_t maxleafkey;		/* Leaf page max key size */
 	uint32_t maxleafvalue;		/* Leaf page max value size */
-	uint64_t maxmempage;		/* In memory page max size */
+	uint64_t maxmempage;		/* In-memory page max size */
+	uint64_t splitmempage;		/* In-memory split trigger size */
 
 	void *huffman_key;		/* Key huffman encoding */
 	void *huffman_value;		/* Value huffman encoding */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -349,13 +349,6 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 		__wt_cache_dirty_incr(session, page);
 
 		/*
-		 * The page can never end up with changes older than the oldest
-		 * running transaction.
-		 */
-		if (F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT))
-			page->modify->disk_snap_min = session->txn.snap_min;
-
-		/*
 		 * We won the race to dirty the page, but another thread could
 		 * have committed in the meantime, and the last_running field
 		 * been updated past it.  That is all very unlikely, but not

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1005,7 +1005,7 @@ __wt_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * reconciliation will be wrong, so we can't evict immediately).
 	 */
 	if (page->type != WT_PAGE_ROW_LEAF ||
-	    page->memory_footprint < btree->maxmempage ||
+	    page->memory_footprint < btree->splitmempage ||
 	    !__wt_page_is_modified(page))
 		return (false);
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -963,11 +963,11 @@ __wt_ref_info(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_page_can_split --
+ * __wt_leaf_page_can_split --
  *	Check whether a page can be split in memory.
  */
 static inline bool
-__wt_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
+__wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
 	WT_BTREE *btree;
 	WT_INSERT_HEAD *ins_head;
@@ -1064,7 +1064,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	 * detailed eviction tests. We don't need further tests since the page
 	 * won't be written or discarded from the cache.
 	 */
-	if (__wt_page_can_split(session, page)) {
+	if (__wt_leaf_page_can_split(session, page)) {
 		if (inmem_splitp != NULL)
 			*inmem_splitp = true;
 		return (true);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1098,9 +1098,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	 * pages cannot be evicted until all threads are known to have exited
 	 * the original parent page's index, because evicting an internal page
 	 * discards its WT_REF array, and a thread traversing the original
-	 * parent page index might see a freed WT_REF. During the split we set
-	 * a transaction value, we can evict the created page as soon as that
-	 * transaction value is globally visible.
+	 * parent page index might see a freed WT_REF.
 	 */
 	if (WT_PAGE_IS_INTERNAL(page) &&
 	    F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_BLOCK))

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1103,7 +1103,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	 * transaction value is globally visible.
 	 */
 	if (WT_PAGE_IS_INTERNAL(page) &&
-            F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_BLOCK))
+	    F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_BLOCK))
 		return (false);
 
 	return (true);


### PR DESCRIPTION
Specifically, do an in-memory split when we hit 80% of memory_page_max.