### PR TITLE
WT-3987 Avoid reading lookaside pages in truncate fast path.

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -208,12 +208,12 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 			 * anywhere.
 			 *
 			 * The page is in an in-memory state, which means it
-			 * was instantiated at some point. Walk the list of
+			 * was instantiated at some point. Walk any list of
 			 * update structures and abort them.
 			 */
-			for (upd =
-			    ref->page_del->update_list; *upd != NULL; ++upd)
-				(*upd)->txnid = WT_TXN_ABORTED;
+			if ((upd = ref->page_del->update_list) != NULL)
+				for (; *upd != NULL; ++upd)
+					(*upd)->txnid = WT_TXN_ABORTED;
 			goto done;
 		case WT_REF_DISK:
 		case WT_REF_LIMBO:

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -242,7 +242,6 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 	if ((updp = ref->page_del->update_list) != NULL)
 		for (; *updp != NULL; ++updp)
 			(*updp)->txnid = WT_TXN_ABORTED;
-		goto done;
 
 	ref->state = current_state;
 

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -172,7 +172,7 @@ err:	__wt_free(session, ref->page_del);
 int
 __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 {
-	WT_UPDATE **upd;
+	WT_UPDATE **updp;
 	uint64_t sleep_count, yield_count;
 
 	/*
@@ -211,9 +211,9 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 			 * was instantiated at some point. Walk any list of
 			 * update structures and abort them.
 			 */
-			if ((upd = ref->page_del->update_list) != NULL)
-				for (; *upd != NULL; ++upd)
-					(*upd)->txnid = WT_TXN_ABORTED;
+			if ((updp = ref->page_del->update_list) != NULL)
+				for (; *updp != NULL; ++updp)
+					(*updp)->txnid = WT_TXN_ABORTED;
 			goto done;
 		case WT_REF_DISK:
 		case WT_REF_LIMBO:

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -444,7 +444,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 			 */
 			if ((page_del = child->page_del) == NULL ||
 			    page_del->txnid == WT_TXN_ABORTED ||
-			    !__wt_txn_visible_all(session, page_del->txnid,
+			    __wt_txn_visible_all(session, page_del->txnid,
 			    WT_TIMESTAMP_NULL(&page_del->timestamp)))
 				break;
 			return (EBUSY);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -426,13 +426,28 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 static int
 __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 {
+	WT_PAGE_DELETED *page_del;
 	WT_REF *child;
 
 	WT_INTL_FOREACH_BEGIN(session, parent->page, child) {
 		switch (child->state) {
 		case WT_REF_DISK:		/* On-disk */
-		case WT_REF_DELETED:		/* On-disk, deleted */
 			break;
+		case WT_REF_DELETED:		/* Deleted */
+			/*
+			 * If the page was part of a fast-delete, transaction
+			 * rollback might switch this page into its previous
+			 * state at any time, so the delete must be resolved.
+			 * We don't have to lock the page, as no thread of
+			 * control can be running below our locked internal
+			 * page.
+			 */
+			if ((page_del = child->page_del) == NULL ||
+			    page_del->txnid == WT_TXN_ABORTED ||
+			    !__wt_txn_visible_all(session, page_del->txnid,
+			    WT_TIMESTAMP_NULL(&page_del->timestamp)))
+				break;
+			return (EBUSY);
 		default:
 			return (EBUSY);
 		}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -290,12 +290,11 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	WT_DECL_RET;
 
 	/*
-	 * Discard the page and update the reference structure; if the page has
-	 * an address, it's a disk page; if it has no address, it's a deleted
-	 * page re-instantiated (for example, by searching) and never written.
-	 *
-	 * If evicting a WT_REF_LIMBO reference, we get to here and transition
-	 * back to WT_REF_LOOKASIDE.
+	 * Discard the page and update the reference structure. If evicting a
+	 * WT_REF_LIMBO page, transition back to WT_REF_LOOKASIDE. Otherwise,
+	 * a page with a disk address is an on-disk page, and a page without
+	 * a disk address is a re-instantiated deleted page (for example, by
+	 * searching), that was never subsequently written.
 	 */
 	__wt_ref_out(session, ref);
 	if (!closing && ref->page_las != NULL &&

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -676,6 +676,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_REF *ref;
 	WT_UPDATE **updp;
 	wt_timestamp_t prev_commit_timestamp, ts;
+	uint32_t previous_state;
 	bool update_timestamp;
 #endif
 
@@ -857,11 +858,31 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 			__wt_timestamp_set(
 			    &ref->page_del->timestamp, &txn->commit_timestamp);
 
+			/*
+			 * The page-deleted list can be discarded by eviction,
+			 * lock the WT_REF to ensure we don't race.
+			 */
+			if (ref->page_del->update_list == NULL)
+				break;
+
+			for (;;) {
+				previous_state = ref->state;
+				if (__wt_atomic_casv32(
+				    &ref->state, previous_state, WT_REF_LOCKED))
+					break;
+			}
+
 			if ((updp = ref->page_del->update_list) != NULL)
 				for (; *updp != NULL; ++updp)
 					__wt_timestamp_set(
 					    &(*updp)->timestamp,
 					    &txn->commit_timestamp);
+
+			/*
+			 * Publish to ensure we don't let the page be evicted
+			 * and the updates discarded before being written.
+			 */
+			WT_PUBLISH(ref->state, previous_state);
 #endif
 			break;
 		case WT_TXN_OP_TRUNCATE_COL:


### PR DESCRIPTION
@michaelcahill, this is [Zseries failure 41508](http://build.wiredtiger.com:8080/job/wiredtiger-test-format-stress-zseries/41508/console).

I believe the fix to only read `WT_REF.addr` once is needed, but I've never seen it fail, I noticed it while looking at the core dump.