### PR TITLE
WT-3940 Enhance libwiredtiger file checking in s_export

### DIFF
--- a/dist/s_export
+++ b/dist/s_export
@@ -44,13 +44,12 @@ check()
 # top-level or build_posix directories, check the previously built library,
 # if it exists. And, allow this script to be run from the top-level directory
 # as well as locally.
-for d in .libs build_posix/.libs; do
-	f="$d/libwiredtiger.a"
-	test -f $f && check $f
-
-	f="../$d/libwiredtiger.a"
-	test -f $f && check $f
+for d in .. ../build_posix; do
+	for ext in a so dylib; do
+		f="$d/.libs/libwiredtiger.$ext"
+		test -f $f && check $f
+	done
 done
 
-echo "skipped: libwiredtiger.a not found"
+echo "skipped: libwiredtiger.[a|so|dylib] not found"
 exit 0


### PR DESCRIPTION
Hi @keithbostic, since @michaelcahill mentioned adding support to macOS, so I just enhanced the lib file checking by incorporate all 3 file extensions - .a / .so / .dylib (macOS). If none of the files is found then print the message. 