### PR TITLE
WT-2328: schema drop does direct unlink, change to a block manager interface

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -44,6 +44,16 @@ err:	WT_TRET(__wt_close(session, &fh));
 }
 
 /*
+ * __wt_block_manager_drop --
+ *	Drop a file.
+ */
+int
+__wt_block_manager_drop(WT_SESSION_IMPL *session, const char *filename)
+{
+	 return (__wt_remove_if_exists(session, filename));
+}
+
+/*
  * __wt_block_manager_create --
  *	Create a file.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -45,6 +45,7 @@ extern int __wt_block_map( WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapp
 extern int __wt_block_unmap( WT_SESSION_IMPL *session, WT_BLOCK *block, void *map, size_t maplen, void **mappingcookie);
 extern int __wt_block_manager_open(WT_SESSION_IMPL *session, const char *filename, const char *cfg[], bool forced_salvage, bool readonly, uint32_t allocsize, WT_BM **bmp);
 extern int __wt_block_manager_truncate( WT_SESSION_IMPL *session, const char *filename, uint32_t allocsize);
+extern int __wt_block_manager_drop(WT_SESSION_IMPL *session, const char *filename);
 extern int __wt_block_manager_create( WT_SESSION_IMPL *session, const char *filename, uint32_t allocsize);
 extern void __wt_block_configure_first_fit(WT_BLOCK *block, bool on);
 extern int __wt_block_open(WT_SESSION_IMPL *session, const char *filename, const char *cfg[], bool forced_salvage, bool readonly, uint32_t allocsize, WT_BLOCK **blockp);

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -141,7 +141,7 @@ __meta_track_apply(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
 		    ret = bm->checkpoint_resolve(bm, session));
 		break;
 	case WT_ST_DROP_COMMIT:
-		if ((ret = __wt_remove_if_exists(session, trk->a)) != 0)
+		if ((ret = __wt_block_manager_drop(session, trk->a)) != 0)
 			__wt_err(session, ret,
 			    "metadata remove dropped file %s", trk->a);
 		break;


### PR DESCRIPTION
WT-2328: schema drop does direct unlink, change to a block manager interface

@agorrod, @michaelcahill: a small restructuring to put the block manager into the drop-file path.

If/when we have multiple block managers, this will change, but for now I think it's correct.