### PR TITLE
WT-3120 Fix ordering problem in connection_close for filesystem loaded in an extension

### DIFF
--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -399,6 +399,7 @@ demo_fs_directory_list(WT_FILE_SYSTEM *file_system,
 	uint32_t allocated, count;
 	int ret = 0;
 	char *name, **entries;
+	void *p;
 
 	(void)session;						/* Unused */
 
@@ -424,14 +425,16 @@ demo_fs_directory_list(WT_FILE_SYSTEM *file_system,
 		 * matter if the list is a bit longer than necessary.
 		 */
 		if (count >= allocated) {
-			entries = realloc(
+			p = realloc(
 			    entries, (allocated + 10) * sizeof(*entries));
-			if (entries == NULL) {
+			if (p == NULL) {
 				ret = ENOMEM;
 				goto err;
 			}
-			memset(entries + allocated * sizeof(char *),
-			    0, 10 * sizeof(char *));
+
+			entries = p;
+			memset(entries + allocated * sizeof(*entries),
+			    0, 10 * sizeof(*entries));
 			allocated += 10;
 		}
 		entries[count++] = strdup(name);

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -425,7 +425,7 @@ demo_fs_directory_list(WT_FILE_SYSTEM *file_system,
 		 */
 		if (count >= allocated) {
 			entries = realloc(
-			    entries, (allocated + 10) * sizeof(char *));
+			    entries, (allocated + 10) * sizeof(*entries));
 			if (entries == NULL) {
 				ret = ENOMEM;
 				goto err;

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -224,10 +224,11 @@ fail_file_read(WT_FILE_HANDLE *file_handle,
 		chunk = (len < FAIL_FS_GIGABYTE) ? len : FAIL_FS_GIGABYTE;
 		if ((nr = pread(fail_fh->fd, addr, chunk, offset)) <= 0) {
 			(void)wtext->err_printf(wtext, session,
-			    "%s: handle-read: failed to read %" PRIu64
-			    " bytes at offset %" PRIu64 ": %s",
-			    fail_fh->iface.name, (uint64_t)len,
-			    (uint64_t)offset, wtext->strerror(wtext, NULL, nr));
+			    "%s: handle-read: failed to read %" PRIuMAX
+			    " bytes at offset %" PRIuMAX ": %s",
+			    fail_fh->iface.name,
+			    (uintmax_t)len, (uintmax_t)offset,
+			    wtext->strerror(wtext, NULL, errno));
 			ret = (nr == 0 ? WT_ERROR : errno);
 			break;
 		}
@@ -327,10 +328,11 @@ fail_file_write(WT_FILE_HANDLE *file_handle, WT_SESSION *session,
 		chunk = (len < FAIL_FS_GIGABYTE) ? len : FAIL_FS_GIGABYTE;
 		if ((nr = pwrite(fail_fh->fd, addr, chunk, offset)) <= 0) {
 			(void)wtext->err_printf(wtext, session,
-			    "%s: handle-write: failed to write %" PRIu64
-			    " bytes at offset %" PRIu64 ": %s",
-			    fail_fh->iface.name, (uint64_t)len,
-			    (uint64_t)offset, wtext->strerror(wtext, NULL, nr));
+			    "%s: handle-write: failed to write %" PRIuMAX
+			    " bytes at offset %" PRIuMAX ": %s",
+			    fail_fh->iface.name,
+			    (uintmax_t)len, (uintmax_t)offset,
+			    wtext->strerror(wtext, NULL, errno));
 			ret = (nr == 0 ? WT_ERROR : errno);
 			break;
 		}

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -404,7 +404,7 @@ fail_fs_directory_list(WT_FILE_SYSTEM *file_system,
 		 */
 		if (count >= allocated) {
 			entries = realloc(
-			    entries, (allocated + 10) * sizeof(char *));
+			    entries, (allocated + 10) * sizeof(*entries));
 			if (entries == NULL) {
 				ret = ENOMEM;
 				goto err;

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -378,6 +378,7 @@ fail_fs_directory_list(WT_FILE_SYSTEM *file_system,
 	uint32_t allocated, count;
 	int ret;
 	char *name, **entries;
+	void *p;
 
 	(void)session;						/* Unused */
 
@@ -403,14 +404,15 @@ fail_fs_directory_list(WT_FILE_SYSTEM *file_system,
 		 * matter if the list is a bit longer than necessary.
 		 */
 		if (count >= allocated) {
-			entries = realloc(
+			p = realloc(
 			    entries, (allocated + 10) * sizeof(*entries));
-			if (entries == NULL) {
+			if (p == NULL) {
 				ret = ENOMEM;
 				goto err;
 			}
-			memset(entries + allocated * sizeof(char *),
-			    0, 10 * sizeof(char *));
+			entries = p;
+			memset(entries + allocated * sizeof(*entries),
+			    0, 10 * sizeof(*entries));
 			allocated += 10;
 		}
 		entries[count++] = strdup(name);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1987,6 +1987,16 @@ __conn_set_file_system(
 	CONNECTION_API_CALL(conn, session, set_file_system, config, cfg);
 	WT_UNUSED(cfg);
 
+	/*
+	 * You can only configure a file system once, and attempting to do it
+	 * again probably means the extension argument didn't have early-load
+	 * set and we've already configured the default file system.
+	 */
+	if (conn->file_system != NULL)
+		WT_ERR_MSG(session, EPERM,
+		    "filesystem already configured; custom filesystems should "
+		    "enable \"early_load\" configuration");
+
 	conn->file_system = file_system;
 
 err:	API_END_RET(session, ret);

--- a/test/csuite/wt3120_filesys/main.c
+++ b/test/csuite/wt3120_filesys/main.c
@@ -36,6 +36,8 @@
  * than that.
  */
 
+#define	WT_FAIL_FS_LIB	"../../ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so"
+
 int
 main(int argc, char *argv[])
 {
@@ -43,7 +45,7 @@ main(int argc, char *argv[])
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
 	char *kstr, *vstr;
-	char buf[100];
+	char buf[1024];
 
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
@@ -51,8 +53,7 @@ main(int argc, char *argv[])
 	testutil_make_work_dir(opts->home);
 
 	snprintf(buf, sizeof(buf),
-	    "create,extensions="
-	    "[\"../../ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so\"]");
+	    "create,extensions=(" WT_FAIL_FS_LIB "=(early_load=true))");
 	testutil_check(wiredtiger_open(opts->home, NULL, buf, &opts->conn));
 	testutil_check(
 	    opts->conn->open_session(opts->conn, NULL, NULL, &session));


### PR DESCRIPTION
Lint/Coverity. Some of the code was copied from example code, which is why there are changes there as well.