### PR TITLE
WT-3905 Save the checkpoint timestamp in metadata. Use it in tests.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -338,8 +338,7 @@ file_meta = file_config + [
     Config('checkpoint_lsn', '', r'''
         LSN of the last checkpoint'''),
     Config('checkpoint_timestamp', '', r'''
-        stable timestamp of the last checkpoint''',
-        type=string),
+        stable timestamp of the last checkpoint'''),
     Config('id', '', r'''
         the file's ID number'''),
     Config('version', '(major=0,minor=0)', r'''

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -337,6 +337,9 @@ file_meta = file_config + [
         the file checkpoint entries'''),
     Config('checkpoint_lsn', '', r'''
         LSN of the last checkpoint'''),
+    Config('checkpoint_timestamp', '', r'''
+        stable timestamp of the last checkpoint''',
+        type=string),
     Config('id', '', r'''
         the file's ID number'''),
     Config('version', '(major=0,minor=0)', r'''
@@ -1339,7 +1342,7 @@ methods = {
         \c oldest_timestamp and the read timestamps of all active readers, and
         \c stable returns the most recent \c stable_timestamp set with
         WT_CONNECTION::set_timestamp.  See @ref transaction_timestamps''',
-        choices=['all_committed','oldest','pinned','stable']),
+        choices=['all_committed','oldest','pinned','recovery','stable']),
 ]),
 
 'WT_CONNECTION.set_timestamp' : Method([

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -45,7 +45,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_open_session[] = {
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_query_timestamp[] = {
 	{ "get", "string",
 	    NULL, "choices=[\"all_committed\",\"oldest\",\"pinned\","
-	    "\"stable\"]",
+	    "\"recovery\",\"stable\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -592,6 +592,7 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
 	{ "cache_resident", "boolean", NULL, NULL, NULL, 0 },
 	{ "checkpoint", "string", NULL, NULL, NULL, 0 },
 	{ "checkpoint_lsn", "string", NULL, NULL, NULL, 0 },
+	{ "checkpoint_timestamp", "string", NULL, NULL, NULL, 0 },
 	{ "checksum", "string",
 	    NULL, "choices=[\"on\",\"off\",\"uncompressed\"]",
 	    NULL, 0 },
@@ -1412,18 +1413,19 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
 	  "assert=(commit_timestamp=none,read_timestamp=none),"
 	  "block_allocation=best,block_compressor=,cache_resident=false,"
-	  "checkpoint=,checkpoint_lsn=,checksum=uncompressed,collator=,"
-	  "columns=,dictionary=0,encryption=(keyid=,name=),format=btree,"
-	  "huffman_key=,huffman_value=,id=,"
-	  "ignore_in_memory_cache_size=false,internal_item_max=0,"
-	  "internal_key_max=0,internal_key_truncate=true,"
-	  "internal_page_max=4KB,key_format=u,key_gap=10,leaf_item_max=0,"
-	  "leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=0,"
-	  "log=(enabled=true),memory_page_max=5MB,os_cache_dirty_max=0,"
-	  "os_cache_max=0,prefix_compression=false,prefix_compression_min=4"
-	  ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
-	  "value_format=u,version=(major=0,minor=0)",
-	  confchk_file_meta, 40
+	  "checkpoint=,checkpoint_lsn=,checkpoint_timestamp=,"
+	  "checksum=uncompressed,collator=,columns=,dictionary=0,"
+	  "encryption=(keyid=,name=),format=btree,huffman_key=,"
+	  "huffman_value=,id=,ignore_in_memory_cache_size=false,"
+	  "internal_item_max=0,internal_key_max=0,"
+	  "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+	  "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
+	  "leaf_value_max=0,log=(enabled=true),memory_page_max=5MB,"
+	  "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,"
+	  "prefix_compression_min=4,split_deepen_min_child=0,"
+	  "split_deepen_per_child=0,split_pct=90,value_format=u,"
+	  "version=(major=0,minor=0)",
+	  confchk_file_meta, 41
 	},
 	{ "index.meta",
 	  "app_metadata=,collator=,columns=,extractor=,immutable=false,"

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -832,7 +832,7 @@ extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_timestamp_to_hex_string( WT_SESSION_IMPL *session, char *hex_timestamp, const wt_timestamp_t *ts_src) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, const wt_timestamp_t *ts, const char *msg);
-extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval, bool zero_ok) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_query_timestamp( WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -832,7 +832,8 @@ extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_timestamp_to_hex_string( WT_SESSION_IMPL *session, char *hex_timestamp, const wt_timestamp_t *ts_src) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, const wt_timestamp_t *ts, const char *msg);
-extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval, bool zero_ok) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_query_timestamp( WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -104,6 +104,7 @@ struct __wt_txn_global {
 	WT_DECL_TIMESTAMP(commit_timestamp)
 	WT_DECL_TIMESTAMP(oldest_timestamp)
 	WT_DECL_TIMESTAMP(pinned_timestamp)
+	WT_DECL_TIMESTAMP(recovery_timestamp)
 	WT_DECL_TIMESTAMP(stable_timestamp)
 	bool has_commit_timestamp;
 	bool has_oldest_timestamp;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2397,7 +2397,7 @@ struct __wt_connection {
 	 * set with WT_CONNECTION::set_timestamp.  See @ref
 	 * transaction_timestamps., a string\, chosen from the following
 	 * options: \c "all_committed"\, \c "oldest"\, \c "pinned"\, \c
-	 * "stable"; default \c all_committed.}
+	 * "recovery"\, \c "stable"; default \c all_committed.}
 	 * @configend
 	 * @errors
 	 * If there is no matching timestamp (e.g., if this method is called

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -375,6 +375,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	time_t secs;
 	int64_t maxorder;
 	const char *sep;
+	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 1];
 
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	maxorder = 0;
@@ -452,6 +453,27 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 		WT_ERR(__wt_buf_catfmt(session, buf,
 		    ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
 		    ckptlsn->l.file, (uintmax_t)ckptlsn->l.offset));
+	hex_timestamp[0] = '0';
+	hex_timestamp[1] = '\0';
+#ifdef HAVE_TIMESTAMPS
+	/*
+	 * We need to record the timestamp of the checkpoint in the metadata's
+	 * checkpoint record. Although the read_timestamp remains set for the
+	 * duration of the checkpoint, we set and unset the flag based on the
+	 * file's durability. Record the timestamp if the flag is set, or if
+	 * this is the metadata record.
+	 *
+	 * !!! We're recording the timestamp on each table's metadata although
+	 * only the one in the metadata is useful after recovery for now.
+	 * This allows future possiblity of querying individual tables.
+	 */
+	if (F_ISSET(&session->txn, WT_TXN_HAS_TS_READ) ||
+	    strcmp(fname, WT_METAFILE_URI) == 0)
+		WT_ERR(__wt_timestamp_to_hex_string(session, hex_timestamp,
+		    &session->txn.read_timestamp));
+#endif
+	WT_ERR(__wt_buf_catfmt(session, buf,
+	    ",checkpoint_timestamp=\"%s\"", hex_timestamp));
 	WT_ERR(__ckpt_set(session, fname, buf->mem));
 
 err:	__wt_scr_free(session, &buf);

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -465,7 +465,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	 *
 	 * !!! We're recording the timestamp on each table's metadata although
 	 * only the one in the metadata is useful after recovery for now.
-	 * This allows future possiblity of querying individual tables.
+	 * This allows future possibility of querying individual tables.
 	 */
 	if (F_ISSET(&session->txn, WT_TXN_HAS_TS_READ) ||
 	    strcmp(fname, WT_METAFILE_URI) == 0)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -460,15 +460,9 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	 * We need to record the timestamp of the checkpoint in the metadata's
 	 * checkpoint record. Although the read_timestamp remains set for the
 	 * duration of the checkpoint, we set and unset the flag based on the
-	 * file's durability. Record the timestamp if the flag is set, or if
-	 * this is the metadata record.
-	 *
-	 * !!! We're recording the timestamp on each table's metadata although
-	 * only the one in the metadata is useful after recovery for now.
-	 * This allows future possibility of querying individual tables.
+	 * file's durability. Record the timestamp if the flag is set.
 	 */
-	if (F_ISSET(&session->txn, WT_TXN_HAS_TS_READ) ||
-	    strcmp(fname, WT_METAFILE_URI) == 0)
+	if (F_ISSET(&session->txn, WT_TXN_HAS_TS_READ))
 		WT_ERR(__wt_timestamp_to_hex_string(session, hex_timestamp,
 		    &session->txn.read_timestamp));
 #endif

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -375,7 +375,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	time_t secs;
 	int64_t maxorder;
 	const char *sep;
-	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 1];
+	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
 
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	maxorder = 0;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -446,8 +446,7 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 		bool round_to_oldest;
 
 		txn_global = &S2C(session)->txn_global;
-		WT_RET(__wt_txn_parse_timestamp(
-		    session, "read", &ts, &cval, false));
+		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
 
 		/*
 		 * Prepare transactions are supported only in timestamp build.
@@ -742,8 +741,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	    __wt_config_gets_def(session, cfg, "commit_timestamp", 0, &cval));
 	if (cval.len != 0) {
 #ifdef HAVE_TIMESTAMPS
-		WT_ERR(__wt_txn_parse_timestamp(
-		    session, "commit", &ts, &cval, false));
+		WT_ERR(__wt_txn_parse_timestamp(session, "commit", &ts, &cval));
 		WT_ERR(__wt_timestamp_validate(session,
 		    "commit", &ts, &cval, true, true, true));
 		__wt_timestamp_set(&txn->commit_timestamp, &ts);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -446,7 +446,8 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 		bool round_to_oldest;
 
 		txn_global = &S2C(session)->txn_global;
-		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
+		WT_RET(__wt_txn_parse_timestamp(
+		    session, "read", &ts, &cval, false));
 
 		/*
 		 * Prepare transactions are supported only in timestamp build.
@@ -741,7 +742,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	    __wt_config_gets_def(session, cfg, "commit_timestamp", 0, &cval));
 	if (cval.len != 0) {
 #ifdef HAVE_TIMESTAMPS
-		WT_ERR(__wt_txn_parse_timestamp(session, "commit", &ts, &cval));
+		WT_ERR(__wt_txn_parse_timestamp(
+		    session, "commit", &ts, &cval, false));
 		WT_ERR(__wt_timestamp_validate(session,
 		    "commit", &ts, &cval, true, true, true));
 		__wt_timestamp_set(&txn->commit_timestamp, &ts);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -706,7 +706,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 		__wt_timestamp_set(
 		    &txn->read_timestamp, &txn_global->stable_timestamp);
 		F_SET(txn, WT_TXN_HAS_TS_READ);
-	}
+	} else
+		__wt_timestamp_set_zero(&txn->read_timestamp);
 #else
 	WT_UNUSED(use_timestamp);
 #endif

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -361,6 +361,8 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 		    r->session, &r->file_alloc, fileid + 1, &r->files));
 		r->nfiles = fileid + 1;
 	}
+
+#ifdef HAVE_TIMESTAMPS
 	/*
 	 * If we're reading the config for the metadata from the turtle file
 	 * save the stable timestamp of the last checkpoint for later query.
@@ -381,6 +383,7 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 			__wt_timestamp_set_zero(
 			    &S2C(r->session)->txn_global.recovery_timestamp);
 	}
+#endif
 
 	WT_RET(__wt_strdup(r->session, uri, &r->files[fileid].uri));
 	WT_RET(

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -377,8 +377,8 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 		__wt_verbose(r->session, WT_VERB_RECOVERY,
 		    "%s: Recovery timestamp %.*s",
 		    uri, (int)cval.len, cval.str);
-		WT_RET(__wt_txn_parse_timestamp(r->session, "recovery",
-		    &ckpt_timestamp, &cval, true));
+		WT_RET(__wt_txn_parse_timestamp_raw(r->session, "recovery",
+		    &ckpt_timestamp, &cval));
 		/*
 		 * Keep track of the largest checkpoint timestamp seen.
 		 */

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -82,12 +82,12 @@ __wt_verbose_timestamp(WT_SESSION_IMPL *session,
 }
 
 /*
- * __wt_txn_parse_timestamp --
- *	Decodes and sets a timestamp.
+ * __wt_txn_parse_timestamp_raw --
+ *	Decodes and sets a timestamp. Don't do any checking.
  */
 int
-__wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name,
-    wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval, bool zero_ok)
+__wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *name,
+    wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval)
 {
 	__wt_timestamp_set_zero(timestamp);
 
@@ -172,7 +172,19 @@ __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name,
 	    ts.data, ts.size);
 	}
 #endif
