### PR TITLE
WT-2313 Wrap clearing of WT_DHANDLE_OPEN with eviction exclusive calls.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -119,23 +119,6 @@ __wt_conn_dhandle_find(
 }
 
 /*
- * __conn_dhandle_mark_dead --
- *	Mark a data handle dead.
- */
-static int
-__conn_dhandle_mark_dead(WT_SESSION_IMPL *session)
-{
-	/*
-	 * Handle forced discard (e.g., when dropping a file).
-	 *
-	 * We need exclusive access to the file -- disable ordinary
-	 * eviction and drain any blocks already queued.
-	 */
-	F_SET(session->dhandle, WT_DHANDLE_DEAD);
-	return (0);
-}
-
-/*
  * __wt_conn_btree_sync_and_close --
  *	Sync and close the underlying btree handle.
  */
@@ -192,7 +175,7 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	if (!F_ISSET(btree,
 	    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY)) {
 		if (force && (bm == NULL || !bm->is_mapped(bm, session))) {
-			WT_ERR(__conn_dhandle_mark_dead(session));
+			F_SET(session->dhandle, WT_DHANDLE_DEAD);
 			marked_dead = true;
 		}
 		if (!marked_dead || final)

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -64,11 +64,9 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 	WT_BTREE *btree;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	bool evict_reset;
 
 	btree = S2BT(session);
 	dhandle = session->dhandle;
-	evict_reset = false;
 
 	/*
 	 * Acquire an exclusive lock on the handle and mark it dead.
@@ -92,18 +90,12 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 	    !__wt_txn_visible_all(session, btree->rec_max_txn))
 		goto err;
 
-	/* Ensure that we aren't racing with the eviction server */
-	WT_ERR(__wt_evict_file_exclusive_on(session, &evict_reset));
-
 	/*
 	 * Mark the handle as dead and close the underlying file
 	 * handle. Closing the handle decrements the open file count,
 	 * meaning the close loop won't overrun the configured minimum.
 	 */
 	ret = __wt_conn_btree_sync_and_close(session, false, true);
-
-	if (evict_reset)
-		__wt_evict_file_exclusive_off(session);
 
 err:	WT_TRET(__wt_writeunlock(session, dhandle->rwlock));
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -988,6 +988,7 @@ __evict_walk(WT_SESSION_IMPL *session)
 
 	conn = S2C(session);
 	cache = S2C(session)->cache;
+	btree = NULL;
 	dhandle = NULL;
 	dhandle_locked = incr = false;
 	retries = 0;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1104,7 +1104,7 @@ retry:	while (slot < max_entries && ret == 0) {
 		 * exclusive access when a handle is being closed.
 		 */
 		if (!F_ISSET(btree, WT_BTREE_NO_EVICTION)) {
-			/* Remember the file we should visit first, next loop. */
+			/* Remember the file to visit first, next loop. */
 			cache->evict_file_next = dhandle;
 
 			WT_WITH_DHANDLE(session, dhandle,

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1124,7 +1124,9 @@ retry:	while (slot < max_entries && ret == 0) {
 		/* Remember the file we should visit first, next loop. */
 		cache->evict_file_next = dhandle;
 
-		WT_ASSERT(session, dhandle->session_inuse > 0);
+		WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_OPEN) &&
+		    !F_ISSET(btree, WT_BTREE_NO_EVICTION) &&
+		    dhandle->session_inuse > 0);
 		(void)__wt_atomic_subi32(&dhandle->session_inuse, 1);
 		incr = false;
 	}


### PR DESCRIPTION
@keithbostic Please review and run this on  your machine with `verbose=(temporary)` turned on.  If you see the `clear_open...` message and it successfully completes then it took the original code path.  This is not ready to merge until the debug verbose message is removed.