### PR TITLE
WT-2397: Cursor traversal from end of the tree skips records.

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -89,11 +89,11 @@ __ref_is_leaf(WT_REF *ref)
 }
 
 /*
- * __page_ascend --
+ * __ref_ascend --
  *	Ascend the tree one level.
  */
-static void
-__page_ascend(WT_SESSION_IMPL *session,
+static inline void
+__ref_ascend(WT_SESSION_IMPL *session,
     WT_REF **refp, WT_PAGE_INDEX **pindexp, uint32_t *slotp)
 {
 	WT_REF *parent_ref, *ref;
@@ -163,11 +163,11 @@ __page_ascend(WT_SESSION_IMPL *session,
 }
 
 /*
- * __page_descend_prev --
+ * __ref_descend_prev --
  *	Descend the tree one level, during a previous-cursor walk.
  */
-static void
-__page_descend_prev(
+static inline void
+__ref_descend_prev(
     WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp)
 {
 	WT_PAGE_INDEX *pindex;
@@ -239,12 +239,12 @@ __page_descend_prev(
 }
 
 /*
- * __page_initial_descent_prev --
+ * __ref_initial_descent_prev --
  *	Descend the tree one level, when setting up the initial cursor position
  * for a previous-cursor walk.
  */
-static bool
-__page_initial_descent_prev(
+static inline bool
+__ref_initial_descent_prev(
     WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp)
 {
 	WT_PAGE_INDEX *pindex;
@@ -378,7 +378,7 @@ restart:	/*
 		while ((prev && slot == 0) ||
 		    (!prev && slot == pindex->entries - 1)) {
 			/* Ascend to the parent. */
-			__page_ascend(session, &ref, &pindex, &slot);
+			__ref_ascend(session, &ref, &pindex, &slot);
 
 			/*
 			 * If we got all the way through an internal page and
@@ -623,12 +623,12 @@ descend:			couple = ref;
 					    session, ref->page, pindex);
 					slot = 0;
 				} else if (initial_descent) {
-					if (!__page_initial_descent_prev(
+					if (!__ref_initial_descent_prev(
 					    session, ref, &pindex))
 						goto restart;
 					slot = pindex->entries - 1;
 				} else {
-					__page_descend_prev(
+					__ref_descend_prev(
 					    session, ref, &pindex);
 					slot = pindex->entries - 1;
 				}

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -361,7 +361,7 @@ restart:	/*
 	/*
 	 * If the active page was the root, we've reached the walk's end; we
 	 * only get here if we've returned the root to our caller, so we're
-	 * holding no hazard references.
+	 * holding no hazard pointers.
 	 */
 	if (__wt_ref_is_root(ref))
 		goto done;
@@ -670,7 +670,7 @@ __wt_tree_walk(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags)
 /*
  * __wt_tree_walk_count --
  *	Move to the next/previous page in the tree, tracking how many
- *	references were visited to get there.
+ * references were visited to get there.
  */
 int
 __wt_tree_walk_count(WT_SESSION_IMPL *session,

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -145,9 +145,8 @@ restart:	/*
 			 * If on the last slot (the key is larger than any key
 			 * on the page), check for an internal page split race.
 			 */
-			if (parent_pindex != NULL &&
-			    __wt_split_intl_race(
-			    session, current->home, parent_pindex))
+			if (__wt_split_descent_race(
+			    session, current, parent_pindex))
 				goto restart;
 
 			goto descend;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -425,9 +425,8 @@ restart:	/*
 		 * page), check for an internal page split race.
 		 */
 		if (pindex->entries == base) {
-append:			if (parent_pindex != NULL &&
-			    __wt_split_intl_race(
-			    session, current->home, parent_pindex))
+append:			if (__wt_split_descent_race(
+			    session, current, parent_pindex))
 				goto restart;
 		}
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1446,14 +1446,18 @@ __wt_btree_lsm_over_size(WT_SESSION_IMPL *session, uint64_t maxsize)
 }
 
 /*
- * __wt_split_intl_race --
+ * __wt_split_descent_race --
  *	Return if we raced with an internal page split when descending the tree.
  */
 static inline bool
-__wt_split_intl_race(
-    WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE_INDEX *saved_pindex)
+__wt_split_descent_race(
+    WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX *saved_pindex)
 {
 	WT_PAGE_INDEX *pindex;
+
+	/* No test when starting the descent (there's no home to check). */
+	if (__wt_ref_is_root(ref))
+		return (false);
 
 	/*
 	 * A place to hang this comment...
@@ -1509,6 +1513,6 @@ __wt_split_intl_race(
 	 * content the split page retains after the split, and we ignore this
 	 * race.
 	 */
-	WT_INTL_INDEX_GET(session, parent, pindex);
+	WT_INTL_INDEX_GET(session, ref->home, pindex);
 	return (pindex != saved_pindex);
 }

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1294,19 +1294,19 @@ __wt_page_swap_func(
 	bool acquired;
 
 	/*
-	 * In rare cases when walking the tree, we try to swap to the same
-	 * page.  Fast-path that to avoid thinking about error handling.
-	 */
-	if (held == want)
-		return (0);
-
-	/*
 	 * This function is here to simplify the error handling during hazard
 	 * pointer coupling so we never leave a hazard pointer dangling.  The
 	 * assumption is we're holding a hazard pointer on "held", and want to
 	 * acquire a hazard pointer on "want", releasing the hazard pointer on
 	 * "held" when we're done.
+	 *
+	 * When walking the tree, we sometimes swap to the same page. Fast-path
+	 * that to avoid thinking about error handling.
 	 */
+	if (held == want)
+		return (0);
+
+	/* Get the wanted page. */
 	ret = __wt_page_in_func(session, want, flags
 #ifdef HAVE_DIAGNOSTIC
 	    , file, line


### PR DESCRIPTION
Positioning a cursor at the end of the tree can race with page splits.
During the initial descent of the tree in the cursor.prev case, do the
same tests for races we do for a search past the end of the tree.