### PR TITLE
WT-3288 fix error codes for event_handler to be consistent in file operations

### DIFF
--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -54,11 +54,12 @@ __win_fs_remove(WT_FILE_SYSTEM *file_system,
 	WT_RET(__wt_to_utf16_string(session, name, &name_wide));
 
 	if (DeleteFileW(name_wide->data) == FALSE) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
 		    "%s: file-remove: DeleteFileW: %s",
+		    windows_error,
 		    name, __wt_formatmessage(session, windows_error));
-		WT_ERR(__wt_map_windows_error(windows_error));
+		WT_ERR(windows_error);
 	}
 
 err:	__wt_scr_free(session, &name_wide);
@@ -92,19 +93,21 @@ __win_fs_rename(WT_FILE_SYSTEM *file_system,
 	 */
 	if (GetFileAttributesW(to_wide->data) != INVALID_FILE_ATTRIBUTES)
 		if (DeleteFileW(to_wide->data) == FALSE) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: file-rename: DeleteFileW: %s",
 			    to, __wt_formatmessage(session, windows_error));
-			WT_ERR(__wt_map_windows_error(windows_error));
+			WT_ERR(windows_error);
 		}
 
 	if (MoveFileW(from_wide->data, to_wide->data) == FALSE) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s to %s: file-rename: MoveFileW: %s",
 		    from, to, __wt_formatmessage(session, windows_error));
-		WT_ERR(__wt_map_windows_error(windows_error));
+		WT_ERR(windows_error);
 	}
 
 err:	__wt_scr_free(session, &from_wide);
@@ -133,11 +136,12 @@ __wt_win_fs_size(WT_FILE_SYSTEM *file_system,
 
 	if (GetFileAttributesExW(
 	    name_wide->data, GetFileExInfoStandard, &data) == 0) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s: file-size: GetFileAttributesEx: %s",
 		    name, __wt_formatmessage(session, windows_error));
-		WT_ERR(__wt_map_windows_error(windows_error));
+		WT_ERR(windows_error);
 	}
 
 	*sizep = ((int64_t)data.nFileSizeHigh << 32) | data.nFileSizeLow;
@@ -170,22 +174,24 @@ __win_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 	 */
 	if (win_fh->filehandle != INVALID_HANDLE_VALUE &&
 	    CloseHandle(win_fh->filehandle) == 0) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s: handle-close: CloseHandle: %s",
 		    file_handle->name,
 		    __wt_formatmessage(session, windows_error));
-		ret = __wt_map_windows_error(windows_error);
+		ret = windows_error;
 	}
 
 	if (win_fh->filehandle_secondary != INVALID_HANDLE_VALUE &&
 	    CloseHandle(win_fh->filehandle_secondary) == 0) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s: handle-close: secondary: CloseHandle: %s",
 		    file_handle->name,
 		    __wt_formatmessage(session, windows_error));
-		ret = __wt_map_windows_error(windows_error);
+		ret = windows_error;
 	}
 
 	__wt_free(session, file_handle->name);
@@ -220,21 +226,23 @@ __win_file_lock(
 	 */
 	if (lock) {
 		if (LockFile(win_fh->filehandle, 0, 0, 1, 0) == FALSE) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: handle-lock: LockFile: %s",
 			    file_handle->name,
 			    __wt_formatmessage(session, windows_error));
-			return (__wt_map_windows_error(windows_error));
+			return windows_error;
 		}
 	} else
 		if (UnlockFile(win_fh->filehandle, 0, 0, 1, 0) == FALSE) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: handle-lock: UnlockFile: %s",
 			    file_handle->name,
 			    __wt_formatmessage(session, windows_error));
-			return (__wt_map_windows_error(windows_error));
+			return windows_error;
 		}
 	return (0);
 }
@@ -275,13 +283,14 @@ __win_file_read(WT_FILE_HANDLE *file_handle,
 
 		if (!ReadFile(
 		    win_fh->filehandle, addr, chunk, &nr, &overlapped)) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: handle-read: ReadFile: failed to read %lu "
 			    "bytes at offset %" PRIuMAX ": %s",
 			    file_handle->name, chunk, (uintmax_t)offset,
 			    __wt_formatmessage(session, windows_error));
-			return (__wt_map_windows_error(windows_error));
+			return windows_error;
 		}
 	}
 	return (0);
