### PR TITLE
SERVER-23622 Allow eviction to consider pages from files being checkpointed

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1143,11 +1143,10 @@ retry:	while (slot < max_entries && ret == 0) {
 			continue;
 
 		/*
-		 * Also skip files that are checkpointing or configured to
-		 * stick in cache until we get aggressive.
+		 * Also skip files that are configured to stick in cache until
+		 * we get aggressive.
 		 */
-		if ((btree->checkpointing != WT_CKPT_OFF ||
-		    btree->evict_priority != 0) &&
+		if (btree->evict_priority != 0 &&
 		    !FLD_ISSET(cache->state, WT_EVICT_PASS_AGGRESSIVE))
 			continue;
 


### PR DESCRIPTION
Otherwise eviction will never queue clean pages from files while they
are being checkpointed. This causes problems in some MongoDB workloads.
In particular workloads where the oplog is generating most of the
work in a checkpoint, and is the major source of read pressure
(i.e: clean pages) in the cache.