### PR TITLE
WT-3540 For debugging only copy log files.

### DIFF
--- a/test/recovery/random-abort.c
+++ b/test/recovery/random-abort.c
@@ -350,7 +350,9 @@ main(int argc, char *argv[])
 		testutil_die(errno, "parent chdir: %s", home);
 
 	testutil_check(__wt_snprintf(buf, sizeof(buf),
-	    "rm -rf ../%s.SAVE; cp -rp ../%s ../%s.SAVE;", home, home, home));
+	    "rm -rf ../%s.SAVE; mkdir ../%s.SAVE; "
+	    "cp -p WiredTigerLog.* ../%s.SAVE;",
+	    home, home, home));
 	if ((status = system(buf)) < 0)
 		testutil_die(status, "system: %s", buf);
 

--- a/test/recovery/timestamp-abort.c
+++ b/test/recovery/timestamp-abort.c
@@ -403,7 +403,7 @@ main(int argc, char *argv[])
 	uint32_t i, nth, timeout;
 	int ch, status, ret;
 	const char *working_dir;
-	char buf[128], fname[64], kname[64], statname[1024];
+	char buf[512], fname[64], kname[64], statname[1024];
 	bool fatal, rand_th, rand_time, verify_only;
 
 	(void)testutil_set_progname(argv);
@@ -523,7 +523,8 @@ main(int argc, char *argv[])
 	if (chdir(home) != 0)
 		testutil_die(errno, "parent chdir: %s", home);
 	testutil_check(__wt_snprintf(buf, sizeof(buf),
-	    "rm -rf ../%s.SAVE && mkdir ../%s.SAVE && cp -rp * ../%s.SAVE",
+	    "rm -rf ../%s.SAVE && mkdir ../%s.SAVE && "
+	    "cp -p WiredTigerLog.* ../%s.SAVE",
 	     home, home, home));
 	(void)system(buf);
 	printf("Open database, run recovery and verify content\n");


### PR DESCRIPTION
Tables can be so large that they fill test machine file systems.