### PR TITLE
WT-2729 Focus eviction on the largest trees in cache (mongodb-3.2).

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -414,6 +414,7 @@ dsrc_stats = [
     ##########################################
     # Cache and eviction statistics
     ##########################################
+    CacheStat('cache_bytes_inuse', 'bytes currently in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_read', 'bytes read into cache', 'size'),
     CacheStat('cache_bytes_write', 'bytes written from cache', 'size'),
     CacheStat('cache_eviction_checkpoint', 'checkpoint blocked page eviction'),

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -41,6 +41,9 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 	WT_STAT_SET(session, stats, btree_maxleafpage, btree->maxleafpage);
 	WT_STAT_SET(session, stats, btree_maxleafvalue, btree->maxleafvalue);
 
+	WT_STAT_SET(session, stats, cache_bytes_inuse,
+	    __wt_btree_bytes_inuse(session));
+
 	/* Everything else is really, really expensive. */
 	if (!F_ISSET(cst, WT_CONN_STAT_ALL))
 		return (0);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -26,12 +26,14 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	uint64_t internal_bytes, internal_pages, leaf_bytes, leaf_pages;
 	uint64_t oldest_id, saved_snap_min;
 	uint32_t flags;
+	u_int saved_evict_walk_period;
 
 	conn = S2C(session);
 	btree = S2BT(session);
 	walk = NULL;
 	txn = &session->txn;
 	saved_snap_min = WT_SESSION_TXN_STATE(session)->snap_min;
+	saved_evict_walk_period = btree->evict_walk_period;
 	flags = WT_READ_CACHE | WT_READ_NO_GEN;
 
 	internal_bytes = leaf_bytes = 0;
@@ -236,10 +238,10 @@ err:	/* On error, clear any left-over tree walk. */
 		WT_FULL_BARRIER();
 
 		/*
-		 * If this tree was being skipped by the eviction server during
-		 * the checkpoint, clear the wait.
+		 * In case this tree was being skipped by the eviction server
+		 * during the checkpoint, restore the previous state.
 		 */
-		btree->evict_walk_period = 0;
+		btree->evict_walk_period = saved_evict_walk_period;
 
 		/*
 		 * Wake the eviction server, in case application threads have

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1062,7 +1062,7 @@ __evict_walk(WT_SESSION_IMPL *session)
 	 * per walk.
 	 */
 	start_slot = slot = cache->evict_entries;
-	max_entries = slot + WT_EVICT_WALK_INCR;
+	max_entries = WT_MIN(slot + WT_EVICT_WALK_INCR, cache->evict_slots);
 
 retry:	while (slot < max_entries && ret == 0) {
 		/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -16,7 +16,7 @@ static int  __evict_lru_walk(WT_SESSION_IMPL *);
 static int  __evict_page(WT_SESSION_IMPL *, bool);
 static int  __evict_pass(WT_SESSION_IMPL *);
 static int  __evict_walk(WT_SESSION_IMPL *);
-static int  __evict_walk_file(WT_SESSION_IMPL *, u_int *);
+static int  __evict_walk_file(WT_SESSION_IMPL *, u_int, u_int *);
 static WT_THREAD_RET __evict_worker(void *);
 static int  __evict_server_work(WT_SESSION_IMPL *);
 
@@ -32,11 +32,6 @@ __evict_read_gen(const WT_EVICT_ENTRY *entry)
 	uint64_t read_gen;
 
 	btree = entry->btree;
-
-	/* Never prioritize empty slots. */
-	if (entry->ref == NULL)
-		return (UINT64_MAX);
-
 	page = entry->ref->page;
 
 	/* Any page set to the oldest generation should be discarded. */
@@ -71,14 +66,15 @@ __evict_read_gen(const WT_EVICT_ENTRY *entry)
  *	Qsort function: sort the eviction array.
  */
 static int WT_CDECL
-__evict_lru_cmp(const void *a, const void *b)
+__evict_lru_cmp(const void *a_arg, const void *b_arg)
 {
-	uint64_t a_lru, b_lru;
+	const WT_EVICT_ENTRY *a = a_arg, *b = b_arg;
+	uint64_t a_score, b_score;
 
-	a_lru = __evict_read_gen(a);
-	b_lru = __evict_read_gen(b);
+	a_score = (a->ref == NULL ? UINT64_MAX : a->score);
+	b_score = (b->ref == NULL ? UINT64_MAX : b->score);
 
-	return ((a_lru < b_lru) ? -1 : (a_lru == b_lru) ? 0 : 1);
+	return ((a_score < b_score) ? -1 : (a_score == b_score) ? 0 : 1);
 }
 
 /*
@@ -901,7 +897,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 {
 	WT_CACHE *cache;
 	WT_DECL_RET;
-	uint64_t cutoff, read_gen_oldest;
+	uint64_t read_gen_oldest;
 	uint32_t candidates, entries;
 
 	cache = S2C(session)->cache;
@@ -959,7 +955,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		read_gen_oldest = WT_READGEN_OLDEST;
 		for (candidates = 0; candidates < entries; ++candidates) {
 			read_gen_oldest =
-			    __evict_read_gen(&cache->evict_queue[candidates]);
+			    cache->evict_queue[candidates].score;
 			if (read_gen_oldest != WT_READGEN_OLDEST)
 				break;
 		}
@@ -968,35 +964,29 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		 * Take all candidates if we only gathered pages with an oldest
 		 * read generation set.
 		 *
-		 * We normally never take more than 50% of the entries; if 50%
-		 * of the entries were at the oldest read generation, take them.
+		 * We normally never take more than 50% of the entries but if
+		 * 50% of the entries were at the oldest read generation, take
+		 * all of them.
 		 */
 		if (read_gen_oldest == WT_READGEN_OLDEST)
 			cache->evict_candidates = entries;
 		else if (candidates >= entries / 2)
 			cache->evict_candidates = candidates;
 		else {
-			/* Save the calculated oldest generation. */
-			cache->read_gen_oldest = read_gen_oldest;
-
-			/* Find the bottom 25% of read generations. */
-			cutoff =
-			    (3 * read_gen_oldest + __evict_read_gen(
-			    &cache->evict_queue[entries - 1])) / 4;
-
 			/*
-			 * Don't take less than 10% or more than 50% of entries,
-			 * regardless. That said, if there is only one entry,
-			 * which is normal when populating an empty file, don't
-			 * exclude it.
+			 * Take all of the urgent pages plus a third of
+			 * ordinary candidates (which could be expressed as
+			 * WT_EVICT_WALK_INCR / WT_EVICT_WALK_BASE).  In the
+			 * steady state, we want to get as many candidates as
+			 * the eviction walk adds to the queue.
+			 *
+			 * That said, if there is only one entry, which is
+			 * normal when populating an empty file, don't exclude
+			 * it.
 			 */
-			for (candidates = 1 + entries / 10;
-			    candidates < entries / 2;
-			    candidates++)
-				if (__evict_read_gen(
-				    &cache->evict_queue[candidates]) > cutoff)
-					break;
-			cache->evict_candidates = candidates;
+			cache->evict_candidates =
+			    1 + candidates + ((entries - candidates) - 1) / 3;
+			cache->read_gen_oldest = read_gen_oldest;
 		}
 	}
 
@@ -1052,7 +1042,7 @@ __evict_walk(WT_SESSION_IMPL *session)
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	u_int prev_slot, retries, slot, start_slot, spins;
+	u_int max_entries, prev_slot, retries, slot, start_slot, spins;
 	bool dhandle_locked, incr;
 
 	conn = S2C(session);
@@ -1072,8 +1062,9 @@ __evict_walk(WT_SESSION_IMPL *session)
 	 * per walk.
 	 */
 	start_slot = slot = cache->evict_entries;
+	max_entries = slot + WT_EVICT_WALK_INCR;
 
-retry:	while (slot < cache->evict_slots && ret == 0) {
+retry:	while (slot < max_entries && ret == 0) {
 		/*
 		 * If another thread is waiting on the eviction server to clear
 		 * the walk point in a tree, give up.
@@ -1179,7 +1170,8 @@ retry:	while (slot < cache->evict_slots && ret == 0) {
 			if (!F_ISSET(btree, WT_BTREE_NO_EVICTION)) {
 				cache->evict_file_next = dhandle;
 				WT_WITH_DHANDLE(session, dhandle,
-				    ret = __evict_walk_file(session, &slot));
+				    ret = __evict_walk_file(
+					session, max_entries, &slot));
 				WT_ASSERT(session, session->split_gen == 0);
 			}
 			__wt_spin_unlock(session, &cache->evict_walk_lock);
@@ -1213,7 +1205,7 @@ retry:	while (slot < cache->evict_slots && ret == 0) {
 	 * candidates and we aren't finding more.
 	 */
 	if (!F_ISSET(cache, WT_CACHE_CLEAR_WALKS) && ret == 0 &&
-	    slot < cache->evict_slots && (retries < 2 ||
+	    slot < max_entries && (retries < 2 ||
 	    (retries < 10 &&
 	    !FLD_ISSET(cache->state, WT_EVICT_PASS_WOULD_BLOCK) &&
 	    (slot == cache->evict_entries || slot > start_slot)))) {
@@ -1246,8 +1238,9 @@ __evict_init_candidate(
 
 	if (evict->ref != NULL)
 		__evict_list_clear(session, evict);
-	evict->ref = ref;
 	evict->btree = S2BT(session);
+	evict->ref = ref;
+	evict->score = __evict_read_gen(evict);
 
 	/* Mark the page on the list; set last to flush the other updates. */
 	F_SET_ATOMIC(ref->page, WT_PAGE_EVICT_LRU);
@@ -1258,7 +1251,7 @@ __evict_init_candidate(
  *	Get a few page eviction candidates from a single underlying file.
  */
 static int
-__evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
+__evict_walk_file(WT_SESSION_IMPL *session, u_int max_entries, u_int *slotp)
 {
 	WT_BTREE *btree;
 	WT_CACHE *cache;
@@ -1268,7 +1261,8 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
 	WT_REF *ref;
-	uint64_t btree_inuse, cache_inuse, pages_seen, refs_walked;
+	uint64_t btree_inuse, bytes_per_slot, cache_inuse;
+	uint64_t pages_seen, refs_walked;
 	uint32_t remaining_slots, target_pages, total_slots, walk_flags;
 	int internal_pages, restarts;
 	bool enough, modified;
@@ -1286,10 +1280,20 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 	start = cache->evict_queue + *slotp;
 	btree_inuse = __wt_btree_bytes_inuse(session);
 	cache_inuse = __wt_cache_bytes_inuse(cache);
-	remaining_slots = cache->evict_slots - *slotp;
-	total_slots = cache->evict_slots - cache->evict_entries;
+	remaining_slots = max_entries - *slotp;
+	total_slots = max_entries - cache->evict_entries;
 	target_pages = (uint32_t)(btree_inuse /
 	    (cache_inuse / total_slots));
+
+	/*
+	 * The target number of pages for this tree is proportional to the
+	 * space it is taking up in cache.  Round to the nearest number of
+	 * slots so we assign all of the slots to a tree filling 99+% of the
+	 * cache (and only have to walk it once).
+	 */
+	bytes_per_slot = cache_inuse / total_slots;
+	target_pages = (uint32_t)(
+	    (btree_inuse + bytes_per_slot / 2) / bytes_per_slot);
 	if (target_pages == 0) {
 		/*
 		 * Randomly walk trees with a tiny fraction of the cache in
@@ -1510,12 +1514,13 @@ __evict_get_ref(
 		candidates /= 2;
 
 	/* Get the next page queued for eviction. */
-	while ((evict = cache->evict_current) != NULL &&
-	    evict < cache->evict_queue + candidates && evict->ref != NULL) {
+	for (evict = cache->evict_current;
+	    evict >= cache->evict_queue &&
+	    evict < cache->evict_queue + candidates;
+	    ++evict) {
+		if (evict->ref == NULL)
+			continue;
 		WT_ASSERT(session, evict->btree != NULL);
-
-		/* Move to the next item. */
-		++cache->evict_current;
 
 		/*
 		 * Lock the page while holding the eviction mutex to prevent
@@ -1546,8 +1551,11 @@ __evict_get_ref(
 	}
 
 	/* Clear the current pointer if there are no more candidates. */
-	if (evict >= cache->evict_queue + cache->evict_candidates)
+	if (evict == NULL || evict + 1 >=
+	    cache->evict_queue + cache->evict_candidates)
 		cache->evict_current = NULL;
+	else
+		cache->evict_current = evict + 1;
 	__wt_spin_unlock(session, &cache->evict_lock);
 
 	return ((*refp == NULL) ? WT_NOTFOUND : 0);
@@ -1571,14 +1579,13 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	 * An internal session flags either the server itself or an eviction
 	 * worker thread.
 	 */
-	if (F_ISSET(session, WT_SESSION_INTERNAL)) {
-		if (is_server)
-			WT_STAT_FAST_CONN_INCR(
-			    session, cache_eviction_server_evicting);
-		else
-			WT_STAT_FAST_CONN_INCR(
-			    session, cache_eviction_worker_evicting);
-	} else {
+	if (is_server)
+		WT_STAT_FAST_CONN_INCR(
+		    session, cache_eviction_server_evicting);
+	else if (F_ISSET(session, WT_SESSION_INTERNAL))
+		WT_STAT_FAST_CONN_INCR(
+		    session, cache_eviction_worker_evicting);
+	else {
 		if (__wt_page_is_modified(ref->page))
 			WT_STAT_FAST_CONN_INCR(
 			    session, cache_eviction_app_dirty);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1052,7 +1052,7 @@ __evict_walk(WT_SESSION_IMPL *session)
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	u_int max_entries, prev_slot, retries, slot, start_slot, spins;
+	u_int prev_slot, retries, slot, start_slot, spins;
 	bool dhandle_locked, incr;
 
 	conn = S2C(session);
@@ -1072,9 +1072,8 @@ __evict_walk(WT_SESSION_IMPL *session)
 	 * per walk.
 	 */
 	start_slot = slot = cache->evict_entries;
-	max_entries = slot + WT_EVICT_WALK_INCR;
 
-retry:	while (slot < max_entries && ret == 0) {
+retry:	while (slot < cache->evict_slots && ret == 0) {
 		/*
 		 * If another thread is waiting on the eviction server to clear
 		 * the walk point in a tree, give up.
@@ -1155,7 +1154,6 @@ retry:	while (slot < max_entries && ret == 0) {
 		 * useful in the past.
 		 */
 		if (btree->evict_walk_period != 0 &&
-		    cache->evict_entries >= WT_EVICT_WALK_INCR &&
 		    btree->evict_walk_skips++ < btree->evict_walk_period)
 			continue;
 		btree->evict_walk_skips = 0;
@@ -1215,7 +1213,7 @@ retry:	while (slot < max_entries && ret == 0) {
 	 * candidates and we aren't finding more.
 	 */
 	if (!F_ISSET(cache, WT_CACHE_CLEAR_WALKS) && ret == 0 &&
-	    slot < max_entries && (retries < 2 ||
+	    slot < cache->evict_slots && (retries < 2 ||
 	    (retries < 10 &&
 	    !FLD_ISSET(cache->state, WT_EVICT_PASS_WOULD_BLOCK) &&
 	    (slot == cache->evict_entries || slot > start_slot)))) {
@@ -1270,8 +1268,8 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
 	WT_REF *ref;
-	uint64_t pages_seen, refs_walked;
-	uint32_t walk_flags;
+	uint64_t btree_inuse, cache_inuse, pages_seen, refs_walked;
+	uint32_t remaining_slots, target_pages, total_slots, walk_flags;
 	int internal_pages, restarts;
 	bool enough, modified;
 
@@ -1281,11 +1279,33 @@ __evict_walk_file(WT_SESSION_IMPL *session, u_int *slotp)
 	internal_pages = restarts = 0;
 	enough = false;
 
+	/*
+	 * Figure out how many slots to fill from this tree.
+	 * Note that some care is taken in the calculation to avoid overflow.
+	 */
 	start = cache->evict_queue + *slotp;
-	end = start + WT_EVICT_WALK_PER_FILE;
+	btree_inuse = __wt_btree_bytes_inuse(session);
+	cache_inuse = __wt_cache_bytes_inuse(cache);
+	remaining_slots = cache->evict_slots - *slotp;
+	total_slots = cache->evict_slots - cache->evict_entries;
+	target_pages = (uint32_t)(btree_inuse /
+	    (cache_inuse / total_slots));
+	if (target_pages == 0) {
+		/*
+		 * Randomly walk trees with a tiny fraction of the cache in
+		 * case there are so many trees that none of them use enough of
+		 * the cache to be allocated slots.
+		 */
+		if (__wt_random(&session->rnd) / (double)UINT32_MAX >
+		    btree_inuse / (double)cache_inuse)
+			return (0);
+		target_pages = 10;
+	}
+
 	if (F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
-	    end > cache->evict_queue + cache->evict_slots)
-		end = cache->evict_queue + cache->evict_slots;
+	    target_pages > remaining_slots)
+		target_pages = remaining_slots;
+	end = start + target_pages;
 
 	walk_flags =
 	    WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT;

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -129,6 +129,8 @@ struct __wt_btree {
 	uint64_t rec_max_txn;		/* Maximum txn seen (clean trees) */
 	uint64_t write_gen;		/* Write generation */
 
+	uint64_t    bytes_inmem;	/* Cache bytes in memory. */
+
 	WT_REF	   *evict_ref;		/* Eviction thread's location */
 	uint64_t    evict_priority;	/* Relative priority of cached pages */
 	u_int	    evict_walk_period;	/* Skip this many LRU walks */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -23,6 +23,7 @@
 struct __wt_evict_entry {
 	WT_BTREE *btree;		/* Enclosing btree object */
 	WT_REF	 *ref;			/* Page to flush/evict */
+	uint64_t  score;		/* Relative eviction priority */
 };
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -13,7 +13,6 @@
 #define	WT_EVICT_INT_SKEW  (1<<20)	/* Prefer leaf pages over internal
 					   pages by this many increments of the
 					   read generation. */
-#define	WT_EVICT_WALK_PER_FILE	 10	/* Pages to queue per file */
 #define	WT_EVICT_WALK_BASE	300	/* Pages tracked across file visits */
 #define	WT_EVICT_WALK_INCR	100	/* Pages added each walk */
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -447,6 +447,7 @@ struct __wt_dsrc_stats {
 	int64_t btree_compact_rewrite;
 	int64_t btree_row_internal;
 	int64_t btree_row_leaf;
+	int64_t cache_bytes_inuse;
 	int64_t cache_bytes_read;
 	int64_t cache_bytes_write;
 	int64_t cache_eviction_checkpoint;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4138,125 +4138,127 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2038
 /*! btree: row-store leaf pages */
 #define	WT_STAT_DSRC_BTREE_ROW_LEAF			2039
+/*! cache: bytes currently in the cache */
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2040
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2040
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2041
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2041
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2042
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2042
+#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2043
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2043
+#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2044
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2044
+#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2045
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2045
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2046
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2046
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2047
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2047
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2048
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2048
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2049
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2049
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2050
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2051
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2051
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2052
 /*! cache: overflow values cached in memory */
-#define	WT_STAT_DSRC_CACHE_OVERFLOW_VALUE		2052
+#define	WT_STAT_DSRC_CACHE_OVERFLOW_VALUE		2053
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2054
 /*! cache: page written requiring lookaside records */
-#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2054
+#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2055
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2055
+#define	WT_STAT_DSRC_CACHE_READ				2056
 /*! cache: pages read into cache requiring lookaside entries */
-#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2056
+#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2057
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2057
+#define	WT_STAT_DSRC_CACHE_WRITE			2058
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2058
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2059
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2060
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2060
+#define	WT_STAT_DSRC_COMPRESS_READ			2061
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2061
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2062
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2062
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2063
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2063
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2064
 /*! compression: raw compression call failed, additional data available */
-#define	WT_STAT_DSRC_COMPRESS_RAW_FAIL_TEMPORARY	2064
+#define	WT_STAT_DSRC_COMPRESS_RAW_FAIL_TEMPORARY	2065
 /*! compression: raw compression call failed, no additional data available */
-#define	WT_STAT_DSRC_COMPRESS_RAW_FAIL			2065
+#define	WT_STAT_DSRC_COMPRESS_RAW_FAIL			2066
 /*! compression: raw compression call succeeded */
-#define	WT_STAT_DSRC_COMPRESS_RAW_OK			2066
+#define	WT_STAT_DSRC_COMPRESS_RAW_OK			2067
 /*! cursor: bulk-loaded cursor-insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2067
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2068
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2068
+#define	WT_STAT_DSRC_CURSOR_CREATE			2069
 /*! cursor: cursor-insert key and value bytes inserted */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2069
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2070
 /*! cursor: cursor-remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2070
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2071
 /*! cursor: cursor-update value bytes updated */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2071
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2072
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2072
+#define	WT_STAT_DSRC_CURSOR_INSERT			2073
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2073
+#define	WT_STAT_DSRC_CURSOR_NEXT			2074
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2074
+#define	WT_STAT_DSRC_CURSOR_PREV			2075
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2075
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2076
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2076
+#define	WT_STAT_DSRC_CURSOR_RESET			2077
 /*! cursor: restarted searches */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2077
+#define	WT_STAT_DSRC_CURSOR_RESTART			2078
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2078
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2079
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2079
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2080
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2080
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2081
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2081
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2082
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2082
+#define	WT_STAT_DSRC_REC_DICTIONARY			2083
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2083
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2084
 /*! reconciliation: internal page key bytes discarded using suffix
  * compression */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2084
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2085
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2085
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2086
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2086
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2087
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2087
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2088
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2088
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2089
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2089
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2090
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2090
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2091
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2091
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2092
 /*! reconciliation: page checksum matches */
-#define	WT_STAT_DSRC_REC_PAGE_MATCH			2092
+#define	WT_STAT_DSRC_REC_PAGE_MATCH			2093
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2093
+#define	WT_STAT_DSRC_REC_PAGES				2094
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2094
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2095
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2095
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2096
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2096
+#define	WT_STAT_DSRC_SESSION_COMPACT			2097
 /*! session: open cursor count */
-#define	WT_STAT_DSRC_SESSION_CURSOR_OPEN		2097
+#define	WT_STAT_DSRC_SESSION_CURSOR_OPEN		2098
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2098
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2099
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -43,6 +43,7 @@ static const char * const __stats_dsrc_desc[] = {
 	"btree: pages rewritten by compaction",
 	"btree: row-store internal pages",
 	"btree: row-store leaf pages",
+	"cache: bytes currently in the cache",
 	"cache: bytes read into cache",
 	"cache: bytes written from cache",
 	"cache: checkpoint blocked page eviction",
@@ -172,6 +173,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->btree_compact_rewrite = 0;
 	stats->btree_row_internal = 0;
 	stats->btree_row_leaf = 0;
+		/* not clearing cache_bytes_inuse */
 	stats->cache_bytes_read = 0;
 	stats->cache_bytes_write = 0;
 	stats->cache_eviction_checkpoint = 0;
@@ -298,6 +300,7 @@ __wt_stat_dsrc_aggregate_single(
 	to->btree_compact_rewrite += from->btree_compact_rewrite;
 	to->btree_row_internal += from->btree_row_internal;
 	to->btree_row_leaf += from->btree_row_leaf;
+	to->cache_bytes_inuse += from->cache_bytes_inuse;
 	to->cache_bytes_read += from->cache_bytes_read;
 	to->cache_bytes_write += from->cache_bytes_write;
 	to->cache_eviction_checkpoint += from->cache_eviction_checkpoint;
@@ -430,6 +433,7 @@ __wt_stat_dsrc_aggregate(
 	    WT_STAT_READ(from, btree_compact_rewrite);
 	to->btree_row_internal += WT_STAT_READ(from, btree_row_internal);
 	to->btree_row_leaf += WT_STAT_READ(from, btree_row_leaf);
+	to->cache_bytes_inuse += WT_STAT_READ(from, cache_bytes_inuse);
 	to->cache_bytes_read += WT_STAT_READ(from, cache_bytes_read);
 	to->cache_bytes_write += WT_STAT_READ(from, cache_bytes_write);
 	to->cache_eviction_checkpoint +=

--- a/tools/wtstats/stat_data.py
+++ b/tools/wtstats/stat_data.py
@@ -60,6 +60,7 @@ no_scale_per_second_list = [
     'btree: overflow pages',
     'btree: row-store internal pages',
     'btree: row-store leaf pages',
+    'cache: bytes currently in the cache',
     'cache: overflow values cached in memory',
     'LSM: bloom filters in the LSM tree',
     'LSM: chunks in the LSM tree',
@@ -104,6 +105,7 @@ no_clear_list = [
     'transaction: transaction range of IDs currently pinned by a checkpoint',
     'transaction: transaction range of IDs currently pinned by named snapshots',
     'btree: btree checkpoint generation',
+    'cache: bytes currently in the cache',
     'session: open cursor count',
 ]
 prefix_list = [


### PR DESCRIPTION
Randomize visits to trees that use a tiny fraction of the cache.

(cherry picked from commit 1d58fe48c7eeefcbe5ee0412daea3c8c16177432)