### PR TITLE
WT-2584: don't use periods in error messages

### DIFF
--- a/src/bloom/bloom.c
+++ b/src/bloom/bloom.c
@@ -295,7 +295,7 @@ __wt_bloom_hash_get(WT_BLOOM *bloom, WT_BLOOM_HASH *bhash)
 err:	/* Don't return WT_NOTFOUND from a failed search. */
 	if (ret == WT_NOTFOUND)
 		ret = WT_ERROR;
-	__wt_err(bloom->session, ret, "Failed lookup in bloom filter.");
+	__wt_err(bloom->session, ret, "Failed lookup in bloom filter");
 	return (ret);
 }
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1587,8 +1587,9 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 
 	if (conn->is_new) {
 		if (F_ISSET(conn, WT_CONN_READONLY))
-			WT_ERR_MSG(session, EINVAL, "Creating a new database is"
-			    " incompatible with read-only configuration.");
+			WT_ERR_MSG(session, EINVAL,
+			    "Creating a new database is incompatible with "
+			    "read-only configuration");
 		len = (size_t)snprintf(buf, sizeof(buf),
 		    "%s\n%s\n", WT_WIREDTIGER, WIREDTIGER_VERSION_STRING);
 		WT_ERR(__wt_write(session, fh, (wt_off_t)0, len, buf));

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -448,7 +448,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session,
 	if (WT_CURSOR_RECNO(cursor))
 		WT_ERR_MSG(session, WT_ERROR,
 		    "Column store indexes based on a record number primary "
-		    "key are not supported.");
+		    "key are not supported");
 
 	/* Handle projections. */
 	if (columns != NULL) {

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -479,7 +479,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
 	    lsm_rows_merged, insert_count % LSM_MERGE_CHECK_INTERVAL);
 	++lsm_tree->merge_progressing;
 	WT_ERR(__wt_verbose(session, WT_VERB_LSM,
-	    "Bloom size for %" PRIu64 " has %" PRIu64 " items inserted.",
+	    "Bloom size for %" PRIu64 " has %" PRIu64 " items inserted",
 	    record_count, insert_count));
 
 	/*

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -189,14 +189,15 @@ __wt_turtle_init(WT_SESSION_IMPL *session)
 		if (exist_incr)
 			WT_RET_MSG(session, EINVAL,
 			    "Incremental backup after running recovery "
-			    "is not allowed.");
+			    "is not allowed");
 		/*
 		 * If we have a backup file and metadata and turtle files,
 		 * we want to recreate the metadata from the backup.
 		 */
 		if (exist_backup) {
-			WT_RET(__wt_msg(session, "Both %s and %s exist. "
-			    "Recreating metadata from backup.",
+			WT_RET(__wt_msg(session,
+			    "Both %s and %s exist; recreating metadata from "
+			    "backup",
 			    WT_METADATA_TURTLE, WT_METADATA_BACKUP));
 			WT_RET(__wt_remove_if_exists(session, WT_METAFILE));
 			WT_RET(__wt_remove_if_exists(

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1109,7 +1109,7 @@ __session_truncate(WT_SESSION *wt_session,
 			if (!WT_STREQ(uri, "log:"))
 				WT_ERR_MSG(session, EINVAL,
 				    "the truncate method should not specify any"
-				    "target after the log: URI prefix.");
+				    "target after the log: URI prefix");
 			WT_ERR(__wt_log_truncate_files(session, start, cfg));
 		} else if (WT_PREFIX_MATCH(uri, "file:"))
 			WT_ERR(__wt_session_range_truncate(

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -519,7 +519,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		 */
 		if (F_ISSET(txn, WT_TXN_SYNC_SET))
 			WT_RET_MSG(session, EINVAL,
-			    "Sync already set during begin_transaction.");
+			    "Sync already set during begin_transaction");
 		if (WT_STRING_MATCH("background", cval.str, cval.len))
 			txn->txn_logsync = WT_LOG_BACKGROUND;
 		else if (WT_STRING_MATCH("off", cval.str, cval.len))

--- a/src/txn/txn_nsnap.c
+++ b/src/txn/txn_nsnap.c
@@ -343,7 +343,7 @@ __wt_txn_named_snapshot_config(WT_SESSION_IMPL *session,
 	if (!*has_create && !*has_drops)
 		WT_RET_MSG(session, EINVAL,
 		    "WT_SESSION::snapshot API called without any drop or "
-		    "name option.");
+		    "name option");
 
 	return (0);
 }

--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -88,7 +88,7 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
                 self.session.verify(self.uri)
 
     def test_backup(self):
-        with self.expectedStdoutPattern('Recreating metadata'):
+        with self.expectedStdoutPattern('recreating metadata'):
             self.backup()
 
 if __name__ == '__main__':

--- a/test/suite/test_txn04.py
+++ b/test/suite/test_txn04.py
@@ -193,7 +193,7 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
         self.hot_backup(self.uri, committed)
 
     def test_ops(self):
-        with self.expectedStdoutPattern('Recreating metadata'):
+        with self.expectedStdoutPattern('recreating metadata'):
             self.ops()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Periods followed by colons looks bad, remove periods from error messages.