### PR TITLE
WT-2553 Fix implicit size_t conversion in test/format.

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -368,7 +368,7 @@ config_in_memory(void)
 static void
 config_in_memory_check(void)
 {
-	size_t cache;
+	uint32_t cache;
 
 	if (g.c_in_memory == 0)
 		return;


### PR DESCRIPTION
test/format/config.c:415:16: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]