### PR TITLE
WT-3824 Move tick calibration early - into global process structure.

### DIFF
--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -381,7 +381,7 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 		time_stop = __wt_rdtsc(session);
 		WT_STAT_CONN_INCR(session, cache_write_app_count);
 		WT_STAT_CONN_INCRV(session, cache_write_app_time,
-		    WT_TSCDIFF_US(session, time_stop, time_start));
+		    WT_TSCDIFF_US(time_stop, time_start));
 	}
 
 	WT_STAT_CONN_INCR(session, cache_write);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -386,7 +386,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 		time_stop = __wt_rdtsc(session);
 		WT_STAT_CONN_INCR(session, cache_read_app_count);
 		WT_STAT_CONN_INCRV(session, cache_read_app_time,
-		    WT_TSCDIFF_US(session, time_stop, time_start));
+		    WT_TSCDIFF_US(time_stop, time_start));
 	}
 
 	/*

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -338,7 +338,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		    syncop == WT_SYNC_WRITE_LEAVES ?
 		    "WRITE_LEAVES" : "CHECKPOINT",
 		    leaf_pages, leaf_bytes, internal_pages, internal_bytes,
-		    WT_TSCDIFF_MS(session, time_stop, time_start));
+		    WT_TSCDIFF_MS(time_stop, time_start));
 	}
 
 err:	/* On error, clear any left-over tree walk. */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1286,66 +1286,6 @@ err:	API_END_RET(session, ret);
 }
 
 /*
- * __conn_calibrate_ticks --
- *	Calibrate a ratio from rdtsc ticks to nanoseconds.
- */
-static void
-__conn_calibrate_ticks(WT_SESSION_IMPL *session)
-{
-#if defined (__i386) || defined (__amd64)
-	struct timespec start, stop;
-	uint64_t diff_nsec, diff_tsc, min_nsec, min_tsc;
-	uint64_t tries, tsc_start, tsc_stop;
-	volatile uint64_t i;
-
-	min_nsec = min_tsc = 0;
-	/*
-	 * Run this calibration loop a few times to make sure we get a
-	 * reading that does not have a potential scheduling shift in it.
-	 * The inner loop is CPU intensive but a scheduling change in the
-	 * middle could throw off calculations. Take the minimum amount
-	 * of time and compute the ratio.
-	 */
-	for (tries = 0; tries < 3; ++tries) {
-		__wt_epoch(session, &start);
-		tsc_start = __wt_rdtsc(session);
-		/*
-		 * This needs to be CPU intensive and large enough.
-		 */
-		for (i = 0; i < WT_MILLION * 100; i++)
-			;
-		tsc_stop = __wt_rdtsc(session);
-		__wt_epoch(session, &stop);
-		diff_nsec = WT_TIMEDIFF_NS(stop, start);
-		diff_tsc = tsc_stop - tsc_start;
-		if (min_nsec == 0)
-			min_nsec = diff_nsec;
-		else
-			min_nsec = WT_MIN(min_nsec, diff_nsec);
-		if (min_tsc == 0)
-			min_tsc = diff_tsc;
-		else
-			min_tsc = WT_MIN(min_tsc, diff_tsc);
-	}
-
-	/*
-	 * If we couldn't get a good reading then fallback to getting
-	 * time with wt_epoch. One possible reason is that the system's
-	 * clock granularity is not fine-grained enough.
-	 */
-	if (min_nsec == 0) {
-		F_SET(S2C(session), WT_CONN_USE_EPOCHTIME);
-		S2C(session)->tsc_nsec_ratio = 1.0;
-	} else
-		S2C(session)->tsc_nsec_ratio =
-		    (double)min_tsc / (double)min_nsec;
-#else
-	F_SET(S2C(session), WT_CONN_USE_EPOCHTIME);
-	S2C(session)->tsc_nsec_ratio = 1.0;
-#endif
-}
-
-/*
  * __conn_config_append --
  *	Append an entry to a config stack.
  */
@@ -2721,11 +2661,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 * Configuration completed; optionally write a base configuration file.
 	 */
 	WT_ERR(__conn_write_base_config(session, cfg));
