### PR TITLE
WT-2790 Look at removed statistics instead of files closed.

### DIFF
--- a/test/suite/test_sweep01.py
+++ b/test/suite/test_sweep01.py
@@ -106,6 +106,7 @@ class test_sweep01(wttest.WiredTigerTestCase, suite_subprocess):
         k = 0
         sleep = 0
         max = 60
+        final_nfile = 4
         while sleep < max:
             self.session.checkpoint()
             k = k+1
@@ -114,14 +115,16 @@ class test_sweep01(wttest.WiredTigerTestCase, suite_subprocess):
             time.sleep(2)
             # Give slow machines time to process files.
             stat_cursor = self.session.open_cursor('statistics:', None, None)
+            this_nfile = stat_cursor[stat.conn.file_open][2]
             removed = stat_cursor[stat.conn.dh_sweep_remove][2]
             stat_cursor.close()
             self.pr("==== loop " + str(sleep))
+            self.pr("this_nfile " + str(this_nfile))
             self.pr("removed " + str(removed))
             # On slow machines there can be a lag where files get closed but
             # the sweep server cannot yet remove the handles.  So wait for the
-            # removed statistic to indicate forward progress.
-            if removed != remove1:
+            # removed statistic to indicate forward progress too.
+            if this_nfile == final_nfile and removed != remove1:
                 break
         c.close()
         self.pr("Sweep loop took " + str(sleep))


### PR DESCRIPTION
Ready for review once testing on evergreen completes.  After looking at some debugging statistics during a failure, I realized there is a lag between when sweep closes files and when it can remove data handles from the connection list.  On slow machines, we can hit the test failure if we catch it between those two.  So I modified the test where it looks at statistics to look for any change in the removed statistic instead of closed files.