### PR TITLE
WT-2307 workaround. Reposition and retry next when we detect out of order.

### DIFF
--- a/bench/wtperf/runners/stress-btree-split.wtperf
+++ b/bench/wtperf/runners/stress-btree-split.wtperf
@@ -1,10 +1,10 @@
-conn_config="cache_size=8GB,statistics=[fast,clear],statistics_log=(wait=10),eviction=(threads_max=4,threads_min=4)"
+conn_config="cache_size=2GB,statistics=[fast,clear],statistics_log=(wait=10),eviction=(threads_max=4,threads_min=4)"
 table_config="type=file,leaf_page_max=8k,internal_page_max=8k,memory_page_max=2MB,split_deepen_min_child=250"
-icount=2000000
+icount=200000
 report_interval=5
 run_time=3600
 reopen_connection=false
 populate_threads=2
 value_sz=256
 read_range=100
-threads=((count=1,inserts=1,throttle=10000),(count=4,updates=1),(count=8,reads=1))
+threads=((count=4,inserts=1,throttle=100000),(count=8,reads=1))

--- a/bench/wtperf/runners/stress-btree-split.wtperf
+++ b/bench/wtperf/runners/stress-btree-split.wtperf
@@ -1,0 +1,10 @@
+conn_config="cache_size=8GB,statistics=[fast,clear],statistics_log=(wait=10),eviction=(threads_max=4,threads_min=4)"
+table_config="type=file,leaf_page_max=8k,internal_page_max=8k,memory_page_max=2MB,split_deepen_min_child=250"
+icount=2000000
+report_interval=5
+run_time=3600
+reopen_connection=false
+populate_threads=2
+value_sz=256
+read_range=100
+threads=((count=1,inserts=1,throttle=10000),(count=4,updates=1),(count=8,reads=1))

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -473,10 +473,8 @@ __wt_key_order_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	 * The cursor next hit a bug due to a race in splits, move the cursor
 	 * back to the last known good position and retry the next.
 	 */
-	//WT_ASSERT(session, F_ISSET(&cbt->iface, WT_CURSTD_KEY_SET));
 	key->data = cbt->lastkey->data;
 	key->size = cbt->lastkey->size;
-	cbt->ref = &btree->root;
 	if ((ret = __wt_btcur_search(cbt)) != 0)
 		WT_RET_MSG(session, ret,
 		    "WT-2307: searching for the previous key failed");

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -480,6 +480,10 @@ __wt_key_order_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	if ((ret = __wt_btcur_search(cbt)) != 0)
 		WT_RET_MSG(session, ret,
 		    "WT-2307: searching for the previous key failed");
+
+	/* Set last op as a next, in case we need to loop retrying */
+	cbt->last_op[0] = WT_LASTOP_NEXT;
+
 	/* Return a duplicate key error to tell next it needs to retry. */
 	return (WT_DUPLICATE_KEY);
 }

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -532,6 +532,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	bool newpage;
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
+	__wt_set_last_op(cbt, WT_LASTOP_PREV);
 
 	WT_STAT_FAST_CONN_INCR(session, cursor_prev);
 	WT_STAT_FAST_DATA_INCR(session, cursor_prev);

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -288,6 +288,7 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_RESET);
 	WT_STAT_FAST_CONN_INCR(session, cursor_reset);
 	WT_STAT_FAST_DATA_INCR(session, cursor_reset);
 
@@ -313,6 +314,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 	session = (WT_SESSION_IMPL *)cursor->session;
 	upd = NULL;					/* -Wuninitialized */
 
+	__wt_set_last_op(cbt, WT_LASTOP_SEARCH);
 	WT_STAT_FAST_CONN_INCR(session, cursor_search);
 	WT_STAT_FAST_DATA_INCR(session, cursor_search);
 
@@ -380,6 +382,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 	upd = NULL;					/* -Wuninitialized */
 	exact = 0;
 
+	__wt_set_last_op(cbt, WT_LASTOP_SEARCH_NEAR);
 	WT_STAT_FAST_CONN_INCR(session, cursor_search_near);
 	WT_STAT_FAST_DATA_INCR(session, cursor_search_near);
 
