### PR TITLE
WT-3865 avoid cache misses in WiredTiger tree-walk and hazard functions

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -293,7 +293,7 @@ __tree_walk_internal(WT_SESSION_IMPL *session,
 	WT_DECL_RET;
 	WT_PAGE_INDEX *pindex;
 	WT_REF *couple, *couple_orig, *ref;
-	uint32_t slot;
+	uint32_t current_state, slot;
 	bool empty_internal, initial_descent, prev, skip;
 
 	btree = S2BT(session);
@@ -460,7 +460,8 @@ restart:	/*
 			 * If we see any child states other than deleted, the
 			 * page isn't empty.
 			 */
-			if (ref->state != WT_REF_DELETED &&
+			current_state = ref->state;
+			if (current_state != WT_REF_DELETED &&
 			    !LF_ISSET(WT_READ_TRUNCATE))
 				empty_internal = false;
 
@@ -470,12 +471,12 @@ restart:	/*
 				 * fast-path some common cases.
 				 */
 				if (LF_ISSET(WT_READ_NO_WAIT) &&
-				    ref->state != WT_REF_MEM &&
-				    ref->state != WT_REF_LIMBO)
+				    current_state != WT_REF_MEM &&
+				    current_state != WT_REF_LIMBO)
 					break;
 
 				/* Skip lookaside pages if not requested. */
-				if (ref->state == WT_REF_LOOKASIDE &&
+				if (current_state == WT_REF_LOOKASIDE &&
 				    !LF_ISSET(WT_READ_LOOKASIDE))
 					break;
 			} else if (LF_ISSET(WT_READ_TRUNCATE)) {
@@ -483,7 +484,7 @@ restart:	/*
 				 * Avoid pulling a deleted page back in to try
 				 * to delete it again.
 				 */
-				if (ref->state == WT_REF_DELETED &&
+				if (current_state == WT_REF_DELETED &&
 				    __wt_delete_page_skip(session, ref, false))
 					break;
 				/*
@@ -503,7 +504,7 @@ restart:	/*
 				/*
 				 * Try to skip deleted pages visible to us.
 				 */
-				if (ref->state == WT_REF_DELETED &&
+				if (current_state == WT_REF_DELETED &&
 				    __wt_delete_page_skip(session, ref, false))
 					break;
 			}

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -72,6 +72,7 @@ __wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
     )
 {
 	WT_HAZARD *hp;
+	uint32_t current_state;
 
 	*busyp = false;
 
@@ -84,7 +85,8 @@ __wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
 	 * eviction and splits, we re-check it after a barrier to make sure
 	 * we have a valid reference.
 	 */
-	if (ref->state != WT_REF_LIMBO && ref->state != WT_REF_MEM) {
+	current_state = ref->state;
+	if (current_state != WT_REF_LIMBO && current_state != WT_REF_MEM) {
 		*busyp = true;
 		return (0);
 	}
@@ -154,7 +156,8 @@ __wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
 	 * Check if the page state is still valid, where valid means a
 	 * state of WT_REF_LIMBO or WT_REF_MEM.
 	 */
-	if (ref->state == WT_REF_LIMBO || ref->state == WT_REF_MEM) {
+	current_state = ref->state;
+	if (current_state == WT_REF_LIMBO || current_state == WT_REF_MEM) {
 		++session->nhazard;
 
 		/*


### PR DESCRIPTION
WT_REF.state is a volatile, avoid pounding on memory in the heavily-used tree-walk and hazard pointer functions.

@michaelcahill, feel free to discard this branch without further discussion if you don't think it's worth doing. (I made a note to myself based on some debugging in WT-3767 to review if WT_REF.state should really be declared non-volatile -- after reviewing that today, I think it's better being volatile, but we are forcing a bunch of cache misses in some heavily-used code.)