### PR TITLE
WT-3121 In the test suite, create a standard way to load extensions

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -324,7 +324,8 @@ if __name__ == '__main__':
     # All global variables should be set before any test classes are loaded.
     # That way, verbose printing can be done at the class definition level.
     wttest.WiredTigerTestCase.globalSetup(preserve, timestamp, gdbSub,
-                                          verbose, dirarg, longtest)
+                                          verbose, wt_builddir, dirarg,
+                                          longtest)
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:

--- a/test/suite/test_async01.py
+++ b/test/suite/test_async01.py
@@ -132,7 +132,7 @@ class test_async01(wttest.WiredTigerTestCase, suite_subprocess):
     ])
 
     # Enable async for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'async=(enabled=true,ops_max=%s,' % self.async_ops + \
             'threads=%s)' % self.async_threads
 

--- a/test/suite/test_async02.py
+++ b/test/suite/test_async02.py
@@ -129,7 +129,7 @@ class test_async02(wttest.WiredTigerTestCase, suite_subprocess):
     ])
 
     # Enable async for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'async=(enabled=true,ops_max=%s,' % self.async_ops + \
             'threads=%s)' % self.async_threads
 

--- a/test/suite/test_backup04.py
+++ b/test/suite/test_backup04.py
@@ -60,7 +60,7 @@ class test_backup_target(wttest.WiredTigerTestCase, suite_subprocess):
     ])
 
     # Create a large cache, otherwise this test runs quite slowly.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'cache_size=1G,log=(archive=false,enabled,file_max=%s)' % \
             self.logmax
 

--- a/test/suite/test_bug011.py
+++ b/test/suite/test_bug011.py
@@ -43,7 +43,7 @@ class test_bug011(wttest.WiredTigerTestCase):
     nrows = 10000
     nops = 10000
     # Add connection configuration for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'cache_size=1GB'
 
     @wttest.longtest("Eviction copes with lots of files")

--- a/test/suite/test_collator.py
+++ b/test/suite/test_collator.py
@@ -48,34 +48,7 @@ class test_collator(wttest.WiredTigerTestCase):
     nentries = 100
     nindices = 4
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, libname) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + libname + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        extarg = self.extensionArg([('extractors', 'csv', 'csv_extractor'),
-                                ('collators', 'revint', 'revint_collator')])
-        connarg = 'create,error_prefix="{0}: ",{1}'.format(
-            self.shortid(), extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+    conn_extensions = [ 'extractors/csv', 'collators/revint' ]
 
     def create_indices(self):
         # Create self.nindices index files, each with a column from the CSV

--- a/test/suite/test_compress01.py
+++ b/test/suite/test_compress01.py
@@ -51,22 +51,10 @@ class test_compress01(wttest.WiredTigerTestCase):
     nrecords = 10000
     bigvalue = "abcdefghij" * 1000
 
-    # Load the compression extension, compression is enabled elsewhere.
-    def conn_config(self, dir):
-        return self.extensionArg(self.compress)
-
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, name):
-        if name == None:
-            return ''
-
-        testdir = os.path.dirname(__file__)
-        extdir = os.path.join(run.wt_builddir, 'ext/compressors')
-        extfile = os.path.join(
-            extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-        if not os.path.exists(extfile):
-            self.skipTest('compression extension "' + extfile + '" not built')
-        return ',extensions=["' + extfile + '"]'
+    # Load the compression extension, skip the test if missing
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('compressors', self.compress)
 
     # Create a table, add keys with both big and small values, then verify them.
     def test_compress(self):

--- a/test/suite/test_cursor07.py
+++ b/test/suite/test_cursor07.py
@@ -49,7 +49,7 @@ class test_cursor07(wttest.WiredTigerTestCase, suite_subprocess):
         ('reopen', dict(reopen=True))
     ])
     # Enable logging for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
             'transaction_sync="(method=dsync,enabled)"'
 

--- a/test/suite/test_cursor08.py
+++ b/test/suite/test_cursor08.py
@@ -54,24 +54,14 @@ class test_cursor08(wttest.WiredTigerTestCase, suite_subprocess):
     ]
     scenarios = make_scenarios(reopens, compress)
     # Load the compression extension, and enable it for logging.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%s,' % self.logmax + \
             'compressor=%s),' % self.compress + \
