### PR TITLE
WT-3123 Have thread active/pause wrapper in thread group code.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -271,11 +271,11 @@ __wt_evict_server_wake(WT_SESSION_IMPL *session)
 }
 
 /*
- * __evict_thread_run_chk --
+ * __wt_evict_thread_chk --
  *	Check to decide if the eviction thread should continue running.
  */
-static bool
-__evict_thread_run_chk(WT_SESSION_IMPL *session)
+bool
+__wt_evict_thread_chk(WT_SESSION_IMPL *session)
 {
 	return (F_ISSET(S2C(session), WT_CONN_EVICTION_RUN));
 }
@@ -303,79 +303,81 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
 		__wt_epoch(session, &cache->stuck_ts);
 #endif
 
-	for (;;) {
-		if (!F_ISSET(thread, WT_THREAD_RUN))
-			break;
-		if (F_ISSET(thread, WT_THREAD_ACTIVE)) {
-			if (conn->evict_server_running &&
-			    __wt_spin_trylock(
-			    session, &cache->evict_pass_lock) == 0) {
-				/*
-				 * Cannot use WT_WITH_PASS_LOCK because this is
-				 * a try lock.  Fix when that is supported.  We
-				 * set the flag * on both sessions because we
-				 * may call clear_walk when we are walking with
-				 * the walk session, locked.
-				 */
-				F_SET(session, WT_SESSION_LOCKED_PASS);
-				F_SET(cache->walk_session,
-				    WT_SESSION_LOCKED_PASS);
-				ret = __evict_server(session, &did_work);
-				F_CLR(cache->walk_session,
-				    WT_SESSION_LOCKED_PASS);
-				F_CLR(session, WT_SESSION_LOCKED_PASS);
-				was_intr = cache->pass_intr != 0;
-				__wt_spin_unlock(session,
-				    &cache->evict_pass_lock);
-				WT_ERR(ret);
+	if (conn->evict_server_running &&
+	    __wt_spin_trylock(session, &cache->evict_pass_lock) == 0) {
+		/*
+		 * Cannot use WT_WITH_PASS_LOCK because this is a try lock.
+		 * Fix when that is supported.  We set the flag on both sessions
+		 * because we may call clear_walk when we are walking with
+		 * the walk session, locked.
+		 */
+		F_SET(session, WT_SESSION_LOCKED_PASS);
+		F_SET(cache->walk_session, WT_SESSION_LOCKED_PASS);
+		ret = __evict_server(session, &did_work);
+		F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
+		F_CLR(session, WT_SESSION_LOCKED_PASS);
+		was_intr = cache->pass_intr != 0;
+		__wt_spin_unlock(session, &cache->evict_pass_lock);
+		WT_ERR(ret);
 
-				/*
-				 * If the eviction server was interrupted, wait
-				 * until requests have been processed: the
-				 * system may otherwise be busy so don't go
-				 * to sleep.
-				 */
-				if (was_intr) {
-					while (cache->pass_intr != 0 &&
-					    F_ISSET(conn,
-						WT_CONN_EVICTION_RUN) &&
-					    F_ISSET(thread, WT_THREAD_RUN))
-						__wt_yield();
-					continue;
-				}
-				__wt_verbose(session,
-				    WT_VERB_EVICTSERVER, "sleeping");
+		/*
+		 * If the eviction server was interrupted, wait until requests
+		 * have been processed: the system may otherwise be busy so
+		 * don't go to sleep.
+		 */
+		if (was_intr)
+			while (cache->pass_intr != 0 &&
+			    F_ISSET(conn, WT_CONN_EVICTION_RUN) &&
+			    F_ISSET(thread, WT_THREAD_RUN))
+				__wt_yield();
+		else {
+			__wt_verbose(session, WT_VERB_EVICTSERVER, "sleeping");
 
-				/* Don't rely on signals: check periodically. */
-				__wt_cond_auto_wait(session,
-				    cache->evict_cond, did_work, NULL);
-				__wt_verbose(session,
-				    WT_VERB_EVICTSERVER, "waking");
-			} else
-				WT_ERR(__evict_lru_pages(session, false));
-		} else
-			__wt_cond_wait(session, thread->pause_cond,
-			    WT_EVICT_THREAD_PAUSE * WT_MILLION,
-			    __evict_thread_run_chk);
+			/* Don't rely on signals: check periodically. */
+			__wt_cond_auto_wait(session,
+			    cache->evict_cond, did_work, NULL);
+			__wt_verbose(session, WT_VERB_EVICTSERVER, "waking");
+		}
+	} else
+		WT_ERR(__evict_lru_pages(session, false));
+
+	if (0) {
+err:		WT_PANIC_MSG(session, ret, "cache eviction thread error");
 	}
+	return (ret);
+}
 
