### PR TITLE
WT-2457 Wait for LSM work units to drain when getting exclusive access.

### DIFF
--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -179,7 +179,7 @@ struct __wt_lsm_tree {
 	int collator_owned;
 
 	uint32_t refcnt;		/* Number of users of the tree */
-	uint8_t exclusive;		/* Tree is locked exclusively */
+	WT_SESSION_IMPL *exclusive;	/* Tree is locked exclusively */
 
 #define	LSM_TREE_MAX_QUEUE	100
 	uint32_t queue_ref;

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -179,7 +179,7 @@ struct __wt_lsm_tree {
 	int collator_owned;
 
 	uint32_t refcnt;		/* Number of users of the tree */
-	WT_SESSION_IMPL *exclusive;	/* Tree is locked exclusively */
+	WT_SESSION_IMPL *excl_session;	/* Session has exclusive lock */
 
 #define	LSM_TREE_MAX_QUEUE	100
 	uint32_t queue_ref;

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1556,7 +1556,7 @@ __wt_clsm_open(WT_SESSION_IMPL *session,
 	WT_ERR(ret);
 
 	/* Make sure we have exclusive access if and only if we want it */
-	WT_ASSERT(session, !bulk || lsm_tree->exclusive);
+	WT_ASSERT(session, !bulk || lsm_tree->excl_session != NULL);
 
 	WT_ERR(__wt_calloc_one(session, &clsm));
 

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -114,11 +114,14 @@ __lsm_tree_close(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		if (i % WT_THOUSAND == 0) {
 			WT_WITHOUT_LOCKS(session, ret =
 			    __wt_lsm_manager_clear_tree(session, lsm_tree));
-			WT_RET(ret);
+			WT_ERR(ret);
 		}
 		__wt_yield();
 	}
 	return (0);
+
+err:	F_SET(lsm_tree, WT_LSM_TREE_ACTIVE);
+	return (ret);
 }
 
 /*
@@ -360,27 +363,25 @@ __lsm_tree_find(WT_SESSION_IMPL *session,
 	/* See if the tree is already open. */
 	TAILQ_FOREACH(lsm_tree, &S2C(session)->lsmqh, q)
 		if (strcmp(uri, lsm_tree->name) == 0) {
-			/*
-			 * Short circuit if the handle is already held
-			 * exclusively or exclusive access is requested and
-			 * there are references held.
-			 */
-			if ((exclusive && lsm_tree->refcnt > 0) ||
-			    lsm_tree->exclusive)
-				return (EBUSY);
-
 			if (exclusive) {
 				/*
 				 * Make sure we win the race to switch on the
 				 * exclusive flag.
 				 */
-				if (!__wt_atomic_cas8(
-				    &lsm_tree->exclusive, 0, 1))
+				if (!__wt_atomic_cas_ptr(
+				    &lsm_tree->exclusive, NULL, session))
 					return (EBUSY);
-				/* Make sure there are no readers */
-				if (!__wt_atomic_cas32(
+
+				/*
+				 * Drain the work queue before checking for
+				 * open cursors - otherwise we can generate
+				 * spurious busy returns.
+				 */
+				if (__lsm_tree_close(session, lsm_tree) != 0 ||
+				    !__wt_atomic_cas32(
 				    &lsm_tree->refcnt, 0, 1)) {
-					lsm_tree->exclusive = 0;
+					F_SET(lsm_tree, WT_LSM_TREE_ACTIVE);
+					lsm_tree->exclusive = NULL;
 					return (EBUSY);
 				}
 			} else {
@@ -390,7 +391,7 @@ __lsm_tree_find(WT_SESSION_IMPL *session,
 				 * We got a reference, check if an exclusive
 				 * lock beat us to it.
 				 */
-				if (lsm_tree->exclusive) {
+				if (lsm_tree->exclusive != NULL) {
 					WT_ASSERT(session,
 					    lsm_tree->refcnt > 0);
 					(void)__wt_atomic_sub32(
@@ -486,7 +487,7 @@ __lsm_tree_open(WT_SESSION_IMPL *session,
 	 * with getting handles exclusive.
 	 */
 	lsm_tree->refcnt = 1;
-	lsm_tree->exclusive = exclusive ? 1 : 0;
+	lsm_tree->exclusive = exclusive ? session : NULL;
 	lsm_tree->queue_ref = 0;
 
 	/* Set a flush timestamp as a baseline. */
@@ -521,7 +522,7 @@ __wt_lsm_tree_get(WT_SESSION_IMPL *session,
 		ret = __lsm_tree_open(session, uri, exclusive, treep);
 
 	WT_ASSERT(session, ret != 0 ||
-	    (exclusive ? 1 : 0)  == (*treep)->exclusive);
+	    (exclusive ? session : NULL)  == (*treep)->exclusive);
 	return (ret);
 }
 
@@ -533,8 +534,11 @@ void
 __wt_lsm_tree_release(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 {
 	WT_ASSERT(session, lsm_tree->refcnt > 0);
-	if (lsm_tree->exclusive)
-		lsm_tree->exclusive = 0;
+	if (lsm_tree->exclusive == session) {
+		/* We cleared the active flag when getting exclusive access. */
+		F_SET(lsm_tree, WT_LSM_TREE_ACTIVE);
+		lsm_tree->exclusive = NULL;
+	}
 	(void)__wt_atomic_sub32(&lsm_tree->refcnt, 1);
 }
 
@@ -848,9 +852,6 @@ __wt_lsm_tree_drop(
 	    ret = __wt_lsm_tree_get(session, name, true, &lsm_tree));
 	WT_RET(ret);
 
-	/* Shut down the LSM worker. */
-	WT_ERR(__lsm_tree_close(session, lsm_tree));
-
 	/* Prevent any new opens. */
 	WT_ERR(__wt_lsm_tree_writelock(session, lsm_tree));
 	locked = true;
@@ -909,9 +910,6 @@ __wt_lsm_tree_rename(WT_SESSION_IMPL *session,
 	WT_WITH_HANDLE_LIST_LOCK(session,
 	    ret = __wt_lsm_tree_get(session, olduri, true, &lsm_tree));
 	WT_RET(ret);
-
-	/* Shut down the LSM worker. */
-	WT_ERR(__lsm_tree_close(session, lsm_tree));
 
 	/* Prevent any new opens. */
 	WT_ERR(__wt_lsm_tree_writelock(session, lsm_tree));
@@ -984,9 +982,6 @@ __wt_lsm_tree_truncate(
 	WT_WITH_HANDLE_LIST_LOCK(session,
 	    ret = __wt_lsm_tree_get(session, name, true, &lsm_tree));
 	WT_RET(ret);
-
-	/* Shut down the LSM worker. */
-	WT_ERR(__lsm_tree_close(session, lsm_tree));
 
 	/* Prevent any new opens. */
 	WT_ERR(__wt_lsm_tree_writelock(session, lsm_tree));

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -139,7 +139,7 @@ __lsm_worker(void *arg)
 			if (ret == WT_NOTFOUND) {
 				F_CLR(entry->lsm_tree, WT_LSM_TREE_COMPACTING);
 				ret = 0;
-			} else if (ret == EBUSY)
+			} else if (ret == EBUSY || ret == EINTR)
 				ret = 0;
 
 			/* Paranoia: clear session state. */

--- a/test/suite/test_lsm03.py
+++ b/test/suite/test_lsm03.py
@@ -33,14 +33,14 @@ from helper import simple_populate
 #    Check to make sure that LSM schema operations don't get EBUSY when
 #    there are no user operations active.
 class test_lsm03(wttest.WiredTigerTestCase):
-    name = 'test_rebalance'
+    name = 'test_lsm03'
 
     # Use small pages so we generate some internal layout
     # Setup LSM so multiple chunks are present
     config = 'key_format=S,allocation_size=512,internal_page_max=512' + \
              ',leaf_page_max=1k,lsm=(chunk_size=512k,merge_min=10)'
 
-    # Populate an object, then rebalance it.
+    # Populate an object then drop it.
     def test_lsm_drop_active(self):
         uri = 'lsm:' + self.name
         simple_populate(self, uri, self.config, 10000)

--- a/test/suite/test_lsm03.py
+++ b/test/suite/test_lsm03.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2016 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wtscenario, wttest
+from helper import simple_populate
+
+# test_lsm03.py
+#    Check to make sure that LSM schema operations don't get EBUSY when
+#    there are no user operations active.
+class test_lsm03(wttest.WiredTigerTestCase):
+    name = 'test_rebalance'
+
+    # Use small pages so we generate some internal layout
+    # Setup LSM so multiple chunks are present
+    config = 'key_format=S,allocation_size=512,internal_page_max=512' + \
+             ',leaf_page_max=1k,lsm=(chunk_size=512k,merge_min=10)'
+
+    # Populate an object, then rebalance it.
+    def test_lsm_drop_active(self):
+        uri = 'lsm:' + self.name
+        simple_populate(self, uri, self.config, 10000)
+
+        # Force to disk
+        self.reopen_conn()
+
+        # An open cursors should cause failure.
+        cursor = self.session.open_cursor(uri, None, None)
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(uri, None))
+        cursor.close()
+
+        # Add enough records that a merge should be running
+        simple_populate(self, uri, self.config, 50000)
+        # The drop should succeed even when LSM work units are active
+        self.session.drop(uri)


### PR DESCRIPTION
Otherwise we can return EBUSY unexpectedly. Fixed several outstanding
bugs along the way.

This change isn't ready for review yet - it needs further testing and a round of cleanup.