### PR TITLE
WT-2229 Remove compression backoff stats

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -212,7 +212,6 @@ connection_stats = [
     LogStat('log_close_yields', 'yields waiting for previous log file close'),
     LogStat('log_compress_len', 'total size of compressed records'),
     LogStat('log_compress_mem', 'total in-memory size of compressed records'),
-    LogStat('log_compress_skipped', 'log record compression skipped'),
     LogStat('log_compress_small', 'log records too small to compress'),
     LogStat('log_compress_write_fails', 'log records not compressed'),
     LogStat('log_compress_writes', 'log records compressed'),
@@ -432,7 +431,6 @@ dsrc_stats = [
     CompressStat('compress_read', 'compressed pages read'),
     CompressStat('compress_write', 'compressed pages written'),
     CompressStat('compress_write_fail', 'page written failed to compress'),
-    CompressStat('compress_write_skipped', 'page write compression skipped'),
     CompressStat('compress_write_too_small', 'page written was too small to compress'),
 
     ##########################################

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -235,10 +235,9 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 	else if (buf->size <= btree->allocsize) {
 		ip = buf;
 		WT_STAT_FAST_DATA_INCR(session, compress_write_too_small);
-	} else if (__wt_compression_skip_next(&btree->compression_fail_skip)) {
+	} else if (__wt_compression_skip_next(&btree->compression_fail_skip))
 		ip = buf;
-		WT_STAT_FAST_DATA_INCR(session, compress_write_skipped);
-	} else {
+	else {
 		/* Skip the header bytes of the source data. */
 		src = (uint8_t *)buf->mem + WT_BLOCK_COMPRESS_SKIP;
 		src_len = buf->size - WT_BLOCK_COMPRESS_SKIP;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -315,7 +315,6 @@ struct __wt_connection_stats {
 	int64_t log_close_yields;
 	int64_t log_compress_len;
 	int64_t log_compress_mem;
-	int64_t log_compress_skipped;
 	int64_t log_compress_small;
 	int64_t log_compress_write_fails;
 	int64_t log_compress_writes;
@@ -457,7 +456,6 @@ struct __wt_dsrc_stats {
 	int64_t compress_read;
 	int64_t compress_write;
 	int64_t compress_write_fail;
-	int64_t compress_write_skipped;
 	int64_t compress_write_too_small;
 	int64_t cursor_create;
 	int64_t cursor_insert;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3855,155 +3855,153 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LOG_COMPRESS_LEN			1086
 /*! log: total in-memory size of compressed records */
 #define	WT_STAT_CONN_LOG_COMPRESS_MEM			1087
-/*! log: log record compression skipped */
-#define	WT_STAT_CONN_LOG_COMPRESS_SKIPPED		1088
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1089
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1088
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1090
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1089
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1091
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1090
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1092
+#define	WT_STAT_CONN_LOG_FLUSH				1091
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1093
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1092
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1094
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1093
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1095
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1094
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1096
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1095
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1097
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1096
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1098
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1097
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1099
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1098
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1100
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1099
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1101
+#define	WT_STAT_CONN_LOG_SCANS				1100
 /*! log: consolidated slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1102
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1101
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1103
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1102
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1104
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1103
 /*! log: consolidated slot joins */
-#define	WT_STAT_CONN_LOG_SLOT_JOINS			1105
+#define	WT_STAT_CONN_LOG_SLOT_JOINS			1104
 /*! log: consolidated slot join races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1106
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1105
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1107
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1106
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1108
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1107
 /*! log: consolidated slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1109
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1108
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1110
+#define	WT_STAT_CONN_LOG_SYNC				1109
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1111
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1110
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1112
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1111
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1113
+#define	WT_STAT_CONN_LOG_WRITES				1112
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1114
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1113
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1115
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1114
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1116
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1115
 /*! LSM: rows merged in an LSM tree */
-#define	WT_STAT_CONN_LSM_ROWS_MERGED			1117
+#define	WT_STAT_CONN_LSM_ROWS_MERGED			1116
 /*! LSM: application work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1118
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_APP			1117
 /*! LSM: merge work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1119
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MANAGER		1118
 /*! LSM: tree queue hit maximum */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1120
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_MAX			1119
 /*! LSM: switch work units currently queued */
-#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1121
+#define	WT_STAT_CONN_LSM_WORK_QUEUE_SWITCH		1120
 /*! LSM: tree maintenance operations scheduled */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1122
+#define	WT_STAT_CONN_LSM_WORK_UNITS_CREATED		1121
 /*! LSM: tree maintenance operations discarded */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1123
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DISCARDED		1122
 /*! LSM: tree maintenance operations executed */
-#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1124
+#define	WT_STAT_CONN_LSM_WORK_UNITS_DONE		1123
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1125
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1124
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1126
+#define	WT_STAT_CONN_MEMORY_FREE			1125
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1127
+#define	WT_STAT_CONN_MEMORY_GROW			1126
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1128
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1127
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1129
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1128
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1130
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1129
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1131
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1130
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1132
+#define	WT_STAT_CONN_PAGE_SLEEP				1131
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1133
+#define	WT_STAT_CONN_READ_IO				1132
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1134
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1133
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1135
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1134
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1136
+#define	WT_STAT_CONN_REC_PAGES				1135
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1137
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1136
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1138
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1137
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1139
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1138
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1140
+#define	WT_STAT_CONN_RWLOCK_READ			1139
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1141
+#define	WT_STAT_CONN_RWLOCK_WRITE			1140
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1142
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1141
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1143
+#define	WT_STAT_CONN_SESSION_OPEN			1142
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1144
+#define	WT_STAT_CONN_TXN_BEGIN				1143
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1145
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1144
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1146
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1145
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1147
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1146
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1148
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1147
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1149
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1148
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1150
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1149
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1151
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1150
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1152
+#define	WT_STAT_CONN_TXN_COMMIT				1151
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1153
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1152
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1154
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1153
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1155
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1154
 /*! transaction: transaction range of IDs currently pinned by named
  * snapshots */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1156
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1155
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1157
+#define	WT_STAT_CONN_TXN_ROLLBACK			1156
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1158
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1157
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1159
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1158
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1160
+#define	WT_STAT_CONN_TXN_SYNC				1159
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1161
+#define	WT_STAT_CONN_WRITE_IO				1160
 
 /*!
  * @}
@@ -4133,86 +4131,84 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_COMPRESS_WRITE			2059
 /*! compression: page written failed to compress */
 #define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2060
-/*! compression: page write compression skipped */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_SKIPPED		2061
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2062
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2061
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2063
+#define	WT_STAT_DSRC_CURSOR_CREATE			2062
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2064
+#define	WT_STAT_DSRC_CURSOR_INSERT			2063
 /*! cursor: bulk-loaded cursor-insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2065
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2064
 /*! cursor: cursor-insert key and value bytes inserted */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2066
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2065
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2067
+#define	WT_STAT_DSRC_CURSOR_NEXT			2066
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2068
+#define	WT_STAT_DSRC_CURSOR_PREV			2067
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2069
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2068
 /*! cursor: cursor-remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2070
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2069
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2071
+#define	WT_STAT_DSRC_CURSOR_RESET			2070
 /*! cursor: restarted searches */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2072
+#define	WT_STAT_DSRC_CURSOR_RESTART			2071
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2073
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2072
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2074
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2073
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2075
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2074
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2076
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2075
 /*! cursor: cursor-update value bytes updated */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2077
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2076
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_DSRC_LSM_CHECKPOINT_THROTTLE		2078
+#define	WT_STAT_DSRC_LSM_CHECKPOINT_THROTTLE		2077
 /*! LSM: chunks in the LSM tree */
-#define	WT_STAT_DSRC_LSM_CHUNK_COUNT			2079
+#define	WT_STAT_DSRC_LSM_CHUNK_COUNT			2078
 /*! LSM: highest merge generation in the LSM tree */
-#define	WT_STAT_DSRC_LSM_GENERATION_MAX			2080
+#define	WT_STAT_DSRC_LSM_GENERATION_MAX			2079
 /*! LSM: queries that could have benefited from a Bloom filter that did
  * not exist */
-#define	WT_STAT_DSRC_LSM_LOOKUP_NO_BLOOM		2081
+#define	WT_STAT_DSRC_LSM_LOOKUP_NO_BLOOM		2080
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_DSRC_LSM_MERGE_THROTTLE			2082
+#define	WT_STAT_DSRC_LSM_MERGE_THROTTLE			2081
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2083
+#define	WT_STAT_DSRC_REC_DICTIONARY			2082
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2084
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2083
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2085
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2084
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2086
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2085
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2087
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2086
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2088
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2087
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2089
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2088
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2090
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2089
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2091
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2090
 /*! reconciliation: page checksum matches */
-#define	WT_STAT_DSRC_REC_PAGE_MATCH			2092
+#define	WT_STAT_DSRC_REC_PAGE_MATCH			2091
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2093
+#define	WT_STAT_DSRC_REC_PAGES				2092
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2094
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2093
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2095
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2094
 /*! reconciliation: internal page key bytes discarded using suffix
  * compression */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2096
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2095
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2097
+#define	WT_STAT_DSRC_SESSION_COMPACT			2096
 /*! session: open cursor count */
-#define	WT_STAT_DSRC_SESSION_CURSOR_OPEN		2098
+#define	WT_STAT_DSRC_SESSION_CURSOR_OPEN		2097
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2099
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2098
 
 /*!
  * @}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1815,8 +1815,6 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 			newlrp->mem_len = WT_STORE_SIZE(record->size);
 		}
 	}
-	if (compressor != NULL)
-		WT_STAT_FAST_CONN_INCR(session, log_compress_skipped);
 	if ((kencryptor = conn->kencryptor) != NULL) {
 		/*
 		 * Allocate enough space for the original record plus the

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -64,7 +64,6 @@ static const char * const __stats_dsrc_desc[] = {
 	"compression: compressed pages read",
 	"compression: compressed pages written",
 	"compression: page written failed to compress",
-	"compression: page write compression skipped",
 	"compression: page written was too small to compress",
 	"cursor: create calls",
 	"cursor: insert calls",
@@ -183,7 +182,6 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->cache_eviction_clean = 0;
 	stats->compress_read = 0;
 	stats->compress_write = 0;
-	stats->compress_write_skipped = 0;
 	stats->compress_write_fail = 0;
 	stats->compress_write_too_small = 0;
 	stats->compress_raw_fail_temporary = 0;
@@ -310,7 +308,6 @@ __wt_stat_dsrc_aggregate_single(
 	to->cache_eviction_clean += from->cache_eviction_clean;
 	to->compress_read += from->compress_read;
 	to->compress_write += from->compress_write;
-	to->compress_write_skipped += from->compress_write_skipped;
 	to->compress_write_fail += from->compress_write_fail;
 	to->compress_write_too_small += from->compress_write_too_small;
 	to->compress_raw_fail_temporary += from->compress_raw_fail_temporary;
@@ -448,8 +445,6 @@ __wt_stat_dsrc_aggregate(
 	to->cache_eviction_clean += WT_STAT_READ(from, cache_eviction_clean);
 	to->compress_read += WT_STAT_READ(from, compress_read);
 	to->compress_write += WT_STAT_READ(from, compress_write);
-	to->compress_write_skipped +=
-	    WT_STAT_READ(from, compress_write_skipped);
 	to->compress_write_fail += WT_STAT_READ(from, compress_write_fail);
 	to->compress_write_too_small +=
 	    WT_STAT_READ(from, compress_write_too_small);
@@ -602,7 +597,6 @@ static const char * const __stats_connection_desc[] = {
 	"log: yields waiting for previous log file close",
 	"log: total size of compressed records",
 	"log: total in-memory size of compressed records",
-	"log: log record compression skipped",
 	"log: log records too small to compress",
 	"log: log records not compressed",
 	"log: log records compressed",
@@ -805,7 +799,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->log_bytes_written = 0;
 	stats->log_zero_fills = 0;
 	stats->log_flush = 0;
-	stats->log_compress_skipped = 0;
 	stats->log_compress_writes = 0;
 	stats->log_compress_write_fails = 0;
 	stats->log_compress_small = 0;
@@ -1000,7 +993,6 @@ __wt_stat_connection_aggregate(
 	to->log_bytes_written += WT_STAT_READ(from, log_bytes_written);
 	to->log_zero_fills += WT_STAT_READ(from, log_zero_fills);
 	to->log_flush += WT_STAT_READ(from, log_flush);
-	to->log_compress_skipped += WT_STAT_READ(from, log_compress_skipped);
 	to->log_compress_writes += WT_STAT_READ(from, log_compress_writes);
 	to->log_compress_write_fails +=
 	    WT_STAT_READ(from, log_compress_write_fails);


### PR DESCRIPTION
@daveh86 Here's a branch of the compression-backoff change that removes those stats per the suggestion from @keithbostic .  I created a pull request but I don't expect to merge this unless it is shown to be the cause of the performance regression.