### PR TITLE
WT-3431 Replace WT_TXN_STATE with sorted lists.

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -199,6 +199,7 @@ src/support/time.c
 src/txn/txn.c
 src/txn/txn_ckpt.c
 src/txn/txn_ext.c
+src/txn/txn_global.c
 src/txn/txn_log.c
 src/txn/txn_nsnap.c
 src/txn/txn_recover.c

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -511,6 +511,7 @@ bzDecompressInit
 bzalloc
 bzfree
 bzip
+calc
 call's
 calloc
 cas

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -84,7 +84,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	btree = S2BT(session);
 	walk = NULL;
 	txn = &session->txn;
-	saved_pinned_id = WT_SESSION_TXN_STATE(session)->pinned_id;
+	saved_pinned_id = txn->pinned_id;
 	flags = WT_READ_CACHE | WT_READ_NO_GEN;
 
 	internal_bytes = leaf_bytes = 0;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2225,15 +2225,15 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
+	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
-	WT_TXN_STATE *txn_state;
 	uint64_t init_evict_count, max_pages_evicted;
 	bool timer;
 
 	conn = S2C(session);
 	cache = conn->cache;
+	txn = &session->txn;
 	txn_global = &conn->txn_global;
-	txn_state = WT_SESSION_TXN_STATE(session);
 
 	/*
 	 * It is not safe to proceed if the eviction server threads aren't
@@ -2261,7 +2261,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 		 * abort the transaction to give up all hazard pointers before
 		 * trying again.
 		 */
