### PR TITLE
WT-3831 uninitialized buffer value in statlog server path comparison

### DIFF
--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -614,9 +614,6 @@ __statlog_server(void *arg)
 	session = arg;
 	conn = S2C(session);
 
-	WT_CLEAR(path);
-	WT_CLEAR(tmp);
-
 	/*
 	 * We need a temporary place to build a path and an entry prefix.
 	 * The length of the path plus 128 should be more than enough.
@@ -624,8 +621,12 @@ __statlog_server(void *arg)
 	 * We also need a place to store the current path, because that's
 	 * how we know when to close/re-open the file.
 	 */
+	WT_CLEAR(path);
 	WT_ERR(__wt_buf_init(session, &path, strlen(conn->stat_path) + 128));
+	WT_ERR(__wt_buf_set(session, &path, "", 0));
+	WT_CLEAR(tmp);
 	WT_ERR(__wt_buf_init(session, &tmp, strlen(conn->stat_path) + 128));
+	WT_ERR(__wt_buf_set(session, &tmp, "", 0));
 
 	for (;;) {
 		/* Wait until the next event. */


### PR DESCRIPTION
@sueloverso,  here's the valgrind failure: http://build.wiredtiger.com:8080/job/wiredtiger-valgrind/2664/valgrindResult/pid=34127,0x0/