### PR TITLE
WT-2495 Make malloc calls use tcmalloc when configured.

### DIFF
--- a/src/os_posix/os_alloc.c
+++ b/src/os_posix/os_alloc.c
@@ -18,6 +18,7 @@
 #include <gperftools/tcmalloc.h>
 
 #define	calloc			tc_calloc
+#define	malloc			tc_malloc
 #define	realloc 		tc_realloc
 #define	posix_memalign 		tc_posix_memalign
 #define	free 			tc_free


### PR DESCRIPTION
Otherwise we can free memoy with tcmalloc that was allocated
with the system allocator.