### PR TITLE
WT-3646 Don't trigger eviction from checkpoints in write heavy workloads

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -60,7 +60,7 @@ static inline bool
 __cursor_page_pinned(WT_CURSOR_BTREE *cbt)
 {
 	return (F_ISSET(cbt, WT_CBT_ACTIVE) &&
-	    cbt->ref->page->read_gen != WT_READGEN_OLDEST);
+	    !WT_READGEN_EVICT_SOON(cbt->ref->page->read_gen));
 }
 
 /*

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -60,7 +60,7 @@ static inline bool
 __cursor_page_pinned(WT_CURSOR_BTREE *cbt)
 {
 	return (F_ISSET(cbt, WT_CBT_ACTIVE) &&
-	    !WT_READGEN_EVICT_SOON(cbt->ref->page->read_gen));
+	    cbt->ref->page->read_gen != WT_READGEN_OLDEST);
 }
 
 /*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -621,7 +621,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			page = ref->page;
 			if (page->read_gen == WT_READGEN_NOTSET) {
 				if (wont_need)
-					page->read_gen = WT_READGEN_WONTNEED;
+					page->read_gen = WT_READGEN_WONT_NEED;
 				else
 					__wt_cache_read_gen_new(session, page);
 			} else if (!LF_ISSET(WT_READ_NO_GEN))

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -453,7 +453,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 	WT_PAGE *page;
 	uint64_t sleep_cnt, wait_cnt;
 	int force_attempts;
-	bool busy, cache_work, did_read, evict_soon, stalled;
+	bool busy, cache_work, did_read, stalled, wont_need;
 
 	btree = S2BT(session);
 
@@ -466,7 +466,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 		WT_STAT_DATA_INCR(session, cache_pages_requested);
 	}
 
-	for (did_read = evict_soon = stalled = false,
+	for (did_read = wont_need = stalled = false,
 	    force_attempts = 0, sleep_cnt = wait_cnt = 0;;) {
 		switch (ref->state) {
 		case WT_REF_DELETED:
@@ -520,7 +520,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			 * here because we don't want to evict the page before
 			 * we "acquire" it.
 			 */
-			evict_soon = LF_ISSET(WT_READ_WONT_NEED) ||
+			wont_need = LF_ISSET(WT_READ_WONT_NEED) ||
 			    F_ISSET(session, WT_SESSION_NO_CACHE);
 			continue;
 		case WT_REF_READING:
