### PR TITLE
WT-3112 Add lock statistics to try_lock path.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -326,7 +326,7 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 	 * otherwise we can block applications evicting large pages.
 	 */
 	if (!__wt_cache_stuck(session)) {
-		for (spins = 0; (ret = __wt_spin_trylock(
+		for (spins = 0; (ret = __wt_spin_trylock_track(
 		    session, &conn->dhandle_lock)) == EBUSY &&
 		    cache->pass_intr == 0; spins++) {
 			if (spins < WT_THOUSAND)
@@ -1264,7 +1264,7 @@ retry:	while (slot < max_entries) {
 		 * reference count to keep it alive while we sweep.
 		 */
 		if (!dhandle_locked) {
-			for (spins = 0; (ret = __wt_spin_trylock(
+			for (spins = 0; (ret = __wt_spin_trylock_track(
 			    session, &conn->dhandle_lock)) == EBUSY &&
 			    cache->pass_intr == 0;
 			    spins++) {

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -102,7 +102,7 @@ struct __wt_table {
 	ret = 0;							\
 	if (F_ISSET(session, (flag))) {					\
 		op;							\
-	} else if ((ret = __wt_spin_trylock(session, lock)) == 0) {	\
+	} else if ((ret = __wt_spin_trylock_track(session, lock)) == 0) {\
 		F_SET(session, (flag));					\
 		op;							\
 		F_CLR(session, (flag));					\


### PR DESCRIPTION
@keithbostic Please review this change to add the locking stats to the try-lock path.  I ran the evict-btree.wtperf workload on develop and this branch.  Develop acquires the dhandle list lock 47 times.  This branch is 116721 acquisitions.