@@ -487,6 +490,7 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_INSERT);
 	WT_STAT_FAST_CONN_INCR(session, cursor_insert);
 	WT_STAT_FAST_DATA_INCR(session, cursor_insert);
 	WT_STAT_FAST_DATA_INCRV(session,
@@ -655,6 +659,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_REMOVE);
 	WT_STAT_FAST_CONN_INCR(session, cursor_remove);
 	WT_STAT_FAST_DATA_INCR(session, cursor_remove);
 	WT_STAT_FAST_DATA_INCRV(session, cursor_remove_bytes, cursor->key.size);
@@ -740,6 +745,7 @@ __wt_btcur_update(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_UPDATE);
 	WT_STAT_FAST_CONN_INCR(session, cursor_update);
 	WT_STAT_FAST_DATA_INCR(session, cursor_update);
 	WT_STAT_FAST_DATA_INCRV(
@@ -1159,6 +1165,8 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
 	cbt = (start != NULL) ? start : stop;
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 	btree = cbt->btree;
+
+	__wt_set_last_op(cbt, WT_LASTOP_TRUNCATE);
 	WT_STAT_FAST_DATA_INCR(session, cursor_truncate);
 
 	/*
@@ -1233,6 +1241,8 @@ __wt_btcur_open(WT_CURSOR_BTREE *cbt)
 {
 	cbt->row_key = &cbt->_row_key;
 	cbt->tmp = &cbt->_tmp;
+
+	cbt->lastkey = &cbt->_lastkey;
 }
 
 /*
@@ -1258,6 +1268,7 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt, bool lowlevel)
 
 	__wt_buf_free(session, &cbt->_row_key);
 	__wt_buf_free(session, &cbt->_tmp);
+	__wt_buf_free(session, &cbt->_lastkey);
 
 	return (ret);
 }

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -288,7 +288,6 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
-	__wt_set_last_op(cbt, WT_LASTOP_RESET);
 	WT_STAT_FAST_CONN_INCR(session, cursor_reset);
 	WT_STAT_FAST_DATA_INCR(session, cursor_reset);
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1119,7 +1119,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	    alloc_index->entries, parent_incr, false, false));
 
 	/* !! Widen the window for races with other operations. */
-	__wt_sleep(0, 10000);
+	__wt_sleep(1, 0);
 
 	/*
 	 * A note on error handling: until this point, there's no problem with

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1118,6 +1118,9 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	WT_ERR(__split_parent(session, page_ref, alloc_index->index,
 	    alloc_index->entries, parent_incr, false, false));
 
+	/* !! Widen the window for races with other operations. */
+	__wt_sleep(0, 10000);
+
 	/*
 	 * A note on error handling: until this point, there's no problem with
 	 * unwinding on error.  We allocated a new page index, a new set of

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -549,7 +549,13 @@ struct __wt_page {
 #define	WT_PAGE_UPDATE_IGNORE	0x80	/* Ignore updates on page discard */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 
-	uint8_t unused[2];		/* Unused padding */
+#define	WT_SPLIT_ACTION_INSERT	1
+#define	WT_SPLIT_ACTION_MULTI	2
+#define	WT_SPLIT_ACTION_REVERSE	3
+#define	WT_SPLIT_ACTION_REWRITE	4
+	uint8_t split_action;
+
+	uint8_t split_gen;
 
 	/*
 	 * Used to protect and co-ordinate splits for internal pages and

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -192,9 +192,7 @@ struct __wt_cursor_btree {
 	WT_UPDATE *modify_update;
 
 	/*
-	 * SUPPORT-1531 information.
-	 *
-	 * Last returned keys.
+	 * WT-2307 tracking for a bug where cursor next jumps backwards.
 	 */
 	WT_ITEM *lastkey, _lastkey;
 

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -279,6 +279,8 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
 {
 	WT_DECL_RET;
 
+	__wt_set_last_op(cbt, WT_LASTOP_RESET);
+
 	/*
 	 * The cursor is leaving the API, and no longer holds any position,
 	 * generally called to clean up the cursor after an error.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -91,6 +91,7 @@ extern int __wt_bloom_drop(WT_BLOOM *bloom, const char *config);
 extern int __wt_compact(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp);
 extern void __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt);
+extern void __wt_set_last_op(WT_CURSOR_BTREE *cbt, int v);
 extern int __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating);
 extern int __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating);
 extern int __wt_btcur_reset(WT_CURSOR_BTREE *cbt);


### PR DESCRIPTION
This improves the situation with the wtperf reproducer, but I still
see wtperf reporting out of order keys during traversal occasionally.