### PR TITLE
WT-3708 Cast page->memory_footprint for debug statement.

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -733,7 +733,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 	WT_RET(ds->f(ds, ", entries %" PRIu32, entries));
 	WT_RET(ds->f(ds,
 	    ", %s", __wt_page_is_modified(page) ? "dirty" : "clean"));
-	WT_RET(ds->f(ds, ", memory_size %" PRIu64, page->memory_footprint));
+	WT_RET(ds->f(ds,
+	    ", memory_size %" PRIu64, (uint64_t)page->memory_footprint));
 
 	if (F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
 		WT_RET(ds->f(ds, ", keys-built"));


### PR DESCRIPTION
@michaelcahill Please review this simple fix for the build problem.  @keithbostic you can too if you're still around.