### PR TITLE
WT-3327 Check for backward time in wt_epoch

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -150,6 +150,7 @@ connection_stats = [
     ConnStat('read_io', 'total read I/Os'),
     ConnStat('rwlock_read', 'pthread mutex shared lock read-lock calls'),
     ConnStat('rwlock_write', 'pthread mutex shared lock write-lock calls'),
+    ConnStat('time_travel', 'detected system time went backwards'),
     ConnStat('write_io', 'total write I/Os'),
 
     ##########################################

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -54,6 +54,25 @@ __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
 	*timep = t.tv_sec;
 }
 
+static inline void
+__wt_time_backward(WT_SESSION_IMPL *session, struct timespec *tsp)
+{
+	/*
+	 * Detect time going backward.  If so, use the last
+	 * saved timestamp.
+	 */
+	if (session == NULL)
+		return;
+
+	if (tsp->tv_sec < session->last_epoch.tv_sec ||
+	     (tsp->tv_sec == session->last_epoch.tv_sec &&
+	     tsp->tv_nsec < session->last_epoch.tv_nsec)) {
+		WT_STAT_CONN_INCR(session, time_travel);
+		*tsp = session->last_epoch;
+	}
+	session->last_epoch = *tsp;
+}
+
 /*
  * __wt_verbose --
  * 	Verbose message.

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -55,13 +55,13 @@ __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
 }
 
 /*
- * __wt_time_backward --
- *	Check and prevent time running backward.  If we detect it
- *	we set the time structure to the previous values, making
- *	time stand still for this call.
+ * __wt_time_check_monotonic --
+ *	Check and prevent time running backward.  If we detect that it has, we
+ *	set the time structure to the previous values, making time stand still
+ *	until we see a time in the future of the highest value seen so far.
  */
 static inline void
