### PR TITLE
WT-3758 Turn on snappy by default for LAS

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -182,9 +182,16 @@ struct __wt_ovfl_reuse {
  * makes the lookaside table's value more likely to overflow the page size when
  * the row-store key is relatively large.
  */
+#ifdef HAVE_BUILTIN_EXTENSION_SNAPPY
+#define	WT_LAS_CONFIG							\
+    "key_format=" WT_UNCHECKED_STRING(QIQu)				\
+    ",value_format=" WT_UNCHECKED_STRING(QuBu)				\
+    ",block_compressor=snappy"
+#else
 #define	WT_LAS_CONFIG							\
     "key_format=" WT_UNCHECKED_STRING(QIQu)				\
     ",value_format=" WT_UNCHECKED_STRING(QuBu)
+#endif
 
 /*
  * WT_PAGE_LOOKASIDE --


### PR DESCRIPTION
To turn on snappy by default for LAS.
This improves the performance of insert-heavy workloads that end up disk-bound writing lookaside records.