### PR TITLE
WT-2743 Fixup new I/O thread count statistics.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -81,10 +81,10 @@ class SessionStat(Stat):
     prefix = 'session'
     def __init__(self, name, desc, flags=''):
         Stat.__init__(self, name, SessionStat.prefix, desc, flags)
-class ThreadState(Stat):
+class ThreadStat(Stat):
     prefix = 'thread-state'
     def __init__(self, name, desc, flags=''):
-        Stat.__init__(self, name, ThreadState.prefix, desc, flags)
+        Stat.__init__(self, name, ThreadStat.prefix, desc, flags)
 class TxnStat(Stat):
     prefix = 'transaction'
     def __init__(self, name, desc, flags=''):
@@ -105,7 +105,7 @@ groups['evict'] = [
     BlockStat.prefix,
     CacheStat.prefix,
     ConnStat.prefix,
-    ThreadState.prefix
+    ThreadStat.prefix
 ]
 groups['lsm'] = [LSMStat.prefix, TxnStat.prefix]
 groups['memory'] = [CacheStat.prefix, ConnStat.prefix, RecStat.prefix]
@@ -113,7 +113,7 @@ groups['system'] = [
     ConnStat.prefix,
     DhandleStat.prefix,
     SessionStat.prefix,
-    ThreadState.prefix
+    ThreadStat.prefix
 ]
 
 ##########################################
@@ -351,11 +351,11 @@ connection_stats = [
     CursorStat('cursor_update', 'cursor update calls'),
 
     ##########################################
-    # Thread State statistics
+    # Thread Count statistics
     ##########################################
-    ThreadState('fsync_active', 'active filesystem fsync calls','no_clear,no_scale'),
-    ThreadState('read_active', 'active filesystem read calls','no_clear,no_scale'),
-    ThreadState('write_active', 'active filesystem write calls','no_clear,no_scale'),
+    ThreadStat('thread_fsync_active', 'active filesystem fsync calls','no_clear,no_scale'),
+    ThreadStat('thread_read_active', 'active filesystem read calls','no_clear,no_scale'),
+    ThreadStat('thread_write_active', 'active filesystem write calls','no_clear,no_scale'),
 
     ##########################################
     # Yield statistics

--- a/src/include/os_fhandle.i
+++ b/src/include/os_fhandle.i
@@ -26,7 +26,7 @@ __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
 	 * There is no way to check when the non-blocking sync-file-range is
 	 * complete, but we track the time taken in the call for completeness.
 	 */
-	WT_STAT_FAST_CONN_INCR_ATOMIC(session, fsync_active);
+	WT_STAT_FAST_CONN_INCR_ATOMIC(session, thread_fsync_active);
 	WT_STAT_FAST_CONN_INCR(session, fsync_io);
 	if (block)
 		ret = (handle->fh_sync == NULL ? 0 :
@@ -34,7 +34,7 @@ __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
 	else
 		ret = (handle->fh_sync_nowait == NULL ? 0 :
 		    handle->fh_sync_nowait(handle, (WT_SESSION *)session));
-	WT_STAT_FAST_CONN_DECR_ATOMIC(session, fsync_active);
+	WT_STAT_FAST_CONN_DECR_ATOMIC(session, thread_fsync_active);
 	return (ret);
 }
 
@@ -107,13 +107,13 @@ __wt_read(
 	    "%s: handle-read: %" WT_SIZET_FMT " at %" PRIuMAX,
 	    fh->handle->name, len, (uintmax_t)offset));
 
-	WT_STAT_FAST_CONN_INCR_ATOMIC(session, read_active);
+	WT_STAT_FAST_CONN_INCR_ATOMIC(session, thread_read_active);
 	WT_STAT_FAST_CONN_INCR(session, read_io);
 
 	ret = fh->handle->fh_read(
 	    fh->handle, (WT_SESSION *)session, offset, len, buf);
 
-	WT_STAT_FAST_CONN_DECR_ATOMIC(session, read_active);
+	WT_STAT_FAST_CONN_DECR_ATOMIC(session, thread_read_active);
 	return (ret);
 }
 
@@ -165,12 +165,12 @@ __wt_write(WT_SESSION_IMPL *session,
 	    "%s: handle-write: %" WT_SIZET_FMT " at %" PRIuMAX,
 	    fh->handle->name, len, (uintmax_t)offset));
 
