### PR TITLE
SERVER-22064: Coverity, function return value not checked for error

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -85,7 +85,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			WT_ASSERT(session,
 			    F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
 			    __wt_page_can_evict(session, ref, NULL));
-			__wt_evict_page_clean_update(session, ref, true);
+			__wt_ref_out(session, ref);
 			break;
 		WT_ILLEGAL_VALUE_ERR(session);
 		}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -8,8 +8,9 @@
 
 #include "wt_internal.h"
 
-static int  __evict_page_dirty_update(WT_SESSION_IMPL *, WT_REF *, bool);
-static int  __evict_review(WT_SESSION_IMPL *, WT_REF *, bool *, bool);
+static int __evict_page_clean_update(WT_SESSION_IMPL *, WT_REF *, bool);
+static int __evict_page_dirty_update(WT_SESSION_IMPL *, WT_REF *, bool);
+static int __evict_review(WT_SESSION_IMPL *, WT_REF *, bool *, bool);
 
 /*
  * __evict_exclusive_clear --
@@ -117,7 +118,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		 * Pages that belong to dead trees never write back to disk
 		 * and can't support page splits.
 		 */
-		WT_ERR(__wt_evict_page_clean_update(
+		WT_ERR(__evict_page_clean_update(
 		    session, ref, tree_dead || closing));
 	else
 		WT_ERR(__evict_page_dirty_update(session, ref, closing));
@@ -200,12 +201,11 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 }
 
 /*
- * __wt_evict_page_clean_update --
+ * __evict_page_clean_update --
  *	Update a clean page's reference on eviction.
  */
-int
-__wt_evict_page_clean_update(
-    WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
+static int
+__evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 {
 	WT_DECL_RET;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -338,7 +338,6 @@ extern void __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session);
 extern int __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full);
 extern int __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile);
 extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing);
-extern int __wt_evict_page_clean_update( WT_SESSION_IMPL *session, WT_REF *ref, bool closing);
 extern int __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);
 extern int __wt_log_flush_lsn(WT_SESSION_IMPL *session, WT_LSN *lsn, bool start);
 extern int __wt_log_background(WT_SESSION_IMPL *session, WT_LSN *lsn);


### PR DESCRIPTION
Coverity analysis defect 77699: Unchecked return value, problem
introduced in SERVER-21619 change, commit 354c031.

Instead of calling __wt_evict_page_clean_update() when discarding pages,
call __wt_ref_out() directly, __wt_evict_page_clean_update() doesn't do
any useful additional work.

This allows __wt_evict_page_clean_update() to be static in evict_page.c,
rename to __evict_page_clean_update().