### PR TITLE
WT-2247: variable-length column-store in-memory page splits.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1618,6 +1618,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_PAGE *page, *right;
 	WT_REF *child, *split_ref[2] = { NULL, NULL };
 	size_t page_decr, parent_incr, right_incr;
+	uint8_t type;
 	int i;
 
 	WT_STAT_FAST_CONN_INCR(session, cache_inmem_split);
@@ -1626,6 +1627,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	page = ref->page;
 	right = NULL;
 	page_decr = parent_incr = right_incr = 0;
+	type = page->type;
 
 	/*
 	 * Assert splitting makes sense; specifically assert the page is dirty,
@@ -1639,9 +1641,11 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	F_SET_ATOMIC(page, WT_PAGE_SPLIT_INSERT);
 
 	/* Find the last item on the page. */
-	ins_head = page->pg_row_entries == 0 ?
+	ins_head = type == WT_PAGE_ROW_LEAF ?
+	    (page->pg_row_entries == 0 ?
 	    WT_ROW_INSERT_SMALLEST(page) :
-	    WT_ROW_INSERT_SLOT(page, page->pg_row_entries - 1);
+	    WT_ROW_INSERT_SLOT(page, page->pg_row_entries - 1)) :
+	    WT_COL_APPEND(page);
 	moved_ins = WT_SKIP_LAST(ins_head);
 
 	/*
@@ -1651,15 +1655,9 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 *
 	 * The new WT_REF is not quite identical: we have to instantiate a key,
 	 * and the new reference is visible to readers once the split completes.
-	 *
-	 * The key-instantiation code checks for races, leave the key fields
-	 * zeroed we don't trigger them.
-	 *
-	 * Don't copy any deleted page state: we may be splitting a page that
-	 * was instantiated after a truncate and that history should not be
-	 * carried onto these new child pages.
 	 */
 	WT_ERR(__wt_calloc_one(session, &split_ref[0]));
+	parent_incr += sizeof(WT_REF);
 	child = split_ref[0];
 	child->page = ref->page;
 	child->home = ref->home;
@@ -1667,49 +1665,77 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	child->state = WT_REF_MEM;
 	child->addr = ref->addr;
 
-	/*
-	 * Copy the first key from the original page into first ref in the new
-	 * parent.  Pages created in memory always have a "smallest" insert
-	 * list, so look there first.  If we don't find one, get the first key
-	 * from the disk image.
-	 *
-	 * We can't just use the key from the original ref: it may have been
-	 * suffix-compressed, and after the split the truncated key may not be
-	 * valid.
-	 */
-	WT_ERR(__wt_scr_alloc(session, 0, &key));
-	if ((ins = WT_SKIP_FIRST(WT_ROW_INSERT_SMALLEST(page))) != NULL) {
-		key->data = WT_INSERT_KEY(ins);
-		key->size = WT_INSERT_KEY_SIZE(ins);
+	if (type == WT_PAGE_ROW_LEAF) {
+		/*
+		 * Copy the first key from the original page into first ref in
+		 * the new parent. Pages created in memory always have a
+		 * "smallest" insert list, so look there first.  If we don't
+		 * find one, get the first key from the disk image.
+		 *
+		 * We can't just use the key from the original ref: it may have
+		 * been suffix-compressed, and after the split the truncated key
+		 * may not be valid.
+		 */
+		WT_ERR(__wt_scr_alloc(session, 0, &key));
+		if ((ins =
+		    WT_SKIP_FIRST(WT_ROW_INSERT_SMALLEST(page))) != NULL) {
+			key->data = WT_INSERT_KEY(ins);
+			key->size = WT_INSERT_KEY_SIZE(ins);
+		} else
+			WT_ERR(__wt_row_leaf_key(
+			    session, page, &page->pg_row_d[0], key, true));
+		WT_ERR(__wt_row_ikey(session, 0, key->data, key->size, child));
+		parent_incr += sizeof(WT_IKEY) + key->size;
+		__wt_scr_free(session, &key);
 	} else
-		WT_ERR(__wt_row_leaf_key(
-		    session, page, &page->pg_row_d[0], key, true));
-	WT_ERR(__wt_row_ikey(session, 0, key->data, key->size, child));
-	parent_incr += sizeof(WT_REF) + sizeof(WT_IKEY) + key->size;
-	__wt_scr_free(session, &key);
+		child->key.recno = ref->key.recno;
+
+	/*
+	 * Don't copy any deleted page state: we may be splitting a page that
+	 * was instantiated after a truncate and that history should not be
+	 * carried onto these new child pages.
+	 */
+	child->page_del = NULL;
 
 	/*
 	 * The second page in the split is a new WT_REF/page pair.
 	 */
-	WT_ERR(__wt_page_alloc(session, WT_PAGE_ROW_LEAF, 0, 0, false, &right));
-	WT_ERR(__wt_calloc_one(session, &right->pg_row_ins));
-	WT_ERR(__wt_calloc_one(session, &right->pg_row_ins[0]));
+	if (type == WT_PAGE_ROW_LEAF)
+		WT_ERR(__wt_page_alloc(session, type, 0, 0, false, &right));
+	else
+		WT_ERR(__wt_page_alloc(session,
+		    type, WT_INSERT_RECNO(moved_ins), 0, false, &right));
+
+	/*
+	 * The new page is dirty by definition, column-store splits update the
+	 * page-modify structure, so create it now.
+	 */
+	WT_ERR(__wt_page_modify_init(session, right));
+	__wt_page_modify_set(session, right);
+
+	if (type == WT_PAGE_ROW_LEAF) {
+		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins));
+		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins[0]));
+	} else {
+		WT_ERR(__wt_calloc_one(session, &right->modify->mod_append));
+		WT_ERR(__wt_calloc_one(session, &right->modify->mod_append[0]));
+	}
 	right_incr += sizeof(WT_INSERT_HEAD);
 	right_incr += sizeof(WT_INSERT_HEAD *);
 
 	WT_ERR(__wt_calloc_one(session, &split_ref[1]));
