### PR TITLE
WT-3648 Read the thread's timestamp information once.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -151,7 +151,7 @@ thread_ts_run(void *arg)
 			this_ts = th_ts[i];
 			if (this_ts == 0)
 				goto ts_wait;
-			if (this_ts != 0 && this_ts < oldest_ts)
+			else if (this_ts < oldest_ts)
 				oldest_ts = this_ts;
 		}
 

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -121,7 +121,7 @@ thread_ts_run(void *arg)
 	WT_CURSOR *cur_stable;
 	WT_SESSION *session;
 	THREAD_DATA *td;
-	uint64_t i, last_ts, oldest_ts;
+	uint64_t i, last_ts, oldest_ts, this_ts;
 	char tscfg[64];
 
 	td = (THREAD_DATA *)arg;
@@ -148,10 +148,11 @@ thread_ts_run(void *arg)
 			 * any thread still with a zero timestamp we go to
 			 * sleep.
 			 */
-			if (th_ts[i] == 0)
+			this_ts = th_ts[i];
+			if (this_ts == 0)
 				goto ts_wait;
-			if (th_ts[i] != 0 && th_ts[i] < oldest_ts)
-				oldest_ts = th_ts[i];
+			if (this_ts != 0 && this_ts < oldest_ts)
+				oldest_ts = this_ts;
 		}
 
 		if (oldest_ts != UINT64_MAX &&

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -75,7 +75,7 @@ static const char * const ckpt_file = "checkpoint_done";
 
 static bool compat, inmem, use_ts;
 static volatile uint64_t global_ts = 1;
-static uint64_t th_ts[MAX_TH];
+static volatile uint64_t th_ts[MAX_TH];
 
 #define	ENV_CONFIG_COMPAT	",compatibility=(release=\"2.9\")"
 #define	ENV_CONFIG_DEF						\

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -591,7 +591,7 @@ timestamp(void *arg)
 	WT_SESSION *session;
 	TINFO **tinfo_list, *tinfo;
 	time_t last, now;
-	uint64_t oldest_timestamp, usecs;
+	uint64_t oldest_timestamp, this_ts, usecs;
 	uint32_t i;
 	char config_buf[64];
 
@@ -614,9 +614,10 @@ timestamp(void *arg)
 		oldest_timestamp = UINT64_MAX;
 		for (i = 0; i < g.c_threads; ++i) {
 			tinfo = tinfo_list[i];
-			if (tinfo->timestamp != 0 &&
-			    tinfo->timestamp < oldest_timestamp)
-				oldest_timestamp = tinfo->timestamp;
+			this_ts = tinfo->timestamp;
+			if (this_ts != 0 &&
+			    this_ts < oldest_timestamp)
+				oldest_timestamp = this_ts;
 		}
 		if (oldest_timestamp == UINT64_MAX) {
 			__wt_sleep(1, 0);


### PR DESCRIPTION
@agorrod Please review.  This should fix the failure seen in `timestamp_abort` and fixes the similar usage in `test/format`.