### PR TITLE
WT-2285: configure should set BUFFER_ALIGNMENT_DEFAULT to 4kb on linux

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -103,7 +103,7 @@ esac
 
 # Linux requires buffers aligned to 4KB boundaries for O_DIRECT to work.
 BUFFER_ALIGNMENT=0
-if test "$ac_cv_func_posix_memalign" = "yes" ; then
+if test "$ax_cv_func_posix_memalign_works" = "yes" ; then
 	case "$host_os" in
 	linux*)	BUFFER_ALIGNMENT=4096 ;;
 	esac


### PR DESCRIPTION
A variable name changed as part of ecc674b8f5fc58c1df9a1c6b957491d73a27603d.