### PR TITLE
WT-2959 don't use WT_SESSION_IMPL before it's initialized

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -723,7 +723,7 @@ extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_F
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_init(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);
 extern int __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1757,10 +1757,12 @@ __open_session(WT_CONNECTION_IMPL *conn,
 	if (i >= conn->session_cnt)	/* Defend against off-by-one errors. */
 		conn->session_cnt = i + 1;
 
-	session_ret->id = i;
 	session_ret->iface =
 	    F_ISSET(conn, WT_CONN_READONLY) ? stds_readonly : stds;
 	session_ret->iface.connection = &conn->iface;
+
+	session_ret->name = NULL;
+	session_ret->id = i;
 
 	WT_ERR(__wt_cond_alloc(session, "session", false, &session_ret->cond));
 
@@ -1777,10 +1779,10 @@ __open_session(WT_CONNECTION_IMPL *conn,
 	 * Allocate the table hash array as well.
 	 */
 	if (session_ret->dhhash == NULL)
-		WT_ERR(__wt_calloc(session_ret, WT_HASH_ARRAY_SIZE,
+		WT_ERR(__wt_calloc(session, WT_HASH_ARRAY_SIZE,
 		    sizeof(struct __dhandles_hash), &session_ret->dhhash));
 	if (session_ret->tablehash == NULL)
-		WT_ERR(__wt_calloc(session_ret, WT_HASH_ARRAY_SIZE,
+		WT_ERR(__wt_calloc(session, WT_HASH_ARRAY_SIZE,
 		    sizeof(struct __tables_hash), &session_ret->tablehash));
 	for (i = 0; i < WT_HASH_ARRAY_SIZE; i++) {
 		TAILQ_INIT(&session_ret->dhhash[i]);
@@ -1789,7 +1791,7 @@ __open_session(WT_CONNECTION_IMPL *conn,
 
 	/* Initialize transaction support: default to read-committed. */
 	session_ret->isolation = WT_ISO_READ_COMMITTED;
-	WT_ERR(__wt_txn_init(session_ret));
+	WT_ERR(__wt_txn_init(session, session_ret));
 
 	/*
 	 * The session's hazard pointer memory isn't discarded during normal
@@ -1815,8 +1817,6 @@ __open_session(WT_CONNECTION_IMPL *conn,
 	if (config != NULL)
 		WT_ERR(
 		    __session_reconfigure((WT_SESSION *)session_ret, config));
-
-	session_ret->name = NULL;
 
 	/*
 	 * Publish: make the entry visible to server threads.  There must be a

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -659,20 +659,20 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
  *	Initialize a session's transaction data.
  */
 int
-__wt_txn_init(WT_SESSION_IMPL *session)
+__wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret)
 {
 	WT_TXN *txn;
 
-	txn = &session->txn;
+	txn = &session_ret->txn;
 	txn->id = WT_TXN_NONE;
 
 	WT_RET(__wt_calloc_def(session,
-	    S2C(session)->session_size, &txn->snapshot));
+	    S2C(session_ret)->session_size, &txn->snapshot));
 
 #ifdef HAVE_DIAGNOSTIC
-	if (S2C(session)->txn_global.states != NULL) {
+	if (S2C(session_ret)->txn_global.states != NULL) {
 		WT_TXN_STATE *txn_state;
-		txn_state = WT_SESSION_TXN_STATE(session);
+		txn_state = WT_SESSION_TXN_STATE(session_ret);
 		WT_ASSERT(session, txn_state->pinned_id == WT_TXN_NONE);
 	}
 #endif
@@ -683,7 +683,7 @@ __wt_txn_init(WT_SESSION_IMPL *session)
 	 */
 	txn->mod = NULL;
 
-	txn->isolation = session->isolation;
+	txn->isolation = session_ret->isolation;
 	return (0);
 }
 


### PR DESCRIPTION
@agorrod, I managed to get a core dump with an experimental change I was playing with, and the reason is we're using the WT_SESSION_IMPL we're initializing before we've finished initializing it.

Feel free to throw this away if you don't like it, it wouldn't have fired if I hadn't been modifying session initialization.