### PR TITLE
WT-2632 Tolerate EBUSY when a checkpoint cursor is open.

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -530,9 +530,16 @@ ops(void *arg)
 				ckpt_config = ckpt_name;
 			}
 
-			testutil_checkfmt(
-			    session->checkpoint(session, ckpt_config),
-			    "%s", ckpt_config == NULL ? "" : ckpt_config);
+			ret = session->checkpoint(session, ckpt_config);
+			/*
+			 * We may be trying to create a named checkpoint while
+			 * we hold a cursor open to the previous checkpoint.
+			 * In that case we'll get back EBUSY.  Tolerate EBUSY
+			 * if we have the readonly cursor open.
+			 */
+			if (ret != 0 && (ret != EBUSY || !readonly))
+				testutil_die(ret, "%s",
+				    ckpt_config == NULL ? "" : ckpt_config);
 
 			if (ckpt_config != NULL)
 				testutil_check(

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -534,12 +534,12 @@ ops(void *arg)
 			/*
 			 * We may be trying to create a named checkpoint while
 			 * we hold a cursor open to the previous checkpoint.
-			 * In that case we'll get back EBUSY.  Tolerate EBUSY
-			 * if we have the readonly cursor open.
+			 * Tolerate EBUSY.
 			 */
-			if (ret != 0 && (ret != EBUSY || !readonly))
+			if (ret != 0 && ret != EBUSY)
 				testutil_die(ret, "%s",
 				    ckpt_config == NULL ? "" : ckpt_config);
+			ret = 0;
 
 			if (ckpt_config != NULL)
 				testutil_check(


### PR DESCRIPTION
@keithbostic Please review this change.