### PR TITLE
WT-3380 Remove packed attribute from WT_UPDATE.

### DIFF
--- a/build_posix/aclocal/strict.m4
+++ b/build_posix/aclocal/strict.m4
@@ -82,7 +82,6 @@ AC_DEFUN([AM_GCC_WARNINGS], [
 AC_DEFUN([AM_CLANG_WARNINGS], [
 	w="-Weverything -Werror"
 
-	w="$w -Wno-address-of-packed-member"
 	w="$w -Wno-cast-align"
 	w="$w -Wno-documentation-unknown-command"
 	w="$w -Wno-format-nonliteral"

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -75,7 +75,7 @@ AC_SUBST(AM_LIBTOOLFLAGS)
 # WiredTiger uses anonymous unions to pad structures. It's part of C11, but
 # some compilers require -std=c11 to support them. Turn on that flag for any
 # compiler that supports it, except for Solaris, where gcc -std=c11 makes
-# some none-C11 prototypes unavailable.
+# some non-C11 prototypes unavailable.
 if test "$wt_cv_solaris" = "no"; then
 	AX_CHECK_COMPILE_FLAG([-std=c11], [AM_CFLAGS="$AM_CFLAGS -std=c11"])
 fi

--- a/dist/s_style
+++ b/dist/s_style
@@ -56,6 +56,11 @@ else
 		cat $t
 	fi
 
+	if grep 'sizeof(WT_UPDATE)' $f > $t; then
+		echo "$f: Use WT_UPDATE_SIZE rather than sizeof(WT_UPDATE)"
+		cat $t
+	fi
+
 	if ! expr "$f" : 'src/include/queue\.h' > /dev/null &&
 	    egrep 'STAILQ_|SLIST_|\bLIST_' $f ; then
 		echo "$f: use TAILQ for all lists"

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -61,7 +61,7 @@ __cursor_fix_append_next(WT_CURSOR_BTREE *cbt, bool newpage)
 		cbt->v = 0;
 		val->data = &cbt->v;
 	} else
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 	val->size = 1;
 	return (0);
 }
@@ -110,7 +110,7 @@ new_page:
 		cbt->v = __bit_getv_recno(cbt->ref, cbt->recno, btree->bitcnt);
 		val->data = &cbt->v;
 	} else
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 	val->size = 1;
 	return (0);
 }
@@ -147,7 +147,7 @@ new_page:	if (cbt->ins == NULL)
 				++cbt->page_deleted_count;
 			continue;
 		}
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 		val->size = upd->size;
 		return (0);
 	}
@@ -211,7 +211,7 @@ new_page:	/* Find the matching WT_COL slot. */
 				continue;
 			}
 
-			val->data = WT_UPDATE_DATA(upd);
+			val->data = upd->data;
 			val->size = upd->size;
 			return (0);
 		}
@@ -332,7 +332,7 @@ new_insert:	if ((ins = cbt->ins) != NULL) {
 			}
 			key->data = WT_INSERT_KEY(ins);
 			key->size = WT_INSERT_KEY_SIZE(ins);
-			val->data = WT_UPDATE_DATA(upd);
+			val->data = upd->data;
 			val->size = upd->size;
 			return (0);
 		}

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -207,7 +207,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 		cbt->v = 0;
 		val->data = &cbt->v;
 	} else
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 	val->size = 1;
 	return (0);
 }
@@ -256,7 +256,7 @@ new_page:
 		cbt->v = __bit_getv_recno(cbt->ref, cbt->recno, btree->bitcnt);
 		val->data = &cbt->v;
 	} else
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 	val->size = 1;
 	return (0);
 }
@@ -293,7 +293,7 @@ new_page:	if (cbt->ins == NULL)
 				++cbt->page_deleted_count;
 			continue;
 		}
-		val->data = WT_UPDATE_DATA(upd);
+		val->data = upd->data;
 		val->size = upd->size;
 		return (0);
 	}
@@ -358,7 +358,7 @@ new_page:	if (cbt->recno < cbt->ref->ref_recno)
 				continue;
 			}
 
