### PR TITLE
SERVER-24306 Do log file prealloc every second.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -31,7 +31,7 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn)
 	log = conn->log;
 	log->ckpt_lsn = *ckp_lsn;
 	if (conn->log_cond != NULL)
-		WT_RET(__wt_cond_auto_signal(session, conn->log_cond));
+		WT_RET(__wt_cond_signal(session, conn->log_cond));
 	return (0);
 }
 
@@ -838,8 +838,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 		if (create_log) {
 			WT_STAT_FAST_CONN_INCR(session, log_prealloc_missed);
 			if (conn->log_cond != NULL)
-				WT_RET(__wt_cond_auto_signal(
-				    session, conn->log_cond));
+				WT_RET(
+				    __wt_cond_signal(session, conn->log_cond));
 		}
 	}
 	/*
@@ -2017,8 +2017,9 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 		 *
 		 * XXX I've seen times when conditions are NULL.
 		 */
-		if (conn->log_cond != NULL) {
-			WT_ERR(__wt_cond_auto_signal(session, conn->log_cond));
+		if (conn->log_wrlsn_cond != NULL) {
+			WT_ERR(__wt_cond_auto_signal(
+			    session, conn->log_wrlsn_cond));
 			__wt_yield();
 		} else
 			WT_ERR(__wt_log_force_write(session, 1, NULL));


### PR DESCRIPTION
With the switch to auto-tuning condition variables, logging threads
need to track elapsed time to determine when to do heavyweight
operations such as log file pre-allocation and archiving.