### PR TITLE
WT-3605 LSM doesn't support type 'r'

### DIFF
--- a/src/docs/lsm.dox
+++ b/src/docs/lsm.dox
@@ -111,9 +111,12 @@ session.create("table:T", "type=lsm");
 @m_endif
 @endcode
 
-The default type for all schema objects will continue to be btree.
-
 @section lsm_caveats Caveats
+
+@subsection lsm_key_format Key_format configuration
+
+LSM only supports key formats of \c S or \c u, that is, \c key_format
+must be configured to one of those two column types.
 
 @subsection lsm_hazard Hazard configuration
 

--- a/src/docs/lsm.dox
+++ b/src/docs/lsm.dox
@@ -115,8 +115,8 @@ session.create("table:T", "type=lsm");
 
 @subsection lsm_key_format Key_format configuration
 
-LSM only supports key formats of \c S or \c u, that is, \c key_format
-must be configured to one of those two column types.
+LSM does not support column-store trees, \c key_format may not be set
+to type \c 'r'.
 
 @subsection lsm_checkpoints Named checkpoints
 

--- a/src/docs/lsm.dox
+++ b/src/docs/lsm.dox
@@ -118,15 +118,6 @@ session.create("table:T", "type=lsm");
 LSM only supports key formats of \c S or \c u, that is, \c key_format
 must be configured to one of those two column types.
 
-@subsection lsm_hazard Hazard configuration
-
-Reads from an LSM cursor may need to position a cursor in each active chunk.
-The number of chunks depends on the chunk size, and how many chunks have
-been merged.  There must be at least as many hazard pointers available as
-there are chunks in the tree for each cursor that is open on the LSM tree.
-The number of hazard pointers is configured with the \c "hazard_max"
-configuration key to ::wiredtiger_open.
-
 @subsection lsm_checkpoints Named checkpoints
 
 Named checkpoints are not supported on LSM trees, and cursors cannot be

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -351,10 +351,9 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 		 */
 		WT_ERR(__wt_config_getones(
 		    session, config, "key_format", &cval));
-		if (!WT_STRING_MATCH("S", cval.str, cval.len) &&
-		    !WT_STRING_MATCH("u", cval.str, cval.len))
+		if (WT_STRING_MATCH("r", cval.str, cval.len))
 			WT_ERR_MSG(session, EINVAL,
-			    "LSM trees require a key_format of 'S' or 'u'");
+			    "LSM trees do not support a key format of 'r'");
 
 		WT_ERR(__wt_config_merge(session, cfg, NULL, &metadata));
 		WT_ERR(__wt_metadata_insert(session, uri, metadata));

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -349,8 +349,7 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 		/*
 		 * LSM only supports S or u key formats.
 		 */
