### PR TITLE
WT-3135 WT-3159 Fix search_near() with custom collators for index keys of variable length.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1182,6 +1182,7 @@ txt
 typedef
 uB
 uS
+ui
 uint
 uintmax
 unbare

--- a/dist/s_void
+++ b/dist/s_void
@@ -87,6 +87,10 @@ func_ok()
 	    -e '/int handle_progress$/d' \
 	    -e '/int helium_cursor_reset$/d' \
 	    -e '/int helium_session_verify$/d' \
+	    -e '/int index_compare_primary$/d' \
+	    -e '/int index_compare_S$/d' \
+	    -e '/int index_compare_u$/d' \
+	    -e '/int index_extractor_u$/d' \
 	    -e '/int log_print_err$/d' \
 	    -e '/int lz4_error$/d' \
 	    -e '/int lz4_pre_size$/d' \

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -246,7 +246,7 @@ __curindex_search(WT_CURSOR *cursor)
 	 * all the visible fields so it unpacks correctly.
 	 */
 	if (cindex->index->collator != NULL)
-		WT_ERR(__wt_struct_repack(session, cindex->child->key_format,
+		WT_ERR(__wt_struct_repack(session, child->key_format,
 		    cindex->iface.key_format, &child->key, &found_key));
 	else
 		found_key.size = cursor->key.size;

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -242,9 +242,8 @@ __curindex_search(WT_CURSOR *cursor)
 		WT_ERR(WT_NOTFOUND);
 
 	/*
-	 * Custom collators will use unpack functions to
-	 * get the visible key fields. We need to provide
-	 * those fields in their entirety.
+	 * Custom collators expect to see complete keys, pass an item containing
+	 * all the visible fields so it unpacks correctly.
 	 */
 	if (cindex->index->collator != NULL)
 		WT_ERR(__wt_struct_repack(session, cindex->child->key_format,
@@ -319,9 +318,8 @@ __curindex_search_near(WT_CURSOR *cursor, int *exact)
 	found_key = child->key;
 	if (found_key.size > cursor->key.size) {
 		/*
-		 * Custom collators will use unpack functions to
-		 * get the visible key fields. We need to provide
-		 * those fields in their entirety.
+		 * Custom collators expect to see complete keys, pass an item
+		 * containing all the visible fields so it unpacks correctly.
 		 */
 		if (cindex->index->collator != NULL)
 			WT_ERR(__wt_struct_repack(session,

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -172,8 +172,10 @@ next:	if (pack->cur == pack->end)
 		pv->type = (!pv->havesize && *pack->cur != '\0') ? 'U' : 'u';
 		return (0);
 	case 'U':
-		/* Special case for items with a size prefix. */
-		pv->type = !pv->havesize ? 'U' : 'u';
+		/*
+		 * Don't change the type. 'U' is used internally, so this type
+		 * was already changed to explicitly include the size.
+		 */
 		return (0);
 	case 'b':
 	case 'h':

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -168,9 +168,12 @@ next:	if (pack->cur == pack->end)
 			    (int)(pack->end - pack->orig), pack->orig);
 		return (0);
 	case 'u':
-	case 'U':
 		/* Special case for items with a size prefix. */
 		pv->type = (!pv->havesize && *pack->cur != '\0') ? 'U' : 'u';
+		return (0);
+	case 'U':
+		/* Special case for items with a size prefix. */
+		pv->type = !pv->havesize ? 'U' : 'u';
 		return (0);
 	case 'b':
 	case 'h':

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -269,7 +269,7 @@ __wt_txn_checkpoint_logread(WT_SESSION_IMPL *session,
 	WT_ITEM ckpt_snapshot_unused;
 	uint32_t ckpt_file, ckpt_offset;
 	u_int ckpt_nsnapshot_unused;
-	const char *fmt = WT_UNCHECKED_STRING(IIIU);
+	const char *fmt = WT_UNCHECKED_STRING(IIIu);
 
 	if ((ret = __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt,
 	    &ckpt_file, &ckpt_offset,
@@ -297,7 +297,7 @@ __wt_txn_checkpoint_log(
 	uint8_t *end, *p;
 	size_t recsize;
 	uint32_t i, rectype = WT_LOGREC_CHECKPOINT;
-	const char *fmt = WT_UNCHECKED_STRING(IIIIU);
+	const char *fmt = WT_UNCHECKED_STRING(IIIIu);
 
 	txn = &session->txn;
 	ckpt_lsn = &txn->ckpt_lsn;

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -40,6 +40,9 @@ noinst_PROGRAMS += test_wt2853_perf
 test_wt2999_join_extractor_SOURCES = wt2999_join_extractor/main.c
 noinst_PROGRAMS += test_wt2999_join_extractor
 
+test_wt3135_search_near_collator_SOURCES = wt3135_search_near_collator/main.c
+noinst_PROGRAMS += test_wt3135_search_near_collator
+
 # Run this during a "make check" smoke test.
 TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -39,7 +39,7 @@
  * because the truncation appeared in the middle of a key.
  */
 
-#define TEST_ENTRY_COUNT	5
+#define	TEST_ENTRY_COUNT	5
 typedef const char *TEST_SET[TEST_ENTRY_COUNT];
 static TEST_SET test_sets[] = {
 	{ "0", "01", "012", "0123", "01234" },
@@ -47,7 +47,7 @@ static TEST_SET test_sets[] = {
 	{ "5", "54", "543", "5432", "54321" },
 	{ "54321", "5433", "544", "55", "6" }
 };
-#define TEST_SET_COUNT	(sizeof(test_sets) / sizeof(test_sets[0]))
+#define	TEST_SET_COUNT	(sizeof(test_sets) / sizeof(test_sets[0]))
 
 static
 bool item_str_equal(WT_ITEM *item, const char *str)

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -49,21 +49,21 @@ static TEST_SET test_sets[] = {
 };
 #define	TEST_SET_COUNT	(sizeof(test_sets) / sizeof(test_sets[0]))
 
-static
-bool item_str_equal(WT_ITEM *item, const char *str)
+static bool
+item_str_equal(WT_ITEM *item, const char *str)
 {
 	return (item->size == strlen(str) + 1 && strncmp((char *)item->data,
 	    str, item->size) == 0);
 }
 
-static
-int compare_int(int a, int b)
+static int
+compare_int(int a, int b)
 {
 	return (a < b ? -1 : (a > b ? 1 : 0));
 }
 
-static
-int index_compare_primary(WT_PACK_STREAM *s1, WT_PACK_STREAM *s2, int *cmp)
+static int
+index_compare_primary(WT_PACK_STREAM *s1, WT_PACK_STREAM *s2, int *cmp)
 {
 	int64_t pkey1, pkey2;
 	int rc1, rc2;
@@ -82,8 +82,8 @@ int index_compare_primary(WT_PACK_STREAM *s1, WT_PACK_STREAM *s2, int *cmp)
 	return (0);
 }
 
-static
-int index_compare_S(WT_COLLATOR *collator, WT_SESSION *session,
+static int
+index_compare_S(WT_COLLATOR *collator, WT_SESSION *session,
     const WT_ITEM *key1, const WT_ITEM *key2, int *cmp)
 {
 	WT_PACK_STREAM *s1, *s2;
@@ -108,8 +108,8 @@ int index_compare_S(WT_COLLATOR *collator, WT_SESSION *session,
 	return (0);
 }
 
-static
-int index_compare_u(WT_COLLATOR *collator, WT_SESSION *session,
+static int
+index_compare_u(WT_COLLATOR *collator, WT_SESSION *session,
     const WT_ITEM *key1, const WT_ITEM *key2, int *cmp)
 {
 	WT_ITEM skey1, skey2;
@@ -134,8 +134,8 @@ int index_compare_u(WT_COLLATOR *collator, WT_SESSION *session,
 	return (0);
 }
 
-static
-int index_extractor_u(WT_EXTRACTOR *extractor, WT_SESSION *session,
+static int
+index_extractor_u(WT_EXTRACTOR *extractor, WT_SESSION *session,
     const WT_ITEM *key, const WT_ITEM *value, WT_CURSOR *result_cursor)
 {
 	(void)extractor;
@@ -154,7 +154,7 @@ static WT_EXTRACTOR extractor_u = { index_extractor_u, NULL, NULL };
  * Check search() and search_near() using the test string indicated
  * by test_index.
  */
-void
+static void
 search_using_str(WT_CURSOR *cursor, TEST_SET test_set, int test_index)
 {
 	int exact, ret;
@@ -195,7 +195,7 @@ search_using_str(WT_CURSOR *cursor, TEST_SET test_set, int test_index)
  * Check search() and search_near() using the test string indicated
  * by test_index against a table containing a variable sized item.
  */
-void
+static void
 search_using_item(WT_CURSOR *cursor, TEST_SET test_set, int test_index)
 {
 	WT_ITEM item;
@@ -241,7 +241,8 @@ search_using_item(WT_CURSOR *cursor, TEST_SET test_set, int test_index)
 /*
  * For each set of data, perform tests.
  */
-void test_one_set(TEST_OPTS *opts, WT_SESSION *session, TEST_SET set)
+static void
+test_one_set(TEST_OPTS *opts, WT_SESSION *session, TEST_SET set)
 {
 	WT_CURSOR *cursor;
 	WT_ITEM item;

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -190,7 +190,7 @@ main(int argc, char *argv[])
 	testutil_check(cursor->search_near(cursor, &exact));
 	testutil_check(cursor->get_key(cursor, &found_key));
 	testutil_assert((strcmp(found_key, "12345") == 0 && exact > 0) ||
-	    strcmp(found_key, "123") == 0 && exact < 0);
+	    (strcmp(found_key, "123") == 0 && exact < 0));
 	testutil_check(cursor->close(cursor));
 
 	/* Check search_near in custom_collator index */
@@ -200,7 +200,7 @@ main(int argc, char *argv[])
 	testutil_check(cursor->search_near(cursor, &exact));
 	testutil_check(cursor->get_key(cursor, &found_key));
 	testutil_assert((strcmp(found_key, "12345") == 0 && exact > 0) ||
-	    strcmp(found_key, "123") == 0 && exact < 0);
+	    (strcmp(found_key, "123") == 0 && exact < 0));
 	testutil_check(cursor->close(cursor));
 
 	/*
@@ -220,7 +220,7 @@ main(int argc, char *argv[])
 	testutil_check(session->open_cursor(session,
 	    "table:main2", NULL, NULL, &cursor));
 
-	memset(&item, sizeof(item), 0);
+	memset(&item, 0, sizeof(item));
 	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++)
 	{
 		item.size = strlen(values[i]) + 1;
@@ -240,7 +240,7 @@ main(int argc, char *argv[])
 	testutil_check(cursor->search_near(cursor, &exact));
 	testutil_check(cursor->get_key(cursor, &item));
 	testutil_assert((item_str_equal(&item, "12345") && exact > 0) ||
-	    item_str_equal(&item, "123") && exact < 0);
+	    (item_str_equal(&item, "123") && exact < 0));
 	testutil_check(cursor->close(cursor));
 
 	testutil_check(session->close(session, NULL));

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -1,0 +1,249 @@
+/*-
+ * Public Domain 2014-2016 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * JIRA ticket reference: WT-3135
+ * Test case description: There are two tests, one uses a custom collator,
+ * the second uses a custom collator and extractor. In each case there
+ * are index keys having variable length and search_near is used with
+ * keys both longer and shorter than the keys in the index.
+ * Failure mode: The custom compare routine is given a truncated
+ * key to compare, and the unpack functions return errors because of that.
+ */
+
+static
+bool item_str_equal(WT_ITEM *item, const char *str)
+{
+	return (item->size == strlen(str) + 1 && strncmp((char *)item->data,
+	    str, item->size) == 0);
+}
+
+static
+int compare_int(int a, int b)
+{
+    return (a < b ? -1 : (a > b ? 1 : 0));
+}
+
+static
+int index_compare_primary(WT_PACK_STREAM *s1, WT_PACK_STREAM *s2, int *cmp)
+{
+	int64_t pkey1, pkey2;
+	int rc1, rc2;
+
+	rc1 = wiredtiger_unpack_int(s1, &pkey1);
+	rc2 = wiredtiger_unpack_int(s2, &pkey2);
+
+	if (rc1 == 0 && rc2 == 0)
+		*cmp = compare_int(pkey1, pkey2);
+	else if (rc1 != 0 && rc2 != 0)
+		*cmp = 0;
+	else if (rc1 != 0)
+		*cmp = -1;
+	else
+		*cmp = 1;
+	return (0);
+}
+
+static
+int index_compare_S(WT_COLLATOR *collator, WT_SESSION *session,
+    const WT_ITEM *key1, const WT_ITEM *key2, int *cmp)
+{
+    WT_PACK_STREAM *s1, *s2;
+    const char *skey1, *skey2;
+
+    testutil_check(wiredtiger_unpack_start(session, "Si", key1->data,
+	key1->size, &s1));
+    testutil_check(wiredtiger_unpack_start(session, "Si", key2->data,
+	key2->size, &s2));
+
+    testutil_check(wiredtiger_unpack_str(s1, &skey1));
+    testutil_check(wiredtiger_unpack_str(s2, &skey2));
+
+    if ((*cmp = strcmp(skey1, skey2)) == 0)
+	    testutil_check(index_compare_primary(s1, s2, cmp));
+
+    testutil_check(wiredtiger_pack_close(s1, NULL));
+    testutil_check(wiredtiger_pack_close(s2, NULL));
+
+    return (0);
+}
+
+static
+int index_compare_u(WT_COLLATOR *collator, WT_SESSION *session,
+    const WT_ITEM *key1, const WT_ITEM *key2, int *cmp)
+{
+	WT_ITEM skey1, skey2;
+	WT_PACK_STREAM *s1, *s2;
+
+	testutil_check(wiredtiger_unpack_start(session, "ui", key1->data,
+	    key1->size, &s1));
+	testutil_check(wiredtiger_unpack_start(session, "ui", key2->data,
+	    key2->size, &s2));
+
+	testutil_check(wiredtiger_unpack_item(s1, &skey1));
+	testutil_check(wiredtiger_unpack_item(s2, &skey2));
+
+	if ((*cmp = strcmp(skey1.data, skey2.data)) == 0)
+		testutil_check(index_compare_primary(s1, s2, cmp));
+
+	testutil_check(wiredtiger_pack_close(s1, NULL));
+	testutil_check(wiredtiger_pack_close(s2, NULL));
+
+	return (0);
+}
+
+static
+int index_extractor_u(WT_EXTRACTOR *extractor, WT_SESSION *session,
+    const WT_ITEM *key, const WT_ITEM *value, WT_CURSOR *result_cursor)
+{
+	(void)extractor;
+	(void)session;
+	(void)key;
+
+	result_cursor->set_key(result_cursor, value);
+	return result_cursor->insert(result_cursor);
+}
+
+static WT_COLLATOR collator_S = { index_compare_S, NULL, NULL };
+static WT_COLLATOR collator_u = { index_compare_u, NULL, NULL };
+static WT_EXTRACTOR extractor_u = { index_extractor_u, NULL, NULL };
+
+int
+main(int argc, char *argv[])
+{
+	TEST_OPTS *opts, _opts;
+	WT_CURSOR *cursor;
+	WT_ITEM item;
+	WT_SESSION *session;
+	int32_t i;
+	int exact;
+	const char *found_key;
+	const char *search_key = "1234";
+	const char *values[] = { "123", "12345" };
+
+	opts = &_opts;
+	memset(opts, 0, sizeof(*opts));
+	testutil_check(testutil_parse_opts(argc, argv, opts));
+	testutil_make_work_dir(opts->home);
+
+	testutil_check(wiredtiger_open(opts->home, NULL, "create",
+	    &opts->conn));
+	testutil_check(
+	    opts->conn->open_session(opts->conn, NULL, NULL, &session));
+
+	/*
+	 * Part 1: Using a custom collator, insert some elements
+	 * and verify results from search_near.
+	 */
+	testutil_check(opts->conn->add_collator(opts->conn, "collator_S",
+	    &collator_S, NULL));
+
+	testutil_check(session->create(session,
+	    "table:main", "key_format=i,value_format=S,columns=(k,v)"));
+	testutil_check(session->create(session,
+	    "index:main:def_collator", "columns=(v)"));
+	testutil_check(session->create(session,
+	    "index:main:custom_collator",
+	    "columns=(v),collator=collator_S"));
+
+	testutil_check(session->open_cursor(session,
+	    "table:main", NULL, NULL, &cursor));
+
+	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++)
+	{
+		cursor->set_key(cursor, i);
+		cursor->set_value(cursor, values[i]);
+		testutil_check(cursor->insert(cursor));
+	}
+	testutil_check(cursor->close(cursor));
+
+	/* Check search_near in def_collator index. */
+	testutil_check(session->open_cursor(session,
+	    "index:main:def_collator", NULL, NULL, &cursor));
+	cursor->set_key(cursor, search_key);
+	testutil_check(cursor->search_near(cursor, &exact));
+	testutil_check(cursor->get_key(cursor, &found_key));
+	testutil_assert((strcmp(found_key, "12345") == 0 && exact > 0) ||
+	    strcmp(found_key, "123") == 0 && exact < 0);
+	testutil_check(cursor->close(cursor));
+
+	/* Check search_near in custom_collator index */
+	testutil_check(session->open_cursor(session,
+	    "index:main:custom_collator", NULL, NULL, &cursor));
+	cursor->set_key(cursor, search_key);
+	testutil_check(cursor->search_near(cursor, &exact));
+	testutil_check(cursor->get_key(cursor, &found_key));
+	testutil_assert((strcmp(found_key, "12345") == 0 && exact > 0) ||
+	    strcmp(found_key, "123") == 0 && exact < 0);
+	testutil_check(cursor->close(cursor));
+
+	/*
+	 * Part 2: perform the same checks using a custom collator and
+	 * extractor.
+	 */
+	testutil_check(opts->conn->add_collator(opts->conn, "collator_u",
+	    &collator_u, NULL));
+	testutil_check(opts->conn->add_extractor(opts->conn, "extractor_u",
+	    &extractor_u, NULL));
+	testutil_check(session->create(session,
+	    "table:main2", "key_format=i,value_format=u,columns=(k,v)"));
+
+	testutil_check(session->create(session, "index:main2:idx_w_coll",
+	    "key_format=u,collator=collator_u,extractor=extractor_u"));
+
+	testutil_check(session->open_cursor(session,
+	    "table:main2", NULL, NULL, &cursor));
+
+	memset(&item, sizeof(item), 0);
+	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++)
+	{
+		item.size = strlen(values[i]) + 1;
+		item.data = values[i];
+
+		cursor->set_key(cursor, i);
+		cursor->set_value(cursor, &item);
+		testutil_check(cursor->insert(cursor));
+	}
+	testutil_check(cursor->close(cursor));
+
+	testutil_check(session->open_cursor(session,
+	    "index:main2:idx_w_coll", NULL, NULL, &cursor));
+	item.data = search_key;
+	item.size = sizeof(search_key);
+	cursor->set_key(cursor, &item);
+	testutil_check(cursor->search_near(cursor, &exact));
+	testutil_check(cursor->get_key(cursor, &item));
+	testutil_assert((item_str_equal(&item, "12345") && exact > 0) ||
+	    item_str_equal(&item, "123") && exact < 0);
+	testutil_check(cursor->close(cursor));
+
+	testutil_check(session->close(session, NULL));
+	testutil_cleanup(opts);
+	return (EXIT_SUCCESS);
+}

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -47,7 +47,7 @@ bool item_str_equal(WT_ITEM *item, const char *str)
 static
 int compare_int(int a, int b)
 {
-    return (a < b ? -1 : (a > b ? 1 : 0));
+	return (a < b ? -1 : (a > b ? 1 : 0));
 }
 
 static
@@ -74,24 +74,26 @@ static
 int index_compare_S(WT_COLLATOR *collator, WT_SESSION *session,
     const WT_ITEM *key1, const WT_ITEM *key2, int *cmp)
 {
-    WT_PACK_STREAM *s1, *s2;
-    const char *skey1, *skey2;
+	WT_PACK_STREAM *s1, *s2;
+	const char *skey1, *skey2;
 
-    testutil_check(wiredtiger_unpack_start(session, "Si", key1->data,
-	key1->size, &s1));
-    testutil_check(wiredtiger_unpack_start(session, "Si", key2->data,
-	key2->size, &s2));
+	(void)collator;
 
-    testutil_check(wiredtiger_unpack_str(s1, &skey1));
-    testutil_check(wiredtiger_unpack_str(s2, &skey2));
+	testutil_check(wiredtiger_unpack_start(session, "Si", key1->data,
+	    key1->size, &s1));
+	testutil_check(wiredtiger_unpack_start(session, "Si", key2->data,
+	    key2->size, &s2));
 
-    if ((*cmp = strcmp(skey1, skey2)) == 0)
-	    testutil_check(index_compare_primary(s1, s2, cmp));
+	testutil_check(wiredtiger_unpack_str(s1, &skey1));
+	testutil_check(wiredtiger_unpack_str(s2, &skey2));
 
-    testutil_check(wiredtiger_pack_close(s1, NULL));
-    testutil_check(wiredtiger_pack_close(s2, NULL));
+	if ((*cmp = strcmp(skey1, skey2)) == 0)
+		testutil_check(index_compare_primary(s1, s2, cmp));
 
-    return (0);
+	testutil_check(wiredtiger_pack_close(s1, NULL));
+	testutil_check(wiredtiger_pack_close(s2, NULL));
+
+	return (0);
 }
 
 static
@@ -100,6 +102,8 @@ int index_compare_u(WT_COLLATOR *collator, WT_SESSION *session,
 {
 	WT_ITEM skey1, skey2;
 	WT_PACK_STREAM *s1, *s2;
+
+	(void)collator;
 
 	testutil_check(wiredtiger_unpack_start(session, "ui", key1->data,
 	    key1->size, &s1));
@@ -175,8 +179,7 @@ main(int argc, char *argv[])
 	testutil_check(session->open_cursor(session,
 	    "table:main", NULL, NULL, &cursor));
 
-	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++)
-	{
+	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++) {
 		cursor->set_key(cursor, i);
 		cursor->set_value(cursor, values[i]);
 		testutil_check(cursor->insert(cursor));
@@ -221,8 +224,7 @@ main(int argc, char *argv[])
 	    "table:main2", NULL, NULL, &cursor));
 
 	memset(&item, 0, sizeof(item));
-	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++)
-	{
+	for (i = 0; i < (int32_t)(sizeof(values) / sizeof(values[0])); i++) {
 		item.size = strlen(values[i]) + 1;
 		item.data = values[i];
 

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -242,7 +242,7 @@ search_using_item(WT_CURSOR *cursor, TEST_SET test_set, int test_index)
  * For each set of data, perform tests.
  */
 static void
-test_one_set(TEST_OPTS *opts, WT_SESSION *session, TEST_SET set)
+test_one_set(WT_SESSION *session, TEST_SET set)
 {
 	WT_CURSOR *cursor;
 	WT_ITEM item;
@@ -351,7 +351,7 @@ main(int argc, char *argv[])
 
 	for (i = 0; i < (int32_t)TEST_SET_COUNT; i++) {
 		printf("test set %d\n", i);
-		test_one_set(opts, session, test_sets[i]);
+		test_one_set(session, test_sets[i]);
 	}
 
 	testutil_check(session->close(session, NULL));


### PR DESCRIPTION
As part of the fix for search_near, this includes a fix for how format 'U' is interpreted.  'U' should always include the size, before this change, it did not if the 'U' appeared at the end of the format. As a side effect of this change, WT-3159 is also fixed.