### PR TITLE
WT-2437 Adjust expected error messages to support Windows.

### DIFF
--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -44,14 +44,6 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
     create_params = 'key_format=i,value_format=i'
     freq = 5
 
-    def copy_windows(self, olddir, newdir):
-        os.mkdir(newdir)
-        for fname in os.listdir(olddir):
-            fullname = os.path.join(olddir, fname)
-            # Skip lock file on Windows since it is locked
-            if os.path.isfile(fullname) and "WiredTiger.lock" not in fullname:
-                shutil.copy(fullname, newdir)
-
     def check_manual_backup(self, i, olddir, newdir):
         ''' Simulate a manual backup from olddir and restart in newdir. '''
         self.session.checkpoint()

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -265,7 +265,7 @@ class test_checkpoint_cursor_update(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(self.uri, None, "checkpoint=ckpt")
         cursor.set_key(key_populate(cursor, 10))
         cursor.set_value("XXX")
-        msg = "/not supported/"
+        msg = "/Unsupported cursor/"
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: cursor.insert(), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_cursor06.py
+++ b/test/suite/test_cursor06.py
@@ -89,7 +89,7 @@ class test_cursor06(wttest.WiredTigerTestCase):
             self.session.drop(uri, "force")
             self.populate(uri)
             cursor = self.session.open_cursor(uri, None, open_config)
-            msg = '/not supported/'
+            msg = '/Unsupported cursor/'
             if open_config == "readonly=1":
                 self.set_kv(cursor)
                 self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -51,7 +51,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         uri = self.type
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri, None, self.config)
-        msg = "/not supported/"
+        msg = "/Unsupported cursor/"
         self.assertRaisesWithMessage(
             wiredtiger.WiredTigerError, lambda: cursor.compare(cursor), msg)
         self.assertRaisesWithMessage(

--- a/test/suite/test_join01.py
+++ b/test/suite/test_join01.py
@@ -341,7 +341,7 @@ class test_join01(wttest.WiredTigerTestCase):
             '/index cursor is being used in a join/')
 
         # Only a small number of operations allowed on a join cursor
-        msg = "/not supported/"
+        msg = "/Unsupported cursor/"
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: jc.search(), msg)
 

--- a/test/suite/test_readonly01.py
+++ b/test/suite/test_readonly01.py
@@ -136,7 +136,7 @@ class test_readonly01(wttest.WiredTigerTestCase, suite_subprocess):
         self.create = True
 
     def test_readonly(self):
-        if self.dirchmod:
+        if self.dirchmod and os.name == 'posix':
             with self.expectedStderrPattern('Permission'):
                 self.readonly()
         else:

--- a/test/suite/test_readonly01.py
+++ b/test/suite/test_readonly01.py
@@ -96,7 +96,10 @@ class test_readonly01(wttest.WiredTigerTestCase, suite_subprocess):
         # connection with readonly.
         #
         self.close_conn()
-        if self.dirchmod:
+        #
+        # The chmod command is not fully portable to windows.
+        #
+        if self.dirchmod and os.name == 'posix':
             for f in os.listdir(self.home):
                 if os.path.isfile(f):
                     os.chmod(f, 0444)

--- a/test/suite/test_readonly02.py
+++ b/test/suite/test_readonly02.py
@@ -66,8 +66,10 @@ class test_readonly02(wttest.WiredTigerTestCase, suite_subprocess):
         if self.create:
             #   1. setting readonly on a new database directory
             # Setting readonly prevents creation so we should see an
-            # ENOENT error because the lock file does not exist.
+            # error because the lock file does not exist.
             msg = '/No such file/'
+            if os.name != 'posix':
+                msg = '/cannot find the file/'
             os.mkdir(rdonlydir)
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda: self.wiredtiger_open(

--- a/test/suite/test_readonly03.py
+++ b/test/suite/test_readonly03.py
@@ -68,7 +68,7 @@ class test_readonly03(wttest.WiredTigerTestCase, suite_subprocess):
         # Now close and reopen.  Note that the connection function
         # above will reopen it readonly.
         self.reopen_conn()
-        msg = '/not supported/'
+        msg = '/Unsupported/'
         c = self.session.open_cursor(self.uri, None, None)
         for op in self.cursor_ops:
             c.set_key(1)


### PR DESCRIPTION
Look for WT-specific portion of the message or detect Posix/Windows.
@michaelcahill Here is a change to fix the test failures on Windows.

I modified the tests to look for non-Posix portions of error messages.  It does bring up again whether we need a translation layer.