### PR TITLE
WT-3435 Fix lookaside eviction with timestamps.

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -58,8 +58,6 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_PAGE *page)
 		    i = 0; i < mod->mod_multi_entries; ++multi, ++i)
 			if (multi->addr.addr == NULL)
 				return (false);
-
-	WT_ASSERT(session, mod->mod_replace.addr != NULL);
 	return (true);
 }
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -79,6 +79,7 @@
 	    ret == WT_NOTFOUND || ret == WT_RESTART))			\
 		ret = __ret;						\
 } while (0)
+#define	WT_TRET_BUSY_OK(a)	WT_TRET_ERROR_OK(a, EBUSY)
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Return and branch-to-err-label cases for switch statements. */


### PR DESCRIPTION
@michaelcahill, here's a possible change for checkpoint eviction.

Instead of trying to maintain our position in the tree while evicting, we accumulate pages we'd like to evict, and once we step past an internal page, we process the list and evict the pages we've accumulated. It's obviously not as efficient with respect to the cache, but it avoids trying to maintain our position in the tree.