### PR TITLE
WT-3105 Fix the thread group usage on eviction reconfigure and add test.

### DIFF
--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -144,8 +144,7 @@ __wt_cache_config(WT_SESSION_IMPL *session, bool reconfigure, const char *cfg[])
 		WT_RET(__wt_thread_group_resize(
 		    session, &conn->evict_threads,
 		    conn->evict_threads_min,
-		    WT_MAX(conn->evict_threads_min,
-			   WT_MIN(conn->evict_threads_max, EVICT_GROUP_INCR)),
+		    conn->evict_threads_max,
 		    WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL));
 
 	return (0);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -301,7 +301,6 @@ struct __wt_connection_impl {
 	uint32_t	 evict_threads_max;/* Max eviction threads */
 	uint32_t	 evict_threads_min;/* Min eviction threads */
 
-#define	EVICT_GROUP_INCR 4    /* Evict group size increased in batches */
 	uint32_t         evict_tune_datapts_needed;/* Data needed to tune */
 	struct timespec  evict_tune_last_action_time;/* Time of last action */
 	struct timespec  evict_tune_last_time;	/* Time of last check */

--- a/test/suite/test_reconfig01.py
+++ b/test/suite/test_reconfig01.py
@@ -64,6 +64,18 @@ class test_reconfig01(wttest.WiredTigerTestCase):
         # same ops_max of 512 and thread of 8.
         self.conn.reconfigure("async=(enabled=true)")
 
+    def test_reconfig_eviction(self):
+        # Increase the max number of running threads (default 8).
+        self.conn.reconfigure("eviction=(threads_max=10)")
+        # Increase the min number of running threads (default 1).
+        self.conn.reconfigure("eviction=(threads_min=5)")
+        # Decrease the max number of running threads.
+        self.conn.reconfigure("eviction=(threads_max=7)")
+        # Decrease the min number of running threads.
+        self.conn.reconfigure("eviction=(threads_min=2)")
+        # Set min and max the same.
+        self.conn.reconfigure("eviction=(threads_min=6,threads_max=6)")
+
     def test_reconfig_lsm_manager(self):
         # We create and populate a tiny LSM so that we can start off with
         # the LSM threads running and change the numbers of threads.


### PR DESCRIPTION
@agorrod Please review this omission from the original change.  I discovered that reconfigure was not fixed and that we had no test to eviction thread changes.  I did run the new test the first time with `verbose=(thread_group)` to confirm the right stuff is happening.