### PR TITLE
WT-3303 Deadlock during first access to lookaside table

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -811,6 +811,7 @@ intl
 intnum
 intpack
 intptr
+intr
 intrin
 inuse
 io

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -150,7 +150,7 @@ struct __wt_btree {
 	u_int	    evict_walk_period;	/* Skip this many LRU walks */
 	u_int	    evict_walk_saved;	/* Saved walk skips for checkpoints */
 	u_int	    evict_walk_skips;	/* Number of walks skipped */
-	int	    evict_disabled;	/* Eviction disabled count */
+	int32_t	    evict_disabled;	/* Eviction disabled count */
 	volatile uint32_t evict_busy;	/* Count of threads in eviction */
 	int	    evict_start_type;	/* Start position for eviction walk
 					   (see WT_EVICT_WALK_START). */


### PR DESCRIPTION
Don't acquire the eviction walk-lock when releasing exclusive eviction access to a file, it can deadlock. Instead, atomically decrement the counter.