### PR TITLE
WT-2659: csuite tests, assorted lint and cleanup.

### DIFF
--- a/test/csuite/wt1965_col_efficiency/main.c
+++ b/test/csuite/wt1965_col_efficiency/main.c
@@ -61,7 +61,7 @@ static void
 	opts = (TEST_OPTS *)arg;
 	thr_idx = __wt_atomic_fetch_addv64(&opts->next_threadid, 1);
 	ts = g_ts;
-	obj_data = calloc(
+	obj_data = dcalloc(
 	    (NR_OBJECTS/NR_THREADS + 1) * NR_FIELDS, sizeof(*obj_data));
 
 	testutil_check(opts->conn->open_session(
@@ -101,7 +101,7 @@ static void
 
 			++g_ts;
 			/* 5K updates/sec */
-			usleep(1000000ULL * NR_THREADS / 5000);
+			(void)usleep(1000000ULL * NR_THREADS / 5000);
 		}
 	}
 
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
 		    &thr[t], NULL, thread_func, (void *)opts));
 
 	for (t = 0; t < NR_THREADS; ++t)
-		pthread_join(thr[t], NULL);
+		(void)pthread_join(thr[t], NULL);
 
 	testutil_check(opts->conn->open_session(
 	    opts->conn, NULL, NULL, &session));

--- a/test/csuite/wt1965_col_efficiency/main.c
+++ b/test/csuite/wt1965_col_efficiency/main.c
@@ -179,6 +179,7 @@ main(int argc, char *argv[])
 			printf("\t%" PRIu64, f[i]);
 		printf("\n");
 	}
+	testutil_assert(ret == WT_NOTFOUND);
 
 	testutil_cleanup(opts);
 

--- a/test/csuite/wt1965_col_efficiency/main.c
+++ b/test/csuite/wt1965_col_efficiency/main.c
@@ -37,7 +37,6 @@
 
 void (*custom_die)(void) = NULL;
 
-#define	BUF_SIZE 256
 /* If changing field count also need to change set_value and get_value calls */
 #define	NR_FIELDS 8
 #define	NR_OBJECTS 100

--- a/test/csuite/wt1965_col_efficiency/main.c
+++ b/test/csuite/wt1965_col_efficiency/main.c
@@ -43,7 +43,7 @@ void (*custom_die)(void) = NULL;
 #define	NR_OBJECTS 100
 #define	NR_THREADS 4
 
-static uint64_t g_ts;
+static uint64_t g_ts = 0;
 
 /*
  * Each thread inserts a set of keys into the record store database. The keys

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
 	    session->open_cursor(session, opts->uri, NULL, NULL, &c));
 	c->set_key(c, 1);
 	testutil_check(c->search(c));
-	c->get_value(c, &current_value);
+	testutil_check(c->get_value(c, &current_value));
 	if (current_value != opts->nthreads * opts->nrecords) {
 		fprintf(stderr,
 		    "ERROR: didn't get expected number of changes\n");
@@ -131,8 +131,8 @@ thread_insert_race(void *arg)
 		testutil_check(
 		    session->begin_transaction(session, "isolation=snapshot"));
 		cursor->set_key(cursor, 1);
-		cursor->search(cursor);
-		cursor->get_value(cursor, &value);
+		testutil_check(cursor->search(cursor));
+		testutil_check(cursor->get_value(cursor, &value));
 		cursor->set_key(cursor, 1);
 		cursor->set_value(cursor, value + 1);
 		if ((ret = cursor->update(cursor)) != 0) {

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -48,8 +48,8 @@ main(int argc, char *argv[])
 	WT_SESSION *session;
 	clock_t ce, cs;
 	pthread_t id[100];
-	int i;
 	uint64_t current_value;
+	int i;
 
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
@@ -92,8 +92,8 @@ main(int argc, char *argv[])
 	if (current_value != opts->nthreads * opts->nrecords) {
 		fprintf(stderr,
 		    "ERROR: didn't get expected number of changes\n");
-		fprintf(stderr, "got: %d, expected: %d\n",
-		    (int)current_value, (int)(opts->nthreads * opts->nrecords));
+		fprintf(stderr, "got: %" PRIu64 ", expected: %" PRIu64 "\n",
+		    current_value, opts->nthreads * opts->nrecords);
 		return (EXIT_FAILURE);
 	}
 	testutil_check(session->close(session, NULL));
@@ -114,10 +114,10 @@ thread_insert_race(void *arg)
 {
 	TEST_OPTS *opts;
 	WT_CONNECTION *conn;
-	WT_SESSION *session;
 	WT_CURSOR *cursor;
-	int ret;
+	WT_SESSION *session;
 	uint64_t i, value;
+	int ret;
 
 	opts = (TEST_OPTS *)arg;
 	conn = opts->conn;
@@ -146,7 +146,7 @@ thread_insert_race(void *arg)
 		}
 		testutil_check(session->commit_transaction(session, NULL));
 		if (i % 10000 == 0) {
-			printf("insert: %d\r", (int)i);
+			printf("insert: %" PRIu64 "\r", i);
 			fflush(stdout);
 		}
 	}

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -132,12 +132,9 @@ testutil_cleanup(TEST_OPTS *opts)
 	if (!opts->preserve)
 		testutil_clean_work_dir(opts->home);
 
-	if (opts->conn_config != NULL)
-		free(opts->conn_config);
-	if (opts->table_config != NULL)
-		free(opts->table_config);
-	if (opts->uri != NULL)
-		free(opts->uri);
+	free(opts->conn_config);
+	free(opts->table_config);
+	free(opts->uri);
 	free(opts->home);
 }
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -79,7 +79,7 @@ typedef struct {
  *	Complain and quit if something isn't true.
  */
 #define	testutil_assert(a) do {						\
