### PR TITLE
WT-3030  Fix a race between scans and splits reading the index hint.

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -48,13 +48,13 @@ retry:	WT_INTL_INDEX_GET(session, ref->home, pindex);
 	while (++i < pindex->entries)
 		if (pindex->index[i]->page == ref->page) {
 			*pindexp = pindex;
-			*slotp = ref->pindex_hint = i;
+			*slotp = i;
 			return;
 		}
 	for (i = 0; i < pindex->entries; ++i)
 		if (pindex->index[i]->page == ref->page) {
 			*pindexp = pindex;
-			*slotp = ref->pindex_hint = i;
+			*slotp = i;
 			return;
 		}
 


### PR DESCRIPTION
WT-3030  Fix a race between scans and splits reading the index hint.