### PR TITLE
WT-2430 Ensure that statistics cursor is always positioned at the first 'set' of statistics.

### DIFF
--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -200,8 +200,6 @@ __curstat_next(WT_CURSOR *cursor)
 	if (cst->notinitialized) {
 		WT_ERR(__wt_curstat_init(
 		    session, cursor->internal_uri, NULL, cst->cfg, cst));
-		if (cst->next_set != NULL)
-			WT_ERR((*cst->next_set)(session, cst, true, true));
 		cst->notinitialized = false;
 	}
 
@@ -244,8 +242,6 @@ __curstat_prev(WT_CURSOR *cursor)
 	if (cst->notinitialized) {
 		WT_ERR(__wt_curstat_init(
 		    session, cursor->internal_uri, NULL, cst->cfg, cst));
-		if (cst->next_set != NULL)
-			WT_ERR((*cst->next_set)(session, cst, false, true));
 		cst->notinitialized = false;
 	}
 
@@ -449,7 +445,6 @@ __curstat_join_next_set(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst,
 	WT_JOIN_STATS_GROUP *join_group;
 	ssize_t pos;
 
-	WT_ASSERT(session, WT_STREQ(cst->iface.uri, "statistics:join"));
 	join_group = &cst->u.join_stats_group;
 	cjoin = join_group->join_cursor;
 	if (init)
@@ -542,25 +537,31 @@ __wt_curstat_init(WT_SESSION_IMPL *session,
 	dsrc_uri = uri + strlen("statistics:");
 
 	if (WT_STREQ(dsrc_uri, "join"))
-		return (__curstat_join_init(session, curjoin, cfg, cst));
+		WT_RET(__curstat_join_init(session, curjoin, cfg, cst));
 
-	if (WT_PREFIX_MATCH(dsrc_uri, "colgroup:"))
-		return (
+	else if (WT_PREFIX_MATCH(dsrc_uri, "colgroup:"))
+		WT_RET(
 		    __wt_curstat_colgroup_init(session, dsrc_uri, cfg, cst));
 
-	if (WT_PREFIX_MATCH(dsrc_uri, "file:"))
-		return (__curstat_file_init(session, dsrc_uri, cfg, cst));
+	else if (WT_PREFIX_MATCH(dsrc_uri, "file:"))
+		WT_RET(__curstat_file_init(session, dsrc_uri, cfg, cst));
 
-	if (WT_PREFIX_MATCH(dsrc_uri, "index:"))
-		return (__wt_curstat_index_init(session, dsrc_uri, cfg, cst));
+	else if (WT_PREFIX_MATCH(dsrc_uri, "index:"))
+		WT_RET(__wt_curstat_index_init(session, dsrc_uri, cfg, cst));
 
-	if (WT_PREFIX_MATCH(dsrc_uri, "lsm:"))
-		return (__wt_curstat_lsm_init(session, dsrc_uri, cst));
+	else if (WT_PREFIX_MATCH(dsrc_uri, "lsm:"))
+		WT_RET(__wt_curstat_lsm_init(session, dsrc_uri, cst));
 
-	if (WT_PREFIX_MATCH(dsrc_uri, "table:"))
-		return (__wt_curstat_table_init(session, dsrc_uri, cfg, cst));
+	else if (WT_PREFIX_MATCH(dsrc_uri, "table:"))
+		WT_RET(__wt_curstat_table_init(session, dsrc_uri, cfg, cst));
 
-	return (__wt_bad_object_type(session, uri));
+	else
+		return (__wt_bad_object_type(session, uri));
+
+	if (cst->next_set != NULL)
+		WT_RET((*cst->next_set)(session, cst, false, true));
+
+	return (0);
 }
 
 /*

--- a/test/suite/test_join01.py
+++ b/test/suite/test_join01.py
@@ -33,7 +33,6 @@ from wtscenario import check_scenarios, multiply_scenarios, number_scenarios
 #    Join operations
 # Basic tests for join
 class test_join01(wttest.WiredTigerTestCase):
-    table_name1 = 'test_join01'
     nentries = 100
 
     scenarios = [
@@ -391,6 +390,7 @@ class test_join01(wttest.WiredTigerTestCase):
     def test_cursor_close2(self):
         self.cursor_close_common(False)
 
+    # test statistics using the framework set up for this test
     def test_stats(self):
         bloomcfg1000 = ',strategy=bloom,count=1000'
         bloomcfg10 = ',strategy=bloom,count=10'
@@ -399,6 +399,40 @@ class test_join01(wttest.WiredTigerTestCase):
         # Intentially run with an underconfigured Bloom filter,
         # statistics should pick up some false positives.
         self.join_common(bloomcfg10, bloomcfg10, False, True)
+
+    # test statistics with a simple one index join cursor
+    def test_simple_stats(self):
+        self.session.create("table:join01b",
+                       "key_format=i,value_format=i,columns=(k,v)")
+        self.session.create("index:join01b:index", "columns=(v)")
+
+        cursor = self.session.open_cursor("table:join01b", None, None)
+        cursor[1] = 11
+        cursor[2] = 12
+        cursor[3] = 13
+        cursor.close()
+
+        cursor = self.session.open_cursor("index:join01b:index", None, None)
+        cursor.set_key(11)
+        cursor.search()
+
+        jcursor = self.session.open_cursor("join:table:join01b", None, None)
+        self.session.join(jcursor, cursor, "compare=gt")
+
+        while jcursor.next() == 0:
+            [k] = jcursor.get_keys()
+            [v] = jcursor.get_values()
+
+        statcur = self.session.open_cursor("statistics:join", jcursor, None)
+        found = False
+        while statcur.next() == 0:
+            [desc, pvalue, value] = statcur.get_values()
+            #self.tty(str(desc) + "=" + str(pvalue))
+            found = True
+        self.assertEquals(found, True)
+
+        jcursor.close()
+        cursor.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fix is relevant for getting statistics on join cursors.  This fixes the user submitted test case, and also passes a new test case, which is derived from the user submitted one.