### PR TITLE
WT-2968 Fix a segfault when a drop races with closing a backup cursor.

### DIFF
--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -27,12 +27,17 @@ __wt_schema_backup_check(WT_SESSION_IMPL *session, const char *name)
 	if (!conn->hot_backup)
 		return (0);
 	__wt_readlock(session, conn->hot_backup_lock);
-	if (!conn->hot_backup) {
+	/*
+	 * There is a window at the end of a backup where the list has been
+	 * cleared from the connection but the flag is still set.  It is safe
+	 * to drop at that point.
+	 */
+	if (!conn->hot_backup ||
+	    (backup_list = conn->hot_backup_list) == NULL) {
 		__wt_readunlock(session, conn->hot_backup_lock);
 		return (0);
 	}
-	for (i = 0, backup_list = conn->hot_backup_list;
-	    backup_list[i] != NULL; ++i) {
+	for (i = 0; backup_list[i] != NULL; ++i) {
 		if (strcmp(backup_list[i], name) == 0) {
 			ret = EBUSY;
 			break;


### PR DESCRIPTION
We were clearing the shared pointer to the list of filenames in the
backup, then releasing the hotbackup lock before clearing the hotbackup
flag.  That means drops need to check both the flag and that the pointer
is non-NULL.