-
-	/*
-	 * Calibrate the ratio of rdtsc ticks to nanoseconds.
-	 */
-	__conn_calibrate_ticks(session);
 
 	/*
 	 * Check on the turtle and metadata files, creating them if necessary

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -953,7 +953,7 @@ __log_server(void *arg)
 		__wt_cond_auto_wait_signal(
 		    session, conn->log_cond, did_work, NULL, &signalled);
 		time_stop = __wt_rdtsc(session);
-		timediff = WT_TSCDIFF_MS(session, time_stop, time_start);
+		timediff = WT_TSCDIFF_MS(time_stop, time_start);
 	}
 
 	if (0) {

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -200,7 +200,7 @@ __curfile_search(WT_CURSOR *cursor)
 	WT_ERR(__wt_btcur_search(cbt));
 	time_stop = __wt_rdtsc(session);
 	 __wt_stat_usecs_hist_incr_opread(session,
-	    WT_TSCDIFF_US(session, time_stop, time_start));
+	    WT_TSCDIFF_US(time_stop, time_start));
 
 	/* Search maintains a position, key and value. */
 	WT_ASSERT(session,
@@ -231,7 +231,7 @@ __curfile_search_near(WT_CURSOR *cursor, int *exact)
 	WT_ERR(__wt_btcur_search_near(cbt, exact));
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_usecs_hist_incr_opread(session,
-	    WT_TSCDIFF_US(session, time_stop, time_start));
+	    WT_TSCDIFF_US(time_stop, time_start));
 
 	/* Search-near maintains a position, key and value. */
 	WT_ASSERT(session,
@@ -265,7 +265,7 @@ __curfile_insert(WT_CURSOR *cursor)
 	WT_ERR(__wt_btcur_insert(cbt));
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_usecs_hist_incr_opwrite(session,
-	    WT_TSCDIFF_US(session, time_stop, time_start));
+	    WT_TSCDIFF_US(time_stop, time_start));
 
 	/*
 	 * Insert maintains no position, key or value (except for column-store
@@ -366,7 +366,7 @@ __curfile_update(WT_CURSOR *cursor)
 	WT_ERR(__wt_btcur_update(cbt));
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_usecs_hist_incr_opwrite(session,
-	    WT_TSCDIFF_US(session, time_stop, time_start));
+	    WT_TSCDIFF_US(time_stop, time_start));
 
 	/* Update maintains a position, key and value. */
 	WT_ASSERT(session,
@@ -398,7 +398,7 @@ __curfile_remove(WT_CURSOR *cursor)
 	WT_ERR(__wt_btcur_remove(cbt));
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_usecs_hist_incr_opwrite(session,
-	    WT_TSCDIFF_US(session, time_stop, time_start));
+	    WT_TSCDIFF_US(time_stop, time_start));
 
 	/*
 	 * Remove with a search-key is fire-and-forget, no position and no key.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -741,7 +741,7 @@ __evict_pass(WT_SESSION_IMPL *session)
 		 * transactions and writing updates to the lookaside table.
 		 */
 		if (eviction_progress == cache->eviction_progress) {
-			if (WT_TSCDIFF_MS(session, time_now, time_prev) >= 20 &&
+			if (WT_TSCDIFF_MS(time_now, time_prev) >= 20 &&
 			    F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD |
 			    WT_CACHE_EVICT_DIRTY_HARD)) {
 				if (cache->evict_aggressive_score < 100)
@@ -2312,7 +2312,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 		time_stop = __wt_rdtsc(session);
 		WT_STAT_CONN_INCRV(session,
 		    application_evict_time,
-		    WT_TSCDIFF_US(session, time_stop, time_start));
+		    WT_TSCDIFF_US(time_stop, time_start));
 	}
 	WT_TRACK_OP_END(session);
 	return (ret);
