### PR TITLE
WT-2760 Backup file removal requires ordering, so needs to sync the directory

### DIFF
--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -124,12 +124,10 @@ static int demo_fs_directory_list(WT_FILE_SYSTEM *, WT_SESSION *,
     const char *, const char *, char ***, uint32_t *);
 static int demo_fs_directory_list_free(
     WT_FILE_SYSTEM *, WT_SESSION *, char **, uint32_t);
-static int demo_fs_directory_sync(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *session, const char *directory);
 static int demo_fs_exist(WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *);
-static int demo_fs_remove(WT_FILE_SYSTEM *, WT_SESSION *, const char *);
+static int demo_fs_remove(WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool);
 static int demo_fs_rename(
-    WT_FILE_SYSTEM *, WT_SESSION *, const char *, const char *);
+    WT_FILE_SYSTEM *, WT_SESSION *, const char *, const char *, bool);
 static int demo_fs_size(
     WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *);
 static int demo_fs_terminate(WT_FILE_SYSTEM *, WT_SESSION *);
@@ -255,7 +253,6 @@ demo_file_system_create(WT_CONNECTION *conn, WT_CONFIG_ARG *config)
 	/* Initialize the in-memory jump table. */
 	file_system->fs_directory_list = demo_fs_directory_list;
 	file_system->fs_directory_list_free = demo_fs_directory_list_free;
-	file_system->fs_directory_sync = demo_fs_directory_sync;
 	file_system->fs_exist = demo_fs_exist;
 	file_system->fs_open_file = demo_fs_open;
 	file_system->fs_remove = demo_fs_remove;
@@ -469,21 +466,6 @@ demo_fs_directory_list_free(WT_FILE_SYSTEM *file_system,
 }
 
 /*
- * demo_fs_directory_sync --
- *	Directory sync for our demo file system, which is a no-op.
- */
-static int
-demo_fs_directory_sync(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *session, const char *directory)
-{
-	(void)file_system;		/* Unused */
-	(void)session;			/* Unused */
-	(void)directory;		/* Unused */
-
-	return (0);
-}
-
-/*
  * demo_fs_exist --
  *	Return if the file exists.
  */
