### PR TITLE
WT-2496 Fix a race between checkpoint and starting a hot backup.

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -140,8 +140,9 @@ __wt_curbackup_open(WT_SESSION_IMPL *session,
 	 * Start the backup and fill in the cursor's list.  Acquire the schema
 	 * lock, we need a consistent view when creating a copy.
 	 */
-	WT_WITH_SCHEMA_LOCK(session, ret,
-	    ret = __backup_start(session, cb, cfg));
+	WT_WITH_CHECKPOINT_LOCK(session, ret,
+	    WT_WITH_SCHEMA_LOCK(session, ret,
+		ret = __backup_start(session, cb, cfg)));
 	WT_ERR(ret);
 
 	/* __wt_cursor_init is last so we don't have to clean up on error. */


### PR DESCRIPTION
In particular, a checkpoint could mark and lock an old checkpoint for
deletion before a hotbackup starts.  The hotbackup could then write
metadata referencing that old backup which the checkpoint goes on to
delete.

The fix is crude: don't allow a hotbackup to start while a checkpoint
is in progress.