### PR TITLE
WT-2366 Extend wtperf to support changing record sizes in update ops

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -296,6 +296,7 @@ config_threads(CONFIG *cfg, const char *config, size_t len)
 						goto err;
 					/* Special random value */
 					workp->update_delta = INT64_MAX;
+					F_SET(cfg, CFG_GROW);
 				} else {
 					workp->update_delta = v.val;
 					if (v.val > 0)

--- a/bench/wtperf/runners/update-delta-mix1.wtperf
+++ b/bench/wtperf/runners/update-delta-mix1.wtperf
@@ -1,0 +1,18 @@
+# wtperf options file: Mixed workload where we grow some values and shrink
+# others.  Mixed load leaning toward growing the dataset.
+#
+conn_config="cache_size=2GB,checkpoint=(wait=30)"
+table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
+# The values are starting small, insert a lot so our database grows larger than
+# cache quickly.
+icount=200000
+report_interval=5
+run_time=300
+populate_threads=1
+#
+# Run more grow workload threads than shrink threads.
+#
+threads=((count=4,update=1,update_delta=100),(count=2,update=1,update_delta=-150))
+value_sz=20000
+value_sz_min=1000
+value_sz_max=65536

--- a/bench/wtperf/runners/update-delta-mix2.wtperf
+++ b/bench/wtperf/runners/update-delta-mix2.wtperf
@@ -1,0 +1,18 @@
+# wtperf options file: Mixed workload where we grow some values and shrink
+# others.  Mixed load leaning toward shrinking the dataset.
+#
+conn_config="cache_size=2GB,checkpoint=(wait=30)"
+table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
+# The values are starting small, insert a lot so our database grows larger than
+# cache quickly.
+icount=200000
+report_interval=5
+run_time=300
+populate_threads=1
+#
+# Run more shrink workload threads than grow threads.
+#
+threads=((count=2,update=1,update_delta=150),(count=4,update=1,update_delta=-100))
+value_sz=20000
+value_sz_min=1000
+value_sz_max=65536

--- a/bench/wtperf/runners/update-delta-mix3.wtperf
+++ b/bench/wtperf/runners/update-delta-mix3.wtperf
@@ -1,0 +1,18 @@
+# wtperf options file: Mixed workload where we grow some values and shrink
+# others.  Mixed load leaning toward mostly a balance.
+#
+conn_config="cache_size=2GB,checkpoint=(wait=30)"
+table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
+# The values are starting small, insert a lot so our database grows larger than
+# cache quickly.
+icount=200000
+report_interval=5
+run_time=300
+populate_threads=1
+#
+# Run a balance of threads.
+#
+threads=((count=3,update=1,update_delta=100),(count=3,update=1,update_delta=-100))
+value_sz=20000
+value_sz_min=1000
+value_sz_max=65536

--- a/bench/wtperf/runners/update-grow-stress.wtperf
+++ b/bench/wtperf/runners/update-grow-stress.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: Grow the size of documents while there is cache
 # pressure and appends are happening as well.
-conn_config="cache_size=2GB,checkpoint=(wait=60)"
+conn_config="cache_size=2GB,checkpoint=(wait=30)"
 table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
 # The values are starting small, insert a lot so our database grows larger than
 # cache quickly.

--- a/bench/wtperf/runners/update-grow-stress.wtperf
+++ b/bench/wtperf/runners/update-grow-stress.wtperf
@@ -1,0 +1,15 @@
+# wtperf options file: Grow the size of documents while there is cache
+# pressure and appends are happening as well.
+conn_config="cache_size=2GB,checkpoint=(wait=60)"
+table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
+# The values are starting small, insert a lot so our database grows larger than
+# cache quickly.
+icount=20000000
+report_interval=5
+run_time=240
+populate_threads=1
+# Continue inserting new records.
+threads=((count=1,inserts=1,throttle=1000),(count=4,update=1,update_delta=100))
+# Start with small values and let them grow slowly to large values.
+value_sz=20
+value_sz_max=65536

--- a/bench/wtperf/runners/update-shrink-stress.wtperf
+++ b/bench/wtperf/runners/update-shrink-stress.wtperf
@@ -1,0 +1,14 @@
+# wtperf options file: Grow the size of documents while there is cache
+# pressure and appends are happening as well.
+conn_config="cache_size=2GB,checkpoint=(wait=60)"
+table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
+# Since we're continually inserting, start with a small number initially.
+icount=200000
+report_interval=5
+run_time=240
+populate_threads=1
+# Continue inserting new records.
+threads=((count=1,inserts=1,throttle=1000),(count=4,update=1,update_delta=-100))
+# Start with moderate values and let them shrink slowly.
+value_sz_min=1000
+value_sz=20000

--- a/bench/wtperf/runners/update-shrink-stress.wtperf
+++ b/bench/wtperf/runners/update-shrink-stress.wtperf
@@ -1,8 +1,9 @@
-# wtperf options file: Grow the size of documents while there is cache
-# pressure and appends are happening as well.
-conn_config="cache_size=2GB,checkpoint=(wait=60)"
+# wtperf options file: Shrink the size of values.  Checkpoint frequently
+# and insert new records too.
+#
+conn_config="cache_size=2GB,checkpoint=(wait=30)"
 table_config="type=file,leaf_page_max=32k,leaf_value_max=128k,split_pct=90"
-# Since we're continually inserting, start with a small number initially.
+# Since we're continually inserting, start with a smaller number initially.
 icount=200000
 report_interval=5
 run_time=240

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -87,6 +87,7 @@ static int	 start_threads(CONFIG *,
 		    WORKLOAD *, CONFIG_THREAD *, u_int, void *(*)(void *));
 static int	 stop_threads(CONFIG *, u_int, CONFIG_THREAD *);
 static void	*thread_run_wtperf(void *);
+static void	 update_value_delta(CONFIG_THREAD *);
 static void	*worker(void *);
 
 static uint64_t	 wtperf_rand(CONFIG_THREAD *);
@@ -105,24 +106,91 @@ get_next_incr(CONFIG *cfg)
 	return (__wt_atomic_add64(&cfg->insert_key, 1));
 }
 
