### PR TITLE
WT-2558 WT_PAGE structure reorganization

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -168,8 +168,8 @@ __cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp)
 			return (false);
 
 		/*
-		 * Updates aren't stored on the page, an update would have
-		 * appeared as an "insert" object; no further checks to do.
+		 * An update would have appeared as an "insert" object; no
+		 * further checks to do.
 		 */
 		break;
 	case BTREE_COL_VAR:
@@ -179,19 +179,18 @@ __cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp)
 		WT_ASSERT(session, cbt->slot < page->pg_var_entries);
 
 		/*
-		 * Column-store updates aren't stored on the page, instead they
-		 * are stored as "insert" objects. If search returned an insert
-		 * object we can't return, the returned on-page object must be
-		 * checked for a match.
+		 * Column-store updates are stored as "insert" objects. If
+		 * search returned an insert object we can't return, the
+		 * returned on-page object must be checked for a match.
 		 */
 		if (cbt->ins != NULL && !F_ISSET(cbt, WT_CBT_VAR_ONPAGE_MATCH))
 			return (false);
 
 		/*
-		 * Updates aren't stored on the page, an update would have
-		 * appeared as an "insert" object; however, variable-length
-		 * column store deletes are written into the backing store,
-		 * check the cell for a record already deleted when read.
+		 * Although updates would have appeared as an "insert" objects,
+		 * variable-length column store deletes are written into the
+		 * backing store; check the cell for a record already deleted
+		 * when read.
 		 */
 		cip = &page->pg_var_d[cbt->slot];
 		if ((cell = WT_COL_PTR(page, cip)) == NULL ||
@@ -211,9 +210,11 @@ __cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp)
 		if (cbt->ins != NULL)
 			return (false);
 
-		/* Updates are stored on the page, check for a delete. */
-		if (page->pg_row_upd != NULL && (upd = __wt_txn_read(
-		    session, page->pg_row_upd[cbt->slot])) != NULL) {
+		/* Check for an update. */
+		if (page->modify != NULL &&
+		    page->modify->mod_row_update != NULL &&
+		    (upd = __wt_txn_read(session,
+		    page->modify->mod_row_update[cbt->slot])) != NULL) {
 			if (WT_UPDATE_DELETED_ISSET(upd))
 				return (false);
 			if (updp != NULL)
@@ -596,9 +597,12 @@ __curfile_update_check(WT_CURSOR_BTREE *cbt)
 		return (0);
 	if (cbt->ins != NULL)
 		return (__wt_txn_update_check(session, cbt->ins->upd));
-	if (btree->type == BTREE_ROW && cbt->ref->page->pg_row_upd != NULL)
-		return (__wt_txn_update_check(
-		    session, cbt->ref->page->pg_row_upd[cbt->slot]));
+
+	if (btree->type == BTREE_ROW &&
+	    cbt->ref->page->modify != NULL &&
+	    cbt->ref->page->modify->mod_row_update != NULL)
+		return (__wt_txn_update_check(session,
+		    cbt->ref->page->modify->mod_row_update[cbt->slot]));
 	return (0);
 }
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -164,7 +164,7 @@ __cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp)
 		 * column-store pages don't have slots, but map one-to-one to
 		 * keys, check for retrieval past the end of the page.
 		 */
-		if (cbt->recno >= page->pg_fix_recno + page->pg_fix_entries)
+		if (cbt->recno >= cbt->ref->ref_recno + page->pg_fix_entries)
 			return (false);
 
 		/*

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -36,17 +36,17 @@ static int  __debug_config(WT_SESSION_IMPL *, WT_DBG *, const char *);
 static int  __debug_dsk_cell(WT_DBG *, const WT_PAGE_HEADER *);
 static void __debug_dsk_col_fix(WT_DBG *, const WT_PAGE_HEADER *);
 static void __debug_item(WT_DBG *, const char *, const void *, size_t);
-static int  __debug_page(WT_DBG *, WT_PAGE *, uint32_t);
-static void __debug_page_col_fix(WT_DBG *, WT_PAGE *);
+static int  __debug_page(WT_DBG *, WT_REF *, uint32_t);
+static void __debug_page_col_fix(WT_DBG *, WT_REF *);
 static int  __debug_page_col_int(WT_DBG *, WT_PAGE *, uint32_t);
-static int  __debug_page_col_var(WT_DBG *, WT_PAGE *);
-static int  __debug_page_metadata(WT_DBG *, WT_PAGE *);
+static int  __debug_page_col_var(WT_DBG *, WT_REF *);
+static int  __debug_page_metadata(WT_DBG *, WT_REF *);
 static int  __debug_page_row_int(WT_DBG *, WT_PAGE *, uint32_t);
 static int  __debug_page_row_leaf(WT_DBG *, WT_PAGE *);
 static void __debug_ref(WT_DBG *, WT_REF *);
 static void __debug_row_skip(WT_DBG *, WT_INSERT_HEAD *);
 static int  __debug_tree(
-	WT_SESSION_IMPL *, WT_BTREE *, WT_PAGE *, const char *, uint32_t);
+	WT_SESSION_IMPL *, WT_BTREE *, WT_REF *, const char *, uint32_t);
 static void __debug_update(WT_DBG *, WT_UPDATE *, bool);
 static void __dmsg(WT_DBG *, const char *, ...)
 	WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3)));
@@ -498,10 +498,10 @@ __wt_debug_tree_shape(
  */
 int
 __wt_debug_tree_all(
-    WT_SESSION_IMPL *session, WT_BTREE *btree, WT_PAGE *page, const char *ofile)
+    WT_SESSION_IMPL *session, WT_BTREE *btree, WT_REF *ref, const char *ofile)
 {
 	return (__debug_tree(session,
-	    btree, page, ofile, WT_DEBUG_TREE_LEAF | WT_DEBUG_TREE_WALK));
+	    btree, ref, ofile, WT_DEBUG_TREE_LEAF | WT_DEBUG_TREE_WALK));
 }
 
 /*
@@ -513,9 +513,9 @@ __wt_debug_tree_all(
  */
 int
 __wt_debug_tree(
-    WT_SESSION_IMPL *session, WT_BTREE *btree, WT_PAGE *page, const char *ofile)
+    WT_SESSION_IMPL *session, WT_BTREE *btree, WT_REF *ref, const char *ofile)
 {
-	return (__debug_tree(session, btree, page, ofile, WT_DEBUG_TREE_WALK));
+	return (__debug_tree(session, btree, ref, ofile, WT_DEBUG_TREE_WALK));
 }
 
 /*
@@ -523,7 +523,7 @@ __wt_debug_tree(
  *	Dump the in-memory information for a page.
  */
 int
