### PR TITLE
WT-2265: Correct PPC64 barriers

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -144,6 +144,7 @@ INIT
 INITIALIZER
 INMEM
 INTL
+ISA
 ITEMs
 Inline
 Intra
@@ -719,6 +720,7 @@ lsn
 lsnappy
 lt
 lu
+lwsync
 lz
 lzo
 madvise
@@ -726,6 +728,8 @@ majorp
 malloc
 marshall
 marshalled
+mbll
+mbss
 mem
 memalign
 membar


### PR DESCRIPTION
Use the cheaper `lwsync` for read and write barriers on PPC64. `lwsync` only allows
store#load re-ordering.

See Book 2, section 4.4.3 in Power ISA 2.07B manual for more details. In figure 5, the manual says that `mbll` and `mbss` map to `lwsync`.

Test: Builds on POWER8 ppc64le, and runs examples.