### PR TITLE
WT-2686 Report an error any time we fail to scan the log.

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -256,9 +256,6 @@ struct __wt_log {
 #ifdef HAVE_DIAGNOSTIC
 	uint64_t	 write_calls;		/* Calls to log_write */
 #endif
-
-#define	WT_LOG_NOT_VERIFIED	0x1		/* Log just started */
-	uint32_t	 flags;
 };
 
 struct __wt_log_record {

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1090,7 +1090,6 @@ __wt_log_open(WT_SESSION_IMPL *session)
 	logcount = 0;
 	lastlog = 0;
 	firstlog = UINT32_MAX;
-	F_SET(log, WT_LOG_NOT_VERIFIED);
 
 	/*
 	 * Open up a file handle to the log directory if we haven't.
@@ -1750,7 +1749,7 @@ err:	WT_STAT_FAST_CONN_INCR(session, log_scans);
 	 * an error recovery is likely going to fail.  Try to provide
 	 * a helpful failure message.
 	 */
-	if (ret != 0 && F_ISSET(log, WT_LOG_NOT_VERIFIED)) {
+	if (ret != 0 && firstrecord) {
 		__wt_errx(session,
 		    "WiredTiger is unable to read the recovery log.");
 		__wt_errx(session, "This may be due to the log"
@@ -1760,7 +1759,6 @@ err:	WT_STAT_FAST_CONN_INCR(session, log_scans);
 		    " opened the database with the correct options including"
 		    " all encryption and compression options");
 	}
-	F_CLR(log, WT_LOG_NOT_VERIFIED);
 
 	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 


### PR DESCRIPTION
Don't use a flag on the log structure: we may not have one if logging
is disabled, but we still scan log files if they exist.