+/*
+ * __wt_evict_thread_stop --
+ *	Shutdown function for an eviction thread.
+ */
+int
+__wt_evict_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
+{
+	WT_CACHE *cache;
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+
+	if (thread->id != 0)
+		return (0);
+
+	conn = S2C(session);
+	cache = conn->cache;
 	/*
 	 * The only time the first eviction thread is stopped is on shutdown:
 	 * in case any trees are still open, clear all walks now so that they
 	 * can be closed.
 	 */
-	if (thread->id == 0) {
-		WT_WITH_PASS_LOCK(session,
-		    ret = __evict_clear_all_walks(session));
-		WT_ERR(ret);
-		/*
-		 * The only two cases when the eviction server is expected to
-		 * stop are when recovery is finished or when the connection is
-		 * closing.
-		 */
-		WT_ASSERT(session,
-		    F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_RECOVERING));
-	}
+	WT_WITH_PASS_LOCK(session,
+	    ret = __evict_clear_all_walks(session));
+	WT_ERR(ret);
+	/*
+	 * The only two cases when the eviction server is expected to
+	 * stop are when recovery is finished or when the connection is
+	 * closing.
+	 */
+	WT_ASSERT(session,
+	    F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_RECOVERING));
 
 	__wt_verbose(
 	    session, WT_VERB_EVICTSERVER, "cache eviction thread exiting");
@@ -496,7 +498,8 @@ __wt_evict_create(WT_SESSION_IMPL *session)
 	 */
 	WT_RET(__wt_thread_group_create(session, &conn->evict_threads,
 	    "eviction-server", conn->evict_threads_min, conn->evict_threads_max,
-	     WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL, __wt_evict_thread_run));
+	     WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL, __wt_evict_thread_chk,
+	     __wt_evict_thread_run, __wt_evict_thread_stop));
 
 	/*
 	 * Allow queues to be populated now that the eviction threads

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -18,8 +18,6 @@
 
 #define	WT_EVICT_MAX_TREES	1000	/* Maximum walk points */
 
-#define	WT_EVICT_THREAD_PAUSE	10	/* Thread pause timeout in seconds */
-
 /*
  * WT_EVICT_ENTRY --
  *	Encapsulation of an eviction candidate.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -344,7 +344,9 @@ extern int __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURS
 extern int __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_evict_server_wake(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern bool __wt_evict_thread_chk(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern int __wt_evict_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_evict_create(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_evict_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_evict_file_exclusive_on(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
@@ -723,9 +725,8 @@ extern void __wt_stat_join_init_single(WT_JOIN_STATS *stats) WT_GCC_FUNC_DECL_AT
 extern void __wt_stat_join_clear_single(WT_JOIN_STATS *stats) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_stat_join_clear_all(WT_JOIN_STATS **stats) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_stat_join_aggregate( WT_JOIN_STATS **from, WT_JOIN_STATS *to) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern WT_THREAD_RET __wt_thread_run(void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_thread_group_resize( WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t new_min, uint32_t new_max, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern int __wt_thread_group_create( WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, const char *name, uint32_t min, uint32_t max, uint32_t flags, int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern int __wt_thread_group_create( WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, const char *name, uint32_t min, uint32_t max, uint32_t flags, bool (*chk_func)(WT_SESSION_IMPL *session), int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context), int (*stop_func)(WT_SESSION_IMPL *session, WT_THREAD *context)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_thread_group_destroy(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_thread_group_start_one( WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, bool is_locked) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));

--- a/src/include/thread_group.h
+++ b/src/include/thread_group.h
@@ -6,6 +6,8 @@
  * See the file LICENSE for redistribution information.
  */
 
+#define	WT_THREAD_PAUSE		10	/* Thread pause timeout in seconds */
+
 /*
  * WT_THREAD --
  *	Encapsulation of a thread that belongs to a thread group.
@@ -30,8 +32,13 @@ struct __wt_thread {
 	 * threads wait on this condition.
 	 */
 	WT_CONDVAR      *pause_cond;
+
+	/* The check function used by all threads. */
+	bool (*chk_func)(WT_SESSION_IMPL *session);
 	/* The runner function used by all threads. */
 	int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context);
