### PR TITLE
WT-2756 the autoconf archive package doesn't check for swig 3.0.

### DIFF
--- a/build_posix/aclocal/ax_pkg_swig.m4
+++ b/build_posix/aclocal/ax_pkg_swig.m4
@@ -32,9 +32,9 @@
 # LICENSE
 #
 #   Copyright (c) 2008 Sebastian Huber <sebastian-huber@web.de>
-#   Copyright (c) 2008 Alan W. Irwin <irwin@beluga.phys.uvic.ca>
+#   Copyright (c) 2008 Alan W. Irwin
 #   Copyright (c) 2008 Rafael Laboissiere <rafael@laboissiere.net>
-#   Copyright (c) 2008 Andrew Collier <colliera@ukzn.ac.za>
+#   Copyright (c) 2008 Andrew Collier
 #   Copyright (c) 2011 Murray Cumming <murrayc@openismus.com>
 #
 #   This program is free software; you can redistribute it and/or modify it
@@ -63,11 +63,11 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 11
 
 AC_DEFUN([AX_PKG_SWIG],[
-        # Some systems have SWIG 2.0 named "swig2.0"
-        AC_PATH_PROGS([SWIG],[swig2.0 swig])
+        # Ubuntu has swig 2.0 as /usr/bin/swig2.0
+        AC_PATH_PROGS([SWIG],[swig swig2.0])
         if test -z "$SWIG" ; then
                 m4_ifval([$3],[$3],[:])
         elif test -n "$1" ; then

--- a/build_posix/aclocal/ax_pkg_swig.m4
+++ b/build_posix/aclocal/ax_pkg_swig.m4
@@ -67,7 +67,7 @@
 
 AC_DEFUN([AX_PKG_SWIG],[
         # Ubuntu has swig 2.0 as /usr/bin/swig2.0
-        AC_PATH_PROGS([SWIG],[swig swig2.0])
+        AC_PATH_PROGS([SWIG],[swig swig3.0 swig2.0])
         if test -z "$SWIG" ; then
                 m4_ifval([$3],[$3],[:])
         elif test -n "$1" ; then


### PR DESCRIPTION
@sulabhM, @agorrod, swig 3.0 is out.

I upgraded the swig autoconf archive package and added a check for swig 3.0.