+	parent_incr += sizeof(WT_REF);
 	child = split_ref[1];
 	child->page = right;
 	child->state = WT_REF_MEM;
-	WT_ERR(__wt_row_ikey(session, 0,
-	    WT_INSERT_KEY(moved_ins), WT_INSERT_KEY_SIZE(moved_ins),
-	    child));
-	parent_incr +=
-	    sizeof(WT_REF) + sizeof(WT_IKEY) + WT_INSERT_KEY_SIZE(moved_ins);
 
-	/* The new page is dirty by definition. */
-	WT_ERR(__wt_page_modify_init(session, right));
-	__wt_page_modify_set(session, right);
+	if (type == WT_PAGE_ROW_LEAF) {
+		WT_ERR(__wt_row_ikey(session, 0,
+		    WT_INSERT_KEY(moved_ins), WT_INSERT_KEY_SIZE(moved_ins),
+		    child));
+		parent_incr += sizeof(WT_IKEY) + WT_INSERT_KEY_SIZE(moved_ins);
+	} else
+		child->key.recno = WT_INSERT_RECNO(moved_ins);
 
 	/*
 	 * We modified the page above, which will have set the first dirty
@@ -1740,8 +1766,12 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * for simplicity, the previous skip list pointers originally allocated
 	 * can be ignored.)
 	 */
-	right->pg_row_ins[0]->head[0] =
-	    right->pg_row_ins[0]->tail[0] = moved_ins;
+	if (type == WT_PAGE_ROW_LEAF)
+		right->pg_row_ins[0]->head[0] =
+		    right->pg_row_ins[0]->tail[0] = moved_ins;
+	else
+		right->modify->mod_append[0]->head[0] =
+		    right->modify->mod_append[0]->tail[0] = moved_ins;
 
 	/*
 	 * Remove the entry from the orig page (i.e truncate the skip list).
@@ -1826,45 +1856,54 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	__wt_cache_page_inmem_incr(session, right, right_incr);
 
 	/*
-	 * Split into the parent.  After this, the original page is no
+	 * Split into the parent. On successful return, the original page is no
 	 * longer locked, so we cannot safely look at it.
 	 */
 	page = NULL;
 	if ((ret = __split_parent(
-	    session, ref, split_ref, 2, parent_incr, false, true)) != 0) {
-		/*
-		 * Move the insert list element back to the original page list.
-		 * For simplicity, the previous skip list pointers originally
-		 * allocated can be ignored, just append the entry to the end of
-		 * the level 0 list. As before, we depend on the list having
-		 * multiple elements and ignore the edge cases small lists have.
-		 */
+	    session, ref, split_ref, 2, parent_incr, false, true)) == 0)
+		return (0);
+
+	/*
+	 * Failure.
+	 *
+	 * Clear the allocated page's reference to the moved insert list element
+	 * so it's not freed when we discard the page.
+	 *
+	 * Move the element back to the original page list. For simplicity, the
+	 * previous skip list pointers originally allocated can be ignored, just
+	 * append the entry to the end of the level 0 list. As before, we depend
+	 * on the list having multiple elements and ignore the edge cases small
+	 * lists have.
+	 */
+	if (type == WT_PAGE_ROW_LEAF)
 		right->pg_row_ins[0]->head[0] =
 		    right->pg_row_ins[0]->tail[0] = NULL;
