### PR TITLE
WT-2962 Allow configuration of builtin extensions.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -652,6 +652,11 @@ wiredtiger_open_common =\
         should be used (4KB on Linux systems when direct I/O is configured,
         zero elsewhere)''',
         min='-1', max='1MB'),
+    Config('builtin_extension_config', '', r'''
+        A structure where the keys are the names of builtin extensions and the
+        values are passed to WT_CONNECTION::load_extension as the \c config
+        parameter (for example,
+        <code>builtin_extension_config={zlib={compression_level=3}}</code>)'''),
     Config('checkpoint_sync', 'true', r'''
         flush files to stable storage when closing or writing
         checkpoints''',

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1085,6 +1085,15 @@ main(void)
 	 * The connection has been closed.
 	 */
 
+	/*! [Configure zlib extension with compression level] */
+	ret = wiredtiger_open(home, NULL,
+	    "create,"
+	    "extensions=[/usr/local/lib/"
+	    "libwiredtiger_zlib.so=[config=[compression_level=3]]]", &conn);
+	/*! [Configure zlib extension with compression level] */
+	if (ret == 0)
+		(void)conn->close(conn, NULL);
+
 #ifdef MIGHT_NOT_RUN
 	/*
 	 * This example code gets run, and the compression libraries might not
@@ -1112,15 +1121,6 @@ main(void)
 	    "create,"
 	    "extensions=[/usr/local/lib/libwiredtiger_zlib.so]", &conn);
 	/*! [Configure zlib extension] */
-	if (ret == 0)
-		(void)conn->close(conn, NULL);
-
-	/*! [Configure zlib extension with compression level] */
-	ret = wiredtiger_open(home, NULL,
-	    "create,"
-	    "extensions=[/usr/local/lib/"
-	    "libwiredtiger_zlib.so=[config=[compression_level=3]]]", &conn);
-	/*! [Configure zlib extension with compression level] */
 	if (ret == 0)
 		(void)conn->close(conn, NULL);
 

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1085,15 +1085,6 @@ main(void)
 	 * The connection has been closed.
 	 */
 
-	/*! [Configure zlib extension with compression level] */
-	ret = wiredtiger_open(home, NULL,
-	    "create,"
-	    "extensions=[/usr/local/lib/"
-	    "libwiredtiger_zlib.so=[config=[compression_level=3]]]", &conn);
-	/*! [Configure zlib extension with compression level] */
-	if (ret == 0)
-		(void)conn->close(conn, NULL);
-
 #ifdef MIGHT_NOT_RUN
 	/*
 	 * This example code gets run, and the compression libraries might not
@@ -1121,6 +1112,15 @@ main(void)
 	    "create,"
 	    "extensions=[/usr/local/lib/libwiredtiger_zlib.so]", &conn);
 	/*! [Configure zlib extension] */
+	if (ret == 0)
+		(void)conn->close(conn, NULL);
+
+	/*! [Configure zlib extension with compression level] */
+	ret = wiredtiger_open(home, NULL,
+	    "create,"
+	    "extensions=[/usr/local/lib/"
+	    "libwiredtiger_zlib.so=[config=[compression_level=3]]]", &conn);
+	/*! [Configure zlib extension with compression level] */
 	if (ret == 0)
 		(void)conn->close(conn, NULL);
 

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -194,19 +194,9 @@ demo_file_system_create(WT_CONNECTION *conn, WT_CONFIG_ARG *config)
 	 * the underlying filesystem implementation. See the main function for
 	 * the setup of those configuration strings; here we parse configuration
 	 * information as passed in by main, through WiredTiger.
-	 *
-	 * Retrieve our configuration information, the "config" value.
 	 */
-	if ((ret = wtext->config_get(wtext, NULL, config, "config", &v)) != 0) {
-		(void)wtext->err_printf(wtext, NULL,
-		    "WT_EXTENSION_API.config_get: config: %s",
-		    wtext->strerror(wtext, NULL, ret));
-		goto err;
-	}
-
-	/* Open a WiredTiger parser on the "config" value. */
-	if ((ret = wtext->config_parser_open(
-	    wtext, NULL, v.str, v.len, &config_parser)) != 0) {
+	if ((ret = wtext->config_parser_open_arg(
+	    wtext, NULL, config, &config_parser)) != 0) {
 		(void)wtext->err_printf(wtext, NULL,
 		    "WT_EXTENSION_API.config_parser_open: config: %s",
 		    wtext->strerror(wtext, NULL, ret));

--- a/ext/datasources/helium/helium.c
+++ b/ext/datasources/helium/helium.c
@@ -3380,15 +3380,9 @@ wiredtiger_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
 		goto err;
 	ds->lockinit = 1;
 
-	/* Get the configuration string. */
-	if ((ret = wt_api->config_get(wt_api, NULL, config, "config", &v)) != 0)
-		EMSG_ERR(wt_api, NULL, ret,
-		    "WT_EXTENSION_API.config_get: config: %s",
-		    wt_api->strerror(wt_api, NULL, ret));
-
 	/* Step through the list of Helium sources, opening each one. */
-	if ((ret = wt_api->config_parser_open(
-	    wt_api, NULL, v.str, v.len, &config_parser)) != 0)
+	if ((ret = wt_api->config_parser_open_arg(
+	    wt_api, NULL, config, &config_parser)) != 0)
 		EMSG_ERR(wt_api, NULL, ret,
 		    "WT_EXTENSION_API.config_parser_open: config: %s",
 		    wt_api->strerror(wt_api, NULL, ret));

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -711,7 +711,7 @@ __wt_config_getones(WT_SESSION_IMPL *session,
 /*
  * __wt_config_getones_none --
  *	Get the value for a given string key from a single config string.
- * Treat "none" as empty.
+ *	Treat "none" as empty.
  */
 int
 __wt_config_getones_none(WT_SESSION_IMPL *session,

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -657,6 +657,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
+	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -742,6 +743,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
+	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -828,6 +830,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
+	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -908,6 +911,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
+	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1226,38 +1230,62 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
-	  "wait=0),checkpoint_sync=true,config_base=true,create=false,"
-	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
-	  "eviction=(threads_max=1,threads_min=1),"
-	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
-	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-	  ",wait=0),transaction_sync=(enabled=false,method=fsync),"
+	  ",builtin_extension_config=,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=1,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=false,method=fsync),"
 	  "use_environment=true,use_environment_priv=false,verbose=,"
 	  "write_through=",
-	  confchk_wiredtiger_open, 39
+	  confchk_wiredtiger_open, 40
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
-	  "wait=0),checkpoint_sync=true,config_base=true,create=false,"
-	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  ",builtin_extension_config=,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=1,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=false,method=fsync),"
+	  "use_environment=true,use_environment_priv=false,verbose=,"
+	  "version=(major=0,minor=0),write_through=",
+	  confchk_wiredtiger_open_all, 41
+	},
+	{ "wiredtiger_open_basecfg",
+	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
+	  ",builtin_extension_config=,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=1,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
+	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
+	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
 	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
@@ -1265,44 +1293,22 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
 	  "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
 	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-	  ",wait=0),transaction_sync=(enabled=false,method=fsync),"
-	  "use_environment=true,use_environment_priv=false,verbose=,"
-	  "version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_all, 40
-	},
-	{ "wiredtiger_open_basecfg",
-	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
-	  "wait=0),checkpoint_sync=true,direct_io=,encryption=(keyid=,name="
-	  ",secretkey=),error_prefix=,eviction=(threads_max=1,"
-	  "threads_min=1),eviction_checkpoint_target=5,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=true,"
-	  "compressor=,enabled=false,file_max=100MB,path=\".\","
-	  "prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
 	  ",wait=0),transaction_sync=(enabled=false,method=fsync),verbose=,"
 	  "version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_basecfg, 34
+	  confchk_wiredtiger_open_basecfg, 35
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
-	  "wait=0),checkpoint_sync=true,direct_io=,encryption=(keyid=,name="
-	  ",secretkey=),error_prefix=,eviction=(threads_max=1,"
-	  "threads_min=1),eviction_checkpoint_target=5,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,log=(archive=true,"
-	  "compressor=,enabled=false,file_max=100MB,path=\".\","
-	  "prealloc=true,recover=on,zero_fill=false),"
+	  ",builtin_extension_config=,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=1,threads_min=1),"
+	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
+	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
+	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
+	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
+	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
 	  "mmap=true,multiprocess=false,readonly=false,session_max=100,"
 	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
@@ -1310,7 +1316,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
 	  ",wait=0),transaction_sync=(enabled=false,method=fsync),verbose=,"
 	  "write_through=",
-	  confchk_wiredtiger_open_usercfg, 33
+	  confchk_wiredtiger_open_usercfg, 34
 	},
 	{ NULL, NULL, NULL, 0 }
 };

--- a/src/config/config_ext.c
+++ b/src/config/config_ext.c
@@ -9,22 +9,9 @@
 #include "wt_internal.h"
 
 /*
- * __wt_ext_config_parser_open --
- *	WT_EXTENSION_API->config_parser_open implementation
- */
-int
-__wt_ext_config_parser_open(WT_EXTENSION_API *wt_ext, WT_SESSION *wt_session,
-    const char *config, size_t len, WT_CONFIG_PARSER **config_parserp)
-{
-	WT_UNUSED(wt_ext);
-	return (wiredtiger_config_parser_open(
-	    wt_session, config, len, config_parserp));
-}
-
-/*
  * __wt_ext_config_get --
  *	Given a NULL-terminated list of configuration strings, find the final
- * value for a given string key (external API version).
+ *	value for a given string key (external API version).
  */
 int
 __wt_ext_config_get(WT_EXTENSION_API *wt_api,
@@ -42,4 +29,66 @@ __wt_ext_config_get(WT_EXTENSION_API *wt_api,
 	if ((cfg = (const char **)cfg_arg) == NULL)
 		return (WT_NOTFOUND);
 	return (__wt_config_gets(session, cfg, key, cval));
+}
+
+/*
+ * __wt_ext_config_get_string --
+ *	Given a configuration string, find the value for a given string key
+ *	(external API version).
+ */
+int
+__wt_ext_config_get_string(WT_EXTENSION_API *wt_api,
+    WT_SESSION *wt_session, const char *config, const char *key,
+    WT_CONFIG_ITEM *cval)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_SESSION_IMPL *session;
+
+	conn = (WT_CONNECTION_IMPL *)wt_api->conn;
+	if ((session = (WT_SESSION_IMPL *)wt_session) == NULL)
+		session = conn->default_session;
+
+	return (__wt_config_getones(session, config, key, cval));
+}
+
+/*
+ * __wt_ext_config_parser_open --
+ *	WT_EXTENSION_API->config_parser_open implementation
+ */
+int
+__wt_ext_config_parser_open(WT_EXTENSION_API *wt_ext, WT_SESSION *wt_session,
+    const char *config, size_t len, WT_CONFIG_PARSER **config_parserp)
+{
+	WT_UNUSED(wt_ext);
+	return (wiredtiger_config_parser_open(
+	    wt_session, config, len, config_parserp));
+}
+
+/*
+ * __wt_ext_config_parser_open_arg --
+ *	WT_EXTENSION_API->config_parser_open_arg implementation
+ */
+int
+__wt_ext_config_parser_open_arg(WT_EXTENSION_API *wt_ext,
+    WT_SESSION *wt_session, WT_CONFIG_ARG *cfg_arg,
+    WT_CONFIG_PARSER **config_parserp)
+{
+	const char **cfg, *p;
+	size_t len;
+
+	WT_UNUSED(wt_ext);
+
+	/* Find the last non-NULL entry in the configuration stack. */
+	if ((cfg = (const char **)cfg_arg) == NULL || *cfg == NULL) {
+		p = NULL;
+		len = 0;
+	} else {
+		while (cfg[1] != NULL)
+			++cfg;
+		p = *cfg;
+		len = strlen(p);
+	}
+
+	return (wiredtiger_config_parser_open(
+	    wt_session, p, len, config_parserp));
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -809,9 +809,11 @@ __conn_builtin_init(WT_CONNECTION_IMPL *conn, const char *name,
 
 	session = conn->default_session;
 
-	WT_RET(__wt_config_gets(session, cfg, "builtin_extension_config", &all_configs));
+	WT_RET(__wt_config_gets(
+	    session, cfg, "builtin_extension_config", &all_configs));
 	WT_CLEAR(cval);
-	WT_RET_NOTFOUND_OK(__wt_config_subgets(session, &all_configs, name, &cval));
+	WT_RET_NOTFOUND_OK(__wt_config_subgets(
+	    session, &all_configs, name, &cval));
 	WT_RET(__wt_strndup(session, cval.str, cval.len, &config));
 	ext_cfg[0] = config;
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -756,8 +756,11 @@ __conn_get_extension_api(WT_CONNECTION *wt_conn)
 	conn->extension_api.scr_free = __wt_ext_scr_free;
 	conn->extension_api.collator_config = ext_collator_config;
 	conn->extension_api.collate = ext_collate;
-	conn->extension_api.config_parser_open = __wt_ext_config_parser_open;
 	conn->extension_api.config_get = __wt_ext_config_get;
+	conn->extension_api.config_get_string = __wt_ext_config_get_string;
+	conn->extension_api.config_parser_open = __wt_ext_config_parser_open;
+	conn->extension_api.config_parser_open_arg =
+	    __wt_ext_config_parser_open_arg;
 	conn->extension_api.metadata_insert = __wt_ext_metadata_insert;
 	conn->extension_api.metadata_remove = __wt_ext_metadata_remove;
 	conn->extension_api.metadata_search = __wt_ext_metadata_search;
@@ -789,39 +792,68 @@ __conn_get_extension_api(WT_CONNECTION *wt_conn)
 	return (&conn->extension_api);
 }
 
+/*
+ * __conn_builtin_init --
+ *	Initialize and configure a builtin extension.
+ */
+static int
+__conn_builtin_init(WT_CONNECTION_IMPL *conn, const char *name,
+    int (*extension_init)(WT_CONNECTION *, WT_CONFIG_ARG *),
+    const char *cfg[])
+{
+	WT_CONFIG_ITEM all_configs, cval;
+	WT_DECL_RET;
+	WT_SESSION_IMPL *session;
+	char *config;
+	const char *ext_cfg[] = { NULL, NULL };
+
+	session = conn->default_session;
+
+	WT_RET(__wt_config_gets(session, cfg, "builtin_extension_config", &all_configs));
+	WT_CLEAR(cval);
+	WT_RET_NOTFOUND_OK(__wt_config_subgets(session, &all_configs, name, &cval));
+	WT_RET(__wt_strndup(session, cval.str, cval.len, &config));
+	ext_cfg[0] = config;
+
+	ret = extension_init(&conn->iface, NULL);
+	__wt_free(session, config);
+
+	return (ret);
+}
+
 #ifdef HAVE_BUILTIN_EXTENSION_LZ4
-	extern int lz4_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+extern int lz4_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_SNAPPY
-	extern int snappy_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+extern int snappy_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_ZLIB
-	extern int zlib_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+extern int zlib_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_ZSTD
-	extern int zstd_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
+extern int zstd_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
 #endif
 
 /*
- * __conn_load_default_extensions --
+ * __conn_builtin_extensions --
  *	Load extensions that are enabled via --with-builtins
  */
 static int
-__conn_load_default_extensions(WT_CONNECTION_IMPL *conn)
+__conn_builtin_extensions(WT_CONNECTION_IMPL *conn, const char *cfg[])
 {
 	WT_UNUSED(conn);
 
 #ifdef HAVE_BUILTIN_EXTENSION_LZ4
-	WT_RET(lz4_extension_init(&conn->iface, NULL));
+	WT_RET(__conn_builtin_init(conn, "lz4", lz4_extension_init, cfg));
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_SNAPPY
-	WT_RET(snappy_extension_init(&conn->iface, NULL));
+	WT_RET(__conn_builtin_init(conn, "snappy", snappy_extension_init, cfg));
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_ZLIB
-	WT_RET(zlib_extension_init(&conn->iface, NULL));
+	WT_RET(__conn_builtin_init(conn, "zlib", zlib_extension_init, cfg));
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_ZSTD
-	WT_RET(zstd_extension_init(&conn->iface, NULL));
+	WT_RET(__conn_builtin_init(conn, "zstd", zstd_extension_init, cfg));
 #endif
 	return (0);
 }
@@ -839,10 +871,11 @@ __conn_load_extension_int(WT_SESSION_IMPL *session,
 	WT_DLH *dlh;
 	int (*load)(WT_CONNECTION *, WT_CONFIG_ARG *);
 	bool is_local;
-	const char *init_name, *terminate_name;
+	const char *ext_config, *init_name, *terminate_name;
+	const char *ext_cfg[2];
 
 	dlh = NULL;
-	init_name = terminate_name = NULL;
+	ext_config = init_name = terminate_name = NULL;
 	is_local = strcmp(path, "local") == 0;
 
 	/* Ensure that the load matches the phase of startup we are in. */
@@ -872,8 +905,14 @@ __conn_load_extension_int(WT_SESSION_IMPL *session,
 	WT_ERR(
 	    __wt_dlsym(session, dlh, terminate_name, false, &dlh->terminate));
 
+	WT_CLEAR(cval);
+	WT_ERR_NOTFOUND_OK(__wt_config_gets(session, cfg, "config", &cval));
+	WT_ERR(__wt_strndup(session, cval.str, cval.len, &ext_config));
+	ext_cfg[0] = ext_config;
+	ext_cfg[1] = NULL;
+
 	/* Call the load function last, it simplifies error handling. */
-	WT_ERR(load(&S2C(session)->iface, (WT_CONFIG_ARG *)cfg));
+	WT_ERR(load(&S2C(session)->iface, (WT_CONFIG_ARG *)ext_cfg));
 
 	/* Link onto the environment's list of open libraries. */
 	__wt_spin_lock(session, &S2C(session)->api_lock);
@@ -2355,7 +2394,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 * everything else to be in place, and the extensions call back into the
 	 * library.
 	 */
-	WT_ERR(__conn_load_default_extensions(conn));
+	WT_ERR(__conn_builtin_extensions(conn, cfg));
 	WT_ERR(__conn_load_extensions(session, cfg, false));
 
 	/*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -859,6 +859,7 @@ __conn_builtin_extensions(WT_CONNECTION_IMPL *conn, const char *cfg[])
 	/* Avoid warnings if no builtin extensions are configured. */
 	WT_UNUSED(conn);
 	WT_UNUSED(cfg);
+	WT_UNUSED(__conn_builtin_init);
 
 	return (0);
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -817,7 +817,7 @@ __conn_builtin_init(WT_CONNECTION_IMPL *conn, const char *name,
 	WT_RET(__wt_strndup(session, cval.str, cval.len, &config));
 	ext_cfg[0] = config;
 
-	ret = extension_init(&conn->iface, NULL);
+	ret = extension_init(&conn->iface, (WT_CONFIG_ARG *)ext_cfg);
 	__wt_free(session, config);
 
 	return (ret);
@@ -843,8 +843,6 @@ extern int zstd_extension_init(WT_CONNECTION *, WT_CONFIG_ARG *);
 static int
 __conn_builtin_extensions(WT_CONNECTION_IMPL *conn, const char *cfg[])
 {
-	WT_UNUSED(conn);
-
 #ifdef HAVE_BUILTIN_EXTENSION_LZ4
 	WT_RET(__conn_builtin_init(conn, "lz4", lz4_extension_init, cfg));
 #endif
@@ -857,6 +855,11 @@ __conn_builtin_extensions(WT_CONNECTION_IMPL *conn, const char *cfg[])
 #ifdef HAVE_BUILTIN_EXTENSION_ZSTD
 	WT_RET(__conn_builtin_init(conn, "zstd", zstd_extension_init, cfg));
 #endif
+
+	/* Avoid warnings if no builtin extensions are configured. */
+	WT_UNUSED(conn);
+	WT_UNUSED(cfg);
+
 	return (0);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -226,8 +226,10 @@ extern int __wt_config_merge(WT_SESSION_IMPL *session, const char **cfg, const c
 extern int __wt_conn_config_init(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern const WT_CONFIG_ENTRY *__wt_conn_config_match(const char *method);
-extern int __wt_ext_config_parser_open(WT_EXTENSION_API *wt_ext, WT_SESSION *wt_session, const char *config, size_t len, WT_CONFIG_PARSER **config_parserp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ext_config_get(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, WT_CONFIG_ARG *cfg_arg, const char *key, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ext_config_get_string(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *config, const char *key, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ext_config_parser_open(WT_EXTENSION_API *wt_ext, WT_SESSION *wt_session, const char *config, size_t len, WT_CONFIG_PARSER **config_parserp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ext_config_parser_open_arg(WT_EXTENSION_API *wt_ext, WT_SESSION *wt_session, WT_CONFIG_ARG *cfg_arg, WT_CONFIG_PARSER **config_parserp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_config_upgrade(WT_SESSION_IMPL *session, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_wiredtiger_error(int error);
 extern int __wt_collator_config(WT_SESSION_IMPL *session, const char *uri, WT_CONFIG_ITEM *cname, WT_CONFIG_ITEM *metadata, WT_COLLATOR **collatorp, int *ownp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2204,6 +2204,11 @@ struct __wt_connection {
  * I/O. The default value of -1 indicates a platform-specific alignment value
  * should be used (4KB on Linux systems when direct I/O is configured\, zero
  * elsewhere)., an integer between -1 and 1MB; default \c -1.}
+ * @config{builtin_extension_config, A structure where the keys are the names of
+ * builtin extensions and the values are passed to WT_CONNECTION::load_extension
+ * as the \c config parameter (for example\,
+ * <code>builtin_extension_config={zlib={compression_level=3}}</code>)., a
+ * string; default empty.}
  * @config{cache_overhead, assume the heap allocator overhead is the specified
  * percentage\, and adjust the cache usage by that amount (for example\, if
  * there is 10GB of data in cache\, a percentage of 10 means WiredTiger treats

--- a/src/include/wiredtiger_ext.h
+++ b/src/include/wiredtiger_ext.h
@@ -204,18 +204,12 @@ struct __wt_extension_api {
 	    WT_COLLATOR *collator, WT_ITEM *first, WT_ITEM *second, int *cmp);
 
 	/*!
-	 * @copydoc wiredtiger_config_parser_open
-	 */
-	int (*config_parser_open)(WT_EXTENSION_API *wt_api, WT_SESSION *session,
-	    const char *config, size_t len, WT_CONFIG_PARSER **config_parserp);
-
-	/*!
-	 * Return the value of a configuration string.
+	 * Return the value of a configuration key.
 	 *
 	 * @param wt_api the extension handle
 	 * @param session the session handle (or NULL if none available)
-	 * @param key configuration key string
 	 * @param config the configuration information passed to an application
+	 * @param key configuration key string
 	 * @param value the returned value
 	 * @errors
 	 *
@@ -223,6 +217,34 @@ struct __wt_extension_api {
 	 */
 	int (*config_get)(WT_EXTENSION_API *wt_api, WT_SESSION *session,
 	    WT_CONFIG_ARG *config, const char *key, WT_CONFIG_ITEM *value);
+
+	/*!
+	 * Return the value of a configuration key from a string.
+	 *
+	 * @param wt_api the extension handle
+	 * @param session the session handle (or NULL if none available)
+	 * @param config the configuration string
+	 * @param key configuration key string
+	 * @param value the returned value
+	 * @errors
+	 *
+	 * @snippet ex_data_source.c WT_EXTENSION config_get
+	 */
+	int (*config_get_string)(WT_EXTENSION_API *wt_api, WT_SESSION *session,
+	    const char *config, const char *key, WT_CONFIG_ITEM *value);
+
+	/*!
+	 * @copydoc wiredtiger_config_parser_open
+	 */
+	int (*config_parser_open)(WT_EXTENSION_API *wt_api, WT_SESSION *session,
+	    const char *config, size_t len, WT_CONFIG_PARSER **config_parserp);
+
+	/*!
+	 * @copydoc wiredtiger_config_parser_open
+	 */
+	int (*config_parser_open_arg)(WT_EXTENSION_API *wt_api,
+	    WT_SESSION *session, WT_CONFIG_ARG *config,
+	    WT_CONFIG_PARSER **config_parserp);
 
 	/*!
 	 * Insert a row into the metadata if it does not already exist.

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -301,7 +301,7 @@ config_compression(const char *conf_name)
 		break;
 #endif
 #ifdef HAVE_BUILTIN_EXTENSION_ZSTD
-	case 15: case 16 case 17:		/* 15% zstd */
+	case 15: case 16: case 17:		/* 15% zstd */
 		cstr = "zstd";
 		break;
 #endif


### PR DESCRIPTION
While in the area, fix sending "config={values}" to extensions: just
the values should be passed in.