### PR TITLE
WT-2330: in-memory configurations should not create on-disk collection files

### DIFF
--- a/build_win/filelist.win
+++ b/build_win/filelist.win
@@ -109,6 +109,7 @@ src/os_posix/os_init.c
 src/os_posix/os_inmemory.c
 src/os_posix/os_mtx_rw.c
 src/os_posix/os_posix.c
+src/os_posix/os_stdio.c
 src/os_posix/os_strtouq.c
 src/os_win/os_dir.c
 src/os_win/os_dlopen.c

--- a/dist/filelist
+++ b/dist/filelist
@@ -122,6 +122,7 @@ src/os_posix/os_path.c
 src/os_posix/os_posix.c
 src/os_posix/os_priv.c
 src/os_posix/os_sleep.c
+src/os_posix/os_stdio.c
 src/os_posix/os_strtouq.c
 src/os_posix/os_thread.c
 src/os_posix/os_time.c

--- a/dist/log.py
+++ b/dist/log.py
@@ -89,7 +89,7 @@ def printf_line(f, optype, i, ishex):
         ifbegin = 'if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {' + nl_indent
         if postcomma == '':
             precomma = ',\\n'
-    body = '%s%s(__wt_fprintf(session, WT_STDOUT,' % (
+    body = '%s%s(__wt_fprintf(session, WT_STDOUT(session),' % (
         printf_setup(f, ishex, nl_indent),
         'WT_ERR' if has_escape(optype.fields) else 'WT_RET') + \
         '%s    "%s        \\"%s\\": \\"%s\\"%s",%s));' % (
@@ -300,7 +300,7 @@ __wt_logop_%(name)s_print(WT_SESSION_IMPL *session,
 \t%(arg_unused)s%(arg_init)sWT_RET(__wt_logop_%(name)s_unpack(
 \t    session, pp, end%(arg_addrs)s));
 
-\tWT_RET(__wt_fprintf(session, WT_STDOUT,
+\tWT_RET(__wt_fprintf(session, WT_STDOUT(session),
 \t    " \\"optype\\": \\"%(name)s\\",\\n"));
 \t%(print_args)s
 %(arg_fini)s

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -201,7 +201,7 @@ __wt_debug_addr_print(
 	WT_DECL_RET;
 
 	WT_RET(__wt_scr_alloc(session, 128, &buf));
-	ret = __wt_fprintf(session, WT_STDERR,
+	ret = __wt_fprintf(session, WT_STDERR(session),
 	    "%s\n", __wt_addr_string(session, addr, addr_size, buf));
 	__wt_scr_free(session, &buf);
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1934,10 +1934,12 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	session = conn->default_session = &conn->dummy_session;
 	session->iface.connection = &conn->iface;
 	session->name = "wiredtiger_open";
-	__wt_random_init(&session->rnd);
+
+	/* Do standard I/O and error handling first. */
+	WT_ERR(__wt_os_stdio(session));
 	__wt_event_handler_set(session, event_handler);
 
-	/* Remaining basic initialization of the connection structure. */
+	/* Basic initialization of the connection structure. */
 	WT_ERR(__wt_connection_init(conn));
 
 	/* Check the application-specified configuration string. */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1940,13 +1940,55 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	/* Remaining basic initialization of the connection structure. */
 	WT_ERR(__wt_connection_init(conn));
 
-	/* Check/set the application-specified configuration string. */
+	/* Check the application-specified configuration string. */
 	WT_ERR(__wt_config_check(session,
 	    WT_CONFIG_REF(session, wiredtiger_open), config, 0));
+
+	/*
+	 * Build the temporary, initial configuration stack, in the following
+	 * order (where later entries override earlier entries):
+	 *
+	 * 1. the base configuration for the wiredtiger_open call
+	 * 2. the config passed in by the application
+	 * 3. environment variable settings (optional)
+	 *
+	 * In other words, a configuration stack based on the application's
+	 * passed-in information and nothing else.
+	 */
 	cfg[0] = WT_CONFIG_BASE(session, wiredtiger_open);
 	cfg[1] = config;
+	WT_ERR(__wt_scr_alloc(session, 0, &i1));
+	WT_ERR(__conn_config_env(session, cfg, i1));
 
-	/* Capture the config_base setting file for later use. */
+	/*
+	 * We need to know if configured for read-only or in-memory behavior
+	 * before reading/writing the filesystem. The only way the application
+	 * can configure that before we touch the filesystem is the wiredtiger
+	 * config string or the WIREDTIGER_CONFIG environment variable.
+	 *
+	 * The environment isn't trusted by default, for security reasons; if
+	 * the application wants us to trust the environment before reading
+	 * the filesystem, the wiredtiger_open config string is the only way.
+	 */
+	WT_ERR(__wt_config_gets(session, cfg, "in_memory", &cval));
+	if (cval.val != 0)
+		F_SET(conn, WT_CONN_IN_MEMORY);
+	WT_ERR(__wt_config_gets(session, cfg, "readonly", &cval));
+	if (cval.val)
+		F_SET(conn, WT_CONN_READONLY);
+
+	/*
+	 * After checking readonly and in-memory, but before we do anything that
+	 * touches the filesystem, configure the OS layer.
+	 */
+	WT_ERR(__wt_os_init(session));
+
+	/*
+	 * Capture the config_base setting file for later use. Again, if the
+	 * application doesn't want us to read the base configuration file,
+	 * the WIREDTIGER_CONFIG environment variable or the wiredtiger_open
+	 * config string are the only ways.
+	 */
 	WT_ERR(__wt_config_gets(session, cfg, "config_base", &cval));
 	config_base_set = cval.val != 0;
 
@@ -1956,36 +1998,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 		WT_ERR(__wt_strndup(
 		    session, cval.str, cval.len, &conn->error_prefix));
 
-	/*
-	 * Look for read-only early (for example, it configures use of the base
-	 * config file).
-	 *
-	 * XXX
-	 * We haven't read the WIREDTIGER_CONFIG environment variable, we need
-	 * to fix that.
-	 */
-	WT_ERR(__wt_config_gets(session, cfg, "readonly", &cval));
-	if (cval.val)
-		F_SET(conn, WT_CONN_READONLY);
-
-	/*
-	 * Look for in-memory early (for example, it configures writing the base
-	 * config file).
-	 *
-	 * XXX
-	 * We haven't read the WIREDTIGER_CONFIG environment variable, we need
-	 * to fix that.
-	 */
-	WT_ERR(__wt_config_gets(session, cfg, "in_memory", &cval));
-	if (cval.val != 0)
-		F_SET(conn, WT_CONN_IN_MEMORY);
-
-	/*
-	 * After checking readonly and in-memory, but before we do anything
-	 * that touches an underlying filesystem, configure the OS layer.
-	 */
-	WT_ERR(__wt_os_init(session));
-
 	/* Get the database home. */
 	WT_ERR(__conn_home(session, home, cfg));
 
@@ -1993,8 +2005,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__conn_single(session, cfg));
 
 	/*
-	 * Build the configuration stack, in the following order (where later
-	 * entries override earlier entries):
+	 * Build the real configuration stack, in the following order (where
+	 * later entries override earlier entries):
 	 *
 	 * 1. all possible wiredtiger_open configurations
 	 * 2. the WiredTiger compilation version (expected to be overridden by
@@ -2008,7 +2020,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 * Clear the entries we added to the stack, we're going to build it in
 	 * order.
 	 */
-	WT_ERR(__wt_scr_alloc(session, 0, &i1));
 	WT_ERR(__wt_scr_alloc(session, 0, &i2));
 	WT_ERR(__wt_scr_alloc(session, 0, &i3));
 	cfg[0] = WT_CONFIG_BASE(session, wiredtiger_open_all);
@@ -2031,11 +2042,15 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 * Merge the full configuration stack and save it for reconfiguration.
 	 */
 	WT_ERR(__wt_config_merge(session, cfg, NULL, &merge_cfg));
+
 	/*
-	 * The read-only setting may have been set in a configuration file.
-	 * Get it again so that we can override other configuration settings
-	 * before they are processed by the subsystems.
+	 * Read-only and in-memory settings may have been set in a configuration
+	 * file (not optimal, but we can handle it). Get those settings again so
+	 * we can override other configuration settings as they are processed.
 	 */
+	WT_ERR(__wt_config_gets(session, cfg, "in_memory", &cval));
+	if (cval.val != 0)
+		F_SET(conn, WT_CONN_IN_MEMORY);
 	WT_ERR(__wt_config_gets(session, cfg, "readonly", &cval));
 	if (cval.val)
 		F_SET(conn, WT_CONN_READONLY);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1118,7 +1118,8 @@ __conn_config_append(const char *cfg[], const char *config)
 {
 	while (*cfg != NULL)
 		++cfg;
-	*cfg = config;
+	cfg[0] = config;
+	cfg[1] = NULL;
 }
 
 /*

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -41,6 +41,9 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
 	TAILQ_INIT(&conn->lsm_manager.appqh);
 	TAILQ_INIT(&conn->lsm_manager.managerqh);
 
+	/* Random numbers. */
+	__wt_random_init(&session->rnd);
+
 	/* Configuration. */
 	WT_RET(__wt_conn_config_init(session));
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1702,7 +1702,7 @@ __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 	total_bytes = 0;
 
 	if (ofile == NULL)
-		fh = WT_STDERR;
+		fh = WT_STDERR(session);
 	else
 		WT_RET(__wt_open(session, ofile, WT_FILE_TYPE_REGULAR,
 		    WT_OPEN_CREATE | WT_STREAM_WRITE, &fh));
@@ -1785,7 +1785,7 @@ __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 	    "MB vs tracked inuse %" PRIu64 "MB\n",
 	    total_bytes >> 20, __wt_cache_bytes_inuse(conn->cache) >> 20);
 	(void)__wt_fprintf(session, fh, "==========\n");
-	if (fh != WT_STDERR)
+	if (ofile != NULL)
 		WT_RET(__wt_close(session, &fh));
 	return (0);
 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -25,36 +25,6 @@ struct __wt_process {
 					/* Locked: connection queue */
 	TAILQ_HEAD(__wt_connection_impl_qh, __wt_connection_impl) connqh;
 	WT_CACHE_POOL *cache_pool;
-
-	void *inmemory;			/* In-memory configuration cookie */
-
-	/*
-	 * OS library/system call jump table, to support in-memory and readonly
-	 * configurations as well as special devices with other non-POSIX APIs.
-	 */
-#define	WT_JUMP(func, ...)	__wt_process.func(__VA_ARGS__)
-	int	(*j_directory_sync)(WT_SESSION_IMPL *, const char *path);
-	int	(*j_file_exist)(WT_SESSION_IMPL *, const char *, bool *);
-	int	(*j_file_remove)(WT_SESSION_IMPL *, const char *);
-	int	(*j_file_rename)(WT_SESSION_IMPL *, const char *, const char *);
-	int	(*j_file_size)(
-		    WT_SESSION_IMPL *, const char *, bool, wt_off_t *);
-	int	(*j_handle_advise)(
-		    WT_SESSION_IMPL *, WT_FH *, wt_off_t, wt_off_t, int);
-	int	(*j_handle_close)(WT_SESSION_IMPL *, WT_FH *);
-	int	(*j_handle_getc)(WT_SESSION_IMPL *, WT_FH *, int *);
-	int	(*j_handle_lock)(WT_SESSION_IMPL *, WT_FH *, bool);
-	int	(*j_handle_open)(
-		    WT_SESSION_IMPL *, WT_FH *, const char *, int, u_int);
-	int	(*j_handle_printf)(
-		    WT_SESSION_IMPL *, WT_FH *, const char *, va_list);
-	int	(*j_handle_read)(
-		    WT_SESSION_IMPL *, WT_FH *, wt_off_t, size_t, void *);
-	int	(*j_handle_size)(WT_SESSION_IMPL *, WT_FH *, wt_off_t *);
-	int	(*j_handle_sync)(WT_SESSION_IMPL *, WT_FH *, bool);
-	int	(*j_handle_truncate)(WT_SESSION_IMPL *, WT_FH *, wt_off_t);
-	int	(*j_handle_write)(
-		    WT_SESSION_IMPL *, WT_FH *, wt_off_t, size_t, const void *);
 };
 extern WT_PROCESS __wt_process;
 
@@ -450,6 +420,24 @@ struct __wt_connection_impl {
 	bool	 mmap;			/* mmap configuration */
 	int page_size;			/* OS page size for mmap alignment */
 	uint32_t verbose;
+
+	void *inmemory;			/* In-memory configuration cookie */
+
+#define	WT_STDERR(s)	(&S2C(s)->wt_stderr)
+#define	WT_STDOUT(s)	(&S2C(s)->wt_stdout)
+	WT_FH wt_stderr, wt_stdout;
+
+	/*
+	 * OS library/system call jump table, to support in-memory and readonly
+	 * configurations as well as special devices with other non-POSIX APIs.
+	 */
+	int	(*file_directory_sync)(WT_SESSION_IMPL *, const char *path);
+	int	(*file_exist)(WT_SESSION_IMPL *, const char *, bool *);
+	int	(*file_remove)(WT_SESSION_IMPL *, const char *);
+	int	(*file_rename)(WT_SESSION_IMPL *, const char *, const char *);
+	int	(*file_size)(WT_SESSION_IMPL *, const char *, bool, wt_off_t *);
+	int	(*handle_open)(
+		    WT_SESSION_IMPL *, WT_FH *, const char *, int, u_int);
 
 	uint32_t flags;
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -537,6 +537,7 @@ extern int __wt_os_posix(WT_SESSION_IMPL *session);
 extern int __wt_os_posix_cleanup(WT_SESSION_IMPL *session);
 extern bool __wt_has_priv(void);
 extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds);
+extern int __wt_os_stdio(WT_SESSION_IMPL *session);
 extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base);
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg);
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid);

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -96,7 +96,7 @@ __wt_directory_sync_fh(WT_SESSION_IMPL *session, WT_FH *fh)
 	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
 
 #ifdef __linux__
-	return (fh->handle_sync(session, fh, true));
+	return (fh->fh_sync(session, fh, true));
 #else
 	WT_UNUSED(fh);
 	return (0);

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -70,3 +70,197 @@ __wt_verbose(WT_SESSION_IMPL *session, int flag, const char *fmt, ...)
 	return (0);
 #endif
 }
+
+/*
+ * __wt_directory_sync --
+ *	Flush a directory to ensure file creation is durable.
+ */
+static inline int
+__wt_directory_sync(WT_SESSION_IMPL *session, const char *path)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+	return (S2C(session)->file_directory_sync(session, path));
+}
+
+/*
+ * __wt_directory_sync_fh --
+ *	Flush a directory file handle to ensure file creation is durable.
+ *
+ * We don't use the normal sync path because many file systems don't require
+ * this step and we don't want to penalize them.
+ */
+static inline int
+__wt_directory_sync_fh(WT_SESSION_IMPL *session, WT_FH *fh)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+#ifdef __linux__
+	return (fh->handle_sync(session, fh, true));
+#else
+	WT_UNUSED(fh);
+	return (0);
+#endif
+}
+
+/*
+ * __wt_exist --
+ *	Return if the file exists.
+ */
+static inline int
+__wt_exist(WT_SESSION_IMPL *session, const char *name, bool *existp)
+{
+	return (S2C(session)->file_exist(session, name, existp));
+}
+
+/*
+ * __wt_posix_fadvise --
+ *	POSIX fadvise.
+ */
+static inline int
+__wt_posix_fadvise(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t offset, wt_off_t len, int advice)
+{
+#if defined(HAVE_POSIX_FADVISE)
+	return (fh->fh_advise(session, fh, offset, len, advice));
+#else
+	return (0);
+#endif
+}
+
+/*
+ * __wt_file_lock --
+ *	Lock/unlock a file.
+ */
+static inline int
+__wt_file_lock(WT_SESSION_IMPL * session, WT_FH *fh, bool lock)
+{
+	return (fh->fh_lock(session, fh, lock));
+}
+
+/*
+ * __wt_filesize --
+ *	Get the size of a file in bytes, by file handle.
+ */
+static inline int
+__wt_filesize(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
+{
+	return (fh->fh_size(session, fh, sizep));
+}
+
+/*
+ * __wt_filesize_name --
+ *	Get the size of a file in bytes, by file name.
+ */
+static inline int
+__wt_filesize_name(
+    WT_SESSION_IMPL *session, const char *name, bool silent, wt_off_t *sizep)
+{
+	return (S2C(session)->file_size(session, name, silent, sizep));
+}
+
+/*
+ * __wt_fsync --
+ *	POSIX fflush/fsync.
+ */
+static inline int
+__wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+	return (fh->fh_sync(session, fh, block));
+}
+
+/*
+ * __wt_ftruncate --
+ *	POSIX ftruncate.
+ */
+static inline int
+__wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+	return (fh->fh_truncate(session, fh, len));
+}
+
+/*
+ * __wt_read --
+ *	POSIX pread.
+ */
+static inline int
+__wt_read(
+    WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void *buf)
+{
+	WT_STAT_FAST_CONN_INCR(session, read_io);
+
+	return (fh->fh_read(session, fh, offset, len, buf));
+}
+
+/*
+ * __wt_remove --
+ *	POSIX remove.
+ */
+static inline int
+__wt_remove(WT_SESSION_IMPL *session, const char *name)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+	return (S2C(session)->file_remove(session, name));
+}
+
+/*
+ * __wt_rename --
+ *	POSIX rename.
+ */
+static inline int
+__wt_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
+	return (S2C(session)->file_rename(session, from, to));
+}
+
+/*
+ * __wt_write --
+ *	POSIX pwrite.
+ */
+static inline int
+__wt_write(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t offset, size_t len, const void *buf)
+{
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY) ||
+	    WT_STRING_MATCH(fh->name,
+	    WT_SINGLETHREAD, strlen(WT_SINGLETHREAD)));
+
+	WT_STAT_FAST_CONN_INCR(session, write_io);
+
+	return (fh->fh_write(session, fh, offset, len, buf));
+}
+
+/*
+ * __wt_vfprintf --
+ *	ANSI C vfprintf.
+ */
+static inline int
+__wt_vfprintf(WT_SESSION_IMPL *session, WT_FH *fh, const char *fmt, va_list ap)
+{
+	return (fh->fh_printf(session, fh, fmt, ap));
+}
+
+/*
+ * __wt_fprintf --
+ *	ANSI C fprintf.
+ */
+static inline int
+__wt_fprintf(WT_SESSION_IMPL *session, WT_FH *fh, const char *fmt, ...)
+    WT_GCC_FUNC_ATTRIBUTE((format (printf, 3, 4)))
+{
+	WT_DECL_RET;
+	va_list ap;
+
+	va_start(ap, fmt);
+	ret = __wt_vfprintf(session, fh, fmt, ap);
+	va_end(ap);
+
+	return (ret);
+}

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -66,11 +66,8 @@
 #define	WT_STREAM_READ		0x020	/* Open a stream: read */
 #define	WT_STREAM_WRITE		0x040	/* Open a stream: write */
 
