### PR TITLE
WT-4012 Fix lookaside entry count.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -113,7 +113,7 @@ __las_page_instantiate_verbose(WT_SESSION_IMPL *session, uint64_t las_pageid)
  *	Instantiate lookaside update records in a recently read page.
  */
 static int
-__las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
+__las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_CACHE *cache;
 	WT_CURSOR *cursor;
@@ -136,11 +136,12 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
 	locked = false;
 	total_incr = 0;
 	current_recno = recno = WT_RECNO_OOB;
+	las_pageid = ref->page_las->las_pageid;
 	session_flags = 0;		/* [-Werror=maybe-uninitialized] */
 	WT_CLEAR(las_key);
 
 	cache = S2C(session)->cache;
-	__las_page_instantiate_verbose(session, ref->page_las->las_pageid);
+	__las_page_instantiate_verbose(session, las_pageid);
 	WT_STAT_CONN_INCR(session, cache_read_lookaside);
 	WT_STAT_DATA_INCR(session, cache_read_lookaside);
 
@@ -159,10 +160,11 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
 	 * for a key and then insert those updates into the page, then all the
 	 * updates for the next key, and so on.
 	 */
-	ret = __wt_las_cursor_position(cursor, ref->page_las->las_pageid);
 	__wt_readlock(session, &cache->las_sweepwalk_lock);
 	locked = true;
-	for (; ret == 0; ret = cursor->next(cursor)) {
+	for (ret = __wt_las_cursor_position(cursor, las_pageid);
+	    ret == 0;
+	    ret = cursor->next(cursor)) {
 		WT_ERR(cursor->get_key(cursor,
 		    &las_pageid, &las_id, &las_counter, &las_key));
 
@@ -170,8 +172,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
 		 * Confirm the search using the unique prefix; if not a match,
 		 * we're done searching for records for this page.
 		 */
-		if (las_id != btree_id ||
-		    las_pageid != ref->page_las->las_pageid)
+		if (las_pageid != ref->page_las->las_pageid)
 			break;
 
 		/* Allocate the WT_UPDATE structure. */
@@ -366,7 +367,6 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 static int
 __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 {
-	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_ITEM tmp;
 	WT_PAGE *notused;
@@ -376,7 +376,6 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	const uint8_t *addr;
 	bool timer;
 
-	btree = S2BT(session);
 	time_start = time_stop = 0;
 
 	/*
@@ -482,7 +481,7 @@ skip_read:
 		 * then apply the delete.
 		 */
 		if (ref->page_las != NULL) {
-			WT_ERR(__las_page_instantiate(session, ref, btree->id));
+			WT_ERR(__las_page_instantiate(session, ref));
 			ref->page_las->eviction_to_lookaside = false;
 		}
 
@@ -503,7 +502,7 @@ skip_read:
 		if (previous_state == WT_REF_LIMBO)
 			WT_STAT_CONN_INCR(session, cache_read_lookaside_delay);
 
-		WT_ERR(__las_page_instantiate(session, ref, btree->id));
+		WT_ERR(__las_page_instantiate(session, ref));
 		ref->page_las->eviction_to_lookaside = false;
 		break;
 	}

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -159,8 +159,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t btree_id)
 	 * for a key and then insert those updates into the page, then all the
 	 * updates for the next key, and so on.
 	 */
-	ret = __wt_las_cursor_position(
-	    cursor, btree_id, ref->page_las->las_pageid);
+	ret = __wt_las_cursor_position(cursor, ref->page_las->las_pageid);
 	__wt_readlock(session, &cache->las_sweepwalk_lock);
 	locked = true;
 	for (; ret == 0; ret = cursor->next(cursor)) {
@@ -518,7 +517,7 @@ skip_read:
 	 */
 	if (final_state == WT_REF_MEM && ref->page_las != NULL)
 		WT_IGNORE_RET(__wt_las_remove_block(
-		    session, btree->id, ref->page_las->las_pageid));
+		    session, ref->page_las->las_pageid, false));
 
 	WT_PUBLISH(ref->state, final_state);
 	return (ret);

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1149,9 +1149,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		++remove_cnt;
 	}
 
