### PR TITLE
WT-2682 add option to configure WiredTiger with strict compiler flags

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -39,7 +39,7 @@ if test "$wt_cv_enable_strict" = "yes"; then
 	case "$wt_cv_cc_version" in
 	*clang*)
 		AM_CLANG_WARNINGS;;
-	*gcc*)
+	*gcc*|*GCC*)
 		AM_GCC_WARNINGS;;
 	*)
 		AC_MSG_ERROR(


### PR DESCRIPTION
Fix for AWS, compiler reports: "cc (GCC) 4.8.3 20140911 (Red Hat 4.8.3-9)"