### PR TITLE
WT-3127 bug: CPU yield calls don't necessarily imply memory barriers

### DIFF
--- a/src/os_posix/os_yield.c
+++ b/src/os_posix/os_yield.c
@@ -16,5 +16,13 @@ void
 __wt_yield(void)
     WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
+	/*
+	 * Yielding the processor isn't documented as a memory barrier, and it's
+	 * a reasonable expectation to have. There's no reason not to explicitly
+	 * include a barrier since we're giving up the CPU, and ensures callers
+	 * aren't ever surprised.
+	 */
+	WT_FULL_BARRIER();
+
 	sched_yield();
 }

--- a/src/os_win/os_yield.c
+++ b/src/os_win/os_yield.c
@@ -15,5 +15,13 @@
 void
 __wt_yield(void)
 {
+	/*
+	 * Yielding the processor isn't documented as a memory barrier, and it's
+	 * a reasonable expectation to have. There's no reason not to explicitly
+	 * include a barrier since we're giving up the CPU, and ensures callers
+	 * aren't ever surprised.
+	 */
+	WT_FULL_BARRIER();
+
 	SwitchToThread();
 }


### PR DESCRIPTION
bug: CPU yield calls don't necessarily imply memory barriers
Add a full-barrier as part of the yield call.