### PR TITLE
WT-2408 Windows error translation layer

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -86,6 +86,7 @@ DbEnv
 Decrement
 Decrypt
 DeleteFileA
+EACCES
 EAGAIN
 EB
 EBUSY
@@ -601,6 +602,7 @@ eof
 eq
 equalp
 errhandler
+errmap
 errno
 errx
 esc

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -744,7 +744,7 @@ extern int __wt_getenv(WT_SESSION_IMPL *session, const char *variable, const cha
 extern int __wt_getlasterror(void);
 extern int __wt_getopt( const char *progname, int nargc, char *const *nargv, const char *ostr);
 extern int __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp);
-extern int __wt_map_error_rdonly(int error);
+extern int __wt_map_windows_error_to_posix_error(int error);
 extern int __wt_nfilename( WT_SESSION_IMPL *session, const char *name, size_t namelen, char **path);
 extern int __wt_once(void (*init_routine)(void));
 extern int __wt_open(WT_SESSION_IMPL *session, const char *name, WT_OPEN_FILE_TYPE file_type, u_int flags, WT_FH **fhp);
@@ -767,11 +767,10 @@ extern int __wt_rename_and_sync_directory( WT_SESSION_IMPL *session, const char 
 extern int __wt_strndup(WT_SESSION_IMPL *session, const void *str, size_t len, void *retp);
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg);
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid);
-extern int __wt_win_directory_list(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *directory, const char *prefix, char ***dirlistp, uint32_t *countp);
-extern int __wt_win_directory_list_free(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, char **dirlist, uint32_t count);
-extern int __wt_win_fs_size(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name, wt_off_t *sizep);
-extern int __wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_regionp, size_t *lenp, void *mapped_cookiep);
-extern int __wt_win_unmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_region, size_t length, void *mapped_cookie);
+extern int __wt_win_directory_list_errmap(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *directory, const char *prefix, char ***dirlistp, uint32_t *countp);
+extern int __wt_win_directory_list_free_errmap(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, char **dirlist, uint32_t count);
+extern int __wt_win_map_errmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_regionp, size_t *lenp, void *mapped_cookiep);
+extern int __wt_win_unmap_errmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_region, size_t length, void *mapped_cookie);
 extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base);
 extern void __wt_abort(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 extern void __wt_free_int(WT_SESSION_IMPL *session, const void *p_arg);

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -11,6 +11,28 @@
 #include <dirent.h>
 
 /*
+ * __wt_posix_directory_list_free --
+ *	Free memory returned by __wt_posix_directory_list.
+ */
+int
+__wt_posix_directory_list_free(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, char **dirlist, uint32_t count)
+{
+	WT_SESSION_IMPL *session;
+
+	WT_UNUSED(file_system);
+
+	session = (WT_SESSION_IMPL *)wt_session;
+
+	if (dirlist != NULL) {
+		while (count > 0)
+			__wt_free(session, dirlist[--count]);
+		__wt_free(session, dirlist);
+	}
+	return (0);
+}
+
+/*
  * __wt_posix_directory_list --
  *	Get a list of files from a directory, POSIX version.
  */
@@ -84,26 +106,4 @@ err:	if (dirp != NULL) {
 	WT_RET_MSG(session, ret,
 	    "%s: directory-list, prefix \"%s\"",
 	    directory, prefix == NULL ? "" : prefix);
-}
-
-/*
- * __wt_posix_directory_list_free --
- *	Free memory returned by __wt_posix_directory_list.
- */
-int
-__wt_posix_directory_list_free(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *wt_session, char **dirlist, uint32_t count)
-{
-	WT_SESSION_IMPL *session;
-
-	WT_UNUSED(file_system);
-
-	session = (WT_SESSION_IMPL *)wt_session;
-
-	if (dirlist != NULL) {
-		while (count > 0)
-			__wt_free(session, dirlist[--count]);
-		__wt_free(session, dirlist);
-	}
-	return (0);
 }

--- a/src/os_posix/os_errno.c
+++ b/src/os_posix/os_errno.c
@@ -23,22 +23,6 @@ __wt_errno(void)
 }
 
 /*
- * __wt_map_error_rdonly --
- *	Map an error into a  WiredTiger error code specific for
- *	read-only operation which intercepts based on certain types
- *	of failures.
- */
-int
-__wt_map_error_rdonly(int error)
-{
-	if (error == ENOENT)
-		return (WT_NOTFOUND);
-	else if (error == EACCES)
-		return (WT_PERM_DENIED);
-	return (error);
-}
-
-/*
  * __wt_strerror --
  *	POSIX implementation of WT_SESSION.strerror and wiredtiger_strerror.
  */