-	__wt_writeunlock(session, &cache->las_sweepwalk_lock);
-	locked = false;
-
 	/*
 	 * If the loop terminates after completing a work unit, we will
 	 * continue the table sweep next time. Get a local copy of the

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -455,7 +455,7 @@ __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref)
  */
 static int
 __las_remove_block(WT_SESSION_IMPL *session,
-    WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid, uint64_t *decrp)
+    WT_CURSOR *cursor, uint64_t pageid, bool lock_wait, uint64_t *remove_cntp)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
@@ -463,30 +463,32 @@ __las_remove_block(WT_SESSION_IMPL *session,
 	uint64_t las_counter, las_pageid;
 	uint32_t las_id;
 
-	*decrp = 0;
+	*remove_cntp = 0;
 
 	conn = S2C(session);
 
-	__wt_writelock(session, &conn->cache->las_sweepwalk_lock);
+	/* Prevent the sweep thread from removing the block. */
+	if (lock_wait)
+		__wt_writelock(session, &conn->cache->las_sweepwalk_lock);
+	else
+		WT_RET(__wt_try_writelock(
+		    session, &conn->cache->las_sweepwalk_lock));
 
 	/*
 	 * Search for the block's unique btree ID and page ID prefix and step
 	 * through all matching records, removing them.
 	 */
-	for (ret = __wt_las_cursor_position(cursor, btree_id, pageid);
+	for (ret = __wt_las_cursor_position(cursor, pageid);
 	    ret == 0; ret = cursor->next(cursor)) {
 		WT_ERR(cursor->get_key(cursor,
 		    &las_pageid, &las_id, &las_counter, &las_key));
 
-		/*
-		 * Confirm the record matches; if not a match, we're done
-		 * searching for records for this page.
-		 */
-		if (las_pageid != pageid || las_id != btree_id)
+		/* Confirm that we have a matching record. */
+		if (las_pageid != pageid)
 			break;
 
 		WT_ERR(cursor->remove(cursor));
-		++*decrp;
+		++*remove_cntp;
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 
@@ -580,7 +582,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	WT_SESSION_IMPL *las_session;
 	WT_TXN_ISOLATION saved_isolation;
 	WT_UPDATE *upd;
-	uint64_t adjust, decrement_cnt, insert_cnt, insert_estimate;
+	uint64_t insert_cnt;
 	uint64_t las_counter, las_pageid;
 	uint32_t btree_id, i, slot;
 	uint8_t *p;
@@ -590,12 +592,11 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	conn = S2C(session);
 	WT_CLEAR(las_timestamp);
 	WT_CLEAR(las_value);
-	decrement_cnt = insert_cnt = insert_estimate = 0;
+	insert_cnt = 0;
 	btree_id = btree->id;
 	local_txn = false;
 
-	las_pageid = multi->page_las.las_pageid =
-	    __wt_atomic_add64(&conn->cache->las_pageid, 1);
+	las_pageid = __wt_atomic_add64(&conn->cache->las_pageid, 1);
 
 	if (!btree->lookaside_entries)
 		btree->lookaside_entries = true;
@@ -606,12 +607,18 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	WT_ERR(__wt_txn_begin(las_session, NULL));
 	local_txn = true;
 
+#ifdef HAVE_DIAGNOSTIC
+	{
+	uint64_t remove_cnt;
 	/*
-	 * Make sure there are no leftover entries (e.g., from a handle
-	 * reopen).
+	 * There should never be any entries with the page ID we are about to
+	 * use.
 	 */
-	WT_ERR(__las_remove_block(
-	    session, cursor, btree_id, las_pageid, &decrement_cnt));
+	WT_ERR_BUSY_OK(__las_remove_block(
+	    session, cursor, las_pageid, false, &remove_cnt));
+	WT_ASSERT(session, remove_cnt == 0);
+	}
+#endif
 
 	/* Enter each update in the boundary's list into the lookaside store. */
 	for (las_counter = 0, i = 0,
@@ -707,18 +714,6 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 				    upd->type, &las_value);
 
 			/*
-			 * If remove is running concurrently, it's possible for
-			 * records to be removed before the insert transaction
-			 * commits (since both are running read-uncommitted).
-			 * Make sure increments stay ahead of decrements.
-			 */
-			if (insert_estimate <= insert_cnt) {
-				insert_estimate += 100;
-				(void)__wt_atomic_add64(
-				    &conn->cache->las_entry_count, 100);
-			}
-
-			/*
 			 * Using update looks a little strange because the keys
 			 * are guaranteed to not exist, but since we're
 			 * appending, we want the cursor to stay positioned in
@@ -731,27 +726,32 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 
 err:	/* Resolve the transaction. */
 	if (local_txn) {
-		if (ret == 0)
-			ret = __wt_txn_commit(las_session, NULL);
-		else
+		if (ret == 0) {
+			/*
+			 * Adjust the entry count.
+			 *
+			 * For inserts, we increment before committing.  As
+			 * soon as we commit, sweep could catch up and remove
+			 * the block, and we don't want the count to underflow.
+			 * In the unlikely event that the commit fails, roll
+			 * back the increment.
+			 */
+			__wt_atomic_add64(
+			    &conn->cache->las_entry_count, insert_cnt);
+			if ((ret = __wt_txn_commit(las_session, NULL)) != 0)
+				__wt_cache_decr_check_uint64(session,
+				    &conn->cache->las_entry_count,
+				    insert_cnt, "lookaside entry count");
+		} else
 			WT_TRET(__wt_txn_rollback(las_session, NULL));
 	}
 
 	__las_restore_isolation(las_session, saved_isolation);
 
-	/*
-	 * Adjust the final entry count. If successful, decrement by the rows
-	 * initially discarded plus the difference between the insert estimate
-	 * and the actual insert count. If we failed, decrement by the insert
-	 * estimate, the changes were rolled back.
-	 */
-	adjust = ret == 0 ?
-	    decrement_cnt + (insert_estimate - insert_cnt) : insert_estimate;
-	__wt_cache_decr_check_uint64(session,
-	    &conn->cache->las_entry_count, adjust, "lookaside entry count");
-
-	if (ret == 0 && insert_cnt > 0)
+	if (ret == 0 && insert_cnt > 0) {
+		multi->page_las.las_pageid = las_pageid;
 		ret = __las_insert_block_verbose(session, multi);
+	}
 
 	return (ret);
 }
@@ -764,7 +764,7 @@ err:	/* Resolve the transaction. */
  *	WT_CONNECTION::rollback_to_stable.
  */
 int
-__wt_las_cursor_position(WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid)
+__wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid)
 {
 	WT_ITEM las_key;
 	uint64_t las_counter, las_pageid;
@@ -788,7 +788,7 @@ __wt_las_cursor_position(WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid)
 	for (;;) {
 		WT_CLEAR(las_key);
 		cursor->set_key(cursor,
-		    pageid, btree_id, (uint64_t)0, &las_key);
+		    pageid, (uint32_t)0, (uint64_t)0, &las_key);
 		WT_RET(cursor->search_near(cursor, &exact));
 		if (exact < 0) {
 			WT_RET(cursor->next(cursor));
@@ -805,8 +805,7 @@ __wt_las_cursor_position(WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid)
 			 */
 			WT_RET(cursor->get_key(cursor,
 			    &las_pageid, &las_id, &las_counter, &las_key));
-			if (las_pageid < pageid || (las_pageid == pageid &&
-			    las_id < btree_id))
+			if (las_pageid < pageid)
 				continue;
 		}
 
@@ -822,14 +821,14 @@ __wt_las_cursor_position(WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid)
  */
 int
 __wt_las_remove_block(
-    WT_SESSION_IMPL *session, uint32_t btree_id, uint64_t pageid)
+    WT_SESSION_IMPL *session, uint64_t pageid, bool lock_wait)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 	WT_SESSION_IMPL *las_session;
 	WT_TXN_ISOLATION saved_isolation;
-	uint64_t decrement_cnt;
+	uint64_t remove_cnt;
 	uint32_t session_flags;
 
 	conn = S2C(session);
@@ -848,7 +847,7 @@ __wt_las_remove_block(
 	WT_ERR(__wt_txn_begin(las_session, NULL));
 
 	ret = __las_remove_block(
-	    las_session, cursor, btree_id, pageid, &decrement_cnt);
+	    las_session, cursor, pageid, lock_wait, &remove_cnt);
 	if (ret == 0)
 		ret = __wt_txn_commit(las_session, NULL);
 	else
@@ -856,7 +855,7 @@ __wt_las_remove_block(
 	if (ret == 0)
 		__wt_cache_decr_check_uint64(session,
 		    &conn->cache->las_entry_count,
-		    decrement_cnt, "lookaside entry count");
+		    remove_cnt, "lookaside entry count");
 
 err:	__las_restore_isolation(las_session, saved_isolation);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
@@ -985,7 +984,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 #else
 	wt_timestamp_t *val_ts;
 #endif
-	uint64_t cnt, decrement_cnt, las_counter, las_pageid, saved_pageid;
+	uint64_t cnt, remove_cnt, las_counter, las_pageid, saved_pageid;
 	uint64_t las_txnid;
 	uint32_t las_id, session_flags;
 	uint8_t upd_type;
@@ -995,7 +994,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	cache = S2C(session)->cache;
 	cursor = NULL;
 	sweep_key = &cache->las_sweep_key;
-	decrement_cnt = 0;
+	remove_cnt = 0;
 	session_flags = 0;		/* [-Werror=maybe-uninitialized] */
 	local_txn = locked = false;
 
@@ -1012,6 +1011,9 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	WT_ERR(__wt_txn_begin(session, NULL));
 	local_txn = true;
 
+	/*
+	 * Prevent other threads removing entries from underneath the sweep.
+	 */
 	__wt_writelock(session, &cache->las_sweepwalk_lock);
 	locked = true;
 
@@ -1097,7 +1099,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		    __bit_test(cache->las_sweep_dropmap,
 		    las_id - cache->las_sweep_dropmin)) {
 			WT_ERR(cursor->remove(cursor));
-			++decrement_cnt;
+			++remove_cnt;
 			saved_key->size = 0;
 			continue;
 		}
