### PR TITLE
WT-3494 __cursor_needvalue() calls __cursor_localkey(), not __cursor_localvalue()

### DIFF
--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -109,7 +109,7 @@ __cursor_needkey(WT_CURSOR *cursor)
 static inline int
 __cursor_needvalue(WT_CURSOR *cursor)
 {
-	WT_RET(__cursor_localkey(cursor));
+	WT_RET(__cursor_localvalue(cursor));
 	return (__cursor_checkvalue(cursor));
 }
 


### PR DESCRIPTION
Found as a bug in the Helium port.