### PR TITLE
WT-3936 Add prepare testing to timestamp_abort and format.

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -267,6 +267,7 @@ typedef struct {
 	WT_RAND_STATE rnd;			/* thread RNG state */
 
 	uint64_t commit;			/* transaction resolution */
+	uint64_t prepare;
 	uint64_t rollback;
 	uint64_t deadlock;
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -587,9 +587,8 @@ prepare_transaction(TINFO *tinfo, WT_SESSION *session)
 
 	/*
 	 * We cannot prepare a transaction if logging on the table is set.
-	 * It is currently too unwieldly to separate tables and deal with
-	 * non-logged tables. Prepare also requires timestamps. Skip if
-	 * not using timestamps or if using logging.
+	 * Prepare also requires timestamps. Skip if not using timestamps
+	 * or if using logging.
 	 */
 	if (!g.c_txn_timestamps || g.c_logging)
 		return (0);


### PR DESCRIPTION
Here are the changes to test prepare in both `test/format` and `timestamp_abort`. It required some slight gymnastics in `timestamp_abort` because of the assertion in the code that there are no logged records that are part of the transaction when we prepare. It also means we cannot test prepared transactions in `format` unless logging is turned off.

Please review.