### PR TITLE
WT-2972 Make partial updates more efficient - Python support

### DIFF
--- a/lang/java/wiredtiger.i
+++ b/lang/java/wiredtiger.i
@@ -47,6 +47,7 @@
 %}
 
 %{
+#include "wiredtiger.h"
 #include "src/include/wt_internal.h"
 
 /*
@@ -318,6 +319,10 @@ WT_CLASS(struct __wt_async_op, WT_ASYNC_OP, op)
 %rename (getKeyFormat) __wt_async_op::getKey_format;
 %rename (getValueFormat) __wt_async_op::getValue_format;
 %rename (getType) __wt_async_op::get_type;
+
+/* XXX WT_MODIFY support not yet implemented for Java. */
+%ignore __wt_modify;
+%ignore __wt_cursor::modify;
 
 /*
  * Special cases: override the out typemap, return checking is done in the

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -373,8 +373,8 @@ retry:
 }
 %enddef
 
-/* Any API that returns an enum type uses this. */
-%define ENUM_OK(m)
+/* An API that returns a value that shouldn't be checked uses this. */
+%define ANY_OK(m)
 %exception m {
 	$action
 }
@@ -408,12 +408,16 @@ retry:
 %enddef
 
 EBUSY_OK(__wt_connection::async_new_op)
-ENUM_OK(__wt_async_op::get_type)
+ANY_OK(__wt_async_op::get_type)
 NOTFOUND_OK(__wt_cursor::next)
 NOTFOUND_OK(__wt_cursor::prev)
 NOTFOUND_OK(__wt_cursor::remove)
 NOTFOUND_OK(__wt_cursor::search)
 NOTFOUND_OK(__wt_cursor::update)
+ANY_OK(__wt_modify::__wt_modify)
+ANY_OK(__wt_modify::~__wt_modify)
+ANY_OK(__wt_modify_list::__wt_modify_list)
+ANY_OK(__wt_modify_list::~__wt_modify_list)
 
 COMPARE_OK(__wt_cursor::_compare)
 COMPARE_OK(__wt_cursor::_equals)
@@ -448,6 +452,11 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_cursor::get_value;
 %ignore __wt_cursor::set_key;
 %ignore __wt_cursor::set_value;
+%ignore __wt_modify::data;
+%ignore __wt_modify::position;
+%ignore __wt_modify::size;
+%ignore __wt_cursor::modify;
+%rename (modify_wrap) __wt_cursor::modify;
 
 /* Next, override methods that return integers via arguments. */
 %ignore __wt_cursor::compare(WT_CURSOR *, WT_CURSOR *, int *);
@@ -772,6 +781,10 @@ typedef int int_void;
 		return (cursorFreeHandler($self));
 	}
 
