### PR TITLE
WT-2268 WT-2597 JSON load/dump Unicode fixes

### DIFF
--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -155,7 +155,9 @@ __curdump_set_key(WT_CURSOR *cursor, ...)
 	WT_SESSION_IMPL *session;
 	uint64_t recno;
 	va_list ap;
+	const uint8_t *up;
 	const char *p;
+	bool json;
 
 	cdump = (WT_CURSOR_DUMP *)cursor;
 	child = cdump->child;
@@ -168,16 +170,23 @@ __curdump_set_key(WT_CURSOR *cursor, ...)
 		p = va_arg(ap, const char *);
 	va_end(ap);
 
+	json = F_ISSET(cursor, WT_CURSTD_DUMP_JSON);
+	if (json)
+		WT_ERR(__wt_json_to_item(session, p, cursor->key_format,
+		    (WT_CURSOR_JSON *)cursor->json_private, true,
+		    &cursor->key));
+
 	if (WT_CURSOR_RECNO(cursor) && !F_ISSET(cursor, WT_CURSTD_RAW)) {
-		WT_ERR(str2recno(session, p, &recno));
+		if (json) {
+			up = (const uint8_t *)cursor->key.data;
+			WT_ERR(__wt_vunpack_uint(&up, cursor->key.size,
+			    &recno));
+		} else
+			WT_ERR(str2recno(session, p, &recno));
 
 		child->set_key(child, recno);
 	} else {
-		if (F_ISSET(cursor, WT_CURSTD_DUMP_JSON))
-			WT_ERR(__wt_json_to_item(session, p, cursor->key_format,
-			    (WT_CURSOR_JSON *)cursor->json_private, true,
-			    &cursor->key));
-		else
+		if (!json)
 			WT_ERR(__dump_to_raw(session, p, &cursor->key,
 			    F_ISSET(cursor, WT_CURSTD_DUMP_HEX)));
 

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -48,6 +48,10 @@ static int __json_pack_size(WT_SESSION_IMPL *, const char *, WT_CONFIG_ITEM *,
 	case 't':							\
 		WT_RET(json_uint_arg(session, &jstr, &pv.u.u));		\
 		break;							\
+	case 'u':							\
+		WT_RET(json_string_arg(session, &jstr, &pv.u.item));	\
+		pv.type = 'J';						\
+		break;							\
 	/* User format strings have already been validated. */		\
 	WT_ILLEGAL_VALUE(session);					\
 	}								\
@@ -848,9 +852,9 @@ __wt_json_strlen(const char *src, size_t srclen)
 					 */
 					return (-1);
 			}
-		}
+		} else
+			src++;
 		dstlen++;
-		src++;
 	}
 	if (src != srcend)
 		return (-1);   /* invalid input, e.g. final char is '\\' */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -297,7 +297,7 @@ extern int __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype
 extern const char *__wt_json_tokname(int toktype);
 extern int __wt_json_to_item(WT_SESSION_IMPL *session, const char *jstr, const char *format, WT_CURSOR_JSON *json, bool iskey, WT_ITEM *item);
 extern ssize_t __wt_json_strlen(const char *src, size_t srclen);
-extern int __wt_json_strncpy(char **pdst, size_t dstlen, const char *src, size_t srclen);
+extern int __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char *src, size_t srclen);
 extern int __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR **cursorp);
 extern int __wt_schema_create_final( WT_SESSION_IMPL *session, char *cfg_arg[], char **value_ret);
 extern int __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, const char *cfg[], WT_CURSOR **cursorp);

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -465,12 +465,12 @@ dump_prefix(WT_SESSION *session, bool hex, bool json)
 	    "WiredTiger Dump (WiredTiger Version %d.%d.%d)\n",
 	    vmajor, vminor, vpatch) < 0 ||
 	    printf("Format=%s\n", hex ? "hex" : "print") < 0 ||
-		printf("Header\n") < 0))
+	    printf("Header\n") < 0))
 		return (util_err(session, EIO, NULL));
 	else if (json && printf(
 	    "    \"%s\" : \"%d (%d.%d.%d)\",\n",
-		DUMP_JSON_VERSION_MARKER, DUMP_JSON_CURRENT_VERSION,
-		vmajor, vminor, vpatch) < 0)
+	    DUMP_JSON_VERSION_MARKER, DUMP_JSON_CURRENT_VERSION,
+	    vmajor, vminor, vpatch) < 0)
 		return (util_err(session, EIO, NULL));
 
 	return (0);

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -7,6 +7,7 @@
  */
 
 #include "util.h"
+#include "util_dump.h"
 
 static int dump_config(WT_SESSION *, const char *, bool, bool);
 static int dump_json_begin(WT_SESSION *);
@@ -73,7 +74,9 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
 	if (argc < 1 || (argc != 1 && !json))
 		return (usage());
 
