### PR TITLE
WT-3362 Checkpoints shouldn't block drops.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -481,6 +481,50 @@ err:	WT_DHANDLE_RELEASE(dhandle);
 }
 
 /*
+ * __conn_dhandle_close_one --
+ *	Close a data handles handles with matching name (including all
+ *	checkpoint handles).
+ */
+static int
+__conn_dhandle_close_one(WT_SESSION_IMPL *session,
+    const char *uri, const char *checkpoint, bool force)
+{
+	WT_DECL_RET;
+
+	/*
+	 * Lock the handle exclusively.  If this is part of schema-changing
+	 * operation (indicated by metadata tracking being enabled), hold the
+	 * lock for the duration of the operation.
+	 */
+	WT_RET(__wt_session_get_btree(session, uri, checkpoint,
+	    NULL, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_LOCK_ONLY));
+	if (WT_META_TRACKING(session))
+		WT_RET(__wt_meta_track_handle_lock(session, false));
+
+	/*
+	 * We have an exclusive lock, which means there are no cursors open at
+	 * this point.  Close the handle, if necessary.
+	 */
+	if (F_ISSET(session->dhandle, WT_DHANDLE_OPEN)) {
+		__wt_meta_track_sub_on(session);
+		ret = __wt_conn_btree_sync_and_close(session, false, force);
+
+		/*
+		 * If the close succeeded, drop any locks it acquired.  If
+		 * there was a failure, this function will fail and the whole
+		 * transaction will be rolled back.
+		 */
+		if (ret == 0)
+			ret = __wt_meta_track_sub_off(session);
+	}
+
+	if (!WT_META_TRACKING(session))
+		WT_TRET(__wt_session_release_btree(session));
+
+	return (ret);
+}
+
+/*
  * __wt_conn_dhandle_close_all --
  *	Close all data handles handles with matching name (including all
  *	checkpoint handles).
@@ -500,48 +544,27 @@ __wt_conn_dhandle_close_all(
 	    F_ISSET(session, WT_SESSION_LOCKED_HANDLE_LIST_WRITE));
 	WT_ASSERT(session, session->dhandle == NULL);
 
+	/*
+	 * Lock the live handle exclusively.  If this is part of
+	 * schema-changing operation (indicated by metadata tracking being
+	 * enabled), hold the lock for the duration of the operation.
+	 *
+	 * This ordering is important: we rely on locking the live handle to
+	 * fail fast if the tree is busy (e.g., in a checkpoint).  Otherwise we
+	 * can spin waiting for a handle lock on a checkpoint in the tree that
+	 * is not open but merely locked by the checkpoint.
+	 */
+	WT_ERR(__conn_dhandle_close_one(session, uri, NULL, force));
+
 	bucket = __wt_hash_city64(uri, strlen(uri)) % WT_HASH_ARRAY_SIZE;
 	TAILQ_FOREACH(dhandle, &conn->dhhash[bucket], hashq) {
 		if (strcmp(dhandle->name, uri) != 0 ||
+		    dhandle->checkpoint == NULL ||
 		    F_ISSET(dhandle, WT_DHANDLE_DEAD))
 			continue;
 
-		session->dhandle = dhandle;
-
-		/*
-		 * Lock the handle exclusively.  If this is part of
-		 * schema-changing operation (indicated by metadata tracking
-		 * being enabled), hold the lock for the duration of the
-		 * operation.
-		 */
-		WT_ERR(__wt_session_get_btree(session,
-		    dhandle->name, dhandle->checkpoint,
-		    NULL, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_LOCK_ONLY));
-		if (WT_META_TRACKING(session))
-			WT_ERR(__wt_meta_track_handle_lock(session, false));
-
-		/*
-		 * We have an exclusive lock, which means there are no cursors
-		 * open at this point.  Close the handle, if necessary.
-		 */
-		if (F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
-			__wt_meta_track_sub_on(session);
-			ret = __wt_conn_btree_sync_and_close(
-			    session, false, force);
-
-			/*
-			 * If the close succeeded, drop any locks it acquired.
-			 * If there was a failure, this function will fail and
-			 * the whole transaction will be rolled back.
-			 */
-			if (ret == 0)
-				ret = __wt_meta_track_sub_off(session);
-		}
-
-		if (!WT_META_TRACKING(session))
-			WT_TRET(__wt_session_release_btree(session));
-
-		WT_ERR(ret);
+		WT_ERR(__conn_dhandle_close_one(
+		    session, dhandle->name, dhandle->checkpoint, force));
 	}
 
 err:	session->dhandle = NULL;

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -482,8 +482,7 @@ err:	WT_DHANDLE_RELEASE(dhandle);
 
 /*
  * __conn_dhandle_close_one --
- *	Close a data handles handles with matching name (including all
- *	checkpoint handles).
+ *	Lock and, if necessary, close a data handle.
  */
 static int
 __conn_dhandle_close_one(WT_SESSION_IMPL *session,

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -545,14 +545,9 @@ __wt_conn_dhandle_close_all(
 	WT_ASSERT(session, session->dhandle == NULL);
 
 	/*
-	 * Lock the live handle exclusively.  If this is part of
-	 * schema-changing operation (indicated by metadata tracking being
-	 * enabled), hold the lock for the duration of the operation.
-	 *
-	 * This ordering is important: we rely on locking the live handle to
-	 * fail fast if the tree is busy (e.g., in a checkpoint).  Otherwise we
-	 * can spin waiting for a handle lock on a checkpoint in the tree that
-	 * is not open but merely locked by the checkpoint.
+	 * Lock the live handle first.  This ordering is important: we rely on
+	 * locking the live handle to fail fast if the tree is busy (e.g., with
+	 * cursors open or in a checkpoint).
 	 */
 	WT_ERR(__conn_dhandle_close_one(session, uri, NULL, force));
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -229,7 +229,8 @@ __wt_session_lock_dhandle(
 			WT_ASSERT(session, !F_ISSET(dhandle, WT_DHANDLE_DEAD));
 			return (0);
 		}
-		if (ret != EBUSY || (is_open && want_exclusive))
+		if (ret != EBUSY || (is_open && want_exclusive) ||
+		    LF_ISSET(WT_DHANDLE_LOCK_ONLY))
 			return (ret);
 		lock_busy = true;
 


### PR DESCRIPTION
Testing has uncovered another case where drops can spin trying to lock a checkpoint handle until a checkpoint completes.  This change fixes that in two ways: attempting to lock (but not open) a handle won't spin, and drop will always attempt to lock the live tree before locking any checkpoint handles.