### PR TITLE
WT-3646 Only use lookaside when operations are blocked waiting for cache

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -477,9 +477,8 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 		case WT_REF_DISK:
 		case WT_REF_LOOKASIDE:
 			if (LF_ISSET(WT_READ_CACHE)) {
-				if (ref->state != WT_REF_LOOKASIDE)
-					return (WT_NOTFOUND);
-				if (!LF_ISSET(WT_READ_LOOKASIDE))
+				if (ref->state != WT_REF_LOOKASIDE ||
+				    !LF_ISSET(WT_READ_LOOKASIDE))
 					return (WT_NOTFOUND);
 #ifdef HAVE_TIMESTAMPS
 				/*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -213,7 +213,8 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
 		 * sure we're catching all paths and to avoid regressions.
 		 */
 		WT_ASSERT(session,
-		    S2BT(session)->checkpointing != WT_CKPT_RUNNING);
+		    S2BT(session)->checkpointing != WT_CKPT_RUNNING ||
+		    WT_SESSION_IS_CHECKPOINT(session));
 
 		WT_RET(__wt_ovfl_discard(session, cell));
 	}
@@ -1179,7 +1180,7 @@ __split_internal_lock(
 	 * loop until the exclusive lock is resolved). If we want to split
 	 * the parent, give up to avoid that deadlock.
 	 */
-	if (!trylock && S2BT(session)->checkpointing != WT_CKPT_OFF)
+	if (!trylock && !__wt_btree_can_evict_dirty(session))
 		return (EBUSY);
 
 	/*
@@ -1293,12 +1294,9 @@ __split_internal_should_split(WT_SESSION_IMPL *session, WT_REF *ref)
 static int
 __split_parent_climb(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_PAGE *parent;
 	WT_REF *ref;
-
-	btree = S2BT(session);
 
 	/*
 	 * Disallow internal splits during the final pass of a checkpoint. Most
@@ -1310,7 +1308,7 @@ __split_parent_climb(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * split chunk, but we'll write it upon finding it in a different part
 	 * of the tree.
 	 */
-	if (btree->checkpointing != WT_CKPT_OFF) {
+	if (!__wt_btree_can_evict_dirty(session)) {
 		__split_internal_unlock(session, page);
 		return (0);
 	}
@@ -1638,7 +1636,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	/* Verify any disk image we have. */
 	WT_ASSERT(session, multi->disk_image == NULL ||
 	    __wt_verify_dsk_image(session,
-	    "[page instantiate]", multi->disk_image, 0, false) == 0);
+	    "[page instantiate]", multi->disk_image, 0, true) == 0);
 
 	/*
 	 * If there's an address, the page was written, set it.

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -161,11 +161,8 @@ __ckpt_server_start(WT_CONNECTION_IMPL *conn)
 	 *
 	 * Checkpoint does enough I/O it may be called upon to perform slow
 	 * operations for the block manager.
-	 *
-	 * The checkpoint thread reads the lookaside table for outdated records,
-	 * it gets its own cursor for that purpose.
 	 */
-	session_flags = WT_SESSION_CAN_WAIT | WT_SESSION_LOOKASIDE_CURSOR;
+	session_flags = WT_SESSION_CAN_WAIT;
 	WT_RET(__wt_open_internal_session(conn,
 	    "checkpoint-server", true, session_flags, &conn->ckpt_session));
 	session = conn->ckpt_session;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -574,12 +574,11 @@ __evict_review(
 			}
 
 			/*
-			 * Check if reconciliation suggests trying the
-			 * lookaside table.
+			 * Once the cache is stuck, check if reconciliation
+			 * suggests trying the lookaside table unless lookaside
+			 * eviction is disabled globally.
 			 */