-	if ((a) != true)						\
+	if (!(a))							\
 		testutil_die(0, "%s/%d: %s", __func__, __LINE__, #a);	\
 } while (0)
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -75,13 +75,23 @@ typedef struct {
 } TEST_OPTS;
 
 /*
+ * testutil_assert --
+ *	Complain and quit if something isn't true.
+ */
+#define	testutil_assert(a) do {						\
+	if ((a) != true)						\
+		testutil_die(0, "%s/%d: %s", __func__, __LINE__, #a);	\
+} while (0)
+
+/*
  * testutil_check --
  *	Complain and quit if a function call fails.
  */
 #define	testutil_check(call) do {					\
 	int __r;							\
 	if ((__r = (call)) != 0)					\
-		testutil_die(__r, "%s/%d: %s", __func__, __LINE__, #call);\
+		testutil_die(						\
+		    __r, "%s/%d: %s", __func__, __LINE__, #call);	\
 } while (0)
 
 /*

--- a/test/utility/thread.c
+++ b/test/utility/thread.c
@@ -39,8 +39,8 @@ thread_append(void *arg)
 {
 	TEST_OPTS *opts;
 	WT_CONNECTION *conn;
-	WT_SESSION *session;
 	WT_CURSOR *cursor;
+	WT_SESSION *session;
 	uint64_t id, recno;
 	char buf[64];
 
@@ -81,8 +81,8 @@ thread_insert_append(void *arg)
 {
 	TEST_OPTS *opts;
 	WT_CONNECTION *conn;
-	WT_SESSION *session;
 	WT_CURSOR *cursor;
+	WT_SESSION *session;
 	uint64_t i;
 	char kbuf[64];
 
@@ -99,7 +99,7 @@ thread_insert_append(void *arg)
 		cursor->set_value(cursor, "========== VALUE =======");
 		testutil_check(cursor->insert(cursor));
 		if (i % 100000 == 0) {
-			printf("insert: %d\r", (int)i);
+			printf("insert: %" PRIu64 "\r", i);
 			fflush(stdout);
 		}
 	}
@@ -117,8 +117,8 @@ void *
 thread_prev(void *arg)
 {
 	TEST_OPTS *opts;
-	WT_SESSION *session;
 	WT_CURSOR *cursor;
+	WT_SESSION *session;
 	int ret;
 
 	opts = (TEST_OPTS *)arg;


### PR DESCRIPTION
@sueloverso, @agorrod, I pointed lint at the new csuite tests, just some minor cleanup.

I added a new macro, `testutil_assert`, to make it easy to assert stuff and die if it's not true.