### PR TITLE
WT-3954 prepared operations evicted before commit

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -117,9 +117,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	/*
 	 * If this WT_REF was previously part of a fast-delete operation, there
 	 * may be existing page-delete information. The structure is only read
-	 * after a WT_REF_DELETED state is switched to locked: immediately after
-	 * locking (from a state other than WT_REF_DELETED), free the previous
-	 * version.
+	 * while the state is locked, free the previous version.
 	 *
 	 * Note: changes have been made, we must publish any state change from
 	 * this point on.
@@ -294,9 +292,9 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 
 	/*
 	 * The page_del structure can be freed as soon as the delete is stable:
-	 * it is only read when the ref state is WT_REF_DELETED.  It is worth
-	 * checking every time we come through because once this is freed, we
-	 * no longer need synchronization to check the ref.
+	 * it is only read when the ref state is locked. It is worth checking
+	 * every time we come through because once this is freed, we no longer
+	 * need synchronization to check the ref.
 	 */
 	if (skip && ref->page_del != NULL && (visible_all ||
 	    __wt_txn_visible_all(session, ref->page_del->txnid,

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -819,7 +819,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 #ifdef HAVE_TIMESTAMPS
 			if (__wt_txn_update_needs_timestamp(session, op)) {
 				if (F_ISSET(txn, WT_TXN_PREPARE)) {
-					WT_ASSERT(session, op->u.upd != NULL);
 					/*
 					 * In case of a prepared transaction,
 					 * the order of modification of the

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1107,7 +1107,9 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 		switch (op->type) {
 		case WT_TXN_OP_BASIC:
 		case WT_TXN_OP_INMEM:
-			WT_ASSERT(session, op->u.upd->txnid == txn->id);
+			WT_ASSERT(session,
+			    op->u.upd->txnid == txn->id ||
+			    op->u.upd->txnid == WT_TXN_ABORTED);
 			WT_ASSERT(session,
 			    S2C(session)->cache->las_fileid == 0 ||
 			    op->fileid != S2C(session)->cache->las_fileid);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -530,13 +530,7 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 		 */
 		txn_global->checkpoint_id = 0;
 	} else if (F_ISSET(txn, WT_TXN_HAS_ID)) {
-		/*
-		 * If transaction is prepared, this would have been done in
-		 * prepare.
-		 */
-		if (!F_ISSET(txn, WT_TXN_PREPARE)) {
-			__txn_remove_from_global_table(session);
-		}
+		__txn_remove_from_global_table(session);
 
 		txn->id = WT_TXN_NONE;
 	}
@@ -1033,7 +1027,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 
 			FLD_SET(op->u.upd->state, WT_UPDATE_STATE_PREPARED);
 			break;
-
 		case WT_TXN_OP_REF_DELETE:
 			__wt_timestamp_set(
 			    &op->u.ref->page_del->timestamp, &ts);
@@ -1050,13 +1043,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 
 	/* Release our snapshot in case it is keeping data pinned. */
 	__wt_txn_release_snapshot(session);
-
-	/*
-	 * Clear the transaction's ID from the global table, to facilitate
-	 * prepared data visibility, but not from local txn structure.
-	 */
-	if (F_ISSET(txn, WT_TXN_HAS_ID))
-		__txn_remove_from_global_table(session);
 
 	return (0);
 #else

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1034,7 +1034,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 		switch (op->type) {
 		case WT_TXN_OP_NONE:
 			break;
-
 		case WT_TXN_OP_BASIC:
 		case WT_TXN_OP_INMEM:
 			/*
@@ -1050,8 +1049,7 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 			}
 
 			/* Set prepare timestamp. */
-			if (op->fileid != WT_METAFILE_ID)
-				__wt_timestamp_set(&upd->timestamp, &ts);
+			__wt_timestamp_set(&upd->timestamp, &ts);
 
 			upd->state = WT_UPDATE_STATE_PREPARED;
 			break;
@@ -1059,7 +1057,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 			__wt_timestamp_set(
 			    &op->u.ref->page_del->timestamp, &ts);
 			break;
-
 		case WT_TXN_OP_TRUNCATE_COL:
 		case WT_TXN_OP_TRUNCATE_ROW:
 			/* Other operations don't need timestamps. */

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -534,10 +534,8 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 		 * If transaction is prepared, this would have been done in
 		 * prepare.
 		 */
-		if (!F_ISSET(txn, WT_TXN_PREPARE)) {
+		if (!F_ISSET(txn, WT_TXN_PREPARE))
 			__txn_remove_from_global_table(session);
-		}
-
 		txn->id = WT_TXN_NONE;
 	}
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -864,17 +864,20 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 			 */
 			if (ref->page_del->update_list == NULL)
 				break;
+
 			for (;;) {
 				previous_state = ref->state;
 				if (__wt_atomic_casv32(
 				    &ref->state, previous_state, WT_REF_LOCKED))
 					break;
 			}
+
 			if ((updp = ref->page_del->update_list) != NULL)
 				for (; *updp != NULL; ++updp)
 					__wt_timestamp_set(
 					    &(*updp)->timestamp,
 					    &txn->commit_timestamp);
+
 			/*
 			 * Publish to ensure we don't let the page be evicted
 			 * and the updates discarded before being written.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -879,7 +879,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 			WT_PUBLISH(ref->state, previous_state);
 #endif
 			break;
-
 		case WT_TXN_OP_TRUNCATE_COL:
 		case WT_TXN_OP_TRUNCATE_ROW:
 			/* Other operations don't need timestamps. */
@@ -1031,7 +1030,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 
 			FLD_SET(op->u.upd->state, WT_UPDATE_STATE_PREPARED);
 			break;
-
 		case WT_TXN_OP_REF_DELETE:
 			__wt_timestamp_set(
 			    &op->u.ref->page_del->timestamp, &ts);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1028,15 +1028,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 		switch (op->type) {
 		case WT_TXN_OP_BASIC:
 		case WT_TXN_OP_INMEM:
-			/*
-			 * Switch reserved operation to abort to simplify
-			 * obsolete update list truncation.
-			 */
-			if (op->u.upd->type == WT_UPDATE_RESERVE) {
-				op->u.upd->txnid = WT_TXN_ABORTED;
-				break;
-			}
-
 			/* Set prepare timestamp. */
 			__wt_timestamp_set(&op->u.upd->timestamp, &ts);
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -874,7 +874,11 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 					__wt_timestamp_set(
 					    &(*updp)->timestamp,
 					    &txn->commit_timestamp);
-			ref->state = previous_state;
+			/*
+			 * Publish to ensure we don't let the page be evicted
+			 * and the updates discarded before being written.
+			 */
+			WT_PUBLISH(ref->state, previous_state);
 #endif
 			break;
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -627,8 +627,7 @@ prepare_transaction(TINFO *tinfo, WT_SESSION *session)
 	 * Prepare also requires timestamps. Skip if not using timestamps,
 	 * if no timestamp has yet been set, or if using logging.
 	 */
-	if (/* XXX: CONFIGURE PREPARE OFF FOR NOW */ true ||
-	    !g.c_txn_timestamps || g.timestamp == 0 || g.c_logging)
+	if (!g.c_txn_timestamps || g.timestamp == 0 || g.c_logging)
 		return (0);
 
 	/*
@@ -1092,7 +1091,8 @@ update_instead_of_chosen_op:
 		}
 
 		/* Prepare the transaction 10% of the time. */
-		if (mmrand(&tinfo->rnd, 1, 10) == 1) {
+		/* XXX: CONFIGURE PREPARE OFF FOR NOW */
+		if (mmrand(&tinfo->rnd, 1, 10) == 0) {
 			ret = prepare_transaction(tinfo, session);
 			testutil_assert(ret == 0 || ret == WT_PREPARE_CONFLICT);
 			if (ret == WT_PREPARE_CONFLICT)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -627,7 +627,8 @@ prepare_transaction(TINFO *tinfo, WT_SESSION *session)
 	 * Prepare also requires timestamps. Skip if not using timestamps,
 	 * if no timestamp has yet been set, or if using logging.
 	 */
-	if (!g.c_txn_timestamps || g.timestamp == 0 || g.c_logging)
+	if (/* XXX: CONFIGURE PREPARE OFF FOR NOW */ true ||
+	    !g.c_txn_timestamps || g.timestamp == 0 || g.c_logging)
 		return (0);
 
 	/*


### PR DESCRIPTION
@bvpvamsikrishna, @michaelcahill, for your review.

Commit e4d9ad8 changes format so the oldest timestamp doesn't move past the prepared timestamp. That fix seems right to me, and seems to help, but I may not have it right, since it doesn't avoid the problem entirely (or maybe there's just another failure path I haven't found yet).

Commit 694eeed changes `__wt_txn_rollback()` to allow aborted transactions, `__wt_txn_prepare` sets `WT_UPDATE_RESERVE` updates to aborted. With that change, commit fc4b42d changes format to prepare transactions that are then rolled back.

Commit 6eb70e4 changes the prepare and rollback code to assert no updates are being prepared/rolled back from the lookaside file, and ignores all prepare/rollback updates from the metadata file.  I may have been a little too aggressive here: the original prepare code ignored metadata updates for the purposes of setting the prepare timestamp, but still set the update state to prepared. That looked wrong to me, but the change should be confirmed by one of you.

Edit:
Commit b18dc22 is on a separate commit because I'm suspicious I'm misunderstanding a visibility rule. Anyway, it seems to me like it's unsafe to do a type switch there because the update list can be truncated and freed (that's the whole point of switching the type), which means commit/rollback will update a freed WT_UPDATE.

Edit:
Commit 34bde21 changes prepare to not remove the transaction from the global table, which keeps eviction from discarding pages which include prepared (but not resolved), transactions.
@bvpvamsikrishna, I'd suggest expanding where WT_UPDATE.state field is set so we can assert `__wt_free_update_list()` never frees a WT_UPDATE structure in an unresolved state.

That fixes the last problem I'm seeing, this branch is now passing my testing.