### PR TITLE
WT-2867 Review and fix barrier usage in __lsm_tree_close

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -412,7 +412,7 @@ extern int __wt_lsm_manager_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 extern int __wt_lsm_manager_start(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_lsm_manager_free_work_unit( WT_SESSION_IMPL *session, WT_LSM_WORK_UNIT *entry);
 extern int __wt_lsm_manager_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_lsm_manager_clear_tree( WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_lsm_manager_clear_tree(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree);
 extern int __wt_lsm_manager_pop_entry( WT_SESSION_IMPL *session, uint32_t type, WT_LSM_WORK_UNIT **entryp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_manager_push_entry(WT_SESSION_IMPL *session, uint32_t type, uint32_t flags, WT_LSM_TREE *lsm_tree) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_merge_update_tree(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int start_chunk, u_int nchunks, WT_LSM_CHUNK *chunk) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -491,9 +491,8 @@ err:		WT_PANIC_MSG(session, ret, "LSM worker manager thread error");
  *	introduces an inefficiency if LSM trees are being opened and closed
  *	regularly.
  */
-int
-__wt_lsm_manager_clear_tree(
-    WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
+void
+__wt_lsm_manager_clear_tree(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 {
 	WT_LSM_MANAGER *manager;
 	WT_LSM_WORK_UNIT *current, *next;
@@ -541,7 +540,6 @@ __wt_lsm_manager_clear_tree(
 	}
 	__wt_spin_unlock(session, &manager->manager_lock);
 	WT_STAT_FAST_CONN_INCRV(session, lsm_work_units_discarded, removed);
-	return (0);
 }
 
 /*

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -97,7 +97,7 @@ __lsm_tree_close(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, bool final)
 	 * the tree queue state.
 	 */
 	lsm_tree->active = false;
-	WT_READ_BARRIER();
+	WT_FULL_BARRIER();
 
 	/*
 	 * Wait for all LSM operations to drain. If WiredTiger is shutting

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -384,6 +384,11 @@ __lsm_tree_find(WT_SESSION_IMPL *session,
 				 */
 				(void)__wt_atomic_add32(&lsm_tree->refcnt, 1);
 				__lsm_tree_close(session, lsm_tree, false);
+				if (lsm_tree->refcnt != 1) {
+					__wt_lsm_tree_release(
+					    session, lsm_tree);
+					return (EBUSY);
+				}
 			} else {
 				(void)__wt_atomic_add32(&lsm_tree->refcnt, 1);
 

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -85,10 +85,9 @@ __lsm_tree_discard(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, bool final)
  * __lsm_tree_close --
  *	Close an LSM tree structure.
  */
-static int
+static void
 __lsm_tree_close(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, bool final)
 {
-	WT_DECL_RET;
 	int i;
 
 	/*
@@ -120,17 +119,11 @@ __lsm_tree_close(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, bool final)
 		 * other schema level operations will return EBUSY, even though
 		 * we're dropping the schema lock here.
 		 */
-		if (i % WT_THOUSAND == 0) {
-			WT_WITHOUT_LOCKS(session, ret =
+		if (i % WT_THOUSAND == 0)
+			WT_WITHOUT_LOCKS(session,
 			    __wt_lsm_manager_clear_tree(session, lsm_tree));
-			WT_ERR(ret);
-		}
 		__wt_yield();
 	}
-	return (0);
-
-err:	lsm_tree->active = true;
-	return (ret);
 }
 
 /*
@@ -154,7 +147,7 @@ __wt_lsm_tree_close_all(WT_SESSION_IMPL *session)
 		 * is unconditional.
 		 */
 		(void)__wt_atomic_add32(&lsm_tree->refcnt, 1);
-		WT_TRET(__lsm_tree_close(session, lsm_tree, true));
+		__lsm_tree_close(session, lsm_tree, true);
 		WT_TRET(__lsm_tree_discard(session, lsm_tree, true));
 	}
 
@@ -390,13 +383,7 @@ __lsm_tree_find(WT_SESSION_IMPL *session,
 				 * spurious busy returns.
 				 */
 				(void)__wt_atomic_add32(&lsm_tree->refcnt, 1);
-				if (__lsm_tree_close(
-				    session, lsm_tree, false) != 0 ||
-				    lsm_tree->refcnt != 1) {
-					__wt_lsm_tree_release(
-					    session, lsm_tree);
-					return (EBUSY);
-				}
+				__lsm_tree_close(session, lsm_tree, false);
 			} else {
 				(void)__wt_atomic_add32(&lsm_tree->refcnt, 1);
 


### PR DESCRIPTION
@agorrod, I took a look at this, and the ticket is correct, the barrier should be a full-barrier, not a read-barrier.

I also cleaned up a couple of routines that can return void, not int.

EDIT: I backed out the tricky change -- on second thought, it was incorrect, and this change is now really vanilla.