### PR TITLE
WT-2542: fixed-length column store reconciliation overwrites original values

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -952,8 +952,7 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 			__dmsg(ds, "\tvalue {deleted}\n");
 		else if (hexbyte) {
 			__dmsg(ds, "\t{");
-			__debug_hex_byte(ds,
-			    ((uint8_t *)WT_UPDATE_DATA(upd))[0]);
+			__debug_hex_byte(ds, *(uint8_t *)WT_UPDATE_DATA(upd));
 			__dmsg(ds, "}\n");
 		} else
 			__debug_item(ds,

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -46,7 +46,7 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 		}
 
 		/* Take the value from the original page. */
-		v = __bit_getv_recno(page, cbt->iface.recno, btree->bitcnt);
+		v = __bit_getv_recno(page, cursor->recno, btree->bitcnt);
 		return (__wt_buf_set(session, &cursor->value, &v, 1));
 	case WT_PAGE_COL_VAR:
 		/*

--- a/src/include/bitstring.i
+++ b/src/include/bitstring.i
@@ -305,13 +305,3 @@ __bit_setv(uint8_t *bitf, uint64_t entry, uint8_t width, uint8_t value)
 	__BIT_SET(1, 0x01);
 	}
 }
-
-/*
- * __bit_setv_recno --
- *	Set a record number's bit-field value.
- */
-static inline void
-__bit_setv_recno(WT_PAGE *page, uint64_t recno, uint8_t width, uint8_t value)
-{
-	__bit_setv(page->pg_fix_bitf, recno - page->pg_fix_recno, width, value);
-}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3964,17 +3964,18 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	WT_RET(__rec_split_init(
 	    session, r, page, page->pg_fix_recno, btree->maxleafpage));
 
+	/* Copy the original, disk-image bytes into place. */
+	memcpy(r->first_free, page->pg_fix_bitf,
+	    __bitstr_size((size_t)page->pg_fix_entries * btree->bitcnt));
+
 	/* Update any changes to the original on-page data items. */
 	WT_SKIP_FOREACH(ins, WT_COL_UPDATE_SINGLE(page)) {
 		WT_RET(__rec_txn_read(session, r, ins, NULL, NULL, &upd));
 		if (upd != NULL)
-			__bit_setv_recno(page, WT_INSERT_RECNO(ins),
-			    btree->bitcnt, ((uint8_t *)WT_UPDATE_DATA(upd))[0]);
+			__bit_setv(r->first_free,
+			    WT_INSERT_RECNO(ins) - page->pg_fix_recno,
+			    btree->bitcnt, *(uint8_t *)WT_UPDATE_DATA(upd));
 	}
-
-	/* Copy the updated, disk-image bytes into place. */
-	memcpy(r->first_free, page->pg_fix_bitf,
-	    __bitstr_size((size_t)page->pg_fix_entries * btree->bitcnt));
 
 	/* Calculate the number of entries per page remainder. */
 	entry = page->pg_fix_entries;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -4033,7 +4033,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 			if (nrecs > 0) {
 				__bit_setv(r->first_free, entry, btree->bitcnt,
 				    upd == NULL ? 0 :
-				    ((uint8_t *)WT_UPDATE_DATA(upd))[0]);
+				    *(uint8_t *)WT_UPDATE_DATA(upd));
 				--nrecs;
 				++entry;
 				++r->recno;


### PR DESCRIPTION
@agorrod, @michaelcahill, this is the one I've been chasing in WT-2535.

The problem is fixed-length column-store  reconciliation was updating the original page any time a transaction was globally visible, and that gets snapshot isolation wrong because earlier readers in the system subsequently see the wrong value.

The only interesting commit is 93059b7, ready for review/merge.