### PR TITLE
WT-2099 Account for overflow update structures

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1276,6 +1276,8 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		for (upd = upd_list; upd->next != NULL; upd = upd->next)
 			;
 		upd->next = append;
+		__wt_cache_page_inmem_incr(
+		    session, page, WT_UPDATE_MEMSIZE(append));
 	}
 
 	/*


### PR DESCRIPTION
that get appended to the update list in page->memory_footprint.

@michaelcahill Please review the fix we discussed last night.  I have run this fix with the failing configuration and made sure we took that path but did not get underflow.