### PR TITLE
WT-3967 Fix a coding error that was causing cursor sweep not to run.

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -672,8 +672,11 @@ __wt_cursor_cache_release(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	 * Do any sweeping first, if there are errors, it will
 	 * be easier to clean up if the cursor is not already cached.
 	 */
-	if (--session->cursor_sweep_countdown == 0)
+	if (--session->cursor_sweep_countdown == 0) {
+		session->cursor_sweep_countdown =
+		    WT_SESSION_CURSOR_SWEEP_COUNTDOWN;
 		WT_RET(__wt_session_cursor_cache_sweep(session));
+	}
 
 	WT_ERR(cursor->cache(cursor));
 	WT_STAT_CONN_INCR(session, cursor_cache);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -99,7 +99,6 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 	}
 
 	session->cursor_sweep_position = position;
-	session->cursor_sweep_countdown = WT_SESSION_CURSOR_SWEEP_COUNTDOWN;
 	F_SET(session, WT_SESSION_CACHE_CURSORS);
 
 	WT_STAT_CONN_INCR(session, cursor_sweep);

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -387,11 +387,14 @@ class test_cursor13_big_base(test_cursor13_base):
         return uri_map
 
     def close_uris(self, uri_map, range_arg):
+        closed = 0
         for i in range_arg:
             cursors = uri_map[self.uriname(i)]
             while len(cursors) > 0:
                 cursors.pop().close()
                 self.closecount += 1
+                closed += 1
+        return closed
 
     def open_or_close(self, uri_map, rand, low, high):
         uri = self.uriname(rand.rand_range(low, high))
@@ -465,6 +468,7 @@ class test_cursor13_sweep(test_cursor13_big_base):
         begin_sweep_stats = self.sweep_stats()
         #self.tty('stats before = ' + str(begin_stats))
         #self.tty('sweep stats before = ' + str(begin_sweep_stats))
+        potential_dead = 0
 
         for round_cnt in range(0, self.rounds):
             if round_cnt % 2 == 1:
@@ -472,18 +476,24 @@ class test_cursor13_sweep(test_cursor13_big_base):
                 # use them during this round, so they will be
                 # closed by sweep.
                 half = self.nuris / 2
-                self.close_uris(uri_map, xrange(0, half))
+                potential_dead += self.close_uris(uri_map, xrange(0, half))
                 bottom_range = half
                 # Let the dhandle sweep run and find the closed cursors.
                 time.sleep(3.0)
             else:
                 bottom_range = 0
 
+            # The session cursor sweep runs at most once a second and
+            # traverses a fraction of the cached cursors.  We'll run for
+            # ten seconds with pauses to make sure we see sweep activity.
+            pause_point = self.opens_per_round / 100
+            pause_duration = 0.1
+
             i = 0
             while self.opencount < (1 + round_cnt) * self.opens_per_round:
                 i += 1
-                if i % 100 == 0:
-                    time.sleep(0.0)   # Let other threads run
+                if i % pause_point == 0:
+                    time.sleep(pause_duration)   # over time, let sweep run
                 self.open_or_close(uri_map, rand, bottom_range, self.nuris)
 
         end_stats = self.caching_stats()
@@ -495,7 +505,19 @@ class test_cursor13_sweep(test_cursor13_big_base):
         #self.tty('sweep stats after = ' + str(end_sweep_stats))
         self.assertEquals(end_stats[0] - begin_stats[0], self.closecount)
         swept = end_sweep_stats[3] - begin_sweep_stats[3]
-        min_swept = self.deep * self.nuris
+
+        # Although this is subject to tuning parameters, we know that
+        # in an active sesssion, we'll sweep through minimum of 1% of
+        # the cached cursors per second.  We've set this test to run
+        # 5 rounds. In 2 of the 5 rounds (sandwiched between the others),
+        # some of the uris are allowed to close. So during the 'closing rounds'
+        # we'll sweep a minimum of 20% of the uri space, and in the other
+        # rounds we'll be referencing the closed uris again.
+
+        # We'll pass the test if we see at least 20% of the 'potentially
+        # dead' cursors swept.  There may be more, since the 1% per second
+        # is a minimum.
+        min_swept = 2 * potential_dead / 10
         self.assertGreaterEqual(swept, min_swept)
 
         # No strict equality test for the reopen stats. When we've swept

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -487,6 +487,8 @@ class test_cursor13_sweep(test_cursor13_big_base):
             # traverses a fraction of the cached cursors.  We'll run for
             # ten seconds with pauses to make sure we see sweep activity.
             pause_point = self.opens_per_round / 100
+            if pause_point == 0:
+                pause_point = 1
             pause_duration = 0.1
 
             i = 0


### PR DESCRIPTION
Also updated the long sweep test to correspond to the current sweep algorithm,
which doesn't run as often.