### PR TITLE
WT-2722 s_label fix for false positve

### DIFF
--- a/dist/s_label
+++ b/dist/s_label
@@ -37,7 +37,7 @@ done
 for f in `find bench examples ext src test -name '*.[ci]'`; do
 	file_parse $f | sed "s=^=$f:="
 done | python dist/s_label_loop.py |
-    egrep '{@[^@]*(WT_ILLEGAL_VALUE|WT_RET[_A-Z]*)\([^@]*(WT_ERR[_A-Z]*|WT_ILLEGAL_VALUE_ERR)\(.*err:' |
+    egrep '\{@[^@]*(WT_ILLEGAL_VALUE|WT_RET[_A-Z]*)\([^@]*(WT_ERR[_A-Z]*|WT_ILLEGAL_VALUE_ERR)\(.*err:' |
     sed -e 's/^\([^:]*\): *\([^:]*\):.*/\1:\2: mix of returns and jump to the error label within a loop/'
 
 # Return of 0 in functions after a jump to the error label.


### PR DESCRIPTION
Regular expression meta-character needed to be escaped so that egrep works consistently on all systems.