-		if (__wt_cache_stuck(session) && __wt_txn_am_oldest(session)) {
+		if (__wt_cache_stuck(session) && __wt_txn_is_oldest(session)) {
 			--cache->evict_aggressive_score;
 			WT_STAT_CONN_INCR(session, txn_fail_cache);
 			WT_ERR(WT_ROLLBACK);
@@ -2276,7 +2276,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 		 * limit the work to 5 evictions and return. If that's not the
 		 * case, we can do more.
 		 */
-		if (!busy && txn_state->pinned_id != WT_TXN_NONE &&
+		if (!busy && txn->pinned_id != WT_TXN_NONE &&
 		    txn_global->current != txn_global->oldest_id)
 			busy = true;
 		max_pages_evicted = busy ? 5 : 20;

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -337,8 +337,8 @@ static inline int
 __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool *didworkp)
 {
 	WT_BTREE *btree;
+	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
-	WT_TXN_STATE *txn_state;
 	u_int pct_full;
 
 	if (didworkp != NULL)
@@ -351,11 +351,11 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool *didworkp)
 	 * Otherwise, we are at a transaction boundary and we can work harder
 	 * to make sure there is free space in the cache.
 	 */
+	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
-	txn_state = WT_SESSION_TXN_STATE(session);
-	busy = busy || txn_state->id != WT_TXN_NONE ||
+	busy = busy || F_ISSET(txn, WT_TXN_PUBLIC_ID) ||
 	    session->nhazard > 0 ||
-	    (txn_state->pinned_id != WT_TXN_NONE &&
+	    (txn->pinned_id != WT_TXN_NONE &&
 	    txn_global->current != txn_global->oldest_id);
 
 	/*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -774,7 +774,6 @@ extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FU
 extern void __wt_seconds(WT_SESSION_IMPL *session, time_t *timep);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);
-extern int __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
@@ -783,10 +782,6 @@ extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);
-extern int __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_txn_global_destroy(WT_SESSION_IMPL *session);
-extern int __wt_txn_global_shutdown(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_verbose_dump_txn(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_checkpoint(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -797,6 +792,17 @@ extern int __wt_ext_transaction_isolation_level( WT_EXTENSION_API *wt_api, WT_SE
 extern int __wt_ext_transaction_notify( WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, WT_TXN_NOTIFY *notify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_ext_transaction_oldest(WT_EXTENSION_API *wt_api);
 extern int __wt_ext_transaction_visible( WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, uint64_t transaction_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_txn_publish_id(WT_SESSION_IMPL *session);
+extern void __wt_txn_clear_id(WT_SESSION_IMPL *session);
+extern void __wt_txn_publish_metadata_pinned(WT_SESSION_IMPL *session);
+extern void __wt_txn_clear_metadata_pinned(WT_SESSION_IMPL *session);
+extern void __wt_txn_publish_pinned_id(WT_SESSION_IMPL *session);
+extern void __wt_txn_clear_pinned_id(WT_SESSION_IMPL *session);
+extern int __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_txn_global_destroy(WT_SESSION_IMPL *session);
+extern int __wt_txn_global_shutdown(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_verbose_dump_txn(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_op_free(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 extern int __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -46,6 +46,8 @@
 	((const uint8_t *)(p) + (len) <= (const uint8_t *)(begin) + (maxlen)))
 #define	WT_PTR_IN_RANGE(p, begin, maxlen)				\
 	WT_BLOCK_FITS((p), 1, (begin), (maxlen))
+#define	WT_STRUCT_FROM_FIELD(type, p, field)				\
+	(type *)((uint8_t *)(void *)(p) - offsetof(WT_SESSION_IMPL, field))
 
 /*
  * Align an unsigned value of any type to a specified power-of-2, including the

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -23,10 +23,8 @@
 #define	WT_TXNID_LT(t1, t2)						\
 	((t1) < (t2))
 
-#define	WT_SESSION_TXN_STATE(s) (&S2C(s)->txn_global.states[(s)->id])
-
 #define	WT_SESSION_IS_CHECKPOINT(s)					\
-	((s)->id != 0 && (s)->id == S2C(s)->txn_global.checkpoint_id)
+	((s)->id != 0 && (s)->id == S2C(s)->txn_global.checkpoint_session_id)
 
 /*
  * Perform an operation at the specified isolation level.
@@ -39,8 +37,9 @@
 #define	WT_WITH_TXN_ISOLATION(s, iso, op) do {				\
 	WT_TXN_ISOLATION saved_iso = (s)->isolation;		        \
 	WT_TXN_ISOLATION saved_txn_iso = (s)->txn.isolation;		\
-	WT_TXN_STATE *txn_state = WT_SESSION_TXN_STATE(s);		\
-	WT_TXN_STATE saved_state = *txn_state;				\
+	uint64_t saved_id = (s)->txn.id;				\
+	uint64_t saved_metadata_pinned = (s)->txn.metadata_pinned;	\
+	uint64_t saved_pinned_id = (s)->txn.pinned_id;			\
 	(s)->txn.forced_iso++;						\
 	(s)->isolation = (s)->txn.isolation = (iso);			\
 	op;								\
@@ -48,13 +47,19 @@
 	(s)->txn.isolation = saved_txn_iso;				\
 	WT_ASSERT((s), (s)->txn.forced_iso > 0);                        \
 	(s)->txn.forced_iso--;						\
-	WT_ASSERT((s), txn_state->id == saved_state.id &&		\
-	    (txn_state->metadata_pinned == saved_state.metadata_pinned ||\
-	    saved_state.metadata_pinned == WT_TXN_NONE) &&		\
-	    (txn_state->pinned_id == saved_state.pinned_id ||		\
-	    saved_state.pinned_id == WT_TXN_NONE));			\
-	txn_state->metadata_pinned = saved_state.metadata_pinned;	\
-	txn_state->pinned_id = saved_state.pinned_id;			\
+	WT_ASSERT((s), (s)->txn.id == saved_id &&			\
+	    ((s)->txn.metadata_pinned == saved_metadata_pinned ||	\
+	    saved_metadata_pinned == WT_TXN_NONE) &&			\
+	    ((s)->txn.pinned_id == saved_pinned_id ||			\
+	    saved_pinned_id == WT_TXN_NONE));				\
+	if (saved_metadata_pinned == WT_TXN_NONE)                       \
+		__wt_txn_clear_metadata_pinned(session);                \
+	else                                                            \
+		(s)->txn.metadata_pinned = saved_metadata_pinned;	\
+	if (saved_pinned_id == WT_TXN_NONE)                             \
+		__wt_txn_clear_pinned_id(session);                      \
+	else                                                            \
+		(s)->txn.pinned_id = saved_pinned_id;			\
 } while (0)
 
 struct __wt_named_snapshot {
@@ -65,15 +70,6 @@ struct __wt_named_snapshot {
 	uint64_t id, pinned_id, snap_min, snap_max;
 	uint64_t *snapshot;
 	uint32_t snapshot_count;
-};
-
-struct __wt_txn_state {
-	WT_CACHE_LINE_PAD_BEGIN
-	volatile uint64_t id;
-	volatile uint64_t pinned_id;
-	volatile uint64_t metadata_pinned;
-
-	WT_CACHE_LINE_PAD_END
 };
 
 struct __wt_txn_global {
@@ -99,13 +95,23 @@ struct __wt_txn_global {
 	bool oldest_is_pinned;
 	bool stable_is_pinned;
 
-	WT_SPINLOCK id_lock;
-
-	/* Protects the active transaction states. */
+	/* Protects the active transaction state. */
 	WT_RWLOCK rwlock;
 
 	/* Protects logging, checkpoints and transaction visibility. */
 	WT_RWLOCK visibility_rwlock;
+
+	/* List of transactions sorted by transaction ID. */
+	WT_RWLOCK id_rwlock;
+	TAILQ_HEAD(__wt_txn_id_qh, __wt_txn) idh;
+
+	/* List of transactions sorted by metadata pinned ID. */
+	WT_RWLOCK metadata_pinned_rwlock;
+	TAILQ_HEAD(__wt_txn_mp_qh, __wt_txn) metadata_pinnedh;
+
+	/* List of transactions sorted by pinned ID. */
+	WT_RWLOCK pinned_id_rwlock;
+	TAILQ_HEAD(__wt_txn_pid_qh, __wt_txn) pinned_idh;
 
 	/* List of transactions sorted by commit timestamp. */
 	WT_RWLOCK commit_timestamp_rwlock;
@@ -127,9 +133,10 @@ struct __wt_txn_global {
 	 * it won't revisit it.
 	 */
 	volatile bool	  checkpoint_running;	/* Checkpoint running */
-	volatile uint32_t checkpoint_id;	/* Checkpoint's session ID */
-	WT_TXN_STATE	  checkpoint_state;	/* Checkpoint's txn state */
+	volatile uint32_t checkpoint_session_id;/* Checkpoint's session ID */
 	WT_TXN           *checkpoint_txn;	/* Checkpoint's txn structure */
+	uint64_t 	  checkpoint_txn_id;	/* Checkpoint's txn ID */
+	uint64_t 	  checkpoint_pinned_id;	/* Checkpoint's pinned ID */
 
 	volatile uint64_t metadata_pinned;	/* Oldest ID for metadata */
 
@@ -137,8 +144,6 @@ struct __wt_txn_global {
 	WT_RWLOCK nsnap_rwlock;
 	volatile uint64_t nsnap_oldest_id;
 	TAILQ_HEAD(__wt_nsnap_qh, __wt_named_snapshot) nsnaph;
-
-	WT_TXN_STATE *states;		/* Per-session transaction states */
 };
 
 typedef enum __wt_txn_isolation {
@@ -191,6 +196,8 @@ struct __wt_txn_op {
  */
 struct __wt_txn {
 	uint64_t id;
+	uint64_t metadata_pinned;
+	uint64_t pinned_id;
 
 	WT_TXN_ISOLATION isolation;
 
@@ -224,6 +231,9 @@ struct __wt_txn {
 	/* Read updates committed as of this timestamp. */
 	WT_DECL_TIMESTAMP(read_timestamp)
 
+	TAILQ_ENTRY(__wt_txn) idq;
+	TAILQ_ENTRY(__wt_txn) metadata_pinnedq;
+	TAILQ_ENTRY(__wt_txn) pinned_idq;
 	TAILQ_ENTRY(__wt_txn) commit_timestampq;
 	TAILQ_ENTRY(__wt_txn) read_timestampq;
 
@@ -244,17 +254,20 @@ struct __wt_txn {
 	WT_ITEM		*ckpt_snapshot;
 	bool		full_ckpt;
 
-#define	WT_TXN_AUTOCOMMIT	0x001
-#define	WT_TXN_ERROR		0x002
-#define	WT_TXN_HAS_ID		0x004
-#define	WT_TXN_HAS_SNAPSHOT	0x008
-#define	WT_TXN_HAS_TS_COMMIT	0x010
-#define	WT_TXN_HAS_TS_READ	0x020
-#define	WT_TXN_NAMED_SNAPSHOT	0x040
-#define	WT_TXN_PUBLIC_TS_COMMIT	0x080
-#define	WT_TXN_PUBLIC_TS_READ	0x100
-#define	WT_TXN_READONLY		0x200
-#define	WT_TXN_RUNNING		0x400
-#define	WT_TXN_SYNC_SET		0x800
+#define	WT_TXN_AUTOCOMMIT		0x0001
+#define	WT_TXN_ERROR			0x0002
+#define	WT_TXN_HAS_ID			0x0004
+#define	WT_TXN_HAS_SNAPSHOT		0x0008
+#define	WT_TXN_HAS_TS_COMMIT		0x0010
+#define	WT_TXN_HAS_TS_READ		0x0020
+#define	WT_TXN_NAMED_SNAPSHOT		0x0040
+#define	WT_TXN_PUBLIC_ID		0x0080
+#define	WT_TXN_PUBLIC_METADATA_PINNED	0x0100
+#define	WT_TXN_PUBLIC_PINNED_ID		0x0200
+#define	WT_TXN_PUBLIC_TS_COMMIT		0x0400
+#define	WT_TXN_PUBLIC_TS_READ		0x0800
+#define	WT_TXN_READONLY			0x1000
+#define	WT_TXN_RUNNING			0x2000
+#define	WT_TXN_SYNC_SET			0x4000
 	uint32_t flags;
 };

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -52,6 +52,7 @@
 	    saved_metadata_pinned == WT_TXN_NONE) &&			\
 	    ((s)->txn.pinned_id == saved_pinned_id ||			\
 	    saved_pinned_id == WT_TXN_NONE));				\
+	WT_UNUSED(saved_id);						\
 	if (saved_metadata_pinned == WT_TXN_NONE)                       \
 		__wt_txn_clear_metadata_pinned(session);                \
 	else                                                            \

--- a/src/include/verify_build.h
+++ b/src/include/verify_build.h
@@ -68,7 +68,6 @@ __wt_verify_build(void)
 	    sizeof(s) > WT_CACHE_LINE_ALIGNMENT ||			\
 	    sizeof(s) % WT_CACHE_LINE_ALIGNMENT == 0)
 	WT_PADDING_CHECK(WT_LOGSLOT);
-	WT_PADDING_CHECK(WT_TXN_STATE);
 
 	/*
 	 * The btree code encodes key/value pairs in size_t's, and requires at

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -298,8 +298,6 @@ struct __wt_txn_global;
     typedef struct __wt_txn_global WT_TXN_GLOBAL;
 struct __wt_txn_op;
     typedef struct __wt_txn_op WT_TXN_OP;
-struct __wt_txn_state;
-    typedef struct __wt_txn_state WT_TXN_STATE;
 struct __wt_update;
     typedef struct __wt_update WT_UPDATE;
 union __wt_lsn;

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -229,8 +229,7 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
 			    F_ISSET(clsm, WT_CLSM_OPEN_SNAPSHOT)) {
 				WT_ASSERT(session,
 				    F_ISSET(txn, WT_TXN_HAS_SNAPSHOT));
-				pinned_id =
-				    WT_SESSION_TXN_STATE(session)->pinned_id;
+				pinned_id = txn->pinned_id;
 				for (i = clsm->nchunks - 2;
 				    clsm->nupdates < clsm->nchunks;
 				    clsm->nupdates++, i--) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1441,7 +1441,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		 */
 		WT_ASSERT(session, *updp == NULL ||
 		    (*updp)->txnid !=
-		    S2C(session)->txn_global.checkpoint_state.id ||
+		    S2C(session)->txn_global.checkpoint_txn_id ||
 		    WT_SESSION_IS_CHECKPOINT(session));
 
 		goto check_original_value;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -68,9 +68,9 @@ __wt_txn_get_snapshot(WT_SESSION_IMPL *session)
 
 	/*
 	 * We're going to scan the list of running transactions: wait for the
-	 * lock.
+	 * lock.  Hold the global rwlock to prevent the oldest ID moving
+	 * forward while we scan.
 	 */
-	// XXX -- keep oldest pinned
 	__wt_readlock(session, &txn_global->rwlock);
 	__wt_readlock(session, &txn_global->id_rwlock);
 	current_id = pinned_id = txn_global->current;

--- a/src/txn/txn_global.c
+++ b/src/txn/txn_global.c
@@ -1,0 +1,628 @@
+/*-
+ * Copyright (c) 2014-2017 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_txn_publish_id --
+ *	Publish a transaction's ID.
+ *
+ *	The txn_global->id_rwlock must be held by our caller.
+ */
+void
+__wt_txn_publish_id(WT_SESSION_IMPL *session)
+{
+	WT_TXN *prev, *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	WT_ASSERT(session, F_ISSET(txn, WT_TXN_HAS_ID) &&
+	    !F_ISSET(txn, WT_TXN_PUBLIC_ID));
+
+	for (prev = TAILQ_LAST(&txn_global->idh, __wt_txn_id_qh);
+	    prev != NULL && WT_TXNID_LT(txn->id, prev->id);
+	    prev = TAILQ_PREV(prev, __wt_txn_cts_qh, idq))
+		;
+	if (prev == NULL)
+		TAILQ_INSERT_HEAD(&txn_global->idh, txn, idq);
+	else
+		TAILQ_INSERT_AFTER(&txn_global->idh, prev, txn, idq);
+	F_SET(txn, WT_TXN_PUBLIC_ID);
+}
+
+/*
+ * __wt_txn_clear_id --
+ *	Clear a transaction's published ID.
+ */
+void
+__wt_txn_clear_id(WT_SESSION_IMPL *session)
+{
+	WT_TXN *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	if (!F_ISSET(txn, WT_TXN_PUBLIC_ID))
+		return;
+
+	__wt_writelock(session, &txn_global->id_rwlock);
+	TAILQ_REMOVE(&txn_global->idh, txn, idq);
+	txn->id = WT_TXN_NONE;
+	__wt_writeunlock(session, &txn_global->id_rwlock);
+	F_CLR(txn, WT_TXN_HAS_ID | WT_TXN_PUBLIC_ID);
+}
+
+/*
+ * __wt_txn_publish_metadata_pinned --
+ *	Publish a transaction's metadata pinned transaction ID.
+ */
+void
+__wt_txn_publish_metadata_pinned(WT_SESSION_IMPL *session)
+{
+	WT_TXN *prev, *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	WT_ASSERT(session, txn->metadata_pinned != WT_TXN_NONE &&
+	    !F_ISSET(txn, WT_TXN_PUBLIC_METADATA_PINNED));
+
+	__wt_writelock(session, &txn_global->metadata_pinned_rwlock);
+	for (prev = TAILQ_LAST(&txn_global->metadata_pinnedh, __wt_txn_id_qh);
+	    prev != NULL &&
+	    WT_TXNID_LT(txn->metadata_pinned, prev->metadata_pinned);
+	    prev = TAILQ_PREV(prev, __wt_txn_mp_qh, metadata_pinnedq))
+		;
+	if (prev == NULL)
+		TAILQ_INSERT_HEAD(
+		    &txn_global->metadata_pinnedh, txn, metadata_pinnedq);
+	else
+		TAILQ_INSERT_AFTER(
+		    &txn_global->metadata_pinnedh, prev, txn, metadata_pinnedq);
+	__wt_writeunlock(session, &txn_global->metadata_pinned_rwlock);
+	F_SET(txn, WT_TXN_PUBLIC_METADATA_PINNED);
+}
+
+/*
+ * __wt_txn_clear_metadata_pinned --
+ *	Clear a transaction's published pinned ID.
+ */
+void
+__wt_txn_clear_metadata_pinned(WT_SESSION_IMPL *session)
+{
+	WT_TXN *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	if (!F_ISSET(txn, WT_TXN_PUBLIC_METADATA_PINNED))
+		return;
+
+	__wt_writelock(session, &txn_global->metadata_pinned_rwlock);
+	TAILQ_REMOVE(&txn_global->metadata_pinnedh, txn, metadata_pinnedq);
+	txn->metadata_pinned = WT_TXN_NONE;
+	__wt_writeunlock(session, &txn_global->metadata_pinned_rwlock);
+	F_CLR(txn, WT_TXN_PUBLIC_METADATA_PINNED);
+}
+
+/*
+ * __wt_txn_publish_pinned_id --
+ *	Publish a transaction's pinned transaction ID.
+ */
+void
+__wt_txn_publish_pinned_id(WT_SESSION_IMPL *session)
+{
+	WT_TXN *prev, *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	WT_ASSERT(session, txn->pinned_id != WT_TXN_NONE &&
+	    !F_ISSET(txn, WT_TXN_PUBLIC_PINNED_ID));
+
+	__wt_writelock(session, &txn_global->pinned_id_rwlock);
+	for (prev = TAILQ_LAST(&txn_global->pinned_idh, __wt_txn_id_qh);
+	    prev != NULL && WT_TXNID_LT(txn->pinned_id, prev->pinned_id);
+	    prev = TAILQ_PREV(prev, __wt_txn_cts_qh, pinned_idq))
+		;
+	if (prev == NULL)
+		TAILQ_INSERT_HEAD(&txn_global->pinned_idh, txn, pinned_idq);
+	else
+		TAILQ_INSERT_AFTER(
+		    &txn_global->pinned_idh, prev, txn, pinned_idq);
+	__wt_writeunlock(session, &txn_global->pinned_id_rwlock);
+	F_SET(txn, WT_TXN_PUBLIC_PINNED_ID);
+}
+
+/*
+ * __wt_txn_clear_pinned_id --
+ *	Clear a transaction's published pinned ID.
+ */
+void
+__wt_txn_clear_pinned_id(WT_SESSION_IMPL *session)
+{
+	WT_TXN *txn;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
+
+	if (!F_ISSET(txn, WT_TXN_PUBLIC_PINNED_ID))
+		return;
+
+	__wt_writelock(session, &txn_global->pinned_id_rwlock);
+	TAILQ_REMOVE(&txn_global->pinned_idh, txn, pinned_idq);
+	txn->pinned_id = WT_TXN_NONE;
+	__wt_writeunlock(session, &txn_global->pinned_id_rwlock);
+	F_CLR(txn, WT_TXN_PUBLIC_PINNED_ID);
+}
+
+/*
+ * __txn_oldest_scan --
+ *	Sweep the running transactions to calculate the oldest ID required.
+ */
+static void
+__txn_oldest_scan(WT_SESSION_IMPL *session,
+    uint64_t *oldest_idp, uint64_t *last_runningp, uint64_t *metadata_pinnedp,
+    WT_SESSION_IMPL **oldest_sessionp)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_SESSION_IMPL *oldest_session;
+	WT_TXN *txn;
+	WT_TXN_GLOBAL *txn_global;
+	uint64_t id, last_running, metadata_pinned, oldest_id;
+	uint32_t i, session_cnt;
+
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+	oldest_session = NULL;
+
+	/* The oldest ID cannot change while we are holding the scan lock. */
+	last_running = oldest_id = txn_global->current;
+	if ((metadata_pinned = txn_global->checkpoint_txn_id) == WT_TXN_NONE)
+		metadata_pinned = oldest_id;
+
+	__wt_readlock(session, &txn_global->id_rwlock);
+	if ((txn = TAILQ_FIRST(&txn_global->idh)) != NULL)
+		last_running = txn->id;
+	__wt_readunlock(session, &txn_global->id_rwlock);
+
+	__wt_readlock(session, &txn_global->metadata_pinned_rwlock);
+	if ((txn = TAILQ_FIRST(&txn_global->metadata_pinnedh)) != NULL)
+		metadata_pinned = txn->metadata_pinned;
+	__wt_readunlock(session, &txn_global->metadata_pinned_rwlock);
+
+	__wt_readlock(session, &txn_global->pinned_id_rwlock);
+	/*
+	 * !!!
+	 * Note: Don't ignore pinned ID values older than the previous oldest
+	 * ID.  Read-uncommitted operations publish pinned ID values without
+	 * acquiring the scan lock to protect the global table.  See the
+	 * comment in __wt_txn_cursor_op for more details.
+	 */
+	if ((txn = TAILQ_FIRST(&txn_global->pinned_idh)) != NULL) {
+		oldest_id = txn->pinned_id;
+		oldest_session =
+		    WT_STRUCT_FROM_FIELD(WT_SESSION_IMPL, txn, txn);
+	}
+	__wt_readunlock(session, &txn_global->pinned_id_rwlock);
+
+	if (WT_TXNID_LT(last_running, oldest_id))
+		oldest_id = last_running;
+
+	/* The oldest ID can't move past any named snapshots. */
+	if ((id = txn_global->nsnap_oldest_id) != WT_TXN_NONE &&
+	    WT_TXNID_LT(id, oldest_id))
+		oldest_id = id;
+
+	/* The metadata pinned ID can't move past the oldest ID. */
+	if (WT_TXNID_LT(oldest_id, metadata_pinned))
+		metadata_pinned = oldest_id;
+
+	*last_runningp = last_running;
+	*metadata_pinnedp = metadata_pinned;
+	*oldest_idp = oldest_id;
+	*oldest_sessionp = oldest_session;
+}
+
+/*
+ * __wt_txn_update_oldest --
+ *	Sweep the running transactions to update the oldest ID required.
+ */
+int
+__wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_DECL_RET;
+	WT_SESSION_IMPL *oldest_session;
+	WT_TXN_GLOBAL *txn_global;
+	uint64_t current_id, last_running, metadata_pinned, oldest_id;
+	uint64_t prev_last_running, prev_metadata_pinned, prev_oldest_id;
+	bool strict, wait;
+
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+	strict = LF_ISSET(WT_TXN_OLDEST_STRICT);
+	wait = LF_ISSET(WT_TXN_OLDEST_WAIT);
+
+	current_id = last_running = metadata_pinned = txn_global->current;
+	prev_last_running = txn_global->last_running;
+	prev_metadata_pinned = txn_global->metadata_pinned;
+	prev_oldest_id = txn_global->oldest_id;
+
+#ifdef HAVE_TIMESTAMPS
+	/* Try to move the pinned timestamp forward. */
+	if (strict)
+		WT_RET(__wt_txn_update_pinned_timestamp(session));
+#endif
+
+	/*
+	 * For pure read-only workloads, or if the update isn't forced and the
+	 * oldest ID isn't too far behind, avoid scanning.
+	 */
+	if ((prev_oldest_id == current_id &&
+	    prev_metadata_pinned == current_id) ||
+	    (!strict && WT_TXNID_LT(current_id, prev_oldest_id + 100)))
+		return (0);
+
+	/* First do a read-only scan. */
+	if (wait)
+		__wt_readlock(session, &txn_global->rwlock);
+	else if ((ret =
+	    __wt_try_readlock(session, &txn_global->rwlock)) != 0)
+		return (ret == EBUSY ? 0 : ret);
+	__txn_oldest_scan(session,
+	    &oldest_id, &last_running, &metadata_pinned, &oldest_session);
+	__wt_readunlock(session, &txn_global->rwlock);
+
+	/*
+	 * If the state hasn't changed (or hasn't moved far enough for
+	 * non-forced updates), give up.
+	 */
+	if ((oldest_id == prev_oldest_id ||
+	    (!strict && WT_TXNID_LT(oldest_id, prev_oldest_id + 100))) &&
+	    ((last_running == prev_last_running) ||
+	    (!strict && WT_TXNID_LT(last_running, prev_last_running + 100))) &&
+	    metadata_pinned == prev_metadata_pinned)
+		return (0);
+
+	/* It looks like an update is necessary, wait for exclusive access. */
+	if (wait)
+		__wt_writelock(session, &txn_global->rwlock);
+	else if ((ret =
+	    __wt_try_writelock(session, &txn_global->rwlock)) != 0)
+		return (ret == EBUSY ? 0 : ret);
+
+	/*
+	 * If the oldest ID has been updated while we waited, don't bother
+	 * scanning.
+	 */
+	if (WT_TXNID_LE(oldest_id, txn_global->oldest_id) &&
+	    WT_TXNID_LE(last_running, txn_global->last_running) &&
+	    WT_TXNID_LE(metadata_pinned, txn_global->metadata_pinned))
+		goto done;
+
+	/*
+	 * Re-scan now that we have exclusive access.  This is necessary because
+	 * threads get transaction snapshots with read locks, and we have to be
+	 * sure that there isn't a thread that has got a snapshot locally but
+	 * not yet published its snap_min.
+	 */
+	__txn_oldest_scan(session,
+	    &oldest_id, &last_running, &metadata_pinned, &oldest_session);
+
+#ifdef HAVE_DIAGNOSTIC
+	{
+	/*
+	 * Make sure the ID doesn't move past any named snapshots.
+	 *
+	 * Don't include the read/assignment in the assert statement.  Coverity
+	 * complains if there are assignments only done in diagnostic builds,
+	 * and when the read is from a volatile.
+	 */
+	uint64_t id = txn_global->nsnap_oldest_id;
+	WT_ASSERT(session,
+	    id == WT_TXN_NONE || !WT_TXNID_LT(id, oldest_id));
+	}
+#endif
+	/* Update the public IDs. */
+	if (WT_TXNID_LT(txn_global->metadata_pinned, metadata_pinned))
+		txn_global->metadata_pinned = metadata_pinned;
+	if (WT_TXNID_LT(txn_global->oldest_id, oldest_id))
+		txn_global->oldest_id = oldest_id;
+	if (WT_TXNID_LT(txn_global->last_running, last_running)) {
+		txn_global->last_running = last_running;
+
+#ifdef HAVE_VERBOSE
+		/* Output a verbose message about long-running transactions,
+		 * but only when some progress is being made. */
+		if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
+		    current_id - oldest_id > 10000 && oldest_session != NULL) {
+			__wt_verbose(session, WT_VERB_TRANSACTION,
+			    "old snapshot %" PRIu64
+			    " pinned in session %" PRIu32 " [%s]"
+			    " with snap_min %" PRIu64,
+			    oldest_id, oldest_session->id,
+			    oldest_session->lastop,
+			    oldest_session->txn.snap_min);
+		}
+#endif
+	}
+
+done:	__wt_writeunlock(session, &txn_global->rwlock);
+	return (ret);
+}
+
+/*
+ * __wt_txn_global_init --
+ *	Initialize the global transaction state.
+ */
+int
+__wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_TXN_GLOBAL *txn_global;
+	u_int i;
+
+	WT_UNUSED(cfg);
+	conn = S2C(session);
+
+	txn_global = &conn->txn_global;
+	txn_global->current = txn_global->last_running =
+	    txn_global->metadata_pinned = txn_global->oldest_id = WT_TXN_FIRST;
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->rwlock));
+	WT_RET(__wt_rwlock_init(session, &txn_global->visibility_rwlock));
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->id_rwlock));
+	TAILQ_INIT(&txn_global->idh);
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->metadata_pinned_rwlock));
+	TAILQ_INIT(&txn_global->metadata_pinnedh);
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->pinned_id_rwlock));
+	TAILQ_INIT(&txn_global->pinned_idh);
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->commit_timestamp_rwlock));
+	TAILQ_INIT(&txn_global->commit_timestamph);
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->read_timestamp_rwlock));
+	TAILQ_INIT(&txn_global->read_timestamph);
+
+	WT_RET(__wt_rwlock_init(session, &txn_global->nsnap_rwlock));
+	txn_global->nsnap_oldest_id = WT_TXN_NONE;
+	TAILQ_INIT(&txn_global->nsnaph);
+
+	return (0);
+}
+
+/*
+ * __wt_txn_global_destroy --
+ *	Destroy the global transaction state.
+ */
+void
+__wt_txn_global_destroy(WT_SESSION_IMPL *session)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_TXN_GLOBAL *txn_global;
+
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+
+	if (txn_global == NULL)
+		return;
+
+	__wt_rwlock_destroy(session, &txn_global->rwlock);
+	__wt_rwlock_destroy(session, &txn_global->id_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->metadata_pinned_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->pinned_id_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->commit_timestamp_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->read_timestamp_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->nsnap_rwlock);
+	__wt_rwlock_destroy(session, &txn_global->visibility_rwlock);
+}
+
+/*
+ * __wt_txn_global_shutdown --
+ *	Shut down the global transaction state.
+ */
+int
+__wt_txn_global_shutdown(WT_SESSION_IMPL *session)
+{
+	bool txn_active;
+
+	/*
+	 * We're shutting down.  Make sure everything gets freed.
+	 *
+	 * It's possible that the eviction server is in the middle of a long
+	 * operation, with a transaction ID pinned.  In that case, we will loop
+	 * here until the transaction ID is released, when the oldest
+	 * transaction ID will catch up with the current ID.
+	 */
+	for (;;) {
+		WT_RET(__wt_txn_activity_check(session, &txn_active));
+		if (!txn_active)
+			break;
+
+		WT_STAT_CONN_INCR(session, txn_release_blocked);
+		__wt_yield();
+	}
+
+#ifdef HAVE_TIMESTAMPS
+	/*
+	 * Now that all transactions have completed, no timestamps should be
+	 * pinned.
+	 */
+	__wt_timestamp_set_inf(&S2C(session)->txn_global.pinned_timestamp);
+#endif
+
+	return (0);
+}
+
+#if defined(HAVE_DIAGNOSTIC) || defined(HAVE_VERBOSE)
+/*
+ * __wt_verbose_dump_txn --
+ *	Output diagnostic information about the global transaction state.
+ */
+int
+__wt_verbose_dump_txn(WT_SESSION_IMPL *session)
+{
+	WT_CONNECTION_IMPL *conn;
+	WT_TXN_GLOBAL *txn_global;
+	WT_TXN *txn;
+	const char *iso_tag;
+	uint32_t i, session_cnt;
+#ifdef HAVE_TIMESTAMPS
+	char hex_timestamp[3][2 * WT_TIMESTAMP_SIZE + 1];
+#endif
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+
+	WT_RET(__wt_msg(session, "%s", WT_DIVIDER));
+	WT_RET(__wt_msg(session, "transaction state dump"));
+
+	WT_RET(__wt_msg(session, "current ID: %" PRIu64, txn_global->current));
+	WT_RET(__wt_msg(session,
+	    "last running ID: %" PRIu64, txn_global->last_running));
+	WT_RET(__wt_msg(session, "oldest ID: %" PRIu64, txn_global->oldest_id));
+
+#ifdef HAVE_TIMESTAMPS
+	WT_RET(__wt_timestamp_to_hex_string(
+	    session, hex_timestamp[0], &txn_global->commit_timestamp));
+	WT_RET(__wt_msg(session, "commit timestamp: %s", hex_timestamp[0]));
+	WT_RET(__wt_timestamp_to_hex_string(
+	    session, hex_timestamp[0], &txn_global->oldest_timestamp));
+	WT_RET(__wt_msg(session, "oldest timestamp: %s", hex_timestamp[0]));
+	WT_RET(__wt_timestamp_to_hex_string(
+	    session, hex_timestamp[0], &txn_global->pinned_timestamp));
+	WT_RET(__wt_msg(session, "pinned timestamp: %s", hex_timestamp[0]));
+	WT_RET(__wt_timestamp_to_hex_string(
+	    session, hex_timestamp[0], &txn_global->stable_timestamp));
+	WT_RET(__wt_msg(session, "stable timestamp: %s", hex_timestamp[0]));
+	WT_RET(__wt_msg(session, "has_commit_timestamp: %s",
+	    txn_global->has_commit_timestamp ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "has_oldest_timestamp: %s",
+	    txn_global->has_oldest_timestamp ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "has_pinned_timestamp: %s",
+	    txn_global->has_pinned_timestamp ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "has_stable_timestamp: %s",
+	    txn_global->has_stable_timestamp ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "oldest_is_pinned: %s",
+	    txn_global->oldest_is_pinned ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "stable_is_pinned: %s",
+	    txn_global->stable_is_pinned ? "yes" : "no"));
+#endif
+
+	WT_RET(__wt_msg(session, "checkpoint running: %s",
+	    txn_global->checkpoint_running ? "yes" : "no"));
+	WT_RET(__wt_msg(session, "checkpoint generation: %" PRIu64,
+	    __wt_gen(session, WT_GEN_CHECKPOINT)));
+	WT_RET(__wt_msg(session, "checkpoint pinned ID: %" PRIu64,
+	    txn_global->checkpoint_pinned_id));
+	WT_RET(__wt_msg(session, "checkpoint txn ID: %" PRIu64,
+	    txn_global->checkpoint_txn_id));
+
+	WT_RET(__wt_msg(session,
+	    "oldest named snapshot ID: %" PRIu64, txn_global->nsnap_oldest_id));
+
+	WT_ORDERED_READ(session_cnt, conn->session_cnt);
+	WT_RET(__wt_msg(session, "session count: %" PRIu32, session_cnt));
+	WT_RET(__wt_msg(session, "Transaction state of active sessions:"));
+
+	/*
+	 * Walk each session transaction state and dump information. Accessing
+	 * the content of session handles is not thread safe, so some
+	 * information may change while traversing if other threads are active
+	 * at the same time, which is OK since this is diagnostic code.
+	 */
+	for (i = 0; i < session_cnt; i++) {
+		/* Skip sessions with no active transaction */
+		txn = &conn->sessions[i].txn;
+		if (!F_ISSET(txn, WT_TXN_PUBLIC_ID) &&
+		    txn->pinned_id == WT_TXN_NONE)
+			continue;
+
+		iso_tag = "INVALID";
+		switch (txn->isolation) {
+		case WT_ISO_READ_COMMITTED:
+			iso_tag = "WT_ISO_READ_COMMITTED";
+			break;
+		case WT_ISO_READ_UNCOMMITTED:
+			iso_tag = "WT_ISO_READ_UNCOMMITTED";
+			break;
+		case WT_ISO_SNAPSHOT:
+			iso_tag = "WT_ISO_SNAPSHOT";
+			break;
+		}
+#ifdef HAVE_TIMESTAMPS
+		WT_RET(__wt_timestamp_to_hex_string(
+		    session, hex_timestamp[0], &txn->commit_timestamp));
+		WT_RET(__wt_timestamp_to_hex_string(
+		    session, hex_timestamp[1], &txn->first_commit_timestamp));
+		WT_RET(__wt_timestamp_to_hex_string(
+		    session, hex_timestamp[2], &txn->read_timestamp));
+		WT_RET(__wt_msg(session,
+		    "ID: %8" PRIu64
+		    ", mod count: %u"
+		    ", pinned ID: %8" PRIu64
+		    ", snap min: %" PRIu64
+		    ", snap max: %" PRIu64
+		    ", commit_timestamp: %s"
+		    ", first_commit_timestamp: %s"
+		    ", read_timestamp: %s"
+		    ", metadata pinned ID: %" PRIu64
+		    ", flags: 0x%08" PRIx32
+		    ", name: %s"
+		    ", isolation: %s",
+		    txn->id,
+		    txn->mod_count,
+		    txn->pinned_id,
+		    txn->snap_min,
+		    txn->snap_max,
+		    hex_timestamp[0],
+		    hex_timestamp[1],
+		    hex_timestamp[2],
+		    txn->metadata_pinned,
+		    txn->flags,
+		    conn->sessions[i].name == NULL ?
+		    "EMPTY" : conn->sessions[i].name,
+		    iso_tag));
+#else
+		WT_RET(__wt_msg(session,
+		    "ID: %6" PRIu64
+		    ", mod count: %u"
+		    ", pinned ID: %" PRIu64
+		    ", snap min: %" PRIu64
+		    ", snap max: %" PRIu64
+		    ", metadata pinned ID: %" PRIu64
+		    ", flags: 0x%08" PRIx32
+		    ", name: %s"
+		    ", isolation: %s",
+		    id,
+		    txn->mod_count,
+		    txn->pinned_id,
+		    txn->snap_min,
+		    txn->snap_max,
+		    txn->metadata_pinned,
+		    txn->flags,
+		    conn->sessions[i].name == NULL ?
+		    "EMPTY" : conn->sessions[i].name,
+		    iso_tag));
+#endif
+	}
+	WT_RET(__wt_msg(session, "%s", WT_DIVIDER));
+
+	return (0);
+}
+#endif

