### PR TITLE
WT-2295 On index create, do not populate existing indices.

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -595,8 +595,11 @@ __create_table(WT_SESSION_IMPL *session,
 		return (EINVAL);
 
 	if ((ret = __wt_schema_get_table(session,
-	    tablename, strlen(tablename), false, &table)) == 0)
+	    tablename, strlen(tablename), false, &table)) == 0) {
+		if (exclusive)
+			WT_ERR(EEXIST);
 		exists = true;
+	}
 	WT_RET_NOTFOUND_OK(ret);
 
 	WT_ERR(__wt_config_gets(session, cfg, "colgroups", &cval));

--- a/test/suite/test_index01.py
+++ b/test/suite/test_index01.py
@@ -217,5 +217,20 @@ class test_index01(wttest.WiredTigerTestCase):
             self.assertEqual(list(self.index_iter(i)), [])
         self.drop_table()
 
+    def test_exclusive(self):
+        '''Create indices, then try to create another index exclusively'''
+        self.create_table()
+        # non-exclusive recreate is allowed
+        self.session.create(self.index[0], 'columns=(dept)')
+        # exclusive recreate
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.create(self.index[0],
+            'columns=(dept),exclusive'))
+        # non-exclusive create with differing configuration
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create(self.index[0],
+            'columns=(salary)'), '/does not match existing configuration/')
+        self.drop_table()
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_schema02.py
+++ b/test/suite/test_schema02.py
@@ -99,6 +99,14 @@ class test_schema02(wttest.WiredTigerTestCase):
         # expect this to work
         self.session.create("colgroup:main:c1", "columns=(S1,i2)")
 
+        # exclusive: no error message
+        self.expect_failure_colgroup("main:c1", "columns=(S1,i2),exclusive",
+                                     "")
+
+        # exists with different config
+        self.expect_failure_colgroup("main:c1", "columns=(S1,i4)",
+                                     "/does not match existing configuration/")
+
         # colgroup not declared in initial create
         self.expect_failure_colgroup("main:c3", "columns=(S3,i4)",
                                      "/Column group 'c3' not found in"


### PR DESCRIPTION
These commits fix the test case for populating indices attached to WT-2295.
Also fixes exclusive create for "index:", and disallows calling create on an existing index with a different configuration string.

Added explicit tests for exclusive create and recreating index with a different configuration.  It's probably not possible in python to create a test that detects that existing indices are not repopulated, at least not without help in C.