### PR TITLE
WT-3064 minor tree cleanups: .gitignore, NEWS misspelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,5 @@ _wiredtiger.pyd
 **/test/recovery/random-abort
 **/test/recovery/truncated-log
 **/test/salvage/t
+**/test/syscall/test_wt2336_base
 **/test/thread/t

--- a/NEWS
+++ b/NEWS
@@ -201,7 +201,7 @@ Other noteworthy changes since the previous release:
 * WT-2769	Update documentation to reflect correct limits of memory_page_max
 * WT-2770	Add statistics tracking schema operations
 * WT-2772	Adjust log.wtperf config. Remove unneeded config entries
-* WT-2773	Ensure that search_near in an index find's exact matches
+* WT-2773	Ensure that search_near in an index finds exact matches
 * WT-2774	Minor cleanups/improvements
 * WT-2778	Enhance output formatting when running Python test suite
 * WT-2779	Fix large pages getting generated with raw compression

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -159,6 +159,7 @@ HHHHLL
 HHHLL
 Hendrik
 HyperLevelDB
+ID's
 IEC
 IEEE
 IKEY


### PR DESCRIPTION
WT-3064 minor tree cleanups: .gitignore, NEWS misspelling