### PR TITLE
WT-3354 Fix bugs found by Coverity.

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -15,12 +15,13 @@
 int
 __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
+	WT_DECL_RET;
 	WT_PAGE_MODIFY *modify;
 
 	WT_RET(__wt_calloc_one(session, &modify));
 
 	/* Initialize the spinlock for the page. */
-	WT_RET(__wt_spin_init(session, &modify->page_lock, "btree page"));
+	WT_ERR(__wt_spin_init(session, &modify->page_lock, "btree page"));
 
 	/*
 	 * Multiple threads of control may be searching and deciding to modify
@@ -31,8 +32,8 @@ __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (__wt_atomic_cas_ptr(&page->modify, NULL, modify))
 		__wt_cache_page_inmem_incr(session, page, sizeof(*modify));
 	else
-		__wt_free(session, modify);
-	return (0);
+err:		__wt_free(session, modify);
+	return (ret);
 }
 
 /*

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -472,7 +472,7 @@ __lsm_tree_open(WT_SESSION_IMPL *session,
 
 	/* Try to open the tree. */
 	WT_RET(__wt_calloc_one(session, &lsm_tree));
-	WT_RET(__wt_rwlock_init(session, &lsm_tree->rwlock));
+	WT_ERR(__wt_rwlock_init(session, &lsm_tree->rwlock));
 
 	WT_ERR(__lsm_tree_set_name(session, lsm_tree, uri));
 

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -328,8 +328,9 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	 */
 	saved_isolation = session->txn.isolation;
 	session->txn.isolation = WT_ISO_READ_UNCOMMITTED;
-	WT_ERR(__wt_cache_op(session, WT_SYNC_WRITE_LEAVES));
+	ret = __wt_cache_op(session, WT_SYNC_WRITE_LEAVES);
 	session->txn.isolation = saved_isolation;
+	WT_ERR(ret);
 
 	__wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s",
 	    chunk->uri);

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -235,8 +235,6 @@ stall:			__wt_cond_wait(
 		}
 	}
 
-	WT_ASSERT(session, l->u.s.readers_active > 0);
-
 	/*
 	 * Applications depend on a barrier here so that operations holding the
 	 * lock see consistent data.  The atomic operation above isn't
@@ -245,6 +243,8 @@ stall:			__wt_cond_wait(
 	 * meantime.
 	 */
 	WT_READ_BARRIER();
+
+	WT_ASSERT(session, l->u.s.readers_active > 0);
 }
 
 /*


### PR DESCRIPTION
* two cases where error checking for rwlocks should goto the error label for cleanup.
* LSM code not restoring isolation if a checkpoint fails part way through