### PR TITLE
WT-2956 utility tests -h option is always overridden by the default setup

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2329,7 +2329,6 @@ err:		if (ret == 0)
 
 extern int __wt_optind, __wt_optreset;
 extern char *__wt_optarg;
-void (*custom_die)(void) = NULL;
 
 /*
  * usage --

--- a/test/bloom/test_bloom.c
+++ b/test/bloom/test_bloom.c
@@ -56,8 +56,6 @@ void usage(void)
 extern char *__wt_optarg;
 extern int __wt_optind;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -42,8 +42,6 @@ static int  wt_shutdown(void);
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/csuite/wt1965_col_efficiency/main.c
+++ b/test/csuite/wt1965_col_efficiency/main.c
@@ -35,8 +35,6 @@
  * it is demonstrating an inefficiency rather than a correctness bug.
  */
 
-void (*custom_die)(void) = NULL;
-
 /* If changing field count also need to change set_value and get_value calls */
 #define	NR_FIELDS 8
 #define	NR_OBJECTS 100

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -42,8 +42,6 @@
 
 #define	MILLION		1000000
 
-void (*custom_die)(void) = NULL;
-
 /* Needs to be global for signal handling. */
 static TEST_OPTS *opts, _opts;
 

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -52,8 +52,6 @@
  * of inserts set low as a default.
  */
 
-void (*custom_die)(void) = NULL;
-
 #define	N_RECORDS	10000
 #define	N_INSERT	500000
 #define	N_INSERT_THREAD	2

--- a/test/csuite/wt2447_join_main_table/main.c
+++ b/test/csuite/wt2447_join_main_table/main.c
@@ -49,8 +49,6 @@
  * table.
  */
 
-void (*custom_die)(void) = NULL;
-
 #define	N_RECORDS	10000
 
 static void

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -36,8 +36,6 @@
  * Failure mode: Check that the data is correct at the end of the run.
  */
 
-void (*custom_die)(void) = NULL;
-
 void *thread_insert_race(void *);
 
 int

--- a/test/csuite/wt2592_join_schema/main.c
+++ b/test/csuite/wt2592_join_schema/main.c
@@ -66,8 +66,6 @@ static POP_RECORD pop_data[] = {
 	{ "", 0, 0 }
 };
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/csuite/wt2592_join_schema/main.c
+++ b/test/csuite/wt2592_join_schema/main.c
@@ -36,12 +36,6 @@
  * Failure mode: The failure seen in WT-2592 was that no items were returned
  * by a join.
  */
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include <wiredtiger.h>
 
 /* The C struct for the data we are storing in a WiredTiger table. */
 typedef struct {

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -32,8 +32,6 @@
  * Test case description: Smoke-test the CRC.
  */
 
-void (*custom_die)(void) = NULL;
-
 static inline void
 check(uint32_t hw, uint32_t sw, size_t len, const char *msg)
 {

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -34,8 +34,6 @@
  * Test case description: Fuzz testing for WiredTiger reconfiguration.
  */
 
-void (*custom_die)(void) = NULL;
-
 static const char *list[] = {
 	",async=(enabled=0)",
 	",async=(enabled=1)",

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -34,7 +34,7 @@
  * Test case description: Fuzz testing for WiredTiger reconfiguration.
  */
 
-static const char *list[] = {
+static const char * const list[] = {
 	",async=(enabled=0)",
 	",async=(enabled=1)",
 	",async=(ops_max=2048)",

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -101,8 +101,8 @@ main(int argc, char *argv[])
 	    &maincur));
 	maincur->set_key(maincur, N_RECORDS);
 	maincur->set_value(maincur, 54321, 0, "", 0, N_RECORDS);
-	maincur->insert(maincur);
-	maincur->close(maincur);
+	testutil_check(maincur->insert(maincur));
+	testutil_check(maincur->close(maincur));
 	testutil_check(session->close(session, NULL));
 
 	populate(opts);
@@ -151,6 +151,7 @@ main(int argc, char *argv[])
 		    key, key2, post, balance, flag);
 		count++;
 	}
+	testutil_assert(ret == WT_NOTFOUND);
 	testutil_assert(count == 0);
 
 	testutil_cleanup(opts);
@@ -195,6 +196,6 @@ populate(TEST_OPTS *opts)
 		testutil_check(maincur->insert(maincur));
 		testutil_check(session->commit_transaction(session, NULL));
 	}
-	maincur->close(maincur);
-	session->close(session, NULL);
+	testutil_check(maincur->close(maincur));
+	testutil_check(session->close(session, NULL));
 }

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -39,8 +39,6 @@
  *
  * Failure mode: We get results back from our join.
  */
-void (*custom_die)(void) = NULL;
-
 #define	N_RECORDS	100000
 #define	N_INSERT	1000000
 

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -42,8 +42,6 @@
  * continues until the test ends (~30 seconds).
  */
 
-void (*custom_die)(void) = NULL;
-
 static void *thread_insert(void *);
 static void *thread_get(void *);
 