@@ -2428,7 +2428,7 @@ err:	if (timer) {
 		time_stop = __wt_rdtsc(session);
 		WT_STAT_CONN_INCRV(session,
 		    application_cache_time,
-		    WT_TSCDIFF_US(session, time_stop, time_start));
+		    WT_TSCDIFF_US(time_stop, time_start));
 	}
 
 done:	WT_TRACK_OP_END(session);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -88,7 +88,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 		if (too_big) {
 			WT_STAT_CONN_INCR(session, cache_eviction_force);
 			WT_STAT_CONN_INCRV(session, cache_eviction_force_time,
-			    WT_TSCDIFF_US(session, time_stop, time_start));
+			    WT_TSCDIFF_US(time_stop, time_start));
 		} else {
 			/*
 			 * If the page isn't too big, we are evicting it because
@@ -98,12 +98,12 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 			WT_STAT_CONN_INCR(session, cache_eviction_force_delete);
 			WT_STAT_CONN_INCRV(session,
 			    cache_eviction_force_delete_time,
-			    WT_TSCDIFF_US(session, time_stop, time_start));
+			    WT_TSCDIFF_US(time_stop, time_start));
 		}
 	} else {
 		WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
 		WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time,
-		    WT_TSCDIFF_US(session, time_stop, time_start));
+		    WT_TSCDIFF_US(time_stop, time_start));
 	}
 
 	(void)__wt_atomic_subv32(&btree->evict_busy, 1);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -25,6 +25,8 @@ struct __wt_process {
 					/* Locked: connection queue */
 	TAILQ_HEAD(__wt_connection_impl_qh, __wt_connection_impl) connqh;
 	WT_CACHE_POOL *cache_pool;
+#define	WT_TSC_DEFAULT_RATIO	1.0
+	double	 tsc_nsec_ratio;	/* rdtsc ticks to nanoseconds */
 
 					/* Checksum function */
 #define	__wt_checksum(chunk, len)	__wt_process.checksum(chunk, len)
@@ -403,7 +405,6 @@ struct __wt_connection_impl {
 
 	bool	 mmap;			/* mmap configuration */
 	int page_size;			/* OS page size for mmap alignment */
-	double	 tsc_nsec_ratio;	/* rdtsc ticks to nanoseconds */
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define	WT_VERB_API			0x000000001u
@@ -484,8 +485,7 @@ struct __wt_connection_impl {
 #define	WT_CONN_SERVER_LSM		0x020000u
 #define	WT_CONN_SERVER_STATISTICS	0x040000u
 #define	WT_CONN_SERVER_SWEEP		0x080000u
-#define	WT_CONN_USE_EPOCHTIME		0x100000u
-#define	WT_CONN_WAS_BACKUP		0x200000u
+#define	WT_CONN_WAS_BACKUP		0x100000u
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 	uint32_t flags;
 };

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -27,6 +27,7 @@ struct __wt_process {
 	WT_CACHE_POOL *cache_pool;
 #define	WT_TSC_DEFAULT_RATIO	1.0
 	double	 tsc_nsec_ratio;	/* rdtsc ticks to nanoseconds */
+	bool use_epochtime;		/* use expensive time */
 
 					/* Checksum function */
 #define	__wt_checksum(chunk, len)	__wt_process.checksum(chunk, len)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -787,7 +787,7 @@ extern void __wt_thread_group_start_one( WT_SESSION_IMPL *session, WT_THREAD_GRO
 extern void __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group);
 extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_seconds(WT_SESSION_IMPL *session, time_t *timep);
-extern uint64_t __wt_tsc_to_nsec(WT_SESSION_IMPL *session, uint64_t end, uint64_t begin);
+extern uint64_t __wt_tsc_to_nsec(uint64_t end, uint64_t begin);
 extern uint64_t __wt_tsc_get_expensive_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -35,7 +35,7 @@ __wt_hex(int c)
  */
 static inline uint64_t
 __wt_rdtsc(WT_SESSION_IMPL *session) {
-	if (F_ISSET(S2C(session), WT_CONN_USE_EPOCHTIME))
+	if (__wt_process.tsc_nsec_ratio == WT_TSC_DEFAULT_RATIO)
 		return (__wt_tsc_get_expensive_timestamp(session));
 #if defined (__i386)
 	{

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -35,7 +35,7 @@ __wt_hex(int c)
  */
 static inline uint64_t
 __wt_rdtsc(WT_SESSION_IMPL *session) {
-	if (__wt_process.tsc_nsec_ratio == WT_TSC_DEFAULT_RATIO)
+	if (__wt_process.use_epochtime)
 		return (__wt_tsc_get_expensive_timestamp(session));
 #if defined (__i386)
 	{

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -304,12 +304,10 @@ __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 		stats[session->stat_bucket][t->stat_count_off]++;
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][t->stat_int_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 		else
 			stats[session->stat_bucket][t->stat_app_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 	} else
 		__wt_spin_lock(session, t);
 }

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -65,14 +65,14 @@
 #define	WT_TIMEDIFF_SEC(end, begin)					\
 	(WT_TIMEDIFF_NS((end), (begin)) / WT_BILLION)
 
-#define	WT_TSCDIFF_NS(s, end, begin)					\
-	(__wt_tsc_to_nsec(s, end, begin))
-#define	WT_TSCDIFF_US(s, end, begin)					\
-	(WT_TSCDIFF_NS(s, end, begin) / WT_THOUSAND)
-#define	WT_TSCDIFF_MS(s, end, begin)					\
-	(WT_TSCDIFF_NS(s, end, begin) / WT_MILLION)
-#define	WT_TSCDIFF_SEC(s, end, begin)					\
-	(WT_TSCDIFF_NS(s, end, begin) / WT_BILLION)
+#define	WT_TSCDIFF_NS(end, begin)					\
+	(__wt_tsc_to_nsec(end, begin))
+#define	WT_TSCDIFF_US(end, begin)					\
+	(WT_TSCDIFF_NS(end, begin) / WT_THOUSAND)
+#define	WT_TSCDIFF_MS(end, begin)					\
+	(WT_TSCDIFF_NS(end, begin) / WT_MILLION)
+#define	WT_TSCDIFF_SEC(end, begin)					\
+	(WT_TSCDIFF_NS(end, begin) / WT_BILLION)
 
 #define	WT_TIMECMP(t1, t2)						\
 	((t1).tv_sec < (t2).tv_sec ? -1 :				\

--- a/src/include/os_fhandle.i
+++ b/src/include/os_fhandle.i
@@ -116,7 +116,7 @@ __wt_read(
 
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_msecs_hist_incr_fsread(session,
-	    WT_TSCDIFF_MS(session, time_stop, time_start));
+	    WT_TSCDIFF_MS(time_stop, time_start));
 	WT_STAT_CONN_DECR_ATOMIC(session, thread_read_active);
 	return (ret);
 }
@@ -195,7 +195,7 @@ __wt_write(WT_SESSION_IMPL *session,
 
 	time_stop = __wt_rdtsc(session);
 	__wt_stat_msecs_hist_incr_fswrite(session,
-	    WT_TSCDIFF_MS(session, time_stop, time_start));
+	    WT_TSCDIFF_MS(time_stop, time_start));
 	WT_STAT_CONN_DECR_ATOMIC(session, thread_write_active);
 	return (ret);
 }

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#include <float.h>
 #include <inttypes.h>
 #ifdef _WIN32
 #include <io.h>

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -314,8 +314,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 		time_start = __wt_rdtsc(session);
 		WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
 		time_stop = __wt_rdtsc(session);
-		fsync_duration_usecs = WT_TSCDIFF_US(session,
-		    time_stop, time_start);
+		fsync_duration_usecs = WT_TSCDIFF_US(time_stop, time_start);
 		log->sync_dir_lsn = *min_lsn;
 		WT_STAT_CONN_INCR(session, log_sync_dir);
 		WT_STAT_CONN_INCRV(session,
@@ -338,8 +337,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
 		time_start = __wt_rdtsc(session);
 		WT_ERR(__wt_fsync(session, log_fh, true));
 		time_stop = __wt_rdtsc(session);
-		fsync_duration_usecs = WT_TSCDIFF_US(session,
-		    time_stop, time_start);
+		fsync_duration_usecs = WT_TSCDIFF_US(time_stop, time_start);
 		log->sync_lsn = *min_lsn;
 		WT_STAT_CONN_INCR(session, log_sync);
 		WT_STAT_CONN_INCRV(session,
@@ -1849,8 +1847,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 			time_start = __wt_rdtsc(session);
 			WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
 			time_stop = __wt_rdtsc(session);
-			fsync_duration_usecs = WT_TSCDIFF_US(session,
-			    time_stop, time_start);
+			fsync_duration_usecs =
+			    WT_TSCDIFF_US(time_stop, time_start);
 			log->sync_dir_lsn = sync_lsn;
 			WT_STAT_CONN_INCR(session, log_sync_dir);
 			WT_STAT_CONN_INCRV(session,
@@ -1871,8 +1869,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 			time_start = __wt_rdtsc(session);
 			WT_ERR(__wt_fsync(session, log->log_fh, true));
 			time_stop = __wt_rdtsc(session);
-			fsync_duration_usecs = WT_TSCDIFF_US(session,
-			    time_stop, time_start);
+			fsync_duration_usecs =
+			    WT_TSCDIFF_US(time_stop, time_start);
 			WT_STAT_CONN_INCRV(session,
 			    log_sync_duration, fsync_duration_usecs);
 			log->sync_lsn = sync_lsn;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -172,7 +172,7 @@ retry:
 			if (count > WT_MILLION) {
 				time_stop = __wt_rdtsc(session);
 				if (WT_TSCDIFF_SEC(
-				    session, time_stop, time_start) > 10) {
+				    time_stop, time_start) > 10) {
 					__wt_errx(session, "SLOT_CLOSE: Slot %"
 					PRIu32 " Timeout unbuffered, state 0x%"
 					PRIx64 " unbuffered %" PRId64,
@@ -272,8 +272,7 @@ __log_slot_new(WT_SESSION_IMPL *session)
 		++count;
 		if (count > WT_MILLION) {
 			time_stop = __wt_rdtsc(session);
-			if (WT_TSCDIFF_SEC(
-			    session, time_stop, time_start) > 10) {
+			if (WT_TSCDIFF_SEC(time_stop, time_start) > 10) {
 				__wt_errx(session,
 				    "SLOT_NEW: Timeout free slot");
 				__log_slot_dump(session);
@@ -600,7 +599,7 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize,
 	else {
 		WT_STAT_CONN_INCR(session, log_slot_yield);
 		time_stop = __wt_rdtsc(session);
-		usecs = WT_TSCDIFF_US(session, time_stop, time_start);
+		usecs = WT_TSCDIFF_US(time_stop, time_start);
 		WT_STAT_CONN_INCRV(session, log_slot_yield_duration, usecs);
 		if (closed)
 			WT_STAT_CONN_INCR(session, log_slot_yield_close);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1635,7 +1635,7 @@ __session_transaction_sync(WT_SESSION *wt_session, const char *config)
 
 		__wt_cond_signal(session, conn->log_file_cond);
 		time_stop = __wt_rdtsc(session);
-		waited_ms = WT_TSCDIFF_MS(session, time_stop, time_start);
+		waited_ms = WT_TSCDIFF_MS(time_stop, time_start);
 		if (waited_ms < timeout_ms) {
 			remaining_usec = (timeout_ms - waited_ms) * WT_THOUSAND;
 			__wt_cond_wait(session, log->log_sync_cond,

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -45,7 +45,7 @@ __wt_endian_check(void)
  *	Calibrate a ratio from rdtsc ticks to nanoseconds.
  */
 static void
-__global_calibrate_ticks()
+__global_calibrate_ticks(void)
 {
 #if defined (__i386) || defined (__amd64)
 	struct timespec start, stop;

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -62,6 +62,7 @@ __global_calibrate_ticks()
 	 * middle could throw off calculations. Take the minimum amount
 	 * of time and compute the ratio.
 	 */
+	__wt_process.use_epochtime = false;
 	for (tries = 0; tries < 3; ++tries) {
 		__wt_epoch(NULL, &start);
 		tsc_start = __wt_rdtsc(NULL);
@@ -90,13 +91,17 @@ __global_calibrate_ticks()
 	 * clock granularity is not fine-grained enough.
 	 */
 	__wt_process.tsc_nsec_ratio = WT_TSC_DEFAULT_RATIO;
+	__wt_process.use_epochtime = true;
 	if (min_nsec != 0) {
 		ratio =
 		    (double)min_tsc / (double)min_nsec;
-		if (ratio > DBL_EPSILON)
+		if (ratio > DBL_EPSILON) {
 			__wt_process.tsc_nsec_ratio = ratio;
+			__wt_process.use_epochtime = false;
+		}
 	}
 #else
+	__wt_process.use_epochtime = true;
 	__wt_process.tsc_nsec_ratio = WT_TSC_DEFAULT_RATIO;
 #endif
 }

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -255,12 +255,10 @@ stall:			__wt_cond_wait(session,
 		time_stop = __wt_rdtsc(session);
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][l->stat_int_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 		else
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 	}
 
 	/*
@@ -428,12 +426,10 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 		time_stop = __wt_rdtsc(session);
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][l->stat_int_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 		else
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
-			    (int64_t)WT_TSCDIFF_US(
-			    session, time_stop, time_start);
+			    (int64_t)WT_TSCDIFF_US(time_stop, time_start);
 	}
 
 	/*

--- a/src/support/time.c
+++ b/src/support/time.c
@@ -81,6 +81,7 @@ __wt_tsc_to_nsec(WT_SESSION_IMPL *session, uint64_t end, uint64_t begin)
 {
 	double tsc_diff;
 
+	WT_UNUSED(session);
 	/*
 	 * If the ticks were reset, consider it an invalid check and just
 	 * return zero as the time difference because we cannot compute
@@ -89,7 +90,7 @@ __wt_tsc_to_nsec(WT_SESSION_IMPL *session, uint64_t end, uint64_t begin)
 	if (end < begin)
 		return (0);
 	tsc_diff = (double)(end - begin);
-	return ((uint64_t)(tsc_diff / S2C(session)->tsc_nsec_ratio));
+	return ((uint64_t)(tsc_diff / __wt_process.tsc_nsec_ratio));
 }
 
 /*

--- a/src/support/time.c
+++ b/src/support/time.c
@@ -77,11 +77,10 @@ __wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
  *	Convert from rdtsc ticks to nanoseconds.
  */
 uint64_t
-__wt_tsc_to_nsec(WT_SESSION_IMPL *session, uint64_t end, uint64_t begin)
+__wt_tsc_to_nsec(uint64_t end, uint64_t begin)
 {
 	double tsc_diff;
 
-	WT_UNUSED(session);
 	/*
 	 * If the ticks were reset, consider it an invalid check and just
 	 * return zero as the time difference because we cannot compute

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -448,7 +448,7 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 
 		__wt_sleep(0, stepdown_us / 10);
 		time_stop = __wt_rdtsc(session);
-		current_us = WT_TSCDIFF_US(session, time_stop, time_last);
+		current_us = WT_TSCDIFF_US(time_stop, time_last);
 		bytes_written_total =
 		    cache->bytes_written - bytes_written_start;
 
@@ -506,7 +506,7 @@ __checkpoint_reduce_dirty_cache(WT_SESSION_IMPL *session)
 	}
 
 	time_stop = __wt_rdtsc(session);
-	total_ms = WT_TSCDIFF_MS(session, time_stop, time_start);
+	total_ms = WT_TSCDIFF_MS(time_stop, time_start);
 	WT_STAT_CONN_SET(session, txn_checkpoint_scrub_time, total_ms);
 }
 
@@ -883,7 +883,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	time_start = __wt_rdtsc(session);
 	WT_ERR(__checkpoint_apply(session, cfg, __wt_checkpoint_sync));
 	time_stop = __wt_rdtsc(session);
-	fsync_duration_usecs = WT_TSCDIFF_US(session, time_stop, time_start);
+	fsync_duration_usecs = WT_TSCDIFF_US(time_stop, time_start);
 	WT_STAT_CONN_INCR(session, txn_checkpoint_fsync_post);
 	WT_STAT_CONN_SET(session,
 	    txn_checkpoint_fsync_post_duration, fsync_duration_usecs);


### PR DESCRIPTION
@keithbostic and @agorrod here's a change that moves the tsc calibration into the `__wt_process` global instead of the connection. 