### PR TITLE
WT-3971 Cursor duplicates use the cursor cache.

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -751,6 +751,7 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
 			return (WT_NOTFOUND);
 	}
 
+	WT_ASSERT(session, uri == NULL || to_dup == NULL);
 	if (to_dup != NULL) {
 		uri = to_dup->uri;
 		hash_value = to_dup->uri_hash;

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -704,7 +704,7 @@ err:		WT_TRET(cursor->reopen(cursor, false));
  */
 int
 __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
-    const char *cfg[], WT_CURSOR **cursorp)
+    WT_CURSOR *to_dup, const char *cfg[], WT_CURSOR **cursorp)
 {
 	WT_CONFIG_ITEM cval;
 	WT_CURSOR *cursor;
@@ -751,11 +751,16 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
 			return (WT_NOTFOUND);
 	}
 
+	if (to_dup != NULL) {
+		uri = to_dup->uri;
+		hash_value = to_dup->uri_hash;
+	} else
+		hash_value = __wt_hash_city64(uri, strlen(uri));
+
 	/*
 	 * Walk through all cursors, if there is a cached
 	 * cursor that matches uri and configuration, use it.
 	 */
-	hash_value = __wt_hash_city64(uri, strlen(uri));
 	bucket = hash_value % WT_HASH_ARRAY_SIZE;
 	TAILQ_FOREACH(cursor, &session->cursor_cache[bucket], q) {
 		if (cursor->uri_hash == hash_value &&

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -751,12 +751,18 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri,
 			return (WT_NOTFOUND);
 	}
 
-	WT_ASSERT(session, uri == NULL || to_dup == NULL);
+	/*
+	 * Caller guarantees that exactly one of the URI and the
+	 * duplicate cursor is non-NULL.
+	 */
 	if (to_dup != NULL) {
+		WT_ASSERT(session, uri == NULL);
 		uri = to_dup->uri;
 		hash_value = to_dup->uri_hash;
-	} else
+	} else {
+		WT_ASSERT(session, uri != NULL);
 		hash_value = __wt_hash_city64(uri, strlen(uri));
+	}
 
 	/*
 	 * Walk through all cursors, if there is a cached

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -353,7 +353,7 @@ extern void __wt_cursor_set_valuev(WT_CURSOR *cursor, va_list ap);
 extern int __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);
 extern int __wt_cursor_cache_release(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool *released) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup, const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_close(WT_CURSOR *cursor) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_equals(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -607,27 +607,29 @@ __session_open_cursor(WT_SESSION *wt_session,
 
 	statjoin = (to_dup != NULL && uri != NULL &&
 	    WT_STREQ(uri, "statistics:join"));
-	if ((to_dup == NULL && uri == NULL) ||
-	    (to_dup != NULL && uri != NULL && !statjoin))
-		WT_ERR_MSG(session, EINVAL,
-		    "should be passed either a URI or a cursor to duplicate, "
-		    "but not both");
+	if (!statjoin) {
+		if ((to_dup == NULL && uri == NULL) ||
+		    (to_dup != NULL && uri != NULL))
+			WT_ERR_MSG(session, EINVAL,
+			    "should be passed either a URI or a cursor to "
+			    "duplicate, but not both");
 
-	if ((ret = __wt_cursor_cache_get(
-	    session, uri, to_dup, cfg, &cursor)) == 0)
-		goto done;
-	WT_ERR_NOTFOUND_OK(ret);
+		if ((ret = __wt_cursor_cache_get(
+		    session, uri, to_dup, cfg, &cursor)) == 0)
+			goto done;
+		WT_ERR_NOTFOUND_OK(ret);
 
-	if (to_dup != NULL && !statjoin) {
-		uri = to_dup->uri;
-		if (!WT_PREFIX_MATCH(uri, "colgroup:") &&
-		    !WT_PREFIX_MATCH(uri, "index:") &&
-		    !WT_PREFIX_MATCH(uri, "file:") &&
-		    !WT_PREFIX_MATCH(uri, "lsm:") &&
-		    !WT_PREFIX_MATCH(uri, WT_METADATA_URI) &&
-		    !WT_PREFIX_MATCH(uri, "table:") &&
-		    __wt_schema_get_source(session, uri) == NULL)
-			WT_ERR(__wt_bad_object_type(session, uri));
+		if (to_dup != NULL) {
+			uri = to_dup->uri;
+			if (!WT_PREFIX_MATCH(uri, "colgroup:") &&
+			    !WT_PREFIX_MATCH(uri, "index:") &&
+			    !WT_PREFIX_MATCH(uri, "file:") &&
+			    !WT_PREFIX_MATCH(uri, "lsm:") &&
+			    !WT_PREFIX_MATCH(uri, WT_METADATA_URI) &&
+			    !WT_PREFIX_MATCH(uri, "table:") &&
+			    __wt_schema_get_source(session, uri) == NULL)
+				WT_ERR(__wt_bad_object_type(session, uri));
+		}
 	}
 
 	WT_ERR(__session_open_cursor_int(session, uri, NULL,

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -614,7 +614,7 @@ __session_open_cursor(WT_SESSION *wt_session,
 		    "but not both");
 
 	if ((ret = __wt_cursor_cache_get(
-	    session, uri, to_dup, cfg, cursorp)) == 0)
+	    session, uri, to_dup, cfg, &cursor)) == 0)
 		goto done;
 	WT_ERR_NOTFOUND_OK(ret);
 
@@ -632,7 +632,9 @@ __session_open_cursor(WT_SESSION *wt_session,
 
 	WT_ERR(__session_open_cursor_int(session, uri, NULL,
 	    statjoin ? to_dup : NULL, cfg, &cursor));
-	if (to_dup != NULL && !statjoin && F_ISSET(to_dup, WT_CURSTD_KEY_SET))
+
+done:
+	if (to_dup != NULL && !statjoin)
 		WT_ERR(__wt_cursor_dup_position(to_dup, cursor));
 
 	*cursorp = cursor;
@@ -641,7 +643,6 @@ __session_open_cursor(WT_SESSION *wt_session,
 err:		if (cursor != NULL)
 			WT_TRET(cursor->close(cursor));
 	}
-done:
 	/*
 	 * Opening a cursor on a non-existent data source will set ret to
 	 * either of ENOENT or WT_NOTFOUND at this point. However,

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -538,6 +538,7 @@ class test_cursor13_dup(test_cursor13_base):
         cursor.close()
 
         c1 = self.session.open_cursor(uri, None)
+        c1.next()
         for notused in range(0, 100):
             self.session.breakpoint()
             c2 = self.session.open_cursor(None, c1, None)

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -527,3 +527,21 @@ class test_cursor13_sweep(test_cursor13_big_base):
         # by approximately the number of swept cursors, but it's less
         # predictable.
         self.assertGreater(end_stats[1] - begin_stats[1], 0)
+
+class test_cursor13_dup(test_cursor13_base):
+    def test_dup(self):
+        self.cursor_stats_init()
+        uri = 'table:test_cursor13_dup'
+        self.session.create(uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(uri)
+        cursor['A'] = 'B'
+        cursor.close()
+
+        c1 = self.session.open_cursor(uri, None)
+        for notused in range(0, 100):
+            self.session.breakpoint()
+            c2 = self.session.open_cursor(None, c1, None)
+            c2.close()
+        stats = self.caching_stats()
+        self.assertGreaterEqual(stats[0], 100)
+        self.assertGreaterEqual(stats[1], 100)


### PR DESCRIPTION
This fixes a cursor cache leak of sorts when dups of the same URI are repeatedly made.