### PR TITLE
WT-2369 Use C compiler to detect headers instead of C++ compiler

### DIFF
--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -148,10 +148,8 @@ no)	if test "$wt_cv_with_builtin_extension_snappy" = "yes"; then
 esac
 AC_MSG_RESULT($wt_cv_enable_snappy)
 if test "$wt_cv_enable_snappy" = "yes"; then
-	AC_LANG_PUSH([C++])
-	AC_CHECK_HEADER(snappy.h,,
+	AC_CHECK_HEADER(snappy-c.h,,
 	    [AC_MSG_ERROR([--enable-snappy requires snappy.h])])
-	AC_LANG_POP([C++])
 	AC_CHECK_LIB(snappy, snappy_compress,,
 	    [AC_MSG_ERROR([--enable-snappy requires snappy library])])
 fi
@@ -176,10 +174,8 @@ no)	if test "$wt_cv_with_builtin_extension_lz4" = "yes"; then
 esac
 AC_MSG_RESULT($wt_cv_enable_lz4)
 if test "$wt_cv_enable_lz4" = "yes"; then
-	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADER(lz4.h,,
 	    [AC_MSG_ERROR([--enable-lz4 requires lz4.h])])
-	AC_LANG_POP([C++])
 	AC_CHECK_LIB(lz4, LZ4_compress_destSize,,
 	    [AC_MSG_ERROR([--enable-lz4 requires lz4 library with LZ4_compress_destSize support])])
 fi
@@ -195,10 +191,8 @@ no)	wt_cv_enable_tcmalloc=no;;
 esac
 AC_MSG_RESULT($wt_cv_enable_tcmalloc)
 if test "$wt_cv_enable_tcmalloc" = "yes"; then
-	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADER(gperftools/tcmalloc.h,,
 	    [AC_MSG_ERROR([--enable-tcmalloc requires gperftools/tcmalloc.h])])
-	AC_LANG_POP([C++])
 	AC_CHECK_LIB(tcmalloc, tc_calloc,,
 	    [AC_MSG_ERROR([--enable-tcmalloc requires tcmalloc library])])
 fi

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -31,7 +31,7 @@ LT_INIT([pic-only])
 AC_SUBST([LIBTOOL_DEPS])
 
 AC_PROG_CC(cc gcc)
-# AC_PROG_CXX(c++ g++)
+AC_PROG_CXX(c++ g++)
 
 if test "$GCC" = "yes"; then
 	# The Solaris gcc compiler gets the additional -pthreads flag.


### PR DESCRIPTION
WiredTiger's options.m4 uses the C++ compiler instead of the C compiler to check for several C headers:
* snappy.h
* lz4.h
* gperftools/tcmalloc.h

`snappy.h` is a C++ header while `snappy-c.h` is the C equivalent, and the one included by `snappy_compress.c`.

By only using the C compiler for both header file checking and compilation, a user only needs to specify `CCFLAGS` instead of both `CCFLAGS` and `CXXFLAGS` during configure.

In order to support the `api/leveldb` directory, we need the C++ compiler. Previously the `AC_LANG_PUSH` macro was adding a dependency on it and now we need to be explicit the C++ compiler.