### PR TITLE
WT-3158 Fix structure layout on Windows.

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -103,8 +103,8 @@ else
 
 	# If we don't have matching pack-begin and pack-end calls, we don't get
 	# an error, we just get a Windows performance regression.
-	egrep WT_PACKED_STRUCT "$f" > $t
-	cnt=`awk 'BEGIN { line=0 } { ++line } END { print line }' $t`
+	egrep WT_PACKED_STRUCT $f > $t
+	cnt=`wc -l < $t`
 	test `expr "$cnt" % 2` -ne 0 && {
 		echo "$f: mismatched WT_PACKED_STRUCT_BEGIN/END lines"
 		cat $t

--- a/dist/s_style
+++ b/dist/s_style
@@ -101,10 +101,12 @@ else
 		cat $t
 	fi
 
-	# Alignment directive before "struct".
-	egrep 'WT_COMPILER_TYPE_ALIGN.*struct' $f > $t
-	test -s $t && {
-		echo "$f: compiler alignment direction must precede \"struct\""
+	# If we don't have matching pack-begin and pack-end calls, we don't get
+	# an error, we just get a Windows performance regression.
+	egrep WT_PACKED_STRUCT "$f" > $t
+	cnt=`awk 'BEGIN { line=0 } { ++line } END { print line }' $t`
+	test `expr "$cnt" % 2` -ne 0 && {
+		echo "$f: mismatched WT_PACKED_STRUCT_BEGIN/END lines"
 		cat $t
 	}
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -938,7 +938,7 @@ WT_PACKED_STRUCT_BEGIN(__wt_update)
 #define	WT_UPDATE_MEMSIZE(upd)						\
 	WT_ALIGN(sizeof(WT_UPDATE) + (WT_UPDATE_DELETED_ISSET(upd) ||	\
 	    WT_UPDATE_RESERVED_ISSET(upd) ? 0 : (upd)->size), 32)
-};
+WT_PACKED_STRUCT_END
 
 /*
  * WT_INSERT --


### PR DESCRIPTION
We use a pragma on Windows to force a struct to be packed, but were
missing the "end" pragma that restores normal layout.  The result was
that most structs were being packed, leading to poor performance for
workloads (particularly when accessing session structures).