### PR TITLE
WT-3074 Automate a test to stress eviction walk

### DIFF
--- a/bench/wtperf/runners/evict-fairness.wtperf
+++ b/bench/wtperf/runners/evict-fairness.wtperf
@@ -1,0 +1,20 @@
+# This configuration is used to test the eviction fairness of visiting all tables.
+# Create a set of tables with uneven distribution of data
+conn_config="cache_size=1G,eviction=(threads_max=8),file_manager=(close_idle_time=100000),checkpoint=(wait=20,log_size=2GB),session_max=1000"
+table_config="type=file"
+table_count=200
+icount=0
+random_range=1000000000
+pareto=0
+range_partition=true
+report_interval=5
+
+run_ops=1000000
+populate_threads=0
+icount=0
+threads=((count=60,inserts=1))
+
+# Warn if a latency over 1 second is seen
+max_latency=1000
+sample_interval=5
+sample_rate=1


### PR DESCRIPTION
Added a new file to wtperf/runners, to test the eviction fairness in walking active trees.
Automation will be done in jenkins, which will use this configuration for test.