### PR TITLE
WT-2687 test suite should verify the exit status of the wt utility

### DIFF
--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -211,6 +211,8 @@ config_list_free(CONFIG_LIST *clp)
 			free(*entry);
 	free(clp->list);
 	clp->list = NULL;
+	clp->entry = 0;
+	clp->max_entry = 0;
 }
 
 /*

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -427,6 +427,9 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
 				    flags)) != 0)
 					goto err;
 				config_list_free(&cl);
+				free(ins->kvraw);
+				ins->kvraw = NULL;
+				config_list_free(&cl);
 				break;
 			}
 			else
@@ -544,15 +547,14 @@ json_skip(WT_SESSION *session, JSON_INPUT_STATE *ins, const char **matches)
 	const char *hit;
 	const char **match;
 
-	if (ins->kvraw != NULL)
-		return (1);
-
+	WT_ASSERT((WT_SESSION_IMPL *)session, ins->kvraw == NULL);
 	hit = NULL;
 	while (!ins->ateof) {
 		for (match = matches; *match != NULL; match++)
 			if ((hit = strstr(ins->p, *match)) != NULL)
 				goto out;
-		if (util_read_line(session, &ins->line, true, &ins->ateof)) {
+		if (util_read_line(session, &ins->line, true, &ins->ateof)
+		    != 0) {
 			ins->toktype = -1;
 			return (1);
 		}

--- a/test/suite/test_dump.py
+++ b/test/suite/test_dump.py
@@ -143,8 +143,8 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate_check(self, uri, self.nentries)
 
         # Re-load the object again, but confirm -n (no overwrite) fails.
-        self.runWt(['-h', self.dir,
-            'load', '-n', '-f', 'dump.out'], errfilename='errfile.out')
+        self.runWt(['-h', self.dir, 'load', '-n', '-f', 'dump.out'],
+            errfilename='errfile.out', failure=True)
         self.check_non_empty_file('errfile.out')
 
         # If there are indices, dump one of them and check the output.

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -208,12 +208,16 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
 
         # this one should work
         self.load_json(self.table_uri2,
-              (('"key0" : "KEY002"', '"value0" : 345,\n"value1" : "str2"'),))
+              (('"key0" : "KEY002"', '"value0" : 34,\n"value1" : "str2"'),))
 
         # extraneous/missing space is okay
         self.load_json(self.table_uri2,
               (('  "key0"\n:\t"KEY003"    ',
-                '"value0":456,"value1"\n\n\r\n:\t\n"str3"'),))
+                '"value0":45,"value1"\n\n\r\n:\t\n"str3"'),))
+
+        table2_json =  (
+            ('"key0" : "KEY002"', '"value0" : 34,\n"value1" : "str2"'),
+            ('"key0" : "KEY003"', '"value0" : 45,\n"value1" : "str3"'))
 
         table3_json =  (
             ('"key0" : 1', '"value0" : "\\u0001\\u0002\\u0003"'),
@@ -284,12 +288,11 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(['load', '-jf', 'jsondump4.out'])
         self.session.drop(self.table_uri4)
 
-        # Note: only the first table is loaded.
         self.runWt(['load', '-jf', 'jsondump-all.out'])
         self.check_json(self.table_uri1, table1_json)
-        #self.check_json(self.table_uri2, table2_json)
-        #self.check_json(self.table_uri3, table3_json)
-        #self.check_json(self.table_uri4, table4_json)
+        self.check_json(self.table_uri2, table2_json)
+        self.check_json(self.table_uri3, table3_json)
+        self.check_json(self.table_uri4, table4_json)
 
     # Generate two byte keys that cover some range of byte values.
     # For simplicity, the keys are monotonically increasing.

--- a/test/suite/test_util02.py
+++ b/test/suite/test_util02.py
@@ -173,7 +173,7 @@ class test_load_commandline(wttest.WiredTigerTestCase, suite_subprocess):
         complex_populate(self, self.uri, "key_format=S,value_format=S", 20)
         self.runWt(["dump", self.uri], outfilename="dump.out")
         loadargs = ["load", "-f", "dump.out"] + args
-        self.runWt(loadargs, errfilename=errfile)
+        self.runWt(loadargs, errfilename=errfile, failure=fail)
         if fail:
                 self.check_non_empty_file(errfile)
         else:
@@ -181,23 +181,24 @@ class test_load_commandline(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Empty arguments should suceed.
     def test_load_commandline_1(self):
-        self.load_commandline([], 0)
+        self.load_commandline([], False)
 
     # Arguments are in pairs.
     def test_load_commandline_2(self):
-        self.load_commandline(["table"], 1)
-        self.load_commandline([self.uri, "block_allocation=first", self.uri], 1)
+        self.load_commandline(["table"], True)
+        self.load_commandline(
+            [self.uri, "block_allocation=first", self.uri], True)
 
     # You can use short-hand URIs for a single object, but cannot match multiple
     # objects.
     def test_load_commandline_3(self):
-        self.load_commandline(["table", "block_allocation=first"], 0)
-        self.load_commandline(["colgroup", "block_allocation=first"], 1)
+        self.load_commandline(["table", "block_allocation=first"], False)
+        self.load_commandline(["colgroup", "block_allocation=first"], True)
 
     # You can't reference non-existent objects.
     def test_load_commandline_4(self):
-        self.load_commandline([self.uri, "block_allocation=first"], 0)
-        self.load_commandline(["table:bar", "block_allocation=first"], 1)
+        self.load_commandline([self.uri, "block_allocation=first"], False)
+        self.load_commandline(["table:bar", "block_allocation=first"], True)
 
     # You can specify multipleconfiguration arguments for the same object.
     def test_load_commandline_5(self):
@@ -205,19 +206,19 @@ class test_load_commandline(wttest.WiredTigerTestCase, suite_subprocess):
             self.uri, "block_allocation=first",
             self.uri, "block_allocation=best",
             self.uri, "block_allocation=first",
-            self.uri, "block_allocation=best"], 0)
+            self.uri, "block_allocation=best"], False)
 
     # You can't modify a format.
     def test_load_commandline_6(self):
-        self.load_commandline(["table", "key_format=d"], 1)
-        self.load_commandline(["table", "value_format=d"], 1)
+        self.load_commandline(["table", "key_format=d"], True)
+        self.load_commandline(["table", "value_format=d"], True)
 
     # You can set the source or version, but it gets stripped; confirm the
     # attempt succeeds, so we know they configuration values are stripped.
     def test_load_commandline_7(self):
-        self.load_commandline(["table", "filename=bar"], 0)
-        self.load_commandline(["table", "source=bar"], 0)
-        self.load_commandline(["table", "version=(100,200)"], 0)
+        self.load_commandline(["table", "filename=bar"], False)
+        self.load_commandline(["table", "source=bar"], False)
+        self.load_commandline(["table", "version=(100,200)"], False)
 
 
 if __name__ == '__main__':

--- a/test/suite/test_util07.py
+++ b/test/suite/test_util07.py
@@ -71,7 +71,8 @@ class test_util07(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create('table:' + self.tablename, self.session_params)
         outfile = "readout.txt"
         errfile = "readerr.txt"
-        self.runWt(["read", 'table:' + self.tablename, 'NoMatch'], outfilename=outfile, errfilename=errfile)
+        self.runWt(["read", 'table:' + self.tablename, 'NoMatch'],
+            outfilename=outfile, errfilename=errfile, failure=True)
         self.check_empty_file(outfile)
         self.check_file_contains(errfile, 'NoMatch: not found\n')
 
@@ -83,10 +84,12 @@ class test_util07(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate(self.tablename)
         outfile = "readout.txt"
         errfile = "readerr.txt"
-        self.runWt(["read", 'table:' + self.tablename, 'KEY49'], outfilename=outfile, errfilename=errfile)
+        self.runWt(["read", 'table:' + self.tablename, 'KEY49'],
+            outfilename=outfile, errfilename=errfile)
         self.check_file_content(outfile, 'VAL49\n')
         self.check_empty_file(errfile)
-        self.runWt(["read", 'table:' + self.tablename, 'key49'], outfilename=outfile, errfilename=errfile)
+        self.runWt(["read", 'table:' + self.tablename, 'key49'],
+            outfilename=outfile, errfilename=errfile, failure=True)
         self.check_empty_file(outfile)
         self.check_file_contains(errfile, 'key49: not found\n')
 

--- a/test/suite/test_util12.py
+++ b/test/suite/test_util12.py
@@ -57,7 +57,8 @@ class test_util12(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create('table:' + self.tablename, self.session_params)
 
         errfile = 'writeerr.txt'
-        self.runWt(['write', 'table:' + self.tablename], errfilename=errfile)
+        self.runWt(['write', 'table:' + self.tablename],
+            errfilename=errfile, failure=True)
         self.check_file_contains(errfile, 'usage:')
 
     def test_write_overwrite(self):
@@ -82,7 +83,7 @@ class test_util12(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create('table:' + self.tablename, self.session_params)
         errfile = 'writeerr.txt'
         self.runWt(['write', 'table:' + self.tablename,
-                    'def', '456', 'abc'], errfilename=errfile)
+                    'def', '456', 'abc'], errfilename=errfile, failure=True)
         self.check_file_contains(errfile, 'usage:')
 
 

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -151,7 +151,8 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         with self.open_and_position(self.tablename, 75) as f:
             for i in range(0, 4096):
                 f.write(struct.pack('B', 0))
-        self.runWt(["verify", "table:" + self.tablename], errfilename="verifyerr.out")
+        self.runWt(["verify", "table:" + self.tablename],
+            errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
 
     def test_verify_process_25pct_junk(self):
@@ -165,7 +166,8 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         with self.open_and_position(self.tablename, 25) as f:
             for i in range(0, 100):
                 f.write('\x01\xff\x80')
-        self.runWt(["verify", "table:" + self.tablename], errfilename="verifyerr.out")
+        self.runWt(["verify", "table:" + self.tablename],
+            errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
 
     def test_verify_process_truncated(self):
@@ -178,7 +180,8 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate(self.tablename)
         with self.open_and_position(self.tablename, 75) as f:
             f.truncate(0)
-        self.runWt(["verify", "table:" + self.tablename], errfilename="verifyerr.out")
+        self.runWt(["verify", "table:" + self.tablename],
+            errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
 
     def test_verify_process_zero_length(self):
@@ -190,7 +193,8 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate(self.tablename)
         with self.open_and_position(self.tablename, 0) as f:
             f.truncate(0)
-        self.runWt(["verify", "table:" + self.tablename], errfilename="verifyerr.out")
+        self.runWt(["verify", "table:" + self.tablename],
+            errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
 
 


### PR DESCRIPTION
@ddanderson, would you please do the review on this one?

Also, this change doesn't pass the test suite:

```
% pyt test_jsondump02.test_jsondump02.test_json_cursor
FERROR in test_jsondump02.test_jsondump02.test_json_cursor

======================================================================
FAIL: test_jsondump02.test_jsondump02.test_json_cursor
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/b/bostic/wt.small/test/suite/test_jsondump02.py", line 288, in test_json_cursor
    self.runWt(['load', '-jf', 'jsondump-all.out'])
  File "/b/bostic/wt.small/test/suite/suite_subprocess.py", line 162, in runWt
    str(procargs) + '": exited ' + str(returncode))
AssertionError: expected success: "['/b/bostic/wt.small/wt', 'load', '-jf', 'jsondump-all.out']": exited 1

----------------------------------------------------------------------
Ran 1 test in 0.416s

FAILED (failures=1)
```

I think this might be a real failure, the `wt load` command thinks there is something wrong with the JSON, and the test suite doesn't appear to anticipate that failure.