### PR TITLE
WT-3250 Fix spinlock statistics tracking on Windows.

### DIFF
--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -32,7 +32,9 @@ __wt_spin_init(WT_SESSION_IMPL *session, WT_SPINLOCK *t, const char *name)
 	WT_UNUSED(name);
 
 	t->lock = 0;
+	t->name = name;
 	t->stat_count_off = t->stat_app_usecs_off = t->stat_int_usecs_off = -1;
+	t->initialized = 1;
 	return (0);
 }
 
@@ -196,6 +198,7 @@ __wt_spin_init(WT_SESSION_IMPL *session, WT_SPINLOCK *t, const char *name)
 	}
 
 	t->name = name;
+	t->stat_count_off = t->stat_app_usecs_off = t->stat_int_usecs_off = -1;
 	t->initialized = 1;
 	return (0);
 }


### PR DESCRIPTION
A MongoDB user on Windows noticed the "LSM: application work units currently queued" statistic was changing in a configuration that involved no LSM code. This was caused by a bug in code that tracks time spent in spinlocks incrementing the wrong statistic.

In particular, spinlocks contain fields describing which statistics should be used to track time spent in that spinlock.  A value of -1 indicates that the spinlock should not be tracked, but a value of zero is the first statistic in the array for a connection, which happens to be the "LSM: application work units currently queued" statistic.  The Windows implementation of spinlocks was not setting these fields to -1, leading to the bug.

This bug was introduced by WT-2955 and also meant that every WiredTiger spinlock on Windows was being timed, which may have negatively impacted Windows performance.