### PR TITLE
WT-2942 Verbose messages should not have newlines.

### DIFF
--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -216,7 +216,7 @@ __async_worker_execop(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op,
 			break;
 		case WT_AOP_NONE:
 			WT_RET_MSG(session, EINVAL,
-			    "Unknown async optype %d\n", op->optype);
+			    "Unknown async optype %d", op->optype);
 	}
 	return (0);
 }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -207,13 +207,12 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {
 		WT_ERR(__wt_epoch(session, &end));
 		__wt_verbose(session, WT_VERB_CHECKPOINT,
-		    "__sync_file WT_SYNC_%s wrote:\n\t %" PRIu64
-		    " bytes, %" PRIu64 " pages of leaves\n\t %" PRIu64
-		    " bytes, %" PRIu64 " pages of internal\n\t"
-		    "Took: %" PRIu64 "ms",
+		    "__sync_file WT_SYNC_%s wrote: %" PRIu64
+		    " leaf pages (%" PRIu64 "B), %" PRIu64
+		    " internal pages (%" PRIu64 "B), and took %" PRIu64 "ms",
 		    syncop == WT_SYNC_WRITE_LEAVES ?
 		    "WRITE_LEAVES" : "CHECKPOINT",
-		    leaf_bytes, leaf_pages, internal_bytes, internal_pages,
+		    leaf_pages, leaf_bytes, internal_pages, internal_bytes,
 		    WT_TIMEDIFF_MS(end, start));
 	}
 

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -47,7 +47,7 @@ __wt_config_collapse(
 		if (k.type != WT_CONFIG_ITEM_STRING &&
 		    k.type != WT_CONFIG_ITEM_ID)
 			WT_ERR_MSG(session, EINVAL,
-			    "Invalid configuration key found: '%s'\n", k.str);
+			    "Invalid configuration key found: '%s'", k.str);
 		WT_ERR(__wt_config_get(session, cfg, &k, &v));
 		/* Include the quotes around string keys/values. */
 		if (k.type == WT_CONFIG_ITEM_STRING) {
@@ -132,7 +132,7 @@ __config_merge_scan(WT_SESSION_IMPL *session,
 		if (k.type != WT_CONFIG_ITEM_STRING &&
 		    k.type != WT_CONFIG_ITEM_ID)
 			WT_ERR_MSG(session, EINVAL,
-			    "Invalid configuration key found: '%s'\n", k.str);
+			    "Invalid configuration key found: '%s'", k.str);
 
 		/* Include the quotes around string keys/values. */
 		if (k.type == WT_CONFIG_ITEM_STRING) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3335,7 +3335,7 @@ supd_check_complete:
 		__wt_verbose(session, WT_VERB_SPLIT,
 		    "Reconciliation creating a page with %" PRIu32
 		    " entries, memory footprint %" WT_SIZET_FMT
-		    ", page count %" PRIu32 ", %s, split state: %d\n",
+		    ", page count %" PRIu32 ", %s, split state: %d",
 		    r->entries, r->page->memory_footprint, r->bnd_next,
 		    F_ISSET(r, WT_EVICTING) ? "evict" : "checkpoint",
 		    r->bnd_state);

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -60,7 +60,7 @@ __thread_group_grow(
 	while (group->current_threads < new_count) {
 		thread = group->threads[group->current_threads++];
 		__wt_verbose(session, WT_VERB_THREAD_GROUP,
-		    "Starting utility thread: %p:%"PRIu32"\n",
+		    "Starting utility thread: %p:%" PRIu32,
 		    (void *)group, thread->id);
 		F_SET(thread, WT_THREAD_RUN);
 		WT_ASSERT(session, thread->session != NULL);
@@ -100,7 +100,7 @@ __thread_group_shrink(WT_SESSION_IMPL *session,
 		/* Wake threads to ensure they notice the state change */
 		if (thread->tid != 0) {
 			__wt_verbose(session, WT_VERB_THREAD_GROUP,
-			    "Stopping utility thread: %p:%"PRIu32"\n",
+			    "Stopping utility thread: %p:%" PRIu32,
 			    (void *)group, thread->id);
 			F_CLR(thread, WT_THREAD_RUN);
 			__wt_cond_signal(session, group->wait_cond);
@@ -224,7 +224,7 @@ __wt_thread_group_resize(
 
 	__wt_verbose(session, WT_VERB_THREAD_GROUP,
 	    "Resize thread group: %p, from min: %" PRIu32 " -> %" PRIu32
-	    " from max: %" PRIu32 " -> %" PRIu32 "\n",
+	    " from max: %" PRIu32 " -> %" PRIu32,
 	    (void *)group, group->min, new_min, group->max, new_max);
 
 	__wt_writelock(session, group->lock);
@@ -253,7 +253,7 @@ __wt_thread_group_create(
 	cond_alloced = false;
 
 	__wt_verbose(session, WT_VERB_THREAD_GROUP,
-	    "Creating thread group: %p\n", (void *)group);
+	    "Creating thread group: %p", (void *)group);
 
 	WT_RET(__wt_rwlock_alloc(session, &group->lock, "Thread group"));
 	WT_ERR(__wt_cond_alloc(
@@ -286,7 +286,7 @@ __wt_thread_group_destroy(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group)
 	WT_DECL_RET;
 
 	__wt_verbose(session, WT_VERB_THREAD_GROUP,
-	    "Destroying thread group: %p\n", (void *)group);
+	    "Destroying thread group: %p", (void *)group);
 
 	WT_ASSERT(session, __wt_rwlock_islocked(session, group->lock));
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -360,7 +360,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
 			__wt_verbose(session, WT_VERB_TRANSACTION,
 			    "old snapshot %" PRIu64
 			    " pinned in session %" PRIu32 " [%s]"
-			    " with snap_min %" PRIu64 "\n",
+			    " with snap_min %" PRIu64,
 			    oldest_id, oldest_session->id,
 			    oldest_session->lastop,
 			    oldest_session->txn.snap_min);


### PR DESCRIPTION
@keithbostic Please review this minor change to remove extraneous newlines from the new thread group verbose messages.