### PR TITLE
WT-2691 remove/disallow 'char' declarations without 'unsigned'.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -54,9 +54,9 @@ static void config_opt_usage(void);
 static int
 config_unescape(char *orig)
 {
-	char ch, *dst, *s;
+	u_char *dst, *s, ch;
 
-	for (dst = s = orig; *s != '\0';) {
+	for (dst = s = (u_char *)orig; *s != '\0';) {
 		if ((ch = *s++) == '\\') {
 			ch = *s++;
 			switch (ch) {

--- a/dist/s_style
+++ b/dist/s_style
@@ -138,6 +138,14 @@ else
 		}
 	fi
 
+	# Plain char declarations.
+	egrep '\<char[[:space:]]+[[:alnum:]_]+[,;)]' $f |
+	    sed -e '/unsigned char/d' > $t
+	test -s $t && {
+	    echo "$f: type "char" declaration, undefined if signed"
+	    cat $t
+	}
+
 	tr -cd '[:alnum:][:space:][:punct:]' < $f |
 	unexpand |
 	sed -e 's/){/) {/' \

--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -2043,7 +2043,7 @@ err:		if (ret != 0)
 %extend __wt_async_op {
 	long get_id_wrap(JNIEnv *jenv) {
 		WT_UNUSED(jenv);
-		return (self->get_id(self));
+		return (long)(self->get_id(self));
 	}
 }
 
@@ -2054,6 +2054,6 @@ err:		if (ret != 0)
 		ret = self->transaction_pinned_range(self, &range);
 		if (ret != 0)
 			throwWiredTigerException(jenv, ret);
-		return range;
+		return (long)range;
 	}
 }

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -456,7 +456,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 	int result;
 	bool backslash, isalph, isfloat;
 	const char *bad;
-	char ch;
+	u_char ch;
 
 	result = -1;
 	session = (WT_SESSION_IMPL *)wt_session;
@@ -475,7 +475,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 	case '"':
 		backslash = false;
 		src++;
-		while ((ch = *src) != '\0') {
+		while ((ch = (u_char)*src) != '\0') {
 			if (!backslash) {
 				if (ch == '"') {
 					src++;
@@ -520,12 +520,12 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 		isfloat = false;
 		if (*src == '-')
 			src++;
-		while ((ch = *src) != '\0' && isdigit(ch))
+		while ((ch = (u_char)*src) != '\0' && isdigit(ch))
 			src++;
 		if (*src == '.') {
 			isfloat = true;
 			src++;
-			while ((ch = *src) != '\0' &&
+			while ((ch = (u_char)*src) != '\0' &&
 			    isdigit(ch))
 				src++;
 		}
@@ -534,7 +534,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 			src++;
 			if (*src == '+' || *src == '-')
 				src++;
-			while ((ch = *src) != '\0' &&
+			while ((ch = (u_char)*src) != '\0' &&
 			    isdigit(ch))
 				src++;
 		}
@@ -729,7 +729,7 @@ __json_pack_struct(WT_SESSION_IMPL *session, void *buffer, size_t size,
 		JSON_EXPECT_TOKEN_GET(session, jstr, 's', tokstart, toksize);
 		/* the key name was verified in __json_pack_size */
 		JSON_EXPECT_TOKEN(session, jstr, ':');
-		pv.type = fmt[0];
+		pv.type = (u_char)fmt[0];
 		WT_PACK_JSON_GET(session, pv, jstr);
 		return (__pack_write(session, &pv, &p, size));
 	}
@@ -869,16 +869,17 @@ __wt_json_strlen(const char *src, size_t srclen)
  */
 int
 __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen,
-    const char *src, size_t srclen)
+    const char *srcarg, size_t srclen)
 {
 	WT_SESSION_IMPL *session;
-	char ch, *dst;
-	const char *dstend, *srcend;
+	u_char ch, *dst, *src;
+	const u_char *dstend, *srcend;
 	u_char hi, lo;
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
-	dst = *pdst;
+	dst = (u_char *)*pdst;
+	src = (u_char *)srcarg;
 	dstend = dst + dstlen;
 	srcend = src + srclen;
 	while (src < srcend && dst < dstend) {
@@ -898,7 +899,7 @@ __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen,
 					    src - 6);
 					return (EINVAL);
 				}
-				*dst++ = (char)lo;
+				*dst++ = lo;
 				break;
 			case 'f':
 				*dst++ = '\f';
@@ -923,7 +924,7 @@ __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen,
 	}
 	if (src != srcend)
 		return (ENOMEM);
-	*pdst = dst;
+	*pdst = (char *)dst;
 	while (dst < dstend)
 		*dst++ = '\0';
 	return (0);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -297,7 +297,7 @@ extern int __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype
 extern const char *__wt_json_tokname(int toktype);
 extern int __wt_json_to_item(WT_SESSION_IMPL *session, const char *jstr, const char *format, WT_CURSOR_JSON *json, bool iskey, WT_ITEM *item);
 extern ssize_t __wt_json_strlen(const char *src, size_t srclen);
-extern int __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char *src, size_t srclen);
+extern int __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char *srcarg, size_t srclen);
 extern int __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR **cursorp);
 extern int __wt_schema_create_final( WT_SESSION_IMPL *session, char *cfg_arg[], char **value_ret);
 extern int __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, const char *cfg[], WT_CURSOR **cursorp);

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -22,7 +22,7 @@ typedef struct {
 	} u;
 	uint32_t size;
 	int8_t havesize;
