### PR TITLE
WT-2276 decode checkpoints via 'wt list -c' and via standalone Python utility.

### DIFF
--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -14,7 +14,7 @@
  * caller's buffer reference so it can be called repeatedly to load a buffer.
  */
 static int
-__block_buffer_to_addr(WT_BLOCK *block,
+__block_buffer_to_addr(uint32_t allocsize,
     const uint8_t **pp, wt_off_t *offsetp, uint32_t *sizep, uint32_t *cksump)
 {
 	uint64_t o, s, c;
@@ -39,8 +39,8 @@ __block_buffer_to_addr(WT_BLOCK *block,
 		*offsetp = 0;
 		*sizep = *cksump = 0;
 	} else {
-		*offsetp = (wt_off_t)(o + 1) * block->allocsize;
-		*sizep = (uint32_t)s * block->allocsize;
+		*offsetp = (wt_off_t)(o + 1) * allocsize;
+		*sizep = (uint32_t)s * allocsize;
 		*cksump = (uint32_t)c;
 	}
 	return (0);
@@ -80,7 +80,8 @@ int
 __wt_block_buffer_to_addr(WT_BLOCK *block,
     const uint8_t *p, wt_off_t *offsetp, uint32_t *sizep, uint32_t *cksump)
 {
-	return (__block_buffer_to_addr(block, &p, offsetp, sizep, cksump));
+	return (__block_buffer_to_addr(
+	    block->allocsize, &p, offsetp, sizep, cksump));
 }
 
 /*
@@ -139,12 +140,12 @@ __wt_block_addr_string(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_block_buffer_to_ckpt --
+ * __block_buffer_to_ckpt --
  *	Convert a checkpoint cookie into its components.
  */
-int
-__wt_block_buffer_to_ckpt(WT_SESSION_IMPL *session,
-    WT_BLOCK *block, const uint8_t *p, WT_BLOCK_CKPT *ci)
+static int
+__block_buffer_to_ckpt(WT_SESSION_IMPL *session,
+    uint32_t allocsize, const uint8_t *p, WT_BLOCK_CKPT *ci)
 {
 	uint64_t a;
 	const uint8_t **pp;
@@ -154,13 +155,13 @@ __wt_block_buffer_to_ckpt(WT_SESSION_IMPL *session,
 		WT_RET_MSG(session, WT_ERROR, "unsupported checkpoint version");
 
 	pp = &p;
-	WT_RET(__block_buffer_to_addr(block, pp,
+	WT_RET(__block_buffer_to_addr(allocsize, pp,
 	    &ci->root_offset, &ci->root_size, &ci->root_cksum));
-	WT_RET(__block_buffer_to_addr(block, pp,
+	WT_RET(__block_buffer_to_addr(allocsize, pp,
 	    &ci->alloc.offset, &ci->alloc.size, &ci->alloc.cksum));
-	WT_RET(__block_buffer_to_addr(block, pp,
+	WT_RET(__block_buffer_to_addr(allocsize, pp,
 	    &ci->avail.offset, &ci->avail.size, &ci->avail.cksum));
-	WT_RET(__block_buffer_to_addr(block, pp,
+	WT_RET(__block_buffer_to_addr(allocsize, pp,
 	    &ci->discard.offset, &ci->discard.size, &ci->discard.cksum));
 	WT_RET(__wt_vunpack_uint(pp, 0, &a));
 	ci->file_size = (wt_off_t)a;
@@ -168,6 +169,32 @@ __wt_block_buffer_to_ckpt(WT_SESSION_IMPL *session,
 	ci->ckpt_size = a;
 
 	return (0);
+}
+
+/*
+ * __wt_block_buffer_to_ckpt --
+ *	Convert a checkpoint cookie into its components, block manager version.
+ */
+int
+__wt_block_buffer_to_ckpt(WT_SESSION_IMPL *session,
+    WT_BLOCK *block, const uint8_t *p, WT_BLOCK_CKPT *ci)
+{
+	return (__block_buffer_to_ckpt(session, block->allocsize, p, ci));
+}
+
+/*
+ * __wt_block_ckpt_decode --
+ *	Convert a checkpoint cookie into its components, external utility
+ * version.
+ */
+int
+__wt_block_ckpt_decode(WT_SESSION *wt_session,
+    size_t allocsize, const uint8_t *p, WT_BLOCK_CKPT *ci)
+{
+	WT_SESSION_IMPL *session;
+
+	session = (WT_SESSION_IMPL *)wt_session;
+	return ( __block_buffer_to_ckpt(session, allocsize, p, ci));
 }
 
 /*

--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -194,7 +194,7 @@ __wt_block_ckpt_decode(WT_SESSION *wt_session,
 	WT_SESSION_IMPL *session;
 
 	session = (WT_SESSION_IMPL *)wt_session;
-	return ( __block_buffer_to_ckpt(session, allocsize, p, ci));
+	return (__block_buffer_to_ckpt(session, (uint32_t)allocsize, p, ci));
 }
 
 /*

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -29,21 +29,6 @@ static int __block_merge(WT_SESSION_IMPL *,
 	WT_BLOCK *, WT_EXTLIST *, wt_off_t, wt_off_t);
 
 /*
- * __wt_block_ckpt_decode --
- *	Convert a checkpoint cookie into its components.
- */
-int
-__wt_block_ckpt_decode(WT_SESSION_IMPL *session, const uint8_t *p,
-    size_t block_allocsize, WT_BLOCK_CKPT *ci)
-{
-	WT_BLOCK block;
-
-	memset(&block, 0, sizeof(block));
-	block.allocsize = block_allocsize;
-	return (__wt_block_buffer_to_ckpt(session, &block, p, ci));
-}
-
-/*
  * __block_off_srch_last --
  *	Return the last element in the list, along with a stack for appending.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -14,6 +14,7 @@ extern int __wt_block_buffer_to_addr(WT_BLOCK *block, const uint8_t *p, wt_off_t
 extern int __wt_block_addr_invalid(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr, size_t addr_size, bool live);
 extern int __wt_block_addr_string(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, const uint8_t *addr, size_t addr_size);
 extern int __wt_block_buffer_to_ckpt(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *p, WT_BLOCK_CKPT *ci);
+extern int __wt_block_ckpt_decode(WT_SESSION *wt_session, size_t allocsize, const uint8_t *p, WT_BLOCK_CKPT *ci);
 extern int __wt_block_ckpt_to_buffer(WT_SESSION_IMPL *session, WT_BLOCK *block, uint8_t **pp, WT_BLOCK_CKPT *ci);
 extern int __wt_block_ckpt_init( WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci, const char *name);
 extern int __wt_block_checkpoint_load(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr, size_t addr_size, uint8_t *root_addr, size_t *root_addr_sizep, bool checkpoint);
@@ -25,7 +26,6 @@ extern int __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern int __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp);
 extern int __wt_block_compact_page_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr, size_t addr_size, bool *skipp);
-extern int __wt_block_ckpt_decode(WT_SESSION_IMPL *session, const uint8_t *p, size_t block_allocsize, WT_BLOCK_CKPT *ci);
 extern int __wt_block_misplaced(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag, wt_off_t offset, uint32_t size, bool live);
 extern int __wt_block_off_remove_overlap(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST *el, wt_off_t off, wt_off_t size);
 extern int __wt_block_alloc( WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t *offp, wt_off_t size);

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -182,10 +182,9 @@ list_print_checkpoint(WT_SESSION *session, const char *key)
 	WT_BLOCK_CKPT ci;
 	WT_DECL_RET;
 	WT_CKPT *ckpt, *ckptbase;
-	size_t len;
+	size_t allocsize, len;
 	time_t t;
 	uint64_t v;
-	size_t allocsize;
 
 	/*
 	 * We may not find any checkpoints for this file, in which case we don't

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -93,7 +93,7 @@ list_get_allocsize(WT_SESSION *session, const char *key, size_t *allocsize)
 		    progname, session->strerror(session, ret));
 		return (ret);
 	}
-	*allocsize = szvalue.val;
+	*allocsize = (size_t)szvalue.val;
 	return (0);
 }
 
@@ -208,8 +208,8 @@ list_print_checkpoint(WT_SESSION *session, const char *key)
 
 	memset(&ci, 0, sizeof(ci));
 	WT_CKPT_FOREACH(ckptbase, ckpt) {
-		if ((ret = __wt_block_ckpt_decode((WT_SESSION_IMPL *)session,
-		    ckpt->raw.data, allocsize, &ci)) != 0) {
+		if ((ret = __wt_block_ckpt_decode(
+		    session, allocsize, ckpt->raw.data, &ci)) != 0) {
 			fprintf(stderr, "%s: __wt_block_buffer_to_ckpt: %s\n",
 			    progname, session->strerror(session, ret));
 			/* continue if damaged */


### PR DESCRIPTION
@ddanderson, some suggestions for how this change might be structured inside WiredTiger, feel free to discard it if you don't like it better.

Entirely untested (but it builds & lints cleanly).