### PR TITLE
WT-2465: Coverity 1352899: Dereference before null check

### DIFF
--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -370,11 +370,11 @@ dmalloc(size_t len)
  *      Call calloc, dying on failure.
  */
 static inline void *
-dcalloc(size_t num, size_t len)
+dcalloc(size_t num, size_t size)
 {
 	void *p;
 
-	if ((p = calloc(len, num)) == NULL)
+	if ((p = calloc(num, size)) == NULL)
 		die(errno, "calloc");
 	return (p);
 }
@@ -416,11 +416,9 @@ static inline char *
 dstrndup(const char *str, const size_t len)
 {
 	char *p;
-	p = dcalloc(len + 1, 1);
 
-	strncpy(p, str, len);
-	if (p == NULL)
-		die(errno, "dstrndup");
+	p = dcalloc(len + 1, sizeof(char));
+	memcpy(p, str, len);
 	return (p);
 }
 #endif


### PR DESCRIPTION
@daveh86, for your review/consideration.