### PR TITLE
WT-3135 lint.

### DIFF
--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -57,7 +57,7 @@ item_str_equal(WT_ITEM *item, const char *str)
 }
 
 static int
-compare_int(int a, int b)
+compare_int(int64_t a, int64_t b)
 {
 	return (a < b ? -1 : (a > b ? 1 : 0));
 }


### PR DESCRIPTION
test/csuite/wt3135_search_near_collator/main.c:75:22: error: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int' [-Werror,-Wshorten-64-to-32]
                *cmp = compare_int(pkey1, pkey2);