### PR TITLE
WT-2397: Cursor search/traversal returns out of order keys.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -601,6 +601,7 @@ filesystem
 filesystems
 fillms
 firstfit
+firstlast
 fixup
 floatnum
 fmt

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -266,6 +266,12 @@ __firstlast(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags, bool prev)
 	btree = S2BT(session);
 	current = NULL;
 
+	/*
+	 * We need to read the smallest/largest page regardless of whether it's
+	 * currently in the cache or if it's been deleted.
+	 */
+	LF_CLR(WT_READ_NO_EMPTY | WT_READ_CACHE);
+
 	if (0) {
 restart:	/*
 		 * Discard the currently held page and restart the walk from

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -264,6 +264,7 @@ __firstlast(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags, bool prev)
 	*refp = NULL;
 
 	btree = S2BT(session);
+	current = NULL;
 
 	if (0) {
 restart:	/*

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -143,11 +143,11 @@ restart:	/*
 		if (recno >= descent->key.recno) {
 			/*
 			 * If on the last slot (the key is larger than any key
-			 * on the page), check for an internal page split race.
+			 * on the page), check for an right-hand descent page
+			 * split race.
 			 */
-			if (parent_pindex != NULL &&
-			    __wt_split_intl_race(
-			    session, current->home, parent_pindex))
+			if (__wt_split_descent_race(
+			    session, parent_pindex, current))
 				goto restart;
 
 			goto descend;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -422,12 +422,11 @@ restart:	/*
 
 		/*
 		 * If on the last slot (the key is larger than any key on the
-		 * page), check for an internal page split race.
+		 * page), check for an right-hand descent page split race.
 		 */
 		if (pindex->entries == base) {
-append:			if (parent_pindex != NULL &&
-			    __wt_split_intl_race(
-			    session, current->home, parent_pindex))
+append:			if (__wt_split_descent_race(
+			    session, parent_pindex, current))
 				goto restart;
 		}
 


### PR DESCRIPTION
WT-2397: Invariant failure newCommittedSnapshot.opTime >= _currentCommittedSnapshot->opTime