### PR TITLE
WT-2737 Page scrubbing: more fixes.

### DIFF
--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -254,12 +254,6 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 	blk = WT_BLOCK_HEADER_REF(buf->mem);
 	memset(blk, 0, sizeof(*blk));
 
-	/*
-	 * Ensure the page header is in little endian order; this doesn't
-	 * belong here, but it's the best place to catch all callers.
-	 */
-	__wt_page_header_byteswap(buf->mem);
-
 	/* Buffers should be aligned for writing. */
 	if (!F_ISSET(buf, WT_ITEM_ALIGNED)) {
 		WT_ASSERT(session, F_ISSET(buf, WT_ITEM_ALIGNED));
@@ -345,9 +339,16 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 		__wt_spin_unlock(session, &block->live_lock);
 	WT_RET(ret);
 
-	/* Write the block. */
-	if ((ret =
-	    __wt_write(session, fh, offset, align_size, buf->mem)) != 0) {
+	/*
+	 * Ensure the page header is in little endian order; this doesn't belong
+	 * here, but it's the best place to catch all callers. After the write,
+	 * swap values back to native order so callers never see anything other
+	 * than their original content.
+	 */
+	__wt_page_header_byteswap(buf->mem);
+	ret = __wt_write(session, fh, offset, align_size, buf->mem);
+	__wt_page_header_byteswap(buf->mem);
+	if (ret != 0) {
 		if (!caller_locked)
 			__wt_spin_lock(session, &block->live_lock);
 		WT_TRET(__wt_block_off_free(
@@ -374,9 +375,6 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 			block->os_cache_dirty_max = 0;
 		}
 	}
-
-	/* Swap the page header back to native order. */
-	__wt_page_header_byteswap(buf->mem);
 
 	/* Optionally discard blocks from the buffer cache. */
 	WT_RET(__wt_block_discard(session, block, align_size));

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -255,8 +255,8 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 	memset(blk, 0, sizeof(*blk));
 
 	/*
-	 * Swap the page-header as needed; this doesn't belong here, but it's
-	 * the best place to catch all callers.
+	 * Ensure the page header is in little endian order; this doesn't
+	 * belong here, but it's the best place to catch all callers.
 	 */
 	__wt_page_header_byteswap(buf->mem);
 
@@ -374,6 +374,9 @@ __wt_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 			block->os_cache_dirty_max = 0;
 		}
 	}
+
+	/* Swap the page header back to native order. */
+	__wt_page_header_byteswap(buf->mem);
 
 	/* Optionally discard blocks from the buffer cache. */
 	WT_RET(__wt_block_discard(session, block, align_size));

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -504,8 +504,7 @@ __evict_review(
 		LF_SET(WT_VISIBILITY_ERR);
 	else if (!WT_PAGE_IS_INTERNAL(page)) {
 		if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-			LF_SET(WT_EVICT_IN_MEMORY |
-			    WT_EVICT_UPDATE_RESTORE | WT_EVICT_SCRUB);
+			LF_SET(WT_EVICT_IN_MEMORY);
 		else if (page->read_gen == WT_READGEN_OLDEST ||
 		    page->memory_footprint > S2BT(session)->splitmempage)
 			LF_SET(WT_EVICT_UPDATE_RESTORE);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -385,7 +385,7 @@ __wt_reconcile(WT_SESSION_IMPL *session,
 	/*
 	 * Evicting in-memory uses the update/restore mechanisms.
 	 * The update/restore mechanisms use disk images.
-	 */ 
+	 */
 	if (LF_ISSET(WT_EVICT_IN_MEMORY))
 		LF_SET(WT_EVICT_UPDATE_RESTORE);
 	if (LF_ISSET(WT_EVICT_UPDATE_RESTORE))

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3250,7 +3250,7 @@ supd_check_complete:
 	}
 
 	/*
-	 * If we saved the disk image in case updated needed to be restored,
+	 * If we saved the disk image in case updates needed to be restored,
 	 * but then found no updates on this page, free the disk image.
 	 */
 	if (F_ISSET(r, WT_EVICT_UPDATE_RESTORE) &&

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2791,9 +2791,8 @@ no_slots:
 		dsk_dst->u.entries = r->raw_entries[result_slots - 1];
 
 		/*
-		 * Optionally keep a copy of the original data, update initial
-		 * page-header fields of that copy to reflect the actual data
-		 * being written.
+		 * Optionally keep the disk image in cache. Update the initial
+		 * page-header fields to reflect the actual data being written.
 		 */
 		if (F_ISSET(r, WT_EVICT_SCRUB)) {
 			WT_RET(__wt_strndup(session, dsk,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2791,8 +2791,9 @@ no_slots:
 		dsk_dst->u.entries = r->raw_entries[result_slots - 1];
 
 		/*
-		 * Optionally keep the disk image in cache. Update the initial
-		 * fields to reflect the actual disk image that was compressed.
+		 * Optionally keep a copy of the original data, update initial
+		 * page-header fields of that copy to reflect the actual data
+		 * being written.
 		 */
 		if (F_ISSET(r, WT_EVICT_SCRUB)) {
 			WT_RET(__wt_strndup(session, dsk,
@@ -3336,17 +3337,12 @@ supd_check_complete:
 
 copy_image:
 	/*
-	 * Optionally keep the disk image in cache (raw compression has already
-	 * made a copy).
+	 * Optionally keep the disk image in cache (raw compression may have
+	 * already made a copy).
 	 */
-	if (F_ISSET(r, WT_EVICT_SCRUB)) {
-		WT_ASSERT(session,
-		    (bnd->already_compressed && bnd->disk_image != NULL) ||
-		    (!bnd->already_compressed && bnd->disk_image == NULL));
-		if (bnd->disk_image == NULL)
-			WT_ERR(__wt_strndup(
-			    session, buf->data, buf->size, &bnd->disk_image));
-	}
+	if (F_ISSET(r, WT_EVICT_SCRUB) && bnd->disk_image == NULL)
+		WT_ERR(__wt_strndup(
+		    session, buf->data, buf->size, &bnd->disk_image));
 
 err:	__wt_scr_free(session, &key);
 	return (ret);


### PR DESCRIPTION
* Swap endianness of the page header back after writing (for zSeries).
* Deal with restoring updates when the WT_EVICT_SCRUB flag is not set:
  we want to save disk images for only those pages that have updates to
  restore.  Unfortunately, that isn't easy to figure out down in the
  guts of raw compression.