### PR TITLE
WT-2514 Fix logging to not use an empty path name.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -439,7 +439,7 @@ connection_runtime_config = [
         Config('file_max', '100MB', r'''
             the maximum size of log files''',
             min='100KB', max='2GB'),
-        Config('path', '', r'''
+        Config('path', '"."', r'''
             the path to a directory into which the log files are written.
             If the value is not an absolute path name, the files are created
             relative to the database home'''),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -976,7 +976,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "eviction_dirty_trigger=95,eviction_target=80,eviction_trigger=95"
 	  ",file_manager=(close_handle_minimum=250,close_idle_time=30,"
 	  "close_scan_interval=10),log=(archive=,compressor=,enabled=0,"
-	  "file_max=100MB,path=,prealloc=,recover=on,zero_fill=0),"
+	  "file_max=100MB,path=\".\",prealloc=,recover=on,zero_fill=0),"
 	  "lsm_manager=(merge=,worker_thread_max=4),lsm_merge=,"
 	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=0,on_close=0,"
@@ -1177,14 +1177,15 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,file_manager=(close_handle_minimum=250,"
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "in_memory=0,log=(archive=,compressor=,enabled=0,file_max=100MB,"
-	  "path=,prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
-	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0,"
-	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
-	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(json=0,on_close=0,path=\"WiredTigerStat.%d.%H\","
-	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=0,method=fsync),use_environment=,"
-	  "use_environment_priv=0,verbose=,write_through=",
+	  "path=\".\",prealloc=,recover=on,zero_fill=0),lsm_manager=(merge="
+	  ",worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0"
+	  ",session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(json=0,on_close=0,"
+	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),use_environment=,use_environment_priv=0,verbose=,"
+	  "write_through=",
 	  confchk_wiredtiger_open, 38
 	},
 	{ "wiredtiger_open_all",
@@ -1198,15 +1199,15 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "file_extend=,file_manager=(close_handle_minimum=250,"
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "in_memory=0,log=(archive=,compressor=,enabled=0,file_max=100MB,"
-	  "path=,prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
-	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0,"
-	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
-	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(json=0,on_close=0,path=\"WiredTigerStat.%d.%H\","
-	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-	  "transaction_sync=(enabled=0,method=fsync),use_environment=,"
-	  "use_environment_priv=0,verbose=,version=(major=0,minor=0),"
-	  "write_through=",
+	  "path=\".\",prealloc=,recover=on,zero_fill=0),lsm_manager=(merge="
+	  ",worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0"
+	  ",session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(json=0,on_close=0,"
+	  "path=\"WiredTigerStat.%d.%H\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),transaction_sync=(enabled=0"
+	  ",method=fsync),use_environment=,use_environment_priv=0,verbose=,"
+	  "version=(major=0,minor=0),write_through=",
 	  confchk_wiredtiger_open_all, 39
 	},
 	{ "wiredtiger_open_basecfg",
@@ -1218,7 +1219,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "eviction_dirty_trigger=95,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
-	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
+	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=\".\","
 	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0,"
 	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
@@ -1238,7 +1239,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "eviction_dirty_trigger=95,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
-	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=,"
+	  "log=(archive=,compressor=,enabled=0,file_max=100MB,path=\".\","
 	  "prealloc=,recover=on,zero_fill=0),lsm_manager=(merge=,"
 	  "worker_thread_max=4),lsm_merge=,mmap=,multiprocess=0,readonly=0,"
 	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1848,7 +1848,7 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the path to a directory into
 	 * which the log files are written.  If the value is not an absolute
 	 * path name\, the files are created relative to the database home., a
-	 * string; default empty.}
+	 * string; default \c ".".}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc,
 	 * pre-allocate log files., a boolean flag; default \c true.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if
@@ -2344,7 +2344,7 @@ struct __wt_connection {
  * integer between 100KB and 2GB; default \c 100MB.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the path to a directory into which the
  * log files are written.  If the value is not an absolute path name\, the files
- * are created relative to the database home., a string; default empty.}
+ * are created relative to the database home., a string; default \c ".".}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean
  * flag; default \c true.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery


### PR DESCRIPTION
@keithbostic Please review this change to set the default log path to '.' rather than an empty string.  I also added a section to the config test for it.