### PR TITLE
WT-2710 WT_FILE_HANDLE_INMEM no longer needs an off field

### DIFF
--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -79,7 +79,6 @@ typedef struct demo_file_handle {
 	char	*buf;				/* In-memory contents */
 	size_t	 bufsize;			/* In-memory buffer size */
 
-	size_t	 off;				/* Read/write offset */
 	size_t	 size;				/* Read/write data size */
 } DEMO_FILE_HANDLE;
 
@@ -283,7 +282,6 @@ demo_fs_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
 		}
 
 		demo_fh->ref = 1;
-		demo_fh->off = 0;
 
 		*file_handlep = (WT_FILE_HANDLE *)demo_fh;
 		return (0);
@@ -295,7 +293,7 @@ demo_fs_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
 
 	/* Initialize private information. */
 	demo_fh->ref = 1;
-	demo_fh->off = demo_fh->size = 0;
+	demo_fh->size = 0;
 	demo_fh->demo_fs = demo_fs;
 	if ((demo_fh->buf = calloc(1, DEMO_FILE_SIZE_INCREMENT)) == NULL)
 		goto enomem;
@@ -591,7 +589,6 @@ demo_file_read(WT_FILE_HANDLE *file_handle,
 		if (len > demo_fh->size - off)
 			len = demo_fh->size - off;
 		memcpy(buf, (uint8_t *)demo_fh->buf + off, len);
-		demo_fh->off = off + len;
 	} else
 		ret = EINVAL;		/* EOF */
 
@@ -714,7 +711,6 @@ demo_file_write(WT_FILE_HANDLE *file_handle, WT_SESSION *session,
 	memcpy((uint8_t *)demo_fh->buf + off, buf, len);
 	if (off + len > demo_fh->size)
 		demo_fh->size = off + len;
-	demo_fh->off = off + len;
 
 	return (0);
 }

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -136,7 +136,6 @@ struct __wt_file_handle_inmem {
 	TAILQ_ENTRY(__wt_file_handle_inmem) q;	/* internal queue, hash queue */
 	TAILQ_ENTRY(__wt_file_handle_inmem) hashq;
 
-	size_t	 off;				/* Read/write offset */
 	WT_ITEM  buf;				/* Data */
 	u_int	 ref;				/* Reference count */
 };

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -323,7 +323,6 @@ __im_file_read(WT_FILE_HANDLE *file_handle,
 	if (off < im_fh->buf.size) {
 		len = WT_MIN(len, im_fh->buf.size - off);
 		memcpy(buf, (uint8_t *)im_fh->buf.mem + off, len);
-		im_fh->off = off + len;
 	} else
 		ret = WT_ERROR;
 
@@ -422,7 +421,6 @@ __im_file_write(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session,
 	memcpy((uint8_t *)im_fh->buf.data + off, buf, len);
 	if (off + len > im_fh->buf.size)
 		im_fh->buf.size = off + len;
-	im_fh->off = off + len;
 
 err:	__wt_spin_unlock(session, &im_fs->lock);
 	if (ret == 0)
@@ -470,7 +468,6 @@ __im_file_open(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 			    "%s: file-open: already open", name);
 
 		im_fh->ref = 1;
-		im_fh->off = 0;
 
 		*file_handlep = (WT_FILE_HANDLE *)im_fh;
 
@@ -488,7 +485,6 @@ __im_file_open(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 
 	/* Initialize private information. */
 	im_fh->ref = 1;
-	im_fh->off = 0;
 
 	hash = __wt_hash_city64(name, strlen(name));
 	bucket = hash % WT_HASH_ARRAY_SIZE;


### PR DESCRIPTION
Probably a left-over from when stdio was still part of the pluggable API.