### PR TITLE
WT-3202 wtperf should not reopen in-memory connections

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1653,6 +1653,10 @@ close_reopen(WTPERF *wtperf)
 	CONFIG_OPTS *opts;
 	int ret;
 
+	// in_memory has non-persistent connection                                                                                                                                                                                         
+	if (F_ISSET((WT_CONNECTION_IMPL*)cfg->conn, WT_CONN_IN_MEMORY))
+		return (0); 
+
 	opts = wtperf->opts;
 
 	if (!opts->readonly && !opts->reopen_connection)


### PR DESCRIPTION
fix the potential problem on wtperf test wiredtiger in_memory mode. check wt_conn in_memory flag directly and without the "reopen_connection=false" option which is likely to lead to ambiguity 