### PR TITLE
WT-3371 Make Windows/MSVC build warnings fatal.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -67,15 +67,11 @@ var.Add('CPPPATH', 'C Preprocessor include path', [
 ])
 
 var.Add('CFLAGS', 'C Compiler Flags', [
-    "/Z7", # Generate debugging symbols
     "/wd4090", # Ignore warning about mismatched const qualifiers
     "/wd4996", # Ignore deprecated functions
     "/W3", # Warning level 3
-    #"/we4244", # Possible loss of data
-    "/we4013", # Error on undefined functions
-    #"/we4047", # Indirection differences in types
-    #"/we4024", # Differences in parameter types
-    #"/we4100", # Unreferenced local parameter
+    "/WX", # Warnings are fatal
+    "/Z7", # Generate debugging symbols
     "/TC", # Compile as C code
     #"/Od", # Disable optimization
     "/Ob1", # inline expansion
@@ -338,6 +334,8 @@ if GetOption("lang-python"):
             "-nodefaultctor",
             "-nodefaultdtor",
             ])
+    # Ignore warnings in swig-generated code.
+    pythonEnv['CFLAGS'].remove("/WX")
 
     swiglib = pythonEnv.SharedLibrary('_wiredtiger',
                       [ 'lang\python\wiredtiger.i'],


### PR DESCRIPTION
The exception is the SWIG-generated Python wrapper code.

I removed the `/weXXX` lines as well, they're all covered by `/W3` and `/WX`.