### PR TITLE
WT-3948 Clarify metadata apply loop, don't exit early on busy errors.

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -85,6 +85,7 @@
 	    ret == WT_NOTFOUND || ret == WT_RESTART))			\
 		ret = __ret;						\
 } while (0)
+#define	WT_TRET_BUSY_OK(a)	WT_TRET_ERROR_OK(a, EBUSY)
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Return and branch-to-err-label cases for switch statements. */

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -85,7 +85,6 @@
 	    ret == WT_NOTFOUND || ret == WT_RESTART))			\
 		ret = __ret;						\
 } while (0)
-#define	WT_TRET_BUSY_OK(a)	WT_TRET_ERROR_OK(a, EBUSY)
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Return and branch-to-err-label cases for switch statements. */

--- a/src/meta/meta_apply.c
+++ b/src/meta/meta_apply.c
@@ -39,13 +39,15 @@ __meta_btree_apply(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 		 * We need to pull the handle into the session handle cache
 		 * and make sure it's referenced to stop other internal code
 		 * dropping the handle (e.g in LSM when cleaning up obsolete
-		 * chunks).  Holding the metadata lock isn't enough.
+		 * chunks).  Holding the schema lock isn't enough.
 		 */
 		if ((ret = __wt_session_get_dhandle(
-		    session, uri, NULL, NULL, 0)) != 0)
-			return (ret == EBUSY ? 0 : ret);
-		WT_SAVE_DHANDLE(session, ret = file_func(session, cfg));
-		WT_TRET(__wt_session_release_dhandle(session));
+		    session, uri, NULL, NULL, 0)) == 0) {
+			WT_SAVE_DHANDLE(session, ret = file_func(session, cfg));
+			WT_TRET(__wt_session_release_dhandle(session));
+		} else
+			WT_TRET_BUSY_OK(ret);
+
 		WT_RET(ret);
 	}
 	WT_RET_NOTFOUND_OK(ret);
@@ -67,6 +69,7 @@ __wt_meta_apply_all(WT_SESSION_IMPL *session,
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 
+	WT_ASSERT(session, F_ISSET(session, WT_SESSION_LOCKED_SCHEMA));
 	WT_RET(__wt_metadata_cursor(session, &cursor));
 	WT_SAVE_DHANDLE(session, ret =
 	    __meta_btree_apply(session, cursor, file_func, name_func, cfg));

--- a/src/meta/meta_apply.c
+++ b/src/meta/meta_apply.c
@@ -45,10 +45,15 @@ __meta_btree_apply(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 		    session, uri, NULL, NULL, 0)) == 0) {
 			WT_SAVE_DHANDLE(session, ret = file_func(session, cfg));
 			WT_TRET(__wt_session_release_dhandle(session));
-		} else
-			WT_TRET_BUSY_OK(ret);
+		}
 
-		WT_RET(ret);
+		/*
+		 * Handles that are busy are skipped without the whole
+		 * operation failing.  This deals among other cases with
+		 * checkpoint encountering handles that are locked (e.g., for
+		 * bulk loads or verify operations).
+		 */
+		WT_RET_BUSY_OK(ret);
 	}
 	WT_RET_NOTFOUND_OK(ret);
 


### PR DESCRIPTION
Here's a possible way to make this clearer, to invite discussion.  Open question as to whether an EBUSY is even possible. And if it is, is it safe to ignore?