### PR TITLE
WT-3139 Implement scans as read_range.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -788,6 +788,13 @@ config_sanity(WTPERF *wtperf)
 				    "truncate specified with readonly\n");
 				return (EINVAL);
 			}
+			if (workp->insert != 0 &&
+			    workp->table_index != INT32_MAX) {
+				fprintf(stderr,
+				    "Invalid workload: Cannot insert into "
+				    "specific table only\n");
+				return (EINVAL);
+			}
 			if (workp->table_index != INT32_MAX &&
 			    workp->table_index >= (int32_t)opts->table_count) {
 				fprintf(stderr,

--- a/bench/wtperf/stress/btree-split-stress.wtperf
+++ b/bench/wtperf/stress/btree-split-stress.wtperf
@@ -6,5 +6,4 @@ run_time=300
 reopen_connection=false
 populate_threads=2
 value_sz=256
-read_range=100
-threads=((count=4,inserts=1,throttle=100000),(count=8,reads=1))
+threads=((count=4,inserts=1,throttle=100000),(count=8,reads=1,read_range=100))

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -619,7 +619,7 @@ worker(void *arg)
 
 	while (!wtperf->stop) {
 		if (workload->pause != 0)
-			(void)sleep((uint)workload->pause);
+			(void)sleep((unsigned int)workload->pause);
 		/*
 		 * Generate the next key and setup operation specific
 		 * statistics tracking objects.
@@ -902,7 +902,7 @@ run_mix_schedule_op(WORKLOAD *workp, int op, int64_t op_cnt)
 	uint8_t *p, *end;
 
 	/* Jump around the array to roughly spread out the operations. */
-	jump = 100 / op_cnt;
+	jump = (int)(100 / op_cnt);
 
 	/*
 	 * Find a read operation and replace it with another operation.  This

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -434,14 +434,12 @@ err:		wtperf->error = wtperf->stop = true;
 static int
 do_range_reads(WTPERF *wtperf, WT_CURSOR *cursor, int64_t read_range)
 {
-	CONFIG_OPTS *opts;
 	uint64_t next_val, prev_val;
 	int64_t range;
 	char *range_key_buf;
 	char buf[512];
 	int ret;
 
-	opts = wtperf->opts;
 	ret = 0;
 
 	if (read_range == 0)

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2913,6 +2913,14 @@ wtperf_rand(WTPERF_THREAD *thread)
 			    "worker: rand next key retrieval");
 			return (0);
 		}
+		/*
+		 * Resetting the cursor is not fatal.  We still return the
+		 * value we retrieved above.  We do it so that we don't
+		 * leave a cursor positioned.
+		 */
+		if ((ret = rnd_cursor->reset(rnd_cursor)) != 0)
+			lprintf(wtperf, ret, 0,
+			    "worker: rand cursor reset failed");
 		extract_key(key_buf, &rval);
 		return (rval);
 	}

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -66,22 +66,19 @@ typedef struct {
 	uint64_t throttle;		/* Maximum operations/second */
 		/* Number of operations per transaction. Zero for autocommit */
 	int64_t ops_per_txn;
+	int64_t pause;			/* Time between scans */
+	int64_t read_range;		/* Range of reads */
+	int32_t table_index;		/* Table to focus ops on */
 	int64_t truncate;		/* Truncate ratio */
 	uint64_t truncate_pct;		/* Truncate Percent */
 	uint64_t truncate_count;	/* Truncate Count */
 	int64_t update_delta;		/* Value size change on update */
 
-	/* The following options are specific to scan threads at the moment */
-	int64_t scan_count;		/* If non-zero this is a scan thread */
-	char *table_name;		/* Table to focus ops on */
-	int64_t pause;			/* Time between scans */
-
 #define	WORKER_INSERT		1	/* Insert */
 #define	WORKER_INSERT_RMW	2	/* Insert with read-modify-write */
 #define	WORKER_READ		3	/* Read */
-#define	WORKER_SCAN		4	/* Scan */
-#define	WORKER_TRUNCATE		5	/* Truncate */
-#define	WORKER_UPDATE		6	/* Update */
+#define	WORKER_TRUNCATE		4	/* Truncate */
+#define	WORKER_UPDATE		5	/* Update */
 	uint8_t ops[100];		/* Operation schedule */
 } WORKLOAD;
 

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -228,6 +228,7 @@ typedef struct {
 
 struct __wtperf_thread {		/* Per-thread structure */
 	WTPERF *wtperf;			/* Enclosing configuration */
+	WT_CURSOR *rand_cursor;		/* Random key cursor */
 
 	WT_RAND_STATE rnd;		/* Random number generation state */
 

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -150,7 +150,6 @@ DEF_OPT_AS_UINT32(random_range, 0,
     "insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
 DEF_OPT_AS_BOOL(range_partition, 0, "partition data by range (vs hash)")
-DEF_OPT_AS_UINT32(read_range, 0, "scan a range of keys after each search")
 DEF_OPT_AS_BOOL(readonly, 0,
     "reopen the connection between populate and workload phases in readonly "
     "mode.  Requires reopen_connection turned on (default).  Requires that "
@@ -192,9 +191,10 @@ DEF_OPT_AS_STRING(threads, "", "workload configuration: each 'count' "
     "'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))' "
     "which would create 2 threads doing nothing but reads and 8 threads "
     "each doing 50% inserts and 25% reads and updates.  Allowed configuration "
-    "values are 'count', 'throttle', 'update_delta', 'reads', 'inserts', "
-    "'updates', 'truncate', 'truncate_pct' and 'truncate_count'. There are "
-    "also behavior modifiers, supported modifiers are 'ops_per_txn'")
+    "values are 'count', 'throttle', 'update_delta', 'reads', 'read_range', "
+    "'inserts', 'updates', 'truncate', 'truncate_pct' and 'truncate_count'. "
+    "There are also behavior modifiers, supported modifiers are "
+    "'ops_per_txn'")
 DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
     "WT_SESSION.begin_transaction configuration string, applied during the "
     "populate phase when populate_ops_per_txn is nonzero")

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -201,8 +201,6 @@ if non zero choose a value from within this range as the key for  insert operati
 generate random content for the value
 @par range_partition (boolean, default=false)
 partition data by range (vs hash)
-@par read_range (unsigned int, default=0)
-scan a range of keys after each search
 @par readonly (boolean, default=false)
 reopen the connection between populate and workload phases in readonly  mode.  Requires reopen_connection turned on (default).  Requires that  read be the only workload specified
 @par reopen_connection (boolean, default=true)
@@ -228,7 +226,7 @@ number of tables to run operations over. Keys are divided evenly  over the table
 @par table_count_idle (unsigned int, default=0)
 number of tables to create, that won't be populated. Default 0.
 @par threads (string, default="")
-workload configuration: each 'count'  entry is the total number of threads, and the 'insert', 'read' and  'update' entries are the ratios of insert, read and update operations  done by each worker thread; If a throttle value is provided each thread  will do a maximum of that number of operations per second; multiple  workload configurations may be specified per threads configuration;  for example, a more complex threads configuration might be  'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))'  which would create 2 threads doing nothing but reads and 8 threads  each doing 50% inserts and 25% reads and updates.  Allowed configuration  values are 'count', 'throttle', 'update_delta', 'reads', 'inserts',  'updates', 'truncate', 'truncate_pct' and 'truncate_count'. There are  also behavior modifiers, supported modifiers are 'ops_per_txn'
+workload configuration: each 'count'  entry is the total number of threads, and the 'insert', 'read' and  'update' entries are the ratios of insert, read and update operations  done by each worker thread; If a throttle value is provided each thread  will do a maximum of that number of operations per second; multiple  workload configurations may be specified per threads configuration;  for example, a more complex threads configuration might be  'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))'  which would create 2 threads doing nothing but reads and 8 threads  each doing 50% inserts and 25% reads and updates.  Allowed configuration  values are 'count', 'throttle', 'update_delta', 'reads', 'read_range',  'inserts', 'updates', 'truncate', 'truncate_pct' and 'truncate_count'.  There are also behavior modifiers, supported modifiers are  'ops_per_txn'
 @par transaction_config (string, default="")
 WT_SESSION.begin_transaction configuration string, applied during the  populate phase when populate_ops_per_txn is nonzero
 @par table_name (string, default="test")


### PR DESCRIPTION
@agorrod I took a pass at implementing my suggestions and I think it is a bit cleaner and requires less new code than your original implementation.  I didn't take it any further than testing the one `stress` workload I found using `read_range`.  Review and merge if you like this better (it is based off your branch).