### PR TITLE
WT-3028 Count eviction of dirty pages as progress.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2264,9 +2264,16 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 	 *
 	 * Pages with unresolved changes are not marked clean during
 	 * reconciliation, do it now.
+	 *
+	 * The page is not being completely evicted: instead it is being split.
+	 * Don't increment the count of pages evicted, which we use to decide
+	 * whether eviction is making progress.  Repeatedly splitting a page
+	 * isn't progress.
 	 */
 	__wt_page_modify_clear(session, page);
+	F_SET(session, WT_SESSION_IN_SPLIT);
 	__wt_ref_out(session, ref);
+	F_CLR(session, WT_SESSION_IN_SPLIT);
 
 	/* Swap the new page into place. */
 	ref->page = new->page;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -163,10 +163,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		 */
 		WT_ERR(__evict_page_clean_update(
 		    session, ref, tree_dead || closing));
-	else {
-		ret = __evict_page_dirty_update(session, ref, closing);
-		WT_ERR(ret);
-	}
+	else
+		WT_ERR(__evict_page_dirty_update(session, ref, closing));
 
 	if (clean_page) {
 		WT_STAT_CONN_INCR(session, cache_eviction_clean);
@@ -317,21 +315,13 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		 * that case, we end up here with a single block that we can't
 		 * write. Take advantage of the fact we have exclusive access
 		 * to the page and rewrite it in memory.
-		 *
-		 * The page is not being completely evicted: instead it is
-		 * being split.  Don't increment the count of pages evicted,
-		 * which we use to decide whether eviction is making progress.
-		 * Repeatedly splitting a page isn't progress.
 		 */
-		F_SET(session, WT_SESSION_IN_SPLIT);
 		if (mod->mod_multi_entries == 1) {
 			WT_ASSERT(session, closing == false);
-			ret = __wt_split_rewrite(
-			    session, ref, &mod->mod_multi[0]);
+			WT_RET(__wt_split_rewrite(
+			    session, ref, &mod->mod_multi[0]));
 		} else
-			ret = __wt_split_multi(session, ref, closing);
-		F_CLR(session, WT_SESSION_IN_SPLIT);
-		WT_RET(ret);
+			WT_RET(__wt_split_multi(session, ref, closing));
 		break;
 	case WT_PM_REC_REPLACE: 			/* 1-for-1 page swap */
 		/*
@@ -361,17 +351,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 			memset(&multi, 0, sizeof(multi));
 			multi.disk_image = mod->mod_disk_image;
 
-			/*
-			 * The page is not being completely evicted: instead it
-			 * is being replaced.  Don't increment the count of
-			 * pages evicted, which we use to decide whether
-			 * eviction is making progress.  Repeatedly rewriting
-			 * the same page isn't progress.
-			 */
-			F_SET(session, WT_SESSION_IN_SPLIT);
-			ret = __wt_split_rewrite(session, ref, &multi);
-			F_CLR(session, WT_SESSION_IN_SPLIT);
-			WT_RET(ret);
+			WT_RET(__wt_split_rewrite(session, ref, &multi));
 		}
 
 		break;


### PR DESCRIPTION
Fixes part of WT-3023, which was only supposed to avoid counting page
rewrites as progress...