### PR TITLE
WT-3197 aarch64 CRC32C support fails to compile on non-linux ARM platforms

### DIFF
--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -91,7 +91,7 @@ __wt_checksum_hw(const void *chunk, size_t len)
 void
 __wt_checksum_init(void)
 {
-#if defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_CRC32)

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -100,7 +100,7 @@ __wt_checksum_hw(const void *chunk, size_t len)
 void
 __wt_checksum_init(void)
 {
-#if defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_S390_VX)


### PR DESCRIPTION
getauxval is a Linux system call, don't attempt to call it unless we're running on a Linux system.