### PR TITLE
WT-2946 dist/s_docs incompatible with OS X Xcode installation

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -1,7 +1,8 @@
 #! /bin/sh
 
+src=__wt.$$.c
 t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+trap 'rm -f $src $t' 0 1 2 3 13 15
 
 # Skip this when building release packages: docs are built separately
 test -n "$WT_RELEASE_BUILD" && exit 0
@@ -30,9 +31,15 @@ wtperf_config()
 {
 	# The Linux ed command writes line numbers to stderr, redirect both
 	# stdout and stderr to keep things quiet.
-	cat ../bench/wtperf/wtperf_opt.i |
-	    cpp -DOPT_DEFINE_DOXYGEN |
-	    python wtperf_config.py > $t
+	#
+	# The OS X cpp program injects line number output in the middle of lines
+	# and doesn't stringify #XXX entries; use the -E option to the compiler
+	# instead.
+	#
+	# The OS X C pre-processor won't take input from stdin, use a temporary
+	# source file.
+	cp ../bench/wtperf/wtperf_opt.i $src
+	${CC:-cc} -E -DOPT_DEFINE_DOXYGEN $src | python wtperf_config.py > $t
 	(echo '/START_AUTO_GENERATED_WTPERF_CONFIGURATION/+3,/STOP_AUTO_GENERATED_WTPERF_CONFIGURATION/-1d'
 	 echo 'i'
 	 echo ''


### PR DESCRIPTION
@ddanderson, my apologies for the failure, I don't usually build documentation on my OS X box.

This change fixes the problem for me, for your review/consideration.

cc: @sueloverso 