+	int _modify(WT_MODIFY_LIST *list) {
+		return (self->modify(self, list->mod_array, list->count));
+	}
+
 %pythoncode %{
 	def get_key(self):
 		'''get_key(self) -> object
@@ -867,7 +880,65 @@ typedef int int_void;
 		self.set_value(value)
 		if self.insert() != 0:
 			raise KeyError
+
+	def modify(self, modifies):
+		l = WT_MODIFY_LIST(len(modifies))
+		pos = 0
+		for m in modifies:
+			l.set(pos, m)
+			pos += 1
+		self._modify(l)
 %}
+};
+
+/*
+ * Support for WT_CURSOR.modify.  An internal Python class encapsulates
+ * a list of Modify objects (stored as a WT_MODIFY array in C).
+ */
+%inline %{
+typedef struct __wt_modify_list {
+	WT_MODIFY *mod_array;
+	int count;
+} WT_MODIFY_LIST;
+%}
+%extend __wt_modify_list {
+	__wt_modify_list(int count) {
+		WT_MODIFY_LIST *self =
+		    (WT_MODIFY_LIST *)calloc(1, sizeof(WT_MODIFY_LIST));
+		self->mod_array = (WT_MODIFY *)calloc(count, sizeof(WT_MODIFY));
+		self->count = count;
+		return (self);
+	}
+	~__wt_modify_list() {
+		free(self->mod_array);
+		free(self);
+	}
+	int set(int i, WT_MODIFY *m) {
+		self->mod_array[i] = *m;
+	}
+};
+
+%extend __wt_modify {
+	__wt_modify() {
+		WT_MODIFY *self = (WT_MODIFY *)calloc(1, sizeof(WT_MODIFY));
+		self->data.data = NULL;
+		self->data.size = 0;
+		self->offset = 0;
+		self->size = 0;
+		return (self);
+	}
+	__wt_modify(char *itemdata,
+	    size_t offset, size_t size) {
+		WT_MODIFY *self = (WT_MODIFY *)calloc(1, sizeof(WT_MODIFY));
+		self->data.data = itemdata;
+		self->data.size = strlen(itemdata);
+		self->offset = offset;
+		self->size = size;
+		return (self);
+	}
+	~__wt_modify() {
+		free(self);
+	}
 };
 
 %extend __wt_session {
@@ -951,6 +1022,7 @@ OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))
 
 %rename(AsyncOp) __wt_async_op;
 %rename(Cursor) __wt_cursor;
+%rename(Modify) __wt_modify;
 %rename(Session) __wt_session;
 %rename(Connection) __wt_connection;
 
@@ -1232,4 +1304,3 @@ _rename_with_prefix('WT_STAT_CONN_', stat.conn)
 _rename_with_prefix('WT_STAT_DSRC_', stat.dsrc)
 del _rename_with_prefix
 %}
-

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -416,8 +416,8 @@ NOTFOUND_OK(__wt_cursor::search)
 NOTFOUND_OK(__wt_cursor::update)
 ANY_OK(__wt_modify::__wt_modify)
 ANY_OK(__wt_modify::~__wt_modify)
-ANY_OK(__wt_modify_list::__wt_modify_list)
-ANY_OK(__wt_modify_list::~__wt_modify_list)
+ANY_OK(__wt_python_modify_list::__wt_python_modify_list)
+ANY_OK(__wt_python_modify_list::~__wt_python_modify_list)
 
 COMPARE_OK(__wt_cursor::_compare)
 COMPARE_OK(__wt_cursor::_equals)
@@ -896,20 +896,20 @@ typedef int int_void;
  * a list of Modify objects (stored as a WT_MODIFY array in C).
  */
 %inline %{
-typedef struct __wt_modify_list {
+typedef struct __wt_python_modify_list {
 	WT_MODIFY *mod_array;
 	int count;
 } WT_MODIFY_LIST;
 %}
-%extend __wt_modify_list {
-	__wt_modify_list(int count) {
+%extend __wt_python_modify_list {
+	__wt_python_modify_list(int count) {
 		WT_MODIFY_LIST *self =
 		    (WT_MODIFY_LIST *)calloc(1, sizeof(WT_MODIFY_LIST));
 		self->mod_array = (WT_MODIFY *)calloc(count, sizeof(WT_MODIFY));
 		self->count = count;
 		return (self);
 	}
-	~__wt_modify_list() {
+	~__wt_python_modify_list() {
 		free(self->mod_array);
 		free(self);
 	}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -49,12 +49,6 @@ extern "C" {
 #define	WT_ATTRIBUTE_LIBRARY_VISIBLE	__attribute__((visibility("default")))
 #endif
 
-#ifdef SWIG
-%{
-#include <wiredtiger.h>
-%}
-#endif
-
 /*!
  * @defgroup wt WiredTiger API
  * The functions, handles and methods applications use to access and manage

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2017 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet, ComplexDataSet, ComplexLSMDataSet
+from wtscenario import make_scenarios
+
+# test_cursor12.py
+#    Test cursor modify call
+class test_cursor12(wttest.WiredTigerTestCase):
+    uri = 'table:cursor12'
+
+    def test_modify(self):
+        """
+        Create entries, and modify a portion of each
+        """
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor['ABC'] = '\x01\x02\x03\x04'
+        cursor['DEF'] = '\x11\x12\x13\x14'
+        mods = []
+        mod = wiredtiger.Modify('\xA1\xA2\xA3\xA4', 1, 1)
+        mods.append(mod)
+        mod = wiredtiger.Modify('\xB1\xB2\xB3\xB4', 1, 1)
+        mods.append(mod)
+        cursor.set_key('ABC')
+        self.KNOWN_FAILURE('WT_CURSOR.modify() is not yet implemented')
+        cursor.modify(mods)
+        print str(cursor['ABC'])
+        cursor.set_key('DEF')
+        cursor.modify(mods)
+        print str(cursor['DEF'])
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
@keithbostic, this should support Python (there's a little bit more I might do there), and I ignored the new interfaces in Java in this commit.  Will work on Java next.