### PR TITLE
WT-3616 format failed to report a stuck cache

### DIFF
--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -111,10 +111,11 @@ __async_new_op_alloc(WT_SESSION_IMPL *session, const char *uri,
 	WT_CONNECTION_IMPL *conn;
 	uint32_t i, save_i, view;
 
+	*opp = NULL;
+
 	conn = S2C(session);
 	async = conn->async;
 	WT_STAT_CONN_INCR(session, async_op_alloc);
-	*opp = NULL;
 
 retry:
 	op = NULL;

--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -22,8 +22,9 @@ __async_op_dequeue(WT_CONNECTION_IMPL *conn, WT_SESSION_IMPL *session,
 	uint64_t sleep_usec;
 	uint32_t tries;
 
-	async = conn->async;
 	*op = NULL;
+
+	async = conn->async;
 	/*
 	 * Wait for work to do.  Work is available when async->head moves.
 	 * Then grab the slot containing the work.  If we lose, try again.
@@ -125,8 +126,9 @@ __async_worker_cursor(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op,
 	WT_DECL_RET;
 	WT_SESSION *wt_session;
 
-	wt_session = (WT_SESSION *)session;
 	*cursorp = NULL;
+
+	wt_session = (WT_SESSION *)session;
 	/*
 	 * Compact doesn't need a cursor.
 	 */

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -53,14 +53,14 @@ __wt_block_checkpoint_load(WT_SESSION_IMPL *session, WT_BLOCK *block,
 	WT_DECL_RET;
 	uint8_t *endp;
 
-	ci = NULL;
-
 	/*
 	 * Sometimes we don't find a root page (we weren't given a checkpoint,
 	 * or the checkpoint was empty).  In that case we return an empty root
 	 * address, set that up now.
 	 */
 	*root_addr_sizep = 0;
+
+	ci = NULL;
 
 #ifdef HAVE_VERBOSE
 	if (WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT)) {

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -150,10 +150,11 @@ __wt_block_open(WT_SESSION_IMPL *session,
 	uint64_t bucket, hash;
 	uint32_t flags;
 
+	*blockp = block = NULL;
+
 	__wt_verbose(session, WT_VERB_BLOCK, "open: %s", filename);
 
 	conn = S2C(session);
-	*blockp = block = NULL;
 	hash = __wt_hash_city64(filename, strlen(filename));
 	bucket = hash % WT_HASH_ARRAY_SIZE;
 	__wt_spin_lock(session, &conn->block_lock);

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -220,6 +220,8 @@ __wt_compact_page_skip(
 	u_int type;
 
 	WT_UNUSED(context);
+	*skipp = false;				/* Default to reading */
+
 	/*
 	 * Skip deleted pages, rewriting them doesn't seem useful; in a better
 	 * world we'd write the parent to delete the page.
@@ -228,8 +230,6 @@ __wt_compact_page_skip(
 		*skipp = true;
 		return (0);
 	}
-
-	*skipp = false;				/* Default to reading */
 
 	/*
 	 * If the page is in-memory, we want to look at it (it may have been

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -112,10 +112,7 @@ __page_out_int(WT_SESSION_IMPL *session, WT_PAGE **pagep, bool rewrite)
 		break;
 	}
 
-	/*
-	 * Update the cache's information. Don't count rewrites or checkpoint
-	 * I/O as eviction, there's no guarantee we are making real progress.
-	 */
+	/* Update the cache's information. */
 	__wt_cache_page_evict(session, page, rewrite);
 
 	dsk = (WT_PAGE_HEADER *)page->dsk;

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -116,8 +116,7 @@ __page_out_int(WT_SESSION_IMPL *session, WT_PAGE **pagep, bool rewrite)
 	 * Update the cache's information. Don't count rewrites or checkpoint
 	 * I/O as eviction, there's no guarantee we are making real progress.
 	 */
-	__wt_cache_page_evict(session, page,
-	    !rewrite && !F_ISSET_ATOMIC(page, WT_PAGE_CHECKPOINT_READ));
+	__wt_cache_page_evict(session, page, rewrite);
 
 	dsk = (WT_PAGE_HEADER *)page->dsk;
 	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -112,8 +112,12 @@ __page_out_int(WT_SESSION_IMPL *session, WT_PAGE **pagep, bool rewrite)
 		break;
 	}
 
-	/* Update the cache's information. */
-	__wt_cache_page_evict(session, page, rewrite);
+	/*
+	 * Update the cache's information. Don't count rewrites or checkpoint
+	 * I/O as eviction, there's no guarantee we are making real progress.
+	 */
+	__wt_cache_page_evict(session, page,
+	    !rewrite && !F_ISSET_ATOMIC(page, WT_PAGE_CHECKPOINT_READ));
 
 	dsk = (WT_PAGE_HEADER *)page->dsk;
 	if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -312,12 +312,13 @@ __inmem_col_var_repeats(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t *np)
 	const WT_PAGE_HEADER *dsk;
 	uint32_t i;
 
+	*np = 0;
+
 	btree = S2BT(session);
 	dsk = page->dsk;
 	unpack = &_unpack;
 
 	/* Walk the page, counting entries for the repeats array. */
-	*np = 0;
 	WT_CELL_FOREACH(btree, dsk, cell, unpack, i) {
 		__wt_cell_unpack(cell, unpack);
 		if (__wt_cell_rle(unpack) > 1)

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -304,7 +304,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_ITEM tmp;
 	WT_PAGE *page;
 	size_t addr_size;
-	uint32_t new_state, previous_state;
+	uint32_t flags, new_state, previous_state;
 	const uint8_t *addr;
 	bool timer;
 
@@ -372,9 +372,11 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * the allocated copy of the disk image on return, the in-memory object
 	 * steals it.
 	 */
-	WT_ERR(__wt_page_inmem(session, ref, tmp.data,
-	    WT_DATA_IN_ITEM(&tmp) ?
-	    WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page));
+	flags =
+	    WT_DATA_IN_ITEM(&tmp) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED;
+	if (WT_SESSION_IS_CHECKPOINT(session))
+		LF_SET(WT_PAGE_CHECKPOINT_READ);
+	WT_ERR(__wt_page_inmem(session, ref, tmp.data, flags, &page));
 	tmp.mem = NULL;
 
 skip_read:

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -296,7 +296,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
  *	Read a page from the file.
  */
 static int
-__page_read(WT_SESSION_IMPL *session, WT_REF *ref)
+__page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 {
 	struct timespec start, stop;
 	WT_BTREE *btree;
@@ -304,7 +304,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_ITEM tmp;
 	WT_PAGE *page;
 	size_t addr_size;
-	uint32_t flags, new_state, previous_state;
+	uint32_t page_flags, new_state, previous_state;
 	const uint8_t *addr;
 	bool timer;
 
@@ -372,11 +372,12 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * the allocated copy of the disk image on return, the in-memory object
 	 * steals it.
 	 */
-	flags =
+	page_flags =
 	    WT_DATA_IN_ITEM(&tmp) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED;
-	if (WT_SESSION_IS_CHECKPOINT(session))
-		LF_SET(WT_PAGE_CHECKPOINT_READ);
-	WT_ERR(__wt_page_inmem(session, ref, tmp.data, flags, &page));
+	if (LF_ISSET(WT_READ_NO_EVICT) ||
+	    F_ISSET(session, WT_SESSION_NO_EVICTION))
+		FLD_SET(page_flags, WT_PAGE_READ_NO_EVICT);
+	WT_ERR(__wt_page_inmem(session, ref, tmp.data, page_flags, &page));
 	tmp.mem = NULL;
 
 skip_read:
@@ -501,7 +502,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			if (!LF_ISSET(WT_READ_NO_EVICT))
 				WT_RET(__wt_cache_eviction_check(
 				    session, 1, NULL));
-			WT_RET(__page_read(session, ref));
+			WT_RET(__page_read(session, ref, flags));
 
 			/*
 			 * We just read a page, don't evict it before we have a

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -696,9 +696,10 @@ __verify_overflow_cell(
 	const WT_PAGE_HEADER *dsk;
 	uint32_t cell_num, i;
 
+	*found = false;
+
 	btree = S2BT(session);
 	unpack = &_unpack;
-	*found = false;
 
 	/*
 	 * If a tree is empty (just created), it won't have a disk image;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -23,9 +23,10 @@ __search_insert_append(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	WT_ITEM key;
 	int cmp, i;
 
+	*donep = 0;
+
 	btree = S2BT(session);
 	collator = btree->collator;
-	*donep = 0;
 
 	if ((ins = WT_SKIP_LAST(ins_head)) == NULL)
 		return (0);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -346,12 +346,12 @@ __config_next(WT_CONFIG *conf, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value)
 		"", 0, 1, WT_CONFIG_ITEM_BOOL
 	};
 
-	out = key;
-	utf8_remain = 0;
-
-	key->len = 0;
 	/* Keys with no value default to true. */
 	*value = true_value;
+
+	out = key;
+	utf8_remain = 0;
+	key->len = 0;
 
 	if (conf->go == NULL)
 		conf->go = gostruct;

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -73,6 +73,7 @@ wiredtiger_config_parser_open(WT_SESSION *wt_session,
 	WT_SESSION_IMPL *session;
 
 	*config_parserp = NULL;
+
 	session = (WT_SESSION_IMPL *)wt_session;
 
 	WT_RET(__wt_calloc_one(session, &config_parser));

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -295,11 +295,11 @@ __wt_cache_destroy(WT_SESSION_IMPL *session)
 		return (0);
 
 	/* The cache should be empty at this point.  Complain if not. */
-	if (cache->pages_inmem != cache->pages_evict)
+	if (cache->pages_inmem != cache->pages_evicted)
 		__wt_errx(session,
 		    "cache server: exiting with %" PRIu64 " pages in "
 		    "memory and %" PRIu64 " pages evicted",
-		    cache->pages_inmem, cache->pages_evict);
+		    cache->pages_inmem, cache->pages_evicted);
 	if (cache->bytes_image != 0)
 		__wt_errx(session,
 		    "cache server: exiting with %" PRIu64 " image bytes in "

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -575,6 +575,7 @@ __cache_pool_adjust(WT_SESSION_IMPL *session,
 	bool busy, decrease_ok, grow, pool_full;
 
 	*adjustedp = false;
+
 	cp = __wt_process.cache_pool;
 	grow = false;
 	pool_full = cp->currently_used >= cp->size;

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -159,9 +159,9 @@ __sweep_discard_trees(WT_SESSION_IMPL *session, u_int *dead_handlesp)
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 
-	conn = S2C(session);
-
 	*dead_handlesp = 0;
+
+	conn = S2C(session);
 
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {
 		if (WT_DHANDLE_CAN_DISCARD(dhandle))

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -54,6 +54,7 @@ __curjoin_iter_init(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin,
 	WT_CURSOR_JOIN_ITER *iter;
 
 	*iterp = NULL;
+
 	WT_RET(__wt_calloc_one(session, iterp));
 	iter = *iterp;
 	iter->cjoin = cjoin;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -458,8 +458,8 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 		}
 #endif
 	}
-	return (0);
 #endif
+	return (0);
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -377,13 +377,11 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
-	uint64_t orig_pages_evict;
 
 	*did_work = false;
 
 	conn = S2C(session);
 	cache = conn->cache;
-	orig_pages_evict = cache->pages_evict;
 
 	/* Evict pages from the cache as needed. */
 	WT_RET(__evict_pass(session));
@@ -411,15 +409,17 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 		__wt_readunlock(session, &conn->dhandle_lock);
 		WT_RET(ret);
 
-		*did_work = orig_pages_evict != cache->pages_evict;
+		/* Make sure we'll notice next time we're stuck. */
+		cache->last_eviction_progress = 0;
 		return (0);
 	}
 
-	if (orig_pages_evict != cache->pages_evict)  {
+	/* Eviction is stuck, check if we have made progress. */
+	if (cache->last_eviction_progress != cache->eviction_progress) {
 #if defined(HAVE_DIAGNOSTIC) || defined(HAVE_VERBOSE)
-		/* Eviction is stuck, but still did work, save the time. */
 		__wt_epoch(session, &cache->stuck_time);
 #endif
+		cache->last_eviction_progress = cache->eviction_progress;
 		*did_work = true;
 		return (0);
 	}
@@ -630,7 +630,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_TXN_GLOBAL *txn_global;
-	uint64_t oldest_id, pages_evicted, prev_oldest_id;
+	uint64_t eviction_progress, oldest_id, prev_oldest_id;
 	u_int loop;
 
 	conn = S2C(session);
@@ -638,7 +638,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 	txn_global = &conn->txn_global;
 
 	/* Track whether pages are being evicted and progress is made. */
-	pages_evicted = cache->pages_evict;
+	eviction_progress = cache->eviction_progress;
 	prev_oldest_id = txn_global->oldest_id;
 	WT_CLEAR(prev);
 
@@ -713,7 +713,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 		 * treat the cache as stuck and start rolling back
 		 * transactions and writing updates to the lookaside table.
 		 */
-		if (pages_evicted == cache->pages_evict) {
+		if (eviction_progress == cache->eviction_progress) {
 			if (WT_TIMEDIFF_MS(now, prev) >= 20 &&
 			    F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD |
 			    WT_CACHE_EVICT_DIRTY_HARD)) {
@@ -765,7 +765,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 				    cache->evict_aggressive_score);
 			}
 			loop = 0;
-			pages_evicted = cache->pages_evict;
+			eviction_progress = cache->eviction_progress;
 		}
 	}
 	return (0);
@@ -967,7 +967,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	uint64_t delta_msec, delta_pages;
-	uint64_t pgs_evicted_cur, pgs_evicted_persec_cur, time_diff;
+	uint64_t eviction_progress, eviction_progress_rate, time_diff;
 	int32_t cur_threads, i, target_threads, thread_surplus;
 
 	conn = S2C(session);
@@ -980,16 +980,16 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 	if (conn->evict_threads_max == conn->evict_threads_min)
 		return;
 
-	pgs_evicted_cur = 0;
+	eviction_progress_rate = 0;
 
 	__wt_epoch(session, &current_time);
-	time_diff = WT_TIMEDIFF_MS(current_time, conn->evict_tune_last_time);
+	time_diff = WT_TIMEDIFF_MS(current_time, cache->evict_tune_last_time);
 
 	/*
 	 * If we have reached the stable state and have not run long enough to
 	 * surpass the forced re-tuning threshold, return.
 	 */
-	if (conn->evict_tune_stable) {
+	if (cache->evict_tune_stable) {
 		if (time_diff < EVICT_FORCE_RETUNE)
 			return;
 
@@ -997,11 +997,11 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 		 * Stable state was reached a long time ago. Let's re-tune.
 		 * Reset all the state.
 		 */
-		conn->evict_tune_stable = false;
-		conn->evict_tune_last_action_time.tv_sec = 0;
-		conn->evict_tune_pgs_last = 0;
-		conn->evict_tune_num_points = 0;
-		conn->evict_tune_pg_sec_max = 0;
+		cache->evict_tune_stable = false;
+		cache->evict_tune_last_action_time.tv_sec = 0;
+		cache->evict_tune_progress_last = 0;
+		cache->evict_tune_num_points = 0;
+		cache->evict_tune_progress_rate_max = 0;
 
 		/* Reduce the number of eviction workers by one */
 		thread_surplus =
@@ -1025,10 +1025,10 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 			return;
 
 	/*
-	 * Measure the number of evicted pages so far. Eviction rate correlates
-	 * to performance, so this is our metric of success.
+	 * Measure the evicted progress so far. Eviction rate correlates to
+	 * performance, so this is our metric of success.
 	 */
-	pgs_evicted_cur = cache->pages_evict;
+	eviction_progress = cache->eviction_progress;
 
 	/*
 	 * If we have recorded the number of pages evicted at the end of
@@ -1037,21 +1037,21 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 	 * measurement interval.
 	 * Otherwise, we just record the number of evicted pages and return.
 	 */
-	if (conn->evict_tune_pgs_last == 0)
+	if (cache->evict_tune_progress_last == 0)
 		goto done;
 
-	delta_msec = WT_TIMEDIFF_MS(current_time, conn->evict_tune_last_time);
-	delta_pages = pgs_evicted_cur - conn->evict_tune_pgs_last;
-	pgs_evicted_persec_cur = (delta_pages * WT_THOUSAND) / delta_msec;
-	conn->evict_tune_num_points++;
+	delta_msec = WT_TIMEDIFF_MS(current_time, cache->evict_tune_last_time);
+	delta_pages = eviction_progress - cache->evict_tune_progress_last;
+	eviction_progress_rate = (delta_pages * WT_THOUSAND) / delta_msec;
+	cache->evict_tune_num_points++;
 
 	/*
 	 * Keep track of the maximum eviction throughput seen and the number
 	 * of workers corresponding to that throughput.
 	 */
-	if (pgs_evicted_persec_cur > conn->evict_tune_pg_sec_max) {
-		conn->evict_tune_pg_sec_max = pgs_evicted_persec_cur;
-		conn->evict_tune_workers_best =
+	if (eviction_progress_rate > cache->evict_tune_progress_rate_max) {
+		cache->evict_tune_progress_rate_max = eviction_progress_rate;
+		cache->evict_tune_workers_best =
 		    conn->evict_threads.current_threads;
 	}
 
@@ -1065,8 +1065,8 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 	 * we will go back to the best observed number of workers and
 	 * settle into a stable state.
 	 */
-	if (conn->evict_tune_num_points >= conn->evict_tune_datapts_needed) {
-		if (conn->evict_tune_workers_best ==
+	if (cache->evict_tune_num_points >= cache->evict_tune_datapts_needed) {
+		if (cache->evict_tune_workers_best ==
 		    conn->evict_threads.current_threads &&
 		    conn->evict_threads.current_threads <
 		    conn->evict_threads_max) {
@@ -1074,7 +1074,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 			 * Keep adding workers. We will check again
 			 * at the next check point.
 			 */
-			conn->evict_tune_datapts_needed += WT_MIN(
+			cache->evict_tune_datapts_needed += WT_MIN(
 			    EVICT_TUNE_DATAPT_MIN,
 			    (conn->evict_threads_max -
 			    conn->evict_threads.current_threads) /
@@ -1087,7 +1087,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 			 */
 			thread_surplus =
 			    (int32_t)conn->evict_threads.current_threads -
-			    (int32_t)conn->evict_tune_workers_best;
+			    (int32_t)cache->evict_tune_workers_best;
 
 			for (i = 0; i < thread_surplus; i++) {
 				__wt_thread_group_stop_one(
@@ -1097,8 +1097,8 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 			}
 			WT_STAT_CONN_SET(session,
 			    cache_eviction_stable_state_workers,
-			    conn->evict_tune_workers_best);
-			conn->evict_tune_stable = true;
+			    cache->evict_tune_workers_best);
+			cache->evict_tune_stable = true;
 			WT_STAT_CONN_SET(session, cache_eviction_active_workers,
 			    conn->evict_threads.current_threads);
 			goto done;
@@ -1111,8 +1111,8 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 	 * we must accumulate before deciding if we should keep adding workers
 	 * or settle on a previously tried stable number of workers.
 	 */
-	if (conn->evict_tune_last_action_time.tv_sec == 0)
-		conn->evict_tune_datapts_needed = EVICT_TUNE_DATAPT_MIN;
+	if (cache->evict_tune_last_action_time.tv_sec == 0)
+		cache->evict_tune_datapts_needed = EVICT_TUNE_DATAPT_MIN;
 
 	if (F_ISSET(cache, WT_CACHE_EVICT_ALL)) {
 		cur_threads = (int32_t)conn->evict_threads.current_threads;
@@ -1129,14 +1129,14 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
 			__wt_verbose(session,
 			    WT_VERB_EVICTSERVER, "%s", "added worker thread");
 		}
-		conn->evict_tune_last_action_time = current_time;
+		cache->evict_tune_last_action_time = current_time;
 	}
 
 	WT_STAT_CONN_SET(session, cache_eviction_active_workers,
 	    conn->evict_threads.current_threads);
 
-done:	conn->evict_tune_last_time = current_time;
-	conn->evict_tune_pgs_last = pgs_evicted_cur;
+done:	cache->evict_tune_last_time = current_time;
+	cache->evict_tune_progress_last = eviction_progress;
 }
 
 /*
@@ -2263,7 +2263,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 	WT_DECL_RET;
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_STATE *txn_state;
-	uint64_t init_evict_count, max_pages_evicted;
+	uint64_t initial_progress, max_progress;
 	bool timer;
 
 	conn = S2C(session);
@@ -2290,7 +2290,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 	if (timer)
 		__wt_epoch(session, &enter);
 
-	for (init_evict_count = cache->pages_evict;; ret = 0) {
+	for (initial_progress = cache->eviction_progress;; ret = 0) {
 		/*
 		 * A pathological case: if we're the oldest transaction in the
 		 * system and the eviction server is stuck trying to find space,
@@ -2315,12 +2315,12 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 		if (!busy && txn_state->pinned_id != WT_TXN_NONE &&
 		    txn_global->current != txn_global->oldest_id)
 			busy = true;
-		max_pages_evicted = busy ? 5 : 20;
+		max_progress = busy ? 5 : 20;
 
 		/* See if eviction is still needed. */
 		if (!__wt_eviction_needed(session, busy, &pct_full) ||
-		    (pct_full < 100 &&
-		    cache->pages_evict > init_evict_count + max_pages_evicted))
+		    (pct_full < 100 && cache->eviction_progress >
+		    initial_progress + max_progress))
 			break;
 
 		/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -378,10 +378,9 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 
-	*did_work = false;
-
 	conn = S2C(session);
 	cache = conn->cache;
+	*did_work = false;
 
 	/* Evict pages from the cache as needed. */
 	WT_RET(__evict_pass(session));

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -411,7 +411,7 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
 		__wt_readunlock(session, &conn->dhandle_lock);
 		WT_RET(ret);
 
-		*did_work = true;
+		*did_work = orig_pages_evict != cache->pages_evict;
 		return (0);
 	}
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -585,7 +585,7 @@ struct __wt_page {
 	uint8_t type;			/* Page type */
 
 #define	WT_PAGE_BUILD_KEYS	0x01	/* Keys have been built in memory */
-#define	WT_PAGE_CHECKPOINT_READ	0x02	/* Page read for checkpoint */
+#define	WT_PAGE_READ_NO_EVICT	0x02	/* Page read with eviction disabled */
 #define	WT_PAGE_DISK_ALLOC	0x04	/* Disk image in allocated memory */
 #define	WT_PAGE_DISK_MAPPED	0x08	/* Disk image in mapped memory */
 #define	WT_PAGE_EVICT_LRU	0x10	/* Page is on the LRU queue */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -585,11 +585,11 @@ struct __wt_page {
 	uint8_t type;			/* Page type */
 
 #define	WT_PAGE_BUILD_KEYS	0x01	/* Keys have been built in memory */
-#define	WT_PAGE_READ_NO_EVICT	0x02	/* Page read with eviction disabled */
-#define	WT_PAGE_DISK_ALLOC	0x04	/* Disk image in allocated memory */
-#define	WT_PAGE_DISK_MAPPED	0x08	/* Disk image in mapped memory */
-#define	WT_PAGE_EVICT_LRU	0x10	/* Page is on the LRU queue */
-#define	WT_PAGE_OVERFLOW_KEYS	0x20	/* Page has overflow keys */
+#define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
+#define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
+#define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
+#define	WT_PAGE_OVERFLOW_KEYS	0x10	/* Page has overflow keys */
+#define	WT_PAGE_READ_NO_EVICT	0x20	/* Page read with eviction disabled */
 #define	WT_PAGE_SPLIT_INSERT	0x40	/* A leaf page was split for append */
 #define	WT_PAGE_UPDATE_IGNORE	0x80	/* Ignore updates on page discard */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -585,12 +585,13 @@ struct __wt_page {
 	uint8_t type;			/* Page type */
 
 #define	WT_PAGE_BUILD_KEYS	0x01	/* Keys have been built in memory */
-#define	WT_PAGE_DISK_ALLOC	0x02	/* Disk image in allocated memory */
-#define	WT_PAGE_DISK_MAPPED	0x04	/* Disk image in mapped memory */
-#define	WT_PAGE_EVICT_LRU	0x08	/* Page is on the LRU queue */
-#define	WT_PAGE_OVERFLOW_KEYS	0x10	/* Page has overflow keys */
-#define	WT_PAGE_SPLIT_INSERT	0x20	/* A leaf page was split for append */
-#define	WT_PAGE_UPDATE_IGNORE	0x40	/* Ignore updates on page discard */
+#define	WT_PAGE_CHECKPOINT_READ	0x02	/* Page read for checkpoint */
+#define	WT_PAGE_DISK_ALLOC	0x04	/* Disk image in allocated memory */
+#define	WT_PAGE_DISK_MAPPED	0x08	/* Disk image in mapped memory */
+#define	WT_PAGE_EVICT_LRU	0x10	/* Page is on the LRU queue */
+#define	WT_PAGE_OVERFLOW_KEYS	0x20	/* Page has overflow keys */
+#define	WT_PAGE_SPLIT_INSERT	0x40	/* A leaf page was split for append */
+#define	WT_PAGE_UPDATE_IGNORE	0x80	/* Ignore updates on page discard */
 	uint8_t flags_atomic;		/* Atomic flags, use F_*_ATOMIC */
 
 	uint8_t unused[2];		/* Unused padding */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -454,14 +454,9 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool rewrite)
 		}
 	}
 
-	/* Update pages and bytes evicted. */
+	/* Update bytes and pages evicted. */
 	(void)__wt_atomic_add64(&cache->bytes_evict, page->memory_footprint);
-
-	/* Rewriting pages in memory is accounted for separately. */
-	if (!rewrite)
-		(void)__wt_atomic_sub64(&cache->pages_inmem, 1);
-	else
-		(void)__wt_atomic_addv64(&cache->pages_evicted, 1);
+	(void)__wt_atomic_addv64(&cache->pages_evicted, 1);
 
 	/*
 	 * Track if eviction makes progress.  This is used in various places to

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -463,20 +463,20 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool rewrite)
 	else
 		(void)__wt_atomic_addv64(&cache->pages_evicted, 1);
 
-        /*
-         * Track if eviction makes progress.  This is used in various places to
-         * determine whether eviction is stuck.
-         *
-         * We don't count rewrites as progress.
-         *
-         * Further, if a page was read with eviction disabled, we don't count
-         * evicting a it as progress.  Since disabling eviction allows pages to
-         * be read even when the cache is full, we want to avoid workloads
-         * repeatedly reading a page with eviction disabled (e.g., from the
-         * metadata), then evicting that page and deciding that is a sign that
-         * eviction is unstuck.
-         */
-        if (!rewrite && !F_ISSET_ATOMIC(page, WT_PAGE_READ_NO_EVICT))
+	/*
+	 * Track if eviction makes progress.  This is used in various places to
+	 * determine whether eviction is stuck.
+	 *
+	 * We don't count rewrites as progress.
+	 *
+	 * Further, if a page was read with eviction disabled, we don't count
+	 * evicting a it as progress.  Since disabling eviction allows pages to
+	 * be read even when the cache is full, we want to avoid workloads
+	 * repeatedly reading a page with eviction disabled (e.g., from the
+	 * metadata), then evicting that page and deciding that is a sign that
+	 * eviction is unstuck.
+	 */
+	if (!rewrite && !F_ISSET_ATOMIC(page, WT_PAGE_READ_NO_EVICT))
 		(void)__wt_atomic_addv64(&cache->eviction_progress, 1);
 }
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -413,7 +413,7 @@ __wt_cache_page_image_incr(WT_SESSION_IMPL *session, uint32_t size)
  *	Evict pages from the cache.
  */
 static inline void
-__wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool eviction)
+__wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool rewrite)
 {
 	WT_BTREE *btree;
 	WT_CACHE *cache;
@@ -457,11 +457,27 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool eviction)
 	/* Update pages and bytes evicted. */
 	(void)__wt_atomic_add64(&cache->bytes_evict, page->memory_footprint);
 
-	/* Some "evictions" are just churn and don't count as progress. */
-	if (eviction)
-		(void)__wt_atomic_addv64(&cache->pages_evict, 1);
-	else
+	/* Rewriting pages in memory is accounted for separately. */
+	if (!rewrite)
 		(void)__wt_atomic_sub64(&cache->pages_inmem, 1);
+	else
+		(void)__wt_atomic_addv64(&cache->pages_evicted, 1);
+
+        /*
+         * Track if eviction makes progress.  This is used in various places to
+         * determine whether eviction is stuck.
+         *
+         * We don't count rewrites as progress.
+         *
+         * Further, if a page was read with eviction disabled, we don't count
+         * evicting a it as progress.  Since disabling eviction allows pages to
+         * be read even when the cache is full, we want to avoid workloads
+         * repeatedly reading a page with eviction disabled (e.g., from the
+         * metadata), then evicting that page and deciding that is a sign that
+         * eviction is unstuck.
+         */
+        if (!rewrite && !F_ISSET_ATOMIC(page, WT_PAGE_READ_NO_EVICT))
+		(void)__wt_atomic_addv64(&cache->eviction_progress, 1);
 }
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -64,7 +64,7 @@ struct __wt_cache {
 	uint64_t bytes_dirty_leaf;
 	uint64_t pages_dirty_leaf;
 	uint64_t bytes_evict;		/* Bytes/pages discarded by eviction */
-	volatile uint64_t pages_evicted;
+	uint64_t pages_evicted;
 	uint64_t bytes_image;		/* Bytes of disk images */
 	uint64_t bytes_inmem;		/* Bytes/pages in memory */
 	uint64_t pages_inmem;
@@ -72,7 +72,7 @@ struct __wt_cache {
 	uint64_t bytes_read;		/* Bytes read into memory */
 	uint64_t bytes_written;
 
-	uint64_t eviction_progress;	/* Eviction progress count */
+	volatile uint64_t eviction_progress;	/* Eviction progress count */
 	uint64_t last_eviction_progress;/* Tracked eviction progress */
 
 	uint64_t app_waits;		/* User threads waited for cache */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -64,13 +64,16 @@ struct __wt_cache {
 	uint64_t bytes_dirty_leaf;
 	uint64_t pages_dirty_leaf;
 	uint64_t bytes_evict;		/* Bytes/pages discarded by eviction */
-	volatile uint64_t pages_evict;
+	volatile uint64_t pages_evicted;
 	uint64_t bytes_image;		/* Bytes of disk images */
 	uint64_t bytes_inmem;		/* Bytes/pages in memory */
 	uint64_t pages_inmem;
 	uint64_t bytes_internal;	/* Bytes of internal pages */
 	uint64_t bytes_read;		/* Bytes read into memory */
 	uint64_t bytes_written;
+
+	uint64_t eviction_progress;	/* Eviction progress count */
+	uint64_t last_eviction_progress;/* Tracked eviction progress */
 
 	uint64_t app_waits;		/* User threads waited for cache */
 	uint64_t app_evicts;		/* Pages evicted by user threads */
@@ -108,6 +111,18 @@ struct __wt_cache {
 					   scrubs */
 
 	u_int overhead_pct;	        /* Cache percent adjustment */
+
+	/*
+	 * Eviction thread tuning information.
+	 */
+	uint32_t evict_tune_datapts_needed;         /* Data needed to tune */
+	struct timespec evict_tune_last_action_time;/* Time of last action */
+	struct timespec evict_tune_last_time;	    /* Time of last check */
+	uint32_t evict_tune_num_points;	            /* Number of values tried */
+	uint64_t evict_tune_progress_last;	    /* Progress counter */
+	uint64_t evict_tune_progress_rate_max;	    /* Max progress rate */
+	bool evict_tune_stable;	                    /* Are we stable? */
+	uint32_t evict_tune_workers_best;           /* Best performing value */
 
 	/*
 	 * Pass interrupt counter.

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -65,7 +65,6 @@ struct __wt_cache {
 	uint64_t pages_dirty_leaf;
 	uint64_t bytes_evict;		/* Bytes/pages discarded by eviction */
 	volatile uint64_t pages_evict;
-	uint64_t pages_evicted;		/* Pages evicted during a pass */
 	uint64_t bytes_image;		/* Bytes of disk images */
 	uint64_t bytes_inmem;		/* Bytes/pages in memory */
 	uint64_t pages_inmem;

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -128,7 +128,7 @@ __wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 static inline uint64_t
 __wt_cache_pages_inuse(WT_CACHE *cache)
 {
-	return (cache->pages_inmem - cache->pages_evict);
+	return (cache->pages_inmem - cache->pages_evicted);
 }
 
 /*

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -289,15 +289,6 @@ struct __wt_connection_impl {
 	uint32_t	 evict_threads_max;/* Max eviction threads */
 	uint32_t	 evict_threads_min;/* Min eviction threads */
 
-	uint32_t         evict_tune_datapts_needed;/* Data needed to tune */
-	struct timespec  evict_tune_last_action_time;/* Time of last action */
-	struct timespec  evict_tune_last_time;	/* Time of last check */
-	uint32_t         evict_tune_num_points;	/* Number of values tried */
-	uint64_t	 evict_tune_pgs_last;	/* Number of pages evicted */
-	uint64_t	 evict_tune_pg_sec_max;	/* Max throughput encountered */
-	bool             evict_tune_stable;	/* Are we stable? */
-	uint32_t	 evict_tune_workers_best;/* Best performing value */
-
 #define	WT_STATLOG_FILENAME	"WiredTigerStat.%d.%H"
 	WT_SESSION_IMPL *stat_session;	/* Statistics log session */
 	wt_thread_t	 stat_tid;	/* Statistics log thread */

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -159,11 +159,11 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	WT_DECL_RET;
 	WT_INSERT *new_ins = *new_insp;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
-
 	/* Clear references to memory we now own and must free on error. */
 	*new_insp = NULL;
+
+	/* Check for page write generation wrap. */
+	WT_RET(__page_write_gen_wrapped_check(page));
 
 	/*
 	 * Acquire the page's spinlock unless we already have exclusive access.
@@ -210,11 +210,11 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	u_int i;
 	bool simple;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
-
 	/* Clear references to memory we now own and must free on error. */
 	*new_insp = NULL;
+
+	/* Check for page write generation wrap. */
+	WT_RET(__page_write_gen_wrapped_check(page));
 
 	simple = true;
 	for (i = 0; i < skipdepth; i++)
@@ -265,11 +265,11 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	WT_UPDATE *obsolete, *upd = *updp;
 	uint64_t txn;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
-
 	/* Clear references to memory we now own and must free on error. */
 	*updp = NULL;
+
+	/* Check for page write generation wrap. */
+	WT_RET(__page_write_gen_wrapped_check(page));
 
 	/*
 	 * All structure setup must be flushed before the structure is entered

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -152,8 +152,9 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
 {
 	WT_TXN *txn;
 
-	txn = &session->txn;
 	*opp = NULL;
+
+	txn = &session->txn;
 
 	/*
 	 * We're about to perform an update.

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -345,14 +345,15 @@ __wt_log_needs_recovery(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn, bool *recp)
 	uint64_t dummy_txnid;
 	uint32_t dummy_fileid, dummy_optype, rectype;
 
-	conn = S2C(session);
-	log = conn->log;
-
 	/*
 	 * Default is to run recovery always (regardless of whether this
 	 * connection has logging enabled).
 	 */
 	*recp = true;
+
+	conn = S2C(session);
+	log = conn->log;
+
 	if (log == NULL)
 		return (0);
 
@@ -430,11 +431,11 @@ __wt_log_get_all_files(WT_SESSION_IMPL *session,
 
 	*filesp = NULL;
 	*countp = 0;
+	*maxid = 0;
 
 	id = 0;
 	log = S2C(session)->log;
 
-	*maxid = 0;
 	/*
 	 * These may be files needed by backup.  Force the current slot
 	 * to get written to the file.
@@ -1659,10 +1660,11 @@ __log_has_hole(WT_SESSION_IMPL *session,
 	size_t bufsz, rdlen;
 	char *buf, *zerobuf;
 
+	*hole = false;
+
 	conn = S2C(session);
 	log = conn->log;
 	remainder = log_size - offset;
-	*hole = false;
 
 	/*
 	 * It can be very slow looking for the last real record in the log

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -104,11 +104,11 @@ __log_slot_close(
 	int count;
 #endif
 
+	*releasep = false;
+
 	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SLOT));
-	WT_ASSERT(session, releasep != NULL);
 	conn = S2C(session);
 	log = conn->log;
-	*releasep = 0;
 	if (slot == NULL)
 		return (WT_NOTFOUND);
 retry:
@@ -149,7 +149,7 @@ retry:
 	 */
 	WT_STAT_CONN_INCR(session, log_slot_closes);
 	if (WT_LOG_SLOT_DONE(new_state))
-		*releasep = 1;
+		*releasep = true;
 	slot->slot_end_lsn = slot->slot_start_lsn;
 	/*
 	 * A thread setting the unbuffered flag sets the unbuffered size after

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -593,9 +593,9 @@ __wt_lsm_manager_pop_entry(
 	WT_LSM_MANAGER *manager;
 	WT_LSM_WORK_UNIT *entry;
 
+	*entryp = entry = NULL;
+
 	manager = &S2C(session)->lsm_manager;
-	*entryp = NULL;
-	entry = NULL;
 
 	/*
 	 * Pop the entry off the correct queue based on our work type.

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -77,6 +77,7 @@ __wt_lsm_get_chunk_to_flush(WT_SESSION_IMPL *session,
 	uint32_t i;
 
 	*chunkp = NULL;
+
 	chunk = evict_chunk = flush_chunk = NULL;
 
 	WT_ASSERT(session, lsm_tree->queue_ref > 0);
@@ -130,7 +131,6 @@ __wt_lsm_get_chunk_to_flush(WT_SESSION_IMPL *session,
 	}
 
 err:	__wt_lsm_tree_readunlock(session, lsm_tree);
-
 	*chunkp = chunk;
 	return (ret);
 }
@@ -168,8 +168,8 @@ __wt_lsm_work_switch(
 
 	/* We've become responsible for freeing the work unit. */
 	entry = *entryp;
-	*ran = false;
 	*entryp = NULL;
+	*ran = false;
 
 	if (entry->lsm_tree->need_switch) {
 		WT_WITH_SCHEMA_LOCK(session,

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -54,6 +54,7 @@ __lsm_worker_general_op(
 	bool force;
 
 	*completed = false;
+
 	/*
 	 * Return if this thread cannot process a bloom, drop or flush.
 	 */

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -28,11 +28,10 @@ __wt_posix_directory_list(WT_FILE_SYSTEM *file_system,
 	int tret;
 	char **entries;
 
-	session = (WT_SESSION_IMPL *)wt_session;
-
 	*dirlistp = NULL;
 	*countp = 0;
 
+	session = (WT_SESSION_IMPL *)wt_session;
 	dirp = NULL;
 	dirallocsz = 0;
 	entries = NULL;


### PR DESCRIPTION
@agorrod, there are two changes here.

48cc54c sets a flag when a page is read on behalf of checkpoint, and then doesn't count evicting that page towards eviction progress. I am hesitant to not count "normal" eviction of metadata or lookaside pages towards eviction progress, it's not impossible that those pages could consume a reasonable piece of the cache and evicting them could be progress. So instead, I don't count the eviction of pages read on behalf of a checkpoint as eviction progress. (To be clear, I'm not excited about this approach, and it's a special case I'd rather not have, I just couldn't think of anything I liked better.)

4d8c187 restructures `__evict_server()` to remove the `WT_CACHE.pages_evicted` field.  In summary, I think `WT_CACHE.pages_evicted` can be more replaced with comparing the value of `WT_CACHE.pages_evict` when `__evict_server()` is entered, against its current value when evaluating if work has been done. The original code was relatively tricky though, I might have missed something.