### PR TITLE
WT-3424 additional gcc 7.1 compile warnings.

### DIFF
--- a/examples/c/ex_backup.c
+++ b/examples/c/ex_backup.c
@@ -48,7 +48,7 @@ static int
 compare_backups(int i)
 {
 	int ret;
-	char buf[1024], msg[8];
+	char buf[1024], msg[32];
 
 	/*
 	 * We run 'wt dump' on both the full backup directory and the
@@ -83,7 +83,7 @@ compare_backups(int i)
 	    full_out, i, incr_out, i);
 	ret = system(buf);
 	if (i == 0)
-		(void)strncpy(msg, "MAIN", sizeof(msg));
+		(void)snprintf(msg, sizeof(msg), "%s", "MAIN");
 	else
 		(void)snprintf(msg, sizeof(msg), "%d", i);
 	printf(

--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -427,7 +427,7 @@ main(int argc, char *argv[])
 	WT_CURSOR *c1, *c2, *nc;
 	WT_SESSION *session;
 	int i, ret;
-	char keybuf[16], valbuf[16];
+	char keybuf[32], valbuf[32];
 	char *key1, *key2, *key3, *val1, *val2, *val3;
 
 	home = example_setup(argc, argv);

--- a/examples/c/ex_log.c
+++ b/examples/c/ex_log.c
@@ -269,7 +269,7 @@ main(int argc, char *argv[])
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
 	int count_min, i, record_count;
-	char cmd_buf[256], k[16], v[16];
+	char cmd_buf[256], k[32], v[32];
 
 	(void)argc;                                     /* Unused variable */
 	(void)testutil_set_progname(argv);

--- a/examples/c/ex_sync.c
+++ b/examples/c/ex_sync.c
@@ -43,7 +43,7 @@ main(int argc, char *argv[])
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
 	int i, record_count, ret;
-	char k[16], v[16];
+	char k[32], v[32];
 	const char *conf;
 
 	home = example_setup(argc, argv);


### PR DESCRIPTION
Printing out an "int" takes 20 characters.