### PR TITLE
WT-2311 Support Sparc

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -181,6 +181,7 @@ LevelDB
 Levyx
 Llqr
 Llqrt
+LoadLoad
 LockFile
 Lookaside
 Lookup
@@ -285,10 +286,13 @@ Spinlock
 Spinlocks
 Split's
 Stoica
+StoreLoad
+StoreStore
 TAILQ
 TCMalloc
 TODO
 TORTIOUS
+TSO
 TXN
 TXNC
 Timespec
@@ -303,6 +307,7 @@ ULINE
 URI
 URIs
 UTF
+UltraSparc
 Unbuffered
 UnixLib
 Unmap
@@ -415,6 +420,7 @@ bzip
 calloc
 cas
 catfmt
+ccr
 cd
 centric
 cfg

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -212,11 +212,10 @@ __wt_atomic_cas_ptr(void *vp, void *old, void *new)
 #define	WT_WRITE_BARRIER()	WT_FULL_BARRIER()
 
 #elif defined(__sparc__)
-
 #define	WT_PAUSE()	__asm__ volatile("rd %%ccr, %%g0" ::: "memory")
 
 #define	WT_FULL_BARRIER() do {						\
-	  __asm__ volatile ("membar #StoreLoad" ::: "memory");		\
+	__asm__ volatile ("membar #StoreLoad" ::: "memory");		\
 } while (0)
 
 /*
@@ -224,11 +223,11 @@ __wt_atomic_cas_ptr(void *vp, void *old, void *new)
  * READ_BARRIER = #LoadLoad, and WRITE_BARRIER = #StoreStore are noop.
  */
 #define	WT_READ_BARRIER() do {						\
-	  __asm__ volatile ("" ::: "memory");				\
+	__asm__ volatile ("" ::: "memory");				\
 } while (0)
 
 #define	WT_WRITE_BARRIER() do {						\
-	  __asm__ volatile ("" ::: "memory");				\
+	__asm__ volatile ("" ::: "memory");				\
 } while (0)
 
 #else

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -211,6 +211,26 @@ __wt_atomic_cas_ptr(void *vp, void *old, void *new)
 #define	WT_READ_BARRIER()	WT_FULL_BARRIER()
 #define	WT_WRITE_BARRIER()	WT_FULL_BARRIER()
 
+#elif defined(__sparc__)
+
+#define	WT_PAUSE()	__asm__ volatile("rd %%ccr, %%g0" ::: "memory")
+
+#define	WT_FULL_BARRIER() do {						\
+	  __asm__ volatile ("membar #StoreLoad" ::: "memory");		\
+} while (0)
+
+/*
+ * On UltraSparc machines, TSO is used, and so there is no need for membar.
+ * READ_BARRIER = #LoadLoad, and WRITE_BARRIER = #StoreStore are noop.
+ */
+#define	WT_READ_BARRIER() do {						\
+	  __asm__ volatile ("" ::: "memory");				\
+} while (0)
+
+#define	WT_WRITE_BARRIER() do {						\
+	  __asm__ volatile ("" ::: "memory");				\
+} while (0)
+
 #else
 #error "No write barrier implementation for this hardware"
 #endif

--- a/src/support/hash_city.c
+++ b/src/support/hash_city.c
@@ -99,6 +99,12 @@ static uint32_t UNALIGNED_LOAD32(const char *p) {
 #define	bswap_32(x) OSSwapInt32(x)
 #define	bswap_64(x) OSSwapInt64(x)
 
+#elif defined(__sun)
+
+#include <sys/byteorder.h>
+#define	bswap_32 BSWAP_32
+#define	bswap_64 BSWAP_64
+
 #else
 #include <byteswap.h>
 #endif


### PR DESCRIPTION
On UltraSparc IIIi (2003) and later (also likely earlier), Sun/Oracle Sparc chips uses TSO. This means that we only need `membar` when we need to prevent `StoreLoad` reorderings as all others are NOPs on Sparc (See TABLE 8-1 in UltraSparc IIIi manual). 