### PR TITLE
WT-2630: Rename WT_FSTREAM methods to avoid using C99 reserved names

### DIFF
--- a/src/include/os.h
+++ b/src/include/os.h
@@ -140,8 +140,9 @@ struct __wt_fstream {
 #define	WT_STREAM_WRITE		0x04		/* Open a stream for write */
 	uint32_t flags;
 
-	int (*close)(WT_SESSION_IMPL *, WT_FSTREAM *);
-	int (*flush)(WT_SESSION_IMPL *, WT_FSTREAM *);
-	int (*getline)(WT_SESSION_IMPL *, WT_FSTREAM *, WT_ITEM *);
-	int (*printf)(WT_SESSION_IMPL *, WT_FSTREAM *, const char *, va_list);
+	int (*fstream_close)(WT_SESSION_IMPL *, WT_FSTREAM *);
+	int (*fstream_flush)(WT_SESSION_IMPL *, WT_FSTREAM *);
+	int (*fstream_getline)(WT_SESSION_IMPL *, WT_FSTREAM *, WT_ITEM *);
+	int (*fstream_printf)(
+	    WT_SESSION_IMPL *, WT_FSTREAM *, const char *, va_list);
 };

--- a/src/include/os_fstream.i
+++ b/src/include/os_fstream.i
@@ -13,7 +13,7 @@
 static inline int
 __wt_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fs, WT_ITEM *buf)
 {
-	return (fs->getline(session, fs, buf));
+	return (fs->fstream_getline(session, fs, buf));
 }
 
 /*
@@ -28,7 +28,7 @@ __wt_fclose(WT_SESSION_IMPL *session, WT_FSTREAM **fsp)
 	if ((fs = *fsp) == NULL)
 		return (0);
 	*fsp = NULL;
-	return (fs->close(session, fs));
+	return (fs->fstream_close(session, fs));
 }
 
 /*
@@ -38,7 +38,7 @@ __wt_fclose(WT_SESSION_IMPL *session, WT_FSTREAM **fsp)
 static inline int
 __wt_fflush(WT_SESSION_IMPL *session, WT_FSTREAM *fs)
 {
-	return (fs->flush(session, fs));
+	return (fs->fstream_flush(session, fs));
 }
 
 /*
@@ -52,7 +52,7 @@ __wt_vfprintf(
 	WT_RET(__wt_verbose(
 	    session, WT_VERB_HANDLEOPS, "%s: handle-printf", fs->name));
 
-	return (fs->printf(session, fs, fmt, ap));
+	return (fs->fstream_printf(session, fs, fmt, ap));
 }
 
 /*

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -21,7 +21,7 @@ __fstream_close(WT_SESSION_IMPL *session, WT_FSTREAM *fs)
 	WT_DECL_RET;
 
 	if (!F_ISSET(fs, WT_STREAM_READ))
-		WT_TRET(fs->flush(session, fs));
+		WT_TRET(fs->fstream_flush(session, fs));
 
 	WT_TRET(__wt_close(session, &fs->fh));
 	__wt_buf_free(session, &fs->buf);
@@ -192,19 +192,19 @@ __wt_fopen(WT_SESSION_IMPL *session,
 	fs->name = fh->name;
 	fs->flags = flags;
 
-	fs->close = __fstream_close;
+	fs->fstream_close = __fstream_close;
 	WT_ERR(__wt_filesize(session, fh, &fs->size));
 	if (LF_ISSET(WT_STREAM_APPEND))
 		fs->off = fs->size;
 	if (LF_ISSET(WT_STREAM_APPEND | WT_STREAM_WRITE)) {
-		fs->flush = __fstream_flush;
-		fs->getline = __fstream_getline_notsup;
-		fs->printf = __fstream_printf;
+		fs->fstream_flush = __fstream_flush;
+		fs->fstream_getline = __fstream_getline_notsup;
+		fs->fstream_printf = __fstream_printf;
 	} else {
 		WT_ASSERT(session, LF_ISSET(WT_STREAM_READ));
-		fs->flush = __fstream_flush_notsup;
-		fs->getline = __fstream_getline;
-		fs->printf = __fstream_printf_notsup;
+		fs->fstream_flush = __fstream_flush_notsup;
+		fs->fstream_getline = __fstream_getline;
+		fs->fstream_printf = __fstream_printf_notsup;
 	}
 	*fsp = fs;
 	return (0);

--- a/src/os_common/os_fstream_stdio.c
+++ b/src/os_common/os_fstream_stdio.c
@@ -64,10 +64,10 @@ __stdio_init(WT_FSTREAM *fs, const char *name, FILE *fp)
 	fs->name = name;
 	fs->fp = fp;
 
-	fs->close = __stdio_close;
-	fs->flush = __stdio_flush;
-	fs->getline = __stdio_getline;
-	fs->printf = __stdio_printf;
+	fs->fstream_close = __stdio_close;
+	fs->fstream_flush = __stdio_flush;
+	fs->fstream_getline = __stdio_getline;
+	fs->fstream_printf = __stdio_printf;
 }
 
 /*


### PR DESCRIPTION
Ready for review/merge.