### PR TITLE
WT-3612 backup cursors and checkpoint durability can lose committed data

### DIFF
--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -59,10 +59,12 @@ During the period the backup cursor is open, database checkpoints can
 be created, but no checkpoints can be deleted.  This may result in
 significant file growth.
 
-Additionally, if a crash occurs during the period the backup cursor is open and
-logging is disabled, then the system will be restored to the most recent
-checkpoint prior to the opening of the backup cursor, even if later database
-checkpoints were created.
+Additionally, if a crash occurs during the period the backup cursor is
+open and logging is disabled (in other words, when depending on
+checkpoints for durability), then the system will be restored to the
+most recent checkpoint prior to the opening of the backup cursor, even
+if later database checkpoints were completed. <b>Note this exception to
+WiredTiger's checkpoint durability guarantees.</b>
 
 The following is a programmatic example of creating a backup:
 

--- a/src/docs/checkpoint.dox
+++ b/src/docs/checkpoint.dox
@@ -22,6 +22,10 @@ configuration to ::wiredtiger_open.
 All transactional updates committed before a checkpoint are made durable
 by the checkpoint, therefore the frequency of checkpoints limits the
 volume of data that may be lost due to application or system failure.
+<b>This guarantee has an exception:</b> If a crash occurs when a backup
+cursor is open, then the system will be restored to the most recent
+checkpoint prior to the opening of the backup cursor, even if later
+database checkpoints were completed.
 
 Data sources that are involved in an exclusive operation when the
 checkpoint starts, including bulk load, verify or salvage, will be skipped


### PR DESCRIPTION
Cross-document the issues with backup cursors and checkpoint durability.