@@ -507,12 +489,14 @@ demo_fs_exist(WT_FILE_SYSTEM *file_system,
  *	POSIX remove.
  */
 static int
-demo_fs_remove(
-    WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name)
+demo_fs_remove(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *session, const char *name, bool durable)
 {
 	DEMO_FILE_SYSTEM *demo_fs;
 	DEMO_FILE_HANDLE *demo_fh;
 	int ret = 0;
+
+	(void)durable;					/* Unused */
 
 	demo_fs = (DEMO_FILE_SYSTEM *)file_system;
 
@@ -531,12 +515,14 @@ demo_fs_remove(
  */
 static int
 demo_fs_rename(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *session, const char *from, const char *to)
+    WT_SESSION *session, const char *from, const char *to, bool durable)
 {
 	DEMO_FILE_HANDLE *demo_fh;
 	DEMO_FILE_SYSTEM *demo_fs;
 	char *copy;
 	int ret = 0;
+
+	(void)durable;					/* Unused */
 
 	demo_fs = (DEMO_FILE_SYSTEM *)file_system;
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -44,7 +44,8 @@ __wt_block_manager_create(
 	 */
 	for (;;) {
 		if ((ret = __wt_open(session, filename, WT_OPEN_FILE_TYPE_DATA,
-		    WT_OPEN_CREATE | WT_OPEN_EXCLUSIVE, &fh)) == 0)
+		    WT_OPEN_CREATE | WT_OPEN_DURABLE | WT_OPEN_EXCLUSIVE,
+		    &fh)) == 0)
 			break;
 		WT_ERR_TEST(ret != EEXIST, ret);
 
@@ -76,13 +77,6 @@ __wt_block_manager_create(
 
 	/* Close the file handle. */
 	WT_TRET(__wt_close(session, &fh));
-
-	/*
-	 * Some filesystems require that we sync the directory to be confident
-	 * that the file will appear.
-	 */
-	if (ret == 0)
-		WT_TRET(__wt_fs_directory_sync(session, filename));
 
 	/* Undo any create on error. */
 	if (ret != 0)

--- a/src/include/os_fs.i
+++ b/src/include/os_fs.i
@@ -61,61 +61,6 @@ __wt_fs_directory_list_free(
 }
 
 /*
- * __wt_fs_directory_sync --
- *	Flush a directory to ensure file creation is durable.
- */
-static inline int
-__wt_fs_directory_sync(WT_SESSION_IMPL *session, const char *name)
-{
-	WT_DECL_RET;
-	WT_FILE_SYSTEM *file_system;
-	WT_SESSION *wt_session;
-	char *copy, *dir;
-
-	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
-
-	WT_RET(__wt_verbose(
-	    session, WT_VERB_FILEOPS, "%s: directory-sync", name));
-
-	/*
-	 * POSIX 1003.1 does not require that fsync of a file handle ensures the
-	 * entry in the directory containing the file has also reached disk (and
-	 * there are historic Linux filesystems requiring it). If the underlying
-	 * filesystem method is set, do an explicit fsync on a file descriptor
-	 * for the directory to be sure.
-	 *
-	 * directory-sync is not a required call, no method means the call isn't
-	 * needed.
-	 */
-	file_system = S2C(session)->file_system;
-	if (file_system->fs_directory_sync == NULL)
-		return (0);
-
-	copy = NULL;
-	if (name == NULL || strchr(name, '/') == NULL)
-		name = S2C(session)->home;
-	else {
-		/*
-		 * File name construction should not return a path without any
-		 * slash separator, but caution isn't unreasonable.
-		 */
-		WT_RET(__wt_filename(session, name, &copy));
-		if ((dir = strrchr(copy, '/')) == NULL)
-			name = S2C(session)->home;
-		else {
-			dir[1] = '\0';
-			name = copy;
-		}
-	}
-
-	wt_session = (WT_SESSION *)session;
-	ret = file_system->fs_directory_sync(file_system, wt_session, name);
-
-	__wt_free(session, copy);
-	return (ret);
-}
-
-/*
  * __wt_fs_exist --
  *	Return if the file exists.
  */
@@ -169,12 +114,9 @@ __wt_fs_remove(WT_SESSION_IMPL *session, const char *name)
 
 	file_system = S2C(session)->file_system;
 	wt_session = (WT_SESSION *)session;
-	WT_ERR(file_system->fs_remove(file_system, wt_session, path));
+	ret = file_system->fs_remove(file_system, wt_session, path, true);
 
-	/* Flush the backing directory to guarantee the remove. */
-	ret = __wt_fs_directory_sync(session, name);
-
-err:	__wt_free(session, path);
+	__wt_free(session, path);
 	return (ret);
 }
 
@@ -188,9 +130,7 @@ __wt_fs_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
 	WT_DECL_RET;
 	WT_FILE_SYSTEM *file_system;
 	WT_SESSION *wt_session;
-	const char *fp, *tp;
 	char *from_path, *to_path;
-	bool same_directory;
 
 	WT_ASSERT(session, !F_ISSET(S2C(session), WT_CONN_READONLY));
 
@@ -216,31 +156,8 @@ __wt_fs_rename(WT_SESSION_IMPL *session, const char *from, const char *to)
 
 	file_system = S2C(session)->file_system;
 	wt_session = (WT_SESSION *)session;
-	WT_ERR(file_system->fs_rename(
-	    file_system, wt_session, from_path, to_path));
-
-	/*
-	 * Flush the backing directory to guarantee the rename. My reading of
-	 * POSIX 1003.1 is there's no guarantee flushing only one of the from
-	 * or to directories, or flushing a common parent, is sufficient, and
-	 * even if POSIX were to make that guarantee, existing filesystems are
-	 * known to not provide the guarantee or only provide the guarantee
-	 * with specific mount options. Flush both of the from/to directories
-	 * until it's a performance problem.
-	 */
-	WT_ERR(__wt_fs_directory_sync(session, from));
-
-	/*
-	 * In almost all cases, we're going to be renaming files in the same
-	 * directory, we can at least fast-path that.
-	 */
-	fp = strrchr(from, '/');
-	tp = strrchr(to, '/');
-	same_directory = (fp == NULL && tp == NULL) ||
-	    (fp != NULL && tp != NULL &&
-	    fp - from == tp - to && memcmp(from, to, (size_t)(fp - from)) == 0);
-
-	ret = same_directory ? 0 : __wt_fs_directory_sync(session, to);
+	ret = file_system->fs_rename(
+	    file_system, wt_session, from_path, to_path, true);
 
 err:	__wt_free(session, from_path);
 	__wt_free(session, to_path);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3690,13 +3690,15 @@ typedef enum {
 #define	WT_OPEN_CREATE		0x001
 /*! WT_FILE_SYSTEM::open_file flags: direct I/O requested */
 #define	WT_OPEN_DIRECTIO	0x002
+/*! WT_FILE_SYSTEM::open_file flags: durable creation required */
+#define	WT_OPEN_DURABLE		0x004
 /*! WT_FILE_SYSTEM::open_file flags: error if exclusive use not available */
-#define	WT_OPEN_EXCLUSIVE	0x004
+#define	WT_OPEN_EXCLUSIVE	0x008
 #ifndef DOXYGEN
-#define	WT_OPEN_FIXED		0x008	/* Path not home relative (internal) */
+#define	WT_OPEN_FIXED		0x010	/* Path not home relative (internal) */
 #endif
 /*! WT_FILE_SYSTEM::open_file flags: open is read-only */
-#define	WT_OPEN_READONLY	0x010
+#define	WT_OPEN_READONLY	0x020
 
 /*!
  * The interface implemented by applications to provide a custom file system
@@ -3746,23 +3748,6 @@ struct __wt_file_system {
 	    WT_SESSION *session, char **dirlist, uint32_t count);
 
 	/*!
-	 * Flush the named directory.
-	 *
-	 * This method is not required for readonly file systems or file systems
-	 * where it is not necessary to flush a file's directory to ensure the
-	 * durability of file system operations, and should be set to NULL when
-	 * not required by the file system.
-	 *
-	 * @errors
-	 *
-	 * @param file_system the WT_FILE_SYSTEM
-	 * @param session the current WiredTiger session
-	 * @param directory the name of the directory
-	 */
-	int (*fs_directory_sync)(WT_FILE_SYSTEM *file_system,
-	    WT_SESSION *session, const char *directory);
-
-	/*!
 	 * Return if the named file system object exists.
 	 *
 	 * @errors
@@ -3778,10 +3763,15 @@ struct __wt_file_system {
 	/*!
 	 * Open a handle for a named file system object
 	 *
-	 * The method should return ENOENT if the file does not exist.
+	 * The method should return ENOENT if the file is not being created and
+	 * does not exist.
+	 *
 	 * The method should return EACCES if the file cannot be opened in the
 	 * requested mode (for example, a file opened for writing in a readonly
 	 * file system).
+	 *
+	 * The method should return EBUSY if ::WT_OPEN_EXCLUSIVE is set and the
+	 * file is in use.
 	 *
 	 * @errors
 	 *
@@ -3792,8 +3782,8 @@ struct __wt_file_system {
 	 *    The file type is provided to allow optimization for different file
 	 *    access patterns.
 	 * @param flags flags indicating how to open the file, one or more of
-	 *    ::WT_OPEN_CREATE, ::WT_OPEN_DIRECTIO, ::WT_OPEN_EXCLUSIVE or
-	 *    ::WT_OPEN_READONLY.
+	 *    ::WT_OPEN_CREATE, ::WT_OPEN_DIRECTIO, ::WT_OPEN_DURABLE,
+	 *    ::WT_OPEN_EXCLUSIVE or ::WT_OPEN_READONLY.
 	 * @param[out] file_handlep the handle to the newly opened file. File
 	 *    system implementations must allocate memory for the handle and
 	 *    the WT_FILE_HANDLE::name field, and fill in the WT_FILE_HANDLE::
@@ -3816,9 +3806,10 @@ struct __wt_file_system {
 	 * @param file_system the WT_FILE_SYSTEM
 	 * @param session the current WiredTiger session
 	 * @param name the name of the file system object
+	 * @param durable if the operation requires durability
 	 */
-	int (*fs_remove)(
-	    WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name);
+	int (*fs_remove)(WT_FILE_SYSTEM *file_system,
+	    WT_SESSION *session, const char *name, bool durable);
 
 	/*!
 	 * Rename a named file system object
@@ -3832,9 +3823,10 @@ struct __wt_file_system {
 	 * @param session the current WiredTiger session
 	 * @param from the original name of the object
 	 * @param to the new name for the object
+	 * @param durable if the operation requires durability
 	 */
-	int (*fs_rename)(WT_FILE_SYSTEM *file_system,
-	    WT_SESSION *session, const char *from, const char *to);
+	int (*fs_rename)(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
+	    const char *from, const char *to, bool durable);
 
 	/*!
 	 * Return the size of a named file system object

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -188,13 +188,15 @@ __im_fs_exist(WT_FILE_SYSTEM *file_system,
  *	POSIX remove.
  */
 static int
-__im_fs_remove(
-    WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name)
+__im_fs_remove(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, const char *name, bool durable)
 {
 	WT_DECL_RET;
 	WT_FILE_HANDLE_INMEM *im_fh;
 	WT_FILE_SYSTEM_INMEM *im_fs;
 	WT_SESSION_IMPL *session;
+
+	WT_UNUSED(durable);
 
 	im_fs = (WT_FILE_SYSTEM_INMEM *)file_system;
 	session = (WT_SESSION_IMPL *)wt_session;
@@ -215,7 +217,7 @@ __im_fs_remove(
  */
 static int
 __im_fs_rename(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *wt_session, const char *from, const char *to)
+    WT_SESSION *wt_session, const char *from, const char *to, bool durable)
 {
 	WT_DECL_RET;
 	WT_FILE_HANDLE_INMEM *im_fh;
@@ -223,6 +225,8 @@ __im_fs_rename(WT_FILE_SYSTEM *file_system,
 	WT_SESSION_IMPL *session;
 	uint64_t bucket;
 	char *copy;
+
+	WT_UNUSED(durable);
 
 	im_fs = (WT_FILE_SYSTEM_INMEM *)file_system;
 	session = (WT_SESSION_IMPL *)wt_session;

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -36,13 +36,14 @@ __win_fs_exist(WT_FILE_SYSTEM *file_system,
  *	Remove a file.
  */
 static int
-__win_fs_remove(
-    WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name)
+__win_fs_remove(WT_FILE_SYSTEM *file_system,
+    WT_SESSION *wt_session, const char *name, bool durable)
 {
 	DWORD windows_error;
 	WT_SESSION_IMPL *session;
 
 	WT_UNUSED(file_system);
+	WT_UNUSED(durable);
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
@@ -62,12 +63,13 @@ __win_fs_remove(
  */
 static int
 __win_fs_rename(WT_FILE_SYSTEM *file_system,
-    WT_SESSION *wt_session, const char *from, const char *to)
+    WT_SESSION *wt_session, const char *from, const char *to, bool durable)
 {
 	DWORD windows_error;
 	WT_SESSION_IMPL *session;
 
 	WT_UNUSED(file_system);
+	WT_UNUSED(durable);
 
 	session = (WT_SESSION_IMPL *)wt_session;
 


### PR DESCRIPTION
@agorrod, @michaelcahill, something occurred to me today, I thought I'd run it by you.

As you know, we have a file-system directory-sync method, provided for Linux filesystems that require the enclosing directory to be synced for durability during file create, remove and rename. Currently, only Linux needs the directory-sync method.

 First, by having a separate method, we're making it significantly harder to write pluggable filesystems. Imagine a pluggable filesystem that has to do something for durability, but it's nothing like directory-sync. That filesystem can either not specify a directory-sync method and make all operations durable (which might be expensive), or it can specify a directory-sync method and somehow match WiredTiger's call of the directory-sync method to a previous filesystem method call. (It would have to somehow match the path names, there's nothing else to use.)

Second, currently we call `__wt_filename()` (or a variant), to create the pathnames we're going to open, remove or rename. We then re-create that pathname in order to call the directory-sync method. Staring at the two chunks of code, I think they're correct (but they're not identical). It would be much cleaner to only create a single path and use it both for the operation and for any subsequent directory flush.

I suggest we get rid of the directory-sync method, and replace it with boolean "durable" flags to the open, remove and rename methods; here's the branch.
