### PR TITLE
WT-2412 Truncate should not return EBUSY any longer.

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1409,7 +1409,7 @@ struct __wt_session {
 	 * if <code>NULL</code>, the truncate continues to the end of the
 	 * object
 	 * @configempty{WT_SESSION.truncate, see dist/api_data.py}
-	 * @ebusy_errors
+	 * @errors
 	 */
 	int __F(truncate)(WT_SESSION *session,
 	    const char *name,


### PR DESCRIPTION
@keithbostic Please review this 5 character change!