### PR TITLE
WT-3516 Optimize schema operations when we are certain of URI prefixes.

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -629,23 +629,22 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 	if (bulk)
 		LF_SET(WT_BTREE_BULK | WT_DHANDLE_EXCLUSIVE);
 
+	WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:"));
+
 	/* Get the handle and lock it while the cursor is using it. */
-	if (WT_PREFIX_MATCH(uri, "file:")) {
-		/*
-		 * If we are opening exclusive and don't want a bulk cursor
-		 * open to fail with EBUSY due to a database-wide checkpoint,
-		 * get the handle while holding the checkpoint lock.
-		 */
-		if (LF_ISSET(WT_DHANDLE_EXCLUSIVE) && checkpoint_wait)
-			WT_WITH_CHECKPOINT_LOCK(session,
-			    ret = __wt_session_get_btree_ckpt(
-			    session, uri, cfg, flags));
-		else
-			ret = __wt_session_get_btree_ckpt(
-			    session, uri, cfg, flags);
-		WT_RET(ret);
-	} else
-		WT_RET(__wt_bad_object_type(session, uri));
+	/*
+	 * If we are opening exclusive and don't want a bulk cursor
+	 * open to fail with EBUSY due to a database-wide checkpoint,
+	 * get the handle while holding the checkpoint lock.
+	 */
+	if (LF_ISSET(WT_DHANDLE_EXCLUSIVE) && checkpoint_wait)
+		WT_WITH_CHECKPOINT_LOCK(session,
+		    ret = __wt_session_get_btree_ckpt(
+		    session, uri, cfg, flags));
+	else
+		ret = __wt_session_get_btree_ckpt(
+		    session, uri, cfg, flags);
+	WT_RET(ret);
 
 	WT_ERR(__curfile_create(session, owner, cfg, bulk, bitmap, cursorp));
 

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -971,8 +971,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 	ctable = NULL;
 
 	tablename = uri;
-	if (!WT_PREFIX_SKIP(tablename, "table:"))
-		return (__wt_unexpected_object_type(session, uri, "table:"));
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
 	columns = strchr(tablename, '(');
 	if (columns == NULL)
 		size = strlen(tablename);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -214,6 +214,12 @@
 #define	WT_PREFIX_SKIP(str, pfx)					\
 	(WT_PREFIX_MATCH(str, pfx) ? ((str) += strlen(pfx), 1) : 0)
 
