### PR TITLE
WT-2405: test utility error handling.

### DIFF
--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -37,21 +37,18 @@ check_copy(void)
 {
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	int ret;
 
 	wts_open(g.home_backup, 0, &conn);
 
-	if ((ret = conn->open_session(
-	    conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "connection.open_session: %s", g.home_backup);
+	testutil_checkfmt(
+	    conn->open_session(conn, NULL, NULL, &session),
+	    "%s", g.home_backup);
 
-	ret = session->verify(session, g.uri, NULL);
-	if (ret != 0)
-		testutil_die(ret,
-		    "session.verify: %s: %s", g.home_backup, g.uri);
+	testutil_checkfmt(
+	    session->verify(session, g.uri, NULL),
+	    "%s: %s", g.home_backup, g.uri);
 
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "connection.close: %s", g.home_backup);
+	testutil_checkfmt(conn->close(conn, NULL), "%s", g.home_backup);
 }
 
 /*
@@ -63,14 +60,12 @@ copy_file(const char *name)
 {
 	size_t len;
 	char *cmd;
-	int ret;
 
 	len = strlen(g.home) + strlen(g.home_backup) + strlen(name) * 2 + 20;
 	cmd = dmalloc(len);
 	(void)snprintf(cmd, len,
 	    "cp %s/%s %s/%s", g.home, name, g.home_backup, name);
-	if ((ret = system(cmd)) != 0)
-		testutil_die(ret, "backup copy: %s", cmd);
+	testutil_checkfmt(system(cmd), "backup copy: %s", cmd);
 	free(cmd);
 }
 
@@ -116,8 +111,9 @@ backup(void *arg)
 		testutil_check(pthread_rwlock_wrlock(&g.backup_lock));
 
 		/* Re-create the backup directory. */
-		if ((ret = system(g.home_backup_init)) != 0)
-			testutil_die(ret, "backup directory creation failed");
+		testutil_checkfmt(
+		    system(g.home_backup_init),
+		    "%s", "backup directory creation failed");
 
 		/*
 		 * open_cursor can return EBUSY if a metadata operation is
@@ -130,9 +126,8 @@ backup(void *arg)
 			testutil_die(ret, "session.open_cursor: backup");
 
 		while ((ret = backup_cursor->next(backup_cursor)) == 0) {
-			if ((ret =
-			    backup_cursor->get_key(backup_cursor, &key)) != 0)
-				testutil_die(ret, "cursor.get_key");
+			testutil_check(
+			    backup_cursor->get_key(backup_cursor, &key));
 			copy_file(key);
 		}
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -229,7 +229,7 @@ ops(void *arg)
 	uint32_t op;
 	uint8_t *keybuf, *valbuf;
 	u_int np;
-	int ckpt_available, dir, insert, intxn, notfound, readonly, ret;
+	int ckpt_available, dir, insert, intxn, notfound, readonly;
 	char *ckpt_config, ckpt_name[64];
 
 	tinfo = arg;
@@ -352,11 +352,9 @@ ops(void *arg)
 				testutil_check(
 				    pthread_rwlock_wrlock(&g.backup_lock));
 
-			if ((ret =
-			    session->checkpoint(session, ckpt_config)) != 0)
-				testutil_die(ret, "session.checkpoint%s%s",
-				    ckpt_config == NULL ? "" : ": ",
-				    ckpt_config == NULL ? "" : ckpt_config);
+			testutil_checkfmt(
+			    session->checkpoint(session, ckpt_config),
+			    "%s", ckpt_config == NULL ? "" : ckpt_config);
 
 			if (ckpt_config != NULL)
 				testutil_check(
@@ -554,7 +552,6 @@ wts_read_scan(void)
 	WT_SESSION *session;
 	uint64_t cnt, last_cnt;
 	uint8_t *keybuf;
-	int ret;
 
 	conn = g.wts_conn;
 
@@ -578,8 +575,8 @@ wts_read_scan(void)
 		}
 
 		key.data = keybuf;
-		if ((ret = read_row(cursor, &key, cnt, 0)) != 0)
-			testutil_die(ret, "read_scan");
+		testutil_checkfmt(
+		    read_row(cursor, &key, cnt, 0), "%s", "read_scan");
 	}
 
 	testutil_check(session->close(session, NULL));
@@ -1074,8 +1071,7 @@ col_insert(TINFO *tinfo,
 			return (WT_ROLLBACK);
 		testutil_die(ret, "cursor.insert");
 	}
-	if ((ret = cursor->get_key(cursor, &keyno)) != 0)
-		testutil_die(ret, "cursor.get_key");
+	testutil_check(cursor->get_key(cursor, &keyno));
 	*keynop = (uint32_t)keyno;
 
 	table_append(keyno);			/* Extend the object. */

--- a/test/format/rebalance.c
+++ b/test/format/rebalance.c
@@ -33,7 +33,6 @@ wts_rebalance(void)
 {
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	int ret;
 	char cmd[1024];
 
 	if (g.c_rebalance == 0)
@@ -45,8 +44,7 @@ wts_rebalance(void)
 	(void)snprintf(cmd, sizeof(cmd),
 	    "../../wt -h %s dump -f %s/rebalance.orig %s",
 	    g.home, g.home, g.uri);
-	if ((ret = system(cmd)) != 0)
-		testutil_die(ret, "command failed: %s", cmd);
+	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 
 	/* Rebalance, then verify the object. */
 	wts_reopen();
@@ -56,8 +54,8 @@ wts_rebalance(void)
 		(void)g.wt_api->msg_printf(g.wt_api, session,
 		    "=============== rebalance start ===============");
 
-	if ((ret = session->rebalance(session, g.uri, NULL)) != 0)
-		testutil_die(ret, "session.rebalance: %s: %s", g.uri);
+	testutil_checkfmt(
+	    session->rebalance(session, g.uri, NULL), "%s", g.uri);
 
 	if (g.logging != 0)
 		(void)g.wt_api->msg_printf(g.wt_api, session,
@@ -70,13 +68,11 @@ wts_rebalance(void)
 	(void)snprintf(cmd, sizeof(cmd),
 	    "../../wt -h %s dump -f %s/rebalance.new %s",
 	    g.home, g.home, g.uri);
-	if ((ret = system(cmd)) != 0)
-		testutil_die(ret, "command failed: %s", cmd);
+	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 
 	/* Compare the old/new versions of the object. */
 	(void)snprintf(cmd, sizeof(cmd),
 	    "cmp %s/rebalance.orig %s/rebalance.new > /dev/null",
 	    g.home, g.home);
-	if ((ret = system(cmd)) != 0)
-		testutil_die(ret, "command failed: %s", cmd);
+	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 }

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -234,8 +234,8 @@ wts_open(const char *home, int set_api, WT_CONNECTION **connp)
 	if (strstr(config, "direct_io") != NULL)
 		g.c_backups = 0;
 
-	if ((ret = wiredtiger_open(home, &event_handler, config, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open: %s", home);
+	testutil_checkfmt(
+	    wiredtiger_open(home, &event_handler, config, &conn), "%s", home);
 
 	if (set_api)
 		g.wt_api = conn->get_extension_api(conn);
@@ -271,11 +271,8 @@ wts_open(const char *home, int set_api, WT_CONNECTION **connp)
 void
 wts_reopen(void)
 {
-	int ret;
-
-	if ((ret = wiredtiger_open(g.home,
-	    &event_handler, g.wiredtiger_open_config, &g.wts_conn)) != 0)
-		testutil_die(ret, "wiredtiger_open: %s", g.home);
+	testutil_checkfmt(wiredtiger_open(g.home, &event_handler,
+	    g.wiredtiger_open_config, &g.wts_conn), "%s", g.home);
 }
 
 /*
@@ -288,7 +285,6 @@ wts_create(void)
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
 	uint32_t maxintlpage, maxintlkey, maxleafpage, maxleafkey, maxleafvalue;
-	int ret;
 	char config[4096], *end, *p;
 
 	conn = g.wts_conn;
@@ -439,8 +435,7 @@ wts_create(void)
 	 * Create the underlying store.
 	 */
 	testutil_check(conn->open_session(conn, NULL, NULL, &session));
-	if ((ret = session->create(session, g.uri, config)) != 0)
-		testutil_die(ret, "session.create: %s", g.uri);
+	testutil_checkfmt(session->create(session, g.uri, config), "%s", g.uri);
 	testutil_check(session->close(session, NULL));
 }
 
@@ -464,7 +459,6 @@ wts_dump(const char *tag, int dump_bdb)
 {
 #ifdef HAVE_BERKELEY_DB
 	size_t len;
-	int ret;
 	char *cmd;
 
 	/*
@@ -489,8 +483,7 @@ wts_dump(const char *tag, int dump_bdb)
 	    g.uri == NULL ? "" : "-n",
 	    g.uri == NULL ? "" : g.uri);
 
-	if ((ret = system(cmd)) != 0)
-		testutil_die(ret, "%s: dump comparison failed", tag);
+	testutil_checkfmt(system(cmd), "%s: dump comparison failed", tag);
 	free(cmd);
 #else
 	(void)tag;				/* [-Wunused-variable] */

--- a/test/utility/test_util.i
+++ b/test/utility/test_util.i
@@ -76,13 +76,24 @@ testutil_die(int e, const char *fmt, ...)
 }
 
 /*
- * check --
+ * testutil_check --
  *	Complain and quit if a function call fails.
  */
 #define	testutil_check(call) do {					\
 	int __r;							\
 	if ((__r = (call)) != 0)					\
 		testutil_die(__r, "%s/%d: %s", __func__, __LINE__, #call);\
+} while (0)
+
+/*
+ * testutil_checkfmt --
+ *	Complain and quit if a function call fails, with additional arguments.
+ */
+#define	testutil_checkfmt(call, fmt, ...) do {				\
+	int __r;							\
+	if ((__r = (call)) != 0)					\
+		testutil_die(__r, "%s/%d: %s: " fmt,			\
+		    __func__, __LINE__, #call, __VA_ARGS__);		\
 } while (0)
 
 /*


### PR DESCRIPTION
Add testutil_checkfmt, a macro that supports additional error output.