### PR TITLE
WT-3253 Update Python transaction tests to have correct flush configuration

### DIFF
--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -137,7 +137,10 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         self.check(self.session2, "isolation=read-uncommitted", current)
 
         # Opening a clone of the database home directory should run
-        # recovery and see the committed results.
+        # recovery and see the committed results.  Flush the log because
+        # the backup may not get all the log records if we are running
+        # without a sync option.  Use sync=off to force a write to the OS.
+        self.session.log_flush('sync=off')
         self.backup(self.backup_dir)
         backup_conn_params = 'log=(enabled,file_max=%s)' % self.logmax
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -101,7 +101,10 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         self.check(self.session2, "isolation=read-uncommitted", current)
 
         # Opening a clone of the database home directory should run
-        # recovery and see the committed results.
+        # recovery and see the committed results.  Flush the log because
+        # the backup may not get all the log records if we are running
+        # without a sync option.  Use sync=off to force a write to the OS.
+        self.session.log_flush('sync=off')
         self.backup(self.backup_dir)
         backup_conn_params = 'log=(enabled,file_max=%s)' % self.logmax
         backup_conn = self.wiredtiger_open(self.backup_dir, backup_conn_params)

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -112,7 +112,10 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         self.check(self.session2, "isolation=read-uncommitted", current)
 
         # Opening a clone of the database home directory should run
-        # recovery and see the committed results.
+        # recovery and see the committed results.  Flush the log because
+        # the backup may not get all the log records if we are running
+        # without a sync option.  Use sync=off to force a write to the OS.
+        self.session.log_flush('sync=off')
         self.backup(self.backup_dir)
         backup_conn_params = 'log=(enabled,file_max=%s,' % self.logmax + \
                 'compressor=%s)' % self.compress + \


### PR DESCRIPTION
@ddanderson Please review this changes to a few txn tests.  If we are only writing log records in memory we need to flush the log before making a backup to make sure all records are there before copying.  This bug has been in there a long time but recent changes widened a window.