+/* Assert that a string matches a prefix, and move past it. */
+#define	WT_PREFIX_SKIP_REQUIRED(session, str, pfx) do {			\
+	WT_ASSERT(session, WT_PREFIX_MATCH(str, pfx));			\
+	(str) += strlen(pfx);						\
+} while (0)
+
 /*
  * Check if a variable string equals a constant string.  Inline the common
  * case for WiredTiger of a single byte string.  This is required because not

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -69,8 +69,7 @@ __create_file(WT_SESSION_IMPL *session,
 	is_metadata = strcmp(uri, WT_METAFILE_URI) == 0;
 
 	filename = uri;
-	if (!WT_PREFIX_SKIP(filename, "file:"))
-		return (__wt_unexpected_object_type(session, uri, "file:"));
+	WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
 
 	/* Check if the file already exists. */
 	if (!is_metadata && (ret =
@@ -192,9 +191,7 @@ __create_colgroup(WT_SESSION_IMPL *session,
 	exists = false;
 
 	tablename = name;
-	if (!WT_PREFIX_SKIP(tablename, "colgroup:"))
-		return (
-		    __wt_unexpected_object_type(session, name, "colgroup:"));
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "colgroup:");
 	cgname = strchr(tablename, ':');
 	if (cgname != NULL) {
 		tlen = (size_t)(cgname - tablename);
@@ -384,8 +381,7 @@ __create_index(WT_SESSION_IMPL *session,
 	exists = have_extractor = false;
 
 	tablename = name;
-	if (!WT_PREFIX_SKIP(tablename, "index:"))
-		return (__wt_unexpected_object_type(session, name, "index:"));
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "index:");
 	idxname = strchr(tablename, ':');
 	if (idxname == NULL)
 		WT_RET_MSG(session, EINVAL, "Invalid index name, "
@@ -570,8 +566,7 @@ __create_table(WT_SESSION_IMPL *session,
 	exists = false;
 
 	tablename = name;
-	if (!WT_PREFIX_SKIP(tablename, "table:"))
-		return (__wt_unexpected_object_type(session, name, "table:"));
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
 
 	if ((ret = __wt_schema_get_table(session,
 	    tablename, strlen(tablename), false, &table)) == 0) {

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -25,8 +25,7 @@ __drop_file(
 	remove_files = cval.val != 0;
 
 	filename = uri;
-	if (!WT_PREFIX_SKIP(filename, "file:"))
-		return (__wt_unexpected_object_type(session, uri, "file:"));
+	WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
 
 	WT_RET(__wt_schema_backup_check(session, filename));
 	/* Close all btree handles associated with this file. */
@@ -111,7 +110,7 @@ __drop_table(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 	u_int i;
 
 	name = uri;
-	(void)WT_PREFIX_SKIP(name, "table:");
+	WT_PREFIX_SKIP_REQUIRED(session, name, "table:");
 
 	table = NULL;
 	WT_ERR(__wt_schema_get_table(

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -55,7 +55,7 @@ __schema_find_table(WT_SESSION_IMPL *session,
 restart:
 	TAILQ_FOREACH(table, &session->tablehash[bucket], hashq) {
 		tablename = table->name;
-		(void)WT_PREFIX_SKIP(tablename, "table:");
+		WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
 		if (WT_STRING_MATCH(tablename, name, namelen)) {
 			/*
 			 * Ignore stale tables.

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -21,7 +21,7 @@ __wt_schema_colgroup_name(WT_SESSION_IMPL *session,
 	const char *tablename;
 
 	tablename = table->name;
-	(void)WT_PREFIX_SKIP(tablename, "table:");
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
 
 	return ((table->ncolgroups == 0) ?
 	    __wt_buf_fmt(session, buf, "colgroup:%s", tablename) :
@@ -285,7 +285,7 @@ __schema_open_index(WT_SESSION_IMPL *session,
 
 	/* Build a search key. */
 	tablename = table->name;
-	(void)WT_PREFIX_SKIP(tablename, "table:");
+	WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
 	WT_ERR(__wt_scr_alloc(session, 512, &tmp));
 	WT_ERR(__wt_buf_fmt(session, tmp, "index:%s:", tablename));
 

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -24,11 +24,9 @@ __rename_file(
 	newvalue = oldvalue = NULL;
 
 	filename = uri;
-	if (!WT_PREFIX_SKIP(filename, "file:"))
-		return (__wt_unexpected_object_type(session, uri, "file:"));
+	WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
 	newfile = newuri;
-	if (!WT_PREFIX_SKIP(newfile, "file:"))
-		return (__wt_unexpected_object_type(session, newuri, "file:"));
+	WT_PREFIX_SKIP_REQUIRED(session, newfile, "file:");
 
 	WT_RET(__wt_schema_backup_check(session, filename));
 	WT_RET(__wt_schema_backup_check(session, newfile));
@@ -98,7 +96,7 @@ __rename_tree(WT_SESSION_IMPL *session,
 	value = NULL;
 
 	newname = newuri;
-	(void)WT_PREFIX_SKIP(newname, "table:");
+	WT_PREFIX_SKIP_REQUIRED(session, newname, "table:");
 
 	/*
 	 * Create the new data source URI and update the schema value.

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -67,7 +67,7 @@ __wt_schema_worker(WT_SESSION_IMPL *session,
 		    session, uri, false, NULL, &colgroup));
 		WT_ERR(__wt_schema_worker(session,
 		    colgroup->source, file_func, name_func, cfg, open_flags));
-	} else if (WT_PREFIX_SKIP(tablename, "index:")) {
+	} else if (WT_PREFIX_MATCH(uri, "index:")) {
 		idx = NULL;
 		WT_ERR(__wt_schema_get_index(session, uri, false, NULL, &idx));
 		WT_ERR(__wt_schema_worker(session, idx->source,


### PR DESCRIPTION
These changes speed up a focused benchmark by 13%.  The benchmark is a single threaded application that does cursor_open in a loop.