### PR TITLE
WT-2476 - Revert changing the cache evict_walk_lock to the btree evict_lock

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -164,7 +164,6 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 
 	/* Destroy locks. */
 	WT_TRET(__wt_rwlock_destroy(session, &btree->ovfl_lock));
-	__wt_spin_destroy(session, &btree->evict_lock);
 	__wt_spin_destroy(session, &btree->flush_lock);
 
 	/* Free allocated memory. */
@@ -351,7 +350,6 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 	/* Initialize locks. */
 	WT_RET(__wt_rwlock_alloc(
 	    session, &btree->ovfl_lock, "btree overflow lock"));
-	WT_RET(__wt_spin_init(session, &btree->evict_lock, "btree evict"));
 	WT_RET(__wt_spin_init(session, &btree->flush_lock, "btree flush"));
 
 	btree->checkpointing = WT_CKPT_OFF;		/* Not checkpointing */

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -158,6 +158,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ERR(__wt_cond_alloc(session,
 	    "eviction waiters", false, &cache->evict_waiter_cond));
 	WT_ERR(__wt_spin_init(session, &cache->evict_lock, "cache eviction"));
+	WT_ERR(__wt_spin_init(session, &cache->evict_walk_lock, "cache walk"));
 
 	/* Allocate the LRU eviction queue. */
 	cache->evict_slots = WT_EVICT_WALK_BASE + WT_EVICT_WALK_INCR;
@@ -254,6 +255,7 @@ __wt_cache_destroy(WT_SESSION_IMPL *session)
 	WT_TRET(__wt_cond_auto_destroy(session, &cache->evict_cond));
 	WT_TRET(__wt_cond_destroy(session, &cache->evict_waiter_cond));
 	__wt_spin_destroy(session, &cache->evict_lock);
+	__wt_spin_destroy(session, &cache->evict_walk_lock);
 
 	__wt_free(session, cache->evict_queue);
 	__wt_free(session, conn->cache);

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -129,7 +129,6 @@ struct __wt_btree {
 	uint64_t rec_max_txn;		/* Maximum txn seen (clean trees) */
 	uint64_t write_gen;		/* Write generation */
 
-	WT_SPINLOCK evict_lock;		/* Eviction lock */
 	WT_REF	   *evict_ref;		/* Eviction thread's location */
 	uint64_t    evict_priority;	/* Relative priority of cached pages */
 	u_int	    evict_walk_period;	/* Skip this many LRU walks */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -84,6 +84,7 @@ struct __wt_cache {
 	 */
 	WT_CONDVAR *evict_cond;		/* Eviction server condition */
 	WT_SPINLOCK evict_lock;		/* Eviction LRU queue */
+	WT_SPINLOCK evict_walk_lock;	/* Eviction walk location */
 	/* Condition signalled when the eviction server populates the queue */
 	WT_CONDVAR *evict_waiter_cond;
 


### PR DESCRIPTION
@keithbostic, this is a change i put together when looking into WT-2476.

If you think moving back towards a cache lock rather than a btree lock is the way to go, then this may be suitable.