### PR TITLE
WT-2301 Add reading a range of keys to wtperf.

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -371,6 +371,11 @@ err:		cfg->error = cfg->stop = 1;
 	return (NULL);
 }
 
+/*
+ * do_range_reads --
+ *	If configured to execute a sequence of next operations after each
+ *	search do them. Ensuring the keys we see are always in order.
+ */
 static int
 do_range_reads(CONFIG *cfg, WT_CURSOR *cursor)
 {
@@ -388,8 +393,11 @@ do_range_reads(CONFIG *cfg, WT_CURSOR *cursor)
 
 	memset(&buf[0], 0, 512 * sizeof(char));
 	range_key_buf = &buf[0];
+
+	/* Save where the first key is for comparisons. */
 	cursor->get_key(cursor, &range_key_buf);
 	extract_key(range_key_buf, &next_val);
+
 	/*
 	 * TODO: This is inefficient, if we keep range operations and want to
 	 * maintain the ability to track the returned values should allocate
@@ -401,6 +409,7 @@ do_range_reads(CONFIG *cfg, WT_CURSOR *cursor)
 		    "worker: couldn't allocate value tracking array");
 		return (ENOMEM);
 	}
+
 	for (r = 0; r < cfg->read_range; ++r) {
 		prev_val = next_val;
 		vals[r] = prev_val;

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -555,9 +555,10 @@ worker(void *arg)
 					if (ret != 0)
 						break;
 					cursor->get_key(cursor, &key_buf);
-	 				extract_key(key_buf, &next_val);
+					extract_key(key_buf, &next_val);
 					lprintf(cfg, 0, 0,
-					    "%d: key_buf %s prev %" PRIu64 " next %" PRIu64,
+					    "%d: key_buf %s prev %"
+					    PRIu64 " next %" PRIu64,
 					    r, key_buf, prev_val, next_val);
 					if (next_val < prev_val) {
 						for (r1 = 0; r1 <= r; ++r1)

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -391,8 +391,8 @@ do_range_reads(CONFIG *cfg, WT_CURSOR *cursor)
 	cursor->get_key(cursor, &range_key_buf);
 	extract_key(range_key_buf, &next_val);
 	/*
-	 * TODO: This is inefficient, if we keep range operations and want
-	 * to maintain the ability to track the returned values should allocate
+	 * TODO: This is inefficient, if we keep range operations and want to
+	 * maintain the ability to track the returned values should allocate
 	 * this buffer just once.
 	 */
 	vals = (uint64_t *)calloc(cfg->read_range, sizeof(uint64_t));
@@ -406,7 +406,7 @@ do_range_reads(CONFIG *cfg, WT_CURSOR *cursor)
 		vals[r] = prev_val;
 		ret = cursor->next(cursor);
 		/*
-		 * We could be walking near the end.  If we get to the end that
+		 * We could be walking near the end. If we get to the end that
 		 * is okay.
 		 */
 		if (ret != 0)

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -189,6 +189,7 @@ struct __config {			/* Configuration structure */
 
 #define	ELEMENTS(a)	(sizeof(a) / sizeof(a[0]))
 
+#define	READ_RANGE_OPS	10
 #define	THROTTLE_OPS	100
 
 #define	THOUSAND	(1000ULL)
@@ -303,6 +304,12 @@ generate_key(CONFIG *cfg, char *key_buf, uint64_t keyno)
 	 * Don't change to snprintf, sprintf is faster in some tests.
 	 */
 	sprintf(key_buf, "%0*" PRIu64, cfg->key_sz - 1, keyno);
+}
+
+static inline void
+extract_key(char *key_buf, uint64_t *keynop)
+{
+	sscanf(key_buf, "%" PRIu64, &keynop);
 }
 
 #endif

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -309,7 +309,7 @@ generate_key(CONFIG *cfg, char *key_buf, uint64_t keyno)
 static inline void
 extract_key(char *key_buf, uint64_t *keynop)
 {
-	sscanf(key_buf, "%" PRIu64, &keynop);
+	sscanf(key_buf, "%" SCNu64, keynop);
 }
 
 #endif

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -140,6 +140,7 @@ DEF_OPT_AS_UINT32(random_range, 0,
     "if non zero choose a value from within this range as the key for "
     "insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
+DEF_OPT_AS_BOOL(read_range, 0, "read a range of keys")
 DEF_OPT_AS_BOOL(reopen_connection, 1,
     "close and reopen the connection between populate and workload phases")
 DEF_OPT_AS_UINT32(report_interval, 2,

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -140,7 +140,7 @@ DEF_OPT_AS_UINT32(random_range, 0,
     "if non zero choose a value from within this range as the key for "
     "insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
-DEF_OPT_AS_BOOL(read_range, 0, "read a range of keys")
+DEF_OPT_AS_UINT32(read_range, 0, "scan a range of keys after each search")
 DEF_OPT_AS_BOOL(reopen_connection, 1,
     "close and reopen the connection between populate and workload phases")
 DEF_OPT_AS_UINT32(report_interval, 2,

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -206,8 +206,8 @@ if non zero choose a value from within this range as the key for
 insert operations
 @par random_value (boolean, default=false)
 generate random content for the value
-@par read_range (boolean, default=false)
-read a range of keys
+@par read_range (unsigned int, default=0)
+scan a range of keys after each search
 @par reopen_connection (boolean, default=true)
 close and reopen the connection between populate and workload phases
 @par report_interval (unsigned int, default=2)

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -206,6 +206,8 @@ if non zero choose a value from within this range as the key for
 insert operations
 @par random_value (boolean, default=false)
 generate random content for the value
+@par read_range (boolean, default=false)
+read a range of keys
 @par reopen_connection (boolean, default=true)
 close and reopen the connection between populate and workload phases
 @par report_interval (unsigned int, default=2)


### PR DESCRIPTION
@agorrod Please review this change.  In particular, is there some obvious error in my change? I am not seeing it.
The config I tested was based off `mongodb-oplog.wtperf` and was:
```
conn_config="cache_size=2GB,checkpoint=(wait=60)"
table_config="type=file"
# Start with a small set of inserts in the populate phase.
icount=50000
report_interval=5
run_time=300
populate_threads=1
read_range=true
threads=((count=3,inserts=1,throttle=4000),(count=1,reads=1))
```
It fails very quickly with this error in `test.stat` anytime I run a workload that involves reads and either inserts or updates:
```
Starting 1 populate thread(s) for 50000 items
Finished load of 50000 items
Load time: 0.07
load ops/sec: 0
Starting workload #1: 3 threads, inserts=1, reads=0, updates=0, truncate=0, throttle=4000
Starting workload #2: 1 threads, inserts=0, reads=1, updates=0, truncate=0, throttle=0
675630 reads, 60015 inserts, 0 updates, 0 truncates, 0 checkpoints in 5 secs (5 total secs)
insert failed for: 0000000000000146365, range: 146360 Error: WT_PANIC: WiredTiger library panic
```
and this is written to stdout where I started wtperf (the key numbers printed vary run to run, but are always very small):
```
[1450725323:260732][64645:0x104e6c000], file:test.wt, eviction-server: the 1 and 3 keys on page at [write-check] are incorrectly sorted
[1450725323:260772][64645:0x104e6c000], eviction-server: cache eviction server error: WT_ERROR: non-specific WiredTiger error
insert failed for: 0000000000000146365, range: 146360[1450725323:260777][64645:0x104e6c000], eviction-server: the process must exit and restart: WT_PANIC: WiredTiger library panic
 Error: WT_PANIC: WiredTiger library panic
[1450725323:260900][64645:0x104e6c000], eviction-server: aborting WiredTiger library
Abort (core dumped)
```
It makes me think there is something wrong with my change but it is pretty small and simple.  This fails every time.  