### PR TITLE
WT-3223 Progress messages for checkpoint operation.

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -633,7 +633,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 						conn->ckpt_tree_verb_time);
 			if (time_diff > 15)
 				__wt_verbose(session, WT_VERB_CHECKPOINT,
-			            "delete-checkpoint took : %" PRIu64 "sec",
+				    "delete-checkpoint took : %" PRIu64 "sec",
 				    time_diff);
 			conn->ckpt_tree_verb_time = current_time;
 		}

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -627,7 +627,6 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 		 */
 		WT_ERR(__wt_block_extlist_overlap(session, block, b));
 
-#ifdef HAVE_VERBOSE
 		if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {
 			__wt_epoch(session, &current_time);
 			time_diff = WT_TIMEDIFF_SEC(current_time,
@@ -638,7 +637,6 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 				    time_diff);
 			conn->ckpt_tree_verb_time = current_time;
 		}
-#endif
 
 		/*
 		 * If we're updating the live system's information, we're done.

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -388,14 +388,14 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
 static int
 __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 {
+	struct timespec current_time;
 	WT_BLOCK_CKPT *a, *b, *ci;
-	WT_CONNECTION_IMPL *conn;
 	WT_CKPT *ckpt, *next_ckpt;
+	WT_CONNECTION_IMPL *conn;
 	WT_DECL_ITEM(tmp);
 	WT_DECL_RET;
 	uint64_t ckpt_size;
 	uint64_t time_diff;
-	struct timespec current_time;
 	bool deleting, fatal, locked;
 
 	ci = &block->live;
@@ -549,6 +549,9 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 		    !F_ISSET(ckpt, WT_CKPT_DELETE))
 			continue;
 
+		/* Set the checkpoint deletion start time. */
+		__wt_epoch(session, &conn->ckpt_tree_verb_time);
+
 #ifdef HAVE_VERBOSE
 		if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {
 			if (tmp == NULL)
@@ -630,7 +633,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 		if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {
 			__wt_epoch(session, &current_time);
 			time_diff = WT_TIMEDIFF_SEC(current_time,
-						conn->ckpt_tree_verb_time);
+			    conn->ckpt_tree_verb_time);
 			if (time_diff > 15)
 				__wt_verbose(session, WT_VERB_CHECKPOINT,
 				    "delete-checkpoint took : %" PRIu64 "sec",

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -75,8 +75,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	WT_PAGE *page;
 	WT_REF *walk;
 	WT_TXN *txn;
-	uint64_t int_bytes_delta, int_page_delta, leaf_bytes_delta, leaf_delta;
-	uint64_t prev_int_bytes, prev_int_pages, prev_leaf_bytes, prev_leaf;
+	uint64_t int_bytes_svpt, int_page_svpt, leaf_bytes_svpt, leaf_svpt;
 	uint64_t internal_bytes, internal_pages, leaf_bytes, leaf_pages;
 	uint64_t oldest_id, saved_pinned_id;
 	uint32_t page_counter;
@@ -93,8 +92,8 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
 	internal_bytes = leaf_bytes = 0;
 	internal_pages = leaf_pages = 0;
-	prev_int_bytes = prev_leaf_bytes = 0;
-	prev_int_pages = prev_leaf = 0;
+	int_bytes_svpt = leaf_bytes_svpt = 0;
+	int_page_svpt = leaf_svpt = 0;
 	page_counter = 0;
 	timer = WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT);
 	if (timer)
@@ -239,13 +238,14 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 						conn->ckpt_tree_verb_time);
 
 				if (time_diff > 20) {
-					int_bytes_delta =
-					    internal_bytes - prev_int_bytes;
-					int_page_delta =
-					    internal_pages - prev_int_pages;
-					leaf_bytes_delta =
-					    leaf_bytes - prev_leaf_bytes;
-					leaf_delta = leaf_pages - prev_leaf;
+
+					int_bytes_svpt =
+					    internal_bytes - int_bytes_svpt;
+					int_page_svpt =
+					    internal_pages - int_page_svpt;
+					leaf_bytes_svpt =
+					    leaf_bytes - leaf_bytes_svpt;
+					leaf_svpt = leaf_pages - leaf_svpt;
 
 					__wt_verbose(session,
 					    WT_VERB_CHECKPOINT,
@@ -253,14 +253,14 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 					    " took %" PRIu64 "sec to write: %"
 					    PRIu64" leaf pages (%" PRIu64 "B),"
 					    "%" PRIu64 " internal pages (%"
-					    PRIu64 "B)", time_diff, leaf_delta,
-					    leaf_bytes_delta, int_page_delta,
-					    int_bytes_delta);
+					    PRIu64 "B)", time_diff, leaf_svpt,
+					    leaf_bytes_svpt, int_page_svpt,
+					    int_bytes_svpt);
 
-					prev_int_bytes = internal_bytes;
-					prev_int_pages = internal_pages;
-					prev_leaf_bytes = leaf_bytes;
-					prev_leaf = leaf_pages;
+					int_bytes_svpt = internal_bytes;
+					int_page_svpt = internal_pages;
+					leaf_bytes_svpt = leaf_bytes;
+					leaf_svpt = leaf_pages;
 					conn->ckpt_tree_verb_time = cur_time;
 				}
 

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -248,7 +248,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 					    internal_pages - int_pg_save;
 					leaf_bytes_save =
 					    leaf_bytes - leaf_bytes_save;
-					leaf_pg_save = 
+					leaf_pg_save =
 					    leaf_pages - leaf_pg_save;
 
 					__wt_verbose(session,

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -239,11 +239,11 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 						conn->ckpt_tree_verb_time);
 
 				if (time_diff > 20) {
-					int_bytes_delta = 
+					int_bytes_delta =
 					    internal_bytes - prev_int_bytes;
-					int_page_delta = 
+					int_page_delta =
 					    internal_pages - prev_int_pages;
-					leaf_bytes_delta = 
+					leaf_bytes_delta =
 					    leaf_bytes - prev_leaf_bytes;
 					leaf_delta = leaf_pages - prev_leaf;
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -267,6 +267,7 @@ struct __wt_connection_impl {
 	uint64_t  ckpt_time_min;
 	uint64_t  ckpt_time_recent;	/* Checkpoint time recent/total */
 	uint64_t  ckpt_time_total;
+	struct timespec ckpt_tree_verb_time;	/* Checkpoint verbosity timer */
 
 	uint32_t stat_flags;		/* Options declared in flags.py */
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1466,6 +1466,9 @@ __checkpoint_tree(
 			goto fake;
 		}
 
+	/* Start the tree checkpoint verbosity timer */
+	__wt_epoch(session, &conn->ckpt_tree_verb_time);
+
 	/*
 	 * Mark the root page dirty to ensure something gets written. (If the
 	 * tree is modified, we must write the root page anyway, this doesn't


### PR DESCRIPTION
While checkpointing a table (tree), log verbose message every 20 seconds
indicating the amount of work done in that duration. It was also observed that
the step of deleting the checkpoints, that are no longer required, is consuming
considerable amount of time while checkpointing a tree. Hence added a log
message at this step too.