-__wt_debug_page(WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile)
+__wt_debug_page(WT_SESSION_IMPL *session, WT_REF *ref, const char *ofile)
 {
 	WT_DBG *ds, _ds;
 	WT_DECL_RET;
@@ -533,7 +533,7 @@ __wt_debug_page(WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile)
 	ds = &_ds;
 	WT_RET(__debug_config(session, ds, ofile));
 
-	ret = __debug_page(ds, page, WT_DEBUG_TREE_LEAF);
+	ret = __debug_page(ds, ref, WT_DEBUG_TREE_LEAF);
 
 	__dmsg_wrapup(ds);
 
@@ -549,9 +549,8 @@ __wt_debug_page(WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile)
  *	in this function
  */
 static int
-__debug_tree(
-    WT_SESSION_IMPL *session, WT_BTREE *btree,
-    WT_PAGE *page, const char *ofile, uint32_t flags)
+__debug_tree(WT_SESSION_IMPL *session,
+    WT_BTREE *btree, WT_REF *ref, const char *ofile, uint32_t flags)
 {
 	WT_DBG *ds, _ds;
 	WT_DECL_RET;
@@ -560,10 +559,10 @@ __debug_tree(
 	WT_RET(__debug_config(session, ds, ofile));
 
 	/* A NULL page starts at the top of the tree -- it's a convenience. */
-	if (page == NULL)
-		page = btree->root.page;
+	if (ref == NULL)
+		ref = &btree->root;
 
-	WT_WITH_BTREE(session, btree, ret = __debug_page(ds, page, flags));
+	WT_WITH_BTREE(session, btree, ret = __debug_page(ds, ref, flags));
 
 	__dmsg_wrapup(ds);
 
@@ -575,7 +574,7 @@ __debug_tree(
  *	Dump the in-memory information for an in-memory page.
  */
 static int
-__debug_page(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
+__debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
 {
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
@@ -583,32 +582,32 @@ __debug_page(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 	session = ds->session;
 
 	/* Dump the page metadata. */
-	WT_WITH_PAGE_INDEX(session, ret = __debug_page_metadata(ds, page));
+	WT_WITH_PAGE_INDEX(session, ret = __debug_page_metadata(ds, ref));
 	WT_RET(ret);
 
 	/* Dump the page. */
-	switch (page->type) {
+	switch (ref->page->type) {
 	case WT_PAGE_COL_FIX:
 		if (LF_ISSET(WT_DEBUG_TREE_LEAF))
-			__debug_page_col_fix(ds, page);
+			__debug_page_col_fix(ds, ref);
 		break;
 	case WT_PAGE_COL_INT:
 		WT_WITH_PAGE_INDEX(session,
-		    ret = __debug_page_col_int(ds, page, flags));
+		    ret = __debug_page_col_int(ds, ref->page, flags));
 		WT_RET(ret);
 		break;
 	case WT_PAGE_COL_VAR:
 		if (LF_ISSET(WT_DEBUG_TREE_LEAF))
-			WT_RET(__debug_page_col_var(ds, page));
+			WT_RET(__debug_page_col_var(ds, ref));
 		break;
 	case WT_PAGE_ROW_INT:
 		WT_WITH_PAGE_INDEX(session,
-		    ret = __debug_page_row_int(ds, page, flags));
+		    ret = __debug_page_row_int(ds, ref->page, flags));
 		WT_RET(ret);
 		break;
 	case WT_PAGE_ROW_LEAF:
 		if (LF_ISSET(WT_DEBUG_TREE_LEAF))
-			WT_RET(__debug_page_row_leaf(ds, page));
+			WT_RET(__debug_page_row_leaf(ds, ref->page));
 		break;
 	WT_ILLEGAL_VALUE(session);
 	}
@@ -621,30 +620,32 @@ __debug_page(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
  *	Dump an in-memory page's metadata.
  */
 static int
-__debug_page_metadata(WT_DBG *ds, WT_PAGE *page)
+__debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 {
+	WT_PAGE *page;
 	WT_PAGE_INDEX *pindex;
 	WT_PAGE_MODIFY *mod;
 	WT_SESSION_IMPL *session;
 	uint32_t entries;
 
 	session = ds->session;
+	page = ref->page;
 	mod = page->modify;
 
 	__dmsg(ds, "%p", page);
 
 	switch (page->type) {
 	case WT_PAGE_COL_INT:
-		__dmsg(ds, " recno %" PRIu64, page->pg_intl_recno);
+		__dmsg(ds, " recno %" PRIu64, ref->ref_recno);
 		WT_INTL_INDEX_GET(session, page, pindex);
 		entries = pindex->entries;
 		break;
 	case WT_PAGE_COL_FIX:
-		__dmsg(ds, " recno %" PRIu64, page->pg_fix_recno);
+		__dmsg(ds, " recno %" PRIu64, ref->ref_recno);
 		entries = page->pg_fix_entries;
 		break;
 	case WT_PAGE_COL_VAR:
-		__dmsg(ds, " recno %" PRIu64, page->pg_var_recno);
+		__dmsg(ds, " recno %" PRIu64, ref->ref_recno);
 		entries = page->pg_var_entries;
 		break;
 	case WT_PAGE_ROW_INT:
@@ -707,10 +708,11 @@ __debug_page_metadata(WT_DBG *ds, WT_PAGE *page)
  *	Dump an in-memory WT_PAGE_COL_FIX page.
  */
 static void
-__debug_page_col_fix(WT_DBG *ds, WT_PAGE *page)
+__debug_page_col_fix(WT_DBG *ds, WT_REF *ref)
 {
 	WT_BTREE *btree;
 	WT_INSERT *ins;
+	WT_PAGE *page;
 	const WT_PAGE_HEADER *dsk;
 	WT_SESSION_IMPL *session;
 	uint64_t recno;
@@ -721,8 +723,9 @@ __debug_page_col_fix(WT_DBG *ds, WT_PAGE *page)
 
 	session = ds->session;
 	btree = S2BT(session);
+	page = ref->page;
 	dsk = page->dsk;
-	recno = page->pg_fix_recno;
+	recno = ref->ref_recno;
 
 	if (dsk != NULL) {
 		ins = WT_SKIP_FIRST(WT_COL_UPDATE_SINGLE(page));
@@ -767,7 +770,7 @@ __debug_page_col_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 	session = ds->session;
 
 	WT_INTL_FOREACH_BEGIN(session, page, ref) {
-		__dmsg(ds, "\trecno %" PRIu64 "\n", ref->key.recno);
+		__dmsg(ds, "\trecno %" PRIu64 "\n", ref->ref_recno);
 		__debug_ref(ds, ref);
 	} WT_INTL_FOREACH_END;
 
@@ -775,7 +778,7 @@ __debug_page_col_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 		WT_INTL_FOREACH_BEGIN(session, page, ref) {
 			if (ref->state == WT_REF_MEM) {
 				__dmsg(ds, "\n");
-				WT_RET(__debug_page(ds, ref->page, flags));
+				WT_RET(__debug_page(ds, ref, flags));
 			}
 		} WT_INTL_FOREACH_END;
 
@@ -787,18 +790,20 @@ __debug_page_col_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
  *	Dump an in-memory WT_PAGE_COL_VAR page.
  */
 static int
-__debug_page_col_var(WT_DBG *ds, WT_PAGE *page)
+__debug_page_col_var(WT_DBG *ds, WT_REF *ref)
 {
 	WT_CELL *cell;
 	WT_CELL_UNPACK *unpack, _unpack;
 	WT_COL *cip;
 	WT_INSERT_HEAD *update;
+	WT_PAGE *page;
 	uint64_t recno, rle;
 	uint32_t i;
 	char tag[64];
 
 	unpack = &_unpack;
-	recno = page->pg_var_recno;
+	page = ref->page;
+	recno = ref->ref_recno;
 
 	WT_COL_FOREACH(page, cip, i) {
 		if ((cell = WT_COL_PTR(page, cip)) == NULL) {
@@ -849,7 +854,7 @@ __debug_page_row_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 		WT_INTL_FOREACH_BEGIN(session, page, ref) {
 			if (ref->state == WT_REF_MEM) {
 				__dmsg(ds, "\n");
-				WT_RET(__debug_page(ds, ref->page, flags));
+				WT_RET(__debug_page(ds, ref, flags));
 			}
 		} WT_INTL_FOREACH_END;
 	return (0);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -288,10 +288,9 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * read-only or if the application never modifies the tree, we're not
 	 * able to do so.)
 	 */
-	if (btree->modified) {
-		WT_RET(__wt_page_modify_init(session, page));
+	WT_RET(__wt_page_modify_init(session, page));
+	if (btree->modified)
 		__wt_page_modify_set(session, page);
-	}
 
 	/*
 	 * An operation is accessing a "deleted" page, and we're building an
@@ -326,7 +325,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	/* Allocate the per-page update array. */
 	WT_ERR(__wt_calloc_def(session, page->pg_row_entries, &upd_array));
-	page->pg_row_upd = upd_array;
+	page->modify->mod_row_update = upd_array;
 
 	/*
 	 * Fill in the per-reference update array with references to update

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -194,12 +194,12 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 			__free_skip_list(
 			    session, WT_SKIP_FIRST(append), update_ignore);
 			__wt_free(session, append);
-			__wt_free(session, mod->mod_append);
+			__wt_free(session, mod->mod_col_append);
 		}
 
 		/* Free the insert/update array. */
-		if (mod->mod_update != NULL)
-			__free_skip_array(session, mod->mod_update,
+		if (mod->mod_col_update != NULL)
+			__free_skip_array(session, mod->mod_col_update,
 			    page->type ==
 			    WT_PAGE_COL_FIX ? 1 : page->pg_var_entries,
 			    update_ignore);

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -204,6 +204,23 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 			    WT_PAGE_COL_FIX ? 1 : page->pg_var_entries,
 			    update_ignore);
 		break;
+	case WT_PAGE_ROW_LEAF:
+		/*
+		 * Free the insert array.
+		 *
+		 * Row-store tables have one additional slot in the insert array
+		 * (the insert array has an extra slot to hold keys that sort
+		 * before keys found on the original page).
+		 */
+		if (mod->mod_row_insert != NULL)
+			__free_skip_array(session, mod->mod_row_insert,
+			    page->pg_row_entries + 1, update_ignore);
+
+		/* Free the update array. */
+		if (mod->mod_row_update != NULL)
+			__free_update(session, mod->mod_row_update,
+			    page->pg_row_entries, update_ignore);
+		break;
 	}
 
 	/* Free the overflow on-page, reuse and transaction-cache skiplists. */
@@ -324,10 +341,6 @@ __free_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 	WT_ROW *rip;
 	uint32_t i;
 	void *copy;
-	bool update_ignore;
-
-	/* In some failed-split cases, we can't discard updates. */
-	update_ignore = F_ISSET_ATOMIC(page, WT_PAGE_UPDATE_IGNORE);
 
 	/*
 	 * Free the in-memory index array.
@@ -342,22 +355,6 @@ __free_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 		    page, copy, &ikey, NULL, NULL, NULL);
 		__wt_free(session, ikey);
 	}
-
-	/*
-	 * Free the insert array.
-	 *
-	 * Row-store tables have one additional slot in the insert array (the
-	 * insert array has an extra slot to hold keys that sort before keys
-	 * found on the original page).
-	 */
-	if (page->pg_row_ins != NULL)
-		__free_skip_array(session,
-		    page->pg_row_ins, page->pg_row_entries + 1, update_ignore);
-
-	/* Free the update array. */
-	if (page->pg_row_upd != NULL)
-		__free_update(session,
-		    page->pg_row_upd, page->pg_row_entries, update_ignore);
 }
 
 /*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -377,9 +377,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	if (addr == NULL) {
 		WT_ASSERT(session, previous_state == WT_REF_DELETED);
 
-		WT_ERR(__wt_btree_new_leaf_page(session,
-		    btree->type == BTREE_ROW ? WT_RECNO_OOB : ref->key.recno,
-		    &page));
+		WT_ERR(__wt_btree_new_leaf_page(session, &page));
 		ref->page = page;
 		goto done;
 	}

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -90,7 +90,7 @@ __rebalance_leaf_append(WT_SESSION_IMPL *session,
 	if (recno == WT_RECNO_OOB)
 		WT_RET(__wt_row_ikey(session, 0, key, key_len, copy));
 	else
-		copy->key.recno = recno;
+		copy->ref_recno = recno;
 
 	copy->page_del = NULL;
 	return (0);
@@ -147,8 +147,7 @@ __rebalance_internal(WT_SESSION_IMPL *session, WT_REBALANCE_STUFF *rs)
 	leaf_next = (uint32_t)rs->leaf_next;
 
 	/* Allocate a row-store root (internal) page and fill it in. */
-	WT_RET(__wt_page_alloc(session, rs->type,
-	    rs->type == WT_PAGE_COL_INT ? 1 : 0, leaf_next, false, &page));
+	WT_RET(__wt_page_alloc(session, rs->type, leaf_next, false, &page));
 	page->pg_intl_parent_ref = &btree->root;
 	WT_ERR(__wt_page_modify_init(session, page));
 	__wt_page_modify_set(session, page);

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -46,7 +46,7 @@ __wt_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 		}
 
 		/* Take the value from the original page. */
-		v = __bit_getv_recno(page, cursor->recno, btree->bitcnt);
+		v = __bit_getv_recno(cbt->ref, cursor->recno, btree->bitcnt);
 		return (__wt_buf_set(session, &cursor->value, &v, 1));
 	case WT_PAGE_COL_VAR:
 		/*

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -304,13 +304,13 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 		case WT_PAGE_COL_VAR:
 			WT_WITH_PAGE_INDEX(session,
 			    ret = __slvg_col_build_internal(
-			    session, leaf_cnt, ss));
+				session, leaf_cnt, ss));
 			WT_ERR(ret);
 			break;
 		case WT_PAGE_ROW_LEAF:
 			WT_WITH_PAGE_INDEX(session,
 			    ret = __slvg_row_build_internal(
-			    session, leaf_cnt, ss));
+			        session, leaf_cnt, ss));
 			WT_ERR(ret);
 			break;
 		}

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1520,7 +1520,7 @@ __split_multi_inmem(
 			/* Build a key. */
 			if (supd->ins == NULL) {
 				slot = WT_ROW_SLOT(orig, supd->rip);
-				upd = orig->pg_row_upd[slot];
+				upd = orig->modify->mod_row_update[slot];
 
 				WT_ERR(__wt_row_leaf_key(
 				    session, orig, supd->rip, key, false));
@@ -1583,7 +1583,7 @@ __split_multi_inmem_final(WT_PAGE *orig, WT_MULTI *multi)
 		case WT_PAGE_ROW_LEAF:
 			if (supd->ins == NULL) {
 				slot = WT_ROW_SLOT(orig, supd->rip);
-				orig->pg_row_upd[slot] = NULL;
+				orig->modify->mod_row_update[slot] = NULL;
 			} else
 				supd->ins->upd = NULL;
 			break;
@@ -1783,8 +1783,10 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	__wt_page_modify_set(session, right);
 
 	if (type == WT_PAGE_ROW_LEAF) {
-		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins));
-		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins[0]));
+		WT_ERR(__wt_calloc_one(
+		    session, &right->modify->mod_row_insert));
+		WT_ERR(__wt_calloc_one(
+		    session, &right->modify->mod_row_insert[0]));
 	} else {
 		WT_ERR(__wt_calloc_one(
 		    session, &right->modify->mod_col_append));
@@ -1840,7 +1842,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * can be ignored.)
 	 */
 	tmp_ins_head = type == WT_PAGE_ROW_LEAF ?
-	    right->pg_row_ins[0] : right->modify->mod_col_append[0];
+	    right->modify->mod_row_insert[0] : right->modify->mod_col_append[0];
 	tmp_ins_head->head[0] = tmp_ins_head->tail[0] = moved_ins;
 
 	/*
@@ -1975,8 +1977,8 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * lists have.
 	 */
 	if (type == WT_PAGE_ROW_LEAF)
-		right->pg_row_ins[0]->head[0] =
-		    right->pg_row_ins[0]->tail[0] = NULL;
+		right->modify->mod_row_insert[0]->head[0] =
+		    right->modify->mod_row_insert[0]->tail[0] = NULL;
 	else
 		right->modify->mod_col_append[0]->head[0] =
 		    right->modify->mod_col_append[0]->tail[0] = NULL;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -207,8 +207,8 @@ __split_verify_intl_key_order(WT_SESSION_IMPL *session, WT_PAGE *page)
 		WT_INTL_FOREACH_BEGIN(session, page, ref) {
 			WT_ASSERT(session, ref->home == page);
 
-			WT_ASSERT(session, ref->key.recno > recno);
-			recno = ref->key.recno;
+			WT_ASSERT(session, ref->ref_recno > recno);
+			recno = ref->ref_recno;
 		} WT_INTL_FOREACH_END;
 		break;
 	case WT_PAGE_ROW_INT:
@@ -335,7 +335,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 		if ((ikey = __wt_ref_key_instantiated(ref)) == NULL) {
 			__wt_ref_key(from_home, ref, &key, &size);
 			WT_RET(__wt_row_ikey(session, 0, key, size, ref));
-			ikey = ref->key.ikey;
+			ikey = ref->ref_ikey;
 		} else {
 			WT_RET(
 			    __split_ovfl_key_cleanup(session, from_home, ref));
@@ -529,7 +529,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	WT_REF **child_refp, *ref, **root_refp;
 	WT_SPLIT_ERROR_PHASE complete;
 	size_t child_incr, root_decr, root_incr, size;
-	uint64_t recno, split_gen;
+	uint64_t split_gen;
 	uint32_t children, chunk, i, j, remain;
 	uint32_t slots;
 	void *p;
@@ -593,10 +593,8 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	    alloc_refp = alloc_index->index, i = 0; i < children; ++i) {
 		slots = i == children - 1 ? remain : chunk;
 
-		recno = root->type == WT_PAGE_COL_INT ?
-		    (*root_refp)->key.recno : WT_RECNO_OOB;
 		WT_ERR(__wt_page_alloc(
-		    session, root->type, recno, slots, false, &child));
+		    session, root->type, slots, false, &child));
 
 		/*
 		 * Initialize the page's child reference; we need a copy of the
@@ -611,7 +609,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 			WT_ERR(__wt_row_ikey(session, 0, p, size, ref));
 			root_incr += sizeof(WT_IKEY) + size;
 		} else
-			ref->key.recno = recno;
+			ref->ref_recno = (*root_refp)->ref_recno;
 		ref->state = WT_REF_MEM;
 
 		/* Initialize the child page. */
@@ -1013,7 +1011,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	WT_REF **child_refp, *page_ref, **page_refp, *ref;
 	WT_SPLIT_ERROR_PHASE complete;
 	size_t child_incr, page_decr, page_incr, parent_incr, size;
-	uint64_t recno, split_gen;
+	uint64_t split_gen;
 	uint32_t children, chunk, i, j, remain;
 	uint32_t slots;
 	void *p;
@@ -1098,10 +1096,8 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	for (alloc_refp = alloc_index->index + 1, i = 1; i < children; ++i) {
 		slots = i == children - 1 ? remain : chunk;
 
-		recno = page->type == WT_PAGE_COL_INT ?
-		    (*page_refp)->key.recno : WT_RECNO_OOB;
 		WT_ERR(__wt_page_alloc(
-		    session, page->type, recno, slots, false, &child));
+		    session, page->type, slots, false, &child));
 
 		/*
 		 * Initialize the page's child reference; we need a copy of the
@@ -1116,7 +1112,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 			WT_ERR(__wt_row_ikey(session, 0, p, size, ref));
 			parent_incr += sizeof(WT_IKEY) + size;
 		} else
-			ref->key.recno = recno;
+			ref->ref_recno = (*page_refp)->ref_recno;
 		ref->state = WT_REF_MEM;
 
 		/* Initialize the child page. */
@@ -1662,7 +1658,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		incr += sizeof(WT_IKEY) + ikey->size;
 		break;
 	default:
-		ref->key.recno = multi->key.recno;
+		ref->ref_recno = multi->key.recno;
 		break;
 	}
 
@@ -1772,17 +1768,12 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 		parent_incr += sizeof(WT_IKEY) + key->size;
 		__wt_scr_free(session, &key);
 	} else
-		child->key.recno = ref->key.recno;
+		child->ref_recno = ref->ref_recno;
 
 	/*
 	 * The second page in the split is a new WT_REF/page pair.
 	 */
-	if (type == WT_PAGE_ROW_LEAF)
-		WT_ERR(__wt_page_alloc(session,
-		    type, WT_RECNO_OOB, 0, false, &right));
-	else
-		WT_ERR(__wt_page_alloc(session,
-		    type, WT_INSERT_RECNO(moved_ins), 0, false, &right));
+	WT_ERR(__wt_page_alloc(session, type, 0, false, &right));
 
 	/*
 	 * The new page is dirty by definition, plus column-store splits update
@@ -1813,7 +1804,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 		    child));
 		parent_incr += sizeof(WT_IKEY) + WT_INSERT_KEY_SIZE(moved_ins);
 	} else
-		child->key.recno = WT_INSERT_RECNO(moved_ins);
+		child->ref_recno = WT_INSERT_RECNO(moved_ins);
 
 	/*
 	 * Allocation operations completed, we're going to split.
@@ -1823,7 +1814,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	if (type != WT_PAGE_ROW_LEAF) {
 		WT_ASSERT(session,
 		    page->modify->mod_split_recno == WT_RECNO_OOB);
-		page->modify->mod_split_recno = child->key.recno;
+		page->modify->mod_split_recno = child->ref_recno;
 	}
 
 	/*
@@ -1998,12 +1989,12 @@ err:	if (split_ref[0] != NULL) {
 		ref->addr = split_ref[0]->addr;
 
 		if (type == WT_PAGE_ROW_LEAF)
-			__wt_free(session, split_ref[0]->key.ikey);
+			__wt_free(session, split_ref[0]->ref_ikey);
 		__wt_free(session, split_ref[0]);
 	}
 	if (split_ref[1] != NULL) {
 		if (type == WT_PAGE_ROW_LEAF)
-			__wt_free(session, split_ref[1]->key.ikey);
+			__wt_free(session, split_ref[1]->ref_ikey);
 		__wt_free(session, split_ref[1]);
 	}
 	if (right != NULL) {

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1786,8 +1786,10 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins));
 		WT_ERR(__wt_calloc_one(session, &right->pg_row_ins[0]));
 	} else {
-		WT_ERR(__wt_calloc_one(session, &right->modify->mod_append));
-		WT_ERR(__wt_calloc_one(session, &right->modify->mod_append[0]));
+		WT_ERR(__wt_calloc_one(
+		    session, &right->modify->mod_col_append));
+		WT_ERR(__wt_calloc_one(
+		    session, &right->modify->mod_col_append[0]));
 	}
 	right_incr += sizeof(WT_INSERT_HEAD);
 	right_incr += sizeof(WT_INSERT_HEAD *);
@@ -1813,8 +1815,8 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 */
 	if (type != WT_PAGE_ROW_LEAF) {
 		WT_ASSERT(session,
-		    page->modify->mod_split_recno == WT_RECNO_OOB);
-		page->modify->mod_split_recno = child->ref_recno;
+		    page->modify->mod_col_split_recno == WT_RECNO_OOB);
+		page->modify->mod_col_split_recno = child->ref_recno;
 	}
 
 	/*
@@ -1838,7 +1840,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * can be ignored.)
 	 */
 	tmp_ins_head = type == WT_PAGE_ROW_LEAF ?
-	    right->pg_row_ins[0] : right->modify->mod_append[0];
+	    right->pg_row_ins[0] : right->modify->mod_col_append[0];
 	tmp_ins_head->head[0] = tmp_ins_head->tail[0] = moved_ins;
 
 	/*
@@ -1960,7 +1962,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * Reset the split column-store page record.
 	 */
 	if (type != WT_PAGE_ROW_LEAF)
-		page->modify->mod_split_recno = WT_RECNO_OOB;
+		page->modify->mod_col_split_recno = WT_RECNO_OOB;
 
 	/*
 	 * Clear the allocated page's reference to the moved insert list element
@@ -1976,8 +1978,8 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 		right->pg_row_ins[0]->head[0] =
 		    right->pg_row_ins[0]->tail[0] = NULL;
 	else
-		right->modify->mod_append[0]->head[0] =
-		    right->modify->mod_append[0]->tail[0] = NULL;
+		right->modify->mod_col_append[0]->head[0] =
+		    right->modify->mod_col_append[0]->tail[0] = NULL;
 
 	ins_head->tail[0]->next[0] = moved_ins;
 	ins_head->tail[0] = moved_ins;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -355,7 +355,7 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_VSTUFF *vs)
 	if (vs->dump_blocks)
 		WT_RET(__wt_debug_disk(session, page->dsk, NULL));
 	if (vs->dump_pages)
-		WT_RET(__wt_debug_page(session, page, NULL));
+		WT_RET(__wt_debug_page(session, ref, NULL));
 #endif
 
 	/*
@@ -364,13 +364,11 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_VSTUFF *vs)
 	 */
 	switch (page->type) {
 	case WT_PAGE_COL_FIX:
-		recno = page->pg_fix_recno;
-		goto recno_chk;
 	case WT_PAGE_COL_INT:
-		recno = page->pg_intl_recno;
+		recno = ref->ref_recno;
 		goto recno_chk;
 	case WT_PAGE_COL_VAR:
-		recno = page->pg_var_recno;
+		recno = ref->ref_recno;
 recno_chk:	if (recno != vs->record_total + 1)
 			WT_RET_MSG(session, WT_ERROR,
 			    "page at %s has a starting record of %" PRIu64
@@ -485,7 +483,7 @@ celltype_err:			WT_RET_MSG(session, WT_ERROR,
 			 * reviewed to this point.
 			 */
 			++entry;
-			if (child_ref->key.recno != vs->record_total + 1) {
+			if (child_ref->ref_recno != vs->record_total + 1) {
 				WT_RET_MSG(session, WT_ERROR,
 				    "the starting record number in entry %"
 				    PRIu32 " of the column internal page at "
@@ -494,7 +492,7 @@ celltype_err:			WT_RET_MSG(session, WT_ERROR,
 				    entry,
 				    __wt_page_addr_string(
 				    session, child_ref, vs->tmp1),
-				    child_ref->key.recno,
+				    child_ref->ref_recno,
 				    vs->record_total + 1);
 			}
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -108,17 +108,17 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		/* Allocate the append/update list reference as necessary. */
 		if (append) {
 			WT_PAGE_ALLOC_AND_SWAP(session,
-			    page, mod->mod_append, ins_headp, 1);
-			ins_headp = &mod->mod_append[0];
+			    page, mod->mod_col_append, ins_headp, 1);
+			ins_headp = &mod->mod_col_append[0];
 		} else if (page->type == WT_PAGE_COL_FIX) {
 			WT_PAGE_ALLOC_AND_SWAP(session,
-			    page, mod->mod_update, ins_headp, 1);
-			ins_headp = &mod->mod_update[0];
+			    page, mod->mod_col_update, ins_headp, 1);
+			ins_headp = &mod->mod_col_update[0];
 		} else {
 			WT_PAGE_ALLOC_AND_SWAP(session,
-			    page, mod->mod_update, ins_headp,
+			    page, mod->mod_col_update, ins_headp,
 			    page->pg_var_entries);
-			ins_headp = &mod->mod_update[cbt->slot];
+			ins_headp = &mod->mod_col_update[cbt->slot];
 		}
 
 		/* Allocate the WT_INSERT_HEAD structure as necessary. */
@@ -143,8 +143,9 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		 * it's easy (as opposed to in row-store) and a difficult bug to
 		 * otherwise diagnose.
 		 */
-		WT_ASSERT(session, mod->mod_split_recno == WT_RECNO_OOB ||
-		    (recno != WT_RECNO_OOB && mod->mod_split_recno > recno));
+		WT_ASSERT(session, mod->mod_col_split_recno == WT_RECNO_OOB ||
+		    (recno != WT_RECNO_OOB &&
+		    mod->mod_col_split_recno > recno));
 
 		if (upd_arg == NULL) {
 			WT_ERR(

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -55,7 +55,8 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		 */
 		if (recno == WT_RECNO_OOB ||
 		    recno > (btree->type == BTREE_COL_VAR ?
-		    __col_var_last_recno(page) : __col_fix_last_recno(page)))
+		    __col_var_last_recno(cbt->ref) :
+		    __col_fix_last_recno(cbt->ref)))
 			append = true;
 	}
 

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -30,7 +30,7 @@ __check_leaf_key_range(WT_SESSION_IMPL *session,
 	 * Check if the search key is smaller than the parent's starting key for
 	 * this page.
 	 */
-	if (recno < leaf->key.recno) {
+	if (recno < leaf->ref_recno) {
 		cbt->compare = 1;		/* page keys > search key */
 		return (0);
 	}
@@ -48,7 +48,7 @@ __check_leaf_key_range(WT_SESSION_IMPL *session,
 	WT_INTL_INDEX_GET(session, leaf->home, pindex);
 	indx = leaf->pindex_hint;
 	if (indx + 1 < pindex->entries && pindex->index[indx] == leaf)
-		if (recno >= pindex->index[indx + 1]->key.recno) {
+		if (recno >= pindex->index[indx + 1]->ref_recno) {
 			cbt->compare = -1;	/* page keys < search key */
 			return (0);
 		}
@@ -133,14 +133,12 @@ restart:	/*
 		if (page->type != WT_PAGE_COL_INT)
 			break;
 
-		WT_ASSERT(session, current->key.recno == page->pg_intl_recno);
-
 		WT_INTL_INDEX_GET(session, page, pindex);
 		base = pindex->entries;
 		descent = pindex->index[base - 1];
 
 		/* Fast path appends. */
-		if (recno >= descent->key.recno) {
+		if (recno >= descent->ref_recno) {
 			/*
 			 * If on the last slot (the key is larger than any key
 			 * on the page), check for an internal page split race.
@@ -158,9 +156,9 @@ restart:	/*
 			indx = base + (limit >> 1);
 			descent = pindex->index[indx];
 
-			if (recno == descent->key.recno)
+			if (recno == descent->ref_recno)
 				break;
-			if (recno < descent->key.recno)
+			if (recno < descent->ref_recno)
 				continue;
 			base = indx + 1;
 			--limit;
@@ -172,7 +170,7 @@ descend:	/*
 		 * (last + 1) index.  The slot for descent is the one before
 		 * base.
 		 */
-		if (recno != descent->key.recno) {
+		if (recno != descent->ref_recno) {
 			/*
 			 * We don't have to correct for base == 0 because the
 			 * only way for base to be 0 is if recno is the page's
@@ -237,13 +235,13 @@ leaf_only:
 	 * do in that case, the record may be appended to the page.
 	 */
 	if (page->type == WT_PAGE_COL_FIX) {
-		if (recno < page->pg_fix_recno) {
-			cbt->recno = page->pg_fix_recno;
+		if (recno < current->ref_recno) {
+			cbt->recno = current->ref_recno;
 			cbt->compare = 1;
 			return (0);
 		}
-		if (recno >= page->pg_fix_recno + page->pg_fix_entries) {
-			cbt->recno = page->pg_fix_recno + page->pg_fix_entries;
+		if (recno >= current->ref_recno + page->pg_fix_entries) {
+			cbt->recno = current->ref_recno + page->pg_fix_entries;
 			goto past_end;
 		} else {
 			cbt->recno = recno;
@@ -251,14 +249,14 @@ leaf_only:
 			ins_head = WT_COL_UPDATE_SINGLE(page);
 		}
 	} else {
-		if (recno < page->pg_var_recno) {
-			cbt->recno = page->pg_var_recno;
+		if (recno < current->ref_recno) {
+			cbt->recno = current->ref_recno;
 			cbt->slot = 0;
 			cbt->compare = 1;
 			return (0);
 		}
-		if ((cip = __col_var_search(page, recno, NULL)) == NULL) {
-			cbt->recno = __col_var_last_recno(page);
+		if ((cip = __col_var_search(current, recno, NULL)) == NULL) {
+			cbt->recno = __col_var_last_recno(current);
 			cbt->slot = page->pg_var_entries == 0 ?
 			    0 : page->pg_var_entries - 1;
 			goto past_end;

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -517,7 +517,7 @@ __wt_row_ikey(WT_SESSION_IMPL *session,
 	{
 	uintptr_t oldv;
 
-	oldv = (uintptr_t)ref->key.ikey;
+	oldv = (uintptr_t)ref->ref_ikey;
 	WT_DIAGNOSTIC_YIELD;
 
 	/*
@@ -527,10 +527,10 @@ __wt_row_ikey(WT_SESSION_IMPL *session,
 	WT_ASSERT(session, oldv == 0 || (oldv & WT_IK_FLAG) != 0);
 	WT_ASSERT(session, ref->state != WT_REF_SPLIT);
 	WT_ASSERT(session,
-	    __wt_atomic_cas_ptr(&ref->key.ikey, (WT_IKEY *)oldv, ikey));
+	    __wt_atomic_cas_ptr(&ref->ref_ikey, (WT_IKEY *)oldv, ikey));
 	}
 #else
-	ref->key.ikey = ikey;
+	ref->ref_ikey = ikey;
 #endif
 	return (0);
 }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -53,6 +53,7 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	WT_INSERT *ins;
 	WT_INSERT_HEAD *ins_head, **ins_headp;
 	WT_PAGE *page;
+	WT_PAGE_MODIFY *mod;
 	WT_UPDATE *old_upd, *upd, **upd_entry;
 	size_t ins_size, upd_size;
 	uint32_t ins_slot;
@@ -70,6 +71,7 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 
 	/* If we don't yet have a modify structure, we'll need one. */
 	WT_RET(__wt_page_modify_init(session, page));
+	mod = page->modify;
 
 	/*
 	 * Modify: allocate an update array as necessary, build a WT_UPDATE
@@ -83,11 +85,12 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	if (cbt->compare == 0) {
 		if (cbt->ins == NULL) {
 			/* Allocate an update array as necessary. */
-			WT_PAGE_ALLOC_AND_SWAP(session, page,
-			    page->pg_row_upd, upd_entry, page->pg_row_entries);
+			WT_PAGE_ALLOC_AND_SWAP(session,
+			    page, mod->mod_row_update,
+			    upd_entry, page->pg_row_entries);
 
 			/* Set the WT_UPDATE array reference. */
-			upd_entry = &page->pg_row_upd[cbt->slot];
+			upd_entry = &mod->mod_row_update[cbt->slot];
 		} else
 			upd_entry = &cbt->ins->upd;
 
@@ -144,11 +147,11 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 		 * slot.  That's hard, so we set a flag.
 		 */
 		WT_PAGE_ALLOC_AND_SWAP(session, page,
-		    page->pg_row_ins, ins_headp, page->pg_row_entries + 1);
+		    mod->mod_row_insert, ins_headp, page->pg_row_entries + 1);
 
 		ins_slot = F_ISSET(cbt, WT_CBT_SEARCH_SMALLEST) ?
 		    page->pg_row_entries: cbt->slot;
-		ins_headp = &page->pg_row_ins[ins_slot];
+		ins_headp = &mod->mod_row_insert[ins_slot];
 
 		/* Allocate the WT_INSERT_HEAD structure as necessary. */
 		WT_PAGE_ALLOC_AND_SWAP(session, page, *ins_headp, ins_head, 1);

--- a/src/include/bitstring.i
+++ b/src/include/bitstring.i
@@ -261,10 +261,10 @@ __bit_getv(uint8_t *bitf, uint64_t entry, uint8_t width)
  *	Return a record number's bit-field value.
  */
 static inline uint8_t
-__bit_getv_recno(WT_PAGE *page, uint64_t recno, uint8_t width)
+__bit_getv_recno(WT_REF *ref, uint64_t recno, uint8_t width)
 {
 	return (__bit_getv(
-	    page->pg_fix_bitf, recno - page->pg_fix_recno, width));
+	    ref->page->pg_fix_bitf, recno - ref->ref_recno, width));
 }
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -251,6 +251,7 @@ struct __wt_page_modify {
 	 */
 	union {
 	WT_ADDR	 replace;		/* Single, written replacement block */
+#undef	mod_replace
 #define	mod_replace	u1.replace
 
 	struct {			/* Multiple replacement blocks */
@@ -295,7 +296,9 @@ struct __wt_page_modify {
 	} *multi;
 	uint32_t multi_entries;		/* Multiple blocks element count */
 	} m;
+#undef	mod_multi
 #define	mod_multi		u1.m.multi
+#undef	mod_multi_entries
 #define	mod_multi_entries	u1.m.multi_entries
 	} u1;
 
@@ -318,6 +321,7 @@ struct __wt_page_modify {
 		 */
 		WT_PAGE *root_split;	/* Linked list of root split pages */
 	} intl;
+#undef	mod_root_split
 #define	mod_root_split		u2.intl.root_split
 	struct {
 		/*
@@ -344,10 +348,13 @@ struct __wt_page_modify {
 		 * write any implicitly created deleted records for the page.
 		 */
 		uint64_t split_recno;
-	} leaf;
-#define	mod_append		u2.leaf.append
-#define	mod_update		u2.leaf.update
-#define	mod_split_recno		u2.leaf.split_recno
+	} column_leaf;
+#undef	mod_col_append
+#define	mod_col_append		u2.column_leaf.append
+#undef	mod_col_update
+#define	mod_col_update		u2.column_leaf.update
+#undef	mod_col_split_recno
+#define	mod_col_split_recno	u2.column_leaf.split_recno
 	} u2;
 
 	/*
@@ -1023,8 +1030,9 @@ struct __wt_insert_head {
  * of pointers and the specific structure exist, else NULL.
  */
 #define	WT_COL_UPDATE_SLOT(page, slot)					\
-	((page)->modify == NULL || (page)->modify->mod_update == NULL ?	\
-	    NULL : (page)->modify->mod_update[slot])
+	((page)->modify == NULL ||					\
+	    (page)->modify->mod_col_update == NULL ?			\
+	    NULL : (page)->modify->mod_col_update[slot])
 #define	WT_COL_UPDATE(page, ip)						\
 	WT_COL_UPDATE_SLOT(page, WT_COL_SLOT(page, ip))
 
@@ -1040,8 +1048,9 @@ struct __wt_insert_head {
  * appends.
  */
 #define	WT_COL_APPEND(page)						\
-	((page)->modify != NULL && (page)->modify->mod_append != NULL ?	\
-	    (page)->modify->mod_append[0] : NULL)
+	((page)->modify != NULL &&					\
+	    (page)->modify->mod_col_append != NULL ?			\
+	    (page)->modify->mod_col_append[0] : NULL)
 
 /* WT_FIX_FOREACH walks fixed-length bit-fields on a disk page. */
 #define	WT_FIX_FOREACH(btree, dsk, v, i)				\

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -433,7 +433,6 @@ struct __wt_page {
 		 * doesn't read it multiple times).
 		 */
 		struct {
-			uint64_t recno;		/* Starting recno */
 			WT_REF	*parent_ref;	/* Parent reference */
 
 			struct __wt_page_index {
@@ -442,8 +441,7 @@ struct __wt_page {
 				WT_REF	**index;
 			} * volatile __index;	/* Collated children */
 		} intl;
-#undef	pg_intl_recno
-#define	pg_intl_recno			u.intl.recno
+#undef	pg_intl_parent_ref
 #define	pg_intl_parent_ref		u.intl.parent_ref
 
 	/*
@@ -509,13 +507,9 @@ struct __wt_page {
 
 		/* Fixed-length column-store leaf page. */
 		struct {
-			uint64_t recno;		/* Starting recno */
-
 			uint8_t	*bitf;		/* Values */
 			uint32_t entries;	/* Entries */
 		} col_fix;
-#undef	pg_fix_recno
-#define	pg_fix_recno	u.col_fix.recno
 #undef	pg_fix_bitf
 #define	pg_fix_bitf	u.col_fix.bitf
 #undef	pg_fix_entries
@@ -523,8 +517,6 @@ struct __wt_page {
 
 		/* Variable-length column-store leaf page. */
 		struct {
-			uint64_t recno;		/* Starting recno */
-
 			WT_COL *d;		/* Values */
 
 			/*
@@ -537,8 +529,6 @@ struct __wt_page {
 
 			uint32_t    entries;	/* Entries */
 		} col_var;
-#undef	pg_var_recno
-#define	pg_var_recno	u.col_var.recno
 #undef	pg_var_d
 #define	pg_var_d	u.col_var.d
 #undef	pg_var_repeats
@@ -732,6 +722,10 @@ struct __wt_ref {
 		uint64_t recno;		/* Column-store: starting recno */
 		void	*ikey;		/* Row-store: key */
 	} key;
+#undef	ref_recno
+#define	ref_recno	key.recno
+#undef	ref_ikey
+#define	ref_ikey	key.ikey
 
 	WT_PAGE_DELETED	*page_del;	/* Deleted on-disk page information */
 };

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -511,8 +511,8 @@ __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep)
 
 	/*
 	 * An internal page key is in one of two places: if we instantiated the
-	 * key (for example, when reading the page), WT_REF.key.ikey references
-	 * a WT_IKEY structure, otherwise WT_REF.key.ikey references an on-page
+	 * key (for example, when reading the page), WT_REF.ref_ikey references
+	 * a WT_IKEY structure, otherwise WT_REF.ref_ikey references an on-page
 	 * key offset/length pair.
 	 *
 	 * Now the magic: allocated memory must be aligned to store any standard
@@ -536,14 +536,14 @@ __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep)
 #define	WT_IK_DECODE_KEY_LEN(v)		((v) >> 32)
 #define	WT_IK_ENCODE_KEY_OFFSET(v)	((uintptr_t)(v) << 1)
 #define	WT_IK_DECODE_KEY_OFFSET(v)	(((v) & 0xFFFFFFFF) >> 1)
-	v = (uintptr_t)ref->key.ikey;
+	v = (uintptr_t)ref->ref_ikey;
 	if (v & WT_IK_FLAG) {
 		*(void **)keyp =
 		    WT_PAGE_REF_OFFSET(page, WT_IK_DECODE_KEY_OFFSET(v));
 		*sizep = WT_IK_DECODE_KEY_LEN(v);
 	} else {
-		*(void **)keyp = WT_IKEY_DATA(ref->key.ikey);
-		*sizep = ((WT_IKEY *)ref->key.ikey)->size;
+		*(void **)keyp = WT_IKEY_DATA(ref->ref_ikey);
+		*sizep = ((WT_IKEY *)ref->ref_ikey)->size;
 	}
 }
 
@@ -562,7 +562,7 @@ __wt_ref_key_onpage_set(WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK *unpack)
 	v = WT_IK_ENCODE_KEY_LEN(unpack->size) |
 	    WT_IK_ENCODE_KEY_OFFSET(WT_PAGE_DISK_OFFSET(page, unpack->data)) |
 	    WT_IK_FLAG;
-	ref->key.ikey = (void *)v;
+	ref->ref_ikey = (void *)v;
 }
 
 /*
@@ -577,8 +577,8 @@ __wt_ref_key_instantiated(WT_REF *ref)
 	/*
 	 * See the comment in __wt_ref_key for an explanation of the magic.
 	 */
-	v = (uintptr_t)ref->key.ikey;
-	return (v & WT_IK_FLAG ? NULL : ref->key.ikey);
+	v = (uintptr_t)ref->ref_ikey;
+	return (v & WT_IK_FLAG ? NULL : ref->ref_ikey);
 }
 
 /*
@@ -591,10 +591,10 @@ __wt_ref_key_clear(WT_REF *ref)
 	/*
 	 * The key union has 2 8B fields; this is equivalent to:
 	 *
-	 *	ref->key.recno = WT_RECNO_OOB;
-	 *	ref->key.ikey = NULL;
+	 *	ref->ref_recno = WT_RECNO_OOB;
+	 *	ref->ref_ikey = NULL;
 	 */
-	ref->key.recno = 0;
+	ref->ref_recno = 0;
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -118,9 +118,9 @@ extern int __wt_debug_offset_blind( WT_SESSION_IMPL *session, wt_off_t offset, c
 extern int __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size, uint32_t cksum, const char *ofile);
 extern int __wt_debug_disk( WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, const char *ofile);
 extern int __wt_debug_tree_shape( WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile);
-extern int __wt_debug_tree_all( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_PAGE *page, const char *ofile);
-extern int __wt_debug_tree( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_PAGE *page, const char *ofile);
-extern int __wt_debug_page(WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile);
+extern int __wt_debug_tree_all( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_REF *ref, const char *ofile);
+extern int __wt_debug_tree( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_REF *ref, const char *ofile);
+extern int __wt_debug_page(WT_SESSION_IMPL *session, WT_REF *ref, const char *ofile);
 extern int __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp);
 extern void __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref);
 extern bool __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all);
@@ -134,7 +134,7 @@ extern int __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[]);
 extern int __wt_btree_close(WT_SESSION_IMPL *session);
 extern void __wt_root_ref_init(WT_REF *root_ref, WT_PAGE *root, bool is_recno);
 extern int __wt_btree_tree_open( WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);
-extern int __wt_btree_new_leaf_page( WT_SESSION_IMPL *session, uint64_t recno, WT_PAGE **pagep);
+extern int __wt_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_PAGE **pagep);
 extern void __wt_btree_evictable(WT_SESSION_IMPL *session, bool on);
 extern int __wt_btree_huffman_open(WT_SESSION_IMPL *session);
 extern void __wt_btree_huffman_close(WT_SESSION_IMPL *session);
@@ -148,7 +148,7 @@ extern const char *__wt_buf_set_printable( WT_SESSION_IMPL *session, const void 
 extern int __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK *unpack, WT_ITEM *store);
 extern int __wt_ovfl_cache(WT_SESSION_IMPL *session, WT_PAGE *page, void *cookie, WT_CELL_UNPACK *vpack);
 extern int __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_CELL *cell);
-extern int __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint64_t recno, uint32_t alloc_entries, bool alloc_refs, WT_PAGE **pagep);
+extern int __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, bool alloc_refs, WT_PAGE **pagep);
 extern int __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, size_t memsize, uint32_t flags, WT_PAGE **pagep);
 extern int __wt_las_remove_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id, const uint8_t *addr, size_t addr_size);
 extern int

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -299,13 +299,13 @@ static int  __rec_cell_build_ovfl(WT_SESSION_IMPL *,
 		WT_RECONCILE *, WT_KV *, uint8_t, uint64_t);
 static int  __rec_cell_build_val(WT_SESSION_IMPL *,
 		WT_RECONCILE *, const void *, size_t, uint64_t);
-static int  __rec_col_fix(WT_SESSION_IMPL *, WT_RECONCILE *, WT_PAGE *);
+static int  __rec_col_fix(WT_SESSION_IMPL *, WT_RECONCILE *, WT_REF *);
 static int  __rec_col_fix_slvg(WT_SESSION_IMPL *,
-		WT_RECONCILE *, WT_PAGE *, WT_SALVAGE_COOKIE *);
-static int  __rec_col_int(WT_SESSION_IMPL *, WT_RECONCILE *, WT_PAGE *);
+		WT_RECONCILE *, WT_REF *, WT_SALVAGE_COOKIE *);
+static int  __rec_col_int(WT_SESSION_IMPL *, WT_RECONCILE *, WT_REF *);
 static int  __rec_col_merge(WT_SESSION_IMPL *, WT_RECONCILE *, WT_PAGE *);
 static int  __rec_col_var(WT_SESSION_IMPL *,
-		WT_RECONCILE *, WT_PAGE *, WT_SALVAGE_COOKIE *);
+		WT_RECONCILE *, WT_REF *, WT_SALVAGE_COOKIE *);
 static int  __rec_col_var_helper(WT_SESSION_IMPL *, WT_RECONCILE *,
 		WT_SALVAGE_COOKIE *, WT_ITEM *, bool, uint8_t, uint64_t);
 static int  __rec_destroy_session(WT_SESSION_IMPL *);
@@ -391,16 +391,16 @@ __wt_reconcile(WT_SESSION_IMPL *session,
 	switch (page->type) {
 	case WT_PAGE_COL_FIX:
 		if (salvage != NULL)
-			ret = __rec_col_fix_slvg(session, r, page, salvage);
+			ret = __rec_col_fix_slvg(session, r, ref, salvage);
 		else
-			ret = __rec_col_fix(session, r, page);
+			ret = __rec_col_fix(session, r, ref);
 		break;
 	case WT_PAGE_COL_INT:
 		WT_WITH_PAGE_INDEX(session,
-		    ret = __rec_col_int(session, r, page));
+		    ret = __rec_col_int(session, r, ref));
 		break;
 	case WT_PAGE_COL_VAR:
-		ret = __rec_col_var(session, r, page, salvage);
+		ret = __rec_col_var(session, r, ref, salvage);
 		break;
 	case WT_PAGE_ROW_INT:
 		WT_WITH_PAGE_INDEX(session,
@@ -630,12 +630,12 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 	 */
 	switch (page->type) {
 	case WT_PAGE_COL_INT:
-		WT_RET(__wt_page_alloc(session, WT_PAGE_COL_INT,
-		    1, mod->mod_multi_entries, false, &next));
+		WT_RET(__wt_page_alloc(session,
+		    WT_PAGE_COL_INT, mod->mod_multi_entries, false, &next));
 		break;
 	case WT_PAGE_ROW_INT:
-		WT_RET(__wt_page_alloc(session, WT_PAGE_ROW_INT,
-		    WT_RECNO_OOB, mod->mod_multi_entries, false, &next));
+		WT_RET(__wt_page_alloc(session,
+		    WT_PAGE_ROW_INT, mod->mod_multi_entries, false, &next));
 		break;
 	WT_ILLEGAL_VALUE(session);
 	}
@@ -3787,7 +3787,7 @@ __rec_vtype(WT_ADDR *addr)
  *	Reconcile a column-store internal page.
  */
 static int
-__rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
+__rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 {
 	WT_ADDR *addr;
 	WT_BTREE *btree;
@@ -3795,11 +3795,12 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	WT_CHILD_STATE state;
 	WT_DECL_RET;
 	WT_KV *val;
-	WT_PAGE *child;
+	WT_PAGE *child, *page;
 	WT_REF *ref;
 	bool hazard;
 
 	btree = S2BT(session);
+	page = pageref->page;
 	child = NULL;
 	hazard = false;
 
@@ -3807,12 +3808,12 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	vpack = &_vpack;
 
 	WT_RET(__rec_split_init(
-	    session, r, page, page->pg_intl_recno, btree->maxintlpage));
+	    session, r, page, pageref->ref_recno, btree->maxintlpage));
 
 	/* For each entry in the in-memory page... */
 	WT_INTL_FOREACH_BEGIN(session, page, ref) {
 		/* Update the starting record number in case we split. */
-		r->recno = ref->key.recno;
+		r->recno = ref->ref_recno;
 
 		/*
 		 * Modified child.
@@ -3886,7 +3887,7 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		} else
 			__rec_cell_build_addr(session, r,
 			    addr->addr, addr->size,
-			    __rec_vtype(addr), ref->key.recno);
+			    __rec_vtype(addr), ref->ref_recno);
 		WT_CHILD_RELEASE_ERR(session, hazard, ref);
 
 		/* Boundary: split or write the page. */
@@ -3951,18 +3952,20 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
  *	Reconcile a fixed-width, column-store leaf page.
  */
 static int
-__rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
+__rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 {
 	WT_BTREE *btree;
 	WT_INSERT *ins;
+	WT_PAGE *page;
 	WT_UPDATE *upd;
 	uint64_t recno;
 	uint32_t entry, nrecs;
 
 	btree = S2BT(session);
+	page = pageref->page;
 
 	WT_RET(__rec_split_init(
-	    session, r, page, page->pg_fix_recno, btree->maxleafpage));
+	    session, r, page, pageref->ref_recno, btree->maxleafpage));
 
 	/* Copy the original, disk-image bytes into place. */
 	memcpy(r->first_free, page->pg_fix_bitf,
@@ -3973,7 +3976,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		WT_RET(__rec_txn_read(session, r, ins, NULL, NULL, &upd));
 		if (upd != NULL)
 			__bit_setv(r->first_free,
-			    WT_INSERT_RECNO(ins) - page->pg_fix_recno,
+			    WT_INSERT_RECNO(ins) - pageref->ref_recno,
 			    btree->bitcnt, *(uint8_t *)WT_UPDATE_DATA(upd));
 	}
 
@@ -4077,13 +4080,15 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
  */
 static int
 __rec_col_fix_slvg(WT_SESSION_IMPL *session,
-    WT_RECONCILE *r, WT_PAGE *page, WT_SALVAGE_COOKIE *salvage)
+    WT_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
 	WT_BTREE *btree;
+	WT_PAGE *page;
 	uint64_t page_start, page_take;
 	uint32_t entry, nrecs;
 
 	btree = S2BT(session);
+	page = pageref->page;
 
 	/*
 	 * !!!
@@ -4098,7 +4103,7 @@ __rec_col_fix_slvg(WT_SESSION_IMPL *session,
 	 * don't want to have to retrofit the code later.
 	 */
 	WT_RET(__rec_split_init(
-	    session, r, page, page->pg_fix_recno, btree->maxleafpage));
+	    session, r, page, pageref->ref_recno, btree->maxleafpage));
 
 	/* We may not be taking all of the entries on the original page. */
 	page_take = salvage->take == 0 ? page->pg_fix_entries : salvage->take;
@@ -4221,7 +4226,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r,
  */
 static int
 __rec_col_var(WT_SESSION_IMPL *session,
-    WT_RECONCILE *r, WT_PAGE *page, WT_SALVAGE_COOKIE *salvage)
+    WT_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
 	enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
 	WT_BTREE *btree;
@@ -4232,6 +4237,7 @@ __rec_col_var(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	WT_INSERT *ins;
 	WT_ITEM *last;
+	WT_PAGE *page;
 	WT_UPDATE *upd;
 	uint64_t n, nrepeat, repeat_count, rle, skip, src_recno;
 	uint32_t i, size;
@@ -4239,6 +4245,7 @@ __rec_col_var(WT_SESSION_IMPL *session,
 	const void *data;
 
 	btree = S2BT(session);
+	page = pageref->page;
 	last = r->last;
 	vpack = &_vpack;
 
@@ -4248,7 +4255,7 @@ __rec_col_var(WT_SESSION_IMPL *session,
 	upd = NULL;
 
 	WT_RET(__rec_split_init(
-	    session, r, page, page->pg_var_recno, btree->maxleafpage));
+	    session, r, page, pageref->ref_recno, btree->maxleafpage));
 
 	/*
 	 * The salvage code may be calling us to reconcile a page where there

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -4006,7 +4006,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 			 * the last key on this page, we have to decrement it.
 			 */
 			if ((recno =
-			    page->modify->mod_split_recno) == WT_RECNO_OOB)
+			    page->modify->mod_col_split_recno) == WT_RECNO_OOB)
 				break;
 			recno -= 1;
 
@@ -4569,7 +4569,8 @@ compare:		/*
 			 * first key on the split page, that is, one larger than
 			 * the last key on this page, we have to decrement it.
 			 */
-			if ((n = page->modify->mod_split_recno) == WT_RECNO_OOB)
+			if ((n = page->
+			    modify->mod_col_split_recno) == WT_RECNO_OOB)
 				break;
 			WT_ASSERT(session, n >= src_recno);
 			n -= 1;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3431,7 +3431,7 @@ __rec_update_las(WT_SESSION_IMPL *session,
 		case WT_PAGE_ROW_LEAF:
 			if (list->ins == NULL) {
 				slot = WT_ROW_SLOT(page, list->rip);
-				upd = page->pg_row_upd[slot];
+				upd = page->modify->mod_row_update[slot];
 			} else
 				upd = list->ins->upd;
 			break;

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -159,7 +159,7 @@ int
 usage(void)
 {
 	(void)fprintf(stderr,
-	    "usage: %s [-v] [-r run] [-t fix|rle|var|row]\n", progname);
+	    "usage: %s [-v] [-r run] [-t fix|var|row]\n", progname);
 	return (EXIT_FAILURE);
 }
 


### PR DESCRIPTION
@agorrod, @michaelcahill, for your consideration, I thought it likely reducing the size of the `WT_PAGE` structure to 64B could help our malloc fragmentation. (The `WT_PAGE_MODIFY` structure remains at 104B.)

This one needs relatively careful review -- I'm happy to do that myself, this week, if you want the change.