### PR TITLE
WT-3164 Reset ckpt field on error.  Add error reset function.

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -525,11 +525,11 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session,
 }
 
 /*
- * __txn_fail_reset --
+ * __checkpoint_fail_reset --
  *	Reset fields when a failure occurs.
  */
 static void
-__txn_fail_reset(WT_SESSION_IMPL *session)
+__checkpoint_fail_reset(WT_SESSION_IMPL *session)
 {
 	S2BT(session)->modified = true;
 	S2BT(session)->ckpt = NULL;
@@ -880,7 +880,7 @@ err:	/*
 		 */
 		if (failed)
 			WT_WITH_DHANDLE(session, session->ckpt_handle[i],
-			    __txn_fail_reset(session));
+			    __checkpoint_fail_reset(session));
 		WT_WITH_DHANDLE(session, session->ckpt_handle[i],
 		    WT_TRET(__wt_session_release_btree(session)));
 	}

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -525,6 +525,17 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session,
 }
 
 /*
+ * __txn_fail_reset --
+ *	Reset fields when a failure occurs.
+ */
+static void
+__txn_fail_reset(WT_SESSION_IMPL *session)
+{
+	S2BT(session)->modified = true;
+	S2BT(session)->ckpt = NULL;
+}
+
+/*
  * __txn_checkpoint --
  *	Checkpoint a database or a list of objects in the database.
  */
@@ -869,7 +880,7 @@ err:	/*
 		 */
 		if (failed)
 			WT_WITH_DHANDLE(session, session->ckpt_handle[i],
-			    S2BT(session)->modified = true);
+			    __txn_fail_reset(session));
 		WT_WITH_DHANDLE(session, session->ckpt_handle[i],
 		    WT_TRET(__wt_session_release_btree(session)));
 	}


### PR DESCRIPTION
@agorrod and @ddanderson Here is a fix for WT-3164 that is based off develop, but tested with Don's branch.  With this fix (and my hand placed error per the ticket) the command now proceeds further and fails with the same error as WT-3165.  Without any hand-injected error at that specific location the test command succeeds.  But the fix needs to be in develop and can then be merged into Don's branch.  Please review.