### PR TITLE
WT-2338 Skip pre-allocated log files if backup cursor is open.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -741,6 +741,12 @@ __log_server(void *arg)
 			 * Perform log pre-allocation.
 			 */
 			if (conn->log_prealloc > 0) {
+				/*
+				 * Log file pre-allocation is disabled when a
+				 * hot backup cursor is open because we have
+				 * agreed not to rename or remove any files in
+				 * the database directory.
+				 */
 				WT_ERR(__wt_readlock(
 				    session, conn->hot_backup_lock));
 				locked = true;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -791,9 +791,10 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	WT_FULL_BARRIER();
 	/*
 	 * If we're pre-allocating log files, look for one.  If there aren't any
-	 * or we're not pre-allocating, then create one.
+	 * or we're not pre-allocating, or a backup cursor is open, then
+	 * create one.
 	 */
-	if (conn->log_prealloc > 0) {
+	if (conn->log_prealloc > 0 && !conn->hot_backup) {
 		ret = __log_alloc_prealloc(session, log->fileid);
 		/*
 		 * If ret is 0 it means we found a pre-allocated file.


### PR DESCRIPTION
@michaelcahill Please review this fix for WT-2338 which is from BF-1399 - skip using pre-allocated log files if a backup is in progress.  This does not include a test for forcing that specific scenario.  I can add one if you want.