### PR TITLE
WT-2609: Incorrect "skips API_END call" error.

### DIFF
--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1110,10 +1110,14 @@ __curjoin_next(WT_CURSOR *cursor)
 		c = cjoin->main;
 		__wt_cursor_set_raw_key(c, iter->curkey);
 
-		/* A failed search is not expected, don't return WT_NOTFOUND. */
+		/*
+		 * A failed search is not expected, convert WT_NOTFOUND into a
+		 * generic error.
+		 */
 		if ((ret = c->search(c)) == WT_NOTFOUND)
 			ret = WT_ERROR;
 		WT_ERR(ret);
+
 		F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
 	} else if (ret == WT_NOTFOUND &&
 	    (tret = __curjoin_iter_close_all(iter)) != 0)


### PR DESCRIPTION
A comment in cursor/cur_join.c contains "return WT_NOTFOUND", which is triggering a complaint from the scripts that check for returns that skip error labels.