-	if (json && (ret = dump_json_begin(session)) != 0)
+	if (json &&
+	    ((ret = dump_json_begin(session)) != 0 ||
+	    (ret = dump_prefix(session, hex, json)) != 0))
 		goto err;
 
 	for (i = 0; i < argc; i++) {
@@ -155,7 +158,7 @@ dump_config(WT_SESSION *session, const char *uri, bool hex, bool json)
 	 */
 	cursor->set_key(cursor, uri);
 	if ((ret = cursor->search(cursor)) == 0) {
-		if (dump_prefix(session, hex, json) != 0 ||
+		if ((!json && dump_prefix(session, hex, json) != 0) ||
 		    dump_table_config(session, cursor, uri, json) != 0 ||
 		    dump_suffix(session, json) != 0)
 			ret = 1;
@@ -456,17 +459,20 @@ dump_prefix(WT_SESSION *session, bool hex, bool json)
 {
 	int vmajor, vminor, vpatch;
 
-	if (json)
-		return (0);
-
 	(void)wiredtiger_version(&vmajor, &vminor, &vpatch);
 
-	if (printf(
+	if (!json && (printf(
 	    "WiredTiger Dump (WiredTiger Version %d.%d.%d)\n",
 	    vmajor, vminor, vpatch) < 0 ||
 	    printf("Format=%s\n", hex ? "hex" : "print") < 0 ||
-	    printf("Header\n") < 0)
+		printf("Header\n") < 0))
 		return (util_err(session, EIO, NULL));
+	else if (json && printf(
+	    "    \"%s\" : \"%d (%d.%d.%d)\",\n",
+		DUMP_JSON_VERSION_MARKER, DUMP_JSON_CURRENT_VERSION,
+		vmajor, vminor, vpatch) < 0)
+		return (util_err(session, EIO, NULL));
+
 	return (0);
 }
 

--- a/src/utilities/util_dump.h
+++ b/src/utilities/util_dump.h
@@ -1,0 +1,11 @@
+/*-
+ * Copyright (c) 2014-2016 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#define	DUMP_JSON_VERSION_MARKER	"WiredTiger Dump Version"
+#define	DUMP_JSON_CURRENT_VERSION	1
+#define	DUMP_JSON_SUPPORTED_VERSION	1

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -187,9 +187,8 @@ json_strdup(WT_SESSION *session, JSON_INPUT_STATE *ins, char **resultp)
 	}
 	*resultp = result;
 	resultcpy = result;
-	if ((ret = __wt_json_strncpy(session, &resultcpy, (size_t)resultlen,
-	    src, srclen))
-	    != 0) {
+	if ((ret = __wt_json_strncpy(
+	    session, &resultcpy, (size_t)resultlen, src, srclen)) != 0) {
 		ret = util_err(session, ret, NULL);
 		goto err;
 	}

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -7,6 +7,7 @@
  */
 
 #include "util.h"
+#include "util_dump.h"
 #include "util_load.h"
 
 /*
@@ -344,13 +345,16 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
 {
 	CONFIG_LIST cl;
 	WT_DECL_RET;
-	int toktype;
 	static const char *json_markers[] = {
 	    "\"config\"", "\"colgroups\"", "\"indices\"", "\"data\"", NULL };
 	char *config, *tableuri;
+	int curversion, toktype;
+	bool hasversion;
 
 	memset(&cl, 0, sizeof(cl));
 	tableuri = NULL;
+	hasversion = false;
+
 	JSON_EXPECT(session, ins, '{');
 	while (json_peek(session, ins) == 's') {
 		JSON_EXPECT(session, ins, 's');
@@ -358,6 +362,24 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
 		snprintf(tableuri, ins->toklen, "%.*s",
 		    (int)(ins->toklen - 2), ins->tokstart + 1);
 		JSON_EXPECT(session, ins, ':');
+		if (!hasversion) {
+			if (strcmp(tableuri, DUMP_JSON_VERSION_MARKER) != 0) {
+				ret = util_err(session, ENOTSUP,
+				    "missing \"%s\"", DUMP_JSON_VERSION_MARKER);
+				goto err;
+			}
+			hasversion = true;
+			JSON_EXPECT(session, ins, 's');
+			if ((curversion = atoi(ins->tokstart + 1)) <= 0 ||
+			    curversion > DUMP_JSON_SUPPORTED_VERSION) {
+				ret = util_err(session, ENOTSUP,
+				    "unsupported JSON dump version \"%.*s\"",
+				    (int)(ins->toklen - 1), ins->tokstart + 1);
+				goto err;
+			}
+			JSON_EXPECT(session, ins, ',');
+			continue;
+		}
 
 		/*
 		 * Allow any ordering of 'config', 'colgroups',

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -187,8 +187,8 @@ json_strdup(WT_SESSION *session, JSON_INPUT_STATE *ins, char **resultp)
 	}
 	*resultp = result;
 	resultcpy = result;
-	if ((ret = __wt_json_strncpy(&resultcpy, (size_t)resultlen, src,
-	    srclen))
+	if ((ret = __wt_json_strncpy(session, &resultcpy, (size_t)resultlen,
+	    src, srclen))
 	    != 0) {
 		ret = util_err(session, ret, NULL);
 		goto err;


### PR DESCRIPTION
This version of JSON load/dump is incompatible with older versions.  The issue is that older JSON dump tried to dump 's' and 'S' strings as Unicode.  If the byte sequence ... 0x03 0xC0 ... appeared, then this is a valid Unicode escape sequence and we showed '...\u03c0...'.  All fine if the string is Unicode, but if not (e.g. ... 0xFF 0xFE ...), there is no Unicode sequence that we can emit that will map back to these bytes when we reload. It seemed to me the simplest way to solve this was to treat every character in a string as a raw byte (that is, not interpreted as Unicode), but emit a unicode value between '\u0000' and '\u00ff'.  If the byte is printable, we show the printable character in the string.  Byte arrays (schema type 'u') are dumped using the same rules, except that we don't never should the printable character, always \u0000 to \u00ff.

Since this breaks compatibility (old JSON dumps may translate to different bytes in a new JSON loader, and vice versa), I added a version string and a check. A new JSON dump loaded by old code will also give an error (it won't expect to see the version string). I didn't make any attempt to try to load old dumps via some byte translation; it may be possible, but there may be ambiguities. I figured anyone really interested in moving data via dump/load would not use JSON to do it. The important thing is to catch mistakes in misusage.

Note: This also fixes WT-2597, I've added lots of new tests, including LSM.