### PR TITLE
WT-2682 fix --enable-strict warnings when building on PPC.

### DIFF
--- a/src/checksum/checksum.c
+++ b/src/checksum/checksum.c
@@ -1103,6 +1103,7 @@ static const uint32_t g_crc_slicing[8][256] = {
 #endif
 };
 
+#if !defined(__powerpc64__)
 /*
  * __wt_cksum_sw --
  *	Return a checksum for a chunk of memory, computed in software.
@@ -1171,6 +1172,7 @@ __wt_cksum_sw(const void *chunk, size_t len)
 #endif
 	return (~crc);
 }
+#endif
 
 #if (defined(__amd64) || defined(__x86_64))
 /*

--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -2,7 +2,7 @@
 #define CRC_TABLE
 #include "crc32_constants.h"
 
-#define VMX_ALIGN	16
+#define VMX_ALIGN	16U
 #define VMX_ALIGN_MASK	(VMX_ALIGN-1)
 
 #ifdef REFLECT
@@ -26,6 +26,9 @@ static unsigned int crc32_align(unsigned int crc, unsigned char *p,
 unsigned int __crc32_vpmsum(unsigned int crc, unsigned char *p,
 			    unsigned long len);
 
+/* -Werror=missing-prototypes */
+unsigned int crc32_vpmsum(unsigned int crc, unsigned char *p,
+			  unsigned long len);
 unsigned int crc32_vpmsum(unsigned int crc, unsigned char *p,
 			  unsigned long len)
 {


### PR DESCRIPTION
@agorrod, @sueloverso, this should make --enable-strict compile cleanly on the PPC.