### PR TITLE
WT-2650 Allow for backslash escapes in the configuration value for "error_prefix"

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2094,8 +2094,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	/* Configure error messages so we get them right early. */
 	WT_ERR(__wt_config_gets(session, cfg, "error_prefix", &cval));
 	if (cval.len != 0)
-		WT_ERR(__wt_strndup(
-		    session, cval.str, cval.len, &conn->error_prefix));
+		WT_ERR(__wt_config_unescape(
+		    session, &cval, &conn->error_prefix));
 
 	/* Get the database home. */
 	WT_ERR(__conn_home(session, home, cfg));
@@ -2189,8 +2189,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_config_gets(session, cfg, "error_prefix", &cval));
 	if (cval.len != 0) {
 		__wt_free(session, conn->error_prefix);
-		WT_ERR(__wt_strndup(
-		    session, cval.str, cval.len, &conn->error_prefix));
+		WT_ERR(__wt_config_unescape(
+		    session, &cval, &conn->error_prefix));
 	}
 	WT_ERR(__wt_verbose_config(session, cfg));
 


### PR DESCRIPTION
This is potentially part of WT-2650, I separated it out.  It shows how we can allow for escapes in configuration values (whether we really need it this particular case, I'm not sure).

To illustrate, consider `blorg.wtperf`:
```
$ cat blorg.wtperf
conn_config="cache_size=500MB,error_prefix=\"hello,\\\"world\\\": \""
sess_config="BLORG"
$ ./wtperf -O blorg.wtperf
[1470334114:635446][3704:0x7fff70dde000], hello,"world": , WT_CONNECTION.open_session: unknown configuration key: 'BLORG': Invalid argument
Error opening a session on WT_TEST Error: Invalid argument
```
