### PR TITLE
WT-2637: The file-extension documentation doesn't cover not-supported cases

### DIFF
--- a/src/docs/custom-file-systems.dox
+++ b/src/docs/custom-file-systems.dox
@@ -5,17 +5,23 @@ used by WiredTiger to interact with the I/O subsystem using the
 WT_FILE_SYSTEM and WT_FILE_HANDLE interfaces.
 
 It is not necessary for all file system providers to implement all methods
-in the WT_FILE_SYSTEM and WT_FILE_HANDLE structures. The documentation for
+in the WT_FILE_SYSTEM and WT_FILE_HANDLE structures, and documentation for
 those structures indicate which methods are optional. Methods which are not
 provided should be set to NULL. Generally the function pointers should not
 be changed once a handle is created. There is one exception to this, which
-are the fallocate and fallocate_nolock - for an example of how fallocate
-can be changed after create see the WiredTiger POSIX file system
-implementation.
+are the fallocate and fallocate_nolock - for an example of how the
+fallocate method might be changed after create see the WiredTiger POSIX
+file system implementation. (Note that the WiredTiger POSIX file system
+implementation code is in the public domain, and may be used as a starting
+point for other file system implementations.)
 
 WT_FILE_SYSTEM and WT_FILE_HANDLE methods which fail but not fatally
-(for example, a file truncation call which fails because the file is
-currently mapped into memory), should return EBUSY.
+(for example, a WT_FILE_HANDLE::truncate method call which fails because
+the file is currently mapped into memory), should return EBUSY.
+
+WT_FILE_SYSTEM and WT_FILE_HANDLE methods which fail fatally, but not
+in all cases (for example, a WT_FILE_HANDLE::fadvise method call which
+only supports ::WT_FILE_HANDLE_WILLNEED), should return ENOTSUP.
 
 Unless explicitly stated otherwise, WiredTiger may invoke methods on the
 WT_FILE_SYSTEM and WT_FILE_HANDLE interfaces from multiple threads

--- a/src/docs/custom-file-systems.dox
+++ b/src/docs/custom-file-systems.dox
@@ -7,13 +7,17 @@ WT_FILE_SYSTEM and WT_FILE_HANDLE interfaces.
 It is not necessary for all file system providers to implement all methods
 in the WT_FILE_SYSTEM and WT_FILE_HANDLE structures, and documentation for
 those structures indicate which methods are optional. Methods which are not
-provided should be set to NULL. Generally the function pointers should not
-be changed once a handle is created. There is one exception to this, which
-are the fallocate and fallocate_nolock - for an example of how the
-fallocate method might be changed after create see the WiredTiger POSIX
-file system implementation. (Note that the WiredTiger POSIX file system
-implementation code is in the public domain, and may be used as a starting
-point for other file system implementations.)
+provided should be set to NULL.
+
+Generally, function pointers should not be changed once a handle is
+created. An exception to this are the WT_FILE_HANDLE::fallocate and
+WT_FILE_HANDLE::fallocate_nolock methods, because a file system
+implementation may not know what support the system provides until file
+allocation is attempted. See the WiredTiger POSIX file system
+implementation for an example of how the fallocate method might be
+changed after initialization. (Note that the WiredTiger POSIX file
+system implementation code is in the public domain, and may be used as
+a starting point for other file system implementations.)
 
 WT_FILE_SYSTEM and WT_FILE_HANDLE methods which fail but not fatally
 (for example, a WT_FILE_HANDLE::truncate method call which fails because

--- a/src/docs/custom-file-systems.dox
+++ b/src/docs/custom-file-systems.dox
@@ -15,9 +15,7 @@ WT_FILE_HANDLE::fallocate_nolock methods, because a file system
 implementation may not know what support the system provides until file
 allocation is attempted. See the WiredTiger POSIX file system
 implementation for an example of how the fallocate method might be
-changed after initialization. (Note that the WiredTiger POSIX file
-system implementation code is in the public domain, and may be used as
-a starting point for other file system implementations.)
+changed after initialization.
 
 WT_FILE_SYSTEM and WT_FILE_HANDLE methods which fail but not fatally
 (for example, a WT_FILE_HANDLE::truncate method call which fails because
@@ -31,5 +29,10 @@ Unless explicitly stated otherwise, WiredTiger may invoke methods on the
 WT_FILE_SYSTEM and WT_FILE_HANDLE interfaces from multiple threads
 concurrently. It is the responsibility of the implementation to protect
 any shared data.
+
+See @ex_ref{ex_file_system.c} for an example implementation of a custom
+file system; the WiredTiger code for a POSIX standard file system is in
+the public domain and may also be useful as a starting point for a custom
+file system implementation.
 
 */

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -81,6 +81,7 @@ Seward's
 SiH
 TXT
 URIs
+WILLNEED
 WiredTiger
 WiredTiger's
 WiredTigerCheckpoint
@@ -210,8 +211,8 @@ erlang
 errno
 exe
 fadvise
-fallocate
 failchk
+fallocate
 fd's
 fdatasync
 fieldname

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -1,9 +1,29 @@
 /*-
- * Copyright (c) 2014-2016 MongoDB, Inc.
- * Copyright (c) 2008-2014 WiredTiger, Inc.
- *	All rights reserved.
+ * Public Domain 2014-2016 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
  *
- * See the file LICENSE for redistribution information.
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include "wt_internal.h"


### PR DESCRIPTION
The file-extension documentation doesn't cover not-supported cases.

Public domain the POSIX file system implementation, it's a natural starting point for anyone writing their own implementation.