### PR TITLE
WT-2954 Try to evict pages that exceed memory_page_max even if the tr…

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -328,8 +328,10 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 		return (false);
 
 	/*
-	 * If we have already tried and the transaction state has not moved on,
-	 * eviction is highly likely to fail.
+	 * Allow some leeway if the transaction ID isn't moving forward since
+	 * it is unlikely eviction will be able to evict the page. Don't keep
+	 * skipping the page indefinitely or large records can lead to
+	 * extremely large memory footprints.
 	 */
 	if (page->memory_footprint < btree->maxmempage &&
 	    page->modify->last_eviction_id == __wt_txn_oldest_id(session))

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -331,7 +331,8 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * If we have already tried and the transaction state has not moved on,
 	 * eviction is highly likely to fail.
 	 */
-	if (page->modify->last_eviction_id == __wt_txn_oldest_id(session))
+	if (page->memory_footprint < btree->maxmempage &&
+	    page->modify->last_eviction_id == __wt_txn_oldest_id(session))
 		return (false);
 
 	if (page->memory_footprint < btree->maxmempage)

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1167,15 +1167,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * There is no point doing an in-memory split unless there is a lot of
 	 * data in the last skiplist on the page.  Split if there are enough
 	 * items and the skiplist does not fit within a single disk page.
-	 *
-	 * Rather than scanning the whole list, walk a higher level, which
-	 * gives a sample of the items -- at level 0 we have all the items, at
-	 * level 1 we have 1/4 and at level 2 we have 1/16th.  If we see more
-	 * than 30 items and more data than would fit in a disk page, split.
 	 */
-#define	WT_MIN_SPLIT_DEPTH	2
-#define	WT_MIN_SPLIT_COUNT	30
-#define	WT_MIN_SPLIT_MULTIPLIER 16      /* At level 2, we see 1/16th entries */
 
 	ins_head = page->type == WT_PAGE_ROW_LEAF ?
 	    (page->pg_row_entries == 0 ?
@@ -1184,8 +1176,40 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	    WT_COL_APPEND(page);
 	if (ins_head == NULL)
 		return (false);
+
+        /*
+         * In the extreme case, where the page is much larger than the maximum
+         * size, split as soon as there are 5 items on the page.
+         */
+#define	WT_MAX_SPLIT_COUNT	5
+        if (page->memory_footprint > btree->maxleafpage * 2) {
+                for (count = 0, ins = ins_head->head[0];
+                    ins != NULL;
+                    ins = ins->next[0]) {
+                        if (++count < WT_MAX_SPLIT_COUNT)
+                                continue;
+
+                        WT_STAT_CONN_INCR(session, cache_inmem_splittable);
+                        WT_STAT_DATA_INCR(session, cache_inmem_splittable);
+                        return (true);
+                }
+
+                return (false);
+        }
+
+        /*
+	 * Rather than scanning the whole list, walk a higher level, which
+	 * gives a sample of the items -- at level 0 we have all the items, at
+	 * level 1 we have 1/4 and at level 2 we have 1/16th.  If we see more
+	 * than 30 items and more data than would fit in a disk page, split.
+         */
+#define	WT_MIN_SPLIT_DEPTH	2
+#define	WT_MIN_SPLIT_COUNT	30
+#define	WT_MIN_SPLIT_MULTIPLIER 16      /* At level 2, we see 1/16th entries */
+
 	for (count = 0, size = 0, ins = ins_head->head[WT_MIN_SPLIT_DEPTH];
-	    ins != NULL; ins = ins->next[WT_MIN_SPLIT_DEPTH]) {
+	    ins != NULL;
+            ins = ins->next[WT_MIN_SPLIT_DEPTH]) {
 		count += WT_MIN_SPLIT_MULTIPLIER;
 		size += WT_MIN_SPLIT_MULTIPLIER *
 		    (WT_INSERT_KEY_SIZE(ins) + WT_UPDATE_MEMSIZE(ins->upd));

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1177,39 +1177,39 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (ins_head == NULL)
 		return (false);
 
-        /*
-         * In the extreme case, where the page is much larger than the maximum
-         * size, split as soon as there are 5 items on the page.
-         */
+	/*
+	 * In the extreme case, where the page is much larger than the maximum
+	 * size, split as soon as there are 5 items on the page.
+	 */
 #define	WT_MAX_SPLIT_COUNT	5
-        if (page->memory_footprint > btree->maxleafpage * 2) {
-                for (count = 0, ins = ins_head->head[0];
-                    ins != NULL;
-                    ins = ins->next[0]) {
-                        if (++count < WT_MAX_SPLIT_COUNT)
-                                continue;
+	if (page->memory_footprint > btree->maxleafpage * 2) {
+		for (count = 0, ins = ins_head->head[0];
+		    ins != NULL;
+		    ins = ins->next[0]) {
+			if (++count < WT_MAX_SPLIT_COUNT)
+				continue;
 
-                        WT_STAT_CONN_INCR(session, cache_inmem_splittable);
-                        WT_STAT_DATA_INCR(session, cache_inmem_splittable);
-                        return (true);
-                }
+			WT_STAT_CONN_INCR(session, cache_inmem_splittable);
+			WT_STAT_DATA_INCR(session, cache_inmem_splittable);
+			return (true);
+		}
 
-                return (false);
-        }
+		return (false);
+	}
 
-        /*
+	/*
 	 * Rather than scanning the whole list, walk a higher level, which
 	 * gives a sample of the items -- at level 0 we have all the items, at
 	 * level 1 we have 1/4 and at level 2 we have 1/16th.  If we see more
 	 * than 30 items and more data than would fit in a disk page, split.
-         */
+	 */
 #define	WT_MIN_SPLIT_DEPTH	2
 #define	WT_MIN_SPLIT_COUNT	30
 #define	WT_MIN_SPLIT_MULTIPLIER 16      /* At level 2, we see 1/16th entries */
 
 	for (count = 0, size = 0, ins = ins_head->head[WT_MIN_SPLIT_DEPTH];
 	    ins != NULL;
-            ins = ins->next[WT_MIN_SPLIT_DEPTH]) {
+	    ins = ins->next[WT_MIN_SPLIT_DEPTH]) {
 		count += WT_MIN_SPLIT_MULTIPLIER;
 		size += WT_MIN_SPLIT_MULTIPLIER *
 		    (WT_INSERT_KEY_SIZE(ins) + WT_UPDATE_MEMSIZE(ins->upd));


### PR DESCRIPTION
…ansaction ID isn't increasing

Workloads that insert large values checking only for the transaction ID
moving forward can lead to very large in-memory pages. Allow the page to exceed
the split size, but not the configured maximum.

Skipping such pages is a performance optimization - allow the optimization to
work as long as pages are between split size and maximum size.

Also don't require so many entries on a leaf page to trigger a split when
there are large values.