### PR TITLE
WT-3197 aarch64 CRC32C support fails to compile on non-linux ARM platforms

### DIFF
--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -28,7 +28,7 @@
 
 #include "wt_internal.h"
 
-#if defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
 
@@ -82,7 +82,7 @@ __wt_checksum_hw(const void *chunk, size_t len)
 
 	return (~crc);
 }
-#endif /* HAVE_CRC32_HARDWARE */
+#endif
 
 /*
  * __wt_checksum_init --
@@ -99,7 +99,7 @@ __wt_checksum_init(void)
 	else
 		__wt_process.checksum = __wt_checksum_sw;
 
-#else /* !HAVE_CRC32_HARDWARE */
+#else
 	__wt_process.checksum = __wt_checksum_sw;
-#endif /* HAVE_CRC32_HARDWARE */
+#endif
 }

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -11,8 +11,7 @@
 #include <sys/types.h>
 #include <endian.h>
 
-#if defined(HAVE_CRC32_HARDWARE)
-
+#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 #include <sys/auxv.h>
 
 /* RHEL 7 has kernel support, but does not define this constant in the lib c headers. */
@@ -108,7 +107,7 @@ __wt_checksum_init(void)
 	else
 		__wt_process.checksum = __wt_checksum_sw;
 
-#else /* !HAVE_CRC32_HARDWARE */
+#else
 	__wt_process.checksum = __wt_checksum_sw;
 #endif
 }


### PR DESCRIPTION
First change was insufficient, need to test __linux__ when including header files.