### PR TITLE
WT-2593 Free the dirlist at the end of the function.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -258,7 +258,6 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
 	 */
 	WT_ERR(__wt_fs_directory_list(
 	    session, conn->log_path, WT_LOG_PREPNAME, &recfiles, &reccount));
-	WT_ERR(__wt_fs_directory_list_free(session, &recfiles, &reccount));
 
 	/*
 	 * Adjust the number of files to pre-allocate if we find that

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -230,7 +230,7 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
 err:		__wt_err(session, ret, "log archive server error");
 	if (locked)
 		WT_TRET(__wt_readunlock(session, conn->hot_backup_lock));
-	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 	return (ret);
 }
 
@@ -288,7 +288,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
 
 	if (0)
 err:		__wt_err(session, ret, "log pre-alloc server error");
-	WT_TRET(__wt_fs_directory_list_free(session, &recfiles, &reccount));
+	WT_TRET(__wt_fs_directory_list_free(session, &recfiles, reccount));
 	return (ret);
 }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -178,7 +178,7 @@ __backup_log_append(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool active)
 		for (i = 0; i < logcount; i++)
 			WT_ERR(__backup_list_append(session, cb, logfiles[i]));
 	}
-err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 	return (ret);
 }
 

--- a/src/include/os_fs.i
+++ b/src/include/os_fs.i
@@ -43,7 +43,7 @@ __wt_fs_directory_list(WT_SESSION_IMPL *session,
  */
 static inline int
 __wt_fs_directory_list_free(
-    WT_SESSION_IMPL *session, char ***dirlistp, u_int *countp)
+    WT_SESSION_IMPL *session, char ***dirlistp, u_int count)
 {
 	WT_DECL_RET;
 	WT_FILE_SYSTEM *file_system;
@@ -53,11 +53,10 @@ __wt_fs_directory_list_free(
 		file_system = S2C(session)->file_system;
 		wt_session = (WT_SESSION *)session;
 		ret = file_system->directory_list_free(
-		    file_system, wt_session, *dirlistp, *countp);
+		    file_system, wt_session, *dirlistp, count);
 	}
 
 	*dirlistp = NULL;
-	*countp = 0;
 	return (ret);
 }
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -310,7 +310,7 @@ __wt_log_get_all_files(WT_SESSION_IMPL *session,
 	*countp = count;
 
 	if (0) {
-err:		WT_TRET(__wt_fs_directory_list_free(session, &files, &count));
+err:		WT_TRET(__wt_fs_directory_list_free(session, &files, count));
 	}
 	return (ret);
 }
@@ -765,7 +765,7 @@ __log_alloc_prealloc(WT_SESSION_IMPL *session, uint32_t to_num)
 
 err:	__wt_scr_free(session, &from_path);
 	__wt_scr_free(session, &to_path);
-	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 	return (ret);
 }
 
@@ -987,7 +987,7 @@ __log_truncate(WT_SESSION_IMPL *session,
 		}
 	}
 err:	WT_TRET(__wt_close(session, &log_fh));
-	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 	return (ret);
 }
 
@@ -1116,7 +1116,7 @@ __wt_log_open(WT_SESSION_IMPL *session)
 			    session, WT_LOG_TMPNAME, lognum));
 		}
 		WT_ERR(
-		    __wt_fs_directory_list_free(session, &logfiles, &logcount));
+		    __wt_fs_directory_list_free(session, &logfiles, logcount));
 		WT_ERR(__log_get_files(session,
 		    WT_LOG_PREPNAME, &logfiles, &logcount));
 		for (i = 0; i < logcount; i++) {
@@ -1126,7 +1126,7 @@ __wt_log_open(WT_SESSION_IMPL *session)
 			    session, WT_LOG_PREPNAME, lognum));
 		}
 		WT_ERR(
-		    __wt_fs_directory_list_free(session, &logfiles, &logcount));
+		    __wt_fs_directory_list_free(session, &logfiles, logcount));
 	}
 
 	/*
@@ -1164,7 +1164,7 @@ __wt_log_open(WT_SESSION_IMPL *session)
 		FLD_SET(conn->log_flags, WT_CONN_LOG_EXISTED);
 	}
 
-err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 	return (ret);
 }
 
@@ -1549,7 +1549,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 		WT_SET_LSN(&start_lsn, firstlog, 0);
 		WT_SET_LSN(&end_lsn, lastlog, 0);
 		WT_ERR(
-		    __wt_fs_directory_list_free(session, &logfiles, &logcount));
+		    __wt_fs_directory_list_free(session, &logfiles, logcount));
 	}
 	WT_ERR(__log_openfile(
 	    session, false, &log_fh, WT_LOG_FILENAME, start_lsn.l.file));
@@ -1745,7 +1745,7 @@ advance:
 
 err:	WT_STAT_FAST_CONN_INCR(session, log_scans);
 
-	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, &logcount));
+	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 
 	__wt_scr_free(session, &buf);
 	__wt_scr_free(session, &decryptitem);


### PR DESCRIPTION
@keithbostic This should fix the runaway creation of pre-allocated log files.  Please review