### PR TITLE
WT-3418 Fix a block manager race in tree close/open

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -188,18 +188,20 @@ __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force)
 	if (!F_ISSET(btree,
 	    WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY)) {
 		/*
-		 * If the object is already marked dead, we're just here to
+		 * If the handle is already marked dead, we're just here to
 		 * discard it.
 		 */
 		if (F_ISSET(dhandle, WT_DHANDLE_DEAD))
 			discard = true;
 
 		/*
-		 * If a standard object and it's OK to mark the handle dead
-		 * (letting the tree be discarded later), do so. Don't mark
-		 * memory-mapped trees dead (we close the file handle to allow
-		 * the file to be removed, but mapped trees contain pointers
-		 * into memory that become invalid if the mapping is closed).
+		 * Mark the handle dead (letting the tree be discarded later) if
+		 * it's not already marked dead, our caller allows it, it's not
+		 * a final close, and it's not a memory-mapped tree. (We can't
+		 * mark memory-mapped tree handles dead because we close the
+		 * underlying file handle to allow the file to be removed and
+		 * memory-mapped trees contain pointers into memory that become
+		 * invalid if the mapping is closed.)
 		 */
 		if (!discard && force && !final &&
 		    (bm == NULL || !bm->is_mapped(bm, session)))

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -248,12 +248,12 @@ __wt_conn_btree_sync_and_close(
 		F_SET(dhandle, WT_DHANDLE_DEAD);
 
 	/*
-	 * Get rid of any non-durable trees we couldn't mark dead (or trees
-	 * previously marked dead), by simply discarding them from the cache.
-	 * That work is done after marking the data handle dead for a couple of
-	 * reasons: first, we don't need to hold an exclusive handle to do it,
-	 * second, code we call to clear the cache expects the data handle dead
-	 * flag to be set when discarding modified pages.
+	 * Discard from cache any trees not marked dead in this call (that is,
+	 * including trees previously marked dead). Done after marking the data
+	 * handle dead for a couple reasons: first, we don't need to hold an
+	 * exclusive handle to do it, second, code we call to clear the cache
+	 * expects the data handle dead flag to be set when discarding modified
+	 * pages.
 	 */
 	if (discard)
 		WT_TRET(__wt_cache_op(session, WT_SYNC_DISCARD));

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -727,7 +727,7 @@ restart:
 
 		WT_WITH_DHANDLE(session, dhandle,
 		    WT_TRET(__wt_conn_dhandle_discard_single(
-		    session, true, F_ISSET(conn, WT_CONN_IN_MEMORY))));
+		    session, true, false)));
 		goto restart;
 	}
 
