### PR TITLE
WT-98 Update the current cursor value without a search

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -718,7 +718,7 @@ skip_checkpoint:	/* Pick the next checkpoint operation. */
 			} else {
 				if (ret == WT_ROLLBACK && intxn)
 					goto deadlock;
-				testutil_assert(ret == 0);
+				testutil_assert(ret == 0 || ret == WT_ROLLBACK);
 			}
 			break;
 		case UPDATE:
@@ -745,7 +745,7 @@ update_instead_of_insert:
 				positioned = false;
 				if (ret == WT_ROLLBACK && intxn)
 					goto deadlock;
-				testutil_assert(ret == 0);
+				testutil_assert(ret == 0 || ret == WT_ROLLBACK);
 			}
 			break;
 		case READ:


### PR DESCRIPTION
The real change is 1cf0ba0, cf573d6 is just code shuffling.

The fix is in format, so I'm going to go ahead and merge this change once it passes testing.