-		ins_head->tail[0]->next[0] = moved_ins;
-		ins_head->tail[0] = moved_ins;
+	else
+		right->modify->mod_append[0]->head[0] =
+		    right->modify->mod_append[0]->tail[0] = NULL;
 
-		/*
-		 * We marked the new page dirty; we're going to discard it, but
-		 * first mark it clean and fix up the cache statistics.
-		 */
-		__wt_page_modify_clear(session, right);
-
-		WT_ERR(ret);
-	}
-
-	return (0);
+	ins_head->tail[0]->next[0] = moved_ins;
+	ins_head->tail[0] = moved_ins;
 
 err:	if (split_ref[0] != NULL) {
-		__wt_free(session, split_ref[0]->key.ikey);
+		if (type == WT_PAGE_ROW_LEAF)
+			__wt_free(session, split_ref[0]->key.ikey);
 		__wt_free(session, split_ref[0]);
 	}
 	if (split_ref[1] != NULL) {
-		__wt_free(session, split_ref[1]->key.ikey);
+		if (type == WT_PAGE_ROW_LEAF)
+			__wt_free(session, split_ref[1]->key.ikey);
 		__wt_free(session, split_ref[1]);
 	}
-	if (right != NULL)
+	if (right != NULL) {
+		/*
+		 * We marked the new page dirty; we're going to discard it,
+		 * but first mark it clean and fix up the cache statistics.
+		 */
+		__wt_page_modify_clear(session, right);
 		__wt_page_out(session, &right);
+	}
 	__wt_scr_free(session, &key);
 	return (ret);
 }

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -305,7 +305,7 @@ struct __wt_page_modify {
 	struct {
 		/*
 		 * Appended items to column-stores: there is only a single one
-		 * of these per column-store tree.
+		 * of these active at a time per column-store tree.
 		 */
 		WT_INSERT_HEAD **append;
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -991,15 +991,14 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * do it without making the appending threads wait. See if it's worth
 	 * doing a split to let the threads continue before doing eviction.
 	 *
-	 * Ignore anything other than large, dirty row-store or variable-length
-	 * column-store leaf pages. We depend on the page being dirty for
-	 * correctness (the page must be reconciled again before being evicted
-	 * after the split, information from a previous reconciliation will be
-	 * wrong, so we can't evict immediately).
+	 * Ignore anything other than large, dirty leaf pages. We depend on the
+	 * page being dirty for correctness (the page must be reconciled again
+	 * before being evicted after the split, information from a previous
+	 * reconciliation will be wrong, so we can't evict immediately).
 	 */
 	if (page->memory_footprint < btree->splitmempage)
 		return (false);
-	if (page->type != WT_PAGE_ROW_LEAF && page->type != WT_PAGE_COL_VAR)
+	if (WT_PAGE_IS_INTERNAL(page))
 		return (false);
 	if (!__wt_page_is_modified(page))
 		return (false);


### PR DESCRIPTION
@michaelcahill, @agorrod, this change supports in-memory page splits for variable-length column-store trees.

I branched off WT-2244 (#2340) because there was stuff there that would collide, but that was just for convenience, if WT-2244 goes in before we open up develop more generally, I'll rebase the pull request.