### PR TITLE
SERVER-24580 Don't have application threads spin to access the evicti…

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1424,7 +1424,7 @@ fast:		/* If the page can't be evicted, give up. */
 	 * hazard pointers, and the root page complicates that calculation.
 	 *
 	 * Likewise if we found no new candidates during the walk: there is no
-	 * point keeping a page pinned, since it may be the only candiate in an
+	 * point keeping a page pinned, since it may be the only candidate in an
 	 * idle tree.
 	 *
 	 * If we land on a page requiring forced eviction, move on to the next

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -631,7 +631,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 		 * of whether the cache is full, to prevent the oldest ID
 		 * falling too far behind.
 		 */
-		WT_RET(__wt_txn_update_oldest(session, loop > 0));
+		WT_RET(__wt_txn_update_oldest(session, false));
 
 		if (!__evict_update_work(session))
 			break;
@@ -1520,6 +1520,10 @@ __evict_get_ref(
 	for (;;) {
 		if (__wt_spin_trylock(session, &evict_queue->evict_lock) == 0)
 			break;
+		if (!F_ISSET(session, WT_SESSION_INTERNAL)) {
+			__wt_spin_unlock(session, &cache->evict_queue_lock);
+			return (WT_NOTFOUND);
+		}
 		__wt_yield();
 	}
 	/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1423,11 +1423,15 @@ fast:		/* If the page can't be evicted, give up. */
 	 * If we happen to end up on the root page, clear it.  We have to track
 	 * hazard pointers, and the root page complicates that calculation.
 	 *
+	 * Likewise if we found no new candidates during the walk: there is no
+	 * point keeping a page pinned, since it may be the only candiate in an
+	 * idle tree.
+	 *
 	 * If we land on a page requiring forced eviction, move on to the next
 	 * page: we want this page evicted as quickly as possible.
 	 */
 	if ((ref = btree->evict_ref) != NULL) {
-		if (__wt_ref_is_root(ref))
+		if (__wt_ref_is_root(ref) || evict == start)
 			WT_RET(__evict_clear_walk(session));
 		else if (ref->page->read_gen == WT_READGEN_OLDEST)
 			WT_RET_NOTFOUND_OK(__wt_tree_walk_count(


### PR DESCRIPTION
…on queue.

When the cache hits eviction triggers, all application threads can
hammer the eviction queue lock, starving each other and server threads.

Also, noticed with the same workload, the eviction server doesn't need
to force updates to the oldest ID (which can starve the eviction server
thread if there are hundreds of application threads getting snapshots).
It is sufficient to update it lazily.