### PR TITLE
WT-3310 Fix test/format to tolerate EBUSY with LSM.

### DIFF
--- a/test/format/compact.c
+++ b/test/format/compact.c
@@ -63,8 +63,13 @@ compact(void *arg)
 		if (g.workers_finished)
 			break;
 
+		/*
+		 * Tolerate EBUSY from LSM.
+		 */
 		if ((ret = session->compact(
-		    session, g.uri, NULL)) != 0 && ret != WT_ROLLBACK)
+		    session, g.uri, NULL)) != 0 &&
+		    (!(ret == EBUSY && DATASOURCE("lsm")) &&
+		    ret != WT_ROLLBACK))
 			testutil_die(ret, "session.compact");
 	}
 


### PR DESCRIPTION
@keithbostic Please take a look at this.  This fixes the several test/format failures when alter, LSM and compact are configured.  In that case, it is normal that EBUSY could be returned and test/format should not die in that case.