-			val->data = WT_UPDATE_DATA(upd);
+			val->data = upd->data;
 			val->size = upd->size;
 			return (0);
 		}
@@ -489,7 +489,7 @@ new_insert:	if ((ins = cbt->ins) != NULL) {
 			}
 			key->data = WT_INSERT_KEY(ins);
 			key->size = WT_INSERT_KEY_SIZE(ins);
-			val->data = WT_UPDATE_DATA(upd);
+			val->data = upd->data;
 			val->size = upd->size;
 			return (0);
 		}

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -999,12 +999,10 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 			WT_RET(ds->f(ds, "\tvalue {reserved}\n"));
 		else if (hexbyte) {
 			WT_RET(ds->f(ds, "\t{"));
-			WT_RET(__debug_hex_byte(ds,
-			    *(uint8_t *)WT_UPDATE_DATA(upd)));
+			WT_RET(__debug_hex_byte(ds, *(uint8_t *)upd->data));
 			WT_RET(ds->f(ds, "}\n"));
 		} else
-			WT_RET(__debug_item(ds,
-			    "value", WT_UPDATE_DATA(upd), upd->size));
+			WT_RET(__debug_item(ds, "value", upd->data, upd->size));
 		WT_RET(ds->f(ds, "\t" "txn id %" PRIu64, upd->txnid));
 
 #ifdef HAVE_TIMESTAMPS

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -999,7 +999,7 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 			WT_RET(ds->f(ds, "\tvalue {reserved}\n"));
 		else if (hexbyte) {
 			WT_RET(ds->f(ds, "\t{"));
-			WT_RET(__debug_hex_byte(ds, *(uint8_t *)upd->data));
+			WT_RET(__debug_hex_byte(ds, *upd->data));
 			WT_RET(ds->f(ds, "}\n"));
 		} else
 			WT_RET(__debug_item(ds, "value", upd->data, upd->size));

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -78,7 +78,7 @@ __wt_ovfl_read(WT_SESSION_IMPL *session,
 				break;
 			}
 		WT_ASSERT(session, i < track->remove_next);
-		store->data = WT_UPDATE_DATA(upd);
+		store->data = upd->data;
 		store->size = upd->size;
 	} else
 		ret = __ovfl_read(session, unpack->data, unpack->size, store);

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -95,7 +95,7 @@ __value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 
 	/* If the cursor references a WT_UPDATE item, return it. */
 	if (upd != NULL) {
-		cursor->value.data = WT_UPDATE_DATA(upd);
+		cursor->value.data = upd->data;
 		cursor->value.size = upd->size;
 		return (0);
 	}

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -269,7 +269,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
 	 */
 	if (modify_type == WT_UPDATE_DELETED ||
 	    modify_type == WT_UPDATE_RESERVED)
