### PR TITLE
WT-3471 the session table cache is never cleared leading to apparent memory leaks

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -836,6 +836,8 @@ __session_reset(WT_SESSION *wt_session)
 
 	WT_TRET(__wt_session_reset_cursors(session, true));
 
+	WT_TRET(__wt_schema_close_tables(session));
+
 	/* Release common session resources. */
 	WT_TRET(__wt_session_release_resources(session));
 


### PR DESCRIPTION
@agorrod, I'm suspicious this is the problem we're seeing in HELP-4534.

Note that this fix isn't sufficient in the case of a session never being reset.