### PR TITLE
WT-2266 Add max_latency_fatal and min_throughput_fatal settings.

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1097,10 +1097,10 @@ monitor(void *arg)
 	uint32_t read_avg, read_min, read_max;
 	uint32_t insert_avg, insert_min, insert_max;
 	uint32_t update_avg, update_min, update_max;
-	uint32_t latency_max;
+	uint32_t latency_max, level;
 	u_int i;
-	int ret;
-	char buf[64], *path;
+	int msg_err, ret;
+	char buf[64], *path, *str;
 
 	cfg = (CONFIG *)arg;
 	assert(cfg->sample_interval != 0);
@@ -1197,25 +1197,41 @@ monitor(void *arg)
 
 		if (latency_max != 0 &&
 		    (read_max > latency_max || insert_max > latency_max ||
-		     update_max > latency_max))
-			/*
-			 * Make this a non-fatal error and print WARNING in
-			 * the output so Jenkins can flag it as unstable.
-			 */
-			lprintf(cfg, 0, 0,
-			    "WARNING: max latency exceeded: threshold %" PRIu32
+		     update_max > latency_max)) {
+			if (cfg->max_latency_fatal) {
+				level = 1;
+				msg_err = WT_PANIC;
+				str = "ERROR";
+			} else {
+				level = 0;
+				msg_err = 0;
+				str = "WARNING";
+			}
+			lprintf(cfg, msg_err, level,
+			    "%s: max latency exceeded: threshold %" PRIu32
 			    " read max %" PRIu32 " insert max %" PRIu32
-			    " update max %" PRIu32, latency_max,
+			    " update max %" PRIu32, str, latency_max,
 			    read_max, insert_max, update_max);
+		}
 		if (min_thr != 0 &&
 		    ((cur_reads != 0 && cur_reads < min_thr) ||
 		    (cur_inserts != 0 && cur_inserts < min_thr) ||
-		    (cur_updates != 0 && cur_updates < min_thr)))
-			lprintf(cfg, WT_PANIC, 0,
-			    "minimum throughput not met: threshold %" PRIu64
+		    (cur_updates != 0 && cur_updates < min_thr))) {
+			if (cfg->min_throughput_fatal) {
+				level = 1;
+				msg_err = WT_PANIC;
+				str = "ERROR";
+			} else {
+				level = 0;
+				msg_err = 0;
+				str = "WARNING";
+			}
+			lprintf(cfg, msg_err, level,
+			    "%s: minimum throughput not met: threshold %" PRIu64
 			    " reads %" PRIu64 " inserts %" PRIu64
-			    " updates %" PRIu64, min_thr, cur_reads,
+			    " updates %" PRIu64, str, min_thr, cur_reads,
 			    cur_inserts, cur_updates);
+		}
 		last_reads = reads;
 		last_inserts = inserts;
 		last_updates = updates;

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1100,7 +1100,8 @@ monitor(void *arg)
 	uint32_t latency_max, level;
 	u_int i;
 	int msg_err, ret;
-	char buf[64], *path, *str;
+	const char *str;
+	char buf[64], *path;
 
 	cfg = (CONFIG *)arg;
 	assert(cfg->sample_interval != 0);

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -117,11 +117,17 @@ DEF_OPT_AS_BOOL(insert_rmw, 0,
 DEF_OPT_AS_UINT32(key_sz, 20, "key size")
 DEF_OPT_AS_BOOL(log_partial, 0, "perform partial logging on first table only.")
 DEF_OPT_AS_UINT32(min_throughput, 0,
-    "abort if any throughput measured is less than this amount.  Requires "
-    "sample_interval to be configured")
-DEF_OPT_AS_UINT32(max_latency, 0,
-    "abort if any latency measured exceeds this number of milliseconds."
+    "notify if any throughput measured is less than this amount. "
+    "Aborts or prints warning based on min_throughput_fatal setting. "
     "Requires sample_interval to be configured")
+DEF_OPT_AS_BOOL(min_throughput_fatal, 0,
+    "print warning (false) or abort (true) of min_throughput failure.")
+DEF_OPT_AS_UINT32(max_latency, 0,
+    "notify if any latency measured exceeds this number of milliseconds."
+    "Aborts or prints warning based on min_throughput_fatal setting. "
+    "Requires sample_interval to be configured")
+DEF_OPT_AS_BOOL(max_latency_fatal, 0,
+    "print warning (false) or abort (true) of max_latency failure.")
 DEF_OPT_AS_UINT32(pareto, 0, "use pareto distribution for random numbers. Zero "
     "to disable, otherwise a percentage indicating how aggressive the "
     "distribution should be.")

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -182,11 +182,17 @@ key size
 @par log_partial (boolean, default=false)
 perform partial logging on first table only.
 @par min_throughput (unsigned int, default=0)
-abort if any throughput measured is less than this amount.  Requires
+notify if any throughput measured is less than this amount. Aborts or
+prints warning based on min_throughput_fatal setting. Requires
 sample_interval to be configured
+@par min_throughput_fatal (boolean, default=false)
+print warning (false) or abort (true) of min_throughput failure.
 @par max_latency (unsigned int, default=0)
-abort if any latency measured exceeds this number of
-milliseconds.Requires sample_interval to be configured
+notify if any latency measured exceeds this number of
+milliseconds.Aborts or prints warning based on min_throughput_fatal
+setting. Requires sample_interval to be configured
+@par max_latency_fatal (boolean, default=false)
+print warning (false) or abort (true) of max_latency failure.
 @par pareto (unsigned int, default=0)
 use pareto distribution for random numbers. Zero to disable, otherwise
 a percentage indicating how aggressive the distribution should be.


### PR DESCRIPTION
@daveh86 Please review this change to add a warning/failure selection to the max_latency and min_throughput.  It may be useful to crash or warn in the test framework you're working on.