### PR TITLE
WT-3053 Python and Java support use internal WiredTiger functions

### DIFF
--- a/bench/wtperf/idle_table_cycle.c
+++ b/bench/wtperf/idle_table_cycle.c
@@ -83,7 +83,7 @@ cycle_idle_tables(void *arg)
 		snprintf(uri, sizeof(uri),
 		    "%s_cycle%07d", wtperf->uris[0], cycle_count);
 		/* Don't busy cycle in this loop. */
-		__wt_sleep(1, 0);
+		(void)sleep(1);
 
 		/* Setup a start timer. */
 		__wt_epoch(NULL, &start);
@@ -126,7 +126,7 @@ cycle_idle_tables(void *arg)
 		 */
 		while ((ret = session->drop(
 		    session, uri, "force,checkpoint_wait=false")) == EBUSY)
-			__wt_sleep(1, 0);
+			(void)sleep(1);
 
 		if (ret != 0 && ret != EBUSY) {
 			lprintf(wtperf, ret, 0,

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -366,7 +366,7 @@ retry:
 		SWIG_ERROR_IF_NOT_SET(result);
 	else if (result == EBUSY) {
 		SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-#if defined(_MSC_VER)
+#ifdef SWIGWIN
 		(void)Sleep(10);			/* ms */
 #else
 		(void)usleep(10000);			/* us */

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -366,7 +366,11 @@ retry:
 		SWIG_ERROR_IF_NOT_SET(result);
 	else if (result == EBUSY) {
 		SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-		__wt_sleep(0, 10000);
+#if defined(_MSC_VER)
+		(void)Sleep(10);			/* ms */
+#else
+		(void)usleep(10000);			/* us */
+#endif
 		SWIG_PYTHON_THREAD_END_ALLOW;
 		goto retry;
 	}
@@ -1149,6 +1153,8 @@ pythonAsyncCallback(WT_ASYNC_CALLBACK *cb, WT_ASYNC_OP *asyncop, int opret,
 	PY_CALLBACK *pcb;
 	PyObject *arglist, *notify_method, *pyresult;
 	WT_ASYNC_OP_IMPL *op;
+	WT_EXTENSION_API *wt_api;
+	WT_SESSION *wt_session;
 	WT_SESSION_IMPL *session;
 
 	/*
@@ -1179,7 +1185,12 @@ pythonAsyncCallback(WT_ASYNC_CALLBACK *cb, WT_ASYNC_OP *asyncop, int opret,
 	if (0) {
 		if (ret == 0)
 			ret = EINVAL;
-err:		__wt_err(session, ret, "python async callback error");
+err:		wt_session = (WT_SESSION *)session;
+		wt_api = wt_session->
+		    connection->get_extension_api(wt_session->connection);
+		(void)wt_api->err_printf(wt_api, wt_session,
+		    "python async callback error: %s",
+		    wt_api->strerror(wt_api, wt_session, ret));
 	}
 	Py_XDECREF(pyresult);
 	Py_XDECREF(notify_method);

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -366,11 +366,11 @@ retry:
 		SWIG_ERROR_IF_NOT_SET(result);
 	else if (result == EBUSY) {
 		SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-#ifdef SWIGWIN
+%#if defined(_MSC_VER)
 		(void)Sleep(10);			/* ms */
-#else
+%#else
 		(void)usleep(10000);			/* us */
-#endif
+%#endif
 		SWIG_PYTHON_THREAD_END_ALLOW;
 		goto retry;
 	}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -493,13 +493,13 @@ extern int __wt_nfilename( WT_SESSION_IMPL *session, const char *name, size_t na
 extern int __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name, bool durable) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_abort(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern int __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_realloc(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_realloc_noclear(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_realloc_aligned(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_strndup(WT_SESSION_IMPL *session, const void *str, size_t len, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern void __wt_free_int(WT_SESSION_IMPL *session, const void *p_arg) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_free_int(WT_SESSION_IMPL *session, const void *p_arg) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_errno(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern const char *__wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_ext_map_windows_error( WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, uint32_t windows_error) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
@@ -620,7 +620,7 @@ extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor
 extern void __wt_encrypt_size(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t incoming_size, size_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_event_handler_set(WT_SESSION_IMPL *session, WT_EVENT_HANDLER *handler) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error, const char *file_name, int line_number, const char *fmt, va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern void __wt_err(WT_SESSION_IMPL *session, int error, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_err(WT_SESSION_IMPL *session, int error, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_errx(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3))) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_ext_err_printf( WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -23,7 +23,7 @@ extern const char *__wt_path_separator(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibil
 extern bool __wt_has_priv(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_stream_set_line_buffer(FILE *fp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_stream_set_no_buffer(FILE *fp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_thread_id(char *buf, size_t buflen) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -30,7 +30,6 @@
  */
 int
 __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)
-    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	void *p;
 
@@ -283,7 +282,6 @@ __wt_strndup(WT_SESSION_IMPL *session, const void *str, size_t len, void *retp)
  */
 void
 __wt_free_int(WT_SESSION_IMPL *session, const void *p_arg)
-    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	void *p;
 

--- a/src/os_posix/os_sleep.c
+++ b/src/os_posix/os_sleep.c
@@ -14,7 +14,6 @@
  */
 void
 __wt_sleep(uint64_t seconds, uint64_t micro_seconds)
-    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	struct timeval t;
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -304,7 +304,6 @@ void
 __wt_err(WT_SESSION_IMPL *session, int error, const char *fmt, ...)
     WT_GCC_FUNC_ATTRIBUTE((cold))
     WT_GCC_FUNC_ATTRIBUTE((format (printf, 3, 4)))
-    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	va_list ap;
 


### PR DESCRIPTION
Remove calls to internal WiredTiger functions from the Java and Python APIs, meaning we no longer need to expose a few more internal WiredTiger functions.