### PR TITLE
SERVER-21553 Enable fast-path truncate after splits.

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -102,22 +102,15 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	 * out is to check the on-page cell type for the page, cells for leaf
 	 * pages that have no overflow items are special.
 	 *
-	 * In some cases, the reference address may not reference an on-page
-	 * cell (for example, some combination of page splits), in which case
-	 * we can't check the original cell value and we fail.
-	 *
 	 * To look at an on-page cell, we need to look at the parent page, and
 	 * that's dangerous, our parent page could change without warning if
 	 * the parent page were to split, deepening the tree.  It's safe: the
 	 * page's reference will always point to some valid page, and if we find
 	 * any problems we simply fail the fast-delete optimization.
-	 *
-	 * !!!
-	 * I doubt it's worth the effort, but we could copy the cell's type into
-	 * the reference structure, and then we wouldn't need an on-page cell.
 	 */
 	parent = ref->home;
-	if (__wt_off_page(parent, ref->addr) ||
+	if (__wt_off_page(parent, ref->addr) ?
+	    ((WT_ADDR *)ref->addr)->type != WT_ADDR_LEAF_NO :
 	    __wt_cell_type_raw(ref->addr) != WT_CELL_ADDR_LEAF_NO)
 		goto err;
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -352,6 +352,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 			break;
 		WT_ILLEGAL_VALUE(session);
 		}
+		ref->addr = addr;
 	}
 
 	/* And finally, copy the WT_REF pointer itself. */

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -340,9 +340,18 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 			return (ret);
 		}
 		addr->size = (uint8_t)unpack.size;
-		addr->type =
-		    unpack.raw == WT_CELL_ADDR_INT ? WT_ADDR_INT : WT_ADDR_LEAF;
-		ref->addr = addr;
+		switch (unpack.raw) {
+		case WT_CELL_ADDR_INT:
+			addr->type = WT_ADDR_INT;
+			break;
+		case WT_CELL_ADDR_LEAF:
+			addr->type = WT_ADDR_LEAF;
+			break;
+		case WT_CELL_ADDR_LEAF_NO:
+			addr->type = WT_ADDR_LEAF_NO;
+			break;
+		WT_ILLEGAL_VALUE(session);
+		}
 	}
 
 	/* And finally, copy the WT_REF pointer itself. */


### PR DESCRIPTION
A truncate operation attempts to mark leaf pages deleted without reading them
into cache.  One of the conditions that has to be met for that fast-path
truncate of pages is that the leaf page not contain overflow items (or we would
need to read it in order to delete the overflow items).

The "no overflow" flag was not being preseved across internal page splits, so
recent changes to splits were defeating fast-path truncation.

Add tracking of the "no overflow" flag for in-memory page addresses so
fast-path truncates work after internal pages are split.