### PR TITLE
WT-2918 the dist scripts create C files s_whitespace complains about

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -56,7 +56,7 @@ errchk()
 
 	# Some tests shouldn't return an error, we exclude them here.
 	case "$1" in
-	*s_export*)
+	*s_export|*s_tags)
 		break;;
 	*)
 		errfound=1;;

--- a/dist/s_export
+++ b/dist/s_export
@@ -2,7 +2,7 @@
 
 # Check for illegal external symbols.
 #
-t=__a.c
+t=__wt.$$
 trap 'rm -f $t; exit 0' 0 1 2 3 13 15
 
 case `uname` in
@@ -40,8 +40,10 @@ check()
 }
 
 # This check would normally be done after the library is built, but this way
-# we don't forget about a symbol during development.   Check the previously
-# built library, if it exists.
+# we don't forget about a symbol during development. We usually build in the
+# top-level or build_posix directories, check the previously built library,
+# if it exists. And, allow this script to be run from the top-level directory
+# as well as locally.
 for d in .libs build_posix/.libs; do
 	f="$d/libwiredtiger.a"
 	test -f $f && check $f

--- a/dist/s_tags
+++ b/dist/s_tags
@@ -1,10 +1,16 @@
 #! /bin/sh
 
 # Build tags files.
-trap 'rm -f tags; exit 0' 0 1 2 3 13 15
+trap 'rm -f tags' 0 1 2 3 13 15
 
 # Skip this when building release packages
 test -n "$WT_RELEASE_BUILD" && exit 0
+
+# We have to be in the dist directory to run.
+test -f s_tags || {
+	echo "s_tags requires dist be the current working directory"
+	exit 1
+}
 
 # We require ctags which may not be installed.
 type ctags > /dev/null 2>&1 || {
@@ -46,3 +52,5 @@ for i in $dirs; do
 
 	(cd $i && link_tag)
 done
+
+exit 0

--- a/dist/s_tags
+++ b/dist/s_tags
@@ -1,41 +1,37 @@
 #! /bin/sh
 
-# Build tags file.
-#
-t=__a.c
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+# Build tags files.
+trap 'rm -f tags; exit 0' 0 1 2 3 13 15
 
 # Skip this when building release packages
 test -n "$WT_RELEASE_BUILD" && exit 0
 
 # We require ctags which may not be installed.
 type ctags > /dev/null 2>&1 || {
-	echo 'skipped: ctags not found' > $t
+	echo 'skipped: ctags not found'
 	exit 0
 }
 
 # Test to see what flags this ctags binary supports.
-# Use the -d, -t and -w flags to ctags if available.
 flags=""
-echo "f() { int a; }" > $t
 for i in -d -t -w --language-force=C; do
-	if ctags $i $t 2>/dev/null; then
+	if ctags $i ../src/conn/api_strerror.c 2>/dev/null; then
 		flags="$i $flags"
 	fi
 done
 
-# Generate a tags file for the build directory
-(cd ../build_posix
-rm -f tags
-ctags $flags ../src/include/*.in ../src/*/*.[chi] 2>/dev/null)
+# Generate a tags file for the standard build directory.
+(cd ../build_posix &&
+rm -f tags &&
+ctags $flags ../src/include/*.in `find ../src -name '*.[chi]'` 2>/dev/null)
 
-# Put the shared tags file in the include directory, it's at the same level in
-# the tree as the other source files.
-(cd ../src/include
-rm -f tags
-ctags $flags ../include/*.in ../*/*.[chi] 2>/dev/null)
+# Generate a tags file for the src/include directory.
+(cd ../src/include &&
+rm -f tags &&
+ctags $flags ../include/*.in `find .. -name '*.[chi]'` 2>/dev/null)
 
-# Link the tags file into place if we're at the right level.
+# Link the tags file into place in the standard source directories, if we're
+# at the right level.
 link_tag()
 {
 	if test -e ../include/tags; then
@@ -46,8 +42,7 @@ link_tag()
 # Link to the tags file from standard build and source directories.
 dirs="`python -c 'import dist; dist.print_source_dirs()'` ../src/os_win"
 for i in $dirs; do
-	if expr "$i" : ".*/include" > /dev/null; then
-		continue
-	fi
+	expr "$i" : ".*/include" > /dev/null && continue
+
 	(cd $i && link_tag)
 done


### PR DESCRIPTION
I'm seeing complaints when I run the dist scripts about `.c` files in dist. The `s_export` script creates the file `__a.c` and shouldn't, the `s_tags` script can avoid creating a `.c` file.

Random minor cleanups along the way.

Ready for review/merge.