-#define	WT_STDERR	((void *)0x1)	/* WT_FH to stderr */
-#define	WT_STDOUT	((void *)0x2)	/* WT_FH to stdout */
-
 struct __wt_fh {
-	char	*name;				/* File name */
+	const char *name;			/* File name */
 	uint64_t name_hash;			/* Hash of name */
 	TAILQ_ENTRY(__wt_fh) q;			/* List of open handles */
 	TAILQ_ENTRY(__wt_fh) hashq;		/* Hashed list of handles */
@@ -108,204 +105,19 @@ struct __wt_fh {
 	    WT_FALLOCATE_SYS } fallocate_available;
 	bool fallocate_requires_locking;
 
-#define	WT_FH_IN_MEMORY		0x01		/* In-memory, don't remove */
-#define	WT_FH_FLUSH_ON_CLOSE	0x02		/* Flush when closing */
+#define	WT_FH_FLUSH_ON_CLOSE	0x01		/* Flush when closing */
+#define	WT_FH_IN_MEMORY		0x02		/* In-memory, don't remove */
 	uint32_t flags;
+
+	int (*fh_advise)(WT_SESSION_IMPL *, WT_FH *, wt_off_t, wt_off_t, int);
+	int (*fh_close)(WT_SESSION_IMPL *, WT_FH *);
+	int (*fh_getc)(WT_SESSION_IMPL *, WT_FH *, int *);
+	int (*fh_lock)(WT_SESSION_IMPL *, WT_FH *, bool);
+	int (*fh_printf)(WT_SESSION_IMPL *, WT_FH *, const char *, va_list);
+	int (*fh_read)(WT_SESSION_IMPL *, WT_FH *, wt_off_t, size_t, void *);
+	int (*fh_size)(WT_SESSION_IMPL *, WT_FH *, wt_off_t *);
+	int (*fh_sync)(WT_SESSION_IMPL *, WT_FH *, bool);
+	int (*fh_truncate)(WT_SESSION_IMPL *, WT_FH *, wt_off_t);
+	int (*fh_write)(
+	    WT_SESSION_IMPL *, WT_FH *, wt_off_t, size_t, const void *);
 };
