### PR TITLE
WT-3213 Only error if fixed-length and long_running_txn is set.

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -462,7 +462,7 @@ config_lrt(void)
 	 * stores.
 	 */
 	if (g.type == FIX) {
-		if (config_is_perm("long_running_txn"))
+		if (config_is_perm("long_running_txn") && g.c_long_running_txn)
 			testutil_die(EINVAL,
 			    "long_running_txn not supported with fixed-length "
 			    "column store");


### PR DESCRIPTION
@keithbostic Please review this small fix to allow the generated CONFIG to be used on the next run.