### PR TITLE
WT-3137 Fix a hang in logging due to a race condition

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -163,7 +163,7 @@ struct __wt_logslot {
 	WT_CACHE_LINE_PAD_BEGIN
 	volatile int64_t slot_state;	/* Slot state */
 	int64_t	 slot_unbuffered;	/* Unbuffered data in this slot */
-	int32_t	 slot_error;		/* Error value */
+	int	 slot_error;		/* Error value */
 	wt_off_t slot_start_offset;	/* Starting file offset */
 	wt_off_t slot_last_offset;	/* Last record offset */
 	WT_LSN	 slot_release_lsn;	/* Slot release LSN */

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -19,7 +19,7 @@ __log_slot_dump(WT_SESSION_IMPL *session)
 	WT_CONNECTION_IMPL *conn;
 	WT_LOG *log;
 	WT_LOGSLOT *slot;
-	int32_t earliest, i;
+	int earliest, i;
 
 	conn = S2C(session);
 	log = conn->log;
@@ -39,9 +39,9 @@ __log_slot_dump(WT_SESSION_IMPL *session)
 		__wt_errx(session, "    Release LSN: %" PRIu32 "/%" PRIu32,
 		    slot->slot_release_lsn.l.file,
 		    slot->slot_release_lsn.l.offset);
-		__wt_errx(session, "    Offset: start: %" PRIu32
-		    " last:%" PRIu32, (uint32_t)slot->slot_start_offset,
-		    (uint32_t)slot->slot_last_offset);
+		__wt_errx(session, "    Offset: start: %" PRIuMAX
+		    " last:%" PRIuMAX, (uintmax_t)slot->slot_start_offset,
+		    (uintmax_t)slot->slot_last_offset);
 		__wt_errx(session, "    Unbuffered: %" PRId64
 		    " error: %" PRId32, slot->slot_unbuffered,
 		    slot->slot_error);


### PR DESCRIPTION
Lint:
Don't print int32_t's with %d.
WT_LOGSLOT.slot_error is an int, not an int32_t.
Don't print off_t's as 32-bits, use the maximum size unsigned object.