### PR TITLE
WT-3082 Python test suite: shorten default run to avoid timeouts.

### DIFF
--- a/test/suite/test_backup03.py
+++ b/test/suite/test_backup03.py
@@ -74,7 +74,7 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
         ('backup_9', dict(big=3,list=[])),         # Backup everything
     ]
 
-    scenarios = make_scenarios(list)
+    scenarios = make_scenarios(list, prune=3, prunelong=1000)
     # Create a large cache, otherwise this test runs quite slowly.
     conn_config = 'cache_size=1G'
 

--- a/test/suite/test_config03.py
+++ b/test/suite/test_config03.py
@@ -71,7 +71,7 @@ class test_config03(test_base03.test_base03):
         cache_size_scenarios, create_scenarios, error_prefix_scenarios,
         eviction_target_scenarios, eviction_trigger_scenarios,
         multiprocess_scenarios, session_max_scenarios,
-        transactional_scenarios, verbose_scenarios, prune=1000)
+        transactional_scenarios, verbose_scenarios, prune=100, prunelong=1000)
 
     #wttest.WiredTigerTestCase.printVerbose(2, 'test_config03: running ' + \
     #                      str(len(scenarios)) + ' of ' + \

--- a/test/suite/test_intpack.py
+++ b/test/suite/test_intpack.py
@@ -126,8 +126,8 @@ class PackTester:
 class test_intpack(wttest.WiredTigerTestCase):
     name = 'test_intpack'
 
-    # We have to be a bit verbose here with naming, as there can be problems with
-    # case insensitive test names:w
+    # We have to be a bit verbose here with naming, scenario names are
+    # case insensitive and must be unique.
 
     scenarios = make_scenarios([
         ('int8_t_b', dict(formatcode='b', low=-128, high=127, nbits=8)),

--- a/test/suite/test_join01.py
+++ b/test/suite/test_join01.py
@@ -69,7 +69,7 @@ class test_join01(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(type_scen, bloom0_scen, bloom1_scen,
                                projection_scen, nested_scen, stats_scen,
-                               order_scen)
+                               order_scen, prune=50, prunelong=1000)
 
     # We need statistics for these tests.
     conn_config = 'statistics=(all)'

--- a/test/suite/test_lsm01.py
+++ b/test/suite/test_lsm01.py
@@ -57,7 +57,7 @@ class test_lsm01(wttest.WiredTigerTestCase):
     scenarios = wtscenario.make_scenarios(
         chunk_size_scenarios, merge_max_scenarios, bloom_scenarios,
         bloom_bit_scenarios, bloom_hash_scenarios, record_count_scenarios,
-        prune=500)
+        prune=100, prunelong=500)
 
     # Test drop of an object.
     def test_lsm(self):

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -183,11 +183,11 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
     # those tests to file objects.
     types = [
         ('file', dict(type='file:', valuefmt='S',
-            config='allocation_size=512,leaf_page_max=512')),
+            config='allocation_size=512,leaf_page_max=512', P=0.25)),
         ('file8t', dict(type='file:', valuefmt='8t',
-            config='allocation_size=512,leaf_page_max=512')),
+            config='allocation_size=512,leaf_page_max=512', P=0.25)),
         ('table', dict(type='table:', valuefmt='S',
-            config='allocation_size=512,leaf_page_max=512')),
+            config='allocation_size=512,leaf_page_max=512', P=0.5)),
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
@@ -203,7 +203,8 @@ class test_truncate_cursor(wttest.WiredTigerTestCase):
         ('big', dict(nentries=1000,skip=37)),
     ]
 
-    scenarios = make_scenarios(types, keyfmt, size, reopen)
+    scenarios = make_scenarios(types, keyfmt, size, reopen,
+        prune=10, prunelong=1000)
 
     # Set a cursor key.
     def cursorKey(self, ds, uri, key):

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -85,7 +85,8 @@ class test_truncate_fast_delete(wttest.WiredTigerTestCase):
         ('txn2', dict(commit=False)),
         ]
 
-    scenarios = make_scenarios(types, keyfmt, overflow, reads, writes, txn)
+    scenarios = make_scenarios(types, keyfmt, overflow, reads, writes, txn,
+                               prune=20, prunelong=1000)
 
     # Return the number of records visible to the cursor; test both forward
     # and backward iteration, they are different code paths in this case.

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -70,7 +70,8 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         ('none', dict(compress='')),
     ]
 
-    scenarios = make_scenarios(types, op1s, txn1s, compress)
+    scenarios = make_scenarios(types, op1s, txn1s, compress,
+                               prune=30, prunelong=1000)
     # Overrides WiredTigerTestCase
     def setUpConnectionOpen(self, dir):
         self.home = dir


### PR DESCRIPTION
Tests that have lots of scenarios will have the number of scenarios pruned in the default case.  Running with --long restores the previous larger number of scenarios.

This runs about 25% faster in my standalone testing.