### PR TITLE
WT-2331 Require that reference cursors that are joined be positioned

### DIFF
--- a/src/packing/pack_impl.c
+++ b/src/packing/pack_impl.c
@@ -176,6 +176,8 @@ __wt_struct_repack(WT_SESSION_IMPL *session, const char *infmt,
 
 	/* Outfmt should complete before infmt */
 	while ((ret = __pack_next(&packout, &pvout)) == 0) {
+		if (p >= end)
+			WT_ERR(EINVAL);
 		WT_ERR(__pack_next(&packin, &pvin));
 		before = p;
 		WT_ERR(__unpack_read(session, &pvin, &p, (size_t)(end - p)));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -648,6 +648,7 @@ static int
 __session_join(WT_SESSION *wt_session, WT_CURSOR *join_cursor,
     WT_CURSOR *ref_cursor, const char *config)
 {
+	WT_CURSOR *firstcg;
 	WT_CONFIG_ITEM cval;
 	WT_CURSOR_INDEX *cindex;
 	WT_CURSOR_JOIN *cjoin;
@@ -661,6 +662,7 @@ __session_join(WT_SESSION *wt_session, WT_CURSOR *join_cursor,
 	uint8_t flags, range;
 
 	count = 0;
+	firstcg = NULL;
 	session = (WT_SESSION_IMPL *)wt_session;
 	SESSION_API_CALL(session, join, config, cfg);
 	table = NULL;
@@ -672,15 +674,18 @@ __session_join(WT_SESSION *wt_session, WT_CURSOR *join_cursor,
 		cindex = (WT_CURSOR_INDEX *)ref_cursor;
 		idx = cindex->index;
 		table = cindex->table;
-		WT_CURSOR_CHECKKEY(ref_cursor);
+		firstcg = cindex->cg_cursors[0];
 	} else if (WT_PREFIX_MATCH(ref_cursor->uri, "table:")) {
 		idx = NULL;
 		ctable = (WT_CURSOR_TABLE *)ref_cursor;
 		table = ctable->table;
-		WT_CURSOR_CHECKKEY(ctable->cg_cursors[0]);
+		firstcg = ctable->cg_cursors[0];
 	} else
 		WT_ERR_MSG(session, EINVAL, "not an index or table cursor");
 
+	if (!F_ISSET(firstcg, WT_CURSTD_KEY_SET))
+		WT_ERR_MSG(session, EINVAL,
+		    "requires reference cursor be positioned");
 	cjoin = (WT_CURSOR_JOIN *)join_cursor;
 	if (cjoin->table != table)
 		WT_ERR_MSG(session, EINVAL,


### PR DESCRIPTION
Additionally add tests to verify that cursors that merely have a key set, or
that have failed a positioning API (search), not be usable in a join.  Give
a better error message in all these cases.

Add a check in __wt_struct_repack so that an empty or shorter than expected
input array give an error, and not be interpreted as unbounded size.