### PR TITLE
WT-2376: Modules should compile without including wt_internal.h header file

### DIFF
--- a/dist/s_export
+++ b/dist/s_export
@@ -25,7 +25,9 @@ check()
 	sed 's/.* //' |
 	egrep -v '^__wt') |
 	sort |
-	uniq -u > $t
+	uniq -u |
+	egrep -v \
+	    'zlib_extension_init|lz4_extension_init|snappy_extension_init' > $t
 
 	test -s $t && {
 		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="

--- a/dist/s_export
+++ b/dist/s_export
@@ -12,10 +12,7 @@ Darwin)
 *)
 	# We require GNU nm, which may not be installed.
 	type nm > /dev/null 2>&1 &&
-	    (nm --version | grep 'GNU nm') > /dev/null 2>&1 || {
-		echo 'skipped: GNU nm not found'
-		exit 0
-	}
+	    (nm --version | grep 'GNU nm') > /dev/null 2>&1 || exit 0
 	NM='nm --extern-only --defined-only --print-file-name $f'
 	;;
 esac

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -1,6 +1,4 @@
 # List of OK external symbols.
-lz4_extension_init
-snappy_extension_init
 wiredtiger_config_parser_open
 wiredtiger_config_validate
 wiredtiger_open
@@ -20,4 +18,3 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
-zlib_extension_init

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -1,4 +1,6 @@
 # List of OK external symbols.
+lz4_extension_init
+snappy_extension_init
 wiredtiger_config_parser_open
 wiredtiger_config_validate
 wiredtiger_open
@@ -18,3 +20,4 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
+zlib_extension_init

--- a/ext/compressors/snappy/snappy_compress.c
+++ b/ext/compressors/snappy/snappy_compress.c
@@ -26,12 +26,14 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <wt_internal.h>
-
 #include <snappy-c.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <wiredtiger_config.h>
+#include <wiredtiger.h>
+#include <wiredtiger_ext.h>
 
 /* Local compressor structure. */
 typedef struct {
@@ -39,6 +41,27 @@ typedef struct {
 
 	WT_EXTENSION_API *wt_api;		/* Extension API */
 } SNAPPY_COMPRESSOR;
+
+#ifdef WORDS_BIGENDIAN
+/*
+ * wt_bswap64 --
+ *	64-bit unsigned little-endian to/from big-endian value.
+ */
+static inline uint64_t
+wt_bswap64(uint64_t v)
+{
+	return (
+	    ((v << 56) & 0xff00000000000000UL) |
+	    ((v << 40) & 0x00ff000000000000UL) |
+	    ((v << 24) & 0x0000ff0000000000UL) |
+	    ((v <<  8) & 0x000000ff00000000UL) |
+	    ((v >>  8) & 0x00000000ff000000UL) |
+	    ((v >> 24) & 0x0000000000ff0000UL) |
+	    ((v >> 40) & 0x000000000000ff00UL) |
+	    ((v >> 56) & 0x00000000000000ffUL)
+	);
+}
+#endif
 
 /*
  * wt_snappy_error --
@@ -109,7 +132,7 @@ wt_snappy_compress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 			 * Store the value in little-endian format.
 			 */
 #ifdef WORDS_BIGENDIAN
-			snaplen = __wt_bswap64(snaplen);
+			snaplen = wt_bswap64(snaplen);
 #endif
 			*(size_t *)dst = snaplen;
 		} else
@@ -142,7 +165,7 @@ wt_snappy_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 	 */
 	snaplen = *(size_t *)src;
 #ifdef WORDS_BIGENDIAN
-	snaplen = __wt_bswap64(snaplen);
+	snaplen = wt_bswap64(snaplen);
 #endif
 	if (snaplen + sizeof(size_t) > src_len) {
 		(void)wt_api->err_printf(wt_api,

--- a/ext/compressors/snappy/snappy_compress.c
+++ b/ext/compressors/snappy/snappy_compress.c
@@ -44,11 +44,11 @@ typedef struct {
 
 #ifdef WORDS_BIGENDIAN
 /*
- * wt_bswap64 --
+ * snappy_bswap64 --
  *	64-bit unsigned little-endian to/from big-endian value.
  */
 static inline uint64_t
-wt_bswap64(uint64_t v)
+snappy_bswap64(uint64_t v)
 {
 	return (
 	    ((v << 56) & 0xff00000000000000UL) |
@@ -132,7 +132,7 @@ wt_snappy_compress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 			 * Store the value in little-endian format.
 			 */
 #ifdef WORDS_BIGENDIAN
-			snaplen = wt_bswap64(snaplen);
+			snaplen = snappy_bswap64(snaplen);
 #endif
 			*(size_t *)dst = snaplen;
 		} else
@@ -165,7 +165,7 @@ wt_snappy_decompress(WT_COMPRESSOR *compressor, WT_SESSION *session,
 	 */
 	snaplen = *(size_t *)src;
 #ifdef WORDS_BIGENDIAN
-	snaplen = wt_bswap64(snaplen);
+	snaplen = snappy_bswap64(snaplen);
 #endif
 	if (snaplen + sizeof(size_t) > src_len) {
 		(void)wt_api->err_printf(wt_api,


### PR DESCRIPTION
@agorrod, for your review consideration, the changes to not include `wt_internal.h` in the compression modules.