### PR TITLE
WT-2256 Fix interval timer for wtperf throttling.

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2427,6 +2427,11 @@ worker_throttle(int64_t throttle, int64_t *ops, struct timespec *interval)
 	if (usecs_to_complete < USEC_PER_SEC)
 		(void)usleep((useconds_t)(USEC_PER_SEC - usecs_to_complete));
 
+	/*
+	 * After sleeping, set the interval to the current time.
+	 */
+	if (__wt_epoch(NULL, &now) != 0)
+		return;
 	*ops = 0;
 	*interval = now;
 }


### PR DESCRIPTION
@daveh86 or @agorrod Please review this change that fixes throttling.  We need to set the timer to the post-sleep time.  This is what was causing the nearly 2x number of ops.