### PR TITLE
WT-3981 Update transaction snapshot when a read_timestamp is set.

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -691,18 +691,20 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		txn_global = &S2C(session)->txn_global;
 		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
 
-		/* Read timestamps imply / require snapshot isolation. */
+		/*
+		 * Read timestamps imply / require snapshot isolation.
+		 *
+		 * If we already have a snapshot, it may be too early
+		 * to match the timestamp.  Get a new one.
+		 */
 		if (!F_ISSET(txn, WT_TXN_RUNNING))
 			txn->isolation = WT_ISO_SNAPSHOT;
-		else if (txn->isolation != WT_ISO_SNAPSHOT)
+		else if (txn->isolation == WT_ISO_SNAPSHOT)
+			__wt_txn_get_snapshot(session);
+		else
 			WT_RET_MSG(session, EINVAL, "setting a read_timestamp"
 			    " requires a transaction running at snapshot"
 			    " isolation");
-		/*
-		 * If we already have a snapshot, it may be too early to match
-		 * the timestamp.  Get a new one.
-		 */
-		__wt_txn_get_snapshot(session);
 
 		/* Read timestamps can't change once set. */
 		if (F_ISSET(txn, WT_TXN_HAS_TS_READ))

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -691,13 +691,14 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		txn_global = &S2C(session)->txn_global;
 		WT_RET(__wt_txn_parse_timestamp(session, "read", &ts, &cval));
 
-		/* Read timestamps imply / require snapshot isolation. */
-		if (!F_ISSET(txn, WT_TXN_RUNNING))
-			txn->isolation = WT_ISO_SNAPSHOT;
-		else if (txn->isolation != WT_ISO_SNAPSHOT)
-			WT_RET_MSG(session, EINVAL, "setting a read_timestamp"
-			    " requires a transaction running at snapshot"
-			    " isolation");
+		/*
+		 * Read timestamps imply / require snapshot isolation.
+		 *
+		 * If we already have a snapshot, it may be too early to match
+		 * the timestamp.  Get a new one.
+		 */
+		txn->isolation = WT_ISO_SNAPSHOT;
+		__wt_txn_get_snapshot(session);
 
 		/* Read timestamps can't change once set. */
 		if (F_ISSET(txn, WT_TXN_HAS_TS_READ))


### PR DESCRIPTION
Without this change, reads could miss committed updates with commit_timestamp lower than the read_timestamp if the commit raced with starting the read transaction.