### PR TITLE
WT-3933 test/format failure illegal WT_REF.state rolling back deleted page

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -125,7 +125,6 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	 * this point on.
 	 */
 	if (ref->page_del != NULL) {
-		WT_ASSERT(session, ref->page_del->txnid == WT_TXN_ABORTED);
 		__wt_free(session, ref->page_del->update_list);
 		__wt_free(session, ref->page_del);
 	}
@@ -185,8 +184,6 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_UPDATE **upd;
 	uint64_t sleep_count, yield_count;
-
-	ref->page_del->txnid = WT_TXN_ABORTED;
 
 	/*
 	 * If the page is still "deleted", it's as we left it, reset the state

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1350,8 +1350,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
 		return (false);
 
-	/* Pages being truncated can't be evicted until truncate completion. */
-	if (ref->page_del != NULL &&
+	/* A truncated page can't be evicted until the truncate completes. */
+	if (ref->page_del != NULL && ref->page_del->txnid != WT_TXN_ABORTED &&
 	    !__wt_txn_visible_all(session,
 	    ref->page_del->txnid, WT_TIMESTAMP_NULL(&ref->page_del->timestamp)))
 		return (false);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1350,11 +1350,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	    F_ISSET_ATOMIC(ref->home, WT_PAGE_OVERFLOW_KEYS))
 		return (false);
 
-	/*
-	 * If the page was restored after a truncate, it can't be evicted until
-	 * the truncate completes.
-	 */
-	if (ref->page_del != NULL && ref->page_del->txnid != WT_TXN_ABORTED &&
+	/* Pages being truncated can't be evicted until truncate completion. */
+	if (ref->page_del != NULL &&
 	    !__wt_txn_visible_all(session,
 	    ref->page_del->txnid, WT_TIMESTAMP_NULL(&ref->page_del->timestamp)))
 		return (false);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -127,7 +127,7 @@ extern int __wt_debug_tree_all( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_RE
 extern int __wt_debug_tree( WT_SESSION_IMPL *session, WT_BTREE *btree, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_page(WT_SESSION_IMPL *session, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref);
+extern int __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all);
 extern int __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -265,6 +265,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 static inline int
 __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
 {
+	WT_DECL_RET;
 	WT_TXN *txn;
 	WT_TXN_OP *op;
 
@@ -281,7 +282,11 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
 	op->u.ref = ref;
 	ref->page_del->txnid = txn->id;
 
-	return (__wt_txn_log_op(session, NULL));
+	WT_ERR(__wt_txn_log_op(session, NULL));
+	return (0);
+
+err:	__wt_txn_unmodify(session);
+	return (ret);
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1177,7 +1177,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 			op->u.upd->txnid = WT_TXN_ABORTED;
 			break;
 		case WT_TXN_OP_REF_DELETE:
-			__wt_delete_page_rollback(session, op->u.ref);
+			WT_TRET(__wt_delete_page_rollback(session, op->u.ref));
 			break;
 		case WT_TXN_OP_TRUNCATE_COL:
 		case WT_TXN_OP_TRUNCATE_ROW:

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -279,7 +279,7 @@ __txn_rollback_to_stable_btree_walk(
 		/* Review deleted page saved to the ref */
 		if (ref->page_del != NULL && __wt_timestamp_cmp(
 		    rollback_timestamp, &ref->page_del->timestamp) < 0)
-			__wt_delete_page_rollback(session, ref);
+			WT_RET(__wt_delete_page_rollback(session, ref));
 
 		if (!__wt_page_is_modified(ref->page))
 			continue;


### PR DESCRIPTION
@michaelcahill, setting `WT_REF.page_del.txnid` to `WT_TXN_ABORTED` allows the page to be evicted and the `WT_REF.page_del` structure to be discarded.

So, making that change before marking the updates are aborted means we can drop core accessing the updates, making the change after we swap in the WT_REF's previous state means we can drop core getting to the `WT_REF.page_del.txnid` field.