### PR TITLE
WT-2497 Create second backup copy.

### DIFF
--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -67,6 +67,13 @@ copy_file(const char *name)
 	    "cp %s/%s %s/%s", g.home, name, g.home_backup, name);
 	testutil_checkfmt(system(cmd), "backup copy: %s", cmd);
 	free(cmd);
+
+	len = strlen(g.home) + strlen(g.home_backup2) + strlen(name) * 2 + 20;
+	cmd = dmalloc(len);
+	(void)snprintf(cmd, len,
+	    "cp %s/%s %s/%s", g.home, name, g.home_backup2, name);
+	testutil_checkfmt(system(cmd), "backup copy: %s", cmd);
+	free(cmd);
 }
 
 /*

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -109,6 +109,7 @@ typedef struct {
 
 	char *home;				/* Home directory */
 	char *home_backup;			/* Hot-backup directory */
+	char *home_backup2;			/* Saved Hot-backup directory */
 	char *home_backup_init;			/* Initialize backup command */
 	char *home_bdb;				/* BDB directory */
 	char *home_config;			/* Run CONFIG file path */

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -310,6 +310,10 @@ path_setup(const char *home)
 	g.home_backup = dmalloc(len);
 	snprintf(g.home_backup, len, "%s/%s", g.home, "BACKUP");
 
+	len = strlen(g.home) + strlen("BACKUP2") + 2;
+	g.home_backup2 = dmalloc(len);
+	snprintf(g.home_backup2, len, "%s/%s", g.home, "BACKUP2");
+
 	/* BDB directory. */
 	len = strlen(g.home) + strlen("bdb") + 2;
 	g.home_bdb = dmalloc(len);
@@ -340,13 +344,15 @@ path_setup(const char *home)
 	/* Backup directory initialize command, remove and re-create it. */
 #undef	CMD
 #ifdef _WIN32
-#define	CMD	"del /s /q >:nul && mkdir %s"
+#define	CMD	"del /s /q >:nul && mkdir %s %s"
 #else
-#define	CMD	"rm -rf %s && mkdir %s"
+#define	CMD	"rm -rf %s %s && mkdir %s %s"
 #endif
-	len = strlen(g.home_backup) * 2 + strlen(CMD) + 1;
+	len = strlen(g.home_backup) * 2 +
+	    strlen(g.home_backup2) * 2 + strlen(CMD) + 1;
 	g.home_backup_init = dmalloc(len);
-	snprintf(g.home_backup_init, len, CMD, g.home_backup, g.home_backup);
+	snprintf(g.home_backup_init, len, CMD, g.home_backup, g.home_backup2,
+	    g.home_backup, g.home_backup2);
 
 	/*
 	 * Salvage command, save the interesting files so we can replay the


### PR DESCRIPTION
@keithbostic This is for your consideration.  It is only a debugging aid so that if/when a failure happens on a backup directory we have an exact version of the backup directory before WT did anything like removed the `WiredTiger.backup` file, ran recovery, etc.  