### PR TITLE
WT-3710 Get page-level lock to ensure single threaded page-split

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -345,6 +345,9 @@ __split_ref_prepare(
 	 * ascend into the created children, but eventually fail as that parent
 	 * page won't yet know about the created children pages. That's OK, we
 	 * spin there until the parent's page index is updated.
+	 *
+	 * Get a page-level lock on the newly created parent page to
+	 * single-thread the split in this page.
 	 */
 	for (i = skip_first ? 1 : 0; i < pindex->entries; ++i) {
 		ref = pindex->index[i];
@@ -352,10 +355,12 @@ __split_ref_prepare(
 
 		/* Switch the WT_REF's to their new page. */
 		j = 0;
+		WT_PAGE_LOCK(session, child);
 		WT_INTL_FOREACH_BEGIN(session, child, child_ref) {
 			child_ref->home = child;
 			child_ref->pindex_hint = j++;
 		} WT_INTL_FOREACH_END;
+		WT_PAGE_UNLOCK(session, child);
 
 #ifdef HAVE_DIAGNOSTIC
 		WT_WITH_PAGE_INDEX(session,

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -346,8 +346,8 @@ __split_ref_prepare(
 	 * page won't yet know about the created children pages. That's OK, we
 	 * spin there until the parent's page index is updated.
 	 *
-	 * Get a page-level lock on the newly created parent page to
-	 * single-thread the split in this page.
+	 * Lock the newly created page to ensure it doesn't split until all
+	 * child pages have been updated.
 	 */
 	for (i = skip_first ? 1 : 0; i < pindex->entries; ++i) {
 		ref = pindex->index[i];


### PR DESCRIPTION
When a page split is in progress it is possible to get another split on this
page through its child in another thread. Acquire a page lock on the page
undergoing the split to prevent concurrent split on same page.