### PR TITLE
WT-2691 Use wrappers for ctype functions to avoid sign extension errors

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1156,14 +1156,14 @@ static void
 __debug_item(WT_DBG *ds, const char *tag, const void *data_arg, size_t size)
 {
 	size_t i;
-	int ch;
+	u_char ch;
 	const uint8_t *data;
 
 	__dmsg(ds, "\t%s%s{", tag == NULL ? "" : tag, tag == NULL ? "" : " ");
 	for (data = data_arg, i = 0; i < size; ++i, ++data) {
 		ch = data[0];
 		if (__wt_isprint(ch))
-			__dmsg(ds, "%c", ch);
+			__dmsg(ds, "%c", (int)ch);
 		else
 			__debug_hex_byte(ds, data[0]);
 	}

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1298,7 +1298,8 @@ __conn_config_file(WT_SESSION_IMPL *session,
 		 * the next character is a hash mark, skip to the next newline.
 		 */
 		for (;;) {
-			for (*t++ = ','; --len > 0 && __wt_isspace(*++p);)
+			for (*t++ = ',';
+			    --len > 0 && __wt_isspace((u_char)*++p);)
 				;
 			if (len == 0)
 				break;

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -128,7 +128,7 @@ str2recno(WT_SESSION_IMPL *session, const char *p, uint64_t *recnop)
 	 * forth -- none of them are OK with us.  Check the string starts with
 	 * digit, that turns off the special processing.
 	 */
-	if (!__wt_isdigit(p[0]))
+	if (!__wt_isdigit((u_char)p[0]))
 		goto format;
 
 	errno = 0;

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -390,7 +390,7 @@ __wt_json_column_init(WT_CURSOR *cursor, const char *keyformat,
 	}
 
 	for (nkeys = 0; *keyformat; keyformat++)
-		if (!__wt_isdigit(*keyformat))
+		if (!__wt_isdigit((u_char)*keyformat))
 			nkeys++;
 
 	p = beginkey;
@@ -414,12 +414,12 @@ __wt_json_column_init(WT_CURSOR *cursor, const char *keyformat,
 #define	MATCH_KEYWORD(session, in, result, keyword, matchval) 	do {	\
 	size_t _kwlen = strlen(keyword);				\
 	if (strncmp(in, keyword, _kwlen) == 0 &&			\
-	    !__wt_isalnum(in[_kwlen])) {				\
+	    !__wt_isalnum((u_char)in[_kwlen])) {			\
 		in += _kwlen;						\
 		result = matchval;					\
 	} else {							\
 		const char *_bad = in;					\
-		while (__wt_isalnum(*in))				\
+		while (__wt_isalnum((u_char)*in))			\
 			in++;						\
 		__wt_errx(session, "unknown keyword \"%.*s\" in JSON",	\
 		    (int)(in - _bad), _bad);				\
@@ -461,7 +461,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 
 	result = -1;
 	session = (WT_SESSION_IMPL *)wt_session;
-	while (__wt_isspace(*src))
+	while (__wt_isspace((u_char)*src))
 		src++;
 	*tokstart = src;
 
@@ -521,12 +521,12 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 		isfloat = false;
 		if (*src == '-')
 			src++;
-		while ((ch = *src) != '\0' && __wt_isdigit(ch))
+		while ((ch = *src) != '\0' && __wt_isdigit((u_char)ch))
 			src++;
 		if (*src == '.') {
 			isfloat = true;
 			src++;
-			while ((ch = *src) != '\0' && __wt_isdigit(ch))
+			while ((ch = *src) != '\0' && __wt_isdigit((u_char)ch))
 				src++;
 		}
 		if (*src == 'e' || *src == 'E') {
@@ -534,7 +534,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 			src++;
 			if (*src == '+' || *src == '-')
 				src++;
-			while ((ch = *src) != '\0' && __wt_isdigit(ch))
+			while ((ch = *src) != '\0' && __wt_isdigit((u_char)ch))
 				src++;
 		}
 		result = isfloat ? 'f' : 'i';
@@ -559,10 +559,10 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype,
 	default:
 		/* An illegal token, move past it anyway */
 		bad = src;
-		isalph = __wt_isalnum(*src);
+		isalph = __wt_isalnum((u_char)*src);
 		src++;
 		if (isalph)
-			while (*src != '\0' && __wt_isalnum(*src))
+			while (*src != '\0' && __wt_isalnum((u_char)*src))
 				src++;
 		__wt_errx(session, "unknown token \"%.*s\" in JSON",
 		    (int)(src - bad), bad);

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -435,7 +435,7 @@ __wt_cursor_get_valuev(WT_CURSOR *cursor, va_list ap)
 	} else if (WT_STREQ(fmt, "S"))
 		*va_arg(ap, const char **) = cursor->value.data;
 	else if (WT_STREQ(fmt, "t") ||
-	    (__wt_isdigit(fmt[0]) && WT_STREQ(fmt + 1, "t")))
+	    (__wt_isdigit((u_char)fmt[0]) && WT_STREQ(fmt + 1, "t")))
 		*va_arg(ap, uint8_t *) = *(uint8_t *)cursor->value.data;
 	else
 		ret = __wt_struct_unpackv(session,
@@ -496,7 +496,7 @@ __wt_cursor_set_valuev(WT_CURSOR *cursor, va_list ap)
 		sz = strlen(str) + 1;
 		buf->data = str;
 	} else if (WT_STREQ(fmt, "t") ||
-	    (__wt_isdigit(fmt[0]) && WT_STREQ(fmt + 1, "t"))) {
+	    (__wt_isdigit((u_char)fmt[0]) && WT_STREQ(fmt + 1, "t"))) {
 		sz = 1;
 		WT_ERR(__wt_buf_initsize(session, buf, sz));
 		*(uint8_t *)buf->mem = (uint8_t)va_arg(ap, int);

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -138,7 +138,7 @@ __pack_next(WT_PACK *pack, WT_PACK_VALUE *pv)
 next:	if (pack->cur == pack->end)
 		return (WT_NOTFOUND);
 
-	if (__wt_isdigit(*pack->cur)) {
+	if (__wt_isdigit((u_char)*pack->cur)) {
 		pv->havesize = 1;
 		pv->size = WT_STORE_SIZE(strtoul(pack->cur, &endsize, 10));
 		pack->cur = endsize;

--- a/src/schema/schema_project.c
+++ b/src/schema/schema_project.c
@@ -353,8 +353,8 @@ __wt_schema_project_slice(WT_SESSION_IMPL *session, WT_CURSOR **cp,
 
 				/* Make sure the types are compatible. */
 				WT_ASSERT(session,
-				    __wt_tolower(pv.type) ==
-				    __wt_tolower(vpv.type));
+				    __wt_tolower((u_char)pv.type) ==
+				    __wt_tolower((u_char)vpv.type));
 				pv.u = vpv.u;
 
 				len = __pack_size(session, &pv);
@@ -460,8 +460,8 @@ __wt_schema_project_merge(WT_SESSION_IMPL *session,
 				WT_RET(__pack_next(&vpack, &vpv));
 				/* Make sure the types are compatible. */
 				WT_ASSERT(session,
-				    __wt_tolower(pv.type) ==
-				    __wt_tolower(vpv.type));
+				    __wt_tolower((u_char)pv.type) ==
+				    __wt_tolower((u_char)vpv.type));
 				vpv.u = pv.u;
 				len = __pack_size(session, &vpv);
 				WT_RET(__wt_buf_grow(session,

--- a/src/support/hex.c
+++ b/src/support/hex.c
@@ -84,7 +84,7 @@ __wt_raw_to_esc_hex(
 	WT_RET(__wt_buf_init(session, to, size * 3 + 1));
 
 	for (p = from, t = to->mem, i = size; i > 0; --i, ++p)
-		if (__wt_isprint((int)*p)) {
+		if (__wt_isprint((u_char)*p)) {
 			if (*p == '\\')
 				*t++ = '\\';
 			*t++ = *p;

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -248,7 +248,7 @@ json_data(WT_SESSION *session,
 	keyformat = cursor->key_format;
 	isrec = strcmp(keyformat, "r") == 0;
 	for (nkeys = 0; *keyformat; keyformat++)
-		if (!__wt_isdigit(*keyformat))
+		if (!__wt_isdigit((u_char)*keyformat))
 			nkeys++;
 
 	recno = 0;
@@ -471,7 +471,7 @@ json_peek(WT_SESSION *session, JSON_INPUT_STATE *ins)
 
 	if (!ins->peeking) {
 		while (!ins->ateof) {
-			while (__wt_isspace(*ins->p))
+			while (__wt_isspace((u_char)*ins->p))
 				ins->p++;
 			if (*ins->p)
 				break;

--- a/src/utilities/util_misc.c
+++ b/src/utilities/util_misc.c
@@ -108,7 +108,7 @@ util_str2recno(WT_SESSION *session, const char *p, uint64_t *recnop)
 	 * forth -- none of them are OK with us.  Check the string starts with
 	 * digit, that turns off the special processing.
 	 */
-	if (!__wt_isdigit(p[0]))
+	if (!__wt_isdigit((u_char)p[0]))
 		goto format;
 
 	errno = 0;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1465,7 +1465,7 @@ print_item(const char *tag, WT_ITEM *item)
 	static const char hex[] = "0123456789abcdef";
 	const uint8_t *data;
 	size_t size;
-	int ch;
+	u_char ch;
 
 	data = item->data;
 	size = item->size;
@@ -1477,7 +1477,7 @@ print_item(const char *tag, WT_ITEM *item)
 		for (; size > 0; --size, ++data) {
 			ch = data[0];
 			if (__wt_isprint(ch))
-				fprintf(stderr, "%c", ch);
+				fprintf(stderr, "%c", (int)ch);
 			else
 				fprintf(stderr, "%x%x",
 				    hex[(data[0] & 0xf0) >> 4],

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -701,7 +701,7 @@ print_res(int key, int value, int cnt)
 		switch (page_type) {			/* Print value */
 		case WT_PAGE_COL_FIX:
 			ch = value & 0x7f;
-			if (__wt_isprint(ch)) {
+			if (__wt_isprint((u_char)ch)) {
 				if (ch == '\\')
 					fputc('\\', res_fp);
 				fputc(ch, res_fp);


### PR DESCRIPTION
gcc 4.7, clang 3.4 and clang 3.8 all complain about different things; cast the arguments to our new wrapper functions, hopefully that makes all of the complaints go away.