-
-/*
- * OS calls that are currently just stubs.
- */
-/*
- * __wt_directory_sync --
- *	Flush a directory to ensure file creation is durable.
- */
-static inline int
-__wt_directory_sync(WT_SESSION_IMPL *session, const char *path)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	return (WT_JUMP(j_directory_sync, session, path));
-}
-
-/*
- * __wt_directory_sync_fh --
- *	Flush a directory file handle to ensure file creation is durable.
- *
- * We don't use the normal sync path because many file systems don't require
- * this step and we don't want to penalize them.
- */
-static inline int
-__wt_directory_sync_fh(WT_SESSION_IMPL *session, WT_FH *fh)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-#ifdef __linux__
-	return (WT_JUMP(j_handle_sync, session, fh, true));
-#else
-	WT_UNUSED(fh);
-	return (0);
-#endif
-}
-
-/*
- * __wt_exist --
- *	Return if the file exists.
- */
-static inline int
-__wt_exist(WT_SESSION_IMPL *session, const char *name, bool *existp)
-{
-	return (WT_JUMP(j_file_exist, session, name, existp));
-}
-
-/*
- * __wt_posix_fadvise --
- *	POSIX fadvise.
- */
-static inline int
-__wt_posix_fadvise(WT_SESSION_IMPL *session,
-    WT_FH *fh, wt_off_t offset, wt_off_t len, int advice)
-{
-#if defined(HAVE_POSIX_FADVISE)
-	return (WT_JUMP(j_handle_advise, session, fh, offset, len, advice));
-#else
-	return (0);
-#endif
-}
-
-/*
- * __wt_file_lock --
- *	Lock/unlock a file.
- */
-static inline int
-__wt_file_lock(WT_SESSION_IMPL * session, WT_FH *fh, bool lock)
-{
-	return (WT_JUMP(j_handle_lock, session, fh, lock));
-}
-
-/*
- * __wt_filesize --
- *	Get the size of a file in bytes, by file handle.
- */
-static inline int
-__wt_filesize(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
-{
-	return (WT_JUMP(j_handle_size, session, fh, sizep));
-}
-
-/*
- * __wt_filesize_name --
- *	Get the size of a file in bytes, by file name.
- */
-static inline int
-__wt_filesize_name(
-    WT_SESSION_IMPL *session, const char *name, bool silent, wt_off_t *sizep)
-{
-	return (WT_JUMP(j_file_size, session, name, silent, sizep));
-}
-
-/*
- * __wt_fsync --
- *	POSIX fflush/fsync.
- */
-static inline int
-__wt_fsync(WT_SESSION_IMPL *session, void *fh, bool block)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	return (WT_JUMP(j_handle_sync, session, fh, block));
-}
-
-/*
- * __wt_ftruncate --
- *	POSIX ftruncate.
- */
-static inline int
-__wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	return (WT_JUMP(j_handle_truncate, session, fh, len));
-}
-
-/*
- * __wt_read --
- *	POSIX pread.
- */
-static inline int
-__wt_read(
-    WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void *buf)
-{
-	WT_STAT_FAST_CONN_INCR(session, read_io);
-
-	return (WT_JUMP(j_handle_read, session, fh, offset, len, buf));
-}
-
-/*
- * __wt_remove --
- *	POSIX remove.
- */
-static inline int
-__wt_remove(WT_SESSION_IMPL *session, const char *name)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	return (WT_JUMP(j_file_remove, session, name));
-}
-
-/*
- * __wt_rename --
- *	POSIX rename.
- */
-static inline int
-__wt_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	return (WT_JUMP(j_file_rename, session, from, to));
-}
-
-/*
- * __wt_write --
- *	POSIX pwrite.
- */
-static inline int
-__wt_write(WT_SESSION_IMPL *session,
-    WT_FH *fh, wt_off_t offset, size_t len, const void *buf)
-{
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY) ||
-	    WT_STRING_MATCH(fh->name,
-	    WT_SINGLETHREAD, strlen(WT_SINGLETHREAD)));
-
-	WT_STAT_FAST_CONN_INCR(session, write_io);
-
-	return (WT_JUMP(j_handle_write, session, fh, offset, len, buf));
-}
-
-/*
- * __wt_vfprintf --
- *	ANSI C vfprintf.
- */
-static inline int
-__wt_vfprintf(WT_SESSION_IMPL *session, WT_FH *fh, const char *fmt, va_list ap)
-{
-	return (WT_JUMP(j_handle_printf, session, fh, fmt, ap));
-}
-
-/*
- * __wt_fprintf --
- *	ANSI C fprintf.
- */
-static inline int
-__wt_fprintf(WT_SESSION_IMPL *session, WT_FH *fh, const char *fmt, ...)
-    WT_GCC_FUNC_ATTRIBUTE((format (printf, 3, 4)))
-{
-	WT_DECL_RET;
-	va_list ap;
-
-	va_start(ap, fmt);
-	ret = __wt_vfprintf(session, fh, fmt, ap);
-	va_end(ap);
-
-	return (ret);
-}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -339,6 +339,7 @@ union __wt_rand_state;
 #include "log.h"
 #include "lsm.h"
 #include "meta.h"
