### PR TITLE
WT-3910 Fix evergreen build on macOS.

### DIFF
--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -65,6 +65,16 @@ tasks:
               ./build_posix/reconf
               ${configure_env_vars|} ./configure --enable-diagnostic --enable-python --enable-zlib --enable-strict
               ${make_command|make} ${smp_command|} 2>&1
+
+              # On macOS, change the binary location with install_name_tool since DYLD_LIBRARY_PATH
+              # appears not to work for dynamic modules loaded by python. For wt, the libtool generated
+              # script has the wrong path for running on test machines.
+              if [ "$(uname -s)" == "Darwin" ]; then
+                WT_VERSION=$(m4 build_posix/aclocal/version.m4)
+                install_name_tool -change /usr/local/lib/libwiredtiger-$WT_VERSION.dylib $(pwd)/.libs/libwiredtiger-$WT_VERSION.dylib lang/python/_wiredtiger*.so
+                install_name_tool -change /usr/local/lib/libwiredtiger-$WT_VERSION.dylib $(pwd)/.libs/libwiredtiger-$WT_VERSION.dylib .libs/wt
+              fi
+
               ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 ${make_command|make} VERBOSE=1 check 2>&1
             fi
       - command: archive.targz_pack
@@ -178,9 +188,9 @@ buildvariants:
   - macos-1012
   expansions:
     smp_command: -j $(sysctl -n hw.logicalcpu)
-    configure_env_vars: PATH=/opt/local/bin:$PATH
-    make_command: PATH=/opt/local/bin:$PATH ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future make
-    test_env_vars: PATH=/opt/local/bin:$PATH DYLD_LIBRARY_PATH=`pwd`/.libs
+    configure_env_vars: PATH=/opt/mongodbtoolchain/v2/bin:$PATH
+    make_command: PATH=/opt/mongodbtoolchain/v2/bin:$PATH ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future make
+    test_env_vars: PATH=/opt/mongodbtoolchain/v2/bin:$PATH DYLD_LIBRARY_PATH=`pwd`/.libs
   tasks:
     - name: compile
     - name: unit-test


### PR DESCRIPTION
In particular, force the use of Python from mongodbtoolchain/v2 and fix up the libwiredtiger.so path in binaries.