### PR TITLE
WT-3589 replace return checks and testutil_die() pairs, with testutil_check().

### DIFF
--- a/test/bloom/test_bloom.c
+++ b/test/bloom/test_bloom.c
@@ -106,11 +106,9 @@ setup(void)
 {
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	int ret;
 	char config[512];
 
-	if ((ret = system("rm -f WiredTiger* *.bf")) != 0)
-		testutil_die(ret, "system cleanup call failed");
+	testutil_check(system("rm -f WiredTiger* *.bf"));
 
 	/*
 	 * This test doesn't test public Wired Tiger functionality, it still

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -603,8 +603,8 @@ main(int argc, char *argv[])
 	stable_val = 0;
 	memset(val, 0, sizeof(val));
 	while (cur_stable->next(cur_stable) == 0) {
-		cur_stable->get_key(cur_stable, &key);
-		cur_stable->get_value(cur_stable, &val[key]);
+		testutil_check(cur_stable->get_key(cur_stable, &key));
+		testutil_check(cur_stable->get_value(cur_stable, &val[key]));
 		if (val[key] > stable_val)
 			stable_val = val[key];
 

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -67,28 +67,22 @@ write_and_read_new(WT_SESSION *session)
 	 * Write a log record and force it to disk so we can read it.
 	 */
 	printf("Write log_printf record and verify.\n");
-	if ((ret = session->log_printf(session, "Test Log Record")) != 0)
-		testutil_die(ret, "log_printf");
-	if ((ret = session->log_flush(session, "sync=on")) != 0)
-		testutil_die(ret, "log_flush");
-	if ((ret = session->open_cursor(
-	    session, "log:", NULL, NULL, &logc)) != 0)
-		testutil_die(ret, "open_cursor: log");
-	if ((ret = session->open_cursor(
-	    session, "log:", NULL, NULL, &logc)) != 0)
-		testutil_die(ret, "open_cursor: log");
+	testutil_check(session->log_printf(session, "Test Log Record"));
+	testutil_check(session->log_flush(session, "sync=on"));
+	testutil_check(
+	    session->open_cursor(session, "log:", NULL, NULL, &logc));
+	testutil_check(
+	    session->open_cursor(session, "log:", NULL, NULL, &logc));
 	saw_msg = false;
 	while ((ret = logc->next(logc)) == 0) {
 		/*
 		 * We don't really need to get the key, but in case we want
 		 * the LSN for some message, get it.
 		 */
-		if ((ret = logc->get_key(logc,
-		    &log_file, &log_offset, &opcount)) != 0)
-			testutil_die(errno, "get_key");
-		if ((ret = logc->get_value(logc, &txnid, &rectype,
-		    &optype, &fileid, &logrec_key, &logrec_value)) != 0)
-			testutil_die(errno, "get_value");
+		testutil_check(logc->get_key(
+		    logc, &log_file, &log_offset, &opcount));
+		testutil_check(logc->get_value(logc, &txnid,
+		    &rectype, &optype, &fileid, &logrec_key, &logrec_value));
 		/*
 		 * We should never see a record from us in log file 2.  We wrote
 		 * a record there, but then the record in log file 1 was
@@ -116,8 +110,7 @@ write_and_read_new(WT_SESSION *session)
 			break;
 		}
 	}
-	if ((ret = logc->close(logc)) != 0)
-		testutil_die(ret, "log cursor close");
+	testutil_check(logc->close(logc));
 	if (!saw_msg)
 		testutil_die(EINVAL, "Did not traverse log printf record");
 }
@@ -155,16 +148,11 @@ fill_db(void)
 	 */
 	if (chdir(home) != 0)
 		testutil_die(errno, "chdir: %s", home);
-	if ((ret = wiredtiger_open(NULL, NULL, ENV_CONFIG, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "WT_CONNECTION:open_session");
-	if ((ret = session->create(session,
-	    uri, "key_format=S,value_format=S")) != 0)
-		testutil_die(ret, "WT_SESSION.create: %s", uri);
-	if ((ret =
-	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "WT_SESSION.open_cursor: %s", uri);
+	testutil_check(wiredtiger_open(NULL, NULL, ENV_CONFIG, &conn));
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(
+	    session->create(session, uri, "key_format=S,value_format=S"));
+	testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
 	/*
 	 * Keep a separate file with the records we wrote for checking.
@@ -197,27 +185,23 @@ fill_db(void)
 		    (int)(V_SIZE - (strlen("value") + 1)), (int)i));
 		cursor->set_key(cursor, k);
 		cursor->set_value(cursor, v);
-		if ((ret = cursor->insert(cursor)) != 0)
-			testutil_die(ret, "WT_CURSOR.insert");
+		testutil_check(cursor->insert(cursor));
 
 		/*
 		 * Walking the ever growing log can be slow, so only start
 		 * looking for the cross into log file 2 after a minimum.
 		 */
 		if (i > min_key) {
-			if ((ret = session->open_cursor(
-			    session, "log:", NULL, NULL, &logc)) != 0)
-				testutil_die(ret, "open_cursor: log");
+			testutil_check(session->open_cursor(
+			    session, "log:", NULL, NULL, &logc));
 			if (save_lsn.l.file != 0) {
 				logc->set_key(logc,
 				    save_lsn.l.file, save_lsn.l.offset, 0);
-				if ((ret = logc->search(logc)) != 0)
-					testutil_die(ret, "search");
+				testutil_check(logc->search(logc));
 			}
 			while ((ret = logc->next(logc)) == 0) {
-				if ((ret = logc->get_key(logc,
-				    &lsn.l.file, &lsn.l.offset, &unused)) != 0)
-					testutil_die(ret, "get_key");
+				testutil_check(logc->get_key(
+				    logc, &lsn.l.file, &lsn.l.offset, &unused));
 				/*
 				 * Save the LSN so that we know the offset
 				 * of the last LSN in log file 1 later.
@@ -243,8 +227,7 @@ fill_db(void)
 				}
 			}
 			first = false;
-			if ((ret = logc->close(logc)) != 0)
-				testutil_die(ret, "log cursor close");
+			testutil_check(logc->close(logc));
 		}
 	}
 	if (fclose(fp) != 0)
@@ -332,13 +315,9 @@ main(int argc, char *argv[])
 	if ((ret = truncate(LOG_FILE_1, (wt_off_t)new_offset)) != 0)
 		testutil_die(errno, "truncate");
 
-	if ((ret = wiredtiger_open(NULL, NULL, ENV_CONFIG_REC, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "WT_CONNECTION:open_session");
-	if ((ret =
-	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "WT_SESSION.open_cursor: %s", uri);
+	testutil_check(wiredtiger_open(NULL, NULL, ENV_CONFIG_REC, &conn));
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
 	/*
 	 * For every key in the saved file, verify that the key exists
@@ -366,7 +345,6 @@ main(int argc, char *argv[])
 	 * read that log record that is beyond the truncated record.
 	 */
 	write_and_read_new(session);
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
+	testutil_check(conn->close(conn, NULL));
 	return (EXIT_SUCCESS);
 }

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -298,7 +298,8 @@ main(int argc, char *argv[])
 	ret = fscanf(fp, "%" SCNu64 " %" SCNu32 "\n", &offset, &max_key);
 	if (ret != 2)
 		testutil_die(errno, "fscanf");
-	testutil_check(fclose(fp));
+	if (fclose(fp) != 0)
+		testutil_die(errno, "fclose");
 	/*
 	 * The offset is the beginning of the last record.  Truncate to
 	 * the middle of that last record (i.e. ahead of that offset).

--- a/test/cursor_order/cursor_order.c
+++ b/test/cursor_order/cursor_order.c
@@ -178,7 +178,6 @@ wt_connect(SHARED_CONFIG *cfg, char *config_open)
 		NULL,
 		NULL	/* Close handler. */
 	};
-	int ret;
 	char config[512];
 
 	testutil_clean_work_dir(home);
@@ -190,9 +189,8 @@ wt_connect(SHARED_CONFIG *cfg, char *config_open)
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));
 
-	if ((ret = wiredtiger_open(
-	    home, &event_handler, config, &cfg->conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
+	testutil_check(wiredtiger_open(
+	    home, &event_handler, config, &cfg->conn));
 }
 
 /*
@@ -204,18 +202,14 @@ wt_shutdown(SHARED_CONFIG *cfg)
 {
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	int ret;
 
 	conn = cfg->conn;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret = session->checkpoint(session, NULL)) != 0)
-		testutil_die(ret, "session.checkpoint");
+	testutil_check(session->checkpoint(session, NULL));
 
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "conn.close");
+	testutil_check(conn->close(conn, NULL));
 }
 
 /*

--- a/test/cursor_order/cursor_order_file.c
+++ b/test/cursor_order/cursor_order_file.c
@@ -38,8 +38,7 @@ file_create(SHARED_CONFIG *cfg, const char *name)
 
 	conn = cfg->conn;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
 	    "key_format=%s,"
@@ -54,8 +53,7 @@ file_create(SHARED_CONFIG *cfg, const char *name)
 		if (ret != EEXIST)
 			testutil_die(ret, "session.create");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -67,19 +65,16 @@ load(SHARED_CONFIG *cfg, const char *name)
 	WT_SESSION *session;
 	size_t len;
 	uint64_t keyno;
-	int ret;
 	char keybuf[64], valuebuf[64];
 
 	conn = cfg->conn;
 
 	file_create(cfg, name);
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret =
-	    session->open_cursor(session, name, NULL, "bulk", &cursor)) != 0)
-		testutil_die(ret, "cursor.open");
+	testutil_check(
+	    session->open_cursor(session, name, NULL, "bulk", &cursor));
 
 	value = &_value;
 	for (keyno = 1; keyno <= cfg->nkeys; ++keyno) {
@@ -99,19 +94,15 @@ load(SHARED_CONFIG *cfg, const char *name)
 			value->size = (uint32_t)len;
 			cursor->set_value(cursor, value);
 		}
-		if ((ret = cursor->insert(cursor)) != 0)
-			testutil_die(ret, "cursor.insert");
+		testutil_check(cursor->insert(cursor));
 	}
 
 	/* Setup the starting key range for the workload phase. */
 	cfg->key_range = cfg->nkeys;
-	if ((ret = cursor->close(cursor)) != 0)
-		testutil_die(ret, "cursor.close");
-	if ((ret = session->checkpoint(session, NULL)) != 0)
-		testutil_die(ret, "session.checkpoint");
+	testutil_check(cursor->close(cursor));
+	testutil_check(session->checkpoint(session, NULL));
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -119,16 +110,12 @@ verify(SHARED_CONFIG *cfg, const char *name)
 {
 	WT_CONNECTION *conn;
 	WT_SESSION *session;
-	int ret;
 
 	conn = cfg->conn;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret = session->verify(session, name, NULL)) != 0)
-		testutil_die(ret, "session.create");
+	testutil_check(session->verify(session, name, NULL));
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }

--- a/test/cursor_order/cursor_order_ops.c
+++ b/test/cursor_order/cursor_order_ops.c
@@ -170,8 +170,7 @@ reverse_scan_op(
 	prev_key = this_key = 0;
 
 	/* Reset the cursor */
-	if ((ret = cursor->reset(cursor)) != 0)
-		testutil_die(ret, "cursor.reset");
+	testutil_check(cursor->reset(cursor));
 
 	/* Save the key range. */
 	initial_key_range = cfg->key_range - cfg->append_inserters;
@@ -184,13 +183,11 @@ reverse_scan_op(
 		}
 
 		if (cfg->ftype == ROW) {
-			if ((ret = cursor->get_key(cursor, &strkey)) != 0)
-				testutil_die(ret, "cursor.get_key");
+			testutil_check(cursor->get_key(cursor, &strkey));
 			this_key = (uint64_t)atol(strkey);
 		} else
-			if ((ret = cursor->get_key(
-			    cursor, (uint64_t *)&this_key)) != 0)
-				testutil_die(ret, "cursor.get_key");
+			testutil_check(cursor->get_key(
+			    cursor, (uint64_t *)&this_key));
 
 		if (i == 0 && this_key < initial_key_range)
 			testutil_die(ret,
@@ -219,7 +216,6 @@ reverse_scan(void *arg)
 	WT_SESSION *session;
 	uintmax_t id;
 	uint64_t i;
-	int ret;
 	char tid[128];
 
 	id = (uintmax_t)arg;
@@ -234,17 +230,14 @@ reverse_scan(void *arg)
 
 	__wt_yield();		/* Get all the threads created. */
 
-	if ((ret = cfg->conn->open_session(
-	    cfg->conn, NULL, "isolation=snapshot", &session)) != 0)
-		testutil_die(ret, "conn.open_session");
-	if ((ret = session->open_cursor(
-	    session, s->name, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "session.open_cursor");
+	testutil_check(cfg->conn->open_session(
+	    cfg->conn, NULL, "isolation=snapshot", &session));
+	testutil_check(session->open_cursor(
+	    session, s->name, NULL, NULL, &cursor));
 	for (i = 0; i < s->nops && !cfg->thread_finish;
 	    ++i, ++s->reverse_scans, __wt_yield())
 		reverse_scan_op(cfg, session, cursor, s);
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 
 	printf(" reverse scan thread %2" PRIuMAX
 	    " stopping: tid: %s, file: %s\n",
@@ -267,7 +260,6 @@ append_insert_op(
 	WT_ITEM *value, _value;
 	uint64_t keyno;
 	size_t len;
-	int ret;
 	char keybuf[64], valuebuf[64];
 
 	WT_UNUSED(session);
@@ -292,8 +284,7 @@ append_insert_op(
 		value->size = (uint32_t)len;
 		cursor->set_value(cursor, value);
 	}
-	if ((ret = cursor->insert(cursor)) != 0)
-		testutil_die(ret, "cursor.insert");
+	testutil_check(cursor->insert(cursor));
 }
 
 /*
@@ -309,7 +300,6 @@ append_insert(void *arg)
 	WT_SESSION *session;
 	uintmax_t id;
 	uint64_t i;
-	int ret;
 	char tid[128];
 
 	id = (uintmax_t)arg;
@@ -323,16 +313,13 @@ append_insert(void *arg)
 
 	__wt_yield();		/* Get all the threads created. */
 
-	if ((ret = cfg->conn->open_session(
-	    cfg->conn, NULL, "isolation=snapshot", &session)) != 0)
-		testutil_die(ret, "conn.open_session");
-	if ((ret = session->open_cursor(
-	    session, s->name, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "session.open_cursor");
+	testutil_check(cfg->conn->open_session(
+	    cfg->conn, NULL, "isolation=snapshot", &session));
+	testutil_check(session->open_cursor(
+	    session, s->name, NULL, NULL, &cursor));
 	for (i = 0; i < s->nops && !cfg->thread_finish; ++i, __wt_yield())
 		append_insert_op(cfg, session, cursor, s);
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 
 	printf("write thread %2" PRIuMAX " stopping: tid: %s, file: %s\n",
 	    id, tid, s->name);

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -37,8 +37,7 @@ obj_bulk(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->create(session, uri, config)) != 0)
 		if (ret != EEXIST && ret != EBUSY)
@@ -48,13 +47,11 @@ obj_bulk(void)
 		__wt_yield();
 		if ((ret = session->open_cursor(
 		    session, uri, NULL, "bulk", &c)) == 0) {
-			if ((ret = c->close(c)) != 0)
-				testutil_die(ret, "cursor.close");
+			testutil_check(c->close(c));
 		} else if (ret != ENOENT && ret != EBUSY && ret != EINVAL)
 			testutil_die(ret, "session.open_cursor bulk");
 	}
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -65,19 +62,15 @@ obj_bulk_unique(int force)
 	int ret;
 	char new_uri[64];
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/* Generate a unique object name. */
-	if ((ret = pthread_rwlock_wrlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_wrlock single");
+	testutil_check(pthread_rwlock_wrlock(&single));
 	testutil_check(__wt_snprintf(
 	    new_uri, sizeof(new_uri), "%s.%u", uri, ++uid));
-	if ((ret = pthread_rwlock_unlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_unlock single");
+	testutil_check(pthread_rwlock_unlock(&single));
 
-	if ((ret = session->create(session, new_uri, config)) != 0)
-		testutil_die(ret, "session.create: %s", new_uri);
+	testutil_check(session->create(session, new_uri, config));
 
 	__wt_yield();
 	/*
@@ -85,10 +78,9 @@ obj_bulk_unique(int force)
 	 * which created a checkpoint of the empty file, and triggers an EINVAL
 	 */
 	if ((ret = session->open_cursor(
-	    session, new_uri, NULL, "bulk", &c)) == 0) {
-		if ((ret = c->close(c)) != 0)
-			testutil_die(ret, "cursor.close");
-	} else if (ret != EINVAL)
+	    session, new_uri, NULL, "bulk", &c)) == 0)
+		testutil_check(c->close(c));
+	else if (ret != EINVAL)
 		testutil_die(ret,
 		    "session.open_cursor bulk unique: %s, new_uri");
 
@@ -97,8 +89,7 @@ obj_bulk_unique(int force)
 		if (ret != EBUSY)
 			testutil_die(ret, "session.drop: %s", new_uri);
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -108,19 +99,15 @@ obj_cursor(void)
 	WT_CURSOR *cursor;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret =
 	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0) {
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.open_cursor");
-	} else {
-		if ((ret = cursor->close(cursor)) != 0)
-			testutil_die(ret, "cursor.close");
-	}
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	} else
+		testutil_check(cursor->close(cursor));
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -129,15 +116,13 @@ obj_create(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->create(session, uri, config)) != 0)
 		if (ret != EEXIST && ret != EBUSY)
 			testutil_die(ret, "session.create");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -147,19 +132,15 @@ obj_create_unique(int force)
 	int ret;
 	char new_uri[64];
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/* Generate a unique object name. */
-	if ((ret = pthread_rwlock_wrlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_wrlock single");
+	testutil_check(pthread_rwlock_wrlock(&single));
 	testutil_check(__wt_snprintf(
 	    new_uri, sizeof(new_uri), "%s.%u", uri, ++uid));
-	if ((ret = pthread_rwlock_unlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_unlock single");
+	testutil_check(pthread_rwlock_unlock(&single));
 
-	if ((ret = session->create(session, new_uri, config)) != 0)
-		testutil_die(ret, "session.create");
+	testutil_check(session->create(session, new_uri, config));
 
 	__wt_yield();
 	while ((ret = session->drop(
@@ -167,8 +148,7 @@ obj_create_unique(int force)
 		if (ret != EBUSY)
 			testutil_die(ret, "session.drop: %s", new_uri);
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -177,15 +157,13 @@ obj_drop(int force)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->drop(session, uri, force ? "force" : NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.drop");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -194,8 +172,7 @@ obj_checkpoint(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/*
 	 * Force the checkpoint so it has to be taken. Forced checkpoints can
@@ -206,8 +183,7 @@ obj_checkpoint(void)
 		if (ret != EBUSY && ret != ENOENT)
 			testutil_die(ret, "session.checkpoint");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -216,15 +192,13 @@ obj_rebalance(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->rebalance(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.rebalance");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -233,15 +207,13 @@ obj_upgrade(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->upgrade(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.upgrade");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -250,13 +222,11 @@ obj_verify(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->verify(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.verify");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -67,13 +67,12 @@ main(int argc, char *argv[])
 		{ NULL,		NULL, NULL }
 	};
 	u_int nthreads;
-	int ch, cnt, ret, runs;
+	int ch, cnt, runs;
 	char *config_open, *working_dir;
 
 	(void)testutil_set_progname(argv);
 
-	if ((ret = pthread_rwlock_init(&single, NULL)) != 0)
-		testutil_die(ret, "pthread_rwlock_init: single");
+	testutil_check(pthread_rwlock_init(&single, NULL));
 
 	nops = 1000;
 	nthreads = 10;
@@ -151,7 +150,6 @@ wt_startup(char *config_open)
 		NULL,
 		NULL	/* Close handler. */
 	};
-	int ret;
 	char config_buf[128];
 
 	testutil_make_work_dir(home);
@@ -161,9 +159,8 @@ wt_startup(char *config_open)
 	    progname,
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));
-	if ((ret = wiredtiger_open(
-	    home, &event_handler, config_buf, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
+	testutil_check(
+	    wiredtiger_open(home, &event_handler, config_buf, &conn));
 }
 
 /*
@@ -173,10 +170,7 @@ wt_startup(char *config_open)
 static void
 wt_shutdown(void)
 {
-	int ret;
-
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "conn.close");
+	testutil_check(conn->close(conn, NULL));
 }
 
 /*

--- a/test/format/salvage.c
+++ b/test/format/salvage.c
@@ -36,15 +36,13 @@ static void
 salvage(void)
 {
 	WT_CONNECTION *conn;
-	WT_DECL_RET;
 	WT_SESSION *session;
 
 	conn = g.wts_conn;
 	track("salvage", 0ULL, NULL);
 
 	testutil_check(conn->open_session(conn, NULL, NULL, &session));
-	if ((ret = session->salvage(session, g.uri, "force=true")) != 0)
-		testutil_die(ret, "session.salvage: %s", g.uri);
+	testutil_check(session->salvage(session, g.uri, "force=true"));
 	testutil_check(session->close(session, NULL));
 }
 

--- a/test/huge/huge.c
+++ b/test/huge/huge.c
@@ -87,7 +87,6 @@ run(CONFIG *cp, int bigkey, size_t bytes)
 	WT_SESSION *session;
 	WT_CURSOR *cursor;
 	uint64_t keyno;
-	int ret;
 	void *p;
 
 	big[bytes - 1] = '\0';
@@ -108,17 +107,12 @@ run(CONFIG *cp, int bigkey, size_t bytes)
 	 * Open/create the database, connection, session and cursor; set the
 	 * cache size large, we don't want to try and evict anything.
 	 */
-	if ((ret = wiredtiger_open(
-	    home, NULL, "create,cache_size=10GB", &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "WT_CONNECTION.open_session");
-	if ((ret = session->create(session, cp->uri, cp->config)) != 0)
-		testutil_die(ret,
-		    "WT_SESSION.create: %s %s", cp->uri, cp->config);
-	if ((ret =
-	    session->open_cursor(session, cp->uri, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "WT_SESSION.open_cursor: %s", cp->uri);
+	testutil_check(
+	    wiredtiger_open(home, NULL, "create,cache_size=10GB", &conn));
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(session->create(session, cp->uri, cp->config));
+	testutil_check(
+	    session->open_cursor(session, cp->uri, NULL, NULL, &cursor));
 
 	/* Set the key/value. */
 	if (bigkey)
@@ -131,26 +125,21 @@ run(CONFIG *cp, int bigkey, size_t bytes)
 	cursor->set_value(cursor, big);
 
 	/* Insert the record (use update, insert discards the key). */
-	if ((ret = cursor->update(cursor)) != 0)
-		testutil_die(ret, "WT_CURSOR.insert");
+	testutil_check(cursor->update(cursor));
 
 	/* Retrieve the record and check it. */
-	if ((ret = cursor->search(cursor)) != 0)
-		testutil_die(ret, "WT_CURSOR.search");
-	if (bigkey && (ret = cursor->get_key(cursor, &p)) != 0)
-		testutil_die(ret, "WT_CURSOR.get_key");
-	if ((ret = cursor->get_value(cursor, &p)) != 0)
-		testutil_die(ret, "WT_CURSOR.get_value");
+	testutil_check(cursor->search(cursor));
+	if (bigkey)
+		testutil_check(cursor->get_key(cursor, &p));
+	testutil_check(cursor->get_value(cursor, &p));
 	if (memcmp(p, big, bytes) != 0)
 		testutil_die(0,
 		    "retrieved big key/value item did not match original");
 
 	/* Remove the record. */
-	if ((ret = cursor->remove(cursor)) != 0)
-		testutil_die(ret, "WT_CURSOR.remove");
+	testutil_check(cursor->remove(cursor));
 
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION.close");
+	testutil_check(conn->close(conn, NULL));
 
 	big[bytes - 1] = 'a';
 }

--- a/test/readonly/readonly.c
+++ b/test/readonly/readonly.c
@@ -99,12 +99,9 @@ run_child(const char *homedir, int op, int expect)
 	/*
 	 * Make sure we can read the data.
 	 */
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "WT_CONNECTION:open_session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret =
-	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "WT_SESSION.open_cursor: %s", uri);
+	testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
 	i = 0;
 	while ((ret = cursor->next(cursor)) == 0)

--- a/test/readonly/readonly.c
+++ b/test/readonly/readonly.c
@@ -107,9 +107,8 @@ run_child(const char *homedir, int op, int expect)
 	while ((ret = cursor->next(cursor)) == 0)
 		++i;
 	if (i != MAX_KV)
-		testutil_die(EPERM, "cursor walk");
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "conn_close");
+		testutil_die(ret, "cursor walk");
+	testutil_check(conn->close(conn, NULL));
 	return (0);
 }
 
@@ -237,16 +236,11 @@ main(int argc, char *argv[])
 	/*
 	 * Run in the home directory and create the table.
 	 */
-	if ((ret = wiredtiger_open(home, NULL, ENV_CONFIG, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "WT_CONNECTION:open_session");
-	if ((ret = session->create(session,
-	    uri, "key_format=Q,value_format=u")) != 0)
-		testutil_die(ret, "WT_SESSION.create: %s", uri);
-	if ((ret =
-	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "WT_SESSION.open_cursor: %s", uri);
+	testutil_check(wiredtiger_open(home, NULL, ENV_CONFIG, &conn));
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(
+	    session->create(session, uri, "key_format=Q,value_format=u"));
+	testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
 	/*
 	 * Write data into the table and then cleanly shut down connection.
@@ -257,11 +251,9 @@ main(int argc, char *argv[])
 	for (i = 0; i < MAX_KV; ++i) {
 		cursor->set_key(cursor, i);
 		cursor->set_value(cursor, &data);
-		if ((ret = cursor->insert(cursor)) != 0)
-			testutil_die(ret, "WT_CURSOR.insert");
+		testutil_check(cursor->insert(cursor));
 	}
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
+	testutil_check(conn->close(conn, NULL));
 
 	/*
 	 * Copy the database.  Remove any lock file from one copy
@@ -346,10 +338,8 @@ main(int argc, char *argv[])
 	/*
 	 * Reopen the two writable directories and rerun the child.
 	 */
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
-	if ((ret = conn2->close(conn2, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
+	testutil_check(conn->close(conn, NULL));
+	testutil_check(conn2->close(conn2, NULL));
 	if ((ret = wiredtiger_open(home, NULL, ENV_CONFIG_RD, &conn)) != 0)
 		testutil_die(ret, "wiredtiger_open original home");
 	if ((ret = wiredtiger_open(home_wr, NULL, ENV_CONFIG_RD, &conn2)) != 0)
@@ -377,14 +367,10 @@ main(int argc, char *argv[])
 	/*
 	 * Clean-up.
 	 */
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
-	if ((ret = conn2->close(conn2, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
-	if ((ret = conn3->close(conn3, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
-	if ((ret = conn4->close(conn4, NULL)) != 0)
-		testutil_die(ret, "WT_CONNECTION:close");
+	testutil_check(conn->close(conn, NULL));
+	testutil_check(conn2->close(conn2, NULL));
+	testutil_check(conn3->close(conn3, NULL));
+	testutil_check(conn4->close(conn4, NULL));
 	/*
 	 * We need to chmod the read-only databases back so that they can
 	 * be removed by scripts.

--- a/test/thread/file.c
+++ b/test/thread/file.c
@@ -35,8 +35,7 @@ file_create(const char *name)
 	int ret;
 	char config[128];
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
 	    "key_format=%s,"
@@ -50,8 +49,7 @@ file_create(const char *name)
 		if (ret != EEXIST)
 			testutil_die(ret, "session.create");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -62,17 +60,14 @@ load(const char *name)
 	WT_SESSION *session;
 	uint64_t keyno;
 	size_t len;
-	int ret;
 	char keybuf[64], valuebuf[64];
 
 	file_create(name);
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret =
-	    session->open_cursor(session, name, NULL, "bulk", &cursor)) != 0)
-		testutil_die(ret, "cursor.open");
+	testutil_check(
+	    session->open_cursor(session, name, NULL, "bulk", &cursor));
 
 	key = &_key;
 	value = &_value;
@@ -96,26 +91,20 @@ load(const char *name)
 			value->size = (uint32_t)len;
 			cursor->set_value(cursor, value);
 		}
-		if ((ret = cursor->insert(cursor)) != 0)
-			testutil_die(ret, "cursor.insert");
+		testutil_check(cursor->insert(cursor));
 	}
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
 verify(const char *name)
 {
 	WT_SESSION *session;
-	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret = session->verify(session, name, NULL)) != 0)
-		testutil_die(ret, "session.create");
+	testutil_check(session->verify(session, name, NULL));
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }

--- a/test/thread/rw.c
+++ b/test/thread/rw.c
@@ -186,7 +186,7 @@ reader(void *arg)
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
 	u_int i;
-	int id, ret;
+	int id;
 	char tid[128];
 
 	id = (int)(uintptr_t)arg;
@@ -201,27 +201,20 @@ reader(void *arg)
 
 	if (session_per_op) {
 		for (i = 0; i < s->nops; ++i, ++s->reads, __wt_yield()) {
-			if ((ret = conn->open_session(
-			    conn, NULL, NULL, &session)) != 0)
-				testutil_die(ret, "conn.open_session");
-			if ((ret = session->open_cursor(
-			    session, s->name, NULL, NULL, &cursor)) != 0)
-				testutil_die(ret, "session.open_cursor");
+			testutil_check(
+			    conn->open_session(conn, NULL, NULL, &session));
+			testutil_check(session->open_cursor(
+			    session, s->name, NULL, NULL, &cursor));
 			reader_op(session, cursor, s);
-			if ((ret = session->close(session, NULL)) != 0)
-				testutil_die(ret, "session.close");
+			testutil_check(session->close(session, NULL));
 		}
 	} else {
-		if ((ret = conn->open_session(
-		    conn, NULL, NULL, &session)) != 0)
-			testutil_die(ret, "conn.open_session");
-		if ((ret = session->open_cursor(
-		    session, s->name, NULL, NULL, &cursor)) != 0)
-			testutil_die(ret, "session.open_cursor");
+		testutil_check(conn->open_session(conn, NULL, NULL, &session));
+		testutil_check(session->open_cursor(
+		    session, s->name, NULL, NULL, &cursor));
 		for (i = 0; i < s->nops; ++i, ++s->reads, __wt_yield())
 			reader_op(session, cursor, s);
-		if ((ret = session->close(session, NULL)) != 0)
-			testutil_die(ret, "session.close");
+		testutil_check(session->close(session, NULL));
 	}
 
 	printf(" read thread %2d stopping: tid: %s, file: %s\n",
@@ -257,8 +250,7 @@ writer_op(WT_SESSION *session, WT_CURSOR *cursor, INFO *s)
 		cursor->set_key(cursor, keyno);
 	if (keyno % 5 == 0) {
 		++s->remove;
-		if ((ret =
-		    cursor->remove(cursor)) != 0 && ret != WT_NOTFOUND)
+		if ((ret = cursor->remove(cursor)) != 0 && ret != WT_NOTFOUND)
 			testutil_die(ret, "cursor.remove");
 	} else {
 		++s->update;
@@ -272,8 +264,7 @@ writer_op(WT_SESSION *session, WT_CURSOR *cursor, INFO *s)
 			value->size = (uint32_t)len;
 			cursor->set_value(cursor, value);
 		}
-		if ((ret = cursor->update(cursor)) != 0)
-			testutil_die(ret, "cursor.update");
+		testutil_check(cursor->update(cursor));
 	}
 	if (log_print)
 		testutil_check(session->log_printf(session,
@@ -291,7 +282,7 @@ writer(void *arg)
 	WT_CURSOR *cursor;
 	WT_SESSION *session;
 	u_int i;
-	int id, ret;
+	int id;
 	char tid[128];
 
 	id = (int)(uintptr_t)arg;
@@ -306,27 +297,20 @@ writer(void *arg)
 
 	if (session_per_op) {
 		for (i = 0; i < s->nops; ++i, __wt_yield()) {
-			if ((ret = conn->open_session(
-			    conn, NULL, NULL, &session)) != 0)
-				testutil_die(ret, "conn.open_session");
-			if ((ret = session->open_cursor(
-			    session, s->name, NULL, NULL, &cursor)) != 0)
-				testutil_die(ret, "session.open_cursor");
+			testutil_check(conn->open_session(
+			    conn, NULL, NULL, &session));
+			testutil_check(session->open_cursor(
+			    session, s->name, NULL, NULL, &cursor));
 			writer_op(session, cursor, s);
-			if ((ret = session->close(session, NULL)) != 0)
-				testutil_die(ret, "session.close");
+			testutil_check(session->close(session, NULL));
 		}
 	} else {
-		if ((ret = conn->open_session(
-		    conn, NULL, NULL, &session)) != 0)
-			testutil_die(ret, "conn.open_session");
-		if ((ret = session->open_cursor(
-		    session, s->name, NULL, NULL, &cursor)) != 0)
-			testutil_die(ret, "session.open_cursor");
+		testutil_check(conn->open_session(conn, NULL, NULL, &session));
+		testutil_check(session->open_cursor(
+		    session, s->name, NULL, NULL, &cursor));
 		for (i = 0; i < s->nops; ++i, __wt_yield())
 			writer_op(session, cursor, s);
-		if ((ret = session->close(session, NULL)) != 0)
-			testutil_die(ret, "session.close");
+		testutil_check(session->close(session, NULL));
 	}
 
 	printf("write thread %2d stopping: tid: %s, file: %s\n",

--- a/test/thread/stats.c
+++ b/test/thread/stats.c
@@ -43,16 +43,14 @@ stats(void)
 	char name[64];
 	const char *pval, *desc;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((fp = fopen(FNAME_STAT, "w")) == NULL)
 		testutil_die(errno, "fopen " FNAME_STAT);
 
 	/* Connection statistics. */
-	if ((ret = session->open_cursor(session,
-	    "statistics:", NULL, NULL, &cursor)) != 0)
-		testutil_die(ret, "session.open_cursor");
+	testutil_check(session->open_cursor(
+	    session, "statistics:", NULL, NULL, &cursor));
 
 	while ((ret = cursor->next(cursor)) == 0 &&
 	    (ret = cursor->get_value(cursor, &desc, &pval, &v)) == 0)
@@ -60,16 +58,14 @@ stats(void)
 
 	if (ret != WT_NOTFOUND)
 		testutil_die(ret, "cursor.next");
-	if ((ret = cursor->close(cursor)) != 0)
-		testutil_die(ret, "cursor.close");
+	testutil_check(cursor->close(cursor));
 
 	/* File statistics. */
 	if (!multiple_files) {
 		testutil_check(__wt_snprintf(
 		    name, sizeof(name), "statistics:" FNAME, 0));
-		if ((ret = session->open_cursor(
-		    session, name, NULL, NULL, &cursor)) != 0)
-			testutil_die(ret, "session.open_cursor");
+		testutil_check(session->open_cursor(
+		    session, name, NULL, NULL, &cursor));
 
 		while ((ret = cursor->next(cursor)) == 0 &&
 		    (ret = cursor->get_value(cursor, &desc, &pval, &v)) == 0)
@@ -77,11 +73,9 @@ stats(void)
 
 		if (ret != WT_NOTFOUND)
 			testutil_die(ret, "cursor.next");
-		if ((ret = cursor->close(cursor)) != 0)
-			testutil_die(ret, "cursor.close");
+		testutil_check(cursor->close(cursor));
 
-		if ((ret = session->close(session, NULL)) != 0)
-			testutil_die(ret, "session.close");
+		testutil_check(session->close(session, NULL));
 	}
 	(void)fclose(fp);
 }

--- a/test/thread/t.c
+++ b/test/thread/t.c
@@ -182,7 +182,6 @@ wt_connect(char *config_open)
 		NULL,
 		NULL	/* Close handler. */
 	};
-	int ret;
 	char config[512];
 
 	testutil_clean_work_dir(home);
@@ -194,8 +193,7 @@ wt_connect(char *config_open)
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));
 
-	if ((ret = wiredtiger_open(home, &event_handler, config, &conn)) != 0)
-		testutil_die(ret, "wiredtiger_open");
+	testutil_check(wiredtiger_open(home, &event_handler, config, &conn));
 }
 
 /*
@@ -206,16 +204,12 @@ static void
 wt_shutdown(void)
 {
 	WT_SESSION *session;
-	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-	if ((ret = session->checkpoint(session, NULL)) != 0)
-		testutil_die(ret, "session.checkpoint");
+	testutil_check(session->checkpoint(session, NULL));
 
-	if ((ret = conn->close(conn, NULL)) != 0)
-		testutil_die(ret, "conn.close");
+	testutil_check(conn->close(conn, NULL));
 }
 
 /*

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -131,7 +131,6 @@ void
 testutil_make_work_dir(const char *dir)
 {
 	size_t len;
-	int ret;
 	char *buf;
 
 	testutil_clean_work_dir(dir);
@@ -143,8 +142,7 @@ testutil_make_work_dir(const char *dir)
 
 	/* mkdir shares syntax between Windows and Linux */
 	testutil_check(__wt_snprintf(buf, len, "%s%s", MKDIR_COMMAND, dir));
-	if ((ret = system(buf)) != 0)
-		testutil_die(ret, "%s", buf);
+	testutil_check(system(buf));
 	free(buf);
 }
 


### PR DESCRIPTION
@bvpvamsikrishna, Sulabh, Sue & I have all been incrementally replacing patterns in the test code that look like this:
```
if ((ret = call(args)) != 0)
        testutil_die(ret, message);
```
with:
```
testutil_check(call(args));
```
I started running lint on some test programs that hadn't been linted before, and while I was in the area I did a pass over the test suite to find examples of that pattern and fix them. (I didn't replace them all, specifically, I tried to leave alone any place where the "message" to `testutil_die` actually provided some additional value.)

There are a few bug fixes here as well: places where we reported an error using `errno` paired with calls that don't set `errno`, places where we ignored possible error returns from functions, and places where we set variables that were never subsequently used.

If it's OK with @agorrod and you have time, would you please do the review?