### PR TITLE
WT-2631 nullptr is passed for parameters marked with attribute non-null

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -279,7 +279,8 @@ __wt_update_alloc(
 		WT_UPDATE_DELETED_SET(*updp);
 	else {
 		(*updp)->size = WT_STORE_SIZE(size);
-		memcpy(WT_UPDATE_DATA(*updp), value->data, size);
+		if (size != 0)
+			memcpy(WT_UPDATE_DATA(*updp), value->data, size);
 	}
 
 	*sizep = WT_UPDATE_MEMSIZE(*updp);

--- a/src/include/buf.i
+++ b/src/include/buf.i
@@ -76,7 +76,8 @@ __wt_buf_set(
 	WT_RET(__wt_buf_initsize(session, buf, size));
 
 	/* Copy the data, allowing for overlapping strings. */
-	memmove(buf->mem, data, size);
+	if (size != 0)
+		memmove(buf->mem, data, size);
 
 	return (0);
 }


### PR DESCRIPTION
@agorrod, I believe that I have clean Evergreen runs, so this should be ready to merge.