### PR TITLE
WT-2796 Fix a memory leak when using the lookaside table.

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -533,7 +533,8 @@ __evict_review(
 		 * If we aren't trying to free space in the cache, just
 		 * scrub the page and keep it around.
 		 */
-		if (cache->state != WT_EVICT_STATE_ALL)
+		if (!LF_ISSET(WT_EVICT_LOOKASIDE) &&
+		    cache->state != WT_EVICT_STATE_ALL)
 			LF_SET(WT_EVICT_SCRUB);
 	}
 	*flagsp = flags;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -5821,12 +5821,19 @@ __rec_split_row(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		WT_RET(__wt_row_ikey_alloc(session, 0,
 		    bnd->key.data, bnd->key.size, &multi->key.ikey));
 
-		/* Copy any disk image. */
-		multi->supd = bnd->supd;
-		multi->supd_entries = bnd->supd_next;
-		bnd->supd = NULL;
+		/*
+		 * Copy any disk image.  Don't take saved updates without a
+		 * disk image (which happens if they have been saved to the
+		 * lookaside table): they should be discarded along with the
+		 * original page.
+		 */
 		multi->disk_image = bnd->disk_image;
 		bnd->disk_image = NULL;
+		if (multi->disk_image != NULL) {
+			multi->supd = bnd->supd;
+			multi->supd_entries = bnd->supd_next;
+			bnd->supd = NULL;
+		}
 
 		/* Copy any address. */
 		multi->addr = bnd->addr;
@@ -5861,12 +5868,19 @@ __rec_split_col(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 	    bnd = r->bnd, i = 0; i < r->bnd_next; ++multi, ++bnd, ++i) {
 		multi->key.recno = bnd->recno;
 
-		/* Copy any disk image. */
-		multi->supd = bnd->supd;
-		multi->supd_entries = bnd->supd_next;
-		bnd->supd = NULL;
+		/*
+		 * Copy any disk image.  Don't take saved updates without a
+		 * disk image (which happens if they have been saved to the
+		 * lookaside table): they should be discarded along with the
+		 * original page.
+		 */
 		multi->disk_image = bnd->disk_image;
 		bnd->disk_image = NULL;
+		if (multi->disk_image != NULL) {
+			multi->supd = bnd->supd;
+			multi->supd_entries = bnd->supd_next;
+			bnd->supd = NULL;
+		}
 
 		/* Copy any address. */
 		multi->addr = bnd->addr;


### PR DESCRIPTION
(This was introduced in WT-2737).