### PR TITLE
WT-3881 Skip validating update structures from this txn.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -644,10 +644,12 @@ __txn_commit_timestamp_validate(WT_SESSION_IMPL *session)
 		if (op->type == WT_TXN_OP_BASIC_TS ||
 		    op->type == WT_TXN_OP_BASIC) {
 			/*
-			 * Skip over any aborted update structures.
+			 * Skip over any aborted update structures or ones
+			 * from our own transaction.
 			 */
 			upd = op->u.upd->next;
-			while (upd != NULL && upd->txnid == WT_TXN_ABORTED)
+			while (upd != NULL && (upd->txnid == WT_TXN_ABORTED ||
+			    upd->txnid == txn->id))
 				upd = upd->next;
 
 			/*


### PR DESCRIPTION
@agorrod and @dgottlieb here's a PR that solves an issue Dan saw over the weekend when the commit timestamp is set in the middle or the end of the transaction, the new validate code was comparing against updates from earlier in the transaction. I modified the validation to skip updates from its own transaction. The code does not set the timestamp in the update structures until much later in the commit process, long past the time where we're allowed to error. So we need to skip them.