### PR TITLE
WT-2706 Fix lost log writes when switching files

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -544,8 +544,6 @@ restart:
 	while (i < WT_SLOT_POOL) {
 		save_i = i;
 		slot = &log->slot_pool[i++];
-		WT_ASSERT(session, slot->slot_state != 0 ||
-		    slot->slot_release_lsn.l.file >= log->write_lsn.l.file);
 		if (slot->slot_state != WT_LOG_SLOT_WRITTEN)
 			continue;
 		written[written_i].slot_index = save_i;

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -256,6 +256,8 @@ struct __wt_log {
 #ifdef HAVE_DIAGNOSTIC
 	uint64_t	 write_calls;		/* Calls to log_write */
 #endif
+#define	WT_LOG_OPENED	0x01		/* Log subsystem successfully open */
+	uint32_t	flags;
 };
 
 struct __wt_log_record {

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -790,6 +790,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	WT_FH *log_fh;
 	WT_LOG *log;
 	WT_LSN end_lsn;
 	int yield_cnt;
@@ -862,8 +863,15 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 		WT_RET(__wt_log_allocfile(
 		    session, log->fileid, WT_LOG_FILENAME));
 	}
+	/*
+	 * Since the file system clears the output file handle pointer before
+	 * searching the handle list and filling in the new file handle,
+	 * we must pass in a local file handle.  Otherwise there is a wide
+	 * window where another thread could see a NULL log file handle.
+	 */
 	WT_RET(__log_openfile(session,
-	    false, &log->log_fh, WT_LOG_FILENAME, log->fileid));
+	    false, &log_fh, WT_LOG_FILENAME, log->fileid));
+	log->log_fh = log_fh;
 	/*
 	 * We need to setup the LSNs.  Set the end LSN and alloc LSN to
 	 * the end of the header.
@@ -1176,6 +1184,8 @@ __wt_log_open(WT_SESSION_IMPL *session)
 	}
 
 err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
+	if (ret == 0)
+		F_SET(log, WT_LOG_OPENED);
 	return (ret);
 }
 
@@ -1215,6 +1225,7 @@ __wt_log_close(WT_SESSION_IMPL *session)
 		WT_RET(__wt_close(session, &log->log_dir_fh));
 		log->log_dir_fh = NULL;
 	}
+	F_CLR(log, WT_LOG_OPENED);
 	return (0);
 }
 
@@ -1855,9 +1866,10 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	/*
 	 * An error during opening the logging subsystem can result in it
 	 * being enabled, but without an open log file.  In that case,
-	 * just return.
+	 * just return.  We can also have logging opened for reading in a
+	 * read-only database and attempt to write a record on close.
 	 */
-	if (log->log_fh == NULL)
+	if (!F_ISSET(log, WT_LOG_OPENED) || F_ISSET(conn, WT_CONN_READONLY))
 		return (0);
 	ip = record;
 	if ((compressor = conn->log_compressor) != NULL &&

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -871,7 +871,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 */
 	WT_RET(__log_openfile(session,
 	    false, &log_fh, WT_LOG_FILENAME, log->fileid));
-	log->log_fh = log_fh;
+	WT_PUBLISH(log->log_fh, log_fh);
 	/*
 	 * We need to setup the LSNs.  Set the end LSN and alloc LSN to
 	 * the end of the header.


### PR DESCRIPTION
without writing a log record.
@michaelcahill and @agorrod Please review.  This has been running for a few hundred iterations with both the mongoDB reproducer and random-abort and is ready to merge I believe.
* There was an incorrect assertion where we'd read a slot and fail the assertion because the fields of the slot were changing.
* I added some randomization to the random-abort program.  The minimums are the old values but I let it also run longer and with more threads too.
* There is the fix for the log_fh which is the real fix for the data loss.
* I changed the conditional in `wt_log_write` and added a flag instead of looking at the `log_fh`.  I could have gone either way, adding a `flags` field to the log structure or adding in a log state flag into the connection flags instead. 