### PR TITLE
WT-3265 Allow eviction of recently split pages when tree is locked.

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1354,8 +1354,13 @@ __wt_page_can_evict(
 	 * the original parent page's index, because evicting an internal page
 	 * discards its WT_REF array, and a thread traversing the original
 	 * parent page index might see a freed WT_REF.
+	 *
+	 * One special case where we know this is safe is if the handle is
+	 * locked exclusive (e.g., when the whole tree is being evicted).  In
+	 * that case, no readers can be looking at an old index.
 	 */
-	if (WT_PAGE_IS_INTERNAL(page) &&
+	if (!F_ISSET(session->dhandle, WT_DHANDLE_EXCLUSIVE) &&
+	    WT_PAGE_IS_INTERNAL(page) &&
 	    page->pg_intl_split_gen >= __wt_gen_oldest(session, WT_GEN_SPLIT))
 		return (false);
 


### PR DESCRIPTION
When pages split in WiredTiger, internal pages cannot be evicted
immediately because there is a chance that a reader is still looking at
an index pointing to the page.  We check for this when considering pages
for eviction, and assert that we never evict an internal page in an
active generation.

However, if a page splits and then we try to get exclusive access to
the tree (e.g., to verify it), we could fail to evict the tree from
cache even though we have guaranteed exclusive access to it.

Relax the check on internal pages to allow eviction from trees that are
locked exclusive.