### PR TITLE
WT-2650 Allow quotes to be escaped within a configuration string

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1019,12 +1019,14 @@ stdin
 stdout
 stepp
 str
+strchr
 strcmp
 strdup
 strerror
 strftime
 strget
 strlen
+strnchr
 strncpy
 strndup
 strtok

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -98,16 +98,17 @@ __verify_config_offsets(
 		 */
 		*quitp = true;
 		if (v.len != 0 || sscanf(k.str, "%" SCNu64, &offset) != 1)
-			WT_RET_MSG(session, EINVAL,
+			WT_ERR_MSG(session, EINVAL,
 			    "unexpected dump offset format");
 #if !defined(HAVE_DIAGNOSTIC)
-		WT_RET_MSG(session, ENOTSUP,
+		WT_ERR_MSG(session, ENOTSUP,
 		    "the WiredTiger library was not built in diagnostic mode");
 #else
 		WT_TRET(
 		    __wt_debug_offset_blind(session, (wt_off_t)offset, NULL));
 #endif
 	}
+err:	__wt_config_free(&list);
 	return (ret == WT_NOTFOUND ? 0 : ret);
 }
 

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -22,6 +22,7 @@ __config_parser_close(WT_CONFIG_PARSER *wt_config_parser)
 	if (config_parser == NULL)
 		return (EINVAL);
 
+	__wt_config_free(&config_parser->config);
 	__wt_free(config_parser->session, config_parser);
 	return (0);
 }

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -42,6 +42,7 @@ __wt_config_collapse(
 
 	WT_RET(__wt_scr_alloc(session, 0, &tmp));
 
+	WT_CLEAR(cparser);
 	WT_ERR(__wt_config_init(session, &cparser, cfg[0]));
 	while ((ret = __wt_config_next(&cparser, &k, &v)) == 0) {
 		if (k.type != WT_CONFIG_ITEM_STRING &&
@@ -77,7 +78,8 @@ __wt_config_collapse(
 		--tmp->size;
 	ret = __wt_strndup(session, tmp->data, tmp->size, config_ret);
 
-err:	__wt_scr_free(session, &tmp);
+err:	__wt_config_free(&cparser);
+	__wt_scr_free(session, &tmp);
 	return (ret);
 }
 
@@ -124,6 +126,7 @@ __config_merge_scan(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	size_t len;
 
+	WT_CLEAR(cparser);
 	WT_ERR(__wt_scr_alloc(session, 0, &kb));
 	WT_ERR(__wt_scr_alloc(session, 0, &vb));
 
@@ -205,6 +208,7 @@ __config_merge_scan(WT_SESSION_IMPL *session,
 
 err:	__wt_scr_free(session, &kb);
 	__wt_scr_free(session, &vb);
+	__wt_config_free(&cparser);
 	return (ret);
 }
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -917,6 +917,7 @@ __conn_load_extensions(
 	const char *sub_cfg[] = {
 	    WT_CONFIG_BASE(session, WT_CONNECTION_load_extension), NULL, NULL };
 
+	WT_CLEAR(subconfig);
 	WT_ERR(__wt_config_gets(session, cfg, "extensions", &cval));
 	WT_ERR(__wt_config_subinit(session, &subconfig, &cval));
 	while ((ret = __wt_config_next(&subconfig, &skey, &sval)) == 0) {
@@ -938,6 +939,7 @@ __conn_load_extensions(
 
 err:	__wt_scr_free(session, &expath);
 	__wt_scr_free(session, &exconfig);
+	__wt_config_free(&subconfig);
 
 	return (ret);
 }
@@ -1782,6 +1784,7 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
 
 	fs = NULL;
 	base_config = NULL;
+	WT_CLEAR(parser);
 
 	/*
 	 * Discard any base configuration setup file left-over from previous
@@ -1878,6 +1881,7 @@ err:		WT_TRET(__wt_fclose(session, &fs));
 	}
 
 	__wt_free(session, base_config);
+	__wt_config_free(&parser);
 
 	return (ret);
 }

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -79,6 +79,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 
 	conn = S2C(session);
 	sources = NULL;
+	WT_CLEAR(objectconf);
 
 	WT_RET(__wt_config_gets(session, cfg, "statistics_log.wait", &cval));
 	/* Only start the server if wait time is non-zero */
@@ -110,10 +111,11 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	WT_RET(__wt_config_subinit(session, &objectconf, &cval));
 	for (cnt = 0; (ret = __wt_config_next(&objectconf, &k, &v)) == 0; ++cnt)
 		;
-	WT_RET_NOTFOUND_OK(ret);
+	WT_ERR_NOTFOUND_OK(ret);
+	__wt_config_free(&objectconf);
 	if (cnt != 0) {
-		WT_RET(__wt_calloc_def(session, cnt + 1, &sources));
-		WT_RET(__wt_config_subinit(session, &objectconf, &cval));
+		WT_ERR(__wt_calloc_def(session, cnt + 1, &sources));
+		WT_ERR(__wt_config_subinit(session, &objectconf, &cval));
 		for (cnt = 0;
 		    (ret = __wt_config_next(&objectconf, &k, &v)) == 0; ++cnt) {
 			/*
@@ -161,6 +163,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
 	}
 
 err:	__stat_sources_free(session, &sources);
+	__wt_config_free(&objectconf);
 	return (ret);
 }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -375,6 +375,7 @@ __backup_uri(WT_SESSION_IMPL *session,
 	const char *uri;
 
 	*foundp = *log_only = false;
+	WT_CLEAR(targetconf);
 
 	/*
 	 * If we find a non-empty target configuration string, we have a job,
@@ -425,6 +426,7 @@ __backup_uri(WT_SESSION_IMPL *session,
 	WT_ERR_NOTFOUND_OK(ret);
 
 err:	__wt_scr_free(session, &tmp);
+	__wt_config_free(&targetconf);
 	return (ret);
 }
 

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -11,6 +11,7 @@ struct __wt_config {
 	const char *orig;
 	const char *end;
 	const char *cur;
+	char *unescaped;
 
 	int depth, top;
 	const int8_t *go;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -206,6 +206,7 @@ extern uint32_t __wt_cksum(const void *chunk, size_t len);
 extern void __wt_cksum_init(void);
 extern int __wt_config_initn( WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str, size_t len);
 extern int __wt_config_init(WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str);
+extern void __wt_config_free(WT_CONFIG *conf);
 extern int __wt_config_subinit( WT_SESSION_IMPL *session, WT_CONFIG *conf, WT_CONFIG_ITEM *item);
 extern int __wt_config_next(WT_CONFIG *conf, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value);
 extern int __wt_config_get(WT_SESSION_IMPL *session, const char **cfg_arg, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value);

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -44,7 +44,7 @@ typedef struct {
 	char buf[20];
 	int count;
 	bool iskey;
-	int genname;
+	bool genname;
 } WT_PACK_NAME;
 
 /*
@@ -91,7 +91,7 @@ __pack_name_init(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *names,
 	if (names->str != NULL)
 		WT_RET(__wt_config_subinit(session, &pn->config, names));
 	else
-		pn->genname = 1;
+		pn->genname = true;
 
 	return (0);
 }
@@ -118,6 +118,17 @@ __pack_name_next(WT_PACK_NAME *pn, WT_CONFIG_ITEM *name)
 		WT_RET(__wt_config_next(&pn->config, name, &ignore));
 
 	return (0);
+}
+
+/*
+ * __pack_name_free --
+ *      Free resources for a pack name iterator.
+ */
+static inline void
+__pack_name_free(WT_PACK_NAME *pn)
+{
+	if (!pn->genname)
+		__wt_config_free(&pn->config);
 }
 
 /*

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -23,6 +23,7 @@ __lsm_meta_read_v0(
 	u_int nchunks;
 
 	chunk = NULL;			/* -Wconditional-uninitialized */
+	WT_CLEAR(lparser);
 
 	/* LSM trees inherit the merge setting from the connection. */
 	if (F_ISSET(S2C(session), WT_CONN_LSM_MERGE))
@@ -129,6 +130,7 @@ __lsm_meta_read_v0(
 					continue;
 				}
 			}
+			__wt_config_free(&lparser);
 			WT_ERR_NOTFOUND_OK(ret);
 			lsm_tree->nchunks = nchunks;
 		} else if (WT_STRING_MATCH("old_chunks", ck.str, ck.len)) {
@@ -150,6 +152,7 @@ __lsm_meta_read_v0(
 				    lk.str, lk.len, &chunk->uri));
 				F_SET(chunk, WT_LSM_CHUNK_ONDISK);
 			}
+			__wt_config_free(&lparser);
 			WT_ERR_NOTFOUND_OK(ret);
 			lsm_tree->nold_chunks = nchunks;
 		}
@@ -159,7 +162,10 @@ __lsm_meta_read_v0(
 		 */
 	}
 	WT_ERR_NOTFOUND_OK(ret);
-err:	return (ret);
+
+err:	__wt_config_free(&cparser);
+	__wt_config_free(&lparser);
+	return (ret);
 }
 
 /*
@@ -181,6 +187,7 @@ __lsm_meta_read_v1(
 	u_int nchunks;
 
 	chunk = NULL;			/* -Wconditional-uninitialized */
+	WT_CLEAR(lparser);
 
 	WT_ERR(__wt_config_getones(session, lsmconf, "key_format", &cv));
 	WT_ERR(__wt_strndup(session, cv.str, cv.len, &lsm_tree->key_format));
@@ -295,6 +302,7 @@ __lsm_meta_read_v1(
 			continue;
 		}
 	}
+	__wt_config_free(&lparser);
 	WT_ERR_NOTFOUND_OK(ret);
 	lsm_tree->nchunks = nchunks;
 
@@ -341,6 +349,7 @@ __lsm_meta_read_v1(
 	 * created by a future release, with unknown options.
 	 */
 err:	__wt_scr_free(session, &buf);
+	__wt_config_free(&lparser);
 	return (ret);
 }
 

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -380,6 +380,8 @@ __create_index(WT_SESSION_IMPL *session,
 	WT_CLEAR(fmt);
 	WT_CLEAR(extra_cols);
 	WT_CLEAR(namebuf);
+	WT_CLEAR(kcols);
+	WT_CLEAR(pkcols);
 	exists = have_extractor = false;
 
 	tablename = name;
@@ -538,6 +540,8 @@ err:	__wt_free(session, idxconf);
 	__wt_buf_free(session, &extra_cols);
 	__wt_buf_free(session, &fmt);
 	__wt_buf_free(session, &namebuf);
+	__wt_config_free(&kcols);
+	__wt_config_free(&pkcols);
 
 	__wt_schema_release_table(session, table);
 	return (ret);
@@ -567,6 +571,7 @@ __create_table(WT_SESSION_IMPL *session,
 	table = NULL;
 	tableconf = NULL;
 	exists = false;
+	WT_CLEAR(conf);
 
 	tablename = name;
 	if (!WT_PREFIX_SKIP(tablename, "table:"))
@@ -616,6 +621,7 @@ err:		if (table != NULL) {
 		__wt_schema_release_table(session, table);
 	__wt_free(session, cgname);
 	__wt_free(session, tableconf);
+	__wt_config_free(&conf);
 	return (ret);
 }
 

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -110,6 +110,7 @@ __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
 err:	__wt_scr_free(session, &buf);
 	__wt_schema_destroy_colgroup(session, &colgroup);
 	__wt_free(session, cgconfig);
+	__wt_config_free(&cparser);
 	return (ret);
 }
 
@@ -126,6 +127,8 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 	WT_DECL_ITEM(plan);
 	WT_DECL_RET;
 	u_int npublic_cols, i;
+
+	WT_CLEAR(colconf);
 
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
@@ -202,6 +205,7 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 	 * Now add any primary key columns from the table that are not
 	 * already part of the index key.
 	 */
+	__wt_config_free(&colconf);
 	WT_ERR(__wt_config_subinit(session, &colconf, &table->colconf));
 	for (i = 0; i < table->nkey_columns &&
 	    (ret = __wt_config_next(&colconf, &ckey, &cval)) == 0;
@@ -255,6 +259,7 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
 
 err:	__wt_scr_free(session, &buf);
 	__wt_scr_free(session, &plan);
+	__wt_config_free(&colconf);
 	return (ret);
 }
 
@@ -428,6 +433,7 @@ __schema_open_table(WT_SESSION_IMPL *session,
 	char *tablename;
 
 	*tablep = NULL;
+	WT_CLEAR(cparser);
 
 	cursor = NULL;
 	table = NULL;
@@ -482,6 +488,7 @@ __schema_open_table(WT_SESSION_IMPL *session,
 	    "colgroups", &table->cgconf));
 
 	/* Count the number of column groups. */
+	__wt_config_free(&cparser);
 	WT_ERR(__wt_config_subinit(session, &cparser, &table->cgconf));
 	table->ncolgroups = 0;
 	while ((ret = __wt_config_next(&cparser, &ckey, &cval)) == 0)
@@ -513,6 +520,7 @@ err:		WT_TRET(__wt_schema_destroy_table(session, &table));
 
 	__wt_free(session, tablename);
 	__wt_scr_free(session, &buf);
+	__wt_config_free(&cparser);
 	return (ret);
 }
 

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -72,6 +72,7 @@ __curstat_size_only(WT_SESSION_IMPL *session,
 	bool exist;
 
 	WT_CLEAR(namebuf);
+	WT_CLEAR(cparser);
 	*was_fast = false;
 
 	/* Retrieve the metadata for this table. */
@@ -112,6 +113,7 @@ __curstat_size_only(WT_SESSION_IMPL *session,
 
 err:	__wt_free(session, tableconf);
 	__wt_buf_free(session, &namebuf);
+	__wt_config_free(&cparser);
 
 	return (ret);
 }

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -102,6 +102,7 @@ __checkpoint_apply_all(WT_SESSION_IMPL *session, const char *cfg[],
 	bool ckpt_closed, named, target_list;
 
 	target_list = false;
+	WT_CLEAR(targetconf);
 
 	/* Flag if this is a named checkpoint, and check if the name is OK. */
 	WT_RET(__wt_config_gets(session, cfg, "name", &cval));
@@ -167,6 +168,7 @@ __checkpoint_apply_all(WT_SESSION_IMPL *session, const char *cfg[],
 		*fullp = !target_list;
 
 err:	__wt_scr_free(session, &tmp);
+	__wt_config_free(&targetconf);
 	return (ret);
 }
 
@@ -805,6 +807,7 @@ __checkpoint_lock_tree(WT_SESSION_IMPL *session,
 	dhandle = session->dhandle;
 	hot_backup_locked = false;
 	name_alloc = NULL;
+	WT_CLEAR(dropconf);
 
 	/* Only referenced in diagnostic builds. */
 	WT_UNUSED(is_checkpoint);
@@ -980,6 +983,7 @@ err:	if (hot_backup_locked)
 
 	__wt_meta_ckptlist_free(session, ckptbase);
 	__wt_free(session, name_alloc);
+	__wt_config_free(&dropconf);
 
 	return (ret);
 }

--- a/src/txn/txn_nsnap.c
+++ b/src/txn/txn_nsnap.c
@@ -203,6 +203,8 @@ __wt_txn_named_snapshot_drop(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_CONFIG_ITEM all_config, k, names_config, to_config, before_config, v;
 	WT_DECL_RET;
 
+	WT_CLEAR(objectconf);
+
 	WT_RET(__wt_config_gets_def(session, cfg, "drop.all", 0, &all_config));
 	WT_RET(__wt_config_gets_def(
 	    session, cfg, "drop.names", 0, &names_config));
@@ -225,7 +227,7 @@ __wt_txn_named_snapshot_drop(WT_SESSION_IMPL *session, const char *cfg[])
 		while ((ret = __wt_config_next(&objectconf, &k, &v)) == 0) {
 			ret = __nsnap_drop_one(session, &k);
 			if (ret != 0)
-				WT_RET_MSG(session, EINVAL,
+				WT_ERR_MSG(session, EINVAL,
 				    "Named snapshot '%.*s' for drop not found",
 				    (int)k.len, k.str);
 		}
@@ -233,6 +235,7 @@ __wt_txn_named_snapshot_drop(WT_SESSION_IMPL *session, const char *cfg[])
 			ret = 0;
 	}
 
+err:	__wt_config_free(&objectconf);
 	return (ret);
 }
 

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -13,6 +13,9 @@ noinst_PROGRAMS += test_wt2246_col_append
 test_wt2535_insert_race_SOURCES = wt2535_insert_race/main.c
 noinst_PROGRAMS += test_wt2535_insert_race
 
+test_wt2611_config_quoting_SOURCES = wt2611_config_quoting/main.c
+noinst_PROGRAMS += test_wt2611_config_quoting
+
 # Run this during a "make check" smoke test.
 TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)

--- a/test/csuite/wt2611_config_quoting/main.c
+++ b/test/csuite/wt2611_config_quoting/main.c
@@ -1,0 +1,98 @@
+/*-
+ * Public Domain 2014-2016 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * JIRA ticket reference: WT-2611
+ * Test case description:
+ * Failure mode:
+ */
+
+void (*custom_die)(void) = NULL;
+
+int
+main(int argc, char *argv[])
+{
+	WT_CONFIG_ITEM k,v;
+	WT_CONFIG_PARSER *parser, *parser2, *parser3;
+	TEST_OPTS *opts, _opts;
+	int ret;
+	const char *config_string, *quoted;
+
+	opts = &_opts;
+	memset(opts, 0, sizeof(*opts));
+	testutil_check(testutil_parse_opts(argc, argv, opts));
+	testutil_make_work_dir(opts->home);
+
+	/* Here we use a config string with quoting */
+	config_string =
+	    "path=/dev/loop,page_size=1024,log=(archive=true,file_max=20MB),"
+	    "statistics_log=(sources=(\"table:a\"),wait=10)";
+	testutil_check(wiredtiger_config_parser_open(
+	    NULL, config_string, strlen(config_string), &parser));
+	testutil_check(parser->get(parser, "statistics_log", &v));
+	printf("statistics_log=\"%s\"\n", v.str);
+	testutil_assert(strncmp(v.str, "(sources=(\"table:a\"),wait=10)",
+	    v.len) == 0);
+	testutil_check(wiredtiger_config_parser_open(
+	    NULL, v.str, v.len, &parser2));
+	testutil_check(parser2->get(parser2, "sources", &v));
+	printf("sources=\"%s\"\n", v.str);
+	testutil_assert(strncmp(v.str, "(\"table:a\")", v.len) == 0);
+	testutil_check(wiredtiger_config_parser_open(
+	    NULL, v.str, v.len, &parser3));
+	while ((ret = parser3->next(parser3, &k, &v)) == 0) {
+		printf("%.*s:", (int)k.len, k.str);
+		if (v.type == WT_CONFIG_ITEM_NUM)
+			printf("%d\n", (int)v.val);
+		else
+			printf("%.*s\n", (int)v.len, v.str);
+	}
+	testutil_assert(ret = WT_NOTFOUND);
+	testutil_check(parser3->close(parser3));
+	testutil_check(parser2->close(parser2));
+	testutil_check(parser->close(parser));
+
+	/*
+	 * Here we make sure we can fully quote our original string,
+	 * and get it back.
+	 */
+	quoted =
+	    "quoted=\"path=/dev/loop,page_size=1024,"
+	    "log=(archive=true,file_max=20MB),"
+	    "statistics_log=(sources=(\\\"table:a\\\"),wait=10)\"";
+	testutil_check(wiredtiger_config_parser_open(
+	    NULL, quoted, strlen(quoted), &parser));
+	testutil_check(parser->get(parser, "quoted", &v));
+	testutil_assert(strncmp(v.str, config_string, v.len) == 0);
+	testutil_check(parser->close(parser));
+
+	testutil_cleanup(opts);
+
+	return (0);
+}


### PR DESCRIPTION
__wt_config_next() potentially allocates storage, requiring a call to to clean up WT_CONFIG structs using __wt_config_free().
