### PR TITLE
WT-3982 Fix transaction visibility bugs related to lookaside usage.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -58,7 +58,7 @@ static char home[1024];			/* Program working dir */
  */
 #define	INVALID_KEY	UINT64_MAX
 #define	MAX_CKPT_INVL	5	/* Maximum interval between checkpoints */
-#define	MAX_TH		12
+#define	MAX_TH		256
 #define	MAX_TIME	40
 #define	MAX_VAL		1024
 #define	MIN_TH		5


### PR DESCRIPTION
At low isolation levels, new records can appear in between positioning a cursor and calling next/prev.  For this reason, search_near cannot assume that after calling next (or prev), it will have a key larger (or smaller) than the search key.  Loop and check in this (rare) case instead.

This applies particularly to internal code that searches in the lookaside table, because that access is always done at read-uncommitted isolation.