### PR TITLE
WT-2802 Copy values during commit before releasing snapshot.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -64,12 +64,13 @@ __wt_session_copy_values(WT_SESSION_IMPL *session)
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 
-	/* We have to do this with a transaction ID pinned. */
-	WT_ASSERT(session,
-	   WT_SESSION_TXN_STATE(session)->snap_min != WT_TXN_NONE);
-
 	TAILQ_FOREACH(cursor, &session->cursors, q)
 		if (F_ISSET(cursor, WT_CURSTD_VALUE_INT)) {
+			/* We have to do this with a transaction ID pinned. */
+			WT_ASSERT(session,
+			   WT_SESSION_TXN_STATE(session)->snap_min !=
+			   WT_TXN_NONE);
+
 			F_CLR(cursor, WT_CURSTD_VALUE_INT);
 			WT_RET(__wt_buf_set(session, &cursor->value,
 			    cursor->value.data, cursor->value.size));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -64,6 +64,10 @@ __wt_session_copy_values(WT_SESSION_IMPL *session)
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 
+	/* We have to do this with a transaction ID pinned. */
+	WT_ASSERT(session,
+	   WT_SESSION_TXN_STATE(session)->snap_min != WT_TXN_NONE);
+
 	TAILQ_FOREACH(cursor, &session->cursors, q)
 		if (F_ISSET(cursor, WT_CURSTD_VALUE_INT)) {
 			F_CLR(cursor, WT_CURSTD_VALUE_INT);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -550,6 +550,16 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_TRET(txn->notify->notify(txn->notify,
 		    (WT_SESSION *)session, txn->id, 1));
 
+	/*
+	 * We are about to release the snapshot: copy values into any
+	 * positioned cursors so they don't point to updates that could be
+	 * freed once we don't have a snapshot.
+	 */
+	if (session->ncursors > 0) {
+		WT_DIAGNOSTIC_YIELD;
+		WT_RET(__wt_session_copy_values(session));
+	}
+
 	/* If we are logging, write a commit log record. */
 	if (ret == 0 && txn->mod_count > 0 &&
 	    FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) &&
@@ -578,14 +588,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	for (i = 0, op = txn->mod; i < txn->mod_count; i++, op++)
 		__wt_txn_op_free(session, op);
 	txn->mod_count = 0;
-
-	/*
-	 * We are about to release the snapshot: copy values into any
-	 * positioned cursors so they don't point to updates that could be
-	 * freed once we don't have a transaction ID pinned.
-	 */
-	if (session->ncursors > 0)
-		WT_RET(__wt_session_copy_values(session));
 
 	__wt_txn_release(session);
 	return (0);


### PR DESCRIPTION
When committing a transaction with cursors positioned, copy values
before releasing the transaction snapshot.  Otherwise, there is a window
where the oldest transaction ID could move past the committing
transaction, and the values it needs to copy get freed by another
thread.

This only applies when logging is enabled, and only in applications that
commit transactions with positioned cursors.