### PR TITLE
WT-3303 Deadlock during first access to lookaside table

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -807,6 +807,7 @@ intl
 intnum
 intpack
 intptr
+intr
 intrin
 inuse
 io

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -880,10 +880,8 @@ void
 __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session)
 {
 	WT_BTREE *btree;
-	WT_CACHE *cache;
 
 	btree = S2BT(session);
-	cache = S2C(session)->cache;
 
 	/*
 	 * We have seen subtle bugs with multiple threads racing to turn
@@ -891,12 +889,26 @@ __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session)
 	 */
 	WT_DIAGNOSTIC_YIELD;
 
-	/* Hold the walk lock to turn on eviction. */
-	__wt_spin_lock(session, &cache->evict_walk_lock);
-	WT_ASSERT(session,
-	    btree->evict_ref == NULL && btree->evict_disabled > 0);
-	--btree->evict_disabled;
-	__wt_spin_unlock(session, &cache->evict_walk_lock);
+	/*
+	 * Atomically decrement the evict-disabled count, without acquiring the
+	 * eviction walk-lock. We can't acquire that lock here because there's
+	 * a potential deadlock. When acquiring exclusive eviction access, we
+	 * acquire the eviction walk-lock and then the cache's pass-intr lock.
+	 * The current eviction implementation can hold the pass-intr lock and
+	 * call into this function (see WT-3303 for the details), which might
+	 * deadlock with another thread trying to get exclusive eviction access.
+	 */
+#if defined(HAVE_DIAGNOSTIC)
+	{
+	int32_t v;
+
+	WT_ASSERT(session, btree->evict_ref == NULL);
+	v = __wt_atomic_subi32(&btree->evict_disabled, 1);
+	WT_ASSERT(session, v >= 0);
+	}
+#else
+	(void)__wt_atomic_subi32(&btree->evict_disabled, 1);
+#endif
 }
 
 #define	EVICT_TUNE_BATCH	1	/* Max workers to add each period */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -167,7 +167,7 @@ struct __wt_btree {
 	u_int	    evict_walk_period;	/* Skip this many LRU walks */
 	u_int	    evict_walk_saved;	/* Saved walk skips for checkpoints */
 	u_int	    evict_walk_skips;	/* Number of walks skipped */
-	int	    evict_disabled;	/* Eviction disabled count */
+	int32_t	    evict_disabled;	/* Eviction disabled count */
 	bool	    evict_disabled_open;/* Eviction disabled on open */
 	volatile uint32_t evict_busy;	/* Count of threads in eviction */
 	int	    evict_start_type;	/* Start position for eviction walk


### PR DESCRIPTION
Don't acquire the eviction walk-lock when releasing exclusive eviction access to a file, it can deadlock. Instead, atomically decrement the counter.
(cherry picked from commit 5c4e0e9ee90b343e9878dd8f6cab1365fc0dce97)