### PR TITLE
WT-3559 Checkpoint contention with metadata content

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -263,21 +263,19 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_CURSOR_BTREE *cbt;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	bool txn_error = false;
+	int tret;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
-	/*
-	 * Retain the transaction error state across the function
-	 */
-	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR);
 	WT_ERR(__cursor_checkkey(cursor));
 
-	ret = __wt_btcur_insert_check(cbt);
+	tret = __wt_btcur_insert_check(cbt);
 
+	/*
+	 * Detecting a conflict should not cause transaction error
+	 */
 err:	CURSOR_UPDATE_API_END(session, ret);
-	if (!txn_error && F_ISSET(&session->txn, WT_TXN_ERROR))
-		F_CLR(&session->txn, WT_TXN_ERROR);
+	WT_TRET(tret);
 	return (ret);
 }
 

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -263,14 +263,21 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_CURSOR_BTREE *cbt;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
+	bool txn_error;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
+	/*
+  	 * Retain the transaction error state across the function
+  	 */
+	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR);
 	WT_ERR(__cursor_checkkey(cursor));
 
 	ret = __wt_btcur_insert_check(cbt);
 
 err:	CURSOR_UPDATE_API_END(session, ret);
+	if (!txn_error && F_ISSET(&session->txn, WT_TXN_ERROR))
+		F_CLR(&session->txn, WT_TXN_ERROR);
 	return (ret);
 }
 

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -263,7 +263,7 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_CURSOR_BTREE *cbt;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	int tret;
+	int tret = 0;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -263,16 +263,17 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_CURSOR_BTREE *cbt;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	int tret = 0;
+	int tret;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
+	tret = 0;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
 	WT_ERR(__cursor_checkkey(cursor));
 
 	tret = __wt_btcur_insert_check(cbt);
 
 	/*
-	 * Detecting a conflict should not cause transaction error
+	 * Detecting a conflict should not cause transaction error.
 	 */
 err:	CURSOR_UPDATE_API_END(session, ret);
 	WT_TRET(tret);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -263,14 +263,14 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	WT_CURSOR_BTREE *cbt;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	bool txn_error;
+	bool txn_error = false;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
 	/*
 	 * Retain the transaction error state across the function
 	 */
-	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR);
+	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR) ? true : false;
 	WT_ERR(__cursor_checkkey(cursor));
 
 	ret = __wt_btcur_insert_check(cbt);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -270,7 +270,7 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	/*
 	 * Retain the transaction error state across the function
 	 */
-	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR) ? true : false;
+	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR);
 	WT_ERR(__cursor_checkkey(cursor));
 
 	ret = __wt_btcur_insert_check(cbt);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -268,8 +268,8 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
 	/*
-  	 * Retain the transaction error state across the function
-  	 */
+	 * Retain the transaction error state across the function
+	 */
 	txn_error = F_ISSET(&session->txn, WT_TXN_ERROR);
 	WT_ERR(__cursor_checkkey(cursor));
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -313,10 +313,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 			 * see the dhandle before the commit, which will lead
 			 * to the rollback error. We will ignore this dhandle as
 			 * part of this checkpoint by returning from here.
-			 * Also clear the txn error set.
 			 */
-			if (F_ISSET(&session->txn, WT_TXN_ERROR))
-				F_CLR(&session->txn, WT_TXN_ERROR);
 			WT_TRET(__wt_metadata_cursor_release(session,
 			    &meta_cursor));
 			return (0);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -289,7 +289,6 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 	if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT))
 		return (0);
 
