### PR TITLE
WT-3224 LSM assertion failure pindex->entries == 1

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -590,8 +590,9 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			 */
 			if (LF_ISSET(WT_READ_NO_EVICT) ||
 			    F_ISSET(session, WT_SESSION_NO_EVICTION) ||
+			    btree->lsm_primary ||
 			    (btree->evict_disabled > 0 &&
-			     !F_ISSET(btree, WT_BTREE_NO_RECONCILE)))
+			    !F_ISSET(btree, WT_BTREE_ALLOW_SPLITS)))
 				goto skip_evict;
 
 			/*

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -186,9 +186,9 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		 * to grow significantly larger than the configured maximum
 		 * size.
 		 */
-		F_SET(btree, WT_BTREE_NO_RECONCILE);
+		F_SET(btree, WT_BTREE_ALLOW_SPLITS);
 		ret = __wt_evict_file_exclusive_on(session);
-		F_CLR(btree, WT_BTREE_NO_RECONCILE);
+		F_CLR(btree, WT_BTREE_ALLOW_SPLITS);
 		WT_ERR(ret);
 		__wt_evict_file_exclusive_off(session);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -480,8 +480,8 @@ __evict_review(
 		if (LF_ISSET(WT_EVICT_INMEM_SPLIT))
 			return (__wt_split_insert(session, ref));
 
-		/* We are done if reconciliation is disabled. */
-		if (F_ISSET(S2BT(session), WT_BTREE_NO_RECONCILE))
+		/* If splits are the only permitted operation, we're done. */
+		if (F_ISSET(S2BT(session), WT_BTREE_ALLOW_SPLITS))
 			return (EBUSY);
 	}
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -157,14 +157,14 @@ struct __wt_btree {
 	WT_SPINLOCK	flush_lock;	/* Lock to flush the tree's pages */
 
 	/* Flags values up to 0xff are reserved for WT_DHANDLE_* */
-#define	WT_BTREE_BULK		0x000100 /* Bulk-load handle */
-#define	WT_BTREE_CLOSED		0x000200 /* Handle closed */
-#define	WT_BTREE_IGNORE_CACHE	0x000400 /* Cache-resident object */
-#define	WT_BTREE_IN_MEMORY	0x000800 /* Cache-resident object */
-#define	WT_BTREE_LOOKASIDE	0x001000 /* Look-aside table */
+#define	WT_BTREE_ALLOW_SPLITS	0x000100 /* Allow splits, even with no evict */
+#define	WT_BTREE_BULK		0x000200 /* Bulk-load handle */
+#define	WT_BTREE_CLOSED		0x000400 /* Handle closed */
+#define	WT_BTREE_IGNORE_CACHE	0x000800 /* Cache-resident object */
+#define	WT_BTREE_IN_MEMORY	0x001000 /* Cache-resident object */
+#define	WT_BTREE_LOOKASIDE	0x002000 /* Look-aside table */
 #define	WT_BTREE_NO_CHECKPOINT	0x004000 /* Disable checkpoints */
 #define	WT_BTREE_NO_LOGGING	0x008000 /* Disable logging */
-#define	WT_BTREE_NO_RECONCILE	0x010000 /* Allow splits, even with no evict */
 #define	WT_BTREE_REBALANCE	0x020000 /* Handle is for rebalance */
 #define	WT_BTREE_SALVAGE	0x040000 /* Handle is for salvage */
 #define	WT_BTREE_SKIP_CKPT	0x080000 /* Handle skipped checkpoint */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1224,12 +1224,15 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (!__wt_page_is_modified(page))
 		return (false);
 
+	/* We don't split the LSM primary. */
+	if (btree->lsm_primary)
+		return (false);
+
 	/*
 	 * There is no point doing an in-memory split unless there is a lot of
 	 * data in the last skiplist on the page.  Split if there are enough
 	 * items and the skiplist does not fit within a single disk page.
 	 */
-
 	ins_head = page->type == WT_PAGE_ROW_LEAF ?
 	    (page->entries == 0 ?
 	    WT_ROW_INSERT_SMALLEST(page) :

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1224,10 +1224,6 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (!__wt_page_is_modified(page))
 		return (false);
 
-	/* We don't split the LSM primary. */
-	if (btree->lsm_primary)
-		return (false);
-
 	/*
 	 * There is no point doing an in-memory split unless there is a lot of
 	 * data in the last skiplist on the page.  Split if there are enough


### PR DESCRIPTION
Don't do in-memory splits on the LSM primary.