### PR TITLE
SERVER-25247 MongoDB primary node crashes after SIGINT (ctrl+c)

### DIFF
--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -186,27 +186,18 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
 	}
 
 	/*
-	 * The session's split stash isn't discarded during normal session close
-	 * because it may persist past the life of the session.  Discard it now.
+	 * The session split stash, hazard information and handle arrays aren't
+	 * discarded during normal session close, they persist past the life of
+	 * the session. Discard them now.
 	 */
-	if ((s = conn->sessions) != NULL)
-		for (i = 0; i < conn->session_size; ++s, ++i)
-			__wt_split_stash_discard_all(session, s);
-
-	/*
-	 * The session's hazard pointer memory isn't discarded during normal
-	 * session close because access to it isn't serialized.  Discard it
-	 * now.
-	 */
-	if ((s = conn->sessions) != NULL)
-		for (i = 0; i < conn->session_size; ++s, ++i) {
-			/*
-			 * If hash arrays were allocated, free them now.
-			 */
-			__wt_free(session, s->dhhash);
-			__wt_free(session, s->tablehash);
-			__wt_free(session, s->hazard);
-		}
+	if (!F_ISSET(conn, WT_CONN_LEAK_MEMORY))
+		if ((s = conn->sessions) != NULL)
+			for (i = 0; i < conn->session_size; ++s, ++i) {
+				__wt_free(session, s->dhhash);
+				__wt_free(session, s->tablehash);
+				__wt_split_stash_discard_all(session, s);
+				__wt_free(session, s->hazard);
+			}
 
 	/* Destroy the handle. */
 	WT_TRET(__wt_connection_destroy(conn));


### PR DESCRIPTION
@agorrod, I'm giving up on SERVER-25247, I just don't see it.

Here's a workaround that I think will at least avoid the symptom, and given the number of sessions MongoDB allocates, it's a useful change to make.