### PR TITLE
WT-3926 Allow read_timestamp to be set after begin_transaction.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1214,6 +1214,10 @@ methods = {
         read using the specified timestamp.  The supplied value must not be
         older than the current oldest timestamp.  This can only be set once
         for a transaction.  @ref transaction_timestamps'''),
+    Config('round_to_oldest', 'false', r'''
+        if read timestamp is earlier than oldest timestamp,
+        read timestamp will be rounded to oldest timestamp''',
+        type='boolean'),
 ]),
 
 'WT_SESSION.rollback_transaction' : Method([]),

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1161,7 +1161,7 @@ methods = {
         Transactions with higher values are less likely to abort''',
         min='-100', max='100'),
     Config('read_timestamp', '', r'''
-        read using the specified timestamp.  The supplied value should not be
+        read using the specified timestamp.  The supplied value must not be
         older than the current oldest timestamp.  See
         @ref transaction_timestamps'''),
     Config('round_to_oldest', 'false', r'''
@@ -1180,8 +1180,8 @@ methods = {
 'WT_SESSION.commit_transaction' : Method([
     Config('commit_timestamp', '', r'''
         set the commit timestamp for the current transaction.  The supplied
-        value should not be older than the first commit timestamp set for the
-        current transaction.  The value should also not be older than the
+        value must not be older than the first commit timestamp set for the
+        current transaction.  The value must also not be older than the
         current oldest and stable timestamps.  See
         @ref transaction_timestamps'''),
     Config('sync', '', r'''
@@ -1198,7 +1198,7 @@ methods = {
 'WT_SESSION.prepare_transaction' : Method([
     Config('prepare_timestamp', '', r'''
         set the prepare timestamp for the updates of the current transaction.
-        The supplied value should not be older than any active read timestamps.
+        The supplied value must not be older than any active read timestamps.
         This configuration option is mandatory.  See
         @ref transaction_timestamps'''),
 ]),
@@ -1206,10 +1206,14 @@ methods = {
 'WT_SESSION.timestamp_transaction' : Method([
     Config('commit_timestamp', '', r'''
         set the commit timestamp for the current transaction.  The supplied
-        value should not be older than the first commit timestamp set for the
-        current transaction.  The value should also not be older than the
+        value must not be older than the first commit timestamp set for the
+        current transaction.  The value must also not be older than the
         current oldest and stable timestamps.  See
         @ref transaction_timestamps'''),
+    Config('read_timestamp', '', r'''
+        read using the specified timestamp.  The supplied value must not be
+        older than the current oldest timestamp.  This can only be set once
+        for a transaction.  @ref transaction_timestamps'''),
 ]),
 
 'WT_SESSION.rollback_transaction' : Method([]),
@@ -1358,7 +1362,7 @@ methods = {
         timestamps greater than the specified value until the next commit moves
         the tracked commit timestamp forwards.  This is only intended for use
         where the application is rolling back locally committed transactions.
-        The supplied value should not be older than the current oldest and
+        The supplied value must not be older than the current oldest and
         stable timestamps.  See @ref transaction_timestamps'''),
     Config('force', 'false', r'''
         set timestamps even if they violate normal ordering requirements.
@@ -1368,13 +1372,13 @@ methods = {
         future commits and queries will be no earlier than the specified
         timestamp.  Supplied values must be monotonically increasing, any
         attempt to set the value to older than the current is silently ignored.
-        The supplied value should not be newer than the current
+        The supplied value must not be newer than the current
         stable timestamp.  See @ref transaction_timestamps'''),
     Config('stable_timestamp', '', r'''
         checkpoints will not include commits that are newer than the specified
         timestamp in tables configured with \c log=(enabled=false).  Supplied
         values must be monotonically increasing, any attempt to set the value to
-        older than the current is silently ignored.  The supplied value should
+        older than the current is silently ignored.  The supplied value must
         not be older than the current oldest timestamp.  See
         @ref transaction_timestamps'''),
 ]),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -486,6 +486,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_snapshot[] = {
 static const WT_CONFIG_CHECK confchk_WT_SESSION_timestamp_transaction[] = {
 	{ "commit_timestamp", "string", NULL, NULL, NULL, 0 },
 	{ "read_timestamp", "string", NULL, NULL, NULL, 0 },
+	{ "round_to_oldest", "boolean", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -1374,8 +1375,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  NULL, 0
 	},
 	{ "WT_SESSION.timestamp_transaction",
-	  "commit_timestamp=,read_timestamp=",
-	  confchk_WT_SESSION_timestamp_transaction, 2
+	  "commit_timestamp=,read_timestamp=,round_to_oldest=false",
+	  confchk_WT_SESSION_timestamp_transaction, 3
 	},
 	{ "WT_SESSION.transaction_sync",
 	  "timeout_ms=1200000",

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -485,6 +485,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_snapshot[] = {
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_timestamp_transaction[] = {
 	{ "commit_timestamp", "string", NULL, NULL, NULL, 0 },
+	{ "read_timestamp", "string", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -1373,8 +1374,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  NULL, 0
 	},
 	{ "WT_SESSION.timestamp_transaction",
-	  "commit_timestamp=",
-	  confchk_WT_SESSION_timestamp_transaction, 1
+	  "commit_timestamp=,read_timestamp=",
+	  confchk_WT_SESSION_timestamp_transaction, 2
 	},
 	{ "WT_SESSION.transaction_sync",
 	  "timeout_ms=1200000",

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -849,6 +849,7 @@ extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *ts, WT_CONFIG_ITEM *cval, bool cmp_oldest, bool cmp_stable, bool cmp_commit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_clear_commit_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1744,7 +1744,7 @@ struct __wt_session {
 	 * conflicts.  Transactions with higher values are less likely to
 	 * abort., an integer between -100 and 100; default \c 0.}
 	 * @config{read_timestamp, read using the specified timestamp.  The
-	 * supplied value should not be older than the current oldest timestamp.
+	 * supplied value must not be older than the current oldest timestamp.
 	 * See @ref transaction_timestamps., a string; default empty.}
 	 * @config{round_to_oldest, if read timestamp is earlier than oldest
 	 * timestamp\, read timestamp will be rounded to oldest timestamp., a
@@ -1774,8 +1774,8 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.commit_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current
-	 * transaction.  The supplied value should not be older than the first
-	 * commit timestamp set for the current transaction.  The value should
+	 * transaction.  The supplied value must not be older than the first
+	 * commit timestamp set for the current transaction.  The value must
 	 * also not be older than the current oldest and stable timestamps.  See
 	 * @ref transaction_timestamps., a string; default empty.}
 	 * @config{sync, override whether to sync log records when the
@@ -1810,7 +1810,7 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.prepare_transaction, see dist/api_data.py}
 	 * @config{prepare_timestamp, set the prepare timestamp for the updates
-	 * of the current transaction.  The supplied value should not be older
+	 * of the current transaction.  The supplied value must not be older
 	 * than any active read timestamps.  This configuration option is
 	 * mandatory.  See @ref transaction_timestamps., a string; default
 	 * empty.}
@@ -1846,10 +1846,14 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.timestamp_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current
-	 * transaction.  The supplied value should not be older than the first
-	 * commit timestamp set for the current transaction.  The value should
+	 * transaction.  The supplied value must not be older than the first
+	 * commit timestamp set for the current transaction.  The value must
 	 * also not be older than the current oldest and stable timestamps.  See
 	 * @ref transaction_timestamps., a string; default empty.}
+	 * @config{read_timestamp, read using the specified timestamp.  The
+	 * supplied value must not be older than the current oldest timestamp.
+	 * This can only be set once for a transaction.  @ref
+	 * transaction_timestamps., a string; default empty.}
 	 * @configend
 	 * @errors
 	 */
@@ -2444,7 +2448,7 @@ struct __wt_connection {
 	 * than the specified value until the next commit moves the tracked
 	 * commit timestamp forwards.  This is only intended for use where the
 	 * application is rolling back locally committed transactions.  The
-	 * supplied value should not be older than the current oldest and stable
+	 * supplied value must not be older than the current oldest and stable
 	 * timestamps.  See @ref transaction_timestamps., a string; default
 	 * empty.}
 	 * @config{force, set timestamps even if they violate normal ordering
@@ -2453,14 +2457,14 @@ struct __wt_connection {
 	 * @config{oldest_timestamp, future commits and queries will be no
 	 * earlier than the specified timestamp.  Supplied values must be
 	 * monotonically increasing\, any attempt to set the value to older than
-	 * the current is silently ignored.  The supplied value should not be
+	 * the current is silently ignored.  The supplied value must not be
 	 * newer than the current stable timestamp.  See @ref
 	 * transaction_timestamps., a string; default empty.}
 	 * @config{stable_timestamp, checkpoints will not include commits that
 	 * are newer than the specified timestamp in tables configured with \c
 	 * log=(enabled=false). Supplied values must be monotonically
 	 * increasing\, any attempt to set the value to older than the current
-	 * is silently ignored.  The supplied value should not be older than the
+	 * is silently ignored.  The supplied value must not be older than the
 	 * current oldest timestamp.  See @ref transaction_timestamps., a
 	 * string; default empty.}
 	 * @configend

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1854,6 +1854,9 @@ struct __wt_session {
 	 * supplied value must not be older than the current oldest timestamp.
 	 * This can only be set once for a transaction.  @ref
 	 * transaction_timestamps., a string; default empty.}
+	 * @config{round_to_oldest, if read timestamp is earlier than oldest
+	 * timestamp\, read timestamp will be rounded to oldest timestamp., a
+	 * boolean flag; default \c false.}
 	 * @configend
 	 * @errors
 	 */

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -437,84 +437,12 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 		 */
 		WT_RET(__wt_txn_named_snapshot_get(session, &cval));
 
-	WT_RET(__wt_config_gets_def(session, cfg, "read_timestamp", 0, &cval));
-	if (cval.len > 0) {
-#ifdef HAVE_TIMESTAMPS
-		wt_timestamp_t ts;
-		WT_TXN_GLOBAL *txn_global;
-		char hex_timestamp[2][2 * WT_TIMESTAMP_SIZE + 1];
-		bool round_to_oldest;
+	/* Check if prepared updates should be ignored during reads. */
+	WT_RET(__wt_config_gets_def(session, cfg, "ignore_prepare", 0, &cval));
+	if (cval.val)
+		F_SET(txn, WT_TXN_IGNORE_PREPARE);
 
-		txn_global = &S2C(session)->txn_global;
-		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
-
-		/*
-		 * Prepare transactions are supported only in timestamp build.
-		 */
-		WT_RET(__wt_config_gets_def(session,
-		    cfg, "ignore_prepare", 0, &cval));
-		if (cval.val)
-			F_SET(txn, WT_TXN_IGNORE_PREPARE);
-
-		/*
-		 * Read the configuration here to reduce the span of the
-		 * critical section.
-		 */
-		WT_RET(__wt_config_gets_def(session,
-		    cfg, "round_to_oldest", 0, &cval));
-		round_to_oldest = cval.val;
-		/*
-		 * This code is not using the timestamp validate function to
-		 * avoid a race between checking and setting transaction
-		 * timestamp.
-		 */
-		WT_RET(__wt_timestamp_to_hex_string(session,
-		    hex_timestamp[0], &ts));
-		__wt_readlock(session, &txn_global->rwlock);
-		if (__wt_timestamp_cmp(&ts, &txn_global->oldest_timestamp) < 0)
-		{
-			WT_RET(__wt_timestamp_to_hex_string(session,
-			    hex_timestamp[1], &txn_global->oldest_timestamp));
-			/*
-			 * If given read timestamp is earlier than oldest
-			 * timestamp then round the read timestamp to
-			 * oldest timestamp.
-			 */
-			if (round_to_oldest)
-				__wt_timestamp_set(&txn->read_timestamp,
-				    &txn_global->oldest_timestamp);
-			else {
-				__wt_readunlock(session, &txn_global->rwlock);
-				WT_RET_MSG(session, EINVAL, "read timestamp "
-				    "%s older than oldest timestamp %s",
-				    hex_timestamp[0], hex_timestamp[1]);
-			}
-		} else {
-			__wt_timestamp_set(&txn->read_timestamp, &ts);
-			/*
-			 * Reset to avoid a verbose message as read
-			 * timestamp is not rounded to oldest timestamp.
-			 */
-			round_to_oldest = false;
-		}
-
-		__wt_txn_set_read_timestamp(session);
-		__wt_readunlock(session, &txn_global->rwlock);
-		txn->isolation = WT_ISO_SNAPSHOT;
-		if (round_to_oldest) {
-			/*
-			 * This message is generated here to reduce the span of
-			 * critical section.
-			 */
-			__wt_verbose(session, WT_VERB_TIMESTAMP, "Read "
-			    "timestamp %s : Rounded to oldest timestamp %s",
-			    hex_timestamp[0], hex_timestamp[1]);
-		}
-#else
-		WT_RET_MSG(session, EINVAL, "read_timestamp requires a "
-		    "version of WiredTiger built with timestamp support");
-#endif
-	}
+	WT_RET(__wt_txn_parse_read_timestamp(session, cfg));
 
 	return (0);
 }

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -717,8 +717,8 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_RET(__wt_timestamp_to_hex_string(session,
 		    hex_timestamp[0], &ts));
 		__wt_readlock(session, &txn_global->rwlock);
-		if (__wt_timestamp_cmp(&ts, &txn_global->oldest_timestamp) < 0)
-		{
+		if (__wt_timestamp_cmp(
+		    &ts, &txn_global->oldest_timestamp) < 0) {
 			WT_RET(__wt_timestamp_to_hex_string(session,
 			    hex_timestamp[1], &txn_global->oldest_timestamp));
 			/*

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -756,6 +756,7 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 			    hex_timestamp[0], hex_timestamp[1]);
 		}
 #else
+		WT_UNUSED(txn);
 		WT_RET_MSG(session, EINVAL, "read_timestamp requires a "
 		    "version of WiredTiger built with timestamp support");
 #endif

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -632,7 +632,7 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 
 /*
  * __wt_txn_set_timestamp --
- *	Set a transaction's timestamp.
+ *	Parse a request to set a timestamp in a transaction.
  */
 int
 __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
@@ -640,9 +640,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_CONFIG_ITEM cval;
 	WT_DECL_RET;
 
-	/*
-	 * Look for a commit timestamp.
-	 */
+	/* Look for a commit timestamp. */
 	ret = __wt_config_gets_def(session, cfg, "commit_timestamp", 0, &cval);
 	if (ret == 0 && cval.len != 0) {
 #ifdef HAVE_TIMESTAMPS
@@ -661,6 +659,107 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 #endif
 	}
 	WT_RET_NOTFOUND_OK(ret);
+
+	/* Look for a read timestamp. */
+	WT_RET(__wt_txn_parse_read_timestamp(session, cfg));
+
+	return (0);
+}
+
+/*
+ * __wt_txn_parse_read_timestamp --
+ *	Parse a request to set a transaction's read_timestamp.
+ */
+int
+__wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
+{
+	WT_CONFIG_ITEM cval;
+	WT_TXN *txn;
+
+	txn = &session->txn;
+
+	WT_RET(__wt_config_gets_def(session, cfg, "read_timestamp", 0, &cval));
+	if (cval.len > 0) {
+#ifdef HAVE_TIMESTAMPS
+		wt_timestamp_t ts;
+		WT_TXN_GLOBAL *txn_global;
+		char hex_timestamp[2][2 * WT_TIMESTAMP_SIZE + 1];
+		bool round_to_oldest;
+
+		txn_global = &S2C(session)->txn_global;
+		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
+
+		/* Read timestamps imply / require snapshot isolation. */
+		if (!F_ISSET(txn, WT_TXN_RUNNING))
+			txn->isolation = WT_ISO_SNAPSHOT;
+		else if (txn->isolation != WT_ISO_SNAPSHOT)
+			WT_RET_MSG(session, EINVAL, "setting a read_timestamp"
+			    " requires a transaction running at snapshot"
+			    " isolation");
+
+		/* Read timestamps can't change once set. */
+		if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
+			WT_RET_MSG(session, EINVAL, "a read_timestamp"
+			    " may only be set once per transaction");
+
+		/*
+		 * Read the configuration here to reduce the span of the
+		 * critical section.
+		 */
+		WT_RET(__wt_config_gets_def(session,
+		    cfg, "round_to_oldest", 0, &cval));
+		round_to_oldest = cval.val;
+		/*
+		 * This code is not using the timestamp validate function to
+		 * avoid a race between checking and setting transaction
+		 * timestamp.
+		 */
+		WT_RET(__wt_timestamp_to_hex_string(session,
+		    hex_timestamp[0], &ts));
+		__wt_readlock(session, &txn_global->rwlock);
+		if (__wt_timestamp_cmp(&ts, &txn_global->oldest_timestamp) < 0)
+		{
+			WT_RET(__wt_timestamp_to_hex_string(session,
+			    hex_timestamp[1], &txn_global->oldest_timestamp));
+			/*
+			 * If given read timestamp is earlier than oldest
+			 * timestamp then round the read timestamp to
+			 * oldest timestamp.
+			 */
+			if (round_to_oldest)
+				__wt_timestamp_set(&txn->read_timestamp,
+				    &txn_global->oldest_timestamp);
+			else {
+				__wt_readunlock(session, &txn_global->rwlock);
+				WT_RET_MSG(session, EINVAL, "read timestamp "
+				    "%s older than oldest timestamp %s",
+				    hex_timestamp[0], hex_timestamp[1]);
+			}
+		} else {
+			__wt_timestamp_set(&txn->read_timestamp, &ts);
+			/*
+			 * Reset to avoid a verbose message as read
+			 * timestamp is not rounded to oldest timestamp.
+			 */
+			round_to_oldest = false;
+		}
+
+		__wt_txn_set_read_timestamp(session);
+		__wt_readunlock(session, &txn_global->rwlock);
+		if (round_to_oldest) {
+			/*
+			 * This message is generated here to reduce the span of
+			 * critical section.
+			 */
+			__wt_verbose(session, WT_VERB_TIMESTAMP, "Read "
+			    "timestamp %s : Rounded to oldest timestamp %s",
+			    hex_timestamp[0], hex_timestamp[1]);
+		}
+#else
+		WT_RET_MSG(session, EINVAL, "read_timestamp requires a "
+		    "version of WiredTiger built with timestamp support");
+#endif
+	}
 
 	return (0);
 }


### PR DESCRIPTION
Decoupling these means setting a read_timestamp will not be blocked due to a full cache, so is reasonable to do while holding an application lock (which may be necessary to allocate a valid timestamp).