### PR TITLE
WT-2390 Fix OS X warning.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -633,7 +633,7 @@ restart:
 				if (slot->slot_start_lsn.l.offset !=
 				    slot->slot_last_offset)
 					slot->slot_start_lsn.l.offset =
-					    slot->slot_last_offset;
+					    (uint32_t)slot->slot_last_offset;
 				log->write_start_lsn = slot->slot_start_lsn;
 				log->write_lsn = slot->slot_end_lsn;
 				WT_ERR(__wt_cond_signal(


### PR DESCRIPTION
```
src/conn/conn_log.c:636:16: error: implicit conversion loses integer precision: 'wt_off_t' (aka 'long long') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
         slot->slot_last_offset;
```