### PR TITLE
WT-3745 Favor oplog reads when under cache pressure.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -190,6 +190,7 @@ connection_stats = [
     CacheStat('cache_bytes_internal', 'tracked bytes belonging to internal pages in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_inuse', 'bytes currently in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_leaf', 'tracked bytes belonging to leaf pages in the cache', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_lookaside', 'bytes belonging to the lookaside table in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_max', 'maximum bytes configured', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_other', 'bytes not belonging to page images in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_read', 'bytes read into cache', 'size'),

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -160,7 +160,7 @@ __wt_compact(WT_SESSION_IMPL *session)
 		 * checking whether the cache is full.  Check now to throttle
 		 * compact to match eviction speed.
 		 */
-		WT_ERR(__wt_cache_eviction_check(session, false, NULL));
+		WT_ERR(__wt_cache_eviction_check(session, false, false, NULL));
 
 		/*
 		 * Pages read for compaction aren't "useful"; don't update the

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -592,6 +592,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 	 * file.
 	 */
 	flags = WT_READ_SKIP_INTL;			/* tree walk flags */
+	LF_SET(WT_READ_NO_SPLIT);			/* don't try to split */
 	if (truncating)
 		LF_SET(WT_READ_TRUNCATE);
 	for (newpage = false;; newpage = true) {

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -548,6 +548,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	 * of the file.
 	 */
 	flags = WT_READ_PREV | WT_READ_SKIP_INTL;	/* tree walk flags */
+	LF_SET(WT_READ_NO_SPLIT);			/* don't try to split */
 	if (truncating)
 		LF_SET(WT_READ_TRUNCATE);
 	for (newpage = false;; newpage = true) {

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -294,7 +294,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * extremely large memory footprints.
 	 */
 	if (page->modify->update_restored &&
-	    page->modify->last_eviction_id == __wt_txn_oldest_id(session))
+	    !__wt_page_evict_retry(session, page))
 		return (false);
 
 	/* Trigger eviction on the next page release. */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -205,8 +205,26 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
 	if (total_incr != 0) {
 		__wt_cache_page_inmem_incr(session, page, total_incr);
 
-		/* Make sure the page is included in the next checkpoint. */
+		/*
+		 * If the updates in lookaside are newer than the versions on
+		 * the page, it must be included in the next checkpoint.
+		 *
+		 * Otherwise, the page image contained the newest versions of
+		 * data so the updates are all older and it can be marked clean
+		 * (i.e., the next checkpoint can use the version already on
+		 * disk).
+		 *
+		 * This needs care because (a) it creates pages with history
+		 * that can't be evicted until they are marked dirty again, and
+		 * (b) checkpoints may, in fact need to visit these pages to
+		 * resolve changes evicted while a checkpoint is running.
+		 */
 		page->modify->first_dirty_txn = WT_TXN_FIRST;
+		if (!ref->page_las->las_skew_oldest &&
+		    __wt_txn_visible_all(session,
+		    ref->page_las->las_max_txn, WT_TIMESTAMP_NULL(
+		    &ref->page_las->onpage_timestamp)))
+			__wt_page_modify_clear(session, page);
 	}
 
 err:	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
@@ -557,13 +575,13 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 				return (WT_NOTFOUND);
 
 read:			/*
-			 * The page isn't in memory, read it. If this thread is
-			 * allowed to do eviction work, check for space in the
+			 * The page isn't in memory, read it. If this thread
+			 * respects the cache size, check for space in the
 			 * cache.
 			 */
 			if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE))
 				WT_RET(__wt_cache_eviction_check(
-				    session, 1, NULL));
+				    session, true, true, NULL));
 			WT_RET(__page_read(session, ref, flags));
 
 			/*
@@ -730,8 +748,8 @@ skip_evict:		/*
 		 * substitute that for a sleep.
 		 */
 		if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE)) {
-			WT_RET(
-			    __wt_cache_eviction_check(session, 1, &cache_work));
+			WT_RET(__wt_cache_eviction_check(
+			    session, true, true, &cache_work));
 			if (cache_work)
 				continue;
 		}

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1497,6 +1497,8 @@ __split_multi_inmem(
 	 * to avoid repeatedly attempting eviction on the same page.
 	 */
 	page->modify->last_eviction_id = orig->modify->last_eviction_id;
+	__wt_timestamp_set(&page->modify->last_eviction_timestamp,
+	    &orig->modify->last_eviction_timestamp);
 	page->modify->update_restored = 1;
 
 err:	/* Free any resources that may have been cached in the cursor. */

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -206,10 +206,12 @@ __wt_las_cursor_open(WT_SESSION_IMPL *session)
 	 * opens (the first update is safe because it's single-threaded from
 	 * wiredtiger_open).
 	 */
-#define	WT_BTREE_LAS_FLAGS						\
-	(WT_BTREE_LOOKASIDE | WT_BTREE_NO_CHECKPOINT | WT_BTREE_NO_LOGGING)
-	if (F_MASK(btree, WT_BTREE_LAS_FLAGS) != WT_BTREE_LAS_FLAGS)
-		F_SET(btree, WT_BTREE_LAS_FLAGS);
+	if (!F_ISSET(btree, WT_BTREE_LOOKASIDE))
+		F_SET(btree, WT_BTREE_LOOKASIDE);
+	if (!F_ISSET(btree, WT_BTREE_NO_CHECKPOINT))
+		F_SET(btree, WT_BTREE_NO_CHECKPOINT);
+	if (!F_ISSET(btree, WT_BTREE_NO_LOGGING))
+		F_SET(btree, WT_BTREE_NO_LOGGING);
 
 	session->las_cursor = cursor;
 	F_SET(session, WT_SESSION_LOOKASIDE_CURSOR);

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -232,6 +232,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 void
 __wt_cache_stats_update(WT_SESSION_IMPL *session)
 {
+	WT_BTREE *las_tree;
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_CONNECTION_STATS **stats;
@@ -253,34 +254,43 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
 	WT_STAT_SET(session, stats, cache_bytes_inuse, inuse);
 	WT_STAT_SET(session, stats, cache_overhead, cache->overhead_pct);
 
-	WT_STAT_SET(
-	    session, stats, cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
-	WT_STAT_SET(
-	    session, stats, cache_bytes_image, __wt_cache_bytes_image(cache));
-	WT_STAT_SET(
-	    session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
-	WT_STAT_SET(
-	    session, stats, cache_bytes_internal, cache->bytes_internal);
+	WT_STAT_SET(session, stats,
+	    cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
+	WT_STAT_SET(session, stats,
+	    cache_bytes_image, __wt_cache_bytes_image(cache));
+	WT_STAT_SET(session, stats,
+	    cache_pages_inuse, __wt_cache_pages_inuse(cache));
+	WT_STAT_SET(session, stats,
+	    cache_bytes_internal, cache->bytes_internal);
 	WT_STAT_SET(session, stats, cache_bytes_leaf, leaf);
-	WT_STAT_SET(
-	    session, stats, cache_bytes_other, __wt_cache_bytes_other(cache));
+	if (F_ISSET(conn, WT_CONN_LOOKASIDE_OPEN)) {
+		las_tree = ((WT_CURSOR_BTREE *)
+		    cache->las_session[0]->las_cursor)->btree;
+		WT_STAT_SET(session, stats,
+		    cache_bytes_lookaside, __wt_cache_bytes_plus_overhead(cache,
+		    (uint64_t)WT_STAT_READ(las_tree->dhandle->stats,
+		    cache_bytes_inuse)));
+	}
+	WT_STAT_SET(session, stats,
+	    cache_bytes_other, __wt_cache_bytes_other(cache));
 
 	WT_STAT_SET(session, stats,
 	    cache_eviction_maximum_page_size, cache->evict_max_page_size);
 	WT_STAT_SET(session, stats, cache_pages_dirty,
 	    cache->pages_dirty_intl + cache->pages_dirty_leaf);
 
-	WT_STAT_CONN_SET(session, cache_eviction_state, cache->flags);
-	WT_STAT_CONN_SET(session,
+	WT_STAT_SET(session, stats, cache_eviction_state, cache->flags);
+	WT_STAT_SET(session, stats,
 	    cache_eviction_aggressive_set, cache->evict_aggressive_score);
-	WT_STAT_CONN_SET(session,
+	WT_STAT_SET(session, stats,
 	    cache_eviction_empty_score, cache->evict_empty_score);
-	WT_STAT_CONN_SET(session,
+	WT_STAT_SET(session, stats,
 	    cache_lookaside_score, __wt_cache_lookaside_score(cache));
 
-	WT_STAT_CONN_SET(session,
+	WT_STAT_SET(session, stats,
 	    cache_eviction_active_workers, conn->evict_threads.current_threads);
-	WT_STAT_CONN_SET(session, cache_eviction_stable_state_workers,
+	WT_STAT_SET(session, stats,
+	    cache_eviction_stable_state_workers,
 	    cache->evict_tune_workers_best);
 
 	/*

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -608,7 +608,7 @@ __cache_pool_adjust(WT_SESSION_IMPL *session,
 		 */
 		pressure = cache->cp_pass_pressure / highest_percentile;
 		busy = __wt_eviction_needed(
-		    entry->default_session, false, &pct_full);
+		    entry->default_session, false, true, &pct_full);
 
 		__wt_verbose(session, WT_VERB_SHARED_CACHE,
 		    "\t%5" PRIu64 ", %3" PRIu64 ", %2" PRIu32 ", %d, %2u",

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2340,13 +2340,13 @@ __wt_cache_eviction_worker(
 		    initial_progress + max_progress)))
 			break;
 
-                /*
-                 * Don't make application threads participate in scrubbing for
-                 * checkpoints.  Just throttle updates instead.
-                 */
-                if (WT_EVICT_HAS_WORKERS(session) &&
-                    cache->eviction_scrub_limit > 0.0 &&
-                    !F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD)) {
+		/*
+		 * Don't make application threads participate in scrubbing for
+		 * checkpoints.  Just throttle updates instead.
+		 */
+		if (WT_EVICT_HAS_WORKERS(session) &&
+		    cache->eviction_scrub_limit > 0.0 &&
+		    !F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD)) {
 			__wt_yield();
 			continue;
 		}

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2284,7 +2284,8 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
  * crosses its boundaries.
  */
 int
-__wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
+__wt_cache_eviction_worker(
+    WT_SESSION_IMPL *session, bool busy, bool readonly, u_int pct_full)
 {
 	struct timespec enter, leave;
 	WT_CACHE *cache;
@@ -2347,7 +2348,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full)
 		max_progress = busy ? 5 : 20;
 
 		/* See if eviction is still needed. */
-		if (!__wt_eviction_needed(session, busy, &pct_full) ||
+		if (!__wt_eviction_needed(session, busy, readonly, &pct_full) ||
 		    ((pct_full < 100 || cache->eviction_scrub_limit > 0.0) &&
 		    (cache->eviction_progress >
 		    initial_progress + max_progress)))

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2344,9 +2344,9 @@ __wt_cache_eviction_worker(
 			break;
 
 		/*
-		 * Don't make application threads participate in eviction of dirty
-		 * pages until we get desperate.  Just throttle operations
-		 * instead.
+		 * Don't make application threads participate in eviction of
+		 * dirty pages until we get desperate.  Just throttle
+		 * operations instead.
 		 */
 		if (WT_EVICT_HAS_WORKERS(session) &&
 		    F_ISSET(cache, WT_CACHE_EVICT_DIRTY) &&

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -553,6 +553,7 @@ __wt_evict_destroy(WT_SESSION_IMPL *session)
 static bool
 __evict_update_work(WT_SESSION_IMPL *session)
 {
+	WT_BTREE *las_tree;
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	uint64_t bytes_inuse, bytes_max, dirty_inuse;
@@ -568,6 +569,14 @@ __evict_update_work(WT_SESSION_IMPL *session)
 
 	if (!__evict_queue_empty(cache->evict_urgent_queue, false))
 		F_SET(cache, WT_CACHE_EVICT_URGENT);
+
+	if (F_ISSET(conn, WT_CONN_LOOKASIDE_OPEN)) {
+		WT_ASSERT(session,
+		    F_ISSET(session, WT_SESSION_LOOKASIDE_CURSOR));
+
+		las_tree = ((WT_CURSOR_BTREE *)session->las_cursor)->btree;
+		cache->bytes_lookaside = las_tree->bytes_inmem;
+	}
 
 	/*
 	 * If we need space in the cache, try to find clean pages to evict.
@@ -710,8 +719,8 @@ __evict_pass(WT_SESSION_IMPL *session)
 		 * workers, it must service the urgent queue in case all
 		 * application threads are busy.
 		 */
-		if (cache->evict_empty_score < WT_EVICT_SCORE_CUTOFF ||
-		    (!WT_EVICT_HAS_WORKERS(session) &&
+		if (!WT_EVICT_HAS_WORKERS(session) &&
+		    (cache->evict_empty_score < WT_EVICT_SCORE_CUTOFF ||
 		    !__evict_queue_empty(cache->evict_urgent_queue, false)))
 			WT_RET(__evict_lru_pages(session, true));
 
@@ -1577,9 +1586,7 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	WT_EVICT_ENTRY *end, *evict, *start;
 	WT_PAGE *last_parent, *page;
-	WT_PAGE_MODIFY *mod;
 	WT_REF *ref;
-	WT_TXN_GLOBAL *txn_global;
 	uint64_t btree_inuse, bytes_per_slot, cache_inuse, min_pages;
 	uint64_t pages_seen, pages_queued, refs_walked;
 	uint32_t remaining_slots, total_slots, walk_flags;
@@ -1590,7 +1597,6 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 	conn = S2C(session);
 	btree = S2BT(session);
 	cache = conn->cache;
-	txn_global = &conn->txn_global;
 	last_parent = NULL;
 	restarts = 0;
 	give_up = urgent_queued = false;
@@ -1784,6 +1790,7 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 		 * if we get into that situation.
 		 */
 		give_up = !__wt_cache_aggressive(session) &&
+		    !F_ISSET(btree, WT_BTREE_LOOKASIDE) &&
 		    pages_seen > min_pages &&
 		    (pages_queued == 0 || (pages_seen / pages_queued) >
 		    (min_pages / target_pages));
@@ -1946,14 +1953,9 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 		 * recent update on the page is not yet globally visible,
 		 * eviction will fail.  This heuristic avoids repeated attempts
 		 * to evict the same page.
-		 *
-		 * We skip this for the lookaside table because updates there
-		 * can be evicted as soon as they are committed.
 		 */
-		mod = page->modify;
-		if (modified && txn_global->current != txn_global->oldest_id &&
-		    (mod->last_eviction_id == __wt_txn_oldest_id(session) ||
-		    !__wt_txn_visible_all(session, mod->update_txn, NULL)))
+		if (modified && (!__wt_page_evict_retry(session, page) ||
+		    !__txn_visible_all_id(session, page->modify->update_txn)))
 			continue;
 
 fast:		/* If the page can't be evicted, give up. */
@@ -2342,13 +2344,14 @@ __wt_cache_eviction_worker(
 			break;
 
 		/*
-		 * Don't make application threads participate in scrubbing for
-		 * checkpoints.  Just throttle updates instead.
+		 * Don't make application threads participate in eviction of dirty
+		 * pages until we get desperate.  Just throttle operations
+		 * instead.
 		 */
-		if (busy && WT_EVICT_HAS_WORKERS(session) &&
-		    cache->eviction_scrub_limit > 0.0 &&
+		if (WT_EVICT_HAS_WORKERS(session) &&
+		    F_ISSET(cache, WT_CACHE_EVICT_DIRTY) &&
 		    !F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD)) {
-			__wt_yield();
+			__wt_sleep(0, 1000);
 			continue;
 		}
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -564,7 +564,10 @@ __evict_review(
 
 	if (closing)
 		LF_SET(WT_REC_VISIBILITY_ERR);
-	else if (!WT_PAGE_IS_INTERNAL(page) &&
+	else if (WT_SESSION_IS_CHECKPOINT(session)) {
+		if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE))
+			LF_SET(WT_REC_LOOKASIDE);
+	} else if (!WT_PAGE_IS_INTERNAL(page) &&
 	    !F_ISSET(S2BT(session), WT_BTREE_LOOKASIDE)) {
 		if (F_ISSET(conn, WT_CONN_IN_MEMORY))
 			LF_SET(WT_REC_IN_MEMORY |
@@ -576,8 +579,7 @@ __evict_review(
 			 * Don't attempt scrubbing when evicting during a
 			 * checkpoint or if the page needs forced eviction.
 			 */
-			if (!WT_SESSION_IS_CHECKPOINT(session) &&
-			    !WT_READGEN_EVICT_SOON(page->read_gen) &&
+			if (!WT_READGEN_EVICT_SOON(page->read_gen) &&
 			    F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
 				LF_SET(WT_REC_SCRUB);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -570,12 +570,16 @@ __evict_review(
 			LF_SET(WT_REC_IN_MEMORY |
 			    WT_REC_SCRUB | WT_REC_UPDATE_RESTORE);
 		else if (!WT_IS_METADATA(session->dhandle)) {
-			if (!WT_SESSION_IS_CHECKPOINT(session)) {
-				LF_SET(WT_REC_UPDATE_RESTORE);
+			LF_SET(WT_REC_UPDATE_RESTORE);
 
-				if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
-					LF_SET(WT_REC_SCRUB);
-			}
+			/*
+			 * Don't attempt scrubbing when evicting during a
+			 * checkpoint or if the page needs forced eviction.
+			 */
+			if (!WT_SESSION_IS_CHECKPOINT(session) &&
+			    !WT_READGEN_EVICT_SOON(page->read_gen) &&
+			    F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
+				LF_SET(WT_REC_SCRUB);
 
 			/*
 			 * If the cache is under pressure with many updates

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -564,24 +564,18 @@ __evict_review(
 
 	if (closing)
 		LF_SET(WT_REC_VISIBILITY_ERR);
-	else if (WT_SESSION_IS_CHECKPOINT(session)) {
-		if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE))
-			LF_SET(WT_REC_LOOKASIDE);
-	} else if (!WT_PAGE_IS_INTERNAL(page) &&
+	else if (!WT_PAGE_IS_INTERNAL(page) &&
 	    !F_ISSET(S2BT(session), WT_BTREE_LOOKASIDE)) {
 		if (F_ISSET(conn, WT_CONN_IN_MEMORY))
 			LF_SET(WT_REC_IN_MEMORY |
 			    WT_REC_SCRUB | WT_REC_UPDATE_RESTORE);
 		else if (!WT_IS_METADATA(session->dhandle)) {
-			LF_SET(WT_REC_UPDATE_RESTORE);
+			if (!WT_SESSION_IS_CHECKPOINT(session)) {
+				LF_SET(WT_REC_UPDATE_RESTORE);
 
-			/*
-			 * Don't attempt scrubbing when evicting during a
-			 * checkpoint or if the page needs forced eviction.
-			 */
-			if (!WT_READGEN_EVICT_SOON(page->read_gen) &&
-			    F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
-				LF_SET(WT_REC_SCRUB);
+				if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
+					LF_SET(WT_REC_SCRUB);
+			}
 
 			/*
 			 * If the cache is under pressure with many updates

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -209,7 +209,7 @@ struct __wt_page_modify {
 
 	/* The transaction state last time eviction was attempted. */
 	uint64_t last_eviction_id;
-	WT_DECL_TIMESTAMP(last_eviction_timestamp);
+	WT_DECL_TIMESTAMP(last_eviction_timestamp)
 
 #ifdef HAVE_DIAGNOSTIC
 	/* Check that transaction time moves forward. */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -209,6 +209,7 @@ struct __wt_page_modify {
 
 	/* The transaction state last time eviction was attempted. */
 	uint64_t last_eviction_id;
+	WT_DECL_TIMESTAMP(last_eviction_timestamp);
 
 #ifdef HAVE_DIAGNOSTIC
 	/* Check that transaction time moves forward. */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1267,6 +1267,44 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
+ * __wt_page_evict_retry --
+ *	Check if there has been transaction progress since the last eviction
+ *	attempt.
+ */
+static inline bool
+__wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
+{
+	WT_PAGE_MODIFY *mod;
+	WT_TXN_GLOBAL *txn_global;
+
+	txn_global = &S2C(session)->txn_global;
+
+	if ((mod = page->modify) == NULL)
+		return (true);
+
+	if (txn_global->current != txn_global->oldest_id &&
+	    mod->last_eviction_id == __wt_txn_oldest_id(session))
+		return (false);
+
+#ifdef HAVE_TIMESTAMPS
+	{
+	bool same_timestamp;
+
+	if (__wt_timestamp_iszero(&mod->last_eviction_timestamp))
+		return (true);
+
+	WT_WITH_TIMESTAMP_READLOCK(session, txn_global->rwlock,
+	    same_timestamp = __wt_timestamp_cmp(
+	    &mod->last_eviction_timestamp, &txn_global->pinned_timestamp) == 0);
+	if (same_timestamp)
+		return (false);
+	}
+#endif
+
+	return (true);
+}
+
+/*
  * __wt_page_can_evict --
  *	Check whether a page can be evicted.
  */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1293,7 +1293,7 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
 	if (__wt_timestamp_iszero(&mod->last_eviction_timestamp))
 		return (true);
 
-	WT_WITH_TIMESTAMP_READLOCK(session, txn_global->rwlock,
+	WT_WITH_TIMESTAMP_READLOCK(session, &txn_global->rwlock,
 	    same_timestamp = __wt_timestamp_cmp(
 	    &mod->last_eviction_timestamp, &txn_global->pinned_timestamp) == 0);
 	if (same_timestamp)

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -149,8 +149,7 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
 		if (WT_PAGE_IS_INTERNAL(page)) {
 			(void)__wt_atomic_add64(&btree->bytes_dirty_intl, size);
 			(void)__wt_atomic_add64(&cache->bytes_dirty_intl, size);
-		} else if (!btree->lsm_primary &&
-		    !F_ISSET(btree, WT_BTREE_LOOKASIDE)) {
+		} else if (!btree->lsm_primary) {
 			(void)__wt_atomic_add64(&btree->bytes_dirty_leaf, size);
 			(void)__wt_atomic_add64(&cache->bytes_dirty_leaf, size);
 		}
@@ -262,7 +261,7 @@ __wt_cache_page_byte_dirty_decr(
 		    decr, "WT_BTREE.bytes_dirty_intl");
 		__wt_cache_decr_check_uint64(session, &cache->bytes_dirty_intl,
 		    decr, "WT_CACHE.bytes_dirty_intl");
-	} else if (!btree->lsm_primary && !F_ISSET(btree, WT_BTREE_LOOKASIDE)) {
+	} else if (!btree->lsm_primary) {
 		__wt_cache_decr_check_uint64(session, &btree->bytes_dirty_leaf,
 		    decr, "WT_BTREE.bytes_dirty_leaf");
 		__wt_cache_decr_check_uint64(session, &cache->bytes_dirty_leaf,
@@ -322,8 +321,7 @@ __wt_cache_dirty_incr(WT_SESSION_IMPL *session, WT_PAGE *page)
 		(void)__wt_atomic_add64(&cache->bytes_dirty_intl, size);
 		(void)__wt_atomic_add64(&cache->pages_dirty_intl, 1);
 	} else {
-		if (!btree->lsm_primary &&
-		    !F_ISSET(btree, WT_BTREE_LOOKASIDE)) {
+		if (!btree->lsm_primary) {
 			(void)__wt_atomic_add64(&btree->bytes_dirty_leaf, size);
 			(void)__wt_atomic_add64(&cache->bytes_dirty_leaf, size);
 		}
@@ -422,8 +420,7 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page, bool rewrite)
 			__wt_cache_decr_check_uint64(session,
 			    &cache->bytes_dirty_intl,
 			    modify->bytes_dirty, "WT_CACHE.bytes_dirty_intl");
-		} else if (!btree->lsm_primary &&
-		    !F_ISSET(btree, WT_BTREE_LOOKASIDE)) {
+		} else if (!btree->lsm_primary) {
 			__wt_cache_decr_check_uint64(session,
 			    &btree->bytes_dirty_leaf,
 			    modify->bytes_dirty, "WT_BTREE.bytes_dirty_leaf");

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -78,6 +78,8 @@ struct __wt_cache {
 	uint64_t bytes_read;		/* Bytes read into memory */
 	uint64_t bytes_written;
 
+	uint64_t bytes_lookaside;	/* Lookaside bytes inmem */
+
 	volatile uint64_t eviction_progress;	/* Eviction progress count */
 	uint64_t last_eviction_progress;/* Tracked eviction progress */
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -267,7 +267,7 @@ __wt_eviction_clean_needed(WT_SESSION_IMPL *session, u_int *pct_fullp)
 	 * shared cache.
 	 */
 	bytes_max = S2C(session)->cache_size + 1;
-	bytes_inuse = __wt_cache_bytes_inuse(cache);
+	bytes_inuse = cache->bytes_inmem;
 
 	if (pct_fullp != NULL)
 		*pct_fullp = (u_int)((100 * bytes_inuse) / bytes_max);
@@ -294,7 +294,7 @@ __wt_eviction_dirty_needed(WT_SESSION_IMPL *session, u_int *pct_fullp)
 	 * shared cache.
 	 */
 	bytes_max = S2C(session)->cache_size + 1;
-	dirty_inuse = __wt_cache_dirty_leaf_inuse(cache);
+	dirty_inuse = cache->bytes_dirty_leaf;
 
 	if (pct_fullp != NULL)
 		*pct_fullp = (u_int)((100 * dirty_inuse) / bytes_max);
@@ -302,7 +302,23 @@ __wt_eviction_dirty_needed(WT_SESSION_IMPL *session, u_int *pct_fullp)
 	if ((dirty_trigger = cache->eviction_scrub_limit) < 1.0)
 		dirty_trigger = (double)cache->eviction_dirty_trigger;
 
-	return (dirty_inuse > (uint64_t)(dirty_trigger * bytes_max) / 100);
+	if (dirty_inuse > (uint64_t)(dirty_trigger * bytes_max) / 100)
+		return (true);
+
+#if 0
+	/*
+	 * Also stall updates when the lookaside table is more than half of the
+	 * dirty limit.
+	 */
+	if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE) && cache->bytes_lookaside >
+	    (uint64_t)(dirty_trigger * bytes_max) / 200) {
+		if (pct_fullp != NULL)
+			*pct_fullp = 100;
+		return (true);
+	}
+#endif
+
+	return (false);
 }
 
 /*

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -149,7 +149,7 @@ __cursor_enter(WT_SESSION_IMPL *session)
 	 * whether the cache is full.
 	 */
 	if (session->ncursors == 0)
-		WT_RET(__wt_cache_eviction_check(session, false, NULL));
+		WT_RET(__wt_cache_eviction_check(session, false, false, NULL));
 	++session->ncursors;
 	return (0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -366,7 +366,7 @@ extern int __wt_evict_create(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUT
 extern int __wt_evict_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_evict_file_exclusive_on(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session);
-extern int __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, u_int pct_full) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_cache_eviction_worker( WT_SESSION_IMPL *session, bool busy, bool readonly, u_int pct_full) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref);
 extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
@@ -783,7 +783,7 @@ extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);
 extern int __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_txn_release(WT_SESSION_IMPL *session);
+extern int __wt_txn_release(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -783,7 +783,7 @@ extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);
 extern int __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_release(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -293,6 +293,7 @@ struct __wt_connection_stats {
 	int64_t cache_write_app_count;
 	int64_t cache_write_app_time;
 	int64_t cache_bytes_image;
+	int64_t cache_bytes_lookaside;
 	int64_t cache_bytes_inuse;
 	int64_t cache_bytes_other;
 	int64_t cache_bytes_read;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -287,7 +287,8 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
 	 */
 	oldest_id = txn_global->oldest_id;
 	include_checkpoint_txn = btree == NULL ||
-	    btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT);
+	    (!F_ISSET(btree, WT_BTREE_LOOKASIDE) &&
+	    btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT));
 	if (!include_checkpoint_txn)
 		return (oldest_id);
 
@@ -523,6 +524,9 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 		if (session->ncursors > 0)
 			WT_RET(__wt_session_copy_values(session));
 
+		/* Stall here if the cache is completely full. */
+		WT_RET(__wt_cache_eviction_check(session, false, true, NULL));
+
 		__wt_txn_get_snapshot(session);
 	}
 
@@ -567,11 +571,14 @@ __wt_txn_idle_cache_check(WT_SESSION_IMPL *session)
 
 	/*
 	 * Check the published snap_min because read-uncommitted never sets
-	 * WT_TXN_HAS_SNAPSHOT.
+	 * WT_TXN_HAS_SNAPSHOT.  We don't have any transaction information at
+	 * this point, so assume the transaction will be read-only.  The dirty
+	 * cache check will be performed when the transaction completes, if
+	 * necessary.
 	 */
 	if (F_ISSET(txn, WT_TXN_RUNNING) &&
 	    !F_ISSET(txn, WT_TXN_HAS_ID) && txn_state->pinned_id == WT_TXN_NONE)
-		WT_RET(__wt_cache_eviction_check(session, false, false, NULL));
+		WT_RET(__wt_cache_eviction_check(session, false, true, NULL));
 
 	return (0);
 }

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -523,11 +523,6 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 		if (session->ncursors > 0)
 			WT_RET(__wt_session_copy_values(session));
 
-		/*
-		 * We're about to allocate a snapshot: if we need to block for
-		 * eviction, it's better to do it beforehand.
-		 */
-		WT_RET(__wt_cache_eviction_check(session, false, NULL));
 		__wt_txn_get_snapshot(session);
 	}
 
@@ -576,7 +571,7 @@ __wt_txn_idle_cache_check(WT_SESSION_IMPL *session)
 	 */
 	if (F_ISSET(txn, WT_TXN_RUNNING) &&
 	    !F_ISSET(txn, WT_TXN_HAS_ID) && txn_state->pinned_id == WT_TXN_NONE)
-		WT_RET(__wt_cache_eviction_check(session, false, NULL));
+		WT_RET(__wt_cache_eviction_check(session, false, false, NULL));
 
 	return (0);
 }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4742,576 +4742,578 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1034
 /*! cache: bytes belonging to page images in the cache */
 #define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1035
+/*! cache: bytes belonging to the lookaside table in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_LOOKASIDE		1036
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1036
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1037
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1037
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1038
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1038
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1039
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1039
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1040
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1040
+#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1041
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1041
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1042
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1042
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1043
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1043
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1044
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1044
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1045
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1045
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1046
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1046
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1047
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1047
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1048
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1048
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1049
 /*! cache: eviction server evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1049
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1050
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1050
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1051
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1051
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1052
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1052
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1053
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1053
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1054
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1054
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1055
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1055
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1056
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1056
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1057
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1057
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1058
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1058
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1059
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1059
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1060
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1060
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1061
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1061
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1062
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1062
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1063
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1063
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1064
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1064
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1065
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1065
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1066
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1066
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1067
 /*! cache: eviction worker thread evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1067
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1068
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1068
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1069
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1069
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1070
 /*!
  * cache: failed eviction of pages that exceeded the in-memory maximum
  * count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1070
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1071
 /*!
  * cache: failed eviction of pages that exceeded the in-memory maximum
  * time (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1071
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1072
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1072
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1073
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1073
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1074
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1074
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1075
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1075
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1076
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1076
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1077
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1077
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1078
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1078
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1079
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1079
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1080
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1080
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1081
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1081
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1082
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1082
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1083
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1083
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1084
 /*! cache: lookaside score */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_SCORE		1084
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_SCORE		1085
 /*! cache: lookaside table entries */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_ENTRIES		1085
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_ENTRIES		1086
 /*! cache: lookaside table insert calls */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_INSERT		1086
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_INSERT		1087
 /*! cache: lookaside table remove calls */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1087
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1088
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1088
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1089
 /*! cache: maximum page size at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1089
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1090
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1090
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1091
 /*! cache: modified pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1091
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1092
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1092
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1093
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1093
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1094
 /*! cache: page written requiring lookaside records */
-#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1094
+#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1095
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1095
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1096
 /*! cache: pages evicted because they exceeded the in-memory maximum count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1096
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1097
 /*!
  * cache: pages evicted because they exceeded the in-memory maximum time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1097
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1098
 /*! cache: pages evicted because they had chains of deleted items count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1098
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1099
 /*!
  * cache: pages evicted because they had chains of deleted items time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1099
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1100
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1100
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1101
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1102
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1103
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1104
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1104
+#define	WT_STAT_CONN_CACHE_READ				1105
 /*! cache: pages read into cache requiring lookaside entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1105
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1106
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1106
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1107
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1107
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1108
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1108
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1109
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1109
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1110
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1110
+#define	WT_STAT_CONN_CACHE_WRITE			1111
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1111
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1112
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1112
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1113
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1113
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1114
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1114
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1115
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1115
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1116
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1116
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1117
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1117
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1118
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1118
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1119
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1119
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1120
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1120
+#define	WT_STAT_CONN_TIME_TRAVEL			1121
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1121
+#define	WT_STAT_CONN_FILE_OPEN				1122
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1122
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1123
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1123
+#define	WT_STAT_CONN_MEMORY_FREE			1124
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1124
+#define	WT_STAT_CONN_MEMORY_GROW			1125
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1125
+#define	WT_STAT_CONN_COND_WAIT				1126
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1126
+#define	WT_STAT_CONN_RWLOCK_READ			1127
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1127
+#define	WT_STAT_CONN_RWLOCK_WRITE			1128
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1128
+#define	WT_STAT_CONN_FSYNC_IO				1129
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1129
+#define	WT_STAT_CONN_READ_IO				1130
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1130
+#define	WT_STAT_CONN_WRITE_IO				1131
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1131
+#define	WT_STAT_CONN_CURSOR_CREATE			1132
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1132
+#define	WT_STAT_CONN_CURSOR_INSERT			1133
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1133
+#define	WT_STAT_CONN_CURSOR_MODIFY			1134
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1134
+#define	WT_STAT_CONN_CURSOR_NEXT			1135
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1135
+#define	WT_STAT_CONN_CURSOR_PREV			1136
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1136
+#define	WT_STAT_CONN_CURSOR_REMOVE			1137
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1137
+#define	WT_STAT_CONN_CURSOR_RESERVE			1138
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1138
+#define	WT_STAT_CONN_CURSOR_RESET			1139
 /*! cursor: cursor restarted searches */
-#define	WT_STAT_CONN_CURSOR_RESTART			1139
+#define	WT_STAT_CONN_CURSOR_RESTART			1140
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1140
+#define	WT_STAT_CONN_CURSOR_SEARCH			1141
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1141
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1142
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1142
+#define	WT_STAT_CONN_CURSOR_UPDATE			1143
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1143
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1144
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1144
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1145
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1145
+#define	WT_STAT_CONN_DH_SWEEP_REF			1146
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1146
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1147
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1147
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1148
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1148
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1149
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1149
+#define	WT_STAT_CONN_DH_SWEEPS				1150
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1150
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1151
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1151
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1152
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1152
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1153
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1153
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1154
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1154
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1155
 /*!
  * lock: dhandle lock application thread time waiting for the dhandle
  * lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1155
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1156
 /*!
  * lock: dhandle lock internal thread time waiting for the dhandle lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1156
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1157
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1157
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1158
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1158
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1159
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1159
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1160
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1160
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1161
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1161
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1162
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1162
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1163
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1163
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1164
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1164
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1165
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1165
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1166
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1166
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1167
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1167
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1168
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1168
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1169
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1169
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1170
 /*! log: force checkpoint calls slept */
-#define	WT_STAT_CONN_LOG_FORCE_CKPT_SLEEP		1170
+#define	WT_STAT_CONN_LOG_FORCE_CKPT_SLEEP		1171
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1171
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1172
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1172
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1173
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1173
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1174
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1174
+#define	WT_STAT_CONN_LOG_FLUSH				1175
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1175
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1176
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1176
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1177
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1177
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1178
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1178
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1179
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1179
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1180
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1180
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1181
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1181
+#define	WT_STAT_CONN_LOG_SCANS				1182
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1182
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1183
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1183
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1184
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1184
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1185
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1185
+#define	WT_STAT_CONN_LOG_SYNC				1186
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1186
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1187
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1187
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1188
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1188
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1189
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1189
+#define	WT_STAT_CONN_LOG_WRITES				1190
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1190
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1191
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1191
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1192
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1192
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1193
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1193
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1194
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1194
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1195
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1195
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1196
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1196
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1197
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1197
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1198
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1198
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1199
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1199
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1200
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1200
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1201
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1201
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1202
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1202
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1203
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1203
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1204
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1204
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1205
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1205
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1206
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1206
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1207
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1207
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1208
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1208
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1209
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1209
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1210
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1210
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1211
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1211
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1212
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1212
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1213
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1213
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1214
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1214
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1215
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1215
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1216
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1216
+#define	WT_STAT_CONN_REC_PAGES				1217
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1217
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1218
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1218
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1219
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1219
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1220
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1220
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1221
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1221
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1222
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1222
+#define	WT_STAT_CONN_SESSION_OPEN			1223
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1223
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1224
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1224
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1225
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1225
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1226
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1226
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1227
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1227
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1228
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1228
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1229
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1229
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1230
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1230
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1231
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1231
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1232
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1232
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1233
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1233
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1234
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1234
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1235
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1235
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1236
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1236
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1237
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1237
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1238
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1238
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1239
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1239
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1240
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1240
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1241
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1241
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1242
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1242
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1243
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1243
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1244
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1244
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1245
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1245
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1246
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1246
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1247
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1247
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1248
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1248
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1249
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1249
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1250
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1250
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1251
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1251
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1252
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1252
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1253
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1253
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1254
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1254
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1255
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1255
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1256
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1256
+#define	WT_STAT_CONN_PAGE_SLEEP				1257
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1257
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1258
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1258
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1259
 /*!
  * thread-yield: tree descend one level yielded for split page index
  * update
  */
-#define	WT_STAT_CONN_TREE_DESCEND_BLOCKED		1259
+#define	WT_STAT_CONN_TREE_DESCEND_BLOCKED		1260
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1260
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1261
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1261
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1262
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1262
+#define	WT_STAT_CONN_TXN_BEGIN				1263
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1263
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1264
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1264
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1265
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1265
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1266
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1266
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1267
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1267
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1268
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1268
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1269
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1269
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1270
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1270
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1271
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1271
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1272
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1272
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1273
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1273
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1274
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1274
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1275
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1275
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1276
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1276
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1277
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1277
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1278
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1278
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1279
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1279
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1280
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1280
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1281
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1281
+#define	WT_STAT_CONN_TXN_SYNC				1282
 /*! transaction: transactions commit timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1282
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1283
 /*! transaction: transactions commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1283
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1284
 /*! transaction: transactions commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1284
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1285
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1285
+#define	WT_STAT_CONN_TXN_COMMIT				1286
 /*! transaction: transactions read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1286
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1287
 /*! transaction: transactions read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1287
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1288
 /*! transaction: transactions read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1288
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1289
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1289
+#define	WT_STAT_CONN_TXN_ROLLBACK			1290
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1290
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1291
 
 /*!
  * @}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -420,8 +420,15 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref,
 	}
 
 	oldest_id = __wt_txn_oldest_id(session);
-	if (LF_ISSET(WT_REC_EVICT))
+	if (LF_ISSET(WT_REC_EVICT)) {
 		mod->last_eviction_id = oldest_id;
+#ifdef HAVE_TIMESTAMPS
+		WT_WITH_TIMESTAMP_READLOCK(session,
+		    &S2C(session)->txn_global.rwlock,
+		    __wt_timestamp_set(&mod->last_eviction_timestamp,
+		    &S2C(session)->txn_global.pinned_timestamp));
+#endif
+	    }
 
 #ifdef HAVE_DIAGNOSTIC
 	/*

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -761,6 +761,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: application threads page write from cache to disk count",
 	"cache: application threads page write from cache to disk time (usecs)",
 	"cache: bytes belonging to page images in the cache",
+	"cache: bytes belonging to the lookaside table in the cache",
 	"cache: bytes currently in the cache",
 	"cache: bytes not belonging to page images in the cache",
 	"cache: bytes read into cache",
@@ -1094,6 +1095,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cache_write_app_count = 0;
 	stats->cache_write_app_time = 0;
 		/* not clearing cache_bytes_image */
+		/* not clearing cache_bytes_lookaside */
 		/* not clearing cache_bytes_inuse */
 		/* not clearing cache_bytes_other */
 	stats->cache_bytes_read = 0;
@@ -1409,6 +1411,8 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, cache_write_app_count);
 	to->cache_write_app_time += WT_STAT_READ(from, cache_write_app_time);
 	to->cache_bytes_image += WT_STAT_READ(from, cache_bytes_image);
+	to->cache_bytes_lookaside +=
+	    WT_STAT_READ(from, cache_bytes_lookaside);
 	to->cache_bytes_inuse += WT_STAT_READ(from, cache_bytes_inuse);
 	to->cache_bytes_other += WT_STAT_READ(from, cache_bytes_other);
 	to->cache_bytes_read += WT_STAT_READ(from, cache_bytes_read);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -855,7 +855,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	 * a good time to do so.  Note that we must ignore any error return
 	 * because the user's data is committed.
 	 */
-	(void)__wt_cache_eviction_check(session, false, readonly, NULL);
+	if (!readonly)
+		(void)__wt_cache_eviction_check(session, false, false, NULL);
 	return (0);
 
 err:	/*
@@ -935,7 +936,8 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 	 * a good time to do so.  Note that we must ignore any error return
 	 * because the user's data is committed.
 	 */
-	(void)__wt_cache_eviction_check(session, false, readonly, NULL);
+	if (!readonly)
+		(void)__wt_cache_eviction_check(session, false, false, NULL);
 	return (ret);
 }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -541,20 +541,18 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
  * __wt_txn_release --
  *	Release the resources associated with the current transaction.
  */
-int
+void
 __wt_txn_release(WT_SESSION_IMPL *session)
 {
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_STATE *txn_state;
-	bool readonly;
 
 	txn = &session->txn;
 	txn_global = &S2C(session)->txn_global;
 	txn_state = WT_SESSION_TXN_STATE(session);
 
-	readonly = txn->mod_count != 0;
-	txn->mod_count = 0;
+	WT_ASSERT(session, txn->mod_count == 0);
 	txn->notify = NULL;
 
 	/* Clear the transaction's ID from the global table. */
@@ -598,12 +596,6 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 
 	/* Ensure the transaction flags are cleared on exit */
 	txn->flags = 0;
-
-	/*
-	 * We're between transactions: if we need to block for eviction, it's
-	 * better to do it beforehand.
-	 */
-	return (__wt_cache_eviction_check(session, false, readonly, NULL));
 }
 
 /*
@@ -620,7 +612,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_TXN_GLOBAL *txn_global;
 	WT_TXN_OP *op;
 	u_int i;
-	bool locked;
+	bool locked, readonly;
 #ifdef HAVE_TIMESTAMPS
 	wt_timestamp_t prev_commit_timestamp, ts;
 	bool update_timestamp;
@@ -635,6 +627,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_ASSERT(session, !F_ISSET(txn, WT_TXN_ERROR) ||
 	    txn->mod_count == 0);
 
+	readonly = txn->mod_count == 0;
 	/*
 	 * Look for a commit timestamp.
 	 */
@@ -799,6 +792,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
 		__wt_txn_op_free(session, op);
 	}
+	txn->mod_count = 0;
 
 #ifdef HAVE_TIMESTAMPS
 	/*
@@ -811,7 +805,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	update_timestamp = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT);
 #endif
 
-	WT_ERR(__wt_txn_release(session));
+	__wt_txn_release(session);
 	if (locked)
 		__wt_readunlock(session, &txn_global->visibility_rwlock);
 
@@ -856,6 +850,12 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	}
 #endif
 
+	/*
+	 * We're between transactions, if we need to block for eviction, it's
+	 * a good time to do so.  Note that we must ignore any error return
+	 * because the user's data is committed.
+	 */
+	(void)__wt_cache_eviction_check(session, false, readonly, NULL);
 	return (0);
 
 err:	/*
@@ -881,10 +881,12 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_TXN *txn;
 	WT_TXN_OP *op;
 	u_int i;
+	bool readonly;
 
 	WT_UNUSED(cfg);
 
 	txn = &session->txn;
+	readonly = txn->mod_count == 0;
 	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 
 	/* Rollback notification. */
@@ -925,8 +927,15 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 		/* Free any memory allocated for the operation. */
 		__wt_txn_op_free(session, op);
 	}
+	txn->mod_count = 0;
 
-	WT_TRET(__wt_txn_release(session));
+	__wt_txn_release(session);
+	/*
+	 * We're between transactions, if we need to block for eviction, it's
+	 * a good time to do so.  Note that we must ignore any error return
+	 * because the user's data is committed.
+	 */
+	(void)__wt_cache_eviction_check(session, false, readonly, NULL);
 	return (ret);
 }
 


### PR DESCRIPTION
There are several behavior changes here to avoid situations where oplog
reads can block when a primary is under severe cache update pressure.
In particular:
* don't block if a scan encounters a large page;
* don't stall reads when the dirty limit of cache is reached;
* mark pages read from lookaside clean if it is safe to do so.