### PR TITLE
WT-3379 Avoid a performance regression on secondaries.

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -587,8 +587,9 @@ __rec_write_check_complete(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	 * This may lead to saving the page to the lookaside table: that
 	 * decision is made by eviction.
 	 */
-	if (F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && r->bnd_next == 1 &&
-	    r->update_mem_all != 0 && r->update_mem_all == r->update_mem_saved)
+	if (F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && r->bnd->supd != NULL &&
+	    r->bnd_next == 1 && r->update_mem_saved == r->update_mem_all &&
+	    r->update_mem_uncommitted == 0)
 		return (EBUSY);
 
 	return (0);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -568,29 +568,69 @@ __rec_write_check_complete(
 		return (0);
 
 	/*
-	 * Eviction can configure lookaside table reconciliation, flag if
-	 * that's worth trying. The lookaside table doesn't help if we skipped
-	 * updates, it can only help with older readers preventing eviction.
-	 *
-	 * If when doing update/restore based eviction, we didn't split and
-	 * didn't apply any updates, then fall back to using the lookaside
-	 * table.
-	 */
-	if (lookaside_retryp != NULL && r->update_mem_uncommitted == 0 &&
-	    F_ISSET(r, WT_EVICT_UPDATE_RESTORE) && r->bnd->supd != NULL &&
-	    r->bnd_next == 1 && r->update_mem_saved == r->update_mem_all) {
-		*lookaside_retryp = true;
-		return (EBUSY);
-	}
-
-	/*
 	 * If we have used the lookaside table, check for a lookaside table and
 	 * checkpoint collision.
 	 */
 	if (r->cache_write_lookaside && __rec_las_checkpoint_test(session, r))
 		return (EBUSY);
 
-	return (0);
+	/*
+	 * Eviction can configure lookaside table reconciliation, consider if
+	 * it's worth giving up this reconciliation attempt and falling back to
+	 * using the lookaside table.  We continue with evict/restore if
+	 * switching to the lookaside doesn't make sense for any reason: we
+	 * won't retry an evict/restore reconciliation until/unless the
+	 * transactional system moves forward, so at worst it's a single wasted
+	 * effort.
+	 *
+	 * First, check if the lookaside table is a possible alternative.
+	 */
+	if (lookaside_retryp == NULL)
+		return (0);
+
+	/*
+	 * We only suggest lookaside if currently in an evict/restore attempt
+	 * and some updates were saved.  Our caller sets the evict/restore flag
+	 * based on various conditions (like if this is a leaf page), which is
+	 * why we're testing that flag instead of a set of other conditions.
+	 * If no updates were saved, eviction will succeed without needing to
+	 * restore anything.
+	 */
+	if (!F_ISSET(r, WT_EVICT_UPDATE_RESTORE) || r->bnd->supd == NULL)
+		return (0);
+
+	/*
+	 * Check if this reconciliation attempt is making progress.  If there's
+	 * any sign of progress, don't fall back to the lookaside table.
+	 *
+	 * Check if the current reconciliation split, in which case we'll
+	 * likely get to write at least one of the blocks.  If that page is
+	 * empty, that's also progress.
+	 */
+	if (r->bnd_next != 1)
+		return (0);
+
+	/*
+	 * Check if the current reconciliation applied some updates, in which
+	 * case evict/restore should gain us some space.
+	 */
+	if (r->update_mem_saved != r->update_mem_all)
+		return (0);
+
+	/*
+	 * Check if lookaside eviction is possible.  If any of the updates we
+	 * saw were uncommitted, the lookaside table cannot be used: it only
+	 * helps with older readers preventing eviction.
+	 */
+	if (r->update_mem_uncommitted != 0)
+		return (0);
+
+	/*
+	 * The current evict/restore approach shows no signs of being useful,
+	 * lookaside is possible, suggest the lookaside table.
+	 */
+	*lookaside_retryp = true;
+	return (EBUSY);
 }
 
 /*


### PR DESCRIPTION
Continue with update/restore eviction unless we are going to fall back
to using the lookaside table.