### PR TITLE
WT-2948 simplify error handling by making epoch time return never fail

### DIFF
--- a/bench/wtperf/idle_table_cycle.c
+++ b/bench/wtperf/idle_table_cycle.c
@@ -34,21 +34,15 @@ check_timing(WTPERF *wtperf,
 {
 	CONFIG_OPTS *opts;
 	uint64_t last_interval;
-	int ret;
 
 	opts = wtperf->opts;
 
-	if ((ret = __wt_epoch(NULL, stop)) != 0) {
-		lprintf(wtperf, ret, 0,
-		    "Get time failed in cycle_idle_tables.");
-		wtperf->error = true;
-		return (ret);
-	}
+	__wt_epoch(NULL, stop);
 
 	last_interval = (uint64_t)(WT_TIMEDIFF_SEC(*stop, start));
 
 	if (last_interval > opts->idle_table_cycle) {
-		lprintf(wtperf, ret, 0,
+		lprintf(wtperf, ETIMEDOUT, 0,
 		    "Cycling idle table failed because %s took %" PRIu64
 		    " seconds which is longer than configured acceptable"
 		    " maximum of %" PRIu32 ".",
@@ -92,12 +86,7 @@ cycle_idle_tables(void *arg)
 		__wt_sleep(1, 0);
 
 		/* Setup a start timer. */
-		if ((ret = __wt_epoch(NULL, &start)) != 0) {
-			lprintf(wtperf, ret, 0,
-			     "Get time failed in cycle_idle_tables.");
-			wtperf->error = true;
-			return (NULL);
-		}
+		__wt_epoch(NULL, &start);
 
 		/* Create a table. */
 		if ((ret = session->create(

--- a/bench/wtperf/wtperf_throttle.c
+++ b/bench/wtperf/wtperf_throttle.c
@@ -70,7 +70,7 @@ setup_throttle(WTPERF_THREAD *thread)
 	throttle_cfg->ops_count = throttle_cfg->ops_per_increment;
 
 	/* Set the first timestamp of when we incremented */
-	testutil_check(__wt_epoch(NULL, &throttle_cfg->last_increment));
+	__wt_epoch(NULL, &throttle_cfg->last_increment);
 }
 
 /*
@@ -86,7 +86,7 @@ worker_throttle(WTPERF_THREAD *thread)
 
 	throttle_cfg = &thread->throttle_cfg;
 
-	testutil_check(__wt_epoch(NULL, &now));
+	__wt_epoch(NULL, &now);
 
 	/*
 	 * If we did enough operations in the current interval, sleep for
@@ -101,7 +101,7 @@ worker_throttle(WTPERF_THREAD *thread)
 		/*
 		 * After sleeping, set the interval to the current time.
 		 */
-		testutil_check(__wt_epoch(NULL, &throttle_cfg->last_increment));
+		__wt_epoch(NULL, &throttle_cfg->last_increment);
 	} else {
 		throttle_cfg->ops_count = (usecs_delta *
 		    throttle_cfg->ops_per_increment) /

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -37,7 +37,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	internal_bytes = leaf_bytes = 0;
 	internal_pages = leaf_pages = 0;
 	if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT))
-		WT_RET(__wt_epoch(session, &start));
+		__wt_epoch(session, &start);
 
 	switch (syncop) {
 	case WT_SYNC_WRITE_LEAVES:
@@ -205,7 +205,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	}
 
 	if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {
-		WT_ERR(__wt_epoch(session, &end));
+		__wt_epoch(session, &end);
 		__wt_verbose(session, WT_VERB_CHECKPOINT,
 		    "__sync_file WT_SYNC_%s wrote: %" PRIu64
 		    " leaf pages (%" PRIu64 "B), %" PRIu64

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -839,10 +839,10 @@ __log_server(void *arg)
 
 		/* Wait until the next event. */
 
-		WT_ERR(__wt_epoch(session, &start));
+		__wt_epoch(session, &start);
 		__wt_cond_auto_wait_signal(session,
 		    conn->log_cond, did_work, &signalled);
-		WT_ERR(__wt_epoch(session, &now));
+		__wt_epoch(session, &now);
 		timediff = WT_TIMEDIFF_MS(now, start);
 	}
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -415,7 +415,7 @@ __statlog_log_one(WT_SESSION_IMPL *session, WT_ITEM *path, WT_ITEM *tmp)
 	conn = S2C(session);
 
 	/* Get the current local time of day. */
-	WT_RET(__wt_epoch(session, &ts));
+	__wt_epoch(session, &ts);
 	tm = localtime_r(&ts.tv_sec, &_tm);
 
 	/* Create the logging path name for this time of day. */

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -271,7 +271,7 @@ __sweep_server(void *arg)
 		/* Wait until the next event. */
 		__wt_cond_wait(session,
 		    conn->sweep_cond, conn->sweep_interval * WT_MILLION);
-		WT_ERR(__wt_seconds(session, &now));
+		__wt_seconds(session, &now);
 
 		WT_STAT_CONN_INCR(session, dh_sweeps);
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -677,7 +677,7 @@ extern uint32_t __wt_log2_int(uint32_t n);
 extern bool __wt_ispo2(uint32_t v);
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2);
 extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state);
-extern int __wt_random_init_seed( WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_random_init_seed( WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state);
 extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state);
 extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -27,5 +27,5 @@ extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds);
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_thread_id(char *buf, size_t buflen);
-extern int __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp);
 extern void __wt_yield(void);

--- a/src/include/extern_win.h
+++ b/src/include/extern_win.h
@@ -25,7 +25,7 @@ extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds);
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_thread_id(char *buf, size_t buflen);
-extern int __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp);
 extern int __wt_to_utf16_string( WT_SESSION_IMPL *session, const char*utf8, WT_ITEM **outbuf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_to_utf8_string( WT_SESSION_IMPL *session, const wchar_t*wide, WT_ITEM **outbuf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern DWORD __wt_getlasterror(void);

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -33,16 +33,14 @@ __wt_strdup(WT_SESSION_IMPL *session, const char *str, void *retp)
  * __wt_seconds --
  *	Return the seconds since the Epoch.
  */
-static inline int
+static inline void
 __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
 {
 	struct timespec t;
 
-	WT_RET(__wt_epoch(session, &t));
+	__wt_epoch(session, &t);
 
 	*timep = t.tv_sec;
-
-	return (0);
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -128,9 +128,9 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 		    "log_force_sync: sync directory %s to LSN %" PRIu32
 		    "/%" PRIu32,
 		    log->log_dir_fh->name, min_lsn->l.file, min_lsn->l.offset);
-		WT_ERR(__wt_epoch(session, &fsync_start));
+		__wt_epoch(session, &fsync_start);
 		WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
-		WT_ERR(__wt_epoch(session, &fsync_stop));
+		__wt_epoch(session, &fsync_stop);
 		fsync_duration_usecs = WT_TIMEDIFF_US(fsync_stop, fsync_start);
 		log->sync_dir_lsn = *min_lsn;
 		WT_STAT_CONN_INCR(session, log_sync_dir);
@@ -152,9 +152,9 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 		__wt_verbose(session, WT_VERB_LOG,
 		    "log_force_sync: sync %s to LSN %" PRIu32 "/%" PRIu32,
 		    log_fh->name, min_lsn->l.file, min_lsn->l.offset);
-		WT_ERR(__wt_epoch(session, &fsync_start));
+		__wt_epoch(session, &fsync_start);
 		WT_ERR(__wt_fsync(session, log_fh, true));
-		WT_ERR(__wt_epoch(session, &fsync_stop));
+		__wt_epoch(session, &fsync_stop);
 		fsync_duration_usecs = WT_TIMEDIFF_US(fsync_stop, fsync_start);
 		log->sync_lsn = *min_lsn;
 		WT_STAT_CONN_INCR(session, log_sync);
@@ -1478,9 +1478,9 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 			    "/%" PRIu32,
 			    log->log_dir_fh->name,
 			    sync_lsn.l.file, sync_lsn.l.offset);
-			WT_ERR(__wt_epoch(session, &fsync_start));
+			__wt_epoch(session, &fsync_start);
 			WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
-			WT_ERR(__wt_epoch(session, &fsync_stop));
+			__wt_epoch(session, &fsync_stop);
 			fsync_duration_usecs =
 			    WT_TIMEDIFF_US(fsync_stop, fsync_start);
 			log->sync_dir_lsn = sync_lsn;
@@ -1500,9 +1500,9 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 			    log->log_fh->name,
 			    sync_lsn.l.file, sync_lsn.l.offset);
 			WT_STAT_CONN_INCR(session, log_sync);
