### PR TITLE
Fix a JNI thread-safe bug which may cause core dump

### DIFF
--- a/examples/java/com/wiredtiger/examples/ex_thread.java
+++ b/examples/java/com/wiredtiger/examples/ex_thread.java
@@ -36,32 +36,28 @@ import java.io.*;
 import java.util.*;
 
 /*! [thread scan] */
-class ScanThread extends Thread {
+class InsertThread extends Thread {
     private Connection conn;
+    private int threadId;
 
-    public ScanThread(Connection conn) {
+    public InsertThread(Connection conn, int threadId) {
         this.conn = conn;
+        this.threadId = threadId;
     }
 
     public void run()
     {
         try {
             int ret;
-
-            Session session = conn.open_session(null);
-            Cursor cursor = session.open_cursor("table:access", null, null);
-
-            /* Show all records. */
-            while ((ret = cursor.next()) == 0) {
-                String key = cursor.getKeyString();
-                String value = cursor.getValueString();
-                System.out.println("Got record: " + key + " : " + value);
-            }
-            if (ret != wiredtiger.WT_NOTFOUND)
-                System.err.println("Cursor.next: " +
-                                   wiredtiger.wiredtiger_strerror(ret));
-            cursor.close();
-            session.close(null);
+            for (int i = 0; i < 500; i++) {
+                Session session = conn.open_session(null);
+                Cursor cursor = session.open_cursor("table:access", null, "overwrite");
+                cursor.putKeyString("key"+threadId + "-" + i);
+                cursor.putValueString("value1");
+                ret = cursor.insert();
+                cursor.close();
+                ret = session.close(null);
+	    }
         } catch (WiredTigerException wte) {
             System.err.println("Exception " + wte);
         }
@@ -123,7 +119,7 @@ public class ex_thread {
             ret = session.close(null);
 
             for (i = 0; i < NUM_THREADS; i++) {
-                threads[i] = new ScanThread(conn);
+                threads[i] = new InsertThread(conn, i);
                 threads[i].start();
             }
 

--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -78,6 +78,7 @@
  */
 typedef struct {
 	JavaVM *javavm;		/* Used in async threads to craft a jnienv */
+	JNIEnv *jnienv;		/* jni env that created the Session/Cursor */
 	WT_SESSION_IMPL *session; /* session used for alloc/free */
 	jobject jobj;		/* the java Session/Cursor/AsyncOp object */
 	jobject jcallback;	/* callback object for async ops */
@@ -342,6 +343,15 @@ javaClose(JNIEnv *env, WT_SESSION *session, JAVA_CALLBACK *jcb, jfieldID *pfid)
 	jfieldID fid;
 	WT_CONNECTION_IMPL *conn;
 
+	/* If we were not called via an implicit close call,
+	 * we won't have a JNIEnv yet.  Get one from the connection,
+	 * since the thread that started the session may have
+	 * terminated.
+	 */
+	if (env == NULL) {
+		conn = (WT_CONNECTION_IMPL *)session->connection;
+		env = ((JAVA_CALLBACK *)conn->lang_private)->jnienv;
+	}
 	if (pfid == NULL || *pfid == NULL) {
 		cls = (*env)->GetObjectClass(env, jcb->jobj);
 		fid = (*env)->GetFieldID(env, cls, "swigCPtr", "J");
@@ -567,11 +577,11 @@ WT_ASYNC_CALLBACK javaApiAsyncHandler = {javaAsyncHandler};
 	}
 
 	%javamethodmodifiers java_init "protected";
-	int java_init(JNIEnv *jnienv, jobject jasyncop) {
+	int java_init(jobject jasyncop) {
 		JAVA_CALLBACK *jcb =
 		    (JAVA_CALLBACK *)$self->c.lang_private;
-		jcb->jobj = JCALL1(NewGlobalRef, jnienv, jasyncop);
-		JCALL1(DeleteLocalRef, jnienv, jasyncop);
+		jcb->jobj = JCALL1(NewGlobalRef, jcb->jnienv, jasyncop);
+		JCALL1(DeleteLocalRef, jcb->jnienv, jasyncop);
 		return (0);
 	}
 }
@@ -1180,10 +1190,10 @@ WT_ASYNC_CALLBACK javaApiAsyncHandler = {javaAsyncHandler};
 	}
 
 	%javamethodmodifiers java_init "protected";
-	int java_init(JNIEnv *jnienv, jobject jcursor) {
+	int java_init(jobject jcursor) {
 		JAVA_CALLBACK *jcb = (JAVA_CALLBACK *)$self->lang_private;
-		jcb->jobj = JCALL1(NewGlobalRef, jnienv, jcursor);
-		JCALL1(DeleteLocalRef, jnienv, jcursor);
+		jcb->jobj = JCALL1(NewGlobalRef, jcb->jnienv, jcursor);
+		JCALL1(DeleteLocalRef, jcb->jnienv, jcursor);
 		return (0);
 	}
 }
@@ -1881,11 +1891,11 @@ REQUIRE_WRAP(WT_ASYNC_OP::get_id, __wt_async_op::get_id,getId)
 
 %extend ctypename {
 	%javamethodmodifiers java_init "protected";
-	int java_init(JNIEnv *jnienv, jobject jsess) {
+	int java_init(jobject jsess) {
 		implclass *session = (implclass *)$self;
 		JAVA_CALLBACK *jcb = (JAVA_CALLBACK *)session->lang_private;
-		jcb->jobj = JCALL1(NewGlobalRef, jnienv, jsess);
-		JCALL1(DeleteLocalRef, jnienv, jsess);
+		jcb->jobj = JCALL1(NewGlobalRef, jcb->jnienv, jsess);
+		JCALL1(DeleteLocalRef, jcb->jnienv, jsess);
 		return (0);
 	}
 }
@@ -1914,6 +1924,7 @@ WT_CONNECTION *wiredtiger_open_wrap(JNIEnv *jenv, const char *home, const char *
 	if ((ret = __wt_calloc_def(connimpl->default_session, 1, &jcb)) != 0)
 		goto err;
 
+	jcb->jnienv = jenv;
 	connimpl->lang_private = jcb;
 
 err:	if (ret != 0)
@@ -1938,6 +1949,7 @@ err:	if (ret != 0)
 		if ((ret = __wt_calloc_def(connimpl->default_session, 1, &jcb)) != 0)
 			goto err;
 
+		jcb->jnienv = jenv;
 		jcb->session = connimpl->default_session;
 		(*jenv)->GetJavaVM(jenv, &jcb->javavm);
 		jcb->jcallback = JCALL1(NewGlobalRef, jenv, callbackObject);
@@ -1966,6 +1978,7 @@ err:		if (ret != 0)
 		if ((ret = __wt_calloc_def(sessionimpl, 1, &jcb)) != 0)
 			goto err;
 
+		jcb->jnienv = jenv;
 		sessionimpl->lang_private = jcb;
 
 err:		if (ret != 0)
@@ -1990,6 +2003,7 @@ err:		if (ret != 0)
 			    1, &jcb)) != 0)
 			goto err;
 
+		jcb->jnienv = jenv;
 		jcb->session = (WT_SESSION_IMPL *)cursor->session;
 		cursor->lang_private = jcb;
 

--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -236,12 +236,10 @@ WT_CLASS(type, class, name)
 	jcb = (JAVA_CALLBACK *)(priv);
 }
 
-/*
-%typemap(freearg, numinputs=0) class ## _CLOSED *name {
+%typemap(check, numinputs=0) class ## _CLOSED *name {
 	closeHandler(jenv, savesess2, jcb2);
 	priv = NULL;
 }
-*/
 
 %enddef
 


### PR DESCRIPTION
The updated ex_thread test may crash without this fix, because JNI wrapper tried to free session->lang_private after it returned session with connection.close().
After java thread A open the session, it will allocate memory and assign it to session->lang_private, when java thread A close the session, it will call connection.close(session) first, and then try to free session->lang_private. The problem is: after thread A call connection.close() and before it free lang_private, another thread may reuse this session and close it, then thread A found lang_private is set to NULL by another thread and it crashes.
So we need to free lang_private before we call connection.close in the JNI wrapper.