### PR TITLE
WT-3904 Allow log server thread to retry on permission error.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -870,7 +870,7 @@ __log_server(void *arg)
 	WT_DECL_RET;
 	WT_LOG *log;
 	WT_SESSION_IMPL *session;
-	uint64_t time_start, time_stop, timediff;
+	uint64_t retry, time_start, time_stop, timediff;
 	bool did_work, signalled;
 
 	session = arg;
@@ -896,6 +896,7 @@ __log_server(void *arg)
 	 * takes to sync out an earlier file.
 	 */
 	did_work = true;
+	retry = 0;
 	while (F_ISSET(conn, WT_CONN_SERVER_LOG)) {
 		/*
 		 * Slots depend on future activity.  Force out buffered
@@ -940,7 +941,24 @@ __log_server(void *arg)
 					ret = __log_archive_once(session, 0);
 					__wt_writeunlock(
 					    session, &log->log_archive_lock);
-					WT_ERR(ret);
+					/*
+					 * It is possible that an external
+					 * process on some systems may prevent
+					 * removal. If we get a permission
+					 * error, retry a few times.
+					 */
+					if (ret == EACCES &&
+					    retry < WT_RETRY_MAX) {
+						retry++;
+						ret = 0;
+					} else {
+						/*
+						 * Return the error if there is
+						 * one or reset on success.
+						 */
+						WT_ERR(ret);
+						retry = 0;
+					}
 				} else
 					__wt_verbose(session, WT_VERB_LOG, "%s",
 					    "log_archive: Blocked due to open "

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1528,7 +1528,7 @@ retry:	while (slot < max_entries) {
 	 * candidates and we aren't finding more.
 	 */
 	if (slot < max_entries && (retries < 2 ||
-	    (retries < 10 &&
+	    (retries < WT_RETRY_MAX &&
 	    (slot == queue->evict_entries || slot > start_slot)))) {
 		start_slot = slot;
 		++retries;

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -34,9 +34,11 @@
 		(ret) = __wt_errno();					\
 } while (0)
 
+#define	WT_RETRY_MAX	10
+
 #define	WT_SYSCALL_RETRY(call, ret) do {				\
 	int __retry;							\
-	for (__retry = 0; __retry < 10; ++__retry) {			\
+	for (__retry = 0; __retry < WT_RETRY_MAX; ++__retry) {		\
 		WT_SYSCALL(call, ret);					\
 		switch (ret) {						\
 		case EAGAIN:						\


### PR DESCRIPTION
@agorrod Here is the small change to allow the log server thread to retry on a permission error. We record a message and retry up to 10 times. We reset if it soon succeeds and it if doesn't we will eventually panic. Please review. 