### PR TITLE
WT-2492 Change printf format specifier to be Windows compatible.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -878,6 +878,7 @@ ps
 psp
 pthread
 ptr
+ptrdiff
 pushms
 putK
 putV

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -15,14 +15,10 @@
 static int
 __config_err(WT_CONFIG *conf, const char *msg, int err)
 {
-	/*
-	 * Cast the string offset to uintmax_t because the %td format to print
-	 * a type ptrdiff_t isn't supported under MSVC.
-	 */
 	WT_RET_MSG(conf->session, err,
-	    "Error parsing '%.*s' at offset %" PRIuMAX ": %s",
+	    "Error parsing '%.*s' at offset %" WT_PTRDIFFT_FMT ": %s",
 	    (int)(conf->end - conf->orig), conf->orig,
-	    (uintmax_t)(conf->cur - conf->orig), msg);
+	    conf->cur - conf->orig, msg);
 }
 
 /*

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -15,13 +15,14 @@
 static int
 __config_err(WT_CONFIG *conf, const char *msg, int err)
 {
-	ptrdiff_t d;
+	uint64_t offset;
 
-	d = conf->cur - conf->orig;
+	/* Cast because printing a pointer diff isn't platform portable */
+	offset = (uint64_t)(conf->cur - conf->orig);
 
 	WT_RET_MSG(conf->session, err,
-	    "Error parsing '%.*s' at offset %td: %s",
-	    (int)(conf->end - conf->orig), conf->orig, d, msg);
+	    "Error parsing '%.*s' at offset %" PRIu64 ": %s",
+	    (int)(conf->end - conf->orig), conf->orig, offset, msg);
 }
 
 /*

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -15,14 +15,14 @@
 static int
 __config_err(WT_CONFIG *conf, const char *msg, int err)
 {
-	uint64_t offset;
-
-	/* Cast because printing a pointer diff isn't platform portable */
-	offset = (uint64_t)(conf->cur - conf->orig);
-
+	/*
+	 * Cast the string offset to uintmax_t because the %td format to print
+	 * a type ptrdiff_t isn't supported under MSVC.
+	 */
 	WT_RET_MSG(conf->session, err,
-	    "Error parsing '%.*s' at offset %" PRIu64 ": %s",
-	    (int)(conf->end - conf->orig), conf->orig, offset, msg);
+	    "Error parsing '%.*s' at offset %" PRIuMAX ": %s",
+	    (int)(conf->end - conf->orig), conf->orig,
+	    (uintmax_t)(conf->cur - conf->orig), msg);
 }
 
 /*

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -6,6 +6,7 @@
  * See the file LICENSE for redistribution information.
  */
 
+#define	WT_PTRDIFFT_FMT	"td"			/* ptrdiff_t format string */
 #define	WT_SIZET_FMT	"zu"			/* size_t format string */
 
 /* Add GCC-specific attributes to types and function declarations. */

--- a/src/include/lint.h
+++ b/src/include/lint.h
@@ -6,6 +6,7 @@
  * See the file LICENSE for redistribution information.
  */
 
+#define	WT_PTRDIFFT_FMT	"td"			/* ptrdiff_t format string */
 #define	WT_SIZET_FMT	"zu"			/* size_t format string */
 
 #define	WT_COMPILER_TYPE_ALIGN(x)

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -13,6 +13,7 @@
 
 #define	inline __inline
 
+#define	WT_PTRDIFFT_FMT	"Id"			/* ptrdiff_t format string */
 #define	WT_SIZET_FMT	"Iu"			/* size_t format string */
 
 /*


### PR DESCRIPTION
Windows doesn't like "td" for ptrdiff_t