### PR TITLE
WT-3327 If timediff detects backwards time, return 0.

### DIFF
--- a/src/include/os.h
+++ b/src/include/os.h
@@ -55,21 +55,22 @@
 	}								\
 } while (0)
 
+#define	WT_TIMECMP(t1, t2)						\
+	((t1).tv_sec < (t2).tv_sec ? -1 :				\
+	     (t1).tv_sec == (t2).tv_sec ?				\
+	     (t1).tv_nsec < (t2).tv_nsec ? -1 :				\
+	     (t1).tv_nsec == (t2).tv_nsec ? 0 : 1 : 1)
+
 #define	WT_TIMEDIFF_NS(end, begin)					\
-	(WT_BILLION * (uint64_t)((end).tv_sec - (begin).tv_sec) +	\
-	    (uint64_t)(end).tv_nsec - (uint64_t)(begin).tv_nsec)
+	(WT_TIMECMP(end, begin) == -1 ? 0 :				\
+	    (WT_BILLION * (uint64_t)((end).tv_sec - (begin).tv_sec) +	\
+	    (uint64_t)(end).tv_nsec - (uint64_t)(begin).tv_nsec))
 #define	WT_TIMEDIFF_US(end, begin)					\
 	(WT_TIMEDIFF_NS((end), (begin)) / WT_THOUSAND)
 #define	WT_TIMEDIFF_MS(end, begin)					\
 	(WT_TIMEDIFF_NS((end), (begin)) / WT_MILLION)
 #define	WT_TIMEDIFF_SEC(end, begin)					\
 	(WT_TIMEDIFF_NS((end), (begin)) / WT_BILLION)
-
-#define	WT_TIMECMP(t1, t2)						\
-	((t1).tv_sec < (t2).tv_sec ? -1 :				\
-	     (t1).tv_sec == (t2).tv_sec ?				\
-	     (t1).tv_nsec < (t2).tv_nsec ? -1 :				\
-	     (t1).tv_nsec == (t2).tv_nsec ? 0 : 1 : 1)
 
 /*
  * Macros to ensure a file handle is inserted or removed from both the main and


### PR DESCRIPTION
@agorrod and @michaelcahill please review this change.  It is a small change that if timediff sees backward time, it returns 0.  I considered adding a statistic to note that but that got messy pretty quickly (because those macros do not have a session, and that added multiple statements to something used as an expression).  If you look at the ticket I could semi-reliably get checkpoint to hang, and with this fix, it never did (admittedly with a fairly small number of runs in both cases).

This can be merged except I have not do an in-depth code review for where we use timestamps in general.