### PR TITLE
WT-2297: Fix off-by-one error in Huffman config file parsing

### DIFF
--- a/src/btree/bt_huffman.c
+++ b/src/btree/bt_huffman.c
@@ -332,7 +332,7 @@ __wt_huffman_read(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *ip,
 	for (tp = table, lineno = 1; (ret =
 	    fscanf(fp, "%" SCNi64 " %" SCNi64, &symbol, &frequency)) != EOF;
 	    ++tp, ++lineno) {
-		if (lineno > entries)
+		if (lineno - 1 > entries)
 			WT_ERR_MSG(session, EINVAL,
 			    "Huffman table file %.*s is corrupted, "
 			    "more than %" PRIu32 " entries",


### PR DESCRIPTION
Line-numbers are one-based, so reading a Huffman configuration file with 256 lines would result in an complaint that the file had more than 255 lines.