### PR TITLE
WT-3282 Split cache flags and cache_pool flags.

### DIFF
--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -449,7 +449,8 @@ __cache_pool_balance(WT_SESSION_IMPL *session, bool forward)
 	for (i = 0;
 	    i < 2 * WT_CACHE_POOL_BUMP_THRESHOLD &&
 	    F_ISSET(cp, WT_CACHE_POOL_ACTIVE) &&
-	    FLD_ISSET(S2C(session)->cache->pool_flags, WT_CACHE_POOL_RUN); i++) {
+	    FLD_ISSET(S2C(session)->cache->pool_flags, WT_CACHE_POOL_RUN);
+	    i++) {
 		__cache_pool_adjust(
 		    session, highest, bump_threshold, forward, &adjusted);
 		/*

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -277,7 +277,7 @@ __wt_conn_cache_pool_open(WT_SESSION_IMPL *session)
 	 * the active connection shuts down.
 	 */
 	F_SET(cp, WT_CACHE_POOL_ACTIVE);
-	F_SET(cache, WT_CACHE_POOL_RUN);
+	FLD_SET(cache->pool_flags, WT_CACHE_POOL_RUN);
 	WT_RET(__wt_thread_create(session, &cache->cp_tid,
 	    __wt_cache_pool_server, cache->cp_session));
 
@@ -340,7 +340,7 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
 		__wt_spin_unlock(session, &cp->cache_pool_lock);
 		cp_locked = false;
 
-		F_CLR(cache, WT_CACHE_POOL_RUN);
+		FLD_CLR(cache->pool_flags, WT_CACHE_POOL_RUN);
 		__wt_cond_signal(session, cp->cache_pool_cond);
 		WT_TRET(__wt_thread_join(session, cache->cp_tid));
 
@@ -399,7 +399,7 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
 		__wt_spin_unlock(session, &cp->cache_pool_lock);
 
 		/* Notify other participants if we were managing */
-		if (F_ISSET(cache, WT_CACHE_POOL_MANAGER)) {
+		if (FLD_ISSET(cache->pool_flags, WT_CACHE_POOL_MANAGER)) {
 			cp->pool_managed = 0;
 			__wt_verbose(session, WT_VERB_SHARED_CACHE,
 			    "Shutting down shared cache manager connection");
@@ -449,7 +449,7 @@ __cache_pool_balance(WT_SESSION_IMPL *session, bool forward)
 	for (i = 0;
 	    i < 2 * WT_CACHE_POOL_BUMP_THRESHOLD &&
 	    F_ISSET(cp, WT_CACHE_POOL_ACTIVE) &&
-	    F_ISSET(S2C(session)->cache, WT_CACHE_POOL_RUN); i++) {
+	    FLD_ISSET(S2C(session)->cache->pool_flags, WT_CACHE_POOL_RUN); i++) {
 		__cache_pool_adjust(
 		    session, highest, bump_threshold, forward, &adjusted);
 		/*
@@ -760,7 +760,7 @@ __wt_cache_pool_server(void *arg)
 	forward = true;
 
 	while (F_ISSET(cp, WT_CACHE_POOL_ACTIVE) &&
-	    F_ISSET(cache, WT_CACHE_POOL_RUN)) {
+	    FLD_ISSET(cache->pool_flags, WT_CACHE_POOL_RUN)) {
 		if (cp->currently_used <= cp->size)
 			__wt_cond_wait(
 			    session, cp->cache_pool_cond, WT_MILLION, NULL);
@@ -770,12 +770,12 @@ __wt_cache_pool_server(void *arg)
 		 * lock on shutdown.
 		 */
 		if (!F_ISSET(cp, WT_CACHE_POOL_ACTIVE) &&
-		    F_ISSET(cache, WT_CACHE_POOL_RUN))
+		    FLD_ISSET(cache->pool_flags, WT_CACHE_POOL_RUN))
 			break;
 
 		/* Try to become the managing thread */
 		if (__wt_atomic_cas8(&cp->pool_managed, 0, 1)) {
-			F_SET(cache, WT_CACHE_POOL_MANAGER);
+			FLD_SET(cache->pool_flags, WT_CACHE_POOL_MANAGER);
 			__wt_verbose(session, WT_VERB_SHARED_CACHE,
 			    "Cache pool switched manager thread");
 		}
@@ -784,7 +784,7 @@ __wt_cache_pool_server(void *arg)
 		 * Continue even if there was an error. Details of errors are
 		 * reported in the balance function.
 		 */
-		if (F_ISSET(cache, WT_CACHE_POOL_MANAGER)) {
+		if (FLD_ISSET(cache->pool_flags, WT_CACHE_POOL_MANAGER)) {
 			__cache_pool_balance(session, forward);
 			forward = !forward;
 		}

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -562,7 +562,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
 	cache = conn->cache;
 
 	/* Clear previous state. */
-	F_CLR(cache, WT_CACHE_EVICT_MASK);
+	cache->flags = 0;
 
 	if (!F_ISSET(conn, WT_CONN_EVICTION_RUN))
 		return (false);
@@ -619,8 +619,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
 		F_CLR(cache, WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_CLEAN_HARD);
 	}
 
-	WT_STAT_CONN_SET(session, cache_eviction_state,
-	    F_MASK(cache, WT_CACHE_EVICT_MASK));
+	WT_STAT_CONN_SET(session, cache_eviction_state, cache->flags);
 
 	return (F_ISSET(cache, WT_CACHE_EVICT_ALL | WT_CACHE_EVICT_URGENT));
 }

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -179,6 +179,10 @@ struct __wt_cache {
 	/*
 	 * Flags.
 	 */
+#define	WT_CACHE_POOL_MANAGER	  0x001 /* The active cache pool manager */
+#define	WT_CACHE_POOL_RUN	  0x002 /* Cache pool thread running */
+	uint32_t pool_flags;		/* Cache pool flags */
+
 #define	WT_CACHE_EVICT_CLEAN	  0x001 /* Evict clean pages */
 #define	WT_CACHE_EVICT_CLEAN_HARD 0x002 /* Clean % blocking app threads */
 #define	WT_CACHE_EVICT_DIRTY	  0x004 /* Evict dirty pages */
@@ -186,9 +190,6 @@ struct __wt_cache {
 #define	WT_CACHE_EVICT_SCRUB	  0x010 /* Scrub dirty pages */
 #define	WT_CACHE_EVICT_URGENT	  0x020 /* Pages are in the urgent queue */
 #define	WT_CACHE_EVICT_ALL	(WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_DIRTY)
-#define	WT_CACHE_EVICT_MASK	  0x0FF
-#define	WT_CACHE_POOL_MANAGER	  0x100 /* The active cache pool manager */
-#define	WT_CACHE_POOL_RUN	  0x200 /* Cache pool thread running */
 	uint32_t flags;
 };
 


### PR DESCRIPTION
@agorrod Here's the branch for your review.  All the tests are still running.  This is ready to merge after they have run for another day or two.  But you can see the changes now.

I decided to split the flags into a separate field rather than use the {{flags_atomic}} macros for this fix.  The cache pool flags are rarely used/modified and I didn't want to impose atomic operations on every eviction use of the flags.