### PR TITLE
WT-2833 Add projections to wt dump utility

### DIFF
--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -515,8 +515,8 @@ __wt_curindex_open(WT_SESSION_IMPL *session,
 	WT_ERR(__curindex_open_colgroups(session, cindex, cfg));
 
 	if (F_ISSET(cursor, WT_CURSTD_DUMP_JSON))
-		__wt_json_column_init(
-		    cursor, table->key_format, &idx->colconf, &table->colconf);
+		__wt_json_column_init(cursor, uri, table->key_format,
+		    &idx->colconf, &table->colconf);
 
 	if (0) {
 err:		WT_TRET(__curindex_close(cursor));

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -951,7 +951,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 
 	if (F_ISSET(cursor, WT_CURSTD_DUMP_JSON))
 		__wt_json_column_init(
-		    cursor, table->key_format, NULL, &table->colconf);
+		    cursor, uri, table->key_format, NULL, &table->colconf);
 
 	/*
 	 * Open the colgroup cursors immediately: we're going to need them for

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -293,7 +293,7 @@ extern int __wt_curjoin_join(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin, WT
 extern int __wt_json_alloc_unpack(WT_SESSION_IMPL *session, const void *buffer, size_t size, const char *fmt, WT_CURSOR_JSON *json, bool iskey, va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern size_t __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_json_column_init(WT_CURSOR *cursor, const char *keyformat, const WT_CONFIG_ITEM *idxconf, const WT_CONFIG_ITEM *colconf) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern void __wt_json_column_init(WT_CURSOR *cursor, const char *uri, const char *keyformat, const WT_CONFIG_ITEM *idxconf, const WT_CONFIG_ITEM *colconf) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype, const char **tokstart, size_t *toklen) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_json_tokname(int toktype) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern int __wt_json_to_item(WT_SESSION_IMPL *session, const char *jstr, const char *format, WT_CURSOR_JSON *json, bool iskey, WT_ITEM *item) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -6,10 +6,14 @@
  * See the file LICENSE for redistribution information.
  */
 
+#include <assert.h>
 #include "util.h"
 #include "util_dump.h"
 
-static int dump_config(WT_SESSION *, const char *, bool, bool);
+#define	STRING_MATCH_CONFIG(s, item)					\
+	(strncmp(s, (item).str, (item).len) == 0 && (s)[(item).len] == '\0')
+
+static int dump_config(WT_SESSION *, const char *, WT_CURSOR *, bool, bool);
 static int dump_json_begin(WT_SESSION *);
 static int dump_json_end(WT_SESSION *);
 static int dump_json_separator(WT_SESSION *);
@@ -17,7 +21,8 @@ static int dump_json_table_end(WT_SESSION *);
 static int dump_prefix(WT_SESSION *, bool, bool);
 static int dump_record(WT_CURSOR *, bool, bool);
 static int dump_suffix(WT_SESSION *, bool);
-static int dump_table_config(WT_SESSION *, WT_CURSOR *, const char *, bool);
+static int dump_table_config(
+    WT_SESSION *, WT_CURSOR *, WT_CURSOR *, const char *, bool);
 static int dump_table_parts_config(
     WT_SESSION *, WT_CURSOR *, const char *, const char *, bool);
 static int dup_json_string(const char *, char **);
@@ -32,10 +37,11 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
 	size_t len;
 	int ch, i;
 	bool hex, json, reverse;
-	char *checkpoint, *config, *name;
+	char *checkpoint, *config, *name, *p, *simplename;
 
 	hex = json = reverse = false;
-	checkpoint = config = name = NULL;
+	checkpoint = config = name = simplename = NULL;
+	cursor = NULL;
 	while ((ch = __wt_getopt(progname, argc, argv, "c:f:jrx")) != EOF)
 		switch (ch) {
 		case 'c':
@@ -84,12 +90,10 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
 			if ((ret = dump_json_separator(session)) != 0)
 				goto err;
 		free(name);
-		name = NULL;
+		free(simplename);
+		name = simplename = NULL;
 
 		if ((name = util_name(session, argv[i], "table")) == NULL)
-			goto err;
-
-		if (dump_config(session, name, hex, json) != 0)
 			goto err;
 
 		len =
@@ -115,10 +119,26 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
 			goto err;
 		}
 
+		if ((simplename = strdup(name)) == NULL) {
+			ret = util_err(session, errno, NULL);
+			goto err;
+		}
+		if ((p = strchr(simplename, '(')) != NULL)
+			*p = '\0';
+		if (dump_config(session, simplename, cursor, hex, json) != 0)
+			goto err;
+
 		if ((ret = dump_record(cursor, reverse, json)) != 0)
 			goto err;
 		if (json && (ret = dump_json_table_end(session)) != 0)
 			goto err;
+
+		ret = cursor->close(cursor);
+		cursor = NULL;
+		if (ret != 0) {
+			ret = util_err(session, ret, NULL);
+			goto err;
+		}
 	}
 	if (json && ((ret = dump_json_end(session)) != 0))
 		goto err;
