### PR TITLE
WT-3126 bug: dist/s_all script has misplaced quote causing bad error reporting

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -97,10 +97,10 @@ COMMANDS="
 2>&1 ./s_string > ${t_pfx}s_string
 2>&1 ./s_tags > ${t_pfx}tags
 2>&1 ./s_typedef -c > ${t_pfx}s_typedef_c
-2>&1 ./s_void > ${t_pfx}s_void"
+2>&1 ./s_void > ${t_pfx}s_void
 2>&1 ./s_whitespace > ${t_pfx}s_whitespace
 2>&1 ./s_win > ${t_pfx}s_win
-2>&1 python style.py > ${t_pfx}py_style
+2>&1 python style.py > ${t_pfx}py_style"
 
 # Parallelize if possible.
 xp=""


### PR DESCRIPTION
bug: dist/s_all script has misplaced quote causing bad error reporting