### PR TITLE
WT-2282 Remove last_running_moved from verbose conditional.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -339,8 +339,7 @@ retry:
 		}
 	} else {
 		if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
-		    current_id - oldest_id > 10000 && last_running_moved &&
-		    oldest_session != NULL) {
+		    current_id - oldest_id > 10000 && oldest_session != NULL) {
 			(void)__wt_verbose(session, WT_VERB_TRANSACTION,
 			    "old snapshot %" PRIu64
 			    " pinned in session %d [%s]"


### PR DESCRIPTION
@michaelcahill Here's a simple fix but you should review it.  I removed the ``last_running_moved`` part of the conditional.  Or is the "pinned" verbose message more subtle than that and it needs to be moved or copied up into the other part of the new "want to update" part?