### PR TITLE
WT-2447 For cursor joins, avoid main table reads during iteration and bloom initialization

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -288,7 +288,7 @@ struct __wt_cursor_join_iter {
 	WT_CURSOR_JOIN		*cjoin;
 	WT_CURSOR_JOIN_ENTRY	*entry;
 	WT_CURSOR		*cursor;	/* has null projection */
-	WT_CURSOR		*full;		/* has requested projection */
+	WT_CURSOR		*main;		/* main table with projection */
 	WT_ITEM			*curkey;
 	bool			 positioned;
 	bool			 isequal;	/* advancing means we're done */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -287,7 +287,8 @@ struct __wt_cursor_join_iter {
 	WT_SESSION_IMPL		*session;
 	WT_CURSOR_JOIN		*cjoin;
 	WT_CURSOR_JOIN_ENTRY	*entry;
-	WT_CURSOR		*cursor;
+	WT_CURSOR		*cursor;	/* has null projection */
+	WT_CURSOR		*full;		/* has requested projection */
 	WT_ITEM			*curkey;
 	bool			 positioned;
 	bool			 isequal;	/* advancing means we're done */

--- a/test/suite/test_join01.py
+++ b/test/suite/test_join01.py
@@ -148,7 +148,8 @@ class test_join01(wttest.WiredTigerTestCase):
         # and examine primary keys 2,5,8,...,95,98,1,4,7,...,94,97.
         jc = self.session.open_cursor('join:table:join01' + proj_suffix,
                                       None, None)
-        c2 = self.session.open_cursor('index:join01:index2', None, None)
+        # Adding a projection to a reference cursor should be allowed.
+        c2 = self.session.open_cursor('index:join01:index2(v1)', None, None)
         c2.set_key(99)   # skips all entries w/ primary key divisible by three
         self.assertEquals(0, c2.search())
         self.session.join(jc, c2, 'compare=gt')
@@ -166,12 +167,12 @@ class test_join01(wttest.WiredTigerTestCase):
 
         # Then select all numbers whose reverse string representation
         # is in '20' < x < '40'.
-        c1a = self.session.open_cursor('index:join01:index1', None, None)
+        c1a = self.session.open_cursor('index:join01:index1(v1)', None, None)
         c1a.set_key('21')
         self.assertEquals(0, c1a.search())
         self.session.join(jc, c1a, 'compare=gt' + joincfg1)
 
-        c1b = self.session.open_cursor('index:join01:index1', None, None)
+        c1b = self.session.open_cursor('index:join01:index1(v1)', None, None)
         c1b.set_key('41')
         self.assertEquals(0, c1b.search())
         self.session.join(jc, c1b, 'compare=lt' + joincfg1)

--- a/test/suite/test_join02.py
+++ b/test/suite/test_join02.py
@@ -179,15 +179,16 @@ class test_join02(wttest.WiredTigerTestCase):
         c.close()
 
         # Use the primary table in one of the joins.
+        # Use various projections, which should not matter for ref cursors
         c0a = self.session.open_cursor('table:join02', None, None)
-        c0b = self.session.open_cursor('table:join02', None, None)
-        c1a = self.session.open_cursor('index:join02:index1', None, None)
+        c0b = self.session.open_cursor('table:join02(v4)', None, None)
+        c1a = self.session.open_cursor('index:join02:index1(v0)', None, None)
         c1b = self.session.open_cursor('index:join02:index1', None, None)
         c2a = self.session.open_cursor('index:join02:index2', None, None)
         c2b = self.session.open_cursor('index:join02:index2', None, None)
-        c3a = self.session.open_cursor('index:join02:index3', None, None)
-        c3b = self.session.open_cursor('index:join02:index3', None, None)
-        c4a = self.session.open_cursor('index:join02:index4', None, None)
+        c3a = self.session.open_cursor('index:join02:index3(v4)', None, None)
+        c3b = self.session.open_cursor('index:join02:index3(v0)', None, None)
+        c4a = self.session.open_cursor('index:join02:index4(v1)', None, None)
 
         # Attach extra properties to each cursor.  For cursors that
         # may appear on the 'left' side of a range CA < x < CB,


### PR DESCRIPTION
This also reduces main table reads from about 24M of pread data size to about 45K using a slightly modified version of the submitted test case.