### PR TITLE
WT-2804 Don't read values in a tree without a snapshot.

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -66,6 +66,8 @@
 		else if (ret == 0 && !F_ISSET(&(s)->txn, WT_TXN_ERROR))	\
 			ret = __wt_txn_commit((s), NULL);		\
 		else {							\
+			if (retry)					\
+				WT_TRET(__wt_session_copy_values(s));	\
 			WT_TRET(__wt_txn_rollback((s), NULL));		\
 			if ((ret == 0 || ret == WT_ROLLBACK) &&		\
 			    (retry)) {					\

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1152,15 +1152,17 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	if (!skipped &&
 	    (F_ISSET(btree, WT_BTREE_LOOKASIDE) ||
 	    __wt_txn_visible_all(session, max_txn))) {
+#ifdef HAVE_DIAGNOSTIC
 		/*
 		 * The checkpoint transaction is special.  Make sure we never
 		 * write (metadata) updates from a checkpoint in a concurrent
 		 * session.
 		 */
-		WT_ASSERT(session, *updp == NULL ||
-		    (txnid = (*updp)->txnid) == WT_TXN_NONE ||
+		txnid = *updp == NULL ? WT_TXN_NONE : (*updp)->txnid;
+		WT_ASSERT(session, txnid == WT_TXN_NONE ||
 		    txnid != S2C(session)->txn_global.checkpoint_txnid ||
 		    WT_SESSION_IS_CHECKPOINT(session));
+#endif
 		return (0);
 	}
 


### PR DESCRIPTION
Improve two recent assertions, one from WT-2798 relating to writing
metadata updates to disk that are part of a running transaction, and
another from WT-2802 that checks that we don't try to copy values from a
cursor without a transaction pinned.  The latter doesn't apply to
cursors on checkpoints (including chunk cursors in an LSM tree).