### PR TITLE
WT-98 Update the current cursor value without a search

### DIFF
--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -844,8 +844,8 @@ __clsm_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
 		WT_ERR_MSG(session, EINVAL,
 		    "comparison method cursors must reference the same object");
 
-	WT_CURSOR_CHECKKEY(a);
-	WT_CURSOR_CHECKKEY(b);
+	WT_CURSOR_NEEDKEY(a);
+	WT_CURSOR_NEEDKEY(b);
 
 	WT_ERR(__wt_compare(
 	    session, alsm->lsm_tree->collator, &a->key, &b->key, cmpp));
@@ -1521,7 +1521,7 @@ __clsm_insert(WT_CURSOR *cursor)
 	clsm = (WT_CURSOR_LSM *)cursor;
 
 	CURSOR_UPDATE_API_CALL(cursor, session, insert, NULL);
-	WT_CURSOR_CHECKKEY(cursor);
+	WT_CURSOR_NEEDKEY(cursor);
 	WT_CURSOR_NEEDVALUE(cursor);
 	WT_ERR(__clsm_enter(clsm, false, true));
 
@@ -1565,7 +1565,7 @@ __clsm_update(WT_CURSOR *cursor)
 	clsm = (WT_CURSOR_LSM *)cursor;
 
 	CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
-	WT_CURSOR_CHECKKEY(cursor);
+	WT_CURSOR_NEEDKEY(cursor);
 	WT_CURSOR_NEEDVALUE(cursor);
 	WT_ERR(__clsm_enter(clsm, false, true));
 
@@ -1612,7 +1612,7 @@ __clsm_remove(WT_CURSOR *cursor)
 	positioned = F_ISSET(cursor, WT_CURSTD_KEY_INT);
 
 	CURSOR_REMOVE_API_CALL(cursor, session, NULL);
-	WT_CURSOR_CHECKKEY(cursor);
+	WT_CURSOR_NEEDKEY(cursor);
 	WT_CURSOR_NOVALUE(cursor);
 	WT_ERR(__clsm_enter(clsm, false, true));
 


### PR DESCRIPTION
This fixes an AddressSanitizer failure introduced by WT-98 -- by not saving the cursor key/value when entering LSM, we end up searching pages that have been evicted.
```
==16469==ERROR: AddressSanitizer: heap-use-after-free on address 0x62a0020f1d1f at pc 0xda5bd2 bp 0x7fe824451f30 sp 0x7fe824451f28
READ of size 16 at 0x62a0020f1d1f thread T13
    #0 0xda5bd1 in __wt_lex_compare /home/bostic/wiredtiger/./src/include/btree_cmp.i:65:9
    #1 0xd9bec4 in __wt_compare /home/bostic/wiredtiger/./src/include/btree_cmp.i:96:11
    #2 0xd922c3 in __wt_row_search /home/bostic/wiredtiger/src/btree/row_srch.c:318
    #3 0x10f9b1f in __cursor_row_search /home/bostic/wiredtiger/src/btree/bt_cursor.c:358
    #4 0x10fd220 in __wt_btcur_search_near /home/bostic/wiredtiger/src/btree/bt_cursor.c:557
    #5 0xe4988b in __curfile_search_near /home/bostic/wiredtiger/src/cursor/cur_file.c:216
    #6 0xf6395c in __clsm_next /home/bostic/wiredtiger/src/lsm/lsm_cursor.c:886
    #7 0x4afa35 in nextprev /home/bostic/wiredtiger/test/format/ops.c:1005
    #8 0x4a0b2c in ops /home/bostic/wiredtiger/test/format/ops.c:777
    #9 0x7fe832968dc4 in start_thread (/lib64/libpthread.so.0+0x7dc4)
    #10 0x7fe831b4f73c in __clone (/lib64/libc.so.6+0xf773c)

0x62a0020f1d1f is located 15135 bytes inside of 22920-byte region [0x62a0020ee200,0x62a0020f3b88)
freed by thread T14 here:
    #0 0x468159 in free (/home/bostic/wiredtiger/test/format/t+0x468159)
    #1 0x75b590 in __wt_free_int /home/bostic/wiredtiger/src/os_common/os_alloc.c:309
    #2 0xb3fe91 in __wt_page_out /home/bostic/wiredtiger/src/btree/bt_discard.c:145
    #3 0xb3e6a2 in __wt_ref_out /home/bostic/wiredtiger/src/btree/bt_discard.c:59
    #4 0x64e3f4 in __evict_page_clean_update /home/bostic/wiredtiger/src/evict/evict_page.c:255
    #5 0x64906f in __wt_evict /home/bostic/wiredtiger/src/evict/evict_page.c:164
    #6 0x6163d0 in __evict_page /home/bostic/wiredtiger/src/evict/evict_lru.c:2092
    #7 0x60a601 in __evict_lru_pages /home/bostic/wiredtiger/src/evict/evict_lru.c:1097
    #8 0x62cfac in __evict_pass /home/bostic/wiredtiger/src/evict/evict_lru.c:679
    #9 0x608824 in __evict_server /home/bostic/wiredtiger/src/evict/evict_lru.c:387
    #10 0x606c6b in __wt_evict_thread_run /home/bostic/wiredtiger/src/evict/evict_lru.c:308
    #11 0xa1b881 in __wt_thread_run /home/bostic/wiredtiger/src/support/thread_group.c:25
    #12 0x7fe832968dc4 in start_thread (/lib64/libpthread.so.0+0x7dc4)
```
Here's the CONFIG:
```
############################################
#  RUN PARAMETERS
############################################
abort=0
alter=0
auto_throttle=1
backups=0
bitcnt=4
bloom=1
bloom_bit_count=23
bloom_hash_count=26
bloom_oldest=0
cache=30
checkpoints=1
checksum=uncompressed
chunk_size=1
compaction=0
compression=zlib
data_extend=0
data_source=lsm
delete_pct=17
dictionary=0
direct_io=0
encryption=none
evict_max=3
file_type=row-store
firstfit=0
huffman_key=0
huffman_value=0
in_memory=0
insert_pct=2
internal_key_truncation=1
internal_page_max=11
isolation=random
key_gap=12
key_max=83
key_min=29
leaf_page_max=12
leak_memory=0
logging=0
logging_archive=0
logging_compression=none
logging_prealloc=1
long_running_txn=0
lsm_worker_threads=4
merge_max=17
mmap=1
ops=100000
prefix_compression=0
prefix_compression_min=5
quiet=1
read_pct=3
rebalance=1
repeat_data_pct=85
reverse=0
rows=100000
runs=10
salvage=1
split_pct=75
statistics=0
statistics_server=0
threads=7
timer=20
transaction-frequency=47
value_max=2728
value_min=13
verify=1
wiredtiger_config=
write_pct=78
############################################
```
This reverts commit af2c787.