### PR TITLE
WT-3466 Track the first commit_timestamp set in a transaction.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -205,7 +205,21 @@ struct __wt_txn {
 	uint32_t snapshot_count;
 	uint32_t txn_logsync;	/* Log sync configuration */
 
+	/*
+	 * Timestamp copied into updates created by this transaction.
+	 *
+	 * In some use cases, this can be updated while the transaction is
+	 * running.
+	 */
 	WT_DECL_TIMESTAMP(commit_timestamp)
+
+	/*
+	 * Set to the first commit timestamp used in the transaction and fixed
+	 * while the transaction is on the public list of committed timestamps.
+	 */
+	WT_DECL_TIMESTAMP(first_commit_timestamp)
+
+	/* Read updates committed as of this timestamp. */
 	WT_DECL_TIMESTAMP(read_timestamp)
 
 	TAILQ_ENTRY(__wt_txn) commit_timestampq;


### PR DESCRIPTION
In particular, if a commit_timestamp is set via `WT_SESSION::timestamp_transaction` and again later via `WT_SESSION::commit_transaction`, there was a window where `session->txn.commit_timestamp` was zero, which caused `WT_CONNECTION::query_timestamp` to return incorrect results.

Similarly, the shared list of transactions with commit timestamps should be sorted by the first commit timestamp: we don't (and shouldn't) re-sort that list if a transaction's commit_timestamp is updated.