### PR TITLE
WT-3471 Sweep the table cache after schema changes.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -570,6 +570,7 @@ extern int __wt_schema_destroy_index(WT_SESSION_IMPL *session, WT_INDEX **idxp) 
 extern int __wt_schema_destroy_table(WT_SESSION_IMPL *session, WT_TABLE **tablep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_remove_table(WT_SESSION_IMPL *session, WT_TABLE *table) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_close_tables(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_schema_sweep_tables(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_colgroup_name(WT_SESSION_IMPL *session, WT_TABLE *table, const char *cgname, size_t len, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_open_index(WT_SESSION_IMPL *session, WT_TABLE *table, const char *idxname, size_t len, WT_INDEX **indexp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -98,6 +98,12 @@ struct __wt_session_impl {
 	 */
 	TAILQ_HEAD(__tables, __wt_table) tables;
 
+	/*
+	 * Updated when the table cache is swept of all tables older than the
+	 * current schema generation.
+	 */
+	uint64_t table_sweep_gen;
+
 	/* Current rwlock for callback. */
 	WT_RWLOCK *current_rwlock;
 	uint8_t current_rwticket;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -818,6 +818,8 @@ __session_reset(WT_SESSION *wt_session)
 
 	WT_TRET(__wt_session_reset_cursors(session, true));
 
+	WT_TRET(__wt_schema_sweep_tables(session));
+
 	/* Release common session resources. */
 	WT_TRET(__wt_session_release_resources(session));
 


### PR DESCRIPTION
During `WT_SESSION::reset`, if there has been a schema change (such as a `WT_SESSION::drop` operation) since the last sweep, do a pass through the table cache and remove any obsolete table handles.