### PR TITLE
WT-2433 Allow statistics logging in readonly mode.

### DIFF
--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -106,10 +106,6 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	 * If any statistics logging is done, this must not be a read-only
 	 * connection.
 	 */
-	if (F_ISSET(conn, WT_CONN_READONLY))
-		WT_RET_MSG(session, EINVAL,
-		    "Read-only configuration incompatible with statistics "
-		    "logging");
 	WT_RET(__wt_config_gets(session, cfg, "statistics_log.sources", &cval));
 	WT_RET(__wt_config_subinit(session, &objectconf, &cval));
 	for (cnt = 0; (ret = __wt_config_next(&objectconf, &k, &v)) == 0; ++cnt)

--- a/src/docs/readonly.dox
+++ b/src/docs/readonly.dox
@@ -18,7 +18,7 @@ tree merges are turned off when LSM trees are configured, and log file
 archiving is disabled when logging is configured.
 
 Where a user configured setting contradicts read-only operation, WiredTiger
-will return an error.  For example, statistics logging or zero-filling
+will return an error.  For example, zero-filling
 log files is not allowed in read-only mode, and attempting to configure
 them will return an error.
 

--- a/test/suite/test_readonly02.py
+++ b/test/suite/test_readonly02.py
@@ -54,10 +54,8 @@ class test_readonly02(wttest.WiredTigerTestCase, suite_subprocess):
     #   1. setting readonly on a new database directory
     #   2. an unclean shutdown and reopening readonly
     #   3. logging with zero-fill enabled and readonly
-    #   4. readonly and statistics logging
     #
     badcfg1 = 'log=(enabled,zero_fill=true)'
-    badcfg2 = 'statistics_log=(wait=3)'
 
     def setUpConnectionOpen(self, dir):
         self.home = dir
@@ -111,8 +109,6 @@ class test_readonly02(wttest.WiredTigerTestCase, suite_subprocess):
         # Close the connection.  Reopen readonly with other bad settings.
         #   3. logging with zero-fill enabled and readonly
         self.close_checkerror(self.badcfg1)
-        #   4. readonly and statistics logging
-        self.close_checkerror(self.badcfg2)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@michaelcahill Here are changes for allowing statistics logging even in read-only mode.  This is helpful for debugging the performance differences.  Please review.