### PR TITLE
WT-3386 Remove support for timestamps in test/checkpoint.

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -83,7 +83,7 @@ static int
 real_checkpointer(void)
 {
 	WT_SESSION *session;
-	char *checkpoint_config, _buf[128];
+	char *checkpoint_config, buf[128];
 	int ret;
 
 	if (g.running == 0)
@@ -100,8 +100,8 @@ real_checkpointer(void)
 		checkpoint_config = NULL;
 	else {
 		testutil_check(__wt_snprintf(
-		    _buf, sizeof(_buf), "name=%s", g.checkpoint_name));
-		checkpoint_config = _buf;
+		    buf, sizeof(buf), "name=%s", g.checkpoint_name));
+		checkpoint_config = buf;
 	}
 
 	while (g.running) {

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -96,14 +96,15 @@ real_checkpointer(void)
 	if ((ret = g.conn->open_session(g.conn, NULL, NULL, &session)) != 0)
 		return (log_print_err("conn.open_session", ret, 1));
 
-	while (g.running) {
-		if (WT_PREFIX_MATCH(g.checkpoint_name, "WiredTigerCheckpoint"))
-			strcpy(_buf, "");
-		else
-			testutil_check(__wt_snprintf(
-			    _buf, sizeof(_buf), "name=%s", g.checkpoint_name));
+	if (WT_PREFIX_MATCH(g.checkpoint_name, "WiredTigerCheckpoint"))
+		checkpoint_config = NULL;
+	else {
+		testutil_check(__wt_snprintf(
+		    _buf, sizeof(_buf), "name=%s", g.checkpoint_name));
+		checkpoint_config = _buf;
+	}
 
-		checkpoint_config = strlen(_buf) > 0 ? _buf : NULL;
+	while (g.running) {
 		/* Execute a checkpoint */
 		if ((ret = session->checkpoint(
 		    session, checkpoint_config)) != 0)

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -103,11 +103,6 @@ real_checkpointer(void)
 			testutil_check(__wt_snprintf(
 			    _buf, sizeof(_buf), "name=%s", g.checkpoint_name));
 
-		if (g.use_timestamps && g.timestamp > 0)
-			testutil_check(__wt_snprintf(
-			    _buf + strlen(_buf), sizeof(_buf) - strlen(_buf),
-			    ",read_timestamp=%" PRIx64, g.timestamp));
-
 		checkpoint_config = strlen(_buf) > 0 ? _buf : NULL;
 		/* Execute a checkpoint */
 		if ((ret = session->checkpoint(

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -6,11 +6,6 @@ set -e
 echo "checkpoint: 3 mixed tables"
 $TEST_WRAPPER ./t -T 3 -t m
 
-# Smoke-test timestamps
-# Timestamp testing is commented as part of WT-3446
-# echo "checkpoint: 3 mixed tables with timestamps"
-# $TEST_WRAPPER ./t -T 3 -t m -s
-
 # We are done unless long tests are enabled.
 test "$TESTUTIL_ENABLE_LONG_TESTS" = "1" || exit 0
 
@@ -23,14 +18,8 @@ $TEST_WRAPPER ./t -T 6 -t l
 echo "checkpoint: 6 mixed tables"
 $TEST_WRAPPER ./t -T 6 -t m
 
-# echo "checkpoint: 6 mixed tables with timestamps"
-# $TEST_WRAPPER ./t -T 6 -t m -s
-
 echo "checkpoint: 6 row-store tables"
 $TEST_WRAPPER ./t -T 6 -t r
 
 echo "checkpoint: 6 row-store tables, named checkpoint"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r
-
-# echo "checkpoint: 6 row-store tables, named checkpoint"
-# $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r -s

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -320,12 +320,10 @@ type_to_string(table_type type)
 static int
 usage(void)
 {
-	//    progname, argc, argv, "c:C:h:k:l:n:r:t:T:W:")) != EOF)
-
 	fprintf(stderr,
 	    "usage: %s "
 	    "[-C wiredtiger-config] [-c checkpoint] [-h home] [-k keys]\n\t"
-	    "[-l log] [-n ops] [-r runs] [-s] [-t f|r|v] [-T table-config]\n\t"
+	    "[-l log] [-n ops] [-r runs] [-T table-config] [-t f|r|v]\n\t"
 	    "[-W workers]\n",
 	    progname);
 	fprintf(stderr, "%s",
@@ -336,8 +334,8 @@ usage(void)
 	    "\t-l specify a log file\n"
 	    "\t-n set number of operations each thread does\n"
 	    "\t-r set number of runs (0 for continuous)\n"
-	    "\t-t set a file type ( col | mix | row | lsm )\n"
 	    "\t-T specify a table configuration\n"
+	    "\t-t set a file type ( col | mix | row | lsm )\n"
 	    "\t-W set number of worker threads\n");
 	return (EXIT_FAILURE);
 }

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -65,7 +65,7 @@ main(int argc, char *argv[])
 	runs = 1;
 
 	while ((ch = __wt_getopt(
-	    progname, argc, argv, "C:c:h:k:l:n:r:sT:t:W:")) != EOF)
+	    progname, argc, argv, "C:c:h:k:l:n:r:T:t:W:")) != EOF)
 		switch (ch) {
 		case 'c':
 			g.checkpoint_name = __wt_optarg;
@@ -92,25 +92,6 @@ main(int argc, char *argv[])
 		case 'r':			/* runs */
 			runs = atoi(__wt_optarg);
 			break;
-		case 's':
-			/*
-			 * disabled below block temporarily to avoid spurious
-			 * test failures as per ticket WT-3446 and
-			 * to be reverted when WT-3386 is merged.
-			 */
-#if 0
-#ifdef HAVE_TIMESTAMPS
-			g.use_timestamps = true;
-#endif
-			break;
-#endif
-			/*
-			 * The below code segment to be deleted as part of
-			 * reverting the above block i.e. WT-3386
-			 */
-			fprintf(stderr,
-			    "Checkpoint Timestamp testing is not supported\n");
-			return (EXIT_FAILURE);
 		case 't':
 			switch (__wt_optarg[0]) {
 			case 'c':
@@ -355,7 +336,6 @@ usage(void)
 	    "\t-l specify a log file\n"
 	    "\t-n set number of operations each thread does\n"
 	    "\t-r set number of runs (0 for continuous)\n"
-	    "\t-s enable transaction timestamps\n"
 	    "\t-t set a file type ( col | mix | row | lsm )\n"
 	    "\t-T specify a table configuration\n"
 	    "\t-W set number of worker threads\n");

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -57,8 +57,6 @@ typedef struct {
 	WT_CONNECTION *conn;			/* WiredTiger connection */
 	u_int nkeys;				/* Keys to load */
 	u_int nops;				/* Operations per thread */
-	uint64_t timestamp;			/* Current timestamp */
-	bool use_timestamps;			/* Test with timestamps */
 	FILE *logfp;				/* Message log file. */
 	int nworkers;				/* Number workers configured */
 	int ntables;				/* Number tables configured */

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -166,10 +166,8 @@ real_worker(void)
 	WT_CURSOR **cursors;
 	WT_SESSION *session;
 	WT_RAND_STATE rnd;
-	uint64_t ts;
 	u_int i, keyno;
 	int j, ret, t_ret;
-	char config_buf[64];
 
 	ret = t_ret = 0;
 
@@ -204,27 +202,12 @@ real_worker(void)
 				break;
 		}
 		if (ret == 0) {
-			if (g.use_timestamps) {
-				ts = __wt_atomic_add64(&g.timestamp, 1);
-				if (ts > 100 && ts % 100 == 0) {
-					testutil_check(__wt_snprintf(
-					    config_buf, sizeof(config_buf),
-					    "oldest_timestamp=%" PRIx64,
-					    ts - 100));
-					testutil_check(g.conn->set_timestamp(
-					    g.conn, config_buf));
-				}
-				testutil_check(__wt_snprintf(
-				    config_buf, sizeof(config_buf),
-				    "commit_timestamp=%" PRIx64, ts));
-			}
-
-			if ((ret = session->commit_transaction(session,
-			    g.use_timestamps ? config_buf : NULL)) != 0) {
+			if ((ret = session->commit_transaction(
+			    session, NULL)) != 0) {
 				(void)log_print_err(
 				    "real_worker:commit_transaction", ret, 1);
 				goto err;
-			    }
+			}
 		} else if (ret == WT_ROLLBACK) {
 			if ((ret = session->rollback_transaction(
 			    session, NULL)) != 0) {


### PR DESCRIPTION
Coverage in test/recovery/timestamp-abort instead.