-			WT_ERR(__wt_epoch(session, &fsync_start));
+			__wt_epoch(session, &fsync_start);
 			WT_ERR(__wt_fsync(session, log->log_fh, true));
-			WT_ERR(__wt_epoch(session, &fsync_stop));
+			__wt_epoch(session, &fsync_stop);
 			fsync_duration_usecs =
 			    WT_TIMEDIFF_US(fsync_stop, fsync_start);
 			WT_STAT_CONN_INCRV(session,

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -392,7 +392,7 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 		TAILQ_FOREACH(lsm_tree, &S2C(session)->lsmqh, q) {
 			if (!lsm_tree->active)
 				continue;
-			WT_ERR(__wt_epoch(session, &now));
+			__wt_epoch(session, &now);
 			pushms = lsm_tree->work_push_ts.tv_sec == 0 ? 0 :
 			    WT_TIMEDIFF_MS(now, lsm_tree->work_push_ts);
 			fillms = 3 * lsm_tree->chunk_fill_ms;
@@ -651,7 +651,7 @@ __wt_lsm_manager_push_entry(WT_SESSION_IMPL *session,
 		return (0);
 	}
 
-	WT_RET(__wt_epoch(session, &lsm_tree->work_push_ts));
+	__wt_epoch(session, &lsm_tree->work_push_ts);
 	WT_RET(__wt_calloc_one(session, &entry));
 	entry->type = type;
 	entry->flags = flags;

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -265,7 +265,7 @@ __wt_lsm_tree_setup_chunk(
     WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LSM_CHUNK *chunk)
 {
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SCHEMA));
-	WT_RET(__wt_epoch(session, &chunk->create_ts));
+	__wt_epoch(session, &chunk->create_ts);
 
 	WT_RET(__wt_lsm_tree_chunk_name(
 	    session, lsm_tree, chunk->id, &chunk->uri));
@@ -496,7 +496,7 @@ __lsm_tree_open(WT_SESSION_IMPL *session,
 	lsm_tree->queue_ref = 0;
 
 	/* Set a flush timestamp as a baseline. */
-	WT_ERR(__wt_epoch(session, &lsm_tree->last_flush_ts));
+	__wt_epoch(session, &lsm_tree->last_flush_ts);
 
 	/* Now the tree is setup, make it visible to others. */
 	TAILQ_INSERT_HEAD(&S2C(session)->lsmqh, lsm_tree, q);
@@ -1139,7 +1139,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
 		return (0);
 	}
 
-	WT_ERR(__wt_seconds(session, &begin));
+	__wt_seconds(session, &begin);
 
 	/*
 	 * Compacting has two distinct phases.
@@ -1267,7 +1267,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
 				break;
 		}
 		__wt_sleep(1, 0);
-		WT_ERR(__wt_seconds(session, &end));
+		__wt_seconds(session, &end);
 		if (session->compact->max_time > 0 &&
 		    session->compact->max_time < (uint64_t)(end - begin)) {
 			WT_ERR(ETIMEDOUT);

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -358,7 +358,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_lsm_tree_set_chunk_size(session, chunk));
 
 	/* Update the flush timestamp to help track ongoing progress. */
-	WT_ERR(__wt_epoch(session, &lsm_tree->last_flush_ts));
+	__wt_epoch(session, &lsm_tree->last_flush_ts);
 	++lsm_tree->chunks_flushed;
 
 	/* Lock the tree, mark the chunk as on disk and update the metadata. */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -424,7 +424,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 			 * guaranteed, a time_t has to be an arithmetic type,
 			 * but not an integral type.
 			 */
-			WT_ERR(__wt_seconds(session, &secs));
+			__wt_seconds(session, &secs);
 			ckpt->sec = (uintmax_t)secs;
 		}
 		if (strcmp(ckpt->name, WT_CHECKPOINT) == 0)

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -63,7 +63,7 @@ __wt_cond_wait_signal(
 	locked = true;
 
 	if (usecs > 0) {
-		WT_ERR(__wt_epoch(session, &ts));
+		__wt_epoch(session, &ts);
 		ts.tv_sec += (time_t)
 		    (((uint64_t)ts.tv_nsec + WT_THOUSAND * usecs) / WT_BILLION);
 		ts.tv_nsec = (long)

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -12,7 +12,7 @@
  * __wt_epoch --
  *	Return the time since the Epoch.
  */
-int
+void
 __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 {
 	WT_DECL_RET;
@@ -20,8 +20,8 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 #if defined(HAVE_CLOCK_GETTIME)
 	WT_SYSCALL(clock_gettime(CLOCK_REALTIME, tsp), ret);
 	if (ret == 0)
-		return (0);
-	WT_RET_MSG(session, ret, "clock_gettime");
+		return;
+	WT_PANIC_MSG(session, ret, "clock_gettime");
 #elif defined(HAVE_GETTIMEOFDAY)
 	struct timeval v;
 
@@ -29,9 +29,9 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	if (ret == 0) {
 		tsp->tv_sec = v.tv_sec;
 		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
-		return (0);
+		return;
 	}
-	WT_RET_MSG(session, ret, "gettimeofday");
+	WT_PANIC_MSG(session, ret, "gettimeofday");
 #else
 	NO TIME-OF-DAY IMPLEMENTATION: see src/os_posix/os_time.c
 #endif

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -18,14 +18,14 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	WT_DECL_RET;
 
 #if defined(HAVE_CLOCK_GETTIME)
-	WT_SYSCALL(clock_gettime(CLOCK_REALTIME, tsp), ret);
+	WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, tsp), ret);
 	if (ret == 0)
 		return;
 	WT_PANIC_MSG(session, ret, "clock_gettime");
 #elif defined(HAVE_GETTIMEOFDAY)
 	struct timeval v;
 
-	WT_SYSCALL(gettimeofday(&v, NULL), ret);
+	WT_SYSCALL_RETRY(gettimeofday(&v, NULL), ret);
 	if (ret == 0) {
 		tsp->tv_sec = v.tv_sec;
 		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -12,11 +12,11 @@
  * __wt_epoch --
  *	Return the time since the Epoch.
  */
-int
+void
 __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 {
-	uint64_t ns100;
 	FILETIME time;
+	uint64_t ns100;
 
 	WT_UNUSED(session);
 
@@ -26,8 +26,6 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	    - 116444736000000000LL;
 	tsp->tv_sec = ns100 / 10000000;
 	tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
-
-	return (0);
 }
 
 /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1495,14 +1495,14 @@ __session_transaction_sync(WT_SESSION *wt_session, const char *config)
 	if (timeout_ms == 0)
 		WT_ERR(ETIMEDOUT);
 
-	WT_ERR(__wt_epoch(session, &start));
+	__wt_epoch(session, &start);
 	/*
 	 * Keep checking the LSNs until we find it is stable or we reach
 	 * our timeout.
 	 */
 	while (__wt_log_cmp(&session->bg_sync_lsn, &log->sync_lsn) > 0) {
 		__wt_cond_signal(session, conn->log_file_cond);
-		WT_ERR(__wt_epoch(session, &now));
+		__wt_epoch(session, &now);
 		waited_ms = WT_TIMEDIFF_MS(now, start);
 		if (forever || waited_ms < timeout_ms)
 			/*

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -179,17 +179,16 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
  *	Check if the timeout has been exceeded.
  */
 static int
-__session_compact_check_timeout(
-    WT_SESSION_IMPL *session, struct timespec begin)
+__session_compact_check_timeout(WT_SESSION_IMPL *session, struct timespec begin)
 {
 	struct timespec end;
 
 	if (session->compact->max_time == 0)
 		return (0);
 
-	WT_RET(__wt_epoch(session, &end));
+	__wt_epoch(session, &end);
 	if (session->compact->max_time < WT_TIMEDIFF_SEC(end, begin))
-		WT_RET(ETIMEDOUT);
+		return (ETIMEDOUT);
 	return (0);
 }
 
@@ -219,7 +218,7 @@ __compact_file(WT_SESSION_IMPL *session, const char *cfg[])
 	    session, t, "target=(\"%s\"),force=1", dhandle->name));
 	checkpoint_cfg[1] = t->data;
 
-	WT_ERR(__wt_epoch(session, &start_time));
+	__wt_epoch(session, &start_time);
 
 	/*
 	 * We compact 10% of the file on each pass (but the overall size of the

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -8,8 +8,6 @@
 
 #include "wt_internal.h"
 
-static int __session_dhandle_sweep(WT_SESSION_IMPL *);
-
 /*
  * __session_add_dhandle --
  *	Add a handle to the session's cache.
@@ -371,7 +369,7 @@ __wt_session_close_cache(WT_SESSION_IMPL *session)
  * __session_dhandle_sweep --
  *	Discard any session dhandles that are not open.
  */
-static int
+static void
 __session_dhandle_sweep(WT_SESSION_IMPL *session)
 {
 	WT_CONNECTION_IMPL *conn;
@@ -385,9 +383,9 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 	 * Periodically sweep for dead handles; if we've swept recently, don't
 	 * do it again.
 	 */
-	WT_RET(__wt_seconds(session, &now));
+	__wt_seconds(session, &now);
 	if (difftime(now, session->last_sweep) < conn->sweep_interval)
-		return (0);
+		return;
 	session->last_sweep = now;
 
 	WT_STAT_CONN_INCR(session, dh_session_sweeps);
@@ -408,7 +406,6 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 		}
 		dhandle_cache = dhandle_cache_next;
 	}
