### PR TITLE
WT-2272 Flag an error if there is a failure clearing the eviction walk point.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -729,7 +729,7 @@ __evict_request_walk_clear(WT_SESSION_IMPL *session)
 
 	/* An error is unexpected - flag the failure. */
 	if (ret != 0)
-		__wt_err(session, ret, "Failed to clear eviction walk point\n");
+		__wt_err(session, ret, "Failed to clear eviction walk point");
 
 	return (ret);
 }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -727,6 +727,10 @@ __evict_request_walk_clear(WT_SESSION_IMPL *session)
 
 	F_CLR(session, WT_SESSION_CLEAR_EVICT_WALK);
 
+	/* An error is unexpected - flag the failure. */
+	if (ret != 0)
+		__wt_err(session, ret, "Failed to clear eviction walk point\n");
+
 	return (ret);
 }
 


### PR DESCRIPTION
Calling code generally expects the clear to work.