-		WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE), &upd));
+		WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE, &upd));
 	else {
 		/*
 		 * The first 3 data bytes are declared in the WT_UPDATE
@@ -277,7 +277,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
 		 * to calculate the data start. Adjust the value's size.
 		 */
 		len = value->size <= 3 ? 0 : value->size - 3;
-		WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE) + len, &upd));
+		WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE + len, &upd));
 		if (value->size != 0) {
 			upd->size = WT_STORE_SIZE(value->size);
 			memcpy(upd->data, value->data, value->size);

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -259,6 +259,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
     WT_UPDATE **updp, size_t *sizep, u_int modify_type)
 {
 	WT_UPDATE *upd;
+	size_t len;
 
 	*updp = NULL;
 
@@ -270,11 +271,16 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
 	    modify_type == WT_UPDATE_RESERVED)
 		WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE), &upd));
 	else {
-		WT_RET(__wt_calloc(
-		    session, 1, sizeof(WT_UPDATE) + value->size, &upd));
+		/*
+		 * The first 3 data bytes are declared in the WT_UPDATE
+		 * structure to simply structure layout and avoid having
+		 * to calculate the data start. Adjust the value's size.
+		 */
+		len = value->size <= 3 ? 0 : value->size - 3;
+		WT_RET(__wt_calloc(session, 1, sizeof(WT_UPDATE) + len, &upd));
 		if (value->size != 0) {
 			upd->size = WT_STORE_SIZE(value->size);
-			memcpy(WT_UPDATE_DATA(upd), value->data, value->size);
+			memcpy(upd->data, value->data, value->size);
 		}
 	}
 	upd->type = (uint8_t)modify_type;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -259,7 +259,6 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
     WT_UPDATE **updp, size_t *sizep, u_int modify_type)
 {
 	WT_UPDATE *upd;
-	size_t len;
 
 	*updp = NULL;
 
@@ -271,13 +270,8 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
 	    modify_type == WT_UPDATE_RESERVED)
 		WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE, &upd));
 	else {
-		/*
-		 * The first 3 data bytes are declared in the WT_UPDATE
-		 * structure to simply structure layout and avoid having
-		 * to calculate the data start. Adjust the value's size.
-		 */
-		len = value->size <= 3 ? 0 : value->size - 3;
-		WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE + len, &upd));
+		WT_RET(__wt_calloc(
+		    session, 1, WT_UPDATE_SIZE + value->size, &upd));
 		if (value->size != 0) {
 			upd->size = WT_STORE_SIZE(value->size);
 			memcpy(upd->data, value->data, value->size);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -885,8 +885,8 @@ struct __wt_ikey {
  * is done for an entry, WT_UPDATE structures are formed into a forward-linked
  * list.
  */
-WT_PACKED_STRUCT_BEGIN(__wt_update)
-	volatile uint64_t txnid;			/* Transaction ID */
+struct __wt_update {
+	volatile uint64_t txnid;	/* transaction ID */
 	WT_DECL_TIMESTAMP(timestamp)
 
 	WT_UPDATE *next;		/* forward-linked list */
@@ -898,13 +898,16 @@ WT_PACKED_STRUCT_BEGIN(__wt_update)
 #define	WT_UPDATE_RESERVED	2
 	uint8_t type;			/* type (one byte to conserve memory) */
 
-	/* The update includes a complete value. */
+	/* If the update includes a complete value. */
 #define	WT_UPDATE_DATA_VALUE(upd)					\
 	((upd)->type == WT_UPDATE_STANDARD || (upd)->type == WT_UPDATE_DELETED)
 
-	/* The untyped value immediately follows the WT_UPDATE structure. */
-#define	WT_UPDATE_DATA(upd)						\
-	((void *)((uint8_t *)(upd) + sizeof(WT_UPDATE)))
+	/*
+	 * An untyped value immediately follows the WT_UPDATE structure. The
+	 * first 3 bytes are declared to simplify layout and provide a field
+	 * name.
+	 */
+	uint8_t data[3];		/* start of the data */
 
 	/*
 	 * The memory size of an update: include some padding because this is
@@ -913,13 +916,13 @@ WT_PACKED_STRUCT_BEGIN(__wt_update)
 	 */
 #define	WT_UPDATE_MEMSIZE(upd)						\
 	WT_ALIGN(sizeof(WT_UPDATE) + (upd)->size, 32)
-WT_PACKED_STRUCT_END
+};
 
 /*
  * WT_UPDATE_SIZE is the expected structure size -- we verify the build to
  * ensure the compiler hasn't inserted padding.
  */
-#define	WT_UPDATE_SIZE	(21 + WT_TIMESTAMP_SIZE)
+#define	WT_UPDATE_SIZE	32
 
 /*
  * WT_INSERT --

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -925,10 +925,10 @@ struct __wt_update {
 };
 
 /*
- * WT_UPDATE_SIZE is the expected structure size -- we verify the build to
- * ensure the compiler hasn't inserted padding.
+ * WT_UPDATE_SIZE is the expected structure size excluding the payload data --
+ * we verify the build to ensure the compiler hasn't inserted padding.
  */
-#define	WT_UPDATE_SIZE	(24 + WT_TIMESTAMP_SIZE)
+#define	WT_UPDATE_SIZE	(21 + WT_TIMESTAMP_SIZE)
 
 /*
  * WT_INSERT --

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -909,11 +909,11 @@ struct __wt_update {
 #endif
 
 	/*
-	 * An untyped value immediately follows the WT_UPDATE structure. The
-	 * first 3 bytes are declared to simplify layout and provide a field
-	 * name.
+	 * Zero or more bytes of value (the payload) immediately follows the
+	 * WT_UPDATE structure.  We use a C99 flexible array member which has
+	 * the semantics we want.
 	 */
-	uint8_t data[3];		/* start of the data */
+	uint8_t data[];			/* start of the data */
 
 	/*
 	 * The memory size of an update: include some padding because this is

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -928,7 +928,7 @@ struct __wt_update {
  * WT_UPDATE_SIZE is the expected structure size -- we verify the build to
  * ensure the compiler hasn't inserted padding.
  */
-#define	WT_UPDATE_SIZE	32
+#define	WT_UPDATE_SIZE	(24 + WT_TIMESTAMP_SIZE)
 
 /*
  * WT_INSERT --

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -887,7 +887,9 @@ struct __wt_ikey {
  */
 struct __wt_update {
 	volatile uint64_t txnid;	/* transaction ID */
-	WT_DECL_TIMESTAMP(timestamp)
+#if WT_TIMESTAMP_SIZE == 8
+	WT_DECL_TIMESTAMP(timestamp)	/* aligned uint64_t timestamp */
+#endif
 
 	WT_UPDATE *next;		/* forward-linked list */
 
@@ -901,6 +903,10 @@ struct __wt_update {
 	/* If the update includes a complete value. */
 #define	WT_UPDATE_DATA_VALUE(upd)					\
 	((upd)->type == WT_UPDATE_STANDARD || (upd)->type == WT_UPDATE_DELETED)
+
+#if WT_TIMESTAMP_SIZE != 8
+	WT_DECL_TIMESTAMP(timestamp)	/* unaligned uint8_t array timestamp */
+#endif
 
 	/*
 	 * An untyped value immediately follows the WT_UPDATE structure. The

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -921,7 +921,7 @@ struct __wt_update {
 	 * cache overhead calculation.
 	 */
 #define	WT_UPDATE_MEMSIZE(upd)						\
-	WT_ALIGN(sizeof(WT_UPDATE) + (upd)->size, 32)
+	WT_ALIGN(WT_UPDATE_SIZE + (upd)->size, 32)
 };
 
 /*

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -442,7 +442,7 @@ value:
 	 * (if any) is visible.
 	 */
 	if (upd != NULL) {
-		vb->data = WT_UPDATE_DATA(upd);
+		vb->data = upd->data;
 		vb->size = upd->size;
 		return (0);
 	}

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -257,11 +257,14 @@
 #endif
 
 #ifdef HAVE_TIMESTAMPS
-union __wt_timestamp_t {
+struct __wt_timestamp_t {
+#if WT_TIMESTAMP_SIZE == 8
 	uint64_t val;
+#else
 	uint8_t ts[WT_TIMESTAMP_SIZE];
+#endif
 };
-typedef union __wt_timestamp_t wt_timestamp_t;
+typedef struct __wt_timestamp_t wt_timestamp_t;
 #define	WT_DECL_TIMESTAMP(x)	wt_timestamp_t x;
 #define	WT_TIMESTAMP_NULL(x)	(x)
 #else

--- a/src/include/verify_build.h
+++ b/src/include/verify_build.h
@@ -52,7 +52,12 @@ __wt_verify_build(void)
 	/* Check specific structures weren't padded. */
 	WT_SIZE_CHECK(WT_BLOCK_DESC, WT_BLOCK_DESC_SIZE);
 	WT_SIZE_CHECK(WT_REF, WT_REF_SIZE);
-	WT_SIZE_CHECK(WT_UPDATE, WT_UPDATE_SIZE);
+
+	/*
+	 * WT_UPDATE is special, we don't use sizeof on that structure because
+	 * the compiler pads it based on how timestamps are configured.
+	 */
+	WT_STATIC_ASSERT(offsetof(WT_UPDATE, data) + 3 == WT_UPDATE_SIZE);
 
 	/* Check specific structures were padded. */
 #define	WT_PADDING_CHECK(s)						\

--- a/src/include/verify_build.h
+++ b/src/include/verify_build.h
@@ -54,10 +54,13 @@ __wt_verify_build(void)
 	WT_SIZE_CHECK(WT_REF, WT_REF_SIZE);
 
 	/*
-	 * WT_UPDATE is special, we don't use sizeof on that structure because
-	 * the compiler pads it based on how timestamps are configured.
+	 * WT_UPDATE is special: we arrange fields to avoid padding within the
+	 * structure but it could be padded at the end depending on the
+	 * timestamp size.  Further check that the data field in the update
+	 * structure is where we expect it.
 	 */
-	WT_STATIC_ASSERT(offsetof(WT_UPDATE, data) + 3 == WT_UPDATE_SIZE);
+	WT_SIZE_CHECK(WT_UPDATE, WT_ALIGN(WT_UPDATE_SIZE, 8));
+	WT_STATIC_ASSERT(offsetof(WT_UPDATE, data) == WT_UPDATE_SIZE);
 
 	/* Check specific structures were padded. */
 #define	WT_PADDING_CHECK(s)						\

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -290,6 +290,8 @@ struct __wt_thread;
     typedef struct __wt_thread WT_THREAD;
 struct __wt_thread_group;
     typedef struct __wt_thread_group WT_THREAD_GROUP;
+struct __wt_timestamp_t;
+    typedef struct __wt_timestamp_t WT_TIMESTAMP_T;
 struct __wt_txn;
     typedef struct __wt_txn WT_TXN;
 struct __wt_txn_global;
@@ -304,8 +306,6 @@ union __wt_lsn;
     typedef union __wt_lsn WT_LSN;
 union __wt_rand_state;
     typedef union __wt_rand_state WT_RAND_STATE;
-union __wt_timestamp_t;
-    typedef union __wt_timestamp_t WT_TIMESTAMP_T;
 /*
  * Forward type declarations for internal types: END
  * DO NOT EDIT: automatically built by dist/s_typedef.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3774,7 +3774,7 @@ __rec_update_las(WT_SESSION_IMPL *session,
 				continue;
 
 #ifdef HAVE_TIMESTAMPS
-			las_timestamp.data = list->onpage_timestamp.ts;
+			las_timestamp.data = &list->onpage_timestamp;
 			las_timestamp.size = WT_TIMESTAMP_SIZE;
 #endif
 			cursor->set_key(cursor,
@@ -3788,7 +3788,7 @@ __rec_update_las(WT_SESSION_IMPL *session,
 				las_value.size = upd->size;
 			}
 #ifdef HAVE_TIMESTAMPS
-			las_timestamp.data = upd->timestamp.ts;
+			las_timestamp.data = &upd->timestamp;
 			las_timestamp.size = WT_TIMESTAMP_SIZE;
 #endif
 			cursor->set_value(cursor,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3784,7 +3784,7 @@ __rec_update_las(WT_SESSION_IMPL *session,
 			if (upd->type == WT_UPDATE_DELETED)
 				las_value.size = 0;
 			else {
-				las_value.data = WT_UPDATE_DATA(upd);
+				las_value.data = upd->data;
 				las_value.size = upd->size;
 			}
 #ifdef HAVE_TIMESTAMPS
@@ -4322,7 +4322,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 		if (upd != NULL)
 			__bit_setv(r->first_free,
 			    WT_INSERT_RECNO(ins) - pageref->ref_recno,
-			    btree->bitcnt, *(uint8_t *)WT_UPDATE_DATA(upd));
+			    btree->bitcnt, *(uint8_t *)upd->data);
 	}
 
 	/* Calculate the number of entries per page remainder. */
@@ -4379,8 +4379,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 
 			if (nrecs > 0) {
 				__bit_setv(r->first_free, entry, btree->bitcnt,
-				    upd == NULL ? 0 :
-				    *(uint8_t *)WT_UPDATE_DATA(upd));
+				    upd == NULL ? 0 : *(uint8_t *)upd->data);
 				--nrecs;
 				++entry;
 				++r->recno;
@@ -4722,7 +4721,7 @@ record_loop:	/*
 
 				deleted = upd->type == WT_UPDATE_DELETED;
 				if (!deleted) {
-					data = WT_UPDATE_DATA(upd);
+					data = upd->data;
 					size = upd->size;
 				}
 			} else if (vpack->raw == WT_CELL_VALUE_OVFL_RM) {
@@ -4949,7 +4948,7 @@ compare:		/*
 				deleted = upd == NULL ||
 				    upd->type == WT_UPDATE_DELETED;
 				if (!deleted) {
-					data = WT_UPDATE_DATA(upd);
+					data = upd->data;
 					size = upd->size;
 				}
 			}
@@ -5534,8 +5533,7 @@ __rec_row_leaf(WT_SESSION_IMPL *session,
 				val->cell_len = val->len = val->buf.size = 0;
 			} else {
 				WT_ERR(__rec_cell_build_val(session, r,
-				    WT_UPDATE_DATA(upd), upd->size,
-				    (uint64_t)0));
+				    upd->data, upd->size, (uint64_t)0));
 				dictionary = true;
 			}
 		}
@@ -5703,7 +5701,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 			val->len = 0;
 		else
 			WT_RET(__rec_cell_build_val(session, r,
-			    WT_UPDATE_DATA(upd), upd->size, (uint64_t)0));
+			    upd->data, upd->size, (uint64_t)0));
 
 							/* Build key cell. */
 		WT_RET(__rec_cell_build_leaf_key(session, r,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -4322,7 +4322,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 		if (upd != NULL)
 			__bit_setv(r->first_free,
 			    WT_INSERT_RECNO(ins) - pageref->ref_recno,
-			    btree->bitcnt, *(uint8_t *)upd->data);
+			    btree->bitcnt, *upd->data);
 	}
 
 	/* Calculate the number of entries per page remainder. */
@@ -4379,7 +4379,7 @@ __rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 
 			if (nrecs > 0) {
 				__bit_setv(r->first_free, entry, btree->bitcnt,
-				    upd == NULL ? 0 : *(uint8_t *)upd->data);
+				    upd == NULL ? 0 : *upd->data);
 				--nrecs;
 				++entry;
 				++r->recno;

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -74,7 +74,7 @@ __txn_op_log(WT_SESSION_IMPL *session,
 	cursor = &cbt->iface;
 
 	upd = op->u.upd;
-	value.data = WT_UPDATE_DATA(upd);
+	value.data = upd->data;
 	value.size = upd->size;
 
 	/*


### PR DESCRIPTION
@michaelcahill, @sulabhM, here's a different change.

The fundamental change is adding `uint8_t data[3]` at the end of the `WT_UPDATE` structure: that means we can allocate `sizeof(WT_UPDATE)` without wasting bytes and it gives us a field name to use, we can replace `WT_UPDATE_DATA(upd);` with the more natural `upd->data;`

The only downside I see is we potentially waste 3 bytes on `WT_UPDATE` structures with no data package (so, `WT_UPDATE_DELETED`, `WT_UPDATE_RESERVED`, or zero-length values), but because we calculate the memory use of a `WT_UPDATE` structure as aligned to 32B, I don't think there's any actual loss.

Also, I tucked in a separate change in 14d3d0a, which locates the declaration of the `WT_UPDATE` timestamp. If you don't do that, using a non-8B timestamp (for example, `--with-timestamp-size=37`) will either fail the build because padding will get inserted in the middle of the structure, or fields like `upd->next` will be unaligned.