### PR TITLE
WT-2751 column-store statistics incorrectly calculates the number of entries

### DIFF
--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -139,7 +139,7 @@ __stat_page_col_var(
 		} else {
 			orig_deleted = false;
 			__wt_cell_unpack(cell, unpack);
-			if (unpack->type == WT_CELL_ADDR_DEL)
+			if (unpack->type == WT_CELL_DEL)
 				orig_deleted = true;
 			else {
 				entry_cnt += __wt_cell_rle(unpack);

--- a/test/suite/test_stat04.py
+++ b/test/suite/test_stat04.py
@@ -91,6 +91,7 @@ class test_stat04(wttest.WiredTigerTestCase, suite_subprocess):
                 self.checkcount(uri, count)
             cursor[self.genkey(i)] = self.genvalue(i)
             count += 1
+
         # Remove a number of entries, at each step checking that stats match.
         for i in range(0, self.nentries / 37):
             cursor.set_key(self.genkey(i*11 % self.nentries))
@@ -98,6 +99,11 @@ class test_stat04(wttest.WiredTigerTestCase, suite_subprocess):
                 count -= 1
             self.checkcount(uri, count)
         cursor.close()
+
+        # Confirm the count is correct after writing to the backing file,
+        # that tests the on-disk format as well as the in-memory format.
+        self.reopen_conn()
+        self.checkcount(uri, count)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
> Also Alex made some changes to delete some keys and then use wt utility to get stats on the database, and the wt utility shows wrong number of key/val pairs.

@sulabhM, @agorrod, this is the fix for the wt utility mistake.