### PR TITLE
WT-2377 - change wtperfs dstrndup to not call strndup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -456,6 +456,7 @@ if useBdb:
 
 t = env.Program("wtperf", [
     "bench/wtperf/config.c",
+    "bench/wtperf/idle_table_cycle.c",
     "bench/wtperf/misc.c",
     "bench/wtperf/track.c",
     "bench/wtperf/wtperf.c",

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -403,7 +403,8 @@ dstrdup(const char *str)
 
 /*
  * dstrndup --
- *      Call strndup, dying on failure.
+ *      Call emulating strndup, dying on failure. Don't use actual strndup here
+ *	as it is not supported within MSVC.
  */
 static inline char *
 dstrndup(const char *str, const size_t len)

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -88,7 +88,7 @@ typedef struct {
 	int64_t insert;			/* Insert ratio */
 	int64_t read;			/* Read ratio */
 	int64_t update;			/* Update ratio */
-	uint64_t throttle;              /* Maximum operations/second */
+	uint64_t throttle;		/* Maximum operations/second */
 		/* Number of operations per transaction. Zero for autocommit */
 	int64_t ops_per_txn;
 	int64_t truncate;		/* Truncate ratio */
@@ -409,10 +409,11 @@ static inline char *
 dstrndup(const char *str, const size_t len)
 {
 	char *p;
+	p = dcalloc(len + 1, 1);
 
-	if ((p = strndup(str, len)) == NULL)
-		die(errno, "strndup");
+	strncpy(p, str, len);
+	if (p == NULL)
+		die(errno, "dstrndup");
 	return (p);
 }
-
 #endif


### PR DESCRIPTION
as it is not supported on MSVC.

Looks like my regex that was to replace spaces with tabs as part of a copy/paste found a formatting nit, I suspect that it can be left as is.