### PR TITLE
WT-2813 Configure eviction dirty settings explicitly for LSM.

### DIFF
--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -154,6 +154,11 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
 		    ",lsm_manager=(worker_thread_max=%" PRIu32 "),",
 		    g.c_lsm_worker_threads);
 
+	if (DATASOURCE("lsm") || g.c_cache < 20) {
+		p += snprintf(p, REMAIN(p, end),
+		    ",eviction_dirty_target=80,eviction_dirty_trigger=95");
+	}
+
 	/* Eviction worker configuration. */
 	if (g.c_evict_max != 0)
 		p += snprintf(p, REMAIN(p, end),


### PR DESCRIPTION
@agorrod please review.  Your comment in the ticket was a bit confusing, but I changed the settings if the chosen cache size is less than 20Mb as well as if it is using LSM.  This allows the two CONFIGs in the ticket to repeatedly complete now.