### PR TITLE
WT-3499 Add a visibility rwlock between transactions and checkpoints.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -105,7 +105,7 @@ struct __wt_txn_global {
 	/* Protects the active transaction states. */
 	WT_RWLOCK rwlock;
 
-	/* Protects logging, checkpoints and transaction visibilty. */
+	/* Protects logging, checkpoints and transaction visibility. */
 	WT_RWLOCK visibility_rwlock;
 
 	/* List of transactions sorted by commit timestamp. */

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -105,6 +105,9 @@ struct __wt_txn_global {
 	/* Protects the active transaction states. */
 	WT_RWLOCK rwlock;
 
+	/* Protects logging, checkpoints and transaction visibilty. */
+	WT_RWLOCK visibility_rwlock;
+
 	/* List of transactions sorted by commit timestamp. */
 	WT_RWLOCK commit_timestamp_rwlock;
 	TAILQ_HEAD(__wt_txn_cts_qh, __wt_txn) commit_timestamph;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -575,11 +575,12 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	bool update_timestamp;
 #endif
 	u_int i;
-	bool did_update;
+	bool did_update, locked;
 
 	txn = &session->txn;
 	conn = S2C(session);
 	did_update = txn->mod_count != 0;
+	locked = false;
 
 	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 	WT_ASSERT(session, !F_ISSET(txn, WT_TXN_ERROR) || !did_update);
@@ -665,6 +666,14 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		 * This is particularly important for checkpoints.
 		 */
 		__wt_txn_release_snapshot(session);
+		/*
+		 * We hold the visibility lock for reading from the time
+		 * we write our log record until the time we release our
+		 * transaction so that the LSN any checkpoint gets will
+		 * always reflect visible data.
+		 */
+		__wt_readlock(session, &txn_global->visibility_rwlock);
+		locked = true;
 		WT_ERR(__wt_txn_log_commit(session, cfg));
 	}
 
@@ -724,6 +733,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 #endif
 
 	__wt_txn_release(session);
+	if (locked)
+		__wt_readunlock(session, &txn_global->visibility_rwlock);
 
 #ifdef HAVE_TIMESTAMPS
 	/* First check if we've already committed something in the future. */
@@ -760,6 +771,8 @@ err:	/*
 	 * !!!
 	 * Nothing can fail after this point.
 	 */
+	if (locked)
+		__wt_readunlock(session, &txn_global->visibility_rwlock);
 	WT_TRET(__wt_txn_rollback(session, cfg));
 	return (ret);
 }
@@ -930,6 +943,7 @@ __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_RET(__wt_spin_init(
 	    session, &txn_global->id_lock, "transaction id lock"));
 	WT_RET(__wt_rwlock_init(session, &txn_global->rwlock));
+	WT_RET(__wt_rwlock_init(session, &txn_global->visibility_rwlock));
 
 	WT_RET(__wt_rwlock_init(session, &txn_global->commit_timestamp_rwlock));
 	TAILQ_INIT(&txn_global->commit_timestamph);
@@ -971,6 +985,7 @@ __wt_txn_global_destroy(WT_SESSION_IMPL *session)
 	__wt_rwlock_destroy(session, &txn_global->commit_timestamp_rwlock);
 	__wt_rwlock_destroy(session, &txn_global->read_timestamp_rwlock);
 	__wt_rwlock_destroy(session, &txn_global->nsnap_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->visibility_rwlock);
 	__wt_free(session, txn_global->states);
 }
 


### PR DESCRIPTION
@michaelcahill and @agorrod here's a branch that solves the visibility and checkpoint issue that my test uncovered.  Please review.  It solves the problem even with my aggressive sleep repro case.  I am going to point the perf jobs at this branch for the day too.