### PR TITLE
WT-3987 Avoid reading lookaside pages in truncate fast path

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -311,6 +311,31 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 }
 
 /*
+ * __tombstone_update_alloc --
+ *	Allocate and initialize a page-deleted tombstone update structure.
+ */
+static int
+__tombstone_update_alloc(WT_SESSION_IMPL *session,
+    WT_PAGE_DELETED *page_del, WT_UPDATE **updp, size_t *sizep)
+{
+	WT_UPDATE *upd;
+
+	WT_RET(
+	    __wt_update_alloc(session, NULL, &upd, sizep, WT_UPDATE_TOMBSTONE));
+
+	/*
+	 * Cleared memory matches the lowest possible transaction ID and
+	 * timestamp, do nothing.
+	 */
+	if (page_del != NULL) {
+		upd->txnid = page_del->txnid;
+		__wt_timestamp_set(&upd->timestamp, &page_del->timestamp);
+	}
+	*updp = upd;
+	return (0);
+}
+
+/*
  * __wt_delete_page_instantiate --
  *	Instantiate an entirely deleted row-store leaf page.
  */
@@ -319,11 +344,14 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
+	WT_INSERT *ins;
+	WT_INSERT_HEAD *insert;
 	WT_PAGE *page;
 	WT_PAGE_DELETED *page_del;
+	WT_ROW *rip;
 	WT_UPDATE **upd_array, *upd;
 	size_t size;
-	uint32_t i;
+	uint32_t count, i;
 
 	btree = S2BT(session);
 	page = ref->page;
@@ -358,52 +386,75 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * running inside a checkpoint, and now we're being forced to read that
 	 * page.
 	 *
-	 * In the first case, we have a page reference structure, in the second,
-	 * we don't.
-	 *
-	 * Allocate the per-reference update array; in the case of instantiating
-	 * a page, deleted by a running transaction that might eventually abort,
-	 * we need a list of the update structures so we can do that abort.  The
-	 * hard case is if a page splits: the update structures might be moved
-	 * to different pages, and we still have to find them all for an abort.
+	 * Expect a page-deleted structure if there's a running transaction that
+	 * needs to be resolved, otherwise, there may not be one (and, if the
+	 * transaction has resolved, we can ignore the page-deleted structure).
 	 */
-	page_del = ref->page_del;
-	if (page_del != NULL)
-		WT_RET(__wt_calloc_def(
-		    session, page->entries + 1, &page_del->update_list));
+	page_del =
+	    __wt_txn_page_del_visible(session, ref) ? NULL : ref->page_del;
 
 	/*
-	 * Allocate the per-page update array if one doesn't already exist.
-	 * Because deletes may be instantiated after lookaside table updates,
-	 * the update array may already exist.
+	 * Allocate the per-page update array if one doesn't already exist. (It
+	 * might already exist because deletes are instantiated after lookaside
+	 * table updates.)
 	 */