-			if (__wt_cache_aggressive(session) &&
-			    F_ISSET(cache, WT_CACHE_EVICT_CLEAN |
-				WT_CACHE_EVICT_DIRTY_HARD) &&
+			if (__wt_cache_stuck(session) &&
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
 				lookaside_retryp = &lookaside_retry;
 		}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -578,6 +578,8 @@ __evict_review(
 			 * lookaside table.
 			 */
 			if (__wt_cache_aggressive(session) &&
+			    F_ISSET(cache, WT_CACHE_EVICT_CLEAN |
+				WT_CACHE_EVICT_DIRTY_HARD) &&
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
 				lookaside_retryp = &lookaside_retry;
 		}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -344,6 +344,9 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		/*
 		 * Update the parent to reference the replacement page.
 		 *
+		 * A page evicted with lookaside entries may not have an
+		 * address, if no updates were visible to reconciliation.
+		 *
 		 * Publish: a barrier to ensure the structure fields are set
 		 * before the state change makes the page available to readers.
 		 */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -574,11 +574,17 @@ __evict_review(
 			}
 
 			/*
-			 * Once the cache is stuck, check if reconciliation
-			 * suggests trying the lookaside table unless lookaside
-			 * eviction is disabled globally.
+			 * If the cache is nearly stuck, check if
+			 * reconciliation suggests trying the lookaside table
+			 * unless lookaside eviction is disabled globally.
+			 *
+			 * We don't wait until the cache is completely stuck:
+			 * for workloads where lookaside eviction is necessary
+			 * to make progress, we don't want a single successful
+			 * page eviction to make the cache "unstuck" so we have
+			 * to wait again before evicting the next page.
 			 */
-			if (__wt_cache_stuck(session) &&
+			if (__wt_cache_nearly_stuck(session) &&
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
 				lookaside_retryp = &lookaside_retry;
 		}

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1165,6 +1165,24 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __wt_btree_can_evict_dirty --
+ *	Check whether eviction of dirty pages or splits are permitted in the
+ *	current tree.
+ *
+ *      We cannot evict dirty pages or split while a checkpoint is in progress,
+ *      unless the checkpoint thread is doing the work.
+ */
+static inline bool
+__wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
+{
+        WT_BTREE *btree;
+
+        btree = S2BT(session);
+	return (btree->checkpointing == WT_CKPT_OFF ||
+	    WT_SESSION_IS_CHECKPOINT(session));
+}
+
+/*
  * __wt_leaf_page_can_split --
  *	Check whether a page can be split in memory.
  */
@@ -1272,12 +1290,10 @@ static inline bool
 __wt_page_can_evict(
     WT_SESSION_IMPL *session, WT_REF *ref, uint32_t *evict_flagsp)
 {
-	WT_BTREE *btree;
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
 	bool modified;
 
-	btree = S2BT(session);
 	page = ref->page;
 	mod = page->modify;
 
@@ -1291,7 +1307,7 @@ __wt_page_can_evict(
 	 * parent frees the backing blocks for any no-longer-used overflow keys,
 	 * which will corrupt the checkpoint's block management.
 	 */
-	if (btree->checkpointing != WT_CKPT_OFF &&
+	if (!__wt_btree_can_evict_dirty(session) &&
 	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
 		return (false);
 
@@ -1315,8 +1331,7 @@ __wt_page_can_evict(
 	 * previous version might be referenced by an internal page already
 	 * written in the checkpoint, leaving the checkpoint inconsistent.
 	 */
-	if (modified && btree->checkpointing != WT_CKPT_OFF &&
-	    !WT_SESSION_IS_CHECKPOINT(session)) {
+	if (modified && !__wt_btree_can_evict_dirty(session)) {
 		WT_STAT_CONN_INCR(session, cache_eviction_checkpoint);
 		WT_STAT_DATA_INCR(session, cache_eviction_checkpoint);
 		return (false);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1175,9 +1175,9 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
 static inline bool
 __wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
 {
-        WT_BTREE *btree;
+	WT_BTREE *btree;
 
-        btree = S2BT(session);
+	btree = S2BT(session);
 	return (btree->checkpointing == WT_CKPT_OFF ||
 	    WT_SESSION_IS_CHECKPOINT(session));
 }

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -79,6 +79,22 @@ __wt_cache_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
+ * __wt_cache_nearly_stuck --
+ *      Indicate if the cache is nearly stuck.
+ */
+static inline bool
+__wt_cache_nearly_stuck(WT_SESSION_IMPL *session)
+{
+	WT_CACHE *cache;
+
+	cache = S2C(session)->cache;
+	return (cache->evict_aggressive_score >=
+	    (WT_EVICT_SCORE_MAX - WT_EVICT_SCORE_BUMP) &&
+	    F_ISSET(cache,
+		WT_CACHE_EVICT_CLEAN_HARD | WT_CACHE_EVICT_DIRTY_HARD));
+}
+
+/*
  * __wt_cache_stuck --
  *      Indicate if the cache is stuck (i.e., not making progress).
  */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1406,14 +1406,14 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 
 #ifdef HAVE_TIMESTAMPS
 	/* Track the oldest saved timestamp for lookaside. */
-	if (F_ISSET(r, WT_REC_LOOKASIDE)) {
+	if (F_ISSET(r, WT_REC_LOOKASIDE))
 		for (upd = first_upd; upd->next != NULL; upd = upd->next)
-			;
-		if (__wt_timestamp_cmp(
-		    &r->min_saved_timestamp, &upd->timestamp) > 0)
-			__wt_timestamp_set(
-			    &r->min_saved_timestamp, &upd->timestamp);
-	}
+			if (upd->txnid != WT_TXN_ABORTED &&
+			    upd->txnid != WT_TXN_NONE &&
+			    __wt_timestamp_cmp(
+			    &upd->timestamp, &r->min_saved_timestamp) < 0)
+				__wt_timestamp_set(
+				    &r->min_saved_timestamp, &upd->timestamp);
 #endif
 
 check_original_value:
@@ -1659,6 +1659,17 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT));
 			if (F_ISSET(r, WT_REC_EVICT))
 				return (EBUSY);
+
+			/*
+			 * A page evicted with lookaside entries may not have
+			 * an address, if no updates were visible to
+			 * reconciliation.  Any child pages in that state
+			 * should be ignored.
+			 */
+			if (ref->addr == NULL) {
+				*statep = WT_CHILD_IGNORE;
+				WT_CHILD_RELEASE(session, *hazardp, ref);
+			}
 
 			goto done;
 
@@ -1995,6 +2006,29 @@ __rec_leaf_page_max(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	 * Salvage is the backup plan: don't let this fail.
 	 */
 	return (page_size * 2);
+}
+
+#define	WT_REC_MAX_SAVED_UPDATES	100
+
+/*
+ * __rec_need_split --
+ *	Check whether adding some bytes to the page requires a split.
+ *
+ *	This takes into account the disk image growing across a boundary, and
+ *	also triggers a split for row store leaf pages when a threshold number
+ *	of saved updates is reached.  This allows pages to split for update /
+ *	restore and lookaside eviction when there is no visible data that
+ *	causes the disk image to grow.
+ */
+static bool
+__rec_need_split(WT_RECONCILE *r, size_t len)
+{
+	if (r->page->type == WT_PAGE_ROW_LEAF &&
+	    r->supd_next >= WT_REC_MAX_SAVED_UPDATES)
+		return (true);
+
+	return (r->raw_compression ?
+	    len > r->space_avail : WT_CHECK_CROSSING_BND(r, len));
 }
 
 /*
@@ -2457,7 +2491,7 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 	btree = S2BT(session);
 
 	/* Fixed length col store can call with next_len 0 */
-	WT_ASSERT(session, next_len == 0 || r->space_avail < next_len);
+	WT_ASSERT(session, next_len == 0 || __rec_need_split(r, next_len));
 
 	/*
 	 * We should never split during salvage, and we're about to drop core
@@ -2475,7 +2509,7 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 	 * Additionally, grow the buffer to contain the current item if we
 	 * haven't already consumed a reasonable portion of a split chunk.
 	 */
-	if (inuse < r->split_size / 2)
+	if (inuse < r->split_size / 2 && !__rec_need_split(r, 0))
 		goto done;
 
 	/* All page boundaries reset the dictionary. */
@@ -2558,7 +2592,7 @@ __rec_split_crossing_bnd(
 	WT_BTREE *btree;
 	size_t min_offset;
 
-	WT_ASSERT(session, WT_CHECK_CROSSING_BND(r, next_len));
+	WT_ASSERT(session, __rec_need_split(r, next_len));
 
 	/*
 	 * If crossing the minimum split size boundary, store the boundary
@@ -2567,7 +2601,7 @@ __rec_split_crossing_bnd(
 	 * large enough, just split at this point.
 	 */
 	if (WT_CROSSING_MIN_BND(r, next_len) &&
-	    !WT_CROSSING_SPLIT_BND(r, next_len)) {
+	    !WT_CROSSING_SPLIT_BND(r, next_len) && !__rec_need_split(r, 0)) {
 		btree = S2BT(session);
 		WT_ASSERT(session, r->cur_ptr->min_offset == 0);
 
@@ -2641,7 +2675,7 @@ __rec_split_raw_worker(WT_SESSION_IMPL *session,
 	/*
 	 * We can get here if the first key/value pair won't fit.
 	 */
-	if (r->entries == 0)
+	if (r->entries == 0 && !__rec_need_split(r, 0))
 		goto split_grow;
 
 	/*
@@ -4111,13 +4145,13 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 		WT_CHILD_RELEASE_ERR(session, hazard, ref);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (val->len > r->space_avail)
+		if (__rec_need_split(r, val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(session, r, val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, val->len))
+			else
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, val->len));
+		}
 
 		/* Copy the value onto the page. */
 		__rec_copy_incr(session, r, val);
@@ -4159,13 +4193,13 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		    addr->addr, addr->size, __rec_vtype(addr), r->recno);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (val->len > r->space_avail)
+		if (__rec_need_split(r, val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(session, r, val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, val->len))
+			else
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, val->len));
+		}
 
 		/* Copy the value onto the page. */
 		__rec_copy_incr(session, r, val);
@@ -4432,12 +4466,12 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		    session, r, value->data, value->size, rle));
 
 	/* Boundary: split or write the page. */
-	if (r->raw_compression) {
-		if (val->len > r->space_avail)
+	if (__rec_need_split(r, val->len)) {
+		if (r->raw_compression)
 			WT_RET(__rec_split_raw(session, r, val->len));
-	} else
-		if (WT_CHECK_CROSSING_BND(r, val->len))
+		else
 			WT_RET(__rec_split_crossing_bnd(session, r, val->len));
+	}
 
 	/* Copy the value onto the page. */
 	if (!deleted && !overflow_type && btree->dictionary)
@@ -5133,12 +5167,11 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		r->cell_zero = false;
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * In one path above, we copied address blocks
 				 * from the page rather than building the actual
@@ -5154,6 +5187,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key and value onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5203,14 +5237,14 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		    addr->addr, addr->size, __rec_vtype(addr), WT_RECNO_OOB);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len))
+			else
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
+		}
 
 		/* Copy the key and value onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5550,12 +5584,11 @@ build:
 		}
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * If we copied address blocks from the page
 				 * rather than building the actual key, we have
@@ -5586,6 +5619,7 @@ build:
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key/value pair onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5694,12 +5728,11 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 		    WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key));
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * Turn off prefix compression until a full key
 				 * written to the new page, and (unless already
@@ -5718,6 +5751,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key/value pair onto the page. */
 		__rec_copy_incr(session, r, key);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1326,9 +1326,10 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 
 	/*
 	 * The checkpoint transaction is special.  Make sure we never write
-	 * (metadata) updates from a checkpoint in a concurrent session.
+	 * metadata updates from a checkpoint in a concurrent session.
 	 */
-	WT_ASSERT(session, *updp == NULL || (*updp)->txnid == WT_TXN_NONE ||
+	WT_ASSERT(session, !WT_IS_METADATA(session->dhandle) ||
+	    *updp == NULL || (*updp)->txnid == WT_TXN_NONE ||
 	    (*updp)->txnid != S2C(session)->txn_global.checkpoint_state.id ||
 	    WT_SESSION_IS_CHECKPOINT(session));
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1018,7 +1018,7 @@ int
 __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
 {
 	WT_DECL_RET;
-	uint32_t mask;
+	uint32_t orig_flags;
 
 	/*
 	 * Reset open cursors.  Do this explicitly, even though it will happen
@@ -1040,11 +1040,23 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
 	 *
 	 * Application checkpoints wait until the checkpoint lock is available,
 	 * compaction checkpoints don't.
+	 *
+	 * Checkpoints should always use a separate session for lookaside
+	 * updates, otherwise those updates are pinned until the checkpoint
+	 * commits.  Also, there are unfortunate interactions between the
+	 * special rules for lookaside eviction and the special handling of the
+	 * checkpoint transaction.
 	 */
-#define	WT_TXN_SESSION_MASK						\
+#undef WT_CHECKPOINT_SESSION_FLAGS
+#define	WT_CHECKPOINT_SESSION_FLAGS \
 	(WT_SESSION_CAN_WAIT | WT_SESSION_NO_EVICTION)
-	mask = F_MASK(session, WT_TXN_SESSION_MASK);
-	F_SET(session, WT_SESSION_CAN_WAIT | WT_SESSION_NO_EVICTION);
+#undef WT_CHECKPOINT_SESSION_FLAGS_OFF
+#define	WT_CHECKPOINT_SESSION_FLAGS_OFF \
+	(WT_SESSION_LOOKASIDE_CURSOR)
+	orig_flags = F_MASK(session,
+	    WT_CHECKPOINT_SESSION_FLAGS | WT_CHECKPOINT_SESSION_FLAGS_OFF);
+	F_SET(session, WT_CHECKPOINT_SESSION_FLAGS);
+	F_CLR(session, WT_CHECKPOINT_SESSION_FLAGS_OFF);
 
 	/*
 	 * Only one checkpoint can be active at a time, and checkpoints must run
@@ -1060,8 +1072,8 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
 		WT_WITH_CHECKPOINT_LOCK_NOWAIT(session, ret,
 		    ret = __txn_checkpoint_wrapper(session, cfg));
 
-	F_CLR(session, WT_TXN_SESSION_MASK);
-	F_SET(session, mask);
+	F_CLR(session, WT_CHECKPOINT_SESSION_FLAGS);
+	F_SET(session, orig_flags);
 
 	return (ret);
 }


### PR DESCRIPTION
We recently changed eviction to try using the lookaside table sooner. For some workloads, this can lead to poor performance and runaway growth in the lookaside table size.