### PR TITLE
WT-3331 Get time into a local variable so we can read and use a consistent time

### DIFF
--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -50,7 +50,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 		tmp.tv_sec = v.tv_sec;
 		tmp.tv_nsec = v.tv_usec * WT_THOUSAND;
 		__wt_time_check_monotonic(session, &tmp);
-		*tsp->tv_sec = tmp;
+		*tsp = tmp;
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "gettimeofday");

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -43,6 +43,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	}
 	WT_PANIC_MSG(session, ret, "clock_gettime");
 #elif defined(HAVE_GETTIMEOFDAY)
+	{
 	struct timeval v;
 
 	WT_SYSCALL_RETRY(gettimeofday(&v, NULL), ret);
@@ -54,6 +55,7 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "gettimeofday");
+	}
 #else
 	NO TIME-OF-DAY IMPLEMENTATION: see src/os_posix/os_time.c
 #endif

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -16,6 +16,7 @@ void
 __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
     WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
+	struct timespec tmp;
 	WT_DECL_RET;
 
 	/*
@@ -27,10 +28,17 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 	tsp->tv_sec = 0;
 	tsp->tv_nsec = 0;
 
+	/*
+	 * Read into a local variable so that we're comparing the correct
+	 * value when we check for monotonic increasing time.  There are
+	 * many places we read into an unlocked global varible.
+	 */
 #if defined(HAVE_CLOCK_GETTIME)
-	WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, tsp), ret);
+	WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, &tmp), ret);
 	if (ret == 0) {
-		__wt_time_check_monotonic(session, tsp);
+		tsp->tv_sec = tmp.tv_sec;
+		tsp->tv_nsec = tmp.tv_nsec;
+		__wt_time_check_monotonic(session, &tmp);
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "clock_gettime");
@@ -39,9 +47,9 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 
 	WT_SYSCALL_RETRY(gettimeofday(&v, NULL), ret);
 	if (ret == 0) {
-		tsp->tv_sec = v.tv_sec;
-		tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
-		__wt_time_check_monotonic(session, tsp);
+		tmp.tv_sec = tsp->tv_sec = v.tv_sec;
+		tmp.tv_nsec = tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
+		__wt_time_check_monotonic(session, &tmp);
 		return;
 	}
 	WT_PANIC_MSG(session, ret, "gettimeofday");

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -15,6 +15,7 @@
 void
 __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 {
+	struct timespec tmp;
 	FILETIME time;
 	uint64_t ns100;
 
@@ -22,9 +23,9 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 
 	ns100 = (((int64_t)time.dwHighDateTime << 32) + time.dwLowDateTime)
 	    - 116444736000000000LL;
-	tsp->tv_sec = ns100 / 10000000;
-	tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
-	__wt_time_check_monotonic(session, tsp);
+	tmp.tv_sec = tsp->tv_sec = ns100 / 10000000;
+	tmp.tv_nsec = tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
+	__wt_time_check_monotonic(session, &tmp);
 }
 
 /*

--- a/src/os_win/os_time.c
+++ b/src/os_win/os_time.c
@@ -23,9 +23,10 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
 
 	ns100 = (((int64_t)time.dwHighDateTime << 32) + time.dwLowDateTime)
 	    - 116444736000000000LL;
-	tmp.tv_sec = tsp->tv_sec = ns100 / 10000000;
-	tmp.tv_nsec = tsp->tv_nsec = (long)((ns100 % 10000000) * 100);
+	tmp.tv_sec = ns100 / 10000000;
+	tmp.tv_nsec = (long)((ns100 % 10000000) * 100);
 	__wt_time_check_monotonic(session, &tmp);
+	*tsp = tmp;
 }
 
 /*


### PR DESCRIPTION
@agorrod Here's a fix for the LSM failure seen over the weekend.  The new clock check was reading the location passed in by the caller and that was getting set/reset out from under it.  I now read the time into a local variable to do all of the new time checks.

It seems that it could be dangerous to have timestamps being freely overwritten and its possible we could get parts of two timestamps set into a field.  My new checks, reading the same location over and over, was seeing different values each time and was storing a value into the session that was not one it read.