### PR TITLE
Revert "WT-2842 Add explicit include in wtperf to resolve build warning."

### DIFF
--- a/bench/wtperf/doxy.c
+++ b/bench/wtperf/doxy.c
@@ -28,7 +28,6 @@
 
 #include <sys/types.h>
 #include <string.h>
-#include <stdint.h>
 #include <stdio.h>
 
 #include "queue.h"


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#3002