### PR TITLE
WT-2517: wtperf uses setvbuf in a way that isn't supported on Windows

### DIFF
--- a/bench/wtperf/misc.c
+++ b/bench/wtperf/misc.c
@@ -54,7 +54,7 @@ setup_log_file(CONFIG *cfg)
 		return (ret);
 
 	/* Use line buffering for the log file. */
-	(void)setvbuf(cfg->logf, NULL, _IOLBF, 32);
+	(void)setvbuf(cfg->logf, NULL, _IOLBF, 1024);
 	return (0);
 }
 

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2313,7 +2313,7 @@ main(int argc, char *argv[])
 	    cfg->table_name);
 
 	/* Make stdout line buffered, so verbose output appears quickly. */
-	(void)setvbuf(stdout, NULL, _IOLBF, 32);
+	(void)setvbuf(stdout, NULL, _IOLBF, 1024);
 
 	/* Concatenate non-default configuration strings. */
 	if (cfg->verbose > 1 || user_cconfig != NULL ||

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1233,7 +1233,7 @@ monitor(void *arg)
 		goto err;
 	}
 	/* Set line buffering for monitor file. */
-	(void)setvbuf(fp, NULL, _IOLBF, 0);
+	(void)setvbuf(fp, NULL, _IOLBF, 1024);
 	fprintf(fp,
 	    "#time,"
 	    "totalsec,"

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -100,7 +100,7 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile)
 	/* If we're using a file, flush on each line. */
 	WT_RET(__wt_fopen(session, ofile, WT_FHANDLE_WRITE, 0, &ds->fp));
 
-	(void)setvbuf(ds->fp, NULL, _IOLBF, 0);
+	(void)setvbuf(ds->fp, NULL, _IOLBF, 1024);
 	return (0);
 }
 


### PR DESCRIPTION
@agorrod, @sueloverso, for your review/consideration.