### PR TITLE
SERVER-16796 Add recovery messages for progress.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -594,7 +594,10 @@ wiredtiger_open_log_configuration = [
         Config('recover', 'on', r'''
             run recovery or error if recovery needs to run after an
             unclean shutdown''',
-            choices=['error','on'])
+            choices=['error','on']),
+        Config('recover_progress', 'true', r'''
+            print messages indicating progress of recovery''',
+            type='boolean'),
     ]),
 ]
 

--- a/examples/c/ex_backup.c
+++ b/examples/c/ex_backup.c
@@ -51,7 +51,8 @@ static const char * const incr_out = "./backup_incr";
 static const char * const uri = "table:logtest";
 
 #define	CONN_CONFIG \
-    "create,cache_size=100MB,log=(archive=false,enabled=true,file_max=100K)"
+    "create,cache_size=100MB," \
+    "log=(archive=false,enabled=true,file_max=100K,recover_progress=false)"
 #define	MAX_ITERATIONS	5
 #define	MAX_KEYS	10000
 

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -651,6 +651,7 @@ static const WT_CONFIG_CHECK
 	{ "recover", "string",
 	    NULL, "choices=[\"error\",\"on\"]",
 	    NULL, 0 },
+	{ "recover_progress", "boolean", NULL, NULL, NULL, 0 },
 	{ "zero_fill", "boolean", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -722,7 +723,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "in_memory", "boolean", NULL, NULL, NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 8 },
+	    confchk_wiredtiger_open_log_subconfigs, 9 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -808,7 +809,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "in_memory", "boolean", NULL, NULL, NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 8 },
+	    confchk_wiredtiger_open_log_subconfigs, 9 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -891,7 +892,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 8 },
+	    confchk_wiredtiger_open_log_subconfigs, 9 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -972,7 +973,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "hazard_max", "int", NULL, "min=15", NULL, 0 },
 	{ "log", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_log_subconfigs, 8 },
+	    confchk_wiredtiger_open_log_subconfigs, 9 },
 	{ "lsm_manager", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_lsm_manager_subconfigs, 2 },
@@ -1269,12 +1270,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
 	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
-	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
-	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
-	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
-	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "recover_progress=true,zero_fill=false),lsm_manager=(merge=true,"
+	  "worker_thread_max=4),lsm_merge=true,mmap=true,multiprocess=false"
+	  ",readonly=false,session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(json=false,on_close=false,"
+	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "transaction_sync=(enabled=false,method=fsync),"
 	  "use_environment=true,use_environment_priv=false,verbose=,"
 	  "write_through=",
@@ -1293,12 +1294,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
 	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
-	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
-	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
-	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
-	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
-	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
-	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "recover_progress=true,zero_fill=false),lsm_manager=(merge=true,"
+	  "worker_thread_max=4),lsm_merge=true,mmap=true,multiprocess=false"
+	  ",readonly=false,session_max=100,session_scratch_max=2MB,"
+	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "statistics=none,statistics_log=(json=false,on_close=false,"
+	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "transaction_sync=(enabled=false,method=fsync),"
 	  "use_environment=true,use_environment_priv=false,verbose=,"
 	  "version=(major=0,minor=0),write_through=",
@@ -1315,13 +1316,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-	  ",wait=0),transaction_sync=(enabled=false,method=fsync),verbose=,"
+	  "path=\".\",prealloc=true,recover=on,recover_progress=true,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=false,method=fsync),verbose=,"
 	  "version=(major=0,minor=0),write_through=",
 	  confchk_wiredtiger_open_basecfg, 35
 	},
@@ -1336,13 +1338,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
 	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,shared_cache=(chunk=10MB,name=,quota=0,"
-	  "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-	  ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-	  ",wait=0),transaction_sync=(enabled=false,method=fsync),verbose=,"
+	  "path=\".\",prealloc=true,recover=on,recover_progress=true,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,shared_cache=(chunk=10MB"
+	  ",name=,quota=0,reserve=0,size=500MB),statistics=none,"
+	  "statistics_log=(json=false,on_close=false,path=\".\",sources=,"
+	  "timestamp=\"%b %d %H:%M:%S\",wait=0),"
+	  "transaction_sync=(enabled=false,method=fsync),verbose=,"
 	  "write_through=",
 	  confchk_wiredtiger_open_usercfg, 34
 	},

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -161,6 +161,10 @@ __logmgr_config(
 		    session, cfg, "log.recover", 0, &cval));
 		if (WT_STRING_MATCH("error", cval.str, cval.len))
 			FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_ERR);
