### PR TITLE
WT-2382: Problem with custom collator for 'u' format with join cursor

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -552,7 +552,6 @@ extern int __wt_struct_confchk(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *v);
 extern int __wt_struct_size(WT_SESSION_IMPL *session, size_t *sizep, const char *fmt, ...);
 extern int __wt_struct_pack(WT_SESSION_IMPL *session, void *buffer, size_t size, const char *fmt, ...);
 extern int __wt_struct_unpack(WT_SESSION_IMPL *session, const void *buffer, size_t size, const char *fmt, ...);
-extern int __wt_struct_unpack_size(WT_SESSION_IMPL *session, const void *buffer, size_t size, const char *fmt, size_t *resultp);
 extern int __wt_struct_repack(WT_SESSION_IMPL *session, const char *infmt, const char *outfmt, const WT_ITEM *inbuf, WT_ITEM *outbuf);
 extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell);
 extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);

--- a/src/packing/pack_impl.c
+++ b/src/packing/pack_impl.c
@@ -107,36 +107,6 @@ __wt_struct_unpack(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_struct_unpack_size --
- *	Determine the packed size of a buffer matching the format.
- */
-int
-__wt_struct_unpack_size(WT_SESSION_IMPL *session,
-    const void *buffer, size_t size, const char *fmt, size_t *resultp)
-{
-	WT_DECL_PACK_VALUE(pv);
-	WT_DECL_RET;
-	WT_PACK pack;
-	const uint8_t *p, *end;
-
-	p = buffer;
-	end = p + size;
-
-	WT_RET(__pack_init(session, &pack, fmt));
-	while ((ret = __pack_next(&pack, &pv)) == 0)
-		WT_RET(__unpack_read(session, &pv, &p, (size_t)(end - p)));
-
-	/* Be paranoid - __pack_write should never overflow. */
-	WT_ASSERT(session, p <= end);
-
-	if (ret != WT_NOTFOUND)
-		return (ret);
-
-	*resultp = WT_PTRDIFF(p, buffer);
-	return (0);
-}
-
-/*
  * __wt_struct_repack --
  *	Return the subset of the packed buffer that represents part of
  *	the format.  If the result is not contiguous in the existing


### PR DESCRIPTION
Commit a6c183b removed the only caller of `__wt_struct_unpack_size`.