### PR TITLE
Not to MERGE- Only for Review : WT-3769 backport to 36

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -55,15 +55,38 @@ __cursor_state_restore(WT_CURSOR *cursor, WT_CURFILE_STATE *state)
  *	Return if we have a page pinned.
  */
 static inline bool
-__cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool eviction_ok)
+__cursor_page_pinned(WT_CURSOR_BTREE *cbt)
 {
+	WT_CURSOR *cursor;
+
+	cursor = &cbt->iface;
+
 	/*
-	 * Optionally fail the page-pinned test when the page is flagged for
-	 * forced eviction (so we periodically release pages grown too large).
-	 * The test is optional as not all callers can release pinned pages.
+	 * Check the page active flag, asserting the page reference with any
+	 * external key.
 	 */
-	return (F_ISSET(cbt, WT_CBT_ACTIVE) &&
-	    (!eviction_ok || cbt->ref->page->read_gen != WT_READGEN_OLDEST));
+	if (!F_ISSET(cbt, WT_CBT_ACTIVE)) {
+		WT_ASSERT((WT_SESSION_IMPL *)cursor->session,
+		    cbt->ref == NULL && !F_ISSET(cursor, WT_CURSTD_KEY_INT));
+		return (false);
+	}
+
+	/*
+	 * Check if the key references the page. When returning from search,
+	 * the page is active and the key is internal. After the application
+	 * sets a key, the key is external, and the page is useless.
+	 */
+	if (!F_ISSET(cursor, WT_CURSTD_KEY_INT))
+		return (false);
+
+	/*
+	 * Fail if the page is flagged for forced eviction (so we periodically
+	 * release pages grown too large).
+	 */
+	if (cbt->ref->page->read_gen != WT_READGEN_OLDEST)
+		return (false);
+
+	return (true);
 }
 
 /*
@@ -146,7 +169,7 @@ __cursor_disable_bulk(WT_SESSION_IMPL *session, WT_BTREE *btree)
  * __cursor_fix_implicit --
  *	Return if search went past the end of the tree.
  */
