### PR TITLE
WT-3144 bug fix: random cursor returns not-found when descending to an empty page

### DIFF
--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -823,6 +823,7 @@ restart:	/*
 		 * search page contains nothing other than empty pages, restart
 		 * from the root some number of times before giving up.
 		 */
+		descent = NULL;
 		for (i = 0; i < entries; ++i) {
 			descent =
 			    pindex->index[__wt_random(&session->rnd) % entries];
@@ -835,7 +836,7 @@ restart:	/*
 				if (descent->state != WT_REF_DELETED)
 					break;
 			}
-		if (i == entries) {
+		if (i == entries || descent == NULL) {
 			if (--retry > 0)
 				goto restart;
 			return (WT_NOTFOUND);


### PR DESCRIPTION
clang 3.8 complains descent might be left uninitialized in some case. I don't think that's possible, but it's a simple change.