### PR TITLE
WT-2296 Yield instead of sleep if the wrlsn thread is finding work.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -675,7 +675,7 @@ __log_wrlsn_server(void *arg)
 		/*
 		 * If __wt_log_wrlsn did work we want to yield instead of sleep.
 		 */
-		if (yield++ < 1000)
+		if (yield++ < WT_THOUSAND)
 			__wt_yield();
 		else
 			WT_ERR(__wt_cond_wait(session, conn->log_wrlsn_cond, 10000));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -261,7 +261,7 @@ extern int __wt_connection_init(WT_CONNECTION_IMPL *conn);
 extern int __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern int __wt_logmgr_reconfig(WT_SESSION_IMPL *session, const char **cfg);
 extern int __wt_log_truncate_files( WT_SESSION_IMPL *session, WT_CURSOR *cursor, const char *cfg[]);
-extern int __wt_log_wrlsn(WT_SESSION_IMPL *session);
+extern int __wt_log_wrlsn(WT_SESSION_IMPL *session, int *yield);
 extern int __wt_logmgr_create(WT_SESSION_IMPL *session, const char *cfg[]);
 extern int __wt_logmgr_open(WT_SESSION_IMPL *session);
 extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -47,7 +47,7 @@ __wt_log_flush_lsn(WT_SESSION_IMPL *session, WT_LSN *lsn, bool start)
 	conn = S2C(session);
 	log = conn->log;
 	WT_RET(__wt_log_force_write(session, 1));
-	WT_RET(__wt_log_wrlsn(session));
+	WT_RET(__wt_log_wrlsn(session, NULL));
 	if (start)
 		*lsn = log->write_start_lsn;
 	else
@@ -771,7 +771,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SLOT));
 	while (log->log_close_fh != NULL) {
 		WT_STAT_FAST_CONN_INCR(session, log_close_yields);
-		WT_RET(__wt_log_wrlsn(session));
+		WT_RET(__wt_log_wrlsn(session, NULL));
 		if (++yield_cnt > 10000)
 			return (EBUSY);
 		__wt_yield();


### PR DESCRIPTION
@michaelcahill Please review this change that eliminates the performance hit in the 2.7 release for write-no-sync mode.  In fact, this code, in write-no-sync, now runs at 3x the (fixed from WT-2332) 2.6 code (on Linux, it runs equal on my Mac).  This may have a good impact on in-memory log configuration too because the change is in the `wrlsn_server` thread.  This yield code existed in 2.6 and earlier logging code and changed during the rewrite.