### PR TITLE
WT-2869 Fix a performance regression on secondaries.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -327,6 +327,13 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	if (__wt_hazard_count(session, page) > 1)
 		return (false);
 
+	/*
+	 * If we have already tried and the transaction state has not moved on,
+	 * eviction is highly likely to fail.
+	 */
+	if (page->modify->last_oldest_id == __wt_txn_oldest_id(session))
+		return (false);
+
 	if (page->memory_footprint < btree->maxmempage)
 		return (__wt_leaf_page_can_split(session, page));
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2239,6 +2239,14 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 	WT_ERR(__split_multi_inmem(session, page, multi, new));
 
 	/*
+	 * If the new page is modified, save the oldest ID from reconciliation
+	 * to avoid repeatedly attempting eviction on the same page.
+	 */
+	if (new->page->modify != NULL)
+		new->page->modify->last_oldest_id =
+		    page->modify->last_oldest_id;
+
+	/*
 	 * The rewrite succeeded, we can no longer fail.
 	 *
 	 * Finalize the move, discarding moved update lists from the original


### PR DESCRIPTION
Don't try to repeatedly evict pages if the eviction state hasn't moved
forwards.