### PR TITLE
WT-2843 If there is no truncate available, manually zero the log file.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -952,6 +952,33 @@ __wt_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WT_LOGSLOT *slot)
 }
 
 /*
+ * __log_truncate_file --
+ *	Truncate a log file to the specified offset.
+ *
+ *	If the underlying file system doesn't support truncate then we need to
+ *	zero out the rest of the file, doing an effective truncate.
+ */
+static int
+__log_truncate_file(WT_SESSION_IMPL *session, WT_FH *log_fh, wt_off_t offset)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+	WT_LOG *log;
+
+	conn = S2C(session);
+	log = conn->log;
+
+	if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP)) {
+		if ((ret = __wt_ftruncate(session, log_fh, offset)) != ENOTSUP)
+			return (ret);
+
+		F_SET(log, WT_LOG_TRUNCATE_NOTSUP);
+	}
+
+	return (__log_zero(session, log_fh, offset, conn->log_file_max));
+}
+
+/*
  * __log_truncate --
  *	Truncate the log to the given LSN.  If this_log is set, it will only
  *	truncate the log file indicated in the given LSN.  If not set,
@@ -989,24 +1016,7 @@ __log_truncate(WT_SESSION_IMPL *session,
 	 * future truncates.
 	 */
 	WT_ERR(__log_openfile(session, &log_fh, file_prefix, lsn->l.file, 0));
-	if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP)) {
-		if ((ret = __wt_ftruncate(
-		    session, log_fh, lsn->l.offset)) != 0) {
-			if (ret == ENOTSUP) {
-				F_SET(log, WT_LOG_TRUNCATE_NOTSUP);
-				ret = 0;
-				goto slow_trunc;
-			}
-			goto err;
-		}
-	} else
-		/*
-		 * If the underlying file system doesn't support truncate then
-		 * we need to zero out the rest of the file, doing an effective
-		 * truncate.
-		 */
-slow_trunc:	WT_ERR(__log_zero(session,
-		    log_fh, lsn->l.offset, conn->log_file_max));
+	WT_ERR(__log_truncate_file(session, log_fh, lsn->l.offset));
 	WT_ERR(__wt_fsync(session, log_fh, true));
 	WT_ERR(__wt_close(session, &log_fh));
 
@@ -1026,14 +1036,9 @@ slow_trunc:	WT_ERR(__log_zero(session,
 			/*
 			 * If there are intervening files pre-allocated,
 			 * truncate them to the end of the log file header.
-			 * If we don't have truncate, do it manually.
 			 */
-			if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP))
-				WT_ERR(__wt_ftruncate(session,
-				    log_fh, WT_LOG_FIRST_RECORD));
-			else
-				WT_ERR(__log_zero(session, log_fh,
-				    WT_LOG_FIRST_RECORD, conn->log_file_max));
+			WT_ERR(__log_truncate_file(
+			    session, log_fh, WT_LOG_FIRST_RECORD));
 			WT_ERR(__wt_fsync(session, log_fh, true));
 			WT_ERR(__wt_close(session, &log_fh));
 		}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -990,7 +990,8 @@ __log_truncate(WT_SESSION_IMPL *session,
 	 */
 	WT_ERR(__log_openfile(session, &log_fh, file_prefix, lsn->l.file, 0));
 	if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP)) {
-		if ((ret = __wt_ftruncate(session, log_fh, lsn->l.offset)) != 0) {
+		if ((ret = __wt_ftruncate(
+		    session, log_fh, lsn->l.offset)) != 0) {
 			if (ret == ENOTSUP) {
 				F_SET(log, WT_LOG_TRUNCATE_NOTSUP);
 				ret = 0;


### PR DESCRIPTION
@michaelcahill or @agorrod please review this change to handle log files when truncate is not available.  The change is actually pretty small since `log_zero` already exists.  I'm not thrilled with the goto in there but didn't want to make the code ugly to handle the first-time case.

This passes the new `truncated-log` test both with and without truncate configured.  We need to discuss where/how to get that setting into one of the Jenkins jobs to test this regularly.