### PR TITLE
WT-2391: De-prioritize eviction from indexes

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -486,6 +486,15 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 				WT_RET(__wt_cache_eviction_check(
 				    session, 1, NULL));
 			WT_RET(__page_read(session, ref));
+
+			/*
+			 * If configured to not trash the cache, leave the page
+			 * generation unset, we'll set it before returning to
+			 * the oldest read generation, so the page is forcibly
+			 * evicted as soon as possible. We don't do that set
+			 * here because we don't want to evict the page before
+			 * we "acquire" it.
+			 */
 			evict_soon = LF_ISSET(WT_READ_WONT_NEED) ||
 			    F_ISSET(session, WT_SESSION_NO_CACHE);
 			continue;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -597,12 +597,9 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			page = ref->page;
 			if (evict_soon && page->read_gen == WT_READGEN_NOTSET)
 				__wt_page_evict_soon(page);
-			else if (page->read_gen == WT_READGEN_NOTSET ||
-			    (!LF_ISSET(WT_READ_NO_GEN) &&
-			    page->read_gen != WT_READGEN_OLDEST &&
-			    page->read_gen < __wt_cache_read_gen(session)))
-				page->read_gen =
-				    __wt_cache_read_gen_bump(session);
+			else if (!LF_ISSET(WT_READ_NO_GEN) ||
+			    page->read_gen == WT_READGEN_NOTSET)
+				__wt_cache_read_gen_bump(session, page);
 skip_evict:
 			/*
 			 * Check if we need an autocommit transaction.

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -595,10 +595,12 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			 * read generation.
 			 */
 			page = ref->page;
-			if (evict_soon && page->read_gen == WT_READGEN_NOTSET)
-				__wt_page_evict_soon(page);
-			else if (!LF_ISSET(WT_READ_NO_GEN) ||
-			    page->read_gen == WT_READGEN_NOTSET)
+			if (page->read_gen == WT_READGEN_NOTSET) {
+				if (evict_soon)
+					__wt_page_evict_soon(page);
+				else
+					__wt_cache_read_gen_new(session, page);
+			} else if (!LF_ISSET(WT_READ_NO_GEN))
 				__wt_cache_read_gen_bump(session, page);
 skip_evict:
 			/*

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -140,6 +140,12 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_RET(__wt_cache_config(session, false, cfg));
 
 	/*
+	 * The lowest possible page read-generation has a special meaning, it
+	 * marks a page for forcible eviction; don't let it happen by accident.
+	 */
+	cache->read_gen = 10;
+
+	/*
 	 * The target size must be lower than the trigger size or we will never
 	 * get any work done.
 	 */

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -143,7 +143,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	 * The lowest possible page read-generation has a special meaning, it
 	 * marks a page for forcible eviction; don't let it happen by accident.
 	 */
-	cache->read_gen = 10;
+	cache->read_gen = WT_READGEN_START_VALUE;
 
 	/*
 	 * The target size must be lower than the trigger size or we will never

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1315,7 +1315,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 		 * bug doesn't somehow leave a page without a read generation.
 		 */
 		if (page->read_gen == WT_READGEN_NOTSET)
-			page->read_gen = __wt_cache_read_gen_bump(session);
+			__wt_cache_read_gen_bump(session, page);
 
 fast:		/* If the page can't be evicted, give up. */
 		if (!__wt_page_can_evict(session, ref, NULL))
@@ -1476,7 +1476,6 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
-	WT_PAGE *page;
 	WT_REF *ref;
 
 	WT_RET(__evict_get_ref(session, is_server, &btree, &ref));
@@ -1505,9 +1504,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	 * the page and some other thread may have evicted it by the time we
 	 * look at it.
 	 */
