### PR TITLE
WT-2239 Make sure LSM cursors read up to date dsk_gen, it was racing with compact.

### DIFF
--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -205,6 +205,12 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
 			WT_RET(__wt_txn_id_check(session));
 
 			WT_RET(__clsm_enter_update(clsm));
+			/*
+			 * Switching the tree will update the generation before
+			 * updating the switch transaction.  We test the
+			 * transaction in clsm_enter_update.  Now test the
+			 * disk generation to avoid races.
+			 */
 			if (clsm->dsk_gen != clsm->lsm_tree->dsk_gen)
 				goto open;
 

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -771,6 +771,7 @@ __wt_lsm_tree_switch(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	++lsm_tree->dsk_gen;
 
 	lsm_tree->modified = true;
+	WT_FULL_BARRIER();
 
 	/*
 	 * Set the switch transaction in the previous chunk unless this is
@@ -1187,8 +1188,15 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
 	 */
 	if (lsm_tree->nchunks > 0 &&
 	    (chunk = lsm_tree->chunk[lsm_tree->nchunks - 1]) != NULL) {
-		if (chunk->switch_txn == WT_TXN_NONE)
+		if (chunk->switch_txn == WT_TXN_NONE) {
+			/*
+			 * Make sure any cursors open on the tree see the
+			 * new switch generation before updating.
+			 */
+			++lsm_tree->dsk_gen;
+			WT_FULL_BARRIER();
 			chunk->switch_txn = __wt_txn_id_alloc(session, false);
+		}
 		/*
 		 * If we have a chunk, we want to look for it to be on-disk.
 		 * So we need to add a reference to keep it available.

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -771,6 +771,10 @@ __wt_lsm_tree_switch(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 	++lsm_tree->dsk_gen;
 
 	lsm_tree->modified = true;
+	/*
+	 * Ensure the updated disk generation is visible to all other threads
+	 * before updating the transaction ID.
+	 */
 	WT_FULL_BARRIER();
 
 	/*


### PR DESCRIPTION
@michaelcahill and @agorrod Please review this change to fix the assertion failure as we discussed last night.  I have see it detect the assertion-triggering situation a few times and continue on with the fix on bengal.