-	return (0);
 }
 
 /*
@@ -446,7 +443,7 @@ __session_get_dhandle(
 	}
 
 	/* Sweep the handle list to remove any dead handles. */
-	WT_RET(__session_dhandle_sweep(session));
+	__session_dhandle_sweep(session);
 
 	/*
 	 * We didn't find a match in the session cache, search the shared

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -66,20 +66,18 @@ __wt_random_init(WT_RAND_STATE volatile * rnd_state)
  * threads and we want each thread to initialize its own random state based
  * on a different random seed.
  */
-int
+void
 __wt_random_init_seed(
     WT_SESSION_IMPL *session, WT_RAND_STATE volatile * rnd_state)
 {
 	struct timespec ts;
 	WT_RAND_STATE rnd;
 
-	WT_RET(__wt_epoch(session, &ts));
+	__wt_epoch(session, &ts);
 	M_W(rnd) = (uint32_t)(ts.tv_nsec + 521288629);
 	M_Z(rnd) = (uint32_t)(ts.tv_nsec + 362436069);
 
 	*rnd_state = rnd;
-
-	return (0);
 }
 
 /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -314,7 +314,7 @@ __checkpoint_update_generation(WT_SESSION_IMPL *session)
  * __checkpoint_reduce_dirty_cache --
  *	Release clean trees from the list cached for checkpoints.
  */
