### PR TITLE
WT-2646 Add checkpoint_wait configuration option to drop (#2736)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -787,15 +787,19 @@ methods = {
 ]),
 
 'WT_SESSION.drop' : Method([
+    Config('checkpoint_wait', 'true', r'''
+        wait for the checkpoint lock, if \c checkpoint_wait=false, fail if
+        this lock is not available immediately''',
+        type='boolean', undoc=True),
     Config('force', 'false', r'''
         return success if the object does not exist''',
-        type='boolean'),
-    Config('remove_files', 'true', r'''
-        should the underlying files be removed?''',
         type='boolean'),
     Config('lock_wait', 'true', r'''
         wait for locks, if \c lock_wait=false, fail if any required locks are
         not available immediately''',
+        type='boolean', undoc=True),
+    Config('remove_files', 'true', r'''
+        should the underlying files be removed?''',
         type='boolean'),
 ]),
 

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -291,6 +291,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
 };
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_drop[] = {
+	{ "checkpoint_wait", "boolean", NULL, NULL, NULL, 0 },
 	{ "force", "boolean", NULL, NULL, NULL, 0 },
 	{ "lock_wait", "boolean", NULL, NULL, NULL, 0 },
 	{ "remove_files", "boolean", NULL, NULL, NULL, 0 },
@@ -1026,8 +1027,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  confchk_WT_SESSION_create, 40
 	},
 	{ "WT_SESSION.drop",
-	  "force=0,lock_wait=,remove_files=",
-	  confchk_WT_SESSION_drop, 3
+	  "checkpoint_wait=,force=0,lock_wait=,remove_files=",
+	  confchk_WT_SESSION_drop, 4
 	},
 	{ "WT_SESSION.join",
 	  "bloom_bit_count=16,bloom_hash_count=8,compare=\"eq\",count=,"

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1221,9 +1221,6 @@ struct __wt_session {
 	 * @configstart{WT_SESSION.drop, see dist/api_data.py}
 	 * @config{force, return success if the object does not exist., a
 	 * boolean flag; default \c false.}
-	 * @config{lock_wait, wait for locks\, if \c lock_wait=false\, fail if
-	 * any required locks are not available immediately., a boolean flag;
-	 * default \c true.}
 	 * @config{remove_files, should the underlying files be removed?., a
 	 * boolean flag; default \c true.}
 	 * @configend

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -722,18 +722,29 @@ __wt_session_drop(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 {
 	WT_DECL_RET;
 	WT_CONFIG_ITEM cval;
-	bool lock_wait;
+	bool checkpoint_wait, lock_wait;
 
+	WT_RET(__wt_config_gets_def(session, cfg, "checkpoint_wait", 1, &cval));
+	checkpoint_wait = cval.val != 0;
 	WT_RET(__wt_config_gets_def(session, cfg, "lock_wait", 1, &cval));
 	lock_wait = cval.val != 0 || F_ISSET(session, WT_SESSION_LOCK_NO_WAIT);
 
 	if (!lock_wait)
 		F_SET(session, WT_SESSION_LOCK_NO_WAIT);
 
-	WT_WITH_CHECKPOINT_LOCK(session, ret,
-	    WT_WITH_SCHEMA_LOCK(session, ret,
-		WT_WITH_TABLE_LOCK(session, ret,
-		    ret = __wt_schema_drop(session, uri, cfg))));
+	/*
+	 * The checkpoint lock only is needed to avoid a spurious EBUSY error
+	 * return.
+	 */
+	if (checkpoint_wait)
+		WT_WITH_CHECKPOINT_LOCK(session, ret,
+		    WT_WITH_SCHEMA_LOCK(session, ret,
+			WT_WITH_TABLE_LOCK(session, ret,
+			    ret = __wt_schema_drop(session, uri, cfg))));
+	else
+		WT_WITH_SCHEMA_LOCK(session, ret,
+		    WT_WITH_TABLE_LOCK(session, ret,
+			ret = __wt_schema_drop(session, uri, cfg)));
 
 	if (!lock_wait)
 		F_CLR(session, WT_SESSION_LOCK_NO_WAIT);


### PR DESCRIPTION
* Default checkpoint_wait is true. This change is useful because it means concurrent create/drop calls don't generate EBUSY returns.
* Mark lock_wait and checkpoint_wait as undoc

(cherry picked from commit 4b48ad6fb787a8b8662b5eacad6840d0b3ae9fb5)