### PR TITLE
WT-3643 Set panic on error path if recovery needed.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2645,8 +2645,15 @@ err:	/* Discard the scratch buffers. */
 		__wt_scr_discard(session);
 	__wt_scr_discard(&conn->dummy_session);
 
-	if (ret != 0)
+	if (ret != 0) {
+		/*
+		 * Set panic if we're returning the run recovery error so that
+		 * we don't try to checkpoint data handles.
+		 */
+		if (ret == WT_RUN_RECOVERY)
+			F_SET(conn, WT_CONN_PANIC);
 		WT_TRET(__wt_connection_close(conn));
+	}
 
 	return (ret);
 }


### PR DESCRIPTION
@michaelcahill Please review this.  There is explanation in the ticket as well.  Basically on the error path out of wiredtiger_open, we were checkpointing the metadata file, updating the checkpoint LSN causing us to ignore and never recover the data.  This is one approach, because having panic set means we discard the dhandle.  Given it is the error path of `wiredtiger_open` it seemed cleaner than drilling more special case connection checking down into the dhandle code.