### PR TITLE
WT-3840 Dump more information on data corruption in diagnostic mode

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -221,10 +221,11 @@ __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 	case WT_CKPT_INPROGRESS:
 	case WT_CKPT_PANIC_ON_FAILURE:
 	case WT_CKPT_SALVAGE:
-		ret = __wt_block_panic(session, EINVAL,
+		__wt_err(session, EINVAL,
 		    "%s: an unexpected checkpoint start: the checkpoint "
 		    "has already started or was configured for salvage",
 		    block->name);
+		ret = __wt_block_panic(session);
 		break;
 	case WT_CKPT_NONE:
 		block->ckpt_state = WT_CKPT_INPROGRESS;
@@ -433,10 +434,11 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
 		break;
 	case WT_CKPT_NONE:
 	case WT_CKPT_PANIC_ON_FAILURE:
-		ret = __wt_block_panic(session, EINVAL,
+		__wt_err(session, EINVAL,
 		    "%s: an unexpected checkpoint attempt: the checkpoint "
 		    "was never started or has already completed",
 		    block->name);
+		ret = __wt_block_panic(session);
 		break;
 	case WT_CKPT_SALVAGE:
 		/* Salvage doesn't use the standard checkpoint APIs. */
@@ -718,9 +720,11 @@ live_update:
 		    "list");
 #endif
 
-err:	if (ret != 0 && fatal)
-		ret = __wt_block_panic(session, ret,
+err:	if (ret != 0 && fatal) {
+		__wt_err(session, ret,
 		    "%s: fatal checkpoint failure", block->name);
+		ret = __wt_block_panic(session);
+	}
 
 	if (locked)
 		__wt_spin_unlock(session, &block->live_lock);
@@ -842,26 +846,30 @@ __wt_block_checkpoint_resolve(
 		goto done;
 	case WT_CKPT_NONE:
 	case WT_CKPT_SALVAGE:
-		ret = __wt_block_panic(session, EINVAL,
+		__wt_err(session, EINVAL,
 		    "%s: an unexpected checkpoint resolution: the checkpoint "
 		    "was never started or completed, or configured for salvage",
 		    block->name);
+		ret = __wt_block_panic(session);
 		break;
 	case WT_CKPT_PANIC_ON_FAILURE:
 		if (!failed)
 			break;
-		ret = __wt_block_panic(session, EINVAL,
+		__wt_err(session, EINVAL,
 		    "%s: the checkpoint failed, the system must restart",
 		    block->name);
+		ret = __wt_block_panic(session);
 		break;
 	}
 	WT_ERR(ret);
 
 	if ((ret = __wt_block_extlist_merge(
-	    session, block, &ci->ckpt_avail, &ci->avail)) != 0)
-		WT_ERR(__wt_block_panic(session, ret,
+	    session, block, &ci->ckpt_avail, &ci->avail)) != 0) {
+		__wt_err(session, ret,
 		    "%s: fatal checkpoint failure during extent list merge",
-		    block->name));
+		    block->name);
+		ret = __wt_block_panic(session);
+	}
 	__wt_spin_unlock(session, &block->live_lock);
 
 	/* Discard the lists remaining after the checkpoint call. */

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -638,20 +638,9 @@ err:	WT_TRET(bm->close(bm, session));
  * 	Report an error, then panic the handle and the system.
  */
 int
-__wt_block_panic(WT_SESSION_IMPL *session, int error, const char *fmt, ...)
+__wt_block_panic(WT_SESSION_IMPL *session)
     WT_GCC_FUNC_ATTRIBUTE((cold))
-    WT_GCC_FUNC_ATTRIBUTE((format (printf, 3, 4)))
 {
-	va_list ap;
-
-	/*
-	 * Ignore error returns from underlying event handlers, we already have
-	 * an error value to return.
-	 */
-	va_start(ap, fmt);
-	WT_IGNORE_RET(__wt_eventv(session, false, error, NULL, 0, fmt, ap));
-	va_end(ap);
-
 	/* Switch the handle into read-only mode. */
 	__bm_method_set(S2BT(session)->bm, true);
 

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -569,6 +569,7 @@ __bm_method_set(WT_BM *bm, bool readonly)
 	bm->compact_page_skip = __bm_compact_page_skip;
 	bm->compact_skip = __bm_compact_skip;
 	bm->compact_start = __bm_compact_start;
+	bm->corrupt = __wt_bm_corrupt;
 	bm->free = __bm_free;
 	bm->is_mapped = __bm_is_mapped;
 	bm->map_discard = __bm_map_discard;

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -107,6 +107,77 @@ __wt_bm_read(WT_BM *bm, WT_SESSION_IMPL *session,
 	return (0);
 }
 
+/*
+ * __wt_bm_corrupt_dump --
+ *	Dump a block into the log in 1KB chunks.
+ */
+static int
+__wt_bm_corrupt_dump(WT_SESSION_IMPL *session,
+    WT_ITEM *buf, wt_off_t offset, uint32_t size, uint32_t checksum)
+    WT_GCC_FUNC_ATTRIBUTE((cold))
+{
+	WT_DECL_ITEM(tmp);
+	WT_DECL_RET;
+	size_t chunk, i, nchunks;
+
+#define	WT_CORRUPT_FMT	"{%" PRIuMAX ", %" PRIu32 ", %" PRIu32 "}"
+	if (buf->size == 0) {
+		__wt_errx(session,
+		    WT_CORRUPT_FMT ": empty buffer, no dump available",
+		    (uintmax_t)offset, size, checksum);
+		return (0);
+	}
+
+	WT_RET(__wt_scr_alloc(session, 4 * 1024, &tmp));
+
+	nchunks = buf->size / 1024 + (buf->size % 1024 == 0 ? 0 : 1);
+	for (chunk = i = 0;;) {
+		WT_ERR(__wt_buf_catfmt(
+		    session, tmp, "%02x ", ((uint8_t *)buf->data)[i]));
+		if (++i == buf->size || i % 1024 == 0) {
+			__wt_errx(session,
+			    WT_CORRUPT_FMT
+			    ": (chunk %" WT_SIZET_FMT " of %" WT_SIZET_FMT
+			    "): %.*s",
+			    (uintmax_t)offset, size, checksum,
+			    ++chunk, nchunks,
+			    (int)tmp->size, tmp->data);
+			if (i == buf->size)
+				break;
+			WT_ERR(__wt_buf_set(session, tmp, "", 0));
+		}
+	}
+
+err:	__wt_scr_free(session, &tmp);
+	return (ret);
+}
+
+/*
+ * __wt_bm_corrupt --
+ *	Report a block has been corrupted, external API.
+ */
+int
+__wt_bm_corrupt(WT_BM *bm,
+    WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
+{
+	WT_DECL_ITEM(tmp);
+	WT_DECL_RET;
+	wt_off_t offset;
+	uint32_t checksum, size;
+
+	/* Read the block. */
+	WT_RET(__wt_scr_alloc(session, 0, &tmp));
+	WT_ERR(__wt_bm_read(bm, session, tmp, addr, addr_size));
+
+	/* Crack the cookie, dump the block. */
+	WT_ERR(__wt_block_buffer_to_addr(
+	    bm->block, addr, &offset, &size, &checksum));
+	WT_ERR(__wt_bm_corrupt_dump(session, tmp, offset, size, checksum));
+
+err:	__wt_scr_free(session, &tmp);
+	return (ret);
+}
+
 #ifdef HAVE_DIAGNOSTIC
 /*
  * __wt_block_read_off_blind --
@@ -220,6 +291,10 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 			    "of %" PRIu32 " doesn't match expected checksum "
 			    "of %" PRIu32,
 			    size, (uintmax_t)offset, swap.checksum, checksum);
+
+	if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
+		WT_IGNORE_RET(
+		    __wt_bm_corrupt_dump(session, buf, offset, size, checksum));
 
 	/* Panic if a checksum fails during an ordinary read. */
 	return (block->verify ||

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -141,7 +141,7 @@ __wt_bm_corrupt_dump(WT_SESSION_IMPL *session,
 			    "): %.*s",
 			    (uintmax_t)offset, size, checksum,
 			    ++chunk, nchunks,
-			    (int)tmp->size, tmp->data);
+			    (int)tmp->size, (char *)tmp->data);
 			if (i == buf->size)
 				break;
 			WT_ERR(__wt_buf_set(session, tmp, "", 0));

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -154,7 +154,9 @@ corrupt:	if (ret == 0)
 		if (!F_ISSET(btree, WT_BTREE_VERIFY) &&
 		    !F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE)) {
 			__wt_err(session, ret, "%s", fail_msg);
-			ret = __wt_illegal_value(session, btree->dhandle->name);
+			WT_TRET(bm->corrupt(bm, session, addr, addr_size));
+			WT_TRET(
+			    __wt_illegal_value(session, btree->dhandle->name));
 		}
 	}
 

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -174,6 +174,7 @@ struct __wt_bm {
 	    (WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t, bool *);
 	int (*compact_skip)(WT_BM *, WT_SESSION_IMPL *, bool *);
 	int (*compact_start)(WT_BM *, WT_SESSION_IMPL *);
+	int (*corrupt)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
 	int (*free)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
 	bool (*is_mapped)(WT_BM *, WT_SESSION_IMPL *);
 	int (*map_discard)(WT_BM *, WT_SESSION_IMPL *, void *, size_t);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -45,7 +45,7 @@ extern void __wt_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);
 extern int __wt_block_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapped_regionp, size_t *lengthp, void *mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_unmap(WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapped_region, size_t length, void *mapped_cookie) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_manager_open(WT_SESSION_IMPL *session, const char *filename, const char *cfg[], bool forced_salvage, bool readonly, uint32_t allocsize, WT_BM **bmp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_panic(WT_SESSION_IMPL *session, int error, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_manager_drop( WT_SESSION_IMPL *session, const char *filename, bool durable) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_manager_create( WT_SESSION_IMPL *session, const char *filename, uint32_t allocsize) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_block_configure_first_fit(WT_BLOCK *block, bool on);
@@ -57,6 +57,7 @@ extern int __wt_block_manager_size(WT_BM *bm, WT_SESSION_IMPL *session, wt_off_t
 extern int __wt_block_manager_named_size( WT_SESSION_IMPL *session, const char *name, wt_off_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bm_preload( WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bm_read(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bm_corrupt(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_read_off_blind( WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_off_t offset) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_off_t offset, uint32_t size, uint32_t checksum) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -661,7 +662,6 @@ extern int __wt_decrypt(WT_SESSION_IMPL *session, WT_ENCRYPTOR *encryptor, size_
 extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t skip, WT_ITEM *in, WT_ITEM *out) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_encrypt_size(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t incoming_size, size_t *sizep);
 extern void __wt_event_handler_set(WT_SESSION_IMPL *session, WT_EVENT_HANDLER *handler);
-extern int __wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error, const char *file_name, int line_number, const char *fmt, va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_err(WT_SESSION_IMPL *session, int error, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_errx(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3)));
 extern int __wt_ext_err_printf( WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -279,6 +279,17 @@ __wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
 			__handler_failure(session, ret, "error", true);
 	}
 
+	/*
+	 * The buffer is fixed sized, complain if we overflow. (The test is for
+	 * no more bytes remaining in the buffer, so technically we might have
+	 * just filled it exactly.) Be cautious changing this this code, we're
+	 * calling recursively.
+	 */
+	if (ret == 0 && remain == 0)
+		__wt_err(session, ENOMEM,
+		    "error or message truncated: internal WiredTiger buffer "
+		    "too small");
+
 	if (ret != 0) {
 err:		if (fprintf(stderr,
 		    "WiredTiger Error%s%s: ",

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -169,11 +169,11 @@ __wt_event_handler_set(WT_SESSION_IMPL *session, WT_EVENT_HANDLER *handler)
 } while (0)
 
 /*
- * __wt_eventv --
+ * __eventv --
  * 	Report a message to an event handler.
  */
-int
-__wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
+static int
+__eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
     const char *file_name, int line_number, const char *fmt, va_list ap)
     WT_GCC_FUNC_ATTRIBUTE((cold))
 {
@@ -282,8 +282,8 @@ __wt_eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
 	/*
 	 * The buffer is fixed sized, complain if we overflow. (The test is for
 	 * no more bytes remaining in the buffer, so technically we might have
-	 * just filled it exactly.) Be cautious changing this this code, we're
-	 * calling recursively.
+	 * filled it exactly.) Be cautious changing this code, it's a recursive
+	 * call.
 	 */
 	if (ret == 0 && remain == 0)
 		__wt_err(session, ENOMEM,
@@ -325,7 +325,7 @@ __wt_err(WT_SESSION_IMPL *session, int error, const char *fmt, ...)
 	 * an error value to return.
 	 */
 	va_start(ap, fmt);
-	WT_IGNORE_RET(__wt_eventv(session, false, error, NULL, 0, fmt, ap));
+	WT_IGNORE_RET(__eventv(session, false, error, NULL, 0, fmt, ap));
 	va_end(ap);
 }
 
@@ -345,7 +345,7 @@ __wt_errx(WT_SESSION_IMPL *session, const char *fmt, ...)
 	 * an error value to return.
 	 */
 	va_start(ap, fmt);
-	WT_IGNORE_RET(__wt_eventv(session, false, 0, NULL, 0, fmt, ap));
+	WT_IGNORE_RET(__eventv(session, false, 0, NULL, 0, fmt, ap));
 	va_end(ap);
 }
 
@@ -366,7 +366,7 @@ __wt_ext_err_printf(
 		session = ((WT_CONNECTION_IMPL *)wt_api->conn)->default_session;
 
 	va_start(ap, fmt);
-	ret = __wt_eventv(session, false, 0, NULL, 0, fmt, ap);
+	ret = __eventv(session, false, 0, NULL, 0, fmt, ap);
 	va_end(ap);
 	return (ret);
 }
@@ -383,7 +383,7 @@ __wt_verbose_worker(WT_SESSION_IMPL *session, const char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	WT_IGNORE_RET(__wt_eventv(session, true, 0, NULL, 0, fmt, ap));
+	WT_IGNORE_RET(__eventv(session, true, 0, NULL, 0, fmt, ap));
 	va_end(ap);
 }
 
@@ -504,7 +504,7 @@ __wt_assert(WT_SESSION_IMPL *session,
 	va_list ap;
 
 	va_start(ap, fmt);
-	WT_IGNORE_RET(__wt_eventv(
+	WT_IGNORE_RET(__eventv(
 	    session, false, error, file_name, line_number, fmt, ap));
 	va_end(ap);
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -193,7 +193,7 @@ __eventv(WT_SESSION_IMPL *session, bool msg_event, int error,
 	 * SECURITY:
 	 * Buffer placed at the end of the stack in case snprintf overflows.
 	 */
-	char s[2048];
+	char s[4 * 1024];
 	p = s;
 	remain = sizeof(s);
 


### PR DESCRIPTION
@agorrod, I ended up increasing the stack buffer size from 2KB to 4KB, and I added an error complaint, if we truncate a message we should notice it.