### PR TITLE
WT-3417 Check for active transactions during upgrade/downgrade.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -402,7 +402,9 @@ connection_runtime_config = [
             min='0', max='100000'),
         ]),
     Config('compatibility', '', r'''
-        set compatibility version of database''',
+        set compatibility version of database.  Changing the compatibility
+        version requires that there are no active operations for the duration
+        of the call.''',
         type='category', subconfig=[
         Config('release', '', r'''
             compatibility release version string'''),

--- a/dist/filelist
+++ b/dist/filelist
@@ -72,6 +72,7 @@ src/conn/conn_dhandle.c
 src/conn/conn_handle.c
 src/conn/conn_log.c
 src/conn/conn_open.c
+src/conn/conn_reconfig.c
 src/conn/conn_stat.c
 src/conn/conn_sweep.c
 src/cursor/cur_backup.c

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -8,8 +8,6 @@
 
 #include "wt_internal.h"
 
-static int __conn_statistics_config(WT_SESSION_IMPL *, const char *[]);
-
 /*
  * ext_collate --
  *	Call the collation function (external API version).
@@ -187,45 +185,6 @@ __wt_conn_remove_collator(WT_SESSION_IMPL *session)
 	}
 
 	return (ret);
-}
-
-/*
- * __conn_compat_config --
- *	Configure compatibility version.
- */
-static int
-__conn_compat_config(WT_SESSION_IMPL *session, const char **cfg)
-{
-	WT_CONFIG_ITEM cval;
-	WT_CONNECTION_IMPL *conn;
-	uint16_t patch;
-
-	conn = S2C(session);
-	WT_RET(__wt_config_gets(session, cfg,
-	    "compatibility.release", &cval));
-	if (cval.len != 0) {
-		/*
-		 * Accept either a major.minor release string or a
-		 * major.minor.patch release string.  We ignore the patch
-		 * value, but allow it in the string.
-		 */
-		if (sscanf(cval.str, "%" SCNu16 ".%" SCNu16,
-		    &conn->compat_major, &conn->compat_minor) != 2 &&
-		    sscanf(cval.str, "%" SCNu16 ".%" SCNu16 ".%" SCNu16,
-		    &conn->compat_major, &conn->compat_minor, &patch) != 3)
-			WT_RET_MSG(session,
-			    EINVAL, "illegal compatibility release");
-		if (conn->compat_major > WIREDTIGER_VERSION_MAJOR)
-			WT_RET_MSG(session, EINVAL, "unknown major version");
-		if (conn->compat_major == WIREDTIGER_VERSION_MAJOR &&
-		    conn->compat_minor > WIREDTIGER_VERSION_MINOR)
-			WT_RET_MSG(session,
-			    EINVAL, "illegal compatibility version");
-	} else {
-		conn->compat_major = WIREDTIGER_VERSION_MAJOR;
-		conn->compat_minor = WIREDTIGER_VERSION_MINOR;
-	}
-	return (0);
 }
 
 /*
@@ -1143,57 +1102,12 @@ __conn_reconfigure(WT_CONNECTION *wt_conn, const char *config)
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	const char *p;
-	bool locked;
 
 	conn = (WT_CONNECTION_IMPL *)wt_conn;
-	locked = false;
 
 	CONNECTION_API_CALL(conn, session, reconfigure, config, cfg);
-
-	/* Serialize reconfiguration. */
-	__wt_spin_lock(session, &conn->reconfig_lock);
-	locked = true;
-
-	/*
-	 * The configuration argument has been checked for validity, update the
-	 * previous connection configuration.
-	 *
-	 * DO NOT merge the configuration before the reconfigure calls.  Some
-	 * of the underlying reconfiguration functions do explicit checks with
-	 * the second element of the configuration array, knowing the defaults
-	 * are in slot #1 and the application's modifications are in slot #2.
-	 *
-	 * First, replace the base configuration set up by CONNECTION_API_CALL
-	 * with the current connection configuration, otherwise reconfiguration
-	 * functions will find the base value instead of previously configured
-	 * value.
-	 */
-	cfg[0] = conn->cfg;
-	cfg[1] = config;
-
-	/* Second, reconfigure the system. */
-	WT_ERR(__conn_compat_config(session, cfg));
-	WT_ERR(__conn_statistics_config(session, cfg));
-	WT_ERR(__wt_async_reconfig(session, cfg));
-	WT_ERR(__wt_cache_config(session, true, cfg));
-	WT_ERR(__wt_checkpoint_server_create(session, cfg));
-	WT_ERR(__wt_logmgr_reconfig(session, cfg));
-	WT_ERR(__wt_lsm_manager_reconfig(session, cfg));
-	WT_ERR(__wt_statlog_create(session, cfg));
-	WT_ERR(__wt_sweep_config(session, cfg));
-	WT_ERR(__wt_verbose_config(session, cfg));
-	WT_ERR(__wt_timing_stress_config(session, cfg));
-
-	/* Third, merge everything together, creating a new connection state. */
-	WT_ERR(__wt_config_merge(session, cfg, NULL, &p));
-	__wt_free(session, conn->cfg);
-	conn->cfg = p;
-
-err:	if (locked)
-		__wt_spin_unlock(session, &conn->reconfig_lock);
-
-	API_END_RET(session, ret);
+	ret = __wt_conn_reconfig(session, cfg);
+err:	API_END_RET(session, ret);
 }
 
 /*
@@ -1788,94 +1702,6 @@ err:	/*
 	return (ret);
 }
 
-/*
- * __conn_statistics_config --
- *	Set statistics configuration.
- */
-static int
-__conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[])
-{
-	WT_CONFIG_ITEM cval, sval;
-	WT_CONNECTION_IMPL *conn;
-	WT_DECL_RET;
-	uint32_t flags;
-	int set;
-
-	conn = S2C(session);
-
-	WT_RET(__wt_config_gets(session, cfg, "statistics", &cval));
-
-	flags = 0;
-	set = 0;
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "none", &sval)) == 0 && sval.val != 0) {
-		flags = 0;
-		++set;
-	}
-	WT_RET_NOTFOUND_OK(ret);
-
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "fast", &sval)) == 0 && sval.val != 0) {
-		LF_SET(WT_STAT_TYPE_FAST);
-		++set;
-	}
-	WT_RET_NOTFOUND_OK(ret);
-
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "all", &sval)) == 0 && sval.val != 0) {
-		LF_SET(
-		    WT_STAT_TYPE_ALL | WT_STAT_TYPE_CACHE_WALK |
-		    WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK);
-		++set;
-	}
-	WT_RET_NOTFOUND_OK(ret);
-
-	if (set > 1)
-		WT_RET_MSG(session, EINVAL,
-		    "Only one of all, fast, none configuration values should "
-		    "be specified");
-
-	/*
-	 * Now that we've parsed general statistics categories, process
-	 * sub-categories.
-	 */
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "cache_walk", &sval)) == 0 && sval.val != 0)
-		/*
-		 * Configuring cache walk statistics implies fast statistics.
-		 * Keep that knowledge internal for now - it may change in the
-		 * future.
-		 */
-		LF_SET(WT_STAT_TYPE_FAST | WT_STAT_TYPE_CACHE_WALK);
-	WT_RET_NOTFOUND_OK(ret);
-
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "tree_walk", &sval)) == 0 && sval.val != 0)
-		/*
-		 * Configuring tree walk statistics implies fast statistics.
-		 * Keep that knowledge internal for now - it may change in the
-		 * future.
-		 */
-		LF_SET(WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK);
-	WT_RET_NOTFOUND_OK(ret);
-
-	if ((ret = __wt_config_subgets(
-	    session, &cval, "clear", &sval)) == 0 && sval.val != 0) {
-		if (!LF_ISSET(WT_STAT_TYPE_ALL | WT_STAT_TYPE_CACHE_WALK |
-		    WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK))
-			WT_RET_MSG(session, EINVAL,
-			    "the value \"clear\" can only be specified if "
-			    "statistics are enabled");
-		LF_SET(WT_STAT_CLEAR);
-	}
-	WT_RET_NOTFOUND_OK(ret);
-
-	/* Configuring statistics clears any existing values. */
-	conn->stat_flags = flags;
-
-	return (0);
-}
-
 /* Simple structure for name and flag configuration searches. */
 typedef struct {
 	const char *name;
@@ -2345,7 +2171,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	/*
 	 * Set compatibility versions early so that any subsystem sees it.
 	 */
-	WT_ERR(__conn_compat_config(session, cfg));
+	WT_ERR(__wt_conn_compat_config(session, cfg));
 
 	/*
 	 * If the application didn't configure its own file system, configure
@@ -2532,7 +2358,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__wt_config_gets(session, cfg, "mmap", &cval));
 	conn->mmap = cval.val != 0;
 
-	WT_ERR(__conn_statistics_config(session, cfg));
+	WT_ERR(__wt_conn_statistics_config(session, cfg));
 	WT_ERR(__wt_lsm_manager_config(session, cfg));
 	WT_ERR(__wt_sweep_config(session, cfg));
 

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -1,0 +1,212 @@
+/*-
+ * Copyright (c) 2014-2017 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_conn_compat_config --
+ *	Configure compatibility version.
+ */
+int
+__wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg)
+{
+	WT_CONFIG_ITEM cval;
+	WT_CONNECTION_IMPL *conn;
+	uint16_t patch;
+	bool txn_active;
+
+	conn = S2C(session);
+	WT_RET(__wt_config_gets(session, cfg,
+	    "compatibility.release", &cval));
+	if (cval.len == 0) {
+		conn->compat_major = WIREDTIGER_VERSION_MAJOR;
+		conn->compat_minor = WIREDTIGER_VERSION_MINOR;
+		return (0);
+	}
+
+	/*
+	 * Accept either a major.minor release string or a
+	 * major.minor.patch release string.  We ignore the patch
+	 * value, but allow it in the string.
+	 */
+	if (sscanf(cval.str, "%" SCNu16 ".%" SCNu16,
+	    &conn->compat_major, &conn->compat_minor) != 2 &&
+	    sscanf(cval.str, "%" SCNu16 ".%" SCNu16 ".%" SCNu16,
+	    &conn->compat_major, &conn->compat_minor, &patch) != 3)
+		WT_RET_MSG(session,
+		    EINVAL, "illegal compatibility release");
+	if (conn->compat_major > WIREDTIGER_VERSION_MAJOR)
+		WT_RET_MSG(session, EINVAL, "unknown major version");
+	if (conn->compat_major == WIREDTIGER_VERSION_MAJOR &&
+	    conn->compat_minor > WIREDTIGER_VERSION_MINOR)
+		WT_RET_MSG(session,
+		    EINVAL, "illegal compatibility version");
+
+	/*
+	 * We're doing an upgrade or downgrade, check whether transactions are
+	 * active.  Wait for any in-progress checkpoints to complete.
+	 */
+	WT_RET(__wt_txn_activity_check(session, &txn_active));
+	if (txn_active)
+		WT_RET_MSG(session,
+		    ENOTSUP, "upgrade / downgrade must run single-threaded");
+	return (0);
+}
+
+/*
+ * __wt_conn_statistics_config --
+ *	Set statistics configuration.
+ */
+int
+__wt_conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[])
+{
+	WT_CONFIG_ITEM cval, sval;
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+	uint32_t flags;
+	int set;
+
+	conn = S2C(session);
+
+	WT_RET(__wt_config_gets(session, cfg, "statistics", &cval));
+
+	flags = 0;
+	set = 0;
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "none", &sval)) == 0 && sval.val != 0) {
+		flags = 0;
+		++set;
+	}
+	WT_RET_NOTFOUND_OK(ret);
+
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "fast", &sval)) == 0 && sval.val != 0) {
+		LF_SET(WT_STAT_TYPE_FAST);
+		++set;
+	}
+	WT_RET_NOTFOUND_OK(ret);
+
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "all", &sval)) == 0 && sval.val != 0) {
+		LF_SET(
+		    WT_STAT_TYPE_ALL | WT_STAT_TYPE_CACHE_WALK |
+		    WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK);
+		++set;
+	}
+	WT_RET_NOTFOUND_OK(ret);
+
+	if (set > 1)
+		WT_RET_MSG(session, EINVAL,
+		    "Only one of all, fast, none configuration values should "
+		    "be specified");
+
+	/*
+	 * Now that we've parsed general statistics categories, process
+	 * sub-categories.
+	 */
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "cache_walk", &sval)) == 0 && sval.val != 0)
+		/*
+		 * Configuring cache walk statistics implies fast statistics.
+		 * Keep that knowledge internal for now - it may change in the
+		 * future.
+		 */
+		LF_SET(WT_STAT_TYPE_FAST | WT_STAT_TYPE_CACHE_WALK);
+	WT_RET_NOTFOUND_OK(ret);
+
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "tree_walk", &sval)) == 0 && sval.val != 0)
+		/*
+		 * Configuring tree walk statistics implies fast statistics.
+		 * Keep that knowledge internal for now - it may change in the
+		 * future.
+		 */
+		LF_SET(WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK);
+	WT_RET_NOTFOUND_OK(ret);
+
+	if ((ret = __wt_config_subgets(
+	    session, &cval, "clear", &sval)) == 0 && sval.val != 0) {
+		if (!LF_ISSET(WT_STAT_TYPE_ALL | WT_STAT_TYPE_CACHE_WALK |
+		    WT_STAT_TYPE_FAST | WT_STAT_TYPE_TREE_WALK))
+			WT_RET_MSG(session, EINVAL,
+			    "the value \"clear\" can only be specified if "
+			    "statistics are enabled");
+		LF_SET(WT_STAT_CLEAR);
+	}
+	WT_RET_NOTFOUND_OK(ret);
+
+	/* Configuring statistics clears any existing values. */
+	conn->stat_flags = flags;
+
+	return (0);
+}
+
+/*
+ * __wt_conn_reconfig --
+ *	Reconfigure a connection (internal version).
+ */
+int
+__wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+	const char *p;
+
+	conn = S2C(session);
+
+	/* Serialize reconfiguration. */
+	__wt_spin_lock(session, &conn->reconfig_lock);
+
+	/*
+	 * The configuration argument has been checked for validity, update the
+	 * previous connection configuration.
+	 *
+	 * DO NOT merge the configuration before the reconfigure calls.  Some
+	 * of the underlying reconfiguration functions do explicit checks with
+	 * the second element of the configuration array, knowing the defaults
+	 * are in slot #1 and the application's modifications are in slot #2.
+	 *
+	 * Replace the base configuration set up by CONNECTION_API_CALL with
+	 * the current connection configuration, otherwise reconfiguration
+	 * functions will find the base value instead of previously configured
+	 * value.
+	 */
+	cfg[0] = conn->cfg;
+
+	/*
+	 * Reconfigure the system.
+	 *
+	 * The compatibility version check is special: upgrade / downgrade
+	 * cannot be done with transactions active, and checkpoints must not
+	 * span a version change.  Hold the checkpoint lock to avoid conflicts
+	 * with WiredTiger's checkpoint thread, and rely on the documentation
+	 * specifying that no new operations can start until the upgrade /
+	 * downgrade completes.
+	 */
+	WT_WITH_CHECKPOINT_LOCK(session,
+	    ret = __wt_conn_compat_config(session, cfg));
+	WT_ERR(__wt_conn_statistics_config(session, cfg));
+	WT_ERR(__wt_async_reconfig(session, cfg));
+	WT_ERR(__wt_cache_config(session, true, cfg));
+	WT_ERR(__wt_checkpoint_server_create(session, cfg));
+	WT_ERR(__wt_logmgr_reconfig(session, cfg));
+	WT_ERR(__wt_lsm_manager_reconfig(session, cfg));
+	WT_ERR(__wt_statlog_create(session, cfg));
+	WT_ERR(__wt_sweep_config(session, cfg));
+	WT_ERR(__wt_verbose_config(session, cfg));
+	WT_ERR(__wt_timing_stress_config(session, cfg));
+
+	/* Third, merge everything together, creating a new connection state. */
+	WT_ERR(__wt_config_merge(session, cfg, NULL, &p));
+	__wt_free(session, conn->cfg);
+	conn->cfg = p;
+
+err:	__wt_spin_unlock(session, &conn->reconfig_lock);
+
+	return (ret);
+}

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -38,23 +38,21 @@ __wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg)
 	    &conn->compat_major, &conn->compat_minor) != 2 &&
 	    sscanf(cval.str, "%" SCNu16 ".%" SCNu16 ".%" SCNu16,
 	    &conn->compat_major, &conn->compat_minor, &patch) != 3)
-		WT_RET_MSG(session,
-		    EINVAL, "illegal compatibility release");
+		WT_RET_MSG(session, EINVAL, "illegal compatibility release");
 	if (conn->compat_major > WIREDTIGER_VERSION_MAJOR)
 		WT_RET_MSG(session, EINVAL, "unknown major version");
 	if (conn->compat_major == WIREDTIGER_VERSION_MAJOR &&
 	    conn->compat_minor > WIREDTIGER_VERSION_MINOR)
-		WT_RET_MSG(session,
-		    EINVAL, "illegal compatibility version");
+		WT_RET_MSG(session, EINVAL, "illegal compatibility version");
 
 	/*
 	 * We're doing an upgrade or downgrade, check whether transactions are
-	 * active.  Wait for any in-progress checkpoints to complete.
+	 * active.
 	 */
 	WT_RET(__wt_txn_activity_check(session, &txn_active));
 	if (txn_active)
-		WT_RET_MSG(session,
-		    ENOTSUP, "upgrade / downgrade must run single-threaded");
+		WT_RET_MSG(session, ENOTSUP,
+		    "upgrade / downgrade must run single-threaded");
 	return (0);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -278,6 +278,9 @@ extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIB
 extern int __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_connection_close(WT_CONNECTION_IMPL *conn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);
 extern int __wt_statlog_create(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_statlog_destroy(WT_SESSION_IMPL *session, bool is_close) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -740,11 +740,11 @@ __wt_txn_am_oldest(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_txn_are_any_active --
+ * __wt_txn_activity_check --
  *	Check whether there are any running transactions.
  */
 static inline int
-__wt_txn_are_any_active(WT_SESSION_IMPL *session, bool *any_active)
+__wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
 {
 	WT_TXN_GLOBAL *txn_global;
 
@@ -757,6 +757,8 @@ __wt_txn_are_any_active(WT_SESSION_IMPL *session, bool *any_active)
 	WT_RET(__wt_txn_update_oldest(session,
 	    WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
-	*any_active = (txn_global->oldest_id != txn_global->current);
+	*txn_active = (txn_global->oldest_id != txn_global->current ||
+	    txn_global->metadata_pinned != txn_global->current);
+
 	return (0);
 }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1998,8 +1998,10 @@ struct __wt_connection {
 	 * checkpoint; setting this value above 0 configures periodic
 	 * checkpoints., an integer between 0 and 100000; default \c 0.}
 	 * @config{ ),,}
-	 * @config{compatibility = (, set compatibility version of database., a
-	 * set of related configuration options defined below.}
+	 * @config{compatibility = (, set compatibility version of database.
+	 * Changing the compatibility version requires that there are no active
+	 * operations for the duration of the call., a set of related
+	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release
 	 * version string., a string; default empty.}
 	 * @config{ ),,}
@@ -2295,8 +2297,8 @@ struct __wt_connection {
 	 * WT_CONNECTION::set_timestamp. Any updates to checkpoint durable
 	 * tables that are more recent than the stable timestamp are removed.
 	 *
-	 * This method requires that there are no active cursor operations
-	 * for the duration of the call.
+	 * This method requires that there are no active operations for the
+	 * duration of the call.
 	 *
 	 * Any updates made to logged tables will not be rolled back. Any
 	 * updates made without an associated timestamp will not be rolled
@@ -2530,10 +2532,12 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{checkpoint_sync, flush files to stable storage when closing or
  * writing checkpoints., a boolean flag; default \c true.}
- * @config{compatibility = (, set compatibility version of database., a set of
- * related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release version
- * string., a string; default empty.}
+ * @config{compatibility = (, set compatibility version of database.  Changing
+ * the compatibility version requires that there are no active operations for
+ * the duration of the call., a set of related configuration options defined
+ * below.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release
+ * version string., a string; default empty.}
  * @config{ ),,}
  * @config{config_base, write the base configuration file if creating the
  * database.  If \c false in the config passed directly to ::wiredtiger_open\,

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1000,8 +1000,8 @@ __wt_txn_global_destroy(WT_SESSION_IMPL *session)
 int
 __wt_txn_global_shutdown(WT_SESSION_IMPL *session)
 {
-	WT_DECL_RET;
 	WT_TXN_GLOBAL *txn_global;
+	bool txn_active;
 
 	txn_global = &S2C(session)->txn_global;
 
@@ -1014,10 +1014,8 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session)
 	 * transaction ID will catch up with the current ID.
 	 */
 	for (;;) {
-		WT_TRET(__wt_txn_update_oldest(session,
-		    WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
-		if (txn_global->oldest_id == txn_global->current &&
-		    txn_global->metadata_pinned == txn_global->current)
+		WT_RET(__wt_txn_activity_check(session, &txn_active));
+		if (!txn_active)
 			break;
 
 		WT_STAT_CONN_INCR(session, txn_release_blocked);
@@ -1032,7 +1030,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session)
 	__wt_timestamp_set_inf(&txn_global->pinned_timestamp);
 #endif
 
-	return (ret);
+	return (0);
 }
 
 #if defined(HAVE_DIAGNOSTIC) || defined(HAVE_VERBOSE)

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -333,7 +333,7 @@ static int
 __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
 {
 	WT_TXN_GLOBAL *txn_global;
-	bool active_txns, stable_set;
+	bool stable_set, txn_active;
 
 	txn_global = &S2C(session)->txn_global;
 	__wt_readlock(session, &txn_global->rwlock);
@@ -349,8 +349,8 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
 	 * require peeking into all open sessions, which isn't really
 	 * kosher.
 	 */
-	WT_RET(__wt_txn_are_any_active(session, &active_txns));
-	if (active_txns)
+	WT_RET(__wt_txn_activity_check(session, &txn_active));
+	if (txn_active)
 		WT_RET_MSG(session, EINVAL,
 		    "rollback_to_stable illegal with active transactions");
 


### PR DESCRIPTION
Fail upgrade / downgrade if the system isn't quiescent.  Document that applications must wait for an upgrade / downgrade to complete before starting any new operations.  Handle WiredTiger's checkpoint thread carefully: make sure no checkpoint is in progress when the compatibility version changes, and the checkpoint thread is already restarted by reconfigure.

Split out the reconfigure functionality into its own source file.