### PR TITLE
WT-3772 Do not increment missed pre-allocated logs counter when a hot backup …

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -976,11 +976,12 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 * If we need to create the log file, do so now.
 	 */
 	if (create_log) {
-                /*
-                 * Do not increment missed prep logs counter when a hot backup
+		/*
+		 * Do not increment missed prep logs counter when a hot backup
 		 * is in progress and pre-allocation is enabled since
-		 * we deliberately not using prep log files in that case (see comments above).
-                 */
+		 * we deliberately not using prep log files in that case
+		 * (see comments above).
+		 */
 		if ((conn->log_prealloc == 0) || !conn->hot_backup)
 			log->prep_missed++;
 		WT_RET(__wt_log_allocfile(

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -976,7 +976,13 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 * If we need to create the log file, do so now.
 	 */
 	if (create_log) {
-		log->prep_missed++;
+                /*
+                 * Do not increment missed prep logs counter when a hot backup
+                 * is in progress since we deliberately not using prep log files
+                 * in that case (see comments above).
+                 */
+                if (!conn->hot_backup)
+			log->prep_missed++;
 		WT_RET(__wt_log_allocfile(
 		    session, log->fileid, WT_LOG_FILENAME));
 	}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -978,10 +978,10 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	if (create_log) {
                 /*
                  * Do not increment missed prep logs counter when a hot backup
-                 * is in progress since we deliberately not using prep log files
-                 * in that case (see comments above).
+		 * is in progress and pre-allocation is enabled since
+		 * we deliberately not using prep log files in that case (see comments above).
                  */
-                if (!conn->hot_backup)
+		if ((conn->log_prealloc == 0) || !conn->hot_backup)
 			log->prep_missed++;
 		WT_RET(__wt_log_allocfile(
 		    session, log->fileid, WT_LOG_FILENAME));

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -977,12 +977,12 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 	 */
 	if (create_log) {
 		/*
-		 * Do not increment missed prep logs counter when a hot backup
-		 * is in progress and pre-allocation is enabled since
-		 * we deliberately not using prep log files in that case
-		 * (see comments above).
+		 * Increment the missed pre-allocated file counter only
+		 * if a hot backup is not in progress. We are deliberately
+		 * not using pre-allocated log files during backup
+		 * (see comment above).
 		 */
-		if ((conn->log_prealloc == 0) || !conn->hot_backup)
+		if (!conn->hot_backup)
 			log->prep_missed++;
 		WT_RET(__wt_log_allocfile(
 		    session, log->fileid, WT_LOG_FILENAME));


### PR DESCRIPTION
…is in progress since we deliberately not using pre-allocated log files in that case.

To resolve https://jira.mongodb.org/browse/WT-3772