### PR TITLE
WT-3175 Don't verify children during splits up the tree.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -251,29 +251,33 @@ __split_verify_intl_key_order(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
- * __split_verify_intl --
- *	Verify a set of internal pages involved in a split.
+ * __split_verify_root --
+ *	Verify a root page involved in a split.
  */
 static int
-__split_verify_intl(WT_SESSION_IMPL *session,
-    WT_PAGE *page1, WT_PAGE *page2, WT_PAGE *pindex_page, bool skip_first)
+__split_verify_root(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
 	WT_DECL_RET;
 	WT_REF *ref;
 
 	/* The split is complete and live, verify all of the pages involved. */
-	if (page1 != NULL)
-		__split_verify_intl_key_order(session, page1);
-	if (page2 != NULL)
-		__split_verify_intl_key_order(session, page2);
+	__split_verify_intl_key_order(session, page);
 
-	/* Skip the first slot on non-root internal pages, it's not set. */
-	WT_INTL_FOREACH_BEGIN(session, pindex_page, ref) {
-		if (skip_first) {
-			skip_first = false;
+	WT_INTL_FOREACH_BEGIN(session, page, ref) {
+		/*
+		 * An eviction thread might be attempting to evict the page
+		 * (the WT_REF may be WT_REF_LOCKED), or it may be a disk based
+		 * page (the WT_REF may be WT_REF_READING), or it may be in
+		 * some other state.  Acquire a hazard pointer for any
+		 * in-memory pages so we know the state of the page.
+		 *
+		 * Ignore pages not in-memory (deleted, on-disk, being read),
+		 * there's no in-memory structure to check.
+		 */
+		if ((ret = __wt_page_in(session,
+		    ref, WT_READ_CACHE | WT_READ_NO_EVICT)) == WT_NOTFOUND)
 			continue;
-		}
-		WT_ERR(__wt_page_in(session, ref, WT_READ_NO_EVICT));
+		WT_ERR(ret);
 
 		__split_verify_intl_key_order(session, ref->page);
 
@@ -653,7 +657,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 
 #ifdef HAVE_DIAGNOSTIC
 	WT_WITH_PAGE_INDEX(session,
-	    ret = __split_verify_intl(session, root, NULL, root, false));
+	    ret = __split_verify_root(session, root));
 	WT_ERR(ret);
 #endif
 
@@ -1170,8 +1174,9 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
 #ifdef HAVE_DIAGNOSTIC
 	WT_WITH_PAGE_INDEX(session,
-	    ret = __split_verify_intl(session, parent, page, page, true));
-	WT_ERR(ret);
+	    __split_verify_intl_key_order(session, parent));
+	WT_WITH_PAGE_INDEX(session,
+	    __split_verify_intl_key_order(session, page));
 #endif
 
 	/* The split is complete and verified, ignore benign errors. */


### PR DESCRIPTION
Reverts part of 7f5d0f9981214c723f2ed90cf4533887ed406176.

Fixes a deadlock in diagnostic mode.  Also revert a change that could
cause diagnostic code to read pages into cache: we don't want diagnostic
adding cache pressure and we already verify pages as they are evicted.