### PR TITLE
WT-3468 Avoid shared timespec usage in LSM

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -785,6 +785,7 @@ iS
 iSh
 ibackup
 icount
+idlems
 idx
 ifdef
 ifdef's
@@ -1057,7 +1058,6 @@ psp
 pthread
 ptr
 ptrdiff
-pushms
 putK
 putV
 pv

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -212,9 +212,11 @@ struct __wt_lsm_tree {
 	struct timespec last_flush_time;/* Time last flush finished */
 	uint64_t chunks_flushed;	/* Count of chunks flushed since open */
 	struct timespec merge_aggressive_time;/* Time for merge aggression */
-	struct timespec work_push_time;	/* Time last work unit added */
 	uint64_t merge_progressing;	/* Bumped when merges are active */
 	uint32_t merge_syncing;		/* Bumped when merges are syncing */
+	struct timespec last_active;	/* Time last work unit added */
+	uint64_t mgr_work_count;	/* Manager work count */
+	uint64_t work_count;		/* Work units added */
 
 	/* Configuration parameters */
 	uint32_t bloom_bit_count;

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -388,7 +388,7 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 	WT_DECL_RET;
 	WT_LSM_TREE *lsm_tree;
 	struct timespec now;
-	uint64_t fillms, pushms;
+	uint64_t fillms, idlems;
 	bool dhandle_locked;
 
 	conn = S2C(session);
@@ -405,8 +405,18 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 			if (!lsm_tree->active)
 				continue;
 			__wt_epoch(session, &now);
-			pushms = lsm_tree->work_push_time.tv_sec == 0 ? 0 :
-			    WT_TIMEDIFF_MS(now, lsm_tree->work_push_time);
+			/*
+			 * If work was added reset our counts and time.
+			 * Otherwise compute an idle time.
+			 */
+			if (lsm_tree->work_count != lsm_tree->mgr_work_count ||
+			    lsm_tree->work_count == 0) {
+				idlems = 0;
+				lsm_tree->mgr_work_count = lsm_tree->work_count;
+				lsm_tree->last_active = now;
+			} else
+				idlems =
+				    WT_TIMEDIFF_MS(now, lsm_tree->last_active);
 			fillms = 3 * lsm_tree->chunk_fill_ms;
 			if (fillms == 0)
 				fillms = 10000;
@@ -434,7 +444,7 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 			    (lsm_tree->merge_aggressiveness >
 			    WT_LSM_AGGRESSIVE_THRESHOLD &&
 			     !F_ISSET(lsm_tree, WT_LSM_TREE_COMPACTING)) ||
-			    pushms > fillms) {
+			    idlems > fillms) {
 				WT_ERR(__wt_lsm_manager_push_entry(
 				    session, WT_LSM_WORK_SWITCH, 0, lsm_tree));
 				WT_ERR(__wt_lsm_manager_push_entry(
@@ -448,13 +458,13 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 				    "MGR %s: queue %" PRIu32 " mod %d "
 				    "nchunks %" PRIu32
 				    " flags %#" PRIx32 " aggressive %" PRIu32
-				    " pushms %" PRIu64
+				    " idlems %" PRIu64
 				    " fillms %" PRIu64,
 				    lsm_tree->name, lsm_tree->queue_ref,
 				    lsm_tree->modified, lsm_tree->nchunks,
 				    lsm_tree->flags,
 				    lsm_tree->merge_aggressiveness,
-				    pushms, fillms);
+				    idlems, fillms);
 				WT_ERR(__wt_lsm_manager_push_entry(
 				    session, WT_LSM_WORK_MERGE, 0, lsm_tree));
 			}
@@ -661,7 +671,7 @@ __wt_lsm_manager_push_entry(WT_SESSION_IMPL *session,
 		return (0);
 	}
 
-	__wt_epoch(session, &lsm_tree->work_push_time);
+	(void)__wt_atomic_add64(&lsm_tree->work_count, 1);
 	WT_RET(__wt_calloc_one(session, &entry));
 	entry->type = type;
 	entry->flags = flags;

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -413,12 +413,12 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	/* Now the file is written, get the chunk size. */
 	WT_ERR(__wt_lsm_tree_set_chunk_size(session, chunk));
 
-	/* Update the flush timestamp to help track ongoing progress. */
-	__wt_epoch(session, &lsm_tree->last_flush_time);
 	++lsm_tree->chunks_flushed;
 
 	/* Lock the tree, mark the chunk as on disk and update the metadata. */
 	__wt_lsm_tree_writelock(session, lsm_tree);
+	/* Update the flush timestamp to help track ongoing progress. */
+	__wt_epoch(session, &lsm_tree->last_flush_time);
 	F_SET(chunk, WT_LSM_CHUNK_ONDISK);
 	ret = __wt_lsm_meta_write(session, lsm_tree, NULL);
 	++lsm_tree->dsk_gen;


### PR DESCRIPTION
@agorrod Please review.  I implemented a form of @michaelcahill 's suggestions.  I have an atomic work unit counter and only the server thread looks for idleness and keeps track of how long a tree has been idle.

I've run `make check` and all the `run.py lsm` and `test/format` with `data_source=lsm` for over 100 iterations.  But I do not know for sure whether or not the lsm manager idle settings have kicked in or not.