### PR TITLE
WT-2730 column-store incorrectly matches key slots on new pages

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -179,11 +179,11 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
-		cbt->cip_saved = NULL;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);
 		__cursor_set_recno(cbt, cbt->ref->ref_recno);
+		cbt->cip_saved = NULL;
 		goto new_page;
 	}
 
@@ -302,12 +302,13 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage)
 	 * WT_INSERT_HEAD[0], and so on.  This means WT_INSERT lists are
 	 * odd-numbered slots, and WT_ROW array slots are even-numbered slots.
 	 *
-	 * New page configuration.
+	 * Initialize for each new page.
 	 */
 	if (newpage) {
 		cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		cbt->ins = WT_SKIP_FIRST(cbt->ins_head);
 		cbt->row_iteration_slot = 1;
+		cbt->rip_saved = NULL;
 		goto new_insert;
 	}
 

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -519,10 +519,12 @@ __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt)
 	 */
 	F_SET(cbt, WT_CBT_ITERATE_NEXT | WT_CBT_ITERATE_PREV);
 
-	/*
-	 * Clear the count of deleted items on the page.
-	 */
+	/* Clear the count of deleted items on the page. */
 	cbt->page_deleted_count = 0;
+
+	/* Clear saved iteration cursor position information. */
+	cbt->cip_saved = NULL;
+	cbt->rip_saved = NULL;
 
 	/*
 	 * If we don't have a search page, then we're done, we're starting at

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -325,11 +325,11 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
-		cbt->cip_saved = NULL;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);
 		__cursor_set_recno(cbt, cbt->last_standard_recno);
+		cbt->cip_saved = NULL;
 		goto new_page;
 	}
 
@@ -448,7 +448,7 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 	 * WT_INSERT_HEAD[0], and so on.  This means WT_INSERT lists are
 	 * odd-numbered slots, and WT_ROW array slots are even-numbered slots.
 	 *
-	 * New page configuration.
+	 * Initialize for each new page.
 	 */
 	if (newpage) {
 		/*
@@ -465,6 +465,7 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 			    WT_ROW_INSERT_SLOT(page, page->pg_row_entries - 1);
 		cbt->ins = WT_SKIP_LAST(cbt->ins_head);
 		cbt->row_iteration_slot = page->pg_row_entries * 2 + 1;
+		cbt->rip_saved = NULL;
 		goto new_insert;
 	}
 

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -38,8 +38,6 @@ __cursor_pos_clear(WT_CURSOR_BTREE *cbt)
 	cbt->ins_head = NULL;
 	cbt->ins_stack[0] = NULL;
 
-	cbt->rip_saved = NULL;
-
 	F_CLR(cbt, WT_CBT_POSITION_MASK);
 }
 


### PR DESCRIPTION
@agorrod, I think `WT_CURSOR_BTREE.rip_saved` potentially has the same problem.

I've never seen it happen, this is just by inspection.