### PR TITLE
WT-2672 handle system calls that don't set errno

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -442,6 +442,7 @@ bzDecompressInit
 bzalloc
 bzfree
 bzip
+call's
 calloc
 cas
 catfmt

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -38,7 +38,7 @@ __wt_posix_directory_list(WT_FILE_SYSTEM *file_system,
 	dirallocsz = 0;
 	entries = NULL;
 
-	WT_SYSCALL_RETRY(((dirp = opendir(directory)) == NULL ? 1 : 0), ret);
+	WT_SYSCALL_RETRY(((dirp = opendir(directory)) == NULL ? -1 : 0), ret);
 	if (ret != 0)
 		WT_RET_MSG(session, ret,
 		    "%s: directory-list: opendir", directory);

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -169,11 +169,6 @@ __win_file_lock(
 	 * WiredTiger requires this function be able to acquire locks past
 	 * the end of file.
 	 *
-	 * Note we're using fcntl(2) locking: all fcntl locks associated with a
-	 * file for a given process are removed when any file descriptor for the
-	 * file is closed by the process, even if a lock was never requested for
-	 * that file descriptor.
-	 *
 	 * http://msdn.microsoft.com/
 	 *    en-us/library/windows/desktop/aa365202%28v=vs.85%29.aspx
 	 *


### PR DESCRIPTION
@michaelcahill, I tried coding up your suggestion, and I agree it's better than #2757.

I think we should review how we're using SYSCALL_RETRY, though. We're calling it for things that aren't worth retrying (gettimeofday), and we're not calling it for things that might reasonably need to be retried (pread, pwrite). I could see using retry for open(2) calls, but I don't think it has much value outside of that, since pread/pwrite clearly don't need it.
