### PR TITLE
WT-3833 Allow 0 as cache minimum.

### DIFF
--- a/test/format/config.h
+++ b/test/format/config.h
@@ -103,7 +103,7 @@ static CONFIG c[] = {
 
 	{ "cache_minimum",
 	  "minimum size of the cache in MB",
-	  C_IGNORE, 1, 0, 100 * 1024, &g.c_cache_minimum, NULL },
+	  C_IGNORE, 0, 0, 100 * 1024, &g.c_cache_minimum, NULL },
 
 	{ "checkpoints",
 	  "type of checkpoints (on | off | wiredtiger)",


### PR DESCRIPTION
@keithbostic This is a simplistic fix for the bug that a generated CONFIG gives an error when reused. You added the `cache_minimum` setting. I'm happy to close this branch if you have a better informed solution.