### PR TITLE
WT-4028 page-is-modified check requires the page be locked

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -71,13 +71,9 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
 	*skipp = false;
 
-	/*
-	 * If we have a clean page in memory, attempt to evict it. Do a fast
-	 * check for a dirty page, and then repeat the test once we're locked.
-	 */
+	/* If we have a clean page in memory, attempt to evict it. */
 	previous_state = ref->state;
 	if ((previous_state == WT_REF_MEM || previous_state == WT_REF_LIMBO) &&
-	    !__wt_page_is_modified(ref->page) &&
 	    __wt_atomic_casv32(&ref->state, previous_state, WT_REF_LOCKED)) {
 		if (__wt_page_is_modified(ref->page)) {
 			ref->state = previous_state;


### PR DESCRIPTION
Revert part of 32793d9: it's not safe to call page-is-modified without first locking the WT_REF, the page can be evicted out from underneath.