--- a/src/os_win/os_dlopen.c
+++ b/src/os_win/os_dlopen.c
@@ -9,11 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_dlopen --
+ * __win_dlopen --
  *	Open a dynamic library.
  */
-int
-__wt_dlopen(WT_SESSION_IMPL *session, const char *path, WT_DLH **dlhp)
+static inline int
+__win_dlopen(WT_SESSION_IMPL *session, const char *path, WT_DLH **dlhp)
 {
 	WT_DECL_RET;
 	WT_DLH *dlh;
@@ -44,11 +44,24 @@ err:		__wt_free(session, dlh->name);
 }
 
 /*
- * __wt_dlsym --
- *	Lookup a symbol in a dynamic library.
+ * __wt_dlopen --
+ *	Open a dynamic library.
  */
 int
-__wt_dlsym(WT_SESSION_IMPL *session,
+__wt_dlopen(WT_SESSION_IMPL *session, const char *path, WT_DLH **dlhp)
+{
+	WT_DECL_RET;
+
+	ret = __win_dlopen(session, path, dlhp);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
+ * __win_dlsym --
+ *	Lookup a symbol in a dynamic library.
+ */
+static inline int
+__win_dlsym(WT_SESSION_IMPL *session,
     WT_DLH *dlh, const char *name, bool fail, void *sym_ret)
 {
 	void *sym;
@@ -65,11 +78,25 @@ __wt_dlsym(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_dlclose --
- *	Close a dynamic library
+ * __wt_dlsym --
+ *	Lookup a symbol in a dynamic library.
  */
 int
-__wt_dlclose(WT_SESSION_IMPL *session, WT_DLH *dlh)
+__wt_dlsym(WT_SESSION_IMPL *session,
+    WT_DLH *dlh, const char *name, bool fail, void *sym_ret)
+{
+	WT_DECL_RET;
+
+	ret = __win_dlsym(session, dlh, name, fail, sym_ret);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
+ * __win_dlclose --
+ *	Close a dynamic library
+ */
+static inline int
+__win_dlclose(WT_SESSION_IMPL *session, WT_DLH *dlh)
 {
 	WT_DECL_RET;
 
@@ -81,4 +108,17 @@ __wt_dlclose(WT_SESSION_IMPL *session, WT_DLH *dlh)
 	__wt_free(session, dlh->name);
 	__wt_free(session, dlh);
 	return (ret);
+}
+
+/*
+ * __wt_dlclose --
+ *	Close a dynamic library
+ */
+int
+__wt_dlclose(WT_SESSION_IMPL *session, WT_DLH *dlh)
+{
+	WT_DECL_RET;
+
+	ret = __win_dlclose(session, dlh);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
 }

--- a/src/os_win/os_errno.c
+++ b/src/os_win/os_errno.c
@@ -8,51 +8,135 @@
 
 #include "wt_internal.h"
 
-static const int windows_error_offset = -29000;
-
 /*
- * __wt_map_error_to_windows_error --
- *	Return a negative integer, an encoded Windows error
- * Standard C errors are positive integers from 0 - ~200
- * Windows errors are from 0 - 15999 according to the documentation
+ * Error-handling in WiredTiger is messy. First, WiredTiger's upper-level code
+ * sometimes checks for POSIX/ANSI error values, for example, EACCES or EBUSY.
+ * Second, Windows error codes overlap with POSIX/ANSI error codes.
+ *
+ * Handle the first issue by mapping Windows errors to POSIX/ANSI errors as part
+ * of returning errors out of the Windows-specific code.
+ *
+ * Handle the second issue by mapping Windows errors into values outside of the
+ * POSIX/ANSI and WiredTiger error name spaces (POSIX/ANSI errors are positive
+ * integers from 0-1000, WiredTiger errors are negative integers from -31,800
+ * to -31,999, use values less than -32,000). There's a Windows-specific error
+ * message processing routine that distinguishes between negative and positive
+ * error codes. This is only useful for errors inside the Windows code because
+ * of the eventual mapping of them to POSIX/ANSI errors, but at least the error
+ * messages from inside the Windows code will report all of the information we
+ * have.
  */
-static DWORD
-__wt_map_error_to_windows_error(int error)
-{
-	/*
-	 * Ensure we do not exceed the error range
-	 * Also validate we do not get any COM errors
-	 * (which are negative integers)
-	 */
-	WT_ASSERT(NULL, error < 0);
-
-	return (error + -(windows_error_offset));
-}
+#define	WT_WINDOWS_ERROR_OFFSET	32000
 
 /*
- * __wt_map_windows_error_to_error --
- *	Return a positive integer, a decoded Windows error
+ * __encode_windows_error --
+ *	Return an encoded Windows error.
  */
 static int
-__wt_map_windows_error_to_error(DWORD winerr)
+__encode_windows_error(DWORD error)
 {
-	return (winerr + windows_error_offset);
+	return (-WT_WINDOWS_ERROR_OFFSET - error);
 }
 
 /*
- * __wt_map_error_rdonly --
- *	Map an error into a  WiredTiger error code specific for
- *	read-only operation which intercepts based on certain types
- *	of failures.
+ * __decode_windows_error --
+ *	Return a decoded Windows error.
+ */
+static DWORD
+__decode_windows_error(int error)
+{
+	return ((DWORD)(-error - WT_WINDOWS_ERROR_OFFSET));
+}
+
+/*
+ * __is_encoded_windows_error --
+ *	Return if we're looking at an encoded Windows error.
+ */
+static bool
+__is_encoded_windows_error(int error)
+{
+	return (error < -WT_WINDOWS_ERROR_OFFSET);
+}
+
+/*
+ * __wt_map_windows_error_to_posix_error --
+ *	Map Windows errors to POSIX errors.
  */
 int
-__wt_map_error_rdonly(int error)
+__wt_map_windows_error_to_posix_error(int error)
 {
-	if (error == ERROR_FILE_NOT_FOUND)
-		return (WT_NOTFOUND);
-	else if (error == ERROR_ACCESS_DENIED)
-		return (WT_PERM_DENIED);
-	return (error);
+	static const struct {
+		int	windows_error;
+		int	posix_error;
+	} list[] = {
+		{ ERROR_ACCESS_DENIED,		EACCES },
+		{ ERROR_ALREADY_EXISTS,		EEXIST },
+		{ ERROR_ARENA_TRASHED,		EFAULT },
+		{ ERROR_BAD_COMMAND,		EFAULT },
+		{ ERROR_BAD_ENVIRONMENT,	EFAULT },
+		{ ERROR_BAD_FORMAT,		EFAULT },
+		{ ERROR_BAD_NETPATH,		ENOENT },
+		{ ERROR_BAD_NET_NAME,		ENOENT },
+		{ ERROR_BAD_PATHNAME,		ENOENT },
+		{ ERROR_BROKEN_PIPE,		EPIPE },
+		{ ERROR_CANNOT_MAKE,		EACCES },
+		{ ERROR_CHILD_NOT_COMPLETE,	ECHILD },
+		{ ERROR_CURRENT_DIRECTORY,	EACCES },
+		{ ERROR_DIRECT_ACCESS_HANDLE,	EBADF },
+		{ ERROR_DIR_NOT_EMPTY,		ENOTEMPTY },
+		{ ERROR_DISK_FULL,		ENOSPC },
+		{ ERROR_DRIVE_LOCKED,		EACCES },
+		{ ERROR_FAIL_I24,		EACCES },
+		{ ERROR_FILENAME_EXCED_RANGE,	ENOENT },
+		{ ERROR_FILE_EXISTS,		EEXIST },
+		{ ERROR_FILE_NOT_FOUND,		ENOENT },
+		{ ERROR_GEN_FAILURE,		EFAULT },
+		{ ERROR_INVALID_ACCESS,		EACCES },
+		{ ERROR_INVALID_BLOCK,		EFAULT },
+		{ ERROR_INVALID_DATA,		EFAULT },
+		{ ERROR_INVALID_DRIVE,		ENOENT },
+		{ ERROR_INVALID_FUNCTION,	EINVAL },
+		{ ERROR_INVALID_HANDLE,		EBADF },
+		{ ERROR_INVALID_PARAMETER,	EINVAL },
+		{ ERROR_INVALID_TARGET_HANDLE,	EBADF },
+		{ ERROR_LOCK_FAILED,		EBUSY },
+		{ ERROR_LOCK_VIOLATION,		EBUSY },
+		{ ERROR_MAX_THRDS_REACHED,	EAGAIN },
+		{ ERROR_NEGATIVE_SEEK,		EINVAL },
+		{ ERROR_NESTING_NOT_ALLOWED,	EAGAIN },
+		{ ERROR_NETWORK_ACCESS_DENIED,	EACCES },
+		{ ERROR_NOT_ENOUGH_MEMORY,	ENOMEM },
+		{ ERROR_NOT_ENOUGH_QUOTA,	ENOMEM },
+		{ ERROR_NOT_LOCKED,		EACCES },
+		{ ERROR_NOT_READY,		EBUSY },
+		{ ERROR_NOT_SAME_DEVICE,	EXDEV },
+		{ ERROR_NO_DATA,		EPIPE },
+		{ ERROR_NO_MORE_FILES,		EMFILE },
+		{ ERROR_NO_PROC_SLOTS,		EAGAIN },
+		{ ERROR_PATH_NOT_FOUND,		ENOENT },
+		{ ERROR_READ_FAULT,		EFAULT },
+		{ ERROR_RETRY,			EINTR },
+		{ ERROR_SEEK_ON_DEVICE,		EACCES },
+		{ ERROR_SHARING_VIOLATION,	EBUSY },
+		{ ERROR_TOO_MANY_OPEN_FILES,	EMFILE },
+		{ ERROR_WAIT_NO_CHILDREN,	ECHILD },
+		{ ERROR_WRITE_FAULT,		EFAULT },
+		{ ERROR_WRITE_PROTECT,		EACCES },
+	};
+	DWORD windows_error;
+	int i;
+
+	/* Ignore anything other than encoded Windows errors. */
+	if (!__is_encoded_windows_error(error))
+		return (error);
+
+	windows_error = __decode_windows_error(error);
+	for (i = 0; i < WT_ELEMENTS(list); ++i)
+		if (windows_error == list[i].windows_error)
+			return (list[i].posix_error);
+
+	/* Untranslatable error, go generic. */
+	return (WT_ERROR);
 }
 
 /*
@@ -65,8 +149,8 @@ __wt_errno(void)
 	/*
 	 * Check for 0:
 	 * It's easy to introduce a problem by calling the wrong error function,
-	 * for example, this function when the MSVC function set the C runtime
-	 * error value. Handle gracefully and always return an error.
+	 * for example, this function when the MSVC function set the system
+	 * error code. Handle gracefully and always return an error.
 	 */
 	return (errno == 0 ? WT_ERROR : errno);
 }
@@ -79,10 +163,10 @@ int
 __wt_getlasterror(void)
 {
 	/*
-	 * Called when we know an error occurred, and we want the system
-	 * error code.
+	 * Called when we know an error occurred, and we want the system error
+	 * code.
 	 */
-	DWORD err = GetLastError();
+	DWORD windows_error = GetLastError();
 
 	/*
 	 * Check for ERROR_SUCCESS:
@@ -90,8 +174,8 @@ __wt_getlasterror(void)
 	 * for example, this function when the MSVC function set the C runtime
 	 * error value. Handle gracefully and always return an error.
 	 */
-	return (err == ERROR_SUCCESS ?
-	    WT_ERROR : __wt_map_windows_error_to_error(err));
+	return (windows_error == ERROR_SUCCESS ?
+	    WT_ERROR : __encode_windows_error(windows_error));
 }
 
 /*
@@ -101,7 +185,7 @@ __wt_getlasterror(void)
 const char *
 __wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)
 {
-	DWORD lasterror;
+	DWORD lasterror, windows_error;
 	const char *p;
 	char buf[512];
 
@@ -112,19 +196,19 @@ __wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)
 		return (p);
 
 	/*
+	 * Check for Windows errors.
+	 *
 	 * When called from wiredtiger_strerror, write a passed-in buffer.
 	 * When called from WT_SESSION.strerror, write the session's buffer.
-	 *
-	 * Check for Windows errors.
 	 */
-	if (error < 0) {
-		error = __wt_map_error_to_windows_error(error);
+	if (__is_encoded_windows_error(error)) {
+		windows_error = __decode_windows_error(error);
 
 		lasterror = FormatMessageA(
 			FORMAT_MESSAGE_FROM_SYSTEM |
 			    FORMAT_MESSAGE_IGNORE_INSERTS,
 			NULL,
-			error,
+			windows_error,
 			0, /* let system choose the correct LANGID */
 			buf,
 			sizeof(buf),
@@ -136,16 +220,24 @@ __wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)
 		if (lasterror != 0 && session != NULL &&
 		    __wt_buf_fmt(session, &session->err, "%s", buf) == 0)
 			return (session->err.data);
+
+		/* Fallback to a generic message. */
+		if (session == NULL && snprintf(
+		    errbuf, errlen, "Windows error code: %d", error) > 0)
+			return (errbuf);
+		if (session != NULL && __wt_buf_fmt(session,
+		    &session->err, "Windows error code: %d", error) == 0)
+			return (session->err.data);
+	} else {
+		/* Fallback to a generic message. */
+		if (session == NULL && snprintf(
+		    errbuf, errlen, "POSIX/ANSI error code: %d", error) > 0)
+			return (errbuf);
+		if (session != NULL && __wt_buf_fmt(session,
+		    &session->err, "POSIX/ANSI error code: %d", error) == 0)
+			return (session->err.data);
 	}
 
-	/* Fallback to a generic message. */
-	if (session == NULL &&
-	    snprintf(errbuf, errlen, "error return: %d", error) > 0)
-		return (errbuf);
-	if (session != NULL && __wt_buf_fmt(
-	    session, &session->err, "error return: %d", error) == 0)
-		return (session->err.data);
-
 	/* Defeated. */
-	return ("Unable to return error string");
+	return ("unable to return error string");
 }

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -12,7 +12,7 @@
  * __win_fs_exist --
  *	Return if the file exists.
  */
-static int
+static inline int
 __win_fs_exist(WT_FILE_SYSTEM *file_system,
     WT_SESSION *wt_session, const char *name, bool *existp)
 {
@@ -32,10 +32,24 @@ __win_fs_exist(WT_FILE_SYSTEM *file_system,
 }
 
 /*
+ * __win_fs_exist_errmap --
+ *	Return if the file exists.
+ */
+static int
+__win_fs_exist_errmap(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, const char *name, bool *existp)
+{
+	WT_DECL_RET;
+
+	ret = __win_fs_exist(file_system, wt_session, name, existp);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_fs_remove --
  *	Remove a file.
  */
-static int
+static inline int
 __win_fs_remove(
     WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name)
 {
@@ -54,10 +68,24 @@ __win_fs_remove(
 }
 
 /*
+ * __win_fs_remove_errmap --
+ *	Remove a file.
+ */
+static int
+__win_fs_remove_errmap(
+    WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name)
+{
+	WT_DECL_RET;
+
+	ret = __win_fs_remove(file_system, wt_session, name);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_fs_rename --
  *	Rename a file.
  */
-static int
+static inline int
 __win_fs_rename(WT_FILE_SYSTEM *file_system,
     WT_SESSION *wt_session, const char *from, const char *to)
 {
@@ -85,11 +113,25 @@ __win_fs_rename(WT_FILE_SYSTEM *file_system,
 }
 
 /*
- * __wt_win_fs_size --
+ * __win_fs_rename_errmap --
+ *	Rename a file.
+ */
+static int
+__win_fs_rename_errmap(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, const char *from, const char *to)
+{
+	WT_DECL_RET;
+
+	ret = __win_fs_rename(file_system, wt_session, from, to);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
+ * __win_fs_size --
  *	Get the size of a file in bytes, by file name.
  */
-int
-__wt_win_fs_size(WT_FILE_SYSTEM *file_system,
+static inline int
+__win_fs_size(WT_FILE_SYSTEM *file_system,
     WT_SESSION *wt_session, const char *name, wt_off_t *sizep)
 {
 	WIN32_FILE_ATTRIBUTE_DATA data;
@@ -110,10 +152,24 @@ __wt_win_fs_size(WT_FILE_SYSTEM *file_system,
 }
 
 /*
+ * __win_fs_size_errmap --
+ *	Get the size of a file in bytes, by file name.
+ */
+static int
+__win_fs_size_errmap(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, const char *name, wt_off_t *sizep)
+{
+	WT_DECL_RET;
+
+	ret = __win_fs_size(file_system, wt_session, name, sizep);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_close --
  *	ANSI C close.
  */
-static int
+static inline int
 __win_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 {
 	WT_DECL_RET;
@@ -151,10 +207,23 @@ __win_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 }
 
 /*
+ * __win_file_close_errmap --
+ *	ANSI C close.
+ */
+static int
+__win_file_close_errmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_close(file_handle, wt_session);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_lock --
  *	Lock/unlock a file.
  */
-static int
+static inline int
 __win_file_lock(
     WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, bool lock)
 {
@@ -191,10 +260,24 @@ __win_file_lock(
 }
 
 /*
+ * __win_file_lock_errmap --
+ *	Lock/unlock a file.
+ */
+static int
+__win_file_lock_errmap(
+    WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, bool lock)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_lock(file_handle, wt_session, lock);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_read --
  *	Read a chunk.
  */
-static int
+static inline int
 __win_file_read(WT_FILE_HANDLE *file_handle,
     WT_SESSION *wt_session, wt_off_t offset, size_t len, void *buf)
 {
@@ -236,10 +319,24 @@ __win_file_read(WT_FILE_HANDLE *file_handle,
 }
 
 /*
+ * __win_file_read_errmap --
+ *	Read a chunk.
+ */
+static int
+__win_file_read_errmap(WT_FILE_HANDLE *file_handle,
+    WT_SESSION *wt_session, wt_off_t offset, size_t len, void *buf)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_read(file_handle, wt_session, offset, len, buf);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_size --
  *	Get the size of a file in bytes, by file handle.
  */
-static int
+static inline int
 __win_file_size(
     WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t *sizep)
 {
@@ -260,10 +357,24 @@ __win_file_size(
 }
 
 /*
+ * __win_file_size_errmap --
+ *	Get the size of a file in bytes, by file handle.
+ */
+static int
+__win_file_size_errmap(
+    WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t *sizep)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_size(file_handle, wt_session, sizep);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_sync --
  *	MSVC fsync.
  */
-static int
+static inline int
 __win_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 {
 	WT_DECL_RET;
@@ -292,10 +403,23 @@ __win_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 }
 
 /*
+ * __win_file_sync_errmap --
+ *	MSVC fsync.
+ */
+static int
+__win_file_sync_errmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_sync(file_handle, wt_session);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_truncate --
  *	Truncate a file.
  */
-static int
+static inline int
 __win_file_truncate(
     WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t len)
 {
@@ -330,10 +454,24 @@ __win_file_truncate(
 }
 
 /*
+ * __win_file_truncate_errmap --
+ *	Truncate a file.
+ */
+static int
+__win_file_truncate_errmap(
+    WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t len)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_truncate(file_handle, wt_session, len);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_file_write --
  *	Write a chunk.
  */
-static int
+static inline int
 __win_file_write(WT_FILE_HANDLE *file_handle,
     WT_SESSION *wt_session, wt_off_t offset, size_t len, const void *buf)
 {
@@ -375,10 +513,24 @@ __win_file_write(WT_FILE_HANDLE *file_handle,
 }
 
 /*
+ * __win_file_write_errmap --
+ *	Write a chunk.
+ */
+static int
+__win_file_write_errmap(WT_FILE_HANDLE *file_handle,
+    WT_SESSION *wt_session, wt_off_t offset, size_t len, const void *buf)
+{
+	WT_DECL_RET;
+
+	ret = __win_file_write(file_handle, wt_session, offset, len, buf);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
+}
+
+/*
  * __win_open_file --
  *	Open a file handle.
  */
-static int
+static inline int
 __win_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
     const char *name, WT_OPEN_FILE_TYPE file_type, uint32_t flags,
     WT_FILE_HANDLE **file_handlep)
@@ -492,22 +644,22 @@ directory_open:
 	file_handle = (WT_FILE_HANDLE *)win_fh;
 	WT_ERR(__wt_strdup(session, name, &file_handle->name));
 
-	file_handle->close = __win_file_close;
-	file_handle->fh_lock = __win_file_lock;
+	file_handle->close = __win_file_close_errmap;
+	file_handle->fh_lock = __win_file_lock_errmap;
 #ifdef WORDS_BIGENDIAN
 	/*
 	 * The underlying objects are little-endian, mapping objects isn't
 	 * currently supported on big-endian systems.
 	 */
 #else
-	file_handle->fh_map = __wt_win_map;
-	file_handle->fh_unmap = __wt_win_unmap;
+	file_handle->fh_map = __wt_win_map_errmap;
+	file_handle->fh_unmap = __wt_win_unmap_errmap;
 #endif
-	file_handle->fh_read = __win_file_read;
-	file_handle->fh_size = __win_file_size;
-	file_handle->fh_sync = __win_file_sync;
-	file_handle->fh_truncate = __win_file_truncate;
-	file_handle->fh_write = __win_file_write;
+	file_handle->fh_read = __win_file_read_errmap;
+	file_handle->fh_size = __win_file_size_errmap;
+	file_handle->fh_sync = __win_file_sync_errmap;
+	file_handle->fh_truncate = __win_file_truncate_errmap;
+	file_handle->fh_write = __win_file_write_errmap;
 
 	*file_handlep = file_handle;
 
@@ -515,6 +667,22 @@ directory_open:
 
 err:	WT_TRET(__win_file_close((WT_FILE_HANDLE *)win_fh, wt_session));
 	return (ret);
+}
+
+/*
+ * __win_open_file_errmap --
+ *	Open a file handle.
+ */
+static int
+__win_open_file_errmap(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
+    const char *name, WT_OPEN_FILE_TYPE file_type, uint32_t flags,
+    WT_FILE_HANDLE **file_handlep)
+{
+	WT_DECL_RET;
+
+	ret = __win_open_file(
+	    file_system, wt_session, name, file_type, flags, file_handlep);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
 }
 
 /*
@@ -547,13 +715,14 @@ __wt_os_win(WT_SESSION_IMPL *session)
 	WT_RET(__wt_calloc_one(session, &file_system));
 
 	/* Initialize the Windows jump table. */
-	file_system->fs_directory_list = __wt_win_directory_list;
-	file_system->fs_directory_list_free = __wt_win_directory_list_free;
-	file_system->fs_exist = __win_fs_exist;
-	file_system->fs_open_file = __win_open_file;
-	file_system->fs_remove = __win_fs_remove;
-	file_system->fs_rename = __win_fs_rename;
-	file_system->fs_size = __wt_win_fs_size;
+	file_system->fs_directory_list = __wt_win_directory_list_errmap;
+	file_system->fs_directory_list_free =
+	    __wt_win_directory_list_free_errmap;
+	file_system->fs_exist = __win_fs_exist_errmap;
+	file_system->fs_open_file = __win_open_file_errmap;
+	file_system->fs_remove = __win_fs_remove_errmap;
+	file_system->fs_rename = __win_fs_rename_errmap;
+	file_system->fs_size = __win_fs_size_errmap;
 	file_system->terminate = __win_terminate;
 
 	/* Switch it into place. */

--- a/src/os_win/os_getenv.c
+++ b/src/os_win/os_getenv.c
@@ -9,11 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_getenv --
+ * __win_getenv --
  * 	Get a non-NULL, greater than zero-length environment variable.
  */
-int
-__wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
+static inline int
+__win_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
 {
 	WT_DECL_RET;
 	DWORD size;
@@ -33,4 +33,17 @@ __wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
 		    "GetEnvironmentVariableA failed: %s", variable);
 
 	return (0);
+}
+
+/*
+ * __wt_getenv --
+ * 	Get a non-NULL, greater than zero-length environment variable.
+ */
+int
+__wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
+{
+	WT_DECL_RET;
+
+	ret = __win_getenv(session, variable, envp);
+	return (ret >= 0 ? ret : __wt_map_windows_error_to_posix_error(ret));
 }

--- a/src/support/huffman.c
+++ b/src/support/huffman.c
@@ -813,7 +813,7 @@ __wt_huffman_decode(WT_SESSION_IMPL *session, void *huffman_arg,
 		    (bits >> (valid - max)) : (bits << (max - valid)));
 		symbol = huffman->code2symbol[pattern & mask];
 		len = huffman->codes[symbol].length;
-		valid -= len;
+		valid -= (uint8_t)len;
 
 		/*
 		 * from_len_bits is the total number of input bits, reduced by


### PR DESCRIPTION
@agorrod, @michaelcahill, @markbenvenuto: here's an approach to the Windows-to-POSIX/ANSI translation layer.

My goal was to leave as much code alone as possible and I wanted us to be able to continue to mix-and-match code in the Windows port that returns errno, MSVC system errors and WiredTiger errors without any new macros (for example, I didn't want to create `WT_RET_MSG_WIN32`). To make that work, I ended up inlining the "standard" code in a wrapping function that maps any returned Windows errors to a POSIX/ANSI error, and leaves all other returns alone.

I moved the Windows encoding to be past the WiredTiger error range encoding so there's no way they can overlap.

I replaced @sueloverso's readonly mapping with POSIX error checks.

This branch doesn't yet have the changes to export error mapping functionality through the `WT_EXTENSION_API` handle, I wanted to make sure I wasn't making this more complicated than it should be and there's not a simpler/better solution.