-static inline int
+static inline bool
 __cursor_fix_implicit(WT_BTREE *btree, WT_CURSOR_BTREE *cbt)
 {
 	/*
@@ -468,7 +491,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 	 * from the root.
 	 */
 	valid = false;
-	if (__cursor_page_pinned(cbt, true)) {
+	if (__cursor_page_pinned(cbt)) {
 		__wt_txn_cursor_op(session);
 
 		WT_ERR(btree->type == BTREE_ROW ?
@@ -565,7 +588,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 	 * existing record.
 	 */
 	valid = false;
-	if (btree->type == BTREE_ROW && __cursor_page_pinned(cbt, true)) {
+	if (btree->type == BTREE_ROW && __cursor_page_pinned(cbt)) {
 		__wt_txn_cursor_op(session);
 
 		WT_ERR(__cursor_row_search(session, cbt, cbt->ref, true));
@@ -691,14 +714,12 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
 
 	/*
 	 * If inserting with overwrite configured, and positioned to an on-page
-	 * key, the update doesn't require another search. The cursor won't be
-	 * positioned on a page with an external key set, but be sure. Cursors
-	 * configured for append aren't included, regardless of whether or not
-	 * they meet all other criteria.
+	 * key, the update doesn't require another search. Cursors configured
+	 * for append aren't included, regardless of whether or not they meet
+	 * all other criteria.
 	 */
-	if (__cursor_page_pinned(cbt, true) &&
-	    F_ISSET_ALL(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_OVERWRITE) &&
-	    !append_key) {
+	if (__cursor_page_pinned(cbt) &&
+	    F_ISSET(cursor, WT_CURSTD_OVERWRITE) && !append_key) {
 		WT_ERR(__wt_txn_autocommit_check(session));
 		/*
 		 * The cursor position may not be exact (the cursor's comparison
@@ -771,7 +792,7 @@ retry:	WT_ERR(__cursor_func_init(cbt, true));
 		WT_ERR(__cursor_col_modify(session, cbt, WT_UPDATE_STANDARD));
 
 		if (append_key)
-			cbt->iface.recno = cbt->recno;
+			cursor->recno = cbt->recno;
 	}
 
 err:	if (ret == WT_RESTART) {
@@ -784,7 +805,7 @@ done:	/* Insert doesn't maintain a position across calls, clear resources. */
 	if (ret == 0) {
 		F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 		if (append_key)
-			F_SET(cursor, WT_CURSTD_KEY_INT);
+			F_SET(cursor, WT_CURSTD_KEY_EXT);
 	}
 	WT_TRET(__cursor_reset(cbt));
 	if (ret != 0)
@@ -884,12 +905,12 @@ err:	if (ret == WT_RESTART) {
 int
 __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 {
+	enum { NO_POSITION, POSITIONED, SEARCH_POSITION } positioned;
 	WT_BTREE *btree;
 	WT_CURFILE_STATE state;
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	bool positioned;
 
 	btree = cbt->btree;
 	cursor = &cbt->iface;
@@ -902,8 +923,27 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 	/*
 	 * WT_CURSOR.remove has a unique semantic, the cursor stays positioned
 	 * if it starts positioned, otherwise clear the cursor on completion.
+	 *
+	 * However, if we unpin the page (because the page is in WT_REF_LIMBO or
+	 * it was selected for forcible eviction), and every item on the page is
+	 * deleted, eviction can delete the page and our subsequent search will
+	 * re-instantiate an empty page for us, with no key/value pairs. Cursor
+	 * remove will search that page and return not-found, which is OK unless
+	 * cursor-overwrite is configured (which causes cursor remove to return
+	 * success even if there's no item to delete). In that case, we're
+	 * supposed to return a positioned cursor, but there's nothing to which
+	 * we can position, and we'll fail attempting to point the cursor at the
+	 * key on the page to satisfy the positioned requirement.
+	 *
+	 * Do the best we can: If we start with a positioned cursor, and we let
+	 * go of our pinned page, reset our state to use the search position,
+	 * that is, use a successful search to return to a "positioned" state.
+	 * If we start with a positioned cursor, let go of our pinned page, and
+	 * the search fails, leave the cursor's key set so the cursor appears
+	 * positioned to the application.
 	 */
-	positioned = F_ISSET(cursor, WT_CURSTD_KEY_INT);
+	positioned =
+	    F_ISSET(cursor, WT_CURSTD_KEY_INT) ? POSITIONED : NO_POSITION;
 
 	/* Save the cursor state. */
 	__cursor_state_save(cursor, &state);
@@ -912,9 +952,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 	 * If remove positioned to an on-page key, the remove doesn't require
 	 * another search. We don't care about the "overwrite" configuration
 	 * because regardless of the overwrite setting, any existing record is
-	 * removed, and the record must exist with a positioned cursor. The
-	 * cursor won't be positioned on a page with an external key set, but
-	 * be sure.
+	 * removed, and the record must exist with a positioned cursor.
 	 *
 	 * There's trickiness in the page-pinned check. By definition a remove
 	 * operation leaves a cursor positioned if it's initially positioned.
@@ -929,8 +967,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 	 * that's all a positioned cursor implies), but it's probably safer to
 	 * avoid page eviction entirely in the positioned case.
 	 */
-	if (__cursor_page_pinned(cbt, !positioned) &&
-	    F_ISSET(cursor, WT_CURSTD_KEY_INT)) {
+	if (__cursor_page_pinned(cbt)) {
 		WT_ERR(__wt_txn_autocommit_check(session));
 
 		/*
@@ -958,6 +995,9 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt)
 		__cursor_state_save(cursor, &state);
 		goto err;
 	}
+
+	if (positioned == POSITIONED)
+		positioned = SEARCH_POSITION;
 
 	/*
 	 * The pinned page goes away if we do a search, get a local copy of any
@@ -1024,19 +1064,37 @@ err:	if (ret == WT_RESTART) {
 	if (F_ISSET(cursor, WT_CURSTD_OVERWRITE) && ret == WT_NOTFOUND)
 		ret = 0;
 
-done:	/*
-	 * If the cursor was positioned, it stays positioned, point the cursor
-	 * at an internal copy of the key. Otherwise, there's no position or
-	 * key/value.
-	 */
-	if (ret == 0)
-		F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-	if (ret == 0 && positioned)
-		WT_TRET(__wt_key_return(session, cbt));
-	else
+done:	if (ret == 0) {
+		F_CLR(cursor, WT_CURSTD_VALUE_SET);
+		switch (positioned) {
+		case NO_POSITION:
+			/*
+			 * Never positioned and we leave it that way, clear any
+			 * key and reset the cursor.
+			 */
+			F_CLR(cursor, WT_CURSTD_KEY_SET);
+			WT_TRET(__cursor_reset(cbt));
+			break;
+		case POSITIONED:
+			/*
+			 * Positioned and we used the pinned page, leave the key
+			 * alone, whatever it is.
+			 */
+			break;
+		case SEARCH_POSITION:
+			/*
+			 * Positioned and we did a search anyway, get a key to
+			 * return.
+			 */
+			WT_TRET(__wt_key_return(session, cbt));
+			break;
+		}
+	}
+
+	if (ret != 0) {
 		WT_TRET(__cursor_reset(cbt));
-	if (ret != 0)
 		__cursor_state_restore(cursor, &state);
+	}
 
 	return (ret);
 }
@@ -1068,12 +1126,9 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
 	 * If update positioned to an on-page key, the update doesn't require
 	 * another search. We don't care about the "overwrite" configuration
 	 * because regardless of the overwrite setting, any existing record is
-	 * updated, and the record must exist with a positioned cursor. The
-	 * cursor won't be positioned on a page with an external key set, but
-	 * be sure.
+	 * updated, and the record must exist with a positioned cursor.
 	 */
-	if (__cursor_page_pinned(cbt, true) &&
-	    F_ISSET(cursor, WT_CURSTD_KEY_INT)) {
+	if (__cursor_page_pinned(cbt)) {
 		WT_ERR(__wt_txn_autocommit_check(session));
 
 		/*

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -83,7 +83,7 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt)
 	 * Fail if the page is flagged for forced eviction (so we periodically
 	 * release pages grown too large).
 	 */
-	if (cbt->ref->page->read_gen != WT_READGEN_OLDEST)
+	if (cbt->ref->page->read_gen == WT_READGEN_OLDEST)
 		return (false);
 
 	return (true);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -90,6 +90,7 @@ __curfile_next(WT_CURSOR *cursor)
 
 	/* Next maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -115,6 +116,7 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
 
 	/* Next-random maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -139,6 +141,7 @@ __curfile_prev(WT_CURSOR *cursor)
 
 	/* Prev maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -163,6 +166,7 @@ __curfile_reset(WT_CURSOR *cursor)
 
 	/* Reset maintains no position, key or value. */
 	WT_ASSERT(session,
+	    !F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == 0 &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == 0);
 
@@ -188,6 +192,7 @@ __curfile_search(WT_CURSOR *cursor)
 
 	/* Search maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -213,6 +218,7 @@ __curfile_search_near(WT_CURSOR *cursor, int *exact)
 
 	/* Search-near maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -244,10 +250,12 @@ __curfile_insert(WT_CURSOR *cursor)
 	 * appends, where we are returning a key).
 	 */
 	WT_ASSERT(session,
-	    (F_ISSET(cursor, WT_CURSTD_APPEND) &&
-	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT) ||
+	    !F_ISSET(cbt, WT_CBT_ACTIVE) &&
+	    ((F_ISSET(cursor, WT_CURSTD_APPEND) &&
+	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_EXT) ||
 	    (!F_ISSET(cursor, WT_CURSTD_APPEND) &&
-	    F_MASK(cursor, WT_CURSTD_KEY_SET) == 0));
+	    F_MASK(cursor, WT_CURSTD_KEY_SET) == 0)));
+	WT_ASSERT(session, F_MASK(cursor, WT_CURSTD_VALUE_SET) == 0);
 
 err:	CURSOR_UPDATE_API_END(session, ret);
 	return (ret);
@@ -307,6 +315,7 @@ __curfile_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 	 * always an internal value.
 	 */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
 	WT_ASSERT(session, F_MASK(cursor, WT_CURSTD_VALUE_SET) != 0);
 
@@ -334,6 +343,7 @@ __curfile_update(WT_CURSOR *cursor)
 
 	/* Update maintains a position, key and value. */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT &&
 	    F_MASK(cursor, WT_CURSTD_VALUE_SET) == WT_CURSTD_VALUE_INT);
 
@@ -360,13 +370,10 @@ __curfile_remove(WT_CURSOR *cursor)
 
 	/*
 	 * Remove with a search-key is fire-and-forget, no position and no key.
-	 * Remove starting from a position maintains the position and a key.
-	 * We don't know which it was at this layer, so can only assert the key
-	 * is not set at all, or internal. There's never a value.
+	 * Remove starting from a position maintains the position and a key,
+	 * but the key can end up being internal, external, or not set, there's
+	 * nothing to assert. There's never a value.
 	 */
-	WT_ASSERT(session,
-	    F_MASK(cursor, WT_CURSTD_KEY_SET) == 0 ||
-	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
 	WT_ASSERT(session, F_MASK(cursor, WT_CURSTD_VALUE_SET) == 0);
 
 err:	CURSOR_UPDATE_API_END(session, ret);
@@ -398,6 +405,7 @@ __curfile_reserve(WT_CURSOR *cursor)
 	 * each successful reserve operation.
 	 */
 	WT_ASSERT(session,
+	    F_ISSET(cbt, WT_CBT_ACTIVE) &&
 	    F_MASK(cursor, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
 	WT_ASSERT(session, F_MASK(cursor, WT_CURSTD_VALUE_SET) == 0);
 

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -547,7 +547,7 @@ __curtable_insert(WT_CURSOR *cursor)
 	 */
 	F_CLR(primary, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 	if (F_ISSET(primary, WT_CURSTD_APPEND))
-		F_SET(primary, WT_CURSTD_KEY_INT);
+		F_SET(primary, WT_CURSTD_KEY_EXT);
 
 err:	CURSOR_UPDATE_API_END(session, ret);
 	return (ret);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -140,7 +140,6 @@
 
 #define	F_CLR(p, mask)		        FLD_CLR((p)->flags, mask)
 #define	F_ISSET(p, mask)	        FLD_ISSET((p)->flags, mask)
-#define	F_ISSET_ALL(p, mask)	        (FLD_MASK((p)->flags, mask) == (mask))
 #define	F_MASK(p, mask)	                FLD_MASK((p)->flags, mask)
 #define	F_SET(p, mask)		        FLD_SET((p)->flags, mask)
 


### PR DESCRIPTION
@keithbostic 
This pull request is to backport [WT-3769](https://jira.mongodb.org/browse/WT-3769).
Request your review and to indicate your review result in this pull request, but not to merge.

Once you approve the changes, I will push them directly to mongodb-3.6.

I tested timestamp04.py which triggered this change.

@agorrod 
The changes of this backport is only bug fixing identified as part of enabling compression by default on LAS, but doesn't include the change to LAS config to enable compression by default. Request to check and confirm  if required I can add the change to LAS config to enable compression by default.
