### PR TITLE
WT-3541 Python test_reconfig02 timeout on the PPC

### DIFF
--- a/test/suite/test_reconfig02.py
+++ b/test/suite/test_reconfig02.py
@@ -81,7 +81,7 @@ class test_reconfig02(wttest.WiredTigerTestCase):
         #
         # Potentially loop a few times in case it is a very slow system.
         self.conn.reconfigure("log=(prealloc=true)")
-        for x in xrange(0, 20):
+        for x in xrange(0, 100):
             time.sleep(1)
             prep_logs = fnmatch.filter(os.listdir('.'), "*Prep*")
             if len(prep_logs) != 0:


### PR DESCRIPTION
I can't reproduce this failure, but I do see the test taking over 10 seconds for the pre-allocated log files to appear, so I don't think it's unlikely that periodically some runs take even longer.