### PR TITLE
WT-3680 metadata unroll should discard in-process checkpoints

### DIFF
--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -167,12 +167,18 @@ __meta_track_apply(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
 static int
 __meta_track_unroll(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
 {
+	WT_BM *bm;
+	WT_BTREE *btree;
 	WT_DECL_RET;
 
 	switch (trk->op) {
 	case WT_ST_EMPTY:	/* Unused slot */
 		break;
 	case WT_ST_CHECKPOINT:	/* Checkpoint, see above */
+		btree = trk->dhandle->handle;
+		bm = btree->bm;
+		WT_WITH_DHANDLE(session, trk->dhandle,
+		    ret = bm->checkpoint_resolve(bm, session, true));
 		break;
 	case WT_ST_DROP_COMMIT:
 		break;
@@ -233,6 +239,7 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 	WT_DECL_RET;
 	WT_META_TRACK *trk, *trk_orig;
 	WT_SESSION_IMPL *ckpt_session;
+	int saved_ret;
 
 	WT_ASSERT(session,
 	    WT_META_TRACKING(session) && session->meta_track_nest > 0);
@@ -255,12 +262,9 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 	if (trk == trk_orig)
 		return (0);
 
-	if (unroll) {
-		while (--trk >= trk_orig)
-			WT_TRET(__meta_track_unroll(session, trk));
-		/* Unroll operations don't need to flush the metadata. */
-		return (ret);
-	}
+	/* Unrolling doesn't require syncing the metadata. */
+	if (unroll)
+		goto done;
 
 	/*
 	 * If we don't have the metadata cursor (e.g, we're in the process of
@@ -271,13 +275,12 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 		goto done;
 
 	/* If we're logging, make sure the metadata update was flushed. */
-	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED)) {
+	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED))
 		WT_WITH_DHANDLE(session,
 		    WT_SESSION_META_DHANDLE(session),
 		    ret = __wt_txn_checkpoint_log(
-			session, false, WT_TXN_LOG_CKPT_SYNC, NULL));
-		WT_RET(ret);
-	} else {
+		    session, false, WT_TXN_LOG_CKPT_SYNC, NULL));
+	else {
 		WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SCHEMA));
 		ckpt_session = S2C(session)->meta_ckpt_session;
 		/*
@@ -288,21 +291,32 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 		F_SET(ckpt_session, WT_SESSION_LOCKED_METADATA);
 		WT_WITH_METADATA_LOCK(session,
 		    WT_WITH_DHANDLE(ckpt_session,
-			WT_SESSION_META_DHANDLE(session),
-			ret = __wt_checkpoint(ckpt_session, NULL)));
+		    WT_SESSION_META_DHANDLE(session),
+		    ret = __wt_checkpoint(ckpt_session, NULL)));
 		F_CLR(ckpt_session, WT_SESSION_LOCKED_METADATA);
 		ckpt_session->txn.id = WT_TXN_NONE;
-		WT_RET(ret);
-		WT_WITH_DHANDLE(session,
-		    WT_SESSION_META_DHANDLE(session),
-		    ret = __wt_checkpoint_sync(session, NULL));
-		WT_RET(ret);
+		if (ret == 0)
+			WT_WITH_DHANDLE(session,
+			    WT_SESSION_META_DHANDLE(session),
+			    ret = __wt_checkpoint_sync(session, NULL));
 	}
 
-done:	/* Apply any tracked operations post-commit. */
-	for (; trk_orig < trk; trk_orig++)
-		WT_TRET(__meta_track_apply(session, trk_orig));
-	return (ret);
+done:	/*
+	 * Undo any tracked operations on failure.
+	 * Apply any tracked operations post-commit.
+	 */
+	if (unroll || ret != 0) {
+		saved_ret = ret;
+		ret = 0;
+		while (--trk >= trk_orig)
+			WT_TRET(__meta_track_unroll(session, trk));
+	} else
+		for (; trk_orig < trk; trk_orig++)
+			WT_TRET(__meta_track_apply(session, trk_orig));
+	if (ret != 0)
+		WT_PANIC_RET(session, ret,
+		    "failed to apply or unroll all tracked operations");
+	return (saved_ret == 0 ? 0 : saved_ret);
 }
 
 /*

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -241,6 +241,8 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 	WT_SESSION_IMPL *ckpt_session;
 	int saved_ret;
 
+	saved_ret = 0;
+
 	WT_ASSERT(session,
 	    WT_META_TRACKING(session) && session->meta_track_nest > 0);
 


### PR DESCRIPTION
Alex, I don't know what happened in BF-6928, but my guess is an operation did a checkpoint and then subsequently failed, and we don't clean up checkpoints when unrolling tracked operations.

I've added code to do that, and I've also added code to panic if we fail to successfully either apply or unroll any set of tracked operations.