### PR TITLE
WT-2827 Set a reasonable minimum for log_size.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -375,7 +375,8 @@ connection_runtime_config = [
         type='category', subconfig=[
         Config('log_size', '0', r'''
             wait for this amount of log record bytes to be written to
-                the log between each checkpoint.  A database can configure
+                the log between each checkpoint.  If non-zero, this value will
+                use a minimum of the log file size.  A database can configure
                 both log_size and wait to set an upper bound for checkpoints;
                 setting this value above 0 configures periodic checkpoints''',
             min='0', max='2GB'),

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -38,6 +38,13 @@ __ckpt_server_config(WT_SESSION_IMPL *session, const char **cfg, bool *startp)
 	if (conn->ckpt_usecs != 0 ||
 	    (conn->ckpt_logsize != 0 &&
 	    FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))) {
+		/*
+		 * If non-zero, use a minimum of the log file size.  The logging
+		 * subsystem has already been initialized.
+		 */
+		if (conn->ckpt_logsize != 0)
+			conn->ckpt_logsize = WT_MAX(
+			    conn->ckpt_logsize, conn->log_file_max);
 		/* Checkpoints are incompatible with in-memory configuration */
 		WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
 		if (cval.val != 0)

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -39,10 +39,12 @@ __ckpt_server_config(WT_SESSION_IMPL *session, const char **cfg, bool *startp)
 	    (conn->ckpt_logsize != 0 &&
 	    FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))) {
 		/*
-		 * If non-zero, use a minimum of the log file size.  The logging
-		 * subsystem has already been initialized.
+		 * If checkpointing based on log data, use a minimum of the
+		 * log file size.  The logging subsystem has already been
+		 * initialized.
 		 */
-		if (conn->ckpt_logsize != 0)
+		if (conn->ckpt_logsize != 0 &&
+		    FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
 			conn->ckpt_logsize = WT_MAX(
 			    conn->ckpt_logsize, conn->log_file_max);
 		/* Checkpoints are incompatible with in-memory configuration */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1785,7 +1785,8 @@ struct __wt_connection {
 	 * Enabling the checkpoint server uses a session from the configured
 	 * session_max., a set of related configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_size, wait for this amount of log
-	 * record bytes to be written to the log between each checkpoint.  A
+	 * record bytes to be written to the log between each checkpoint.  If
+	 * non-zero\, this value will use a minimum of the log file size.  A
 	 * database can configure both log_size and wait to set an upper bound
 	 * for checkpoints; setting this value above 0 configures periodic
 	 * checkpoints., an integer between 0 and 2GB; default \c 0.}
@@ -2203,14 +2204,14 @@ struct __wt_connection {
  * checkpoint server uses a session from the configured session_max., a set of
  * related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_size, wait for this amount of log record
- * bytes to be written to the log between each checkpoint.  A database can
- * configure both log_size and wait to set an upper bound for checkpoints;
- * setting this value above 0 configures periodic checkpoints., an integer
- * between 0 and 2GB; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait,
- * seconds to wait between each checkpoint; setting this value above 0
- * configures periodic checkpoints., an integer between 0 and 100000; default \c
- * 0.}
+ * bytes to be written to the log between each checkpoint.  If non-zero\, this
+ * value will use a minimum of the log file size.  A database can configure both
+ * log_size and wait to set an upper bound for checkpoints; setting this value
+ * above 0 configures periodic checkpoints., an integer between 0 and 2GB;
+ * default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to wait between
+ * each checkpoint; setting this value above 0 configures periodic checkpoints.,
+ * an integer between 0 and 100000; default \c 0.}
  * @config{ ),,}
  * @config{checkpoint_sync, flush files to stable storage when closing or
  * writing checkpoints., a boolean flag; default \c true.}

--- a/test/suite/test_reconfig03.py
+++ b/test/suite/test_reconfig03.py
@@ -54,5 +54,13 @@ class test_reconfig03(wttest.WiredTigerTestCase):
         time.sleep(1)
         self.conn.reconfigure("shared_cache=(chunk=11MB, name=bar, reserve=12MB, size=1G)")
 
+    def test_reconfig03_log_size(self):
+        #
+        # Reconfigure checkpoint based on log size.
+        #
+        self.conn.reconfigure("checkpoint=(log_size=20)")
+        self.conn.reconfigure("checkpoint=(log_size=1M)")
+        self.conn.reconfigure("checkpoint=(log_size=0)")
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@agorrod Please review this change.  If a user sets a small `log_size` it will use the log file size.  We may or may not want this semi-silent change to the user's config. 