--- a/test/cursor_order/cursor_order.c
+++ b/test/cursor_order/cursor_order.c
@@ -44,8 +44,6 @@ static void wt_shutdown(SHARED_CONFIG *);
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -51,8 +51,6 @@ static void wt_shutdown(void);
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -38,14 +38,14 @@ static void usage(void)
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = format_die;		/* Local death handler. */
-
 int
 main(int argc, char *argv[])
 {
 	time_t start;
 	int ch, onerun, reps;
 	const char *config, *home;
+
+	custom_die = format_die;		/* Local death handler. */
 
 	config = NULL;
 

--- a/test/huge/huge.c
+++ b/test/huge/huge.c
@@ -159,8 +159,6 @@ run(CONFIG *cp, int bigkey, size_t bytes)
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/manydbs/manydbs.c
+++ b/test/manydbs/manydbs.c
@@ -68,8 +68,6 @@ usage(void)
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 static WT_CONNECTION **connections = NULL;
 static WT_CURSOR **cursors = NULL;
 static WT_RAND_STATE rnd;

--- a/test/packing/intpack-test.c
+++ b/test/packing/intpack-test.c
@@ -28,8 +28,6 @@
 
 #include "test_util.h"
 
-void (*custom_die)(void) = NULL;
-
 int
 main(void)
 {

--- a/test/packing/intpack-test2.c
+++ b/test/packing/intpack-test2.c
@@ -28,8 +28,6 @@
 
 #include "test_util.h"
 
-void (*custom_die)(void) = NULL;
-
 int
 main(void)
 {

--- a/test/packing/intpack-test3.c
+++ b/test/packing/intpack-test3.c
@@ -28,8 +28,6 @@
 
 #include "test_util.h"
 
-void (*custom_die)(void) = NULL;
-
 void test_value(int64_t);
 void test_spread(int64_t, int64_t, int64_t);
 

--- a/test/packing/packing-test.c
+++ b/test/packing/packing-test.c
@@ -28,8 +28,6 @@
 
 #include "test_util.h"
 
-void (*custom_die)(void) = NULL;
-
 static void
 check(const char *fmt, ...)
 {

--- a/test/readonly/readonly.c
+++ b/test/readonly/readonly.c
@@ -158,8 +158,6 @@ open_dbs(int op, const char *dir,
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/recovery/random-abort.c
+++ b/test/recovery/random-abort.c
@@ -179,8 +179,6 @@ fill_db(uint32_t nth)
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/recovery/truncated-log.c
+++ b/test/recovery/truncated-log.c
@@ -258,8 +258,6 @@ fill_db(void)
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -64,8 +64,6 @@ static int	 verbose;			/* -v flag */
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/thread/t.c
+++ b/test/thread/t.c
@@ -52,8 +52,6 @@ static void wt_shutdown(void);
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-void (*custom_die)(void) = NULL;
-
 int
 main(int argc, char *argv[])
 {

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -27,6 +27,8 @@
  */
 #include "test_util.h"
 
+void (*custom_die)(void) = NULL;
+
 /*
  * die --
  *	Report an error and quit.

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -144,8 +144,6 @@ testutil_cleanup(TEST_OPTS *opts)
 	if (!opts->preserve)
 		testutil_clean_work_dir(opts->home);
 
-	free(opts->conn_config);
-	free(opts->table_config);
 	free(opts->uri);
 	free(opts->home);
 }

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -116,12 +116,14 @@ testutil_parse_opts(int argc, char * const *argv, TEST_OPTS *opts)
 		}
 
 	/*
-	 * Setup the home directory. It needs to be unique for every test
-	 * or the auto make parallel tester gets upset.
+	 * Setup the home directory if not explicitly specified. It needs to be
+	 * unique for every test or the auto make parallel tester gets upset.
 	 */
-	len = strlen("WT_TEST.")  + strlen(opts->progname) + 10;
-	opts->home = dmalloc(len);
-	snprintf(opts->home, len, "WT_TEST.%s", opts->progname);
+	if (opts->home == NULL) {
+		len = strlen("WT_TEST.")  + strlen(opts->progname) + 10;
+		opts->home = dmalloc(len);
+		snprintf(opts->home, len, "WT_TEST.%s", opts->progname);
+	}
 
 	/* Setup the default URI string */
 	len = strlen("table:") + strlen(opts->progname) + 10;

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -27,10 +27,6 @@
  */
 #include "test_util.h"
 
-extern int   __wt_opterr;		/* if error message should be printed */
-extern int   __wt_optind;		/* index into parent argv vector */
-extern int   __wt_optopt;		/* character checked for validity */
-extern int   __wt_optreset;		/* reset getopt */
 extern char *__wt_optarg;		/* argument associated with option */
 
 /*
@@ -59,7 +55,7 @@ testutil_parse_opts(int argc, char * const *argv, TEST_OPTS *opts)
 			opts->n_append_threads = (uint64_t)atoll(__wt_optarg);
 			break;
 		case 'h': /* Home directory */
-			opts->home = __wt_optarg;
+			opts->home = dstrdup(__wt_optarg);
 			break;
 		case 'n': /* Number of records */
 			opts->nrecords = (uint64_t)atoll(__wt_optarg);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -68,10 +68,8 @@ typedef struct {
 	 * resources.
 	 */
 	WT_CONNECTION *conn;
-	char	  *conn_config;
 	WT_SESSION    *session;
 	bool	   running;
-	char	  *table_config;
 	char	  *uri;
 	volatile uint64_t   next_threadid;
 	uint64_t   max_inserted_id;


### PR DESCRIPTION
@agorrod, for your review/consideration.