### PR TITLE
WT-3189 Fix a segfault in eviction random page search.

### DIFF
--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -201,6 +201,17 @@ restart:	/*
 	current = &btree->root;
 	for (;;) {
 		page = current->page;
+		/*
+		 * It is possible for the eviction server to see a NULL page
+		 * here, if it is inspecting a tree while an exclusive
+		 * operation that uses non-standard protection mechanisms is in
+		 * flight.
+		 */
+		if (page == NULL) {
+			WT_ASSERT(session, eviction);
+			break;
+		}
+
 		if (!WT_PAGE_IS_INTERNAL(page))
 			break;
 

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -202,8 +202,9 @@ restart:	/*
 	for (;;) {
 		page = current->page;
 		/*
-		 * The descent can see a NULL page if searching in a tree
-		 * while an exclusive operation is active on the handle.
+		 * When walking a tree for eviction, an exclusive operation may
+		 * be in progress leaving the root page is not valid.  Just give
+		 * up in that case.
 		 */
 		if (page == NULL) {
 			WT_ASSERT(session, eviction);

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -202,10 +202,8 @@ restart:	/*
 	for (;;) {
 		page = current->page;
 		/*
-		 * It is possible for the eviction server to see a NULL page
-		 * here, if it is inspecting a tree while an exclusive
-		 * operation that uses non-standard protection mechanisms is in
-		 * flight.
+		 * The descent can see a NULL page if searching in a tree
+		 * while an exclusive operation is active on the handle.
 		 */
 		if (page == NULL) {
 			WT_ASSERT(session, eviction);


### PR DESCRIPTION
A NULL page could be encountered when traversing a tree that is
being used by exclusive access.