### PR TITLE
WT-3193 Close a race between verify opening a handle and eviction visiting it

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -36,8 +36,9 @@ __btree_initialize(WT_BTREE *btree, bool closing)
 	 */
 	if (closing) {
 		/*
-		 * Closing: clear everything except cache/eviction information
-		 * and one LSM flag.
+		 * Closing: clear everything except cache/eviction information.
+		 * (The LSM flag is used during cache eviction as an accounting
+		 * modifier, eviction also uses the WT_DATA_HANDLE reference.)
 		 */
 		dhandle = btree->dhandle;
 
@@ -47,13 +48,9 @@ __btree_initialize(WT_BTREE *btree, bool closing)
 		btree->dhandle = dhandle;
 	} else {
 		/* Opening: clear everything except the special flags. */
-		dhandle = btree->dhandle;
 		mask = F_MASK(btree, WT_BTREE_SPECIAL_FLAGS);
-
 		memset(btree, 0, sizeof(*btree));
-
 		btree->flags = mask;
-		btree->dhandle = dhandle;
 	}
 }
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -21,6 +21,7 @@ static int __btree_tree_open_empty(WT_SESSION_IMPL *, bool);
 static void
 __btree_initialize(WT_BTREE *btree, bool closing)
 {
+	WT_DATA_HANDLE *dhandle;
 	uint32_t mask;
 
 	/*
@@ -38,13 +39,21 @@ __btree_initialize(WT_BTREE *btree, bool closing)
 		 * Closing: clear everything except cache/eviction information
 		 * and one LSM flag.
 		 */
+		dhandle = btree->dhandle;
+
 		memset(btree, 0, WT_BTREE_CLEAR_SIZE);
 		F_CLR(btree, ~(WT_BTREE_LSM_PRIMARY | WT_BTREE_NO_EVICTION));
+
+		btree->dhandle = dhandle;
 	} else {
 		/* Opening: clear everything except the special flags. */
+		dhandle = btree->dhandle;
 		mask = F_MASK(btree, WT_BTREE_SPECIAL_FLAGS);
+
 		memset(btree, 0, sizeof(*btree));
+
 		btree->flags = mask;
+		btree->dhandle = dhandle;
 	}
 }
 


### PR DESCRIPTION
@agorrod, I think this change fixes a core dump on the zSeries today:
```
Backtrace:
build_posix/../src/evict/evict_lru.c:103 (discriminator 1)(__evict_entry_priority)[0x800386e2]
build_posix/../src/evict/evict_lru.c:1521(__evict_push_candidate)[0x8003c212]
build_posix/../src/evict/evict_lru.c:2272 (discriminator 1)(__wt_page_evict_urgent)[0x8003e7d4]
build_posix/../src/evict/evict_lru.c:1778(__evict_walk_file)[0x8003cb3e]
build_posix/../src/evict/evict_lru.c:1444(__evict_walk)[0x8003bef4]
build_posix/../src/evict/evict_lru.c:1167(__evict_lru_walk)[0x8003b558]
build_posix/../src/evict/evict_lru.c:664(__evict_pass)[0x80039e82]
build_posix/../src/evict/evict_lru.c:387(__evict_server)[0x8003933e]
build_posix/../src/evict/evict_lru.c:308(__wt_evict_thread_run)[0x80038f56]
build_posix/../src/support/thread_group.c:25(__wt_thread_run)[0x800bba84]
```
Basically, the changes in f3747a2 didn't preserve `WT_BTREE.dhandle` across the handle close, and eviction uses it in some cases.
