### PR TITLE
WT-3182 Switch make-check to run the short test suite by default

### DIFF
--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -6,8 +6,8 @@ set -e
 echo "checkpoint: 3 mixed tables"
 $TEST_WRAPPER ./t -T 3 -t m
 
-# We are done if short tests are requested
-test -z "$TESTUTIL_DISABLE_LONG_TESTS" || exit 0
+# We are done unless long tests are enabled.
+test "$TESTUTIL_ENABLE_LONG_TESTS" = "1" || exit 0
 
 echo "checkpoint: 6 column-store tables"
 $TEST_WRAPPER ./t -T 6 -t c

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -101,9 +101,10 @@ main(int argc, char *argv[])
 	uint64_t i, id;
 	char buf[100];
 
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
-	if (testutil_disable_long_tests())
-		return (0);
 	memset(opts, 0, sizeof(*opts));
 	opts->table_type = TABLE_ROW;
 	opts->n_append_threads = N_APPEND_THREADS;

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -92,10 +92,11 @@ main(int argc, char *argv[])
 	TEST_OPTS *opts, _opts;
 	const char *tablename;
 
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
 	sharedopts = &_sharedopts;
-	if (testutil_disable_long_tests())
-		return (0);
 	memset(opts, 0, sizeof(*opts));
 	memset(sharedopts, 0, sizeof(*sharedopts));
 

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -49,9 +49,10 @@ main(int argc, char *argv[])
 	uint64_t current_value;
 	int i;
 
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
-	if (testutil_disable_long_tests())
-		return (0);
 	memset(opts, 0, sizeof(*opts));
 	opts->nthreads = 10;
 	opts->nrecords = 1000;

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -59,11 +59,11 @@ main(int argc, char *argv[])
 	char flaguri[256];
 	char joinuri[256];
 
-	opts = &_opts;
-	if (testutil_disable_long_tests())
-		return (0);
-	memset(opts, 0, sizeof(*opts));
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
 
+	opts = &_opts;
+	memset(opts, 0, sizeof(*opts));
 	testutil_check(testutil_parse_opts(argc, argv, opts));
 	testutil_make_work_dir(opts->home);
 

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -82,11 +82,11 @@ main(int argc, char *argv[])
 	int i, nfail;
 	const char *tablename;
 
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
 	sharedopts = &_sharedopts;
-
-	if (testutil_disable_long_tests())
-		return (0);
 	memset(opts, 0, sizeof(*opts));
 	memset(sharedopts, 0, sizeof(*sharedopts));
 	memset(insert_args, 0, sizeof(insert_args));

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -98,7 +98,6 @@ static void run_check_subtest_range(TEST_OPTS *, const char *, bool);
 static int run_process(TEST_OPTS *, const char *, char *[], int *);
 static int subtest_main(int, char *[], bool);
 static void subtest_populate(TEST_OPTS *, bool);
-int main(int, char *[]);
 
 extern int   __wt_optind;
 
@@ -454,8 +453,6 @@ subtest_main(int argc, char *argv[], bool close_test)
 	char config[1024], filename[1024];
 	struct rlimit rlim;
 
-	if (testutil_disable_long_tests())
-		return (0);
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
 	memset(&rlim, 0, sizeof(rlim));
@@ -622,8 +619,9 @@ main(int argc, char *argv[])
 	uint64_t nresults;
 	const char *debugger;
 
-	if (testutil_disable_long_tests())
-		return (0);
+	if (!testutil_enable_long_tests())	/* Ignore unless requested */
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
 	debugger = NULL;

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -96,7 +96,7 @@ static void run_check_subtest(TEST_OPTS *, const char *, uint64_t, bool,
     uint64_t *);
 static void run_check_subtest_range(TEST_OPTS *, const char *, bool);
 static int run_process(TEST_OPTS *, const char *, char *[], int *);
-static int subtest_main(int, char *[], bool);
+static void subtest_main(int, char *[], bool);
 static void subtest_populate(TEST_OPTS *, bool);
 
 extern int   __wt_optind;
@@ -445,7 +445,7 @@ run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *status)
  * subtest_main --
  *	The main program for the subtest
  */
-static int
+static void
 subtest_main(int argc, char *argv[], bool close_test)
 {
 	TEST_OPTS *opts, _opts;
@@ -496,8 +496,6 @@ subtest_main(int argc, char *argv[], bool close_test)
 	subtest_populate(opts, close_test);
 
 	testutil_cleanup(opts);
-
-	return (0);
 }
 
 /*
@@ -633,11 +631,13 @@ main(int argc, char *argv[])
 		opts->nrecords = 50000;
 
 	while (argc > 0) {
-		if (strcmp(argv[0], "subtest") == 0)
-			return (subtest_main(argc, argv, false));
-		else if (strcmp(argv[0], "subtest_close") == 0)
-			return (subtest_main(argc, argv, true));
-		else if (strcmp(argv[0], "gdb") == 0)
+		if (strcmp(argv[0], "subtest") == 0) {
+			subtest_main(argc, argv, false);
+			return (0);
+		} else if (strcmp(argv[0], "subtest_close") == 0) {
+			subtest_main(argc, argv, true);
+			return (0);
+		} else if (strcmp(argv[0], "gdb") == 0)
 			debugger = "/usr/bin/gdb";
 		else
 			testutil_assert(false);

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -166,20 +166,25 @@ testutil_cleanup(TEST_OPTS *opts)
 }
 
 /*
- * testutil_disable_long_tests --
- *	Return if TESTUTIL_DISABLE_LONG_TESTS is set.
+ * testutil_enable_long_tests --
+ *	Return if TESTUTIL_ENABLE_LONG_TESTS is set.
  */
 bool
-testutil_disable_long_tests(void)
+testutil_enable_long_tests(void)
 {
 	const char *res;
+	bool enable_long_tests;
 
 	if (__wt_getenv(NULL,
-	    "TESTUTIL_DISABLE_LONG_TESTS", &res) == WT_NOTFOUND)
+	    "TESTUTIL_ENABLE_LONG_TESTS", &res) == WT_NOTFOUND)
 		return (false);
 
+	/* Accept anything other than "TESTUTIL_ENABLE_LONG_TESTS=0". */
+	enable_long_tests = res[0] != '0';
+
 	free((void *)res);
-	return (true);
+
+	return (enable_long_tests);
 }
 
 /*

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -185,7 +185,7 @@ void *dstrdup(const void *);
 void *dstrndup(const char *, size_t);
 void  testutil_clean_work_dir(const char *);
 void  testutil_cleanup(TEST_OPTS *);
-bool  testutil_disable_long_tests(void);
+bool  testutil_enable_long_tests(void);
 void  testutil_make_work_dir(char *);
 int   testutil_parse_opts(int, char * const *, TEST_OPTS *);
 void  testutil_work_dir_from_path(char *, size_t, const char *);


### PR DESCRIPTION
@agorrod, here's a first cut at this one.

I think this is all that's necessary in the source code, but maybe I'm missing the big picture!

Let me know if you agree -- we can merge, which will just turn off long tests everywhere.

We can talk over what test harnesses should enable long tests and I'll make/test those changes.