### PR TITLE
WT-3219 Make the clang-analyzer job fail when lint is introduced

### DIFF
--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -471,6 +471,8 @@ __wt_row_ikey_alloc(WT_SESSION_IMPL *session,
 {
 	WT_IKEY *ikey;
 
+	WT_ASSERT(session, key != NULL);	/* quiet clang scan-build */
+
 	/*
 	 * Allocate memory for the WT_IKEY structure and the key, then copy
 	 * the key into place.

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -266,6 +266,8 @@ __wt_strndup(WT_SESSION_IMPL *session, const void *str, size_t len, void *retp)
 
 	WT_RET(__wt_malloc(session, len + 1, &p));
 
+	WT_ASSERT(session, p != NULL);		/* quiet clang scan-build */
+
 	/*
 	 * Don't change this to strncpy, we rely on this function to duplicate
 	 * "strings" that contain nul bytes.

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -37,7 +37,13 @@ __wt_posix_directory_list(WT_FILE_SYSTEM *file_system,
 	dirallocsz = 0;
 	entries = NULL;
 
+	/*
+	 * If opendir fails, we should have a NULL pointer with an error value,
+	 * but various static analysis programs remain unconvinced, check both.
+	 */
 	WT_SYSCALL_RETRY(((dirp = opendir(directory)) == NULL ? -1 : 0), ret);
+	if (dirp == NULL && ret == 0)
+		ret = EINVAL;
 	if (ret != 0)
 		WT_RET_MSG(session, ret,
 		    "%s: directory-list: opendir", directory);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1102,7 +1102,6 @@ int
 __wt_session_range_truncate(WT_SESSION_IMPL *session,
     const char *uri, WT_CURSOR *start, WT_CURSOR *stop)
 {
-	WT_CURSOR *cursor;
 	WT_DECL_RET;
 	int cmp;
 	bool local_start;
@@ -1131,12 +1130,13 @@ __wt_session_range_truncate(WT_SESSION_IMPL *session,
 	}
 
 	/*
-	 * Cursor truncate is only supported for some objects, check for the
-	 * supporting methods we need, range_truncate and compare.
+	 * Cursor truncate is only supported for some objects, check for a
+	 * supporting compare method.
 	 */
-	cursor = start == NULL ? stop : start;
-	if (cursor->compare == NULL)
-		WT_ERR(__wt_bad_object_type(session, cursor->uri));
+	if (start != NULL && start->compare == NULL)
+		WT_ERR(__wt_bad_object_type(session, start->uri));
+	if (stop != NULL && stop->compare == NULL)
+		WT_ERR(__wt_bad_object_type(session, stop->uri));
 
 	/*
 	 * If both cursors set, check they're correctly ordered with respect to
@@ -1147,6 +1147,9 @@ __wt_session_range_truncate(WT_SESSION_IMPL *session,
 	 * reference the same object and the keys are set.
 	 */
 	if (start != NULL && stop != NULL) {
+						/* quiet clang scan-build */
+		WT_ASSERT(session, start->compare != NULL);
+
 		WT_ERR(start->compare(start, stop, &cmp));
 		if (cmp > 0)
 			WT_ERR_MSG(session, EINVAL,


### PR DESCRIPTION
Quiet the four remaining clang-analyzer complaints.