### PR TITLE
WT-2579: in-memory configurations break debugging support

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -19,7 +19,7 @@ typedef struct {
 	 * When using the standard event handlers, the debugging output has to
 	 * do its own message handling because its output isn't line-oriented.
 	 */
-	WT_FSTREAM	*fs;			/* Output file stream */
+	FILE		*fp;
 	WT_ITEM		*msg;			/* Buffered message */
 
 	WT_ITEM		*tmp;			/* Temporary space */
@@ -97,8 +97,11 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile)
 	if (ofile == NULL)
 		return (__wt_scr_alloc(session, 512, &ds->msg));
 
-	return (__wt_fopen(session, ofile, WT_OPEN_CREATE,
-	    WT_STREAM_LINE_BUFFER | WT_STREAM_WRITE, &ds->fs));
+	if ((ds->fp = fopen(ofile, "w")) == NULL)
+		return (EIO);
+	__wt_stream_set_line_buffer(ds->fp);
+
+	return (0);
 }
 
 /*
@@ -127,7 +130,8 @@ __dmsg_wrapup(WT_DBG *ds)
 	}
 
 	/* Close any file we opened. */
-	(void)__wt_fclose(session, &ds->fs);
+	if (ds->fp != NULL)
+		(void)fclose(ds->fp);
 }
 
 /*
@@ -152,7 +156,7 @@ __dmsg(WT_DBG *ds, const char *fmt, ...)
 	 * the output chunk, and pass it to the event handler once we see a
 	 * terminating newline.
 	 */
-	if (ds->fs == NULL) {
+	if (ds->fp == NULL) {
 		msg = ds->msg;
 		for (;;) {
 			p = (char *)msg->mem + msg->size;
@@ -184,7 +188,7 @@ __dmsg(WT_DBG *ds, const char *fmt, ...)
 		}
 	} else {
 		va_start(ap, fmt);
-		(void)__wt_vfprintf(session, ds->fs, fmt, ap);
+		(void)vfprintf(ds->fp, fmt, ap);
 		va_end(ap);
 	}
 }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1779,9 +1779,9 @@ __wt_evict_priority_clear(WT_SESSION_IMPL *session)
 int
 __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 {
+	FILE *fp;
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle, *saved_dhandle;
-	WT_FSTREAM *fs;
 	WT_PAGE *page;
 	WT_REF *next_walk;
 	uint64_t dirty_bytes, dirty_pages, intl_bytes, intl_pages;
@@ -1793,13 +1793,12 @@ __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 	total_bytes = 0;
 
 	if (ofile == NULL)
-		fs = WT_STDERR(session);
-	else
-		WT_RET(__wt_fopen(session, ofile,
-		    WT_OPEN_CREATE, WT_STREAM_WRITE, &fs));
+		fp = stderr;
+	else if ((fp = fopen(ofile, "w")) == NULL)
+		return (EIO);
 
 	/* Note: odd string concatenation avoids spelling errors. */
-	(void)__wt_fprintf(session, fs, "==========\n" "cache dump\n");
+	(void)fprintf(fp, "==========\n" "cache dump\n");
 
 	saved_dhandle = session->dhandle;
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {
@@ -1838,24 +1837,22 @@ __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 		session->dhandle = NULL;
 
 		if (dhandle->checkpoint == NULL)
-			(void)__wt_fprintf(session, fs,
-			    "%s(<live>): \n", dhandle->name);
+			(void)fprintf(fp, "%s(<live>): \n", dhandle->name);
 		else
-			(void)__wt_fprintf(session, fs,
-			    "%s(checkpoint=%s): \n",
+			(void)fprintf(fp, "%s(checkpoint=%s): \n",
 			    dhandle->name, dhandle->checkpoint);
 		if (intl_pages != 0)
-			(void)__wt_fprintf(session, fs,
+			(void)fprintf(fp,
 			    "\t" "internal pages: %" PRIu64 " pages, %" PRIu64
 			    " max, %" PRIu64 "MB total\n",
 			    intl_pages, max_intl_bytes, intl_bytes >> 20);
 		if (leaf_pages != 0)
-			(void)__wt_fprintf(session, fs,
+			(void)fprintf(fp,
 			    "\t" "leaf pages: %" PRIu64 " pages, %" PRIu64
 			    " max, %" PRIu64 "MB total\n",
 			    leaf_pages, max_leaf_bytes, leaf_bytes >> 20);
 		if (dirty_pages != 0)
-			(void)__wt_fprintf(session, fs,
+			(void)fprintf(fp,
 			    "\t" "dirty pages: %" PRIu64 " pages, %" PRIu64
 			    " max, %" PRIu64 "MB total\n",
 			    dirty_pages, max_dirty_bytes, dirty_bytes >> 20);
@@ -1871,13 +1868,13 @@ __wt_cache_dump(WT_SESSION_IMPL *session, const char *ofile)
 	if (conn->cache->overhead_pct != 0)
 		total_bytes +=
 		    (total_bytes * (uint64_t)conn->cache->overhead_pct) / 100;
-	(void)__wt_fprintf(session, fs,
+	(void)fprintf(fp,
 	    "cache dump: total found = %" PRIu64
 	    "MB vs tracked inuse %" PRIu64 "MB\n",
 	    total_bytes >> 20, __wt_cache_bytes_inuse(conn->cache) >> 20);
-	(void)__wt_fprintf(session, fs, "==========\n");
-	if (ofile != NULL)
-		WT_RET(__wt_fclose(session, &fs));
+	(void)fprintf(fp, "==========\n");
+	if (ofile != NULL && fclose(fp) != 0)
+		return (EIO);
 	return (0);
 }
 #endif

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -139,9 +139,8 @@ struct __wt_fstream {
 	WT_ITEM  buf;				/* Data */
 
 #define	WT_STREAM_APPEND	0x01		/* Open a stream for append */
-#define	WT_STREAM_LINE_BUFFER	0x02		/* Line buffer the stream */
-#define	WT_STREAM_READ		0x04		/* Open a stream for read */
-#define	WT_STREAM_WRITE		0x08		/* Open a stream for write */
+#define	WT_STREAM_READ		0x02		/* Open a stream for read */
+#define	WT_STREAM_WRITE		0x04		/* Open a stream for write */
 	uint32_t flags;
 
 	int (*close)(WT_SESSION_IMPL *, WT_FSTREAM *);

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -148,8 +148,7 @@ __fstream_printf(
 		if (len < space) {
 			buf->size += len;
 
-			return (F_ISSET(fs, WT_STREAM_LINE_BUFFER) ||
-			    buf->size >= WT_STREAM_BUFSIZE ?
+			return (buf->size >= WT_STREAM_BUFSIZE ?
 			    __wt_fflush(session, fs) : 0);
 		}
 		WT_RET(__wt_buf_extend(session, buf, buf->size + len + 1));

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -206,7 +206,7 @@ __wt_fopen(WT_SESSION_IMPL *session,
 	*fsp = fs;
 	return (0);
 
-err:	__wt_close(session, &fh);
+err:	WT_TRET(__wt_close(session, &fh));
 	__wt_free(session, *fsp);
 	return (ret);
 }


### PR DESCRIPTION
@michaelcahill, @agorrod: I want to give up trying to run the debugging functions through the pluggable I/O functions, it's too hard.

This also removes the need for the `WT_STREAM_LINE_BUFFER` flag.