### PR TITLE
WT-3977 Print out actual checkpoint stable timestamp in timestamp_abort.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -211,7 +211,7 @@ thread_ckpt_run(void *arg)
 		testutil_check(td->conn->query_timestamp(
 		    td->conn, buf, "get=last_checkpoint"));
 		sscanf(buf, "%" SCNx64, &stable);
-		printf("Checkpoint %d complete. Ckpt at stable %"
+		printf("Checkpoint %d complete at stable %"
 		    PRIu64 ".\n", i, stable);
 		fflush(stdout);
 		/*

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -184,10 +184,11 @@ thread_ckpt_run(void *arg)
 	WT_RAND_STATE rnd;
 	WT_SESSION *session;
 	THREAD_DATA *td;
-	uint64_t ts;
+	uint64_t stable;
 	uint32_t sleep_time;
 	int i;
 	bool first_ckpt;
+	char buf[128];
 
 	__wt_random_init(&rnd);
 
@@ -198,20 +199,20 @@ thread_ckpt_run(void *arg)
 	(void)unlink(ckpt_file);
 	testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 	first_ckpt = true;
-	ts = 0;
 	for (i = 0; ;++i) {
 		sleep_time = __wt_random(&rnd) % MAX_CKPT_INVL;
 		sleep(sleep_time);
-		if (use_ts)
-			ts = global_ts;
 		/*
 		 * Since this is the default, send in this string even if
 		 * running without timestamps.
 		 */
 		testutil_check(session->checkpoint(
 		    session, "use_timestamp=true"));
-		printf("Checkpoint %d complete.  Minimum ts %" PRIu64 "\n",
-		    i, ts);
+		testutil_check(td->conn->query_timestamp(
+		    td->conn, buf, "get=last_checkpoint"));
+		sscanf(buf, "%" SCNx64, &stable);
+		printf("Checkpoint %d complete. Ckpt at stable %"
+		    PRIu64 ".\n", i, stable);
 		fflush(stdout);
 		/*
 		 * Create the checkpoint file so that the parent process knows
@@ -638,7 +639,7 @@ main(int argc, char *argv[])
 		    use_ts ? "true" : "false");
 		printf("Parent: Create %" PRIu32
 		    " threads; sleep %" PRIu32 " seconds\n", nth, timeout);
-		printf("CONFIG: %s%s%s%s -h %s -T %" PRIu32 "-t %" PRIu32 "\n",
+		printf("CONFIG: %s%s%s%s -h %s -T %" PRIu32 " -t %" PRIu32 "\n",
 		    progname,
 		    compat ? " -C" : "",
 		    inmem ? " -m" : "",


### PR DESCRIPTION
@keithbostic Please review. Now that WT-3958 is merged the test can print out the actual timestamp used in a checkpoint instead of an approximation. Knowing that exact value will help debug the failure.