-		WT_ERR(__wt_config_getones(
-		    session, config, "key_format", &cval));
+		WT_ERR(__wt_config_gets(session, cfg, "key_format", &cval));
 		if (WT_STRING_MATCH("r", cval.str, cval.len))
 			WT_ERR_MSG(session, EINVAL,
 			    "LSM trees do not support a key format of 'r'");

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -329,6 +329,7 @@ int
 __wt_lsm_tree_create(WT_SESSION_IMPL *session,
     const char *uri, bool exclusive, const char *config)
 {
+	WT_CONFIG_ITEM cval;
 	WT_DECL_RET;
 	WT_LSM_TREE *lsm_tree;
 	const char *cfg[] =
@@ -345,6 +346,16 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 	WT_RET_NOTFOUND_OK(ret);
 
 	if (!F_ISSET(S2C(session), WT_CONN_READONLY)) {
+		/*
+		 * LSM only supports S or u key formats.
+		 */
+		WT_ERR(__wt_config_getones(
+		    session, config, "key_format", &cval));
+		if (!WT_STRING_MATCH("S", cval.str, cval.len) &&
+		    !WT_STRING_MATCH("u", cval.str, cval.len))
+			WT_ERR_MSG(session, EINVAL,
+			    "LSM trees require a key_format of 'S' or 'u'");
+
 		WT_ERR(__wt_config_merge(session, cfg, NULL, &metadata));
 		WT_ERR(__wt_metadata_insert(session, uri, metadata));
 	}

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -346,9 +346,7 @@ __wt_lsm_tree_create(WT_SESSION_IMPL *session,
 	WT_RET_NOTFOUND_OK(ret);
 
 	if (!F_ISSET(S2C(session), WT_CONN_READONLY)) {
-		/*
-		 * LSM only supports S or u key formats.
-		 */
+		/* LSM doesn't yet support the 'r' format. */
 		WT_ERR(__wt_config_gets(session, cfg, "key_format", &cval));
 		if (WT_STRING_MATCH("r", cval.str, cval.len))
 			WT_ERR_MSG(session, EINVAL,

--- a/test/csuite/scope/main.c
+++ b/test/csuite/scope/main.c
@@ -336,8 +336,6 @@ main(int argc, char *argv[])
 
 	run(opts->conn, "lsm:lsm.SS", "key_format=S,value_format=S");
 	run(opts->conn, "lsm:lsm.Su", "key_format=S,value_format=S");
-	run(opts->conn, "lsm:lsm.rS", "key_format=r,value_format=S");
-	run(opts->conn, "lsm:lsm.ru", "key_format=r,value_format=S");
 
 	run(opts->conn, "table:table.SS", "key_format=S,value_format=S");
 	run(opts->conn, "table:table.Su", "key_format=S,value_format=u");

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -332,6 +332,9 @@ class test_cursor12(wttest.WiredTigerTestCase):
     # Check that modify returns not-found when an insert is not yet committed
     # and after it's aborted.
     def test_modify_abort(self):
+        if self.skip():
+            return
+
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -30,7 +30,7 @@ import random, string
 import wiredtiger, wttest
 from helper import copy_wiredtiger_home
 from wtdataset import SimpleDataSet
-from wtscenario import make_scenarios
+from wtscenario import filter_scenarios, make_scenarios
 
 # test_cursor12.py
 #    Test cursor modify call
@@ -44,7 +44,9 @@ class test_cursor12(wttest.WiredTigerTestCase):
         ('lsm', dict(uri='lsm:modify')),
         ('table', dict(uri='table:modify')),
     ]
-    scenarios = make_scenarios(types, keyfmt)
+    # Skip record number keys with LSM.
+    scenarios = filter_scenarios(make_scenarios(types, keyfmt),
+        lambda name, d: not ('lsm' in d['uri'] and d['keyfmt'] == 'r'))
 
     # List with original value, final value, and modifications to get
     # there.
@@ -174,10 +176,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
     }
     ]
 
-    # Skip record number keys with LSM.
-    def lsm_recno_skip(self):
-        return self.keyfmt == 'r' and 'lsm' in self.uri
-
     # Create a set of modified records and verify in-memory reads.
     def modify_load(self, ds, single):
         # For each test in the list:
@@ -225,9 +223,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, operating on a group of records.
     def test_modify_smoke(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 100, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -235,9 +230,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, operating on a single record
     def test_modify_smoke_single(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 100, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -245,9 +237,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, closing and re-opening the database.
     def test_modify_smoke_reopen(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 100, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -260,9 +249,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, recovering the database.
     def test_modify_smoke_recover(self):
-        if self.lsm_recno_skip():
-            return
-
         # Close the original database.
         self.conn.close()
 
@@ -291,9 +277,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Check that we can perform a large number of modifications to a record.
     def test_modify_many(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -317,9 +300,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Check that modify returns not-found after a delete.
     def test_modify_delete(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -338,9 +318,6 @@ class test_cursor12(wttest.WiredTigerTestCase):
     # Check that modify returns not-found when an insert is not yet committed
     # and after it's aborted.
     def test_modify_abort(self):
-        if self.lsm_recno_skip():
-            return
-
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -175,7 +175,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
     ]
 
     # Skip record number keys with LSM.
-    def skip(self):
+    def lsm_recno_skip(self):
         return self.keyfmt == 'r' and 'lsm' in self.uri
 
     # Create a set of modified records and verify in-memory reads.
@@ -225,7 +225,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, operating on a group of records.
     def test_modify_smoke(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         ds = SimpleDataSet(self,
@@ -235,7 +235,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, operating on a single record
     def test_modify_smoke_single(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         ds = SimpleDataSet(self,
@@ -245,7 +245,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, closing and re-opening the database.
     def test_modify_smoke_reopen(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         ds = SimpleDataSet(self,
@@ -260,7 +260,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Smoke-test the modify API, recovering the database.
     def test_modify_smoke_recover(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         # Close the original database.
@@ -291,6 +291,9 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Check that we can perform a large number of modifications to a record.
     def test_modify_many(self):
+        if self.lsm_recno_skip():
+            return
+
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -314,6 +317,9 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
     # Check that modify returns not-found after a delete.
     def test_modify_delete(self):
+        if self.lsm_recno_skip():
+            return
+
         ds = SimpleDataSet(self,
             self.uri, 20, key_format=self.keyfmt, value_format='u')
         ds.populate()
@@ -332,7 +338,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
     # Check that modify returns not-found when an insert is not yet committed
     # and after it's aborted.
     def test_modify_abort(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         ds = SimpleDataSet(self,

--- a/test/suite/test_cursor_compare.py
+++ b/test/suite/test_cursor_compare.py
@@ -28,7 +28,7 @@
 
 import wiredtiger, wttest, exceptions
 from wtdataset import SimpleDataSet, ComplexDataSet, ComplexLSMDataSet
-from wtscenario import make_scenarios
+from wtscenario import filter_scenarios, make_scenarios
 
 # Test cursor comparisons.
 class test_cursor_comparison(wttest.WiredTigerTestCase):
@@ -44,16 +44,11 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
         ('recno', dict(keyfmt='r')),
         ('string', dict(keyfmt='S'))
     ]
-    scenarios = make_scenarios(types, keyfmt)
-
     # Skip record number keys with LSM.
-    def lsm_recno_skip(self):
-        return self.lsm and self.keyfmt == 'r'
+    scenarios = filter_scenarios(make_scenarios(types, keyfmt),
+        lambda name, d: not (d['lsm'] and d['keyfmt'] == 'r'))
 
     def test_cursor_comparison(self):
-        if self.lsm_recno_skip():
-            return
-
         uri = self.type + 'compare'
         uriX = self.type + 'compareX'
 
@@ -143,9 +138,6 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
             wiredtiger.WiredTigerError, lambda: cX.compare(c1), msg)
 
     def test_cursor_equality(self):
-        if self.lsm_recno_skip():
-            return
-
         uri = self.type + 'equality'
         uriX = self.type + 'compareX'
 

--- a/test/suite/test_cursor_compare.py
+++ b/test/suite/test_cursor_compare.py
@@ -35,9 +35,9 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
     name = 'test_compare'
 
     types = [
-        ('file', dict(type='file:', dataset=SimpleDataSet)),
-        ('lsm', dict(type='table:', dataset=ComplexLSMDataSet)),
-        ('table', dict(type='table:', dataset=ComplexDataSet))
+        ('file', dict(type='file:', lsm=False, dataset=SimpleDataSet)),
+        ('lsm', dict(type='table:', lsm=True, dataset=ComplexLSMDataSet)),
+        ('table', dict(type='table:', lsm=False, dataset=ComplexDataSet))
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
@@ -46,7 +46,14 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(types, keyfmt)
 
+    # Skip record number keys with LSM.
+    def lsm_recno_skip(self):
+        return self.lsm and self.keyfmt == 'r'
+
     def test_cursor_comparison(self):
+        if self.lsm_recno_skip():
+            return
+
         uri = self.type + 'compare'
         uriX = self.type + 'compareX'
 
@@ -136,6 +143,9 @@ class test_cursor_comparison(wttest.WiredTigerTestCase):
             wiredtiger.WiredTigerError, lambda: cX.compare(c1), msg)
 
     def test_cursor_equality(self):
+        if self.lsm_recno_skip():
+            return
+
         uri = self.type + 'equality'
         uriX = self.type + 'compareX'
 

--- a/test/suite/test_lsm04.py
+++ b/test/suite/test_lsm04.py
@@ -27,30 +27,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wiredtiger, wttest
-from wtscenario import make_scenarios
 
 # test_lsm_key_format
-#    Test LSM tree key configurations.
+#    LSM doesn't current support column-store keys.
 class test_lsm_key_format(wttest.WiredTigerTestCase):
-    formats = [
-        ('Q1', dict(key_format='key_format=Q', ok=False)),
-        ('Q2', dict(key_format='key_format=q', ok=False)),
-        ('r', dict(key_format='key_format=r', ok=False)),
-        ('S', dict(key_format='key_format=S', ok=True)),
-        ('u', dict(key_format='key_format=u', ok=True))
-    ]
-
-    scenarios = make_scenarios(formats)
-
     def test_lsm_key_format(self):
-        if (self.ok):
-            self.session.create(
-                "table:A", self.key_format + ",value_format=S,type=lsm")
-        else:
-            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                lambda: self.session.create(
-                "table:A", self.key_format + ",value_format=S,type=lsm"),
-                '/key_format/')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create(
+            "table:A", "key_format=r,value_format=S,type=lsm"),
+            '/key_format/')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_lsm04.py
+++ b/test/suite/test_lsm04.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2017 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# test_lsm_key_format
+#    Test LSM tree key configurations.
+class test_lsm_key_format(wttest.WiredTigerTestCase):
+    formats = [
+        ('Q1', dict(key_format='key_format=Q', ok=False)),
+        ('Q2', dict(key_format='key_format=q', ok=False)),
+        ('r', dict(key_format='key_format=r', ok=False)),
+        ('S', dict(key_format='key_format=S', ok=True)),
+        ('u', dict(key_format='key_format=u', ok=True))
+    ]
+
+    scenarios = make_scenarios(formats)
+
+    def test_lsm_key_format(self):
+        if (self.ok):
+            self.session.create(
+                "table:A", self.key_format + ",value_format=S,type=lsm")
+        else:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.create(
+                "table:A", self.key_format + ",value_format=S,type=lsm"),
+                '/key_format/')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_overwrite.py
+++ b/test/suite/test_overwrite.py
@@ -41,23 +41,23 @@ class test_overwrite(wttest.WiredTigerTestCase):
         ('string', dict(keyfmt='S')),
     ]
     types = [
-        ('file', dict(uri='file:', ds=SimpleDataSet)),
-        ('lsm', dict(uri='lsm:', ds=SimpleDataSet)),
-        ('table-complex', dict(uri='table:', ds=ComplexDataSet)),
-        ('table-complex-lsm', dict(uri='table:', ds=ComplexLSMDataSet)),
-        ('table-index', dict(uri='table:', ds=SimpleIndexDataSet)),
-        ('table-simple', dict(uri='table:', ds=SimpleDataSet)),
-        ('table-simple-lsm', dict(uri='table:', ds=SimpleLSMDataSet)),
+        ('file', dict(uri='file:', lsm=False, ds=SimpleDataSet)),
+        ('lsm', dict(uri='lsm:', lsm=True, ds=SimpleDataSet)),
+        ('table-complex', dict(uri='table:', lsm=False, ds=ComplexDataSet)),
+        ('table-complex-lsm', dict(uri='table:', lsm=True, ds=ComplexLSMDataSet)),
+        ('table-index', dict(uri='table:', lsm=False, ds=SimpleIndexDataSet)),
+        ('table-simple', dict(uri='table:', lsm=False, ds=SimpleDataSet)),
+        ('table-simple-lsm', dict(uri='table:', lsm=True, ds=SimpleLSMDataSet)),
     ]
     scenarios = make_scenarios(types, keyfmt)
-    def skip(self):
-        return self.keyfmt == 'r' and \
-            (self.ds.is_lsm() or self.uri == 'lsm')
+    # Skip record number keys with LSM.
+    def lsm_recno_skip(self):
+        return self.lsm and self.keyfmt == 'r'
 
     # Confirm a cursor configured with/without overwrite correctly handles
     # non-existent records during insert, remove and update operations.
     def test_overwrite_insert(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         uri = self.uri + self.name
@@ -100,7 +100,7 @@ class test_overwrite(wttest.WiredTigerTestCase):
         self.assertEquals(cursor.insert(), 0)
 
     def test_overwrite_remove(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         uri = self.uri + self.name
@@ -128,7 +128,7 @@ class test_overwrite(wttest.WiredTigerTestCase):
         self.assertEquals(cursor.remove(), 0)
 
     def test_overwrite_update(self):
-        if self.skip():
+        if self.lsm_recno_skip():
             return
 
         uri = self.uri + self.name

--- a/test/suite/test_overwrite.py
+++ b/test/suite/test_overwrite.py
@@ -29,7 +29,7 @@
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet, SimpleIndexDataSet
 from wtdataset import SimpleLSMDataSet, ComplexDataSet, ComplexLSMDataSet
-from wtscenario import make_scenarios
+from wtscenario import filter_scenarios, make_scenarios
 
 # test_overwrite.py
 #    cursor overwrite configuration method
@@ -49,17 +49,13 @@ class test_overwrite(wttest.WiredTigerTestCase):
         ('table-simple', dict(uri='table:', lsm=False, ds=SimpleDataSet)),
         ('table-simple-lsm', dict(uri='table:', lsm=True, ds=SimpleLSMDataSet)),
     ]
-    scenarios = make_scenarios(types, keyfmt)
     # Skip record number keys with LSM.
-    def lsm_recno_skip(self):
-        return self.lsm and self.keyfmt == 'r'
+    scenarios = filter_scenarios(make_scenarios(types, keyfmt),
+        lambda name, d: not (d['lsm'] and d['keyfmt'] == 'r'))
 
     # Confirm a cursor configured with/without overwrite correctly handles
     # non-existent records during insert, remove and update operations.
     def test_overwrite_insert(self):
-        if self.lsm_recno_skip():
-            return
-
         uri = self.uri + self.name
         ds = self.ds(self, uri, 100, key_format=self.keyfmt)
         ds.populate()
@@ -100,9 +96,6 @@ class test_overwrite(wttest.WiredTigerTestCase):
         self.assertEquals(cursor.insert(), 0)
 
     def test_overwrite_remove(self):
-        if self.lsm_recno_skip():
-            return
-
         uri = self.uri + self.name
         ds = self.ds(self, uri, 100, key_format=self.keyfmt)
         ds.populate()
@@ -128,9 +121,6 @@ class test_overwrite(wttest.WiredTigerTestCase):
         self.assertEquals(cursor.remove(), 0)
 
     def test_overwrite_update(self):
-        if self.lsm_recno_skip():
-            return
-
         uri = self.uri + self.name
         ds = self.ds(self, uri, 100, key_format=self.keyfmt)
         ds.populate()

--- a/test/suite/wtscenario.py
+++ b/test/suite/wtscenario.py
@@ -196,6 +196,12 @@ def prune_scenarios(scenes, default_count = -1, long_count = -1):
             del scene[1]['_order']
         return check_scenarios(scenes)
 
+def filter_scenarios(scenes, pred):
+    """
+    Filter scenarios that match a predicate
+    """
+    return [s for s in scenes if pred(*s)]
+
 def number_scenarios(scenes):
     """
     Add a 'scenario_number' and 'scenario_name' variable to each scenario.


### PR DESCRIPTION
@agorrod, I took a look at WT-3605 (because it was a user question), and here's a branch that I hope makes things better.

It looks to me like LSM doesn't currently support anything other than 'S' or 'u' because the underlying file format is always 'u' (and 'S' is the only other format than  'u' that naturally looks like 'u' when it's stored in a WT_ITEM structure).

That said, it seems LSM could support other formats? (For example, couldn't a record-number be packed and stored in a WT_ITEM as format 'u'?)

I'm also unclear on how this connects to more complex tables schemas, that can presumably be configured to store in LSM tables.

Anyway, I hope this branch is moving in the right direction. Happy to wrap this up if you can give me a little guidance, or happy to have it handed off to someone else.