### PR TITLE
WT-2177 Add an optional random seed to WiredTiger rand implementation

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2328,12 +2328,7 @@ start_threads(CONFIG *cfg,
 		 * We don't want the threads executing in lock-step, move each
 		 * new RNG state further along in the sequence.
 		 */
-		if (i == 0)
-			__wt_random_init(&thread->rnd);
-		else
-			thread->rnd = (thread - 1)->rnd;
-		for (j = 0; j < 1000; ++j)
-			(void)__wt_random(&thread->rnd);
+		__wt_random_init_seed(NULL, &thread->rnd);
 
 		/*
 		 * Every thread gets a key/data buffer because we don't bother

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2316,7 +2316,7 @@ start_threads(CONFIG *cfg,
     WORKLOAD *workp, CONFIG_THREAD *base, u_int num, void *(*func)(void *))
 {
 	CONFIG_THREAD *thread;
-	u_int i, j;
+	u_int i;
 	int ret;
 
 	/* Initialize the threads. */

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -6,7 +6,7 @@ trap 'rm -f $t; exit 0' 0 1 2 3 13 15
 
 # List of files to search.
 l=`sed -e 's,#.*,,' -e '/^$/d' -e 's,^,../,' filelist`
-l="$l `echo ../src/*/*.i ../src/utilities/*.c`"
+l="$l `echo ../src/*/*.i ../src/utilities/*.c ../bench/wtperf/*.c`"
 
 (
 # Copy out the functions we don't use, but it's OK.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -668,6 +668,7 @@ extern uint32_t __wt_log2_int(uint32_t n);
 extern bool __wt_ispo2(uint32_t v);
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2);
 extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state);
+extern void __wt_random_init_seed(WT_SESSION *session, WT_RAND_STATE volatile *rnd_state);
 extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state);
 extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size);
 extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4)));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -668,7 +668,7 @@ extern uint32_t __wt_log2_int(uint32_t n);
 extern bool __wt_ispo2(uint32_t v);
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2);
 extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state);
-extern void __wt_random_init_seed(WT_SESSION *session, WT_RAND_STATE volatile *rnd_state);
+extern void __wt_random_init_seed( WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state);
 extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state);
 extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size);
 extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4)));

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -67,7 +67,8 @@ __wt_random_init(WT_RAND_STATE volatile * rnd_state)
  * on a different random seed.
  */
 void
-__wt_random_init_seed(WT_SESSION *session, WT_RAND_STATE volatile * rnd_state)
+__wt_random_init_seed(
+    WT_SESSION_IMPL *session, WT_RAND_STATE volatile * rnd_state)
 {
 	WT_RAND_STATE rnd;
 	struct timespec ts;

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -62,24 +62,22 @@ __wt_random_init(WT_RAND_STATE volatile * rnd_state)
 /*
  * __wt_random_init_seed --
  *	Initialize the state of a 32-bit pseudo-random number.
- *
  * Use this, instead of __wt_random_init if we are running with multiple
- * threads and we want each thread to initialize its own rnd_state based
- * on a different random seed. 
+ * threads and we want each thread to initialize its own random state based
+ * on a different random seed.
  */
 void
 __wt_random_init_seed(WT_SESSION *session, WT_RAND_STATE volatile * rnd_state)
 {
 	WT_RAND_STATE rnd;
 	struct timespec ts;
-	
+
 	__wt_epoch(session, &ts);
 	M_W(rnd) = ts.tv_nsec + 521288629;
 	M_Z(rnd) = ts.tv_nsec + 362436069;
 
 	*rnd_state = rnd;
 }
-
 
 /*
  * __wt_random --

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -60,6 +60,28 @@ __wt_random_init(WT_RAND_STATE volatile * rnd_state)
 }
 
 /*
+ * __wt_random_init_seed --
+ *	Initialize the state of a 32-bit pseudo-random number.
+ *
+ * Use this, instead of __wt_random_init if we are running with multiple
+ * threads and we want each thread to initialize its own rnd_state based
+ * on a different random seed. 
+ */
+void
+__wt_random_init_seed(WT_SESSION *session, WT_RAND_STATE volatile * rnd_state)
+{
+	WT_RAND_STATE rnd;
+	struct timespec ts;
+	
+	__wt_epoch(session, &ts);
+	M_W(rnd) = ts.tv_nsec + 521288629;
+	M_Z(rnd) = ts.tv_nsec + 362436069;
+
+	*rnd_state = rnd;
+}
+
+
+/*
  * __wt_random --
  *	Return a 32-bit pseudo-random number.
  */


### PR DESCRIPTION
From @fedorova.

Added a function to optionally initialize a seed, used by __wt_random(), from a random number. Added a call to this function to wtperf. Please take a look.
