### PR TITLE
SERVER-23661: $sample takes disproportionately long time on newly created collection

### DIFF
--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -765,6 +765,15 @@ __wt_row_random_leaf(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	cbt->ins_head = ins_head;
 	cbt->compare = 0;
 
+	/*
+	 * MongoDB $sample can be significantly slower than expected if the
+	 * collection is newly created and the content is in a in a single
+	 * skiplist. If searching a relatively large skiplist, schedule it
+	 * for eviction to split up the skiplist.
+	 */
+	if (page->memory_footprint > 5 * WT_MEGABYTE)
+		__wt_page_evict_soon(page);
+
 	return (0);
 }
 

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -767,14 +767,13 @@ __wt_row_random_leaf(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	cbt->compare = 0;
 
 	/*
-	 * MongoDB $sample can be slow in a newly created collection where the
-	 * content is a single skiplist. If searching a large skiplist in a
-	 * large page, schedule the page for eviction to split up the skiplist.
-	 * The check of both the number of sampled entries and page footprint
-	 * is to avoid repeatedly evicting a small page with large individual
-	 * items, to no effect.
+	 * Random lookups in newly created collections can be slow if a page
+	 * consists of a large skiplist. Schedule the page for eviction if we
+	 * encounter a large skiplist. This worthwhile because applications
+	 * that take a sample often take many samples, so the overhead of
+	 * traversing the skip list each time accumulates to real time.
 	 */
-	if (samples > 5000 && page->memory_footprint > 5 * WT_MEGABYTE)
+	if (samples > 5000)
 		__wt_page_evict_soon(page);
 
 	return (0);


### PR DESCRIPTION
@michaelcahill, calling `__wt_page_evict_soon` works well, in my tests it brings $sample of newly created collections down to about the same time as a re-opened collection.

I ended up with a pretty stupid "should we evict this page" test of "greater than 5MB". That performed as well as anything else I tried, and it didn't seem unreasonable to use the page's memory footprint for this purpose, once we know the page's footprint reflects just the one big skiplist.

Ready for review/merge.