### PR TITLE
WT-2972 partial updates: fix Python to allow a no-op modify.

### DIFF
--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -44,6 +44,10 @@ class test_cursor12(wttest.WiredTigerTestCase):
         # there.
         list = [
         {
+        'o' : 'ABCDEFGH',           # no operation
+        'f' : 'ABCDEFGH',
+        'mods' : [['', 0, 0]]
+        },{
         'o' : 'ABCDEFGH',           # rewrite beginning
         'f' : '--CDEFGH',
         'mods' : [['--', 0, 2]]


### PR DESCRIPTION
To transmit the length of the WT_MODIFY array from the typemap to the call site in SWIG, we put the length into an (otherwise unused) first element.  Changed from using a blank entry as a sentinel, as a blank can legally appear in an list of Modify elements.