### PR TITLE
 WT-2574 Ensure test/format doesn't leak memory

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -627,8 +627,10 @@ config_single(const char *s, int perm)
 		 * Free the previous setting if a configuration has been
 		 * passed in twice.
 		 */
-		if (*cp->vstr != NULL)
+		if (*cp->vstr != NULL) {
 			free(*cp->vstr);
+			*cp->vstr = NULL;
+		}
 
 		if (strncmp(s, "checksum", strlen("checksum")) == 0) {
 			config_map_checksum(ep, &g.c_checksum_flag);

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -623,6 +623,13 @@ config_single(const char *s, int perm)
 			    exit(EXIT_FAILURE);
 		}
 
+		/*
+		 * Free the previous setting if a configuration has been
+		 * passed in twice.
+		 */
+		if (*cp->vstr != NULL)
+			free(*cp->vstr);
+
 		if (strncmp(s, "checksum", strlen("checksum")) == 0) {
 			config_map_checksum(ep, &g.c_checksum_flag);
 			*cp->vstr = strdup(ep);


### PR DESCRIPTION
It can if an option is specified in the configuration file and
the command line.