### PR TITLE
Revert "WT-2231: check the leaf page's parent keys before doing the full binary search"

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -272,7 +272,7 @@ __inmem_col_int(WT_SESSION_IMPL *session, WT_PAGE *page)
 	const WT_PAGE_HEADER *dsk;
 	WT_PAGE_INDEX *pindex;
 	WT_REF **refp, *ref;
-	uint32_t hint, i;
+	uint32_t i;
 
 	btree = S2BT(session);
 	dsk = page->dsk;
@@ -284,11 +284,9 @@ __inmem_col_int(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 */
 	pindex = WT_INTL_INDEX_GET_SAFE(page);
 	refp = pindex->index;
-	hint = 0;
 	WT_CELL_FOREACH(btree, dsk, cell, unpack, i) {
 		ref = *refp++;
 		ref->home = page;
-		ref->pindex_hint = hint++;
 
 		__wt_cell_unpack(cell, unpack);
 		ref->addr = cell;
@@ -406,7 +404,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 	const WT_PAGE_HEADER *dsk;
 	WT_PAGE_INDEX *pindex;
 	WT_REF *ref, **refp;
-	uint32_t hint, i;
+	uint32_t i;
 	bool overflow_keys;
 
 	btree = S2BT(session);
@@ -423,11 +421,9 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 	pindex = WT_INTL_INDEX_GET_SAFE(page);
 	refp = pindex->index;
 	overflow_keys = false;
-	hint = 0;
 	WT_CELL_FOREACH(btree, dsk, cell, unpack, i) {
 		ref = *refp;
 		ref->home = page;
-		ref->pindex_hint = hint++;
 
 		__wt_cell_unpack(cell, unpack);
 		switch (unpack->type) {

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -404,12 +404,12 @@ __split_child_block_evict_and_split(WT_PAGE *child)
  */
 static int
 __split_ref_move_final(
-    WT_SESSION_IMPL *session, WT_PAGE_INDEX *pindex, bool skip_first)
+    WT_SESSION_IMPL *session, WT_REF **refp, uint32_t entries)
 {
 	WT_DECL_RET;
 	WT_PAGE *child;
 	WT_REF *ref, *child_ref;
-	uint32_t i, j;
+	uint32_t i;
 
 	/*
 	 * The WT_REF structures moved to newly allocated child pages reference
@@ -420,11 +420,8 @@ __split_ref_move_final(
 	 * happens the thread waits for the reference's home page to be updated,
 	 * which we do here: walk the children and fix them up.
 	 */
-	for (i = skip_first ? 1 : 0; i < pindex->entries; ++i) {
-		ref = pindex->index[i];
-
-		/* Update the WT_REF's page-index hint. */
-		ref->pindex_hint = i;
+	for (i = 0; i < entries; ++i, ++refp) {
+		ref = *refp;
 
 		/*
 		 * We don't hold hazard pointers on created pages, they cannot
@@ -454,7 +451,6 @@ __split_ref_move_final(
 		 * know about that flag; use the standard macros to ensure that
 		 * reading the child's page index structure is safe.
 		 */
-		j = 0;
 		WT_ENTER_PAGE_INDEX(session);
 		WT_INTL_FOREACH_BEGIN(session, child, child_ref) {
 			/*
@@ -463,11 +459,10 @@ __split_ref_move_final(
 			 * disk pages may have been read in since then, and
 			 * those pages would have correct parent references.
 			 */
-			if (child_ref->home != child)
+			if (child_ref->home != child) {
 				child_ref->home = child;
-
-			/* Update the WT_REF's page-index hint. */
-			child_ref->pindex_hint = j++;
+				child_ref->pindex_hint = 0;
+			}
 		} WT_INTL_FOREACH_END;
 		WT_LEAVE_PAGE_INDEX(session);
 
@@ -643,7 +638,8 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	    __split_verify_intl_key_order(session, root));
 #endif
 	/* Fix up the moved WT_REF structures. */
-	WT_ERR(__split_ref_move_final(session, alloc_index, false));
+	WT_ERR(__split_ref_move_final(
+	    session, alloc_index->index, alloc_index->entries));
 
 	/* We've installed the allocated page-index, ensure error handling. */
 	alloc_index = NULL;
@@ -704,7 +700,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	WT_REF **alloc_refp, *next_ref;
 	size_t parent_decr, size;
 	uint64_t split_gen;
-	uint32_t hint, i, j;
+	uint32_t i, j;
 	uint32_t deleted_entries, parent_entries, result_entries;
 	uint32_t *deleted_refs;
 	bool complete, empty_parent;
@@ -772,31 +768,22 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	 * Allocate and initialize a new page index array for the parent, then
 	 * copy references from the original index array, plus references from
 	 * the newly created split array, into place.
-	 *
-	 * Update the WT_REF's page-index hint as we go. This can race with a
-	 * thread setting the hint based on an older page-index, and the change
-	 * isn't backed out in the case of an error, so there ways for the hint
-	 * to be wrong; OK because it's just a hint.
 	 */
 	size = sizeof(WT_PAGE_INDEX) + result_entries * sizeof(WT_REF *);
 	WT_ERR(__wt_calloc(session, 1, size, &alloc_index));
 	parent_incr += size;
 	alloc_index->index = (WT_REF **)(alloc_index + 1);
 	alloc_index->entries = result_entries;
-	for (alloc_refp = alloc_index->index,
-	    hint = i = 0; i < parent_entries; ++i) {
+	for (alloc_refp = alloc_index->index, i = 0; i < parent_entries; ++i) {
 		next_ref = pindex->index[i];
 		if (next_ref == ref)
 			for (j = 0; j < new_entries; ++j) {
 				ref_new[j]->home = parent;
-				ref_new[j]->pindex_hint = hint++;
 				*alloc_refp++ = ref_new[j];
 			}
-		else if (next_ref->state != WT_REF_SPLIT) {
+		else if (next_ref->state != WT_REF_SPLIT)
 			/* Skip refs we have marked for deletion. */
-			next_ref->pindex_hint = hint++;
 			*alloc_refp++ = next_ref;
-		}
 	}
 
 	/* Check that we filled in all the entries. */
@@ -1141,7 +1128,8 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 #endif
 
 	/* Fix up the moved WT_REF structures. */
-	WT_ERR(__split_ref_move_final(session, alloc_index, true));
+	WT_ERR(__split_ref_move_final(
+	    session, alloc_index->index + 1, alloc_index->entries - 1));
 
 	/*
 	 * We don't care about the page-index we allocated, all we needed was

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -132,56 +132,6 @@ __wt_search_insert(
 }
 
 /*
- * __check_leaf_key_range --
- *	Check the search key is in the leaf page's key range.
- */
-static inline int
-__check_leaf_key_range(WT_SESSION_IMPL *session,
-    WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt)
-{
-	WT_BTREE *btree;
-	WT_COLLATOR *collator;
-	WT_ITEM *item;
-	WT_PAGE_INDEX *pindex;
-	uint32_t indx;
-	int cmp;
-
-	btree = S2BT(session);
-	collator = btree->collator;
-	item = cbt->tmp;
-
-	/*
-	 * Check if the search key is less than the parent's starting key for
-	 * this page.
-	 */
-	__wt_ref_key(leaf->home, leaf, &item->data, &item->size);
-	WT_RET(__wt_compare(session, collator, srch_key, item, &cmp));
-	if (cmp < 0) {
-		cbt->compare = 1;		/* page keys > search key */
-		return (0);
-	}
-
-	/*
-	 * Check if the search key is greater than or equal to the starting key
-	 * for the parent's next page.
-	 */
-	WT_INTL_INDEX_GET(session, leaf->home, pindex);
-	indx = leaf->pindex_hint;
-	if (pindex->index[indx] == leaf && indx + 1 < pindex->entries) {
-		__wt_ref_key(leaf->home,
-		    pindex->index[indx + 1], &item->data, &item->size);
-		WT_RET(__wt_compare(session, collator, srch_key, item, &cmp));
-		if (cmp >= 0) {
-			cbt->compare = -1;	/* page keys < search key */
-			return (0);
-		}
-	}
-
-	cbt->compare = 0;
-	return (0);
-}
-
-/*
  * __wt_row_search --
  *	Search a row-store tree for a specific key.
  */
@@ -229,29 +179,8 @@ __wt_row_search(WT_SESSION_IMPL *session,
 	append_check = insert && cbt->append_tree;
 	descend_right = true;
 
-	/*
-	 * We may be searching only a single leaf page, not the full tree. In
-	 * the normal case where the page links to a parent, check the page's
-	 * parent keys before doing the full search, it's faster when the
-	 * cursor is being re-positioned. (One case where the page doesn't
-	 * have a parent is if it is being re-instantiated in memory as part
-	 * of a split).
-	 */
+	/* We may only be searching a single leaf page, not the full tree. */
 	if (leaf != NULL) {
-		if (leaf->home != NULL) {
-			WT_RET(__check_leaf_key_range(
-			    session, srch_key, leaf, cbt));
-			if (cbt->compare != 0) {
-				/*
-				 * !!!
-				 * WT_CURSOR.search_near uses the slot value to
-				 * decide if there was an on-page match.
-				 */
-				cbt->slot = 0;
-				return (0);
-			}
-		}
-
 		current = leaf;
 		goto leaf_only;
 	}


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#2325, which introduced a segfault.