### PR TITLE
WT-3039 Add uniqueness to python list of log files.

### DIFF
--- a/test/suite/test_compat01.py
+++ b/test/suite/test_compat01.py
@@ -108,7 +108,7 @@ class test_compat01(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(prev_lsn_count, contains)
 
     def check_log(self, reconfig):
-        orig_logs = fnmatch.filter(os.listdir('.'), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir('.'), "*gerLog*")
         compat_str = self.make_compat_str(False)
         if self.current1:
             prev_lsn_logs = len(orig_logs)

--- a/test/suite/test_reconfig02.py
+++ b/test/suite/test_reconfig02.py
@@ -100,9 +100,9 @@ class test_reconfig02(wttest.WiredTigerTestCase):
         c.close()
         # Close and reopen connection to write a checkpoint, move to the
         # next log file and verify that archive did not run.
-        orig_logs = fnmatch.filter(os.listdir('.'), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir('.'), "*gerLog*")
         self.reopen_conn()
-        cur_logs = fnmatch.filter(os.listdir('.'), "*Log*")
+        cur_logs = fnmatch.filter(os.listdir('.'), "*gerLog*")
         for o in orig_logs:
             self.assertEqual(True, o in cur_logs)
 
@@ -111,7 +111,7 @@ class test_reconfig02(wttest.WiredTigerTestCase):
         self.conn.reconfigure("log=(archive=true)")
         self.session.checkpoint("force")
         time.sleep(2)
-        cur_logs = fnmatch.filter(os.listdir('.'), "*Log*")
+        cur_logs = fnmatch.filter(os.listdir('.'), "*gerLog*")
         for o in orig_logs:
             self.assertEqual(False, o in cur_logs)
 

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -163,7 +163,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
             self.scenario_number % len(self.archive_list)]
         backup_conn_params = \
             'log=(enabled,file_max=%s,archive=%s)' % (self.logmax, self.archive)
-        orig_logs = fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         endcount = 2
         count = 0
         while count < endcount:
@@ -183,7 +183,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         # have been archived if configured. Subsequent openings would not
         # archive because no checkpoint is written due to no modifications.
         #
-        cur_logs = fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+        cur_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         for o in orig_logs:
             if self.archive == 'true':
                 self.assertEqual(False, o in cur_logs)
@@ -195,7 +195,7 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         # it does not.
         #
         self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
-        pr_logs = fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+        pr_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         self.assertEqual(cur_logs, pr_logs)
 
     def test_ops(self):

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -127,7 +127,7 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
             self.scenario_number % len(self.archive_list)]
         backup_conn_params = \
             'log=(enabled,file_max=%s,archive=%s)' % (self.logmax, self.archive)
-        orig_logs = fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         endcount = 2
         count = 0
         while count < endcount:
@@ -142,7 +142,7 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
                 time.sleep(1.0)
                 if count == 0:
                     first_logs = \
-                        fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+                        fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
                 backup_conn.close()
             count += 1
         #
@@ -150,7 +150,7 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         # have been archived if configured. Subsequent openings would not
         # archive because no checkpoint is written due to no modifications.
         #
-        cur_logs = fnmatch.filter(os.listdir(self.backup_dir), "*Log*")
+        cur_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         for o in orig_logs:
             # Creating the backup was effectively an unclean shutdown so
             # even after sleeping, we should never archive log files

--- a/test/suite/test_txn11.py
+++ b/test/suite/test_txn11.py
@@ -50,12 +50,12 @@ class test_txn11(wttest.WiredTigerTestCase, suite_subprocess):
             'transaction_sync=(enabled=false),'
 
     def run_checkpoints(self):
-        orig_logs = fnmatch.filter(os.listdir(self.home), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir(self.home), "*gerLog*")
         checkpoints = 0
         sorig = set(orig_logs)
         while checkpoints < 500:
             self.session.checkpoint()
-            cur_logs = fnmatch.filter(os.listdir(self.home), "*Log*")
+            cur_logs = fnmatch.filter(os.listdir(self.home), "*gerLog*")
             scur = set(cur_logs)
             if scur.isdisjoint(sorig):
                 break

--- a/test/suite/test_txn16.py
+++ b/test/suite/test_txn16.py
@@ -82,14 +82,14 @@ class test_txn16(wttest.WiredTigerTestCase, suite_subprocess):
         loop = 0
         # Record original log files.  There should never be overlap
         # with these even after they're removed.
-        orig_logs = fnmatch.filter(os.listdir(homedir), "*Log*")
+        orig_logs = fnmatch.filter(os.listdir(homedir), "*gerLog*")
         while loop < 3:
             # Reopen with logging on to run recovery first time
             on_conn = self.wiredtiger_open(homedir, self.conn_on)
             on_conn.close()
             if loop > 0:
                 # Get current log files.
-                cur_logs = fnmatch.filter(os.listdir(homedir), "*Log*")
+                cur_logs = fnmatch.filter(os.listdir(homedir), "*gerLog*")
                 scur = set(cur_logs)
                 sorig = set(orig_logs)
                 # There should never be overlap with the log files that
@@ -106,7 +106,7 @@ class test_txn16(wttest.WiredTigerTestCase, suite_subprocess):
                 last_logs = cur_logs
             loop += 1
             # Remove all log files before opening without logging.
-            cur_logs = fnmatch.filter(os.listdir(homedir), "*Log*")
+            cur_logs = fnmatch.filter(os.listdir(homedir), "*gerLog*")
             for l in cur_logs:
                 path=homedir + "/" + l
                 os.remove(path)


### PR DESCRIPTION
This accounts for case insensitivity.
@keithbostic Please review.  The new `test_compat01.py` is the first test to need to know how many log files there were and *Log* is case insensitive on Windows and was also grabbing the pre-allocated log files causing the test to fail on Windows.