### PR TITLE
WT-2435: __wt_evict_file_exclusive_on/off cleanups

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -164,6 +164,7 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 
 	/* Destroy locks. */
 	WT_TRET(__wt_rwlock_destroy(session, &btree->ovfl_lock));
+	__wt_spin_destroy(session, &btree->evict_lock);
 	__wt_spin_destroy(session, &btree->flush_lock);
 
 	/* Free allocated memory. */
@@ -350,7 +351,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 	/* Initialize locks. */
 	WT_RET(__wt_rwlock_alloc(
 	    session, &btree->ovfl_lock, "btree overflow lock"));
-	WT_RET(__wt_spin_init(session, &btree->flush_lock, "btree flush lock"));
+	WT_RET(__wt_spin_init(session, &btree->evict_lock, "btree evict"));
+	WT_RET(__wt_spin_init(session, &btree->flush_lock, "btree flush"));
 
 	btree->checkpointing = WT_CKPT_OFF;		/* Not checkpointing */
 	btree->modified = 0;				/* Clean */

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -147,7 +147,6 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 
 	btree = S2BT(session);
 
-	/* Close the block manager. */
 	if ((bm = btree->bm) != NULL) {
 		/* Unload the checkpoint, unless it's a special command. */
 		if (!F_ISSET(btree,
@@ -163,7 +162,10 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 	/* Close the Huffman tree. */
 	__wt_btree_huffman_close(session);
 
+	/* Destroy locks. */
 	WT_TRET(__wt_rwlock_destroy(session, &btree->ovfl_lock));
+	__wt_spin_destroy(session, &btree->evict_lock);
+	__wt_spin_destroy(session, &btree->flush_lock);
 
 	/* Free allocated memory. */
 	__wt_free(session, btree->key_format);
@@ -179,17 +181,6 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 	btree->kencryptor = NULL;
 
 	btree->bulk_load_ok = false;
-
-	/* Reset eviction information. */
-	__wt_spin_destroy(session, &btree->evict_lock);
-	btree->evict_ref = NULL;
-	btree->evict_walk_period = 0;
-	btree->evict_walk_skips = 0;
-	btree->evict_disabled = 0;
-	btree->evict_busy = 0;
-	F_CLR(btree, WT_BTREE_NO_EVICTION);
-
-	__wt_spin_destroy(session, &btree->flush_lock);
 
 	F_CLR(btree, WT_BTREE_SPECIAL_FLAGS);
 

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -412,6 +412,7 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_UNUSED(cfg);
 
 	btree = S2BT(session);
+	evict_reset = false;
 
 	/*
 	 * If the tree has never been written to disk, we're done, rebalance
@@ -470,7 +471,10 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 	btree->root.page = rs->root;
 	rs->root = NULL;
 
-err:	/* Discard any leftover root page we created. */
+err:	if (evict_reset)
+	    __wt_evict_file_exclusive_off(session);
+
+	/* Discard any leftover root page we created. */
 	if (rs->root != NULL) {
 		__wt_page_modify_clear(session, rs->root);
 		__wt_page_out(session, &rs->root);

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -439,7 +439,8 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 	 * cache is the root page, and that cannot be evicted; however, this way
 	 * eviction ignores the tree entirely.)
 	 */
-	WT_ERR(__wt_evict_file_exclusive_on(session, &evict_reset));
+	WT_ERR(__wt_evict_file_exclusive_on(session));
+	evict_reset = true;
 
 	/* Recursively walk the tree. */
 	switch (rs->type) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -25,7 +25,6 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	uint64_t internal_bytes, internal_pages, leaf_bytes, leaf_pages;
 	uint64_t oldest_id, saved_snap_min;
 	uint32_t flags;
-	bool evict_reset;
 
 	btree = S2BT(session);
 	walk = NULL;
@@ -123,9 +122,8 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		 */
 		WT_PUBLISH(btree->checkpointing, WT_CKPT_PREPARE);
 
-		WT_ERR(__wt_evict_file_exclusive_on(session, &evict_reset));
-		if (evict_reset)
-			__wt_evict_file_exclusive_off(session);
+		WT_ERR(__wt_evict_file_exclusive_on(session));
+		__wt_evict_file_exclusive_off(session);
 
 		WT_PUBLISH(btree->checkpointing, WT_CKPT_RUNNING);
 

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -152,7 +152,6 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ERR(__wt_cond_alloc(session,
 	    "eviction waiters", false, &cache->evict_waiter_cond));
 	WT_ERR(__wt_spin_init(session, &cache->evict_lock, "cache eviction"));
-	WT_ERR(__wt_spin_init(session, &cache->evict_walk_lock, "cache walk"));
 
 	/* Allocate the LRU eviction queue. */
 	cache->evict_slots = WT_EVICT_WALK_BASE + WT_EVICT_WALK_INCR;
@@ -249,7 +248,6 @@ __wt_cache_destroy(WT_SESSION_IMPL *session)
 	WT_TRET(__wt_cond_destroy(session, &cache->evict_cond));
 	WT_TRET(__wt_cond_destroy(session, &cache->evict_waiter_cond));
 	__wt_spin_destroy(session, &cache->evict_lock);
-	__wt_spin_destroy(session, &cache->evict_walk_lock);
 
 	__wt_free(session, cache->evict_queue);
 	__wt_free(session, conn->cache);

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -129,19 +129,18 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	WT_BTREE *btree;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	bool evict_reset, marked_dead, no_schema_lock;
+	bool marked_dead, no_schema_lock;
 
 	btree = S2BT(session);
 	bm = btree->bm;
 	dhandle = session->dhandle;
-	evict_reset = marked_dead = false;
+	marked_dead = false;
 
 	if (!F_ISSET(dhandle, WT_DHANDLE_OPEN))
 		return (0);
 
 	/* Turn off eviction. */
 	WT_RET(__wt_evict_file_exclusive_on(session));
-	evict_reset = true;
 
 	/*
 	 * If we don't already have the schema lock, make it an error to try
@@ -186,16 +185,11 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 			WT_ERR(__wt_checkpoint_close(session, final));
 	}
 
-	/*
-	 * Once the underlying btree handle is closed, don't turn eviction back
-	 * on, that function operates on the underlying btree handle.
-	 */
 	WT_TRET(__wt_btree_close(session));
-	evict_reset = false;
 
 	/*
-	 * If we marked a handle dead it will be closed by sweep, via another
-	 * call to sync and close.
+	 * If we marked a handle dead it will be closed by sweep, via
+	 * another call to sync and close.
 	 */
 	if (!marked_dead) {
 		F_CLR(dhandle, WT_DHANDLE_OPEN);
@@ -211,8 +205,7 @@ err:	__wt_spin_unlock(session, &dhandle->close_lock);
 	if (no_schema_lock)
 		F_CLR(session, WT_SESSION_NO_SCHEMA_LOCK);
 
-	if (evict_reset)
-		__wt_evict_file_exclusive_off(session);
+	__wt_evict_file_exclusive_off(session);
 
 	return (ret);
 }

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -18,13 +18,12 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	WT_DECL_RET;
 	WT_PAGE *page;
 	WT_REF *next_ref, *ref;
-	bool evict_reset;
 
 	/*
 	 * We need exclusive access to the file -- disable ordinary eviction
 	 * and drain any blocks already queued.
 	 */
-	WT_RET(__wt_evict_file_exclusive_on(session, &evict_reset));
+	WT_RET(__wt_evict_file_exclusive_on(session));
 
 	/* Make sure the oldest transaction ID is up-to-date. */
 	__wt_txn_update_oldest(session, true);
@@ -98,8 +97,7 @@ err:		/* On error, clear any left-over tree walk. */
 			    session, next_ref, WT_READ_NO_EVICT));
 	}
 
