### PR TITLE
WT-2533 Don't let in-memory tables return a zero size.

### DIFF
--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -308,7 +308,12 @@ __im_handle_size(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
 {
 	WT_UNUSED(session);
 
-	*sizep = (wt_off_t)fh->buf.size;
+	/*
+	 * XXX hack - MongoDB assumes that any file with content will have a
+	 * non-zero size. In memory tables generally are zero-sized, make
+	 * MongoDB happy.
+	 */
+	*sizep = fh->buf.size == 0 ? 0 : (wt_off_t)fh->buf.size;
 	return (0);
 }
 

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -8,6 +8,8 @@
 
 #include "wt_internal.h"
 
+static int __im_handle_size(WT_SESSION_IMPL *, WT_FH *, wt_off_t *);
+
 /*
  * In-memory information.
  */

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -151,12 +151,12 @@ __im_file_size(
 	__wt_spin_lock(session, &im->lock);
 
 	if (__wt_handle_search(session, name, true, NULL, &fh)) {
-		*sizep = (wt_off_t)fh->buf.size;
-		ret = __wt_close(session, &fh);
+		WT_ERR(__im_handle_size(session, fh, sizep));
+		WT_ERR(__wt_close(session, &fh));
 	} else
 		ret = ENOENT;
 
-	__wt_spin_unlock(session, &im->lock);
+err:	__wt_spin_unlock(session, &im->lock);
 	return (ret);
 }
 

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -313,7 +313,7 @@ __im_handle_size(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t *sizep)
 	 * non-zero size. In memory tables generally are zero-sized, make
 	 * MongoDB happy.
 	 */
-	*sizep = fh->buf.size == 0 ? 0 : (wt_off_t)fh->buf.size;
+	*sizep = fh->buf.size == 0 ? 1024 : (wt_off_t)fh->buf.size;
 	return (0);
 }
 


### PR DESCRIPTION
Returning a zero size breaks MongoDB replication. Return a non-zero
size for now until SERVER-23526 is resolved.