+/*
+ * Each time this function is called we will overwrite the first and one
+ * other element in the value buffer.
+ */
 static void
 randomize_value(CONFIG_THREAD *thread, char *value_buf)
 {
 	uint8_t *vb;
-	uint32_t i;
+	uint32_t i, max_range, rand_val;
 
 	/*
-	 * Each time we're called overwrite value_buf[0] and one other
-	 * randomly chosen byte (other than the trailing NUL).
-	 * Make sure we don't write a NUL: keep the value the same length.
+	 * Limit how much of the buffer we validate for length, this means
+	 * that only threads that do growing updates will ever make changes to
+	 * values outside of the initial value size, but that's a fair trade
+	 * off for avoiding figuring out how long the value is more accurately
+	 * in this performance sensitive function.
 	 */
-	i = __wt_random(&thread->rnd) % (thread->cfg->value_sz - 1);
+	if (thread->workload->update_delta == 0)
+		max_range = thread->cfg->value_sz;
+	else
+		max_range = thread->cfg->value_sz_max;
+
+	/*
+	 * Generate a single random value and re-use it. We generally only
+	 * have small ranges in this function, so avoiding a bunch of calls
+	 * is worthwhile.
+	 */
+	rand_val = __wt_random(&thread->rnd);
+	i = rand_val % (max_range - 1);
+
+	/*
+	 * Ensure we don't write past the end of a value when configured for
+	 * randomly sized values.
+	 */
 	while (value_buf[i] == '\0' && i > 0)
 		--i;
-	if (i > 0) {
-		vb = (uint8_t *)value_buf;
-		vb[0] = (__wt_random(&thread->rnd) % 255) + 1;
-		vb[i] = (__wt_random(&thread->rnd) % 255) + 1;
+
+	vb = (uint8_t *)value_buf;
+	vb[0] = ((rand_val >> 8) % 255) + 1;
+	/*
+	 * If i happened to be 0, we'll be re-writing the same value
+	 * twice, but that doesn't matter.
+	 */
+	vb[i] = ((rand_val >> 16) % 255) + 1;
+}
+
+/*
+ * Figure out and extend the size of the value string, used for growing
+ * updates. We know that the value to be updated is in the threads value
+ * scratch buffer.
+ */
+static inline void
+update_value_delta(CONFIG_THREAD *thread)
+{
+	CONFIG *cfg;
+	char * value;
+	int64_t delta, len, new_len;
+
+	cfg = thread->cfg;
+	value = thread->value_buf;
+	delta = thread->workload->update_delta;
+	len = (int64_t)strlen(value);
+
+	if (delta == INT64_MAX)
+		delta = __wt_random(&thread->rnd) %
+		    (cfg->value_sz_max - cfg->value_sz);
+
+	/* Ensure we aren't changing across boundaries */
+	if (delta > 0 && len + delta > cfg->value_sz_max)
+		delta = cfg->value_sz_max - len;
+	else if (delta < 0 && -delta > len)
+		delta = -(len - 1);
+
+	/* Bail if there isn't anything to do */
+	if (delta == 0)
+		return;
+
+	if (delta < 0) {
+		value[len + delta] = '\0';
+	} else {
+		/* Extend the value by the configured amount. */
+		for (new_len = len;
+		    new_len < cfg->value_sz_max && new_len - len < delta;
+		    new_len++)
+			value[new_len] = 'a';
 	}
 }
 
@@ -624,8 +692,10 @@ worker(void *arg)
 				 * Copy as much of the previous value as is
 				 * safe, and be sure to NUL-terminate.
 				 */
-				strncpy(value_buf, value, cfg->value_sz);
-				value_buf[cfg->value_sz - 1] = '\0';
+				strncpy(value_buf,
+				    value, cfg->value_sz_max - 1);
+				if (thread->workload->update_delta != 0)
+					update_value_delta(thread);
 				if (value_buf[0] == 'a')
 					value_buf[0] = 'b';
 				else
@@ -2374,7 +2444,8 @@ start_threads(CONFIG *cfg,
 		 * strings: trailing NUL is included in the size.
 		 */
 		thread->key_buf = dcalloc(cfg->key_sz, 1);
-		thread->value_buf = dcalloc(cfg->value_sz, 1);
+		thread->value_buf = dcalloc(cfg->value_sz_max, 1);
+
 		/*
 		 * Initialize and then toss in a bit of random values if needed.
 		 */

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -94,6 +94,7 @@ typedef struct {
 	int64_t truncate;		/* Truncate ratio */
 	uint64_t truncate_pct;		/* Truncate Percent */
 	uint64_t truncate_count;	/* Truncate Count */
+	int64_t update_delta;		/* Value size change on update */
 
 #define	WORKER_INSERT		1	/* Insert */
 #define	WORKER_INSERT_RMW	2	/* Insert with read-modify-write */

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -191,7 +191,10 @@ struct __config {			/* Configuration structure */
 
 	volatile uint32_t totalsec;	/* total seconds running */
 
-	u_int		 has_truncate;  /* if there is a truncate workload */
+#define	CFG_GROW	0x0001		/* There is a grow workload */
+#define	CFG_SHRINK	0x0002		/* There is a shrink workload */
+#define	CFG_TRUNCATE	0x0004		/* There is a truncate workload */
+	uint32_t	flags;		/* flags */
 
 	/* Queue head for use with the Truncate Logic */
 	TAILQ_HEAD(__truncate_qh, __truncate_queue_entry) stone_head;

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -184,13 +184,15 @@ DEF_OPT_AS_STRING(threads, "", "workload configuration: each 'count' "
     "'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))' "
     "which would create 2 threads doing nothing but reads and 8 threads "
     "each doing 50% inserts and 25% reads and updates.  Allowed configuration "
-    "values are 'count', 'throttle', 'reads', 'inserts', 'updates', 'truncate',"
-    " 'truncate_pct' and 'truncate_count'. There are "
+    "values are 'count', 'throttle', 'update_delta', 'reads', 'inserts', "
+    "'updates', 'truncate', 'truncate_pct' and 'truncate_count'. There are "
     "also behavior modifiers, supported modifiers are 'ops_per_txn'")
 DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
     "transaction configuration string, relevant when populate_opts_per_txn "
     "is nonzero")
 DEF_OPT_AS_STRING(table_name, "test", "table name")
+DEF_OPT_AS_UINT32(value_sz_max, 1000,
+    "maximum value size when delta updates are present. Default disabled")
 DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(verbose, 1, "verbosity")
 DEF_OPT_AS_UINT32(warmup, 0,

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -193,6 +193,8 @@ DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
 DEF_OPT_AS_STRING(table_name, "test", "table name")
 DEF_OPT_AS_UINT32(value_sz_max, 1000,
     "maximum value size when delta updates are present. Default disabled")
+DEF_OPT_AS_UINT32(value_sz_min, 1,
+    "minimum value size when delta updates are present. Default disabled")
 DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(verbose, 1, "verbosity")
 DEF_OPT_AS_UINT32(warmup, 0,

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -983,6 +983,7 @@ superset
 sw
 sy
 sys
+sz
 t's
 tV
 tablename

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -262,6 +262,8 @@ is nonzero
 table name
 @par value_sz_max (unsigned int, default=1000)
 maximum value size when delta updates are present. Default disabled
+@par value_sz_min (unsigned int, default=1)
+minimum value size when delta updates are present. Default disabled
 @par value_sz (unsigned int, default=100)
 value size
 @par verbose (unsigned int, default=1)

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -251,14 +251,17 @@ threads configuration might be
 'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))'
 which would create 2 threads doing nothing but reads and 8 threads
 each doing 50% inserts and 25% reads and updates.  Allowed
-configuration values are 'count', 'throttle', 'reads', 'inserts',
-'updates', 'truncate', 'truncate_pct' and 'truncate_count'. There are
-also behavior modifiers, supported modifiers are 'ops_per_txn'
+configuration values are 'count', 'throttle', 'update_delta', 'reads',
+'inserts', 'updates', 'truncate', 'truncate_pct' and 'truncate_count'.
+There are also behavior modifiers, supported modifiers are
+'ops_per_txn'
 @par transaction_config (string, default=)
 transaction configuration string, relevant when populate_opts_per_txn
 is nonzero
 @par table_name (string, default=test)
 table name
+@par value_sz_max (unsigned int, default=1000)
+maximum value size when delta updates are present. Default disabled
 @par value_sz (unsigned int, default=100)
 value size
 @par verbose (unsigned int, default=1)


### PR DESCRIPTION
Via a new update_delta setting in the thread group which takes either
a signed number of "rand" as an argument. Defaults to 0 (disabled).

There is also a new value_sz_max configuration option to limit how
large values can grow.