-	if (evict_reset)
-		__wt_evict_file_exclusive_off(session);
+	__wt_evict_file_exclusive_off(session);
 
 	return (ret);
 }

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -129,10 +129,11 @@ struct __wt_btree {
 	uint64_t rec_max_txn;		/* Maximum txn seen (clean trees) */
 	uint64_t write_gen;		/* Write generation */
 
-	WT_REF  *evict_ref;		/* Eviction thread's location */
-	uint64_t evict_priority;	/* Relative priority of cached pages */
-	u_int    evict_walk_period;	/* Skip this many LRU walks */
-	u_int    evict_walk_skips;	/* Number of walks skipped */
+	WT_SPINLOCK evict_lock;		/* Eviction lock */
+	WT_REF	   *evict_ref;		/* Eviction thread's location */
+	uint64_t    evict_priority;	/* Relative priority of cached pages */
+	u_int	    evict_walk_period;	/* Skip this many LRU walks */
+	u_int	    evict_walk_skips;	/* Number of walks skipped */
 	volatile uint32_t evict_busy;	/* Count of threads in eviction */
 
 	enum {

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -134,6 +134,7 @@ struct __wt_btree {
 	uint64_t    evict_priority;	/* Relative priority of cached pages */
 	u_int	    evict_walk_period;	/* Skip this many LRU walks */
 	u_int	    evict_walk_skips;	/* Number of walks skipped */
+	u_int	    evict_disabled;	/* Eviction disabled count */
 	volatile uint32_t evict_busy;	/* Count of threads in eviction */
 
 	enum {

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -84,7 +84,6 @@ struct __wt_cache {
 	 */
 	WT_CONDVAR *evict_cond;		/* Eviction server condition */
 	WT_SPINLOCK evict_lock;		/* Eviction LRU queue */
-	WT_SPINLOCK evict_walk_lock;	/* Eviction walk location */
 	/* Condition signalled when the eviction server populates the queue */
 	WT_CONDVAR *evict_waiter_cond;
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -119,12 +119,11 @@ __wt_session_can_wait(WT_SESSION_IMPL *session)
 		return (0);
 
 	/*
-	 * LSM sets the no-eviction flag when holding the LSM tree lock,
-	 * in that case, or when holding the schema lock, we don't want to
-	 * highjack the thread for eviction.
+	 * LSM sets the no-eviction flag when holding the LSM tree lock, in that
+	 * case, or when holding the schema lock, we don't want to highjack the
+	 * thread for eviction.
 	 */
-	if (F_ISSET(session,
-	    WT_SESSION_NO_EVICTION | WT_SESSION_LOCKED_SCHEMA))
+	if (F_ISSET(session, WT_SESSION_NO_EVICTION | WT_SESSION_LOCKED_SCHEMA))
 		return (0);
 
 	return (1);
@@ -224,11 +223,11 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool *didworkp)
 		return (0);
 
 	/*
-	 * Threads operating on trees that cannot be evicted are ignored,
-	 * mostly because they're not contributing to the problem.
+	 * Threads operating on cache-resident trees are ignored because they're
+	 * not contributing to the problem.
 	 */
 	btree = S2BT_SAFE(session);
-	if (btree != NULL && F_ISSET(btree, WT_BTREE_NO_EVICTION))
+	if (btree != NULL && F_ISSET(btree, WT_BTREE_IN_MEMORY))
 		return (0);
 
 	/* Check if eviction is needed. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -341,7 +341,7 @@ extern void __wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref);
 extern int __wt_evict_server_wake(WT_SESSION_IMPL *session);
 extern int __wt_evict_create(WT_SESSION_IMPL *session);
 extern int __wt_evict_destroy(WT_SESSION_IMPL *session);
-extern int __wt_evict_file_exclusive_on(WT_SESSION_IMPL *session, bool *evict_resetp);
+extern int __wt_evict_file_exclusive_on(WT_SESSION_IMPL *session);
 extern void __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session);
 extern int __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full);
 extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);


### PR DESCRIPTION
@agorrod, @michaelcahill, for your review/consideration.

This was the simplest approach I saw for reference counting requests for eviction disable/enable on a file. A few comments:

* I moved the `WT_CACHE.evict_walk_lock` to `WT_BTREE.evict_lock` in the btree handle, so now there's a cache `evict_lock` and a per-handle `evict_lock`. The reason is because reference counting eviction disable/enable requests requires we hold the no-eviction lock a lot longer than before, and I didn't want file close to stall eviction. We could avoid this part of the change by doing a try-lock call on the global lock, but this seemed better to me.

* I left the `WT_BTREE_NO_EVICTION` flag in place. If you like this change, we might want to take a run at removing that flag in favor of just a reference count (instead of initially setting the flag, we'd increment and never decrement the reference count). Where that gets tricky is we explicitly set `WT_BTREE_NO_EVICTION` in a few places and we'd need be sure there's no way the reference count could go wrong. See `__wt_btree_evictable` for one of the places I'm thinking of.

* I left the `__evict_request_walk_clear` code alone. If there's a per-btree eviction lock, we could use that instead of the current signalling mechanism, that is, the eviction server could try to acquire the per-btree eviction lock instead of checking the `WT_SESSION_CLEAR_EVICT_WALK` flag, and the exclusive code could then clear the current eviction point if it's holding that lock. Not sure if that's a bad idea or not.

* A few miscellaneous fixes: 8ed209b, 5a1f23d, 1257c17, I'd like to cherry-pick these out if you don't like the overall direction of this change.

Anyway, if you don't like this approach feel free to discard it, I was looking at Michael's comment in BF-1841 and wanted to see how deep the rabbit hole went.