### PR TITLE
WT-3200 Reset the bloom filter cursor after failed search

### DIFF
--- a/src/bloom/bloom.c
+++ b/src/bloom/bloom.c
@@ -301,6 +301,7 @@ __wt_bloom_hash_get(WT_BLOOM *bloom, WT_BLOOM_HASH *bhash)
 err:	/* Don't return WT_NOTFOUND from a failed search. */
 	if (ret == WT_NOTFOUND)
 		ret = WT_ERROR;
+	c->reset(c);
 	__wt_err(bloom->session, ret, "Failed lookup in bloom filter");
 	return (ret);
 }

--- a/src/bloom/bloom.c
+++ b/src/bloom/bloom.c
@@ -274,6 +274,7 @@ __wt_bloom_hash_get(WT_BLOOM *bloom, WT_BLOOM_HASH *bhash)
 	WT_ASSERT(bloom->session, bloom->bitstring == NULL);
 
 	/* Create a cursor on the first time through. */
+	c = NULL;
 	WT_ERR(__bloom_open_cursor(bloom, NULL));
 	c = bloom->c;
 
@@ -301,7 +302,8 @@ __wt_bloom_hash_get(WT_BLOOM *bloom, WT_BLOOM_HASH *bhash)
 err:	/* Don't return WT_NOTFOUND from a failed search. */
 	if (ret == WT_NOTFOUND)
 		ret = WT_ERROR;
-	c->reset(c);
+	if (c != NULL)
+		(void)c->reset(c);
 	__wt_err(bloom->session, ret, "Failed lookup in bloom filter");
 	return (ret);
 }


### PR DESCRIPTION
On error, the bloom cursor is positioned at whatever key it was on from the
search. As a general practice a cursor should be reset after its use. So reset
this cursor after a failed search too.