### PR TITLE
WT-3495 Don't ftruncate if log cursors are open

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -543,7 +543,8 @@ __log_file_server(void *arg)
 				if (!conn->hot_backup) {
 					__wt_readlock(
 					    session, &conn->hot_backup_lock);
-					if (!conn->hot_backup)
+					if (!conn->hot_backup &&
+					    conn->log_cursors == 0)
 						WT_ERR_ERROR_OK(
 						    __wt_ftruncate(session,
 						    close_fh,

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -336,6 +336,7 @@ struct __wt_connection_impl {
 	bool		 log_wrlsn_tid_set;/* Log write lsn thread set */
 	WT_LOG		*log;		/* Logging structure */
 	WT_COMPRESSOR	*log_compressor;/* Logging compressor */
+	uint32_t	 log_cursors;	/* Log cursor count */
 	wt_off_t	 log_file_max;	/* Log file max size */
 	const char	*log_path;	/* Logging path format */
 	uint32_t	 log_prealloc;	/* Log file pre-allocation */


### PR DESCRIPTION
@agorrod Please review this.  It avoids the ftruncate if there are log cursors open.  Other than test programs log cursors are very rarely used so I don't think it has much user-visible impact.