### PR TITLE
WT-2396 Grab the checkpoint lock around drops and renames.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -597,9 +597,10 @@ __session_rename(WT_SESSION *wt_session,
 	WT_ERR(__wt_str_name_check(session, uri));
 	WT_ERR(__wt_str_name_check(session, newuri));
 
-	WT_WITH_SCHEMA_LOCK(session, ret,
-	    WT_WITH_TABLE_LOCK(session, ret,
-		ret = __wt_schema_rename(session, uri, newuri, cfg)));
+	WT_WITH_CHECKPOINT_LOCK(session, ret,
+	    WT_WITH_SCHEMA_LOCK(session, ret,
+		WT_WITH_TABLE_LOCK(session, ret,
+		    ret = __wt_schema_rename(session, uri, newuri, cfg))));
 
 err:	API_END_RET_NOTFOUND_MAP(session, ret);
 }
@@ -646,9 +647,10 @@ __wt_session_drop(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 	if (!lock_wait)
 		F_SET(session, WT_SESSION_LOCK_NO_WAIT);
 
-	WT_WITH_SCHEMA_LOCK(session, ret,
-	    WT_WITH_TABLE_LOCK(session, ret,
-		ret = __wt_schema_drop(session, uri, cfg)));
+	WT_WITH_CHECKPOINT_LOCK(session, ret,
+	    WT_WITH_SCHEMA_LOCK(session, ret,
+		WT_WITH_TABLE_LOCK(session, ret,
+		    ret = __wt_schema_drop(session, uri, cfg))));
 
 	if (!lock_wait)
 		F_CLR(session, WT_SESSION_LOCK_NO_WAIT);


### PR DESCRIPTION
Since database-wide checkpoints have references to all handles in the
system, drops are generally not possible during a checkpoint regardless
of this change.  This prevents a deadlock where checkpoint waits on the
handle list lock after it has some handles locked exclusive.

A better longer-term solution would be to have checkpoint gather all
handles (including locking old checkpoints) at the beginning so it
doesn't have to acquire the handle list lock after locking handles.