### PR TITLE
WT-2568 Add a backward compatible constructor for PackInputStream.

### DIFF
--- a/lang/java/src/com/wiredtiger/db/PackInputStream.java
+++ b/lang/java/src/com/wiredtiger/db/PackInputStream.java
@@ -51,6 +51,17 @@ public class PackInputStream {
      * \param format A String that contains the WiredTiger format that
      *               defines the layout of this packed value.
      * \param value The raw bytes that back the stream.
+     */
+    public PackInputStream(String format, byte[] value) {
+        this(format, value, false, 0, value.length);
+    }
+
+    /**
+     * Constructor.
+     *
+     * \param format A String that contains the WiredTiger format that
+     *               defines the layout of this packed value.
+     * \param value The raw bytes that back the stream.
      * \param isRaw The stream is opened raw.
      */
     public PackInputStream(String format, byte[] value, boolean isRaw) {


### PR DESCRIPTION
This fixes java's PackTest (and potentially other code) that may have been affected by changing a constructor in WT-2550.

Aside: Apparently our pull request tester doesn't build java, and I didn't see it because I didn't rebuild from scratch when testing.
