### PR TITLE
WT-3105 Create all eviction sessions initially to avoid deadlock.

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -107,7 +107,7 @@ struct __wt_named_extractor {
  * Allocate some additional slots for internal sessions so the user cannot
  * configure too few sessions for us to run.
  */
-#define	WT_EXTRA_INTERNAL_SESSIONS	10
+#define	WT_EXTRA_INTERNAL_SESSIONS	20
 
 /*
  * WT_CONN_CHECK_PANIC --


### PR DESCRIPTION
@agorrod Here's the change to allocate and create all the eviction thread sessions at the start to avoid the deadlock,