### PR TITLE
WT-2557 Need to truncate logs before closing backup cursor.

### DIFF
--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -156,13 +156,13 @@ backup(void *arg)
 		if (ret != WT_NOTFOUND)
 			testutil_die(ret, "backup-cursor");
 
-		testutil_check(backup_cursor->close(backup_cursor));
-		testutil_check(pthread_rwlock_unlock(&g.backup_lock));
-
 		/* After an incremental backup, truncate the log files. */
 		if (incremental)
 			testutil_check(session->truncate(
 			    session, "log:", backup_cursor, NULL, NULL));
+
+		testutil_check(backup_cursor->close(backup_cursor));
+		testutil_check(pthread_rwlock_unlock(&g.backup_lock));
 
 		/*
 		 * If automatic log archival isn't configured, optionally do


### PR DESCRIPTION
@keithbostic Please review this change for the incremental log truncating log files.  The truncate/archive needs to be done before closing the backup cursor.  I should have caught this when I reviewed it yesterday.  It is the cause of the heap-use-after-free sanitizer failure.