### PR TITLE
WT-2846 Add flags and fix for destroying thread group.

### DIFF
--- a/src/include/thread_group.h
+++ b/src/include/thread_group.h
@@ -25,7 +25,7 @@ struct __wt_thread {
  * Flags for thread group functions.
  */
 #define	WT_THREAD_CAN_WAIT		0x01
-#define	WT_THREAD_FORCE			0x02
+#define	WT_THREAD_CLOSE_ALL		0x02
 #define	WT_THREAD_FREE			0x04
 #define	WT_THREAD_PANIC_FAIL		0x08
 

--- a/src/include/thread_group.h
+++ b/src/include/thread_group.h
@@ -21,8 +21,13 @@ struct __wt_thread {
 	int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context);
 };
 
+/*
+ * Flags for thread group functions.
+ */
 #define	WT_THREAD_CAN_WAIT		0x01
-#define	WT_THREAD_PANIC_FAIL		0x02
+#define	WT_THREAD_FORCE			0x02
+#define	WT_THREAD_FREE			0x04
+#define	WT_THREAD_PANIC_FAIL		0x08
 
 /*
  * WT_THREAD_GROUP --

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -154,7 +154,7 @@ __thread_group_resize(
 
 	if (group->current_threads > new_max)
 		WT_RET(__thread_group_shrink(
-		    session, group, new_max, true));
+		    session, group, new_max, WT_THREAD_FREE));
 
 	/*
 	 * Only reallocate the thread array if it is the largest ever, since


### PR DESCRIPTION
@agorrod This fixes the leak and allows the failing `test/format` config finish successfully.