### PR TITLE
WT-2689 Fix heap-use-after-free on cursor error path.

### DIFF
--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -972,7 +972,8 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 
 	if (0) {
 err:		if (*cursorp != NULL) {
-			WT_TRET(__wt_cursor_close(*cursorp));
+			if (*cursorp != cursor)
+				WT_TRET(__wt_cursor_close(*cursorp));
 			*cursorp = NULL;
 		}
 		WT_TRET(__curtable_close(cursor));


### PR DESCRIPTION
@agorrod Please review this.  This fixes the bug reported.  However, I went through the error path code of all `cur_*.c` for `open_cursor` and there is a lot of variation.  Some just free, some just call `wt_cursor_close`, some set `*cursorp = NULL` and some do not.  I'm not convinced in `cur_table.c` that the conditional for `*cursorp` is needed at all.