### PR TITLE
WT-2731 Finer adjustment for page size with raw compression

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -135,12 +135,6 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	if (LF_ISSET(WT_EVICT_INMEM_SPLIT))
 		return (0);
 
-	/*
-	 * Update the page's modification reference, reconciliation might have
-	 * changed it.
-	 */
-	mod = page->modify;
-
 	/* Count evictions of internal pages during normal operation. */
 	if (!closing && WT_PAGE_IS_INTERNAL(page)) {
 		WT_STAT_FAST_CONN_INCR(session, cache_eviction_internal);
@@ -156,6 +150,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		conn->cache->evict_max_page_size = page->memory_footprint;
 
 	/* Figure out whether reconciliation was done on the page */
+	mod = page->modify;
 	clean_page = mod == NULL || mod->rec_result == 0;
 
 	/* Update the reference and discard the page. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1971,7 +1971,7 @@ __rec_split_init(WT_SESSION_IMPL *session,
 	 */
 	r->page_size = r->page_size_orig = max;
 	if (r->raw_compression)
-		r->page_size = WT_MIN(r->page_size * 10,
+		r->page_size = (uint32_t)WT_MIN(r->page_size * 10,
 		    WT_MAX(r->page_size, btree->maxmempage / 2));
 
 	/*


### PR DESCRIPTION
clang 3.4.1 doesn't like this:
```
rec_write.c:1975:46: error: implicit conversion loses integer precision: 'unsigned long' to
'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
```

Also, minor cleanup in `__wt_evict()`.