### PR TITLE
WT-3939 test_txn14.test_txn14.test_log_flush timeout

### DIFF
--- a/test/suite/test_txn14.py
+++ b/test/suite/test_txn14.py
@@ -93,11 +93,11 @@ class test_txn14(wttest.WiredTigerTestCase, suite_subprocess):
         c.close()
         self.session.log_flush(cfgarg)
         if self.sync == 'background':
-            # If doing a background flush, wait 10 seconds. I have seen an
+            # If doing a background flush, wait 30 seconds. I have seen an
             # individual log file's fsync take more than a second on some
-            # systems, and we've seen timeouts at lower levels on systems
+            # systems, and we've seen timeouts at 10 seconds on systems
             # with slow I/O. So give it time to flush perhaps a few files.
-            self.session.transaction_sync('timeout_ms=10000')
+            self.session.transaction_sync('timeout_ms=30000')
         self.simulate_crash_restart(".", "RESTART")
         c = self.session.open_cursor(self.t1, None, None)
         i = 0


### PR DESCRIPTION
Increase the timeout to 30 seconds, it's been periodically failing on the PPC at 10 seconds.