### PR TITLE
WT-2569 __win_handle_read needs to call GetLastError()

### DIFF
--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -276,7 +276,7 @@ __win_handle_read(
 
 		if (!ReadFile(fh->filehandle, addr, chunk, &nr, &overlapped))
 			WT_RET_MSG(session,
-			    nr == 0 ? WT_ERROR : __wt_getlasterror(),
+			    __wt_getlasterror(),
 			    "%s: handle-read: ReadFile: failed to read %lu "
 			    "bytes at offset %" PRIuMAX,
 			    fh->name, chunk, (uintmax_t)offset);


### PR DESCRIPTION
When `ReadFile` returns an error on Windows, `nr` is always set to 0. Therefore we always return `WT_ERROR` instead of calling `GetLastError` and lose valuable error information.

*Tests*:
By injecting a fault via `SetLastError(ERROR_QUORUM_DISK_NOT_FOUND)` and some code modifications, we now get more useful information in the logs when `ReadFile` fails:

*Sample log*:
```
2016-04-20T16:57:22.786-0400 E STORAGE  [initandlisten] WiredTiger (-23914) [1461185842:786997][19764:140725103342688], txn-recover: journal/WiredTigerLog.0000000001 read error: failed to read 511102156800 bytes at offset 2105728: The quorum disk could not be located by the cluster service.
2016-04-20T16:57:22.797-0400 E STORAGE  [initandlisten] WiredTiger (-23914) [1461185842:797033][19764:140725103342688], txn-recover: Recovery failed: The quorum disk could not be located by the cluster service.
2016-04-20T16:57:22.802-0400 E STORAGE  [initandlisten] WiredTiger (-23914) [1461185842:802036][19764:140725103342688], file:WiredTiger.wt, connection: WiredTiger.wt read error: failed to read 511101112320 bytes at offset 16384: The quorum disk could not be located by the cluster service.
2016-04-20T16:57:22.807-0400 E STORAGE  [initandlisten] WiredTiger (-23914) [1461185842:807537][19764:140725103342688], file:WiredTiger.wt, connection: Final close of file:WiredTiger.wt failed: The quorum disk could not be located by the cluster service.
```