### PR TITLE
WT-2603 Track the hash bucket ID for hash queues, not the name hash value

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -102,11 +102,9 @@ __block_destroy(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
-	uint64_t bucket;
 
 	conn = S2C(session);
-	bucket = block->name_hash % WT_HASH_ARRAY_SIZE;
-	WT_CONN_BLOCK_REMOVE(conn, block, bucket);
+	WT_CONN_BLOCK_REMOVE(conn, block, block->name_bucket);
 
 	__wt_free(session, block->name);
 
@@ -152,15 +150,17 @@ __wt_block_open(WT_SESSION_IMPL *session,
 	WT_CONFIG_ITEM cval;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
-	uint64_t bucket, hash;
+	uint64_t bucket;
 	uint32_t flags;
+
+	*blockp = NULL;
 
 	WT_RET(__wt_verbose(session, WT_VERB_BLOCK, "open: %s", filename));
 
 	conn = S2C(session);
-	*blockp = block = NULL;
-	hash = __wt_hash_city64(filename, strlen(filename));
-	bucket = hash % WT_HASH_ARRAY_SIZE;
+	block = NULL;
+	bucket =
+	    __wt_hash_city64(filename, strlen(filename)) % WT_HASH_ARRAY_SIZE;
 	__wt_spin_lock(session, &conn->block_lock);
 	TAILQ_FOREACH(block, &conn->blockhash[bucket], hashq) {
 		if (strcmp(filename, block->name) == 0) {
@@ -180,7 +180,7 @@ __wt_block_open(WT_SESSION_IMPL *session,
 	 */
 	WT_ERR(__wt_calloc_one(session, &block));
 	block->ref = 1;
-	block->name_hash = hash;
+	block->name_bucket = bucket;
 	block->allocsize = allocsize;
 	WT_CONN_BLOCK_INSERT(conn, block, bucket);
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -405,7 +405,7 @@ __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval,
 	WT_ENCRYPTOR *custom, *encryptor;
 	WT_KEYED_ENCRYPTOR *kenc;
 	WT_NAMED_ENCRYPTOR *nenc;
-	uint64_t bucket, hash;
+	uint64_t bucket;
 
 	*kencryptorp = NULL;
 
@@ -430,8 +430,7 @@ __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval,
 	if (conn->kencryptor == NULL && kencryptorp != &conn->kencryptor)
 		WT_ERR_MSG(session, EINVAL, "table encryption "
 		    "requires connection encryption to be set");
-	hash = __wt_hash_city64(keyid->str, keyid->len);
-	bucket = hash % WT_HASH_ARRAY_SIZE;
+	bucket = __wt_hash_city64(keyid->str, keyid->len) % WT_HASH_ARRAY_SIZE;
 	TAILQ_FOREACH(kenc, &nenc->keyedhashqh[bucket], q)
 		if (WT_STRING_MATCH(kenc->keyid, keyid->str, keyid->len))
 			goto out;
@@ -2322,7 +2321,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 */
 	WT_ERR(__wt_turtle_init(session));
 
-	__wt_metadata_init(session);
 	WT_ERR(__wt_metadata_cursor(session, NULL));
 
 	/* Start the worker threads and run recovery. */

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -40,10 +40,15 @@ __conn_dhandle_alloc(WT_SESSION_IMPL *session,
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 
+	*dhandlep = NULL;
+
 	WT_RET(__wt_calloc_one(session, &dhandle));
 
 	WT_ERR(__wt_rwlock_alloc(session, &dhandle->rwlock, "data handle"));
-	dhandle->name_hash = __wt_hash_city64(uri, strlen(uri));
+
+	dhandle->name_bucket =
+	    __wt_hash_city64(uri, strlen(uri)) % WT_HASH_ARRAY_SIZE;
+
 	WT_ERR(__wt_strdup(session, uri, &dhandle->name));
 	WT_ERR(__wt_strdup(session, checkpoint, &dhandle->checkpoint));
 
@@ -56,6 +61,15 @@ __conn_dhandle_alloc(WT_SESSION_IMPL *session,
 	    session, &dhandle->close_lock, "data handle close"));
 
 	__wt_stat_dsrc_init(dhandle);
+
+	if (strcmp(uri, WT_METAFILE_URI) == 0)
+		F_SET(dhandle, WT_DHANDLE_IS_METADATA);
+
+	/*
+	 * Prepend the handle to the connection list, assuming we're likely to
+	 * need new files again soon, until they are cached by all sessions.
+	 */
+	WT_CONN_DHANDLE_INSERT(S2C(session), dhandle, dhandle->name_bucket);
 
 	*dhandlep = dhandle;
 	return (0);
@@ -105,14 +119,6 @@ __wt_conn_dhandle_find(
 		}
 
 	WT_RET(__conn_dhandle_alloc(session, uri, checkpoint, &dhandle));
-
-	/*
-	 * Prepend the handle to the connection list, assuming we're likely to
-	 * need new files again soon, until they are cached by all sessions.
-	 * Find the right hash bucket to insert into as well.
-	 */
-	bucket = dhandle->name_hash % WT_HASH_ARRAY_SIZE;
-	WT_CONN_DHANDLE_INSERT(conn, dhandle, bucket);
 
 	session->dhandle = dhandle;
 	return (0);
@@ -508,11 +514,9 @@ __conn_dhandle_remove(WT_SESSION_IMPL *session, bool final)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
-	uint64_t bucket;
 
 	conn = S2C(session);
 	dhandle = session->dhandle;
-	bucket = dhandle->name_hash % WT_HASH_ARRAY_SIZE;
 
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_HANDLE_LIST));
 	WT_ASSERT(session, dhandle != conn->cache->evict_file_next);
@@ -522,7 +526,7 @@ __conn_dhandle_remove(WT_SESSION_IMPL *session, bool final)
 	    (dhandle->session_inuse != 0 || dhandle->session_ref != 0))
 		return (EBUSY);
 
-	WT_CONN_DHANDLE_REMOVE(conn, dhandle, bucket);
+	WT_CONN_DHANDLE_REMOVE(conn, dhandle, dhandle->name_bucket);
 	return (0);
 
 }

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -214,10 +214,10 @@ struct __wt_bm {
  */
 struct __wt_block {
 	const char *name;		/* Name */
-	uint64_t name_hash;		/* Hash of name */
 
 	/* A list of block manager handles, sharing a file descriptor. */
 	uint32_t ref;			/* References */
+	uint64_t name_bucket;		/* Name's hash bucket */
 	TAILQ_ENTRY(__wt_block) q;	/* Linked list of handles */
 	TAILQ_ENTRY(__wt_block) hashq;	/* Hashed list of handles */
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -352,7 +352,6 @@ struct __wt_connection_impl {
 	uint32_t	 txn_logsync;	/* Log sync configuration */
 
 	WT_SESSION_IMPL *meta_ckpt_session;/* Metadata checkpoint session */
-	uint64_t	 meta_uri_hash;	/* Metadata file name hash */
 
 	WT_SESSION_IMPL *sweep_session;	   /* Handle sweep session */
 	wt_thread_t	 sweep_tid;	   /* Handle sweep thread */

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -43,6 +43,8 @@
  */
 struct __wt_data_handle {
 	WT_RWLOCK *rwlock;		/* Lock for shared/exclusive ops */
+
+	uint64_t name_bucket;		/* Name's hash bucket */
 	TAILQ_ENTRY(__wt_data_handle) q;
 	TAILQ_ENTRY(__wt_data_handle) hashq;
 
@@ -57,7 +59,6 @@ struct __wt_data_handle {
 	time_t	 timeofdeath;		/* Use count went to 0 */
 	WT_SESSION_IMPL *excl_session;	/* Session with exclusive use, if any */
 
-	uint64_t name_hash;		/* Hash of name */
 	const char *name;		/* Object name as a URI */
 	const char *checkpoint;		/* Checkpoint name (or NULL) */
 	const char **cfg;		/* Configuration information */
@@ -82,7 +83,8 @@ struct __wt_data_handle {
 #define	WT_DHANDLE_DISCARD	        0x02	/* Discard on release */
 #define	WT_DHANDLE_DISCARD_FORCE	0x04	/* Force discard on release */
 #define	WT_DHANDLE_EXCLUSIVE	        0x08	/* Need exclusive access */
-#define	WT_DHANDLE_LOCK_ONLY	        0x10	/* Handle only used as a lock */
-#define	WT_DHANDLE_OPEN		        0x20	/* Handle is open */
+#define	WT_DHANDLE_IS_METADATA	        0x10	/* Metadata handle */
+#define	WT_DHANDLE_LOCK_ONLY	        0x20	/* Handle only used as a lock */
+#define	WT_DHANDLE_OPEN		        0x40	/* Handle is open */
 	uint32_t flags;
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -461,7 +461,6 @@ extern int __wt_ext_metadata_search(WT_EXTENSION_API *wt_api, WT_SESSION *wt_ses
 extern int __wt_ext_metadata_update(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *key, const char *value);
 extern int __wt_metadata_get_ckptlist( WT_SESSION *session, const char *name, WT_CKPT **ckptbasep);
 extern void __wt_metadata_free_ckptlist(WT_SESSION *session, WT_CKPT *ckptbase);
-extern void __wt_metadata_init(WT_SESSION_IMPL *session);
 extern int __wt_metadata_cursor_open( WT_SESSION_IMPL *session, const char *config, WT_CURSOR **cursorp);
 extern int __wt_metadata_cursor(WT_SESSION_IMPL *session, WT_CURSOR **cursorp);
 extern int __wt_metadata_cursor_release(WT_SESSION_IMPL *session, WT_CURSOR **cursorp);

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -34,8 +34,7 @@
  * when diagnostic is enabled.
  */
 #define	WT_IS_METADATA(session, dh)					\
-	((dh)->name_hash == S2C(session)->meta_uri_hash &&		\
-	strcmp((dh)->name, WT_METAFILE_URI) == 0)
+	F_ISSET((dh), WT_DHANDLE_IS_METADATA)
 #define	WT_METAFILE_ID		0			/* Metadata file ID */
 
 #define	WT_METADATA_VERSION	"WiredTiger version"	/* Version keys */

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -76,7 +76,7 @@ struct __wt_fh {
 	 */
 	const char *name;			/* File name */
 
-	uint64_t name_hash;			/* hash of name */
+	uint64_t name_bucket;			/* name's hash bucket */
 	TAILQ_ENTRY(__wt_fh) q;			/* internal queue */
 	TAILQ_ENTRY(__wt_fh) hashq;		/* internal hash queue */
 	u_int ref;				/* reference count */
@@ -117,7 +117,7 @@ struct __wt_file_handle_inmem {
 	/*
 	 * In memory specific file handle fields
 	 */
-	uint64_t name_hash;			/* hash of name */
+	uint64_t name_bucket;			/* name's hash bucket */
 	TAILQ_ENTRY(__wt_file_handle_inmem) q;	/* internal queue, hash queue */
 	TAILQ_ENTRY(__wt_file_handle_inmem) hashq;
 

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -54,7 +54,6 @@ struct __wt_index {
 struct __wt_table {
 	const char *name, *config, *plan;
 	const char *key_format, *value_format;
-	uint64_t name_hash;		/* Hash of name */
 
 	WT_CONFIG_ITEM cgconf, colconf;
 
@@ -62,6 +61,7 @@ struct __wt_table {
 	WT_INDEX **indices;
 	size_t idx_alloc;
 
+	uint64_t name_bucket;		/* Name's hash bucket */
 	TAILQ_ENTRY(__wt_table) q;
 	TAILQ_ENTRY(__wt_table) hashq;
 

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -9,18 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __wt_metadata_init --
- *	Metadata initialization.
- */
-void
-__wt_metadata_init(WT_SESSION_IMPL *session)
-{
-	/* We cache the metadata file's URI hash for fast detection. */
-	S2C(session)->meta_uri_hash =
-	    __wt_hash_city64(WT_METAFILE_URI, strlen(WT_METAFILE_URI));
-}
-
-/*
  * __metadata_turtle --
  *	Return if a key's value should be taken from the turtle file.
  */

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -32,12 +32,11 @@ __im_handle_search(WT_FILE_SYSTEM *file_system, const char *name)
 {
 	WT_FILE_HANDLE_INMEM *im_fh;
 	WT_FILE_SYSTEM_INMEM *im_fs;
-	uint64_t bucket, hash;
+	uint64_t bucket;
 
 	im_fs = (WT_FILE_SYSTEM_INMEM *)file_system;
 
-	hash = __wt_hash_city64(name, strlen(name));
-	bucket = hash % WT_HASH_ARRAY_SIZE;
+	bucket = __wt_hash_city64(name, strlen(name)) % WT_HASH_ARRAY_SIZE;
 	TAILQ_FOREACH(im_fh, &im_fs->fhhash[bucket], hashq)
 		if (strcmp(im_fh->iface.name, name) == 0)
 			break;
@@ -56,7 +55,6 @@ __im_handle_remove(WT_SESSION_IMPL *session,
 {
 	WT_FILE_HANDLE *fhp;
 	WT_FILE_SYSTEM_INMEM *im_fs;
-	uint64_t bucket;
 
 	im_fs = (WT_FILE_SYSTEM_INMEM *)file_system;
 
@@ -64,8 +62,7 @@ __im_handle_remove(WT_SESSION_IMPL *session,
 		WT_RET_MSG(session, EBUSY,
 		    "%s: file-remove", im_fh->iface.name);
 
-	bucket = im_fh->name_hash % WT_HASH_ARRAY_SIZE;
-	WT_FILE_HANDLE_REMOVE(im_fs, im_fh, bucket);
+	WT_FILE_HANDLE_REMOVE(im_fs, im_fh, im_fh->name_bucket);
 
 	/* Clean up private information. */
 	__wt_buf_free(session, &im_fh->buf);
@@ -221,7 +218,6 @@ __im_fs_rename(WT_FILE_SYSTEM *file_system,
 	WT_FILE_HANDLE_INMEM *im_fh;
 	WT_FILE_SYSTEM_INMEM *im_fs;
 	WT_SESSION_IMPL *session;
-	uint64_t bucket;
 	char *copy;
 
 	im_fs = (WT_FILE_SYSTEM_INMEM *)file_system;
@@ -235,11 +231,10 @@ __im_fs_rename(WT_FILE_SYSTEM *file_system,
 		__wt_free(session, im_fh->iface.name);
 		im_fh->iface.name = copy;
 
-		bucket = im_fh->name_hash % WT_HASH_ARRAY_SIZE;
-		WT_FILE_HANDLE_REMOVE(im_fs, im_fh, bucket);
-		im_fh->name_hash = __wt_hash_city64(to, strlen(to));
-		bucket = im_fh->name_hash % WT_HASH_ARRAY_SIZE;
-		WT_FILE_HANDLE_INSERT(im_fs, im_fh, bucket);
+		WT_FILE_HANDLE_REMOVE(im_fs, im_fh, im_fh->name_bucket);
+		im_fh->name_bucket =
+		    __wt_hash_city64(to, strlen(to)) % WT_HASH_ARRAY_SIZE;
+		WT_FILE_HANDLE_INSERT(im_fs, im_fh, im_fh->name_bucket);
 	}
 
 err:	__wt_spin_unlock(session, &im_fs->lock);
@@ -450,7 +445,6 @@ __im_file_open(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 	WT_FILE_HANDLE_INMEM *im_fh;
 	WT_FILE_SYSTEM_INMEM *im_fs;
 	WT_SESSION_IMPL *session;
-	uint64_t bucket, hash;
 
 	WT_UNUSED(file_type);
 	WT_UNUSED(flags);
@@ -490,13 +484,11 @@ __im_file_open(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 	WT_ERR(__wt_strdup(session, name, &file_handle->name));
 
 	/* Initialize private information. */
-	im_fh->ref = 1;
+	im_fh->name_bucket =
+	    __wt_hash_city64(name, strlen(name)) % WT_HASH_ARRAY_SIZE;
+	WT_FILE_HANDLE_INSERT(im_fs, im_fh, im_fh->name_bucket);
 	im_fh->off = 0;
-
-	hash = __wt_hash_city64(name, strlen(name));
-	bucket = hash % WT_HASH_ARRAY_SIZE;
-	im_fh->name_hash = hash;
-	WT_FILE_HANDLE_INSERT(im_fs, im_fh, bucket);
+	im_fh->ref = 1;
 
 	file_handle->close = __im_file_close;
 	file_handle->read = __im_file_read;

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -18,7 +18,6 @@ __schema_add_table(WT_SESSION_IMPL *session,
 {
 	WT_DECL_RET;
 	WT_TABLE *table;
-	uint64_t bucket;
 
 	/* Make sure the metadata is open before getting other locks. */
 	WT_RET(__wt_metadata_cursor(session, NULL));
@@ -28,9 +27,9 @@ __schema_add_table(WT_SESSION_IMPL *session,
 	    session, name, namelen, ok_incomplete, &table));
 	WT_RET(ret);
 
-	bucket = table->name_hash % WT_HASH_ARRAY_SIZE;
 	TAILQ_INSERT_HEAD(&session->tables, table, q);
-	TAILQ_INSERT_HEAD(&session->tablehash[bucket], table, hashq);
+	TAILQ_INSERT_HEAD(
+	    &session->tablehash[table->name_bucket], table, hashq);
 	*tablep = table;
 
 	return (0);
@@ -224,12 +223,10 @@ __wt_schema_destroy_table(WT_SESSION_IMPL *session, WT_TABLE **tablep)
 int
 __wt_schema_remove_table(WT_SESSION_IMPL *session, WT_TABLE *table)
 {
-	uint64_t bucket;
 	WT_ASSERT(session, table->refcnt <= 1);
 
-	bucket = table->name_hash % WT_HASH_ARRAY_SIZE;
 	TAILQ_REMOVE(&session->tables, table, q);
-	TAILQ_REMOVE(&session->tablehash[bucket], table, hashq);
+	TAILQ_REMOVE(&session->tablehash[table->name_bucket], table, hashq);
 	return (__wt_schema_destroy_table(session, &table));
 }
 

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -447,7 +447,8 @@ __schema_open_table(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_calloc_one(session, &table));
 	table->name = tablename;
 	tablename = NULL;
-	table->name_hash = __wt_hash_city64(name, namelen);
+	table->name_bucket =
+	    __wt_hash_city64(name, namelen) % WT_HASH_ARRAY_SIZE;
 
 	WT_ERR(__wt_config_getones(session, tconfig, "columns", &cval));
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -25,7 +25,7 @@ __session_add_dhandle(WT_SESSION_IMPL *session)
 
 	dhandle_cache->dhandle = session->dhandle;
 
-	bucket = dhandle_cache->dhandle->name_hash % WT_HASH_ARRAY_SIZE;
+	bucket = dhandle_cache->dhandle->name_bucket;
 	TAILQ_INSERT_HEAD(&session->dhandles, dhandle_cache, q);
 	TAILQ_INSERT_HEAD(&session->dhhash[bucket], dhandle_cache, hashq);
 
@@ -42,7 +42,7 @@ __session_discard_dhandle(
 {
 	uint64_t bucket;
 
-	bucket = dhandle_cache->dhandle->name_hash % WT_HASH_ARRAY_SIZE;
+	bucket = dhandle_cache->dhandle->name_bucket;
 	TAILQ_REMOVE(&session->dhandles, dhandle_cache, q);
 	TAILQ_REMOVE(&session->dhhash[bucket], dhandle_cache, hashq);
 


### PR DESCRIPTION
@agorrod, for your consideration.

As I said before, I don't care too much if we take this or discard it.

The most valuable piece is probably skipping the metadata name comparison?

FTR, as far as dynamically resizing the hash table, I don't think having the original hash changes the problem much, it only means we don't have to recalculate the hash during the resize.