### PR TITLE
WT-3079 Resume eviction walks per tree.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -689,7 +689,7 @@ __conn_dhandle_remove(WT_SESSION_IMPL *session, bool final)
 
 	WT_ASSERT(session,
 	    F_ISSET(session, WT_SESSION_LOCKED_HANDLE_LIST_WRITE));
-	WT_ASSERT(session, dhandle != conn->cache->evict_file_next);
+	WT_ASSERT(session, dhandle != conn->cache->walk_tree);
 
 	/* Check if the handle was reacquired by a session while we waited. */
 	if (!final &&

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -142,7 +142,8 @@ struct __wt_cache {
 	 */
 	WT_SPINLOCK evict_pass_lock;	/* Eviction pass lock */
 	WT_SESSION_IMPL *walk_session;	/* Eviction pass session */
-	WT_DATA_HANDLE *evict_file_next;/* LRU next file to search */
+	WT_DATA_HANDLE *walk_tree;	/* LRU walk current tree */
+	uint32_t walk_progress, walk_target;/* Progress in current tree */
 
 	WT_SPINLOCK evict_queue_lock;	/* Eviction current queue lock */
 	WT_EVICT_QUEUE evict_queues[WT_EVICT_QUEUE_MAX];


### PR DESCRIPTION
Record how many pages we want and how many pages we have queued so far in a tree, then resume the walk next iteration.  This avoids a single tree with a target larger than the queue size being walked completely before the eviction server moves on to the next tree.