### PR TITLE
WT-2677 Fix JSON output so only printable ASCII is produced.

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -178,7 +178,7 @@ __wt_logop_read(WT_SESSION_IMPL *session,
 }
 
 static size_t
-__logrec_json_unpack_str(char *dest, size_t destlen, const char *src,
+__logrec_json_unpack_str(char *dest, size_t destlen, const u_char *src,
     size_t srclen)
 {
 \tsize_t total;

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -66,7 +66,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv,
     u_char *buf, size_t bufsz, WT_CONFIG_ITEM *name)
 {
 	WT_PACK_VALUE *pv;
-	const char *p, *end;
+	const u_char *p, *end;
 	size_t s, n;
 
 	pv = (WT_PACK_VALUE *)voidpv;
@@ -86,7 +86,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv,
 	case 'S':
 		/* Account for '"' quote in front and back. */
 		s += 2;
-		p = (const char *)pv->u.s;
+		p = (const u_char *)pv->u.s;
 		if (bufsz > 0) {
 			*buf++ = '"';
 			bufsz--;
@@ -122,7 +122,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv,
 	case 'U':
 	case 'u':
 		s += 2;
-		p = (const char *)pv->u.item.data;
+		p = (const u_char *)pv->u.item.data;
 		end = p + pv->u.item.size;
 		if (bufsz > 0) {
 			*buf++ = '"';
@@ -316,12 +316,12 @@ __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 size_t
 __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 {
-	char abbrev;
+	u_char abbrev;
 
 	if (!force_unicode) {
 		if (isprint(ch) && ch != '\\' && ch != '"') {
 			if (bufsz >= 1)
-				*buf = (u_char)ch;
+				*buf = ch;
 			return (1);
 		} else {
 			abbrev = '\0';
@@ -346,7 +346,7 @@ __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 			if (abbrev != '\0') {
 				if (bufsz >= 2) {
 					*buf++ = '\\';
-					*buf = (u_char)abbrev;
+					*buf = abbrev;
 				}
 				return (2);
 			}

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -314,7 +314,7 @@ __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
  *	Can be called with null buf for sizing.
  */
 size_t
-__wt_json_unpack_char(char ch, u_char *buf, size_t bufsz, bool force_unicode)
+__wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 {
 	char abbrev;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -291,7 +291,7 @@ extern int __wt_curjoin_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSO
 extern int __wt_curjoin_join(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin, WT_INDEX *idx, WT_CURSOR *ref_cursor, uint8_t flags, uint8_t range, uint64_t count, uint32_t bloom_bit_count, uint32_t bloom_hash_count);
 extern int __wt_json_alloc_unpack(WT_SESSION_IMPL *session, const void *buffer, size_t size, const char *fmt, WT_CURSOR_JSON *json, bool iskey, va_list ap);
 extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
-extern size_t __wt_json_unpack_char(char ch, u_char *buf, size_t bufsz, bool force_unicode);
+extern size_t __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode);
 extern int __wt_json_column_init(WT_CURSOR *cursor, const char *keyformat, const WT_CONFIG_ITEM *idxconf, const WT_CONFIG_ITEM *colconf);
 extern int __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype, const char **tokstart, size_t *toklen);
 extern const char *__wt_json_tokname(int toktype);

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -44,7 +44,7 @@ __wt_logop_read(WT_SESSION_IMPL *session,
 }
 
 static size_t
-__logrec_json_unpack_str(char *dest, size_t destlen, const char *src,
+__logrec_json_unpack_str(char *dest, size_t destlen, const u_char *src,
     size_t srclen)
 {
 	size_t total;

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -552,14 +552,15 @@ dup_json_string(const char *str, char **result)
 
 	nchars = 0;
 	for (p = str; *p; p++, nchars++)
-		nchars += __wt_json_unpack_char(*p, NULL, 0, false);
+		nchars += __wt_json_unpack_char((u_char)*p, NULL, 0, false);
 	q = malloc(nchars + 1);
 	if (q == NULL)
 		return (1);
 	*result = q;
 	left = nchars;
 	for (p = str; *p; p++, nchars++) {
-		nchars = __wt_json_unpack_char(*p, (u_char *)q, left, false);
+		nchars = __wt_json_unpack_char((u_char)*p, (u_char *)q, left,
+		    false);
 		left -= nchars;
 		q += nchars;
 	}


### PR DESCRIPTION
(Reopening this pull request - @keithbostic saw a compilation error using gcc 4.7, I didn't see that error)

The root cause is a sign extension error that shows up on systems
that have a signed 'char'.