### PR TITLE
WT-3542 Python test_stats_log_on_json_with_tables timeout on the PPC

### DIFF
--- a/test/suite/test_stat_log02.py
+++ b/test/suite/test_stat_log02.py
@@ -26,63 +26,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import glob
-import json
-import os.path
-import time
+import glob, json
 import helper, wiredtiger, wttest
 from wiredtiger import stat
 
 # test_stat_log02.py
-#    Statistics log JSON testing
+#    Statistics log sources argument and JSON testing.
 class test_stat_log02(wttest.WiredTigerTestCase):
-    """
-    Test statistics log JSON outputs
-    """
 
     # Tests need to setup the connection in their own way.
     def setUpConnectionOpen(self, dir):
         return None
-
     def setUpSessionOpen(self, conn):
         return None
-
-    def test_stats_log_json(self):
-        self.conn = self.wiredtiger_open(None,
-            "create,statistics=(fast),statistics_log=(wait=1,json,on_close=1)")
-
-        self.wait_for_stats_file(".")
-        self.check_stats_file(".")
-
-    def test_stats_log_on_json_with_tables(self):
-        self.conn = self.wiredtiger_open(None,
-            "create,statistics=(fast)," +\
-            "statistics_log=(wait=1,json,on_close=1,sources=[file:])")
-
-        # Create a session and table to give us some stats
-        session = self.conn.open_session()
-        session.create("table:foo")
-        c = session.open_cursor("table:foo")
-        c["foo"] = "foo"
-        session.close()
-
-        self.wait_for_stats_file(".")
-        self.close_conn()
-        self.check_stats_file(".")
-        self.check_file_contains_tables(".")
-
-    def wait_for_stats_file(self, dir):
-        # We wait for 30 sleeps then fail
-        number_sleeps = 0
-        while True:
-            files = glob.glob(dir + '/' + 'WiredTigerStat.[0-9]*')
-            for f in files:
-                if os.stat(f).st_size != 0:
-                    return
-
-            time.sleep(1)
-            number_sleeps += 1
-            self.assertLess(number_sleeps, 30)
 
     def check_stats_file(self, dir):
         files = glob.glob(dir + '/' + 'WiredTigerStat.[0-9]*')
@@ -96,22 +52,40 @@ class test_stat_log02(wttest.WiredTigerTestCase):
             json.loads(line)
 
     def check_file_contains_tables(self, dir):
-        # We wait for another 30 sleeps here to avoid erroring in the case where
-        # the stat log has only made the first pass and not yet printed the
-        # individual table stats.
-        number_sleeps = 0
-        while True:
-            files = glob.glob(dir + '/' + 'WiredTigerStat.[0-9]*')
-            f = open(files[0], 'r')
-            for line in f:
-                data = json.loads(line)
-                if "wiredTigerTables" in data:
-                    if "file:foo.wt" in data["wiredTigerTables"]:
-                        return
+        files = glob.glob(dir + '/' + 'WiredTigerStat.[0-9]*')
+        f = open(files[0], 'r')
+        for line in f:
+            data = json.loads(line)
+            if "wiredTigerTables" in data:
+                if "file:foo.wt" in data["wiredTigerTables"]:
+                    return
+        self.fail('Did not find expected sources in statistics log output')
 
-            time.sleep(1)
-            number_sleeps += 1
-            self.assertLess(number_sleeps, 30)
+    def test_stats_log_json(self):
+        self.conn = self.wiredtiger_open(None,
+            "create,statistics=(fast),statistics_log=(wait=1,json,on_close=1)")
+
+        # Closing the connection forces statistics to be written.
+        self.close_conn()
+
+        self.check_stats_file(".")
+
+    def test_stats_log_on_json_with_tables(self):
+        self.conn = self.wiredtiger_open(None,
+            "create,statistics=(fast)," +\
+            "statistics_log=(wait=1,json,on_close=1,sources=[file:])")
+        self.session = self.conn.open_session(None)
+
+        # Create a session and table to give us some stats.
+        self.session.create("table:foo", "key_format=S,value_format=S")
+        c = self.session.open_cursor("table:foo")
+        c["foo"] = "foo"
+
+        # Closing the connection forces statistics to be written.
+        self.close_conn()
+
+        self.check_stats_file(".")
+        self.check_file_contains_tables(".")
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Still seeing timeout failures on the PPC: rewrite to not use timers at all.