@@ -1144,7 +1146,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		}
 
 		WT_ERR(cursor->remove(cursor));
-		++decrement_cnt;
+		++remove_cnt;
 	}
 
 	__wt_writeunlock(session, &cache->las_sweepwalk_lock);
@@ -1178,7 +1180,7 @@ err:		__wt_buf_free(session, sweep_key);
 		if (ret == 0)
 			__wt_cache_decr_check_uint64(session,
 			    &S2C(session)->cache->las_entry_count,
-			    decrement_cnt, "lookaside entry count");
+			    remove_cnt, "lookaside entry count");
 	}
 	if (locked)
 		__wt_writeunlock(session, &cache->las_sweepwalk_lock);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -202,6 +202,8 @@ static inline void
 __wt_cache_decr_check_uint64(
     WT_SESSION_IMPL *session, uint64_t *vp, uint64_t v, const char *fld)
 {
+	uint64_t orig = *vp;
+
 	if (v == 0 || __wt_atomic_sub64(vp, v) < WT_EXABYTE)
 		return;
 
@@ -211,7 +213,8 @@ __wt_cache_decr_check_uint64(
 	 */
 	*vp = 0;
 	__wt_errx(session,
-	    "%s went negative with decrement of %" PRIu64, fld, v);
+	    "%s was %" PRIu64 ", went negative with decrement of %" PRIu64, fld,
+	    orig, v);
 
 #ifdef HAVE_DIAGNOSTIC
 	__wt_abort(session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -210,8 +210,8 @@ extern int __wt_las_cursor_close(WT_SESSION_IMPL *session, WT_CURSOR **cursorp, 
 extern bool __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_las_cursor_position(WT_CURSOR *cursor, uint32_t btree_id, uint64_t pageid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_las_remove_block(WT_SESSION_IMPL *session, uint32_t btree_id, uint64_t pageid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_las_remove_block(WT_SESSION_IMPL *session, uint64_t pageid, bool lock_wait) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_save_dropped(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_sweep(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -6183,18 +6183,18 @@ __rec_las_wrapup_err(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 {
 	WT_DECL_RET;
 	WT_MULTI *multi;
-	uint32_t btree_id, i;
-
-	btree_id = S2BT(session)->id;
+	uint64_t las_pageid;
+	uint32_t i;
 
 	/*
 	 * Note the additional check for a non-zero lookaside page ID, that
 	 * flags if lookaside table entries for this page have been written.
 	 */
 	for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
-		if (multi->supd != NULL && multi->page_las.las_pageid != 0)
-			WT_TRET(__wt_las_remove_block(session,
-			    btree_id, multi->page_las.las_pageid));
+		if (multi->supd != NULL &&
+		    (las_pageid = multi->page_las.las_pageid) != 0)
+			WT_TRET(
+			    __wt_las_remove_block(session, las_pageid, true));
 
 	return (ret);
 }

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -22,13 +22,13 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 	WT_DECL_TIMESTAMP(rollback_timestamp)
 	WT_ITEM las_key, las_timestamp, las_value;
 	WT_TXN_GLOBAL *txn_global;
-	uint64_t las_counter, las_pageid, las_total, las_txnid, remove_cnt;
+	uint64_t las_counter, las_pageid, las_total, las_txnid;
 	uint32_t las_id, session_flags;
 	uint8_t upd_type;
 
 	conn = S2C(session);
 	cursor = NULL;
-	las_total = remove_cnt = 0;
+	las_total = 0;
 	session_flags = 0;		/* [-Werror=maybe-uninitialized] */
 	WT_CLEAR(las_timestamp);
 
@@ -73,17 +73,14 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 		if (__wt_timestamp_cmp(
 		    &rollback_timestamp, las_timestamp.data) < 0) {
 			WT_ERR(cursor->remove(cursor));
-			++remove_cnt;
 			WT_STAT_CONN_INCR(session, txn_rollback_las_removed);
 		} else
 			++las_total;
 	}
 	WT_ERR_NOTFOUND_OK(ret);
-err:	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
+err:	conn->cache->las_entry_count = las_total;
+	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
-	__wt_cache_decr_check_uint64(session,
-	    &conn->cache->las_entry_count, remove_cnt, "lookaside entry count");
-	WT_STAT_CONN_SET(session, cache_lookaside_entries, las_total);
 
 	F_CLR(session, WT_SESSION_READ_WONT_NEED);
 


### PR DESCRIPTION
We now "pre-allocate" the lookaside entry count by incrementing it by
100 as records are inserted.  At the end, we need to fix up the final
count to match the number that were actually inserted.  That is always a
decrement.

I merged this once and it trigger a stress [test failure](http://build.wiredtiger.com:8080/job/wiredtiger-test-format-stress/65747/), so I reverted and re-created the PR based on the original branch.