### PR TITLE
WT-2281: Dynamically query OS for VM page size

### DIFF
--- a/build_win/filelist.win
+++ b/build_win/filelist.win
@@ -121,6 +121,7 @@ src/os_win/os_map.c
 src/os_win/os_mtx_cond.c
 src/os_win/os_once.c
 src/os_win/os_open.c
+src/os_win/os_pagesize.c
 src/os_win/os_path.c
 src/os_win/os_priv.c
 src/os_win/os_remove.c

--- a/dist/filelist
+++ b/dist/filelist
@@ -119,6 +119,7 @@ src/os_posix/os_mtx_cond.c
 src/os_posix/os_mtx_rw.c
 src/os_posix/os_once.c
 src/os_posix/os_open.c
+src/os_posix/os_pagesize.c
 src/os_posix/os_path.c
 src/os_posix/os_priv.c
 src/os_posix/os_remove.c

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1028,6 +1028,7 @@ variable's
 vectorized
 versa
 vfprintf
+vm
 vpack
 vprintf
 vrfy

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -807,6 +807,7 @@ os
 ovfl
 ownp
 packv
+pagesize
 parens
 pareto
 parserp

--- a/dist/s_win
+++ b/dist/s_win
@@ -62,6 +62,7 @@ win_filelist()
 	    -e 's;os_posix/os_mtx_cond.c;os_win/os_mtx_cond.c;' \
 	    -e 's;os_posix/os_once.c;os_win/os_once.c;' \
 	    -e 's;os_posix/os_open.c;os_win/os_open.c;' \
+	    -e 's;os_posix/os_pagesize.c;os_win/os_pagesize.c;' \
 	    -e 's;os_posix/os_path.c;os_win/os_path.c;' \
 	    -e 's;os_posix/os_priv.c;os_win/os_priv.c;' \
 	    -e 's;os_posix/os_remove.c;os_win/os_remove.c;' \

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2003,6 +2003,9 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_sweep_config(session, cfg));
 	WT_ERR(__wt_verbose_config(session, cfg));
 
+	/* Initialize the OS page size for mmap */
+	conn->page_size = __wt_get_pagesize();
+
 	/* Now that we know if verbose is configured, output the version. */
 	WT_ERR(__wt_verbose(
 	    session, WT_VERB_VERSION, "%s", WIREDTIGER_VERSION_STRING));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2004,7 +2004,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_verbose_config(session, cfg));
 
 	/* Initialize the OS page size for mmap */
-	conn->page_size = __wt_get_pagesize();
+	conn->page_size = __wt_get_vm_pagesize();
 
 	/* Now that we know if verbose is configured, output the version. */
 	WT_ERR(__wt_verbose(

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -415,6 +415,7 @@ struct __wt_connection_impl {
 	uint32_t direct_io;
 	uint32_t write_through;		/* FILE_FLAG_WRITE_THROUGH type flags */
 	bool	 mmap;			/* mmap configuration */
+	int page_size;			/* OS page size for mmap alignment */
 	uint32_t verbose;
 
 	uint32_t flags;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -514,6 +514,7 @@ extern int __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK **rwlockp);
 extern int __wt_once(void (*init_routine)(void));
 extern int __wt_open(WT_SESSION_IMPL *session, const char *name, bool ok_create, bool exclusive, int dio_type, WT_FH **fhp);
 extern int __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp);
+extern int __wt_get_pagesize(void);
 extern bool __wt_absolute_path(const char *path);
 extern const char *__wt_path_separator(void);
 extern bool __wt_has_priv(void);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -514,7 +514,7 @@ extern int __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK **rwlockp);
 extern int __wt_once(void (*init_routine)(void));
 extern int __wt_open(WT_SESSION_IMPL *session, const char *name, bool ok_create, bool exclusive, int dio_type, WT_FH **fhp);
 extern int __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp);
-extern int __wt_get_pagesize(void);
+extern int __wt_get_vm_pagesize(void);
 extern bool __wt_absolute_path(const char *path);
 extern const char *__wt_path_separator(void);
 extern bool __wt_has_priv(void);

--- a/src/os_posix/os_map.c
+++ b/src/os_posix/os_map.c
@@ -79,7 +79,7 @@ __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t size)
 	 */
 	size &= ~(size_t)(conn->page_size - 1);
 