+		WT_RET(__wt_config_gets_def(
+		    session, cfg, "log.recover_progress", 0, &cval));
+		if (cval.val != 0)
+			FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_PROGRESS);
 	}
 
 	WT_RET(__wt_config_gets(session, cfg, "log.zero_fill", &cval));

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -328,7 +328,8 @@ struct __wt_connection_impl {
 #define	WT_CONN_LOG_EXISTED		0x04	/* Log files found */
 #define	WT_CONN_LOG_RECOVER_DONE	0x08	/* Recovery completed */
 #define	WT_CONN_LOG_RECOVER_ERR		0x10	/* Error if recovery required */
-#define	WT_CONN_LOG_ZERO_FILL		0x20	/* Manually zero files */
+#define	WT_CONN_LOG_RECOVER_PROGRESS	0x20	/* Recovery progress msgs */
+#define	WT_CONN_LOG_ZERO_FILL		0x40	/* Manually zero files */
 	uint32_t	 log_flags;	/* Global logging configuration */
 	WT_CONDVAR	*log_cond;	/* Log server wait mutex */
 	WT_SESSION_IMPL *log_session;	/* Log server session */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2409,6 +2409,8 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery
  * or error if recovery needs to run after an unclean shutdown., a string\,
  * chosen from the following options: \c "error"\, \c "on"; default \c on.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover_progress, print messages indicating
+ * progress of recovery., a boolean flag; default \c true.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log
  * files., a boolean flag; default \c false.}
  * @config{ ),,}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1674,7 +1674,8 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	    &log_fh, WT_LOG_FILENAME, start_lsn.l.file, WT_LOG_OPEN_VERIFY));
 	WT_ERR(__wt_filesize(session, log_fh, &log_size));
 	rd_lsn = start_lsn;
-	if (LF_ISSET(WT_LOGSCAN_RECOVER)) {
+	if (LF_ISSET(WT_LOGSCAN_RECOVER) &&
+	    FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_PROGRESS)) {
 		WT_ASSERT(session, start_lsn.l.file < end_lsn.l.file);
 		WT_ERR(__wt_msg(session, "Recovering log %" PRIu32
 		    " up to %" PRIu32, start_lsn.l.file, end_lsn.l.file));
@@ -1727,7 +1728,9 @@ advance:
 			WT_ERR(__log_openfile(session,
 			    &log_fh, WT_LOG_FILENAME,
 			    rd_lsn.l.file, WT_LOG_OPEN_VERIFY));
-			if (LF_ISSET(WT_LOGSCAN_RECOVER))
+			if (LF_ISSET(WT_LOGSCAN_RECOVER) &&
+			    FLD_ISSET(conn->log_flags,
+			    WT_CONN_LOG_RECOVER_PROGRESS))
 				WT_ERR(__wt_msg(session,
 				    "Recovering log %" PRIu32 " up to %" PRIu32,
 				    rd_lsn.l.file, end_lsn.l.file));

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1674,6 +1674,11 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	    &log_fh, WT_LOG_FILENAME, start_lsn.l.file, WT_LOG_OPEN_VERIFY));
 	WT_ERR(__wt_filesize(session, log_fh, &log_size));
 	rd_lsn = start_lsn;
+	if (LF_ISSET(WT_LOGSCAN_RECOVER)) {
+		WT_ASSERT(session, start_lsn.l.file < end_lsn.l.file);
+		WT_ERR(__wt_msg(session, "Recovering log %" PRIu32 
+		    " up to %" PRIu32, start_lsn.l.file, end_lsn.l.file));
+	}
 
 	WT_ERR(__wt_scr_alloc(session, WT_LOG_ALIGN, &buf));
 	WT_ERR(__wt_scr_alloc(session, 0, &decryptitem));
@@ -1722,6 +1727,10 @@ advance:
 			WT_ERR(__log_openfile(session,
 			    &log_fh, WT_LOG_FILENAME,
 			    rd_lsn.l.file, WT_LOG_OPEN_VERIFY));
