### PR TITLE
WT-3935 WT-3919 Enable cursor caching by default, add additional tests

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -465,7 +465,7 @@ __curfile_close(WT_CURSOR *cursor)
 	WT_CURSOR_BULK *cbulk;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	bool released;
+	bool dead, released;
 
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, cbt->btree);
@@ -477,8 +477,9 @@ __curfile_close(WT_CURSOR *cursor)
 	 */
 	WT_TRET(__wt_cursor_cache_release(session, cursor, &released));
 	if (released)
-		return (0);
+		goto done;
 
+	dead = F_ISSET(cursor, WT_CURSTD_DEAD);
 	if (F_ISSET(cursor, WT_CURSTD_BULK)) {
 		/* Free the bulk-specific resources. */
 		cbulk = (WT_CURSOR_BULK *)cbt;
@@ -502,9 +503,17 @@ __curfile_close(WT_CURSOR *cursor)
 	if (session->dhandle != NULL) {
 		/* Decrement the data-source's in-use counter. */
 		__wt_cursor_dhandle_decr_use(session);
-		WT_TRET(__wt_session_release_dhandle(session));
+
+		/*
+		 * If the cursor was marked dead, we got here from reopening
+		 * a cached cursor, which had a handle that was dead at that
+		 * time, so it did not obtain a lock on the handle.
+		 */
+		if (!dead)
+			WT_TRET(__wt_session_release_dhandle(session));
 	}
 
+done:
 err:	API_END_RET(session, ret);
 }
 
@@ -550,8 +559,10 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 	if (!check_only) {
 		session->dhandle = dhandle;
 		WT_TRET(__wt_session_lock_dhandle(session, 0, &is_dead));
-		if (is_dead)
+		if (is_dead) {
+			F_SET(cursor, WT_CURSTD_DEAD);
 			WT_TRET(WT_NOTFOUND);
+		}
 		__wt_cursor_reopen(cursor, dhandle);
 	}
 	return (ret);

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -776,16 +776,16 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
 				return (ret);
 			}
 
