### PR TITLE
WT-2688 improve build error messages when SWIG is unavailable.

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -85,8 +85,10 @@ fi
 
 # Java and Python APIs
 if test "$wt_cv_enable_java" = "yes" -o "$wt_cv_enable_python" = "yes"; then
+	# Only a warning, we need to build release packages without SWIG.
 	AX_PKG_SWIG(2.0.4, [],
-	    [AC_MSG_WARN([SWIG is required to rebuild Java or Python APIs.])])
+	    [AC_MSG_WARN([SWIG is required to rebuild Java or Python APIs.]);
+              SWIG="SWIG_NOT_FOUND_DURING_CONFIGURE"])
 fi
 
 if test "$wt_cv_enable_java" = "yes"; then

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -87,7 +87,7 @@ fi
 if test "$wt_cv_enable_java" = "yes" -o "$wt_cv_enable_python" = "yes"; then
 	# Only a warning, we need to build release packages without SWIG.
 	AX_PKG_SWIG(2.0.4, [],
-	    [AC_MSG_WARN([SWIG is required to rebuild Java or Python APIs.]);
+	    [AC_MSG_WARN([SWIG is required to rebuild Java or Python APIs.]) &&
               SWIG="SWIG_NOT_FOUND_DURING_CONFIGURE"])
 fi
 


### PR DESCRIPTION
Instead of getting errors like this:
```
(cd /Users/dda/wt/git/wt-2808-configure-swig/lang/java && \
	     -Wall -v -java -nodefaultctor -nodefaultdtor -package com.wiredtiger.db -I/Users/dda/wt/git/wt-2808-configure-swig/build_posix -outdir src/com/wiredtiger/db -o wiredtiger_wrap.c wiredtiger.i)
/bin/sh: -Wall: command not found
```
you get errors like this:
```
(cd /Users/dda/wt/git/wt-2808-configure-swig/lang/java && \
	    SWIG_NOT_FOUND_DURING_CONFIGURE -Wall -v -java -nodefaultctor -nodefaultdtor -package com.wiredtiger.db -I/Users/dda/wt/git/wt-2808-configure-swig/build_posix -outdir src/com/wiredtiger/db -o wiredtiger_wrap.c wiredtiger.i)
/bin/sh: SWIG_NOT_FOUND_DURING_CONFIGURE: command not found
```