-static int
+static void
 __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 {
 	WT_CACHE *cache;
@@ -332,9 +332,9 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 	/* Give up if scrubbing is disabled. */
 	if (cache->eviction_checkpoint_target == 0 ||
 	    cache->eviction_checkpoint_target >= cache->eviction_dirty_trigger)
-		return (0);
+		return;
 
-	WT_RET(__wt_epoch(session, &start));
+	__wt_epoch(session, &start);
 	last = start;
 	bytes_written_last = 0;
 	bytes_written_start = cache->bytes_written;
@@ -345,7 +345,7 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 	 * cache via reconfigure.  This avoids potential divide by zero.
 	 */
 	if (cache_size < 10 * WT_MEGABYTE)
-		return (0);
+		return;
 	stepdown_us = 10000;
 	work_us = 0;
 	progress = false;
@@ -371,7 +371,7 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 			break;
 
 		__wt_sleep(0, stepdown_us / 10);
-		WT_RET(__wt_epoch(session, &stop));
+		__wt_epoch(session, &stop);
 		current_us = WT_TIMEDIFF_US(stop, last);
 		total_ms = WT_TIMEDIFF_MS(stop, start);
 		bytes_written_total =
@@ -427,14 +427,12 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 		    WT_MAX(cache->eviction_dirty_target, current_dirty - delta);
 		WT_STAT_CONN_SET(session, txn_checkpoint_scrub_target,
 		    cache->eviction_scrub_limit);
-		WT_RET(__wt_epoch(session, &last));
+		__wt_epoch(session, &last);
 	}
 
