### PR TITLE
SERVER-26889 Got signal: 11 (Segmentation fault) in 3.0.13

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -308,7 +308,6 @@ __split_ref_deepen_move(WT_SESSION_IMPL *session,
 		addr->size = (uint8_t)unpack.size;
 		addr->type =
 		    unpack.raw == WT_CELL_ADDR_INT ? WT_ADDR_INT : WT_ADDR_LEAF;
-		ref->addr = addr;
 		if (!__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr)) {
 			__wt_free(session, addr->addr);
 			__wt_free(session, addr);


### PR DESCRIPTION
Fix 552a33b (cherry-picked from 521270d). When the commit was merged, a line was dropped.

@michaelcahill, for your review: you can see the difference if you compare 521270d and 552a33b, the line `ref->addr = addr;` should have been removed and wasn't. I think the result is `ref->addr` can potentially point to freed memory.