### PR TITLE
WT-3812 debugging page output should handle complex key/value items.

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -421,9 +421,10 @@ __cursor_key_order_check_row(
 	WT_PANIC_ERR(session, EINVAL,
 	    "WT_CURSOR.%s out-of-order returns: returned key %s then key %s",
 	    next ? "next" : "prev",
-	    __wt_buf_set_printable(
-	    session, cbt->lastkey->data, cbt->lastkey->size, a),
-	    __wt_buf_set_printable(session, key->data, key->size, b));
+	    __wt_buf_set_printable_format(session,
+	    cbt->lastkey->data, cbt->lastkey->size, btree->key_format, a),
+	    __wt_buf_set_printable_format(session,
+	    key->data, key->size, btree->key_format, b));
 
 err:	__wt_scr_free(session, &a);
 	__wt_scr_free(session, &b);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -16,9 +16,6 @@ typedef struct __wt_dbg WT_DBG;
 struct __wt_dbg {
 	WT_SESSION_IMPL *session;		/* Enclosing session */
 
-	bool integer_key;			/* Integer key formats */
-	bool unsigned_key;
-
 	/*
 	 * When using the standard event handlers, the debugging output has to
 	 * do its own message handling because its output isn't line-oriented.
@@ -28,6 +25,9 @@ struct __wt_dbg {
 
 	int (*f)(WT_DBG *, const char *, ...)	/* Function to write */
 	    WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3)));
+
+	const char *key_format;
+	const char *value_format;
 
 	WT_ITEM *tmp;				/* Temporary space */
 };
@@ -124,25 +124,24 @@ __debug_item(WT_DBG *ds, const char *tag, const void *data_arg, size_t size)
 static int
 __debug_item_key(WT_DBG *ds, const char *tag, const void *data_arg, size_t size)
 {
-	uint64_t ukey;
-	int64_t ikey;
-	const uint8_t *p;
+	return (ds->f(ds, "\t%s%s{%s}\n",
+	    tag == NULL ? "" : tag, tag == NULL ? "" : " ",
+	    __wt_buf_set_printable_format(
+	    ds->session, data_arg, size, ds->key_format, ds->tmp)));
+}
 
-	if (ds->integer_key) {
-		p = data_arg;
-		WT_RET(__wt_vunpack_int(&p, 0, &ikey));
-		WT_RET(ds->f(ds, "\t%s%s{%" PRId64 "}\n",
-		    tag == NULL ? "" : tag, tag == NULL ? "" : " ", ikey));
-		return (0);
-	}
-	if (ds->unsigned_key) {
-		p = data_arg;
-		WT_RET(__wt_vunpack_uint(&p, 0, &ukey));
-		WT_RET(ds->f(ds, "\t%s%s{%" PRIu64 "}\n",
-		    tag == NULL ? "" : tag, tag == NULL ? "" : " ", ukey));
-		return (0);
-	}
-	return (__debug_item(ds, tag, data_arg, size));
+/*
+ * __debug_item_value --
+ *	Dump a single data/size value item, with an optional tag.
+ */
+static int
+__debug_item_value(
+    WT_DBG *ds, const char *tag, const void *data_arg, size_t size)
+{
+	return (ds->f(ds, "\t%s%s{%s}\n",
+	    tag == NULL ? "" : tag, tag == NULL ? "" : " ",
+	    __wt_buf_set_printable_format(
+	    ds->session, data_arg, size, ds->value_format, ds->tmp)));
 }
 
 /*
@@ -247,12 +246,8 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile)
 	}
 
 	btree = S2BT_SAFE(session);
-	ds->integer_key = btree != NULL &&
-	    strchr("hilq", btree->key_format[0]) != NULL &&
-	    btree->key_format[1] == '\0';
-	ds->unsigned_key = btree != NULL &&
-	    strchr("HILQr", btree->key_format[0]) != NULL &&
-	    btree->key_format[1] == '\0';
+	ds->key_format = btree->key_format;
+	ds->value_format = btree->value_format;
 	return (0);
 }
 
@@ -1123,7 +1118,7 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 				WT_RET(__debug_hex_byte(ds, *upd->data));
 				WT_RET(ds->f(ds, "}\n"));
 			} else
-				WT_RET(__debug_item(ds,
+				WT_RET(__debug_item_value(ds,
 				    "value", upd->data, upd->size));
 			break;
 		case WT_UPDATE_TOMBSTONE:
@@ -1294,10 +1289,8 @@ __debug_cell_data(WT_DBG *ds,
 	 * Column-store references to deleted cells return a NULL cell
 	 * reference.
 	 */
