### PR TITLE
WT-3942 Update test_compact02 to handle being halted by eviction pressure

### DIFF
--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -147,13 +147,13 @@ class test_compact02(wttest.WiredTigerTestCase):
 
         # 5. Call compact.
         # Compact can collide with eviction, if that happens we retry. Wait for
-        # up to a minute, the check for EBUSY should mean we're not retrying on
-        # real errors.
-        for i in range(1, 15):
+        # a long time, the check for EBUSY means we're not retrying on any real
+        # errors.
+        for i in range(1, 60):
             if not self.raisesBusy(
               lambda: self.session.compact(self.uri, None)):
                 break
-            time.sleep(4)
+            time.sleep(5)
 
         # 6. Get stats on compacted table.
         sz = self.getSize()


### PR DESCRIPTION
@agorrod, I'm pushing a fix for this one so we don't have to keep triaging the failure.

I don't see any evidence there's an underlying bug, it's just taking a very long time for eviction to finish in the small cache case, so I'm increasing the maximum timer from 1 minute to 5.