### PR TITLE
WT-2434 Fix a race between forced drops and sweep.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -134,13 +134,10 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	btree = S2BT(session);
 	bm = btree->bm;
 	dhandle = session->dhandle;
-	marked_dead = false;
+	evict_reset = marked_dead = false;
 
 	if (!F_ISSET(dhandle, WT_DHANDLE_OPEN))
 		return (0);
-
-	/* Ensure that we aren't racing with the eviction server */
-	WT_RET(__wt_evict_file_exclusive_on(session, &evict_reset));
 
 	/*
 	 * If we don't already have the schema lock, make it an error to try
@@ -162,6 +159,9 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	 */
 	__wt_spin_lock(session, &dhandle->close_lock);
 
+	/* Ensure that we aren't racing with the eviction server */
+	WT_ERR(__wt_evict_file_exclusive_on(session, &evict_reset));
+
 	/*
 	 * The close can fail if an update cannot be written, return the EBUSY
 	 * error to our caller for eventual retry.
@@ -176,23 +176,22 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY)) {
 		if (force && (bm == NULL || !bm->is_mapped(bm, session))) {
 			F_SET(session->dhandle, WT_DHANDLE_DEAD);
+			marked_dead = true;
 
 			/*
 			 * Reset the tree's eviction priority, and the tree is
 			 * evictable by definition.
 			 */
 			__wt_evict_priority_clear(session);
-			F_CLR(S2BT(session), WT_BTREE_NO_EVICTION);
-
-			marked_dead = true;
 		}
 		if (!marked_dead || final)
 			WT_ERR(__wt_checkpoint_close(session, final));
 	}
 
 	WT_TRET(__wt_btree_close(session));
+
 	/*
-	 * If we marked a handle as dead it will be closed by sweep, via
+	 * If we marked a handle dead it will be closed by sweep, via
 	 * another call to sync and close.
 	 */
 	if (!marked_dead) {
@@ -204,10 +203,9 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	    F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
 	    !F_ISSET(dhandle, WT_DHANDLE_OPEN));
 
-err:	__wt_spin_unlock(session, &dhandle->close_lock);
-
-	if (evict_reset)
+err:	if (evict_reset)
 		__wt_evict_file_exclusive_off(session);
+	__wt_spin_unlock(session, &dhandle->close_lock);
 
 	if (no_schema_lock)
 		F_CLR(session, WT_SESSION_NO_SCHEMA_LOCK);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -91,9 +91,9 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 		goto err;
 
 	/*
-	 * Mark the handle as dead and close the underlying file
-	 * handle. Closing the handle decrements the open file count,
-	 * meaning the close loop won't overrun the configured minimum.
+	 * Mark the handle dead and close the underlying file handle.
+	 * Closing the handle decrements the open file count, meaning the close
+	 * loop won't overrun the configured minimum.
 	 */
 	ret = __wt_conn_btree_sync_and_close(session, false, true);
 
@@ -163,7 +163,7 @@ __sweep_discard_trees(WT_SESSION_IMPL *session, u_int *dead_handlesp)
 		    !F_ISSET(dhandle, WT_DHANDLE_DEAD))
 			continue;
 
-		/* If the handle is marked "dead", flush it from cache. */
+		/* If the handle is marked dead, flush it from cache. */
 		WT_WITH_DHANDLE(session, dhandle, ret =
 		    __wt_conn_btree_sync_and_close(session, false, false));
 


### PR DESCRIPTION
During a forced drop, trees are marked dead but remain in cache
temporarily.  The sweep thread is aggressive about trying to discard
dead trees from cache.

If sweep found a tree marked dead before the drop operation had
completed, they could race setting / clearing the "no eviction" flag on
the tree, allowing eviction to run concurrent with sweep's discard.
This could cause a segfault where pages are discarded underneath
eviction.

The fix is to move setting / clearing the "no eviction" flag inside the
spinlock that protects against concurrent close operations.  That way,
even if sweep does find a tree before drop has finished closing it,
sweep will block on the close lock before attempting to discard it.
While in the area, tighten up other checks relating to the "no
eviction" flag.