### PR TITLE
WT-2924 hang when thread holding table lock tapped for eviction

### DIFF
--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -175,7 +175,7 @@ struct __wt_cache {
 #define	WT_CACHE_EVICT_CLEAN_HARD 0x002 /* Clean % blocking app threads */
 #define	WT_CACHE_EVICT_DIRTY	  0x004 /* Evict dirty pages */
 #define	WT_CACHE_EVICT_DIRTY_HARD 0x008 /* Dirty % blocking app threads */
-#define	WT_CACHE_EVICT_SCRUB	  0x010 /* Scrub dirty pages pages */
+#define	WT_CACHE_EVICT_SCRUB	  0x010 /* Scrub dirty pages */
 #define	WT_CACHE_EVICT_URGENT	  0x020 /* Pages are in the urgent queue */
 #define	WT_CACHE_EVICT_ALL	(WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_DIRTY)
 #define	WT_CACHE_EVICT_MASK	  0x0FF

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -206,10 +206,10 @@ __wt_session_can_wait(WT_SESSION_IMPL *session)
 
 	/*
 	 * LSM sets the no-eviction flag when holding the LSM tree lock, in that
-	 * case, or when holding the schema lock, we don't want to highjack the
-	 * thread for eviction.
+	 * case, or when holding a high-level lock, we don't want to highjack
+	 * the thread for eviction.
 	 */
-	if (F_ISSET(session, WT_SESSION_NO_EVICTION))
+	if (F_ISSET(session, WT_SESSION_NO_EVICTION | WT_HIGH_LEVEL_LOCK_MASK))
 		return (0);
 
 	return (1);
@@ -325,7 +325,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool *didworkp)
 	 * the macros that acquire high-level locks. In those cases, we don't
 	 * want to highjack the thread for eviction.
 	 */
-	if (F_ISSET(session, WT_SESSION_NO_EVICTION))
+	if (F_ISSET(session, WT_SESSION_NO_EVICTION | WT_HIGH_LEVEL_LOCK_MASK))
 		return (0);
 
 	/* In memory configurations don't block when the cache is full. */

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -193,7 +193,7 @@ __wt_cache_bytes_other(WT_CACHE *cache)
  * __wt_session_can_wait --
  *	Return if a session available for a potentially slow operation.
  */
-static inline int
+static inline bool
 __wt_session_can_wait(WT_SESSION_IMPL *session)
 {
 	/*
@@ -202,17 +202,15 @@ __wt_session_can_wait(WT_SESSION_IMPL *session)
 	 * the system cache.
 	 */
 	if (!F_ISSET(session, WT_SESSION_CAN_WAIT))
-		return (0);
+		return (false);
 
 	/*
 	 * LSM sets the no-eviction flag when holding the LSM tree lock, in that
 	 * case, or when holding a high-level lock, we don't want to highjack
 	 * the thread for eviction.
 	 */
-	if (F_ISSET(session, WT_SESSION_NO_EVICTION | WT_HIGH_LEVEL_LOCK_MASK))
-		return (0);
-
-	return (1);
+	return (!F_ISSET(session,
+	    WT_SESSION_NO_EVICTION | WT_HIGH_LEVEL_LOCK_MASK));
 }
 
 /*

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -209,7 +209,7 @@ __wt_session_can_wait(WT_SESSION_IMPL *session)
 	 * case, or when holding the schema lock, we don't want to highjack the
 	 * thread for eviction.
 	 */
-	if (F_ISSET(session, WT_SESSION_NO_EVICTION | WT_SESSION_LOCKED_SCHEMA))
+	if (F_ISSET(session, WT_SESSION_NO_EVICTION))
 		return (0);
 
 	return (1);
@@ -321,12 +321,11 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool *didworkp)
 	    txn_global->current != txn_global->oldest_id);
 
 	/*
-	 * LSM sets the no-cache-check flag when holding the LSM tree lock, in
-	 * that case, or when holding the schema or handle list locks (which
-	 * block eviction), we don't want to highjack the thread for eviction.
+	 * LSM sets the no-eviction flag when holding the LSM tree lock as do
+	 * the macros that acquire high-level locks. In those cases, we don't
+	 * want to highjack the thread for eviction.
 	 */
-	if (F_ISSET(session, WT_SESSION_NO_EVICTION |
-	    WT_SESSION_LOCKED_HANDLE_LIST | WT_SESSION_LOCKED_SCHEMA))
+	if (F_ISSET(session, WT_SESSION_NO_EVICTION))
 		return (0);
 
 	/* In memory configurations don't block when the cache is full. */


### PR DESCRIPTION
@agorrod, @michaelcahill, there's some discussion in WT-2924, but the change here is to wrap all high-level locks in a set/clear of the `WT_SESSION_NO_EVICTION` flag so we never tap a thread holding a high-level lock for eviction.

This may cast too wide a net -- I suppose the alternative/obvious change is to enumerate more locks in `__wt_cache_eviction_check()`, but I prefer this change because I think it makes it unlikely we'll introduce this bug again.

EDIT: we can't declare local variables in the WT_WITH_XXX lock macros (because we nest them), so I fell back to enumerating the locks when we check.