### PR TITLE
WT-2755 flexelint configuration treats size_t as 4B type

### DIFF
--- a/ext/compressors/zlib/zlib_compress.c
+++ b/ext/compressors/zlib/zlib_compress.c
@@ -92,7 +92,7 @@ zalloc(void *cookie, uint32_t number, uint32_t size)
 	opaque = cookie;
 	wt_api = ((ZLIB_COMPRESSOR *)opaque->compressor)->wt_api;
 	return (wt_api->scr_alloc(
-	    wt_api, opaque->session, (size_t)(number * size)));
+	    wt_api, opaque->session, (size_t)number * size));
 }
 
 /*

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1245,8 +1245,7 @@ __wt_block_extlist_write(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	WT_EXT *ext;
 	WT_PAGE_HEADER *dsk;
-	size_t size;
-	uint32_t entries;
+	size_t entries, size;
 	uint8_t *p;
 
 	WT_RET(__block_extlist_dump(session, block, el, "write"));

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -28,7 +28,7 @@ __block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp)
 {
 	WT_EXT *ext;
 
-	u_int skipdepth;
+	size_t skipdepth;
 
 	skipdepth = __wt_skip_choose_depth(session);
 	WT_RET(__wt_calloc(session, 1,

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1554,7 +1554,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 		 */
 #define	WT_SINGLETHREAD_STRING	"WiredTiger lock file\n"
 		WT_ERR(__wt_filesize(session, conn->lock_fh, &size));
-		if (size != strlen(WT_SINGLETHREAD_STRING))
+		if ((size_t)size != strlen(WT_SINGLETHREAD_STRING))
 			WT_ERR(__wt_write(session, conn->lock_fh, (wt_off_t)0,
 			    strlen(WT_SINGLETHREAD_STRING),
 			    WT_SINGLETHREAD_STRING));

--- a/src/include/intpack.i
+++ b/src/include/intpack.i
@@ -59,7 +59,7 @@
 /* Count the leading zero bytes. */
 #if defined(__GNUC__)
 #define	WT_LEADING_ZEROS(x, i)						\
-	(i = (x == 0) ? (int)sizeof (x) : __builtin_clzll(x) >> 3)
+	(i = (x == 0) ? (int)sizeof(x) : __builtin_clzll(x) >> 3)
 #elif defined(_MSC_VER)
 #define	WT_LEADING_ZEROS(x, i)	do {					\
 	if (x == 0) i = (int)sizeof(x);				\
@@ -89,7 +89,7 @@ __wt_vpack_posint(uint8_t **pp, size_t maxlen, uint64_t x)
 	int len, lz, shift;
 
 	WT_LEADING_ZEROS(x, lz);
-	len = (int)sizeof (x) - lz;
+	len = (int)sizeof(x) - lz;
 	WT_SIZE_CHECK_PACK(len + 1, maxlen);
 	p = *pp;
 
@@ -114,7 +114,7 @@ __wt_vpack_negint(uint8_t **pp, size_t maxlen, uint64_t x)
 	int len, lz, shift;
 
 	WT_LEADING_ZEROS(~x, lz);
-	len = (int)sizeof (x) - lz;
+	len = (int)sizeof(x) - lz;
 	WT_SIZE_CHECK_PACK(len + 1, maxlen);
 	p = *pp;
 
@@ -170,7 +170,7 @@ __wt_vunpack_negint(const uint8_t **pp, size_t maxlen, uint64_t *retp)
 
 	/* There are four length bits in the first byte. */
 	p = *pp;
-	len = (int)sizeof (x) - (*p++ & 0xf);
+	len = (int)sizeof(x) - (*p++ & 0xf);
 	WT_SIZE_CHECK_UNPACK(len + 1, maxlen);
 
 	for (x = UINT64_MAX; len != 0; --len)

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -131,13 +131,13 @@ struct __wt_item {
  * The maximum packed size of a 64-bit integer.  The ::wiredtiger_struct_pack
  * function will pack single long integers into at most this many bytes.
  */
-#define	WT_INTPACK64_MAXSIZE	((int)sizeof (int64_t) + 1)
+#define	WT_INTPACK64_MAXSIZE	((int)sizeof(int64_t) + 1)
 
 /*!
  * The maximum packed size of a 32-bit integer.  The ::wiredtiger_struct_pack
  * function will pack single integers into at most this many bytes.
  */
-#define	WT_INTPACK32_MAXSIZE	((int)sizeof (int32_t) + 1)
+#define	WT_INTPACK32_MAXSIZE	((int)sizeof(int32_t) + 1)
 
 /*!
  * A WT_CURSOR handle is the interface to a cursor.

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -329,7 +329,7 @@ __wt_txn_checkpoint_log(
 	case WT_TXN_LOG_CKPT_START:
 		/* Take a copy of the transaction snapshot. */
 		txn->ckpt_nsnapshot = txn->snapshot_count;
-		recsize = txn->ckpt_nsnapshot * WT_INTPACK64_MAXSIZE;
+		recsize = (size_t)txn->ckpt_nsnapshot * WT_INTPACK64_MAXSIZE;
 		WT_ERR(__wt_scr_alloc(session, recsize, &txn->ckpt_snapshot));
 		p = txn->ckpt_snapshot->mem;
 		end = p + recsize;

--- a/test/cursor_order/cursor_order_ops.c
+++ b/test/cursor_order/cursor_order_ops.c
@@ -130,7 +130,8 @@ ops_start(SHARED_CONFIG *cfg)
 	seconds = (stop.tv_sec - start.tv_sec) +
 	    (stop.tv_usec - start.tv_usec) * 1e-6;
 	fprintf(stderr, "timer: %.2lf seconds (%d ops/second)\n",
-	    seconds, (int)(((cfg->reverse_scanners + cfg->append_inserters) *
+	    seconds, (int)
+	    (((double)(cfg->reverse_scanners + cfg->append_inserters) *
 	    total_nops) / seconds));
 
 	/* Verify the files. */


### PR DESCRIPTION
My flexelint configuration thought size_t was 4B, fix it and clean up the result.