### PR TITLE
WT-3904 Allow log server thread to retry on permission error. (#3934) -- v3.4 backport

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1510,7 +1510,7 @@ retry:	while (slot < max_entries) {
 	 * candidates and we aren't finding more.
 	 */
 	if (slot < max_entries && (retries < 2 ||
-	    (retries < 10 &&
+	    (retries < WT_RETRY_MAX &&
 	    (slot == queue->evict_entries || slot > start_slot)))) {
 		start_slot = slot;
 		++retries;

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -34,9 +34,11 @@
 		(ret) = __wt_errno();					\
 } while (0)
 
+#define	WT_RETRY_MAX	10
+
 #define	WT_SYSCALL_RETRY(call, ret) do {				\
 	int __retry;							\
-	for (__retry = 0; __retry < 10; ++__retry) {			\
+	for (__retry = 0; __retry < WT_RETRY_MAX; ++__retry) {		\
 		WT_SYSCALL(call, ret);					\
 		switch (ret) {						\
 		case EAGAIN:						\


### PR DESCRIPTION
This is a v3.4 backport. There was a merge conflict while doing git cherry-pick. Solved the conflict by removing the definition of 2 local variables '**time_start**' and '**time_stop**', which seems not being used in v3.4 codebase. 

(cherry picked from commit f9541110bba7dea27adac2a0d083fb077de4d13f)