### PR TITLE
WT-2526: mixing and matching readonly and read/write handles

### DIFF
--- a/src/btree/bt_huffman.c
+++ b/src/btree/bt_huffman.c
@@ -157,8 +157,8 @@ __huffman_confchk_file(
 
 	/* Check the file exists. */
 	WT_RET(__wt_strndup(session, v->str + len, v->len - len, &fname));
-	WT_ERR(__wt_open(session, fname, WT_FILE_TYPE_REGULAR,
-	    WT_OPEN_FIXED | WT_OPEN_READONLY | WT_STREAM_READ, &fh));
+	WT_ERR(__wt_open(session, fname,
+	    WT_FILE_TYPE_REGULAR, WT_OPEN_FIXED | WT_STREAM_READ, &fh));
 
 	/* Optionally return the file handle. */
 	if (fhp == NULL)

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1197,8 +1197,7 @@ __conn_config_file(WT_SESSION_IMPL *session,
 		return (0);
 
 	/* Open the configuration file. */
-	WT_RET(__wt_open(
-	    session, filename, WT_FILE_TYPE_REGULAR, WT_OPEN_READONLY, &fh));
+	WT_RET(__wt_open(session, filename, WT_FILE_TYPE_REGULAR, 0, &fh));
 	WT_ERR(__wt_filesize(session, fh, &size));
 	if (size == 0)
 		goto err;

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -70,14 +70,15 @@
 #define	POSIX_FADV_WILLNEED	0x02
 #endif
 
-#define	WT_OPEN_CREATE		0x001	/* Create is OK */
-#define	WT_OPEN_EXCLUSIVE	0x002	/* Exclusive open */
-#define	WT_OPEN_FIXED		0x004	/* Path isn't relative to home */
-#define	WT_OPEN_READONLY	0x008	/* Readonly open */
-#define	WT_STREAM_APPEND	0x010	/* Open a stream: append */
-#define	WT_STREAM_LINE_BUFFER	0x010	/* Line buffer the stream */
-#define	WT_STREAM_READ		0x020	/* Open a stream: read */
-#define	WT_STREAM_WRITE		0x040	/* Open a stream: write */
+#define	WT_OPEN_CREATE		0x001	/* Create */
+#define	WT_OPEN_DIRECTIO	0x002	/* Direct I/O (if available) */
+#define	WT_OPEN_EXCLUSIVE	0x004	/* Open exclusively */
+#define	WT_OPEN_FIXED		0x008	/* Path isn't relative to home */
+#define	WT_OPEN_READONLY	0x010	/* Open readonly (internal) */
+#define	WT_STREAM_APPEND	0x020	/* Open a stream: append */
+#define	WT_STREAM_LINE_BUFFER	0x040	/* Line buffer the stream */
+#define	WT_STREAM_READ		0x080	/* Open a stream: read */
+#define	WT_STREAM_WRITE		0x100	/* Open a stream: write */
 
 struct __wt_fh {
 	const char *name;			/* File name */

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -78,8 +78,8 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session)
 	WT_RET(__wt_exist(session, WT_METADATA_BACKUP, &exist));
 	if (!exist)
 		return (0);
-	WT_RET(__wt_open(session, WT_METADATA_BACKUP,
-	    WT_FILE_TYPE_REGULAR, WT_OPEN_READONLY | WT_STREAM_READ, &fh));
+	WT_RET(__wt_open(session,
+	    WT_METADATA_BACKUP, WT_FILE_TYPE_REGULAR, WT_STREAM_READ, &fh));
 
 	/* Read line pairs and load them into the metadata file. */
 	WT_ERR(__wt_scr_alloc(session, 512, &key));
@@ -257,8 +257,8 @@ __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
 	if (!exist)
 		return (strcmp(key, WT_METAFILE_URI) == 0 ?
 		    __metadata_config(session, valuep) : WT_NOTFOUND);
-	WT_RET(__wt_open(session, WT_METADATA_TURTLE,
-	    WT_FILE_TYPE_REGULAR, WT_OPEN_READONLY | WT_STREAM_READ, &fh));
+	WT_RET(__wt_open(session,
+	    WT_METADATA_TURTLE, WT_FILE_TYPE_REGULAR, WT_STREAM_READ, &fh));
 
 	/* Search for the key. */
 	WT_ERR(__wt_scr_alloc(session, 512, &buf));

--- a/src/os_common/filename.c
+++ b/src/os_common/filename.c
@@ -160,8 +160,7 @@ __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to)
 	WT_ERR(__wt_remove_if_exists(session, tmp->data));
 
 	/* Open the from and temporary file handles. */
-	WT_ERR(__wt_open(session, from,
-	    WT_FILE_TYPE_REGULAR, WT_OPEN_READONLY, &ffh));
+	WT_ERR(__wt_open(session, from, WT_FILE_TYPE_REGULAR, 0, &ffh));
 	WT_ERR(__wt_open(session, tmp->data,
 	    WT_FILE_TYPE_REGULAR, WT_OPEN_CREATE | WT_OPEN_EXCLUSIVE, &tfh));
 

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -115,10 +115,12 @@ __open_verbose(WT_SESSION_IMPL *session,
 	}
 
 	WT_OPEN_VERBOSE_FLAG(WT_OPEN_CREATE, "create");
+	WT_OPEN_VERBOSE_FLAG(WT_OPEN_DIRECTIO, "direct-IO");
 	WT_OPEN_VERBOSE_FLAG(WT_OPEN_EXCLUSIVE, "exclusive");
 	WT_OPEN_VERBOSE_FLAG(WT_OPEN_FIXED, "fixed");
 	WT_OPEN_VERBOSE_FLAG(WT_OPEN_READONLY, "readonly");
 	WT_OPEN_VERBOSE_FLAG(WT_STREAM_APPEND, "stream-append");
+	WT_OPEN_VERBOSE_FLAG(WT_STREAM_LINE_BUFFER, "stream-line-buffer");
 	WT_OPEN_VERBOSE_FLAG(WT_STREAM_READ, "stream-read");
 	WT_OPEN_VERBOSE_FLAG(WT_STREAM_WRITE, "stream-write");
 
@@ -194,6 +196,14 @@ __wt_open(WT_SESSION_IMPL *session,
 			LF_SET(WT_OPEN_READONLY);
 		WT_ASSERT(session, lock_file || !LF_ISSET(WT_OPEN_CREATE));
 	}
+
+	/*
+	 * Direct I/O: file-type is a flag from the set of possible flags stored
+	 * in the connection handle during configuration, check for a match.
+	 */
+	fh->direct_io = false;
+	if (FLD_ISSET(conn->direct_io, file_type))
+		LF_SET(WT_OPEN_DIRECTIO);
 
 	/* Create the path to the file. */
 	if (!LF_ISSET(WT_OPEN_FIXED))

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -549,18 +549,11 @@ __win_handle_open(WT_SESSION_IMPL *session,
 	} else
 		dwCreationDisposition = OPEN_EXISTING;
 
-	/*
-	 * direct_io means no OS file caching. This requires aligned buffer
-	 * allocations like O_DIRECT.
-	 */
-	if (FLD_ISSET(conn->direct_io, file_type) ||
-	    (LF_ISSET(WT_OPEN_READONLY) &&
-	    file_type == WT_FILE_TYPE_DATA &&
-	    FLD_ISSET(conn->direct_io, WT_FILE_TYPE_CHECKPOINT))) {
+	/* Direct I/O. */
+	if (LF_ISSET(WT_OPEN_DIRECTIO)) {
 		f |= FILE_FLAG_NO_BUFFERING;
-		direct_io = true;
+		fh->direct_io = true;
 	}
-	fh->direct_io = direct_io;
 
 	/* FILE_FLAG_WRITE_THROUGH does not require aligned buffers */
 	if (FLD_ISSET(conn->write_through, file_type))


### PR DESCRIPTION
@agorrod, here are the changes to default to opening file handles read/write (unless the database is configured readonly).

For your review.