### PR TITLE
WT-3114 Avoid archive immediately after recovery.

### DIFF
--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -368,14 +368,16 @@ __wt_txn_checkpoint_log(
 
 		/*
 		 * If this full checkpoint completed successfully and there is
-		 * no hot backup in progress, tell the logging subsystem the
-		 * checkpoint LSN so that it can archive.  Do not update the
-		 * logging checkpoint LSN if this is during a clean connection
-		 * close, only during a full checkpoint.  A clean close may not
-		 * update any metadata LSN and we do not want to archive in
-		 * that case.
+		 * no hot backup in progress and this is not recovery, tell
+		 * the logging subsystem the checkpoint LSN so that it can
+		 * archive.  Do not update the logging checkpoint LSN if this
+		 * is during a clean connection close, only during a full
+		 * checkpoint.  A clean close may not update any metadata LSN
+		 * and we do not want to archive in that case.
 		 */
-		if (!S2C(session)->hot_backup && txn->full_ckpt)
+		if (!S2C(session)->hot_backup && 
+		    !F_ISSET(S2C(session), WT_CONN_RECOVERING) &&
+		    txn->full_ckpt)
 			__wt_log_ckpt(session, ckpt_lsn);
 
 		/* FALLTHROUGH */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -375,7 +375,7 @@ __wt_txn_checkpoint_log(
 		 * checkpoint.  A clean close may not update any metadata LSN
 		 * and we do not want to archive in that case.
 		 */
-		if (!S2C(session)->hot_backup && 
+		if (!S2C(session)->hot_backup &&
 		    !F_ISSET(S2C(session), WT_CONN_RECOVERING) &&
 		    txn->full_ckpt)
 			__wt_log_ckpt(session, ckpt_lsn);

--- a/test/suite/test_reconfig02.py
+++ b/test/suite/test_reconfig02.py
@@ -109,6 +109,7 @@ class test_reconfig02(wttest.WiredTigerTestCase):
         # Now turn on archive, sleep a bit to allow the archive thread
         # to run and then confirm that all original logs are gone.
         self.conn.reconfigure("log=(archive=true)")
+        self.session.checkpoint("force")
         time.sleep(2)
         cur_logs = fnmatch.filter(os.listdir('.'), "*Log*")
         for o in orig_logs:

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -176,8 +176,10 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             backup_conn = self.wiredtiger_open(self.backup_dir,
                                                backup_conn_params)
             try:
-                self.check(backup_conn.open_session(), None, committed)
+                session = backup_conn.open_session()
             finally:
+                session.checkpoint("force");
+                self.check(backup_conn.open_session(), None, committed)
                 # Sleep long enough so that the archive thread is guaranteed
                 # to run before we close the connection.
                 time.sleep(1.0)

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -178,7 +178,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             try:
                 session = backup_conn.open_session()
             finally:
-                session.checkpoint("force");
+                session.checkpoint("force")
                 self.check(backup_conn.open_session(), None, committed)
                 # Sleep long enough so that the archive thread is guaranteed
                 # to run before we close the connection.

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -139,8 +139,12 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
             backup_conn = self.wiredtiger_open(self.backup_dir,
                                                backup_conn_params)
             try:
-                 self.check(backup_conn.open_session(), None, committed)
+                 session = backup_conn.open_session()
             finally:
+                self.check(session, None, committed)
+                # Force a checkpoint because we don't record the recovery
+                # checkpoint as available for archiving.
+                session.checkpoint("force")
                 # Sleep long enough so that the archive thread is guaranteed
                 # to run before we close the connection.
                 time.sleep(1.0)


### PR DESCRIPTION
@agorrod Please review this change.  It was smaller than I originally thought it would be even.  Essentially one line and a few archiving related tests.  This will avoid archiving log files after recovery until after the first "ongoing" checkpoint is written.