### PR TITLE
WT-1162 Add a latency specific test

### DIFF
--- a/bench/wtperf/runners/evict-btree-stress-multi.wtperf
+++ b/bench/wtperf/runners/evict-btree-stress-multi.wtperf
@@ -1,0 +1,12 @@
+conn_config="cache_size=1G,eviction=(threads_max=4),session_max=2000"
+table_config="type=file"
+table_count=100
+icount=100000000
+report_interval=5
+run_time=600
+populate_threads=1
+threads=((count=100,updates=1,reads=4,ops_per_txn=30))
+# Warn if a latency over a quarter second is seen
+max_latency=250
+sample_interval=5
+sample_rate=1


### PR DESCRIPTION
@agorrod This branch only contains a new wtperf config.  I have added some commands to the Jenkins perf-stress job that are commented out.  Once this config exists, I want to turn that on and create a latency plot.  This is the config from WT-2705 primarily.  I used a warning threshold of a quarter second, which is commonly hit on my AWS box (same instance type as the perf jobs).  Please review.