### PR TITLE
WT-3815 Performance changes and code simplification

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -643,7 +643,6 @@ __curfile_create(WT_SESSION_IMPL *session,
 	cursor->internal_uri = btree->dhandle->name;
 	cursor->key_format = btree->key_format;
 	cursor->value_format = btree->value_format;
-	cursor->checkpoint = session->dhandle->checkpoint;
 	cbt->btree = btree;
 
 	/*

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -56,7 +56,6 @@
 	cache,								\
 	reopen,								\
 	0,				/* uri_hash */			\
-	NULL,				/* checkpoint */		\
 	{ NULL, NULL },			/* TAILQ_ENTRY q */		\
 	0,				/* recno key */			\
 	{ 0 },				/* recno raw buffer */		\

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -353,7 +353,7 @@ extern void __wt_cursor_set_valuev(WT_CURSOR *cursor, va_list ap);
 extern int __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);
 extern int __wt_cursor_cache_release(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool *released) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_close(WT_CURSOR *cursor) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_equals(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -39,12 +39,14 @@ struct __wt_hazard {
 
 typedef TAILQ_HEAD(__wt_cursor_list, __wt_cursor)	WT_CURSOR_LIST;
 
-/* Number of cursors cached to trigger sweep. */
+/* Number of cursors cached to trigger cursor sweep. */
 #define	WT_SESSION_CURSOR_SWEEP_COUNTDOWN	20
 
-/* Maximum number of buckets to visit during sweep. */
-#define	WT_SESSION_CURSOR_SWEEP_MAX		32
+/* Minimum number of buckets to visit during cursor sweep. */
+#define	WT_SESSION_CURSOR_SWEEP_MIN		5
 
+/* Maximum number of buckets to visit during cursor sweep. */
+#define	WT_SESSION_CURSOR_SWEEP_MAX		32
 /*
  * WT_SESSION_IMPL --
  *	Implementation of WT_SESSION.
@@ -79,6 +81,7 @@ struct __wt_session_impl {
 	WT_CURSOR_LIST cursors;		/* Cursors closed with the session */
 	uint32_t cursor_sweep_position;	/* Position in cursor_cache for sweep */
 	uint32_t cursor_sweep_countdown;/* Countdown to cursor sweep */
+	time_t last_cursor_sweep;	/* Last sweep for dead cursors */
 
 	WT_CURSOR_BACKUP *bkp_cursor;	/* Hot backup cursor */
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -660,7 +660,6 @@ struct __wt_cursor {
 	int __F(reopen)(WT_CURSOR *cursor, bool check_only);
 
 	uint64_t uri_hash;			/* Hash of URI */
-	const char *checkpoint;			/* Checkpoint, if any */
 
 	/*
 	 * !!!

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -59,12 +59,22 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 	WT_CURSOR *cursor, *cursor_tmp;
 	WT_CURSOR_LIST *cached_list;
 	WT_DECL_RET;
+	time_t now;
 	uint32_t position;
 	int i, t_ret, nbuckets, nexamined, nclosed;
 	bool productive;
 
 	if (!F_ISSET(session, WT_SESSION_CACHE_CURSORS))
 		return (0);
+
+	/*
+	 * Periodically sweep for dead cursors; if we've swept recently, don't
+	 * do it again.
+	 */
+	__wt_seconds(session, &now);
+	if (difftime(now, session->last_cursor_sweep) < 1)
+		return (0);
+	session->last_cursor_sweep = now;
 
 	position = session->cursor_sweep_position;
 	productive = true;
@@ -93,9 +103,9 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 
 		/*
 		 * We continue sweeping as long as we have some good average
-		 * productivity. At a minimum, we look at two buckets.
+		 * productivity, or we are under the minimum.
 		 */
-		productive = (nclosed >= i);
+		productive = (nclosed + WT_SESSION_CURSOR_SWEEP_MIN > i);
 	}
 
 	session->cursor_sweep_position = position;
@@ -566,9 +576,10 @@ __wt_open_cursor(WT_SESSION_IMPL *session,
 {
 	WT_DECL_RET;
 
-	if (owner == NULL && F_ISSET(session, WT_SESSION_CACHE_CURSORS)) {
+	/* We do not cache any subordinate tables/files cursors. */
+	if (owner == NULL) {
 		if ((ret = __wt_cursor_cache_get(
-		    session, uri, owner, cfg, cursorp)) == 0)
+		    session, uri, cfg, cursorp)) == 0)
 			return (0);
 		WT_RET_NOTFOUND_OK(ret);
 	}
@@ -595,9 +606,9 @@ __session_open_cursor(WT_SESSION *wt_session,
 	session = (WT_SESSION_IMPL *)wt_session;
 	SESSION_API_CALL(session, open_cursor, config, cfg);
 
-	if (to_dup == NULL && F_ISSET(session, WT_SESSION_CACHE_CURSORS)) {
+	if (to_dup == NULL) {
 		if ((ret = __wt_cursor_cache_get(
-		    session, uri, NULL, cfg, cursorp)) == 0)
+		    session, uri, cfg, cursorp)) == 0)
 			goto done;
 		WT_RET_NOTFOUND_OK(ret);
 	}


### PR DESCRIPTION
Performance changes include:
  - don't sweep for dead cursors too often
  - handle a "" config string in open_cursor efficiently.
  - cursors with checkpoint specified are not cached.