### PR TITLE
WT-3011 __wt_curjoin_open() saves the wrong URI in the cursor.

### DIFF
--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1326,7 +1326,6 @@ __wt_curjoin_open(WT_SESSION_IMPL *session,
 	cursor = &cjoin->iface;
 	*cursor = iface;
 	cursor->session = &session->iface;
-	cursor->internal_uri = table->name;
 	cursor->key_format = table->key_format;
 	cursor->value_format = table->value_format;
 	cjoin->table = table;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -326,8 +326,7 @@ __curjoin_close(WT_CURSOR *cursor)
 	JOINABLE_CURSOR_API_CALL(cursor, session, close, NULL);
 
 	__wt_schema_release_table(session, cjoin->table);
-	/* These are owned by the table */
-	cursor->internal_uri = NULL;
+	/* This is owned by the table */
 	cursor->key_format = NULL;
 	if (cjoin->projection != NULL) {
 		__wt_free(session, cjoin->projection);

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1310,11 +1310,10 @@ __wt_curjoin_open(WT_SESSION_IMPL *session,
 		WT_RET_MSG(session, EINVAL,
 		    "unable to initialize a join cursor with existing owner");
 
-	if (!WT_PREFIX_SKIP(uri, "join:"))
-		return (__wt_unexpected_object_type(session, uri, "join:"));
 	tablename = uri;
-	if (!WT_PREFIX_SKIP(tablename, "table:"))
-		return (__wt_unexpected_object_type(session, uri, "table:"));
+	if (!WT_PREFIX_SKIP(tablename, "join:table:"))
+		return (
+		    __wt_unexpected_object_type(session, uri, "join:table:"));
 
 	columns = strchr(tablename, '(');
 	if (columns == NULL)


### PR DESCRIPTION
@ddanderson, this one is for you, please.

Two changes.

First, Coverity had a false positive about some code in `__wt_curjoin_open()`, and while looking at it, I noticed we were storing `table:xxx` in the cursor's `internal_uri` field rather than `join:table:xxx`, which looks wrong to me. By happy coincidence, this change should also keep Coverity quiet.

Second, there was one thing I noticed awhile ago was that the __wt_json_token() error handling was a little strange. All but one error wrote out a message and then  fell out of the switch statement to fail (setting the returned token type to -1), and the one other error simply returned (not setting the returned token type). I switched all of the errors to immediately return instead of falling out of the switch statement.

If I'm misunderstanding what's going on here, just kill either or both changes!