### PR TITLE
WT-3105 Avoid thread group deadlock on close.

### DIFF
--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -325,8 +325,8 @@ __wt_thread_group_start_one(
 
 	if (wait)
 		__wt_writelock(session, &group->lock);
-	else if (__wt_try_writelock(session, &group->lock) != 0)
-		return (0);
+	else
+		WT_RET(__wt_try_writelock(session, &group->lock));
 
 	/* Recheck the bounds now that we hold the lock */
 	if (group->current_threads < group->max)
@@ -352,8 +352,8 @@ __wt_thread_group_stop_one(
 
 	if (wait)
 		__wt_writelock(session, &group->lock);
-	else if (__wt_try_writelock(session, &group->lock) != 0)
-		return (0);
+	else
+		WT_RET(__wt_try_writelock(session, &group->lock));
 
 	/* Recheck the bounds now that we hold the lock */
 	if (group->current_threads > group->min)


### PR DESCRIPTION
@agorrod Please review this.  Unfortunately I've been running both the format CONFIG and the evict btree wtperf workload on develop without reproducing the deadlock.  So while I think this fixes the deadlock, I have not been able to confirm either way.  The branch runs fine too for my testing.