### PR TITLE
WT-3761 Don't immediately evict pages even if they look clean

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1428,8 +1428,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	if (WT_READGEN_EVICT_SOON(page->read_gen) &&
 	    btree->evict_disabled == 0 &&
 	    __wt_page_can_evict(session, ref, &inmem_split)) {
-		if (__wt_page_is_modified(page) &&
-		    (LF_ISSET(WT_READ_NO_SPLIT) || (!inmem_split &&
+		if ((LF_ISSET(WT_READ_NO_SPLIT) || (!inmem_split &&
 		    F_ISSET(session, WT_SESSION_NO_RECONCILE))))
 			__wt_page_evict_urgent(session, ref);
 		else {


### PR DESCRIPTION
It is an optimization that tickles a corner case with checkpoints and the fast truncate path.