### PR TITLE
WT-2767 in test/suite/run.py, add -s N option to run an individual scenario

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -108,10 +108,10 @@ def restrictScenario(testcases, restrict):
     elif restrict.isdigit():
         s = int(restrict)
         return [t for t in testcases
-                if hasattr(t, 'scenario_number') and t.scenario_number == s]
+            if hasattr(t, 'scenario_number') and t.scenario_number == s]
     else:
         return [t for t in testcases
-                if hasattr(t, 'scenario_name') and t.scenario_name == restrict]
+            if hasattr(t, 'scenario_name') and t.scenario_name == restrict]
 
 def addScenarioTests(tests, loader, testname, scenario):
     loaded = loader.loadTestsFromName(testname)

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -96,6 +96,7 @@ Tests:\n\
   may be a subsuite name (e.g. \'base\' runs test_base*.py)\n\
 \n\
   When -C or -c are present, there may not be any tests named.\n\
+  When -s is present, there must be a test named.\n\
 '
 
 # capture the category (AKA 'subsuite') part of a test name,
@@ -322,12 +323,17 @@ if __name__ == '__main__':
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
+        if scenario != '':
+            sys.stderr.write(
+                'run.py: specifying a scenario requires a test name\n')
+            usage()
+            sys.exit(2)
         from discover import defaultTestLoader as loader
         suites = loader.discover(suitedir)
         suites = sorted(suites, key=lambda c: str(list(c)[0]))
         if configfile != None:
             suites = configApply(suites, configfile, configwrite)
-        tests.addTests(restrictScenario(generate_scenarios(suites), scenario))
+        tests.addTests(restrictScenario(generate_scenarios(suites), ''))
     else:
         for arg in testargs:
             testsFromArg(tests, loader, arg, scenario)

--- a/test/suite/wtscenario.py
+++ b/test/suite/wtscenario.py
@@ -81,8 +81,8 @@ def multiply_scenarios(sep, *args):
             result = scenes
         else:
             total = []
-            for scena in scenes:
-                for scenb in result:
+            for scena in result:
+                for scenb in scenes:
                     # Create a merged scenario with a concatenated name
                     name = scena[0] + sep + scenb[0]
                     tdict = {}

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -212,8 +212,8 @@ class WiredTigerTestCase(unittest.TestCase):
         # help distinguish tests.
         scen = ''
         if hasattr(self, 'scenario_number') and hasattr(self, 'scenario_name'):
-            scen = '(scenario ' + str(self.scenario_number) + \
-                   ': ' + self.scenario_name + ')'
+            scen = ' -s ' + str(self.scenario_number) + \
+                   ' (' + self.scenario_name + ')'
         return self.simpleName() + scen
 
     def simpleName(self):
@@ -293,6 +293,8 @@ class WiredTigerTestCase(unittest.TestCase):
             raise Exception(self.testdir + ": cannot remove directory")
         os.makedirs(self.testdir)
         os.chdir(self.testdir)
+        with open('testname.txt', 'w+') as namefile:
+            namefile.write(str(self) + '\n')
         self.fdSetUp()
         # tearDown needs a conn field, set it here in case the open fails.
         self.conn = None


### PR DESCRIPTION
Several complimentary changes to make life easier for testing:
- Added -s N option to restrict the run to a scenario with a given number or name.
- When showing the name of the test (for example, with -v 2, or when a test fails), if there is a scenario, print as 'fulltestname -s scenario_number' so it can be easily copied for another command run.
- Created a 'testname.txt' file in the test directory with the name of the test (and '-s NNN', if appropriate).
- Fixed the ordering of the symbolic name of a scenario (e.g. 'file.recno.hex'), it was reversed before.