+#include "os.h"
 #include "schema.h"
 #include "txn.h"
 
@@ -356,7 +357,6 @@ union __wt_rand_state;
 #include "log.i"
 #include "misc.i"
 #include "mutex.i"			/* required by btree.i */
-#include "os.h"				/* requires connection.h */
 #include "packing.i"
 #include "txn.i"			/* required by btree.i */
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -144,18 +144,18 @@ __wt_logop_col_put_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_col_put_unpack(
 	    session, pp, end, &fileid, &recno, &value));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"col_put\",\n"));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"recno\": \"%" PRIu64 "\",\n", recno));
 	WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"value\": \"%s\"", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    ",\n        \"value-hex\": \"%s\"", escaped));
 	}
 
@@ -214,11 +214,11 @@ __wt_logop_col_remove_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_col_remove_unpack(
 	    session, pp, end, &fileid, &recno));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"col_remove\",\n"));
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"recno\": \"%" PRIu64 "\"", recno));
 	return (0);
 }
@@ -275,13 +275,13 @@ __wt_logop_col_truncate_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_col_truncate_unpack(
 	    session, pp, end, &fileid, &start, &stop));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"col_truncate\",\n"));
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"start\": \"%" PRIu64 "\",\n", start));
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"stop\": \"%" PRIu64 "\"", stop));
 	return (0);
 }
