### PR TITLE
WT-2307 workaround for cursor next bug.

### DIFF
--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -532,6 +532,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	bool newpage;
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
+	__wt_set_last_op(cbt, WT_LASTOP_PREV);
 
 	WT_STAT_FAST_CONN_INCR(session, cursor_prev);
 	WT_STAT_FAST_DATA_INCR(session, cursor_prev);

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -278,7 +278,6 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
-	__wt_set_last_op(cbt, WT_LASTOP_RESET);
 	WT_STAT_FAST_CONN_INCR(session, cursor_reset);
 	WT_STAT_FAST_DATA_INCR(session, cursor_reset);
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -278,6 +278,7 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_RESET);
 	WT_STAT_FAST_CONN_INCR(session, cursor_reset);
 	WT_STAT_FAST_DATA_INCR(session, cursor_reset);
 
@@ -303,6 +304,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 	session = (WT_SESSION_IMPL *)cursor->session;
 	upd = NULL;					/* -Wuninitialized */
 
+	__wt_set_last_op(cbt, WT_LASTOP_SEARCH);
 	WT_STAT_FAST_CONN_INCR(session, cursor_search);
 	WT_STAT_FAST_DATA_INCR(session, cursor_search);
 
@@ -370,6 +372,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 	upd = NULL;					/* -Wuninitialized */
 	exact = 0;
 
+	__wt_set_last_op(cbt, WT_LASTOP_SEARCH_NEAR);
 	WT_STAT_FAST_CONN_INCR(session, cursor_search_near);
 	WT_STAT_FAST_DATA_INCR(session, cursor_search_near);
 
@@ -477,6 +480,7 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_INSERT);
 	WT_STAT_FAST_CONN_INCR(session, cursor_insert);
 	WT_STAT_FAST_DATA_INCR(session, cursor_insert);
 	WT_STAT_FAST_DATA_INCRV(session,
@@ -650,6 +654,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_REMOVE);
 	WT_STAT_FAST_CONN_INCR(session, cursor_remove);
 	WT_STAT_FAST_DATA_INCR(session, cursor_remove);
 	WT_STAT_FAST_DATA_INCRV(session, cursor_remove_bytes, cursor->key.size);
@@ -735,6 +740,7 @@ __wt_btcur_update(WT_CURSOR_BTREE *cbt)
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;
 
+	__wt_set_last_op(cbt, WT_LASTOP_UPDATE);
 	WT_STAT_FAST_CONN_INCR(session, cursor_update);
 	WT_STAT_FAST_DATA_INCR(session, cursor_update);
 	WT_STAT_FAST_DATA_INCRV(
@@ -1151,6 +1157,8 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
 	cbt = (start != NULL) ? start : stop;
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 	btree = cbt->btree;
+
+	__wt_set_last_op(cbt, WT_LASTOP_TRUNCATE);
 	WT_STAT_FAST_DATA_INCR(session, cursor_truncate);
 
 	/*
@@ -1225,6 +1233,8 @@ __wt_btcur_open(WT_CURSOR_BTREE *cbt)
 {
 	cbt->row_key = &cbt->_row_key;
 	cbt->tmp = &cbt->_tmp;
+
+	cbt->lastkey = &cbt->_lastkey;
 }
 
 /*
@@ -1250,6 +1260,7 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt, bool lowlevel)
 
 	__wt_buf_free(session, &cbt->_row_key);
 	__wt_buf_free(session, &cbt->_tmp);
+	__wt_buf_free(session, &cbt->_lastkey);
 
 	return (ret);
 }

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -192,6 +192,22 @@ struct __wt_cursor_btree {
 	WT_UPDATE *modify_update;
 
 	/*
+	 * WT-2307 tracking for a bug where cursor next jumps backwards.
+	 */
+	WT_ITEM *lastkey, _lastkey;
+
+#define	WT_LASTOP_NEXT		1
+#define	WT_LASTOP_PREV		2
+#define	WT_LASTOP_RESET		3
+#define	WT_LASTOP_SEARCH	4
+#define	WT_LASTOP_SEARCH_NEAR	5
+#define	WT_LASTOP_INSERT	6
+#define	WT_LASTOP_TRUNCATE	7
+#define	WT_LASTOP_UPDATE	8
+#define	WT_LASTOP_REMOVE	9
+	uint8_t last_op[20];		/* Last 20 operations */
+
+	/*
 	 * Fixed-length column-store items are a single byte, and it's simpler
 	 * and cheaper to allocate the space for it now than keep checking to
 	 * see if we need to grow the buffer.

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -279,6 +279,8 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
 {
 	WT_DECL_RET;
 
+	__wt_set_last_op(cbt, WT_LASTOP_RESET);
+
 	/*
 	 * The cursor is leaving the API, and no longer holds any position,
 	 * generally called to clean up the cursor after an error.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -90,6 +90,7 @@ extern int __wt_bloom_drop(WT_BLOOM *bloom, const char *config);
 extern int __wt_compact(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp);
 extern void __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt);
+extern void __wt_set_last_op(WT_CURSOR_BTREE *cbt, int v);
 extern int __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating);
 extern int __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating);
 extern int __wt_btcur_reset(WT_CURSOR_BTREE *cbt);


### PR DESCRIPTION
Detect when a cursor next returned an invalid result and retry
the next operation. Horrible since it adds a comparison into each
cursor next, but fixes the symptom until we can fix the underlying bug.