### PR TITLE
WT-3595 When running the python example, remove site-dependent dirs from sys.path

### DIFF
--- a/lang/python/run-ex_access
+++ b/lang/python/run-ex_access
@@ -2,4 +2,4 @@
 
 rm -rf WT_TEST ; mkdir WT_TEST
 
-exec env LD_LIBRARY_PATH=../../.libs DYLD_LIBRARY_PATH=../../.libs PYTHONPATH=.:${srcdir} python ${srcdir}/../../examples/python/ex_access.py 
+exec env LD_LIBRARY_PATH=../../.libs DYLD_LIBRARY_PATH=../../.libs PYTHONPATH=.:${srcdir} python -S ${srcdir}/../../examples/python/ex_access.py 


### PR DESCRIPTION
Having site dependent directories searched may mean that a shared objects from a previous build may be mistakenly used.