### PR TITLE
WT-2871 Make verbose formats and argument types match.

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -221,11 +221,11 @@ __block_dump_avail(WT_SESSION_IMPL *session, WT_BLOCK *block, bool start)
 
 	if (!start) {
 		__wt_verbose(session, WT_VERB_COMPACT,
-		    "pages reviewed: %" PRIuMAX, block->compact_pages_reviewed);
+		    "pages reviewed: %" PRIu64, block->compact_pages_reviewed);
 		__wt_verbose(session, WT_VERB_COMPACT,
-		    "pages skipped: %" PRIuMAX, block->compact_pages_skipped);
+		    "pages skipped: %" PRIu64, block->compact_pages_skipped);
 		__wt_verbose(session, WT_VERB_COMPACT,
-		    "pages written: %" PRIuMAX, block->compact_pages_written);
+		    "pages written: %" PRIu64, block->compact_pages_written);
 	}
 
 	__wt_verbose(session, WT_VERB_COMPACT,

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1384,7 +1384,8 @@ fast:		/* If the page can't be evicted, give up. */
 		    ++internal_pages;
 
 		__wt_verbose(session, WT_VERB_EVICTSERVER,
-		    "select: %p, size %" PRIu64, page, page->memory_footprint);
+		    "select: %p, size %" WT_SIZET_FMT,
+		    page, page->memory_footprint);
 	}
 	WT_RET_NOTFOUND_OK(ret);
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3329,7 +3329,7 @@ supd_check_complete:
 	if (WT_VERBOSE_ISSET(session, WT_VERB_SPLIT) && r->entries < 6)
 		__wt_verbose(session, WT_VERB_SPLIT,
 		    "Reconciliation creating a page with %" PRIu32
-		    " entries, memory footprint %" PRIu64
+		    " entries, memory footprint %" WT_SIZET_FMT
 		    ", page count %" PRIu32 ", %s, split state: %d\n",
 		    r->entries, r->page->memory_footprint, r->bnd_next,
 		    F_ISSET(r, WT_EVICTING) ? "evict" : "checkpoint",


### PR DESCRIPTION
OS X clang in particular is fussy about size_t vs uint64_t vs uintmax_t.