-	if (!zero_ok && __wt_timestamp_iszero(timestamp))
+	return (0);
+}
+
+/*
+ * __wt_txn_parse_timestamp --
+ *	Decodes and sets a timestamp checking it is non-zero.
+ */
+int
+__wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name,
+    wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval)
+{
+	WT_RET(__wt_txn_parse_timestamp_int(session, name, timestamp, cval));
+	if (cval->len != 0 && __wt_timestamp_iszero(timestamp))
 		WT_RET_MSG(session, EINVAL,
 		    "Failed to parse %s timestamp '%.*s': zero not permitted",
 		    name, (int)cval->len, cval->str);
@@ -406,11 +418,11 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	 * it is not configured.
 	 */
 	WT_RET(__wt_txn_parse_timestamp(
-	    session, "commit", &commit_ts, &commit_cval, false));
+	    session, "commit", &commit_ts, &commit_cval));
 	WT_RET(__wt_txn_parse_timestamp(
-	    session, "oldest", &oldest_ts, &oldest_cval, false));
+	    session, "oldest", &oldest_ts, &oldest_cval));
 	WT_RET(__wt_txn_parse_timestamp(
-	    session, "stable", &stable_ts, &stable_cval, false));
+	    session, "stable", &stable_ts, &stable_cval));
 
 	WT_RET(__wt_config_gets_def(session,
 	    cfg, "force", 0, &cval));
