### PR TITLE
SERVER-29439 WiredTiger turtle file "MoveFileExW: Access is denied." error.

### DIFF
--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -267,7 +267,9 @@ __wt_metadata_search(WT_SESSION_IMPL *session, const char *key, char **valuep)
 		 * that Coverity complains a lot, add an error check to get some
 		 * peace and quiet.
 		 */
-		if ((ret = __wt_turtle_read(session, key, valuep)) != 0)
+		WT_WITH_TURTLE_LOCK(session,
+		    ret = __wt_turtle_read(session, key, valuep));
+		if (ret != 0)
 			__wt_free(session, *valuep);
 		return (ret);
 	}

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -246,6 +246,9 @@ __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
 
 	*valuep = NULL;
 
+	/* Require single-threading. */
+	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_TURTLE));
+
 	/*
 	 * Open the turtle file; there's one case where we won't find the turtle
 	 * file, yet still succeed.  We create the metadata file before creating
@@ -301,6 +304,9 @@ __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
 	const char *version;
 
 	fs = NULL;
+
+	/* Require single-threading. */
+	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_TURTLE));
 
 	/*
 	 * Create the turtle setup file: we currently re-write it from scratch


### PR DESCRIPTION
I believe the problem was that MongoDB reads the metadata file, and that potentially races with checkpoints. I never caught it in the act, but it fits all the symptoms.