### PR TITLE
WT-3775 Improve set timestamp error message

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -556,8 +556,8 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	bool has_oldest_ts, has_stable_ts;
 
 	/*
- 	 * Added this redundant initialization to circumvent build failure.
- 	 */
+	 * Added this redundant initialization to circumvent build failure.
+	 */
 	__wt_timestamp_set_zero(&oldest_ts);
 	__wt_timestamp_set_zero(&stable_ts);
 	/*

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -563,7 +563,7 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	    if ((has_oldest_ts = txn_global->has_oldest_timestamp))
 		__wt_timestamp_set(&oldest_ts, &txn_global->oldest_timestamp);
 	    if ((has_stable_ts = txn_global->has_stable_timestamp))
-		__wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp););
+		__wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp));
 
 	if (cmp_oldest && has_oldest_ts &&
 	    __wt_timestamp_cmp(ts, &oldest_ts) < 0) {

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -560,12 +560,12 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	 * if the given timestamp is older than oldest and/or stable timestamp.
 	 */
 	WT_WITH_TIMESTAMP_READLOCK(session, &txn_global->rwlock,
-	    has_oldest_ts = txn_global->has_oldest_timestamp;
-	    has_oldest_ts ?
-	    __wt_timestamp_set(&oldest_ts, &txn_global->oldest_timestamp) : 0;
-	    has_stable_ts = txn_global->has_stable_timestamp;
-	    has_stable_ts ?
-	    __wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp) : 0);
+	    (has_oldest_ts = txn_global->has_oldest_timestamp) ?
+	    (__wt_timestamp_set(&oldest_ts, &txn_global->oldest_timestamp),
+	    has_oldest_ts = true) : false;
+	    (has_stable_ts = txn_global->has_stable_timestamp) ?
+	    (__wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp),
+	    has_stable_ts = true) : false);
 
 	if (cmp_oldest && has_oldest_ts &&
 	    __wt_timestamp_cmp(ts, &oldest_ts) < 0) {

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -439,8 +439,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp2, &commit_ts));
 		WT_RET_MSG(session, EINVAL,
-		    "set_timestamp: oldest timestamp %s must not be later than"
-		    " commit timestamp %s", hex_timestamp1, hex_timestamp2);
+		    "set_timestamp: oldest timestamp %s must not be later than "
+		    "commit timestamp %s", hex_timestamp1, hex_timestamp2);
 	}
 
 	if (has_commit && (has_stable || txn_global->has_stable_timestamp) &&
@@ -451,8 +451,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp2, &commit_ts));
 		WT_RET_MSG(session, EINVAL,
-		    "set_timestamp: stable timestamp %s must not be later than"
-		    " commit timestamp %s", hex_timestamp1, hex_timestamp2);
+		    "set_timestamp: stable timestamp %s must not be later than "
+		    "commit timestamp %s", hex_timestamp1, hex_timestamp2);
 	}
 
 	/*
@@ -469,8 +469,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp2, &stable_ts));
 		WT_RET_MSG(session, EINVAL,
-		    "set_timestamp: oldest timestamp %s must not be later than"
-		    " stable timestamp %s", hex_timestamp1, hex_timestamp2);
+		    "set_timestamp: oldest timestamp %s must not be later than "
+		    "stable timestamp %s", hex_timestamp1, hex_timestamp2);
 	}
 
 	__wt_readunlock(session, &txn_global->rwlock);
@@ -568,10 +568,10 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	    __wt_timestamp_cmp(ts, &txn_global->stable_timestamp) < 0));
 
 	if (older_than_oldest_ts) {
-	/*
-	 * As global oldest timestamp access is for error message only, lock was
-	 * not acquired.
-	 */
+		/*
+		 * As global oldest timestamp access is for error message only,
+		 * lock was not acquired.
+		 */
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp, &txn_global->oldest_timestamp));
 		WT_RET_MSG(session, EINVAL,
@@ -579,10 +579,10 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 		    name, (int)cval->len, cval->str, hex_timestamp);
 	}
 	if (older_than_stable_ts) {
-	/*
-	 * As global stable timestamp access is for error message only, lock was
-	 * not acquired.
-	 */
+		/*
+		 * As global stable timestamp access is for error message only,
+		 * lock was not acquired.
+		 */
 		WT_RET(__wt_timestamp_to_hex_string(
 		    session, hex_timestamp, &txn_global->stable_timestamp));
 		WT_RET_MSG(session, EINVAL,

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -556,6 +556,11 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	bool has_oldest_ts, has_stable_ts;
 
 	/*
+ 	 * Added this redundant initialization to circumvent build failure.
+ 	 */
+	__wt_timestamp_set_zero(&oldest_ts);
+	__wt_timestamp_set_zero(&stable_ts);
+	/*
 	 * Compare against the oldest and the stable timestamp. Return an error
 	 * if the given timestamp is older than oldest and/or stable timestamp.
 	 */

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -560,12 +560,10 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	 * if the given timestamp is older than oldest and/or stable timestamp.
 	 */
 	WT_WITH_TIMESTAMP_READLOCK(session, &txn_global->rwlock,
-	    (has_oldest_ts = txn_global->has_oldest_timestamp) ?
-	    (__wt_timestamp_set(&oldest_ts, &txn_global->oldest_timestamp),
-	    has_oldest_ts = true) : false;
-	    (has_stable_ts = txn_global->has_stable_timestamp) ?
-	    (__wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp),
-	    has_stable_ts = true) : false);
+	    if ((has_oldest_ts = txn_global->has_oldest_timestamp))
+		__wt_timestamp_set(&oldest_ts, &txn_global->oldest_timestamp);
+	    if ((has_stable_ts = txn_global->has_stable_timestamp))
+		__wt_timestamp_set(&stable_ts, &txn_global->stable_timestamp););
 
 	if (cmp_oldest && has_oldest_ts &&
 	    __wt_timestamp_cmp(ts, &oldest_ts) < 0) {

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -109,7 +109,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
                 timestamp_str(3) + ',stable_timestamp=' + timestamp_str(1)),
-                '/oldest timestamp must not be later than stable timestamp/')
+                '/oldest timestamp 3 must not be later than stable timestamp 1/')
 
         # Oldest timestamp is 3 at the moment, trying to set it to an earlier
         # timestamp is a no-op.
@@ -128,7 +128,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
                 timestamp_str(6)),
-                '/oldest timestamp must not be later than stable timestamp/')
+                '/oldest timestamp 6 must not be later than stable timestamp 5/')
 
         # Commit timestamp >= Stable timestamp.
         # Check both timestamp_transaction and commit_transaction API.


### PR DESCRIPTION
1. txn_global->rwlock was not acquired as access of txn_global->oldest_timestamp & txn_global->stable_timestamp is for printing in error msg purpose only. 