### PR TITLE
WT-2275: core dump when "wt dump" fails.

### DIFF
--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -968,8 +968,11 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_strdup(session, tmp->data, &ctable->cfg[1]));
 
 	if (0) {
-err:		WT_TRET(__curtable_close(cursor));
-		*cursorp = NULL;
+err:		if (*cursorp != NULL) {
+			WT_TRET(__wt_cursor_close(*cursorp));
+			*cursorp = NULL;
+		}
+		WT_TRET(__curtable_close(cursor));
 	}
 
 	__wt_scr_free(session, &tmp);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -148,7 +148,7 @@ __session_close(WT_SESSION *wt_session, const char *config)
 		 * via the registered close callback.
 		 */
 		if (session->event_handler->handle_close != NULL &&
-		    !WT_STREQ(cursor->uri, WT_LAS_URI))
+		    !WT_STREQ(cursor->internal_uri, WT_LAS_URI))
 			WT_TRET(session->event_handler->handle_close(
 			    session->event_handler, wt_session, cursor));
 		WT_TRET(cursor->close(cursor));

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -226,7 +226,6 @@ main(int argc, char *argv[])
 	ret = func(session, argc, argv);
 
 	/* Close the database. */
-
 err:	if (conn != NULL && (tret = conn->close(conn, NULL)) != 0 && ret == 0)
 		ret = tret;
 


### PR DESCRIPTION
@michaelcahill, @agorrod: two problems. First, we weren't closing a cursor in a table-cursor open error path (commit 2cc1025), and second, we were looking at `WT_CURSOR.uri` in a cursor close path and it hadn't yet been initialized (commit 5196a17).

Please check the table-cursor open change carefully, I'm not that comfortable with the table cursor code, I might have gotten it wrong.

Alex, commit 5196a17 is because `WT_CURSOR.uri` is the last thing we fill in when initializing a cursor, and we were using it inside WiredTiger cursor close code. What would you think of disallowing the use of `WT_CURSOR.uri` inside the WiredTiger library, and only allow using `WT_CURSOR.internal_uri`?