### PR TITLE
WT-3039 Make new log record more general for potential future expansion.

### DIFF
--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -42,7 +42,8 @@ rectypes = [
     LogRecordType('message', 'message', [('string', 'message')]),
 
     # System record
-    LogRecordType('system', 'system', [('WT_LSN','prev_lsn'), ('item', 'unused')]),
+    LogRecordType('system', 'system', [
+        ('WT_LSN','prev_lsn'), ('item', 'unused')]),
 ]
 
 class LogOperationType:

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -42,7 +42,7 @@ rectypes = [
     LogRecordType('message', 'message', [('string', 'message')]),
 
     # System record
-    LogRecordType('prevlsn', 'prevlsn', [('WT_LSN','prev_lsn')]),
+    LogRecordType('system', 'system', [('WT_LSN','prev_lsn'), ('item', 'unused')]),
 ]
 
 class LogOperationType:

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -407,8 +407,8 @@ extern int __wt_log_slot_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTR
 extern void __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT_MYSLOT *myslot) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int64_t __wt_log_slot_release(WT_SESSION_IMPL *session, WT_MYSLOT *myslot, int64_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern int __wt_log_system_prevlsn( WT_SESSION_IMPL *session, WT_FH *log_fh, WT_LSN *lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern int __wt_log_recover_prevlsn(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_LSN *lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern int __wt_log_system_record( WT_SESSION_IMPL *session, WT_FH *log_fh, WT_LSN *lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern int __wt_log_recover_system(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_LSN *lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_clsm_request_switch(WT_CURSOR_LSM *clsm) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_clsm_await_switch(WT_CURSOR_LSM *clsm) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_clsm_init_merge( WT_CURSOR *cursor, u_int start_chunk, uint32_t start_id, u_int nchunks) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -308,8 +308,8 @@ struct __wt_log_desc {
 	uint16_t	minorv;		/* 06-07: Minor version */
 	uint64_t	log_size;	/* 08-15: Log file size */
 };
-#define	WT_LOG_MAJOR_PREVLSN	1
-#define	WT_LOG_MINOR_PREVLSN	1
+#define	WT_LOG_MAJOR_SYSTEM	1
+#define	WT_LOG_MINOR_SYSTEM	1
 
 /*
  * __wt_log_desc_byteswap --

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4288,7 +4288,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! message */
 #define	WT_LOGREC_MESSAGE	3
 /*! system/internal record */
-#define	WT_LOGREC_PREVLSN	4
+#define	WT_LOGREC_SYSTEM	4
 /*! invalid operation */
 #define	WT_LOGOP_INVALID	0
 /*! column put */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -795,9 +795,9 @@ __log_openfile(WT_SESSION_IMPL *session, WT_FH **fhp,
 		 * LSN record, then read that in and set up the LSN.
 		 * We already have a buffer that is the correct size.  Reuse it.
 		 */
-		if (desc->majorv < WT_LOG_MAJOR_PREVLSN ||
-		    (desc->majorv == WT_LOG_MAJOR_PREVLSN &&
-		    desc->minorv < WT_LOG_MINOR_PREVLSN))
+		if (desc->majorv < WT_LOG_MAJOR_SYSTEM ||
+		    (desc->majorv == WT_LOG_MAJOR_SYSTEM &&
+		    desc->minorv < WT_LOG_MINOR_SYSTEM))
 			goto err;
 
 		if (lsnp == NULL)
@@ -813,10 +813,10 @@ __log_openfile(WT_SESSION_IMPL *session, WT_FH **fhp,
 		p = WT_LOG_SKIP_HEADER(buf->data);
 		end = (const uint8_t *)buf->data + buf->size;
 		WT_ERR(__wt_logrec_read(session, &p, end, &rectype));
-		if (rectype != WT_LOGREC_PREVLSN)
+		if (rectype != WT_LOGREC_SYSTEM)
 			WT_ERR_MSG(session, WT_ERROR,
 			    "System log record missing");
-		WT_ERR(__wt_log_recover_prevlsn(session, &p, end, lsnp));
+		WT_ERR(__wt_log_recover_system(session, &p, end, lsnp));
 	}
 err:	__wt_scr_free(session, &buf);
 	return (ret);
@@ -979,7 +979,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 * the end of the header.
 	 */
 	WT_SET_LSN(&log->alloc_lsn, log->fileid, WT_LOG_END_HEADER);
-	WT_RET(__wt_log_system_prevlsn(session,
+	WT_RET(__wt_log_system_record(session,
 	    log_fh, &logrec_lsn));
 	WT_SET_LSN(&log->alloc_lsn, log->fileid, WT_LOG_FIRST_RECORD);
 	end_lsn = log->alloc_lsn;

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -82,12 +82,12 @@ __wt_log_recover_system(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end, WT_LSN *lsnp)
 {
 	WT_DECL_RET;
-	WT_ITEM system_unused;
+	WT_ITEM unused;
 	uint32_t prev_file, prev_offset;
 	const char *fmt = WT_UNCHECKED_STRING(IIU);
 
 	if ((ret = __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt,
-	    &prev_file, &prev_offset, &system_unused)) != 0)
+	    &prev_file, &prev_offset, &unused)) != 0)
 		WT_RET_MSG(session, ret,
 		    "log_recover_prevlsn: unpack failure");
 	if (lsnp != NULL)

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -9,32 +9,39 @@
 #include "wt_internal.h"
 
 /*
- * __wt_log_system_prevlsn --
+ * __wt_log_system_record --
  *	Write a system log record for the previous LSN.
  */
 int
-__wt_log_system_prevlsn(
+__wt_log_system_record(
     WT_SESSION_IMPL *session, WT_FH *log_fh, WT_LSN *lsn)
 {
 	WT_DECL_ITEM(logrec_buf);
 	WT_DECL_RET;
+	WT_ITEM *dummy, empty;
 	WT_LOG *log;
 	WT_LOG_RECORD *logrec;
 	WT_LOGSLOT tmp;
 	WT_MYSLOT myslot;
-	const char *fmt = WT_UNCHECKED_STRING(III);
-	uint32_t rectype = WT_LOGREC_PREVLSN;
+	const char *fmt = WT_UNCHECKED_STRING(IIIU);
+	uint32_t rectype = WT_LOGREC_SYSTEM;
 	size_t recsize;
 
 	log = S2C(session)->log;
 	WT_RET(__wt_logrec_alloc(session, log->allocsize, &logrec_buf));
 	memset((uint8_t *)logrec_buf->mem, 0, log->allocsize);
+	WT_CLEAR(empty);
+	dummy = &empty;
+	/*
+	 * There is currently an unused portion of the system record for
+	 * future use.  Send in a NULL entry.
+	 */
 	WT_ERR(__wt_struct_size(session, &recsize, fmt, rectype,
-	    lsn->l.file, lsn->l.offset));
+	    lsn->l.file, lsn->l.offset, dummy));
 	WT_ASSERT(session, recsize <= log->allocsize);
 	WT_ERR(__wt_struct_pack(session,
 	    (uint8_t *)logrec_buf->data + logrec_buf->size, recsize, fmt,
-	    rectype, lsn->l.file, lsn->l.offset));
+	    rectype, lsn->l.file, lsn->l.offset, dummy));
 	logrec = (WT_LOG_RECORD *)logrec_buf->mem;
 	/*
 	 * We know system records are this size.  And we have to adjust
@@ -67,19 +74,20 @@ err:	__wt_logrec_free(session, &logrec_buf);
 }
 
 /*
- * __wt_log_recover_prevlsn --
+ * __wt_log_recover_system --
  *	Process a system log record for the previous LSN in recovery.
  */
 int
-__wt_log_recover_prevlsn(WT_SESSION_IMPL *session,
+__wt_log_recover_system(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end, WT_LSN *lsnp)
 {
 	WT_DECL_RET;
+	WT_ITEM system_unused;
 	uint32_t prev_file, prev_offset;
-	const char *fmt = WT_UNCHECKED_STRING(II);
+	const char *fmt = WT_UNCHECKED_STRING(IIU);
 
 	if ((ret = __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt,
-	    &prev_file, &prev_offset)) != 0)
+	    &prev_file, &prev_offset, &system_unused)) != 0)
 		WT_RET_MSG(session, ret,
 		    "log_recover_prevlsn: unpack failure");
 	if (lsnp != NULL)

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -539,11 +539,11 @@ __txn_printlog(WT_SESSION_IMPL *session,
 		    "    \"message\" : \"%s\"\n", msg));
 		break;
 
