### PR TITLE
WT-3263 Allow recovery log file archiving on clean shutdown.

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -325,9 +325,10 @@ struct __wt_connection_impl {
 #define	WT_CONN_LOG_ARCHIVE		0x01	/* Archive is enabled */
 #define	WT_CONN_LOG_ENABLED		0x02	/* Logging is enabled */
 #define	WT_CONN_LOG_EXISTED		0x04	/* Log files found */
-#define	WT_CONN_LOG_RECOVER_DONE	0x08	/* Recovery completed */
-#define	WT_CONN_LOG_RECOVER_ERR		0x10	/* Error if recovery required */
-#define	WT_CONN_LOG_ZERO_FILL		0x20	/* Manually zero files */
+#define	WT_CONN_LOG_RECOVER_DIRTY	0x08	/* Recovering unclean */
+#define	WT_CONN_LOG_RECOVER_DONE	0x10	/* Recovery completed */
+#define	WT_CONN_LOG_RECOVER_ERR		0x20	/* Error if recovery required */
+#define	WT_CONN_LOG_ZERO_FILL		0x40	/* Manually zero files */
 	uint32_t	 log_flags;	/* Global logging configuration */
 	WT_CONDVAR	*log_cond;	/* Log server wait mutex */
 	WT_SESSION_IMPL *log_session;	/* Log server session */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -289,6 +289,7 @@ int
 __wt_txn_checkpoint_log(
     WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_LSN *lsnp)
 {
+	WT_CONNECTION_IMPL *conn;
 	WT_DECL_ITEM(logrec);
 	WT_DECL_RET;
 	WT_ITEM *ckpt_snapshot, empty;
@@ -299,6 +300,7 @@ __wt_txn_checkpoint_log(
 	uint32_t i, rectype = WT_LOGREC_CHECKPOINT;
 	const char *fmt = WT_UNCHECKED_STRING(IIIIu);
 
+	conn = S2C(session);
 	txn = &session->txn;
 	ckpt_lsn = &txn->ckpt_lsn;
 
@@ -363,20 +365,20 @@ __wt_txn_checkpoint_log(
 		    txn->ckpt_nsnapshot, ckpt_snapshot));
 		logrec->size += (uint32_t)recsize;
 		WT_ERR(__wt_log_write(session, logrec, lsnp,
-		    F_ISSET(S2C(session), WT_CONN_CKPT_SYNC) ?
+		    F_ISSET(conn, WT_CONN_CKPT_SYNC) ?
 		    WT_LOG_FSYNC : 0));
 
 		/*
 		 * If this full checkpoint completed successfully and there is
-		 * no hot backup in progress and this is not recovery, tell
-		 * the logging subsystem the checkpoint LSN so that it can
-		 * archive.  Do not update the logging checkpoint LSN if this
-		 * is during a clean connection close, only during a full
-		 * checkpoint.  A clean close may not update any metadata LSN
-		 * and we do not want to archive in that case.
+		 * no hot backup in progress and this is not an unclean
+		 * recovery, tell the logging subsystem the checkpoint LSN so
+		 * that it can archive.  Do not update the logging checkpoint
+		 * LSN if this is during a clean connection close, only during
+		 * a full checkpoint.  A clean close may not update any
+		 * metadata LSN and we do not want to archive in that case.
 		 */
-		if (!S2C(session)->hot_backup &&
-		    !F_ISSET(S2C(session), WT_CONN_RECOVERING) &&
+		if (!conn->hot_backup &&
+		    !FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) &&
 		    txn->full_ckpt)
 			__wt_log_ckpt(session, ckpt_lsn);
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -535,6 +535,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	 * this is not a read-only connection.
 	 * We can consider skipping it in the future.
 	 */
+	if (needs_rec)
+		FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY);
 	if (WT_IS_INIT_LSN(&r.ckpt_lsn))
 		WT_ERR(__wt_log_scan(session, NULL,
 		    WT_LOGSCAN_FIRST | WT_LOGSCAN_RECOVER,
@@ -556,7 +558,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	 */
 	WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
-done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
+done:	FLD_SET(conn->log_flags,
+	    WT_CONN_LOG_RECOVER_DIRTY | WT_CONN_LOG_RECOVER_DONE);
 err:	WT_TRET(__recovery_free(&r));
 	__wt_free(session, config);
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -561,6 +561,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 err:	WT_TRET(__recovery_free(&r));
 	__wt_free(session, config);
+	FLD_CLR(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY);
 
 	if (ret != 0)
 		__wt_err(session, ret, "Recovery failed");
@@ -574,7 +575,7 @@ err:	WT_TRET(__recovery_free(&r));
 		WT_TRET(__wt_evict_destroy(session));
 
 	WT_TRET(session->iface.close(&session->iface, NULL));
-	F_CLR(conn, WT_CONN_LOG_RECOVER_DIRTY | WT_CONN_RECOVERING);
+	F_CLR(conn, WT_CONN_RECOVERING);
 
 	return (ret);
 }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -558,8 +558,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	 */
 	WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
-done:	FLD_SET(conn->log_flags,
-	    WT_CONN_LOG_RECOVER_DIRTY | WT_CONN_LOG_RECOVER_DONE);
+done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 err:	WT_TRET(__recovery_free(&r));
 	__wt_free(session, config);
 
@@ -575,7 +574,7 @@ err:	WT_TRET(__recovery_free(&r));
 		WT_TRET(__wt_evict_destroy(session));
 
 	WT_TRET(session->iface.close(&session->iface, NULL));
-	F_CLR(conn, WT_CONN_RECOVERING);
+	F_CLR(conn, WT_CONN_LOG_RECOVER_DIRTY | WT_CONN_RECOVERING);
 
 	return (ret);
 }

--- a/test/recovery/random-abort.c
+++ b/test/recovery/random-abort.c
@@ -47,9 +47,9 @@ static bool inmem;
 #define	RECORDS_FILE	"records-%" PRIu32
 
 #define	ENV_CONFIG_DEF						\
-    "create,log=(file_max=10M,archive=false,enabled)"
+    "create,log=(file_max=10M,enabled)"
 #define	ENV_CONFIG_TXNSYNC					\
-    "create,log=(file_max=10M,archive=false,enabled),"		\
+    "create,log=(file_max=10M,enabled),"		\
     "transaction_sync=(enabled,method=none)"
 #define	ENV_CONFIG_REC "log=(recover=on)"
 #define	MAX_VAL	4096

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -172,7 +172,6 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             try:
                 session = backup_conn.open_session()
             finally:
-                session.checkpoint("force")
                 self.check(backup_conn.open_session(), None, committed)
                 # Sleep long enough so that the archive thread is guaranteed
                 # to run before we close the connection.

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -137,9 +137,6 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
                  session = backup_conn.open_session()
             finally:
                 self.check(session, None, committed)
-                # Force a checkpoint because we don't record the recovery
-                # checkpoint as available for archiving.
-                session.checkpoint("force")
                 # Sleep long enough so that the archive thread is guaranteed
                 # to run before we close the connection.
                 time.sleep(1.0)


### PR DESCRIPTION
Revert test changes that needed a checkpoint for archiving.

@agorrod This is ready for review.