### PR TITLE
WT-3128 wt printlog returns operation-not-supported if it doesn't find any log files

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1655,10 +1655,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 		WT_RET(__log_get_files(session,
 		    WT_LOG_FILENAME, &logfiles, &logcount));
 		if (logcount == 0)
-			/*
-			 * Return it is not supported if none don't exist.
-			 */
-			return (ENOTSUP);
+			WT_RET_MSG(session, ENOTSUP, "no log files found");
 		for (i = 0; i < logcount; i++) {
 			WT_ERR(__wt_log_extract_lognum(session, logfiles[i],
 			    &lognum));


### PR DESCRIPTION
Add a verbose message if we don't find any log files, it's likely the user pointed us at the wrong directory.

@sueloverso, would you please review this change?