### PR TITLE
WT-2555 Make Format run on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -443,28 +443,22 @@ t = env.Program("t_fops",
     "test/fops/t.c"],
     LIBS=[wtlib, shim, testutil] + wtlibs)
 env.Append(CPPPATH=["test/utility"])
-env.Alias("check", env.SmokeTest(t))
 Default(t)
 
-if useBdb:
-    benv = env.Clone()
-
-    benv.Append(CPPDEFINES=['BERKELEY_DB_PATH=\\"' + useBdb.replace("\\", "\\\\") + '\\"'])
-
-    t = benv.Program("t_format",
-        ["test/format/backup.c",
-        "test/format/bdb.c",
-        "test/format/bulk.c",
-        "test/format/compact.c",
-        "test/format/config.c",
-        "test/format/ops.c",
-        "test/format/salvage.c",
-        "test/format/t.c",
-        "test/format/util.c",
-        "test/format/wts.c"],
-         LIBS=[wtlib, shim, "libdb61"] + wtlibs)
-    env.Alias("test", env.SmokeTest(t))
-    Default(t)
+t = env.Program("t_format",
+    ["test/format/backup.c",
+    "test/format/bulk.c",
+    "test/format/compact.c",
+    "test/format/config.c",
+    "test/format/lrt.c",
+    "test/format/ops.c",
+    "test/format/rebalance.c",
+    "test/format/salvage.c",
+    "test/format/t.c",
+    "test/format/util.c",
+    "test/format/wts.c"],
+     LIBS=[wtlib, shim, testutil] + wtlibs)
+Default(t)
 
 #env.Program("t_thread",
     #["test/thread/file.c",

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -643,6 +643,7 @@ extlist
 fadvise
 fallocate
 fblocks
+fc
 fclose
 fcntl
 fd

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -24,7 +24,9 @@ extern "C" {
  *******************************************/
 #ifndef _WIN32
 #include <sys/mman.h>
+#endif
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <sys/time.h>
 #include <sys/uio.h>
 #endif

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -239,7 +239,7 @@ typedef struct {
 } GLOBAL;
 extern GLOBAL g;
 
-typedef struct {
+typedef struct WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT) {
 	WT_RAND_STATE rnd;			/* thread RNG state */
 
 	uint64_t search;			/* operations */
@@ -261,7 +261,7 @@ typedef struct {
 #define	TINFO_COMPLETE	2			/* Finished */
 #define	TINFO_JOINED	3			/* Resolved */
 	volatile int state;			/* state */
-} TINFO WT_COMPILER_TYPE_ALIGN(WT_CACHE_LINE_ALIGNMENT);
+} TINFO;
 
 #ifdef HAVE_BERKELEY_DB
 void	 bdb_close(void);

--- a/test/format/rebalance.c
+++ b/test/format/rebalance.c
@@ -42,7 +42,8 @@ wts_rebalance(void)
 
 	/* Dump the current object. */
 	(void)snprintf(cmd, sizeof(cmd),
-	    "../../wt -h %s dump -f %s/rebalance.orig %s",
+	    ".." DIR_DELIM_STR ".." DIR_DELIM_STR "wt"
+	    " -h %s dump -f %s/rebalance.orig %s",
 	    g.home, g.home, g.uri);
 	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 
@@ -66,13 +67,18 @@ wts_rebalance(void)
 	wts_close();
 
 	(void)snprintf(cmd, sizeof(cmd),
-	    "../../wt -h %s dump -f %s/rebalance.new %s",
+	    ".." DIR_DELIM_STR ".." DIR_DELIM_STR "wt"
+	    " -h %s dump -f %s/rebalance.new %s",
 	    g.home, g.home, g.uri);
 	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 
 	/* Compare the old/new versions of the object. */
 	(void)snprintf(cmd, sizeof(cmd),
+#ifdef _WIN32
+	    "fc /b %s\\rebalance.orig %s\\rebalance.new > NUL",
+#else
 	    "cmp %s/rebalance.orig %s/rebalance.new > /dev/null",
+#endif
 	    g.home, g.home);
 	testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 }

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -319,17 +319,23 @@ path_setup(const char *home)
 	 */
 #undef	CMD
 #ifdef _WIN32
-#define	CMD	"test -e %s || mkdir %s; "				\
-		"cd %s && del /s /q * >:nul && rd /s /q KVS; "		\
-		"mkdir KVS"
+#define	CMD  "del /q rand.copy & " \
+	     "(IF EXIST %s\\rand copy /y %s\\rand rand.copy) & "	\
+	     "(IF EXIST %s rd /s /q %s) & mkdir %s & "			\
+	     "(IF EXIST rand.copy copy rand.copy %s\\rand) & " \
+	     "cd %s & mkdir KVS"
+	len = strlen(g.home) * 7 + strlen(CMD) + 1;
+	g.home_init = dmalloc(len);
+	snprintf(g.home_init, len, CMD,
+	    g.home, g.home, g.home, g.home, g.home, g.home, g.home);
 #else
 #define	CMD	"test -e %s || mkdir %s; "				\
 		"cd %s > /dev/null && rm -rf `ls | sed /rand/d`; "	\
 		"mkdir KVS"