-	if (page->modify->mod_row_update == NULL)
-		WT_ERR(__wt_calloc_def(
+	if (page->entries != 0 && page->modify->mod_row_update == NULL)
+		WT_RET(__wt_calloc_def(
 		    session, page->entries, &page->modify->mod_row_update));
 
 	/*
-	 * Fill in the per-reference update array with references to update
-	 * structures, fill in the per-page update array with references to
-	 * deleted items.
+	 * Allocate the per-reference update array; in the case of instantiating
+	 * a page deleted in a running transaction, we need a list of the update
+	 * structures for the eventual commit or abort.
 	 */
-	upd_array = page->modify->mod_row_update;
-	for (i = 0, size = 0; i < page->entries; ++i) {
-		WT_ERR(__wt_calloc_one(session, &upd));
-		upd->type = WT_UPDATE_TOMBSTONE;
-
-		if (page_del == NULL)
-			upd->txnid = WT_TXN_NONE;	/* Globally visible */
-		else {
-			upd->txnid = page_del->txnid;
-			__wt_timestamp_set(
-			    &upd->timestamp, &page_del->timestamp);
-			page_del->update_list[i] = upd;
+	if (page_del != NULL) {
+		count = 0;
+		if ((insert = WT_ROW_INSERT_SMALLEST(page)) != NULL)
+			WT_SKIP_FOREACH(ins, insert)
+				++count;
+		WT_ROW_FOREACH(page, rip, i) {
+			++count;
+			if ((insert = WT_ROW_INSERT(page, rip)) != NULL)
+				WT_SKIP_FOREACH(ins, insert)
+					++count;
 		}
+		WT_RET(__wt_calloc_def(
+		    session, count + 1, &page_del->update_list));
+	}
 
-		upd->next = upd_array[i];
-		upd_array[i] = upd;
+	/* Walk the page entries, giving each one a tombstone. */
+	size = 0;
+	count = 0;
+	upd_array = page->modify->mod_row_update;
+	if ((insert = WT_ROW_INSERT_SMALLEST(page)) != NULL)
+		WT_SKIP_FOREACH(ins, insert) {
+			WT_ERR(__tombstone_update_alloc(
+			    session, page_del, &upd, &size));
+			upd->next = ins->upd;
+			ins->upd = upd;
 
-		size += sizeof(WT_UPDATE *) + WT_UPDATE_MEMSIZE(upd);
+			if (page_del != NULL)
+				page_del->update_list[count++] = upd;
+		}
+	WT_ROW_FOREACH(page, rip, i) {
+		WT_ERR(__tombstone_update_alloc(
+		    session, page_del, &upd, &size));
+		upd->next = upd_array[WT_ROW_SLOT(page, rip)];
+		upd_array[WT_ROW_SLOT(page, rip)] = upd;
+
+		if (page_del != NULL)
+			page_del->update_list[count++] = upd;
+
+		if ((insert = WT_ROW_INSERT(page, rip)) != NULL)
+			WT_SKIP_FOREACH(ins, insert) {
+				WT_ERR(__tombstone_update_alloc(
+				    session, page_del, &upd, &size));
+				upd->next = ins->upd;
+				ins->upd = upd;
+
+				if (page_del != NULL)
+					page_del->update_list[count++] = upd;
+			}
 	}
 
 	__wt_cache_page_inmem_incr(session, page, size);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -103,7 +103,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		return (0);
 
 	/*
-	 * If this WT_REF was previously part of a fast-delete operation, there
+	 * If this WT_REF was previously part of a truncate operation, there
 	 * may be existing page-delete information. The structure is only read
 	 * while the state is locked, free the previous version.
 	 *
@@ -117,10 +117,10 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	}
 
 	/*
-	 * We cannot fast-delete pages that have overflow key/value items as
-	 * the overflow blocks have to be discarded.  The way we figure that
-	 * out is to check the page's cell type, cells for leaf pages without
-	 * overflow items are special.
+	 * We cannot truncate pages that have overflow key/value items as the
+	 * overflow blocks have to be discarded.  The way we figure that out is
+	 * to check the page's cell type, cells for leaf pages without overflow
+	 * items are special.
 	 *
 	 * To look at an on-page cell, we need to look at the parent page, and
 	 * that's dangerous, our parent page could change without warning if
@@ -264,12 +264,12 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 	bool skip;
 
 	/*
-	 * Deleted pages come from two sources: either it's a fast-delete as
+	 * Deleted pages come from two sources: either it's a truncate as
 	 * described above, or the page has been emptied by other operations
 	 * and eviction deleted it.
 	 *
 	 * In both cases, the WT_REF state will be WT_REF_DELETED.  In the case
-	 * of a fast-delete page, there will be a WT_PAGE_DELETED structure with
+	 * of a truncated page, there will be a WT_PAGE_DELETED structure with
 	 * the transaction ID of the transaction that deleted the page, and the
 	 * page is visible if that transaction ID is visible.  In the case of an
 	 * empty page, there will be no WT_PAGE_DELETED structure and the delete
@@ -391,7 +391,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * transaction has resolved, we can ignore the page-deleted structure).
 	 */
 	page_del =
-	    __wt_txn_page_del_visible(session, ref) ? NULL : ref->page_del;
+	    __wt_btree_truncate_active(session, ref) ? ref->page_del : NULL;
 
 	/*
 	 * Allocate the per-page update array if one doesn't already exist. (It

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -477,7 +477,7 @@ skip_read:
 	switch (previous_state) {
 	case WT_REF_DELETED:
 		/*
-		 * A fast-deleted page may also have lookaside information. The
+		 * A truncated page may also have lookaside information. The
 		 * delete happened after page eviction (writing the lookaside
 		 * information), first update based on the lookaside table and
 		 * then apply the delete.

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -370,7 +370,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_ITEM tmp;
-	WT_PAGE *page;
+	WT_PAGE *notused;
 	size_t addr_size;
 	uint64_t time_start, time_stop;
 	uint32_t page_flags, final_state, new_state, previous_state;
@@ -378,7 +378,6 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	bool timer;
 
 	btree = S2BT(session);
-	page = NULL;
 	time_start = time_stop = 0;
 
 	/*
@@ -427,11 +426,8 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	if (addr == NULL) {
 		WT_ASSERT(session, previous_state != WT_REF_DISK);
 
-		WT_ERR(__wt_btree_new_leaf_page(session, &page));
-		ref->page = page;
-		if (previous_state == WT_REF_LOOKASIDE)
-			goto skip_read;
-		goto done;
+		WT_ERR(__wt_btree_new_leaf_page(session, &ref->page));
+		goto skip_read;
 	}
 
 	/*
@@ -464,7 +460,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	    WT_DATA_IN_ITEM(&tmp) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED;
 	if (LF_ISSET(WT_READ_IGNORE_CACHE_SIZE))
 		FLD_SET(page_flags, WT_PAGE_EVICT_NO_PROGRESS);
-	WT_ERR(__wt_page_inmem(session, ref, tmp.data, page_flags, &page));
+	WT_ERR(__wt_page_inmem(session, ref, tmp.data, page_flags, &notused));
 	tmp.mem = NULL;
 
 	/*
@@ -491,6 +487,7 @@ skip_read:
 			ref->page_las->eviction_to_lookaside = false;
 		}
 
+		/* Move all records to a deleted state. */
 		WT_ERR(__wt_delete_page_instantiate(session, ref));
 		break;
 	case WT_REF_LOOKASIDE:
@@ -523,7 +520,7 @@ skip_read:
 		WT_IGNORE_RET(__wt_las_remove_block(
 		    session, btree->id, ref->page_las->las_pageid));
 
-done:	WT_PUBLISH(ref->state, final_state);
+	WT_PUBLISH(ref->state, final_state);
 	return (ret);
 
 err:	/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -434,14 +434,14 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 			break;
 		case WT_REF_DELETED:		/* Deleted */
 			/*
-			 * If the page was part of a fast-delete, transaction
+			 * If the page was part of a truncate, transaction
 			 * rollback might switch this page into its previous
 			 * state at any time, so the delete must be resolved.
 			 * We don't have to lock the page, as no thread of
 			 * control can be running below our locked internal
 			 * page.
 			 */
-			if (!__wt_txn_page_del_visible(session, child))
+			if (__wt_btree_truncate_active(session, child))
 				return (EBUSY);
 			break;
 		default:

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -426,7 +426,6 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 static int
 __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 {
-	WT_PAGE_DELETED *page_del;
 	WT_REF *child;
 
 	WT_INTL_FOREACH_BEGIN(session, parent->page, child) {
@@ -442,12 +441,9 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 			 * control can be running below our locked internal
 			 * page.
 			 */
-			if ((page_del = child->page_del) == NULL ||
-			    page_del->txnid == WT_TXN_ABORTED ||
-			    __wt_txn_visible_all(session, page_del->txnid,
-			    WT_TIMESTAMP_NULL(&page_del->timestamp)))
-				break;
-			return (EBUSY);
+			if (!__wt_txn_page_del_visible(session, child))
+				return (EBUSY);
+			break;
 		default:
 			return (EBUSY);
 		}

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -773,7 +773,7 @@ struct __wt_page {
 
 /*
  * WT_PAGE_DELETED --
- *	Related information for fast-delete, on-disk pages.
+ *	Related information for truncated pages.
  */
 struct __wt_page_deleted {
 	volatile uint64_t txnid;		/* Transaction ID */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1337,9 +1337,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	mod = page->modify;
 
 	/* A truncated page can't be evicted until the truncate completes. */
-	if (ref->page_del != NULL && ref->page_del->txnid != WT_TXN_ABORTED &&
-	    !__wt_txn_visible_all(session,
-	    ref->page_del->txnid, WT_TIMESTAMP_NULL(&ref->page_del->timestamp)))
+	if (!__wt_txn_page_del_visible(session, ref))
 		return (false);
 
 	/* Otherwise, never modified pages can always be evicted. */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1151,6 +1151,23 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __wt_btree_truncate_active --
+ *	Return if a truncate operation is active.
+ */
+static inline bool
+__wt_btree_truncate_active(WT_SESSION_IMPL *session, WT_REF *ref)
+{
+	WT_PAGE_DELETED *page_del;
+
+	if ((page_del = ref->page_del) == NULL)
+		return (false);
+	if (page_del->txnid == WT_TXN_ABORTED)
+		return (false);
+	return (!__wt_txn_visible_all(session,
+	    page_del->txnid, WT_TIMESTAMP_NULL(&page_del->timestamp)));
+}
+
+/*
  * __wt_btree_can_evict_dirty --
  *	Check whether eviction of dirty pages or splits are permitted in the
  *	current tree.
@@ -1337,7 +1354,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 	mod = page->modify;
 
 	/* A truncated page can't be evicted until the truncate completes. */
-	if (!__wt_txn_page_del_visible(session, ref))
+	if (__wt_btree_truncate_active(session, ref))
 		return (false);
 
 	/* Otherwise, never modified pages can always be evicted. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -296,7 +296,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 
 /*
  * __wt_txn_modify_page_delete --
- *	Remember a page fast-deleted by the current transaction.
+ *	Remember a page truncated by the current transaction.
  */
 static inline int
 __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
@@ -541,23 +541,6 @@ __wt_txn_visible(
 	WT_UNUSED(timestamp);
 	return (true);
 #endif
-}
-
-/*
- * __wt_txn_page_del_visible --
- *	Return if a fast-delete operation is unresolved.
- */
-static inline bool
-__wt_txn_page_del_visible(WT_SESSION_IMPL *session, WT_REF *ref)
-{
-	WT_PAGE_DELETED *page_del;
-
-	if ((page_del = ref->page_del) == NULL)
-		return (true);
-	if (page_del->txnid == WT_TXN_ABORTED)
-		return (true);
-	return (__wt_txn_visible_all(session,
-	    page_del->txnid, WT_TIMESTAMP_NULL(&page_del->timestamp)));
 }
 
 /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -544,6 +544,23 @@ __wt_txn_visible(
 }
 
 /*
+ * __wt_txn_page_del_visible --
+ *	Return if a fast-delete operation is unresolved.
+ */
+static inline bool
+__wt_txn_page_del_visible(WT_SESSION_IMPL *session, WT_REF *ref)
+{
+	WT_PAGE_DELETED *page_del;
+
+	if ((page_del = ref->page_del) == NULL)
+		return (true);
+	if (page_del->txnid == WT_TXN_ABORTED)
+		return (true);
+	return (__wt_txn_visible_all(session,
+	    page_del->txnid, WT_TIMESTAMP_NULL(&page_del->timestamp)));
+}
+
+/*
  * __wt_txn_upd_visible_type --
  *      Visible type of given update for the current transaction.
  */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1785,12 +1785,12 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			/*
 			 * If called during checkpoint, the child is being
 			 * considered by the eviction server or the child is a
-			 * fast-delete page being read.  The eviction may have
+			 * truncated page being read.  The eviction may have
 			 * started before the checkpoint and so we must wait
 			 * for the eviction to be resolved.  I suspect we could
-			 * handle fast-delete reads, but we can't distinguish
-			 * between the two and fast-delete reads aren't expected
-			 * to be common.
+			 * handle reads of truncated pages, but we can't
+			 * distinguish between the two and reads of truncated
+			 * pages aren't expected to be common.
 			 */
 			break;
 


### PR DESCRIPTION
@michaelcahill, @agorrod, for your review.

I split the commits into two parts so we can separately revert them, if I've gone in the wrong direction on page instantiation.

Also, can you think of a reason we didn't see this fail in format stress testing? It seems to me cursors reading from instantiated deleted pages in snapshot isolation should have read the wrong records (because we weren't applying lookaside records in the deleted-page instantiation path). I found the problem by inspection, and I'm worried we're not testing lookaside as well as we should be.