-	if (size > conn->page_size &&
+	if (size > (size_t)conn->page_size &&
 	    (ret = posix_madvise(blk, size, POSIX_MADV_WILLNEED)) != 0)
 		WT_RET_MSG(session, ret, "posix_madvise will need");
 #else

--- a/src/os_posix/os_map.c
+++ b/src/os_posix/os_map.c
@@ -48,8 +48,6 @@ __wt_mmap(WT_SESSION_IMPL *session,
 	return (0);
 }
 
-#define	WT_VM_PAGESIZE	4096
-
 /*
  * __wt_mmap_preload --
  *	Cause a section of a memory map to be faulted in.
@@ -59,9 +57,10 @@ __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t size)
 {
 #ifdef HAVE_POSIX_MADVISE
 	/* Linux requires the address be aligned to a 4KB boundary. */
+	WT_CONNECTION_IMPL *conn = S2C(session);
 	WT_BM *bm = S2BT(session)->bm;
 	WT_DECL_RET;
-	void *blk = (void *)((uintptr_t)p & ~(uintptr_t)(WT_VM_PAGESIZE - 1));
+	void *blk = (void *)((uintptr_t)p & ~(uintptr_t)(conn->page_size - 1));
 	size += WT_PTRDIFF(p, blk);
 
 	/* XXX proxy for "am I doing a scan?" -- manual read-ahead */
@@ -78,9 +77,9 @@ __wt_mmap_preload(WT_SESSION_IMPL *session, const void *p, size_t size)
 	 * Manual pages aren't clear on whether alignment is required for the
 	 * size, so we will be conservative.
 	 */
-	size &= ~(size_t)(WT_VM_PAGESIZE - 1);
+	size &= ~(size_t)(conn->page_size - 1);
 
-	if (size > WT_VM_PAGESIZE &&
+	if (size > conn->page_size &&
 	    (ret = posix_madvise(blk, size, POSIX_MADV_WILLNEED)) != 0)
 		WT_RET_MSG(session, ret, "posix_madvise will need");
 #else
@@ -101,8 +100,9 @@ __wt_mmap_discard(WT_SESSION_IMPL *session, void *p, size_t size)
 {
 #ifdef HAVE_POSIX_MADVISE
 	/* Linux requires the address be aligned to a 4KB boundary. */
+	WT_CONNECTION_IMPL *conn = S2C(session);
 	WT_DECL_RET;
-	void *blk = (void *)((uintptr_t)p & ~(uintptr_t)(WT_VM_PAGESIZE - 1));
+	void *blk = (void *)((uintptr_t)p & ~(uintptr_t)(conn->page_size - 1));
 	size += WT_PTRDIFF(p, blk);
 
 	if ((ret = posix_madvise(blk, size, POSIX_MADV_DONTNEED)) != 0)

--- a/src/os_posix/os_pagesize.c
+++ b/src/os_posix/os_pagesize.c
@@ -1,0 +1,19 @@
+/*-
+ * Copyright (c) 2014-2015 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_get_pagesize --
+ *	Return the default page size of a virtual memory page.
+ */
+int
+__wt_get_pagesize(void)
+{
+	return getpagesize();
+}

--- a/src/os_posix/os_pagesize.c
+++ b/src/os_posix/os_pagesize.c
@@ -9,11 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_get_pagesize --
+ * __wt_get_vm_pagesize --
  *	Return the default page size of a virtual memory page.
  */
 int
-__wt_get_pagesize(void)
+__wt_get_vm_pagesize(void)
 {
-	return getpagesize();
+	return (getpagesize());
 }

--- a/src/os_win/os_pagesize.c
+++ b/src/os_win/os_pagesize.c
@@ -1,0 +1,23 @@
+/*-
+ * Copyright (c) 2014-2015 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_get_pagesize --
+ *	Return the default page size of a virtual memory page.
+ */
+int
+__wt_get_pagesize(void)
+{
+	SYSTEM_INFO system_info;
+
+	GetSystemInfo(&system_info);
+
+	return (system_info.dwPageSize);
+}

--- a/src/os_win/os_pagesize.c
+++ b/src/os_win/os_pagesize.c
@@ -9,11 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_get_pagesize --
+ * __wt_get_vm_pagesize --
  *	Return the default page size of a virtual memory page.
  */
 int
-__wt_get_pagesize(void)
+__wt_get_vm_pagesize(void)
 {
 	SYSTEM_INFO system_info;
 


### PR DESCRIPTION
Mmap requires page aligned addresses. The VM page on most architectures, and operating systems is 4kb. Some of the exceptions to this are Solaris on Sparc (8kb), and Linux on PowerPC LE (64kb).

It is simple and cheap to just query the OS for the page size as part of connection init instead of hard coding it.

Tested: Windows, Mac OS X, Linux x86, and Linux ppc64le.