@@ -340,24 +340,24 @@ __wt_logop_row_put_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_row_put_unpack(
 	    session, pp, end, &fileid, &key, &value));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"row_put\",\n"));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
 	WT_ERR(__logrec_make_json_str(session, &escaped, &key));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"key\": \"%s\",\n", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &key));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    "        \"key-hex\": \"%s\",\n", escaped));
 	}
 	WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"value\": \"%s\"", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    ",\n        \"value-hex\": \"%s\"", escaped));
 	}
 
@@ -418,16 +418,16 @@ __wt_logop_row_remove_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_row_remove_unpack(
 	    session, pp, end, &fileid, &key));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"row_remove\",\n"));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
 	WT_ERR(__logrec_make_json_str(session, &escaped, &key));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"key\": \"%s\"", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &key));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    ",\n        \"key-hex\": \"%s\"", escaped));
 	}
 
@@ -490,27 +490,27 @@ __wt_logop_row_truncate_print(WT_SESSION_IMPL *session,
 	WT_RET(__wt_logop_row_truncate_unpack(
 	    session, pp, end, &fileid, &start, &stop, &mode));
 
-	WT_RET(__wt_fprintf(session, WT_STDOUT,
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 	    " \"optype\": \"row_truncate\",\n"));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"fileid\": \"%" PRIu32 "\",\n", fileid));
 	WT_ERR(__logrec_make_json_str(session, &escaped, &start));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"start\": \"%s\",\n", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &start));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    "        \"start-hex\": \"%s\",\n", escaped));
 	}
 	WT_ERR(__logrec_make_json_str(session, &escaped, &stop));
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"stop\": \"%s\",\n", escaped));
 	if (LF_ISSET(WT_TXN_PRINTLOG_HEX)) {
 		WT_ERR(__logrec_make_hex_str(session, &escaped, &stop));
-		WT_ERR(__wt_fprintf(session, WT_STDOUT,
+		WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 		    "        \"stop-hex\": \"%s\",\n", escaped));
 	}
