### PR TITLE
WT-2937 Fix a warning.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1077,11 +1077,11 @@ __evict_walk(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue)
 	 * candidate pages in cache, don't put all of them on one queue.
 	 */
 	if (F_ISSET(cache, WT_CACHE_EVICT_CLEAN))
-		max_entries =
-		    WT_MIN(max_entries, 1 + __wt_cache_pages_inuse(cache) / 2);
+		max_entries = WT_MIN(max_entries,
+		    1 + (uint32_t)(__wt_cache_pages_inuse(cache) / 2));
 	else
-		max_entries =
-		    WT_MIN(max_entries, 1 + cache->pages_dirty_leaf / 2);
+		max_entries = WT_MIN(max_entries,
+		    1 + (uint32_t)(cache->pages_dirty_leaf / 2));
 
 retry:	while (slot < max_entries) {
 		/*


### PR DESCRIPTION
../src/evict/evict_lru.c:1081:29: error: implicit conversion loses integer precision: 'unsigned long long' to 'u_int' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
                    WT_MIN(max_entries, 1 + __wt_cache_pages_inuse(cache) / 2);
                                        ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/include/misc.h:62:42: note: expanded from macro 'WT_MIN'
                                            ^
../src/evict/evict_lru.c:1084:29: error: implicit conversion loses integer precision: 'unsigned long long' to 'u_int' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
                    WT_MIN(max_entries, 1 + cache->pages_dirty_leaf / 2);
                                        ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/include/misc.h:62:42: note: expanded from macro 'WT_MIN'