### PR TITLE
WT-2460 Fix a flags test in LAS code to use mask not is-set.

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -205,7 +205,7 @@ __wt_las_cursor(
 	 * useful more than once.
 	 */
 	*session_flags =
-	    F_ISSET(session, WT_SESSION_NO_CACHE | WT_SESSION_NO_EVICTION);
+	    F_MASK(session, WT_SESSION_NO_CACHE | WT_SESSION_NO_EVICTION);
 
 	conn = S2C(session);
 


### PR DESCRIPTION
It was attempting to save which flags were set by checking F_ISSET (which returns a boolean). Should have been using WT_MASK.

This was leading to the WT_SESSION_NO_EVICTION flag being cleared unexpectedly and WT_SESSION_CAN_WAIT being set as well.