### PR TITLE
WT-3932 Move hash tables out of session handles.

### DIFF
--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -175,6 +175,8 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
 	if (!F_ISSET(conn, WT_CONN_LEAK_MEMORY))
 		if ((s = conn->sessions) != NULL)
 			for (i = 0; i < conn->session_size; ++s, ++i) {
+				__wt_free(session, s->cursor_cache);
+				__wt_free(session, s->dhhash);
 				__wt_stash_discard_all(session, s);
 				__wt_free(session, s->hazard);
 			}

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -77,9 +77,6 @@ struct __wt_session_impl {
 	struct timespec last_epoch;	/* Last epoch time returned */
 
 	WT_CURSOR_LIST cursors;		/* Cursors closed with the session */
-					/* Hash table of cached cursors */
-
-	WT_CURSOR_LIST cursor_cache[WT_HASH_ARRAY_SIZE];
 	uint32_t cursor_sweep_position;	/* Position in cursor_cache for sweep */
 	uint32_t cursor_sweep_countdown;/* Countdown to cursor sweep */
 
@@ -201,9 +198,14 @@ struct __wt_session_impl {
 	 */
 	WT_RAND_STATE rnd;		/* Random number generation state */
 
+	/*
+	 * Hash tables are allocated lazily as sessions are used to keep the
+	 * size of this structure from growing too large.
+	 */
+	WT_CURSOR_LIST *cursor_cache;	/* Hash table of cached cursors */
+
 					/* Hashed handle reference list array */
-	TAILQ_HEAD(__dhandles_hash, __wt_data_handle_cache)
-				dhhash[WT_HASH_ARRAY_SIZE];
+	TAILQ_HEAD(__dhandles_hash, __wt_data_handle_cache) *dhhash;
 
 					/* Generations manager */
 #define	WT_GEN_CHECKPOINT	0	/* Checkpoint generation */

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2165,6 +2165,17 @@ __open_session(WT_CONNECTION_IMPL *conn,
 	TAILQ_INIT(&session_ret->cursors);
 	TAILQ_INIT(&session_ret->dhandles);
 
+	/*
+	 * If we don't have them, allocate the cursor and dhandle hash arrays.
+	 * Allocate the table hash array as well.
+	 */
+	if (session_ret->cursor_cache == NULL)
+		WT_ERR(__wt_calloc_def(
+		    session, WT_HASH_ARRAY_SIZE, &session_ret->cursor_cache));
+	if (session_ret->dhhash == NULL)
+		WT_ERR(__wt_calloc_def(
+		    session, WT_HASH_ARRAY_SIZE, &session_ret->dhhash));
+
 	/* Initialize the dhandle hash array. */
 	for (i = 0; i < WT_HASH_ARRAY_SIZE; i++)
 		TAILQ_INIT(&session_ret->dhhash[i]);


### PR DESCRIPTION
In 043f61e, we embedded hash tables for cursors and data handles directly in the WT_SESSION_IMPL structure.  That is problematic because we allocate all configured session handles in a single block of memory on startup, and the hash tables grew the structre from just over 1KB to ~18KB.