### PR TITLE
WT-3787 test_compact02 failed as compaction halted due to eviction pressure

### DIFF
--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -146,7 +146,14 @@ class test_compact02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # 5. Call compact.
-        self.session.compact(self.uri, None)
+        # Compact can collide with eviction, if that happens we retry.
+        for i in range(1, 5):
+            try:
+                self.session.compact(self.uri, None)
+            except wiredtiger.WiredTigerError:
+                time.sleep(2)
+            else:
+                break
 
         # 6. Get stats on compacted table.
         sz = self.getSize()

--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -30,7 +30,7 @@
 #   Test that compact reduces the file size.
 #
 
-import wiredtiger, wttest
+import time, wiredtiger, wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
@@ -148,12 +148,10 @@ class test_compact02(wttest.WiredTigerTestCase):
         # 5. Call compact.
         # Compact can collide with eviction, if that happens we retry.
         for i in range(1, 5):
-            try:
-                self.session.compact(self.uri, None)
-            except wiredtiger.WiredTigerError:
-                time.sleep(2)
-            else:
+            if not self.raisesBusy(
+              lambda: self.session.compact(self.uri, None)):
                 break
+            time.sleep(2)
 
         # 6. Get stats on compacted table.
         sz = self.getSize()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -490,6 +490,39 @@ class WiredTigerTestCase(unittest.TestCase):
             with self.expectedStderr(message):
                 self.assertRaises(exceptionType, expr)
 
+    def assertRaisesException(self, exceptionType, expr,
+        exceptionString=None, optional=False):
+        """
+        Like TestCase.assertRaises(), with some additional options.
+        If the exceptionString argument is used, the exception's string
+        must match it. If optional is set, then no assertion occurs
+        if the exception doesn't occur.
+        Returns true if the assertion is raised.
+        """
+        raised = False
+        try:
+            expr()
+        except BaseException, err:
+            if not isinstance(err, exceptionType):
+                self.fail('Exception of incorrect type raised, got type: ' + \
+                    str(type(err)))
+            if exceptionString != None and exceptionString != str(err):
+                self.fail('Exception with incorrect string raised, got: "' + \
+                    str(err) + '"')
+            raised = True
+        if not raised and not optional:
+            self.fail('no assertion raised')
+        return raised
+
+    def raisesBusy(self, expr):
+        """
+        Execute the expression, returning true if a 'Resource busy'
+        exception is raised, returning false if no exception is raised.
+        Any other exception raises a test suite failure.
+        """
+        return self.assertRaisesException(wiredtiger.WiredTigerError, \
+            expr, exceptionString='Resource busy', optional=True)
+
     def assertTimestampsEqual(self, ts1, ts2):
         """
         TestCase.assertEqual() for timestamps


### PR DESCRIPTION
@ddanderson, is there a way to change this code to only ignore failure in the case of `EBUSY`, rather than ignoring all errors?