### PR TITLE
WT-2130 Don't round the split_pct to an allocation size.

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -49,7 +49,7 @@
 	((((uintmax_t)(n)) + ((v) - 1)) & ~(((uintmax_t)(v)) - 1))
 
 #define	WT_ALIGN_NEAREST(n, v)						\
-	((((uintmax_t)(n)) + ((v) / 2 + 1)) & ~(((uintmax_t)(v)) - 1))
+	((((uintmax_t)(n)) + ((v) / 2)) & ~(((uintmax_t)(v)) - 1))
 
 /* Min, max. */
 #define	WT_MIN(a, b)	((a) < (b) ? (a) : (b))

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -48,6 +48,9 @@
 #define	WT_ALIGN(n, v)							\
 	((((uintmax_t)(n)) + ((v) - 1)) & ~(((uintmax_t)(v)) - 1))
 
+#define	WT_ALIGN_NEAREST(n, v)						\
+	((((uintmax_t)(n)) + ((v) / 2 + 1)) & ~(((uintmax_t)(v)) - 1))
+
 /* Min, max. */
 #define	WT_MIN(a, b)	((a) < (b) ? (a) : (b))
 #define	WT_MAX(a, b)	((a) < (b) ? (b) : (a))

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1889,7 +1889,15 @@ __wt_split_page_size(WT_BTREE *btree, uint32_t maxpagesize)
 	 * we don't waste space when we write).
 	 */
 	a = maxpagesize;			/* Don't overflow. */
-	split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);
+	split_size = (uint32_t)WT_ALIGN_NEAREST(
+	    (a * (u_int)btree->split_pct) / 100, btree->allocsize);
+
+	/*
+	 * Respect the configured split percentage if the calculated split
+	 * size is either zero or a full page.
+	 */
+	if (split_size == 0 || split_size == maxpagesize)
+		split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);
 
 	return (split_size);
 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1889,8 +1889,7 @@ __wt_split_page_size(WT_BTREE *btree, uint32_t maxpagesize)
 	 * we don't waste space when we write).
 	 */
 	a = maxpagesize;			/* Don't overflow. */
-	split_size = (uint32_t)
-	    WT_ALIGN((a * (u_int)btree->split_pct) / 100, btree->allocsize);
+	split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);
 
 	/*
 	 * If the result of that calculation is the same as the allocation unit
@@ -3286,6 +3285,16 @@ supd_check_complete:
 		}
 	}
 
+	bnd->entries = r->entries;
+	/* Output a verbose message if we create a page without many entries */
+	if (WT_VERBOSE_ISSET(session, WT_VERB_SPLIT) && r->entries < 6)
+		WT_ERR(__wt_verbose(session, WT_VERB_SPLIT,
+		    "Reconciling page with memory footprint %" PRIu64
+		    ", %" PRIu32 " th page has"
+		    " %" PRIu32 " entries, %s, split state: %d\n",
+		    r->page->memory_footprint, r->bnd_next, r->entries,
+		    F_ISSET(r, WT_EVICTING) ? "evict" : "checkpoint",
+		    r->bnd_state));
 	WT_ERR(__wt_bt_write(session,
 	    buf, addr, &addr_size, false, bnd->already_compressed));
 	WT_ERR(__wt_strndup(session, addr, addr_size, &bnd->addr.addr));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1894,7 +1894,11 @@ __wt_split_page_size(WT_BTREE *btree, uint32_t maxpagesize)
 
 	/*
 	 * Respect the configured split percentage if the calculated split
-	 * size is either zero or a full page.
+	 * size is either zero or a full page. The user has either configured
+	 * an allocation size that matches the page size, or a split
+	 * percentage that is close to zero or one hundred. Rounding is going
+	 * to provide a worse outcome than having a split point that doesn't
+	 * fall on an allocation size boundary in those cases.
 	 */
 	if (split_size == 0 || split_size == maxpagesize)
 		split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1891,14 +1891,6 @@ __wt_split_page_size(WT_BTREE *btree, uint32_t maxpagesize)
 	a = maxpagesize;			/* Don't overflow. */
 	split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);
 
-	/*
-	 * If the result of that calculation is the same as the allocation unit
-	 * (that happens if the maximum size is the same size as an allocation
-	 * unit, use a percentage of the maximum page size).
-	 */
-	if (split_size == btree->allocsize)
-		split_size = (uint32_t)((a * (u_int)btree->split_pct) / 100);
-
 	return (split_size);
 }
 
@@ -3289,12 +3281,13 @@ supd_check_complete:
 	/* Output a verbose message if we create a page without many entries */
 	if (WT_VERBOSE_ISSET(session, WT_VERB_SPLIT) && r->entries < 6)
 		WT_ERR(__wt_verbose(session, WT_VERB_SPLIT,
-		    "Reconciling page with memory footprint %" PRIu64
-		    ", %" PRIu32 " th page has"
-		    " %" PRIu32 " entries, %s, split state: %d\n",
-		    r->page->memory_footprint, r->bnd_next, r->entries,
+		    "Reconciliation creating a page with %" PRIu32
+		    " entries, memory footprint %" PRIu64
+		    ", page count %" PRIu32 ", %s, split state: %d\n",
+		    r->entries, r->page->memory_footprint, r->bnd_next,
 		    F_ISSET(r, WT_EVICTING) ? "evict" : "checkpoint",
 		    r->bnd_state));
+
 	WT_ERR(__wt_bt_write(session,
 	    buf, addr, &addr_size, false, bnd->already_compressed));
 	WT_ERR(__wt_strndup(session, addr, addr_size, &bnd->addr.addr));


### PR DESCRIPTION
The value is passed in via the API, and rounding makes it likely we
won't split as the user expects. Especially if the split percentage
is high, when we'll likely round up to 100%.