### PR TITLE
WT-3339 The CURSOR_UPDATE_API_CALL macro will dump core on a NULL btree handle

### DIFF
--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -317,7 +317,7 @@ __curds_insert(WT_CURSOR *cursor)
 
 	source = ((WT_CURSOR_DATA_SOURCE *)cursor)->source;
 
-	CURSOR_UPDATE_API_CALL(cursor, session, insert, NULL);
+	CURSOR_UPDATE_API_CALL(cursor, session, insert);
 
 	__curds_txn_enter(session);
 
@@ -350,7 +350,7 @@ __curds_update(WT_CURSOR *cursor)
 
 	source = ((WT_CURSOR_DATA_SOURCE *)cursor)->source;
 
-	CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
+	CURSOR_UPDATE_API_CALL(cursor, session, update);
 
 	WT_STAT_CONN_INCR(session, cursor_update);
 	WT_STAT_DATA_INCR(session, cursor_update);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -231,7 +231,7 @@ __curfile_insert(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
-	CURSOR_UPDATE_API_CALL(cursor, session, insert, cbt->btree);
+	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, insert, cbt->btree);
 
 	if (!F_ISSET(cursor, WT_CURSTD_APPEND))
 		WT_ERR(__cursor_checkkey(cursor));
@@ -265,7 +265,7 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
-	CURSOR_UPDATE_API_CALL(cursor, session, update, cbt->btree);
+	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
 	WT_ERR(__cursor_checkkey(cursor));
 
 	ret = __wt_btcur_insert_check(cbt);
@@ -286,7 +286,7 @@ __curfile_update(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
-	CURSOR_UPDATE_API_CALL(cursor, session, update, cbt->btree);
+	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
 	WT_ERR(__cursor_checkkey(cursor));
 	WT_ERR(__cursor_checkvalue(cursor));
 
@@ -345,7 +345,7 @@ __curfile_reserve(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
-	CURSOR_UPDATE_API_CALL(cursor, session, reserve, cbt->btree);
+	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, reserve, cbt->btree);
 	WT_ERR(__cursor_checkkey(cursor));
 
 	WT_ERR(__wt_txn_context_check(session, true));

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -484,7 +484,7 @@ __curtable_insert(WT_CURSOR *cursor)
 	u_int i;
 
 	ctable = (WT_CURSOR_TABLE *)cursor;
-	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, insert, NULL);
+	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, insert);
 	WT_ERR(__curtable_open_indices(ctable));
 
 	/*
@@ -563,7 +563,7 @@ __curtable_update(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	ctable = (WT_CURSOR_TABLE *)cursor;
-	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
+	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, update);
 	WT_ERR(__curtable_open_indices(ctable));
 
 	/*
@@ -673,7 +673,7 @@ __curtable_reserve(WT_CURSOR *cursor)
 	WT_SESSION_IMPL *session;
 
 	ctable = (WT_CURSOR_TABLE *)cursor;
-	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
+	JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, update);
 
 	/*
 	 * We don't have to open the indices here, but it makes the code similar

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1525,7 +1525,7 @@ __clsm_insert(WT_CURSOR *cursor)
 
 	clsm = (WT_CURSOR_LSM *)cursor;
 
-	CURSOR_UPDATE_API_CALL(cursor, session, insert, NULL);
+	CURSOR_UPDATE_API_CALL(cursor, session, insert);
 	WT_ERR(__cursor_needkey(cursor));
 	WT_ERR(__cursor_needvalue(cursor));
 	WT_ERR(__clsm_enter(clsm, false, true));
@@ -1574,7 +1574,7 @@ __clsm_update(WT_CURSOR *cursor)
 
 	clsm = (WT_CURSOR_LSM *)cursor;
 
-	CURSOR_UPDATE_API_CALL(cursor, session, update, NULL);
+	CURSOR_UPDATE_API_CALL(cursor, session, update);
 	WT_ERR(__cursor_needkey(cursor));
 	WT_ERR(__cursor_needvalue(cursor));
 	WT_ERR(__clsm_enter(clsm, false, true));
@@ -1674,7 +1674,7 @@ __clsm_reserve(WT_CURSOR *cursor)
 
 	clsm = (WT_CURSOR_LSM *)cursor;
 
-	CURSOR_UPDATE_API_CALL(cursor, session, reserve, NULL);
+	CURSOR_UPDATE_API_CALL(cursor, session, reserve);
 	WT_ERR(__cursor_needkey(cursor));
 	__cursor_novalue(cursor);
 	WT_ERR(__wt_txn_context_check(session, true));


### PR DESCRIPTION
Split CURSOR_UPDATE_API_CALL into two versions, one of which expects a btree handle, one of which doesn't.