### PR TITLE
WT-3959 Manage recovery timestamp via a new schema entry

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -351,8 +351,6 @@ file_meta = file_config + [
         the file checkpoint entries'''),
     Config('checkpoint_lsn', '', r'''
         LSN of the last checkpoint'''),
-    Config('checkpoint_timestamp', '', r'''
-        stable timestamp of the last checkpoint'''),
     Config('id', '', r'''
         the file's ID number'''),
     Config('version', '(major=0,minor=0)', r'''

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1201,6 +1201,7 @@ sx
 sy
 sys
 syscall
+sysinfo
 sz
 t's
 tV

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -598,7 +598,6 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
 	{ "cache_resident", "boolean", NULL, NULL, NULL, 0 },
 	{ "checkpoint", "string", NULL, NULL, NULL, 0 },
 	{ "checkpoint_lsn", "string", NULL, NULL, NULL, 0 },
-	{ "checkpoint_timestamp", "string", NULL, NULL, NULL, 0 },
 	{ "checksum", "string",
 	    NULL, "choices=[\"on\",\"off\",\"uncompressed\"]",
 	    NULL, 0 },
@@ -1430,19 +1429,18 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
 	  "assert=(commit_timestamp=none,read_timestamp=none),"
 	  "block_allocation=best,block_compressor=,cache_resident=false,"
-	  "checkpoint=,checkpoint_lsn=,checkpoint_timestamp=,"
-	  "checksum=uncompressed,collator=,columns=,dictionary=0,"
-	  "encryption=(keyid=,name=),format=btree,huffman_key=,"
-	  "huffman_value=,id=,ignore_in_memory_cache_size=false,"
-	  "internal_item_max=0,internal_key_max=0,"
-	  "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
-	  "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
-	  "leaf_value_max=0,log=(enabled=true),memory_page_max=5MB,"
-	  "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,"
-	  "prefix_compression_min=4,split_deepen_min_child=0,"
-	  "split_deepen_per_child=0,split_pct=90,value_format=u,"
-	  "version=(major=0,minor=0)",
-	  confchk_file_meta, 41
+	  "checkpoint=,checkpoint_lsn=,checksum=uncompressed,collator=,"
+	  "columns=,dictionary=0,encryption=(keyid=,name=),format=btree,"
+	  "huffman_key=,huffman_value=,id=,"
+	  "ignore_in_memory_cache_size=false,internal_item_max=0,"
+	  "internal_key_max=0,internal_key_truncate=true,"
+	  "internal_page_max=4KB,key_format=u,key_gap=10,leaf_item_max=0,"
+	  "leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=0,"
+	  "log=(enabled=true),memory_page_max=5MB,os_cache_dirty_max=0,"
+	  "os_cache_max=0,prefix_compression=false,prefix_compression_min=4"
+	  ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
+	  "value_format=u,version=(major=0,minor=0)",
+	  confchk_file_meta, 40
 	},
 	{ "index.meta",
 	  "app_metadata=,collator=,columns=,extractor=,immutable=false,"

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1055,9 +1055,10 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
 	if (cval.val != 0)
 		F_SET(conn, WT_CONN_LEAK_MEMORY);
 	WT_TRET(__wt_config_gets(session, cfg, "use_timestamp", &cval));
-	if (cval.val != 0 && conn->txn_global.has_stable_timestamp) {
+	if (cval.val != 0) {
 		ckpt_cfg = "use_timestamp=true";
-		F_SET(conn, WT_CONN_CLOSING_TIMESTAMP);
+		if (conn->txn_global.has_stable_timestamp)
+			F_SET(conn, WT_CONN_CLOSING_TIMESTAMP);
 	}
 
 err:	/*

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -790,7 +790,8 @@ __wt_conn_dhandle_discard(WT_SESSION_IMPL *session)
 restart:
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {
 		if (WT_IS_METADATA(dhandle) ||
-		    strcmp(dhandle->name, WT_LAS_URI) == 0)
+		    strcmp(dhandle->name, WT_LAS_URI) == 0 ||
+		    strcmp(dhandle->name, WT_SYSTEM_URI) == 0)
 			continue;
 
 		WT_WITH_DHANDLE(session, dhandle,

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -470,13 +470,14 @@ __backup_list_uri_append(
 	    !WT_PREFIX_MATCH(name, "colgroup:") &&
 	    !WT_PREFIX_MATCH(name, "index:") &&
 	    !WT_PREFIX_MATCH(name, "lsm:") &&
+	    !WT_PREFIX_MATCH(name, "system:") &&
 	    !WT_PREFIX_MATCH(name, "table:"))
 		WT_RET_MSG(session, ENOTSUP,
 		    "hot backup is not supported for objects of type %s",
 		    name);
 
-	/* Ignore the lookaside table. */
-	if (strcmp(name, WT_LAS_URI) == 0)
+	/* Ignore the lookaside table or system info. */
+	if (strcmp(name, WT_LAS_URI) == 0 || strcmp(name, WT_SYSTEM_URI) == 0)
 		return (0);
 
 	/* Add the metadata entry to the backup file. */

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -477,7 +477,7 @@ __backup_list_uri_append(
 		    name);
 
 	/* Ignore the lookaside table or system info. */
-	if (strcmp(name, WT_LAS_URI) == 0 || strcmp(name, WT_SYSTEM_URI) == 0)
+	if (strcmp(name, WT_LAS_URI) == 0)
 		return (0);
 
 	/* Add the metadata entry to the backup file. */
@@ -485,6 +485,13 @@ __backup_list_uri_append(
 	ret = __wt_fprintf(session, cb->bfs, "%s\n%s\n", name, value);
 	__wt_free(session, value);
 	WT_RET(ret);
+
+	/*
+	 * We want to retain the system information in the backup metadata
+	 * file above, but there is no file object to copy so return now.
+	 */
+	if (strcmp(name, WT_SYSTEM_URI) == 0)
+		return (0);
 
 	/* Add file type objects to the list of files to be copied. */
 	if (WT_PREFIX_MATCH(name, "file:"))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -509,6 +509,7 @@ extern int __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, W
 extern int __wt_meta_ckptlist_set(WT_SESSION_IMPL *session, const char *fname, WT_CKPT *ckptbase, WT_LSN *ckptlsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_meta_ckptlist_free(WT_SESSION_IMPL *session, WT_CKPT **ckptbasep);
 extern void __wt_meta_checkpoint_free(WT_SESSION_IMPL *session, WT_CKPT *ckpt);
+extern int __wt_meta_sysinfo_set(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ext_metadata_insert(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *key, const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ext_metadata_remove(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ext_metadata_search(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char *key, char **valuep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -27,7 +27,7 @@
 #define	WT_METAFILE_URI		"file:WiredTiger.wt"	/* Metadata table URI */
 
 #define	WT_LAS_URI		"file:WiredTigerLAS.wt"	/* Lookaside table URI*/
-#define	WT_SYSTEM_URI		"system:info"		/* System info URI*/
+#define	WT_SYSTEM_URI		"system:checkpoint"	/* System ckpt URI*/
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -27,6 +27,7 @@
 #define	WT_METAFILE_URI		"file:WiredTiger.wt"	/* Metadata table URI */
 
 #define	WT_LAS_URI		"file:WiredTigerLAS.wt"	/* Lookaside table URI*/
+#define	WT_SYSTEM_URI		"system:info"		/* System info URI*/
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -103,6 +103,7 @@ struct __wt_txn_global {
 
 	WT_DECL_TIMESTAMP(commit_timestamp)
 	WT_DECL_TIMESTAMP(last_ckpt_timestamp)
+	WT_DECL_TIMESTAMP(meta_ckpt_timestamp)
 	WT_DECL_TIMESTAMP(oldest_timestamp)
 	WT_DECL_TIMESTAMP(pinned_timestamp)
 	WT_DECL_TIMESTAMP(recovery_timestamp)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -507,6 +507,7 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
 	bool update;
 
+	config = newcfg = NULL;
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	hex_timestamp[0] = '0';
 	hex_timestamp[1] = '\0';
@@ -523,7 +524,6 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 	    "checkpoint_timestamp=\"%s\"", hex_timestamp));
 
 	update = true;
-	config = newcfg = NULL;
 	/* Retrieve the metadata for this file. */
 	cfg[2] = NULL;
 	if ((ret =

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -502,7 +502,10 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 {
 	WT_DECL_ITEM(buf);
 	WT_DECL_RET;
+	const char *cfg[3];
+	char *config, *newcfg;
 	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
+	bool update;
 
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	hex_timestamp[0] = '0';
@@ -518,11 +521,34 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 #endif
 	WT_ERR(__wt_buf_catfmt(session, buf,
 	    "checkpoint_timestamp=\"%s\"", hex_timestamp));
-	WT_ERR(__ckpt_set(session, WT_SYSTEM_URI, buf->mem));
 
-err:	__wt_scr_free(session, &buf);
+	update = true;
+	config = newcfg = NULL;
+	/* Retrieve the metadata for this file. */
+	cfg[2] = NULL;
+	if ((ret =
+	    __wt_metadata_search(session, WT_SYSTEM_URI, &config)) == 0) {
+		cfg[0] = config;
+		cfg[1] = buf->mem;
+	} else if (ret == WT_NOTFOUND) {
+		update = false;
+		cfg[0] = buf->mem;
+		cfg[1] = NULL;
+	} else
+		WT_ERR(ret);
+	/* Replace or insert the system info entry. */
+	WT_ERR(__wt_config_collapse(session, cfg, &newcfg));
+	if (update)
+		WT_ERR(__wt_metadata_update(session, WT_SYSTEM_URI, newcfg));
+	else
+		WT_ERR(__wt_metadata_insert(session, WT_SYSTEM_URI, newcfg));
+
+err:	__wt_free(session, config);
+	__wt_free(session, newcfg);
+	__wt_scr_free(session, &buf);
 	return (ret);
 }
+
 /*
  * __ckpt_version_chk --
  *	Check the version major/minor numbers.

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -375,7 +375,6 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	time_t secs;
 	int64_t maxorder;
 	const char *sep;
-	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
 
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	maxorder = 0;
@@ -453,21 +452,6 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 		WT_ERR(__wt_buf_catfmt(session, buf,
 		    ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
 		    ckptlsn->l.file, (uintmax_t)ckptlsn->l.offset));
-	hex_timestamp[0] = '0';
-	hex_timestamp[1] = '\0';
-#ifdef HAVE_TIMESTAMPS
-	/*
-	 * We need to record the timestamp of the checkpoint in the metadata's
-	 * checkpoint record. Although the read_timestamp remains set for the
-	 * duration of the checkpoint, we set and unset the flag based on the
-	 * file's durability. Record the timestamp if the flag is set.
-	 */
-	if (F_ISSET(&session->txn, WT_TXN_HAS_TS_READ))
-		WT_ERR(__wt_timestamp_to_hex_string(session, hex_timestamp,
-		    &session->txn.read_timestamp));
-#endif
-	WT_ERR(__wt_buf_catfmt(session, buf,
-	    ",checkpoint_timestamp=\"%s\"", hex_timestamp));
 	WT_ERR(__ckpt_set(session, fname, buf->mem));
 
 err:	__wt_scr_free(session, &buf);
@@ -509,6 +493,36 @@ __wt_meta_checkpoint_free(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 	WT_CLEAR(*ckpt);		/* Clear to prepare for re-use. */
 }
 
+/*
+ * __wt_meta_sysinfo_set --
+ *	Set the system information in the metadata.
+ */
+int
+__wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
+{
+	WT_DECL_ITEM(buf);
+	WT_DECL_RET;
+	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
+
+	WT_ERR(__wt_scr_alloc(session, 0, &buf));
+	hex_timestamp[0] = '0';
+	hex_timestamp[1] = '\0';
+#ifdef HAVE_TIMESTAMPS
+	/*
+	 * We need to record the timestamp of the checkpoint in the metadata.
+	 * The timestamp value is set at a higher level, either in checkpoint
+	 * or in recovery.
+	 */
+	WT_ERR(__wt_timestamp_to_hex_string(session, hex_timestamp,
+	    &S2C(session)->txn_global.meta_ckpt_timestamp));
+#endif
+	WT_ERR(__wt_buf_catfmt(session, buf,
+	    "checkpoint_timestamp=\"%s\"", hex_timestamp));
+	WT_ERR(__ckpt_set(session, WT_SYSTEM_URI, buf->mem));
+
+err:	__wt_scr_free(session, &buf);
+	return (ret);
+}
 /*
  * __ckpt_version_chk --
  *	Check the version major/minor numbers.

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -60,7 +60,10 @@ __checkpoint_name_check(WT_SESSION_IMPL *session, const char *uri)
 	 * devices.  If a target list is configured for the checkpoint, this
 	 * function is called with each target list entry; check the entry to
 	 * make sure it's backed by a file.  If no target list is configured,
-	 * confirm the metadata file contains no non-file objects.
+	 * confirm the metadata file contains no non-file objects. Skip any
+	 * internal system objects. We don't want spurious error messages,
+	 * other code will skip over them and the user has no control over
+	 * their existence.
 	 */
 	if (uri == NULL) {
 		WT_RET(__wt_metadata_cursor(session, &cursor));
@@ -69,6 +72,7 @@ __checkpoint_name_check(WT_SESSION_IMPL *session, const char *uri)
 			if (!WT_PREFIX_MATCH(uri, "colgroup:") &&
 			    !WT_PREFIX_MATCH(uri, "file:") &&
 			    !WT_PREFIX_MATCH(uri, "index:") &&
+			    !WT_PREFIX_MATCH(uri, "system:") &&
 			    !WT_PREFIX_MATCH(uri, "table:")) {
 				fail = uri;
 				break;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -899,7 +899,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * Record the timestamp from the transaction if we were successful.
 	 * Store it in a temp variable now because it will be invalidated during
 	 * commit but we don't want to set it until we know the checkpoint
-	 * is successful.
+	 * is successful. We have to set the system information before we
+	 * release the snapshot.
 	 */
 	__wt_timestamp_set_zero(&ckpt_tmp_ts);
 	if (full) {

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -926,6 +926,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 * commit but we don't want to set it until we know the checkpoint
 	 * is successful.
 	 */
+	__wt_timestamp_set_zero(&ckpt_tmp_ts);
 	if (full) {
 		WT_ERR(__wt_meta_sysinfo_set(session));
 		__wt_timestamp_set(&ckpt_tmp_ts, &txn->read_timestamp);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -932,7 +932,9 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 */
 	__wt_timestamp_set_zero(&ckpt_tmp_ts);
 	if (full) {
+		F_SET(session, WT_SESSION_NO_RECONCILE);
 		WT_ERR(__wt_meta_sysinfo_set(session));
+		F_CLR(session, WT_SESSION_NO_RECONCILE);
 		__wt_timestamp_set(&ckpt_tmp_ts, &txn->read_timestamp);
 	}
 #endif

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -24,7 +24,7 @@ typedef struct {
 	u_int max_fileid;		/* Maximum file ID seen. */
 	WT_LSN max_lsn;			/* Maximum checkpoint LSN seen. */
 	u_int nfiles;			/* Number of files in the metadata. */
-	WT_DECL_TIMESTAMP(max_timestamp)
+	WT_DECL_TIMESTAMP(saved_timestamp)
 
 	WT_LSN ckpt_lsn;		/* Start LSN for main recovery loop. */
 
@@ -350,6 +350,7 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 	WT_DECL_TIMESTAMP(ckpt_timestamp)
 	WT_LSN lsn;
 	uint32_t fileid, lsnfile, lsnoffset;
+	char *sys_config;
 
 	WT_RET(__wt_config_getones(r->session, config, "id", &cval));
 	fileid = (uint32_t)cval.val;
@@ -370,21 +371,38 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 	 * save the stable timestamp of the last checkpoint for later query.
 	 * This gets saved in the connection.
 	 */
-	WT_CLEAR(cval);
-	WT_RET_NOTFOUND_OK(__wt_config_getones(r->session,
-	    config, "checkpoint_timestamp", &cval));
-	if (cval.len != 0) {
-		__wt_verbose(r->session, WT_VERB_RECOVERY,
-		    "%s: Recovery timestamp %.*s",
-		    uri, (int)cval.len, cval.str);
-		WT_RET(__wt_txn_parse_timestamp_raw(r->session, "recovery",
-		    &ckpt_timestamp, &cval));
+	if (fileid == WT_METAFILE_ID) {
+		sys_config = NULL;
+		__wt_timestamp_set_zero(&ckpt_timestamp);
 		/*
-		 * Keep track of the largest checkpoint timestamp seen.
+		 * Search in the metadata for the system information.
 		 */
-		if (__wt_timestamp_cmp(&ckpt_timestamp, &r->max_timestamp) > 0)
-			__wt_timestamp_set(&r->max_timestamp, &ckpt_timestamp);
+		WT_RET_NOTFOUND_OK(__wt_metadata_search(r->session,
+		    WT_SYSTEM_URI, &sys_config));
+		if (sys_config != NULL) {
+			WT_CLEAR(cval);
+			WT_RET_NOTFOUND_OK(__wt_config_getones(r->session,
+			sys_config, "checkpoint_timestamp", &cval));
+			if (cval.len != 0) {
+				__wt_verbose(r->session, WT_VERB_RECOVERY,
+				    "%s: Recovery timestamp %.*s",
+				    uri, (int)cval.len, cval.str);
+				WT_RET(__wt_txn_parse_timestamp_raw(r->session,
+				    "recovery", &ckpt_timestamp, &cval));
+			}
+		}
+		/*
+		 * Set the timestamp that will be used for the recovery
+		 * checkpoint timestamp. Recovery should not change the
+		 * timestamp nature of the last shutdown so just set it
+		 * to what it was before.
+		 */
+		__wt_timestamp_set(
+		    &S2C(r->session)->txn_global.meta_ckpt_timestamp,
+		    &ckpt_timestamp);
 	}
+#else
+	WT_UNUSED(sys_config);
 #endif
 
 	WT_RET(__wt_strdup(r->session, uri, &r->files[fileid].uri));
@@ -499,7 +517,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 	WT_MAX_LSN(&r.max_lsn);
 #ifdef HAVE_TIMESTAMPS
 	__wt_timestamp_set_zero(&conn->txn_global.recovery_timestamp);
-	__wt_timestamp_set_zero(&r.max_timestamp);
+	__wt_timestamp_set_zero(&conn->txn_global.meta_ckpt_timestamp);
+	__wt_timestamp_set_zero(&r.saved_timestamp);
 #endif
 
 	F_SET(conn, WT_CONN_RECOVERING);
@@ -666,7 +685,7 @@ done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 	{
 	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 1];
 	__wt_timestamp_set(
-	    &conn->txn_global.recovery_timestamp, &r.max_timestamp);
+	    &conn->txn_global.recovery_timestamp, &r.saved_timestamp);
 	WT_TRET(__wt_timestamp_to_hex_string(session,
 	    hex_timestamp, &conn->txn_global.recovery_timestamp));
 	__wt_verbose(session, WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -24,7 +24,6 @@ typedef struct {
 	u_int max_fileid;		/* Maximum file ID seen. */
 	WT_LSN max_lsn;			/* Maximum checkpoint LSN seen. */
 	u_int nfiles;			/* Number of files in the metadata. */
-	WT_DECL_TIMESTAMP(saved_timestamp)
 
 	WT_LSN ckpt_lsn;		/* Start LSN for main recovery loop. */
 
@@ -518,7 +517,6 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 #ifdef HAVE_TIMESTAMPS
 	__wt_timestamp_set_zero(&conn->txn_global.recovery_timestamp);
 	__wt_timestamp_set_zero(&conn->txn_global.meta_ckpt_timestamp);
-	__wt_timestamp_set_zero(&r.saved_timestamp);
 #endif
 
 	F_SET(conn, WT_CONN_RECOVERING);
@@ -685,7 +683,8 @@ done:	FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 	{
 	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 1];
 	__wt_timestamp_set(
-	    &conn->txn_global.recovery_timestamp, &r.saved_timestamp);
+	    &conn->txn_global.recovery_timestamp,
+	    &conn->txn_global.meta_ckpt_timestamp);
 	WT_TRET(__wt_timestamp_to_hex_string(session,
 	    hex_timestamp, &conn->txn_global.recovery_timestamp));
 	__wt_verbose(session, WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -139,8 +139,11 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 		 * We don't normally say anything about the WiredTiger metadata
 		 * and lookaside tables, they're not application/user "objects"
 		 * in the database.  I'm making an exception for the checkpoint
-		 * and verbose options.
+		 * and verbose options. However, skip over the metadata system
+		 * information with the checkpoint option.
 		 */
+		if (cflag && strcmp(key, WT_SYSTEM_URI) != 0)
+			continue;
 		if (cflag || vflag ||
 		    (strcmp(key, WT_METADATA_URI) != 0 &&
 		    strcmp(key, WT_LAS_URI) != 0))

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -140,9 +140,9 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 		 * and lookaside tables, they're not application/user "objects"
 		 * in the database.  I'm making an exception for the checkpoint
 		 * and verbose options. However, skip over the metadata system
-		 * information with the checkpoint option.
+		 * information for anything except the verbose option.
 		 */
-		if (cflag && strcmp(key, WT_SYSTEM_URI) != 0)
+		if (!vflag && strcmp(key, WT_SYSTEM_URI) == 0)
 			continue;
 		if (cflag || vflag ||
 		    (strcmp(key, WT_METADATA_URI) != 0 &&

--- a/test/suite/test_backup08.py
+++ b/test/suite/test_backup08.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_backup08.py
+#   Timestamps: Verify the saved checkpoint timestamp survives a backup.
+#
+
+import os, shutil
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_backup08(wttest.WiredTigerTestCase):
+    conn_config = 'config_base=false,create,log=(enabled)'
+    dir = 'backup.dir'
+    coll1_uri = 'table:collection10.1'
+    coll2_uri = 'table:collection10.2'
+    coll3_uri = 'table:collection10.3'
+    oplog_uri = 'table:oplog10'
+
+    nentries = 10
+    table_cnt = 3
+
+    types = [
+        ('all', dict(use_stable='false')),
+        ('default', dict(use_stable='default')),
+        ('stable', dict(use_stable='true')),
+    ]
+    scenarios = make_scenarios(types)
+
+    def data_and_checkpoint(self):
+        #
+        # Create several collection-like tables that are checkpoint durability.
+        # Add data to each of them separately and checkpoint so that each one
+        # has a different stable timestamp.
+        #
+        self.session.create(self.oplog_uri, 'key_format=i,value_format=i')
+        self.session.create(self.coll1_uri, 'key_format=i,value_format=i,log=(enabled=false)')
+        self.session.create(self.coll2_uri, 'key_format=i,value_format=i,log=(enabled=false)')
+        self.session.create(self.coll3_uri, 'key_format=i,value_format=i,log=(enabled=false)')
+        c_op = self.session.open_cursor(self.oplog_uri)
+        c = []
+        c.append(self.session.open_cursor(self.coll1_uri))
+        c.append(self.session.open_cursor(self.coll2_uri))
+        c.append(self.session.open_cursor(self.coll3_uri))
+
+        # Begin by adding some data.
+        for table in range(1,self.table_cnt+1):
+            curs = c[table - 1]
+            start = self.nentries * table
+            end = start + self.nentries
+            ts = (end - 3)
+            self.pr("table: " + str(table))
+            for i in range(start,end):
+                self.session.begin_transaction()
+                c_op[i] = i
+                curs[i] = i
+                self.pr("i: " + str(i))
+                self.session.commit_transaction(
+                  'commit_timestamp=' + timestamp_str(i))
+            # Set the oldest and stable timestamp a bit earlier than the data
+            # we inserted. Take a checkpoint to the stable timestamp.
+            self.pr("stable ts: " + str(ts))
+            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(ts) +
+                ',stable_timestamp=' + timestamp_str(ts))
+            # This forces a different checkpoint timestamp for each table.
+            # Default is to use the stable timestamp.
+            expected = ts
+            ckpt_config = ''
+            if self.use_stable == 'false':
+                expected = 0
+                ckpt_config = 'use_timestamp=false'
+            elif self.use_stable == 'true':
+                ckpt_config = 'use_timestamp=true'
+            self.session.checkpoint(ckpt_config)
+            q = self.conn.query_timestamp('get=last_checkpoint')
+            self.assertTimestampsEqual(q, timestamp_str(expected))
+        return expected
+
+    def backup_and_recover(self, expected_rec_ts):
+        #
+        # Perform a live backup. Then open the backup and query the
+        # recovery timestamp verifying it is the expected value.
+        #
+        os.mkdir(self.dir)
+        cursor = self.session.open_cursor('backup:')
+        while True:
+            ret = cursor.next()
+            if ret != 0:
+                break
+            shutil.copy(cursor.get_key(), self.dir)
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+        backup_conn = self.wiredtiger_open(self.dir)
+        q = backup_conn.query_timestamp('get=recovery')
+        self.pr("query recovery ts: " + q)
+        self.assertTimestampsEqual(q, timestamp_str(expected_rec_ts))
+
+    def test_timestamp_backup(self):
+        if not wiredtiger.timestamp_build():
+            self.skipTest('requires a timestamp build')
+
+        # Add some data and checkpoint using the timestamp or not
+        # depending on the configuration. Get the expected timestamp
+        # where the data is checkpointed for the backup.
+        ckpt_ts = self.data_and_checkpoint()
+
+        # Backup and run recovery checking the recovery timestamp.
+        # This tests that the stable timestamp information is transferred
+        # with the backup. It should be part of the backup metadata file.
+        self.backup_and_recover(ckpt_ts)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
This branch was merged once, but introduced [test failures](http://build.wiredtiger.com:8080/job/wiredtiger-test-spinlock/4246/), so I reverted.