-#ifdef HAVE_DIAGNOSTIC
 	/*
 	 * We may have raced between starting the checkpoint transaction and
 	 * some operation completing on the handle that updated the metadata
@@ -321,7 +320,6 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_TRET(__wt_metadata_cursor_release(session, &meta_cursor));
 		WT_RET(ret);
 	}
-#endif
 
 	/*
 	 * Decide whether the tree needs to be included in the checkpoint and

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -308,14 +308,13 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 		ret = __wt_curfile_insert_check(meta_cursor);
 		if (ret == WT_ROLLBACK) {
 			/*
-			 * if create or drop or any schema operation of a table
+			 * If create or drop or any schema operation of a table
 			 * is with in an user transaction then checkpoint can
 			 * see the dhandle before the commit, which will lead
-			 * to this situation. We will ignore this dhandle as
+			 * to the rollback error. We will ignore this dhandle as
 			 * part of this checkpoint by returning from here.
 			 * Also clear the txn error set.
 			 */
-
 			if (F_ISSET(&session->txn, WT_TXN_ERROR))
 				F_CLR(&session->txn, WT_TXN_ERROR);
 			WT_TRET(__wt_metadata_cursor_release(session,

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -301,7 +301,6 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 	 */
 	if (!WT_IS_METADATA(session->dhandle)) {
 		WT_CURSOR *meta_cursor;
-		bool metadata_race;
 
 		WT_ASSERT(session, !F_ISSET(&session->txn, WT_TXN_ERROR));
 		WT_RET(__wt_metadata_cursor(session, &meta_cursor));
@@ -309,12 +308,12 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 		ret = __wt_curfile_insert_check(meta_cursor);
 		if (ret == WT_ROLLBACK) {
 			/*
-			 * if create or drop of a table is with in an user
-			 * transaction then checkpoint can see the dhandle
-			 * before the commit, which will lead to this situation
-			 * we will ignore this dhandle as part of this
-			 * checkpoint. Also clear the txn error set.
-			 * See WT-3558 for more context.
+			 * if create or drop or any schema operation of a table
+			 * is with in an user transaction then checkpoint can
+			 * see the dhandle before the commit, which will lead
+			 * to this situation. We will ignore this dhandle as
+			 * part of this checkpoint by returning from here.
+			 * Also clear the txn error set.
 			 */
 
 			if (F_ISSET(&session->txn, WT_TXN_ERROR))
@@ -322,25 +321,9 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 			WT_TRET(__wt_metadata_cursor_release(session,
 			    &meta_cursor));
 			return (0);
-
-			/*
-			 * Disable this check and assertion for now - it is
-			 * possible that a schema operation with a timestamp in
-			 * the future is in the metadata, but not part of the
-			 * the checkpoint now that checkpoints can be created
-			 * at the stable timestamp.
-			 * See WT-3559 for context on re-adding this assertion.
-			 * This block is not removed for easy reference.
-			 */
-#if 0
-			metadata_race = true;
-			ret = 0;
-#endif
-		} else
-			metadata_race = false;
+		}
 		WT_TRET(__wt_metadata_cursor_release(session, &meta_cursor));
 		WT_RET(ret);
-		WT_ASSERT(session, !metadata_race);
 	}
 #endif
 

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -37,8 +37,7 @@ obj_bulk(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
@@ -50,8 +49,7 @@ obj_bulk(void)
 		__wt_yield();
 		if ((ret = session->open_cursor(
 		    session, uri, NULL, "bulk", &c)) == 0) {
-			if ((ret = c->close(c)) != 0)
-				testutil_die(ret, "cursor.close");
+			testutil_check(c->close(c));
 		} else if (ret != ENOENT && ret != EBUSY && ret != EINVAL)
 			testutil_die(ret, "session.open_cursor bulk");
 	}
@@ -72,8 +70,7 @@ obj_bulk(void)
 			testutil_die(ret, "session.commit bulk");
 	}
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -84,21 +81,17 @@ obj_bulk_unique(int force)
 	int ret;
 	char new_uri[64];
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/* Generate a unique object name. */
-	if ((ret = pthread_rwlock_wrlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_wrlock single");
+	testutil_check(pthread_rwlock_wrlock(&single));
 	testutil_check(__wt_snprintf(
 	    new_uri, sizeof(new_uri), "%s.%u", uri, ++uid));
-	if ((ret = pthread_rwlock_unlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_unlock single");
+	testutil_check(pthread_rwlock_unlock(&single));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
-	if ((ret = session->create(session, new_uri, config)) != 0)
-		testutil_die(ret, "session.create: %s", new_uri);
+	testutil_check(session->create(session, new_uri, config));
 
 	__wt_yield();
 	/*
@@ -107,8 +100,7 @@ obj_bulk_unique(int force)
 	 */
 	if ((ret = session->open_cursor(
 	    session, new_uri, NULL, "bulk", &c)) == 0) {
-		if ((ret = c->close(c)) != 0)
-			testutil_die(ret, "cursor.close");
+		testutil_check(c->close(c));
 	} else if (ret != EINVAL)
 		testutil_die(ret,
 		    "session.open_cursor bulk unique: %s, new_uri");
@@ -122,8 +114,7 @@ obj_bulk_unique(int force)
 	    (ret = session->commit_transaction(session, NULL)) != 0 &&
 	    ret != EINVAL)
 		testutil_die(ret, "session.commit bulk unique");
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -133,8 +124,7 @@ obj_cursor(void)
 	WT_CURSOR *cursor;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
@@ -142,17 +132,14 @@ obj_cursor(void)
 	    session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0) {
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.open_cursor");
-	} else {
-		if ((ret = cursor->close(cursor)) != 0)
-			testutil_die(ret, "cursor.close");
-	}
+	} else
+		testutil_check(cursor->close(cursor));
 
 	if (use_txn &&
 	    (ret = session->commit_transaction(session, NULL)) != 0 &&
 	    ret != EINVAL)
 		testutil_die(ret, "session.commit cursor");
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -161,8 +148,7 @@ obj_create(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
@@ -174,8 +160,7 @@ obj_create(void)
 	    (ret = session->commit_transaction(session, NULL)) != 0 &&
 	    ret != EINVAL)
 		testutil_die(ret, "session.commit create");
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -185,21 +170,17 @@ obj_create_unique(int force)
 	int ret;
 	char new_uri[64];
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/* Generate a unique object name. */
-	if ((ret = pthread_rwlock_wrlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_wrlock single");
+	testutil_check(pthread_rwlock_wrlock(&single));
 	testutil_check(__wt_snprintf(
 	    new_uri, sizeof(new_uri), "%s.%u", uri, ++uid));
-	if ((ret = pthread_rwlock_unlock(&single)) != 0)
-		testutil_die(ret, "pthread_rwlock_unlock single");
+	testutil_check(pthread_rwlock_unlock(&single));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
-	if ((ret = session->create(session, new_uri, config)) != 0)
-		testutil_die(ret, "session.create");
+	testutil_check(session->create(session, new_uri, config));
 
 	if (use_txn &&
 	    (ret = session->commit_transaction(session, NULL)) != 0 &&
@@ -219,8 +200,7 @@ obj_create_unique(int force)
 	    ret != EINVAL)
 		testutil_die(ret, "session.commit create unique");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -229,8 +209,7 @@ obj_drop(int force)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if (use_txn)
 		testutil_check(session->begin_transaction(session, NULL));
@@ -254,8 +233,7 @@ obj_drop(int force)
 			testutil_die(ret, "session.commit drop");
 	}
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -264,8 +242,7 @@ obj_checkpoint(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	/*
 	 * Force the checkpoint so it has to be taken. Forced checkpoints can
@@ -276,8 +253,7 @@ obj_checkpoint(void)
 		if (ret != EBUSY && ret != ENOENT)
 			testutil_die(ret, "session.checkpoint");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -286,15 +262,13 @@ obj_rebalance(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->rebalance(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.rebalance");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -303,15 +277,13 @@ obj_upgrade(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->upgrade(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.upgrade");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }
 
 void
@@ -320,13 +292,11 @@ obj_verify(void)
 	WT_SESSION *session;
 	int ret;
 
-	if ((ret = conn->open_session(conn, NULL, NULL, &session)) != 0)
-		testutil_die(ret, "conn.session");
+	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
 	if ((ret = session->verify(session, uri, NULL)) != 0)
 		if (ret != ENOENT && ret != EBUSY)
 			testutil_die(ret, "session.verify");
 
-	if ((ret = session->close(session, NULL)) != 0)
-		testutil_die(ret, "session.close");
+	testutil_check(session->close(session, NULL));
 }

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -57,9 +57,8 @@ obj_bulk(void)
 	if (use_txn) {
 		/*
 		 * As the operations are being performed concurrently,
-		 * return value can be ENOENT, EBUSY or EINVAL.
-		 * __wt_curfile_insert_check when returns error, will set
-		 * WT_TXN_ERROR to transaction opened by session. In these
+		 * return value can be ENOENT, EBUSY or EINVAL will set
+		 * error to transaction opened by session. In these
 		 * cases the transaction has to be aborted.
 		 */
 		if (ret != ENOENT && ret != EBUSY && ret != EINVAL)
@@ -217,9 +216,8 @@ obj_drop(int force)
 	if (use_txn) {
 		/*
 		 * As the operations are being performed concurrently,
-		 * return value can be ENOENT or EBUSY.
-		 * __wt_schema_drop when returns error, will set
-		 * WT_TXN_ERROR to transaction opened by session. In these
+		 * return value can be ENOENT or EBUSY will set
+		 * error to transaction opened by session. In these
 		 * cases the transaction has to be aborted.
 		 */
 		if (ret != ENOENT && ret != EBUSY)

--- a/test/fops/file.c
+++ b/test/fops/file.c
@@ -57,6 +57,13 @@ obj_bulk(void)
 	}
 
 	if (use_txn) {
+		/*
+		 * As the operations are being performed concurrently,
+		 * return value can be ENOENT, EBUSY or EINVAL.
+		 * __wt_curfile_insert_check when returns error, will set
+		 * WT_TXN_ERROR to transaction opened by session. In these
+		 * cases the transaction has to be aborted.
+		 */
 		if (ret != ENOENT && ret != EBUSY && ret != EINVAL)
 			ret = session->commit_transaction(session, NULL);
 		else
@@ -232,6 +239,13 @@ obj_drop(int force)
 			testutil_die(ret, "session.drop");
 
 	if (use_txn) {
+		/*
+		 * As the operations are being performed concurrently,
+		 * return value can be ENOENT or EBUSY.
+		 * __wt_schema_drop when returns error, will set
+		 * WT_TXN_ERROR to transaction opened by session. In these
+		 * cases the transaction has to be aborted.
+		 */
 		if (ret != ENOENT && ret != EBUSY)
 			ret = session->commit_transaction(session, NULL);
 		else

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -35,6 +35,9 @@ const char *uri;				/* Object */
 const char *config;				/* Object config */
 
 static FILE *logfp;				/* Log file */
+bool explicit_transaction;			/* Operations within explicit
+						   transaction
+						 */
 
 static char home[512];
 
@@ -78,8 +81,9 @@ main(int argc, char *argv[])
 	nops = 1000;
 	nthreads = 10;
 	runs = 1;
+	explicit_transaction = false;
 	config_open = working_dir = NULL;
-	while ((ch = __wt_getopt(progname, argc, argv, "C:h:l:n:r:t:")) != EOF)
+	while ((ch = __wt_getopt(progname, argc, argv, "C:h:l:n:r:t:i")) != EOF)
 		switch (ch) {
 		case 'C':			/* wiredtiger_open config */
 			config_open = __wt_optarg;
@@ -102,6 +106,9 @@ main(int argc, char *argv[])
 			break;
 		case 't':
 			nthreads = (u_int)atoi(__wt_optarg);
+			break;
+		case 'i':
+			explicit_transaction = true;
 			break;
 		default:
 			return (usage());
@@ -251,7 +258,8 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: %s "
-	    "[-C wiredtiger-config] [-l log] [-n ops] [-r runs] [-t threads]\n",
+	    "[-C wiredtiger-config] [-l log] [-n ops] [-r runs] [-t threads] "
+	    "[-i] \n",
 	    progname);
 	fprintf(stderr, "%s",
 	    "\t-C specify wiredtiger_open configuration arguments\n"
@@ -259,6 +267,7 @@ usage(void)
 	    "\t-l specify a log file\n"
 	    "\t-n set number of operations each thread does\n"
 	    "\t-r set number of runs\n"
-	    "\t-t set number of threads\n");
+	    "\t-t set number of threads\n"
+	    "\t-i operations within explicit transaction \n");
 	return (EXIT_FAILURE);
 }

--- a/test/fops/t.c
+++ b/test/fops/t.c
@@ -28,6 +28,7 @@
 
 #include "thread.h"
 
+bool use_txn;					/* Operations with user txn */
 WT_CONNECTION *conn;				/* WiredTiger connection */
 pthread_rwlock_t single;			/* Single thread */
 u_int nops;					/* Operations */
@@ -35,9 +36,6 @@ const char *uri;				/* Object */
 const char *config;				/* Object config */
 
 static FILE *logfp;				/* Log file */
-bool explicit_transaction;			/* Operations within explicit
-						   transaction
-						 */
 
 static char home[512];
 
@@ -81,9 +79,9 @@ main(int argc, char *argv[])
 	nops = 1000;
 	nthreads = 10;
 	runs = 1;
-	explicit_transaction = false;
+	use_txn = false;
 	config_open = working_dir = NULL;
-	while ((ch = __wt_getopt(progname, argc, argv, "C:h:l:n:r:t:i")) != EOF)
+	while ((ch = __wt_getopt(progname, argc, argv, "C:h:l:n:r:t:x")) != EOF)
 		switch (ch) {
 		case 'C':			/* wiredtiger_open config */
 			config_open = __wt_optarg;
@@ -107,8 +105,8 @@ main(int argc, char *argv[])
 		case 't':
 			nthreads = (u_int)atoi(__wt_optarg);
 			break;
-		case 'i':
-			explicit_transaction = true;
+		case 'x':
+			use_txn = true;
 			break;
 		default:
 			return (usage());
@@ -259,7 +257,7 @@ usage(void)
 	fprintf(stderr,
 	    "usage: %s "
 	    "[-C wiredtiger-config] [-l log] [-n ops] [-r runs] [-t threads] "
-	    "[-i] \n",
+	    "[-x] \n",
 	    progname);
 	fprintf(stderr, "%s",
 	    "\t-C specify wiredtiger_open configuration arguments\n"
@@ -268,6 +266,6 @@ usage(void)
 	    "\t-n set number of operations each thread does\n"
 	    "\t-r set number of runs\n"
 	    "\t-t set number of threads\n"
-	    "\t-i operations within explicit transaction \n");
+	    "\t-x operations within user transaction \n");
 	return (EXIT_FAILURE);
 }

--- a/test/fops/thread.h
+++ b/test/fops/thread.h
@@ -30,12 +30,10 @@
 
 #include <signal.h>
 
+extern bool use_txn;				/* Operations with user txn */
 extern WT_CONNECTION *conn;			/* WiredTiger connection */
 
 extern u_int nops;				/* Operations per thread */
-extern bool explicit_transaction;		/* Operations within explicit
-						   transaction
-						 */
 
 extern const char *uri;				/* Object */
 extern const char *config;			/* Object config */

--- a/test/fops/thread.h
+++ b/test/fops/thread.h
@@ -33,6 +33,9 @@
 extern WT_CONNECTION *conn;			/* WiredTiger connection */
 
 extern u_int nops;				/* Operations per thread */
+extern bool explicit_transaction;		/* Operations within explicit
+						   transaction
+						 */
 
 extern const char *uri;				/* Object */
 extern const char *config;			/* Object config */


### PR DESCRIPTION
Checkpoint will skip the tree if it sees more recent version due to contention between checkpoint and DDL operations on that tree.
enhanced fops test as well for detection of this issue with -i option