### PR TITLE
WT-2811 The checkpoint session should not ignore it's own transaction ID

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -129,13 +129,12 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
 	 * if they are only required for the checkpoint and it has already
 	 * seen them.
 	 *
-	 * If there is no active checkpoint, this session is doing the
-	 * checkpoint, or this handle is up to date with the active checkpoint
-	 * then it's safe to ignore the checkpoint ID in the visibility check.
+         * If there is no active checkpoint or this handle is up to date with
+         * the active checkpoint then it's safe to ignore the checkpoint ID in
+         * the visibility check.
 	 */
 	if (!include_checkpoint_txn || checkpoint_pinned == WT_TXN_NONE ||
-	    WT_TXNID_LT(oldest_id, checkpoint_pinned) ||
-	    WT_SESSION_IS_CHECKPOINT(session))
+	    WT_TXNID_LT(oldest_id, checkpoint_pinned))
 		return (oldest_id);
 
 	return (checkpoint_pinned);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -129,9 +129,9 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
 	 * if they are only required for the checkpoint and it has already
 	 * seen them.
 	 *
-         * If there is no active checkpoint or this handle is up to date with
-         * the active checkpoint then it's safe to ignore the checkpoint ID in
-         * the visibility check.
+	 * If there is no active checkpoint or this handle is up to date with
+	 * the active checkpoint then it's safe to ignore the checkpoint ID in
+	 * the visibility check.
 	 */
 	if (!include_checkpoint_txn || checkpoint_pinned == WT_TXN_NONE ||
 	    WT_TXNID_LT(oldest_id, checkpoint_pinned))


### PR DESCRIPTION
There is a sanity check in reconciliation that transaction IDs always
move forward. The tracked ID is updated by both the checkpoint session
and reconciliation in service of eviction. Recent changes in when
a btree is open for eviction mean that interleaving reconciliation
between eviction and checkpoint made it look like time went backwards.