### PR TITLE
WT-2919 dist scripts force exit 0 on error

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -124,3 +124,4 @@ echo 'dist/s_all run finished'
 if test $errmode -ne 0; then
 	exit $errfound;
 fi
+exit 0

--- a/dist/s_c_test_create
+++ b/dist/s_c_test_create
@@ -12,7 +12,7 @@
 # script in the main C suite directory.
 #
 tmp=__a
-trap 'rm -f $tmp; exit 0' 0 1 2 3 13 15
+trap 'rm -f $tmp' 0 1 2 3 13 15
 
 if [ "x$1" = "x" ]; then
 	echo "Usage: $0 test_name"

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -53,7 +53,7 @@ if [ $# -ne 0 ]; then
 	exit 0
 fi
 
-trap 'rm -f $c1 $c2 $c3 $c4; exit 0' 0 1 2 3 13 15
+trap 'rm -f $c1 $c2 $c3 $c4' 0 1 2 3 13 15
 
 year=`date +%Y`
 
@@ -141,3 +141,5 @@ special_copyright LICENSE 1 "$string1"
 special_copyright src/docs/build-javadoc.sh 1 "$string2"
 special_copyright src/docs/style/footer.html 2 "$string2"
 special_copyright src/utilities/util_cpyright.c 1 "$string3"
+
+exit 0

--- a/dist/s_define
+++ b/dist/s_define
@@ -2,7 +2,7 @@
 
 # Complain about unused #defines.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # List of source files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 t=__wt.$$
-trap 'rm -f $t /tmp/__doxy; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t /tmp/__doxy' 0 1 2 3 13 15
 
 # Skip this when building release packages: docs are built separately
 test -n "$WT_RELEASE_BUILD" && exit 0

--- a/dist/s_export
+++ b/dist/s_export
@@ -3,7 +3,7 @@
 # Check for illegal external symbols.
 #
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 case `uname` in
 Darwin)

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -2,7 +2,7 @@
 
 # Complain about unused functions
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # List of files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_label
+++ b/dist/s_label
@@ -2,7 +2,7 @@
 
 # Check WiredTiger error/return macros.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 cd ..
 
@@ -79,3 +79,5 @@ for f in `find bench examples ext src test -name '*.[ci]'`; do
 		sed -e "s,^,$f:," -e 's/$/ [return skips API_END call]/'
 
 done
+
+exit 0

--- a/dist/s_lang
+++ b/dist/s_lang
@@ -2,7 +2,7 @@
 
 # Check lang directories for potential name conflicts
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 cd ../lang
 
@@ -21,5 +21,8 @@ for d in *; do
 		echo "$l: potential SWIG naming conflict"
 		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 		cat $t
+		exit 1
 	}
 done
+
+exit 0

--- a/dist/s_longlines
+++ b/dist/s_longlines
@@ -2,7 +2,7 @@
 
 # Check for long lines
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 l=`(cd .. &&
     find bench/wtperf examples ext src test -name '*.[chisy]' &&
@@ -20,3 +20,5 @@ for f in $l ; do
 	expand -t8 < ../$f | awk -- \
 	    "{if(length(\$0) > 80) printf(\"%s:%d\\n\", \"$f\", NR)}"
 done
+
+exit 0

--- a/dist/s_prototypes
+++ b/dist/s_prototypes
@@ -2,7 +2,7 @@
 
 # Build a list of internal function and variable prototypes.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # proto --
 #	extract public functions.
@@ -83,3 +83,5 @@ l=`sed \
     -e '/os_win/d' \
     -e 's/[	 ].*$//' filelist`
 externs
+
+exit 0

--- a/dist/s_python
+++ b/dist/s_python
@@ -2,7 +2,7 @@
 
 # Python style checks.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 cd ..
 
@@ -25,3 +25,5 @@ test -s $t && {
 	echo 'trailing semi-colons in selected Python code:'
 	cat $t
 }
+
+exit 0

--- a/dist/s_readme
+++ b/dist/s_readme
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 f=../README
 
 . ../RELEASE_INFO
@@ -60,3 +60,5 @@ END_TEXT
 
 cmp $t $f > /dev/null 2>&1 ||
     (echo "Building $f" && rm -f $f && cp $t $f)
+
+exit 0

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -2,7 +2,7 @@
 
 # Complain about unused statistics fields.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # List of files to search: skip stat.c, it lists all of the fields by
 # definition.

--- a/dist/s_string
+++ b/dist/s_string
@@ -3,7 +3,7 @@
 # Check spelling in comments and quoted strings from the source files.
 
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # Insulate against locale-specific sort order
 LC_ALL=C

--- a/dist/s_style
+++ b/dist/s_style
@@ -2,7 +2,7 @@
 
 # General style correction and cleanup.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # Parallelize if possible.
 xp=""
@@ -183,3 +183,5 @@ else
 
 	cmp $t $f > /dev/null 2>&1 || (echo "modifying $f" && cp $t $f)
 fi
+
+exit 0

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # Insulate against locale-specific sort order and IFS from the user's env
 LC_ALL=C

--- a/dist/s_void
+++ b/dist/s_void
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 cd ..
 
@@ -132,3 +132,5 @@ for f in `find bench ext src test -name '*.[ci]'`; do
 		cat $t
 	}
 done
+
+exit 0

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -2,7 +2,7 @@
 
 # Single space and remove trailing whitespace from source files.
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.
@@ -30,3 +30,5 @@ find bench dist examples ext src test \
 | while read f ; do
 	whitespace $f
 done
+
+exit 0

--- a/dist/s_wtstats
+++ b/dist/s_wtstats
@@ -3,7 +3,7 @@
 # Create wtstats.template.html file
 
 t=__wt.$$
-trap 'rm -f $t; exit 0' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # We require npm which may not be installed.
 type npm > /dev/null 2>&1 || {


### PR DESCRIPTION
@agorrod, when fixing `s_tags` today, I noticed we were forcing script exits of 0 almost everywhere (we probably just cut-and-pasted from one place it made sense). This doesn't clean up error handling completely, but I think it makes it incrementally better.

I'm pointing you at this one because I thought there might be something in the `s_all` changes you made awhile back that require scripts to always exit 0?

Anyway, feel free to simply discard this one without further discussion if you don't like it, entirely up to you.