### PR TITLE
WT-2432 Add eviction worker threads to eviction configs.

### DIFF
--- a/bench/wtperf/runners/evict-btree-readonly.wtperf
+++ b/bench/wtperf/runners/evict-btree-readonly.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: evict btree configuration
-conn_config="cache_size=50M"
+conn_config="cache_size=50M,eviction=(threads_max=4),mmap=false"
 table_config="type=file"
 icount=10000000
 report_interval=5

--- a/bench/wtperf/runners/evict-btree.wtperf
+++ b/bench/wtperf/runners/evict-btree.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: evict btree configuration
-conn_config="cache_size=50M"
+conn_config="cache_size=50M,eviction=(threads_max=4)"
 table_config="type=file"
 icount=10000000
 report_interval=5

--- a/bench/wtperf/runners/evict-lsm-readonly.wtperf
+++ b/bench/wtperf/runners/evict-lsm-readonly.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: evict lsm configuration
-conn_config="cache_size=50M,lsm_manager=(worker_thread_max=6)"
+conn_config="cache_size=50M,lsm_manager=(worker_thread_max=6),eviction=(threads_max=4)"
 table_config="type=lsm,lsm=(chunk_size=2M),os_cache_dirty_max=16MB"
 compact=true
 icount=10000000

--- a/bench/wtperf/runners/evict-lsm.wtperf
+++ b/bench/wtperf/runners/evict-lsm.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: evict lsm configuration
-conn_config="cache_size=50M,lsm_manager=(worker_thread_max=6)"
+conn_config="cache_size=50M,lsm_manager=(worker_thread_max=6),eviction=(threads_max=4)"
 table_config="type=lsm,lsm=(chunk_size=2M),os_cache_dirty_max=16MB"
 compact=true
 icount=10000000


### PR DESCRIPTION
Turn off mmap for readonly.

@michaelcahill Here are the changes for the eviction configurations to wtperf, per our discussion.