+	/* The stop function used by all threads. */
+	int (*stop_func)(WT_SESSION_IMPL *session, WT_THREAD *context);
 };
 
 /*
@@ -63,6 +70,10 @@ struct __wt_thread_group {
 	 */
 	WT_THREAD **threads;
 
+	/* The check function used by all threads. */
+	bool (*chk_func)(WT_SESSION_IMPL *session);
 	/* The runner function used by all threads. */
 	int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context);
+	/* The stop function used by all threads. May be NULL */
+	int (*stop_func)(WT_SESSION_IMPL *session, WT_THREAD *context);
 };

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -9,11 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_thread_run --
+ * __thread_run --
  *	General wrapper for any thread.
  */
-WT_THREAD_RET
-__wt_thread_run(void *arg)
+static WT_THREAD_RET
+__thread_run(void *arg)
 {
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
@@ -22,11 +22,21 @@ __wt_thread_run(void *arg)
 	thread = (WT_THREAD*)arg;
 	session = thread->session;
 
+	for (;;) {
+		if (!F_ISSET(thread, WT_THREAD_RUN))
+			return (WT_THREAD_RET_VALUE);
+		if (!F_ISSET(thread, WT_THREAD_ACTIVE))
+			__wt_cond_wait(session, thread->pause_cond,
+			    WT_THREAD_PAUSE * WT_MILLION, thread->chk_func);
+		WT_ERR(thread->run_func(session, thread));
+	}
+
+err:
 	/*
-	 * The subsystem run function is responsible for looking at whether
-	 * a thread is active or paused.
+	 * If a thread is stopping it may have subsystem cleanup to do.
 	 */
-	ret = thread->run_func(session, thread);
+	if (thread->stop_func != NULL)
+		ret = thread->stop_func(session, thread);
 
 	if (ret != 0 && F_ISSET(thread, WT_THREAD_PANIC_FAIL))
 		WT_PANIC_MSG(session, ret,
@@ -166,7 +176,9 @@ __thread_group_resize(
 		if (LF_ISSET(WT_THREAD_PANIC_FAIL))
 			F_SET(thread, WT_THREAD_PANIC_FAIL);
 		thread->id = i;
+		thread->chk_func = group->chk_func;
 		thread->run_func = group->run_func;
+		thread->stop_func = group->stop_func;
 		WT_ERR(__wt_cond_alloc(
 		    session, "Thread cond", &thread->pause_cond));
 		WT_ASSERT(session, group->threads[i] == NULL);
@@ -182,7 +194,7 @@ __thread_group_resize(
 		F_SET(thread, WT_THREAD_RUN);
 		WT_ASSERT(session, thread->session != NULL);
 		WT_ERR(__wt_thread_create(thread->session,
-		    &thread->tid, __wt_thread_run, thread));
+		    &thread->tid, __thread_run, thread));
 	}
 
 err:	/*
@@ -232,7 +244,9 @@ int
 __wt_thread_group_create(
     WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, const char *name,
     uint32_t min, uint32_t max, uint32_t flags,
-    int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context))
+    bool (*chk_func)(WT_SESSION_IMPL *session),
+    int (*run_func)(WT_SESSION_IMPL *session, WT_THREAD *context),
+    int (*stop_func)(WT_SESSION_IMPL *session, WT_THREAD *context))
 {
 	WT_DECL_RET;
 	bool cond_alloced;
@@ -251,7 +265,9 @@ __wt_thread_group_create(
 	cond_alloced = true;
 
 	__wt_writelock(session, &group->lock);
+	group->chk_func = chk_func;
 	group->run_func = run_func;
+	group->stop_func = stop_func;
 	group->name = name;
 
 	WT_TRET(__thread_group_resize(session, group, min, max, flags));

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -24,7 +24,7 @@ __thread_run(void *arg)
 
 	for (;;) {
 		if (!F_ISSET(thread, WT_THREAD_RUN))
-			return (WT_THREAD_RET_VALUE);
+			break;
 		if (!F_ISSET(thread, WT_THREAD_ACTIVE))
 			__wt_cond_wait(session, thread->pause_cond,
 			    WT_THREAD_PAUSE * WT_MILLION, thread->chk_func);


### PR DESCRIPTION
@agorrod Here are the changes to make the thread group code the wrapper for the activate and pause of threads.  It required a bunch of changes.  I think conceptually it is cleaner, but in some ways the eviction code is a bit less intuitive since it is no longer a server loop.  I had to add both a check function and a stop function for threads to call.  Let me know what you think.