-	if (unpack == NULL) {
-		WT_RET(__debug_item(ds, tag, "deleted", strlen("deleted")));
-		return (0);
-	}
+	if (unpack == NULL)
+		return (__debug_item(ds, tag, "deleted", strlen("deleted")));
 
 	switch (unpack->raw) {
 	case WT_CELL_ADDR_DEL:
@@ -1308,28 +1301,32 @@ __debug_cell_data(WT_DBG *ds,
 	case WT_CELL_KEY_OVFL_RM:
 	case WT_CELL_VALUE_OVFL_RM:
 		p = __wt_cell_type_string(unpack->raw);
-		WT_RET(__debug_item(ds, tag, p, strlen(p)));
-		break;
+		return (__debug_item(ds, tag, p, strlen(p)));
+	}
+
+	WT_RET(__wt_scr_alloc(session, 256, &buf));
+	WT_ERR(page == NULL ?
+	    __wt_dsk_cell_data_ref(session, page_type, unpack, buf) :
+	    __wt_page_cell_data_ref(session, page, unpack, buf));
+
+	switch (unpack->raw) {
 	case WT_CELL_KEY:
 	case WT_CELL_KEY_OVFL:
 	case WT_CELL_KEY_PFX:
 	case WT_CELL_KEY_SHORT:
 	case WT_CELL_KEY_SHORT_PFX:
+		WT_ERR(__debug_item_key(ds, tag, buf->data, buf->size));
+		break;
 	case WT_CELL_VALUE:
 	case WT_CELL_VALUE_COPY:
 	case WT_CELL_VALUE_OVFL:
 	case WT_CELL_VALUE_SHORT:
-		WT_RET(__wt_scr_alloc(session, 256, &buf));
-		ret = page == NULL ?
-		    __wt_dsk_cell_data_ref(session, page_type, unpack, buf) :
-		    __wt_page_cell_data_ref(session, page, unpack, buf);
-		if (ret == 0)
-			WT_RET(__debug_item(ds, tag, buf->data, buf->size));
-		__wt_scr_free(session, &buf);
+		WT_ERR(__debug_item_value(ds, tag, buf->data, buf->size));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE_ERR(session);
 	}
 
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 #endif

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -748,6 +748,7 @@ extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t s
 extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_buf_catfmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_buf_set_printable( WT_SESSION_IMPL *session, const void *p, size_t size, WT_ITEM *buf);
+extern const char *__wt_buf_set_printable_format(WT_SESSION_IMPL *session, const void *p, size_t size, const char *format, WT_ITEM *buf);
 extern const char *__wt_buf_set_size( WT_SESSION_IMPL *session, uint64_t size, bool exact, WT_ITEM *buf);
 extern int
 __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -748,7 +748,7 @@ extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t s
 extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_buf_catfmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_buf_set_printable( WT_SESSION_IMPL *session, const void *p, size_t size, WT_ITEM *buf);
-extern const char *__wt_buf_set_printable_format(WT_SESSION_IMPL *session, const void *p, size_t size, const char *format, WT_ITEM *buf);
+extern const char *__wt_buf_set_printable_format(WT_SESSION_IMPL *session, const void *buffer, size_t size, const char *format, WT_ITEM *buf);
 extern const char *__wt_buf_set_size( WT_SESSION_IMPL *session, uint64_t size, bool exact, WT_ITEM *buf);
 extern int
 __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp


### PR DESCRIPTION
@michaelcahill, @bvpvamsikrishna suggested a couple of weeks ago we should crack complex key/value pairs when dumping pages for debugging, and it's a good idea. I ended up implementing it when I was working on WT-3768, it made it a lot easier to figure out what the lookaside table was doing.

First, I ended up using the streaming pack/unpack APIs, is there anything that would be simpler?

Second, it mostly works, but there's a problem with zero-length `u` formats. I'm  using the pack stream APIs you added, and there's some magic around zero-length `U/u` formats that I don't understand.

The lookaside `__wt_las_insert_block()` code has no problem inserting zero-length items, and obviously we can subsequently read them, but when I try and call `wiredtiger_unpack_item()` on the "QuBu" format it fails because the saved byte string isn't long enough -- there's no stored length, as near as I can figure out, and `wiredtiger_unpack_item()` fails here:
```
/* Lower-level packing routines treat a length of zero as unchecked. */
if (ps->p >= ps->end)
        return (ENOMEM);
```
Don't bother chasing this if you don't know the answer off-hand, but I've been staring at it for a little while now, and I'm hoping you just know what's going on.