### PR TITLE
WT-2617: Bug in pluggable file system example

### DIFF
--- a/examples/c/ex_access.c
+++ b/examples/c/ex_access.c
@@ -60,7 +60,7 @@ main(void)
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0 ||
 	    (ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 		return (ret);
 	}
 	/*! [access example connection] */

--- a/examples/c/ex_access.c
+++ b/examples/c/ex_access.c
@@ -61,7 +61,7 @@ main(void)
 	    (ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/*! [access example connection] */
 
@@ -95,5 +95,5 @@ main(void)
 	ret = conn->close(conn, NULL);
 	/*! [access example close] */
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1214,5 +1214,5 @@ main(void)
 	/*! [Get the WiredTiger library version #2] */
 	}
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_async.c
+++ b/examples/c/ex_async.c
@@ -123,7 +123,7 @@ main(void)
 	int i, ret;
 	const char *home;
 	char k[MAX_KEYS][16], v[MAX_KEYS][16];
-	
+
 	/*
 	 * Create a clean test directory for this run of the test program if the
 	 * environment variable isn't already set (as is done by make check).
@@ -160,7 +160,7 @@ main(void)
 			if (ret == EBUSY)
 				sleep(1);
 			else
-				return (ret);
+				return (EXIT_FAILURE);
 		}
 		/*! [async handle allocation] */
 
@@ -210,7 +210,7 @@ main(void)
 			if (ret == EBUSY)
 				sleep(1);
 			else
-				return (ret);
+				return (EXIT_FAILURE);
 		}
 
 		/*! [async search] */
@@ -232,5 +232,5 @@ main(void)
 
 	printf("Searched for %" PRIu32 " keys\n", ex_asynckeys.num_keys);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_async.c
+++ b/examples/c/ex_async.c
@@ -31,7 +31,9 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
 #ifndef _WIN32
 #include <unistd.h>
 #else
@@ -48,7 +50,6 @@
 #define	ATOMIC_ADD(v, val)      __sync_add_and_fetch(&(v), val)
 #endif
 
-static const char * const home = NULL;
 static int global_error = 0;
 
 /*! [async example callback implementation] */
@@ -120,7 +121,18 @@ main(void)
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
 	int i, ret;
+	const char *home;
 	char k[MAX_KEYS][16], v[MAX_KEYS][16];