@@ -610,8 +610,8 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			/*
 			 * If we read the page and are configured to not trash
 			 * the cache, and no other thread has already used the
-			 * page, set the oldest read generation so the page is
-			 * forcibly evicted as soon as possible.
+			 * page, set the read generation so the page is evicted
+			 * soon.
 			 *
 			 * Otherwise, if we read the page, or, if configured to
 			 * update the page's read generation and the page isn't
@@ -620,8 +620,8 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			 */
 			page = ref->page;
 			if (page->read_gen == WT_READGEN_NOTSET) {
-				if (evict_soon)
-					__wt_page_evict_soon(session, ref);
+				if (wont_need)
+					page->read_gen = WT_READGEN_WONTNEED;
 				else
 					__wt_cache_read_gen_new(session, page);
 			} else if (!LF_ISSET(WT_READ_NO_GEN))

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1421,7 +1421,7 @@ __split_multi_inmem(
 	 * leave the new page with the read generation unset.  Eviction will
 	 * set the read generation next time it visits this page.
 	 */
-	if (orig->read_gen != WT_READGEN_OLDEST)
+	if (!WT_READGEN_EVICT_SOON(orig->read_gen))
 		page->read_gen = orig->read_gen;
 
 	/* If there are no updates to apply to the page, we're done. */

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -309,8 +309,8 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			}
 
 			/*
-			 * If the page needs forced eviction, try to do that
-			 * now.
+			 * If the page was pulled into cache by our read, try
+			 * to evict it now.
 			 *
 			 * For eviction to have a chance, we first need to move
 			 * the walk point to the next page checkpoint will
@@ -322,7 +322,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * remember so we don't retry it.
 			 */
 			if (!WT_PAGE_IS_INTERNAL(page) &&
-			    page->read_gen == WT_READGEN_OLDEST &&
+			    page->read_gen == WT_READGEN_WONTNEED &&
 			    !evict_failed) {
 				if ((ret = __sync_evict_page(
 				    session, &walk, flags)) == 0) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -322,7 +322,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * remember so we don't retry it.
 			 */
 			if (!WT_PAGE_IS_INTERNAL(page) &&
-			    page->read_gen == WT_READGEN_WONTNEED &&
+			    page->read_gen == WT_READGEN_WONT_NEED &&
 			    !evict_failed) {
 				if ((ret = __sync_evict_page(
 				    session, &walk, flags)) == 0) {

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -177,7 +177,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 	 * The lowest possible page read-generation has a special meaning, it
 	 * marks a page for forcible eviction; don't let it happen by accident.
 	 */
-	cache->read_gen = WT_READGEN_START_VALUE;
+	cache->read_gen = cache->read_gen_oldest = WT_READGEN_START_VALUE;
 
 	/*
 	 * The target size must be lower than the trigger size or we will never

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -71,7 +71,7 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
 	page = ref->page;
 
 	/* Any page set to the oldest generation should be discarded. */
-	if (page->read_gen == WT_READGEN_OLDEST)
+	if (WT_READGEN_EVICT_SOON(page->read_gen))
 		return (WT_READGEN_OLDEST);
 
 	/* Any page from a dead tree is a great choice. */
@@ -1274,7 +1274,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		read_gen_oldest = WT_READGEN_OLDEST;
 		for (candidates = 0; candidates < entries; ++candidates) {
 			read_gen_oldest = queue->evict_queue[candidates].score;
-			if (read_gen_oldest != WT_READGEN_OLDEST)
+			if (!WT_READGEN_EVICT_SOON(read_gen_oldest))
 				break;
 		}
 
@@ -1286,7 +1286,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		 * 50% of the entries were at the oldest read generation, take
 		 * all of them.
 		 */
-		if (read_gen_oldest == WT_READGEN_OLDEST)
+		if (WT_READGEN_EVICT_SOON(read_gen_oldest))
 			queue->evict_candidates = entries;
 		else if (candidates > entries / 2)
 			queue->evict_candidates = candidates;
@@ -1995,7 +1995,7 @@ fast:		/* If the page can't be evicted, give up. */
 	 */
 	if (ref != NULL) {
 		if (__wt_ref_is_root(ref) || evict == start || give_up ||
-		    ref->page->read_gen == WT_READGEN_OLDEST ||
+		    WT_READGEN_EVICT_SOON(ref->page->read_gen) ||
 		    ref->page->memory_footprint >= btree->splitmempage) {
 			if (restarts == 0)
 				WT_STAT_CONN_INCR(
@@ -2003,7 +2003,7 @@ fast:		/* If the page can't be evicted, give up. */
 			WT_RET(__wt_page_release(cache->walk_session,
 			    ref, WT_READ_NO_EVICT));
 			ref = NULL;
-		} else if (ref->page->read_gen == WT_READGEN_OLDEST)
+		} else if (WT_READGEN_EVICT_SOON(ref->page->read_gen))
 			WT_RET_NOTFOUND_OK(__wt_tree_walk_count(
 			    session, &ref, &refs_walked, walk_flags));
 		btree->evict_ref = ref;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1271,7 +1271,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		 * system.  The queue is sorted, find the first "normal"
 		 * generation.
 		 */
-		read_gen_oldest = WT_READGEN_OLDEST;
+		read_gen_oldest = WT_READGEN_START_VALUE;
 		for (candidates = 0; candidates < entries; ++candidates) {
 			read_gen_oldest = queue->evict_queue[candidates].score;
 			if (!WT_READGEN_EVICT_SOON(read_gen_oldest))

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -617,7 +617,7 @@ struct __wt_page {
 	 */
 #define	WT_READGEN_NOTSET	0
 #define	WT_READGEN_OLDEST	1
-#define	WT_READGEN_WONTNEED	2
+#define	WT_READGEN_WONT_NEED	2
 #define	WT_READGEN_EVICT_SOON(readgen) 					\
 	((readgen) != WT_READGEN_NOTSET && (readgen) < WT_READGEN_START_VALUE)
 #define	WT_READGEN_START_VALUE	100

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -617,6 +617,9 @@ struct __wt_page {
 	 */
 #define	WT_READGEN_NOTSET	0
 #define	WT_READGEN_OLDEST	1
+#define	WT_READGEN_WONTNEED	2
+#define	WT_READGEN_EVICT_SOON(readgen) 					\
+	((readgen) != WT_READGEN_NOTSET && (readgen) < WT_READGEN_START_VALUE)
 #define	WT_READGEN_START_VALUE	100
 #define	WT_READGEN_STEP		100
 	uint64_t read_gen;

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1385,7 +1385,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * tree, then perform a general check if eviction will be possible.
 	 */
 	page = ref->page;
-	if (page->read_gen != WT_READGEN_OLDEST ||
+	if (!WT_READGEN_EVICT_SOON(page->read_gen) ||
 	    LF_ISSET(WT_READ_NO_EVICT) ||
 	    F_ISSET(session, WT_SESSION_NO_EVICTION) ||
 	    btree->evict_disabled > 0 ||

--- a/test/suite/test_colgap.py
+++ b/test/suite/test_colgap.py
@@ -176,7 +176,7 @@ class test_colmax(wttest.WiredTigerTestCase):
 
         # Confirm searching past the end of the table works.
         if not self.bulk:
-            cursor.set_key(recno)
+            cursor.set_key(simple_key(cursor, recno))
             self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
 
         # Insert the big record.
@@ -191,18 +191,18 @@ class test_colmax(wttest.WiredTigerTestCase):
             cursor = self.session.open_cursor(uri, None, None)
 
         # Search for the large record.
-        cursor.set_key(recno)
+        cursor.set_key(simple_key(cursor, recno))
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.get_value(), simple_value(cursor, recno))
 
         # Update it.
         cursor[simple_key(cursor, recno)] = simple_value(cursor, 37)
-        cursor.set_key(recno)
+        cursor.set_key(simple_key(cursor, recno))
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.get_value(), simple_value(cursor, 37))
 
         # Remove it.
-        cursor.set_key(recno)
+        cursor.set_key(simple_key(cursor, recno))
         self.assertEqual(cursor.remove(), 0)
         cursor.set_key(simple_key(cursor, recno))
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)


### PR DESCRIPTION
Previously, checkpoint attempted to push out any page requiring forced eviction.  With this change, pages read into cache by checkpoint are marked with a different read generation, so that checkpoint can distinguish between pages it read (from lookaside) and big / hot pages that happen to be in cache when a checkpoint runs.