### PR TITLE
WT-3603 format threads always traverse the same RNG space.

### DIFF
--- a/test/format/config.h
+++ b/test/format/config.h
@@ -165,9 +165,9 @@ static CONFIG c[] = {
 	  "if values are huffman encoded",			/* 20% */
 	  C_BOOL, 20, 0, 0, &g.c_huffman_value, NULL },
 
-	{ "independent_rng",
+	{ "independent_thread_rng",
 	  "if thread RNG space is independent",			/* 75% */
-	  C_BOOL, 75, 0, 0, &g.c_independent_rng, NULL },
+	  C_BOOL, 75, 0, 0, &g.c_independent_thread_rng, NULL },
 
 	{ "in_memory",
 	  "if in-memory configured",

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -165,6 +165,10 @@ static CONFIG c[] = {
 	  "if values are huffman encoded",			/* 20% */
 	  C_BOOL, 20, 0, 0, &g.c_huffman_value, NULL },
 
+	{ "independent_rng",
+	  "if thread RNG space is independent",			/* 75% */
+	  C_BOOL, 75, 0, 0, &g.c_independent_rng, NULL },
+
 	{ "in_memory",
 	  "if in-memory configured",
 	  C_IGNORE|C_BOOL, 0, 0, 1, &g.c_in_memory, NULL },

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -169,6 +169,7 @@ typedef struct {
 	uint32_t c_huffman_key;
 	uint32_t c_huffman_value;
 	uint32_t c_in_memory;
+	uint32_t c_independent_rng;
 	uint32_t c_insert_pct;
 	uint32_t c_internal_key_truncation;
 	uint32_t c_intl_page_max;

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -169,7 +169,7 @@ typedef struct {
 	uint32_t c_huffman_key;
 	uint32_t c_huffman_value;
 	uint32_t c_in_memory;
-	uint32_t c_independent_rng;
+	uint32_t c_independent_thread_rng;
 	uint32_t c_insert_pct;
 	uint32_t c_internal_key_truncation;
 	uint32_t c_intl_page_max;

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -249,24 +249,24 @@ typedef struct {
 extern GLOBAL g;
 
 typedef struct {
-	WT_RAND_STATE rnd;			/* thread RNG state */
+	int	    id;				/* simple thread ID */
+	wt_thread_t tid;			/* thread ID */
 
-	uint64_t search;			/* operations */
-	uint64_t insert;
-	uint64_t update;
-	uint64_t remove;
-	uint64_t ops;
+	WT_RAND_STATE rnd;			/* thread RNG state */
 
 	uint64_t commit;			/* transaction resolution */
 	uint64_t rollback;
 	uint64_t deadlock;
 
-	int	    id;				/* simple thread ID */
-	wt_thread_t tid;			/* thread ID */
-
 	uint64_t timestamp;			/* last committed timestamp */
 
 	int quit;				/* thread should quit */
+
+	uint64_t search;			/* operation counts */
+	uint64_t insert;
+	uint64_t update;
+	uint64_t remove;
+	uint64_t ops;
 
 #define	TINFO_RUNNING	1			/* Running */
 #define	TINFO_COMPLETE	2			/* Finished */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -152,7 +152,7 @@ wts_ops(int lastrun)
 		 * them traverse the same RNG space. 75% of the time we run in
 		 * independent RNG space.
 		 */
-		if (g.c_independent_rng)
+		if (g.c_independent_thread_rng)
 			__wt_random_init_seed(
 			    (WT_SESSION_IMPL *)session, &tinfo->rnd);
 		else

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -79,8 +79,7 @@ wts_ops(int lastrun)
 	wt_thread_t alter_tid, backup_tid, compact_tid, lrt_tid, timestamp_tid;
 	int64_t fourths, quit_fourths, thread_ops;
 	uint32_t i;
-	int running;
-	bool spread_rng;
+	bool running, spread_rng;
 
 	conn = g.wts_conn;
 
@@ -189,7 +188,7 @@ wts_ops(int lastrun)
 	for (;;) {
 		/* Clear out the totals each pass. */
 		memset(&total, 0, sizeof(total));
-		for (i = 0, running = 0; i < g.c_threads; ++i) {
+		for (i = 0, running = false; i < g.c_threads; ++i) {
 			tinfo = tinfo_list[i];
 			total.commit += tinfo->commit;
 			total.deadlock += tinfo->deadlock;
@@ -201,7 +200,7 @@ wts_ops(int lastrun)
 
 			switch (tinfo->state) {
 			case TINFO_RUNNING:
-				running = 1;
+				running = true;
 				break;
 			case TINFO_COMPLETE:
 				tinfo->state = TINFO_JOINED;


### PR DESCRIPTION
While looking at one of the WT-3435/#3644 failures, I realized all of the format threads were pounding on the same key/value pairs. Interestingly enough, if you change that, the failure goes away.

I think we generally want the format threads to work different parts of the RNG space, but clearly we also want to stress the same key/value pairs as well.