### PR TITLE
WT-3278 log the row-store cursor key instead of page key

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1023,33 +1023,6 @@ __wt_row_leaf_key(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_cursor_row_leaf_key --
- *	Set a buffer to reference a cursor-referenced row-store leaf page key.
- */
-static inline int
-__wt_cursor_row_leaf_key(WT_CURSOR_BTREE *cbt, WT_ITEM *key)
-{
-	WT_PAGE *page;
-	WT_ROW *rip;
-	WT_SESSION_IMPL *session;
-
-	/*
-	 * If the cursor references a WT_INSERT item, take the key from there,
-	 * else take the key from the original page.
-	 */
-	if (cbt->ins == NULL) {
-		session = (WT_SESSION_IMPL *)cbt->iface.session;
-		page = cbt->ref->page;
-		rip = &page->pg_row[cbt->slot];
-		WT_RET(__wt_row_leaf_key(session, page, rip, key, false));
-	} else {
-		key->data = WT_INSERT_KEY(cbt->ins);
-		key->size = WT_INSERT_KEY_SIZE(cbt->ins);
-	}
-	return (0);
-}
-
-/*
  * __wt_row_leaf_value_cell --
  *	Return a pointer to the value cell for a row-store leaf page key, or
  * NULL if there isn't one.

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -13,6 +13,51 @@ typedef struct {
 	uint32_t flags;
 } WT_TXN_PRINTLOG_ARGS;
 
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __txn_op_log_row_key_check --
+ *	Confirm the cursor references the correct key.
+ */
+static void
+__txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+{
+	WT_CURSOR *cursor;
+	WT_ITEM key;
+	WT_PAGE *page;
+	WT_ROW *rip;
+
+	cursor = (WT_CURSOR *)cbt;
+	WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_KEY_SET));
+
+	memset(&key, 0, sizeof(key));
+
+	/*
+	 * Before 04/2017, we took the key for row-store logging from the page
+	 * referenced by the cursor, when we switched to taking it from the
+	 * cursor itself. For a few months, assert they are the same.
+	 *
+	 * If the cursor references a WT_INSERT item, take the key from there,
+	 * else take the key from the original page.
+	 */
+	if (cbt->ins == NULL) {
+		session = (WT_SESSION_IMPL *)cbt->iface.session;
+		page = cbt->ref->page;
+		rip = &page->pg_row[cbt->slot];
+		WT_ASSERT(session,
+		    !__wt_row_leaf_key(session, page, rip, &key, false));
+	} else {
+		key.data = WT_INSERT_KEY(cbt->ins);
+		key.size = WT_INSERT_KEY_SIZE(cbt->ins);
+	}
+
+	WT_ASSERT(session,
+	    key.size == cursor->key.size &&
+	    memcmp(key.data, cursor->key.data, key.size) == 0);
+
+	__wt_buf_free(session, &key);
+}
+#endif
+
 /*
  * __txn_op_log --
  *	Log an operation for the current transaction.
@@ -21,46 +66,46 @@ static int
 __txn_op_log(WT_SESSION_IMPL *session,
     WT_ITEM *logrec, WT_TXN_OP *op, WT_CURSOR_BTREE *cbt)
 {
-	WT_DECL_RET;
-	WT_ITEM key, value;
+	WT_CURSOR *cursor;
+	WT_ITEM value;
 	WT_UPDATE *upd;
 	uint64_t recno;
 
-	WT_CLEAR(key);
+	cursor = (WT_CURSOR *)cbt;
+
 	upd = op->u.upd;
 	value.data = WT_UPDATE_DATA(upd);
 	value.size = upd->size;
 
-	/* We shouldn't be logging reserve operations. */
-	WT_ASSERT(session, !WT_UPDATE_RESERVED_ISSET(upd));
-
 	/*
 	 * Log the operation. It must be a row- or column-store insert, remove
-	 * or update, all of which require log records.
+	 * or update, all of which require log records. We shouldn't ever log
+	 * reserve operations.
 	 */
+	WT_ASSERT(session, !WT_UPDATE_RESERVED_ISSET(upd));
 	if (cbt->btree->type == BTREE_ROW) {
-		WT_ERR(__wt_cursor_row_leaf_key(cbt, &key));
-
+#ifdef HAVE_DIAGNOSTIC
+		__txn_op_log_row_key_check(session, cbt);
+#endif
 		if (WT_UPDATE_DELETED_ISSET(upd))
-			WT_ERR(__wt_logop_row_remove_pack(
-			    session, logrec, op->fileid, &key));
+			WT_RET(__wt_logop_row_remove_pack(
+			    session, logrec, op->fileid, &cursor->key));
 		else
-			WT_ERR(__wt_logop_row_put_pack(
-			    session, logrec, op->fileid, &key, &value));
+			WT_RET(__wt_logop_row_put_pack(
+			    session, logrec, op->fileid, &cursor->key, &value));
 	} else {
 		recno = WT_INSERT_RECNO(cbt->ins);
 		WT_ASSERT(session, recno != WT_RECNO_OOB);
 
 		if (WT_UPDATE_DELETED_ISSET(upd))
-			WT_ERR(__wt_logop_col_remove_pack(
+			WT_RET(__wt_logop_col_remove_pack(
 			    session, logrec, op->fileid, recno));
 		else
-			WT_ERR(__wt_logop_col_put_pack(
+			WT_RET(__wt_logop_col_put_pack(
 			    session, logrec, op->fileid, recno, &value));
 	}
 
-err:	__wt_buf_free(session, &key);
-	return (ret);
+	return (0);
 }
 
 /*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -26,15 +26,15 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	WT_PAGE *page;
 	WT_ROW *rip;
 
-	cursor = (WT_CURSOR *)cbt;
+	cursor = &cbt->iface;
 	WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_KEY_SET));
 
 	memset(&key, 0, sizeof(key));
 
 	/*
-	 * Before 04/2017, we took the key for row-store logging from the page
+	 * We used to take the key for row-store logging from the page
 	 * referenced by the cursor, when we switched to taking it from the
-	 * cursor itself. For a few months, assert they are the same.
+	 * cursor itself. Check that they are the same.
 	 *
 	 * If the cursor references a WT_INSERT item, take the key from there,
 	 * else take the key from the original page.
@@ -44,7 +44,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 		page = cbt->ref->page;
 		rip = &page->pg_row[cbt->slot];
 		WT_ASSERT(session,
-		    !__wt_row_leaf_key(session, page, rip, &key, false));
+		    __wt_row_leaf_key(session, page, rip, &key, false) == 0);
 	} else {
 		key.data = WT_INSERT_KEY(cbt->ins);
 		key.size = WT_INSERT_KEY_SIZE(cbt->ins);
@@ -71,7 +71,7 @@ __txn_op_log(WT_SESSION_IMPL *session,
 	WT_UPDATE *upd;
 	uint64_t recno;
 
-	cursor = (WT_CURSOR *)cbt;
+	cursor = &cbt->iface;
 
 	upd = op->u.upd;
 	value.data = WT_UPDATE_DATA(upd);


### PR DESCRIPTION
It's simpler/faster to take the row-store log key from the cursor instead of getting it from the page.