### PR TITLE
WT-2380 Add option to s_all to return an error code when tests fail

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -17,8 +17,6 @@ force=
 reconf=0
 errmode=0
 errfound=0
-# Some tests just shouldn't return an error. We exclude them here
-err_exclusions=('\./s_export')
 while :
 	do case "$1" in
 	-A)	# Reconfigure the library build.
@@ -55,9 +53,14 @@ errchk()
 	echo "#######################"
 
 	rm -f $2
-	if ! [[ "${err_exclusions[@]}" =~ "$1" ]]; then
-		errfound=1
-	fi
+
+	# Some tests shouldn't return an error, we exclude them here.
+	case "$1" in
+	*s_export*)
+		break;;
+	*)
+		errfound=1;;
+	esac
 }
 
 run()


### PR DESCRIPTION
@daveh86, @agorrod, I replaced part of the 083b69b commit with a more portable construct.

It's fine with me if we want to commit to only running scripts under bash, but I think we should make that decision explicitly, and in that case, we should change the shell script interpreter from `/bin/sh` to `/bin/bash` to enforce it.

FTR, this broke under FreeBSD 10.2.