### PR TITLE
WT-3245 Avoid hangs on shutdown when a utility thread encounters an error

### DIFF
--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -301,11 +301,10 @@ __wt_async_worker(void *arg)
 		WT_ERR(__async_op_dequeue(conn, session, &op));
 		if (op != NULL && op != &async->flush_op) {
 			/*
-			 * If an operation fails, we want the worker thread to
-			 * keep running, unless there is a panic.
+			 * Operation failure doesn't cause the worker thread to
+			 * exit.
 			 */
 			(void)__async_worker_op(session, op, &worker);
-			WT_ERR(WT_SESSION_CHECK_PANIC(session));
 		} else if (async->flush_state == WT_ASYNC_FLUSHING) {
 			/*
 			 * Worker flushing going on.  Last worker to the party

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -522,7 +522,7 @@ __log_file_server(void *arg)
 	}
 
 	if (0) {
-err:		__wt_err(session, ret, "log close server error");
+err:		WT_PANIC_MSG(session, ret, "log close server error");
 	}
 	if (locked)
 		__wt_spin_unlock(session, &log->log_sync_lock);
@@ -740,7 +740,8 @@ __log_wrlsn_server(void *arg)
 	WT_ERR(__wt_log_force_write(session, 1, NULL));
 	__wt_log_wrlsn(session, NULL);
 	if (0) {
-err:		__wt_err(session, ret, "log wrlsn server error");
+err:		WT_PANIC_MSG(session, ret, "log wrlsn server error");
+
 	}
 	return (WT_THREAD_RET_VALUE);
 }
@@ -844,7 +845,7 @@ __log_server(void *arg)
 	}
 
 	if (0) {
-err:		__wt_err(session, ret, "log server error");
+err:		WT_PANIC_MSG(session, ret, "log server error");
 	}
 	return (WT_THREAD_RET_VALUE);
 }


### PR DESCRIPTION
@sueloverso, the log threads didn't panic on unexpected exit, the async worker threads checked for panic (unlike the other server threads).

Can you please review?