### PR TITLE
WT-2414 Avoid main table reads and extractions for the first index

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -289,7 +289,8 @@ struct __wt_cursor_join_iter {
 	WT_CURSOR_JOIN_ENTRY	*entry;
 	WT_CURSOR		*cursor;	/* has null projection */
 	WT_CURSOR		*main;		/* main table with projection */
-	WT_ITEM			*curkey;
+	WT_ITEM			*curkey;	/* primary key */
+	WT_ITEM			 idxkey;
 	bool			 positioned;
 	bool			 isequal;	/* advancing means we're done */
 };


### PR DESCRIPTION
When iterating cursor joins, take advantage of the fact that we have the index key for the first index available.  We don't need to extract it again.