### PR TITLE
WT-3218 Avoid adding duplicate handles to connection dhandle list

### DIFF
--- a/bench/wtperf/runners/many-table-stress.wtperf
+++ b/bench/wtperf/runners/many-table-stress.wtperf
@@ -1,0 +1,19 @@
+# Create a set of tables with uneven distribution of data
+conn_config="cache_size=1G,eviction=(threads_max=8),file_manager=(close_idle_time=100000),checkpoint=(wait=20,log_size=2GB),statistics=(fast),statistics_log=(wait=5,json),session_max=1000"
+table_config="type=file"
+table_count=5000
+icount=0
+random_range=1000000000
+pareto=10
+range_partition=true
+report_interval=5
+
+run_ops=1000000
+populate_threads=0
+icount=0
+threads=((count=60,inserts=1))
+
+# Warn if a latency over 1 second is seen
+max_latency=1000
+sample_interval=5
+sample_rate=1

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -42,6 +42,14 @@ __wt_conn_dhandle_alloc(
 	WT_DECL_RET;
 	uint64_t bucket;
 
+	/*
+	 * Ensure no one beat us to creating the handle now that we hold the
+	 * write lock.
+	 */
+	if ((ret =
+	     __wt_conn_dhandle_find(session, uri, checkpoint)) != WT_NOTFOUND)
+		return (ret);
+
 	WT_RET(__wt_calloc_one(session, &dhandle));
 
 	__wt_rwlock_init(session, &dhandle->rwlock);


### PR DESCRIPTION
Recheck for existence after acquiring write lock when creating a new dhandle.