### PR TITLE
WT-2660 Fix a hang between eviction and connection close

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -434,10 +434,6 @@ __wt_evict_destroy(WT_SESSION_IMPL *session)
 
 		conn->evict_session = NULL;
 	}
-	__wt_spin_lock(session, &cache->evict_queue_lock);
-	cache->evict_current = NULL;
-	cache->evict_current_queue = NULL;
-	__wt_spin_unlock(session, &cache->evict_queue_lock);
 
 	return (ret);
 }
@@ -1732,9 +1728,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 
 		/* See if eviction is still needed. */
 		if (!__wt_eviction_needed(session, NULL) ||
-#if 0
 		    F_ISSET(conn, WT_CONN_CLOSING) ||
-#endif
 		    cache->pages_evict > init_evict_count + max_pages_evicted)
 			return (0);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -434,6 +434,10 @@ __wt_evict_destroy(WT_SESSION_IMPL *session)
 
 		conn->evict_session = NULL;
 	}
+	__wt_spin_lock(session, &cache->evict_queue_lock);
+	cache->evict_current = NULL;
+	cache->evict_current_queue = NULL;
+	__wt_spin_unlock(session, &cache->evict_queue_lock);
 
 	return (ret);
 }
@@ -1728,6 +1732,9 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 
 		/* See if eviction is still needed. */
 		if (!__wt_eviction_needed(session, NULL) ||
+#if 0
+		    F_ISSET(conn, WT_CONN_CLOSING) ||
+#endif
 		    cache->pages_evict > init_evict_count + max_pages_evicted)
 			return (0);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1728,7 +1728,6 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 
 		/* See if eviction is still needed. */
 		if (!__wt_eviction_needed(session, NULL) ||
-		    F_ISSET(conn, WT_CONN_CLOSING) ||
 		    cache->pages_evict > init_evict_count + max_pages_evicted)
 			return (0);
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -166,6 +166,13 @@ __wt_eviction_needed(WT_SESSION_IMPL *session, u_int *pct_fullp)
 	cache = conn->cache;
 
 	/*
+	 * If the connection is closing we do not need eviction from an
+	 * application thread.  The eviction subsystem is already closed.
+	 */
+	if (F_ISSET(conn, WT_CONN_CLOSING))
+		return (false);
+
+	/*
 	 * Avoid division by zero if the cache size has not yet been set in a
 	 * shared cache.
 	 */


### PR DESCRIPTION
@michaelcahill Please review this change.  I added a condition to have the app thread helping with eviction return if it notices we're closing.  You'll see by my first commit (reverted in the second) that I tried to encourage the situation, but have so far been unable to reproduce the original hang.

One consideration for this change is whether we could hit one of the conditionals in `conn_cache_destroy` but I think it is okay.  I just want someone else to think about it for a minute too.