### PR TITLE
WT-2582: cache eviction server error: WT_RESTART

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1478,6 +1478,15 @@ __split_multi_inmem(
 	uint32_t i, slot;
 
 	/*
+	 * In 04/2016, we removed column-store record numbers from the WT_PAGE
+	 * structure, leading to hard-to-debug problems because we corrupt the
+	 * page if we search it using the wrong initial record number. For now,
+	 * assert the record number is set.
+	 */
+	WT_ASSERT(session,
+	    orig->type != WT_PAGE_COL_VAR || ref->ref_recno != 0);
+
+	/*
 	 * This code re-creates an in-memory page that is part of a set created
 	 * while evicting a large page, and adds references to any unresolved
 	 * update chains to the new page. We get here due to choosing to keep
@@ -1627,7 +1636,6 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	WT_REF *ref;
 	size_t incr;
 
-	addr = NULL;
 	incr = 0;
 
 	/* Allocate an underlying WT_REF. */
@@ -1635,25 +1643,10 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	ref = *refp;
 	incr += sizeof(WT_REF);
 
-	/* Any parent reference is filled in by our caller. */
-	ref->home = NULL;
-
-	if (multi->disk_image == NULL) {
-		/*
-		 * Copy the address: we could simply take the buffer, but that
-		 * would complicate error handling, freeing the reference array
-		 * would have to avoid freeing the memory, and it's not worth
-		 * the confusion.
-		 */
-		WT_RET(__wt_calloc_one(session, &addr));
-		ref->addr = addr;
-		addr->size = multi->addr.size;
-		addr->type = multi->addr.type;
-		WT_RET(__wt_strndup(session,
-		    multi->addr.addr, addr->size, &addr->addr));
-	} else
-		WT_RET(__split_multi_inmem(session, page, ref, multi));
-
+	/*
+	 * Set the WT_REF key before (optionally) building the page, underlying
+	 * column-store functions need the page's key space to search it.
+	 */
 	switch (page->type) {
 	case WT_PAGE_ROW_INT:
 	case WT_PAGE_ROW_LEAF:
@@ -1667,12 +1660,27 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		break;
 	}
 
-	ref->state = addr != NULL ? WT_REF_DISK : WT_REF_MEM;
+	/* If there's a disk image, build a page, otherwise set the address. */
+	if (multi->disk_image == NULL) {
+		/*
+		 * Copy the address: we could simply take the buffer, but that
+		 * would complicate error handling, freeing the reference array
+		 * would have to avoid freeing the memory, and it's not worth
+		 * the confusion.
+		 */
+		WT_RET(__wt_calloc_one(session, &addr));
+		ref->addr = addr;
+		addr->size = multi->addr.size;
+		addr->type = multi->addr.type;
+		WT_RET(__wt_strndup(session,
+		    multi->addr.addr, addr->size, &addr->addr));
+		ref->state = WT_REF_DISK;
+	} else {
+		WT_RET(__split_multi_inmem(session, page, ref, multi));
+		ref->state = WT_REF_MEM;
+	}
 
-	/*
-	 * If our caller wants to track the memory allocations, we have a return
-	 * reference.
-	 */
+	/* Optionally return changes in the memory footprint. */
 	if (incrp != NULL)
 		*incrp += incr;
 	return (0);


### PR DESCRIPTION
@michaelcahill, @agorrod, another column-store record-number fix.

I think this change is pretty safe, so I'm going to merge it after it passes the tests so we can get the stress tests going again.