### PR TITLE
WT-3149 Fix a compiler warning on OS X.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1680,9 +1680,6 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 			WT_RET_NOTFOUND_OK(ret);
 		}
 		break;
-	default:
-		WT_RET_MSG(session, EINVAL,
-		    "Invalid btree walk state encountered");
 	}
 
 	/*


### PR DESCRIPTION
src/evict/evict_lru.c:1683:2: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]