-__wt_time_backward(WT_SESSION_IMPL *session, struct timespec *tsp)
+__wt_time_check_monotonic(WT_SESSION_IMPL *session, struct timespec *tsp)
 {
 	/*
 	 * Detect time going backward.  If so, use the last
@@ -75,8 +75,8 @@ __wt_time_backward(WT_SESSION_IMPL *session, struct timespec *tsp)
 	     tsp->tv_nsec < session->last_epoch.tv_nsec)) {
 		WT_STAT_CONN_INCR(session, time_travel);
 		*tsp = session->last_epoch;
-	}
-	session->last_epoch = *tsp;
+	} else
+		session->last_epoch = *tsp;
 }
 
 /*

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -54,6 +54,12 @@ __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
 	*timep = t.tv_sec;
 }
 
+/*
+ * __wt_time_backward --
+ *	Check and prevent time running backward.  If we detect it
+ *	we set the time structure to the previous values, making
+ *	time stand still for this call.
+ */
 static inline void
 __wt_time_backward(WT_SESSION_IMPL *session, struct timespec *tsp)
 {

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -66,6 +66,7 @@ struct __wt_session_impl {
 					/* Session handle reference list */
 	TAILQ_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
 	time_t last_sweep;		/* Last sweep for dead handles */
+	struct timespec last_epoch;	/* Last epoch time returned */
 
 					/* Cursors closed with the session */
 	TAILQ_HEAD(__cursors, __wt_cursor) cursors;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -361,6 +361,7 @@ struct __wt_connection_stats {
 	int64_t cache_eviction_clean;
 	int64_t cond_auto_wait_reset;
 	int64_t cond_auto_wait;
+	int64_t time_travel;
 	int64_t file_open;
 	int64_t memory_allocation;
 	int64_t memory_free;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4588,316 +4588,318 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1102
 /*! connection: auto adjusting condition wait calls */
 #define	WT_STAT_CONN_COND_AUTO_WAIT			1103
+/*! connection: detected system time went backwards */
+#define	WT_STAT_CONN_TIME_TRAVEL			1104
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1104
+#define	WT_STAT_CONN_FILE_OPEN				1105
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1105
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1106
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1106
+#define	WT_STAT_CONN_MEMORY_FREE			1107
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1107
+#define	WT_STAT_CONN_MEMORY_GROW			1108
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1108
+#define	WT_STAT_CONN_COND_WAIT				1109
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1109
+#define	WT_STAT_CONN_RWLOCK_READ			1110
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1110
+#define	WT_STAT_CONN_RWLOCK_WRITE			1111
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1111
+#define	WT_STAT_CONN_FSYNC_IO				1112
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1112
+#define	WT_STAT_CONN_READ_IO				1113
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1113
+#define	WT_STAT_CONN_WRITE_IO				1114
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1114
+#define	WT_STAT_CONN_CURSOR_CREATE			1115
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1115
+#define	WT_STAT_CONN_CURSOR_INSERT			1116
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1116
+#define	WT_STAT_CONN_CURSOR_NEXT			1117
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1117
+#define	WT_STAT_CONN_CURSOR_PREV			1118
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1118
+#define	WT_STAT_CONN_CURSOR_REMOVE			1119
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1119
+#define	WT_STAT_CONN_CURSOR_RESET			1120
 /*! cursor: cursor restarted searches */
-#define	WT_STAT_CONN_CURSOR_RESTART			1120
+#define	WT_STAT_CONN_CURSOR_RESTART			1121
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1121
+#define	WT_STAT_CONN_CURSOR_SEARCH			1122
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1122
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1123
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1123
+#define	WT_STAT_CONN_CURSOR_UPDATE			1124
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1124
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1125
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1125
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1126
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1126
+#define	WT_STAT_CONN_DH_SWEEP_REF			1127
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1127
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1128
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1128
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1129
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1129
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1130
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1130
+#define	WT_STAT_CONN_DH_SWEEPS				1131
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1131
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1132
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1132
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1133
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1133
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1134
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1134
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1135
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1135
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1136
 /*! lock: handle-list lock eviction thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_HANDLE_LIST_WAIT_EVICTION	1136
+#define	WT_STAT_CONN_LOCK_HANDLE_LIST_WAIT_EVICTION	1137
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1137
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1138
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1138
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1139
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1139
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1140
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1140
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1141
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1141
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1142
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1142
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1143
 /*! lock: table lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_COUNT			1143
+#define	WT_STAT_CONN_LOCK_TABLE_COUNT			1144
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1144
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1145
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1145
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1146
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1146
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1147
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1147
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1148
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1148
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1149
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1149
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1150
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1150
+#define	WT_STAT_CONN_LOG_FLUSH				1151
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1151
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1152
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1152
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1153
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1153
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1154
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1154
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1155
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1155
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1156
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1156
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1157
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1157
+#define	WT_STAT_CONN_LOG_SCANS				1158
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1158
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1159
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1159
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1160
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1160
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1161
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1161
+#define	WT_STAT_CONN_LOG_SYNC				1162
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1162
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1163
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1163
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1164
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1164
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1165
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1165
+#define	WT_STAT_CONN_LOG_WRITES				1166
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1166
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1167
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1167
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1168
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1168
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1169
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1169
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1170
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1170
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1171
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1171
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1172
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1172
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1173
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1173
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1174
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1174
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1175
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1175
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1176
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1176
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1177
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1177
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1178
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1178
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1179
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1179
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1180
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1180
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1181
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1181
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1182
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1182
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1183
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1183
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1184
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1184
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1185
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1185
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1186
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1186
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1187
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1187
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1188
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1188
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1189
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1189
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1190
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1190
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1191
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1191
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1192
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1192
+#define	WT_STAT_CONN_REC_PAGES				1193
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1193
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1194
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1194
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1195
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1195
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1196
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1196
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1197
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1197
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1198
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1198
+#define	WT_STAT_CONN_SESSION_OPEN			1199
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1199
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1200
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1200
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1201
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1201
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1202
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1202
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1203
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1203
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1204
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1204
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1205
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1205
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1206
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1206
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1207
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1207
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1208
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1208
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1209
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1209
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1210
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1210
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1211
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1211
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1212
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1212
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1213
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1213
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1214
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1214
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1215
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1215
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1216
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1216
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1217
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1217
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1218
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1218
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1219
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1219
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1220
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1220
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1221
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1221
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1222
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1222
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1223
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1223
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1224
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1224
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1225
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1225
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1226
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1226
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1227
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1227
+#define	WT_STAT_CONN_PAGE_SLEEP				1228
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1228
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1229
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1229
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1230
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1230
+#define	WT_STAT_CONN_TXN_BEGIN				1231
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1231
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1232
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1232
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1233
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1233
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1234
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1234
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1235
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1235
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1236
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1236
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1237
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1237
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1238
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1238
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1239
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1239
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1240
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1240
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1241
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1241
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1242
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1242
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1243
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1243
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1244
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1244
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1245
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1245
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1246
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1246
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1247
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1247
+#define	WT_STAT_CONN_TXN_SYNC				1248
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1248
+#define	WT_STAT_CONN_TXN_COMMIT				1249
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1249
+#define	WT_STAT_CONN_TXN_ROLLBACK			1250
 
 /*!
  * @}

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -30,7 +30,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 #if defined(HAVE_CLOCK_GETTIME)
 	WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, tsp), ret);
 	if (ret == 0) {
-		__wt_time_backward(session, tsp);
+		__wt_time_check_monotonic(session, tsp);
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "clock_gettime");
@@ -41,7 +41,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	if (ret == 0) {
 		tsp->tv_sec = v.tv_sec;
 		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
-		__wt_time_backward(session, tsp);
+		__wt_time_check_monotonic(session, tsp);
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "gettimeofday");

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -39,10 +39,6 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 
 	WT_SYSCALL_RETRY(gettimeofday(&v, NULL), ret);
 	if (ret == 0) {
-		/*
-		 * Detect time going backward.  If so, use the last
-		 * saved timestamp.
-		 */
 		tsp->tv_sec = v.tv_sec;
 		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
 		__wt_time_backward(session, tsp);

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -24,7 +24,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	    - 116444736000000000LL;
 	tsp->tv_sec = ns100 / 10000000;
 	tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
-	__wt_time_backward(session, tsp);
+	__wt_time_check_monotonic(session, tsp);
 }
 
 /*

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -18,14 +18,13 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	FILETIME time;
 	uint64_t ns100;
 
-	WT_UNUSED(session);
-
 	GetSystemTimeAsFileTime(&time);
 
 	ns100 = (((int64_t)time.dwHighDateTime << 32) + time.dwLowDateTime)
 	    - 116444736000000000LL;
 	tsp->tv_sec = ns100 / 10000000;
 	tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
+	__wt_time_backward(session, tsp);
 }
 
 /*

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -728,6 +728,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: unmodified pages evicted",
 	"connection: auto adjusting condition resets",
 	"connection: auto adjusting condition wait calls",
+	"connection: detected system time went backwards",
 	"connection: files currently open",
 	"connection: memory allocations",
 	"connection: memory frees",
@@ -1020,6 +1021,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cache_eviction_clean = 0;
 	stats->cond_auto_wait_reset = 0;
 	stats->cond_auto_wait = 0;
+	stats->time_travel = 0;
 		/* not clearing file_open */
 	stats->memory_allocation = 0;
 	stats->memory_free = 0;
@@ -1332,6 +1334,7 @@ __wt_stat_connection_aggregate(
 	to->cache_eviction_clean += WT_STAT_READ(from, cache_eviction_clean);
 	to->cond_auto_wait_reset += WT_STAT_READ(from, cond_auto_wait_reset);
 	to->cond_auto_wait += WT_STAT_READ(from, cond_auto_wait);
+	to->time_travel += WT_STAT_READ(from, time_travel);
 	to->file_open += WT_STAT_READ(from, file_open);
 	to->memory_allocation += WT_STAT_READ(from, memory_allocation);
 	to->memory_free += WT_STAT_READ(from, memory_free);


### PR DESCRIPTION
@agorrod and @michaelcahill here's a version of fixing the time problems in `wt_epoch` instead of in `WT_TIMEDIFF`.  @keithbostic you might want to look at it too.  I prefer this version over the one I created yesterday in `WT_TIMEDIFF` for a few reasons:
* It allows us to add in a statistic easily to detect and record this situation.
* It is equally as compact and localized for backporting.
* It deals with it at the source rather than in the use of timestamps.

By keeping it in the session, users of `wt_epoch` with a NULL session do not get the benefit of this change but that is only `wtperf` and other local test programs so I'm okay with that.