### PR TITLE
WT-2248: WT_SESSION.close is updating WT_CONNECTION_IMPL.default_session

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -206,6 +206,9 @@ __session_close(WT_SESSION *wt_session, const char *config)
 
 	__wt_spin_unlock(session, &conn->api_lock);
 
+	/* We no longer have a session, don't try to update it. */
+	session = NULL;
+
 err:	API_END_RET_NOTFOUND_MAP(session, ret);
 }
 


### PR DESCRIPTION
@michaelcahill, can you do a quick sanity check on this one?

I think it's safe (I'm using the same trick as in `__conn_close`), but wanted to be sure.

The repro is watching `WT_SESSION.name` change as we work our way through `__wt_connection_close`.