### PR TITLE
WT-2835 WT_CONNECTION.leak-memory can skip memory map and cache cleanup

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -103,6 +103,15 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 	/* Update the cache's information. */
 	__wt_cache_page_evict(session, page);
 
+	dsk = (WT_PAGE_HEADER *)page->dsk;
+	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))
+		__wt_cache_page_image_decr(session, dsk->mem_size);
+
+	/* Discard any mapped image. */
+	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_MAPPED))
+		(void)S2BT(session)->bm->map_discard(
+		    S2BT(session)->bm, session, dsk, (size_t)dsk->mem_size);
+
 	/*
 	 * If discarding the page as part of process exit, the application may
 	 * configure to leak the memory rather than do the work.
@@ -129,17 +138,9 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 		break;
 	}
 
-	/* Discard any disk image. */
-	dsk = (WT_PAGE_HEADER *)page->dsk;
-	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC)) {
-		__wt_cache_page_image_decr(session, dsk->mem_size);
+	/* Discard any allocated disk image. */
+	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))
 		__wt_overwrite_and_free_len(session, dsk, dsk->mem_size);
-	}
-
-	/* Discard any mapped image. */
-	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_MAPPED))
-		(void)S2BT(session)->bm->map_discard(
-		    S2BT(session)->bm, session, dsk, (size_t)dsk->mem_size);
 
 	__wt_overwrite_and_free(session, page);
 }


### PR DESCRIPTION
@agorrod, for your review/consideration.