-	case WT_LOGREC_PREVLSN:
+	case WT_LOGREC_SYSTEM:
 		WT_RET(__wt_struct_unpack(session, p, WT_PTRDIFF(end, p),
 		    WT_UNCHECKED_STRING(II), &lsnfile, &lsnoffset));
 		WT_RET(__wt_fprintf(session, WT_STDOUT(session),
-		    "    \"type\" : \"prevlsn\",\n"));
+		    "    \"type\" : \"system\",\n"));
 		WT_RET(__wt_fprintf(session, WT_STDOUT(session),
 		    "    \"prev_lsn\" : [%" PRIu32 ",%" PRIu32 "]\n",
 		    lsnfile, lsnoffset));

--- a/test/recovery/truncated-log.c
+++ b/test/recovery/truncated-log.c
@@ -106,7 +106,7 @@ write_and_read_new(WT_SESSION *session)
 		 * the previous log file's LSN.  Although it is written by the
 		 * system, we do walk it when using a cursor.
 		 */
-		if (log_file == 2 && rectype != WT_LOGREC_PREVLSN)
+		if (log_file == 2 && rectype != WT_LOGREC_SYSTEM)
 			testutil_die(EINVAL, "Found LSN in Log 2");
 #if 0
 		printf("LSN [%" PRIu32 "][%" PRIu32 "].%" PRIu32


### PR DESCRIPTION
@michaelcahill and @agorrod Here's a slightly different take on the new prevlsn log record.  I've renamed it to `system` and included a currently unused WT_ITEM in the record.  The thought is that we may want to include other information in this record someday and then all the plumbing is there (if the "other information" maps only to a WT_ITEM).  This is a branch off the other branch, wt-3039-prevlsn, so can be merged if you like it.