### PR TITLE
WT-3746 Add sleep if we need to wait for writes to complete.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2658,8 +2658,10 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
 	 * Wait until all current outstanding writes have been written
 	 * to the file system.
 	 */
-	while (__wt_log_cmp(&last_lsn, &lsn) > 0)
+	while (__wt_log_cmp(&last_lsn, &lsn) > 0) {
+		__wt_sleep(0, WT_THOUSAND);
 		WT_RET(__wt_log_flush_lsn(session, &lsn, false));
+	}
 
 	__wt_verbose(session, WT_VERB_LOG,
 	    "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32,


### PR DESCRIPTION
@agorrod please review this small change.  With this 1 msec sleep it eliminates nearly all extraneous calls to `log_force_write`.  The tests I have run show no impact on performance and in MongoDB there is an independent thread calling log flush.