### PR TITLE
WT-3361 Resolve Windows build warnings, build more test programs on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -420,7 +420,6 @@ env.Append(CPPPATH=["test/utility"])
 t = env.Program("t_bloom",
     "test/bloom/test_bloom.c",
     LIBS=[wtlib, testutil])
-env.Alias("check", env.SmokeTest(t))
 Default(t)
 
 t = env.Program("t_checkpoint",

--- a/SConstruct
+++ b/SConstruct
@@ -419,28 +419,28 @@ env.Append(CPPPATH=["test/utility"])
 
 t = env.Program("t_bloom",
     "test/bloom/test_bloom.c",
-    LIBS=[wtlib, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_checkpoint",
     ["test/checkpoint/checkpointer.c",
     "test/checkpoint/test_checkpoint.c",
     "test/checkpoint/workers.c"],
-    LIBS=[wtlib, shim, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_cursor_order",
     ["test/cursor_order/cursor_order.c",
     "test/cursor_order/cursor_order_file.c",
     "test/cursor_order/cursor_order_ops.c"],
-    LIBS=[wtlib, shim, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_fops",
     ["test/fops/file.c",
     "test/fops/fops.c",
     "test/fops/t.c"],
-    LIBS=[wtlib, shim, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_format",
@@ -455,41 +455,41 @@ t = env.Program("t_format",
     "test/format/t.c",
     "test/format/util.c",
     "test/format/wts.c"],
-     LIBS=[wtlib, shim, testutil] + wtlibs)
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_huge",
     "test/huge/huge.c",
-    LIBS=[wtlib, shim, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 t = env.Program("t_manydbs",
     "test/manydbs/manydbs.c",
-    LIBS=[wtlib, shim, testutil])
+    LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
 # t_readonly doesn't currently build/run.
 #t = env.Program("t_readonly",
 #    "test/readonly/readonly.c",
-#    LIBS=[wtlib, shim, testutil])
+#    LIBS=[wtlib, shim, testutil] + wtlibs)
 #Default(t)
 
 # t_random-abort doesn't currently build/run.
 #t = env.Program("t_random-abort",
 #    "test/recovery/random-abort.c",
-#    LIBS=[wtlib, shim, testutil])
+#    LIBS=[wtlib, shim, testutil] + wtlibs)
 #Default(t)
 
 # t_truncated-log doesn't currently build/run.
 #t = env.Program("t_truncated-log",
 #    "test/recovery/truncated-log.c",
-#    LIBS=[wtlib, shim, testutil])
+#    LIBS=[wtlib, shim, testutil] + wtlibs)
 #Default(t)
 
 # t_salvage-log doesn't currently build/run.
 #t = env.Program("t_salvage",
 #    "test/salvage/salvage.c",
-#    LIBS=[wtlib, shim, testutil])
+#    LIBS=[wtlib, shim, testutil] + wtlibs)
 #Default(t)
 
 # t_thread doesn't currently build/run.
@@ -498,7 +498,7 @@ Default(t)
 #    "test/thread/rw.c",
 #    "test/thread/stats.c",
 #    "test/thread/t.c"],
-#    LIBS=[wtlib, shim, testutil])
+#    LIBS=[wtlib, shim, testutil] + wtlibs)
 #Default(t)
 
 t = env.Program("wtperf", [

--- a/SConstruct
+++ b/SConstruct
@@ -410,41 +410,38 @@ def builder_smoke_test(target, source, env):
 env.Append(BUILDERS={'SmokeTest' : Builder(action = builder_smoke_test)})
 
 #Build the tests and setup the "scons test" target
-
 testutil = env.Library('testutil',
             [
                 'test/utility/misc.c',
                 'test/utility/parse_opts.c'
             ])
+env.Append(CPPPATH=["test/utility"])
 
-#Don't test bloom on Windows, its broken
 t = env.Program("t_bloom",
     "test/bloom/test_bloom.c",
-    LIBS=[wtlib, testutil] + wtlibs)
-#env.Alias("check", env.SmokeTest(t))
+    LIBS=[wtlib, testutil])
+env.Alias("check", env.SmokeTest(t))
 Default(t)
 
-#env.Program("t_checkpoint",
-    #["test/checkpoint/checkpointer.c",
-    #"test/checkpoint/test_checkpoint.c",
-    #"test/checkpoint/workers.c"],
-    #LIBS=[wtlib])
+t = env.Program("t_checkpoint",
+    ["test/checkpoint/checkpointer.c",
+    "test/checkpoint/test_checkpoint.c",
+    "test/checkpoint/workers.c"],
+    LIBS=[wtlib, shim, testutil])
+Default(t)
 
-t = env.Program("t_huge",
-    "test/huge/huge.c",
-    LIBS=[wtlib] + wtlibs)
-
-#t = env.Program("t_recovery",
-#    "test/recovery/recovery.c",
-#    LIBS=[wtlib] + wtlibs)
-#Default(t)
+t = env.Program("t_cursor_order",
+    ["test/cursor_order/cursor_order.c",
+    "test/cursor_order/cursor_order_file.c",
+    "test/cursor_order/cursor_order_ops.c"],
+    LIBS=[wtlib, shim, testutil])
+Default(t)
 
 t = env.Program("t_fops",
     ["test/fops/file.c",
     "test/fops/fops.c",
     "test/fops/t.c"],
-    LIBS=[wtlib, shim, testutil] + wtlibs)
-env.Append(CPPPATH=["test/utility"])
+    LIBS=[wtlib, shim, testutil])
 Default(t)
 
 t = env.Program("t_format",
@@ -462,16 +459,48 @@ t = env.Program("t_format",
      LIBS=[wtlib, shim, testutil] + wtlibs)
 Default(t)
 
-#env.Program("t_thread",
-    #["test/thread/file.c",
-    #"test/thread/rw.c",
-    #"test/thread/stats.c",
-    #"test/thread/t.c"],
-    #LIBS=[wtlib])
+t = env.Program("t_huge",
+    "test/huge/huge.c",
+    LIBS=[wtlib, shim, testutil])
+Default(t)
 
-#env.Program("t_salvage",
-    #["test/salvage/salvage.c"],
-    #LIBS=[wtlib])
+t = env.Program("t_manydbs",
+    "test/manydbs/manydbs.c",
+    LIBS=[wtlib, shim, testutil])
+Default(t)
+
+# t_readonly doesn't currently build/run.
+#t = env.Program("t_readonly",
+#    "test/readonly/readonly.c",
+#    LIBS=[wtlib, shim, testutil])
+#Default(t)
+
+# t_random-abort doesn't currently build/run.
+#t = env.Program("t_random-abort",
+#    "test/recovery/random-abort.c",
+#    LIBS=[wtlib, shim, testutil])
+#Default(t)
+
+# t_truncated-log doesn't currently build/run.
+#t = env.Program("t_truncated-log",
+#    "test/recovery/truncated-log.c",
+#    LIBS=[wtlib, shim, testutil])
+#Default(t)
+
+# t_salvage-log doesn't currently build/run.
+#t = env.Program("t_salvage",
+#    "test/salvage/salvage.c",
+#    LIBS=[wtlib, shim, testutil])
+#Default(t)
+
+# t_thread doesn't currently build/run.
+#t = env.Program("t_thread",
+#    ["test/thread/file.c",
+#    "test/thread/rw.c",
+#    "test/thread/stats.c",
+#    "test/thread/t.c"],
+#    LIBS=[wtlib, shim, testutil])
+#Default(t)
 
 t = env.Program("wtperf", [
     "bench/wtperf/config.c",

--- a/bench/wtperf/idle_table_cycle.c
+++ b/bench/wtperf/idle_table_cycle.c
@@ -57,7 +57,7 @@ check_timing(WTPERF *wtperf,
  * Measure how long each step takes, and flag an error if it exceeds the
  * configured maximum.
  */
-static void *
+static WT_THREAD_RET
 cycle_idle_tables(void *arg)
 {
 	struct timespec start, stop;
@@ -76,7 +76,7 @@ cycle_idle_tables(void *arg)
 	    wtperf->conn, NULL, opts->sess_config, &session)) != 0) {
 		lprintf(wtperf, ret, 0,
 		    "Error opening a session on %s", wtperf->home);
-		return (NULL);
+		return (WT_THREAD_RET_VALUE);
 	}
 
 	for (cycle_count = 0; wtperf->idle_cycle_run; ++cycle_count) {
@@ -96,10 +96,10 @@ cycle_idle_tables(void *arg)
 			lprintf(wtperf, ret, 0,
 			     "Table create failed in cycle_idle_tables.");
 			wtperf->error = true;
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		}
 		if (check_timing(wtperf, "create", start, &stop) != 0)
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		start = stop;
 
 		/* Open and close cursor. */
@@ -108,16 +108,16 @@ cycle_idle_tables(void *arg)
 			lprintf(wtperf, ret, 0,
 			     "Cursor open failed in cycle_idle_tables.");
 			wtperf->error = true;
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		}
 		if ((ret = cursor->close(cursor)) != 0) {
 			lprintf(wtperf, ret, 0,
 			     "Cursor close failed in cycle_idle_tables.");
 			wtperf->error = true;
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		}
 		if (check_timing(wtperf, "cursor", start, &stop) != 0)
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		start = stop;
 
 #if 1
@@ -133,14 +133,14 @@ cycle_idle_tables(void *arg)
 			lprintf(wtperf, ret, 0,
 			     "Table drop failed in cycle_idle_tables.");
 			wtperf->error = true;
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 		}
 		if (check_timing(wtperf, "drop", start, &stop) != 0)
-			return (NULL);
+			return (WT_THREAD_RET_VALUE);
 #endif
 	}
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -150,47 +150,33 @@ cycle_idle_tables(void *arg)
  * structure. Should reshuffle the configuration structure so explicit static
  * initialization isn't necessary.
  */
-int
-start_idle_table_cycle(WTPERF *wtperf, pthread_t *idle_table_cycle_thread)
+void
+start_idle_table_cycle(WTPERF *wtperf, wt_thread_t *idle_table_cycle_thread)
 {
 	CONFIG_OPTS *opts;
-	pthread_t thread_id;
-	int ret;
+	wt_thread_t thread_id;
 
 	opts = wtperf->opts;
 
 	if (opts->idle_table_cycle == 0)
-		return (0);
+		return;
 
 	wtperf->idle_cycle_run = true;
-	if ((ret = pthread_create(
-	    &thread_id, NULL, cycle_idle_tables, wtperf)) != 0) {
-		lprintf(wtperf,
-		    ret, 0, "Error creating idle table cycle thread.");
-		wtperf->idle_cycle_run = false;
-		return (ret);
-	}
+	testutil_check(__wt_thread_create(
+	    NULL, &thread_id, cycle_idle_tables, wtperf));
 	*idle_table_cycle_thread = thread_id;
-
-	return (0);
 }
 
-int
-stop_idle_table_cycle(WTPERF *wtperf, pthread_t idle_table_cycle_thread)
+void
+stop_idle_table_cycle(WTPERF *wtperf, wt_thread_t idle_table_cycle_thread)
 {
 	CONFIG_OPTS *opts;
-	int ret;
 
 	opts = wtperf->opts;
 
 	if (opts->idle_table_cycle == 0 || !wtperf->idle_cycle_run)
-		return (0);
+		return;
 
 	wtperf->idle_cycle_run = false;
-	if ((ret = pthread_join(idle_table_cycle_thread, NULL)) != 0) {
-		lprintf(
-		    wtperf, ret, 0, "Error joining idle table cycle thread.");
-		return (ret);
-	}
-	return (0);
+	testutil_check(__wt_thread_join(NULL, idle_table_cycle_thread));
 }

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -32,23 +32,23 @@
 #define	DEFAULT_HOME		"WT_TEST"
 #define	DEFAULT_MONITOR_DIR	"WT_TEST"
 
-static void	*checkpoint_worker(void *);
+static WT_THREAD_RET checkpoint_worker(void *);
 static int	 drop_all_tables(WTPERF *);
 static int	 execute_populate(WTPERF *);
 static int	 execute_workload(WTPERF *);
 static int	 find_table_count(WTPERF *);
-static void	*monitor(void *);
-static void	*populate_thread(void *);
+static WT_THREAD_RET monitor(void *);
+static WT_THREAD_RET populate_thread(void *);
 static void	 randomize_value(WTPERF_THREAD *, char *);
 static void	 recreate_dir(const char *);
 static int	 start_all_runs(WTPERF *);
 static int	 start_run(WTPERF *);
-static int	 start_threads(WTPERF *,
-		    WORKLOAD *, WTPERF_THREAD *, u_int, void *(*)(void *));
-static int	 stop_threads(WTPERF *, u_int, WTPERF_THREAD *);
-static void	*thread_run_wtperf(void *);
+static void	 start_threads(WTPERF *, WORKLOAD *,
+		    WTPERF_THREAD *, u_int, WT_THREAD_CALLBACK(*)(void *));
+static void	 stop_threads(u_int, WTPERF_THREAD *);
+static WT_THREAD_RET thread_run_wtperf(void *);
 static void	 update_value_delta(WTPERF_THREAD *);
-static void	*worker(void *);
+static WT_THREAD_RET worker(void *);
 
 static uint64_t	 wtperf_rand(WTPERF_THREAD *);
 static uint64_t	 wtperf_value_range(WTPERF *);
@@ -312,7 +312,7 @@ op_name(uint8_t *op)
 	/* NOTREACHED */
 }
 
-static void *
+static WT_THREAD_RET
 worker_async(void *arg)
 {
 	CONFIG_OPTS *opts;
@@ -420,7 +420,7 @@ op_err:			lprintf(wtperf, ret, 0,
 	if (0) {
 err:		wtperf->error = wtperf->stop = true;
 	}
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -513,7 +513,7 @@ err:		lprintf(wtperf, ret, 0, "Pre-workload traverse error");
 	return (ret);
 }
 
-static void *
+static WT_THREAD_RET
 worker(void *arg)
 {
 	struct timespec start, stop;
@@ -893,7 +893,7 @@ err:		wtperf->error = wtperf->stop = true;
 	}
 	free(cursors);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -1014,7 +1014,7 @@ run_mix_schedule(WTPERF *wtperf, WORKLOAD *workp)
 	return (0);
 }
 
-static void *
+static WT_THREAD_RET
 populate_thread(void *arg)
 {
 	struct timespec start, stop;
@@ -1163,10 +1163,10 @@ err:		wtperf->error = wtperf->stop = true;
 	}
 	free(cursors);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
-static void *
+static WT_THREAD_RET
 populate_async(void *arg)
 {
 	struct timespec start, stop;
@@ -1261,10 +1261,10 @@ populate_async(void *arg)
 	if (0) {
 err:		wtperf->error = wtperf->stop = true;
 	}
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
-static void *
+static WT_THREAD_RET
 monitor(void *arg)
 {
 	struct timespec t;
@@ -1426,10 +1426,10 @@ err:		wtperf->error = wtperf->stop = true;
 		(void)fclose(fp);
 	free(path);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
-static void *
+static WT_THREAD_RET
 checkpoint_worker(void *arg)
 {
 	CONFIG_OPTS *opts;
@@ -1490,7 +1490,7 @@ checkpoint_worker(void *arg)
 err:		wtperf->error = wtperf->stop = true;
 	}
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 static int
@@ -1498,15 +1498,15 @@ execute_populate(WTPERF *wtperf)
 {
 	struct timespec start, stop;
 	CONFIG_OPTS *opts;
-	WTPERF_THREAD *popth;
 	WT_ASYNC_OP *asyncop;
-	pthread_t idle_table_cycle_thread;
+	WTPERF_THREAD *popth;
+	WT_THREAD_CALLBACK(*pfunc)(void *);
 	size_t i;
 	uint64_t last_ops, msecs, print_ops_sec;
 	uint32_t interval, tables;
+	wt_thread_t idle_table_cycle_thread;
 	double print_secs;
 	int elapsed, ret;
-	void *(*pfunc)(void *);
 
 	opts = wtperf->opts;
 
@@ -1516,9 +1516,7 @@ execute_populate(WTPERF *wtperf)
 	    opts->populate_threads, opts->icount);
 
 	/* Start cycling idle tables if configured. */
-	if ((ret =
-	    start_idle_table_cycle(wtperf, &idle_table_cycle_thread)) != 0)
-		return (ret);
+	start_idle_table_cycle(wtperf, &idle_table_cycle_thread);
 
 	wtperf->insert_key = 0;
 
@@ -1530,9 +1528,8 @@ execute_populate(WTPERF *wtperf)
 		pfunc = populate_async;
 	} else
 		pfunc = populate_thread;
-	if ((ret = start_threads(wtperf, NULL,
-	    wtperf->popthreads, opts->populate_threads, pfunc)) != 0)
-		return (ret);
+	start_threads(wtperf, NULL,
+	    wtperf->popthreads, opts->populate_threads, pfunc);
 
 	__wt_epoch(NULL, &start);
 	for (elapsed = 0, interval = 0, last_ops = 0;
@@ -1568,10 +1565,8 @@ execute_populate(WTPERF *wtperf)
 	 */
 	popth = wtperf->popthreads;
 	wtperf->popthreads = NULL;
-	ret = stop_threads(wtperf, opts->populate_threads, popth);
+	stop_threads(opts->populate_threads, popth);
 	free(popth);
-	if (ret != 0)
-		return (ret);
 
 	/* Report if any worker threads didn't finish. */
 	if (wtperf->error) {
@@ -1640,8 +1635,7 @@ execute_populate(WTPERF *wtperf)
 	}
 
 	/* Stop cycling idle tables. */
-	if ((ret = stop_idle_table_cycle(wtperf, idle_table_cycle_thread)) != 0)
-		return (ret);
+	stop_idle_table_cycle(wtperf, idle_table_cycle_thread);
 
 	return (0);
 }
@@ -1701,13 +1695,13 @@ execute_workload(WTPERF *wtperf)
 	WTPERF_THREAD *threads;
 	WT_CONNECTION *conn;
 	WT_SESSION **sessions;
-	pthread_t idle_table_cycle_thread;
+	WT_THREAD_CALLBACK(*pfunc)(void *);
+	wt_thread_t idle_table_cycle_thread;
 	uint64_t last_ckpts, last_inserts, last_reads, last_truncates;
 	uint64_t last_updates;
 	uint32_t interval, run_ops, run_time;
 	u_int i;
-	int ret, t_ret;
-	void *(*pfunc)(void *);
+	int ret;
 
 	opts = wtperf->opts;
 
@@ -1722,9 +1716,7 @@ execute_workload(WTPERF *wtperf)
 	sessions = NULL;
 
 	/* Start cycling idle tables. */
-	if ((ret =
-	    start_idle_table_cycle(wtperf, &idle_table_cycle_thread)) != 0)
-		return (ret);
+	start_idle_table_cycle(wtperf, &idle_table_cycle_thread);
 
 	if (opts->warmup != 0)
 		wtperf->in_warmup = true;
@@ -1768,9 +1760,8 @@ execute_workload(WTPERF *wtperf)
 			goto err;
 
 		/* Start the workload's threads. */
-		if ((ret = start_threads(
-		    wtperf, workp, threads, (u_int)workp->threads, pfunc)) != 0)
-			goto err;
+		start_threads(
+		    wtperf, workp, threads, (u_int)workp->threads, pfunc);
 		threads += workp->threads;
 	}
 
@@ -1836,12 +1827,9 @@ execute_workload(WTPERF *wtperf)
 err:	wtperf->stop = true;
 
 	/* Stop cycling idle tables. */
-	if ((ret = stop_idle_table_cycle(wtperf, idle_table_cycle_thread)) != 0)
-		return (ret);
+	stop_idle_table_cycle(wtperf, idle_table_cycle_thread);
 
-	if ((t_ret = stop_threads(wtperf,
-	    (u_int)wtperf->workers_cnt, wtperf->workers)) != 0 && ret == 0)
-		ret = t_ret;
+	stop_threads((u_int)wtperf->workers_cnt, wtperf->workers);
 
 	/* Drop tables if configured to and this isn't an error path */
 	if (ret == 0 &&
@@ -2163,9 +2151,9 @@ start_all_runs(WTPERF *wtperf)
 {
 	CONFIG_OPTS *opts;
 	WTPERF *next_wtperf, **wtperfs;
-	pthread_t *threads;
 	size_t i, len;
-	int ret, t_ret;
+	wt_thread_t *threads;
+	int ret;
 
 	opts = wtperf->opts;
 	wtperfs = NULL;
@@ -2178,7 +2166,7 @@ start_all_runs(WTPERF *wtperf)
 	wtperfs = dcalloc(opts->database_count, sizeof(WTPERF *));
 
 	/* Allocate an array to hold our thread IDs. */
-	threads = dcalloc(opts->database_count, sizeof(pthread_t));
+	threads = dcalloc(opts->database_count, sizeof(*threads));
 
 	for (i = 0; i < opts->database_count; i++) {
 		wtperf_copy(wtperf, &next_wtperf);
@@ -2203,22 +2191,15 @@ start_all_runs(WTPERF *wtperf)
 		    strcmp(next_wtperf->home, next_wtperf->monitor_dir) != 0)
 			recreate_dir(next_wtperf->monitor_dir);
 
-		if ((ret = pthread_create(
-		    &threads[i], NULL, thread_run_wtperf, next_wtperf)) != 0) {
-			lprintf(wtperf, ret, 0, "Error creating thread");
-			goto err;
-		}
+		testutil_check(__wt_thread_create(NULL,
+		    &threads[i], thread_run_wtperf, next_wtperf));
 	}
 
 	/* Wait for threads to finish. */
 	for (i = 0; i < opts->database_count; i++)
-		if ((t_ret = pthread_join(threads[i], NULL)) != 0) {
-			lprintf(wtperf, ret, 0, "Error joining thread");
-			if (ret == 0)
-				ret = t_ret;
-		}
+		testutil_check(__wt_thread_join(NULL, threads[i]));
 
-err:	for (i = 0; i < opts->database_count && wtperfs[i] != NULL; i++) {
+	for (i = 0; i < opts->database_count && wtperfs[i] != NULL; i++) {
 		wtperf_free(wtperfs[i]);
 		free(wtperfs[i]);
 	}
@@ -2229,7 +2210,7 @@ err:	for (i = 0; i < opts->database_count && wtperfs[i] != NULL; i++) {
 }
 
 /* Run an instance of wtperf for a given configuration. */
-static void *
+static WT_THREAD_RET
 thread_run_wtperf(void *arg)
 {
 	WTPERF *wtperf;
@@ -2238,14 +2219,14 @@ thread_run_wtperf(void *arg)
 	wtperf = (WTPERF *)arg;
 	if ((ret = start_run(wtperf)) != 0)
 		lprintf(wtperf, ret, 0, "Run failed for: %s.", wtperf->home);
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 static int
 start_run(WTPERF *wtperf)
 {
 	CONFIG_OPTS *opts;
-	pthread_t monitor_thread;
+	wt_thread_t monitor_thread;
 	uint64_t total_ops;
 	uint32_t run_time;
 	int monitor_created, ret, t_ret;
@@ -2272,12 +2253,8 @@ start_run(WTPERF *wtperf)
 
 	/* Start the monitor thread. */
 	if (opts->sample_interval != 0) {
-		if ((ret = pthread_create(
-		    &monitor_thread, NULL, monitor, wtperf)) != 0) {
-			lprintf(wtperf,
-			    ret, 0, "Error creating monitor thread.");
-			goto err;
-		}
+		testutil_check(__wt_thread_create(
+		    NULL, &monitor_thread, monitor, wtperf));
 		monitor_created = 1;
 	}
 
@@ -2306,9 +2283,8 @@ start_run(WTPERF *wtperf)
 			    opts->checkpoint_threads);
 			wtperf->ckptthreads = dcalloc(
 			     opts->checkpoint_threads, sizeof(WTPERF_THREAD));
-			if (start_threads(wtperf, NULL, wtperf->ckptthreads,
-			    opts->checkpoint_threads, checkpoint_worker) != 0)
-				goto err;
+			start_threads(wtperf, NULL, wtperf->ckptthreads,
+			    opts->checkpoint_threads, checkpoint_worker);
 		}
 		if (opts->pre_load_data && (ret = pre_load_data(wtperf)) != 0)
 			goto err;
@@ -2362,16 +2338,10 @@ err:		if (ret == 0)
 	/* Notify the worker threads they are done. */
 	wtperf->stop = true;
 
-	if ((t_ret = stop_threads(wtperf, 1, wtperf->ckptthreads)) != 0)
-		if (ret == 0)
-			ret = t_ret;
+	stop_threads(1, wtperf->ckptthreads);
 
-	if (monitor_created != 0 &&
-	    (t_ret = pthread_join(monitor_thread, NULL)) != 0) {
-		lprintf(wtperf, ret, 0, "Error joining monitor thread.");
-		if (ret == 0)
-			ret = t_ret;
-	}
+	if (monitor_created != 0)
+		testutil_check(__wt_thread_join(NULL, monitor_thread));
 
 	if (wtperf->conn != NULL && opts->close_conn &&
 	    (t_ret = wtperf->conn->close(wtperf->conn, NULL)) != 0) {
@@ -2728,14 +2698,13 @@ err:	wtperf_free(wtperf);
 	return (ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
-static int
-start_threads(WTPERF *wtperf,
-    WORKLOAD *workp, WTPERF_THREAD *base, u_int num, void *(*func)(void *))
+static void
+start_threads(WTPERF *wtperf, WORKLOAD *workp,
+    WTPERF_THREAD *base, u_int num, WT_THREAD_CALLBACK(*func)(void *))
 {
 	CONFIG_OPTS *opts;
 	WTPERF_THREAD *thread;
 	u_int i;
-	int ret;
 
 	opts = wtperf->opts;
 
@@ -2779,29 +2748,20 @@ start_threads(WTPERF *wtperf,
 
 	/* Start the threads. */
 	for (i = 0, thread = base; i < num; ++i, ++thread)
-		if ((ret = pthread_create(
-		    &thread->handle, NULL, func, thread)) != 0) {
-			lprintf(wtperf, ret, 0, "Error creating thread");
-			return (ret);
-		}
-
-	return (0);
+		testutil_check(__wt_thread_create(
+		    NULL, &thread->handle, func, thread));
 }
 
-static int
-stop_threads(WTPERF *wtperf, u_int num, WTPERF_THREAD *threads)
+static void
+stop_threads(u_int num, WTPERF_THREAD *threads)
 {
 	u_int i;
-	int ret;
 
 	if (num == 0 || threads == NULL)
-		return (0);
+		return;
 
 	for (i = 0; i < num; ++i, ++threads) {
-		if ((ret = pthread_join(threads->handle, NULL)) != 0) {
-			lprintf(wtperf, ret, 0, "Error joining thread");
-			return (ret);
-		}
+		testutil_check(__wt_thread_join(NULL, threads->handle));
 
 		free(threads->key_buf);
 		threads->key_buf = NULL;
@@ -2815,7 +2775,6 @@ stop_threads(WTPERF *wtperf, u_int num, WTPERF_THREAD *threads)
 	 * being read by the monitor thread (among others).  As a standalone
 	 * program, leaking memory isn't a concern, and it's simpler that way.
 	 */
-	return (0);
 }
 
 static void

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -232,7 +232,7 @@ struct __wtperf_thread {		/* Per-thread structure */
 
 	WT_RAND_STATE rnd;		/* Random number generation state */
 
-	pthread_t handle;		/* Handle */
+	wt_thread_t handle;		/* Handle */
 
 	char *key_buf, *value_buf;	/* Key/value memory */
 
@@ -269,8 +269,8 @@ int	 run_truncate(
 int	 setup_log_file(WTPERF *);
 void	 setup_throttle(WTPERF_THREAD *);
 int	 setup_truncate(WTPERF *, WTPERF_THREAD *, WT_SESSION *);
-int	 start_idle_table_cycle(WTPERF *, pthread_t *);
-int	 stop_idle_table_cycle(WTPERF *, pthread_t);
+void	 start_idle_table_cycle(WTPERF *, wt_thread_t *);
+void	 stop_idle_table_cycle(WTPERF *, wt_thread_t);
 void	 worker_throttle(WTPERF_THREAD *);
 uint64_t sum_ckpt_ops(WTPERF *);
 uint64_t sum_insert_ops(WTPERF *);

--- a/examples/c/ex_thread.c
+++ b/examples/c/ex_thread.c
@@ -34,22 +34,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef _WIN32
-#include <pthread.h>
-#else
-#include "windows_shim.h"
-#endif
-
-#include <wiredtiger.h>
+#include "wt_internal.h"
 
 static const char *home;
-
-void *scan_thread(void *arg);
 
 #define	NUM_THREADS	10
 
 /*! [thread scan] */
-void *
+static WT_THREAD_RET
 scan_thread(void *conn_arg)
 {
 	WT_CONNECTION *conn;
@@ -74,7 +66,7 @@ scan_thread(void *conn_arg)
 		fprintf(stderr,
 		    "WT_CURSOR.next: %s\n", session->strerror(session, ret));
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 /*! [thread scan] */
 
@@ -85,7 +77,7 @@ main(void)
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
 	WT_CURSOR *cursor;
-	pthread_t threads[NUM_THREADS];
+	wt_thread_t threads[NUM_THREADS];
 	int i, ret;
 
 	/*
@@ -114,10 +106,10 @@ main(void)
 	ret = session->close(session, NULL);
 
 	for (i = 0; i < NUM_THREADS; i++)
-		ret = pthread_create(&threads[i], NULL, scan_thread, conn);
+		ret = __wt_thread_create(NULL, &threads[i], scan_thread, conn);
 
 	for (i = 0; i < NUM_THREADS; i++)
-		ret = pthread_join(threads[i], NULL);
+		ret = __wt_thread_join(NULL, threads[i]);
 
 	ret = conn->close(conn, NULL);
 

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -25,8 +25,8 @@ extern void __wt_stream_set_line_buffer(FILE *fp) WT_GCC_FUNC_DECL_ATTRIBUTE((vi
 extern void __wt_stream_set_no_buffer(FILE *fp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_sleep(uint64_t seconds, uint64_t micro_seconds) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern int __wt_vsnprintf_len_incr( char *buf, size_t size, size_t *retsizep, const char *fmt, va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_thread_id(char *buf, size_t buflen) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_yield(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -15,6 +15,7 @@
 int
 __wt_thread_create(WT_SESSION_IMPL *session,
     wt_thread_t *tidret, WT_THREAD_CALLBACK(*func)(void *), void *arg)
+    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	WT_DECL_RET;
 
@@ -40,6 +41,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
  */
 int
 __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t tid)
+    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	WT_DECL_RET;
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -502,8 +502,12 @@ __wt_panic(WT_SESSION_IMPL *session)
 #if defined(HAVE_DIAGNOSTIC)
 	__wt_abort(session);			/* Drop core if testing. */
 	/* NOTREACHED */
-#else
+#endif
+#if !defined(HAVE_DIAGNOSTIC) || defined(_WIN32)
 	/*
+	 * Confusing #ifdef structure because gcc knows we can't get here and
+	 * Visual Studio doesn't.
+	 *
 	 * Chaos reigns within.
 	 * Reflect, repent, and reboot.
 	 * Order shall return.
@@ -525,12 +529,7 @@ __wt_illegal_value(WT_SESSION_IMPL *session, const char *name)
 	    name == NULL ? "" : name, name == NULL ? "" : ": ",
 	    "encountered an illegal file format or internal value");
 
-#if defined(HAVE_DIAGNOSTIC)
-	__wt_abort(session);			/* Drop core if testing. */
-	/* NOTREACHED */
-#else
 	return (__wt_panic(session));
-#endif
 }
 
 /*

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -28,7 +28,7 @@
 
 #include "test_checkpoint.h"
 
-static void *checkpointer(void *);
+static WT_THREAD_RET checkpointer(void *);
 static int compare_cursors(
     WT_CURSOR *, const char *, WT_CURSOR *, const char *);
 static int diagnose_key_error(WT_CURSOR *, int, WT_CURSOR *, int);
@@ -39,35 +39,28 @@ static int verify_checkpoint(WT_SESSION *);
  * start_checkpoints --
  *     Responsible for creating the checkpoint thread.
  */
-int
+void
 start_checkpoints(void)
 {
-	int ret;
-
-	if ((ret = pthread_create(
-	    &g.checkpoint_thread, NULL, checkpointer, NULL)) != 0)
-		return (log_print_err("pthread_create", ret, 1));
-	return (0);
+	testutil_check(__wt_thread_create(NULL,
+	    &g.checkpoint_thread, checkpointer, NULL));
 }
 
 /*
  * end_checkpoints --
  *     Responsible for cleanly shutting down the checkpoint thread.
  */
-int
+void
 end_checkpoints(void)
 {
-	void *thread_ret;
-
-	return (pthread_join(g.checkpoint_thread, &thread_ret));
-
+	testutil_check(__wt_thread_join(NULL, g.checkpoint_thread));
 }
 
 /*
  * checkpointer --
  *	Checkpoint thread start function.
  */
-static void *
+static WT_THREAD_RET
 checkpointer(void *arg)
 {
 	char tid[128];
@@ -78,7 +71,7 @@ checkpointer(void *arg)
 	printf("checkpointer thread starting: tid: %s\n", tid);
 
 	(void)real_checkpointer();
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -150,20 +150,14 @@ main(int argc, char *argv[])
 			break;
 		}
 
-		if ((ret = start_checkpoints()) != 0) {
-			(void)log_print_err("Start checkpoints failed", ret, 1);
-			break;
-		}
+		start_checkpoints();
 		if ((ret = start_workers(ttype)) != 0) {
 			(void)log_print_err("Start workers failed", ret, 1);
 			break;
 		}
 
 		g.running = 0;
-		if ((ret = end_checkpoints()) != 0) {
-			(void)log_print_err("Start workers failed", ret, 1);
-			break;
-		}
+		end_checkpoints();
 
 		free(g.cookies);
 		g.cookies = NULL;

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -64,12 +64,12 @@ typedef struct {
 	int running;				/* Whether to stop */
 	int status;				/* Exit status */
 	COOKIE *cookies;			/* Per-thread info */
-	pthread_t checkpoint_thread;		/* Checkpoint thread */
+	wt_thread_t checkpoint_thread;		/* Checkpoint thread */
 } GLOBAL;
 extern GLOBAL g;
 
-int end_checkpoints(void);
-int log_print_err(const char *, int, int);
-int start_checkpoints(void);
-int start_workers(table_type);
+void	end_checkpoints(void);
+int	log_print_err(const char *, int, int);
+void	start_checkpoints(void);
+int	start_workers(table_type);
 const char *type_to_string(table_type);

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -29,7 +29,7 @@
 #include "test_checkpoint.h"
 
 static int real_worker(void);
-static void *worker(void *);
+static WT_THREAD_RET worker(void *);
 
 /*
  * create_table --
@@ -64,9 +64,8 @@ start_workers(table_type type)
 	WT_SESSION *session;
 	struct timeval start, stop;
 	double seconds;
-	pthread_t *tids;
+	wt_thread_t *tids;
 	int i, ret;
-	void *thread_ret;
 
 	ret = 0;
 
@@ -98,17 +97,13 @@ start_workers(table_type type)
 	(void)gettimeofday(&start, NULL);
 
 	/* Create threads. */
-	for (i = 0; i < g.nworkers; ++i) {
-		if ((ret = pthread_create(
-		    &tids[i], NULL, worker, &g.cookies[i])) != 0) {
-			(void)log_print_err("pthread_create", ret, 1);
-			goto err;
-		}
-	}
+	for (i = 0; i < g.nworkers; ++i)
+		testutil_check(__wt_thread_create(
+		    NULL, &tids[i], worker, &g.cookies[i]));
 
 	/* Wait for the threads. */
 	for (i = 0; i < g.nworkers; ++i)
-		(void)pthread_join(tids[i], &thread_ret);
+		testutil_check(__wt_thread_join(NULL, tids[i]));
 
 	(void)gettimeofday(&stop, NULL);
 	seconds = (stop.tv_sec - start.tv_sec) +
@@ -146,7 +141,7 @@ worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
  * worker --
  *	Worker thread start function.
  */
-static void *
+static WT_THREAD_RET
 worker(void *arg)
 {
 	char tid[128];
@@ -157,7 +152,7 @@ worker(void *arg)
 	printf("worker thread starting: tid: %s\n", tid);
 
 	(void)real_worker();
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/cursor_order/cursor_order.c
+++ b/test/cursor_order/cursor_order.c
@@ -158,8 +158,7 @@ main(int argc, char *argv[])
 
 		wt_connect(cfg, config_open);	/* WiredTiger connection */
 
-		if (ops_start(cfg))
-			return (EXIT_FAILURE);
+		ops_start(cfg);
 
 		wt_shutdown(cfg);		/* WiredTiger shut down */
 	}

--- a/test/cursor_order/cursor_order.h
+++ b/test/cursor_order/cursor_order.h
@@ -50,5 +50,5 @@ typedef struct {
 } SHARED_CONFIG;
 
 void load(SHARED_CONFIG *, const char *);
-int  ops_start(SHARED_CONFIG *);
+void ops_start(SHARED_CONFIG *);
 void verify(SHARED_CONFIG *, const char *);

--- a/test/cursor_order/cursor_order_ops.c
+++ b/test/cursor_order/cursor_order_ops.c
@@ -28,9 +28,9 @@
 
 #include "cursor_order.h"
 
-static void *append_insert(void *);
+static WT_THREAD_RET append_insert(void *);
 static void  print_stats(SHARED_CONFIG *);
-static void *reverse_scan(void *);
+static WT_THREAD_RET reverse_scan(void *);
 
 typedef struct {
 	char *name;				/* object name */
@@ -45,15 +45,13 @@ typedef struct {
 
 static INFO *run_info;
 
-int
+void
 ops_start(SHARED_CONFIG *cfg)
 {
 	struct timeval start, stop;
 	double seconds;
-	pthread_t *tids;
+	wt_thread_t *tids;
 	uint64_t i, name_index, offset, total_nops;
-	int ret;
-	void *thread_ret;
 
 	tids = NULL;	/* Keep GCC 4.1 happy. */
 	total_nops = 0;
@@ -114,18 +112,15 @@ ops_start(SHARED_CONFIG *cfg)
 
 	/* Create threads. */
 	for (i = 0; i < cfg->reverse_scanners; ++i)
-		if ((ret = pthread_create(
-		    &tids[i], NULL, reverse_scan, (void *)(uintptr_t)i)) != 0)
-			testutil_die(ret, "pthread_create");
-	for (; i < cfg->reverse_scanners + cfg->append_inserters; ++i) {
-		if ((ret = pthread_create(
-		    &tids[i], NULL, append_insert, (void *)(uintptr_t)i)) != 0)
-			testutil_die(ret, "pthread_create");
-	}
+		testutil_check(__wt_thread_create(NULL,
+		    &tids[i], reverse_scan, (void *)(uintptr_t)i));
+	for (; i < cfg->reverse_scanners + cfg->append_inserters; ++i)
+		testutil_check(__wt_thread_create(NULL,
+		    &tids[i], append_insert, (void *)(uintptr_t)i));
 
 	/* Wait for the threads. */
 	for (i = 0; i < cfg->reverse_scanners + cfg->append_inserters; ++i)
-		(void)pthread_join(tids[i], &thread_ret);
+		testutil_check(__wt_thread_join(NULL, tids[i]));
 
 	(void)gettimeofday(&stop, NULL);
 	seconds = (stop.tv_sec - start.tv_sec) +
@@ -154,8 +149,6 @@ ops_start(SHARED_CONFIG *cfg)
 
 	free(run_info);
 	free(tids);
-
-	return (0);
 }
 
 /*
@@ -217,7 +210,7 @@ reverse_scan_op(
  * reverse_scan --
  *	Reader thread start function.
  */
-static void *
+static WT_THREAD_RET
 reverse_scan(void *arg)
 {
 	INFO *s;
@@ -260,7 +253,7 @@ reverse_scan(void *arg)
 	/* Notify all other threads to finish once the first thread is done */
 	cfg->thread_finish = true;
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -307,7 +300,7 @@ append_insert_op(
  * append_insert --
  *	Writer thread start function.
  */
-static void *
+static WT_THREAD_RET
 append_insert(void *arg)
 {
 	INFO *s;
@@ -347,7 +340,7 @@ append_insert(void *arg)
 	/* Notify all other threads to finish once the first thread is done */
 	cfg->thread_finish = true;
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/fops/fops.c
+++ b/test/fops/fops.c
@@ -28,7 +28,7 @@
 
 #include "thread.h"
 
-static void *fop(void *);
+static WT_THREAD_RET fop(void *);
 static void  print_stats(u_int);
 
 typedef struct {
@@ -46,15 +46,13 @@ typedef struct {
 
 static STATS *run_stats;
 
-int
+void
 fop_start(u_int nthreads)
 {
 	struct timeval start, stop;
 	double seconds;
-	pthread_t *tids;
+	wt_thread_t *tids;
 	u_int i;
-	int ret;
-	void *thread_ret;
 
 	tids = NULL; /* Silence GCC 4.1 warning. */
 
@@ -66,13 +64,12 @@ fop_start(u_int nthreads)
 
 	/* Create threads. */
 	for (i = 0; i < nthreads; ++i)
-		if ((ret = pthread_create(
-		    &tids[i], NULL, fop, (void *)(uintptr_t)i)) != 0)
-			testutil_die(ret, "pthread_create");
+		testutil_check(__wt_thread_create(
+		    NULL, &tids[i], fop, (void *)(uintptr_t)i));
 
 	/* Wait for the threads. */
 	for (i = 0; i < nthreads; ++i)
-		(void)pthread_join(tids[i], &thread_ret);
+		testutil_check(__wt_thread_join(NULL, tids[i]));
 
 	(void)gettimeofday(&stop, NULL);
 	seconds = (stop.tv_sec - start.tv_sec) +
@@ -84,15 +81,13 @@ fop_start(u_int nthreads)
 
 	free(run_stats);
 	free(tids);
-
-	return (0);
 }
 
 /*
  * fop --
  *	File operation function.
  */
-static void *
+static WT_THREAD_RET
 fop(void *arg)
 {
 	STATS *s;
@@ -150,7 +145,7 @@ fop(void *arg)
 			break;
 		}
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -129,8 +129,7 @@ main(int argc, char *argv[])
 
 			wt_startup(config_open);
 
-			if (fop_start(nthreads))
-				return (EXIT_FAILURE);
+			fop_start(nthreads);
 
 			wt_shutdown();
 			printf("\n");

--- a/test/fops/thread.h
+++ b/test/fops/thread.h
@@ -39,7 +39,7 @@ extern const char *config;			/* Object config */
 
 extern pthread_rwlock_t single;			/* Single-thread */
 
-int  fop_start(u_int);
+void fop_start(u_int);
 void obj_bulk(void);
 void obj_bulk_unique(int);
 void obj_checkpoint(void);

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -83,7 +83,7 @@ copy_file(WT_SESSION *session, const char *name)
  * backup --
  *	Periodically do a backup and verify it.
  */
-void *
+WT_THREAD_RET
 backup(void *arg)
 {
 	WT_CONNECTION *conn;
@@ -100,7 +100,7 @@ backup(void *arg)
 
 	/* Backups aren't supported for non-standard data sources. */
 	if (DATASOURCE("helium") || DATASOURCE("kvsbdb"))
-		return (NULL);
+		return (WT_THREAD_RET_VALUE);
 
 	/* Open a session. */
 	testutil_check(conn->open_session(conn, NULL, NULL, &session));
@@ -188,5 +188,5 @@ backup(void *arg)
 
 	testutil_check(session->close(session, NULL));
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }

--- a/test/format/compact.c
+++ b/test/format/compact.c
@@ -32,7 +32,7 @@
  * compaction --
  *	Periodically do a compaction operation.
  */
-void *
+WT_THREAD_RET
 compact(void *arg)
 {
 	WT_CONNECTION *conn;
@@ -44,7 +44,7 @@ compact(void *arg)
 
 	/* Compaction isn't supported for all data sources. */
 	if (DATASOURCE("helium") || DATASOURCE("kvsbdb"))
-		return (NULL);
+		return (WT_THREAD_RET_VALUE);
 
 	/* Open a session. */
 	conn = g.wts_conn;
@@ -70,5 +70,5 @@ compact(void *arg)
 
 	testutil_check(session->close(session, NULL));
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -259,7 +259,7 @@ typedef struct {
 	uint64_t deadlock;
 
 	int       id;				/* simple thread ID */
-	pthread_t tid;				/* thread ID */
+	wt_thread_t tid;			/* thread ID */
 
 	int quit;				/* thread should quit */
 
@@ -279,9 +279,9 @@ void	 bdb_remove(uint64_t, int *);
 void	 bdb_update(const void *, size_t, const void *, size_t);
 #endif
 
-void	*alter(void *);
-void	*backup(void *);
-void	*compact(void *);
+WT_THREAD_RET alter(void *);
+WT_THREAD_RET backup(void *);
+WT_THREAD_RET compact(void *);
 void	 config_clear(void);
 void	 config_error(void);
 void	 config_file(const char *);
@@ -293,7 +293,7 @@ void	 key_gen(WT_ITEM *, uint64_t);
 void	 key_gen_insert(WT_RAND_STATE *, WT_ITEM *, uint64_t);
 void	 key_gen_setup(WT_ITEM *);
 void	 key_len_setup(void);
-void	*lrt(void *);
+WT_THREAD_RET lrt(void *);
 void	 path_setup(const char *);
 int	 read_row(WT_CURSOR *, WT_ITEM *, WT_ITEM *, uint64_t);
 uint32_t rng(WT_RAND_STATE *);

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -32,7 +32,7 @@
  * lrt --
  *	Start a long-running transaction.
  */
-void *
+WT_THREAD_RET
 lrt(void *arg)
 {
 	WT_CONNECTION *conn;
@@ -182,5 +182,5 @@ lrt(void *arg)
 	free(value.mem);
 	free(buf);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -36,7 +36,7 @@ static int   col_reserve(WT_CURSOR *, uint64_t, bool);
 static int   col_update(
 		TINFO *, WT_CURSOR *, WT_ITEM *, WT_ITEM *, uint64_t, bool);
 static int   nextprev(WT_CURSOR *, int);
-static void *ops(void *);
+static WT_THREAD_RET ops(void *);
 static int   row_insert(
 		TINFO *, WT_CURSOR *, WT_ITEM *, WT_ITEM *, uint64_t, bool);
 static int   row_modify(
@@ -62,7 +62,7 @@ wts_ops(int lastrun)
 	TINFO **tinfo_list, *tinfo, total;
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	pthread_t alter_tid, backup_tid, compact_tid, lrt_tid;
+	wt_thread_t alter_tid, backup_tid, compact_tid, lrt_tid;
 	int64_t fourths, thread_ops;
 	uint32_t i;
 	int running;
@@ -121,7 +121,8 @@ wts_ops(int lastrun)
 		tinfo_list[i] = tinfo = dcalloc(1, sizeof(TINFO));
 		tinfo->id = (int)i + 1;
 		tinfo->state = TINFO_RUNNING;
-		testutil_check(pthread_create(&tinfo->tid, NULL, ops, tinfo));
+		testutil_check(
+		    __wt_thread_create(NULL, &tinfo->tid, ops, tinfo));
 	}
 
 	/*
@@ -129,14 +130,16 @@ wts_ops(int lastrun)
 	 * long-running reader threads.
 	 */
 	if (g.c_alter)
-		testutil_check(pthread_create(&alter_tid, NULL, alter, NULL));
+		testutil_check(
+		    __wt_thread_create(NULL, &alter_tid, alter, NULL));
 	if (g.c_backups)
-		testutil_check(pthread_create(&backup_tid, NULL, backup, NULL));
+		testutil_check(
+		    __wt_thread_create(NULL, &backup_tid, backup, NULL));
 	if (g.c_compact)
 		testutil_check(
-		    pthread_create(&compact_tid, NULL, compact, NULL));
+		    __wt_thread_create(NULL, &compact_tid, compact, NULL));
 	if (!SINGLETHREADED && g.c_long_running_txn)
-		testutil_check(pthread_create(&lrt_tid, NULL, lrt, NULL));
+		testutil_check(__wt_thread_create(NULL, &lrt_tid, lrt, NULL));
 
 	/* Spin on the threads, calculating the totals. */
 	for (;;) {
@@ -158,7 +161,8 @@ wts_ops(int lastrun)
 				break;
 			case TINFO_COMPLETE:
 				tinfo->state = TINFO_JOINED;
-				(void)pthread_join(tinfo->tid, NULL);
+				testutil_check(
+				    __wt_thread_join(NULL, tinfo->tid));
 				break;
 			case TINFO_JOINED:
 				break;
@@ -196,13 +200,13 @@ wts_ops(int lastrun)
 	/* Wait for the backup, compaction, long-running reader threads. */
 	g.workers_finished = 1;
 	if (g.c_alter)
-		(void)pthread_join(alter_tid, NULL);
+		testutil_check(__wt_thread_join(NULL, alter_tid));
 	if (g.c_backups)
-		(void)pthread_join(backup_tid, NULL);
+		testutil_check(__wt_thread_join(NULL, backup_tid));
 	if (g.c_compact)
-		(void)pthread_join(compact_tid, NULL);
+		testutil_check(__wt_thread_join(NULL, compact_tid));
 	if (!SINGLETHREADED && g.c_long_running_txn)
-		(void)pthread_join(lrt_tid, NULL);
+		testutil_check(__wt_thread_join(NULL, lrt_tid));
 	g.workers_finished = 0;
 
 	if (g.logging != 0) {
@@ -404,7 +408,7 @@ snap_check(WT_CURSOR *cursor,
  * ops --
  *     Per-thread operations.
  */
-static void *
+static WT_THREAD_RET
 ops(void *arg)
 {
 	enum { INSERT, MODIFY, READ, REMOVE, UPDATE } op;
@@ -864,7 +868,7 @@ deadlock:			++tinfo->deadlock;
 	free(value->mem);
 
 	tinfo->state = TINFO_COMPLETE;
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -472,7 +472,7 @@ fclose_and_clear(FILE **fpp)
  * alter --
  *	Periodically alter a table's metadata.
  */
-void *
+WT_THREAD_RET
 alter(void *arg)
 {
 	WT_CONNECTION *conn;
@@ -510,5 +510,5 @@ alter(void *arg)
 	}
 
 	testutil_check(session->close(session, NULL));
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }

--- a/test/recovery/random-abort.c
+++ b/test/recovery/random-abort.c
@@ -69,7 +69,7 @@ typedef struct {
 	uint32_t id;
 } WT_THREAD_DATA;
 
-static void *
+static WT_THREAD_RET
 thread_run(void *arg)
 {
 	FILE *fp;
@@ -161,15 +161,15 @@ static void fill_db(uint32_t)
 static void
 fill_db(uint32_t nth)
 {
-	pthread_t *thr;
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
 	WT_THREAD_DATA *td;
+	wt_thread_t *thr;
 	uint32_t i;
 	int ret;
 	const char *envconf;
 
-	thr = dcalloc(nth, sizeof(pthread_t));
+	thr = dcalloc(nth, sizeof(*thr));
 	td = dcalloc(nth, sizeof(WT_THREAD_DATA));
 	if (chdir(home) != 0)
 		testutil_die(errno, "Child chdir: %s", home);
@@ -192,9 +192,8 @@ fill_db(uint32_t nth)
 		td[i].conn = conn;
 		td[i].start = (UINT64_MAX / nth) * i;
 		td[i].id = i;
-		if ((ret = pthread_create(
-		    &thr[i], NULL, thread_run, &td[i])) != 0)
-			testutil_die(ret, "pthread_create");
+		testutil_check(__wt_thread_create(
+		    NULL, &thr[i], thread_run, &td[i]));
 	}
 	printf("Spawned %" PRIu32 " writer threads\n", nth);
 	fflush(stdout);
@@ -203,7 +202,7 @@ fill_db(uint32_t nth)
 	 * it is killed.
 	 */
 	for (i = 0; i < nth; ++i)
-		testutil_assert(pthread_join(thr[i], NULL) == 0);
+		testutil_check(__wt_thread_join(NULL, thr[i]));
 	/*
 	 * NOTREACHED
 	 */

--- a/test/thread/rw.c
+++ b/test/thread/rw.c
@@ -29,8 +29,8 @@
 #include "thread.h"
 
 static void  print_stats(u_int);
-static void *reader(void *);
-static void *writer(void *);
+static WT_THREAD_RET reader(void *);
+static WT_THREAD_RET writer(void *);
 
 typedef struct {
 	char *name;				/* object name */
@@ -45,15 +45,13 @@ typedef struct {
 
 static INFO *run_info;
 
-int
+void
 rw_start(u_int readers, u_int writers)
 {
 	struct timeval start, stop;
+	wt_thread_t *tids;
 	double seconds;
-	pthread_t *tids;
 	u_int i, name_index, offset, total_nops;
-	int ret;
-	void *thread_ret;
 
 	tids = NULL;	/* Keep GCC 4.1 happy. */
 	total_nops = 0;
@@ -109,18 +107,15 @@ rw_start(u_int readers, u_int writers)
 
 	/* Create threads. */
 	for (i = 0; i < readers; ++i)
-		if ((ret = pthread_create(
-		    &tids[i], NULL, reader, (void *)(uintptr_t)i)) != 0)
-			testutil_die(ret, "pthread_create");
-	for (; i < readers + writers; ++i) {
-		if ((ret = pthread_create(
-		    &tids[i], NULL, writer, (void *)(uintptr_t)i)) != 0)
-			testutil_die(ret, "pthread_create");
-	}
+		testutil_check(__wt_thread_create(
+		    NULL, &tids[i], reader, (void *)(uintptr_t)i));
+	for (; i < readers + writers; ++i)
+		testutil_check(__wt_thread_create(
+		    NULL, &tids[i], writer, (void *)(uintptr_t)i));
 
 	/* Wait for the threads. */
 	for (i = 0; i < readers + writers; ++i)
-		(void)pthread_join(tids[i], &thread_ret);
+		testutil_check(__wt_thread_join(NULL, tids[i]));
 
 	(void)gettimeofday(&stop, NULL);
 	seconds = (stop.tv_sec - start.tv_sec) +
@@ -147,8 +142,6 @@ rw_start(u_int readers, u_int writers)
 
 	free(run_info);
 	free(tids);
-
-	return (0);
 }
 
 /*
@@ -186,7 +179,7 @@ reader_op(WT_SESSION *session, WT_CURSOR *cursor, INFO *s)
  * reader --
  *	Reader thread start function.
  */
-static void *
+static WT_THREAD_RET
 reader(void *arg)
 {
 	INFO *s;
@@ -234,7 +227,7 @@ reader(void *arg)
 	printf(" read thread %2d stopping: tid: %s, file: %s\n",
 	    id, tid, s->name);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -291,7 +284,7 @@ writer_op(WT_SESSION *session, WT_CURSOR *cursor, INFO *s)
  * writer --
  *	Writer thread start function.
  */
-static void *
+static WT_THREAD_RET
 writer(void *arg)
 {
 	INFO *s;
@@ -339,7 +332,7 @@ writer(void *arg)
 	printf("write thread %2d stopping: tid: %s, file: %s\n",
 	    id, tid, s->name);
 
-	return (NULL);
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*

--- a/test/thread/t.c
+++ b/test/thread/t.c
@@ -160,8 +160,7 @@ main(int argc, char *argv[])
 
 		wt_connect(config_open);	/* WiredTiger connection */
 
-		if (rw_start(readers, writers))	/* Loop operations */
-			return (EXIT_FAILURE);
+		rw_start(readers, writers);	/* Loop operations */
 
 		stats();			/* Statistics */
 

--- a/test/thread/thread.h
+++ b/test/thread/thread.h
@@ -46,6 +46,6 @@ extern int   vary_nops;				/* Operations per thread */
 extern int   session_per_op;			/* New session per operation */
 
 void load(const char *);
-int  rw_start(u_int, u_int);
+void rw_start(u_int, u_int);
 void stats(void);
 void verify(const char *);

--- a/test/windows/windows_shim.c
+++ b/test/windows/windows_shim.c
@@ -124,26 +124,3 @@ pthread_rwlock_wrlock(pthread_rwlock_t *rwlock)
 
 	return (0);
 }
-
-#pragma warning( once : 4024 )
-#pragma warning( once : 4047 )
-int
-pthread_create(pthread_t *tidret, const pthread_attr_t *ignored,
-    void *(*func)(void *), void * arg)
-{
-	ignored = ignored;
-	*tidret = CreateThread(NULL, 0, func, arg, 0, NULL);
-
-	if (*tidret != NULL)
-		return (0);
-
-	return (1);
-}
-
-int
-pthread_join(pthread_t thread, void **ignored)
-{
-	ignored = ignored;
-	WaitForSingleObject(thread, INFINITE);
-	return (0);
-}


### PR DESCRIPTION
@markbenvenuto, there's only a minor change to the WiredTiger library itself, the rest is boilerplate to deal with test program portability.

@michaelcahill, with these changes, Windows builds without warnings.