### PR TITLE
WT-2309: Add yields and/or sleeps in #DIAGNOSTIC mode.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -650,12 +650,16 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	/* Prepare the WT_REFs for the move. */
 	__split_ref_step1(session, alloc_index, false);
 
+	__wt_diagnostic_yield(0, 100000);	/* Encourage a race. */
+
 	/*
 	 * Confirm the root page's index hasn't moved, then update it, which
 	 * makes the split visible to threads descending the tree.
 	 */
 	WT_ASSERT(session, WT_INTL_INDEX_GET_SAFE(root) == pindex);
 	WT_INTL_INDEX_SET(root, alloc_index);
+
+	__wt_diagnostic_yield(0, 100000);	/* Encourage a race. */
 
 #ifdef HAVE_DIAGNOSTIC
 	WT_WITH_PAGE_INDEX(session,
@@ -1145,13 +1149,19 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	/* Prepare the WT_REFs for the move. */
 	__split_ref_step1(session, alloc_index, true);
 
+	__wt_diagnostic_yield(0, 100000);	/* Encourage a race. */
+
 	/* Split into the parent. */
 	WT_ERR(__split_parent(session, page_ref, alloc_index->index,
 	    alloc_index->entries, parent_incr, false, false));
 
+	__wt_diagnostic_yield(0, 100000);	/* Encourage a race. */
+
 	/* Confirm the page's index hasn't moved, then update it. */
 	WT_ASSERT(session, WT_INTL_INDEX_GET_SAFE(page) == pindex);
 	WT_INTL_INDEX_SET(page, replace_index);
+
+	__wt_diagnostic_yield(0, 100000);	/* Encourage a race. */
 
 #ifdef HAVE_DIAGNOSTIC
 	WT_WITH_PAGE_INDEX(session,

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -70,3 +70,19 @@ __wt_verbose(WT_SESSION_IMPL *session, int flag, const char *fmt, ...)
 	return (0);
 #endif
 }
+
+/*
+ * __wt_diagnostic_yield --
+ * 	Yield, and optionally pause, in diagnostic mode.
+ */
+static inline void
+__wt_diagnostic_yield(uint64_t seconds, uint64_t micro_seconds)
+{
+#ifdef HAVE_DIAGNOSTIC
+	if (seconds == 0 && micro_seconds == 0)
+		__wt_yield();
+	else
+		__wt_sleep(seconds, micro_seconds);
+#else
+#endif
+}

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -83,6 +83,5 @@ __wt_diagnostic_yield(uint64_t seconds, uint64_t micro_seconds)
 		__wt_yield();
 	else
 		__wt_sleep(seconds, micro_seconds);
-#else
 #endif
 }


### PR DESCRIPTION
WT-2309: Add yields and/or sleeps in #DIAGNOSTIC mode.

Add a new function __wt_diagnostic_yield() that yields (and optionally sleeps), add it to the split code to encourage races.