### PR TITLE
WT-2866 Fix warning.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -844,7 +844,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 	/* If this queue is full, try the other one. */
 	if (__evict_queue_full(queue) && !__evict_queue_full(other_queue))
 		queue = other_queue;
-	other_queue = cache->evict_fill_queue =
+	cache->evict_fill_queue =
 	    &cache->evict_queues[1 - (queue - cache->evict_queues)];
 
 	/*


### PR DESCRIPTION
src/evict/evict_lru.c  977  Warning 438: Last value assigned to
variable 'other_queue' (defined at line 830) not used

@keithbostic Please review this change to fix the warning.