### PR TITLE
SERVER-28820 Add a few error path messages.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1627,8 +1627,8 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 			/* Offsets must be on allocation boundaries. */
 			if (lsnp->l.offset % allocsize != 0)
 				WT_RET_MSG(session, WT_NOTFOUND,
-				    "__wt_log_scan unaligned LSN %" PRIu32 "/%" PRIu32,
-				    lsnp->l.file, lsnp->l.offset);
+				    "__wt_log_scan unaligned LSN %" PRIu32
+				    "/%" PRIu32, lsnp->l.file, lsnp->l.offset);
 			if (lsnp->l.file > log->fileid)
 				WT_RET_MSG(session, WT_NOTFOUND,
 				    "__wt_log_scan LSN %" PRIu32 "/%" PRIu32

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1625,9 +1625,15 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 			    "choose either a start LSN or a start flag");
 
 			/* Offsets must be on allocation boundaries. */
-			if (lsnp->l.offset % allocsize != 0 ||
-			    lsnp->l.file > log->fileid)
-				return (WT_NOTFOUND);
+			if (lsnp->l.offset % allocsize != 0)
+				WT_RET_MSG(session, WT_NOTFOUND,
+				    "__wt_log_scan unaligned LSN %" PRIu32 "/%" PRIu32,
+				    lsnp->l.file, lsnp->l.offset);
+			if (lsnp->l.file > log->fileid)
+				WT_RET_MSG(session, WT_NOTFOUND,
+				    "__wt_log_scan LSN %" PRIu32 "/%" PRIu32
+				    " larger than biggest log file %" PRIu32,
+				    lsnp->l.file, lsnp->l.offset, log->fileid);
 
 			/*
 			 * Log cursors may not know the starting LSN.  If an

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1624,16 +1624,40 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 				WT_RET_MSG(session, WT_ERROR,
 			    "choose either a start LSN or a start flag");
 
-			/* Offsets must be on allocation boundaries. */
-			if (lsnp->l.offset % allocsize != 0)
-				WT_RET_MSG(session, WT_NOTFOUND,
-				    "__wt_log_scan unaligned LSN %" PRIu32
-				    "/%" PRIu32, lsnp->l.file, lsnp->l.offset);
-			if (lsnp->l.file > log->fileid)
-				WT_RET_MSG(session, WT_NOTFOUND,
-				    "__wt_log_scan LSN %" PRIu32 "/%" PRIu32
-				    " larger than biggest log file %" PRIu32,
-				    lsnp->l.file, lsnp->l.offset, log->fileid);
+			/*
+			 * Offsets must be on allocation boundaries.
+			 * An invalid LSN from a user should just return
+			 * WT_NOTFOUND.  It is not an error.  But if it is
+			 * from recovery, we expect valid LSNs so give more
+			 * information about that.
+			 */
+			if (lsnp->l.offset % allocsize != 0) {
+				if (LF_ISSET(WT_LOGSCAN_RECOVER))
+					WT_RET_MSG(session, WT_NOTFOUND,
+					    "__wt_log_scan unaligned LSN %"
+					    PRIu32 "/%" PRIu32,
+					    lsnp->l.file, lsnp->l.offset);
+				else
+					return (WT_NOTFOUND);
+			}
+			/*
+			 * If the file is in the future it doesn't exist.
+			 * An invalid LSN from a user should just return
+			 * WT_NOTFOUND.  It is not an error.  But if it is
+			 * from recovery, we expect valid LSNs so give more
+			 * information about that.
+			 */
+			if (lsnp->l.file > log->fileid) {
+				if (LF_ISSET(WT_LOGSCAN_RECOVER))
+					WT_RET_MSG(session, WT_NOTFOUND,
+					    "__wt_log_scan LSN %" PRIu32 "/%"
+					    PRIu32
+					    " larger than biggest log file %"
+					    PRIu32, lsnp->l.file,
+					    lsnp->l.offset, log->fileid);
+				else
+					return (WT_NOTFOUND);
+			}
 
 			/*
 			 * Log cursors may not know the starting LSN.  If an


### PR DESCRIPTION
@agorrod Please review this change.  It adds a few error messages for some paths in `log_scan` to know why we got `WT_NOTFOUND` including the path in the ticket.