### PR TITLE
WT-2665 Limit allocator fragmentation from the WiredTiger cache

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1569,7 +1569,7 @@ __evict_get_ref(
 	 */
 	for (;;) {
 		/* Verify there are still pages available. */
-		if (queue->evict_current == NULL ||
+		if (queue->evict_current == NULL || (uint32_t)
 		    (queue->evict_current - queue->evict_queue) >= candidates) {
 			WT_STAT_FAST_CONN_INCR(
 			    session, cache_eviction_get_ref_empty2);


### PR DESCRIPTION
evict_lru.c  Warning 574: Signed-unsigned mix with relational
evict_lru.c  Info 737: Loss of sign in promotion from int to unsigned int