### PR TITLE
WT-3964 Stop wrapping schema operations in a transaction

### DIFF
--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -116,7 +116,7 @@ __wt_meta_track_on(WT_SESSION_IMPL *session)
 {
 	if (session->meta_track_nest++ == 0) {
 		if (!F_ISSET(&session->txn, WT_TXN_RUNNING)) {
-#ifndef WT_ENABLE_SCHEMA_TXN
+#ifdef WT_ENABLE_SCHEMA_TXN
 			WT_RET(__wt_txn_begin(session, NULL));
 #endif
 			F_SET(session, WT_SESSION_SCHEMA_TXN);
@@ -277,7 +277,7 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 
 	if (F_ISSET(session, WT_SESSION_SCHEMA_TXN)) {
 		F_CLR(session, WT_SESSION_SCHEMA_TXN);
-#ifndef WT_ENABLE_SCHEMA_TXN
+#ifdef WT_ENABLE_SCHEMA_TXN
 		WT_ERR(__wt_txn_commit(session, NULL));
 #endif
 	}
@@ -338,7 +338,7 @@ err:	/*
 		 */
 		WT_ASSERT(session, unroll || saved_ret != 0 ||
 		    session->txn.mod_count == 0);
-#ifndef WT_ENABLE_SCHEMA_TXN
+#ifdef WT_ENABLE_SCHEMA_TXN
 		WT_TRET(__wt_txn_rollback(session, NULL));
 #endif
 	}

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -116,7 +116,9 @@ __wt_meta_track_on(WT_SESSION_IMPL *session)
 {
 	if (session->meta_track_nest++ == 0) {
 		if (!F_ISSET(&session->txn, WT_TXN_RUNNING)) {
+#ifndef WT_ENABLE_SCHEMA_TXN
 			WT_RET(__wt_txn_begin(session, NULL));
+#endif
 			F_SET(session, WT_SESSION_SCHEMA_TXN);
 		}
 		WT_RET(__meta_track_next(session, NULL));
@@ -275,7 +277,9 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 
 	if (F_ISSET(session, WT_SESSION_SCHEMA_TXN)) {
 		F_CLR(session, WT_SESSION_SCHEMA_TXN);
+#ifndef WT_ENABLE_SCHEMA_TXN
 		WT_ERR(__wt_txn_commit(session, NULL));
+#endif
 	}
 
 	/*
@@ -334,7 +338,9 @@ err:	/*
 		 */
 		WT_ASSERT(session, unroll || saved_ret != 0 ||
 		    session->txn.mod_count == 0);
+#ifndef WT_ENABLE_SCHEMA_TXN
 		WT_TRET(__wt_txn_rollback(session, NULL));
+#endif
 	}
 
 	if (ret != 0)

--- a/test/suite/test_metadata_cursor03.py
+++ b/test/suite/test_metadata_cursor03.py
@@ -65,7 +65,8 @@ class test_metadata03(wttest.WiredTigerTestCase):
         # commit entry itself and the sync record for the metadata file.
         #
         count = self.count_logrecs()
-        self.assertTrue(count == origcnt + 2)
+        # To be re-enabled when WT-3965 is fixed.
+        #self.assertTrue(count == origcnt + 2)
 
     # Test that creating and dropping tables does not write individual
     # log records.


### PR DESCRIPTION
It causes an issue with recovery after a hard crash.