### PR TITLE
WT-3249 Look at slot_state during force while holding lock.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -404,7 +404,7 @@ extern int __wt_logop_row_truncate_unpack( WT_SESSION_IMPL *session, const uint8
 extern int __wt_logop_row_truncate_print(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_txn_op_printlog(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
-extern int __wt_log_slot_switch( WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool retry, bool forced) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
+extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool retry, bool forced, bool *did_work) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_log_slot_init(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_log_slot_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));
 extern int __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT_MYSLOT *myslot) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("hidden")));

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1919,7 +1919,6 @@ __wt_log_force_write(WT_SESSION_IMPL *session, bool retry, bool *did_work)
 {
 	WT_LOG *log;
 	WT_MYSLOT myslot;
-	uint32_t joined;
 
 	log = S2C(session)->log;
 	memset(&myslot, 0, sizeof(myslot));
@@ -1927,14 +1926,7 @@ __wt_log_force_write(WT_SESSION_IMPL *session, bool retry, bool *did_work)
 	if (did_work != NULL)
 		*did_work = true;
 	myslot.slot = log->active_slot;
-	joined = WT_LOG_SLOT_JOINED(log->active_slot->slot_state);
-	if (joined == 0) {
-		WT_STAT_CONN_INCR(session, log_force_write_skip);
-		if (did_work != NULL)
-			*did_work = false;
-		return (0);
-	}
-	return (__wt_log_slot_switch(session, &myslot, retry, true));
+	return (__wt_log_slot_switch(session, &myslot, retry, true, did_work));
 }
 
 /*
@@ -2146,7 +2138,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	ret = 0;
 	if (myslot.end_offset >= WT_LOG_SLOT_BUF_MAX ||
 	    F_ISSET(&myslot, WT_MYSLOT_UNBUFFERED) || force)
-		ret = __wt_log_slot_switch(session, &myslot, true, false);
+		ret = __wt_log_slot_switch(session, &myslot, true, false, NULL);
 	if (ret == 0)
 		ret = __log_fill(session, &myslot, false, record, &lsn);
 	release_size = __wt_log_slot_release(

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -307,12 +307,13 @@ __log_slot_switch_internal(
 	if (slot != log->active_slot)
 		return (0);
 	/*
-	 * If the current active slot is unused, we're done.
+	 * If the current active slot is unused and this is a forced switch,
+	 * we're done.  If this is a non-forced switch we always switch
+	 * because the slot could be part of an unbuffered operation.
 	 */
 	joined = WT_LOG_SLOT_JOINED(slot->slot_state);
-	if (joined == 0) {
-		if (forced)
-			WT_STAT_CONN_INCR(session, log_force_write_skip);
+	if (joined == 0 && forced) {
+		WT_STAT_CONN_INCR(session, log_force_write_skip);
 		if (did_work != NULL)
 			*did_work = false;
 		return (0);

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -286,12 +286,13 @@ __log_slot_new(WT_SESSION_IMPL *session)
  */
 static int
 __log_slot_switch_internal(
-    WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool forced)
+    WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool forced, bool *did_work)
 {
 	WT_DECL_RET;
 	WT_LOG *log;
 	WT_LOGSLOT *slot;
 	bool free_slot, release;
+	uint32_t joined;
 
 	log = S2C(session)->log;
 	release = false;
@@ -305,6 +306,17 @@ __log_slot_switch_internal(
 	 */
 	if (slot != log->active_slot)
 		return (0);
+	/*
+	 * If the current active slot is unused, we're done.
+	 */
+	joined = WT_LOG_SLOT_JOINED(slot->slot_state);
+	if (joined == 0) {
+		if (forced)
+			WT_STAT_CONN_INCR(session, log_force_write_skip);
+		if (did_work != NULL)
+			*did_work = false;
+		return (0);
+	}
 	WT_RET(WT_SESSION_CHECK_PANIC(session));
 
 	/*
@@ -352,8 +364,8 @@ __log_slot_switch_internal(
  *	Switch out the current slot and set up a new one.
  */
 int
-__wt_log_slot_switch(
-    WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool retry, bool forced)
+__wt_log_slot_switch(WT_SESSION_IMPL *session,
+    WT_MYSLOT *myslot, bool retry, bool forced, bool *did_work)
 {
 	WT_DECL_RET;
 	WT_LOG *log;
@@ -373,7 +385,8 @@ __wt_log_slot_switch(
 	 */
 	do {
 		WT_WITH_SLOT_LOCK(session, log,
-		    ret = __log_slot_switch_internal(session, myslot, forced));
+		    ret = __log_slot_switch_internal(
+		    session, myslot, forced, did_work));
 		if (ret == EBUSY) {
 			WT_STAT_CONN_INCR(session, log_slot_switch_busy);
 			__wt_yield();


### PR DESCRIPTION
We could race an in-progress switch that set a new, empty active slot
but has not yet released the previously active slot and get an
incorrect LSN.