### PR TITLE
WT-3136 bug fix: WiredTiger doesn't check sprintf calls for error return

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2608,8 +2608,8 @@ main(int argc, char *argv[])
 			append_comma = ",";
 		}
 		if (opts->in_memory) {
-			pos += (size_t)snprintf(
-			    cc_buf + pos, req_len - pos, "%s%s",
+			testutil_check(__wt_snprintf_len_incr(
+			    cc_buf + pos, req_len - pos, &pos, "%s%s",
 			    append_comma, "in_memory=true");
 			append_comma = ",";
 		}

--- a/dist/s_style
+++ b/dist/s_style
@@ -93,6 +93,14 @@ else
 		cat $t
 	fi
 
+	if ! expr "$f" : 'examples/c/*' > /dev/null &&
+	   ! expr "$f" : 'ext/*' > /dev/null &&
+	   ! expr "$f" : 'src/os_posix/os_snprintf.c' > /dev/null &&
+	    egrep '[^a-z_]snprintf\(|[^a-z_]vsnprintf\(' $f > $t; then
+		echo "$f: snprintf call, use WiredTiger library replacements"
+		cat $t
+	fi
+
 	# Alignment directive before "struct".
 	egrep 'WT_COMPILER_TYPE_ALIGN.*struct' $f > $t
 	test -s $t && {


### PR DESCRIPTION
Add a style check for local snprintf/vnsprintf calls, fix a wtperf snprintf call I missed.

This only changes test and style code, I'm going to merge as soon as it passes the tests.