### PR TITLE
WT-2787 Include src/include/wiredtiger_ext.h is problematic

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -227,6 +227,7 @@ AM_COND_IF([LEVELDB],
 AC_CONFIG_FILES([
 	Makefile
 	wiredtiger.h:src/include/wiredtiger.in
+	wiredtiger_ext.h:src/include/wiredtiger_ext.h
 	wiredtiger.pc:build_posix/wiredtiger.pc.in
 ])
 AC_OUTPUT


### PR DESCRIPTION
@agorrod, @daveh86, as @michaelcahill said, people shouldn't try to build against our source tree -- assuming they're not building the WiredTiger library over and over, requiring a separate install step shouldn't be a big deal.

That said, this particular user is looking at implementing a custom filesystem, so unlike everybody else, he might be repeatedly building the WiredTiger library.

I can't imagine we're going to rename error.h, it's just one of 40 include files, many of which have generic names: api.h, block.h, config.h, extern.h, flags.h, misc.h, posix.h, queue.h and others are all common names, and we're not going to rename all of them.

Here's a possibility: have the configuration step copy wiredtiger_ext.h into the top-level directory along with wiredtiger.h, so you can use `-I /path/to/wiredtiger` instead of reaching down into `src/include/`.

If nobody likes that change, I think we should close WT-2787 without any change.