### PR TITLE
WT-2484: Coverity 1345809: unchecked return value

### DIFF
--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -337,7 +337,7 @@ generate_key(CONFIG *cfg, char *key_buf, uint64_t keyno)
 static inline void
 extract_key(char *key_buf, uint64_t *keynop)
 {
-	sscanf(key_buf, "%" SCNu64, keynop);
+	(void)sscanf(key_buf, "%" SCNu64, keynop);
 }
 
 /*


### PR DESCRIPTION
Explicitly discard the sscanf return value, hopefully that will quiet
Coverity.