+			if (LF_ISSET(WT_LOGSCAN_RECOVER))
+				WT_ERR(__wt_msg(session,
+				    "Recovering log %" PRIu32 " up to %" PRIu32,
+				    rd_lsn.l.file, end_lsn.l.file));
 			WT_ERR(__wt_filesize(session, log_fh, &log_size));
 			eol = false;
 			continue;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1676,7 +1676,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	rd_lsn = start_lsn;
 	if (LF_ISSET(WT_LOGSCAN_RECOVER)) {
 		WT_ASSERT(session, start_lsn.l.file < end_lsn.l.file);
-		WT_ERR(__wt_msg(session, "Recovering log %" PRIu32 
+		WT_ERR(__wt_msg(session, "Recovering log %" PRIu32
 		    " up to %" PRIu32, start_lsn.l.file, end_lsn.l.file));
 	}
 

--- a/test/suite/test_backup04.py
+++ b/test/suite/test_backup04.py
@@ -61,8 +61,8 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Create a large cache, otherwise this test runs quite slowly.
     def conn_config(self, dir):
-        return 'cache_size=1G,log=(archive=false,enabled,file_max=%s)' % \
-            self.logmax
+        return 'cache_size=1G,log=(archive=false,enabled,' + \
+            'recover_progress=false,file_max=%s)' % self.logmax
 
     def populate(self, uri, dsize, rows):
         self.pr('populate: ' + uri + ' with ' + str(rows) + ' rows')

--- a/test/suite/test_cursor07.py
+++ b/test/suite/test_cursor07.py
@@ -51,6 +51,7 @@ class test_cursor07(wttest.WiredTigerTestCase, suite_subprocess):
     # Enable logging for this test.
     def conn_config(self, dir):
         return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+            'log=(recover_progress=false),' + \
             'transaction_sync="(method=dsync,enabled)"'
 
     def test_log_cursor(self):

--- a/test/suite/test_cursor08.py
+++ b/test/suite/test_cursor08.py
@@ -56,7 +56,7 @@ class test_cursor08(wttest.WiredTigerTestCase, suite_subprocess):
     # Load the compression extension, and enable it for logging.
     def conn_config(self, dir):
         return 'log=(archive=false,enabled,file_max=%s,' % self.logmax + \
-            'compressor=%s),' % self.compress + \
+            'recover_progress=false,compressor=%s),' % self.compress + \
             'transaction_sync="(method=dsync,enabled)",' + \
             self.extensionArg(self.compress)
 

--- a/test/suite/test_reconfig02.py
+++ b/test/suite/test_reconfig02.py
@@ -32,7 +32,7 @@ import wiredtiger, wttest
 # test_reconfig02.py
 #    Smoke-test the connection reconfiguration operations.
 class test_reconfig02(wttest.WiredTigerTestCase):
-    init_config = 'log=(archive=false,enabled,file_max=100K,prealloc=false,zero_fill=false)'
+    init_config = 'log=(archive=false,enabled,file_max=100K,prealloc=false,zero_fill=false,recover_progress=false)'
     uri = "table:reconfig02"
     entries = 1000
 
@@ -62,7 +62,7 @@ class test_reconfig02(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.reconfigure("log=(path=foo)"), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.conn.reconfigure("log=(recovery=true)"), msg)
+            lambda: self.conn.reconfigure("log=(recover=error)"), msg)
 
     # Logging starts on, but prealloc is off.  Verify it is off.
     # Reconfigure it on and run again, making sure that log files

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -110,7 +110,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         conn_params = \
                 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
-                'log=(zero_fill=%s),' % zerofill + \
+                'log=(recover_progress=false,zero_fill=%s),' % zerofill + \
                 'create,error_prefix="%s: ",' % self.shortid() + \
                 'transaction_sync="%s",' % self.txn_sync
         # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
@@ -148,7 +148,8 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         # Opening a clone of the database home directory should run
         # recovery and see the committed results.
         self.backup(self.backup_dir)
-        backup_conn_params = 'log=(enabled,file_max=%s)' % self.logmax
+        backup_conn_params = \
+            'log=(enabled,file_max=%s,recover_progress=false)' % self.logmax
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)
         try:
             self.check(backup_conn.open_session(), None, committed)

