### PR TITLE
WT-3945 Support libwiredtiger.so checking in s_export

### DIFF
--- a/dist/s_export
+++ b/dist/s_export
@@ -22,7 +22,7 @@ check()
 	(sed -e '/^#/d' s_export.list &&
 	eval $NM |
 	sed 's/.* //' |
-	egrep -v '^__wt') |
+	egrep -v '^_') |
 	sort |
 	uniq -u |
 	egrep -v \

--- a/dist/s_export
+++ b/dist/s_export
@@ -13,7 +13,7 @@ Darwin)
 	# We require GNU nm, which may not be installed.
 	type nm > /dev/null 2>&1 &&
 	    (nm --version | grep 'GNU nm') > /dev/null 2>&1 || exit 0
-	NM='nm --extern-only --defined-only --print-file-name $f'
+	NM='nm --extern-only --defined-only --print-file-name $f | egrep -v "__bss_start|_edata|_end|_fini|_init"'
 	;;
 esac
 
@@ -22,7 +22,7 @@ check()
 	(sed -e '/^#/d' s_export.list &&
 	eval $NM |
 	sed 's/.* //' |
-	egrep -v '^_') |
+	egrep -v '^__wt') |
 	sort |
 	uniq -u |
 	egrep -v \


### PR DESCRIPTION
Hi @keithbostic, it looks libwiredtiger.so has more symbols compared to libwiredtiger.a, and the old check() picked up below 5 symbols from libwiredtiger.so on Linux env, which I believe to be noise (instead of error).
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
unexpected external symbols in the WiredTiger library
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
__bss_start
_edata
_end
_fini
_init

I know the solution is a bit overdosed by excluding "^_", thought it could auto-cover symbols we could potentially add in the future. But do let me know if you have concern so that I will change it by specifying the 5 symbols in the excluding list. 