-	WT_STAT_FAST_CONN_INCR_ATOMIC(session, write_active);
+	WT_STAT_FAST_CONN_INCR_ATOMIC(session, thread_write_active);
 	WT_STAT_FAST_CONN_INCR(session, write_io);
 
 	ret = fh->handle->fh_write(
 	    fh->handle, (WT_SESSION *)session, offset, len, buf);
 
-	WT_STAT_FAST_CONN_DECR_ATOMIC(session, write_active);
+	WT_STAT_FAST_CONN_DECR_ATOMIC(session, thread_write_active);
 	return (ret);
 }

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -145,14 +145,14 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define	WT_STAT_DECRV(session, stats, fld, value)			\
 	(stats)[WT_STATS_SLOT_ID(session)]->fld -= (int64_t)(value)
 #define	WT_STAT_DECRV_ATOMIC(session, stats, fld, value)		\
-	__wt_atomic_addi64(						\
+	__wt_atomic_subi64(						\
 	    &(stats)[WT_STATS_SLOT_ID(session)]->fld, (int64_t)(value))
 #define	WT_STAT_DECR(session, stats, fld)				\
 	WT_STAT_DECRV(session, stats, fld, 1)
 #define	WT_STAT_INCRV(session, stats, fld, value)			\
 	(stats)[WT_STATS_SLOT_ID(session)]->fld += (int64_t)(value)
 #define	WT_STAT_INCRV_ATOMIC(session, stats, fld, value)		\
-	__wt_atomic_subi64(						\
+	__wt_atomic_addi64(						\
 	    &(stats)[WT_STATS_SLOT_ID(session)]->fld, (int64_t)(value))
 #define	WT_STAT_INCR(session, stats, fld)				\
 	WT_STAT_INCRV(session, stats, fld, 1)
@@ -410,9 +410,9 @@ struct __wt_connection_stats {
 	int64_t rec_split_stashed_objects;
 	int64_t session_cursor_open;
 	int64_t session_open;
-	int64_t fsync_active;
-	int64_t read_active;
-	int64_t write_active;
+	int64_t thread_fsync_active;
+	int64_t thread_read_active;
+	int64_t thread_write_active;
 	int64_t page_busy_blocked;
 	int64_t page_forcible_evict_blocked;
 	int64_t page_locked_blocked;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4537,11 +4537,11 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! session: open session count */
 #define	WT_STAT_CONN_SESSION_OPEN			1164
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_FSYNC_ACTIVE			1165
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1165
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_READ_ACTIVE			1166
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1166
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_WRITE_ACTIVE			1167
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1167
 /*! thread-yield: page acquire busy blocked */
 #define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1168
 /*! thread-yield: page acquire eviction blocked */

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -907,9 +907,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 		/* not clearing rec_split_stashed_objects */
 		/* not clearing session_cursor_open */
 		/* not clearing session_open */
-		/* not clearing fsync_active */
-		/* not clearing read_active */
-		/* not clearing write_active */
+		/* not clearing thread_fsync_active */
+		/* not clearing thread_read_active */
+		/* not clearing thread_write_active */
 	stats->page_busy_blocked = 0;
 	stats->page_forcible_evict_blocked = 0;
 	stats->page_locked_blocked = 0;
@@ -1161,9 +1161,9 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, rec_split_stashed_objects);
 	to->session_cursor_open += WT_STAT_READ(from, session_cursor_open);
 	to->session_open += WT_STAT_READ(from, session_open);
-	to->fsync_active += WT_STAT_READ(from, fsync_active);
-	to->read_active += WT_STAT_READ(from, read_active);
-	to->write_active += WT_STAT_READ(from, write_active);
+	to->thread_fsync_active += WT_STAT_READ(from, thread_fsync_active);
+	to->thread_read_active += WT_STAT_READ(from, thread_read_active);
+	to->thread_write_active += WT_STAT_READ(from, thread_write_active);
 	to->page_busy_blocked += WT_STAT_READ(from, page_busy_blocked);
 	to->page_forcible_evict_blocked +=
 	    WT_STAT_READ(from, page_forcible_evict_blocked);


### PR DESCRIPTION
The increment and decrement were backward, so they never reported positive values.
While I was there make the statistics macros consistent.