### PR TITLE
WT-3638 When restoring updates, don't discard on-page tombstones.

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1478,10 +1478,13 @@ __split_multi_inmem(
 		}
 
 		/*
-		 * The update used to create the on-page disk image must be
-		 * truncated.  This is not just a performance issue: if the
-		 * update is a modification, it cannot safely be reapplied to
-		 * the full value stored on disk.
+		 * Discard the update used to create the on-page disk image.
+		 * This is not just a performance issue: if the update used to
+		 * create the value for this on-page disk image was a modify,
+		 * and it was applied to the previous on-page value to
+		 * determine a value to write to this disk image, that update
+		 * cannot be applied to the new on-page value without risking
+		 * corruption.
 		 */
 		if (supd->onpage_upd != NULL) {
 			for (prev_upd = upd; prev_upd != NULL &&

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1488,9 +1488,16 @@ __split_multi_inmem(
 			    prev_upd->next != supd->onpage_upd;
 			    prev_upd = prev_upd->next)
 				;
+			/*
+			 * If the on-page update was in fact a tombstone, there
+			 * will be no value on the page.  Don't throw the
+			 * tombstone away: we may need it to correctly resolve
+			 * modifications.
+			 */
+			if (supd->onpage_upd->type == WT_UPDATE_DELETED &&
+			   prev_upd != NULL)
+				prev_upd = prev_upd->next;
 			if (prev_upd != NULL) {
-				WT_ASSERT(session,
-				    prev_upd->next == supd->onpage_upd);
 				__wt_update_obsolete_free(
 				    session, page, prev_upd->next);
 				prev_upd->next = NULL;


### PR DESCRIPTION
Reconciliation selects an update as the "on-page" version that is correct as-of the reconciliation.  If that update is a tombstone, no value will appear on the page.  Our API permits a modify of a deleted record, so we can't discard a tombstone if it was chosen as the on-page update, or a later modify update will have no starting value.