### PR TITLE
WT-3901 Fixed the log corruption bug.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -531,7 +531,7 @@ extern int __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **va
 extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_optrack_record_funcid( WT_SESSION_IMPL *session, const char *func, uint16_t *func_idp);
 extern int __wt_optrack_open_file(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern size_t __wt_optrack_flush_buffer(WT_SESSION_IMPL *s);
+extern void __wt_optrack_flush_buffer(WT_SESSION_IMPL *s);
 extern int __wt_filename(WT_SESSION_IMPL *session, const char *name, char **path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_nfilename( WT_SESSION_IMPL *session, const char *name, size_t namelen, char **path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_filename_construct(WT_SESSION_IMPL *session, const char *path, const char *file_prefix, uintmax_t id_1, uint32_t id_2, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/optrack.h
+++ b/src/include/optrack.h
@@ -57,7 +57,8 @@ struct __wt_optrack_record {
 	__tr->op_type = optype;						\
 									\
 	if (++(s)->optrackbuf_ptr == WT_OPTRACK_MAXRECS) {		\
-		(s)->optrack_offset += __wt_optrack_flush_buffer(s);	\
+		size_t __written =__wt_optrack_flush_buffer(s);		\
+		(s)->optrack_offset += __written;			\
 		(s)->optrackbuf_ptr = 0;				\
 	}								\
 } while (0)

--- a/src/include/optrack.h
+++ b/src/include/optrack.h
@@ -57,8 +57,7 @@ struct __wt_optrack_record {
 	__tr->op_type = optype;						\
 									\
 	if (++(s)->optrackbuf_ptr == WT_OPTRACK_MAXRECS) {		\
-		size_t __written =__wt_optrack_flush_buffer(s);		\
-		(s)->optrack_offset += __written;			\
+		__wt_optrack_flush_buffer(s);				\
 		(s)->optrackbuf_ptr = 0;				\
 	}								\
 } while (0)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -224,17 +224,14 @@ __session_close(WT_SESSION *wt_session, const char *config)
 	__wt_txn_destroy(session);
 
 	/*
-	 * Close the file where we tracked long operations.  Do this before
-	 * releasing resources, as we do scratch buffer management when we flush
-	 * optrack buffers to disk
+	 * Close the file where we tracked long operations. Do this before
+	 * releasing resources, as we do scratch buffer management when we
+	 * flush optrack buffers to disk.
 	 */
 	if (F_ISSET(conn, WT_CONN_OPTRACK)) {
 		if (session->optrackbuf_ptr > 0) {
-			WT_IGNORE_RET((int)__wt_optrack_flush_buffer(session));
-			WT_IGNORE_RET(__wt_close(session,
-			    &session->optrack_fh));
-			/* Indicate that the file is closed */
-			session->optrack_fh = NULL;
+			__wt_optrack_flush_buffer(session);
+			WT_TRET(__wt_close(session, &session->optrack_fh));
 		}
 
 		/* Free the operation tracking buffer */

--- a/tools/optrack/wt_optrack_decode.py
+++ b/tools/optrack/wt_optrack_decode.py
@@ -100,7 +100,8 @@ def funcIDtoName(funcID):
     if (functionMap.has_key(funcID)):
         return functionMap[funcID];
     else:
-        return "NULL";
+       print("Could not find the name for func " + str(funcID));
+       return "NULL";
 
 #
 # The format of the record is written down in src/include/optrack.h


### PR DESCRIPTION
Flushing the operation tracking memory buffer to the file works as follows:
1. We remember the old value of the file offset.
2. We flush the buffer, opening the file if it has not been open yet.
3. We add the return value to the remembered offset.

The problem occurs in the situation when we flush to a file that has not been open yet. Here is what happens:
1. We remember the old value. It is 0, because the file has not been opened yet.
2. As we flush the buffer, the file is opened. BUT: opening the file writes some metadata to it and advances the offset to 12. We flush the buffer at offset 12. We return the number of bytes flushed.
Upon return we should add the number of bytes flushed to 12, the previous offset, but:

3. We add the returned value (number of bytes flushed) to the remembered offset, which was 0!
So the offset is now incorrect. Next time we flush the buffer, we corrupt the data.

This fix avoids remembering the old offset value (step 1). It calls the flush function, remembers the number of flushed bytes it returns, then in step 3 it gets the fresh value of the offset and adds to it the returned bytes. 