### PR TITLE
WT-2529 Be less aggressive asserting in readonly connections

### DIFF
--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -273,8 +273,6 @@ __wt_filesize(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
 static inline int
 __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
 {
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
 	WT_RET(__wt_verbose(
 	    session, WT_VERB_HANDLEOPS, "%s: handle-sync", fh->name));
 

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -18,6 +18,8 @@ __posix_sync(WT_SESSION_IMPL *session,
 {
 	WT_DECL_RET;
 
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
 #ifdef	HAVE_SYNC_FILE_RANGE
 	if (!block) {
 		WT_SYSCALL_RETRY(sync_file_range(fd,

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -395,6 +395,8 @@ __win_handle_sync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
 {
 	WT_DECL_RET;
 
+	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
+
 	/*
 	 * We don't open Windows system handles when opening directories
 	 * for flushing, as it is not necessary (or possible) to flush

--- a/test/readonly/smoke.sh
+++ b/test/readonly/smoke.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-trap 'chmod -R u+w WT_*; exit 0' 0 1 2 3 13 15
+trap 'chmod -R u+w WT_*' 0 1 2 3 13 15
 
 set -e
 


### PR DESCRIPTION
Since assertions call fsync on the standard I/O channel regardless of whether the connection is open read only.