### PR TITLE
WT-3730 For simple tables, do not use table dhandle after it is released.

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -570,8 +570,7 @@ __wt_cursor_close(WT_CURSOR *cursor)
 	__wt_buf_free(session, &cursor->value);
 
 	__wt_free(session, cursor->internal_uri);
-	if (!F_ISSET(cursor, WT_CURSTD_URI_SHARED))
-		__wt_free(session, cursor->uri);
+	__wt_free(session, cursor->uri);
 	__wt_overwrite_and_free(session, cursor);
 	return (0);
 }

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -987,22 +987,15 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 
 	if (table->is_simple) {
 		/* Just return a cursor on the underlying data source. */
-		if (table->is_simple_file)
-			ret = __wt_curfile_open(session,
-			    table->cgroups[0]->source, NULL, cfg, cursorp);
-		else
-			ret = __wt_open_cursor(session,
-			    table->cgroups[0]->source, NULL, cfg, cursorp);
+		ret = __wt_open_cursor(session,
+		    table->cgroups[0]->source, NULL, cfg, cursorp);
 
 		WT_TRET(__wt_schema_release_table(session, table));
 		if (ret == 0) {
 			/* Fix up the public URI to match what was passed in. */
 			cursor = *cursorp;
-			if (!F_ISSET(cursor, WT_CURSTD_URI_SHARED))
-				__wt_free(session, cursor->uri);
-			cursor->uri = table->iface.name;
-			WT_ASSERT(session, strcmp(uri, cursor->uri) == 0);
-			F_SET(cursor, WT_CURSTD_URI_SHARED);
+			__wt_free(session, cursor->uri);
+			WT_TRET(__wt_strdup(session, uri, &cursor->uri));
 		}
 		return (ret);
 	}

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -63,7 +63,7 @@ struct __wt_table {
 	WT_INDEX **indices;
 	size_t idx_alloc;
 
-	bool cg_complete, idx_complete, is_simple, is_simple_file;
+	bool cg_complete, idx_complete, is_simple;
 	u_int ncolgroups, nindices, nkey_columns;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -687,9 +687,8 @@ struct __wt_cursor {
 #define	WT_CURSTD_OVERWRITE	0x00400
 #define	WT_CURSTD_RAW		0x00800
 #define	WT_CURSTD_RAW_SEARCH	0x01000
-#define	WT_CURSTD_URI_SHARED	0x02000
-#define	WT_CURSTD_VALUE_EXT	0x04000	/* Value points out of the tree. */
-#define	WT_CURSTD_VALUE_INT	0x08000	/* Value points into the tree. */
+#define	WT_CURSTD_VALUE_EXT	0x02000	/* Value points out of the tree. */
+#define	WT_CURSTD_VALUE_INT	0x04000	/* Value points into the tree. */
 #define	WT_CURSTD_VALUE_SET	(WT_CURSTD_VALUE_EXT | WT_CURSTD_VALUE_INT)
 	uint32_t flags;
 #endif

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -106,8 +106,6 @@ __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
 	}
 
 	table->cg_complete = true;
-	table->is_simple_file = (table->is_simple &&
-	    WT_PREFIX_MATCH(table->cgroups[0]->source, "file:"));
 
 err:	__wt_scr_free(session, &buf);
 	__wt_schema_destroy_colgroup(session, &colgroup);


### PR DESCRIPTION

Reverts "WT-3555 Streamline open_cursor for simple tables. (#3637)"
This reverts commit 982121f68b336eb58edfbae26300ef46935277b8.