### PR TITLE
WT-2805 Avoid infinite recursion on error stream failure.

### DIFF
--- a/src/support/err.c
+++ b/src/support/err.c
@@ -118,7 +118,13 @@ __handler_failure(WT_SESSION_IMPL *session,
 	    handler->handle_error(handler, wt_session, error, s) == 0)
 		return;
 
+	/*
+	 * In case there is a failure in the default error handler, make sure
+	 * we don't recursively try to report *that* error.
+	 */
+	session->event_handler = &__event_handler_default;
 	(void)__handle_error_default(NULL, wt_session, error, s);
+	session->event_handler = handler;
 }
 
 /*


### PR DESCRIPTION
Previously, if both a custom and the default error streams failed to
write it caused infinite recursion.