### PR TITLE
WT-2846 Fixes for new thread group code

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -376,6 +376,7 @@ __wt_evict_destroy(WT_SESSION_IMPL *session)
 	 */
 	F_CLR(conn, WT_CONN_EVICTION_RUN);
 	conn->evict_server_running = false;
+	__wt_evict_server_wake(session);
 
 	__wt_verbose(
 	    session, WT_VERB_EVICTSERVER, "waiting for helper threads");

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -234,9 +234,6 @@ __wt_thread_group_resize(
 	    " from max: %" PRIu32 " -> %" PRIu32 "\n",
 	    group, group->min, new_min, group->max, new_max);
 
-	WT_ASSERT(session,
-	    !__wt_rwlock_islocked(session, group->lock));
-
 	__wt_writelock(session, group->lock);
 	WT_TRET(__thread_group_resize(
 	    session, group, new_min, new_max, flags));


### PR DESCRIPTION
If it were safe there would be no point locking. The test could fail if a reconfigure races with the eviction server starting a new thread.