### PR TITLE
WT-3665 change format to configure the WiredTiger checkpoint thread

### DIFF
--- a/test/format/config.h
+++ b/test/format/config.h
@@ -230,6 +230,10 @@ static CONFIG c[] = {
 	  "type of logging compression " COMPRESSION_LIST,
 	  C_IGNORE|C_STRING, 0, 0, 0, NULL, &g.c_logging_compression },
 
+	{ "logging_file_max",
+	  "maximum log file size in KB",
+	  0x0, 100, 512000, 2097152, &g.c_logging_file_max, NULL },
+
 	{ "logging_prealloc",
 	  "if log file pre-allocation configured",		/* 50% */
 	  C_BOOL, 50, 0, 0, &g.c_logging_prealloc, NULL },

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -102,8 +102,16 @@ static CONFIG c[] = {
 	  0x0, 1, 100, 100 * 1024, &g.c_cache, NULL },
 
 	{ "checkpoints",
-	  "if periodic checkpoints are done",			/* 95% */
-	  C_BOOL, 95, 0, 0, &g.c_checkpoints, NULL },
+	  "type of checkpoints (on | off | wiredtiger)",
+	  C_IGNORE|C_STRING, 0, 0, 0, NULL, &g.c_checkpoint},
+
+	{ "checkpoint_log_size",
+	  "MB of log to wait if wiredtiger checkpoints configured",
+	  0x0, 1, 20, 1024, &g.c_checkpoint_log_size, NULL},
+
+	{ "checkpoint_wait",
+	  "seconds to wait if wiredtiger checkpoints configured",
+	  0x0, 5, 100, 3600, &g.c_checkpoint_wait, NULL},
 
 	{ "checksum",
 	  "type of checksums (on | off | uncompressed)",

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -107,7 +107,7 @@ static CONFIG c[] = {
 
 	{ "checkpoint_log_size",
 	  "MB of log to wait if wiredtiger checkpoints configured",
-	  0x0, 1, 20, 1024, &g.c_checkpoint_log_size, NULL},
+	  0x0, 20, 200, 1024, &g.c_checkpoint_log_size, NULL},
 
 	{ "checkpoint_wait",
 	  "seconds to wait if wiredtiger checkpoints configured",

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -182,8 +182,8 @@ typedef struct {
 	uint32_t c_leaf_page_max;
 	uint32_t c_leak_memory;
 	uint32_t c_logging;
-	char	*c_logging_compression;
 	uint32_t c_logging_archive;
+	char	*c_logging_compression;
 	uint32_t c_logging_file_max;
 	uint32_t c_logging_prealloc;
 	uint32_t c_long_running_txn;

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -182,8 +182,9 @@ typedef struct {
 	uint32_t c_leaf_page_max;
 	uint32_t c_leak_memory;
 	uint32_t c_logging;
-	uint32_t c_logging_archive;
 	char	*c_logging_compression;
+	uint32_t c_logging_archive;
+	uint32_t c_logging_file_max;
 	uint32_t c_logging_prealloc;
 	uint32_t c_long_running_txn;
 	uint32_t c_lsm_worker_threads;

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -151,7 +151,9 @@ typedef struct {
 	uint32_t c_bloom_hash_count;
 	uint32_t c_bloom_oldest;
 	uint32_t c_cache;
-	uint32_t c_checkpoints;
+	char	*c_checkpoint;
+	uint32_t c_checkpoint_log_size;
+	uint32_t c_checkpoint_wait;
 	char	*c_checksum;
 	uint32_t c_chunk_size;
 	uint32_t c_compact;
@@ -215,6 +217,11 @@ typedef struct {
 #define	ROW				2
 #define	VAR				3
 	u_int type;				/* File type's flag value */
+
+#define	CHECKPOINT_OFF			1
+#define	CHECKPOINT_ON			2
+#define	CHECKPOINT_WIREDTIGER		3
+	u_int c_checkpoint_flag;		/* Checkpoint flag value */
 
 #define	CHECKSUM_OFF			1
 #define	CHECKSUM_ON			2

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -175,7 +175,7 @@ wts_ops(int lastrun)
 	if (g.c_backups)
 		testutil_check(
 		    __wt_thread_create(NULL, &backup_tid, backup, NULL));
-	if (g.c_checkpoints)
+	if (g.c_checkpoint_flag == CHECKPOINT_ON)
 		testutil_check(__wt_thread_create(
 		    NULL, &checkpoint_tid, checkpoint, NULL));
 	if (g.c_compact)
@@ -252,7 +252,7 @@ wts_ops(int lastrun)
 		testutil_check(__wt_thread_join(NULL, alter_tid));
 	if (g.c_backups)
 		testutil_check(__wt_thread_join(NULL, backup_tid));
-	if (g.c_checkpoints)
+	if (g.c_checkpoint_flag == CHECKPOINT_ON)
 		testutil_check(__wt_thread_join(NULL, checkpoint_tid));
 	if (g.c_compact)
 		testutil_check(__wt_thread_join(NULL, compact_tid));

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -185,6 +185,12 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
 	if (DATASOURCE("lsm") || g.c_cache < 20)
 		CONFIG_APPEND(p, ",eviction_dirty_trigger=95");
 
+	/* Checkpoints. */
+	if (g.c_checkpoint_flag == CHECKPOINT_WIREDTIGER)
+		CONFIG_APPEND(p,
+		    ",checkpoint=(wait=%" PRIu32 ",log_size=%" PRIu32 ")",
+		    g.c_checkpoint_wait, MEGABYTE(g.c_checkpoint_log_size));
+
 	/* Eviction worker configuration. */
 	if (g.c_evict_max != 0)
 		CONFIG_APPEND(p,
@@ -199,6 +205,7 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
 		    g.c_logging_prealloc ? 1 : 0,
 		    compressor(g.c_logging_compression_flag));
 
+	/* Encryption. */
 	if (g.c_encryption)
 		CONFIG_APPEND(p,
 		    ",encryption=(name=%s)", encryptor(g.c_encryption_flag));

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -199,10 +199,11 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
 	/* Logging configuration. */
 	if (g.c_logging)
 		CONFIG_APPEND(p,
-		    ",log=(enabled=true,archive=%d,prealloc=%d"
-		    ",compressor=\"%s\")",
+		    ",log=(enabled=true,archive=%d,"
+		    "prealloc=%d,file_max=%" PRIu32 ",compressor=\"%s\")",
 		    g.c_logging_archive ? 1 : 0,
 		    g.c_logging_prealloc ? 1 : 0,
+		    KILOBYTE(g.c_logging_file_max),
 		    compressor(g.c_logging_compression_flag));
 
 	/* Encryption. */


### PR DESCRIPTION
@sueloverso, the reason I wanted a review from you is the library checkpoint configuration.

When configuring the library checkpoint thread, I'm waiting between 1 and 20 MB of log file between checkpoints (max 1024MB), and between 5 and 100 seconds (max 3600). Does that sound reasonable to you?
