### PR TITLE
WT-3207 Report a message for conflicting forced checkpoints, rather than an error

### DIFF
--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -13,6 +13,12 @@ In the 2.9.1 release we added statistics tracking handle list lock timing, we
 have switched that lock from a spin lock to a read-write lock, and consequently
 changed the statistics tracking lock related wait time.
 </dd>
+<dt>Forced and named checkpoint error conditions changed</dt>
+<dd>
+There are new cases where checkpoints created with an explicit name or the
+"force" configuration option can return an EBUSY error. This can happen if
+the checkpoint overlaps with other schema operations, for example table create.
+</dd>
 </dl>
 
 @section version_291 Upgrading to Version 2.9.1

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -319,10 +319,12 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 			 * safely be skipped here.
 			 */
 			F_CLR(&session->txn, WT_TXN_ERROR);
-			if (force)
-				WT_RET_MSG(session, EBUSY,
+			if (force) {
+				WT_RET(__wt_msg(session,
 				    "forced or named checkpoint raced with "
-				    "a metadata update");
+				    "a metadata update"));
+				return (EBUSY);
+			}
 			__wt_verbose(session, WT_VERB_CHECKPOINT,
 			    "skipped checkpoint of %s with metadata conflict",
 			    session->dhandle->name);

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -190,9 +190,13 @@ obj_checkpoint(void)
 	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
 		testutil_die(ret, "conn.session");
 
-	/* Force the checkpoint so it has to be taken. */
+	/*
+	 * Force the checkpoint so it has to be taken. Forced checkpoints can
+	 * race with other metadata operations and return EBUSY - we'd expect 
+	 * applications using forced checkpoints to retry on EBUSY.
+	 */
 	if ((ret = session->checkpoint(session, "force")) != 0)
-		if (ret != ENOENT)
+		if (ret != EBUSY && ret != ENOENT)
 			testutil_die(ret, "session.checkpoint");
 
 	if ((ret = session->close(session, NULL)) != 0)

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -51,7 +51,7 @@ obj_bulk(void)
 			if ((ret = c->close(c)) != 0)
 				testutil_die(ret, "cursor.close");
 		} else if (ret != ENOENT && ret != EBUSY && ret != EINVAL)
-			testutil_die(ret, "session.open_cursor");
+			testutil_die(ret, "session.open_cursor bulk");
 	}
 	if ((ret = session->close(session, NULL)) != 0)
 		testutil_die(ret, "session.close");
@@ -79,12 +79,17 @@ obj_bulk_unique(int force)
 		testutil_die(ret, "session.create: %s", new_uri);
 
 	__wt_yield();
-	if ((ret =
-	    session->open_cursor(session, new_uri, NULL, "bulk", &c)) != 0)
-		testutil_die(ret, "session.open_cursor: %s", new_uri);
-
-	if ((ret = c->close(c)) != 0)
-		testutil_die(ret, "cursor.close");
+	/*
+	 * Opening a bulk cursor may have raced with a forced checkpoint
+	 * which created a checkpoint of the empty file, and triggers an EINVAL
+	 */
+	if ((ret = session->open_cursor(
+	    session, new_uri, NULL, "bulk", &c)) == 0) {
+		if ((ret = c->close(c)) != 0)
+			testutil_die(ret, "cursor.close");
+	} else if (ret != EINVAL)
+		testutil_die(ret,
+		    "session.open_cursor bulk unique: %s, new_uri");
 
 	while ((ret = session->drop(
 	    session, new_uri, force ? "force" : NULL)) != 0)

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -192,7 +192,7 @@ obj_checkpoint(void)
 
 	/*
 	 * Force the checkpoint so it has to be taken. Forced checkpoints can
-	 * race with other metadata operations and return EBUSY - we'd expect 
+	 * race with other metadata operations and return EBUSY - we'd expect
 	 * applications using forced checkpoints to retry on EBUSY.
 	 */
 	if ((ret = session->checkpoint(session, "force")) != 0)

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -217,6 +217,11 @@ handle_message(WT_EVENT_HANDLER *handler,
 	(void)(handler);
 	(void)(session);
 
+	/* Ignore messages about failing to create forced checkpoints. */
+	if (strstr(
+	    message, "forced or named checkpoint") != NULL)
+		return (0);
+
 	if (logfp != NULL)
 		return (fprintf(logfp, "%s\n", message) < 0 ? -1 : 0);
 

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -59,11 +59,13 @@ main(int argc, char *argv[])
 		const char *config;
 	} *cp, configs[] = {
 		{ "file:wt",	NULL, NULL },
+#if 0
 		{ "table:wt",	NULL, NULL },
 /* Configure for a modest cache size. */
 #define	LSM_CONFIG	"lsm=(chunk_size=1m,merge_max=2),leaf_page_max=4k"
 		{ "lsm:wt",	NULL, LSM_CONFIG },
 		{ "table:wt",	" [lsm]", "type=lsm," LSM_CONFIG },
+#endif
 		{ NULL,		NULL, NULL }
 	};
 	u_int nthreads;

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -59,13 +59,11 @@ main(int argc, char *argv[])
 		const char *config;
 	} *cp, configs[] = {
 		{ "file:wt",	NULL, NULL },
-#if 0
 		{ "table:wt",	NULL, NULL },
 /* Configure for a modest cache size. */
 #define	LSM_CONFIG	"lsm=(chunk_size=1m,merge_max=2),leaf_page_max=4k"
 		{ "lsm:wt",	NULL, LSM_CONFIG },
 		{ "table:wt",	" [lsm]", "type=lsm," LSM_CONFIG },
-#endif
 		{ NULL,		NULL, NULL }
 	};
 	u_int nthreads;


### PR DESCRIPTION
Continue to return EBUSY. Have test/fops handle EBUSY returns from forced checkpoints.