### PR TITLE
WT-3380 Remove packed attribute from WT_UPDATE.

### DIFF
--- a/build_posix/aclocal/strict.m4
+++ b/build_posix/aclocal/strict.m4
@@ -82,7 +82,6 @@ AC_DEFUN([AM_GCC_WARNINGS], [
 AC_DEFUN([AM_CLANG_WARNINGS], [
 	w="-Weverything -Werror"
 
-	w="$w -Wno-address-of-packed-member"
 	w="$w -Wno-cast-align"
 	w="$w -Wno-documentation-unknown-command"
 	w="$w -Wno-format-nonliteral"

--- a/dist/s_style
+++ b/dist/s_style
@@ -56,6 +56,11 @@ else
 		cat $t
 	fi
 
+	if grep 'sizeof(WT_UPDATE)' $f > $t; then
+		echo "$f: Use WT_UPDATE_SIZE rather than sizeof(WT_UPDATE)"
+		cat $t
+	fi
+
 	if ! expr "$f" : 'src/include/queue\.h' > /dev/null &&
 	    egrep 'STAILQ_|SLIST_|\bLIST_' $f ; then
 		echo "$f: use TAILQ for all lists"

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -268,10 +268,10 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
 	 */
 	if (modify_type == WT_UPDATE_DELETED ||
 	    modify_type == WT_UPDATE_RESERVED)
-		WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE), &upd));
+		WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE, &upd));
 	else {
 		WT_RET(__wt_calloc(
-		    session, 1, sizeof(WT_UPDATE) + value->size, &upd));
+		    session, 1, WT_UPDATE_SIZE + value->size, &upd));
 		if (value->size != 0) {
 			upd->size = WT_STORE_SIZE(value->size);
 			memcpy(WT_UPDATE_DATA(upd), value->data, value->size);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -885,7 +885,7 @@ struct __wt_ikey {
  * is done for an entry, WT_UPDATE structures are formed into a forward-linked
  * list.
  */
-WT_PACKED_STRUCT_BEGIN(__wt_update)
+struct __wt_update {
 	volatile uint64_t txnid;			/* Transaction ID */
 	WT_DECL_TIMESTAMP(timestamp)
 
@@ -902,9 +902,15 @@ WT_PACKED_STRUCT_BEGIN(__wt_update)
 #define	WT_UPDATE_DATA_VALUE(upd)					\
 	((upd)->type == WT_UPDATE_STANDARD || (upd)->type == WT_UPDATE_DELETED)
 
+/*
+ * WT_UPDATE_SIZE is the expected structure size before the data starts --
+ * we verify the build to ensure the compiler hasn't inserted padding.
+ */
+#define	WT_UPDATE_SIZE	(21 + WT_TIMESTAMP_SIZE)
+
 	/* The untyped value immediately follows the WT_UPDATE structure. */
 #define	WT_UPDATE_DATA(upd)						\
-	((void *)((uint8_t *)(upd) + sizeof(WT_UPDATE)))
+	((void *)((uint8_t *)(upd) + WT_UPDATE_SIZE))
 
 	/*
 	 * The memory size of an update: include some padding because this is
@@ -912,14 +918,8 @@ WT_PACKED_STRUCT_BEGIN(__wt_update)
 	 * cache overhead calculation.
 	 */
 #define	WT_UPDATE_MEMSIZE(upd)						\
-	WT_ALIGN(sizeof(WT_UPDATE) + (upd)->size, 32)
-WT_PACKED_STRUCT_END
-
-/*
- * WT_UPDATE_SIZE is the expected structure size -- we verify the build to
- * ensure the compiler hasn't inserted padding.
- */
-#define	WT_UPDATE_SIZE	(21 + WT_TIMESTAMP_SIZE)
+	WT_ALIGN(WT_UPDATE_SIZE + (upd)->size, 32)
+};
 
 /*
  * WT_INSERT --

--- a/src/include/verify_build.h
+++ b/src/include/verify_build.h
@@ -52,7 +52,12 @@ __wt_verify_build(void)
 	/* Check specific structures weren't padded. */
 	WT_SIZE_CHECK(WT_BLOCK_DESC, WT_BLOCK_DESC_SIZE);
 	WT_SIZE_CHECK(WT_REF, WT_REF_SIZE);
-	WT_SIZE_CHECK(WT_UPDATE, WT_UPDATE_SIZE);
+
+	/*
+	 * WT_UPDATE is special, the type field comes last and it's okay if the
+	 * compiler pads after that.
+	 */
+	WT_STATIC_ASSERT(offsetof(WT_UPDATE, type) == WT_UPDATE_SIZE - 1);
 
 	/* Check specific structures were padded. */
 #define	WT_PADDING_CHECK(s)						\


### PR DESCRIPTION
We still check that the compiler doesn't add padding between fields, so the structure is the expected size, but deal with any padding added at the end.

This should allow compilers to generate more efficient code when reading fields from WT_UPDATE because they can assume fields are aligned appropriately.