-	WT_RET(__wt_epoch(session, &stop));
+	__wt_epoch(session, &stop);
 	total_ms = WT_TIMEDIFF_MS(stop, start);
 	WT_STAT_CONN_SET(session, txn_checkpoint_scrub_time, total_ms);
-
-	return (0);
 }
 
 /*
@@ -497,7 +495,7 @@ __checkpoint_stats(
  * __checkpoint_verbose_track --
  *	Output a verbose message with timing information
  */
-static int
+static void
 __checkpoint_verbose_track(WT_SESSION_IMPL *session,
     const char *msg, struct timespec *start)
 {
@@ -506,9 +504,9 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session,
 	uint64_t msec;
 
 	if (!WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT))
-		return (0);
+		return;
 
-	WT_RET(__wt_epoch(session, &stop));
+	__wt_epoch(session, &stop);
 
 	/*
 	 * Get time diff in microseconds.
@@ -526,7 +524,6 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session,
 	WT_UNUSED(msg);
 	WT_UNUSED(start);
 #endif
-	return (0);
 }
 
 /*
@@ -576,7 +573,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	conn->cache->evict_max_page_size = 0;
 
 	/* Initialize the verbose tracking timer */
-	WT_ERR(__wt_epoch(session, &verb_timer));
+	__wt_epoch(session, &verb_timer);
 
 	/*
 	 * Update the global oldest ID so we do all possible cleanup.
@@ -594,18 +591,18 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * Try to reduce the amount of dirty data in cache so there is less
 	 * work do during the critical section of the checkpoint.
 	 */
