### PR TITLE
WT-2295 When populating an index, detect if already exists to avoid full scan

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -451,9 +451,11 @@ extern int __wt_ext_metadata_update(WT_EXTENSION_API *wt_api, WT_SESSION *wt_ses
 extern int __wt_metadata_get_ckptlist( WT_SESSION *session, const char *name, WT_CKPT **ckptbasep);
 extern void __wt_metadata_free_ckptlist(WT_SESSION *session, WT_CKPT *ckptbase);
 extern int __wt_metadata_cursor_open( WT_SESSION_IMPL *session, const char *config, WT_CURSOR **cursorp);
+extern int __wt_metadata_configurable_cursor( WT_SESSION_IMPL *session, const char *config, WT_CURSOR **cursorp);
 extern int __wt_metadata_cursor(WT_SESSION_IMPL *session, WT_CURSOR **cursorp);
 extern int __wt_metadata_cursor_release(WT_SESSION_IMPL *session, WT_CURSOR **cursorp);
 extern int __wt_metadata_insert( WT_SESSION_IMPL *session, const char *key, const char *value);
+extern int __wt_metadata_insert_no_overwrite( WT_SESSION_IMPL *session, const char *key, const char *value);
 extern int __wt_metadata_update( WT_SESSION_IMPL *session, const char *key, const char *value);
 extern int __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key);
 extern int __wt_metadata_search(WT_SESSION_IMPL *session, const char *key, char **valuep);

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -525,7 +525,8 @@ __create_index(WT_SESSION_IMPL *session,
 	cfg[1] = sourceconf;
 	cfg[2] = confbuf.data;
 	WT_ERR(__wt_config_collapse(session, cfg, &idxconf));
-	if ((ret = __wt_metadata_insert(session, name, idxconf)) != 0) {
+	if ((ret = __wt_metadata_insert_no_overwrite(session, name, idxconf))
+	    != 0) {
 		/*
 		 * If the entry already exists in the metadata, we're done.
 		 * This is an error for exclusive creates but okay otherwise.


### PR DESCRIPTION
This passes the submitted test case.