@@ -641,8 +653,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 			WT_RET_MSG(session, EINVAL,
 			    "Transaction must be running "
 			    "to set a commit_timestamp");
-		WT_RET(__wt_txn_parse_timestamp(
-		    session, "commit", &ts, &cval, false));
+		WT_RET(__wt_txn_parse_timestamp(session, "commit", &ts, &cval));
 		WT_RET(__wt_timestamp_validate(session,
 		    "commit", &ts, &cval, true, true, true));
 		__wt_timestamp_set(&txn->commit_timestamp, &ts);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -183,7 +183,7 @@ int
 __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name,
     wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval)
 {
-	WT_RET(__wt_txn_parse_timestamp_int(session, name, timestamp, cval));
+	WT_RET(__wt_txn_parse_timestamp_raw(session, name, timestamp, cval));
 	if (cval->len != 0 && __wt_timestamp_iszero(timestamp))
 		WT_RET_MSG(session, EINVAL,
 		    "Failed to parse %s timestamp '%.*s': zero not permitted",

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -669,7 +669,8 @@ main(int argc, char *argv[])
 	 */
 	stable_val = 0;
 	if (use_ts) {
-		testutil_check(conn->query_timestamp(conn, buf, "get=recovery"));
+		testutil_check(
+		    conn->query_timestamp(conn, buf, "get=recovery"));
 		sscanf(buf, "%" SCNx64, &stable_val);
 		printf("Got stable_val %" PRIu64 "\n", stable_val);
 	}

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -70,7 +70,6 @@ static const char * const uri_local = "table:local";
 static const char * const uri_oplog = "table:oplog";
 static const char * const uri_collection = "table:collection";
 
-static const char * const stable_store = "table:stable";
 static const char * const ckpt_file = "checkpoint_done";
 
 static bool compat, inmem, use_ts;
@@ -118,7 +117,6 @@ usage(void)
 static WT_THREAD_RET
 thread_ts_run(void *arg)
 {
-	WT_CURSOR *cur_stable;
 	WT_SESSION *session;
 	THREAD_DATA *td;
 	uint64_t i, last_ts, oldest_ts, this_ts;
@@ -128,9 +126,6 @@ thread_ts_run(void *arg)
 	last_ts = 0;
 
 	testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-	testutil_check(session->open_cursor(
-	    session, stable_store, NULL, NULL, &cur_stable));
-
 	/*
 	 * Every N records we will record our stable timestamp into the stable
 	 * table. That will define our threshold where we expect to find records
@@ -170,9 +165,6 @@ thread_ts_run(void *arg)
 			testutil_check(
 			    td->conn->set_timestamp(td->conn, tscfg));
 			last_ts = oldest_ts;
-			cur_stable->set_key(cur_stable, td->info);
-			cur_stable->set_value(cur_stable, oldest_ts);
-			testutil_check(cur_stable->insert(cur_stable));
 		} else
 ts_wait:		__wt_sleep(0, 1000);
 	}
@@ -392,8 +384,6 @@ run_workload(uint32_t nth)
 	 * Don't log the stable timestamp table so that we know what timestamp
 	 * was stored at the checkpoint.
 	 */
-	testutil_check(session->create(session, stable_store,
-	    "key_format=Q,value_format=Q,log=(enabled=false)"));
 	testutil_check(session->close(session, NULL));
 
 	/*
@@ -507,12 +497,12 @@ main(int argc, char *argv[])
 	FILE *fp;
 	REPORT c_rep[MAX_TH], l_rep[MAX_TH], o_rep[MAX_TH];
 	WT_CONNECTION *conn;
-	WT_CURSOR *cur_coll, *cur_local, *cur_oplog, *cur_stable;
+	WT_CURSOR *cur_coll, *cur_local, *cur_oplog;
 	WT_RAND_STATE rnd;
 	WT_SESSION *session;
 	pid_t pid;
 	uint64_t absent_coll, absent_local, absent_oplog, count, key, last_key;
-	uint64_t stable_fp, stable_val, val[MAX_TH+1];
+	uint64_t stable_fp, stable_val;
 	uint32_t i, nth, timeout;
 	int ch, status, ret;
 	const char *working_dir;
@@ -673,26 +663,16 @@ main(int argc, char *argv[])
 	    uri_local, NULL, NULL, &cur_local));
 	testutil_check(session->open_cursor(session,
 	    uri_oplog, NULL, NULL, &cur_oplog));
-	testutil_check(session->open_cursor(session,
-	    stable_store, NULL, NULL, &cur_stable));
 
 	/*
 	 * Find the biggest stable timestamp value that was saved.
 	 */
 	stable_val = 0;
-	memset(val, 0, sizeof(val));
-	while (cur_stable->next(cur_stable) == 0) {
-		testutil_check(cur_stable->get_key(cur_stable, &key));
-		testutil_check(cur_stable->get_value(cur_stable, &val[key]));
-		if (val[key] > stable_val)
-			stable_val = val[key];
-
-		if (use_ts)
-			printf("Stable: key %" PRIu64 " value %" PRIu64 "\n",
-			    key, val[key]);
-	}
-	if (use_ts)
+	if (use_ts) {
+		testutil_check(conn->query_timestamp(conn, buf, "get=recovery"));
+		sscanf(buf, "%" SCNx64, &stable_val);
 		printf("Got stable_val %" PRIu64 "\n", stable_val);
+	}
 
 	count = 0;
 	absent_coll = absent_local = absent_oplog = 0;
@@ -761,11 +741,11 @@ main(int argc, char *argv[])
 				 * larger than the saved one.
 				 */
 				if (!inmem &&
-				    stable_fp != 0 && stable_fp <= val[i]) {
+				    stable_fp != 0 && stable_fp <= stable_val) {
 					printf("%s: COLLECTION no record with "
 					    "key %" PRIu64 " record ts %" PRIu64
 					    " <= stable ts %" PRIu64 "\n",
-					    fname, key, stable_fp, val[i]);
+					    fname, key, stable_fp, stable_val);
 					absent_coll++;
 				}
 				if (c_rep[i].first_miss == INVALID_KEY)
@@ -778,6 +758,18 @@ main(int argc, char *argv[])
 				 * after absent records, a hole in our data.
 				 */
 				c_rep[i].exist_key = key;
+				fatal = true;
+			} else if (!inmem &&
+			    stable_fp != 0 && stable_fp > stable_val) {
+				/*
+				 * If we found a record, the stable timestamp
+				 * written to our file better be no larger
+				 * than the checkpoint one.
+				 */
+				printf("%s: COLLECTION record with "
+				    "key %" PRIu64 " record ts %" PRIu64
+				    " > stable ts %" PRIu64 "\n",
+				    fname, key, stable_fp, stable_val);
 				fatal = true;
 			}
 			/*

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -643,7 +643,7 @@ main(int argc, char *argv[])
 	 */
 	testutil_check(__wt_snprintf(buf, sizeof(buf),
 	    "rm -rf ../%s.SAVE && mkdir ../%s.SAVE && "
-	    "cp -p WiredTigerLog.* ../%s.SAVE",
+	    "cp -p * ../%s.SAVE",
 	     home, home, home));
 	if ((status = system(buf)) < 0)
 		testutil_die(status, "system: %s", buf);

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -37,7 +37,7 @@ def timestamp_str(t):
     return '%x' % t
 
 class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
-    tablename = 'test_timestamp08'
+    tablename = 'test_timestamp09'
     uri = 'table:' + tablename
 
     def test_timestamp_api(self):
@@ -55,7 +55,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
 
         # In a single transaction it is illegal to set a commit timestamp
         # older than the first commit timestamp used for this transaction.
-        # Check both timestamp_transaction and commit_transaction API.
+        # Check both timestamp_transaction and commit_transaction APIs.
         self.session.begin_transaction()
         self.session.timestamp_transaction(
             'commit_timestamp=' + timestamp_str(3))
@@ -77,7 +77,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 '/older than the first commit timestamp/')
 
         # Commit timestamp >= Oldest timestamp
