### PR TITLE
WT-2335: crash in config_check_search with invalid configuration string

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -365,6 +365,9 @@ __config_next(WT_CONFIG *conf, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value)
 			    conf, "Unexpected character", EINVAL));
 
 		case A_DOWN:
+			if (conf->top == -1)
+				return (__config_err(
+				    conf, "Unbalanced brackets", EINVAL));
 			--conf->depth;
 			CAP(0);
 			break;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -471,8 +471,7 @@ __config_next(WT_CONFIG *conf, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value)
 	if (conf->depth == 0)
 		return (WT_NOTFOUND);
 
-	return (__config_err(conf,
-	    "Closing brackets missing from config string", EINVAL));
+	return (__config_err(conf, "Unbalanced brackets", EINVAL));
 }
 
 /*

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -158,11 +158,15 @@ class test_config04(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.wiredtiger_open('.', '}'), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '{'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.wiredtiger_open('.', '{}}'), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.wiredtiger_open('.', '(]}'), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.wiredtiger_open('.', '(create=]}'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '(create='), msg)
 
     def test_session_max(self):
         # Note: There isn't any direct way to know that this was set,

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -153,6 +153,17 @@ class test_config04(wttest.WiredTigerTestCase):
         # Note: There isn't any direct way to know that this was set.
         self.common_test('hazard_max=50')
 
+    def test_invalid_config(self):
+        msg = '/Unbalanced brackets/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '}'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '{}}'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '(]}'), msg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open('.', '(create=]}'), msg)
+
     def test_session_max(self):
         # Note: There isn't any direct way to know that this was set,
         # but we'll have a separate functionality test to test for


### PR DESCRIPTION
WT-2335: crash in config_check_search with invalid configuration string

@michaelcahill, would you please do the review?