### PR TITLE
WT-3763 Retry eviction if we're using lookaside.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -297,8 +297,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * skipping the page indefinitely or large records can lead to
 	 * extremely large memory footprints.
 	 */
-	if (page->modify->update_restored &&
-	    !__wt_page_evict_retry(session, page))
+	if (!__wt_page_evict_retry(session, page))
 		return (false);
 
 	/* Trigger eviction on the next page release. */

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1948,14 +1948,13 @@ __evict_walk_file(WT_SESSION_IMPL *session,
 			goto fast;
 
 		/*
-		 * If there are active transaction and oldest transaction
-		 * hasn't changed since the last time this page was written,
-		 * it's unlikely we can make progress.  Similarly, if the most
-		 * recent update on the page is not yet globally visible,
-		 * eviction will fail.  This heuristic avoids repeated attempts
-		 * to evict the same page.
+		 * If the global transaction state hasn't changed since the
+		 * last time we tried eviction, it's unlikely we can make
+		 * progress.  Similarly, if the most recent update on the page
+		 * is not yet globally visible, eviction will fail.  This
+		 * heuristic avoids repeated attempts to evict the same page.
 		 */
-		if (modified && (!__wt_page_evict_retry(session, page) ||
+		if (!__wt_page_evict_retry(session, page) || (modified &&
 		    !__txn_visible_all_id(session, page->modify->update_txn)))
 			continue;
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1279,7 +1279,20 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 	txn_global = &S2C(session)->txn_global;
 
-	if ((mod = page->modify) == NULL)
+	/*
+	 * If the page hasn't been through one round of update/restore, give it
+	 * a try.
+	 */
+	if ((mod = page->modify) == NULL || !mod->update_restored)
+		return (true);
+
+	/*
+	 * If this page is from the lookaside table, or we're going to consider
+	 * lookaside eviction, the ordinary transaction visibility rules aren't
+	 * relevant: try eviction.
+	 */
+	if (F_ISSET(S2BT(session), WT_BTREE_LOOKASIDE) ||
+	    F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_LOOKASIDE))
 		return (true);
 
 	if (txn_global->current != txn_global->oldest_id &&


### PR DESCRIPTION
When we're not under cache pressure, retrying eviction of pages can waste effort if the global transaction state hasn't changed.  However, lookaside eviction allows pages to be evicted even when a timestamp or transaction ID is stuck, so we should retry in that case.