### PR TITLE
WT-2946 dist/s_docs incompatible with OS X Xcode installation

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -1,8 +1,7 @@
 #! /bin/sh
 
-src=__wt.$$.c
 t=__wt.$$
-trap 'rm -f $src $t' 0 1 2 3 13 15
+trap 'rm -f $t' 0 1 2 3 13 15
 
 # Skip this when building release packages: docs are built separately
 test -n "$WT_RELEASE_BUILD" && exit 0
@@ -35,11 +34,8 @@ wtperf_config()
 	# The OS X cpp program injects line number output in the middle of lines
 	# and doesn't stringify #XXX entries; use the -E option to the compiler
 	# instead.
-	#
-	# The OS X C pre-processor won't take input from stdin, use a temporary
-	# source file.
-	cp ../bench/wtperf/wtperf_opt.i $src
-	${CC:-cc} -E -DOPT_DEFINE_DOXYGEN $src | python wtperf_config.py > $t
+	cat ../bench/wtperf/wtperf_opt.i |
+	${CC:-cc} -E -DOPT_DEFINE_DOXYGEN - | python wtperf_config.py > $t
 	(echo '/START_AUTO_GENERATED_WTPERF_CONFIGURATION/+3,/STOP_AUTO_GENERATED_WTPERF_CONFIGURATION/-1d'
 	 echo 'i'
 	 echo ''


### PR DESCRIPTION
@ddanderson, a fix to use `-` instead of a temporary file.