### PR TITLE
WT-2648 cache-line alignment for new ports

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -45,7 +45,16 @@
 	    &(p)->flags_atomic, __orig, __orig & ~(uint8_t)(mask)));	\
 } while (0)
 
-#define	WT_CACHE_LINE_ALIGNMENT	64	/* Cache line alignment */
+/*
+ * Cache line alignment.
+ */
+#if defined(__PPC64__) || defined(PPC64)
+#define	WT_CACHE_LINE_ALIGNMENT	128
+#elif defined(__s390x__)
+#define	WT_CACHE_LINE_ALIGNMENT	256
+#else
+#define	WT_CACHE_LINE_ALIGNMENT	64
+#endif
 #define	WT_CACHE_LINE_ALIGNMENT_VERIFY(session, a)			\
 	WT_ASSERT(session,						\
 	    WT_PTRDIFF(&(a)[1], &(a)[0]) >= WT_CACHE_LINE_ALIGNMENT &&	\


### PR DESCRIPTION
@agorrod, I think this is all we need to do for this ticket.

We might want to consider if we're wasting too much space at some point (the zSeries alignment is 256B, and we align transaction states, for example), but for now I think we should make this change.