### PR TITLE
WT-3602 Write the compatibility version given into the basecfg file.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2418,7 +2418,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	cfg[1] = NULL;
 	WT_ERR(__wt_snprintf(version, sizeof(version),
 	    "version=(major=%d,minor=%d)",
-	    WIREDTIGER_VERSION_MAJOR, WIREDTIGER_VERSION_MINOR));
+	    conn->compat_major, conn->compat_minor));
 	__conn_config_append(cfg, version);
 
 	/* Ignore the base_config file if config_base_set is false. */


### PR DESCRIPTION
@michaelcahill or @agorrod Please review this change.  It only addresses fixing the compatibility in the `basecfg` file on database creation.  It does not address whether we should modify the `basecfg` file on a `conn->reconfigure()` call.  Currently the `basecfg` file is static after creation and that change would be a new path to modifying it later, unless we come up with some other solution.