--- a/src/txn/txn_global.c
+++ b/src/txn/txn_global.c
@@ -182,7 +182,6 @@ __txn_oldest_scan(WT_SESSION_IMPL *session,
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 	uint64_t id, last_running, metadata_pinned, oldest_id;
-	uint32_t i, session_cnt;
 
 	conn = S2C(session);
 	txn_global = &conn->txn_global;
@@ -373,7 +372,6 @@ __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_TXN_GLOBAL *txn_global;
-	u_int i;
 
 	WT_UNUSED(cfg);
 	conn = S2C(session);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -217,7 +217,7 @@ __txn_global_query_timestamp(
 
 		/* Check for a running checkpoint */
 		txn = txn_global->checkpoint_txn;
-		if (txn_global->checkpoint_state.pinned_id != WT_TXN_NONE &&
+		if (txn_global->checkpoint_pinned_id != WT_TXN_NONE &&
 		    !__wt_timestamp_iszero(&txn->read_timestamp) &&
 		    __wt_timestamp_cmp(&txn->read_timestamp, &ts) < 0)
 			__wt_timestamp_set(&ts, &txn->read_timestamp);


### PR DESCRIPTION
Each list is protected by a separate rwlock, allowing us to create
snapshots without sorting and avoid any transaction operations having to
scan sessions.