### PR TITLE
WT-3173 Add runtime detection for s390x CRC32 hardware support

### DIFF
--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -1,4 +1,6 @@
 #if defined(__powerpc64__)
+#include "wt_internal.h"
+
 #define CRC_TABLE
 #include "crc32_constants.h"
 
@@ -67,8 +69,6 @@ out:
 	return crc;
 }
 #endif
-
-#include "wt_internal.h"
 
 /*
  * __wt_checksum_hw --


### PR DESCRIPTION
The CRC32 hardware support for s390x is only available on z13 processors and later and require a Linux kernel version which support the vector extensions. Runtime detection can be accomplished by querying `auxv` for the `HW_CAP` of `HWCAP_S390_VX`.

Change:
`zseries/crc32-s390x.c` :
- Move `wt_internal.h` header to top for consistency and to get the `HAVE_CRC32_HARDWARE` define.
- Include `sys/auxv.h` to call `getauxval` and access `HW_CAP` which reads `/proc/PID/auxv`.
- Define `HWCAP_S390_VX` if not defined, this is needed on RHEL 7.1 which has the kernel support for the VX extensions but not the glibc support. This constant is define in the Linux kernel header `asm/elf.h` for s390.

`power8/crc32_wrapper.c`:
- Move `wt_internal.h` header to top for consistency

**Tests:**
Passes MongoDB compile and unittests on s390x on RHEL 7.2, SUSE 11, SUSE 12, and Ubuntu 16.04.