### PR TITLE
WT-3020 Always make LSM chunks evictable when they are switched out.

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1562,7 +1562,7 @@ __wt_btree_lsm_switch_primary(WT_SESSION_IMPL *session, bool on)
 	cache = S2C(session)->cache;
 	root = btree->root.page;
 
-	if (on && !F_ISSET(btree, WT_BTREE_LSM_PRIMARY))
+	if (!F_ISSET(btree, WT_BTREE_LSM_PRIMARY))
 		F_SET(btree, WT_BTREE_LSM_PRIMARY | WT_BTREE_NO_EVICTION);
 	if (!on && F_ISSET(btree, WT_BTREE_LSM_PRIMARY)) {
 		pindex = WT_INTL_INDEX_GET_SAFE(root);
@@ -1575,21 +1575,19 @@ __wt_btree_lsm_switch_primary(WT_SESSION_IMPL *session, bool on)
 		 * We're reaching down into the page without a hazard pointer,
 		 * but that's OK because we know that no-eviction is set so the
 		 * page can't disappear.
-		 */
-		child = first->page;
-		if (first->state != WT_REF_MEM ||
-		    child->type != WT_PAGE_ROW_LEAF ||
-		    !__wt_page_is_modified(child))
-			return;
-
-		/*
+		 *
 		 * While this tree was the primary, its dirty bytes were not
 		 * included in the cache accounting.  Fix that now before we
 		 * open it up for eviction.
 		 */
-		size = child->modify->bytes_dirty;
-		(void)__wt_atomic_add64(&btree->bytes_dirty_leaf, size);
-		(void)__wt_atomic_add64(&cache->bytes_dirty_leaf, size);
+		child = first->page;
+		if (first->state == WT_REF_MEM &&
+		    child->type == WT_PAGE_ROW_LEAF &&
+		    __wt_page_is_modified(child)) {
+			size = child->modify->bytes_dirty;
+			(void)__wt_atomic_add64(&btree->bytes_dirty_leaf, size);
+			(void)__wt_atomic_add64(&cache->bytes_dirty_leaf, size);
+		}
 
 		F_CLR(btree, WT_BTREE_LSM_PRIMARY | WT_BTREE_NO_EVICTION);
 	}


### PR DESCRIPTION
Reverts a bug introduced in WT-3012.