### PR TITLE
WT-3871 format should read from a timestamp

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -267,7 +267,8 @@ typedef struct {
 	uint64_t rollback;
 	uint64_t deadlock;
 
-	uint64_t timestamp;			/* last committed timestamp */
+	uint64_t commit_timestamp;		/* last committed timestamp */
+	uint64_t read_timestamp;		/* read timestamp */
 
 	bool quit;				/* thread should quit */
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -456,8 +456,8 @@ snap_check(WT_CURSOR *cursor,
  * begin_transaction --
  *	Choose an isolation configuration and begin a transaction.
  */
-static u_int
-begin_transaction(TINFO *tinfo, WT_SESSION *session)
+static void
+begin_transaction(TINFO *tinfo, WT_SESSION *session, u_int *iso_configp)
 {
 	u_int v;
 	char *config, config_buf[64];
@@ -491,9 +491,9 @@ begin_transaction(TINFO *tinfo, WT_SESSION *session)
 		}
 		break;
 	}
-	testutil_check(session->begin_transaction(session, config));
+	*iso_configp = v;
 
-	return (v);
+	testutil_check(session->begin_transaction(session, config));
 }
 
 /*
@@ -667,7 +667,7 @@ ops(void *arg)
 		 */
 		if (!SINGLETHREADED &&
 		    !intxn && mmrand(&tinfo->rnd, 1, 100) >= g.c_txn_freq) {
-			iso_config = begin_transaction(tinfo, session);
+			begin_transaction(tinfo, session, &iso_config);
 			snap =
 			    iso_config == ISOLATION_SNAPSHOT ? snap_list : NULL;
 			intxn = true;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -496,7 +496,6 @@ begin_transaction(TINFO *tinfo, WT_SESSION *session)
 	return (v);
 }
 
-
 /*
  * commit_transaction --
  *     Commit a transaction

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -931,7 +931,7 @@ deadlock:			++tinfo->deadlock;
 		 * Clear the thread's read timestamp: it no longer needs to
 		 * be pinned.
 		 */
-		tinfo->commit_timestamp = 0;
+		tinfo->read_timestamp = 0;
 
 		intxn = false;
 		snap = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -273,35 +273,6 @@ wts_ops(int lastrun)
 	free(tinfo_list);
 }
 
