### PR TITLE
WT-3144 bug fix: random cursor returns not-found when descending to an empty page

### DIFF
--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -831,7 +831,7 @@ restart:	/*
 		}
 		if (i == entries)
 			for (i = 0; i < entries; ++i) {
-				descent = pindex->index[entries];
+				descent = pindex->index[i];
 				if (descent->state != WT_REF_DELETED)
 					break;
 			}

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -792,9 +792,11 @@ __wt_row_random_descent(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	WT_PAGE *page;
 	WT_PAGE_INDEX *pindex;
 	WT_REF *current, *descent;
+	uint32_t i, entries, retry;
 
 	btree = S2BT(session);
 	current = NULL;
+	retry = 100;
 
 	if (0) {
 restart:	/*
@@ -812,8 +814,32 @@ restart:	/*
 			break;
 
 		WT_INTL_INDEX_GET(session, page, pindex);
-		descent = pindex->index[
-		    __wt_random(&session->rnd) % pindex->entries];
+		entries = pindex->entries;
+
+		/*
+		 * There may be empty pages in the tree, and they're useless to
+		 * us. If we don't find a non-empty page in "entries" random
+		 * guesses, take the first non-empty page in the tree. If the
+		 * search page contains nothing other than empty pages, restart
+		 * from the root some number of times before giving up.
+		 */
+		for (i = 0; i < entries; ++i) {
+			descent =
+			    pindex->index[__wt_random(&session->rnd) % entries];
+			if (descent->state != WT_REF_DELETED)
+				break;
+		}
+		if (i == entries)
+			for (i = 0; i < entries; ++i) {
+				descent = pindex->index[entries];
+				if (descent->state != WT_REF_DELETED)
+					break;
+			}
+		if (i == entries) {
+			if (--retry > 0)
+				goto restart;
+			return (WT_NOTFOUND);
+		}
 
 		/*
 		 * Swap the current page for the child page. If the page splits


### PR DESCRIPTION
@michaelcahill, these changes make things better (and pass the existing test), but they don't entirely solve the problem as we won't necessarily recover from descending into an internal page that contains nothing other than deleted leaf pages. That condition should have triggered a reverse split to clean up the parent, but it's obviously not guaranteed we'll be able to reverse split the parent.

I'm not sure how far we want to push this: for example, if the entire tree is filled with empty pages and there's a single valid key/value pair, are we committed to returning that item from a sample call?

I looked at the page-in `WT_READ_NO_EMPTY` flag, but didn't see any obvious way to have it help solve the problem.