### PR TITLE
WT-2330: in-memory configurations should not create on-disk collection files

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -609,6 +609,7 @@ extern int __wt_nfilename( WT_SESSION_IMPL *session, const char *name, size_t na
 extern int __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name);
 extern int __wt_rename_and_sync_directory( WT_SESSION_IMPL *session, const char *from, const char *to);
 extern int __wt_sync_handle_and_rename( WT_SESSION_IMPL *session, WT_FH **fhp, const char *from, const char *to);
+extern int __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to);
 extern int __wt_library_init(void);
 extern int __wt_breakpoint(void);
 extern void __wt_attach(WT_SESSION_IMPL *session);

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -8,11 +8,8 @@
 
 #include "util.h"
 
-static int copy(const char *, const char *);
+static int copy(WT_SESSION *, const char *, const char *);
 static int usage(void);
-
-#define	CBUF_LEN	(128 * 1024)		/* Copy buffer and size. */
-static char *cbuf;
 
 /*
  * append_target --
@@ -86,7 +83,7 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
 	while (
 	    (ret = cursor->next(cursor)) == 0 &&
 	    (ret = cursor->get_key(cursor, &name)) == 0)
-		if ((ret = copy(name, directory)) != 0)
+		if ((ret = copy(session, name, directory)) != 0)
 			goto err;
 	if (ret == WT_NOTFOUND)
 		ret = 0;
@@ -98,97 +95,46 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
 	}
 
 err:	free(config);
-	free(cbuf);
-
 	return (ret);
 }
 
 static int
-copy(const char *name, const char *directory)
+copy(WT_SESSION *session, const char *name, const char *directory)
 {
 	WT_DECL_RET;
-	ssize_t n;
-	int ifd, ofd;
+	size_t len;
+	char *from, *to;
 
-	ret = 1;
-	ifd = ofd = -1;
+	from = to = NULL;
 
-	if (verbose &&
-	    printf("Backing up %s/%s to %s\n", home, name, directory) < 0) {
-		fprintf(stderr, "%s: %s\n", progname, strerror(errno));
-		return (1);
+	/* Build the 2 pathnames we need. */
+	len = strlen(home) + strlen(name) + 2;
+	if ((from = malloc(len)) == NULL)
+		goto memerr;
+	(void)snprintf(from, len, "%s/%s", home, name);
+	len = strlen(directory) + strlen(name) + 2;
+	if ((to = malloc(len)) == NULL)
+		goto memerr;
+	(void)snprintf(to, len, "%s/%s", directory, name);
+
+	if (verbose && printf("Backing up %s to %s\n", from, to) < 0) {
+		fprintf(stderr, "%s: %s\n", progname, strerror(EIO));
+		goto err;
 	}
-
-	/* Allocate a large copy buffer (use it to build pathnames as well. */
-	if (cbuf == NULL && (cbuf = malloc(CBUF_LEN)) == NULL)
-		goto memerr;
-
-	/* Open the read file. */
-	if (snprintf(cbuf, CBUF_LEN, "%s/%s", home, name) >= CBUF_LEN)
-		goto memerr;
-	if ((ifd = open(cbuf, O_BINARY | O_RDONLY, 0)) < 0)
-		goto readerr;
-
-	/* Open the write file. */
-	if (snprintf(cbuf, CBUF_LEN, "%s/%s", directory, name) >= CBUF_LEN)
-		goto memerr;
-	if ((ofd = open(
-	    cbuf, O_BINARY | O_CREAT | O_WRONLY | O_TRUNC, 0666)) < 0)
-		goto writerr;
-
-	/* Copy the file. */
-	while ((n = read(ifd, cbuf, CBUF_LEN)) > 0)
-		if (write(ofd, cbuf, (size_t)n) != n)
-			goto writerr;
-	if (n != 0)
-		goto readerr;
 
 	/*
-	 * Close file descriptors (forcing a flush on the write side), and
-	 * check for any errors.
+	 * Use WiredTiger to copy the file: ensuring stability of the copied
+	 * file on disk requires care, and WiredTiger knows how to do it.
 	 */
-	ret = close(ifd);
-	ifd = -1;
-	if (ret != 0)
-		goto readerr;
+	if ((ret = __wt_copy_and_sync(session, from, to)) != 0)
+		fprintf(stderr, "%s to %s: backup copy: %s\n",
+		    from, to, session->strerror(session, ret));
 
-	/*
-	 * We need to know this file was successfully written, it's a backup.
-	 */
-#ifdef _WIN32
-	if (FlushFileBuffers((HANDLE)_get_osfhandle(ofd)) == 0) {
-		DWORD err = GetLastError();
-		ret = err;
-		goto writerr;
-	}
-#else
-	if (fsync(ofd))
-		goto writerr;
-#endif
-	ret = close(ofd);
-	ofd = -1;
-	if (ret != 0)
-		goto writerr;
-
-	/* Success. */
-	ret = 0;
-
-	if (0) {
-readerr:	fprintf(stderr,
-		    "%s: %s/%s: %s\n", progname, home, name, strerror(errno));
-	}
-	if (0) {
-writerr:	fprintf(stderr, "%s: %s/%s: %s\n",
-		    progname, directory, name, strerror(errno));
-	}
 	if (0) {
 memerr:		fprintf(stderr, "%s: %s\n", progname, strerror(errno));
 	}
-
-	if (ifd >= 0)
-		(void)close(ifd);
-	if (ofd >= 0)
-		(void)close(ofd);
+err:	free(from);
+	free(to);
 
 	return (ret);
 }


### PR DESCRIPTION
@sueloverso, for your review/consideration.

I was reviewing OS-specific code in the library, and noticed the wt backup code had some Windows specific code to flush the copied file to disk. However, I don't think that's sufficient, on Linux, at least, we have to flush the enclosing directory to disk as well.

I think the simplest solution is to create a WiredTiger function to do the copy safely, WiredTiger already knows how to do the magic.