-			F_CLR(cursor, WT_CURSTD_APPEND | WT_CURSTD_OVERWRITE |
-			    WT_CURSTD_RAW);
+			/*
+			 * For these configuration values, there
+			 * is no difference in the resulting
+			 * cursor other than flag values, so fix
+			 * them up according to the given configuration.
+			 */
+			F_CLR(cursor, WT_CURSTD_APPEND | WT_CURSTD_RAW);
+			F_SET(cursor, WT_CURSTD_OVERWRITE);
 
 			if (have_config) {
-				/*
-				 * For these configuration values, there
-				 * is no difference in the resulting
-				 * cursor other than flag values, so fix
-				 * them up now.
-				 */
 				WT_RET(__wt_config_gets_def(
 				    session, cfg, "append", 0, &cval));
 				if (cval.val != 0)
@@ -793,8 +793,8 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
 
 				WT_RET(__wt_config_gets_def(
 				    session, cfg, "overwrite", 1, &cval));
-				if (cval.val != 0)
-					F_SET(cursor, WT_CURSTD_OVERWRITE);
+				if (cval.val == 0)
+					F_CLR(cursor, WT_CURSTD_OVERWRITE);
 
 				WT_RET(__wt_config_gets_def(
 				    session, cfg, "raw", 0, &cval));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -691,19 +691,20 @@ struct __wt_cursor {
 #define	WT_CURSTD_BULK		0x00002u
 #define	WT_CURSTD_CACHEABLE	0x00004u
 #define	WT_CURSTD_CACHED	0x00008u
-#define	WT_CURSTD_DUMP_HEX	0x00010u
-#define	WT_CURSTD_DUMP_JSON	0x00020u
-#define	WT_CURSTD_DUMP_PRINT	0x00040u
-#define	WT_CURSTD_JOINED	0x00080u
-#define	WT_CURSTD_KEY_EXT	0x00100u	/* Key points out of tree. */
-#define	WT_CURSTD_KEY_INT	0x00200u	/* Key points into tree. */
-#define	WT_CURSTD_META_INUSE	0x00400u
-#define	WT_CURSTD_OPEN		0x00800u
-#define	WT_CURSTD_OVERWRITE	0x01000u
-#define	WT_CURSTD_RAW		0x02000u
-#define	WT_CURSTD_RAW_SEARCH	0x04000u
-#define	WT_CURSTD_VALUE_EXT	0x08000u	/* Value points out of tree. */
-#define	WT_CURSTD_VALUE_INT	0x10000u	/* Value points into tree. */
+#define	WT_CURSTD_DEAD		0x00010u
+#define	WT_CURSTD_DUMP_HEX	0x00020u
+#define	WT_CURSTD_DUMP_JSON	0x00040u
+#define	WT_CURSTD_DUMP_PRINT	0x00080u
+#define	WT_CURSTD_JOINED	0x00100u
+#define	WT_CURSTD_KEY_EXT	0x00200u	/* Key points out of tree. */
+#define	WT_CURSTD_KEY_INT	0x00400u	/* Key points into tree. */
+#define	WT_CURSTD_META_INUSE	0x00800u
+#define	WT_CURSTD_OPEN		0x01000u
+#define	WT_CURSTD_OVERWRITE	0x02000u
+#define	WT_CURSTD_RAW		0x04000u
+#define	WT_CURSTD_RAW_SEARCH	0x08000u
+#define	WT_CURSTD_VALUE_EXT	0x10000u	/* Value points out of tree. */
+#define	WT_CURSTD_VALUE_INT	0x20000u	/* Value points into tree. */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 #define	WT_CURSTD_KEY_SET	(WT_CURSTD_KEY_EXT | WT_CURSTD_KEY_INT)
 #define	WT_CURSTD_VALUE_SET	(WT_CURSTD_VALUE_EXT | WT_CURSTD_VALUE_INT)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -599,7 +599,7 @@ __session_open_cursor(WT_SESSION *wt_session,
 	if (to_dup == NULL && F_ISSET(session, WT_SESSION_CACHE_CURSORS)) {
 		if ((ret = __wt_cursor_cache_get(
 		    session, uri, NULL, cfg, cursorp)) == 0)
-			return (0);
+			goto done;
 		WT_RET_NOTFOUND_OK(ret);
 	}
 
@@ -634,7 +634,7 @@ __session_open_cursor(WT_SESSION *wt_session,
 err:		if (cursor != NULL)
 			WT_TRET(cursor->close(cursor));
 	}
-
+done:
 	/*
 	 * Opening a cursor on a non-existent data source will set ret to
 	 * either of ENOENT or WT_NOTFOUND at this point. However,

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -567,7 +567,7 @@ __wt_open_cursor(WT_SESSION_IMPL *session,
 {
 	WT_DECL_RET;
 
-	if (F_ISSET(session, WT_SESSION_CACHE_CURSORS)) {
+	if (owner == NULL && F_ISSET(session, WT_SESSION_CACHE_CURSORS)) {
 		if ((ret = __wt_cursor_cache_get(
 		    session, uri, owner, cfg, cursorp)) == 0)
 			return (0);
@@ -2211,6 +2211,10 @@ __open_session(WT_CONNECTION_IMPL *conn,
 		    session, WT_OPTRACK_BUFSIZE, &session_ret->optrack_buf));
 		session_ret->optrackbuf_ptr = 0;
 	}
+
+	/* Set the default value for session flags. */
+	F_SET(session_ret, WT_SESSION_CACHE_CURSORS);
+
 	/*
 	 * Configuration: currently, the configuration for open_session is the
 	 * same as session.reconfigure, so use that function.

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -299,25 +299,21 @@ class test_cursor13_drops(test_cursor13_base):
             cursor.close()
             session.drop(uri)
 
-class test_cursor13_sweep(test_cursor13_base):
-    aggressive_sweep = False
-    scenarios = make_scenarios([
-        ('file', dict(uri='file:cursor13_sweep_a')),
-        ('table', dict(uri='table:cursor13_sweep_b'))
-    ])
-
+# Shared base class for some bigger tests.
+class test_cursor13_big_base(test_cursor13_base):
     deep = 3
     nuris = 100
-    nopens = 500000
+    opencount = 0
+    closecount = 0
+    uri = None   # set by child classes
+
     def uriname(self, i):
         return self.uri + '.' + str(i)
 
-    def test_cursor_sweep(self):
-        rand = suite_random()
-
-        # Create a large number (self.nuris) of uris, and for each one,
-        # create some number (self.deep) of cached cursors.
-        urimap = {}
+    # Create a large number (self.nuris) of uris, and for each one,
+    # create some number (self.deep) of cached cursors.
+    def create_uri_map(self, baseuri):
+        uri_map = {}
         for i in xrange(0, self.nuris):
             uri = self.uriname(i)
             cursors = []
@@ -326,46 +322,126 @@ class test_cursor13_sweep(test_cursor13_base):
                 cursors.append(self.session.open_cursor(uri, None))
             for c in cursors:
                 c.close()
-
             # Each map entry has a list of the open cursors.
-            # We start with none
-            urimap[uri] = []
+            # Since we just closed them, we start with none
+            uri_map[uri] = []
+
+        return uri_map
+
+    def close_uris(self, uri_map, range_arg):
+        for i in range_arg:
+            cursors = uri_map[self.uriname(i)]
+            while len(cursors) > 0:
+                cursors.pop().close()
+                self.closecount += 1
+
+    def open_or_close(self, uri_map, rand, low, high):
+        uri = self.uriname(rand.rand_range(low, high))
+        cursors = uri_map[uri]
+        ncursors = len(cursors)
+
+        # Keep the range of open cursors between 0 and [deep],
+        # with some random fluctuation
+        if ncursors == 0:
+            do_open = True
+        elif ncursors == self.deep:
+            do_open = False
+        else:
+            do_open = (rand.rand_range(0, 2) == 0)
+
+        if do_open:
+            cursors.append(self.session.open_cursor(uri, None))
+            self.opencount += 1
+        else:
+            i = rand.rand_range(0, ncursors)
+            cursors.pop(i).close()
+            self.closecount += 1
+
+class test_cursor13_big(test_cursor13_big_base):
+    scenarios = make_scenarios([
+        ('file', dict(uri='file:cursor13_sweep_a')),
+        ('table', dict(uri='table:cursor13_sweep_b'))
+    ])
+
+    nopens = 500000
+
+    def test_cursor_big(self):
+        rand = suite_random()
+        uri_map = self.create_uri_map(self.uri)
+        self.cursor_stats_init()
+        begin_stats = self.caching_stats()
+        #self.tty('stats before = ' + str(begin_stats))
 
         # At this point, we'll randomly open/close lots of cursors, keeping
         # track of how many of each. As long as we don't have more than [deep]
         # cursors open for each uri, we should always be taking then from
         # the set of cached cursors.
-        self.cursor_stats_init()
-        begin_stats = self.caching_stats()
-        #self.tty('stats before = ' + str(begin_stats))
-
-        opencount = 0
-        closecount = 0
-
-        while opencount < self.nopens:
-            uri = self.uriname(rand.rand_range(0, self.nuris))
-            cursors = urimap[uri]
-            ncursors = len(cursors)
-
-            # Keep the range of open cursors between 0 and [deep],
-            # with some random fluctuation
-            if ncursors == 0:
-                do_open = True
-            elif ncursors == self.deep:
-                do_open = False
-            else:
-                do_open = (rand.rand_range(0, 2) == 0)
-            if do_open:
-                cursors.append(self.session.open_cursor(uri, None))
-                opencount += 1
-            else:
-                i = rand.rand_range(0, ncursors)
-                cursors.pop(i).close()
-                closecount += 1
+        while self.opencount < self.nopens:
+            self.open_or_close(uri_map, rand, 0, self.nuris)
 
         end_stats = self.caching_stats()
 
-        #self.tty('opens = ' + str(opencount) + ', closes = ' + str(closecount))
+        #self.tty('opens = ' + str(self.opencount) + \
+        #         ', closes = ' + str(self.closecount))
         #self.tty('stats after = ' + str(end_stats))
-        self.assertEquals(end_stats[0] - begin_stats[0], closecount)
-        self.assertEquals(end_stats[1] - begin_stats[1], opencount)
+        self.assertEquals(end_stats[0] - begin_stats[0], self.closecount)
+        self.assertEquals(end_stats[1] - begin_stats[1], self.opencount)
+
+class test_cursor13_sweep(test_cursor13_big_base):
+    # Set dhandle sweep configuration so that dhandles should be closed within
+    # two seconds of all the cursors for the dhandle being closed (cached).
+    conn_config = 'statistics=(fast),' + \
+                  'file_manager=(close_scan_interval=1,close_idle_time=1,' + \
+                  'close_handle_minimum=0)'
+    uri = 'table:cursor13_sweep_b'
+    opens_per_round = 100000
+    rounds = 5
+
+    @wttest.longtest('cursor sweep tests require wait times')
+    def test_cursor_sweep(self):
+        rand = suite_random()
+
+        uri_map = self.create_uri_map(self.uri)
+        self.cursor_stats_init()
+        begin_stats = self.caching_stats()
+        begin_sweep_stats = self.sweep_stats()
+        #self.tty('stats before = ' + str(begin_stats))
+        #self.tty('sweep stats before = ' + str(begin_sweep_stats))
+
+        for round_cnt in range(0, self.rounds):
+            if round_cnt % 2 == 1:
+                # Close cursors in half of the range, and don't
+                # use them during this round, so they will be
+                # closed by sweep.
+                half = self.nuris / 2
+                self.close_uris(uri_map, xrange(0, half))
+                bottom_range = half
+                # Let the dhandle sweep run and find the closed cursors.
+                time.sleep(3.0)
+            else:
+                bottom_range = 0
+
+            i = 0
+            while self.opencount < (1 + round_cnt) * self.opens_per_round:
+                i += 1
+                if i % 100 == 0:
+                    time.sleep(0.0)   # Let other threads run
+                self.open_or_close(uri_map, rand, bottom_range, self.nuris)
+
+        end_stats = self.caching_stats()
+        end_sweep_stats = self.sweep_stats()
+
+        #self.tty('opens = ' + str(self.opencount) + \
+        #         ', closes = ' + str(self.closecount))
+        #self.tty('stats after = ' + str(end_stats))
+        #self.tty('sweep stats after = ' + str(end_sweep_stats))
+        self.assertEquals(end_stats[0] - begin_stats[0], self.closecount)
+        swept = end_sweep_stats[3] - begin_sweep_stats[3]
+        min_swept = self.deep * self.nuris
+        self.assertGreaterEqual(swept, min_swept)
+
+        # No strict equality test for the reopen stats. When we've swept
+        # some closed cursors, we'll have fewer reopens. It's different
+        # by approximately the number of swept cursors, but it's less
+        # predictable.
+        self.assertGreater(end_stats[1] - begin_stats[1], 0)

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -41,9 +41,6 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
     stat_cursor_cache = 0
     stat_cursor_reopen = 0
 
-    def setUpSessionOpen(self, conn):
-        return conn.open_session('cache_cursors=true')
-
     def caching_stats(self):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         cache = stat_cursor[stat.conn.cursor_cache][2]
@@ -125,8 +122,6 @@ class test_cursor13_reopens(test_cursor13_base):
         ('table', dict(uri='table:cursor13_reopen2', dstype=None)),
         ('sfile', dict(uri='file:cursor13_reopen3', dstype=SimpleDataSet)),
         ('stable', dict(uri='table:cursor13_reopen4', dstype=SimpleDataSet)),
-        ('ctable', dict(uri='table:cursor13_reopen5', dstype=ComplexDataSet)),
-        ('clsm', dict(uri='table:cursor13_reopen6', dstype=ComplexLSMDataSet))
     ])
 
     def basic_populate(self, uri, caching_enabled):


### PR DESCRIPTION
Enabling this exposed a bug which is also fixed: cursors with owners should not be eligible for caching.
Modified cursor cache test to expect caching by default, and removed
some scenarios that use complex datasets, they won't work.