### PR TITLE
WT-2453 Evict server decides whether or not to evict.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -179,6 +179,7 @@ connection_stats = [
     CacheStat('cache_eviction_queue_empty', 'eviction server candidate queue empty when topping up'),
     CacheStat('cache_eviction_queue_not_empty', 'eviction server candidate queue not empty when topping up'),
     CacheStat('cache_eviction_server_evicting', 'eviction server evicting pages'),
+    CacheStat('cache_eviction_server_not_evicting', 'eviction server not evicting pages'),
     CacheStat('cache_eviction_server_toobig', 'eviction server skipped very large page'),
     CacheStat('cache_eviction_slow', 'eviction server unable to reach eviction goal'),
     CacheStat('cache_eviction_split_internal', 'internal pages split during eviction'),

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -899,6 +899,36 @@ __evict_lru_pages(WT_SESSION_IMPL *session, bool is_server)
 {
 	WT_DECL_RET;
 
+	/* If this is the server, compute the ratio of occurrences
+	 * when the eviction queue is not empty vs when it is empty.
+	 * The probability of the eviction server evicting is proportional
+	 * to that ratio. If the queue is often not empty, it is a sign that
+	 * eviction workers are not keeping up with the work. In that case,
+	 * the ratio will be high and the eviction server will help evict.
+	 */
+	if(is_server && S2C(session)->evict_workers > 1)
+	{
+		double ratio, rand;
+		double q_empty, q_not_empty;
+
+		q_empty = (double) WT_STAT_READ(S2C(session)->stats,
+				       cache_eviction_queue_empty);
+		q_not_empty = (double) WT_STAT_READ(S2C(session)->stats,
+				       cache_eviction_queue_not_empty);
+		if(q_empty == 0)
+			ratio = 1;
+		else
+			ratio = q_not_empty / q_empty;
+
+		rand = (double)((__wt_random(&session->rnd) % 100))/100;
+
+		if(rand > ratio) {
+			WT_STAT_FAST_CONN_INCR(
+				session,
+				cache_eviction_server_not_evicting);
+			return (ret);
+		}
+	}
 	/*
 	 * Reconcile and discard some pages: EBUSY is returned if a page fails
 	 * eviction because it's unavailable, continue in that case.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -906,7 +906,7 @@ __evict_lru_pages(WT_SESSION_IMPL *session, bool is_server)
 	 * eviction workers are not keeping up with the work. In that case,
 	 * the ratio will be high and the eviction server will help evict.
 	 */
-	if(is_server && S2C(session)->evict_workers > 1)
+	if (is_server && S2C(session)->evict_workers > 1)
 	{
 		double ratio, rand;
 		double q_empty, q_not_empty;
@@ -915,14 +915,14 @@ __evict_lru_pages(WT_SESSION_IMPL *session, bool is_server)
 				       cache_eviction_queue_empty);
 		q_not_empty = (double) WT_STAT_READ(S2C(session)->stats,
 				       cache_eviction_queue_not_empty);
-		if(q_empty == 0)
+		if (q_empty == 0)
 			ratio = 1;
 		else
 			ratio = q_not_empty / q_empty;
 
 		rand = (double)((__wt_random(&session->rnd) % 100))/100;
 
-		if(rand > ratio) {
+		if (rand > ratio) {
 			WT_STAT_FAST_CONN_INCR(
 				session,
 				cache_eviction_server_not_evicting);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -268,6 +268,7 @@ struct __wt_connection_stats {
 	int64_t cache_eviction_queue_empty;
 	int64_t cache_eviction_queue_not_empty;
 	int64_t cache_eviction_server_evicting;
+	int64_t cache_eviction_server_not_evicting;
 	int64_t cache_eviction_server_toobig;
 	int64_t cache_eviction_slow;
 	int64_t cache_eviction_worker_evicting;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3788,265 +3788,267 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1039
 /*! cache: eviction server evicting pages */
 #define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1040
+/*! cache: eviction server not evicting pages */
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_NOT_EVICTING	1041
 /*! cache: eviction server skipped very large page */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_TOOBIG	1041
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_TOOBIG	1042
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1042
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1043
 /*! cache: eviction worker thread evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1043
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1044
 /*! cache: failed eviction of pages that exceeded the in-memory maximum */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1044
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1045
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1045
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1046
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1046
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1047
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1047
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1048
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1048
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1049
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1049
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1050
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1050
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1051
 /*! cache: lookaside table insert calls */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_INSERT		1051
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_INSERT		1052
 /*! cache: lookaside table remove calls */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1052
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1053
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1053
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1054
 /*! cache: maximum page size at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1054
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1055
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1055
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1056
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1056
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1057
 /*! cache: page written requiring lookaside records */
-#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1057
+#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1058
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1058
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1059
 /*! cache: pages evicted because they exceeded the in-memory maximum */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1059
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1060
 /*! cache: pages evicted because they had chains of deleted items */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1060
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1061
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1061
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1062
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1062
+#define	WT_STAT_CONN_CACHE_READ				1063
 /*! cache: pages read into cache requiring lookaside entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1063
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1064
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1064
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1065
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1065
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1066
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1066
+#define	WT_STAT_CONN_CACHE_WRITE			1067
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1067
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1068
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1068
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1069
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1069
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1070
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1070
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1071
 /*! cache: tracked bytes belonging to overflow pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OVERFLOW		1071
+#define	WT_STAT_CONN_CACHE_BYTES_OVERFLOW		1072
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1072
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1073
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1073
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1074
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1074
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1075
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1075
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1076
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1076
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1077
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1077
+#define	WT_STAT_CONN_FILE_OPEN				1078
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1078
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1079
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1079
+#define	WT_STAT_CONN_MEMORY_FREE			1080
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1080
+#define	WT_STAT_CONN_MEMORY_GROW			1081
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1081
+#define	WT_STAT_CONN_COND_WAIT				1082
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1082
+#define	WT_STAT_CONN_RWLOCK_READ			1083
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1083
+#define	WT_STAT_CONN_RWLOCK_WRITE			1084
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1084
+#define	WT_STAT_CONN_READ_IO				1085
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1085
+#define	WT_STAT_CONN_WRITE_IO				1086
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1086
+#define	WT_STAT_CONN_CURSOR_CREATE			1087
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1087
+#define	WT_STAT_CONN_CURSOR_INSERT			1088
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1088
+#define	WT_STAT_CONN_CURSOR_NEXT			1089
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1089
+#define	WT_STAT_CONN_CURSOR_PREV			1090
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1090
+#define	WT_STAT_CONN_CURSOR_REMOVE			1091
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1091
+#define	WT_STAT_CONN_CURSOR_RESET			1092
 /*! cursor: cursor restarted searches */
-#define	WT_STAT_CONN_CURSOR_RESTART			1092
+#define	WT_STAT_CONN_CURSOR_RESTART			1093
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1093
+#define	WT_STAT_CONN_CURSOR_SEARCH			1094
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1094
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1095
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1095
+#define	WT_STAT_CONN_CURSOR_UPDATE			1096
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1096
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1097
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1097
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1098
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1098
+#define	WT_STAT_CONN_DH_SWEEP_REF			1099
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1099
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1100
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1100
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1101
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1101
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1102
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1102
+#define	WT_STAT_CONN_DH_SWEEPS				1103
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1103
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1104
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1104
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1105
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1105
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1106
 /*! log: consolidated slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1106
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1107
 /*! log: consolidated slot join races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1107
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1108
 /*! log: consolidated slot join transitions */
-#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1108
+#define	WT_STAT_CONN_LOG_SLOT_TRANSITIONS		1109
 /*! log: consolidated slot joins */
-#define	WT_STAT_CONN_LOG_SLOT_JOINS			1109
+#define	WT_STAT_CONN_LOG_SLOT_JOINS			1110
 /*! log: consolidated slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1110
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1111
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1111
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1112
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1112
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1113
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1113
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1114
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1114
+#define	WT_STAT_CONN_LOG_FLUSH				1115
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1115
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1116
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1116
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1117
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1117
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1118
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1118
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1119
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1119
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1120
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1120
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1121
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1121
+#define	WT_STAT_CONN_LOG_SCANS				1122
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1122
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1123
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1123
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1124
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1124
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1125
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1125
+#define	WT_STAT_CONN_LOG_SYNC				1126
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1126
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1127
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1127
+#define	WT_STAT_CONN_LOG_WRITES				1128
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1128
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1129
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1129
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1130
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1130
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1131
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1131
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1132
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1132
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1133
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1133
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1134
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1134
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1135
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1135
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1136
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1136
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1137
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1137
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1138
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1138
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1139
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1139
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1140
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1140
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1141
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1141
+#define	WT_STAT_CONN_REC_PAGES				1142
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1142
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1143
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1143
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1144
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1144
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1145
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1145
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1146
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1146
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1147
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1147
+#define	WT_STAT_CONN_SESSION_OPEN			1148
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1148
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1149
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1149
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1150
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1150
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1151
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1151
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1152
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1152
+#define	WT_STAT_CONN_PAGE_SLEEP				1153
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1153
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1154
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1154
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1155
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1155
+#define	WT_STAT_CONN_TXN_BEGIN				1156
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1156
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1157
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1157
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1158
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1158
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1159
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1159
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1160
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1160
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1161
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1161
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1162
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1162
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1163
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1163
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1164
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1164
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1165
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1165
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1166
 /*! transaction: transaction range of IDs currently pinned by named
  * snapshots */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1166
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1167
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1167
+#define	WT_STAT_CONN_TXN_SYNC				1168
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1168
+#define	WT_STAT_CONN_TXN_COMMIT				1169
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1169
+#define	WT_STAT_CONN_TXN_ROLLBACK			1170
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -550,6 +550,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: eviction server candidate queue empty when topping up",
 	"cache: eviction server candidate queue not empty when topping up",
 	"cache: eviction server evicting pages",
+	"cache: eviction server not evicting pages",
 	"cache: eviction server skipped very large page",
 	"cache: eviction server unable to reach eviction goal",
 	"cache: eviction worker thread evicting pages",
@@ -750,6 +751,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cache_eviction_queue_empty = 0;
 	stats->cache_eviction_queue_not_empty = 0;
 	stats->cache_eviction_server_evicting = 0;
+	stats->cache_eviction_server_not_evicting = 0;
 	stats->cache_eviction_server_toobig = 0;
 	stats->cache_eviction_slow = 0;
 	stats->cache_eviction_worker_evicting = 0;
@@ -948,6 +950,8 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, cache_eviction_queue_not_empty);
 	to->cache_eviction_server_evicting +=
 	    WT_STAT_READ(from, cache_eviction_server_evicting);
+	to->cache_eviction_server_not_evicting +=
+	    WT_STAT_READ(from, cache_eviction_server_not_evicting);
 	to->cache_eviction_server_toobig +=
 	    WT_STAT_READ(from, cache_eviction_server_toobig);
 	to->cache_eviction_slow += WT_STAT_READ(from, cache_eviction_slow);


### PR DESCRIPTION
@sueloverso: take a look at this change. The evict server probabilistically decides whether or not to evict based on the evict queue empty / not empty statistics. This gives me up to 40% performance improvements relative to wt-2453 in my tests. I have not yet had a chance to investigate whether we can do any better: wanted to run this by you first. Do you see any performance regressions from this change in your tests? 
