### PR TITLE
WT-2834 Shared bloom filters allow only a partial shortcut.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -708,6 +708,7 @@ ibackup
 icount
 idx
 ifdef's
+iiii
 iiu
 ikey
 im

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -22,6 +22,9 @@ noinst_PROGRAMS += test_wt2592_join_schema
 test_wt2719_reconfig_SOURCES = wt2719_reconfig/main.c
 noinst_PROGRAMS += test_wt2719_reconfig
 
+test_wt2834_join_bloom_fix_SOURCES = wt2834_join_bloom_fix/main.c
+noinst_PROGRAMS += test_wt2834_join_bloom_fix
+
 # Run this during a "make check" smoke test.
 TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -51,7 +51,7 @@ typedef struct {
 	uint32_t seedz;
 } RAND;
 
-void rand_init(RAND *r)
+static void rand_init(RAND *r)
 {
 	r->seedw = 521288629;
 	r->seedz = 362436069;
@@ -61,7 +61,7 @@ void rand_init(RAND *r)
  * Returns a random 32 bit integer.
  * We use Marsaglia's Multiply-with-carry method.
  */
-uint32_t rand_next(RAND *r)
+static uint32_t rand_next(RAND *r)
 {
 	uint32_t w;
 	uint32_t z;
@@ -196,9 +196,9 @@ void *populate(TEST_OPTS *opts)
 	WT_CURSOR *maincur;
 	WT_SESSION *session;
 	int balance, i, flag, key, post;
-	RAND rand;
+	RAND r;
 
-	rand_init(&rand);
+	rand_init(&r);
 
 	testutil_check(opts->conn->open_session(
 	    opts->conn, NULL, NULL, &session));
@@ -208,13 +208,13 @@ void *populate(TEST_OPTS *opts)
 
 	for (i = 0; i < N_INSERT; i++) {
 		testutil_check(session->begin_transaction(session, NULL));
-		key = (rand_next(&rand) % (N_RECORDS));
+		key = (rand_next(&r) % (N_RECORDS));
 		maincur->set_key(maincur, key);
-		if (rand_next(&rand) % 11 == 0)
+		if (rand_next(&r) % 11 == 0)
 			post = 54321;
 		else
 			post = i % 100000;
-		if (rand_next(&rand) % 4 == 0) {
+		if (rand_next(&r) % 4 == 0) {
 			balance = -100;
 			flag = 1;
 		} else {

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -1,0 +1,231 @@
+/*-
+ * Public Domain 2014-2016 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * JIRA ticket reference: WT-2834
+ * Test case description: We are creating bank 'account' records, each
+ * having a postal_code, balance, and an 'overdrawn' flag.  We insert
+ * records with various balances, and only set the overdrawn flag when the
+ * balance is negative.  Then we set up a join to simulate this:
+ *
+ *   select (*) from account where account.postal_code = '54321' and
+ *                      account.balance < 0 and not account.overdrawn
+ *
+ * Failure mode: We get results back from our join.
+ */
+void (*custom_die)(void) = NULL;
+
+#define	N_RECORDS	100000
+#define	N_INSERT	1000000
+
+void *populate(TEST_OPTS *opts);
+
+typedef struct {
+	uint32_t seedw;
+	uint32_t seedz;
+} RAND;
+
+void rand_init(RAND *r)
+{
+	r->seedw = 521288629;
+	r->seedz = 362436069;
+}
+
+/*
+ * Returns a random 32 bit integer.
+ * We use Marsaglia's Multiply-with-carry method.
+ */
+uint32_t rand_next(RAND *r)
+{
+	uint32_t w;
+	uint32_t z;
+
+	w = r->seedw;
+	z = r->seedz;
+	if (w == 0 || z == 0)
+		rand_init(r);
+
+	r->seedz = 36969 * (z & 65535) + (z >> 16);
+	r->seedw = 18000 * (w & 65535) + (w >> 16);
+	return ((z << 16) + (w & 65535));
+}
+
+int
+main(int argc, char *argv[])
+{
+	TEST_OPTS *opts, _opts;
+	WT_CURSOR *maincur;
+	WT_CURSOR *postcur, *balancecur, *flagcur, *joincur;
+	WT_SESSION *session;
+	int balance, count, flag, key, key2, post, ret;
+	char cfg[128];
+	const char *tablename;
+	char posturi[256];
+	char balanceuri[256];
+	char flaguri[256];
+	char joinuri[256];
+
+	opts = &_opts;
+	memset(opts, 0, sizeof(*opts));
+
+	testutil_check(testutil_parse_opts(argc, argv, opts));
+	testutil_make_work_dir(opts->home);
+
+	testutil_check(wiredtiger_open(opts->home, NULL,
+	    "create,cache_size=250M", &opts->conn));
+	testutil_check(
+	    opts->conn->open_session(opts->conn, NULL, NULL, &session));
+	/*
+	 * Note: repeated primary key 'id' as 'id2'.  This makes
+	 * it easier to dump an index and know which record we're
+	 * looking at.
+	 */
+	testutil_check(session->create(session, opts->uri,
+	    "key_format=i,value_format=iiii,"
+	    "columns=(id,post,balance,flag,id2)"));
+
+	tablename = strchr(opts->uri, ':');
+	testutil_assert(tablename != NULL);
+	tablename++;
+	snprintf(posturi, sizeof(posturi), "index:%s:post", tablename);
+	snprintf(balanceuri, sizeof(balanceuri), "index:%s:balance", tablename);
+	snprintf(flaguri, sizeof(flaguri), "index:%s:flag", tablename);
+	snprintf(joinuri, sizeof(joinuri), "join:%s", opts->uri);
+
+	testutil_check(session->create(session, posturi, "columns=(post)"));
+	testutil_check(session->create(session, balanceuri,
+	    "columns=(balance)"));
+	testutil_check(session->create(session, flaguri, "columns=(flag)"));
+
+	/*
+	 * Insert a single record with all items we are search for,
+	 * this makes our logic easier.
+	 */
+	testutil_check(session->open_cursor(session, opts->uri, NULL, NULL,
+	    &maincur));
+	maincur->set_key(maincur, N_RECORDS);
+	maincur->set_value(maincur, 54321, 0, "", 0, N_RECORDS);
+	maincur->insert(maincur);
+	maincur->close(maincur);
+	testutil_check(session->close(session, NULL));
+
+	populate(opts);
+
+	testutil_check(opts->conn->open_session(
+	    opts->conn, NULL, NULL, &session));
+
+	testutil_check(session->begin_transaction(session,
+	    "isolation=snapshot"));
+	testutil_check(session->open_cursor(session,
+	    posturi, NULL, NULL, &postcur));
+	testutil_check(session->open_cursor(session,
+	    balanceuri, NULL, NULL, &balancecur));
+	testutil_check(session->open_cursor(session,
+	    flaguri, NULL, NULL, &flagcur));
+	testutil_check(session->open_cursor(session,
+	    joinuri, NULL, NULL, &joincur));
+
+	postcur->set_key(postcur, 54321);
+	testutil_check(postcur->search(postcur));
+	testutil_check(session->join(session, joincur, postcur,
+	    "compare=eq"));
+
+	balancecur->set_key(balancecur, 0);
+	testutil_check(balancecur->search(balancecur));
+	sprintf(cfg, "compare=lt,strategy=bloom,count=%d",
+	    N_RECORDS / 100);
+	testutil_check(session->join(session, joincur, balancecur, cfg));
+
+	flagcur->set_key(flagcur, 0);
+	testutil_check(flagcur->search(flagcur));
+	sprintf(cfg, "compare=eq,strategy=bloom,count=%d",
+	    N_RECORDS / 100);
+	testutil_check(session->join(session, joincur, flagcur, cfg));
+
+	/* Expect no values returned */
+	count = 0;
+	while ((ret = joincur->next(joincur)) == 0) {
+		/*
+		 * The values may already have been changed, but
+		 * print them for informational purposes.
+		 */
+		testutil_check(joincur->get_key(joincur, &key));
+		testutil_check(joincur->get_value(joincur, &post,
+		    &balance, &flag, &key2));
+		fprintf(stderr, "FAIL: "
+		    "key=%d/%d, postal_code=%d, balance=%d, flag=%d\n",
+		    key, key2, post, balance, flag);
+		count++;
+	}
+	testutil_assert(count == 0);
+
+	testutil_cleanup(opts);
+	/* NOTREACHED */
+
+	return (0);
+}
+
+void *populate(TEST_OPTS *opts)
+{
+	WT_CURSOR *maincur;
+	WT_SESSION *session;
+	int balance, i, flag, key, post;
+	RAND rand;
+
+	rand_init(&rand);
+
+	testutil_check(opts->conn->open_session(
+	    opts->conn, NULL, NULL, &session));
+
+	testutil_check(session->open_cursor(session, opts->uri, NULL, NULL,
+	    &maincur));
+
+	for (i = 0; i < N_INSERT; i++) {
+		testutil_check(session->begin_transaction(session, NULL));
+		key = (rand_next(&rand) % (N_RECORDS));
+		maincur->set_key(maincur, key);
+		if (rand_next(&rand) % 11 == 0)
+			post = 54321;
+		else
+			post = i % 100000;
+		if (rand_next(&rand) % 4 == 0) {
+			balance = -100;
+			flag = 1;
+		} else {
+			balance = 100 * (i + 1);
+			flag = 0;
+		}
+		maincur->set_value(maincur, post, balance, flag, key);
+		testutil_check(maincur->insert(maincur));
+		testutil_check(session->commit_transaction(session, NULL));
+	}
+	maincur->close(maincur);
+	session->close(session, NULL);
+	return (NULL);
+}


### PR DESCRIPTION
This fixes an error in cursor join evaluations that may occur with bloom filters that are shared when false positives are found.  Things to note:

The problem only happens when Bloom filters are specified for parts of the join.  It is less likely when Bloom filters are oversized, and more likely when Bloom filters are undersized. That is the problem occurs with the handling of false positives, which become less likely as the Bloom filter is sized larger. The problem only happens when Bloom filters are shared; that occurs when Bloom filters are specified for multiple parts of a conjunction, and the filters have been given the same size parameter.

The problem will never result in an item not being returned that should be returned.  It will result in item(s) being returned that do not satisfy the conditions of the join.  The fix should ensure that all items returned satisfy the join.