### PR TITLE
WT-3061 Ensure checkpoint syncs are run as part of syscall testing

### DIFF
--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -636,12 +636,7 @@ class Runner:
         errfile = open(self.errfilename, 'w')
         if self.args.verbose:
             print('RUNNING: ' + str(callargs))
-        # We have to overload the WIREDTIGER_CONFIG to ensure we perform
-        # fdatasync operations on checkpoints
-        my_env = { k : v for k, v in os.environ.iteritems()
-            if k != 'WIREDTIGER_CONFIG' }
-        subret = subprocess.call(
-            callargs, stdout=outfile, stderr=errfile, env=my_env)
+        subret = subprocess.call(callargs, stdout=outfile, stderr=errfile)
         outfile.close()
         errfile.close()
         if subret != 0:

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -475,7 +475,7 @@ class Runner:
         if not em:
             self.fail(errline, 'Unknown strace/dtruss output: ' + errline)
             return False
-        gotcall = em.groups()[0]
+        gotcall = re.sub(pwrite_in, pwrite_out, em.groups()[0])
         # filtering syscalls here if needed.  If it's not a match,
         # mark the errline so it is retried.
         if self.strip_syscalls != None and gotcall not in self.strip_syscalls:

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -638,8 +638,8 @@ class Runner:
             print('RUNNING: ' + str(callargs))
         # We have to overload the WIREDTIGER_CONFIG to ensure we perform
         # fdatasync operations on checkpoints
-        my_env = os.environ.copy()
-        my_env["WIREDTIGER_CONFIG"] = "checkpoint_sync=true"
+        my_env = { k : v for k, v in os.environ.iteritems()
+            if k != 'WIREDTIGER_CONFIG' }
         subret = subprocess.call(
             callargs, stdout=outfile, stderr=errfile, env=my_env)
         outfile.close()

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -104,6 +104,9 @@ headpatterns = [ [ tracepat, 'trace_syscalls', 0],
                  [ systempat, 'required_system', 0],
                  [ runpat, 'run_args', 0] ]
 
+pwrite_in = r'pwrite64'
+pwrite_out = r'pwrite'
+
 # To create breakpoints while debugging this script
 def bp():
     import pdb
@@ -417,7 +420,10 @@ class Runner:
         if callname in calls_returning_zero:
             return self.compare("EQ", result, "0", errline)
         elif callname == 'pwrite' or callname == 'pwrite64':
-            return self.compare("EQ", result, eargs[2], errline)
+            return self.compare("EQ",
+                re.sub(pwrite_in, pwrite_out, result),
+                re.sub(pwrite_in, pwrite_out, eargs[2]),
+                errline)
         else:
             self.fail(errline, 'call ' + callname +
                       ': not known, use ASSERT_EQ()')
@@ -475,7 +481,6 @@ class Runner:
         if self.strip_syscalls != None and gotcall not in self.strip_syscalls:
             errline.skip = True
             return False
-
         m = re.match(assignpat, runline)
         if m:
             if m.groups()[1] != gotcall:
@@ -545,10 +550,12 @@ class Runner:
         with outfile, errfile:
             runlines = self.order_runfile(self.runfile)
             errline = errfile.readline()
+            errline = re.sub(pwrite_in, pwrite_out, errline)
             if re.match(dtruss_init_pat, errline):
                 errline = errfile.readline()
             skiplines = False
             for runline in runlines:
+                runline = re.sub(pwrite_in, pwrite_out, runline)
                 if runline == '...':
                     skiplines = True
                     if self.args.verbose:
@@ -620,7 +627,8 @@ class Runner:
         elif self.args.systype == 'Darwin':
             # dtrace has no option to limit the syscalls to be traced,
             # so we'll filter the output.
-            self.strip_syscalls = self.headopts.trace_syscalls.split(',')
+            self.strip_syscalls = re.sub(pwrite_in, pwrite_out,
+                self.headopts.trace_syscalls).split(',')
         callargs.append(self.testexe)
         callargs.extend(self.runargs)
 

--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -125,7 +125,9 @@ close(fd);
 pwrite64(wt, ""..., 0x1000, 0x1000);
 pwrite64(wt, ""..., 0x1000, 0x2000);
 pwrite64(wt, ""..., 0x1000, 0x3000);
+#ifdef __linux__
 fdatasync(wt);
+#endif /* __linux__ */
 fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
 
 close(fd);

--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -46,15 +46,15 @@ SYSTEM("Darwin");
 #define FTRUNCATE(fd, len)			/* do nothing */
 #endif
 
