### PR TITLE
WT-2265 - increase mongodb-oplog wtperf workload throttle to compensate for fix

### DIFF
--- a/bench/wtperf/runners/mongodb-oplog.wtperf
+++ b/bench/wtperf/runners/mongodb-oplog.wtperf
@@ -8,4 +8,4 @@ run_time=500
 populate_threads=1
 # Setup three threads to insert into the oplog
 # Setup one thread to be doing truncates from the oplog
-threads=((count=3,inserts=1,throttle=2000),(count=1,truncate=1,truncate_pct=10,truncate_count=50000))
+threads=((count=3,inserts=1,throttle=4000),(count=1,truncate=1,truncate_pct=10,truncate_count=50000))


### PR DESCRIPTION
@agorrod, can you have a quick look at this change.

It fixes the regression we have seen in the WTPERF truncate workload in jenkins noticed by @sueloverso in https://jira.mongodb.org/browse/WT-2245