### PR TITLE
WT-3707 Install signal handler to detect child unexpectedly failing.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -446,7 +446,7 @@ handler(int sig)
 	/*
 	 * The core file will indicate why the child exited. Choose EINVAL here.
 	 */
-	testutil_die(EINVAL, "Child process %d abnormally exited", pid);
+	testutil_die(EINVAL, "Child process abnormally exited");
 }
 
 int


### PR DESCRIPTION
@keithbostic Please review this change to `timestamp_abort` to install a signal handler.