-	WT_ERR(__checkpoint_reduce_dirty_cache(session));
+	__checkpoint_reduce_dirty_cache(session);
 
 	/* Tell logging that we are about to start a database checkpoint. */
 	if (full && logging)
 		WT_ERR(__wt_txn_checkpoint_log(
 		    session, full, WT_TXN_LOG_CKPT_PREPARE, NULL));
 
-	WT_ERR(__checkpoint_verbose_track(session,
-	    "starting transaction", &verb_timer));
+	__checkpoint_verbose_track(session,
+	    "starting transaction", &verb_timer);
 
 	if (full)
-		WT_ERR(__wt_epoch(session, &start));
+		__wt_epoch(session, &start);
 
 	/*
 	 * Start the checkpoint for real.
@@ -739,23 +736,22 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ERR(__checkpoint_apply(session, cfg, __checkpoint_presync));
 	__wt_evict_server_wake(session);
 
-	WT_ERR(__checkpoint_verbose_track(session,
-	    "committing transaction", &verb_timer));
+	__checkpoint_verbose_track(session,
+	    "committing transaction", &verb_timer);
 
 	/*
 	 * Checkpoints have to hit disk (it would be reasonable to configure for
 	 * lazy checkpoints, but we don't support them yet).
 	 */
-	WT_ERR(__wt_epoch(session, &fsync_start));
+	__wt_epoch(session, &fsync_start);
 	WT_ERR(__checkpoint_apply(session, cfg, __wt_checkpoint_sync));
-	WT_ERR(__wt_epoch(session, &fsync_stop));
+	__wt_epoch(session, &fsync_stop);
 	fsync_duration_usecs = WT_TIMEDIFF_US(fsync_stop, fsync_start);
 	WT_STAT_CONN_INCR(session, txn_checkpoint_fsync_post);
 	WT_STAT_CONN_SET(session,
 	    txn_checkpoint_fsync_post_duration, fsync_duration_usecs);
 