-            'transaction_sync="(method=dsync,enabled)",' + \
-            self.extensionArg(self.compress)
+            'transaction_sync="(method=dsync,enabled)"'
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, name):
-        if name == None or name == 'none':
-            return ''
-
-        testdir = os.path.dirname(__file__)
-        extdir = os.path.join(run.wt_builddir, 'ext/compressors')
-        extfile = os.path.join(
-            extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-        if not os.path.exists(extfile):
-            self.skipTest('compression extension "' + extfile + '" not built')
-        return ',extensions=["' + extfile + '"]'
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('compressors', self.compress)
 
     def test_log_cursor(self):
         # print "Creating %s with config '%s'" % (self.uri, self.create_params)

--- a/test/suite/test_encrypt02.py
+++ b/test/suite/test_encrypt02.py
@@ -39,51 +39,25 @@ from wtscenario import make_scenarios
 class test_encrypt02(wttest.WiredTigerTestCase, suite_subprocess):
     uri = 'file:test_encrypt02'
     encrypt_type = [
-        ('noarg', dict( encrypt='rotn', encrypt_args='name=rotn',
-                        secret_arg=None)),
-        ('keyid', dict( encrypt='rotn', encrypt_args='name=rotn,keyid=11',
-                        secret_arg=None)),
-        ('pass', dict( encrypt='rotn', encrypt_args='name=rotn',
-                        secret_arg='ABC')),
-        ('keyid-pass', dict( encrypt='rotn', encrypt_args='name=rotn,keyid=11',
-                        secret_arg='ABC')),
+        ('noarg', dict( conn_extensions=[ 'encryptors/rotn' ],
+            encrypt_args='name=rotn', secret_arg=None)),
+        ('keyid', dict( conn_extensions=[ 'encryptors/rotn' ],
+            encrypt_args='name=rotn,keyid=11', secret_arg=None)),
+        ('pass', dict( conn_extensions=[ 'encryptors/rotn' ],
+            encrypt_args='name=rotn', secret_arg='ABC')),
+        ('keyid-pass', dict( conn_extensions=[ 'encryptors/rotn' ],
+            encrypt_args='name=rotn,keyid=11', secret_arg='ABC')),
     ]
     scenarios = make_scenarios(encrypt_type)
 
     nrecords = 5000
     bigvalue = "abcdefghij" * 1001    # len(bigvalue) = 10010
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
+    def conn_config(self):
         secretarg = ''
         if self.secret_arg != None:
             secretarg = ',secretkey=' + self.secret_arg
-        encarg = 'encryption=({0}{1})'.format(self.encrypt_args, secretarg)
-        extarg = self.extensionArg([('encryptors', self.encrypt)])
-        connarg = 'create,error_prefix="{0}: ",{1},{2}'.format(
-            self.shortid(), encarg, extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+        return 'encryption=({0}{1})'.format(self.encrypt_args, secretarg)
 
     # Create a table, add keys with both big and small values, then verify them.
     def test_pass(self):

--- a/test/suite/test_encrypt03.py
+++ b/test/suite/test_encrypt03.py
@@ -50,37 +50,13 @@ class test_encrypt03(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(types, encrypt)
 
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        encarg = 'encryption=(name={0}{1}),'.format(
-            self.sys_encrypt, self.sys_encrypt_args)
-        extarg = self.extensionArg([('encryptors', self.sys_encrypt),
-            ('encryptors', self.file_encrypt)])
-        self.pr('encarg = ' + encarg + ' extarg = ' + extarg)
-        conn = self.wiredtiger_open(dir,
-            'create,error_prefix="{0}: ",{1}{2}'.format(
-                self.shortid(), encarg, extarg))
-        self.pr(`conn`)
-        return conn
+    def conn_extensions(self, extlist):
+        extlist.extension('encryptors', self.sys_encrypt)
+        extlist.extension('encryptors', self.file_encrypt)
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
+    def conn_config(self):
+        return 'encryption=(name={0}{1}),'.format(
+            self.sys_encrypt, self.sys_encrypt_args)
 
     # Create a table with encryption values that are in error.
     def test_encrypt(self):

--- a/test/suite/test_encrypt04.py
+++ b/test/suite/test_encrypt04.py
@@ -77,9 +77,15 @@ class test_encrypt04(wttest.WiredTigerTestCase, suite_subprocess):
         wttest.WiredTigerTestCase.__init__(self, *args, **kwargs)
         self.part = 1
 
+    def conn_extensions(self, extlist):
+        extarg = None
+        if self.expect_forceerror:
+            extarg='(config=\"rotn_force_error=true\")'
+        extlist.extension('encryptors', self.name, extarg)
+
     # Override WiredTigerTestCase, we have extensions.
     def setUpConnectionOpen(self, dir):
-        forceerror = None
+        self.expect_forceerror = False
         if self.part == 1:
             self.name = self.name1
             self.keyid = self.keyid1
@@ -93,16 +99,15 @@ class test_encrypt04(wttest.WiredTigerTestCase, suite_subprocess):
             self.fileinclear = self.fileinclear2 if \
                                hasattr(self, 'fileinclear2') else False
             if hasattr(self, 'forceerror1') and hasattr(self, 'forceerror2'):
-                forceerror = "rotn_force_error=true"
-        self.expect_forceerror = forceerror != None
+                self.expect_forceerror = True
         self.got_forceerror = False
 
         encarg = 'encryption=(name={0},keyid={1},secretkey={2}),'.format(
             self.name, self.keyid, self.secretkey)
-        # If forceerror is set for this test, add a config arg to
-        # the extension string. That signals rotn to return a (-1000)
-        # error code, which we'll detect here.
-        extarg = self.extensionArg([('encryptors', self.name, forceerror)])
+        # If forceerror is set for this test, conn_extensions adds a
+        # config arg to the extension string. That signals rotn to
+        # return a (-1000) error code, which we'll detect here.
+        extarg = self.extensionsConfig()
         self.pr('encarg = ' + encarg + ' extarg = ' + extarg)
         completed = False
         try:
@@ -134,29 +139,6 @@ class test_encrypt04(wttest.WiredTigerTestCase, suite_subprocess):
             cursor.set_key(key)
             self.assertEqual(cursor.search(), 0)
             self.assertEquals(cursor.get_value(), val)
-
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, extarg) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                extfile = '"' + extfile + '"'
-                if not extfile in extfiles:
-                    s = extfile
-                    if extarg != None:
-                        s += "=(config=\"" + extarg + "\")"
-                    extfiles.append(s)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=[' + ','.join(extfiles) + ']'
 
     # Evaluate expression, which either must succeed (if expect_okay)
     # or must fail (if !expect_okay).

--- a/test/suite/test_encrypt05.py
+++ b/test/suite/test_encrypt05.py
@@ -49,41 +49,20 @@ class test_encrypt05(wttest.WiredTigerTestCase):
     nrecords = 500
     bigvalue = 'a' * 500 # we use values that will definitely give compression
 
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('encryptors', self.sys_encrypt)
+        extlist.extension('encryptors', self.file_encrypt)
+        extlist.extension('compressors', self.block_compress)
+        extlist.extension('compressors', self.log_compress)
+
+    def conn_config(self):
         encarg = 'encryption=(name={0}{1}),'.format(
             self.sys_encrypt, self.sys_encrypt_args)
         comparg = ''
         if self.log_compress != None:
             comparg='log=(compressor={0}),'.format(self.log_compress)
-        extarg = self.extensionArg([('encryptors', self.sys_encrypt),
-            ('encryptors', self.file_encrypt),
-            ('compressors', self.block_compress),
-            ('compressors', self.log_compress)])
-        conn = self.wiredtiger_open(dir,
-            'create,error_prefix="{0}: ",{1}{2}{3}'.format(
-                self.shortid(), encarg, comparg, extarg))
-        self.pr(`conn`)
-        return conn
-
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
+        return encarg + comparg
 
     def getvalue(self, r, n):
         if n < len(self.bigvalue):

--- a/test/suite/test_encrypt06.py
+++ b/test/suite/test_encrypt06.py
@@ -89,38 +89,14 @@ class test_encrypt06(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(encrypt, storagetype)
     nrecords = 1000
 
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        encarg = 'encryption=(name={0}{1}),'.format(
-            self.sys_encrypt, self.sys_encrypt_args)
-        comparg = ''
-        extarg = self.extensionArg([('encryptors', self.sys_encrypt),
-            ('encryptors', self.file0_encrypt),
-            ('encryptors', self.file1_encrypt)])
-        self.open_params = 'create,error_prefix="{0}: ",{1}{2}{3}'.format(
-                self.shortid(), encarg, comparg, extarg)
-        conn = self.wiredtiger_open(dir, self.open_params)
-        self.pr(`conn`)
-        return conn
+    def conn_extensions(self, extlist):
+        extlist.extension('encryptors', self.sys_encrypt)
+        extlist.extension('encryptors', self.file0_encrypt)
+        extlist.extension('encryptors', self.file1_encrypt)
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
+    def conn_config(self):
+        return 'encryption=(name={0}{1}),'.format(
+            self.sys_encrypt, self.sys_encrypt_args)
 
     def encrypt_file_params(self, name, args):
         if name == None:

--- a/test/suite/test_encrypt07.py
+++ b/test/suite/test_encrypt07.py
@@ -44,35 +44,12 @@ class test_encrypt07(test_salvage.test_salvage):
     nrecords = 5000
     bigvalue = "abcdefghij" * 1007    # len(bigvalue) = 10070
 
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        encarg = 'encryption=(name={0}{1}),'.format(
-            self.sys_encrypt, self.sys_encrypt_args)
-        extarg = self.extensionArg([('encryptors', self.sys_encrypt)])
-        conn = self.wiredtiger_open(dir,
-               'create,error_prefix="{0}: ",{1}{2}'.format(
-                self.shortid(), encarg, extarg))
-        self.pr(`conn`)
-        return conn
+    def conn_extensions(self, extlist):
+        extlist.extension('encryptors', self.sys_encrypt)
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
+    def conn_config(self):
+        return 'encryption=(name={0}{1}),'.format(
+            self.sys_encrypt, self.sys_encrypt_args)
 
     def rot13(self, s):
         return codecs.encode(s, 'rot_13')

--- a/test/suite/test_join03.py
+++ b/test/suite/test_join03.py
@@ -36,33 +36,7 @@ class test_join03(wttest.WiredTigerTestCase):
     table_name1 = 'test_join03'
     nentries = 100
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, libname) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + libname + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        extarg = self.extensionArg([('extractors', 'csv', 'csv_extractor')])
-        connarg = 'create,error_prefix="{0}: ",{1}'.format(
-            self.shortid(), extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+    conn_extensions = [ 'extractors/csv' ]
 
     def gen_key(self, i):
         return [ i + 1 ]

--- a/test/suite/test_join04.py
+++ b/test/suite/test_join04.py
@@ -36,33 +36,7 @@ class test_join04(wttest.WiredTigerTestCase):
     table_name1 = 'test_join04'
     nentries = 100
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, libname) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + libname + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        extarg = self.extensionArg([('extractors', 'csv', 'csv_extractor')])
-        connarg = 'create,error_prefix="{0}: ",{1}'.format(
-            self.shortid(), extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+    conn_extensions = [ 'extractors/csv' ]
 
     # JIRA WT-2308:
     # Test extractors with equality joins

--- a/test/suite/test_join07.py
+++ b/test/suite/test_join07.py
@@ -200,33 +200,7 @@ class test_join07(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(extractscen)
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, libname) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + libname + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        extarg = self.extensionArg([('extractors', 'csv', 'csv_extractor')])
-        connarg = 'create,error_prefix="{0}: ",{1}'.format(
-            self.shortid(), extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+    conn_extensions = [ 'extractors/csv' ]
 
     def expect(self, token, expected):
         if token == None or token.kind not in expected:

--- a/test/suite/test_readonly01.py
+++ b/test/suite/test_readonly01.py
@@ -75,8 +75,7 @@ class test_readonly01(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(basecfg_list, dir_list, log_list, types)
 
-    def conn_config(self, dir):
-        self.home = dir
+    def conn_config(self):
         params = \
             'error_prefix="%s",' % self.shortid() + \
             '%s' % self.logcfg + \

--- a/test/suite/test_schema05.py
+++ b/test/suite/test_schema05.py
@@ -57,33 +57,7 @@ class test_schema05(wttest.WiredTigerTestCase):
         ('index-after', { 'create_index' : 2 }),
     ])
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, exts):
-        extfiles = []
-        for ext in exts:
-            (dirname, name, libname) = ext
-            if name != None and name != 'none':
-                testdir = os.path.dirname(__file__)
-                extdir = os.path.join(run.wt_builddir, 'ext', dirname)
-                extfile = os.path.join(
-                    extdir, name, '.libs', 'libwiredtiger_' + libname + '.so')
-                if not os.path.exists(extfile):
-                    self.skipTest('extension "' + extfile + '" not built')
-                if not extfile in extfiles:
-                    extfiles.append(extfile)
-        if len(extfiles) == 0:
-            return ''
-        else:
-            return ',extensions=["' + '","'.join(extfiles) + '"]'
-
-    # Override WiredTigerTestCase, we have extensions.
-    def setUpConnectionOpen(self, dir):
-        extarg = self.extensionArg([('extractors', 'csv', 'csv_extractor')])
-        connarg = 'create,error_prefix="{0}: ",{1}'.format(
-            self.shortid(), extarg)
-        conn = self.wiredtiger_open(dir, connarg)
-        self.pr(`conn`)
-        return conn
+    conn_extensions = [ 'extractors/csv' ]
 
     def create_indices(self):
         # Create self.nindices index files, each with a column from the CSV

--- a/test/suite/test_schema07.py
+++ b/test/suite/test_schema07.py
@@ -33,8 +33,7 @@ import wiredtiger, wttest
 class test_schema07(wttest.WiredTigerTestCase):
     tablename = 'table:test_schema07'
 
-    def conn_config(self, dir):
-        return 'cache_size=10MB'
+    conn_config = 'cache_size=10MB'
 
     @wttest.longtest("Creating many tables shouldn't fill the cache")
     def test_many_tables(self):

--- a/test/suite/test_stat02.py
+++ b/test/suite/test_stat02.py
@@ -59,7 +59,7 @@ class test_stat_cursor_config(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(uri, data_config, cursor_config)
 
     # Turn on statistics for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'statistics=(%s)' % self.data_config
 
     # For each database/cursor configuration, confirm the right combinations

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -93,11 +93,10 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
     checklog_calls = 100 if wttest.islongtest() else 2
     checklog_mod = (len(scenarios) / checklog_calls + 1)
 
-    def setUpConnectionOpen(self, dir):
-        self.home = dir
+    def conn_config(self):
         # Cycle through the different transaction_sync values in a
         # deterministic manner.
-        self.txn_sync = self.sync_list[
+        txn_sync = self.sync_list[
             self.scenario_number % len(self.sync_list)]
         #
         # We don't want to run zero fill with only the same settings, such
@@ -107,17 +106,9 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         zerofill = 'false'
         if self.scenario_number % freq == 0:
             zerofill = 'true'
-        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
-        conn_params = \
-                'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
-                'log=(zero_fill=%s),' % zerofill + \
-                'create,error_prefix="%s: ",' % self.shortid() + \
-                'transaction_sync="%s",' % self.txn_sync
-        # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
-        conn = self.wiredtiger_open(dir, conn_params)
-        self.pr(`conn`)
-        self.session2 = conn.open_session()
-        return conn
+        return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+            'log=(zero_fill=%s),' % zerofill + \
+            'transaction_sync="%s",' % txn_sync
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
@@ -204,6 +195,8 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(cur_logs, pr_logs)
 
     def test_ops(self):
+        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
+        self.session2 = self.conn.open_session()
         # print "Creating %s with config '%s'" % (self.uri, self.create_params)
         self.session.create(self.uri, self.create_params)
         # Set up the table with entries for 1, 2, 10 and 11.
@@ -226,6 +219,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             # Close and reopen the connection and cursor.
             if reopen == 'reopen':
                 self.reopen_conn()
+                self.session2 = self.conn.open_session()
                 c = self.session.open_cursor(self.uri, None, 'overwrite')
 
             self.session.begin_transaction(

--- a/test/suite/test_txn04.py
+++ b/test/suite/test_txn04.py
@@ -63,24 +63,15 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
     txn1s = [('t1c', dict(txn1='commit')), ('t1r', dict(txn1='rollback'))]
 
     scenarios = make_scenarios(types, op1s, txn1s)
-    # Overrides WiredTigerTestCase
-    def setUpConnectionOpen(self, dir):
-        self.home = dir
+
+    def conn_config(self):
         # Cycle through the different transaction_sync values in a
         # deterministic manner.
-        self.txn_sync = self.sync_list[
+        txn_sync = self.sync_list[
             self.scenario_number % len(self.sync_list)]
-        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         # Set archive false on the home directory.
-        conn_params = \
-                'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
-                'create,error_prefix="%s: ",' % self.shortid() + \
-                'transaction_sync="%s",' % self.txn_sync
-        # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
-        conn = self.wiredtiger_open(dir, conn_params)
-        self.pr(`conn`)
-        self.session2 = conn.open_session()
-        return conn
+        return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+            'transaction_sync="%s",' % txn_sync
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
@@ -146,6 +137,7 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
             # The runWt command closes our connection and sessions so
             # we need to reopen them here.
             self.hot_backup(None, committed)
+            self.session2 = self.conn.open_session()
             c = self.session.open_cursor(self.uri, None, 'overwrite')
             c.set_value(1)
             # Then do the given modification.
@@ -193,6 +185,8 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
         self.hot_backup(self.uri, committed)
 
     def test_ops(self):
+        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
+        self.session2 = self.conn.open_session()
         with self.expectedStdoutPattern('recreating metadata'):
             self.ops()
 

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -64,23 +64,15 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
     txn1s = [('t1c', dict(txn1='commit')), ('t1r', dict(txn1='rollback'))]
 
     scenarios = make_scenarios(types, op1s, txn1s)
-    # Overrides WiredTigerTestCase
-    def setUpConnectionOpen(self, dir):
-        self.home = dir
+
+    def conn_config(self):
         # Cycle through the different transaction_sync values in a
         # deterministic manner.
-        self.txn_sync = self.sync_list[
+        txn_sync = self.sync_list[
             self.scenario_number % len(self.sync_list)]
-        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
-        conn_params = \
-                'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
-                'create,error_prefix="%s: ",' % self.shortid() + \
-                'transaction_sync="%s",' % self.txn_sync
-        # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
-        conn = self.wiredtiger_open(dir, conn_params)
-        self.pr(`conn`)
-        self.session2 = conn.open_session()
-        return conn
+        # Set archive false on the home directory.
+        return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
+            'transaction_sync="%s",' % txn_sync
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
@@ -163,6 +155,8 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
 
     def test_ops(self):
+        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
+        self.session2 = self.conn.open_session()
         # print "Creating %s with config '%s'" % (self.uri, self.create_params)
         self.session.create(self.uri, self.create_params)
         # Set up the table with entries for 1-5.

--- a/test/suite/test_txn06.py
+++ b/test/suite/test_txn06.py
@@ -40,10 +40,10 @@ class test_txn06(wttest.WiredTigerTestCase, suite_subprocess):
     source_uri = 'table:' + tablename + "_src"
     nrows = 100000
 
-    def setUpConnectionOpen(self, *args):
+    def conn_config(self):
         if not wiredtiger.verbose_build():
             self.skipTest('requires a verbose build')
-        return super(test_txn06, self).setUpConnectionOpen(*args)
+        return ''
 
     def test_long_running(self):
         # Populate a table

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -72,42 +72,18 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types, op1s, txn1s, compress,
                                prune=30, prunelong=1000)
-    # Overrides WiredTigerTestCase
-    def setUpConnectionOpen(self, dir):
-        self.home = dir
-        # Cycle through the different transaction_sync values in a
-        # deterministic manner.
-        self.txn_sync = self.sync_list[
-            self.scenario_number % len(self.sync_list)]
-        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
-        conn_params = \
-                'log=(archive=false,enabled,file_max=%s,' % self.logmax + \
-                'compressor=%s)' % self.compress + \
-                self.extensionArg(self.compress) + \
-                ',create,error_prefix="%s: ",' % self.shortid() + \
-                "statistics=(fast)," + \
-                'transaction_sync="%s",' % self.txn_sync
-        # print "Creating conn at '%s' with config '%s'" % (dir, conn_params)
-        try:
-            conn = self.wiredtiger_open(dir, conn_params)
-        except wiredtiger.WiredTigerError as e:
-            print "Failed conn at '%s' with config '%s'" % (dir, conn_params)
-        self.pr(`conn`)
-        self.session2 = conn.open_session()
-        return conn
 
-    # Return the wiredtiger_open extension argument for a shared library.
-    def extensionArg(self, name):
-        if name == None or name == '':
-            return ''
+    def conn_config(self):
+        return 'log=(archive=false,enabled,file_max=%s,' % self.logmax + \
+        'compressor=%s)' % self.compress + \
+        ',create,error_prefix="%s: ",' % self.shortid() + \
+        "statistics=(fast)," + \
+        'transaction_sync="%s",' % \
+        self.sync_list[self.scenario_number % len(self.sync_list)]
 
-        testdir = os.path.dirname(__file__)
-        extdir = os.path.join(run.wt_builddir, 'ext/compressors')
-        extfile = os.path.join(
-            extdir, name, '.libs', 'libwiredtiger_' + name + '.so')
-        if not os.path.exists(extfile):
-            self.skipTest('compression extension "' + extfile + '" not built')
-        return ',extensions=["' + extfile + '"]'
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('compressors', self.compress)
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
@@ -140,7 +116,7 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         self.backup(self.backup_dir)
         backup_conn_params = 'log=(enabled,file_max=%s,' % self.logmax + \
                 'compressor=%s)' % self.compress + \
-                self.extensionArg(self.compress)
+                self.extensionsConfig()
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)
         try:
             self.check(backup_conn.open_session(), None, committed)
@@ -148,6 +124,9 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             backup_conn.close()
 
     def test_ops(self):
+        self.backup_dir = os.path.join(self.home, "WT_BACKUP")
+        self.session2 = self.conn.open_session()
+
         # print "Creating %s with config '%s'" % (self.uri, self.create_params)
         self.session.create(self.uri, self.create_params)
         # Set up the table with entries for 1-5.

--- a/test/suite/test_txn08.py
+++ b/test/suite/test_txn08.py
@@ -41,7 +41,7 @@ class test_txn08(wttest.WiredTigerTestCase, suite_subprocess):
     uri = 'table:' + tablename
 
     # Turn on logging for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
             'transaction_sync="(method=dsync,enabled)"'
 

--- a/test/suite/test_txn09.py
+++ b/test/suite/test_txn09.py
@@ -80,19 +80,9 @@ class test_txn09(wttest.WiredTigerTestCase, suite_subprocess):
         op1s, txn1s, op2s, txn2s, op3s, txn3s, op4s, txn4s,
         prune=20, prunelong=5000)
 
-    # Overrides WiredTigerTestCase
-    def setUpConnectionOpen(self, dir):
-        self.home = dir
-        conn_params = \
-                'create,error_prefix="%s: ",' % self.shortid() + \
-                'log=(archive=false,enabled=%s),' % int(self.log_enabled) + \
-                'transaction_sync=(enabled=false),'
-
-        # print "Opening conn at '%s' with config '%s'" % (dir, conn_params)
-        conn = self.wiredtiger_open(dir, conn_params)
-        self.pr(`conn`)
-        self.session2 = conn.open_session()
-        return conn
+    def conn_config(self):
+        return 'log=(archive=false,enabled=%s),' % int(self.log_enabled) + \
+            'transaction_sync=(enabled=false)'
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
@@ -141,6 +131,7 @@ class test_txn09(wttest.WiredTigerTestCase, suite_subprocess):
             # Close and reopen the connection and cursor, toggling the log
             self.log_enabled = not self.log_enabled
             self.reopen_conn()
+            self.session2 = self.conn.open_session()
             c = self.session.open_cursor(self.uri, None, 'overwrite')
 
             self.session.begin_transaction(

--- a/test/suite/test_txn11.py
+++ b/test/suite/test_txn11.py
@@ -44,7 +44,7 @@ class test_txn11(wttest.WiredTigerTestCase, suite_subprocess):
     uri = 'table:' + tablename
 
     # Turn on logging for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'log=(archive=%s,' % self.archive + \
             'enabled,file_max=%s,prealloc=false),' % self.logmax + \
             'transaction_sync=(enabled=false),'

--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -50,7 +50,7 @@ class test_txn13(wttest.WiredTigerTestCase, suite_subprocess):
     ])
 
     # Turn on logging for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%s)' % self.logmax + \
             ',cache_size=8G'
 

--- a/test/suite/test_txn15.py
+++ b/test/suite/test_txn15.py
@@ -41,7 +41,7 @@ class test_txn15(wttest.WiredTigerTestCase, suite_subprocess):
     create_params = 'key_format=i,value_format=i'
     entries = 100
     # Turn on logging for this test.
-    def conn_config(self, dir):
+    def conn_config(self):
         return 'statistics=(fast),' + \
             'log=(archive=false,enabled,file_max=100K),' + \
             'use_environment=false,' + \

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -37,9 +37,8 @@ except ImportError:
     import unittest
 
 from contextlib import contextmanager
-import os, re, shutil, sys, time, traceback
-import wtscenario
-import wiredtiger
+import glob, os, re, shutil, sys, time, traceback
+import wiredtiger, wtscenario
 
 def shortenWithEllipsis(s, maxlen):
     if len(s) > maxlen:
@@ -152,6 +151,14 @@ class TestSuiteConnection(object):
         else:
             return getattr(self._conn, attr)
 
+# Just like a list of strings, but with a convenience function
+class ExtensionList(list):
+    skipIfMissing = False
+    def extension(self, dirname, name, extarg=None):
+        if name != None and name != 'none':
+            ext = '' if extarg == None else '=' + extarg
+            self.append(dirname + '/' + name + ext)
+
 class WiredTigerTestCase(unittest.TestCase):
     _globalSetup = False
     _printOnceSeen = {}
@@ -160,9 +167,16 @@ class WiredTigerTestCase(unittest.TestCase):
     # Can be a string or a callable function or lambda expression.
     conn_config = ''
 
+    # conn_extensions can be overridden to add a list of extensions to load.
+    # Each entry is a string (directory and extension name) and optional config.
+    # Example:
+    #    conn_extensions = ('extractors/csv_extractor',
+    #                       'test/fail_fs={allow_writes=100}')
+    conn_extensions = ()
+
     @staticmethod
     def globalSetup(preserveFiles = False, useTimestamp = False,
-                    gdbSub = False, verbose = 1, dirarg = None,
+                    gdbSub = False, verbose = 1, builddir = None, dirarg = None,
                     longtest = False):
         WiredTigerTestCase._preserveFiles = preserveFiles
         d = 'WT_TEST' if dirarg == None else dirarg
@@ -172,6 +186,7 @@ class WiredTigerTestCase(unittest.TestCase):
         os.makedirs(d)
         wtscenario.set_long_run(longtest)
         WiredTigerTestCase._parentTestdir = d
+        WiredTigerTestCase._builddir = builddir
         WiredTigerTestCase._origcwd = os.getcwd()
         WiredTigerTestCase._resultfile = open(os.path.join(d, 'results.txt'), "w", 0)  # unbuffered
         WiredTigerTestCase._gdbSubprocess = gdbSub
@@ -224,12 +239,66 @@ class WiredTigerTestCase(unittest.TestCase):
         return "%s.%s.%s" %  (self.__module__,
                               self.className(), self._testMethodName)
 
-    # Can be overridden, but first consider setting self.conn_config .
+    # Return the wiredtiger_open extension argument for
+    # any needed shared library.
+    def extensionsConfig(self):
+        exts = self.conn_extensions
+        if hasattr(exts, '__call__'):
+            exts = ExtensionList()
+            self.conn_extensions(exts)
+        result = ''
+        extfiles = {}
+        skipIfMissing = False
+        if hasattr(exts, 'skip_if_missing'):
+            skipIfMissing = exts.skip_if_missing
+        for ext in exts:
+            extconf = ''
+            if '=' in ext:
+                splits = ext.split('=', 1)
+                ext = splits[0]
+                extconf = '=' + splits[1]
+            splits = ext.split('/')
+            if len(splits) != 2:
+                raise Exception(self.shortid() +
+                    ": " + ext +
+                    ": extension is not named <dir>/<name>")
+            libname = splits[1]
+            dirname = splits[0]
+            pat = os.path.join(WiredTigerTestCase._builddir, 'ext',
+                dirname, libname, '.libs', 'libwiredtiger_*.so')
+            filenames = glob.glob(pat)
+            if len(filenames) == 0:
+                if skipIfMissing:
+                    self.skipTest('extension "' + ext + '" not built')
+                    continue
+                else:
+                    raise Exception(self.shortid() +
+                        ": " + ext +
+                        ": no extensions library found matching: " + pat)
+            elif len(filenames) > 1:
+                raise Exception(self.shortid() +
+                    ": " + ext +
+                    ": multiple extensions libraries found matching: " + pat)
+            complete = '"' + filenames[0] + '"' + extconf
+            if ext in extfiles:
+                if extfiles[ext] != complete:
+                    raise Exception(self.shortid() +
+                        ": non-matching extension arguments in " +
+                        str(exts))
+            else:
+                extfiles[ext] = complete
+        if len(extfiles) != 0:
+            result = ',extensions=[' + ','.join(extfiles.values()) + ']'
+        return result
+
+    # Can be overridden, but first consider setting self.conn_config
+    # or self.conn_extensions
     def setUpConnectionOpen(self, home):
         self.home = home
         config = self.conn_config
         if hasattr(config, '__call__'):
-            config = config(home)
+            config = self.conn_config()
+        config += self.extensionsConfig()
         # In case the open starts additional threads, flush first to
         # avoid confusion.
         sys.stdout.flush()


### PR DESCRIPTION
Many examples of overriding setUpConnectionOpen() can now be handled by a combination of conn_config (as variable or method) and conn_extensions (as variable or method).