-	page = ref->page;
-	if (page->read_gen != WT_READGEN_OLDEST)
-		page->read_gen = __wt_cache_read_gen_bump(session);
+	__wt_cache_read_gen_bump(session, ref->page);
 
 	WT_WITH_BTREE(session, btree, ret = __wt_evict(session, ref, false));
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -598,9 +598,14 @@ struct __wt_page {
 	 * read generation is incremented by the eviction server each time it
 	 * becomes active.  To avoid incrementing a page's read generation too
 	 * frequently, it is set to a future point.
+	 *
+	 * Because low read generation values have special meaning, and there
+	 * are places where we manipulate the value, use an initial value well
+	 * outside of the special range.
 	 */
 #define	WT_READGEN_NOTSET	0
 #define	WT_READGEN_OLDEST	1
+#define	WT_READGEN_START_VALUE	100
 #define	WT_READGEN_STEP		100
 	uint64_t read_gen;
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -75,7 +75,9 @@ struct __wt_cache {
 	/*
 	 * Read information.
 	 */
-	uint64_t   read_gen;		/* Page read generation (LRU) */
+	uint64_t read_gen;		/* Current page read generation */
+	uint64_t read_gen_oldest;	/* Oldest read generation the eviction
+					 * server saw in its last queue load */
 
 	/*
 	 * Eviction thread information.

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -76,8 +76,6 @@ struct __wt_cache {
 	 * Read information.
 	 */
 	uint64_t   read_gen;		/* Page read generation (LRU) */
-	uint64_t   read_gen_oldest;	/* The oldest read generation that
-					   eviction knows about */
 
 	/*
 	 * Eviction thread information.

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -46,19 +46,6 @@ __wt_cache_read_gen_bump(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_cache_read_gen_new --
- *      Get the read generation for a new page in memory.
- */
-static inline uint64_t
-__wt_cache_read_gen_new(WT_SESSION_IMPL *session)
-{
-	WT_CACHE *cache;
-
-	cache = S2C(session)->cache;
-	return (__wt_cache_read_gen(session) + cache->read_gen_oldest) / 2;
-}
-
-/*
  * __wt_cache_pages_inuse --
  *	Return the number of pages in use.
  */

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -28,21 +28,29 @@ __wt_cache_read_gen_incr(WT_SESSION_IMPL *session)
 
 /*
  * __wt_cache_read_gen_bump --
- *      Get the read generation to keep a page in memory.
+ *      Update the page's read generation.
  */
-static inline uint64_t
-__wt_cache_read_gen_bump(WT_SESSION_IMPL *session)
+static inline void
+__wt_cache_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
+	/* Ignore pages set for forcible eviction. */
+	if (page->read_gen == WT_READGEN_OLDEST)
+		return;
+
+	/* Ignore pages already in the future. */
+	if (page->read_gen > __wt_cache_read_gen(session))
+		return;
+
 	/*
-	 * We return read-generations from the future (where "the future" is
-	 * measured by increments of the global read generation).  The reason
-	 * is because when acquiring a new hazard pointer for a page, we can
-	 * check its read generation, and if the read generation isn't less
-	 * than the current global generation, we don't bother updating the
-	 * page.  In other words, the goal is to avoid some number of updates
-	 * immediately after each update we have to make.
+	 * We set read-generations in the future (where "the future" is measured
+	 * by increments of the global read generation).  The reason is because
+	 * when acquiring a new hazard pointer for a page, we can check its read
+	 * generation, and if the read generation isn't less than the current
+	 * global generation, we don't bother updating the page.  In other
+	 * words, the goal is to avoid some number of updates immediately after
+	 * each update we have to make.
 	 */
-	return (__wt_cache_read_gen(session) + WT_READGEN_STEP);
+	page->read_gen = __wt_cache_read_gen(session) + WT_READGEN_STEP;
 }
 
 /*

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -54,6 +54,20 @@ __wt_cache_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
+ * __wt_cache_read_gen_new --
+ *      Get the read generation for a new page in memory.
+ */
+static inline void
+__wt_cache_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page)
+{
+	WT_CACHE *cache;
+
+	cache = S2C(session)->cache;
+	page->read_gen =
+	    (__wt_cache_read_gen(session) + cache->read_gen_oldest) / 2;
+}
+
+/*
  * __wt_cache_pages_inuse --
  *	Return the number of pages in use.
  */


### PR DESCRIPTION
@agorrod, @michaelcahill: I spent a bunch of time chasing what I thought was the problem in WT-2391, but it turned out to be a red herring. Anyway, along the way I accumulated some changes that I think are a minor improvement over the current page read-generation code.

I cleaned them up and created this branch.

If you like this better than the current code, great, if you don't, then just discard the branch. As I said, it's a minor set of cleanups at most, and if you don't like them that's fine with me.