### PR TITLE
WT-3048 WiredTiger maximum size warning uses the wrong format.

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -5,7 +5,8 @@ trap 'rm -f $t' 0 1 2 3 13 15
 
 cd ..
 
-# Turn a C file into a line per function that returns an int.
+# Parse a C file, discarding functions that don't return an int, and formatting
+# the remaining functions as a single line.
 file_parse()
 {
 	sed -n \
@@ -109,7 +110,7 @@ func_ok()
 }
 
 # Complain about functions which return an "int" but which don't return except
-# at the end of the function. This script is a kluge and isn't run by default.
+# at the end of the function.
 for f in `find bench ext src test -name '*.[ci]'`; do
 	if expr "$f" : '.*/windows_shim.c' > /dev/null; then
 		continue

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -41,7 +41,7 @@ __cursor_size_chk(WT_SESSION_IMPL *session, WT_ITEM *kv)
 	if (kv->size > WT_BTREE_MAX_OBJECT_SIZE)
 		WT_RET_MSG(session, EINVAL,
 		    "item size of %" WT_SIZET_FMT " exceeds the maximum "
-		    "supported WiredTiger size of %d",
+		    "supported WiredTiger size of %" PRIu32,
 		    kv->size, WT_BTREE_MAX_OBJECT_SIZE);
 
 	/* Check what the block manager can actually write. */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -44,7 +44,7 @@
  * Record numbers are stored in 64-bit unsigned integers, meaning the largest
  * record number is "really, really big".
  */
-#define	WT_BTREE_MAX_OBJECT_SIZE	(UINT32_MAX - 1024)
+#define	WT_BTREE_MAX_OBJECT_SIZE	((uint32_t)(UINT32_MAX - 1024))
 
 /*
  * A location in a file is a variable-length cookie, but it has a maximum size


### PR DESCRIPTION
WT-3048 WiredTiger maximum size warning uses the wrong format.