### PR TITLE
WT-2283 Add yield to avoid tight looping.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -334,8 +334,10 @@ retry:
 			 */
 			WT_ASSERT(session, txn_global->scan_count > 0);
 			(void)__wt_atomic_subiv32(&txn_global->scan_count, 1);
-			if (force)
+			if (force) {
+				__wt_yield();
 				goto retry;
+			}
 		}
 	} else {
 		if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&


### PR DESCRIPTION
@michaelcahill This fixes the hang I was seeing in my test/format run.  It hung 100% of the time without this fix and has passed/completed several iterations with it.  However it may be a band-aid like fix as the {{scan_count}} usage is taking the place of read/write lock.