### PR TITLE
WT-2320 Backport to 3.0. Only check copyright as part of cutting a release.

### DIFF
--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+# Only run when building a release
+test -z "$WT_RELEASE_BUILD" && exit 0
+
 # Check the copyrights.
 
 c1=__wt.1$$


### PR DESCRIPTION
(cherry picked from commit 051ab40)

Builds on another change that was pushed directly to develop branch: 00c2116