### PR TITLE
Revert "WT-2473: MSVC doesn't support PRId64"

### DIFF
--- a/examples/c/ex_config_parse.c
+++ b/examples/c/ex_config_parse.c
@@ -99,7 +99,7 @@ main(void)
 	while ((ret = parser->next(parser, &k, &v)) == 0) {
 		printf("%.*s:", (int)k.len, k.str);
 		if (v.type == WT_CONFIG_ITEM_NUM)
-			printf("%lld\n", (long long)v.val);
+			printf("%" PRId64 "\n", v.val);
 		else
 			printf("%.*s\n", (int)v.len, v.str);
 	}


### PR DESCRIPTION
This reverts commit 0b2766c1db03e96d5c7bfbb1eae66a9df790e301.