### PR TITLE
WT-3493 wt_verbose_dump_txn should display timestamp information

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1052,17 +1052,10 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 #ifdef HAVE_TIMESTAMPS
 		if (!__wt_timestamp_iszero(
 		    WT_TIMESTAMP_NULL(&upd->timestamp))) {
-#if WT_TIMESTAMP_SIZE == 8
-			WT_RET(ds->f(ds,
-			    ", stamp %" PRIu64, upd->timestamp.val));
-#else
-			int i;
-
-			WT_RET(ds->f(ds, ", stamp 0x"));
-			for (i = 0; i < WT_TIMESTAMP_SIZE; ++i)
-				WT_RET(ds->f(ds,
-				    "%" PRIx8, upd->timestamp.ts[i]));
-#endif
+			char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 1];
+			WT_RET(__wt_timestamp_to_hex_string(
+			    ds->session, hex_timestamp, &upd->timestamp));
+			WT_RET(ds->f(ds, ", stamp %s", hex_timestamp));
 		}
 #endif
 		WT_RET(ds->f(ds, "\n"));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -809,6 +809,7 @@ extern int __wt_txn_named_snapshot_config(WT_SESSION_IMPL *session, const char *
 extern void __wt_txn_named_snapshot_destroy(WT_SESSION_IMPL *session);
 extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_timestamp_to_hex_string( WT_SESSION_IMPL *session, char *hex_timestamp, const wt_timestamp_t *ts_src) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, const wt_timestamp_t *ts, const char *msg);
 extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_query_timestamp( WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -90,8 +90,7 @@ __wt_timestamp_iszero(const wt_timestamp_t *ts)
 {
 	static const wt_timestamp_t zero_timestamp;
 
-	return (memcmp(ts->ts,
-	    WT_TIMESTAMP_NULL(&zero_timestamp), WT_TIMESTAMP_SIZE) == 0);
+	return (memcmp(ts->ts, &zero_timestamp, WT_TIMESTAMP_SIZE) == 0);
 }
 
 /*

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -74,7 +74,7 @@ __wt_verbose_timestamp(WT_SESSION_IMPL *session,
 #ifdef HAVE_VERBOSE
 	char timestamp_buf[2 * WT_TIMESTAMP_SIZE + 1];
 
-	if (0 != __wt_timestamp_to_hex_string(session, timestamp_buf, ts))
+	if (__wt_timestamp_to_hex_string(session, timestamp_buf, ts) != 0)
 	       return;
 
 	__wt_verbose(session,

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -13,13 +13,20 @@
  * __wt_timestamp_to_hex_string --
  *	Convert a timestamp to hex string representation.
  */
-static int
+int
 __wt_timestamp_to_hex_string(
     WT_SESSION_IMPL *session, char *hex_timestamp, const wt_timestamp_t *ts_src)
 {
 	wt_timestamp_t ts;
 
 	__wt_timestamp_set(&ts, ts_src);
+
+	if (__wt_timestamp_iszero(&ts)) {
+		hex_timestamp[0] = '0';
+		hex_timestamp[1] = '\0';
+		return (0);
+	}
+
 #if WT_TIMESTAMP_SIZE == 8
 	{
 	char *p, v;


### PR DESCRIPTION
@michaelcahill, there's one minor change here that might be of interest. I changed `__wt_timestamp_to_hex_string()` to return the string "0" in the case of a zero timestamp.

That's potentially interesting if `__wt_txn_global_query_timestamp()` calls that function with a zero timestamp as we'll return "0" instead of the empty string. I think that's a bug fix, if anything (unless we document somewhere that an empty string is the same as a "0" string), but wanted to call it to your attention.