### PR TITLE
WT-2418: test_rebalance failing with EBUSY

### DIFF
--- a/test/suite/test_rebalance.py
+++ b/test/suite/test_rebalance.py
@@ -59,7 +59,7 @@ class test_rebalance(wttest.WiredTigerTestCase):
         if with_cursor:
             cursor = self.session.open_cursor(uri, None, None)
             self.assertRaises(wiredtiger.WiredTigerError,
-                lambda: self.session.drop(uri, None))
+                lambda: self.session.rebalance(uri, None))
             cursor.close()
 
         self.session.rebalance(uri, None)


### PR DESCRIPTION
Fix a test cut-and-paste error, we're testing WT_SESSION.rebalance here,
not WT_SESSION.drop.