### PR TITLE
WT-2304 - Fix memory leaking issue in config dump when there are multiple databases

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -54,6 +54,7 @@ static void config_opt_usage(void);
 int
 config_assign(CONFIG *dest, const CONFIG *src)
 {
+	CONFIG_QUEUE_ENTRY *conf_line, *tmp_line;
 	size_t i, len;
 	char *newstr, **pstr;
 
@@ -97,6 +98,17 @@ config_assign(CONFIG *dest, const CONFIG *src)
 
 	TAILQ_INIT(&dest->stone_head);
 	TAILQ_INIT(&dest->config_head);
+
+	/* Clone the config string information into the new cfg object */
+	conf_line = TAILQ_FIRST(&src->config_head);
+	while (conf_line != NULL) {
+		len = strlen(conf_line->string);
+		tmp_line = calloc(sizeof(CONFIG_QUEUE_ENTRY),1);
+		tmp_line->string = calloc(len + 1, 1);
+		strncpy(tmp_line->string, conf_line->string, len);
+		TAILQ_INSERT_TAIL(&dest->config_head, tmp_line, c);
+		conf_line = TAILQ_NEXT(conf_line, c);
+	}
 	return (0);
 }
 

--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -96,6 +96,7 @@ config_assign(CONFIG *dest, const CONFIG *src)
 		}
 
 	TAILQ_INIT(&dest->stone_head);
+	TAILQ_INIT(&dest->config_head);
 	return (0);
 }
 

--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -100,14 +100,14 @@ config_assign(CONFIG *dest, const CONFIG *src)
 	TAILQ_INIT(&dest->config_head);
 
 	/* Clone the config string information into the new cfg object */
-	conf_line = TAILQ_FIRST(&src->config_head);
-	while (conf_line != NULL) {
+	TAILQ_FOREACH(conf_line, &src->config_head, c) {
 		len = strlen(conf_line->string);
-		tmp_line = calloc(sizeof(CONFIG_QUEUE_ENTRY),1);
-		tmp_line->string = calloc(len + 1, 1);
+		if ((tmp_line = calloc(sizeof(CONFIG_QUEUE_ENTRY), 1)) == NULL)
+			return (enomem(src));
+		if ((tmp_line->string = calloc(len + 1, 1)) == NULL)
+			return (enomem(src));
 		strncpy(tmp_line->string, conf_line->string, len);
 		TAILQ_INSERT_TAIL(&dest->config_head, tmp_line, c);
-		conf_line = TAILQ_NEXT(conf_line, c);
 	}
 	return (0);
 }


### PR DESCRIPTION
This inits a new config object, thus being always empty and not running afoul of the config_free function.