@@ -129,7 +149,11 @@ err:		ret = 1;
 
 	free(config);
 	free(name);
-
+	free(simplename);
+	if (cursor != NULL && (ret = cursor->close(cursor)) != 0) {
+		(void)util_err(session, ret, NULL);
+		ret = 1;
+	}
 	return (ret);
 }
 
@@ -138,15 +162,16 @@ err:		ret = 1;
  *	Dump the config for the uri.
  */
 static int
-dump_config(WT_SESSION *session, const char *uri, bool hex, bool json)
+dump_config(WT_SESSION *session, const char *uri, WT_CURSOR *cursor, bool hex,
+    bool json)
 {
-	WT_CURSOR *cursor;
+	WT_CURSOR *mcursor;
 	WT_DECL_RET;
 	int tret;
 
 	/* Open a metadata cursor. */
 	if ((ret = session->open_cursor(
-	    session, "metadata:create", NULL, NULL, &cursor)) != 0) {
+	    session, "metadata:create", NULL, NULL, &mcursor)) != 0) {
 		fprintf(stderr, "%s: %s: session.open_cursor: %s\n", progname,
 		    "metadata:create", session->strerror(session, ret));
 		return (1);
@@ -156,10 +181,11 @@ dump_config(WT_SESSION *session, const char *uri, bool hex, bool json)
 	 * want to output a header if the user entered the wrong name. This is
 	 * where we find out a table doesn't exist, use a simple error message.
 	 */
-	cursor->set_key(cursor, uri);
-	if ((ret = cursor->search(cursor)) == 0) {
+	mcursor->set_key(mcursor, uri);
+	if ((ret = mcursor->search(mcursor)) == 0) {
 		if ((!json && dump_prefix(session, hex, json) != 0) ||
-		    dump_table_config(session, cursor, uri, json) != 0 ||
+		    dump_table_config(session, mcursor, cursor,
+		    uri, json) != 0 ||
 		    dump_suffix(session, json) != 0)
 			ret = 1;
 	} else if (ret == WT_NOTFOUND)
@@ -167,8 +193,8 @@ dump_config(WT_SESSION *session, const char *uri, bool hex, bool json)
 	else
 		ret = util_err(session, ret, "%s", uri);
 
-	if ((tret = cursor->close(cursor)) != 0) {
-		tret = util_cerr(cursor, "close", tret);
+	if ((tret = mcursor->close(mcursor)) != 0) {
+		tret = util_cerr(mcursor, "close", tret);
 		if (ret == 0)
 			ret = tret;
 	}
@@ -225,16 +251,105 @@ dump_json_table_end(WT_SESSION *session)
 }
 
 /*
+ * dump_projection --
+ *	Create a new config containing projection information.
+ */
+static int
+dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
+    char **newconfigp)
+{
+	WT_DECL_RET;
+	WT_CONFIG_ITEM key, value;
+	WT_CONFIG_PARSER *parser;
+	WT_EXTENSION_API *wt_api;
+	size_t len, vallen;
+	int nkeys;
+	char *newconfig;
+	const char *keyformat, *p;
+
+	len = strlen(config) + strlen(cursor->value_format) +
+	    strlen(cursor->uri) + 20;
+	if ((newconfig = malloc(len)) == NULL)
+		return util_err(session, errno, NULL);
+	*newconfigp = newconfig;
+
+#define	DUMP_ADD_CONFIG(fmt, ...) do {					\
+		size_t n;						\
+		n = snprintf(newconfig, len, fmt, __VA_ARGS__);		\
+		newconfig += n;						\
+		len -= n;						\
+	} while (0)
+
+	wt_api = session->connection->get_extension_api(session->connection);
+	if ((ret = wt_api->config_parser_open(wt_api, session, config,
+	    strlen(config), &parser)) != 0)
+		return (util_err(
+		    session, ret, "WT_EXTENSION_API.config_parser_open"));
+	keyformat = cursor->key_format;
+	for (nkeys = 0; *keyformat; keyformat++)
+		if (!__wt_isdigit((u_char)*keyformat))
+			nkeys++;
+
+	/*
+	 * Copy the configuration, replacing some fields to match the
+	 * projection.
+	 */
+	while ((ret = parser->next(parser, &key, &value)) == 0) {
+		DUMP_ADD_CONFIG("%.*s=", (int)key.len, key.str);
+		if (STRING_MATCH_CONFIG("value_format", key))
+			DUMP_ADD_CONFIG("%s", cursor->value_format);
+		else if (STRING_MATCH_CONFIG("columns", key)) {
+			/* copy names of keys */
+			p = value.str;
+			vallen = value.len;
+			while (vallen > 0) {
+				if ((*p == ',' || *p == ')') && --nkeys == 0)
+					break;
+				p++;
+				vallen--;
+			}
+			DUMP_ADD_CONFIG("%.*s", (int)(p - value.str),
+			    value.str);
+
+			/* copy names of projected values */
+			p = strchr(cursor->uri, '(');
+			assert(p != NULL);
+			assert(p[strlen(p) - 1] == ')');
+			p++;
+			if (*p != ')')
+				DUMP_ADD_CONFIG("%s", ",");
+			DUMP_ADD_CONFIG("%.*s),", (int)(strlen(p) - 1), p);
+		} else if (value.type == WT_CONFIG_ITEM_STRING &&
+		    value.len != 0)
+			DUMP_ADD_CONFIG("\"%.*s\",", (int)value.len, value.str);
+		else
+			DUMP_ADD_CONFIG("%.*s,", (int)value.len, value.str);
+	}
+	if (ret != WT_NOTFOUND)
+		return (util_err(session, ret, "WT_CONFIG_PARSER.next"));
+
+	assert(len > 0);
+	if ((ret = parser->close(parser)) != 0)
+		return (util_err(
+		    session, ret, "WT_CONFIG_PARSER.close"));
+
+	return (0);
+}
+
+/*
  * dump_table_config --
  *	Dump the config for a table.
  */
 static int
 dump_table_config(
-    WT_SESSION *session, WT_CURSOR *cursor, const char *uri, bool json)
+    WT_SESSION *session, WT_CURSOR *mcursor, WT_CURSOR *cursor,
+    const char *uri, bool json)
 {
 	WT_DECL_RET;
+	char *proj_config;
 	const char *name, *v;
 
+	proj_config = NULL;
 	/* Get the table name. */
 	if ((name = strchr(uri, ':')) == NULL) {
 		fprintf(stderr, "%s: %s: corrupted uri\n", progname, uri);
@@ -246,20 +361,25 @@ dump_table_config(
 	 * Dump out the config information: first, dump the uri entry itself,
 	 * it overrides all subsequent configurations.
 	 */
-	cursor->set_key(cursor, uri);
-	if ((ret = cursor->search(cursor)) != 0)
-		return (util_cerr(cursor, "search", ret));
-	if ((ret = cursor->get_value(cursor, &v)) != 0)
-		return (util_cerr(cursor, "get_value", ret));
+	mcursor->set_key(mcursor, uri);
+	if ((ret = mcursor->search(mcursor)) != 0)
+		return (util_cerr(mcursor, "search", ret));
+	if ((ret = mcursor->get_value(mcursor, &v)) != 0)
+		return (util_cerr(mcursor, "get_value", ret));
 
-	WT_RET(print_config(session, uri, v, json, true));
+	if (strchr(cursor->uri, '(') != NULL) {
+		WT_ERR(dump_projection(session, v, cursor, &proj_config));
+		v = proj_config;
+	}
+	WT_ERR(print_config(session, uri, v, json, true));
 
-	WT_RET(dump_table_parts_config(
-	    session, cursor, name, "colgroup:", json));
-	WT_RET(dump_table_parts_config(
-	    session, cursor, name, "index:", json));
+	WT_ERR(dump_table_parts_config(
+	    session, mcursor, name, "colgroup:", json));
+	WT_ERR(dump_table_parts_config(
+	    session, mcursor, name, "index:", json));
 
-	return (0);
+err:	free(proj_config);
+	return (ret);
 }
 
 /*

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -274,8 +274,10 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
 	*newconfigp = newconfig;
 
 #define	DUMP_ADD_CONFIG(fmt, ...) do {					\
-		size_t n;						\
-		n = snprintf(newconfig, len, fmt, __VA_ARGS__);		\
+		int n;							\
+		if ((n = snprintf(					\
+		    newconfig, len, fmt, __VA_ARGS__)) < 0)		\
+			return (util_err(session, EIO, NULL));		\
 		newconfig += n;						\
 		len -= n;						\
 	} while (0)

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -279,7 +279,7 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
 		    newconfig, len, fmt, __VA_ARGS__)) < 0)		\
 			return (util_err(session, EIO, NULL));		\
 		newconfig += n;						\
-		len -= n;						\
+		len -= (size_t)n;					\
 	} while (0)
 
 	wt_api = session->connection->get_extension_api(session->connection);

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -309,10 +309,10 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
 	 * projection.
 	 */
 	while ((ret = parser->next(parser, &key, &value)) == 0) {
-		WT_RET(dump_add_config(session, &newconfig, &len, 
+		WT_RET(dump_add_config(session, &newconfig, &len,
 		    "%.*s=", (int)key.len, key.str));
 		if (STRING_MATCH_CONFIG("value_format", key))
-			WT_RET(dump_add_config(session, &newconfig, &len, 
+			WT_RET(dump_add_config(session, &newconfig, &len,
 			    "%s", cursor->value_format));
 		else if (STRING_MATCH_CONFIG("columns", key)) {
 			/* copy names of keys */
@@ -324,7 +324,7 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
 				p++;
 				vallen--;
 			}
-			WT_RET(dump_add_config(session, &newconfig, &len, 
+			WT_RET(dump_add_config(session, &newconfig, &len,
 			    "%.*s", (int)(p - value.str), value.str));
 
 			/* copy names of projected values */
@@ -335,14 +335,14 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor,
 			if (*p != ')')
 				WT_RET(dump_add_config(session, &newconfig,
 				    &len, "%s", ","));
-			WT_RET(dump_add_config(session, &newconfig, &len, 
+			WT_RET(dump_add_config(session, &newconfig, &len,
 			    "%.*s),", (int)(strlen(p) - 1), p));
 		} else if (value.type == WT_CONFIG_ITEM_STRING &&
 		    value.len != 0)
-			WT_RET(dump_add_config(session, &newconfig, &len, 
+			WT_RET(dump_add_config(session, &newconfig, &len,
 			    "\"%.*s\",", (int)value.len, value.str));
 		else
-			WT_RET(dump_add_config(session, &newconfig, &len, 
+			WT_RET(dump_add_config(session, &newconfig, &len,
 			    "%.*s,", (int)value.len, value.str));
 	}
 	if (ret != WT_NOTFOUND)

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -234,7 +234,7 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
                 ('"ikey" : 4,\n"Skey" : "key4"',
                  '"S1" : "val16",\n"i2" : 16,\n"S3" : "val64",\n"i4" : 64'))
         self.check_json(self.table_uri4, table4_json)
-        # This projection has 3 value fields reversed with a key at the end
+        # This projection has 3 value fields reversed with a key at the end.
         table4_json_projection = (
                 ('"ikey" : 1,\n"Skey" : "key1"',
                  '"i4" : 1,\n"S3" : "val1",\n"i2" : 1,\n"ikey" : 1'),
@@ -244,6 +244,12 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
                  '"i4" : 27,\n"S3" : "val27",\n"i2" : 9,\n"ikey" : 3'),
                 ('"ikey" : 4,\n"Skey" : "key4"',
                  '"i4" : 64,\n"S3" : "val64",\n"i2" : 16,\n"ikey" : 4'))
+        # bad projection URI
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                 lambda: self.check_json(self.table_uri4 + '(i4,S3,i2,ikey',
+                        table4_json_projection),
+            '/Unbalanced brackets/')
+        # This projection should work.
         self.check_json(self.table_uri4 + '(i4,S3,i2,ikey)',
                         table4_json_projection)
         # The dump config currently is not supported for the index type.

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -234,6 +234,18 @@ class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
                 ('"ikey" : 4,\n"Skey" : "key4"',
                  '"S1" : "val16",\n"i2" : 16,\n"S3" : "val64",\n"i4" : 64'))
         self.check_json(self.table_uri4, table4_json)
+        # This projection has 3 value fields reversed with a key at the end
+        table4_json_projection = (
+                ('"ikey" : 1,\n"Skey" : "key1"',
+                 '"i4" : 1,\n"S3" : "val1",\n"i2" : 1,\n"ikey" : 1'),
+                ('"ikey" : 2,\n"Skey" : "key2"',
+                 '"i4" : 8,\n"S3" : "val8",\n"i2" : 4,\n"ikey" : 2'),
+                ('"ikey" : 3,\n"Skey" : "key3"',
+                 '"i4" : 27,\n"S3" : "val27",\n"i2" : 9,\n"ikey" : 3'),
+                ('"ikey" : 4,\n"Skey" : "key4"',
+                 '"i4" : 64,\n"S3" : "val64",\n"i2" : 16,\n"ikey" : 4'))
+        self.check_json(self.table_uri4 + '(i4,S3,i2,ikey)',
+                        table4_json_projection)
         # The dump config currently is not supported for the index type.
         self.check_json(uri4index1, (
                 ('"Skey" : "key1"',


### PR DESCRIPTION
When dumping with a projection, the dumped metadata associated with the table is modified so that the list of columns matches the list from the projection, and the value format corresponds to projected format.  We use an open cursor using the projection to obtain the value format to show, that requires a slight reordering of when cursors are opened in the dump utility.

Also fix a problem in the JSON dump cursor which did not handle projections.