### PR TITLE
WT-3300 Coverity 1374542: Dereference after null check

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1185,8 +1185,11 @@ __wt_session_range_truncate(WT_SESSION_IMPL *session,
 	 * data structures can move through pages faster forward than backward.
 	 * If we don't have a start cursor, create one and position it at the
 	 * first record.
+	 *
+	 * If start is NULL, stop must not be NULL, but static analyzers have
+	 * a hard time with that, test explicitly.
 	 */
-	if (start == NULL) {
+	if (start == NULL && stop != NULL) {
 		WT_ERR(__session_open_cursor(
 		    (WT_SESSION *)session, stop->uri, NULL, NULL, &start));
 		local_start = true;


### PR DESCRIPTION
False positive, but explicitly checking the stop variable should make the complaint go away.