### PR TITLE
WT-3824 Calibrate the ticks much earlier. Check for too small value.

### DIFF
--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#include <float.h>
 #include <inttypes.h>
 #ifdef _WIN32
 #include <io.h>


### PR DESCRIPTION
@agorrod and @sulabhM Please review these changes. The stack and assertion showed that we were using the time function very early in startup. I moved the calibration to the first thing after creating and initializing the connection structure. I also reorganized the calibration to default to using epoch time and only overriding that if we have good values.