### PR TITLE
WT-2916 Fix and simplify s_whitespace.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -830,7 +830,7 @@ config_consolidate(CONFIG *cfg)
 	CONFIG_QUEUE_ENTRY *conf_line, *test_line, *tmp;
 	char *string_key;
 
-	/* 
+	/*
 	 * This loop iterates over the config queue and for entry checks if an
 	 * entry later in the queue has the same key. If a match is found then
 	 * the current queue entry is removed and we continue.

--- a/dist/api_config.py
+++ b/dist/api_config.py
@@ -330,7 +330,7 @@ __wt_conn_config_discard(WT_SESSION_IMPL *session)
 \t__wt_free(session, conn->config_entries);
 }
 
-/*        
+/*
  * __wt_conn_config_match --
  *      Return the static configuration entry for a method.
  */

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -818,7 +818,7 @@ methods = {
         type='int'),
 ]),
 
-'WT_SESSION.create' : Method(file_config + lsm_config + source_meta + 
+'WT_SESSION.create' : Method(file_config + lsm_config + source_meta +
         index_only_config + table_only_config + [
     Config('exclusive', 'false', r'''
         fail if the object exists.  When false (the default), if the

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -1,7 +1,7 @@
 # Data for log.py, describes the format of log records
 
 # There are a small number of main log record types.
-# 
+#
 # Some log record types, such as transaction commit, also include a list of
 # "log operations" within the same log record.  Both log record types and log
 # operations are described here.

--- a/dist/s_c_test_create
+++ b/dist/s_c_test_create
@@ -64,9 +64,9 @@ mkdir $CSUITE_DIRECTORY/$TEST_NAME
 #include "test_util.h"
 
 /*
- * JIRA ticket reference: 
- * Test case description: 
- * Failure mode: 
+ * JIRA ticket reference:
+ * Test case description:
+ * Failure mode:
  */
 
 void (*custom_die)(void) = NULL;
@@ -91,7 +91,6 @@ main(int argc, char *argv[])
 }
 EOF
 ) > $CSUITE_DIRECTORY/$TEST_NAME/main.c
-
 
 # Now update the C test suite makefile to include the new test case
 

--- a/dist/s_export
+++ b/dist/s_export
@@ -17,7 +17,6 @@ Darwin)
 	;;
 esac
 
-
 check()
 {
 	(sed -e '/^#/d' s_export.list &&

--- a/dist/s_release_docs
+++ b/dist/s_release_docs
@@ -76,4 +76,3 @@ echo "Rebuild documentation root"
 echo "Finished packaging documentation, you should now push the results. Run:"
 echo "cd $DOC_DIR && git push origin"
 echo "To backout changes run 'git reset HEAD~1'"
-

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -24,7 +24,7 @@ find bench dist examples ext src test \
     -name 's_*' -o \
     -name 'Makefile.am' |
     sed -e '/Makefile.in/d' \
-	-e '/checksum\/power8/d' \
+        -e '/checksum\/power8/d' \
         -e '/3rdparty/d' \
         -e '/docs\/tools/d' \
 | while read f ; do

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -4,46 +4,29 @@
 t=__wt.$$
 trap 'rm -f $t; exit 0' 0 1 2 3 13 15
 
-# Clear lines that only contain whitespace, discard trailing empty lines.
-whitespace()
-{
-	sed -e 's/[	 ][	 ]*$//' \
-	    -e '${' \
-	    -e '/^$/d' \
-	    -e '}' < $1 > $t
-	cmp $t $1 > /dev/null 2>&1 || (echo "$1" && cp $t $1)
-}
-
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.
-whitespace_and_empty_line()
+whitespace()
 {
-	sed -e 's/[	 ][	 ]*$//' \
-	    -e '/^$/N' \
-	    -e '/\n$/D' < $1 > $t
+	sed -e 's/[	 ][	 ]*$//' < $1 | \
+	    cat -s | \
+	    sed -e '${' -e '/^$/d' -e '}' > $t
 	cmp $t $1 > /dev/null 2>&1 || (echo "$1" && cp $t $1)
 }
 
 cd ..
 
-# Scripts.
-for f in `find dist -name '*.py' -name 's_*'`; do
-	whitespace_and_empty_line $f
-done
-
-# C-language sources.
-for f in `find bench examples ext src test \
+find bench dist examples ext src test \
     -name '*.[chi]' -o \
     -name '*.dox' -o \
     -name '*.in' -o \
+    -name '*.py' -o \
+    -name 's_*' -o \
     -name 'Makefile.am' |
     sed -e '/Makefile.in/d' \
-	-e '/checksum\/power8/d'`; do
-	whitespace_and_empty_line $f
-done
-
-# Python sources.
-for f in `find test \
-    -name '*.py' | sed '/3rdparty/d'`; do
+	-e '/checksum\/power8/d' \
+        -e '/3rdparty/d' \
+        -e '/docs\/tools/d' \
+| while read f ; do
 	whitespace $f
 done

--- a/dist/style.py
+++ b/dist/style.py
@@ -35,7 +35,6 @@ def lines_could_join():
                     print '\t' + m.group(1).lstrip() + m.group(2)
                     print
 
-
 missing_comment()
 
 # Don't display lines that could be joined by default; in some cases, the code

--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -501,7 +501,7 @@ main(void)
 	ret = session->open_cursor(session, "table:crypto2", NULL, NULL, &c2);
 	ret = session->open_cursor(session, "table:nocrypto", NULL, NULL, &nc);
 
-	/* 
+	/*
 	 * Insert a set of keys and values.  Insert the same data into
 	 * all tables so that we can verify they're all the same after
 	 * we decrypt on read.

--- a/examples/c/ex_stat.c
+++ b/examples/c/ex_stat.c
@@ -63,7 +63,7 @@ print_cursor(WT_CURSOR *cursor)
 }
 /*! [statistics display function] */
 
-int 
+int
 print_database_stats(WT_SESSION *session)
 {
 	WT_CURSOR *cursor;
@@ -81,7 +81,7 @@ print_database_stats(WT_SESSION *session)
 	return (ret);
 }
 
-int 
+int
 print_file_stats(WT_SESSION *session)
 {
 	WT_CURSOR *cursor;
@@ -99,7 +99,7 @@ print_file_stats(WT_SESSION *session)
 	return (ret);
 }
 
-int 
+int
 print_join_cursor_stats(WT_SESSION *session)
 {
 	WT_CURSOR *idx_cursor, *join_cursor, *stat_cursor;

--- a/examples/python/ex_stat.py
+++ b/examples/python/ex_stat.py
@@ -32,7 +32,6 @@
 import os
 from wiredtiger import wiredtiger_open,WIREDTIGER_VERSION_STRING,stat
 
-
 def main():
     # Create a clean test directory for this run of the test program
     os.system('rm -rf WT_HOME')
@@ -58,18 +57,15 @@ def main():
     print_derived_stats(session)
     conn.close()
 
-
 def print_database_stats(session):
     statcursor = session.open_cursor("statistics:")
     print_cursor(statcursor)
     statcursor.close()
 
-
 def print_file_stats(session):
     fstatcursor = session.open_cursor("statistics:table:access")
     print_cursor(fstatcursor)
     fstatcursor.close()
-
 
 def print_overflow_pages(session):
     ostatcursor = session.open_cursor("statistics:table:access")
@@ -77,7 +73,6 @@ def print_overflow_pages(session):
     if val != 0:
         print '%s=%s' % (str(val[0]), str(val[1]))
     ostatcursor.close()
-
 
 def print_derived_stats(session):
     dstatcursor = session.open_cursor("statistics:table:access")
@@ -97,7 +92,6 @@ def print_derived_stats(session):
         print "Write amplification is " + '{:.2f}'.format(fs_writes / (app_insert + app_remove + app_update))
     dstatcursor.close()
 
-
 def print_cursor(mycursor):
     while mycursor.next() == 0:
         val = mycursor.get_value()
@@ -106,4 +100,3 @@ def print_cursor(mycursor):
 
 if __name__ == "__main__":
     main()
-

--- a/ext/datasources/helium/helium.c
+++ b/ext/datasources/helium/helium.c
@@ -1942,7 +1942,7 @@ err:		if (ws != NULL)
 			ESET(ws_source_close(wtext, session, ws));
 	}
 
-	/*      
+	/*
 	 * If there was an error or our caller doesn't need the global lock,
 	 * release the global lock.
 	 */

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -352,7 +352,7 @@ __wt_block_verify_addr(WT_SESSION_IMPL *session,
 	WT_RET(
 	    __wt_block_buffer_to_addr(block, addr, &offset, &size, &checksum));
 
-	/* Add to the per-file list. */ 
+	/* Add to the per-file list. */
 	WT_RET(
 	    __verify_filefrag_add(session, block, NULL, offset, size, false));
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -235,7 +235,7 @@ __cursor_col_search(
 {
 	WT_DECL_RET;
 
-	WT_WITH_PAGE_INDEX(session, 
+	WT_WITH_PAGE_INDEX(session,
 	    ret = __wt_col_search(session, cbt->iface.recno, leaf, cbt));
 	return (ret);
 }
@@ -250,7 +250,7 @@ __cursor_row_search(
 {
 	WT_DECL_RET;
 
-	WT_WITH_PAGE_INDEX(session, 
+	WT_WITH_PAGE_INDEX(session,
 	    ret = __wt_row_search(session, &cbt->iface.key, leaf, cbt, insert));
 	return (ret);
 }

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -210,7 +210,7 @@ leaf_only:
 	page = current->page;
 	cbt->ref = current;
 
-	/* 
+	/*
 	 * Don't bother searching if the caller is appending a new record where
 	 * we'll allocate the record number; we're not going to find a match by
 	 * definition, and we figure out the record number and position when we

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -113,7 +113,7 @@ wiredtiger_config_validate(WT_SESSION *wt_session,
 
 	session = (WT_SESSION_IMPL *)wt_session;
 
-	/* 
+	/*
 	 * It's a logic error to specify both a session and an event handler.
 	 */
 	if (session != NULL && handler != NULL)

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -1323,7 +1323,7 @@ __wt_conn_config_discard(WT_SESSION_IMPL *session)
 	__wt_free(session, conn->config_entries);
 }
 
-/*        
+/*
  * __wt_conn_config_match --
  *      Return the static configuration entry for a method.
  */

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -925,7 +925,7 @@ __wt_logmgr_open(WT_SESSION_IMPL *session)
 
 	conn = S2C(session);
 
-	/* If no log thread services are configured, we're done. */ 
+	/* If no log thread services are configured, we're done. */
 	if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
 		return (0);
 

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -184,12 +184,12 @@ __curds_next(WT_CURSOR *cursor)
 
 	CURSOR_API_CALL(cursor, session, next, NULL);
 
-	WT_STAT_CONN_INCR(session, cursor_next); 
+	WT_STAT_CONN_INCR(session, cursor_next);
 	WT_STAT_DATA_INCR(session, cursor_next);
 
 	WT_ERR(__curds_txn_enter(session));
 
-	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);         
+	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 	ret = __curds_cursor_resolve(cursor, source->next(source));
 
 err:	__curds_txn_leave(session);
@@ -217,7 +217,7 @@ __curds_prev(WT_CURSOR *cursor)
 
 	WT_ERR(__curds_txn_enter(session));
 
-	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);         
+	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 	ret = __curds_cursor_resolve(cursor, source->prev(source));
 
 err:	__curds_txn_leave(session);
@@ -239,7 +239,7 @@ __curds_reset(WT_CURSOR *cursor)
 
 	CURSOR_API_CALL(cursor, session, reset, NULL);
 
-	WT_STAT_CONN_INCR(session, cursor_reset);      
+	WT_STAT_CONN_INCR(session, cursor_reset);
 	WT_STAT_DATA_INCR(session, cursor_reset);
 
 	WT_ERR(source->reset(source));
@@ -323,7 +323,7 @@ __curds_insert(WT_CURSOR *cursor)
 
 	WT_ERR(__curds_txn_enter(session));
 
-	WT_STAT_CONN_INCR(session, cursor_insert);     
+	WT_STAT_CONN_INCR(session, cursor_insert);
 	WT_STAT_DATA_INCR(session, cursor_insert);
 	WT_STAT_DATA_INCRV(session,
 	    cursor_insert_bytes, cursor->key.size + cursor->value.size);
@@ -354,7 +354,7 @@ __curds_update(WT_CURSOR *cursor)
 
 	CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
 
-	WT_STAT_CONN_INCR(session, cursor_update);     
+	WT_STAT_CONN_INCR(session, cursor_update);
 	WT_STAT_DATA_INCR(session, cursor_update);
 	WT_STAT_DATA_INCRV(session, cursor_update_bytes, cursor->value.size);
 
@@ -385,7 +385,7 @@ __curds_remove(WT_CURSOR *cursor)
 
 	CURSOR_REMOVE_API_CALL(cursor, session, NULL);
 
-	WT_STAT_CONN_INCR(session, cursor_remove);     
+	WT_STAT_CONN_INCR(session, cursor_remove);
 	WT_STAT_DATA_INCR(session, cursor_remove);
 	WT_STAT_DATA_INCRV(session, cursor_remove_bytes, cursor->key.size);
 

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -566,7 +566,7 @@ statistics will be logged to the file; if the database is configured
 with "all" or "fast", the corresponding statistics will be logged to the
 file.
 
-In previous releases, the WT_SESSION::cursor method took 
+In previous releases, the WT_SESSION::cursor method took
 \c statistics_clear and a \c statistics_fast configurations.  The
 \c statistics_clear configuration defaulted to false; when set to true,
 statistics counters were reset after they were gathered by the cursor.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -376,7 +376,7 @@ __wt_evict_create(WT_SESSION_IMPL *session)
 	    conn->evict_threads_max, WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL,
 	    __wt_evict_thread_run));
 
-	/* 
+	/*
 	 * Allow queues to be populated now that the eviction threads
 	 * are running.
 	 */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -21,7 +21,7 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
 	txn = &session->txn;
 	*opp = NULL;
 
-	/* 
+	/*
 	 * We're about to perform an update.
 	 * Make sure we have allocated a transaction ID.
 	 */

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -668,7 +668,7 @@ retry:	if (F_ISSET(clsm, WT_CLSM_MERGE)) {
 
 	clsm->dsk_gen = lsm_tree->dsk_gen;
 
-err:	
+err:
 #ifdef HAVE_DIAGNOSTIC
 	/* Check that all cursors are open as expected. */
 	if (ret == 0 && F_ISSET(clsm, WT_CLSM_OPEN_READ)) {

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -54,7 +54,7 @@ __wt_metadata_cursor_open(
 	 */
 	btree = ((WT_CURSOR_BTREE *)(*cursorp))->btree;
 
-	/* 
+	/*
 	 * Special settings for metadata: skew eviction so metadata almost
 	 * always stays in cache and make sure metadata is logged if possible.
 	 *

--- a/src/utilities/util_stat.c
+++ b/src/utilities/util_stat.c
@@ -70,7 +70,6 @@ util_stat(WT_SESSION *session, int argc, char *argv[])
 	}
 	snprintf(uri, urilen, "statistics:%s", objname);
 
-	
 	if ((ret =
 	    session->open_cursor(session, uri, NULL, config, &cursor)) != 0) {
 		fprintf(stderr, "%s: cursor open(%s) failed: %s\n",

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 	testutil_check(testutil_parse_opts(argc, argv, opts));
 	testutil_make_work_dir(opts->home);
 
-	snprintf(buf, sizeof(buf), 
+	snprintf(buf, sizeof(buf),
 	    "create,"
 	    "cache_size=%s,"
 	    "eviction=(threads_max=5),"

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -796,7 +796,7 @@ config_find(const char *s, size_t len)
 {
 	CONFIG *cp;
 
-	for (cp = c; cp->name != NULL; ++cp) 
+	for (cp = c; cp->name != NULL; ++cp)
 		if (strncmp(s, cp->name, len) == 0 && cp->name[len] == '\0')
 			return (cp);
 

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -37,7 +37,7 @@ typedef struct {
 	/* Value is a boolean, yes if roll of 1-to-100 is <= CONFIG->min. */
 #define	C_BOOL		0x001
 
-	/* Not a simple randomization, handle outside the main loop. */ 
+	/* Not a simple randomization, handle outside the main loop. */
 #define	C_IGNORE	0x002
 
 	/* Value was set from command-line or file, ignore for all runs. */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -202,7 +202,7 @@ typedef struct {
 	uint32_t c_verify;
 	uint32_t c_write_pct;
 
-#define	FIX				1	
+#define	FIX				1
 #define	ROW				2
 #define	VAR				3
 	u_int type;				/* File type's flag value */

--- a/test/suite/test_async01.py
+++ b/test/suite/test_async01.py
@@ -107,7 +107,6 @@ class Callback(wiredtiger.AsyncCallback):
 
         return 0
 
-
 # test_async01.py
 #    Async operations
 # Basic smoke-test of file and table async ops: tests get/set key, insert
@@ -260,7 +259,6 @@ class test_async01(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertTrue(callback.nsearch == self.nentries * 2)
         self.assertTrue(callback.nupdate == self.nentries)
         self.assertTrue(callback.nerror == 0)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_async02.py
+++ b/test/suite/test_async02.py
@@ -104,7 +104,6 @@ class Callback(wiredtiger.AsyncCallback):
 
         return 0
 
-
 # test_async02.py
 #    Async operations
 # Basic smoke-test of file and table async ops: tests get/set key, insert
@@ -218,7 +217,6 @@ class test_async02(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Make sure all callbacks went according to plan.
         self.assertTrue(callback.nerror == 0)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_async03.py
+++ b/test/suite/test_async03.py
@@ -36,7 +36,6 @@ class Callback(wiredtiger.AsyncCallback):
     def notify(self, op, op_ret, flags):
         raise AssertionError('callback should not be called in this test')
 
-
 # test_async03.py
 #    Async operations
 # Try to run async code with an incorrect connection config.

--- a/test/suite/test_backup03.py
+++ b/test/suite/test_backup03.py
@@ -149,6 +149,5 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate()
         self.backup_table_cursor(self.list)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_backup04.py
+++ b/test/suite/test_backup04.py
@@ -171,6 +171,5 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
         self.compare(self.uri, full_dir, self.dir)
         self.compare(self.uri, None, self.dir)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -80,7 +80,6 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.drop(self.emptyuri, None)
             self.session.create(self.emptyuri, self.create_params)
 
-
         # Open the new directory and verify
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)

--- a/test/suite/test_bug001.py
+++ b/test/suite/test_bug001.py
@@ -100,7 +100,6 @@ class test_bug001(wttest.WiredTigerTestCase):
         self.assertEquals(cursor.close(), 0)
         self.session.drop(uri)
 
-
     # Test a bug where cursor remove inside implicit records looped infinitely.
     def test_implicit_record_cursor_remove(self):
         uri='file:xxx'
@@ -148,7 +147,6 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         self.assertEquals(cursor.close(), 0)
         self.session.drop(uri)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug003.py
+++ b/test/suite/test_bug003.py
@@ -54,6 +54,5 @@ class test_bug003(wttest.WiredTigerTestCase):
             self.session.checkpoint()
         cursor = self.session.open_cursor(self.uri, None, "bulk")
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug004.py
+++ b/test/suite/test_bug004.py
@@ -90,6 +90,5 @@ class test_bug004(wttest.WiredTigerTestCase):
             self.assertEquals(
                 c1.get_value(), value_populate(c1, i) + 'abcdef' * 100)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug005.py
+++ b/test/suite/test_bug005.py
@@ -59,6 +59,5 @@ class test_bug005(wttest.WiredTigerTestCase):
         # Verify the object again.
         self.session.verify(self.uri)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug006.py
+++ b/test/suite/test_bug006.py
@@ -74,6 +74,5 @@ class test_bug006(wttest.WiredTigerTestCase):
 
         self.session.drop(uri, None)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug007.py
+++ b/test/suite/test_bug007.py
@@ -56,6 +56,5 @@ class test_bug007(wttest.WiredTigerTestCase):
         # Forced salvage should succeed.
         self.session.salvage(uri, "force")
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug008.py
+++ b/test/suite/test_bug008.py
@@ -297,6 +297,5 @@ class test_bug008(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_key(), key_populate(cursor, 119))
             self.assertEqual(cursor.get_value(), value_populate(cursor, 119))
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug016.py
+++ b/test/suite/test_bug016.py
@@ -104,6 +104,5 @@ class test_bug016(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: cursor.get_key(), "/requires key be set/")
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bulk01.py
+++ b/test/suite/test_bulk01.py
@@ -214,6 +214,5 @@ class test_bulk_load(wttest.WiredTigerTestCase):
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(uri, None, "bulk"))
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bulk02.py
+++ b/test/suite/test_bulk02.py
@@ -126,6 +126,5 @@ class test_bulkload_backup(wttest.WiredTigerTestCase, suite_subprocess):
         else:
             self.check_backup(self.conn.open_session())
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -136,7 +136,6 @@ class test_checkpoint(wttest.WiredTigerTestCase):
                 (self.checkpoints[checkpoint_name][0], 0)
         self.check()
 
-
 # Check some specific cursor checkpoint combinations.
 class test_checkpoint_cursor(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([
@@ -202,7 +201,6 @@ class test_checkpoint_cursor(wttest.WiredTigerTestCase):
         self.session.checkpoint("drop=(checkpoint-2)")
         self.session.checkpoint("drop=(from=all)")
 
-
 # Check that you can checkpoint targets.
 class test_checkpoint_target(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([
@@ -249,7 +247,6 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
         self.check(self.uri + '2', 'UPDATE')
         self.check(self.uri + '3', 'ORIGINAL')
 
-
 # Check that you can't write checkpoint cursors.
 class test_checkpoint_cursor_update(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([
@@ -273,7 +270,6 @@ class test_checkpoint_cursor_update(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: cursor.update(), msg)
         cursor.close()
-
 
 # Check that WiredTigerCheckpoint works as a checkpoint specifier.
 class test_checkpoint_last(wttest.WiredTigerTestCase):
@@ -306,7 +302,6 @@ class test_checkpoint_last(wttest.WiredTigerTestCase):
             # Don't close the checkpoint cursor, we want it to remain open until
             # the test completes.
 
-
 # Check we can't use the reserved name as an application checkpoint name.
 class test_checkpoint_illegal_name(wttest.WiredTigerTestCase):
     def test_checkpoint_illegal_name(self):
@@ -331,7 +326,6 @@ class test_checkpoint_illegal_name(wttest.WiredTigerTestCase):
                 self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                     lambda: self.session.checkpoint(conf), msg)
 
-
 # Check we can't name checkpoints that include LSM tables.
 class test_checkpoint_lsm_name(wttest.WiredTigerTestCase):
     def test_checkpoint_lsm_name(self):
@@ -340,7 +334,6 @@ class test_checkpoint_lsm_name(wttest.WiredTigerTestCase):
         msg = '/object does not support named checkpoints/'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("name=ckpt"), msg)
-
 
 class test_checkpoint_empty(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([
@@ -416,7 +409,6 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=WiredTigerCheckpoint")
         self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint02.py
+++ b/test/suite/test_checkpoint02.py
@@ -84,6 +84,5 @@ class test_checkpoint02(wttest.WiredTigerTestCase):
 
         self.assertEqual(i, self.nops)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_colgap.py
+++ b/test/suite/test_colgap.py
@@ -119,7 +119,6 @@ class test_column_store_gap(wttest.WiredTigerTestCase):
         self.forward(cursor, v)
         self.backward(cursor, list(reversed(v)))
 
-
 # Basic testing of variable-length column-store with big records.
 class test_colmax(wttest.WiredTigerTestCase):
     name = 'test_colmax'
@@ -203,7 +202,6 @@ class test_colmax(wttest.WiredTigerTestCase):
         self.assertEqual(cursor.remove(), 0)
         cursor.set_key(key_populate(cursor, recno))
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_collator.py
+++ b/test/suite/test_collator.py
@@ -155,6 +155,5 @@ class test_collator(wttest.WiredTigerTestCase):
         self.create_indices()
         self.check_entries()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -100,6 +100,5 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertLess(stat_cursor[stat.dsrc.btree_row_leaf][2], self.maxpages)
         stat_cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -147,6 +147,5 @@ class test_compact02(wttest.WiredTigerTestCase):
         # After compact, the file size should be less than half the full size.
         self.assertLess(sz, self.fullsize / 2)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_compress01.py
+++ b/test/suite/test_compress01.py
@@ -101,6 +101,5 @@ class test_compress01(wttest.WiredTigerTestCase):
                 self.assertEquals(cursor.get_value(), `idx` + "abcdefg")
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_config06.py
+++ b/test/suite/test_config06.py
@@ -88,6 +88,5 @@ class test_config06(wttest.WiredTigerTestCase):
         cursor[k] = v
         self.assertEquals(cursor[k[:1]], v[:1])
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_cursor02.py
+++ b/test/suite/test_cursor02.py
@@ -150,6 +150,5 @@ class test_cursor02(TestCursorTracker):
         self.cur_check_forward(cursor, -1)
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_cursor_compare.py
+++ b/test/suite/test_cursor_compare.py
@@ -241,6 +241,5 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(
             wiredtiger.WiredTigerError, lambda: cX.equals(c1), msg)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_cursor_pin.py
+++ b/test/suite/test_cursor_pin.py
@@ -114,6 +114,5 @@ class test_cursor_pin(wttest.WiredTigerTestCase):
             list(range(self.nentries + 1, self.nentries + 1000) +\
                  range(self.nentries + 2001, self.nentries + 3000)))
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -147,7 +147,6 @@ class test_cursor_random_column(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.open_cursor(self.uri, None, "next_random=true"), msg)
 
-
 # Check next_random works in the presence a set of updates, some or all of
 # which are invisible to the cursor.
 class test_cursor_random_invisible(wttest.WiredTigerTestCase):
@@ -216,7 +215,6 @@ class test_cursor_random_invisible(wttest.WiredTigerTestCase):
         cursor = s.open_cursor(uri, None, self.config)
         self.assertEquals(cursor.next(), 0)
         self.assertEqual(cursor.get_key(), key_populate(cursor, 99))
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_encrypt01.py
+++ b/test/suite/test_encrypt01.py
@@ -138,6 +138,5 @@ class test_encrypt01(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.get_value(), val)
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_encrypt03.py
+++ b/test/suite/test_encrypt03.py
@@ -97,6 +97,5 @@ class test_encrypt03(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.create(self.uri, params), msg)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_encrypt04.py
+++ b/test/suite/test_encrypt04.py
@@ -230,6 +230,5 @@ class test_encrypt04(wttest.WiredTigerTestCase, suite_subprocess):
             cursor.close()
         self.assertEqual(self.expect_forceerror, self.got_forceerror)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_encrypt06.py
+++ b/test/suite/test_encrypt06.py
@@ -128,7 +128,6 @@ class test_encrypt06(wttest.WiredTigerTestCase):
         else:
             return ',encryption=(name=' + name + args + ')'
 
-
     def match_string_in_file(self, fname, match):
         with open(fname, 'rb') as f:
             return (f.read().find(match) != -1)
@@ -222,7 +221,6 @@ class test_encrypt06(wttest.WiredTigerTestCase):
                          not self.match_string_in_rundir(txt0))
         self.assertEqual(self.expected_encryption(self.encrypt1),
                          not self.match_string_in_rundir(txt1))
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_excl.py
+++ b/test/suite/test_excl.py
@@ -44,6 +44,5 @@ class test_create_excl(wttest.WiredTigerTestCase):
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: self.session.create(uri, "exclusive"))
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_home.py
+++ b/test/suite/test_home.py
@@ -43,7 +43,6 @@ class test_isnew(wttest.WiredTigerTestCase):
         self.conn = self.setUpConnectionOpen(".")
         self.assertEquals(self.conn.is_new(), False)
 
-
 # test_gethome
 #    database get-home method
 class test_gethome(wttest.WiredTigerTestCase):
@@ -60,7 +59,6 @@ class test_gethome(wttest.WiredTigerTestCase):
         self.conn = self.setUpConnectionOpen(name)
         self.assertEquals(self.conn.get_home(), name)
 
-
 # test_base_config
 #       test base configuration file config.
 class test_base_config(wttest.WiredTigerTestCase):
@@ -73,7 +71,6 @@ class test_base_config(wttest.WiredTigerTestCase):
         conn = self.wiredtiger_open("A", "create,config_base=false")
         self.assertFalse(os.path.exists("A/WiredTiger.basecfg"))
         conn.close()
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_huffman01.py
+++ b/test/suite/test_huffman01.py
@@ -72,7 +72,6 @@ class test_huffman01(wttest.WiredTigerTestCase, suite_subprocess):
         config=self.huffkey + self.huffval
         self.session.create(self.table_name, config)
 
-
 # Test Huffman encoding ranges.
 class test_huffman_range(wttest.WiredTigerTestCase):
     table_name = 'table:test_huff'
@@ -122,7 +121,6 @@ class test_huffman_range(wttest.WiredTigerTestCase):
         msg = '/duplicate symbol/'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.create(self.table_name, config), msg)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_join03.py
+++ b/test/suite/test_join03.py
@@ -152,6 +152,5 @@ class test_join03(wttest.WiredTigerTestCase):
             for csvformat in [ 'SS', 'ii', 'Si', 'iS' ]:
                 self.join(csvformat, '', extraargs)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_join04.py
+++ b/test/suite/test_join04.py
@@ -163,6 +163,5 @@ class test_join04(wttest.WiredTigerTestCase):
             for c in cursors:
                 c.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_join08.py
+++ b/test/suite/test_join08.py
@@ -259,6 +259,5 @@ class test_join08(wttest.WiredTigerTestCase):
         jcursor.close()
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -398,6 +398,5 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.drop(self.table_uri5)
         self.session.drop(self.table_uri6)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_metadata_cursor01.py
+++ b/test/suite/test_metadata_cursor01.py
@@ -83,7 +83,6 @@ class test_metadata_cursor01(wttest.WiredTigerTestCase):
         self.session_create(tablearg, create_args)
         self.pr('creating cursor')
 
-
     # Forward iteration.
     def test_forward_iter(self):
         self.create_table()

--- a/test/suite/test_overwrite.py
+++ b/test/suite/test_overwrite.py
@@ -135,6 +135,5 @@ class test_overwrite(wttest.WiredTigerTestCase):
         cursor.set_value('XXXXXXXXXX')
         self.assertEquals(cursor.update(), 0)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_readonly03.py
+++ b/test/suite/test_readonly03.py
@@ -57,7 +57,6 @@ class test_readonly03(wttest.WiredTigerTestCase, suite_subprocess):
         self.create = False
         return conn
 
-
     def test_readonly(self):
         create_params = 'key_format=i,value_format=i'
         entries = 10

--- a/test/suite/test_rebalance.py
+++ b/test/suite/test_rebalance.py
@@ -76,6 +76,5 @@ class test_rebalance(wttest.WiredTigerTestCase):
             self.rebalance(complex_populate, False)
             self.rebalance(complex_populate, True)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_schema02.py
+++ b/test/suite/test_schema02.py
@@ -279,6 +279,5 @@ class test_schema02(wttest.WiredTigerTestCase):
         self.populate()
         self.check_entries()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_schema03.py
+++ b/test/suite/test_schema03.py
@@ -151,7 +151,6 @@ class tabconfig:
                         idx.formats += self.valueformats[colno - self.nkeys]
                 prob *= 0.5
 
-
 class cgconfig:
     """
     Configuration for a column group used in the test.

--- a/test/suite/test_schema04.py
+++ b/test/suite/test_schema04.py
@@ -122,6 +122,5 @@ class test_schema04(wttest.WiredTigerTestCase):
             self.create_indices()
         self.check_entries()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_schema05.py
+++ b/test/suite/test_schema05.py
@@ -169,6 +169,5 @@ class test_schema05(wttest.WiredTigerTestCase):
         self.create_indices()
         self.check_entries()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_stat02.py
+++ b/test/suite/test_stat02.py
@@ -78,7 +78,6 @@ class test_stat_cursor_config(wttest.WiredTigerTestCase):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.open_cursor('statistics:', None, config), msg)
 
-
 # Test the connection "clear" configuration.
 class test_stat_cursor_conn_clear(wttest.WiredTigerTestCase):
     pfx = 'test_stat_cursor_conn_clear'
@@ -98,7 +97,6 @@ class test_stat_cursor_conn_clear(wttest.WiredTigerTestCase):
             'statistics:', None, 'statistics=(all,clear)')
         self.assertGreater(cursor[stat.conn.cache_bytes_dirty][2], 0)
         self.assertEqual(cursor[stat.conn.cursor_insert][2], 0)
-
 
 # Test the data-source "clear" configuration.
 class test_stat_cursor_dsrc_clear(wttest.WiredTigerTestCase):
@@ -129,7 +127,6 @@ class test_stat_cursor_dsrc_clear(wttest.WiredTigerTestCase):
             'statistics:' + self.uri, None, 'statistics=(all,clear)')
         self.assertEqual(cursor[stat.dsrc.cursor_insert][2], 0)
 
-
 # Test the "fast" configuration.
 class test_stat_cursor_fast(wttest.WiredTigerTestCase):
     pfx = 'test_stat_cursor_fast'
@@ -157,7 +154,6 @@ class test_stat_cursor_fast(wttest.WiredTigerTestCase):
             'statistics:' + self.uri, None, 'statistics=(all)')
         self.assertGreater(cursor[stat.dsrc.btree_entries][2], 0)
 
-
 # Test connection error combinations.
 class test_stat_cursor_conn_error(wttest.WiredTigerTestCase):
     def setUpConnectionOpen(self, dir):
@@ -172,7 +168,6 @@ class test_stat_cursor_conn_error(wttest.WiredTigerTestCase):
             msg = '/only one statistics configuration value/'
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda: self.wiredtiger_open('.', config), msg)
-
 
 # Test data-source error combinations.
 class test_stat_cursor_dsrc_error(wttest.WiredTigerTestCase):
@@ -197,7 +192,6 @@ class test_stat_cursor_dsrc_error(wttest.WiredTigerTestCase):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda: self.session.open_cursor(
                 'statistics:' + self.uri, None, config), msg)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_stat03.py
+++ b/test/suite/test_stat03.py
@@ -99,6 +99,5 @@ class test_stat_cursor_reset(wttest.WiredTigerTestCase):
             self.assertEqual(statc[stat.dsrc.btree_entries][2], n)
         statc.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -76,7 +76,6 @@ class test_truncate_arguments(wttest.WiredTigerTestCase):
         c1.close()
         c2.close()
 
-
 # Test truncation of an object using its URI.
 class test_truncate_uri(wttest.WiredTigerTestCase):
     name = 'test_truncate'
@@ -100,7 +99,6 @@ class test_truncate_uri(wttest.WiredTigerTestCase):
             self.session.truncate(uri, None, None, None)
             confirm_empty(self, uri)
             self.session.drop(uri, None)
-
 
 # Test truncation of cursors in an illegal order.
 class test_truncate_cursor_order(wttest.WiredTigerTestCase):
@@ -131,7 +129,6 @@ class test_truncate_cursor_order(wttest.WiredTigerTestCase):
             lambda: self.session.truncate(None, c1, c2, None), msg)
         c2.set_key(key_populate(c2, 20))
         self.session.truncate(None, c1, c2, None)
-
 
 # Test truncation of cursors past the end of the object.
 class test_truncate_cursor_end(wttest.WiredTigerTestCase):
@@ -173,7 +170,6 @@ class test_truncate_cursor_end(wttest.WiredTigerTestCase):
             self.assertEquals(c1.close(), 0)
             self.assertEquals(c2.close(), 0)
             self.session.drop(uri)
-
 
 # Test session.truncate.
 class test_truncate_cursor(wttest.WiredTigerTestCase):
@@ -446,7 +442,6 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
 
             self.truncateRangeAndCheck(uri, begin, end, expected)
             self.session.drop(uri, None)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -204,6 +204,5 @@ class test_truncate_fast_delete(wttest.WiredTigerTestCase):
                 self.cursor_count(cursor, self.nentries)
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_truncate03.py
+++ b/test/suite/test_truncate03.py
@@ -135,6 +135,5 @@ class test_truncate_address_deleted(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), v)
         self.assertEqual(cursor.close(), 0)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn01.py
+++ b/test/suite/test_txn01.py
@@ -131,7 +131,6 @@ class test_txn01(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
         self.check(cursor, self.nentries, self.nentries)
 
-
 # Test that read-committed is the default isolation level.
 class test_read_committed_default(wttest.WiredTigerTestCase):
     uri = 'table:test_txn'
@@ -161,7 +160,6 @@ class test_read_committed_default(wttest.WiredTigerTestCase):
         self.assertEqual(self.cursor_count(cursor), 1)
         s.commit_transaction()
         s.close()
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn11.py
+++ b/test/suite/test_txn11.py
@@ -62,7 +62,6 @@ class test_txn11(wttest.WiredTigerTestCase, suite_subprocess):
             checkpoints += 1
         return
 
-
     def test_ops(self):
         # Populate a table
         simple_populate(self, self.source_uri, 'key_format=S', self.nrows)

--- a/test/suite/test_upgrade.py
+++ b/test/suite/test_upgrade.py
@@ -67,6 +67,5 @@ class test_upgrade(wttest.WiredTigerTestCase):
             self.upgrade(complex_populate, False)
             self.upgrade(complex_populate, True)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util01.py
+++ b/test/suite/test_util01.py
@@ -183,6 +183,5 @@ class test_util01(wttest.WiredTigerTestCase, suite_subprocess):
     def test_dump_api_hex(self):
         self.dump(True, True)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util02.py
+++ b/test/suite/test_util02.py
@@ -162,7 +162,6 @@ class test_util02(wttest.WiredTigerTestCase, suite_subprocess):
     def test_load_process_hex(self):
         self.load_process(True)
 
-
 # test_load_commandline --
 #       Test the command-line processing.
 class test_load_commandline(wttest.WiredTigerTestCase, suite_subprocess):
@@ -219,7 +218,6 @@ class test_load_commandline(wttest.WiredTigerTestCase, suite_subprocess):
         self.load_commandline(["table", "filename=bar"], False)
         self.load_commandline(["table", "source=bar"], False)
         self.load_commandline(["table", "version=(100,200)"], False)
-
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util03.py
+++ b/test/suite/test_util03.py
@@ -69,6 +69,5 @@ class test_util03(wttest.WiredTigerTestCase, suite_subprocess):
             self.fail('table should be empty')
         cursor.close()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util07.py
+++ b/test/suite/test_util07.py
@@ -93,6 +93,5 @@ class test_util07(wttest.WiredTigerTestCase, suite_subprocess):
         self.check_empty_file(outfile)
         self.check_file_contains(errfile, 'key49: not found\n')
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util08.py
+++ b/test/suite/test_util08.py
@@ -42,6 +42,5 @@ class test_util08(wttest.WiredTigerTestCase, suite_subprocess):
             text = f.read(1000)
             self.assertTrue('Copyright' in text)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util09.py
+++ b/test/suite/test_util09.py
@@ -100,6 +100,5 @@ class test_util09(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(["loadtext", "table:" + self.tablename], infilename="loadtext.in")
         self.check_keys(self.tablename, keys)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util11.py
+++ b/test/suite/test_util11.py
@@ -128,6 +128,5 @@ class test_util11(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(["list"], outfilename=outfile)
         self.check_file_content(outfile, filelist)
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_util12.py
+++ b/test/suite/test_util12.py
@@ -86,6 +86,5 @@ class test_util12(wttest.WiredTigerTestCase, suite_subprocess):
                     'def', '456', 'abc'], errfilename=errfile, failure=True)
         self.check_file_contains(errfile, 'usage:')
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -197,6 +197,5 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
             errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_version.py
+++ b/test/suite/test_version.py
@@ -36,6 +36,5 @@ class test_version(wttest.WiredTigerTestCase):
     def test_version(self):
         version = wiredtiger.wiredtiger_version()
 
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -134,7 +134,6 @@ class CapturedFd(object):
                           gotstr + '"')
         self.expectpos = os.path.getsize(self.filename)
 
-
 class TestSuiteConnection(object):
     def __init__(self, conn, connlist):
         connlist.append(conn)
@@ -152,7 +151,6 @@ class TestSuiteConnection(object):
             return getattr(self, attr)
         else:
             return getattr(self._conn, attr)
-
 
 class WiredTigerTestCase(unittest.TestCase):
     _globalSetup = False
@@ -523,7 +521,6 @@ class WiredTigerTestCase(unittest.TestCase):
 
     def className(self):
         return self.__class__.__name__
-
 
 def longtest(description):
     """


### PR DESCRIPTION
Use the same rules for all source files: strip trailing whitespace,
collapse multiple blank lines and strip trailing empty lines.