### PR TITLE
WT-3367 Move to macOS 10.12

### DIFF
--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -95,6 +95,16 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
+
+            # On 10.12, change the binary location with install_name_tool since DYLD_LIBRARY_PATH
+            # appears not to work for dynamic modules loaded by python. For wt, the libtool generated
+            # script has the wrong path for running on test machines.
+            if [ "$(uname -s)" == "Darwin" ]; then
+              WT_VERSION=$(m4 build_posix/aclocal/version.m4)
+              install_name_tool -change /usr/local/lib/libwiredtiger-$WT_VERSION.dylib $(pwd)/.libs/libwiredtiger-$WT_VERSION.dylib lang/python/_wiredtiger.so
+              install_name_tool -change /usr/local/lib/libwiredtiger-$WT_VERSION.dylib $(pwd)/.libs/libwiredtiger-$WT_VERSION.dylib .libs/wt
+            fi
+
             ${test_env_vars|} python ./test/suite/run.py -v 2 ${smp_command|} 2>&1
 
   - name: compile-windows-alt
@@ -182,10 +192,10 @@ buildvariants:
     #- name: format  - Enable when we have a solution for hangs and crashses
     - name: fops
 
-- name: osx-1010
-  display_name: OS X 10.10
+- name: macos-1012
+  display_name: OS X 10.12
   run_on:
-  - osx-1010
+  - macos-1012
   expansions:
     smp_command: -j $(sysctl -n hw.logicalcpu)
     configure_env_vars: PATH=/opt/local/bin:$PATH
@@ -195,3 +205,4 @@ buildvariants:
     - name: compile
     - name: unit-test
     - name: fops
+


### PR DESCRIPTION
Evergreen is moving all OSX machines from 10.10 to 10.12 to support XCode 8.

I updated wiredtiger to use 10.12 but ran into issues with DYLD_LIBRARY_PATH that I needed to use `install_name_tool` to workaround.