### PR TITLE
WT-3470 table open/drop always open a metadata cursor

### DIFF
--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -231,12 +231,23 @@ __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
 		WT_RET_MSG(session, EINVAL,
 		    "%s: remove not supported on the turtle file", key);
 
+	/*
+	 * Take, release, and reaquire the metadata cursor. It's complicated,
+	 * but that way the underlying meta-tracking function doesn't have to
+	 * open a second metadata cursor, it can use the session's cached one.
+	 */
 	WT_RET(__wt_metadata_cursor(session, &cursor));
 	cursor->set_key(cursor, key);
 	WT_ERR(cursor->search(cursor));
+	WT_ERR(__wt_metadata_cursor_release(session, &cursor));
+
 	if (WT_META_TRACKING(session))
 		WT_ERR(__wt_meta_track_update(session, key));
-	WT_ERR(cursor->remove(cursor));
+
+	WT_ERR(__wt_metadata_cursor(session, &cursor));
+	cursor->set_key(cursor, key);
+	ret = cursor->remove(cursor);
+
 err:	WT_TRET(__wt_metadata_cursor_release(session, &cursor));
 	return (ret);
 }

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -232,7 +232,7 @@ __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
 		    "%s: remove not supported on the turtle file", key);
 
 	/*
-	 * Take, release, and reaquire the metadata cursor. It's complicated,
+	 * Take, release, and reacquire the metadata cursor. It's complicated,
 	 * but that way the underlying meta-tracking function doesn't have to
 	 * open a second metadata cursor, it can use the session's cached one.
 	 */


### PR DESCRIPTION
@agorrod, in short, `__schema_open_table` holds the metadata cursor pinned across a call to `__wt_schema_open_colgroups`, which calls `__wt_metadata_search`, and so is forced to open an additional metadata cursor.

There's a similar case when dropping a table: `__wt_metadata_remove` opens a metadata cursor, and then calls `__wt_meta_track_update` which also opens a metadata cursor, forcing drop to open a second metadata cursor. I'm less comfortable with this change, but I think it's safe.