### PR TITLE
WT-3574 No need for atomic add.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -224,7 +224,7 @@ thread_run(void *arg)
 			 * by another thread.
 			 */
 			testutil_check(pthread_rwlock_rdlock(&commit_ts_lock));
-			stable_ts = __wt_atomic_addv64(&global_ts, 1);
+			stable_ts = global_ts++;
 		} else
 			stable_ts = 0;
 		testutil_check(__wt_snprintf(


### PR DESCRIPTION
@agorrod and @sulabhM please review.  I may be missing some motivation that requires this operation to be atomic.  While the test isn't a performance related test, performing more operations means we test more code when it is killed.