### PR TITLE
WT-2818 Change the page visibility check when queuing pages for eviction

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1258,20 +1258,12 @@ __wt_page_can_evict(
 	    F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_BLOCK))
 		return (false);
 
-	/* If the cache is stuck, try anything else. */
-	if (F_ISSET(S2C(session)->cache, WT_CACHE_STUCK))
-		return (true);
-
 	/*
-	 * If the oldest transaction hasn't changed since the last time
-	 * this page was written, it's unlikely we can make progress.
-	 * Similarly, if the most recent update on the page is not yet
-	 * globally visible, eviction will fail.  These heuristics
-	 * attempt to avoid repeated attempts to evict the same page.
+	 * If the page is clean but has modifications that
+	 * appear too new to evict, skip it.
 	 */
-	if (modified &&
-	    (mod->last_oldest_id == __wt_txn_oldest_id(session) ||
-	    !__wt_txn_visible_all(session, mod->update_txn)))
+	if (!modified && mod != NULL &&
+	    !__wt_txn_visible_all(session, mod->rec_max_txn))
 		return (false);
 
 	return (true);


### PR DESCRIPTION
The existing check discards pages that could potentially have
some reconciliation done on them. This change allows workloads
to make more progress when running with constrained cache sizes.