@@ -308,11 +317,12 @@ __win_file_size(
 		return (0);
 	}
 
-	windows_error = __wt_getlasterror();
-	__wt_errx(session,
+	windows_error = __wt_map_windows_error(__wt_getlasterror());
+	__wt_err(session,
+	    windows_error,
 	    "%s: handle-size: GetFileSizeEx: %s",
 	    file_handle->name, __wt_formatmessage(session, windows_error));
-	return (__wt_map_windows_error(windows_error));
+	return windows_error;
 }
 
 /*
@@ -339,12 +349,13 @@ __win_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
 		return (0);
 
 	if (FlushFileBuffers(win_fh->filehandle) == FALSE) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s handle-sync: FlushFileBuffers: %s",
 		    file_handle->name,
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return windows_error;
 	}
 	return (0);
 }
@@ -374,23 +385,25 @@ __win_file_set_end(
 
 	if (SetFilePointerEx(win_fh->filehandle_secondary,
 	    largeint, NULL, FILE_BEGIN) == FALSE) {
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s: handle-set-end: SetFilePointerEx: %s",
 		    file_handle->name,
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return windows_error;
 	}
 
 	if (SetEndOfFile(win_fh->filehandle_secondary) == FALSE) {
 		if (GetLastError() == ERROR_USER_MAPPED_FILE)
 			return (EBUSY);
-		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		windows_error = __wt_map_windows_error(__wt_getlasterror());
+		__wt_err(session,
+		    windows_error,
 		    "%s: handle-set-end: SetEndOfFile: %s",
 		    file_handle->name,
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return windows_error;
 	}
 	return (0);
 }
@@ -431,13 +444,14 @@ __win_file_write(WT_FILE_HANDLE *file_handle,
 
 		if (!WriteFile(
 		    win_fh->filehandle, addr, chunk, &nw, &overlapped)) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: handle-write: WriteFile: failed to write %lu "
 			    "bytes at offset %" PRIuMAX ": %s",
 			    file_handle->name, chunk, (uintmax_t)offset,
 			    __wt_formatmessage(session, windows_error));
-			return (__wt_map_windows_error(windows_error));
+			return windows_error;
 		}
 	}
 	return (0);
@@ -540,15 +554,16 @@ __win_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 			    desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE,
 			    NULL, OPEN_EXISTING, f, NULL);
 		if (win_fh->filehandle == INVALID_HANDLE_VALUE) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    win_fh->direct_io ?
 			    "%s: handle-open: CreateFileW: failed with direct "
 			    "I/O configured, some filesystem types do not "
 			    "support direct I/O: %s" :
 			    "%s: handle-open: CreateFileW: %s",
 			    name, __wt_formatmessage(session, windows_error));
-			WT_ERR(__wt_map_windows_error(windows_error));
+			WT_ERR(windows_error);
 		}
 	}
 
@@ -562,11 +577,12 @@ __win_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session,
 		    desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE,
 		    NULL, OPEN_EXISTING, f, NULL);
 		if (win_fh->filehandle_secondary == INVALID_HANDLE_VALUE) {
-			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			windows_error = __wt_map_windows_error(__wt_getlasterror());
+			__wt_err(session,
+			    windows_error,
 			    "%s: handle-open: Creatively: secondary: %s",
 			    name, __wt_formatmessage(session, windows_error));
-			WT_ERR(__wt_map_windows_error(windows_error));
+			WT_ERR(windows_error);
 		}
 	}
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -143,6 +143,8 @@ __wt_event_handler_set(WT_SESSION_IMPL *session, WT_EVENT_HANDLER *handler)
 			handler->handle_message = __handle_message_default;
 		if (handler->handle_progress == NULL)
 			handler->handle_progress = __handle_progress_default;
+		if (handler->handle_close == NULL)
+			handler->handle_close = __handle_close_default;
 	}
 
 	session->event_handler = handler;


### PR DESCRIPTION
I used WiredTiger library as dependency.
I have updated wiredtiger v2.7.0 => v2.9.1 and found an issue when I call `__wt_open_session` with directory which doesn't exists: 

- `__wt_open_session` return code is correct = 2 (ENOENT)
- `event_handler` receive errorCode = 0, and `wiredtiger_strerror` return `Successful` string for this code

This PR is intended to return consistency to error codes, now `event_handler`'s error code and return code will be consistent for file operations.