### PR TITLE
WT-2275 Restore call to LSM tree truncate.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -836,6 +836,13 @@ __session_truncate(WT_SESSION *wt_session,
 				    "target after the log: URI prefix.");
 			ret = __wt_log_truncate_files(session, start, cfg);
 			goto done;
+		} else if (WT_PREFIX_MATCH(uri, "lsm:")) {
+			/*
+			 * LSM tree truncate needs to handle truncating each
+			 * chunk on its own.
+			 */
+			ret = __wt_lsm_tree_truncate(session, uri, cfg);
+			goto done;
 		} else {
 			/*
 			 * A URI truncate becomes a range truncate where we


### PR DESCRIPTION
@michaelcahill In thinking harder about the LSM truncate and looking at the code, I restored the call to `wt_lsm_tree_truncate`.  The LSM code doesn't do truncate and file manipulation like the others.  While there may be bugs, the LSM code is very different where the truncate sets up a new chunk and moves all the previous chunks to the `old_chunks` list and then does its processing on those chunks.  So if there are bugs in the metadata consistency, it is unlike the original truncate code for files and it exists for any LSM table when it removes chunks from the `old_chunks` array.

There is precedent for checking the `lsm:` URI in `session_api.c` and `session_compact.c` also.

