### PR TITLE
WT-3130 Proposal to change initialization of custom filesystem

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2175,6 +2175,15 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	if (cval.val)
 		F_SET(conn, WT_CONN_READONLY);
 
+	/* Configure error messages so we get them right early. */
+	WT_ERR(__wt_config_gets(session, cfg, "error_prefix", &cval));
+	if (cval.len != 0)
+		WT_ERR(__wt_strndup(
+		    session, cval.str, cval.len, &conn->error_prefix));
+
+	/* Set the database home so extensions have access to it. */
+	WT_ERR(__conn_home(session, home, cfg));
+
 	/*
 	 * Load early extensions before doing further initialization (one early
 	 * extension is to configure a file system).
@@ -2198,6 +2207,9 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(
 	    __conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
 
+	/* Make sure no other thread of control already owns this database. */
+	WT_ERR(__conn_single(session, cfg));
+
 	/*
 	 * Capture the config_base setting file for later use. Again, if the
 	 * application doesn't want us to read the base configuration file,
@@ -2206,18 +2218,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 */
 	WT_ERR(__wt_config_gets(session, cfg, "config_base", &cval));
 	config_base_set = cval.val != 0;
-
-	/* Configure error messages so we get them right early. */
-	WT_ERR(__wt_config_gets(session, cfg, "error_prefix", &cval));
-	if (cval.len != 0)
-		WT_ERR(__wt_strndup(
-		    session, cval.str, cval.len, &conn->error_prefix));
-
-	/* Get the database home. */
-	WT_ERR(__conn_home(session, home, cfg));
-
-	/* Make sure no other thread of control already owns this database. */
-	WT_ERR(__conn_single(session, cfg));
 
 	/*
 	 * Build the real configuration stack, in the following order (where


### PR DESCRIPTION
@agorrod, for your consideration.

I changed it so `WT_CONNECTION.get_home()` will work before we load the extensions. I also configure error handling a little earlier, I thought that made sense to do before loading extensions.