### PR TITLE
WT-2537 Check for an old and new uninitialized LSN for recovery.

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -46,10 +46,12 @@ union __wt_lsn {
  */
 #define	WT_IS_INIT_LSN(l)	((l)->file_offset == ((uint64_t)1 << 32))
 /*
- * XXX Original tested INT32_MAX.
+ * Original tested INT32_MAX.  But if we read one from an older
+ * release we may see UINT32_MAX.
  */
 #define	WT_IS_MAX_LSN(lsn)						\
-	((lsn)->l.file == UINT32_MAX && (lsn)->l.offset == INT32_MAX)
+	((lsn)->l.file == UINT32_MAX &&					\
+	 ((lsn)->l.offset == INT32_MAX || (lsn)->l.offset == UINT32_MAX))
 
 /*
  * Both of the macros below need to change if the content of __wt_lsn


### PR DESCRIPTION
@michaelcahill Please review this change for the reported bug when running recovery with a database that contained an old INIT_LSN in the metadata.