-	WT_ERR(__wt_fprintf(session, WT_STDOUT,
+	WT_ERR(__wt_fprintf(session, WT_STDOUT(session),
 	    "        \"mode\": \"%" PRIu32 "\"", mode));
 
 err:	__wt_free(session, escaped);

--- a/src/os_posix/os_getline.c
+++ b/src/os_posix/os_getline.c
@@ -31,7 +31,7 @@ __wt_getline(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_FH *fh)
 	WT_RET(__wt_buf_init(session, buf, 100));
 
 	for (;;) {
-		WT_RET(WT_JUMP(j_handle_getc, session, fh, &c));
+		WT_RET(fh->fh_getc(session, fh, &c));
 		if (c == EOF)
 			break;
 

--- a/src/os_posix/os_stdio.c
+++ b/src/os_posix/os_stdio.c
@@ -1,0 +1,167 @@
+/*-
+ * Copyright (c) 2014-2016 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __stdio_handle_advise --
+ *	POSIX fadvise.
+ */
+static int
+__stdio_handle_advise(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t offset, wt_off_t len, int advice)
+{
+	WT_UNUSED(offset);
+	WT_UNUSED(len);
+	WT_UNUSED(advice);
+	WT_RET_MSG(session, ENOTSUP, "%s: advise", fh->name);
+}
+
+/*
+ * __stdio_handle_close --
+ *	ANSI C close/fclose.
+ */
+static int
+__stdio_handle_close(WT_SESSION_IMPL *session, WT_FH *fh)
+{
+	WT_RET_MSG(session, ENOTSUP, "%s: close", fh->name);
+}
+
+/*
+ * __stdio_handle_getc --
+ *	ANSI C fgetc.
+ */
+static int
+__stdio_handle_getc(WT_SESSION_IMPL *session, WT_FH *fh, int *chp)
+{
+	WT_UNUSED(chp);
+	WT_RET_MSG(session, ENOTSUP, "%s: getc", fh->name);
+}
+
+/*
+ * __stdio_handle_lock --
+ *	Lock/unlock a file.
+ */
+static int
+__stdio_handle_lock(WT_SESSION_IMPL *session, WT_FH *fh, bool lock)
+{
+	WT_UNUSED(lock);
+	WT_RET_MSG(session, ENOTSUP, "%s: lock", fh->name);
+}
+
+/*
+ * __stdio_handle_printf --
+ *	ANSI C vfprintf.
+ */
+static int
+__stdio_handle_printf(
+    WT_SESSION_IMPL *session, WT_FH *fh, const char *fmt, va_list ap)
+{
+	if (vfprintf(fh->fp, fmt, ap) >= 0)
+		return (0);
+	WT_RET_MSG(session, EIO, "%s: vfprintf", fh->name);
+}
+
+/*
+ * __stdio_handle_read --
+ *	POSIX pread.
+ */
+static int
+__stdio_handle_read(
+    WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void *buf)
+{
+	WT_UNUSED(offset);
+	WT_UNUSED(len);
+	WT_UNUSED(buf);
+	WT_RET_MSG(session, ENOTSUP, "%s: read", fh->name);
+}
+
+/*
+ * __stdio_handle_size --
+ *	Get the size of a file in bytes, by file handle.
+ */
+static int
+__stdio_handle_size(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
+{
+	WT_UNUSED(sizep);
+	WT_RET_MSG(session, ENOTSUP, "%s: size", fh->name);
+}
+
+/*
+ * __stdio_handle_sync --
+ *	POSIX fflush/fsync.
+ */
+static int
+__stdio_handle_sync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
+{
+	WT_UNUSED(block);
+
+	if (fflush(fh->fp) == 0)
+		return (0);
+	WT_RET_MSG(session, __wt_errno(), "%s: fflush", fh->name);
+}
+
+/*
+ * __stdio_handle_truncate --
+ *	POSIX ftruncate.
+ */
+static int
+__stdio_handle_truncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t len)
+{
+	WT_UNUSED(len);
+	WT_RET_MSG(session, ENOTSUP, "%s: truncate", fh->name);
+}
+
+/*
+ * __stdio_handle_write --
+ *	POSIX pwrite.
+ */
+static int
+__stdio_handle_write(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t offset, size_t len, const void *buf)
+{
+	WT_UNUSED(offset);
+	WT_UNUSED(len);
+	WT_UNUSED(buf);
+	WT_RET_MSG(session, ENOTSUP, "%s: write", fh->name);
+}
+
+/*
+ * __stdio_func_init --
+ *	Initialize stdio functions.
+ */
+static void
+__stdio_func_init(WT_FH *fh, const char *name, FILE *fp)
+{
+	fh->name = name;
+	fh->fp = fp;
+
+	fh->fh_advise = __stdio_handle_advise;
+	fh->fh_close = __stdio_handle_close;
+	fh->fh_getc = __stdio_handle_getc;
+	fh->fh_lock = __stdio_handle_lock;
+	fh->fh_printf = __stdio_handle_printf;
+	fh->fh_read = __stdio_handle_read;
+	fh->fh_size = __stdio_handle_size;
+	fh->fh_sync = __stdio_handle_sync;
+	fh->fh_truncate = __stdio_handle_truncate;
+	fh->fh_write = __stdio_handle_write;
+}
+
+/*
+ * __wt_os_stdio --
+ *	Initialize the stdio configuration.
+ */
+int
+__wt_os_stdio(WT_SESSION_IMPL *session)
+{
+	__stdio_func_init(WT_STDERR(session), "stderr", stderr);
+	__stdio_func_init(WT_STDOUT(session), "stdout", stdout);
+
+	return (0);
+}

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -23,8 +23,8 @@ __handle_error_default(WT_EVENT_HANDLER *handler,
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
-	WT_RET(__wt_fprintf(session, WT_STDERR, "%s\n", errmsg));
-	WT_RET(__wt_fsync(session, WT_STDERR, true));
+	WT_RET(__wt_fprintf(session, WT_STDERR(session), "%s\n", errmsg));
+	WT_RET(__wt_fsync(session, WT_STDERR(session), true));
 	return (0);
 }
 
@@ -41,8 +41,8 @@ __handle_message_default(WT_EVENT_HANDLER *handler,
 	WT_UNUSED(handler);
 
 	session = (WT_SESSION_IMPL *)wt_session;
-	WT_RET(__wt_fprintf(session, WT_STDOUT, "%s\n", message));
-	WT_RET(__wt_fsync(session, WT_STDOUT, true));
+	WT_RET(__wt_fprintf(session, WT_STDOUT(session), "%s\n", message));
+	WT_RET(__wt_fsync(session, WT_STDOUT(session), true));
 	return (0);
 }
 
@@ -180,13 +180,13 @@ __wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
 	 * example, we can end up here without a session.)
 	 */
 	if (session == NULL) {
-		WT_RET(__wt_fprintf(session, WT_STDERR,
+		WT_RET(__wt_fprintf(session, WT_STDERR(session),
 		    "WiredTiger Error%s%s: ",
 		    error == 0 ? "" : ": ",
 		    error == 0 ? "" : __wt_strerror(session, error, NULL, 0)));
-		WT_RET(__wt_vfprintf(session, WT_STDERR, fmt, ap));
-		WT_RET(__wt_fprintf(session, WT_STDERR, "\n"));
-		return (__wt_fsync(session, WT_STDERR, true));
+		WT_RET(__wt_vfprintf(session, WT_STDERR(session), fmt, ap));
+		WT_RET(__wt_fprintf(session, WT_STDERR(session), "\n"));
+		return (__wt_fsync(session, WT_STDERR(session), true));
 	}
 
 	p = s;


### PR DESCRIPTION
@sueloverso, @michaelcahill, for your review/consideration.

The idea here is to check the initial inputs we have (the wiredtiger_open config string and the WIREDTIGER_CONFIG environment variable), for either read-only or in-memory configurations, before looking at any of the on-disk information.

Also, there's this code:
```
        /* Ignore the base_config file if config_base_set is false. */
        if (config_base_set || F_ISSET(conn, WT_CONN_READONLY))
                WT_ERR(
                    __conn_config_file(session, WT_BASECONFIG, false, cfg, i1));
```

I didn't touch it, but it looks wrong to me -- why are we ignoring the base configuration file if we're configured read-only?