+	
+	/*
+	 * Create a clean test directory for this run of the test program if the
+	 * environment variable isn't already set (as is done by make check).
+	 */
+	if (getenv("WIREDTIGER_HOME") == NULL) {
+		home = "WT_HOME";
+		ret = system("rm -rf WT_HOME && mkdir WT_HOME");
+	} else
+		home = NULL;
 
 	/*! [async example connection] */
 	ret = wiredtiger_open(home, NULL,

--- a/examples/c/ex_backup.c
+++ b/examples/c/ex_backup.c
@@ -273,12 +273,12 @@ main(void)
 	snprintf(cmd_buf, sizeof(cmd_buf), "rm -rf %s && mkdir %s", home, home);
 	if ((ret = system(cmd_buf)) != 0) {
 		fprintf(stderr, "%s: failed ret %d\n", cmd_buf, ret);
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	if ((ret = wiredtiger_open(home, NULL, CONN_CONFIG, &wt_conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	ret = setup_directories();
@@ -320,7 +320,9 @@ main(void)
 	 * comparison between the incremental and original.
 	 */
 	ret = wt_conn->close(wt_conn, NULL);
+
 	printf("Final comparison: dumping and comparing data\n");
 	ret = compare_backups(0);
-	return (ret);
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_call_center.c
+++ b/examples/c/ex_call_center.c
@@ -108,7 +108,7 @@ main(void)
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
-		return (1);
+		return (EXIT_FAILURE);
 	}
 	/* Note: further error checking omitted for clarity. */
 
@@ -245,5 +245,5 @@ main(void)
 
 	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_call_center.c
+++ b/examples/c/ex_call_center.c
@@ -107,7 +107,7 @@ main(void)
 
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 		return (1);
 	}
 	/* Note: further error checking omitted for clarity. */

--- a/examples/c/ex_config_parse.c
+++ b/examples/c/ex_config_parse.c
@@ -32,6 +32,7 @@
 
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <wiredtiger.h>
@@ -51,12 +52,12 @@ main(void)
 	    NULL, config_string, strlen(config_string), &parser)) != 0) {
 		fprintf(stderr, "Error creating configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	if ((ret = parser->close(parser)) != 0) {
 		fprintf(stderr, "Error closing configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/*! [Create a configuration parser] */
 
@@ -64,7 +65,7 @@ main(void)
 	    NULL, config_string, strlen(config_string), &parser)) != 0) {
 		fprintf(stderr, "Error creating configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	{
@@ -76,7 +77,7 @@ main(void)
 	if ((ret = parser->get(parser, "page_size", &v)) != 0) {
 		fprintf(stderr,
 		    "page_size configuration: %s", wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	my_page_size = v.val;
 	/*! [get] */
@@ -91,7 +92,7 @@ main(void)
 	    NULL, config_string, strlen(config_string), &parser)) != 0) {
 		fprintf(stderr, "Error creating configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/*! [next] */
 	/*
@@ -112,7 +113,7 @@ main(void)
 	    NULL, config_string, strlen(config_string), &parser)) != 0) {
 		fprintf(stderr, "Error creating configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	/*! [nested get] */
@@ -125,7 +126,7 @@ main(void)
 	if ((ret = parser->get(parser, "log.file_max", &v)) != 0) {
 		fprintf(stderr,
 		    "log.file_max configuration: %s", wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	printf("log file max: %" PRId64 "\n", v.val);
 	/*! [nested get] */
@@ -135,7 +136,7 @@ main(void)
 	    NULL, config_string, strlen(config_string), &parser)) != 0) {
 		fprintf(stderr, "Error creating configuration parser: %s\n",
 		    wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/*! [nested traverse] */
 	{
@@ -150,11 +151,10 @@ main(void)
 				    "Error creating nested configuration "
 				    "parser: %s\n",
 				    wiredtiger_strerror(ret));
-				ret = parser->close(parser);
-				return (ret);
+				break;
 			}
-			while ((ret = sub_parser->next(
-			    sub_parser, &k, &v)) == 0)
+			while ((ret =
+			    sub_parser->next(sub_parser, &k, &v)) == 0)
 				printf("\t%.*s\n", (int)k.len, k.str);
 			ret = sub_parser->close(sub_parser);
 		}
@@ -163,5 +163,5 @@ main(void)
 	ret = parser->close(parser);
 	}
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_cursor.c
+++ b/examples/c/ex_cursor.c
@@ -181,12 +181,12 @@ main(void)
 	if ((ret = wiredtiger_open(
 	    home, NULL, "create,statistics=(fast)", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* Open a session for the current thread's work. */
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	ret = session->create(session, "table:world",
 	    "key_format=r,value_format=5sii,"
@@ -222,7 +222,7 @@ main(void)
 	/* Note: closing the connection implicitly closes open session(s). */
 	if ((ret = conn->close(conn, NULL)) != 0)
 		fprintf(stderr, "Error closing %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	return (ret);
 }

--- a/examples/c/ex_cursor.c
+++ b/examples/c/ex_cursor.c
@@ -220,9 +220,11 @@ main(void)
 	ret = cursor->close(cursor);
 
 	/* Note: closing the connection implicitly closes open session(s). */
-	if ((ret = conn->close(conn, NULL)) != 0)
+	if ((ret = conn->close(conn, NULL)) != 0) {
 		fprintf(stderr, "Error closing %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
-	return (ret);
+	return (EXIT_SUCCESS);
 }

--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -667,7 +667,7 @@ main(void)
 	(void)wt_api->msg_printf(wt_api, NULL, "configuration complete");
 	/*! [WT_EXTENSION_API default_session] */
 
-	(void)conn->close(conn, NULL);
+	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -587,6 +587,8 @@ main(void)
 
 		printf("Verified key %s; value %s\n", key1, val1);
 	}
+
 	ret = conn->close(conn, NULL);
-	return (ret);
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -51,7 +51,7 @@ __declspec(dllexport)
 #endif
 int add_my_encryptors(WT_CONNECTION *connection);
 
-static const char *home = NULL;
+static const char *home;
 
 #define	SYS_KEYID	"system"
 #define	SYS_PW		"system_password"

--- a/examples/c/ex_event_handler.c
+++ b/examples/c/ex_event_handler.c
@@ -112,7 +112,7 @@ config_event_handler(void)
 
 	/* Make an invalid API call, to ensure the event handler works. */
 	printf("ex_event_handler: expect an error message to follow\n");
-	(void)conn->open_session(conn, NULL, "isolation=invalid", &session);
+	ret = conn->open_session(conn, NULL, "isolation=invalid", &session);
 
 	ret = conn->close(conn, NULL);
 
@@ -122,6 +122,8 @@ config_event_handler(void)
 int
 main(void)
 {
+	int ret;
+
 	/*
 	 * Create a clean test directory for this run of the test program if the
 	 * environment variable isn't already set (as is done by make check).
@@ -132,5 +134,7 @@ main(void)
 	} else
 		home = NULL;
 
-	return (config_event_handler());
+	ret = config_event_handler();
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_extending.c
+++ b/examples/c/ex_extending.c
@@ -108,7 +108,7 @@ main(void)
 	/* Open a connection to the database, creating it if necessary. */
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/*! [add collator nocase] */
 	ret = conn->add_collator(conn, "nocase", &nocasecoll, NULL);
@@ -119,7 +119,7 @@ main(void)
 	/* Open a session for the current thread's work. */
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* XXX Do some work... */
 
@@ -127,7 +127,7 @@ main(void)
 	if ((ret = conn->close(conn, NULL)) != 0)
 	/*! [add collator prefix10] */
 		fprintf(stderr, "Error closing %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	return (ret);
 }

--- a/examples/c/ex_extending.c
+++ b/examples/c/ex_extending.c
@@ -121,13 +121,10 @@ main(void)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
-	/* XXX Do some work... */
+	/* Do some work... */
 
-	/* Note: closing the connection implicitly closes open session(s). */
-	if ((ret = conn->close(conn, NULL)) != 0)
+	ret = conn->close(conn, NULL);
 	/*! [add collator prefix10] */
-		fprintf(stderr, "Error closing %s: %s\n",
-		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_extractor.c
+++ b/examples/c/ex_extractor.c
@@ -283,5 +283,5 @@ main(void)
 
 	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -112,6 +112,8 @@ static int demo_file_lock(WT_FILE_HANDLE *, WT_SESSION *, bool);
 static int demo_file_read(
     WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, void *);
 static int demo_file_size(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t *);
+static int demo_file_sync(WT_FILE_HANDLE *, WT_SESSION *);
+static int demo_file_sync_nowait(WT_FILE_HANDLE *, WT_SESSION *);
 static int demo_file_truncate(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t);
 static int demo_file_write(
     WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, const void *);
@@ -240,8 +242,8 @@ demo_fs_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
 	file_handle->unmap = NULL;
 	file_handle->read = demo_file_read;
 	file_handle->size = demo_file_size;
-	file_handle->sync = NULL;
-	file_handle->sync_nowait = NULL;
+	file_handle->sync = demo_file_sync;
+	file_handle->sync_nowait = demo_file_sync_nowait;
 	file_handle->truncate = demo_file_truncate;
 	file_handle->write = demo_file_write;
 
@@ -536,6 +538,34 @@ demo_file_size(
 	demo_fh = (DEMO_FILE_HANDLE *)file_handle;
 
 	*sizep = (wt_off_t)demo_fh->size;
+	return (0);
+}
+
+/*
+ * demo_file_sync --
+ *	Ensure the content of the file is stable. This is a no-op in our
+ *	memory backed file system.
+ */
+static int
+demo_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
+{
+	(void)file_handle;					/* Unused */
+	(void)session;						/* Unused */
+
+	return (0);
+}
+
+/*
+ * demo_file_sync_nowait --
+ *	Ensure the content of the file is stable. This is a no-op in our
+ *	memory backed file system.
+ */
+static int
+demo_file_sync_nowait(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
+{
+	(void)file_handle;					/* Unused */
+	(void)session;						/* Unused */
+
 	return (0);
 }
 

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -708,14 +708,14 @@ main(void)
 	/* Open a connection to the database, creating it if necessary. */
 	if ((ret = wiredtiger_open(home, NULL, open_config, &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 		return (ret);
 	}
 	/*! [WT_FILE_SYSTEM register] */
 
 	if ((ret = conn->close(conn, NULL)) != 0)
 		fprintf(stderr, "Error closing connection to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	return (ret);
 }

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -659,8 +659,12 @@ int
 main(void)
 {
 	WT_CONNECTION *conn;
-	const char *open_config;
+	WT_CURSOR *cursor;
+	WT_SESSION *session;
+	const char *key, *open_config, *uri;
+	u_int i;
 	int ret = 0;
+	char kbuf[64];
 
 	/*
 	 * Create a clean test directory for this run of the test program if the
@@ -686,13 +690,78 @@ main(void)
 	if ((ret = wiredtiger_open(home, NULL, open_config, &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/*! [WT_FILE_SYSTEM register] */
 
-	if ((ret = conn->close(conn, NULL)) != 0)
+	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
+		fprintf(stderr, "WT_CONNECTION.open_session: %s\n",
+		    wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	uri = "table:fs";
+	if ((ret = session->create(
+	    session, uri, "key_format=S,value_format=S")) != 0) {
+		fprintf(stderr, "WT_SESSION.create: %s: %s\n",
+		    uri, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	if ((ret = session->open_cursor(
+	    session, uri, NULL, NULL, &cursor)) != 0) {
+		fprintf(stderr, "WT_SESSION.open_cursor: %s: %s\n",
+		    uri, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	for (i = 0; i < 1000; ++i) {
+		(void)snprintf(kbuf, sizeof(kbuf), "%010u KEY -----", i);
+		cursor->set_key(cursor, kbuf);
+		cursor->set_value(cursor, "--- VALUE ---");
+		if ((ret = cursor->insert(cursor)) != 0) {
+			fprintf(stderr, "WT_CURSOR.insert: %s: %s\n",
+			    kbuf, wiredtiger_strerror(ret));
+			return (EXIT_FAILURE);
+		}
+	}
+	if ((ret = cursor->close(cursor)) != 0) {
+		fprintf(stderr, "WT_CURSOR.close: %s\n",
+		    wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	if ((ret = session->open_cursor(
+	    session, uri, NULL, NULL, &cursor)) != 0) {
+		fprintf(stderr, "WT_SESSION.open_cursor: %s: %s\n",
+		    uri, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	for (i = 0; i < 1000; ++i) {
+		if ((ret = cursor->next(cursor)) != 0) {
+			fprintf(stderr, "WT_CURSOR.insert: %s: %s\n",
+			    kbuf, wiredtiger_strerror(ret));
+			return (EXIT_FAILURE);
+		}
+		(void)snprintf(kbuf, sizeof(kbuf), "%010u KEY -----", i);
+		if ((ret = cursor->get_key(cursor, &key)) != 0) {
+			fprintf(stderr, "WT_CURSOR.get_key: %s\n",
+			    wiredtiger_strerror(ret));
+			return (EXIT_FAILURE);
+		}
+		if (strcmp(kbuf, key) != 0) {
+			fprintf(stderr, "Key mismatch: %s, %s\n", kbuf, key);
+			return (EXIT_FAILURE);
+		}
+	}
+	if ((ret = cursor->next(cursor)) != WT_NOTFOUND) {
+		fprintf(stderr,
+		    "WT_CURSOR.insert: expected WT_NOTFOUND, got %s\n",
+		    wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+
+	if ((ret = conn->close(conn, NULL)) != 0) {
 		fprintf(stderr, "Error closing connection to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
-	return (ret);
+	return (EXIT_SUCCESS);
 }

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -111,8 +111,6 @@ static int demo_file_lock(WT_FILE_HANDLE *, WT_SESSION *, bool);
 static int demo_file_read(
     WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, void *);
 static int demo_file_size(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t *);
-static int demo_file_sync(WT_FILE_HANDLE *, WT_SESSION *);
-static int demo_file_sync_nowait(WT_FILE_HANDLE *, WT_SESSION *);
 static int demo_file_truncate(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t);
 static int demo_file_write(
     WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, const void *);
@@ -241,8 +239,8 @@ demo_fs_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
 	file_handle->unmap = NULL;
 	file_handle->read = demo_file_read;
 	file_handle->size = demo_file_size;
-	file_handle->sync = demo_file_sync;
-	file_handle->sync_nowait = demo_file_sync_nowait;
+	file_handle->sync = NULL;
+	file_handle->sync_nowait = NULL;
 	file_handle->truncate = demo_file_truncate;
 	file_handle->write = demo_file_write;
 
@@ -538,34 +536,6 @@ demo_file_size(
 
 	assert(demo_fh->size != 0);
 	*sizep = (wt_off_t)demo_fh->size;
-	return (0);
-}
-
-/*
- * demo_file_sync --
- *	Ensure the content of the file is stable. This is a no-op in our
- *	memory backed file system.
- */
-static int
-demo_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
-{
-	(void)file_handle;					/* Unused */
-	(void)session;						/* Unused */
-
-	return (0);
-}
-
-/*
- * demo_file_sync_nowait --
- *	Ensure the content of the file is stable. This is a no-op in our
- *	memory backed file system.
- */
-static int
-demo_file_sync_nowait(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
-{
-	(void)file_handle;					/* Unused */
-	(void)session;						/* Unused */
-
 	return (0);
 }
 

--- a/examples/c/ex_hello.c
+++ b/examples/c/ex_hello.c
@@ -58,19 +58,19 @@ main(void)
 	/* Open a connection to the database, creating it if necessary. */
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* Open a session for the current thread's work. */
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* Do some work... */
 
 	/* Note: closing the connection implicitly closes open session(s). */
 	if ((ret = conn->close(conn, NULL)) != 0)
 		fprintf(stderr, "Error closing %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	return (ret);
 }

--- a/examples/c/ex_hello.c
+++ b/examples/c/ex_hello.c
@@ -56,21 +56,27 @@ main(void)
 		home = NULL;
 
 	/* Open a connection to the database, creating it if necessary. */
-	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
+	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	/* Open a session for the current thread's work. */
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
+	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error opening a session on %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	/* Do some work... */
 
 	/* Note: closing the connection implicitly closes open session(s). */
-	if ((ret = conn->close(conn, NULL)) != 0)
+	if ((ret = conn->close(conn, NULL)) != 0) {
 		fprintf(stderr, "Error closing %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
-	return (ret);
+	return (EXIT_SUCCESS);
 }

--- a/examples/c/ex_log.c
+++ b/examples/c/ex_log.c
@@ -295,12 +295,12 @@ main(void)
 	    home1, home2, home1, home2);
 	if ((ret = system(cmd_buf)) != 0) {
 		fprintf(stderr, "%s: failed ret %d\n", cmd_buf, ret);
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	if ((ret = wiredtiger_open(home1, NULL, CONN_CONFIG, &wt_conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home1, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	ret = wt_conn->open_session(wt_conn, NULL, NULL, &session);
@@ -348,12 +348,13 @@ main(void)
 	if ((ret = wiredtiger_open(home1, NULL, CONN_CONFIG, &wt_conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home1, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	ret = wt_conn->open_session(wt_conn, NULL, NULL, &session);
 	ret = simple_walk_log(session, count_min);
 	ret = walk_log(session);
 	ret = wt_conn->close(wt_conn, NULL);
-	return (ret);
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_pack.c
+++ b/examples/c/ex_pack.c
@@ -57,12 +57,12 @@ main(void)
 	/* Open a connection to the database, creating it if necessary. */
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* Open a session for the current thread's work. */
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	{
 	/*! [packing] */
@@ -83,7 +83,7 @@ main(void)
 	/* Note: closing the connection implicitly closes open session(s). */
 	if ((ret = conn->close(conn, NULL)) != 0)
 		fprintf(stderr, "Error closing %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	return (ret);
 }

--- a/examples/c/ex_pack.c
+++ b/examples/c/ex_pack.c
@@ -55,14 +55,18 @@ main(void)
 		home = NULL;
 
 	/* Open a connection to the database, creating it if necessary. */
-	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
+	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	/* Open a session for the current thread's work. */
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
+	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error opening a session on %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	{
 	/*! [packing] */
@@ -81,9 +85,11 @@ main(void)
 	}
 
 	/* Note: closing the connection implicitly closes open session(s). */
-	if ((ret = conn->close(conn, NULL)) != 0)
+	if ((ret = conn->close(conn, NULL)) != 0) {
 		fprintf(stderr, "Error closing %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
-	return (ret);
+	return (EXIT_SUCCESS);
 }

--- a/examples/c/ex_process.c
+++ b/examples/c/ex_process.c
@@ -58,22 +58,28 @@ main(void)
 	/*! [processes] */
 	/* Open a connection to the database, creating it if necessary. */
 	if ((ret =
-	    wiredtiger_open(home, NULL, "create,multiprocess", &conn)) != 0)
+	    wiredtiger_open(home, NULL, "create,multiprocess", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	/* Open a session for the current thread's work. */
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
+	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error opening a session on %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 
 	/* XXX Do some work... */
 
 	/* Note: closing the connection implicitly closes open session(s). */
-	if ((ret = conn->close(conn, NULL)) != 0)
+	if ((ret = conn->close(conn, NULL)) != 0) {
 		fprintf(stderr, "Error closing %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
+		return (EXIT_FAILURE);
+	}
 	/*! [processes] */
 
-	return (ret);
+	return (EXIT_SUCCESS);
 }

--- a/examples/c/ex_process.c
+++ b/examples/c/ex_process.c
@@ -60,19 +60,19 @@ main(void)
 	if ((ret =
 	    wiredtiger_open(home, NULL, "create,multiprocess", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* Open a session for the current thread's work. */
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		fprintf(stderr, "Error opening a session on %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 
 	/* XXX Do some work... */
 
 	/* Note: closing the connection implicitly closes open session(s). */
 	if ((ret = conn->close(conn, NULL)) != 0)
 		fprintf(stderr, "Error closing %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 	/*! [processes] */
 
 	return (ret);

--- a/examples/c/ex_schema.c
+++ b/examples/c/ex_schema.c
@@ -90,7 +90,7 @@ main(void)
 	if ((ret = wiredtiger_open(
 	    home, NULL, "create,statistics=(fast)", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 		return (ret);
 	}
 	/* Note: error checking omitted for clarity. */

--- a/examples/c/ex_schema.c
+++ b/examples/c/ex_schema.c
@@ -91,7 +91,7 @@ main(void)
 	    home, NULL, "create,statistics=(fast)", &conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	/* Note: error checking omitted for clarity. */
 
@@ -429,5 +429,5 @@ main(void)
 
 	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_scope.c
+++ b/examples/c/ex_scope.c
@@ -198,7 +198,7 @@ main(void)
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0 ||
 	    (ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 		return (ret);
 	}
 

--- a/examples/c/ex_scope.c
+++ b/examples/c/ex_scope.c
@@ -182,7 +182,7 @@ main(void)
 	WT_CONNECTION *conn;
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
-	int ret, tret;
+	int ret;
 
 	/*
 	 * Create a clean test directory for this run of the test program if the
@@ -199,7 +199,7 @@ main(void)
 	    (ret = conn->open_session(conn, NULL, NULL, &session)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home == NULL ? "." : home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	ret = session->create(session,
@@ -211,8 +211,7 @@ main(void)
 	ret = cursor_scope_ops(cursor);
 
 	/* Close the connection and clean up. */
-	if ((tret = conn->close(conn, NULL)) != 0 && ret == 0)
-		ret = tret;
+	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_stat.c
+++ b/examples/c/ex_stat.c
@@ -257,5 +257,7 @@ main(void)
 
 	ret = print_derived_stats(session);
 
-	return (conn->close(conn, NULL) == 0 ? ret : EXIT_FAILURE);
+	ret = conn->close(conn, NULL);
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_stat.c
+++ b/examples/c/ex_stat.c
@@ -235,9 +235,8 @@ main(void)
 
 	ret = wiredtiger_open(home, NULL, "create,statistics=(all)", &conn);
 	ret = conn->open_session(conn, NULL, NULL, &session);
-	ret = session->create(
-	    session, "table:access",
-	    "key_format=S,value_format=S,columns=(k,v)");
+	ret = session->create(session,
+	    "table:access", "key_format=S,value_format=S,columns=(k,v)");
 
 	ret = session->open_cursor(
 	    session, "table:access", NULL, NULL, &cursor);

--- a/examples/c/ex_sync.c
+++ b/examples/c/ex_sync.c
@@ -63,12 +63,12 @@ main(void)
 	    home, home);
 	if ((ret = system(cmd_buf)) != 0) {
 		fprintf(stderr, "%s: failed ret %d\n", cmd_buf, ret);
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 	if ((ret = wiredtiger_open(home, NULL, CONN_CONFIG, &wt_conn)) != 0) {
 		fprintf(stderr, "Error connecting to %s: %s\n",
 		    home, wiredtiger_strerror(ret));
-		return (ret);
+		return (EXIT_FAILURE);
 	}
 
 	ret = wt_conn->open_session(wt_conn, NULL, NULL, &session);
@@ -149,5 +149,6 @@ main(void)
 	ret = session->log_flush(session, "sync=on");
 
 	ret = wt_conn->close(wt_conn, NULL);
-	return (ret);
+
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/examples/c/ex_thread.c
+++ b/examples/c/ex_thread.c
@@ -101,7 +101,7 @@ main(void)
 
 	if ((ret = wiredtiger_open(home, NULL, "create", &conn)) != 0)
 		fprintf(stderr, "Error connecting to %s: %s\n",
-		    home, wiredtiger_strerror(ret));
+		    home == NULL ? "." : home, wiredtiger_strerror(ret));
 	/* Note: further error checking omitted for clarity. */
 
 	ret = conn->open_session(conn, NULL, NULL, &session);

--- a/examples/c/ex_thread.c
+++ b/examples/c/ex_thread.c
@@ -122,6 +122,6 @@ main(void)
 
 	ret = conn->close(conn, NULL);
 
-	return (ret);
+	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 /*! [thread main] */


### PR DESCRIPTION
@agorrod, the only thing I can find here is the file system example didn't separate the concepts of "buffer data size " and "buffer memory size", so the read of the file was somehow getting confused. I don't see the exact path that would cause it, but I think there's a potential problem there.

If you merge 461c63d, I think we can close the JIRA ticket until it appears again.