### PR TITLE
WT-3878 Iteration can lose its position when updating a limbo page

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1063,8 +1063,7 @@ err:	if (ret == WT_RESTART) {
 	}
 
 	if (ret == 0) {
-done:		F_CLR(cursor, WT_CURSTD_VALUE_SET);
-		switch (positioned) {
+done:		switch (positioned) {
 		case NO_POSITION:
 			/*
 			 * Never positioned and we leave it that way, clear any
@@ -1115,6 +1114,14 @@ done:		F_CLR(cursor, WT_CURSTD_VALUE_SET);
 		if (ret == WT_NOTFOUND && F_ISSET(cursor, WT_CURSTD_OVERWRITE))
 			ret = 0;
 	}
+
+	/*
+	 * Upper level cursor removes don't expect the cursor value to be set
+	 * after a successful remove (and check in diagnostic mode). Error
+	 * handling may have converted failure to a success, do a final check.
+	 */
+	if (ret == 0)
+		F_CLR(cursor, WT_CURSTD_VALUE_SET);
 
 	return (ret);
 }

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1106,11 +1106,11 @@ done:	if (ret == 0) {
 		__cursor_state_restore(cursor, &state);
 
 		/*
-		 * If an iterating cursor was forced to give up its pinned page
-		 * and then a search failed, we've lost our cursor position, no
-		 * subsequent iteration can succeed.
+		 * If an iterating or positioned cursor was forced to give up
+		 * its pinned page and then a search failed, we've lost our
+		 * cursor position, no subsequent iteration can succeed.
 		 */
-		if (ret == WT_NOTFOUND && iterating)
+		if (ret == WT_NOTFOUND && (iterating || positioned))
 			ret = WT_ROLLBACK;
 
 		/*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -498,17 +498,9 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 
 	final_state = WT_REF_MEM;
 
-	/*
-	 * If we already have the page image, just instantiate the history.
-	 *
-	 * We need exclusive access because other threads could be reading the
-	 * page without history and we can't change the state underneath them.
-	 */
-	if (previous_state == WT_REF_LIMBO) {
-		if (__wt_hazard_check(session, ref) != NULL)
-			goto err;
+	/* If we already have the page image, just instantiate the history. */
+	if (previous_state == WT_REF_LIMBO)
 		goto skip_read;
-	}
 
 	/*
 	 * Get the address: if there is no address, the page was deleted or had

--- a/test/format/bdb.c
+++ b/test/format/bdb.c
@@ -116,7 +116,7 @@ bdb_insert(
 }
 
 void
-bdb_np(int next,
+bdb_np(bool next,
     void *keyp, size_t *keysizep,
     void *valuep, size_t *valuesizep, int *notfoundp)
 {

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -317,7 +317,7 @@ WT_THREAD_RET lrt(void *);
 void	 path_setup(const char *);
 void	 print_item(const char *, WT_ITEM *);
 void	 print_item_data(const char *, const uint8_t *, size_t);
-int	 read_row_worker(WT_CURSOR *, WT_ITEM *, uint64_t, WT_ITEM *);
+int	 read_row_worker(WT_CURSOR *, WT_ITEM *, uint64_t, WT_ITEM *, bool);
 uint32_t rng(WT_RAND_STATE *);
 WT_THREAD_RET timestamp(void *);
 void	 track(const char *, uint64_t, TINFO *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -290,7 +290,7 @@ typedef struct {
 #ifdef HAVE_BERKELEY_DB
 void	 bdb_close(void);
 void	 bdb_insert(const void *, size_t, const void *, size_t);
-void	 bdb_np(int, void *, size_t *, void *, size_t *, int *);
+void	 bdb_np(bool, void *, size_t *, void *, size_t *, int *);
 void	 bdb_open(void);
 void	 bdb_read(uint64_t, void *, size_t *, int *);
 void	 bdb_remove(uint64_t, int *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -278,6 +278,9 @@ typedef struct {
 	uint64_t remove;
 	uint64_t ops;
 
+	uint64_t keyno;				/* current key */
+	WT_ITEM	 *key, _key;
+
 #define	TINFO_RUNNING	1			/* Running */
 #define	TINFO_COMPLETE	2			/* Finished */
 #define	TINFO_JOINED	3			/* Resolved */
@@ -314,7 +317,7 @@ WT_THREAD_RET lrt(void *);
 void	 path_setup(const char *);
 void	 print_item(const char *, WT_ITEM *);
 void	 print_item_data(const char *, const uint8_t *, size_t);
-int	 read_row(WT_CURSOR *, WT_ITEM *, WT_ITEM *, uint64_t);
+int	 read_row_worker(WT_CURSOR *, WT_ITEM *, uint64_t, WT_ITEM *);
 uint32_t rng(WT_RAND_STATE *);
 WT_THREAD_RET timestamp(void *);
 void	 track(const char *, uint64_t, TINFO *);

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -71,12 +71,12 @@ lrt(void *arg)
 	for (pinned = 0;;) {
 		if (pinned) {
 			/* Re-read the record at the end of the table. */
-			while ((ret = read_row(
-			    cursor, &key, &value, saved_keyno)) == WT_ROLLBACK)
+			while ((ret = read_row_worker(
+			    cursor, &key, saved_keyno, &value)) == WT_ROLLBACK)
 				;
 			if (ret != 0)
 				testutil_die(ret,
-				    "read_row %" PRIu64, saved_keyno);
+				    "read_row_worker %" PRIu64, saved_keyno);
 
 			/* Compare the previous value with the current one. */
 			if (g.type == FIX) {
@@ -131,13 +131,13 @@ lrt(void *arg)
 				saved_keyno = mmrand(NULL,
 				    (u_int)(g.key_cnt - g.key_cnt / 10),
 				    (u_int)g.key_cnt);
-				while ((ret = read_row(cursor,
-				    &key, &value, saved_keyno)) == WT_ROLLBACK)
+				while ((ret = read_row_worker(cursor,
+				    &key, saved_keyno, &value)) == WT_ROLLBACK)
 					;
 			} while (ret == WT_NOTFOUND);
 			if (ret != 0)
 				testutil_die(ret,
-				    "read_row %" PRIu64, saved_keyno);
+				    "read_row_worker %" PRIu64, saved_keyno);
 
 			/* Copy the cursor's value. */
 			if (g.type == FIX) {
@@ -160,12 +160,13 @@ lrt(void *arg)
 			 */
 			do {
 				keyno = mmrand(NULL, 1, (u_int)g.key_cnt / 5);
-				while ((ret = read_row(cursor,
-				    &key, &value, keyno)) == WT_ROLLBACK)
+				while ((ret = read_row_worker(cursor,
+				    &key, keyno, &value)) == WT_ROLLBACK)
 					;
 			} while (ret == WT_NOTFOUND);
 			if (ret != 0)
-				testutil_die(ret, "read_row %" PRIu64, keyno);
+				testutil_die(ret,
+				    "read_row_worker %" PRIu64, keyno);
 
 			pinned = 1;
 		}

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -71,8 +71,8 @@ lrt(void *arg)
 	for (pinned = 0;;) {
 		if (pinned) {
 			/* Re-read the record at the end of the table. */
-			while ((ret = read_row_worker(
-			    cursor, &key, saved_keyno, &value)) == WT_ROLLBACK)
+			while ((ret = read_row_worker(cursor,
+			    &key, saved_keyno, &value, false)) == WT_ROLLBACK)
 				;
 			if (ret != 0)
 				testutil_die(ret,
@@ -131,8 +131,8 @@ lrt(void *arg)
 				saved_keyno = mmrand(NULL,
 				    (u_int)(g.key_cnt - g.key_cnt / 10),
 				    (u_int)g.key_cnt);
-				while ((ret = read_row_worker(cursor,
-				    &key, saved_keyno, &value)) == WT_ROLLBACK)
+				while ((ret = read_row_worker(cursor, &key,
+				    saved_keyno, &value, false)) == WT_ROLLBACK)
 					;
 			} while (ret == WT_NOTFOUND);
 			if (ret != 0)
@@ -161,7 +161,7 @@ lrt(void *arg)
 			do {
 				keyno = mmrand(NULL, 1, (u_int)g.key_cnt / 5);
 				while ((ret = read_row_worker(cursor,
-				    &key, keyno, &value)) == WT_ROLLBACK)
+				    &key, keyno, &value, false)) == WT_ROLLBACK)
 					;
 			} while (ret == WT_NOTFOUND);
 			if (ret != 0)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -553,7 +553,7 @@ ops(void *arg)
 	WT_SESSION *session;
 	uint64_t reset_op, session_op;
 	uint32_t rnd;
-	u_int i, iso_config;
+	u_int i, j, iso_config;
 	bool intxn, next, positioned, readonly;
 
 	tinfo = arg;
@@ -678,7 +678,6 @@ ops(void *arg)
 
 		/* Select a row. */
 		tinfo->keyno = mmrand(&tinfo->rnd, 1, (u_int)g.rows);
-		positioned = false;
 
 		/* Select an operation. */
 		op = READ;
@@ -712,7 +711,6 @@ ops(void *arg)
 					snap_track(
 					    snap++, tinfo->keyno, NULL, value);
 			} else {
-				positioned = false;
 				if (ret == WT_ROLLBACK && intxn)
 					goto deadlock;
 				testutil_assert(ret == WT_NOTFOUND);
@@ -887,7 +885,8 @@ update_instead_of_chosen_op:
 		 */
 		if (positioned) {
 			next = mmrand(&tinfo->rnd, 0, 1) == 1;
-			for (i = mmrand(&tinfo->rnd, 1, 100); i > 0; --i) {
+			j = mmrand(&tinfo->rnd, 1, 100);
+			for (i = 0; i < j; ++i) {
 				if ((ret = nextprev(tinfo, cursor, next)) == 0)
 					continue;
 				if (ret == WT_ROLLBACK && intxn)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1165,7 +1165,7 @@ nextprev(TINFO *tinfo, WT_CURSOR *cursor, int next)
 			    tinfo->keyno, keyno);
 			testutil_assertfmt(
 			    (next || tinfo->keyno > keyno),
-			    "cursor next returned %" PRIu64 " then %" PRIu64,
+			    "cursor prev returned %" PRIu64 " then %" PRIu64,
 			    tinfo->keyno, keyno);
 
 			tinfo->keyno = keyno;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1061,13 +1061,14 @@ read_row_worker(WT_CURSOR *cursor, WT_ITEM *key, uint64_t keyno, WT_ITEM *value)
 	case WT_NOTFOUND:
 		/*
 		 * In fixed length stores, zero values at the end of the key
-		 * space are returned as not found.  Treat this the same as
+		 * space are returned as not-found. Treat this the same as
 		 * a zero value in the key space, to match BDB's behavior.
+		 * The WiredTiger cursor has lost its position though, so
+		 * we return not-found, the cursor movement can't continue.
 		 */
 		if (g.type == FIX) {
 			*(uint8_t *)(value->data) = 0;
 			value->size = 1;
-			ret = 0;
 		}
 		break;
 	case WT_ROLLBACK:


### PR DESCRIPTION
@agorrod, @michaelcahill, the changes in this branch (so far) are only changes to `format` to validate that cursor next/prev always returns keys in order after an operation that positions the cursor. With these testing changes, the configurations associated with WT-3766 testing will fail.