@@ -753,7 +753,7 @@ restart:
 	WT_TAILQ_SAFE_REMOVE_BEGIN(dhandle, &conn->dhqh, q, dhandle_tmp) {
 		WT_WITH_DHANDLE(session, dhandle,
 		    WT_TRET(__wt_conn_dhandle_discard_single(
-		    session, true, F_ISSET(conn, WT_CONN_IN_MEMORY))));
+		    session, true, false)));
 	} WT_TAILQ_SAFE_REMOVE_END
 
 	return (ret);

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -99,9 +99,9 @@ struct __wt_data_handle {
 
 	/* Flags values over 0xff are reserved for WT_BTREE_* */
 #define	WT_DHANDLE_DEAD		        0x01	/* Dead, awaiting discard */
-#define	WT_DHANDLE_DISCARD	        0x02	/* Discard on release */
-#define	WT_DHANDLE_DISCARD_FORCE	0x04	/* Force discard on release */
-#define	WT_DHANDLE_EXCLUSIVE	        0x08	/* Need exclusive access */
+#define	WT_DHANDLE_DISCARD	        0x02	/* Close on release */
+#define	WT_DHANDLE_DISCARD_KILL		0x04	/* Mark dead on release */
+#define	WT_DHANDLE_EXCLUSIVE	        0x08	/* Exclusive access */
 #define	WT_DHANDLE_IS_METADATA		0x10	/* Metadata handle */
 #define	WT_DHANDLE_LOCK_ONLY	        0x20	/* Handle only used as a lock */
 #define	WT_DHANDLE_OPEN		        0x40	/* Handle is open */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -258,11 +258,11 @@ extern int __wt_checkpoint_server_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_
 extern void __wt_checkpoint_signal(WT_SESSION_IMPL *session, wt_off_t logsize);
 extern int __wt_conn_dhandle_alloc( WT_SESSION_IMPL *session, const char *uri, const char *checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_dhandle_find( WT_SESSION_IMPL *session, const char *uri, const char *checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_conn_btree_sync_and_close(WT_SESSION_IMPL *session, bool final, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_btree_sync_and_close( WT_SESSION_IMPL *session, bool final, bool mark_dead) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_btree_open( WT_SESSION_IMPL *session, const char *cfg[], uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri, int (*file_func)(WT_SESSION_IMPL *, const char *[]), int (*name_func)(WT_SESSION_IMPL *, const char *, bool *), const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_conn_dhandle_close_all( WT_SESSION_IMPL *session, const char *uri, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_conn_dhandle_discard_single( WT_SESSION_IMPL *session, bool final, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_dhandle_close_all( WT_SESSION_IMPL *session, const char *uri, bool mark_dead) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_dhandle_discard_single( WT_SESSION_IMPL *session, bool final, bool mark_dead) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_dhandle_discard(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_connection_init(WT_CONNECTION_IMPL *conn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_connection_destroy(WT_CONNECTION_IMPL *conn);

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -487,7 +487,7 @@ __lsm_discard_handle(
 	WT_RET(__wt_session_get_btree(session, uri, checkpoint, NULL,
 	    WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_LOCK_ONLY));
 
-	F_SET(session->dhandle, WT_DHANDLE_DISCARD_FORCE);
+	F_SET(session->dhandle, WT_DHANDLE_DISCARD_KILL);
 	return (__wt_session_release_btree(session));
 }
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -166,8 +166,7 @@ __session_alter(WT_SESSION *wt_session, const char *uri, const char *config)
 	WT_WITH_CHECKPOINT_LOCK(session,
 	    WT_WITH_SCHEMA_LOCK(session,
 		ret = __wt_schema_worker(session, uri, __wt_alter, NULL, cfg,
-		WT_BTREE_ALTER |
-		WT_DHANDLE_DISCARD_FORCE | WT_DHANDLE_EXCLUSIVE)));
+		WT_BTREE_ALTER | WT_DHANDLE_EXCLUSIVE)));
 
 err:	if (ret != 0)
 		WT_STAT_CONN_INCR(session, session_table_alter_fail);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -261,17 +261,14 @@ __wt_session_release_btree(WT_SESSION_IMPL *session)
 	 * If we had special flags set, close the handle so that future access
 	 * can get a handle without special flags.
 	 */
-	if (F_ISSET(dhandle, WT_DHANDLE_DISCARD | WT_DHANDLE_DISCARD_FORCE)) {
+	if (F_ISSET(dhandle, WT_DHANDLE_DISCARD | WT_DHANDLE_DISCARD_KILL)) {
 		WT_SAVE_DHANDLE(session, __session_find_dhandle(session,
 		    dhandle->name, dhandle->checkpoint, &dhandle_cache));
 		if (dhandle_cache != NULL)
 			__session_discard_dhandle(session, dhandle_cache);
 	}
 
-	if (F_ISSET(dhandle, WT_DHANDLE_DISCARD_FORCE)) {
-		ret = __wt_conn_btree_sync_and_close(session, false, true);
-		F_CLR(dhandle, WT_DHANDLE_DISCARD_FORCE);
-	} else if (F_ISSET(btree, WT_BTREE_BULK)) {
+	if (F_ISSET(btree, WT_BTREE_BULK)) {
 		WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) &&
 		    !F_ISSET(dhandle, WT_DHANDLE_DISCARD));
 		/*
@@ -281,11 +278,12 @@ __wt_session_release_btree(WT_SESSION_IMPL *session)
 		 */
 		WT_WITH_SCHEMA_LOCK(session, ret =
 		    __wt_conn_btree_sync_and_close(session, false, false));
-	} else if (F_ISSET(dhandle, WT_DHANDLE_DISCARD) ||
-	    F_ISSET(btree, WT_BTREE_SPECIAL_FLAGS)) {
+	} else if (F_ISSET(btree, WT_BTREE_SPECIAL_FLAGS) ||
+	    F_ISSET(dhandle, WT_DHANDLE_DISCARD | WT_DHANDLE_DISCARD_KILL)) {
 		WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE));
-		ret = __wt_conn_btree_sync_and_close(session, false, false);
-		F_CLR(dhandle, WT_DHANDLE_DISCARD);
+		ret = __wt_conn_btree_sync_and_close(session, false,
+		    F_ISSET(dhandle, WT_DHANDLE_DISCARD_KILL));
+		F_CLR(dhandle, WT_DHANDLE_DISCARD | WT_DHANDLE_DISCARD_KILL);
 	}
 
 	if (session == dhandle->excl_session) {

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1665,18 +1665,6 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
 	bulk = F_ISSET(btree, WT_BTREE_BULK);
 
 	/*
-	 * If the handle is already dead or the file isn't durable, force the
-	 * discard.
-	 *
-	 * If the file isn't durable, mark the handle dead, there are asserts
-	 * later on that only dead handles can have modified pages.
-	 */
-	if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT))
-		F_SET(session->dhandle, WT_DHANDLE_DEAD);
-	if (F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
-		return (__wt_cache_op(session, WT_SYNC_DISCARD));
-
-	/*
 	 * If closing an unmodified file, check that no update is required
 	 * for active readers.
 	 */


### PR DESCRIPTION
@sueloverso, for your consideration.

I don't see any reason not to delay setting the `WT_DHANDLE_DEAD` flag until after the block object is discarded, it's a cheap operation.

I don't think this helps with WT-3232 because my reading of that ticket was the cache blocks themselves need to be discarded (although I don't understand why that's the case).