### PR TITLE
WT-3783 Fix transaction isolation to use the correct enum

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -61,6 +61,15 @@ else
 		cat $t
 	fi
 
+	if ! expr "$f" : 'examples/c/.*' > /dev/null &&
+	   ! expr "$f" : 'ext/.*' > /dev/null &&
+	   ! expr "$f" : 'src/include/wiredtiger_ext\.h' > /dev/null &&
+	   ! expr "$f" : 'src/txn/txn_ext\.c' > /dev/null &&
+	   grep WT_TXN_ISO_ $f; then
+		echo "$f: WT_TXN_ISO_XXX constants only for the extension API"
+		cat $t
+	fi
+
 	if ! expr "$f" : 'src/include/queue\.h' > /dev/null &&
 	    egrep 'STAILQ_|SLIST_|\bLIST_' $f ; then
 		echo "$f: use TAILQ for all lists"

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -385,7 +385,7 @@ __las_insert_block_verbose(WT_SESSION_IMPL *session, WT_MULTI *multi)
 		    btree_id, multi->page_las.las_pageid,
 		    multi->page_las.las_max_txn,
 		    hex_timestamp,
-		    multi->page_las.las_skew_newest? "newest" : "oldest",
+		    multi->page_las.las_skew_newest ? "newest" : "oldest",
 		    WT_STAT_READ(conn->stats, cache_lookaside_entries),
 		    pct_dirty, pct_full);
 	}

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -725,12 +725,10 @@ __las_sweep_init(WT_SESSION_IMPL *session)
 	cache->las_sweep_dropmin = UINT32_MAX;
 	cache->las_sweep_dropmax = 0;
 	for (i = 0; i < cache->las_dropped_next; i++) {
-		cache->las_sweep_dropmin = WT_MIN(
-		    cache->las_sweep_dropmin,
-		    cache->las_dropped[i]);
-		cache->las_sweep_dropmax = WT_MAX(
-		    cache->las_sweep_dropmax,
-		    cache->las_dropped[i]);
+		cache->las_sweep_dropmin =
+		    WT_MIN(cache->las_sweep_dropmin, cache->las_dropped[i]);
+		cache->las_sweep_dropmax =
+		    WT_MAX(cache->las_sweep_dropmax, cache->las_dropped[i]);
 	}
 
 	/* Initialize the bitmap. */

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -533,7 +533,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	if (insert_cnt > 0) {
 		WT_STAT_CONN_INCRV(
 		    session, cache_lookaside_entries, insert_cnt);
-		__wt_atomic_add64(
+		(void)__wt_atomic_add64(
 		    &S2C(session)->cache->las_entry_count, insert_cnt);
 		WT_ERR(__las_insert_block_verbose(session, multi));
 	}

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -433,7 +433,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	/* Wrap all the updates in a transaction. */
 	las_session = (WT_SESSION_IMPL *)cursor->session;
 	WT_RET(__wt_txn_begin(las_session, NULL));
-	las_session->txn.isolation = WT_TXN_ISO_READ_UNCOMMITTED;
+	las_session->txn.isolation = WT_ISO_READ_UNCOMMITTED;
 
 	/*
 	 * Make sure there are no leftover entries (e.g., from a handle
@@ -639,7 +639,7 @@ __wt_las_remove_block(WT_SESSION_IMPL *session,
 	 */
 	if (local_cursor) {
 		WT_ERR(__wt_txn_begin(las_session, NULL));
-		las_session->txn.isolation = WT_TXN_ISO_READ_UNCOMMITTED;
+		las_session->txn.isolation = WT_ISO_READ_UNCOMMITTED;
 		local_txn = true;
 	}
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1469,7 +1469,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 		    (LF_ISSET(WT_READ_NO_SPLIT) || (!inmem_split &&
 		    F_ISSET(session, WT_SESSION_NO_RECONCILE)))) {
 			if (!WT_SESSION_IS_CHECKPOINT(session))
-				__wt_page_evict_urgent(session, ref);
+				(void)__wt_page_evict_urgent(session, ref);
 		} else {
 			WT_RET_BUSY_OK(__wt_page_release_evict(session, ref));
 			return (0);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -476,7 +476,7 @@ print_missing(REPORT *r, const char *fname, const char *msg)
 		    ". Then keys %" PRIu64 "-%" PRIu64 " exist."
 		    " Key range %" PRIu64 "-%" PRIu64 "\n",
 		    fname, msg,
-		    r->exist_key - r->first_miss - 1,
+		    (r->exist_key - r->first_miss) - 1,
 		    r->first_miss, r->exist_key - 1,
 		    r->exist_key, r->last_key,
 		    r->first_key, r->last_key);


### PR DESCRIPTION
@michaelcahill, can you please look at dfd2c6f?

I think we're setting `las_session->txn.isolation = WT_ISO_SNAPSHOT`, because `WT_TXN_ISO_READ_UNCOMMITTED` == 2.