-/*
- * isolation_config --
- *	Return an isolation configuration.
- */
-static inline u_int
-isolation_config(WT_RAND_STATE *rnd, WT_SESSION *session)
-{
-	u_int v;
-	const char *config;
-
-	if ((v = g.c_isolation_flag) == ISOLATION_RANDOM)
-		v = mmrand(rnd, 2, 4);
-	switch (v) {
-	case ISOLATION_READ_UNCOMMITTED:
-		config = "isolation=read-uncommitted";
-		break;
-	case ISOLATION_READ_COMMITTED:
-		config = "isolation=read-committed";
-		break;
-	case ISOLATION_SNAPSHOT:
-	default:
-		v = ISOLATION_SNAPSHOT;
-		config = "isolation=snapshot";
-		break;
-	}
-	testutil_check(session->reconfigure(session, config));
-	return (v);
-}
-
 typedef struct {
 	uint64_t keyno;			/* Row number */
 
@@ -482,6 +453,51 @@ snap_check(WT_CURSOR *cursor,
 }
 
 /*
+ * begin_transaction --
+ *	Choose an isolation configuration and begin a transaction.
+ */
+static u_int
+begin_transaction(TINFO *tinfo, WT_SESSION *session)
+{
+	u_int v;
+	char *config, config_buf[64];
+
+	if ((v = g.c_isolation_flag) == ISOLATION_RANDOM)
+		v = mmrand(&tinfo->rnd, 2, 4);
+	switch (v) {
+	case ISOLATION_READ_UNCOMMITTED:
+		config = "isolation=read-uncommitted";
+		break;
+	case ISOLATION_READ_COMMITTED:
+		config = "isolation=read-committed";
+		break;
+	case ISOLATION_SNAPSHOT:
+	default:
+		v = ISOLATION_SNAPSHOT;
+		config = "isolation=snapshot";
+		if (g.c_txn_timestamps) {
+			/*
+			 * Update the thread's read timestamp with the current
+			 * value to prevent the oldest timestamp moving past our
+			 * allocated timestamp before the commit completes.
+			 */
+			tinfo->read_timestamp = g.timestamp;
+			tinfo->read_timestamp =
+			    __wt_atomic_addv64(&g.timestamp, 1);
+			testutil_check(__wt_snprintf(
+			    config_buf, sizeof(config_buf),
+			    "read_timestamp=%" PRIx64, tinfo->read_timestamp));
+			config = config_buf;
+		}
+		break;
+	}
+	testutil_check(session->begin_transaction(session, config));
+
+	return (v);
+}
+
+
+/*
  * commit_transaction --
  *     Commit a transaction
  */
@@ -493,11 +509,11 @@ commit_transaction(TINFO *tinfo, WT_SESSION *session)
 
 	if (g.c_txn_timestamps) {
 		/*
-		 * Update the thread's active timestamp with the current value
+		 * Update the thread's update timestamp with the current value
 		 * to prevent the oldest timestamp moving past our allocated
 		 * timestamp before the commit completes.
 		 */
-		tinfo->timestamp = g.timestamp;
+		tinfo->commit_timestamp = g.timestamp;
 		ts = __wt_atomic_addv64(&g.timestamp, 1);
 		testutil_check(__wt_snprintf(
 		    config_buf, sizeof(config_buf),
@@ -511,7 +527,7 @@ commit_transaction(TINFO *tinfo, WT_SESSION *session)
 		 * if we were to race with the timestamp thread, it might see
 		 * our thread update before the transaction commit.
 		 */
-		WT_PUBLISH(tinfo->timestamp, 0);
+		WT_PUBLISH(tinfo->commit_timestamp, 0);
 	} else
 		testutil_check(session->commit_transaction(session, NULL));
 	++tinfo->commit;
@@ -652,10 +668,7 @@ ops(void *arg)
 		 */
 		if (!SINGLETHREADED &&
 		    !intxn && mmrand(&tinfo->rnd, 1, 100) >= g.c_txn_freq) {
-			iso_config = isolation_config(&tinfo->rnd, session);
-			testutil_check(
-			    session->begin_transaction(session, NULL));
-
+			iso_config = begin_transaction(tinfo, session);
 			snap =
 			    iso_config == ISOLATION_SNAPSHOT ? snap_list : NULL;
 			intxn = true;
@@ -913,6 +926,12 @@ deadlock:			++tinfo->deadlock;
 			++tinfo->rollback;
 			break;
 		}
+
+		/*
+		 * Clear the thread's read timestamp: it no longer needs to
+		 * be pinned.
+		 */
+		tinfo->commit_timestamp = 0;
 
 		intxn = false;
 		snap = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -460,7 +460,8 @@ static void
 begin_transaction(TINFO *tinfo, WT_SESSION *session, u_int *iso_configp)
 {
 	u_int v;
-	char *config, config_buf[64];
+	const char *config;
+	char config_buf[64];
 
 	if ((v = g.c_isolation_flag) == ISOLATION_RANDOM)
 		v = mmrand(&tinfo->rnd, 2, 4);

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -614,9 +614,11 @@ timestamp(void *arg)
 		oldest_timestamp = g.timestamp;
 		for (i = 0; i < g.c_threads; ++i) {
 			tinfo = tinfo_list[i];
-			this_ts = tinfo->timestamp;
-			if (this_ts != 0 &&
-			    this_ts < oldest_timestamp)
+			this_ts = tinfo->commit_timestamp;
+			if (this_ts != 0 && this_ts < oldest_timestamp)
+				oldest_timestamp = this_ts;
+			this_ts = tinfo->read_timestamp;
+			if (this_ts != 0 && this_ts < oldest_timestamp)
 				oldest_timestamp = this_ts;
 		}
 

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -608,8 +608,8 @@ timestamp(void *arg)
 	 */
 	while (!g.workers_finished) {
 		/*
-		 * Find the lowest committed timestamp. The timestamp thread
-		 * starts before the operational threads, wait for them.
+		 * Find the lowest in-use timestamp. The timestamp thread starts
+		 * before the operational threads, wait for them.
 		 */
 		oldest_timestamp = g.timestamp;
 		for (i = 0; i < g.c_threads; ++i) {


### PR DESCRIPTION
@michaelcahill, in thinking about the upcoming work in WT-3766 and WT-3805, I thought it would be useful to explicitly read from a timestamp and verify we're seeing the record we expect to see.