### PR TITLE
WT-3923 __wt_txn_context_prepare_check() requires API initialization

### DIFF
--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -539,17 +539,16 @@ __curjoin_extract_insert(WT_CURSOR *cursor)
 	WT_ITEM ikey;
 	WT_SESSION_IMPL *session;
 
-	cextract = (WT_CURJOIN_EXTRACTOR *)cursor;
 	/*
 	 * This insert method may be called multiple times during a single
 	 * extraction.  If we already have a definitive answer to the
 	 * membership question, exit early.
 	 */
+	cextract = (WT_CURJOIN_EXTRACTOR *)cursor;
 	if (cextract->ismember)
 		return (0);
 
-	session = (WT_SESSION_IMPL *)cursor->session;
-	WT_RET(__wt_txn_context_prepare_check(session));
+	CURSOR_API_CALL(cursor, session, insert, NULL);
 
 	WT_ITEM_SET(ikey, cursor->key);
 	/*
@@ -565,7 +564,7 @@ __curjoin_extract_insert(WT_CURSOR *cursor)
 	else if (ret == 0)
 		cextract->ismember = true;
 
-	return (ret);
+err:	API_END_RET(session, ret);
 }
 
 /*

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -908,11 +908,10 @@ __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config)
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
 
-	session = (WT_SESSION_IMPL *)cursor->session;
+	CURSOR_API_CALL(cursor, session, reconfigure, NULL);
 
-	WT_RET(__wt_txn_context_prepare_check(session));
 	/* Reconfiguration resets the cursor. */
-	WT_RET(cursor->reset(cursor));
+	WT_ERR(cursor->reset(cursor));
 
 	/*
 	 * append
@@ -926,7 +925,7 @@ __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config)
 			else
 				F_CLR(cursor, WT_CURSTD_APPEND);
 		} else
-			WT_RET_NOTFOUND_OK(ret);
+			WT_ERR_NOTFOUND_OK(ret);
 	}
 
 	/*
@@ -939,9 +938,9 @@ __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config)
 		else
 			F_CLR(cursor, WT_CURSTD_OVERWRITE);
 	} else
-		WT_RET_NOTFOUND_OK(ret);
+		WT_ERR_NOTFOUND_OK(ret);
 
-	return (0);
+err:	API_END_RET(session, ret);
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -801,7 +801,7 @@ extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config) WT
 extern void __wt_txn_release(WT_SESSION_IMPL *session);
 extern int __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_prepare_clear(WT_SESSION_IMPL *session);
-extern int __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_prepare(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1677,10 +1677,11 @@ __session_prepare_transaction(WT_SESSION *wt_session, const char *config)
 
 	session = (WT_SESSION_IMPL *)wt_session;
 	SESSION_API_CALL(session, prepare_transaction, config, cfg);
+	WT_UNUSED(cfg);
 
 	WT_ERR(__wt_txn_context_check(session, true));
 
-	WT_TRET(__wt_txn_prepare(session, cfg));
+	WT_ERR(__wt_txn_prepare(session));
 
 err:	API_END_RET(session, ret);
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -985,17 +985,9 @@ __wt_txn_prepare_clear(WT_SESSION_IMPL *session)
  *	Prepare the current transaction.
  */
 int
-__wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
+__wt_txn_prepare(WT_SESSION_IMPL *session)
 {
 #ifdef HAVE_TIMESTAMPS
-	WT_DECL_RET;
-#endif
-
-	WT_UNUSED(cfg);
-
-#ifdef HAVE_TIMESTAMPS
-	WT_TRET(__wt_txn_context_check(session, true));
-
 	F_SET(&session->txn, WT_TXN_PREPARE);
 
 #else


### PR DESCRIPTION
@agorrod, I noticed some functions were calling `__wt_txn_context_prepare_check()` explicitly (probably because they didn't call `API_XXX` macros?).

Anyway, that won't work because `__wt_txn_context_prepare_check()` uses `WT_SESSION.name`.

I added `API_XXX` macros in a few places, I don't see any reason that's not safe.