### PR TITLE
WT-2592 Fix joins for the non-recno, non-raw case

### DIFF
--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1113,7 +1113,11 @@ __curjoin_next(WT_CURSOR *cursor)
 		c->set_key(c, iter->curkey);
 		if (!F_ISSET(cursor, WT_CURSTD_RAW))
 			F_CLR(c, WT_CURSTD_RAW);
-		WT_ERR(c->search(c));
+
+		/* A failed search is not expected, don't return WT_NOTFOUND. */
+		if ((ret = c->search(c)) == WT_NOTFOUND)
+			ret = WT_ERROR;
+		WT_ERR(ret);
 		F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
 	} else if (ret == WT_NOTFOUND &&
 	    (tret = __curjoin_iter_close_all(iter)) != 0)

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1105,14 +1105,10 @@ __curjoin_next(WT_CURSOR *cursor)
 		/*
 		 * Position the 'main' cursor, this will be used to retrieve
 		 * values from the cursor join.  The key we have is raw, but
-		 * the values we retrieve may not be raw.  So we need to
-		 * turn on the raw interface temporarily.
+		 * the main cursor may not be raw.
 		 */
 		c = cjoin->main;
-		F_SET(c, WT_CURSTD_RAW);
-		c->set_key(c, iter->curkey);
-		if (!F_ISSET(cursor, WT_CURSTD_RAW))
-			F_CLR(c, WT_CURSTD_RAW);
+		__wt_cursor_set_raw_key(c, iter->curkey);
 
 		/* A failed search is not expected, don't return WT_NOTFOUND. */
 		if ((ret = c->search(c)) == WT_NOTFOUND)


### PR DESCRIPTION
This fixes a rather fundamental problem.  Any joins written in C that do not use recno were not seeing results.  Internally we are using raw keys, but our final 'main' cursor may not be in raw mode, so we may not be able to retrieve the values using the key we have.

Unfortunately, the bulk of the test cases for join are in Python, which use RAW mode, so unaffected.  Our C example uses recno, which took a different path.