### PR TITLE
WT-2672 handle system calls that don't set errno

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -117,6 +117,7 @@ FNV
 FORALL
 FOREACH
 FULLFSYNC
+FindClose
 FindFirstFile
 Fixup
 Fk
@@ -471,6 +472,7 @@ ckptfrag
 ckptlist
 cksum
 cloexec
+closedir
 clsm
 cmd
 cmp

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -6,28 +6,32 @@
  * See the file LICENSE for redistribution information.
  */
 
+#define	WT_SYSCALL(call, ret) do {					\
+	/*								\
+	 * A call returning 0 indicates success; any call where		\
+	 * 0 is not the only successful return must provide an		\
+	 * expression evaluating to 0 in all successful	cases.		\
+	 */								\
+	if (((ret) = (call)) == 0)					\
+		break;							\
+	/*								\
+	 * The call's error was either returned by the call or		\
+	 * is in errno, and there are cases where it depends on		\
+	 * the software release as to which it is (for example,		\
+	 * posix_fadvise on FreeBSD and OS X). Failing calls		\
+	 * must either return a non-zero error value, or -1 if		\
+	 * the error value is in errno. (The WiredTiger errno		\
+	 * function returns WT_ERROR if errno is 0, which isn't		\
+	 * ideal but won't discard the failure.)			\
+	 */								\
+	if ((ret) == -1)						\
+		(ret) = __wt_errno();					\
+} while (0)
+
 #define	WT_SYSCALL_RETRY(call, ret) do {				\
 	int __retry;							\
 	for (__retry = 0; __retry < 10; ++__retry) {			\
-		/*							\
-		 * A call returning 0 indicates success; any call where	\
-		 * 0 is not the only successful return must provide an	\
-		 * expression evaluating to 0 in all successful	cases.	\
-		 */							\
-		if (((ret) = (call)) == 0)				\
-			break;						\
-		/*							\
-		 * The call's error was either returned by the call or	\
-		 * is in errno, and there are cases where it depends on	\
-		 * the software release as to which it is (for example,	\
-		 * posix_fadvise on FreeBSD and OS X). Failing calls	\
-		 * must either return a non-zero error value, or -1 if	\
-		 * the error value is in errno. (The WiredTiger errno	\
-		 * function returns WT_ERROR if errno is 0, which isn't	\
-		 * ideal but won't discard the failure.)		\
-		 */							\
-		if ((ret) == -1)					\
-			(ret) = __wt_errno();				\
+		WT_SYSCALL(call, ret);					\
 		switch (ret) {						\
 		case EAGAIN:						\
 		case EBUSY:						\

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -25,6 +25,7 @@ __wt_posix_directory_list(WT_FILE_SYSTEM *file_system,
 	WT_SESSION_IMPL *session;
 	size_t dirallocsz;
 	uint32_t count;
+	int tret;
 	char **entries;
 
 	WT_UNUSED(file_system);
@@ -64,8 +65,15 @@ __wt_posix_directory_list(WT_FILE_SYSTEM *file_system,
 	*dirlistp = entries;
 	*countp = count;
 
-err:	if (dirp != NULL)
-		(void)closedir(dirp);
+err:	if (dirp != NULL) {
+		WT_SYSCALL(closedir(dirp), tret);
+		if (tret != 0) {
+			__wt_err(session, tret,
+			    "%s: directory-list: closedir", directory);
+			if (ret == 0)
+				ret = tret;
+		}
+	}
 
 	if (ret == 0)
 		return (0);

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -98,7 +98,7 @@ __posix_directory_sync(
 
 	ret = __posix_sync(session, fd, path, "directory-sync");
 
-	WT_SYSCALL_RETRY(close(fd), tret);
+	WT_SYSCALL(close(fd), tret);
 	if (tret != 0) {
 		__wt_err(session, tret, "%s: directory-sync: close", path);
 		if (ret == 0)

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -124,7 +124,7 @@ __posix_fs_exist(WT_FILE_SYSTEM *file_system,
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
-	WT_SYSCALL_RETRY(stat(name, &sb), ret);
+	WT_SYSCALL(stat(name, &sb), ret);
 	if (ret == 0) {
 		*existp = true;
 		return (0);
@@ -158,7 +158,7 @@ __posix_fs_remove(
 	 * where we're not doing any special checking for standards compliance,
 	 * using unlink may be marginally safer.
 	 */
-	WT_SYSCALL_RETRY(unlink(name), ret);
+	WT_SYSCALL(unlink(name), ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "%s: file-remove: unlink", name);
@@ -186,7 +186,7 @@ __posix_fs_rename(WT_FILE_SYSTEM *file_system,
 	 * with the wrong errno (if errno is garbage), or the generic WT_ERROR
 	 * return (if errno is 0), but we've done the best we can.
 	 */
-	WT_SYSCALL_RETRY(rename(from, to) != 0 ? -1 : 0, ret);
+	WT_SYSCALL(rename(from, to) != 0 ? -1 : 0, ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "%s to %s: file-rename: rename", from, to);
@@ -208,7 +208,7 @@ __posix_fs_size(WT_FILE_SYSTEM *file_system,
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
-	WT_SYSCALL_RETRY(stat(name, &sb), ret);
+	WT_SYSCALL(stat(name, &sb), ret);
 	if (ret == 0) {
 		*sizep = sb.st_size;
 		return (0);
@@ -232,7 +232,7 @@ __posix_file_advise(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session,
 	session = (WT_SESSION_IMPL *)wt_session;
 	pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-	WT_SYSCALL_RETRY(posix_fadvise(pfh->fd, offset, len, advice), ret);
+	WT_SYSCALL(posix_fadvise(pfh->fd, offset, len, advice), ret);
 	if (ret == 0)
 		return (0);
 
@@ -268,7 +268,7 @@ __posix_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 
 	/* Close the file handle. */
 	if (pfh->fd != -1) {
-		WT_SYSCALL_RETRY(close(pfh->fd), ret);
+		WT_SYSCALL(close(pfh->fd), ret);
 		if (ret != 0)
 			__wt_err(session, ret,
 			    "%s: handle-close: close", file_handle->name);
@@ -309,7 +309,7 @@ __posix_file_lock(
 	fl.l_type = lock ? F_WRLCK : F_UNLCK;
 	fl.l_whence = SEEK_SET;
 
-	WT_SYSCALL_RETRY(fcntl(pfh->fd, F_SETLK, &fl) == -1 ? -1 : 0, ret);
+	WT_SYSCALL(fcntl(pfh->fd, F_SETLK, &fl) == -1 ? -1 : 0, ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "%s: handle-lock: fcntl", file_handle->name);
@@ -369,7 +369,7 @@ __posix_file_size(
 	session = (WT_SESSION_IMPL *)wt_session;
 	pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-	WT_SYSCALL_RETRY(fstat(pfh->fd, &sb), ret);
+	WT_SYSCALL(fstat(pfh->fd, &sb), ret);
 	if (ret == 0) {
 		*sizep = sb.st_size;
 		return (0);
@@ -617,7 +617,7 @@ __posix_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 	 * interesting.
 	 */
 	if (!pfh->direct_io && file_type == WT_OPEN_FILE_TYPE_DATA) {
-		WT_SYSCALL_RETRY(
+		WT_SYSCALL(
 		    posix_fadvise(pfh->fd, 0, 0, POSIX_FADV_RANDOM), ret);
 		if (ret != 0)
 			WT_ERR_MSG(session, ret,

--- a/src/os_posix/os_map.c
+++ b/src/os_posix/os_map.c
@@ -105,7 +105,7 @@ __wt_posix_map_preload(WT_FILE_HANDLE *fh,
 	if (length <= (size_t)conn->page_size)
 		return (0);
 
-	WT_SYSCALL_RETRY(posix_madvise(blk, length, POSIX_MADV_WILLNEED), ret);
+	WT_SYSCALL(posix_madvise(blk, length, POSIX_MADV_WILLNEED), ret);
 	if (ret == 0)
 		return (0);
 
@@ -138,7 +138,7 @@ __wt_posix_map_discard(WT_FILE_HANDLE *fh,
 	blk = (void *)((uintptr_t)map & ~(uintptr_t)(conn->page_size - 1));
 	length += WT_PTRDIFF(map, blk);
 
-	WT_SYSCALL_RETRY(posix_madvise(blk, length, POSIX_MADV_DONTNEED), ret);
+	WT_SYSCALL(posix_madvise(blk, length, POSIX_MADV_DONTNEED), ret);
 	if (ret == 0)
 		return (0);
 

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -19,7 +19,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 
 	/* Spawn a new thread of control. */
-	WT_SYSCALL(pthread_create(tidret, NULL, func, arg), ret);
+	WT_SYSCALL_RETRY(pthread_create(tidret, NULL, func, arg), ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "pthread_create");

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -19,7 +19,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 
 	/* Spawn a new thread of control. */
-	WT_SYSCALL_RETRY(pthread_create(tidret, NULL, func, arg), ret);
+	WT_SYSCALL(pthread_create(tidret, NULL, func, arg), ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "pthread_create");
@@ -34,7 +34,7 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid)
 {
 	WT_DECL_RET;
 
-	WT_SYSCALL_RETRY(pthread_join(tid, NULL), ret);
+	WT_SYSCALL(pthread_join(tid, NULL), ret);
 	if (ret == 0)
 		return (0);
 

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -18,14 +18,14 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	WT_DECL_RET;
 
 #if defined(HAVE_CLOCK_GETTIME)
-	WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, tsp), ret);
+	WT_SYSCALL(clock_gettime(CLOCK_REALTIME, tsp), ret);
 	if (ret == 0)
 		return (0);
 	WT_RET_MSG(session, ret, "clock_gettime");
 #elif defined(HAVE_GETTIMEOFDAY)
 	struct timeval v;
 
-	WT_SYSCALL_RETRY(gettimeofday(&v, NULL), ret);
+	WT_SYSCALL(gettimeofday(&v, NULL), ret);
 	if (ret == 0) {
 		tsp->tv_sec = v.tv_sec;
 		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;

--- a/src/os_win/os_dir.c
+++ b/src/os_win/os_dir.c
@@ -24,6 +24,7 @@ __wt_win_directory_list(WT_FILE_SYSTEM *file_system,
 	WT_SESSION_IMPL *session;
 	size_t dirallocsz, pathlen;
 	uint32_t count;
+	int tret;
 	char *dir_copy, **entries;
 
 	WT_UNUSED(file_system);
@@ -74,7 +75,14 @@ __wt_win_directory_list(WT_FILE_SYSTEM *file_system,
 	*countp = count;
 
 err:	if (findhandle != INVALID_HANDLE_VALUE)
-		(void)FindClose(findhandle);
+		if (FindClose(findhandle) == 0) {
+			tret = __wt_getlasterror();
+			__wt_err(session, tret,
+			    "%s: directory-list: FindClose", pathbuf->data);
+			if (ret == 0)
+				ret = tret;
+		}
+
 	__wt_free(session, dir_copy);
 	__wt_scr_free(session, &pathbuf);
 


### PR DESCRIPTION
@michaelcahill, in #2765  you said:

> I agree that it makes sense to split WT_SYSCALL_RETRY into two parts: one that gets the best error code for a given call and another than retries in the cases where that makes sense.

This is that change; I left retry in for calls that allocate file descriptors (opendir, open), and that write the file system and were already retrying (fallocate, fcntl(F_FULLFSYNC), fsync, ftruncate, sync_file_range), but didn't add retry semantics to calls that write the file system but weren't already retrying (pread, pwrite).

The only borderline case where I potentially changed things was that I don't retry file-descriptor close calls: technically, they can write the filesystem, but the fsync should have already been done (if we care about the durability of the file).

You also said:

> I'd forgotten we retry for cases like ENOSPC, so it may not be as simple as saying pwrite should never retry.

It doesn't seem unreasonable to me for pread/pwrite to retry, particularly on EIO, and in the case of pwrite, on ENOSPC. Should I make that change?

