### PR TITLE
WT-3003 Don't generate log record and op types.  They must be static.

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -98,34 +98,6 @@ def printf_line(f, optype, i, ishex):
     return ifbegin + body + ifend
 
 #####################################################################
-# Update log.h with #defines for types
-#####################################################################
-log_defines = (
-    ''.join('/*! %s */\n#define\t%s\t%d\n' % (r.desc, r.macro_name(), i)
-        for i, r in enumerate(log_data.rectypes)) +
-    ''.join('/*! %s */\n#define\t%s\t%d\n' % (r.desc, r.macro_name(), i)
-        for i, r in enumerate(log_data.optypes,start=1))
-)
-
-tfile = open(tmp_file, 'w')
-skip = 0
-for line in open('../src/include/wiredtiger.in', 'r'):
-    if skip:
-        if 'Log record declarations: END' in line:
-            tfile.write('/*\n' + line)
-            skip = 0
-    else:
-        tfile.write(line)
-    if 'Log record declarations: BEGIN' in line:
-        skip = 1
-        tfile.write(' */\n')
-        tfile.write('/*! invalid operation */\n')
-        tfile.write('#define\tWT_LOGOP_INVALID\t0\n')
-        tfile.write(log_defines)
-tfile.close()
-compare_srcfile(tmp_file, '../src/include/wiredtiger.in')
-
-#####################################################################
 # Create log_auto.c with handlers for each record / operation type.
 #####################################################################
 f='../src/log/log_auto.c'

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -18,6 +18,11 @@ class LogRecordType:
     def prname(self):
         return '__logrec_print_' + self.name
 
+#
+# If you add a new record type you must also add its record type value in
+# src/include/wiredtiger.in.  The values cannot be generated because they must
+# never change after they're written in a log file.
+#
 rectypes = [
     # A database-wide checkpoint.
     LogRecordType('checkpoint', 'checkpoint', [
@@ -46,6 +51,11 @@ class LogOperationType:
     def macro_name(self):
         return 'WT_LOGOP_%s' % self.name.upper()
 
+#
+# If you add a new operation type you must also add its type value in
+# src/include/wiredtiger.in.  The values cannot be generated because they must
+# never change after they're written in a log file.
+#
 optypes = [
     LogOperationType('col_put', 'column put',
         [('uint32', 'fileid'), ('recno', 'recno'), ('item', 'value')]),

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4200,6 +4200,40 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 
 /*! @} */
 
+/*!
+ * @name Log record and operation types
+ * @anchor log_types
+ * @{
+ */
+/*
+ * NOTE:  The values of these record types and operations must
+ * never change because they're written into the log.  Append
+ * any new records or operations to the appropriate set.
+ */
+/*! invalid operation */
+#define	WT_LOGOP_INVALID	0
+/*! checkpoint */
+#define	WT_LOGREC_CHECKPOINT	0
+/*! transaction commit */
+#define	WT_LOGREC_COMMIT	1
+/*! file sync */
+#define	WT_LOGREC_FILE_SYNC	2
+/*! message */
+#define	WT_LOGREC_MESSAGE	3
+/*! column put */
+#define	WT_LOGOP_COL_PUT	1
+/*! column remove */
+#define	WT_LOGOP_COL_REMOVE	2
+/*! column truncate */
+#define	WT_LOGOP_COL_TRUNCATE	3
+/*! row put */
+#define	WT_LOGOP_ROW_PUT	4
+/*! row remove */
+#define	WT_LOGOP_ROW_REMOVE	5
+/*! row truncate */
+#define	WT_LOGOP_ROW_TRUNCATE	6
+/*! @} */
+
 /*******************************************
  * Statistic reference.
  *******************************************/
@@ -5070,43 +5104,6 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * Statistics section: END
  * DO NOT EDIT: automatically built by dist/api_stat.py.
  */
-/*!
- * @name Log record and operation types
- * @anchor log_types
- * @{
- */
-/*
- * DO NOT EDIT: automatically built by dist/log.py.
- * Log record declarations: BEGIN
- */
-/*! invalid operation */
-#define	WT_LOGOP_INVALID	0
-/*! checkpoint */
-#define	WT_LOGREC_CHECKPOINT	0
-/*! transaction commit */
-#define	WT_LOGREC_COMMIT	1
-/*! file sync */
-#define	WT_LOGREC_FILE_SYNC	2
-/*! message */
-#define	WT_LOGREC_MESSAGE	3
-/*! column put */
-#define	WT_LOGOP_COL_PUT	1
-/*! column remove */
-#define	WT_LOGOP_COL_REMOVE	2
-/*! column truncate */
-#define	WT_LOGOP_COL_TRUNCATE	3
-/*! row put */
-#define	WT_LOGOP_ROW_PUT	4
-/*! row remove */
-#define	WT_LOGOP_ROW_REMOVE	5
-/*! row truncate */
-#define	WT_LOGOP_ROW_TRUNCATE	6
-/*
- * Log record declarations: END
- * DO NOT EDIT: automatically built by dist/log.py.
- */
-/*! @} */
-/*! @} */
 
 #undef __F
 


### PR DESCRIPTION
@keithbostic and @michaelcahill  Please review.  I added comments in log_data.py to remind people to add them to the include file.  Is it clear and visible enough?  Is there an easy way to verify they did add the `#define` in one of the`s_` scripts?