### PR TITLE
WT-3658 Fix the string length calculation when size is given

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1165,6 +1165,7 @@ strget
 strlen
 strncpy
 strndup
+strnlen
 strtok
 strtoll
 strtouq

--- a/src/docs/schema.dox
+++ b/src/docs/schema.dox
@@ -96,7 +96,8 @@ length of 1 byte.
 The \c 'S' type is encoded as a C language string terminated by a
 NUL character. When preceded by a size, that indicates the maximum number of
 bytes the string can store. In a string with characters less than the
-specified size, the remaining bytes are NULL padded.
+specified size, the remaining bytes are NUL padded. If the supplied string
+is longer than the specified size, it will be stored without a trailing NUL.
 @m_if{java}
 Because of this, the associated Java String may not contain the NUL character.
 @m_endif

--- a/src/docs/schema.dox
+++ b/src/docs/schema.dox
@@ -94,7 +94,9 @@ a size, that indicates the number of bytes to store; the default is a
 length of 1 byte.
 
 The \c 'S' type is encoded as a C language string terminated by a
-NUL character.
+NUL character. When preceded by a size, that indicates the maximum number of
+bytes the string can store. In a string with characters less than the
+specified size, the remaining bytes are NULL padded.
 @m_if{java}
 Because of this, the associated Java String may not contain the NUL character.
 @m_endif

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -41,6 +41,20 @@ __wt_strdup(WT_SESSION_IMPL *session, const char *str, void *retp)
 }
 
 /*
+ * __wt_strnlen --
+ *      Determine the length of a fixed-size string
+ */
+static inline size_t
+__wt_strnlen(const char *s, size_t maxlen)
+{
+	size_t i;
+
+	for (i=0; i < maxlen && *s != '\0'; i++, s++)
+		;
+	return (i);
+}
+
+/*
  * __wt_snprintf --
  *	snprintf convenience function, ignoring the returned size.
  */

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -49,7 +49,7 @@ __wt_strnlen(const char *s, size_t maxlen)
 {
 	size_t i;
 
-	for (i=0; i < maxlen && *s != '\0'; i++, s++)
+	for (i = 0; i < maxlen && *s != '\0'; i++, s++)
 		;
 	return (i);
 }

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -342,15 +342,20 @@ __pack_write(
 		*pp += pv->size;
 		break;
 	case 'S':
-		s = strlen(pv->u.s);
+		/*
+		 * When preceded by a size, that indicates the maximum number
+		 * of bytes the string can store, this does not include the
+		 * terminating NUL character. In a string with characters
+		 * less than the specified size, the remaining bytes are
+		 * NULL padded.
+		 */
 		if (pv->havesize) {
-			if (pv->size < s) {
-				s = pv->size;
-				pad = 0;
-			} else
-				pad = pv->size - s;
-		} else
+			s = __wt_strnlen(pv->u.s, pv->size);
+			pad = (s < pv->size) ? pv->size - s : 0;
+		} else {
+			s = strlen(pv->u.s);
 			pad = 1;
+		}
 		WT_SIZE_CHECK_PACK(s + pad, maxlen);
 		if (s > 0)
 			memcpy(*pp, pv->u.s, s);


### PR DESCRIPTION
When the format 'S' is preceded by a size, that indicates the maximum number of
bytes the string can store. This does not include the terminating NULL byte.
Hence strlen cannot be used to determine the length of the string. Instead use
custom version of strnlen.