### PR TITLE
WT-3763 Decide whether to retry eviction based on eviction activity

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1493,12 +1493,10 @@ __split_multi_inmem(
 	page->modify->first_dirty_txn = WT_TXN_FIRST;
 
 	/*
-	 * If the new page is modified, save the oldest ID from reconciliation
-	 * to avoid repeatedly attempting eviction on the same page.
+	 * If the new page is modified, save the eviction generation to avoid
+	 * repeatedly attempting eviction on the same page.
 	 */
-	page->modify->last_eviction_id = orig->modify->last_eviction_id;
-	__wt_timestamp_set(&page->modify->last_eviction_timestamp,
-	    &orig->modify->last_eviction_timestamp);
+	page->modify->last_evict_pass_gen = orig->modify->last_evict_pass_gen;
 	page->modify->update_restored = 1;
 
 err:	/* Free any resources that may have been cached in the cursor. */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -215,6 +215,7 @@ struct __wt_page_modify {
 	uint64_t first_dirty_txn;
 
 	/* The transaction state last time eviction was attempted. */
+	uint64_t last_evict_pass_gen;
 	uint64_t last_eviction_id;
 	WT_DECL_TIMESTAMP(last_eviction_timestamp)
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1282,8 +1282,8 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
 		return (true);
 
 	if (txn_global->current != txn_global->oldest_id &&
-            !__wt_cache_aggressive(session) &&
-            mod->last_evict_pass_gen + 10 < S2C(session)->cache->evict_pass_gen)
+	    !__wt_cache_aggressive(session) &&
+	    mod->last_evict_pass_gen + 10 < S2C(session)->cache->evict_pass_gen)
 		return (false);
 
 	return (true);


### PR DESCRIPTION
Rather than on whether transaction visibility is moving forward, this should help since transaction visibility isn't as simple as it was before timestamps.