### PR TITLE
WT-3458 Checkpoint timestamps only apply to non-logged tables.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1257,7 +1257,7 @@ methods = {
         timestamp. Supplied values must be monotonically increasing.
         See @ref transaction_timestamps'''),
     Config('stable_timestamp', '', r'''
-        checkpoints will not include commits the are new the specified
+        checkpoints will not include commits that are newer than the specified
         timestamp in tables configured with \c log=(enabled=false).  Supplied
         values must be monotonically increasing.  The stable timestamp data
         stability only applies to tables that are not being logged.  See @ref

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1257,10 +1257,11 @@ methods = {
         timestamp. Supplied values must be monotonically increasing.
         See @ref transaction_timestamps'''),
     Config('stable_timestamp', '', r'''
-        future checkpoints will be no later than the specified
-        timestamp. Supplied values must be monotonically increasing.
-        The stable timestamp data stability only applies to tables
-        that are not being logged.  See @ref transaction_timestamps'''),
+        checkpoints will not include commits the are new the specified
+        timestamp in tables configured with \c log=(enabled=false).  Supplied
+        values must be monotonically increasing.  The stable timestamp data
+        stability only applies to tables that are not being logged.  See @ref
+        transaction_timestamps'''),
 ]),
 
 'WT_SESSION.reconfigure' : Method(session_config),

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1760,8 +1760,19 @@ struct __wt_session {
 
 	/*!
 	 * Write a transactionally consistent snapshot of a database or set of
-	 * objects.  The checkpoint includes all transactions committed before
-	 * the checkpoint starts.  Additionally, checkpoints may optionally be
+	 * objects.  In the absence of transaction timestamps, the checkpoint
+	 * includes all transactions committed before the checkpoint starts.
+	 *
+	 * When timestamps are in use and a \c stable_timestamp has been set
+	 * via WT_CONNECTION::set_timestamp and the checkpoint runs with
+	 * \c use_timestamp=true (the default), updates committed with a
+	 * timestamp larger than the \c stable_timestamp will not be included
+	 * in the checkpoint for tables configured with \c log=(enabled=false).
+	 * For tables with logging enabled, all committed changes will be
+	 * included in the checkpoint (since recovery would roll them forward
+	 * anyway).
+	 *
+	 * Additionally, existing named checkpoints may optionally be
 	 * discarded.
 	 *
 	 * @snippet ex_all.c Checkpoint examples
@@ -2251,8 +2262,9 @@ struct __wt_connection {
 	 * earlier than the specified timestamp.  Supplied values must be
 	 * monotonically increasing.  See @ref transaction_timestamps., a
 	 * string; default empty.}
-	 * @config{stable_timestamp, future checkpoints will be no later than
-	 * the specified timestamp.  Supplied values must be monotonically
+	 * @config{stable_timestamp, checkpoints will not include commits the
+	 * are new the specified timestamp in tables configured with \c
+	 * log=(enabled=false). Supplied values must be monotonically
 	 * increasing.  The stable timestamp data stability only applies to
 	 * tables that are not being logged.  See @ref transaction_timestamps.,
 	 * a string; default empty.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2262,8 +2262,8 @@ struct __wt_connection {
 	 * earlier than the specified timestamp.  Supplied values must be
 	 * monotonically increasing.  See @ref transaction_timestamps., a
 	 * string; default empty.}
-	 * @config{stable_timestamp, checkpoints will not include commits the
-	 * are new the specified timestamp in tables configured with \c
+	 * @config{stable_timestamp, checkpoints will not include commits that
+	 * are newer than the specified timestamp in tables configured with \c
 	 * log=(enabled=false). Supplied values must be monotonically
 	 * increasing.  The stable timestamp data stability only applies to
 	 * tables that are not being logged.  See @ref transaction_timestamps.,

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1609,7 +1609,7 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
 	btree = S2BT(session);
 	txn = &session->txn;
 
-	/* Are we using a read timestamp for this checkpoint? */
+	/* Are we using a read timestamp for this checkpoint transaction? */
 	with_timestamp = F_ISSET(txn, WT_TXN_HAS_TS_READ);
 
 	/*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1603,10 +1603,27 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
+	WT_TXN *txn;
+	bool with_timestamp;
 
 	btree = S2BT(session);
+	txn = &session->txn;
+
+	/* Are we using a read timestamp for this checkpoint? */
+	with_timestamp = F_ISSET(txn, WT_TXN_HAS_TS_READ);
+
+	/*
+	 * For tables with immediate durability (indicated by having logging
+	 * enabled), ignore any read timestamp configured for the checkpoint.
+	 */
+	if (!F_ISSET(btree, WT_BTREE_NO_LOGGING))
+		F_CLR(txn, WT_TXN_HAS_TS_READ);
 
 	ret = __checkpoint_tree(session, true, cfg);
+
+	/* Restore the use of the timestamp for other tables. */
+	if (with_timestamp)
+		F_SET(txn, WT_TXN_HAS_TS_READ);
 
 	/*
 	 * Whatever happened, we aren't visiting this tree again in this

--- a/test/suite/test_timestamp03.py
+++ b/test/suite/test_timestamp03.py
@@ -217,13 +217,11 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Take a checkpoint using the given configuration.  Then verify
         # whether value2 appears in a copy of that data or not.
-        valcnt2 = nkeys
+        valcnt2 = valcnt3 = nkeys
         if self.val == 'all':
             valcnt = nkeys
         else:
             valcnt = 0
-        # XXX adjust when logged + timestamps is fixed and defined.
-        valcnt3 = valcnt
         self.ckpt_backup(self.value2, valcnt, valcnt2, valcnt3)
         if self.ckptcfg != 'read_timestamp':
             # Update the stable timestamp to the latest, but not the oldest


### PR DESCRIPTION
When logging is enabled for a table, that indicates that updates should become durable immediately, since they will be unconditionally rolled forward by recovery after a crash.  Since checkpoints with a timestamp are intended to create a version on disk that does not include newer changes, it doesn't make sense with immediately durable tables.