### PR TITLE
WT-3891 A couple more places needing the sweep walk rwlock.

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -22,13 +22,13 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 	WT_DECL_TIMESTAMP(rollback_timestamp)
 	WT_ITEM las_key, las_timestamp, las_value;
 	WT_TXN_GLOBAL *txn_global;
-	uint64_t las_counter, las_pageid, las_total, las_txnid;
+	uint64_t las_counter, las_pageid, las_total, las_txnid, remove_cnt;
 	uint32_t las_id, session_flags;
 	uint8_t upd_type;
 
 	conn = S2C(session);
 	cursor = NULL;
-	las_total = 0;
+	las_total = remove_cnt = 0;
 	session_flags = 0;		/* [-Werror=maybe-uninitialized] */
 	WT_CLEAR(las_timestamp);
 
@@ -49,6 +49,7 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 	F_SET(session, WT_SESSION_READ_WONT_NEED);
 
 	/* Walk the file. */
+	__wt_writelock(session, &conn->cache->las_sweepwalk_lock);
 	while ((ret = cursor->next(cursor)) == 0) {
 		WT_ERR(cursor->get_key(cursor,
 		    &las_pageid, &las_id, &las_counter, &las_key));
@@ -70,13 +71,18 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 		 * be removed.
 		 */
 		if (__wt_timestamp_cmp(
-		    &rollback_timestamp, las_timestamp.data) < 0)
+		    &rollback_timestamp, las_timestamp.data) < 0) {
 			WT_ERR(cursor->remove(cursor));
-		else
+			++remove_cnt;
+		} else
 			++las_total;
 	}
 	WT_ERR_NOTFOUND_OK(ret);
-err:	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
+err:	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
+	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
+	__wt_cache_decr_check_uint64(session,
+	    &conn->cache->las_entry_count, remove_cnt,
+	    "lookaside entry count");
 	WT_STAT_CONN_SET(session, cache_lookaside_entries, las_total);
 
 	F_CLR(session, WT_SESSION_READ_WONT_NEED);


### PR DESCRIPTION
@michaelcahill my run hit a place where I needed to also use the sweepwalk rwlock. @agorrod I also added it to the rollback to stable code. While in there, I noticed that the entry count is not being updated after the removal like it is in all the other remove loops. I fixed that. Please let me know if my change is not correct.