### PR TITLE
WT-3681 Only truncate a log if we're less than the trunc_lsn.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1914,11 +1914,6 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	if (func == NULL)
 		return (0);
 
-	if (LF_ISSET(WT_LOGSCAN_RECOVER))
-		__wt_verbose(session, WT_VERB_LOG,
-		    "__wt_log_scan truncating to %" PRIu32 "/%" PRIu32,
-		    log->trunc_lsn.l.file, log->trunc_lsn.l.offset);
-
 	if (lsnp != NULL &&
 	    LF_ISSET(WT_LOGSCAN_FIRST|WT_LOGSCAN_FROM_CKP))
 		WT_RET_MSG(session, WT_ERROR,
@@ -2042,8 +2037,13 @@ advance:
 			/*
 			 * Truncate this log file before we move to the next.
 			 */
-			if (LF_ISSET(WT_LOGSCAN_RECOVER))
+			if (LF_ISSET(WT_LOGSCAN_RECOVER) &&
+			    __wt_log_cmp(&rd_lsn, &log->trunc_lsn) < 0) {
+				__wt_verbose(session, WT_VERB_LOG,
+				    "Truncate end of log %" PRIu32 "/%" PRIu32,
+				    rd_lsn.l.file, rd_lsn.l.offset);
 				WT_ERR(__log_truncate(session, &rd_lsn, true));
+			}
 			/*
 			 * If we had a partial record, we'll want to break
 			 * now after closing and truncating.  Although for now
@@ -2228,7 +2228,7 @@ advance:
 	if (LF_ISSET(WT_LOGSCAN_RECOVER) &&
 	    __wt_log_cmp(&rd_lsn, &log->trunc_lsn) < 0) {
 		__wt_verbose(session, WT_VERB_LOG,
-		    "__wt_log_scan truncating to %" PRIu32 "/%" PRIu32,
+		    "End of recovery truncate end of log %" PRIu32 "/%" PRIu32,
 		    rd_lsn.l.file, rd_lsn.l.offset);
 		WT_ERR(__log_truncate(session, &rd_lsn, false));
 	}


### PR DESCRIPTION
@michaelcahill Please review this change.  The real fix is checking if `rd_lsn` is less than the `trunc_lsn`.  I also fixed verbose messages.