### PR TITLE
WT-3499 Have checkpoint wait for in-flight commits to finish.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -129,6 +129,13 @@ struct __wt_txn_global {
 	WT_TXN_STATE	  checkpoint_state;	/* Checkpoint's txn state */
 	WT_TXN           *checkpoint_txn;	/* Checkpoint's txn structure */
 
+	/*
+	 * Checkpoint calculates an LSN where recovery should start, and needs
+	 * to make sure all transactions with earlier commit LSNs are visible
+	 * in the checkpoint.  This read/write lock is used to guarantee that.
+	 */
+	WT_RWLOCK committing_rwlock;
+
 	volatile uint64_t metadata_pinned;	/* Oldest ID for metadata */
 
 	/* Named snapshot state. */


### PR DESCRIPTION
After checkpoint calculates an LSN that recovery should roll forward from, it should wait for any commits that are in progress (i.e., transactions that have written to the log but not yet become visible) to complete.  This is done by having all transactions hold a read lock from before the log write until they become visible.  Checkpoint waits for a write lock which ensures all in-flight transactions have drained before checkpoint starts its transaction.