-	WT_ERR(__checkpoint_verbose_track(session,
-	    "sync completed", &verb_timer));
+	__checkpoint_verbose_track(session, "sync completed", &verb_timer);
 
 	/*
 	 * Commit the transaction now that we are sure that all files in the
@@ -793,8 +789,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 		    ret = __wt_checkpoint_sync(session, NULL));
 		WT_ERR(ret);
 
-		WT_ERR(__checkpoint_verbose_track(session,
-		    "metadata sync completed", &verb_timer));
+		__checkpoint_verbose_track(session,
+		    "metadata sync completed", &verb_timer);
 	} else
 		WT_WITH_DHANDLE(session,
 		    WT_SESSION_META_DHANDLE(session),
@@ -808,7 +804,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	txn_global->checkpoint_pinned = WT_TXN_NONE;
 
 	if (full) {
-		WT_ERR(__wt_epoch(session, &stop));
+		__wt_epoch(session, &stop);
 		__checkpoint_stats(session, &start, &stop);
 	}
 

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -227,7 +227,8 @@ test_join(TEST_OPTS *opts, SHARED_OPTS *sharedopts, bool bloom,
 	testutil_check(session->close(session, NULL));
 }
 
-static void *thread_insert(void *arg)
+static void *
+thread_insert(void *arg)
 {
 	SHARED_OPTS *sharedopts;
 	TEST_OPTS *opts;
@@ -241,7 +242,7 @@ static void *thread_insert(void *arg)
 	threadargs = (THREAD_ARGS *)arg;
 	opts = threadargs->testopts;
 	sharedopts = threadargs->sharedopts;
-	testutil_check(__wt_random_init_seed(NULL, &rnd));
+	__wt_random_init_seed(NULL, &rnd);
 
 	testutil_check(opts->conn->open_session(
 	    opts->conn, NULL, NULL, &session));

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -61,7 +61,7 @@ main(int argc, char *argv[])
 	    wiredtiger_open(opts->home, NULL, "create", &opts->conn));
 
 	/* Initialize the RNG. */
-	testutil_check(__wt_random_init_seed(NULL, &rnd));
+	__wt_random_init_seed(NULL, &rnd);
 
 	/* Allocate aligned memory for the data. */
 	data = dcalloc(DATASIZE, sizeof(uint8_t));

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -256,7 +256,7 @@ main(int argc, char *argv[])
 	    session, opts->uri, "type=lsm,key_format=S,value_format=S"));
 
 	/* Initialize the RNG. */
-	testutil_check(__wt_random_init_seed(NULL, &rnd));
+	__wt_random_init_seed(NULL, &rnd);
 
 	/* Allocate memory for the config. */
 	len = WT_ELEMENTS(list) * 64;

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -161,7 +161,8 @@ main(int argc, char *argv[])
 	return (0);
 }
 
-void populate(TEST_OPTS *opts)
+void
+populate(TEST_OPTS *opts)
 {
 	WT_CURSOR *maincur;
 	WT_SESSION *session;
@@ -169,7 +170,7 @@ void populate(TEST_OPTS *opts)
 	int balance, i, flag, post;
 	WT_RAND_STATE rnd;
 
-	testutil_check(__wt_random_init_seed(NULL, &rnd));
+	__wt_random_init_seed(NULL, &rnd);
 
 	testutil_check(opts->conn->open_session(
 	    opts->conn, NULL, NULL, &session));

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -201,7 +201,7 @@ thread_insert(void *arg)
 
 	threadargs = (THREAD_ARGS *)arg;
 	opts = threadargs->testopts;
-	testutil_check(__wt_random_init_seed(NULL, &rnd));
+	__wt_random_init_seed(NULL, &rnd);
 	(void)time(&prevtime);
 
 	testutil_check(opts->conn->open_session(

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	argv += __wt_optind;
 
 	/* Initialize the global RNG. */
-	testutil_check(__wt_random_init_seed(NULL, &g.rnd));
+	__wt_random_init_seed(NULL, &g.rnd);
 
 	/* Set up paths. */
 	path_setup(home);

--- a/test/recovery/random-abort.c
+++ b/test/recovery/random-abort.c
@@ -245,7 +245,7 @@ main(int argc, char *argv[])
 	if (!verify_only) {
 		testutil_make_work_dir(home);
 
-		testutil_assert(__wt_random_init_seed(NULL, &rnd) == 0);
+		__wt_random_init_seed(NULL, &rnd);
 		if (rand_time) {
 			timeout = __wt_random(&rnd) % MAX_TIME;
 			if (timeout < MIN_TIME)


### PR DESCRIPTION
@agorrod, I've been meaning to do this for awhile, and the changes we're considering for WT-2920 are going to be easier with this change.

If you want the change, I'll flag a few places that might deserve real review, in the comments.