--- a/test/suite/test_txn04.py
+++ b/test/suite/test_txn04.py
@@ -74,6 +74,7 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
         # Set archive false on the home directory.
         conn_params = \
                 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+                'log=(recover_progress=false),' + \
                 'create,error_prefix="%s: ",' % self.shortid() + \
                 'transaction_sync="%s",' % self.txn_sync
         # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
@@ -121,7 +122,8 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
 
         cmd += self.backup_dir
         self.runWt(cmd.split())
-        backup_conn_params = 'log=(enabled,file_max=%s)' % self.logmax
+        backup_conn_params = \
+            'log=(enabled,file_max=%s,recover_progress=false)' % self.logmax
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)
         try:
             self.check(backup_conn.open_session(), None, committed)

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -74,6 +74,7 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         conn_params = \
                 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+                'log=(recover_progress=false),' + \
                 'create,error_prefix="%s: ",' % self.shortid() + \
                 'transaction_sync="%s",' % self.txn_sync
         # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
@@ -111,7 +112,8 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         # Opening a clone of the database home directory should run
         # recovery and see the committed results.
         self.backup(self.backup_dir)
-        backup_conn_params = 'log=(enabled,file_max=%s)' % self.logmax
+        backup_conn_params = \
+            'log=(enabled,file_max=%s,recover_progress=false)' % self.logmax
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)
         try:
             self.check(backup_conn.open_session(), None, committed)

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -82,7 +82,7 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         conn_params = \
                 'log=(archive=false,enabled,file_max=%s,' % self.logmax + \
-                'compressor=%s)' % self.compress + \
+                'compressor=%s,recover_progress=false)' % self.compress + \
                 self.extensionArg(self.compress) + \
                 ',create,error_prefix="%s: ",' % self.shortid() + \
                 "statistics=(fast)," + \
@@ -138,7 +138,8 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         # Opening a clone of the database home directory should run
         # recovery and see the committed results.
         self.backup(self.backup_dir)
-        backup_conn_params = 'log=(enabled,file_max=%s,' % self.logmax + \
+        backup_conn_params = \
+            'log=(enabled,file_max=%s,recover_progress=false,' % self.logmax + \
                 'compressor=%s)' % self.compress + \
                 self.extensionArg(self.compress)
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)

--- a/test/suite/test_txn10.py
+++ b/test/suite/test_txn10.py
@@ -38,8 +38,8 @@ class test_txn10(wttest.WiredTigerTestCase, suite_subprocess):
     t1 = 'table:test_txn10_1'
     t2 = 'table:test_txn10_2'
     create_params = 'key_format=i,value_format=i'
-    conn_config = 'log=(archive=false,enabled,file_max=100K),' + \
-                'transaction_sync=(method=dsync,enabled)'
+    conn_config = 'log=(archive=false,enabled,file_max=100K,' + \
+        'recover_progress=false),transaction_sync=(method=dsync,enabled)'
 
     def simulate_crash_restart(self, olddir, newdir):
         ''' Simulate a crash from olddir and restart in newdir. '''

--- a/test/suite/test_txn11.py
+++ b/test/suite/test_txn11.py
@@ -45,7 +45,7 @@ class test_txn11(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Turn on logging for this test.
     def conn_config(self, dir):
-        return 'log=(archive=%s,' % self.archive + \
+        return 'log=(archive=%s,recover_progress=false,' % self.archive + \
             'enabled,file_max=%s,prealloc=false),' % self.logmax + \
             'transaction_sync=(enabled=false),'
 

--- a/test/suite/test_txn14.py
+++ b/test/suite/test_txn14.py
@@ -40,7 +40,8 @@ class test_txn14(wttest.WiredTigerTestCase, suite_subprocess):
     create_params = 'key_format=i,value_format=i'
     entries = 10000
     extra_entries = 5
-    conn_config = 'log=(archive=false,enabled,file_max=100K)'
+    conn_config = \
+        'log=(archive=false,enabled,file_max=100K,recover_progress=false)'
 
     sync_list = [
         ('write', dict(sync='off')),


### PR DESCRIPTION
@michaelcahill and @agorrod I have two branches for this work.  One uses the `wt_progress` call and the other `wt_msg`.  I'm on the fence which I prefer, but I'm leaning toward this one.  Having the ability to give an actual message is both simpler and can be more informative.  I went with something pretty basic.  If you're aware of more information wanted let me know.