### PR TITLE
WT-3646 Improve performance when lookaside eviction is required.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -477,9 +477,8 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 		case WT_REF_DISK:
 		case WT_REF_LOOKASIDE:
 			if (LF_ISSET(WT_READ_CACHE)) {
-				if (ref->state != WT_REF_LOOKASIDE)
-					return (WT_NOTFOUND);
-				if (!LF_ISSET(WT_READ_LOOKASIDE))
+				if (ref->state != WT_REF_LOOKASIDE ||
+				    !LF_ISSET(WT_READ_LOOKASIDE))
 					return (WT_NOTFOUND);
 #ifdef HAVE_TIMESTAMPS
 				/*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1180,8 +1180,7 @@ __split_internal_lock(
 	 * loop until the exclusive lock is resolved). If we want to split
 	 * the parent, give up to avoid that deadlock.
 	 */
-	if (!trylock && S2BT(session)->checkpointing != WT_CKPT_OFF &&
-	    !WT_SESSION_IS_CHECKPOINT(session))
+	if (!trylock && !__wt_btree_can_evict_dirty(session))
 		return (EBUSY);
 
 	/*
@@ -1295,12 +1294,9 @@ __split_internal_should_split(WT_SESSION_IMPL *session, WT_REF *ref)
 static int
 __split_parent_climb(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_PAGE *parent;
 	WT_REF *ref;
-
-	btree = S2BT(session);
 
 	/*
 	 * Disallow internal splits during the final pass of a checkpoint. Most
@@ -1312,8 +1308,7 @@ __split_parent_climb(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * split chunk, but we'll write it upon finding it in a different part
 	 * of the tree.
 	 */
-	if (btree->checkpointing != WT_CKPT_OFF &&
-	    !WT_SESSION_IS_CHECKPOINT(session)) {
+	if (!__wt_btree_can_evict_dirty(session)) {
 		__split_internal_unlock(session, page);
 		return (0);
 	}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -344,6 +344,9 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		/*
 		 * Update the parent to reference the replacement page.
 		 *
+		 * A page evicted with lookaside entries may not have an
+		 * address, if no updates were visible to reconciliation.
+		 *
 		 * Publish: a barrier to ensure the structure fields are set
 		 * before the state change makes the page available to readers.
 		 */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -574,10 +574,14 @@ __evict_review(
 			}
 
 			/*
-			 * Check if reconciliation suggests trying the
-			 * lookaside table.
+			 * We usually only consider lookaside eviction once
+			 * eviction is struggling.  However, eviction in
+			 * service of a checkpoint (which is only done when
+			 * urgent eviction is required) will try lookaside
+			 * eviction immediately.
 			 */
-			if (__wt_cache_aggressive(session) &&
+			if ((__wt_cache_aggressive(session) ||
+			    WT_SESSION_IS_CHECKPOINT(session)) &&
 			    F_ISSET(cache, WT_CACHE_EVICT_CLEAN |
 				WT_CACHE_EVICT_DIRTY_HARD) &&
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1165,6 +1165,24 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __wt_btree_can_evict_dirty --
+ *	Check whether eviction of dirty pages or splits are permitted in the
+ *	current tree.
+ *
+ *      We cannot evict dirty pages or split while a checkpoint is in progress,
+ *      unless the checkpoint thread is doing the work.
+ */
+static inline bool
+__wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
+{
+        WT_BTREE *btree;
+
+        btree = S2BT(session);
+	return (btree->checkpointing == WT_CKPT_OFF ||
+	    WT_SESSION_IS_CHECKPOINT(session));
+}
+
+/*
  * __wt_leaf_page_can_split --
  *	Check whether a page can be split in memory.
  */
@@ -1272,12 +1290,10 @@ static inline bool
 __wt_page_can_evict(
     WT_SESSION_IMPL *session, WT_REF *ref, uint32_t *evict_flagsp)
 {
-	WT_BTREE *btree;
 	WT_PAGE *page;
 	WT_PAGE_MODIFY *mod;
 	bool modified;
 
-	btree = S2BT(session);
 	page = ref->page;
 	mod = page->modify;
 
@@ -1291,8 +1307,7 @@ __wt_page_can_evict(
 	 * parent frees the backing blocks for any no-longer-used overflow keys,
 	 * which will corrupt the checkpoint's block management.
 	 */
-	if (btree->checkpointing != WT_CKPT_OFF &&
-	    !WT_SESSION_IS_CHECKPOINT(session) &&
+	if (!__wt_btree_can_evict_dirty(session) &&
 	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
 		return (false);
 
@@ -1316,8 +1331,7 @@ __wt_page_can_evict(
 	 * previous version might be referenced by an internal page already
 	 * written in the checkpoint, leaving the checkpoint inconsistent.
 	 */
-	if (modified && btree->checkpointing != WT_CKPT_OFF &&
-	    !WT_SESSION_IS_CHECKPOINT(session)) {
+	if (modified && !__wt_btree_can_evict_dirty(session)) {
 		WT_STAT_CONN_INCR(session, cache_eviction_checkpoint);
 		WT_STAT_DATA_INCR(session, cache_eviction_checkpoint);
 		return (false);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1292,6 +1292,7 @@ __wt_page_can_evict(
 	 * which will corrupt the checkpoint's block management.
 	 */
 	if (btree->checkpointing != WT_CKPT_OFF &&
+	    !WT_SESSION_IS_CHECKPOINT(session) &&
 	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
 		return (false);
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1293,7 +1293,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 			*updp = upd;
 
 #ifdef HAVE_TIMESTAMPS
-		/* Track the first update with non-zero timestamp. */
+		/* Track the first/last update with non-zero timestamp. */
 		if (first_ts_upd == NULL &&
 		    !__wt_timestamp_iszero(&upd->timestamp))
 			first_ts_upd = upd;
@@ -1406,14 +1406,13 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 
 #ifdef HAVE_TIMESTAMPS
 	/* Track the oldest saved timestamp for lookaside. */
-	if (F_ISSET(r, WT_REC_LOOKASIDE)) {
+	if (F_ISSET(r, WT_REC_LOOKASIDE))
 		for (upd = first_upd; upd->next != NULL; upd = upd->next)
-			;
-		if (__wt_timestamp_cmp(
-		    &r->min_saved_timestamp, &upd->timestamp) > 0)
-			__wt_timestamp_set(
-			    &r->min_saved_timestamp, &upd->timestamp);
-	}
+			if (!__wt_timestamp_iszero(&upd->timestamp) &&
+			    __wt_timestamp_cmp(
+			    &upd->timestamp, &r->min_saved_timestamp) < 0)
+				__wt_timestamp_set(
+				    &r->min_saved_timestamp, &upd->timestamp);
 #endif
 
 check_original_value:
@@ -1659,6 +1658,11 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT));
 			if (F_ISSET(r, WT_REC_EVICT))
 				return (EBUSY);
+
+			if (ref->addr == NULL) {
+				*statep = WT_CHILD_IGNORE;
+				WT_CHILD_RELEASE(session, *hazardp, ref);
+			}
 
 			goto done;
 
@@ -1995,6 +1999,25 @@ __rec_leaf_page_max(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	 * Salvage is the backup plan: don't let this fail.
 	 */
 	return (page_size * 2);
+}
+
+#define	WT_REC_MAX_SAVED_UPDATES	100
+
+/*
+ * __rec_need_split --
+ *	Check whether adding some bytes to the page requires a split.
+ */
+static bool
+__rec_need_split(WT_RECONCILE *r, size_t next_len)
+{
+	if (r->page->type == WT_PAGE_ROW_LEAF &&
+	    r->supd_next >= WT_REC_MAX_SAVED_UPDATES)
+		return (true);
+
+	if (r->raw_compression)
+		return (next_len > r->space_avail);
+	else
+		return (WT_CHECK_CROSSING_BND(r, next_len));
 }
 
 /*
@@ -2457,7 +2480,7 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 	btree = S2BT(session);
 
 	/* Fixed length col store can call with next_len 0 */
-	WT_ASSERT(session, next_len == 0 || r->space_avail < next_len);
+	WT_ASSERT(session, next_len == 0 || __rec_need_split(r, next_len));
 
 	/*
 	 * We should never split during salvage, and we're about to drop core
@@ -2475,7 +2498,7 @@ __rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 	 * Additionally, grow the buffer to contain the current item if we
 	 * haven't already consumed a reasonable portion of a split chunk.
 	 */
-	if (inuse < r->split_size / 2)
+	if (inuse < r->split_size / 2 && !__rec_need_split(r, 0))
 		goto done;
 
 	/* All page boundaries reset the dictionary. */
@@ -2558,7 +2581,8 @@ __rec_split_crossing_bnd(
 	WT_BTREE *btree;
 	size_t min_offset;
 
-	WT_ASSERT(session, WT_CHECK_CROSSING_BND(r, next_len));
+	WT_ASSERT(session, WT_CHECK_CROSSING_BND(r, next_len) ||
+	    __rec_need_split(r, 0));
 
 	/*
 	 * If crossing the minimum split size boundary, store the boundary
@@ -2567,7 +2591,8 @@ __rec_split_crossing_bnd(
 	 * large enough, just split at this point.
 	 */
 	if (WT_CROSSING_MIN_BND(r, next_len) &&
-	    !WT_CROSSING_SPLIT_BND(r, next_len)) {
+	    !WT_CROSSING_SPLIT_BND(r, next_len) &&
+	    !__rec_need_split(r, 0)) {
 		btree = S2BT(session);
 		WT_ASSERT(session, r->cur_ptr->min_offset == 0);
 
@@ -2641,7 +2666,7 @@ __rec_split_raw_worker(WT_SESSION_IMPL *session,
 	/*
 	 * We can get here if the first key/value pair won't fit.
 	 */
-	if (r->entries == 0)
+	if (r->entries == 0 && !__rec_need_split(r, 0))
 		goto split_grow;
 
 	/*
@@ -4111,13 +4136,13 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 		WT_CHILD_RELEASE_ERR(session, hazard, ref);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (val->len > r->space_avail)
+		if (__rec_need_split(r, val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(session, r, val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, val->len))
+			else
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, val->len));
+		}
 
 		/* Copy the value onto the page. */
 		__rec_copy_incr(session, r, val);
@@ -4159,13 +4184,13 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		    addr->addr, addr->size, __rec_vtype(addr), r->recno);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (val->len > r->space_avail)
+		if (__rec_need_split(r, val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(session, r, val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, val->len))
+			else
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, val->len));
+		}
 
 		/* Copy the value onto the page. */
 		__rec_copy_incr(session, r, val);
@@ -4432,12 +4457,12 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		    session, r, value->data, value->size, rle));
 
 	/* Boundary: split or write the page. */
-	if (r->raw_compression) {
-		if (val->len > r->space_avail)
+	if (__rec_need_split(r, val->len)) {
+		if (r->raw_compression)
 			WT_RET(__rec_split_raw(session, r, val->len));
-	} else
-		if (WT_CHECK_CROSSING_BND(r, val->len))
+		else
 			WT_RET(__rec_split_crossing_bnd(session, r, val->len));
+	}
 
 	/* Copy the value onto the page. */
 	if (!deleted && !overflow_type && btree->dictionary)
@@ -5133,12 +5158,11 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		r->cell_zero = false;
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * In one path above, we copied address blocks
 				 * from the page rather than building the actual
@@ -5154,6 +5178,7 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key and value onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5203,14 +5228,14 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		    addr->addr, addr->size, __rec_vtype(addr), WT_RECNO_OOB);
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len))
+			else
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
+		}
 
 		/* Copy the key and value onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5550,12 +5575,11 @@ build:
 		}
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_ERR(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * If we copied address blocks from the page
 				 * rather than building the actual key, we have
@@ -5586,6 +5610,7 @@ build:
 				WT_ERR(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key/value pair onto the page. */
 		__rec_copy_incr(session, r, key);
@@ -5694,12 +5719,11 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 		    WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key));
 
 		/* Boundary: split or write the page. */
-		if (r->raw_compression) {
-			if (key->len + val->len > r->space_avail)
+		if (__rec_need_split(r, key->len + val->len)) {
+			if (r->raw_compression)
 				WT_RET(__rec_split_raw(
 				    session, r, key->len + val->len));
-		} else
-			if (WT_CHECK_CROSSING_BND(r, key->len + val->len)) {
+			else {
 				/*
 				 * Turn off prefix compression until a full key
 				 * written to the new page, and (unless already
@@ -5718,6 +5742,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 				WT_RET(__rec_split_crossing_bnd(
 				    session, r, key->len + val->len));
 			}
+		}
 
 		/* Copy the key/value pair onto the page. */
 		__rec_copy_incr(session, r, key);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1293,7 +1293,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 			*updp = upd;
 
 #ifdef HAVE_TIMESTAMPS
-		/* Track the first/last update with non-zero timestamp. */
+		/* Track the first update with non-zero timestamp. */
 		if (first_ts_upd == NULL &&
 		    !__wt_timestamp_iszero(&upd->timestamp))
 			first_ts_upd = upd;
@@ -1408,7 +1408,8 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	/* Track the oldest saved timestamp for lookaside. */
 	if (F_ISSET(r, WT_REC_LOOKASIDE))
 		for (upd = first_upd; upd->next != NULL; upd = upd->next)
-			if (!__wt_timestamp_iszero(&upd->timestamp) &&
+			if (upd->txnid != WT_TXN_ABORTED &&
+			    upd->txnid != WT_TXN_NONE &&
 			    __wt_timestamp_cmp(
 			    &upd->timestamp, &r->min_saved_timestamp) < 0)
 				__wt_timestamp_set(

--- a/test/suite/test_timestamp07.py
+++ b/test/suite/test_timestamp07.py
@@ -82,6 +82,34 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
         if txn_config:
             session.commit_transaction()
 
+    # Check reads of all tables at a timestamp
+    def check_reads(self, session, txn_config, check_value, valcnt, valcnt2, valcnt3):
+        if txn_config:
+            session.begin_transaction(txn_config)
+        c = session.open_cursor(self.uri + self.tablename, None)
+        c2 = session.open_cursor(self.uri + self.tablename2, None)
+        c3 = session.open_cursor(self.uri + self.tablename3, None)
+        count = 0
+        for k, v in c:
+            if check_value in str(v):
+                count += 1
+        c.close()
+        count2 = 0
+        for k, v in c2:
+            if check_value in str(v):
+                count2 += 1
+        c2.close()
+        count3 = 0
+        for k, v in c3:
+            if check_value in str(v):
+                count3 += 1
+        c3.close()
+        if txn_config:
+            session.commit_transaction()
+        self.assertEqual(count, valcnt)
+        self.assertEqual(count2, valcnt2)
+        self.assertEqual(count3, valcnt3)
+
     #
     # Take a backup of the database and verify that the value we want to
     # check exists in the tables the expected number of times.
@@ -135,6 +163,15 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.checkpoint(ckptcfg)
         self.backup_check(check_value, valcnt, valcnt2, valcnt3)
 
+    def check_stable(self, check_value, valcnt, valcnt2, valcnt3):
+        self.ckpt_backup(check_value, valcnt, valcnt2, valcnt3)
+
+        # When reading as-of a timestamps, tables 1 and 3 should match (both
+        # use timestamps and we're not running recovery, so logging behavior
+        # should be irrelevant).
+        self.check_reads(self.session, 'read_timestamp=' + self.stablets,
+            check_value, valcnt, valcnt2, valcnt)
+
     def test_timestamp07(self):
         if not wiredtiger.timestamp_build():
             self.skipTest('requires a timestamp build')
@@ -177,9 +214,9 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Bump the oldest timestamp, we're not going back...
         self.assertTimestampsEqual(self.conn.query_timestamp(), timestamp_str(self.nkeys))
-        self.oldts = timestamp_str(self.nkeys)
+        self.oldts = self.stablets = timestamp_str(self.nkeys)
         self.conn.set_timestamp('oldest_timestamp=' + self.oldts)
-        self.conn.set_timestamp('stable_timestamp=' + self.oldts)
+        self.conn.set_timestamp('stable_timestamp=' + self.stablets)
         # print "Oldest " + self.oldts
 
         # Update them and retry.
@@ -204,14 +241,14 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Take a checkpoint using the given configuration.  Then verify
         # whether value2 appears in a copy of that data or not.
-        self.ckpt_backup(self.value2, 0, self.nkeys, self.nkeys if self.using_log else 0)
+        self.check_stable(self.value2, 0, self.nkeys, self.nkeys if self.using_log else 0)
 
         # Update the stable timestamp to the latest, but not the oldest
         # timestamp and make sure we can see the data.  Once the stable
         # timestamp is moved we should see all keys with value2.
-        self.conn.set_timestamp('stable_timestamp=' + \
-            timestamp_str(self.nkeys*2))
-        self.ckpt_backup(self.value2, self.nkeys, self.nkeys, self.nkeys)
+        self.stablets = timestamp_str(self.nkeys*2)
+        self.conn.set_timestamp('stable_timestamp=' + self.stablets)
+        self.check_stable(self.value2, self.nkeys, self.nkeys, self.nkeys)
 
         # If we're not using the log we're done.
         if not self.using_log:
@@ -244,7 +281,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
         # of that data or not.  Both tables that are logged should see
         # all the data regardless of timestamps.  The table that is not
         # logged should not see any of it.
-        self.backup_check(self.value3, 0, self.nkeys, self.nkeys)
+        self.check_stable(self.value3, 0, self.nkeys, self.nkeys)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_timestamp07.py
+++ b/test/suite/test_timestamp07.py
@@ -166,7 +166,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
     def check_stable(self, check_value, valcnt, valcnt2, valcnt3):
         self.ckpt_backup(check_value, valcnt, valcnt2, valcnt3)
 
-        # When reading as-of a timestamps, tables 1 and 3 should match (both
+        # When reading as-of a timestamp, tables 1 and 3 should match (both
         # use timestamps and we're not running recovery, so logging behavior
         # should be irrelevant).
         self.check_reads(self.session, 'read_timestamp=' + self.stablets,


### PR DESCRIPTION
In particular,
* fix the optimization for checkpoints so most lookaside pages can be skipped when the stable timestamp is lagging.
* allow row store leaf pages to split when evicting and no values are visible (currently using a dumb heuristic of splitting as soon as 100 records need updates saved).
* allow use of lookaside and splits when checkpoints do eviction.