### PR TITLE
SERVER-26753 Don't spin on a read-lock in a tight loop.

### DIFF
--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -173,7 +173,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 void
 __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 {
-	wt_rwlock_t *l;
+	wt_rwlock_t *l, old;
 	uint16_t ticket;
 	int pause_cnt;
 
@@ -182,6 +182,15 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 	WT_DIAGNOSTIC_YIELD;
 
 	l = &rwlock->rwlock;
+
+	/* Be optimistic when lock is available to readers. */
+	old = *l;
+	while (old.s.readers == old.s.next) {
+		if (__wt_try_readlock(session, rwlock) == 0)
+			return;
+		WT_PAUSE();
+		old = *l;
+	}
 
 	/*
 	 * Possibly wrap: if we have more than 64K lockers waiting, the ticket
@@ -192,12 +201,9 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 	for (pause_cnt = 0; ticket != l->s.readers;) {
 		/*
 		 * We failed to get the lock; pause before retrying and if we've
-		 * paused enough, sleep so we don't burn CPU to no purpose. This
+		 * paused enough, yield so we don't burn CPU to no purpose. This
 		 * situation happens if there are more threads than cores in the
 		 * system and we're thrashing on shared resources.
-		 *
-		 * Don't sleep long when waiting on a read lock, hopefully we're
-		 * waiting on another read thread to increment the reader count.
 		 */
 		if (++pause_cnt < WT_THOUSAND)
 			WT_PAUSE();

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -199,7 +199,7 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 		 * Don't sleep long when waiting on a read lock, hopefully we're
 		 * waiting on another read thread to increment the reader count.
 		 */
-		if (l->s.readers != l->s.writers && ++pause_cnt < 10 * WT_THOUSAND)
+		if (++pause_cnt < WT_THOUSAND)
 			WT_PAUSE();
 		else
 			__wt_yield();

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -199,10 +199,10 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 		 * Don't sleep long when waiting on a read lock, hopefully we're
 		 * waiting on another read thread to increment the reader count.
 		 */
-		if (l->s.readers != l->s.writers && ++pause_cnt < WT_THOUSAND)
+		if (l->s.readers != l->s.writers && ++pause_cnt < 10 * WT_THOUSAND)
 			WT_PAUSE();
 		else
-			__wt_sleep(0, 10);
+			__wt_yield();
 	}
 
 	/*

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -199,7 +199,7 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *rwlock)
 		 * Don't sleep long when waiting on a read lock, hopefully we're
 		 * waiting on another read thread to increment the reader count.
 		 */
-		if (++pause_cnt < WT_THOUSAND)
+		if (l->s.readers != l->s.writers && ++pause_cnt < WT_THOUSAND)
 			WT_PAUSE();
 		else
 			__wt_sleep(0, 10);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -112,7 +112,6 @@ int
 __wt_txn_get_snapshot(WT_SESSION_IMPL *session)
 {
 	WT_CONNECTION_IMPL *conn;
-	WT_DECL_RET;
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_STATE *s, *txn_state;
@@ -126,14 +125,8 @@ __wt_txn_get_snapshot(WT_SESSION_IMPL *session)
 	txn_state = WT_SESSION_TXN_STATE(session);
 	n = 0;
 
-	/*
-	 * Spin waiting for the lock: the sleeps in our blocking readlock
-	 * implementation are too slow for scanning the transaction table.
-	 */
-	while ((ret =
-	    __wt_try_readlock(session, txn_global->scan_rwlock)) == EBUSY)
-		WT_PAUSE();
-	WT_RET(ret);
+	/* We're going to scan the table: wait for the lock. */
+	__wt_readlock(session, txn_global->scan_rwlock);
 
 	current_id = pinned_id = txn_global->current;
 	prev_oldest_id = txn_global->oldest_id;


### PR DESCRIPTION
We could be starving a thread that we are waiting on of CPU.