### PR TITLE
WT-3752 Allow trimming of obsolete modify updates.

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -314,12 +314,10 @@ __wt_update_obsolete_check(
 	 * update chains.
 	 */
 	for (first = NULL, count = 0; upd != NULL; upd = upd->next, count++)
-		if (WT_UPDATE_DATA_VALUE(upd) &&
-		    __wt_txn_upd_visible_all(session, upd)) {
-			if (first == NULL)
-				first = upd;
-		} else if (upd->txnid != WT_TXN_ABORTED)
+		if (!__wt_txn_upd_visible_all(session, upd))
 			first = NULL;
+		else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
+			first = upd;
 
 	/*
 	 * We cannot discard this WT_UPDATE structure, we can only discard

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -313,11 +313,14 @@ __wt_update_obsolete_check(
 	 * Only updates with globally visible, self-contained data can terminate
 	 * update chains.
 	 */
-	for (first = NULL, count = 0; upd != NULL; upd = upd->next, count++)
+	for (first = NULL, count = 0; upd != NULL; upd = upd->next, count++) {
+		if (upd->txnid == WT_TXN_ABORTED)
+			continue;
 		if (!__wt_txn_upd_visible_all(session, upd))
 			first = NULL;
 		else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
 			first = upd;
+	}
 
 	/*
 	 * We cannot discard this WT_UPDATE structure, we can only discard


### PR DESCRIPTION
Obsolete update discards look for a contiguous block of obsolete updates at the end of an update chain.  Previously, we reset the search each time we saw a modify update.  That is not what we want: it is fine to discard obsolete modify updates as long as there is a complete value somewhere after them in the list.