-TRACE("close,fdatasync,fsync,ftruncate,open,pwrite,rename");
+TRACE("close,fdatasync,fsync,ftruncate,open,pwrite64,rename");
 RUN("");
 ...
 OUTPUT("--------------wiredtiger_open");
 // lock == 3
 lock = open("./WiredTiger.lock", O_RDWR|O_CREAT|O_CLOEXEC, 0666);
-pwrite(lock, "WiredTiger lock file\n", 0x15, 0x0);
+pwrite64(lock, "WiredTiger lock file\n", 0x15, 0x0);
 fd = open("./WiredTiger", O_RDWR|O_CREAT|O_CLOEXEC, 0666);
-pwrite(fd, "WiredTiger\nWiredTiger"..., ...);
+pwrite64(fd, "WiredTiger\nWiredTiger"..., ...);
 #ifdef __linux__
 fdatasync(fd);
 #endif /* __linux__ */
@@ -63,7 +63,7 @@ close(fd);
 ...  // On Linux, there are calls to open and read "/proc/meminfo" here.
 
 fd = open("./WiredTiger.basecfg.set", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666);
-pwrite(fd, "# Do not modify this file."..., ...);
+pwrite64(fd, "# Do not modify this file."..., ...);
 #ifdef __linux__
 fdatasync(fd);
 #endif /* __linux__ */
@@ -84,7 +84,7 @@ fdatasync(dir);
 close(dir);
 #endif /* __linux__ */
 
-pwrite(fd, ""..., 0x1000, 0x0);
+pwrite64(fd, ""..., 0x1000, 0x0);
 #ifdef __linux__
 fdatasync(fd);
 #endif /* __linux__ */
@@ -94,7 +94,7 @@ wt = OPEN_EXISTING("./WiredTiger.wt\0", O_RDWR|O_NOATIME|O_CLOEXEC);
 FTRUNCATE(wt, 0x1000);
 
 fd = open("./WiredTiger.turtle.set\0", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666);
-pwrite(fd, "WiredTiger version string\nWiredTiger"..., ...);
+pwrite64(fd, "WiredTiger version string\nWiredTiger"..., ...);
 #ifdef __linux__
 fdatasync(fd);
 #endif /* __linux__ */
@@ -111,7 +111,7 @@ fdatasync(dir);
 close(dir);
 #endif /* __linux__ */
 
-pwrite(fd, ""..., 0x1000, 0x0);
+pwrite64(fd, ""..., 0x1000, 0x0);
 
 #ifdef __linux__
 fdatasync(fd);
@@ -122,15 +122,15 @@ fd = OPEN_EXISTING("./WiredTigerLAS.wt", O_RDWR|O_NOATIME|O_CLOEXEC);
 FTRUNCATE(fd, 0x1000);
 fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
 close(fd);
-pwrite(wt, ""..., 0x1000, 0x1000);
-pwrite(wt, ""..., 0x1000, 0x2000);
-pwrite(wt, ""..., 0x1000, 0x3000);
+pwrite64(wt, ""..., 0x1000, 0x1000);
+pwrite64(wt, ""..., 0x1000, 0x2000);
+pwrite64(wt, ""..., 0x1000, 0x3000);
 fdatasync(wt);
 fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
 
 close(fd);
 fd = open("./WiredTiger.turtle.set", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666);
-pwrite(fd, "WiredTiger version string\nWiredTiger"..., ...);
+pwrite64(fd, "WiredTiger version string\nWiredTiger"..., ...);
 #ifdef __linux__
 fdatasync(fd);
 #endif /* __linux__ */
@@ -152,7 +152,7 @@ dir = open("./", O_RDONLY);
 fdatasync(dir);
 close(dir);
 #endif /* __linux__ */
-pwrite(hello, "A\330\001"..., 0x1000, 0x0);
+pwrite64(hello, "A\330\001"..., 0x1000, 0x0);
 #ifdef __linux__
 fdatasync(hello);
 #endif /* __linux__ */

--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -125,6 +125,7 @@ close(fd);
 pwrite(wt, ""..., 0x1000, 0x1000);
 pwrite(wt, ""..., 0x1000, 0x2000);
 pwrite(wt, ""..., 0x1000, 0x3000);
+fdatasync(wt);
 fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
 
 close(fd);
@@ -139,6 +140,7 @@ rename("./WiredTiger.turtle.set", "./WiredTiger.turtle");
 dir = open("./", O_RDONLY); 
 fdatasync(dir);
 close(dir);
+fdatasync(wt);
 #endif /* __linux__ */
 
 OUTPUT("--------------open_session");


### PR DESCRIPTION
Not 100% if this is the best way to proceed here, re pwrite vs pwrite64.

If it is, then we would have to exclude some of the Jenkins machines from testing. The alternative is to find a way to check if the system has pwrite or pwrite64 registered in strace.