-#endif
 	len = strlen(g.home) * 3 + strlen(CMD) + 1;
 	g.home_init = dmalloc(len);
 	snprintf(g.home_init, len, CMD, g.home, g.home, g.home);
+#endif
 
 	/* Primary backup directory. */
 	len = strlen(g.home) + strlen("BACKUP") + 2;
@@ -342,7 +348,7 @@ path_setup(const char *home)
 	 */
 #undef	CMD
 #ifdef _WIN32
-#define	CMD	"del %s/%s %s/%s /s /q >:nul && mkdir %s/%s %s/%s"
+#define	CMD	"rd /s /q %s\\%s %s\\%s & mkdir %s\\%s %s\\%s"
 #else
 #define	CMD	"rm -rf %s/%s %s/%s && mkdir %s/%s %s/%s"
 #endif

--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -128,6 +128,20 @@ tasks:
               ./test/fops/t
             fi
 
+  - name: format
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch binaries"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+            # format assumes we run it from the format directory
+            cmd.exe /c "cd test\\format && ..\\..\\t_format.exe reverse=0 encryption=none logging_compression=none runs=20"
+
 buildvariants:
 - name: ubuntu1404
   display_name: Ubuntu 14.04
@@ -165,6 +179,7 @@ buildvariants:
     - name: compile
     - name: compile-windows-alt
     - name: unit-test
+    #- name: format  - Enable when we have a solution for hangs and crashses
     - name: fops
 
 - name: osx-1010

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -82,12 +82,22 @@ testutil_clean_work_dir(char *dir)
 	int ret;
 	char *buf;
 
+#ifdef _WIN32
 	/* Additional bytes for the Windows rd command. */
+	len = 2 * strlen(dir) + strlen(RM_COMMAND) +
+		strlen(DIR_EXISTS_COMMAND) + 4;
+	if ((buf = malloc(len)) == NULL)
+		testutil_die(ENOMEM, "Failed to allocate memory");
+
+	snprintf(buf, len, "%s %s %s %s", DIR_EXISTS_COMMAND, dir,
+		 RM_COMMAND, dir);
+#else
 	len = strlen(dir) + strlen(RM_COMMAND) + 1;
 	if ((buf = malloc(len)) == NULL)
 		testutil_die(ENOMEM, "Failed to allocate memory");
 
 	snprintf(buf, len, "%s%s", RM_COMMAND, dir);
+#endif
 
 	if ((ret = system(buf)) != 0 && ret != ENOENT)
 		testutil_die(ret, "%s", buf);

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -47,7 +47,7 @@ testutil_parse_opts(int argc, char * const *argv, TEST_OPTS *opts)
 	opts->running = true;
 	opts->verbose = false;
 
-	if ((opts->progname = strrchr(argv[0], '/')) == NULL)
+	if ((opts->progname = strrchr(argv[0], DIR_DELIM)) == NULL)
 		opts->progname = argv[0];
 	else
 		++opts->progname;

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -29,9 +29,12 @@
 
 #ifdef _WIN32
 	#define DIR_DELIM '\\'
+	#define DIR_DELIM_STR "\\"
+	#define DIR_EXISTS_COMMAND "IF EXIST "
 	#define RM_COMMAND "rd /s /q "
 #else
 	#define	DIR_DELIM '/'
+	#define	DIR_DELIM_STR "/"
 	#define RM_COMMAND "rm -rf "
 #endif
 

--- a/test/windows/windows_shim.c
+++ b/test/windows/windows_shim.c
@@ -105,6 +105,17 @@ pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
 }
 
 int
+pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock)
+{
+	if (TryAcquireSRWLockExclusive(&rwlock->rwlock)) {
+		rwlock->exclusive_locked = GetCurrentThreadId();
+		return (0);
+	}
+
+	return (EBUSY);
+}
+
+int
 pthread_rwlock_wrlock(pthread_rwlock_t *rwlock)
 {
 	AcquireSRWLockExclusive(&rwlock->rwlock);

--- a/test/windows/windows_shim.h
+++ b/test/windows/windows_shim.h
@@ -30,6 +30,7 @@
 
 #define	WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <errno.h>
 #include <stdint.h>
 #include <direct.h>
 #include <io.h>

--- a/test/windows/windows_shim.h
+++ b/test/windows/windows_shim.h
@@ -109,6 +109,7 @@ int   pthread_rwlock_init(pthread_rwlock_t *,
     const pthread_rwlockattr_t *);
 int   pthread_rwlock_rdlock(pthread_rwlock_t *);
 int   pthread_rwlock_unlock(pthread_rwlock_t *);
+int   pthread_rwlock_trywrlock(pthread_rwlock_t *);
 int   pthread_rwlock_wrlock(pthread_rwlock_t *);
 
 int   pthread_create(pthread_t *, const pthread_attr_t *,


### PR DESCRIPTION
This PR adds support for running `test/format` on Windows.

1. Build format without Berkley DB,
2. Fix up various commands to run on Windows. In some cases, I needed to `ifdef` the test code.
3. Add one more pthread function to the test windows shim.
4. Random minor compilation fixes (`wt_internal.h`, `format.h`)

In terms of MCI integration, I put in an example task but I have not enabled it until there is a solution for handling crashes & hangs in Evergreen in general.