-	char type;
+	u_char type;
 } WT_PACK_VALUE;
 
 /* Default to size = 1 if there is no size prefix. */
@@ -147,7 +147,7 @@ next:	if (pack->cur == pack->end)
 		pv->size = 1;
 	}
 
-	pv->type = *pack->cur++;
+	pv->type = (u_char)*pack->cur++;
 	pack->repeats = 0;
 
 	switch (pv->type) {
@@ -617,7 +617,7 @@ __wt_struct_packv(WT_SESSION_IMPL *session,
 	end = p + size;
 
 	if (fmt[0] != '\0' && fmt[1] == '\0') {
-		pv.type = fmt[0];
+		pv.type = (u_char)fmt[0];
 		WT_PACK_GET(session, pv, ap);
 		return (__pack_write(session, &pv, &p, size));
 	}
@@ -650,7 +650,7 @@ __wt_struct_sizev(
 	size_t total;
 
 	if (fmt[0] != '\0' && fmt[1] == '\0') {
-		pv.type = fmt[0];
+		pv.type = (u_char)fmt[0];
 		WT_PACK_GET(session, pv, ap);
 		*sizep = __pack_size(session, &pv);
 		return (0);
@@ -682,7 +682,7 @@ __wt_struct_unpackv(WT_SESSION_IMPL *session,
 	end = p + size;
 
 	if (fmt[0] != '\0' && fmt[1] == '\0') {
-		pv.type = fmt[0];
+		pv.type = (u_char)fmt[0];
 		WT_RET(__unpack_read(session, &pv, &p, size));
 		WT_UNPACK_PUT(session, pv, ap);
 		return (0);

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -72,7 +72,7 @@ __fstream_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, WT_ITEM *buf)
 {
 	const char *p;
 	size_t len;
-	char c;
+	u_char c;
 
 	/*
 	 * We always NUL-terminate the returned string (even if it's empty),
@@ -94,7 +94,7 @@ __fstream_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, WT_ITEM *buf)
 			fstr->off += (wt_off_t)len;
 		}
 
-		c = *(p = fstr->buf.data);
+		c = (u_char)*(p = fstr->buf.data);
 		fstr->buf.data = ++p;
 
 		/* Leave space for a trailing NUL. */
@@ -104,10 +104,10 @@ __fstream_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, WT_ITEM *buf)
 				continue;
 			break;
 		}
-		((char *)buf->mem)[buf->size++] = c;
+		((u_char *)buf->mem)[buf->size++] = c;
 	}
 
-	((char *)buf->mem)[buf->size] = '\0';
+	((u_char *)buf->mem)[buf->size] = '\0';
 
 	return (0);
 }

--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -14,7 +14,7 @@
  */
 static int
 __find_next_col(WT_SESSION_IMPL *session, WT_TABLE *table,
-    WT_CONFIG_ITEM *colname, u_int *cgnump, u_int *colnump, char *coltype)
+    WT_CONFIG_ITEM *colname, u_int *cgnump, u_int *colnump, u_char *coltype)
 {
 	WT_COLGROUP *colgroup;
 	WT_CONFIG conf;
@@ -134,7 +134,7 @@ __wt_table_check(WT_SESSION_IMPL *session, WT_TABLE *table)
 	WT_CONFIG_ITEM k, v;
 	WT_DECL_RET;
 	u_int cg, col, i;
-	char coltype;
+	u_char coltype;
 
 	if (table->is_simple)
 		return (0);
@@ -181,7 +181,7 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table,
 	WT_DECL_RET;
 	u_int cg, col, current_cg, current_col, i, start_cg, start_col;
 	bool have_it;
-	char coltype, current_coltype;
+	u_char coltype, current_coltype;
 
 	start_cg = start_col = UINT_MAX;	/* -Wuninitialized */
 


### PR DESCRIPTION
Also added casts so that -Wsign-conversion can be used on clang/OSX.