-        # Check both timestamp_transaction and commit_transaction API.
+        # Check both timestamp_transaction and commit_transaction APIs.
         self.session.begin_transaction()
         c[3] = 3
         self.session.commit_transaction(
@@ -131,7 +131,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 '/oldest timestamp 0*6 must not be later than stable timestamp 0*5/')
 
         # Commit timestamp >= Stable timestamp.
-        # Check both timestamp_transaction and commit_transaction API.
+        # Check both timestamp_transaction and commit_transaction APIs.
         # Oldest and stable timestamp are set to 5 at the moment.
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(6))
         self.session.begin_transaction()

--- a/test/suite/test_timestamp10.py
+++ b/test/suite/test_timestamp10.py
@@ -90,7 +90,7 @@ class test_timestamp10(wttest.WiredTigerTestCase, suite_subprocess):
         # Query the recovery timestamp and verify the data in the new database.
         new_session = new_conn.open_session()
         self.assertTimestampsEqual(new_conn.query_timestamp('get=recovery'), timestamp_str(ts))
-        
+
         c_op = new_session.open_cursor(self.oplog_uri)
         c_coll = new_session.open_cursor(self.coll_uri)
         for i in range(1,max):

--- a/test/suite/test_timestamp10.py
+++ b/test/suite/test_timestamp10.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_timestamp10.py
+#   Timestamps: Saving and querying the checkpoint recovery timestamp
+#
+
+import fnmatch, os, shutil
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_timestamp10(wttest.WiredTigerTestCase, suite_subprocess):
+    conn_config = 'config_base=false,create,log=(enabled)'
+    coll_uri = 'table:collection10'
+    oplog_uri = 'table:oplog10'
+
+    def copy_dir(self, olddir, newdir):
+        ''' Simulate a crash from olddir and restart in newdir. '''
+        # with the connection still open, copy files to new directory
+        shutil.rmtree(newdir, ignore_errors=True)
+        os.mkdir(newdir)
+        for fname in os.listdir(olddir):
+            fullname = os.path.join(olddir, fname)
+            # Skip lock file on Windows since it is locked
+            if os.path.isfile(fullname) and \
+              "WiredTiger.lock" not in fullname and \
+              "Tmplog" not in fullname and \
+              "Preplog" not in fullname:
+                shutil.copy(fullname, newdir)
+        # close the original connection.
+        self.close_conn()
+
+    def test_timestamp_recovery(self):
+        if not wiredtiger.timestamp_build():
+            self.skipTest('requires a timestamp build')
+
+        self.session.create(self.oplog_uri, 'key_format=i,value_format=i')
+        self.session.create(self.coll_uri, 'key_format=i,value_format=i,log=(enabled=false)')
+        c_op = self.session.open_cursor(self.oplog_uri)
+        c_coll = self.session.open_cursor(self.coll_uri)
+
+        # Begin by adding some data.
+        max = 10
+        ts = max - 3
+        for i in range(1,max):
+          self.session.begin_transaction()
+          c_op[i] = i
+          c_coll[i] = i
+          self.session.commit_transaction(
+            'commit_timestamp=' + timestamp_str(i))
+
+        # Set the oldest and stable timestamp a bit earlier than the data
+        # we inserted. Take a checkpoint to the stable timestamp.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(ts) +
+            ',stable_timestamp=' + timestamp_str(ts))
+
+        self.session.checkpoint()
+
+        # Copy to a new database and then recover.
+        self.copy_dir(".", "RESTART")
+        new_conn = self.wiredtiger_open("RESTART", self.conn_config)
+        # Query the recovery timestamp and verify the data in the new database.
+        new_session = new_conn.open_session()
+        self.assertTimestampsEqual(new_conn.query_timestamp('get=recovery'), timestamp_str(ts))
+        
+        c_op = new_session.open_cursor(self.oplog_uri)
+        c_coll = new_session.open_cursor(self.coll_uri)
+        for i in range(1,max):
+            self.assertEquals(c_op[i], i)
+            c_coll.set_key(i)
+            if i <= ts:
+                self.assertEquals(c_coll[i], i)
+            else:
+                self.assertEqual(c_coll.search(), wiredtiger.WT_NOTFOUND)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
@michaelcahill Here are the changes to store the timestamp that checkpoint is using in the metadata. @agorrod for your review also. And @dgottlieb mostly FYI for API usage. Some considerations:
1. I write a `checkpoint_stable` record into the metadata. This is written for all file records, not just the record in the turtle file.  The record in the turtle file is the only one used to store the timestamp on restart.  I did this for a couple reasons:
- It allows us to see timestamps in other metadata records in a `wt list -v` that may give helpful information in debugging.
- It allows us to extend querying the recovery timestamp in the future to an individual table if we ever wanted.
2. I named it `query_timestamp("get=recovery")`.
3. One benefit of this is that it allowed me to use it in the `timestamp_abort` test with better accuracy on the verification side and removal of an entire table and a bunch of code.
4. Currently, until WT-3906 is complete, this only works on an unclean shutdown. The APIs work and information is correct but the data after restart from a clean shutdown in a collection-like table will not (yet) be as of the stable. The testing will be extended when I do that ticket.