### PR TITLE
WT-2402 Misaligned structure accesses lead to undefined behavior

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -22,37 +22,12 @@ AC_PROG_CC(cc gcc)
 AC_PROG_CXX(c++ g++)
 AM_PROG_AS(as gas)
 
-# WiredTiger uses anonymous unions to pad structures. It's part of C11, but
-# some compilers require a flag to support them.
-AX_CHECK_COMPILE_FLAG([-std=c11], [AM_CFLAGS="$AM_CFLAGS -std=c11"])
-
-# Configure options.
-AM_OPTIONS
-
 define([AC_LIBTOOL_LANG_CXX_CONFIG], [:])dnl
 define([AC_LIBTOOL_LANG_F77_CONFIG], [:])dnl
+
 LT_PREREQ(2.2.6)
 LT_INIT([pic-only])
 AC_SUBST([LIBTOOL_DEPS])
-
-# If enable-strict is configured, turn on as much error checking as we can for
-# this compiler. Intended for developers, and only works for gcc/clang, but it
-# fills a need.
-if test "$wt_cv_enable_strict" = "yes"; then
-	wt_cv_cc_version="`$CC --version | sed -eq`"
-	case "$wt_cv_cc_version" in
-	*clang*)
-		AM_CLANG_WARNINGS($wt_cv_cc_version);;
-	*cc*|*CC*)					# cc, CC, gcc, GCC
-		AM_GCC_WARNINGS($wt_cv_cc_version);;
-	*)
-		AC_MSG_ERROR(
-		    [--enable-strict does not support "$wt_cv_cc_version".]);;
-	esac
-
-	AM_CFLAGS="$AM_CFLAGS $wt_cv_strict_warnings"
-fi
-
 AM_CONDITIONAL([POSIX_HOST], [true])
 AM_CONDITIONAL([WINDOWS_HOST], [false])
 
@@ -73,6 +48,7 @@ AS_CASE([$host_cpu],
 	[aarch64*], [wt_cv_arm64="yes"],
 	[wt_cv_arm64="no"])
 AM_CONDITIONAL([ARM64_HOST], [test "$wt_cv_arm64" = "yes"])
+AS_CASE([$host_os], [*solaris*], [wt_cv_solaris="yes"], [wt_cv_solaris="no"])
 
 # This is a workaround as part of WT-2459. Currently, clang (v3.7) does not
 # support compiling the ASM code we have to perform the CRC checks on PowerPC.
@@ -86,9 +62,17 @@ if test "$wt_cv_powerpc" = "yes" -a "$CC" != "$CCAS"; then
 fi
 AC_SUBST(AM_LIBTOOLFLAGS)
 
+# WiredTiger uses anonymous unions to pad structures. It's part of C11, but
+# some compilers require -std=c11 to support them. Turn on that flag for any
+# compiler that supports it, except for Solaris, where gcc -std=c11 makes
+# some none-C11 prototypes unavailable.
+if test "$wt_cv_solaris" = "no"; then
+	AX_CHECK_COMPILE_FLAG([-std=c11], [AM_CFLAGS="$AM_CFLAGS -std=c11"])
+fi
+
 if test "$GCC" = "yes"; then
 	# The Solaris gcc compiler gets the additional -pthreads flag.
-	if test "`uname -s`" = "SunOS"; then
+	if test "$wt_cv_solaris" = "yes"; then
 		AM_CFLAGS="$AM_CFLAGS -pthreads"
 	fi
 
@@ -99,10 +83,34 @@ if test "$GCC" = "yes"; then
 	fi
 else
 	# The Solaris native compiler gets the additional -mt flag.
-	if test "`uname -s`" = "SunOS"; then
+	if test "$wt_cv_solaris" = "yes"; then
 		AM_CFLAGS="$AM_CFLAGS -mt"
 	fi
 fi
+
+# Linux requires _GNU_SOURCE to be defined
+AS_CASE([$host_os], [linux*], [AM_CFLAGS="$AM_CFLAGS -D_GNU_SOURCE"])
+
+# If enable-strict is configured, turn on as much error checking as we can for
+# this compiler. Intended for developers, and only works for gcc/clang, but it
+# fills a need.
+if test "$wt_cv_enable_strict" = "yes"; then
+	wt_cv_cc_version="`$CC --version | sed -eq`"
+	case "$wt_cv_cc_version" in
+	*clang*)
+		AM_CLANG_WARNINGS($wt_cv_cc_version);;
+	*cc*|*CC*)					# cc, CC, gcc, GCC
+		AM_GCC_WARNINGS($wt_cv_cc_version);;
+	*)
+		AC_MSG_ERROR(
+		    [--enable-strict does not support "$wt_cv_cc_version".]);;
+	esac
+
+	AM_CFLAGS="$AM_CFLAGS $wt_cv_strict_warnings"
+fi
+
+# Configure options.
+AM_OPTIONS
 
 # Java and Python APIs
 if test "$wt_cv_enable_java" = "yes" -o "$wt_cv_enable_python" = "yes"; then
@@ -162,11 +170,6 @@ if test "$ac_cv_sizeof_void_p" != "8" ; then
     AC_MSG_ERROR([WiredTiger requires a 64-bit build.])
 fi
 AC_MSG_RESULT(yes)
-
-# Linux requires _GNU_SOURCE to be defined
-case "$host_os" in
-linux*)	AM_CFLAGS="$AM_CFLAGS -D_GNU_SOURCE" ;;
-esac
 
 # Linux requires buffers aligned to 4KB boundaries for O_DIRECT to work.
 BUFFER_ALIGNMENT=0

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -468,37 +468,38 @@ void *
 alter(void *arg)
 {
 	WT_CONNECTION *conn;
-	WT_DECL_RET;
 	WT_SESSION *session;
 	u_int period;
-	bool access;
+	bool access_value;
 	char buf[32];
 
 	(void)(arg);
 	conn = g.wts_conn;
 
 	/*
-	 * Only alter the access pattern hint.  If we alter the
-	 * cache resident setting we may end up with a setting that
-	 * fills cache and doesn't allow it to be evicted.
+	 * Only alter the access pattern hint.  If we alter the cache resident
+	 * setting we may end up with a setting that fills cache and doesn't
+	 * allow it to be evicted.
 	 */
-	access = false;
+	access_value = false;
+
 	/* Open a session */
 	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	while (!g.workers_finished) {
 		period = mmrand(NULL, 1, 10);
 
-		snprintf(buf, 32, "access_pattern_hint=%s",
-		    access ? "random" : "none");
-		access = !access;
-		if ((ret = session->alter(session, g.uri, buf)) != 0)
+		snprintf(buf, sizeof(buf),
+		    "access_pattern_hint=%s", access_value ? "random" : "none");
+		access_value = !access_value;
+		if (session->alter(session, g.uri, buf) != 0)
 			break;
 		while (period > 0 && !g.workers_finished) {
 			--period;
 			sleep(1);
 		}
 	}
+
 	testutil_check(session->close(session, NULL));
 	return (NULL);
 }


### PR DESCRIPTION
@michaelcahill, @agorrod, @daveh86: I ended up turning off `std=c11` on Solaris, everything else was just too painful, and involved setting compiler flags that weren't strictly documented.

I also made a pass through `configure.ac.in` to try and clean up how we were setting flags as well as the order in which we set them.

I haven't yet tested this as much as I'd like, but I wanted to push it so you folks have a chance to see where I'm heading and say "no".