### PR TITLE
WT-3387 Fix checkpoint support for read_timestamp.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -230,8 +230,10 @@ struct __wt_txn {
 #define	WT_TXN_HAS_TS_COMMIT	0x010
 #define	WT_TXN_HAS_TS_READ	0x020
 #define	WT_TXN_NAMED_SNAPSHOT	0x040
-#define	WT_TXN_READONLY		0x080
-#define	WT_TXN_RUNNING		0x100
-#define	WT_TXN_SYNC_SET		0x200
+#define	WT_TXN_PUBLIC_TS_COMMIT	0x080
+#define	WT_TXN_PUBLIC_TS_READ	0x100
+#define	WT_TXN_READONLY		0x200
+#define	WT_TXN_RUNNING		0x400
+#define	WT_TXN_SYNC_SET		0x800
 	uint32_t flags;
 };

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -685,9 +685,10 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
 #ifdef HAVE_TIMESTAMPS
 			if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
-			    op->type != WT_TXN_OP_BASIC_TS)
+			    op->type != WT_TXN_OP_BASIC_TS) {
 				__wt_timestamp_set(op->u.upd->timestamp,
 				    txn->commit_timestamp);
+			}
 #endif
 			break;
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -685,10 +685,9 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
 #ifdef HAVE_TIMESTAMPS
 			if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
-			    op->type != WT_TXN_OP_BASIC_TS) {
+			    op->type != WT_TXN_OP_BASIC_TS)
 				__wt_timestamp_set(op->u.upd->timestamp,
 				    txn->commit_timestamp);
-			}
 #endif
 			break;
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -314,7 +314,7 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session)
 	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
 
-	if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT))
+	if (F_ISSET(txn, WT_TXN_PUBLIC_TS_COMMIT))
 		return;
 
 	__wt_writelock(session, &txn_global->commit_timestamp_rwlock);
@@ -330,7 +330,7 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session)
 		TAILQ_INSERT_AFTER(&txn_global->commit_timestamph,
 		    prev, txn, commit_timestampq);
 	__wt_writeunlock(session, &txn_global->commit_timestamp_rwlock);
-	F_SET(txn, WT_TXN_HAS_TS_COMMIT);
+	F_SET(txn, WT_TXN_HAS_TS_COMMIT | WT_TXN_PUBLIC_TS_COMMIT);
 }
 
 /*
@@ -346,12 +346,13 @@ __wt_txn_clear_commit_timestamp(WT_SESSION_IMPL *session)
 	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
 
-	if (!F_ISSET(txn, WT_TXN_HAS_TS_COMMIT))
+	if (!F_ISSET(txn, WT_TXN_PUBLIC_TS_COMMIT))
 		return;
 
 	__wt_writelock(session, &txn_global->commit_timestamp_rwlock);
 	TAILQ_REMOVE(&txn_global->commit_timestamph, txn, commit_timestampq);
 	__wt_writeunlock(session, &txn_global->commit_timestamp_rwlock);
+	F_CLR(txn, WT_TXN_PUBLIC_TS_COMMIT);
 }
 
 /*
@@ -367,7 +368,7 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session)
 	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
 
-	if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
+	if (F_ISSET(txn, WT_TXN_PUBLIC_TS_READ))
 		return;
 
 	__wt_writelock(session, &txn_global->read_timestamp_rwlock);
@@ -383,7 +384,7 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session)
 		TAILQ_INSERT_AFTER(
 		    &txn_global->read_timestamph, prev, txn, read_timestampq);
 	__wt_writeunlock(session, &txn_global->read_timestamp_rwlock);
-	F_SET(txn, WT_TXN_HAS_TS_READ);
+	F_SET(txn, WT_TXN_HAS_TS_READ | WT_TXN_PUBLIC_TS_READ);
 }
 
 /*
@@ -399,12 +400,12 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
 	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
 
-	if (!F_ISSET(txn, WT_TXN_HAS_TS_READ))
+	if (!F_ISSET(txn, WT_TXN_PUBLIC_TS_READ))
 		return;
 
 	__wt_writelock(session, &txn_global->read_timestamp_rwlock);
 	TAILQ_REMOVE(&txn_global->read_timestamph, txn, read_timestampq);
 	__wt_writeunlock(session, &txn_global->read_timestamp_rwlock);
-	F_CLR(txn, WT_TXN_HAS_TS_READ);
+	F_CLR(txn, WT_TXN_PUBLIC_TS_READ);
 }
 #endif


### PR DESCRIPTION
Recent changes cleared the `WT_TXN_HAS_TS_READ` flag in the special handling of the checkpoint transaction in `__checkpoint_prepare`.  This change splits the functional flag (HAS_TS_READ) from the flag indicating whether the information has been published by hooking the transaction into a list (PUBLIC_TS_READ).