### PR TITLE
WT-3672 Test format failure with commit timestamp older than oldest timestamp

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -821,7 +821,7 @@ extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, 
 extern int __wt_txn_global_query_timestamp( WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_timestamp_validate(WT_SESSION_IMPL *session, wt_timestamp_t *ts, WT_CONFIG_ITEM *cval, bool cmp_oldest, bool cmp_stable, bool cmp_commit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *ts, WT_CONFIG_ITEM *cval, bool cmp_oldest, bool cmp_stable, bool cmp_commit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_clear_commit_timestamp(WT_SESSION_IMPL *session);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -446,7 +446,7 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 
 		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
 		WT_RET(__wt_timestamp_validate(session,
-		    &ts, &cval, true, false, false));
+		    "read", &ts, &cval, true, false, false));
 		__wt_timestamp_set(&txn->read_timestamp, &ts);
 		__wt_txn_set_read_timestamp(session);
 		txn->isolation = WT_ISO_SNAPSHOT;
@@ -586,7 +586,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 #ifdef HAVE_TIMESTAMPS
 		WT_ERR(__wt_txn_parse_timestamp(session, "commit", &ts, &cval));
 		WT_ERR(__wt_timestamp_validate(session,
-		    &ts, &cval, true, true, true));
+		    "commit", &ts, &cval, true, true, true));
 		__wt_timestamp_set(&txn->commit_timestamp, &ts);
 		__wt_txn_set_commit_timestamp(session);
 #else

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -481,8 +481,9 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
  *	global stable and/or running transaction commit timestamp.
  */
 int
-__wt_timestamp_validate(WT_SESSION_IMPL *session, wt_timestamp_t *ts,
-    WT_CONFIG_ITEM *cval, bool cmp_oldest, bool cmp_stable, bool cmp_commit)
+__wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
+    wt_timestamp_t *ts, WT_CONFIG_ITEM *cval,
+    bool cmp_oldest, bool cmp_stable, bool cmp_commit)
 {
 	WT_TXN *txn = &session->txn;
 	WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
@@ -503,12 +504,12 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, wt_timestamp_t *ts,
 
 	if (older_than_oldest_ts)
 		WT_RET_MSG(session, EINVAL,
-		    "commit timestamp %.*s older than oldest timestamp",
-		    (int)cval->len, cval->str);
+		    "%s timestamp %.*s older than oldest timestamp",
+		    name, (int)cval->len, cval->str);
 	if (older_than_stable_ts)
 		WT_RET_MSG(session, EINVAL,
-		    "commit timestamp %.*s older than stable timestamp",
-		    (int)cval->len, cval->str);
+		    "%s timestamp %.*s older than stable timestamp",
+		    name, (int)cval->len, cval->str);
 
 	/*
 	 * Compare against the commit timestamp of the current transaction.
@@ -520,9 +521,9 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, wt_timestamp_t *ts,
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp, &txn->first_commit_timestamp));
 		WT_RET_MSG(session, EINVAL,
-		    "commit timestamp %.*s older than the first "
+		    "%s timestamp %.*s older than the first "
 		    "commit timestamp %s for this transaction",
-		    (int)cval->len, cval->str, hex_timestamp);
+		    name, (int)cval->len, cval->str, hex_timestamp);
 	}
 
 	return (0);
@@ -554,7 +555,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 			    "to set a commit_timestamp");
 		WT_RET(__wt_txn_parse_timestamp(session, "commit", &ts, &cval));
 		WT_RET(__wt_timestamp_validate(session,
-		    &ts, &cval, true, true, true));
+		    "commit", &ts, &cval, true, true, true));
 		__wt_timestamp_set(&txn->commit_timestamp, &ts);
 		__wt_txn_set_commit_timestamp(session);
 #else

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -499,8 +499,13 @@ commit_transaction(TINFO *tinfo, WT_SESSION *session)
 		testutil_check(
 		    session->commit_transaction(session, config_buf));
 
-		/* After the commit, update our last timestamp. */
-		tinfo->timestamp = ts;
+		/*
+		 * Update the thread's last-committed timestamp. Don't let the
+		 * compiler re-order this statement, if we were to race with
+		 * the timestamp thread, it might see our thread update before
+		 * the transaction commit.
+		 */
+		WT_PUBLISH(tinfo->timestamp, ts);
 	} else
 		testutil_check(session->commit_transaction(session, NULL));
 	++tinfo->commit;


### PR DESCRIPTION
FTR, I can't reproduce this one, but I think there is a way format can race.