### PR TITLE
WT-3959 Remove metadata entry for checkpoint timestamp if zero.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -791,7 +791,7 @@ restart:
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {
 		if (WT_IS_METADATA(dhandle) ||
 		    strcmp(dhandle->name, WT_LAS_URI) == 0 ||
-		    strcmp(dhandle->name, WT_SYSTEM_URI) == 0)
+		    WT_PREFIX_MATCH(dhandle->name, "system:"))
 			continue;
 
 		WT_WITH_DHANDLE(session, dhandle,

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -791,7 +791,7 @@ restart:
 	TAILQ_FOREACH(dhandle, &conn->dhqh, q) {
 		if (WT_IS_METADATA(dhandle) ||
 		    strcmp(dhandle->name, WT_LAS_URI) == 0 ||
-		    WT_PREFIX_MATCH(dhandle->name, "system:"))
+		    WT_PREFIX_MATCH(dhandle->name, WT_SYSTEM_PREFIX))
 			continue;
 
 		WT_WITH_DHANDLE(session, dhandle,

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -470,7 +470,7 @@ __backup_list_uri_append(
 	    !WT_PREFIX_MATCH(name, "colgroup:") &&
 	    !WT_PREFIX_MATCH(name, "index:") &&
 	    !WT_PREFIX_MATCH(name, "lsm:") &&
-	    !WT_PREFIX_MATCH(name, "system:") &&
+	    !WT_PREFIX_MATCH(name, WT_SYSTEM_PREFIX) &&
 	    !WT_PREFIX_MATCH(name, "table:"))
 		WT_RET_MSG(session, ENOTSUP,
 		    "hot backup is not supported for objects of type %s",
@@ -490,7 +490,7 @@ __backup_list_uri_append(
 	 * We want to retain the system information in the backup metadata
 	 * file above, but there is no file object to copy so return now.
 	 */
-	if (WT_PREFIX_MATCH(name, "system:"))
+	if (WT_PREFIX_MATCH(name, WT_SYSTEM_PREFIX))
 		return (0);
 
 	/* Add file type objects to the list of files to be copied. */

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -490,7 +490,7 @@ __backup_list_uri_append(
 	 * We want to retain the system information in the backup metadata
 	 * file above, but there is no file object to copy so return now.
 	 */
-	if (strcmp(name, WT_SYSTEM_URI) == 0)
+	if (WT_PREFIX_MATCH(name, "system:"))
 		return (0);
 
 	/* Add file type objects to the list of files to be copied. */

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -27,7 +27,7 @@
 #define	WT_METAFILE_URI		"file:WiredTiger.wt"	/* Metadata table URI */
 
 #define	WT_LAS_URI		"file:WiredTigerLAS.wt"	/* Lookaside table URI*/
-#define	WT_SYSTEM_URI		"system:checkpoint"	/* System ckpt URI*/
+#define	WT_SYSTEM_CKPT_URI	"system:checkpoint"	/* System ckpt URI*/
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -27,7 +27,9 @@
 #define	WT_METAFILE_URI		"file:WiredTiger.wt"	/* Metadata table URI */
 
 #define	WT_LAS_URI		"file:WiredTigerLAS.wt"	/* Lookaside table URI*/
-#define	WT_SYSTEM_CKPT_URI	"system:checkpoint"	/* System ckpt URI*/
+
+#define	WT_SYSTEM_PREFIX	"system:"		/* System URI prefix */
+#define	WT_SYSTEM_CKPT_URI	"system:checkpoint"	/* Checkpoint URI */
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -502,12 +502,8 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 {
 	WT_DECL_ITEM(buf);
 	WT_DECL_RET;
-	const char *cfg[3];
-	char *config, *newcfg;
 	char hex_timestamp[2 * WT_TIMESTAMP_SIZE + 2];
-	bool update;
 
-	config = newcfg = NULL;
 	WT_ERR(__wt_scr_alloc(session, 0, &buf));
 	hex_timestamp[0] = '0';
 	hex_timestamp[1] = '\0';
@@ -520,32 +516,23 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 	WT_ERR(__wt_timestamp_to_hex_string(session, hex_timestamp,
 	    &S2C(session)->txn_global.meta_ckpt_timestamp));
 #endif
-	WT_ERR(__wt_buf_catfmt(session, buf,
-	    "checkpoint_timestamp=\"%s\"", hex_timestamp));
 
-	update = true;
-	/* Retrieve the metadata for this file. */
-	cfg[2] = NULL;
-	if ((ret =
-	    __wt_metadata_search(session, WT_SYSTEM_URI, &config)) == 0) {
-		cfg[0] = config;
-		cfg[1] = buf->mem;
-	} else if (ret == WT_NOTFOUND) {
-		update = false;
-		cfg[0] = buf->mem;
-		cfg[1] = NULL;
-	} else
-		WT_ERR(ret);
-	/* Replace or insert the system info entry. */
-	WT_ERR(__wt_config_collapse(session, cfg, &newcfg));
-	if (update)
-		WT_ERR(__wt_metadata_update(session, WT_SYSTEM_URI, newcfg));
-	else
-		WT_ERR(__wt_metadata_insert(session, WT_SYSTEM_URI, newcfg));
+	/*
+	 * Don't leave a zero entry in the metadata: remove it.  This avoids
+	 * downgrade issues if the metadata is opened with an older version of
+	 * WiredTiger that does not understand the new entry.
+	 */
+	if (strcmp(hex_timestamp, "0") == 0)
+		WT_ERR_NOTFOUND_OK(
+		    __wt_metadata_remove(session, WT_SYSTEM_CKPT_URI));
+	else {
+		WT_ERR(__wt_buf_catfmt(session, buf,
+		    "checkpoint_timestamp=\"%s\"", hex_timestamp));
+		WT_ERR(__wt_metadata_update(
+		    session, WT_SYSTEM_CKPT_URI, buf->data));
+	}
 
-err:	__wt_free(session, config);
-	__wt_free(session, newcfg);
-	__wt_scr_free(session, &buf);
+err:	__wt_scr_free(session, &buf);
 	return (ret);
 }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -72,7 +72,7 @@ __checkpoint_name_check(WT_SESSION_IMPL *session, const char *uri)
 			if (!WT_PREFIX_MATCH(uri, "colgroup:") &&
 			    !WT_PREFIX_MATCH(uri, "file:") &&
 			    !WT_PREFIX_MATCH(uri, "index:") &&
-			    !WT_PREFIX_MATCH(uri, "system:") &&
+			    !WT_PREFIX_MATCH(uri, WT_SYSTEM_PREFIX) &&
 			    !WT_PREFIX_MATCH(uri, "table:")) {
 				fail = uri;
 				break;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -366,7 +366,7 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 
 	/* Search in the metadata for the system information. */
 	WT_ERR_NOTFOUND_OK(
-	    __wt_metadata_search(session, WT_SYSTEM_URI, &sys_config));
+	    __wt_metadata_search(session, WT_SYSTEM_CKPT_URI, &sys_config));
 	if (sys_config != NULL) {
 		WT_CLEAR(cval);
 		WT_ERR_NOTFOUND_OK(__wt_config_getones(

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -142,7 +142,7 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 		 * and verbose options. However, skip over the metadata system
 		 * information for anything except the verbose option.
 		 */
-		if (!vflag && strcmp(key, WT_SYSTEM_URI) == 0)
+		if (!vflag && WT_PREFIX_MATCH(key, "system:") == 0)
 			continue;
 		if (cflag || vflag ||
 		    (strcmp(key, WT_METADATA_URI) != 0 &&

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -142,7 +142,7 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 		 * and verbose options. However, skip over the metadata system
 		 * information for anything except the verbose option.
 		 */
-		if (!vflag && WT_PREFIX_MATCH(key, "system:"))
+		if (!vflag && WT_PREFIX_MATCH(key, WT_SYSTEM_PREFIX))
 			continue;
 		if (cflag || vflag ||
 		    (strcmp(key, WT_METADATA_URI) != 0 &&

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -142,7 +142,7 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 		 * and verbose options. However, skip over the metadata system
 		 * information for anything except the verbose option.
 		 */
-		if (!vflag && WT_PREFIX_MATCH(key, "system:") == 0)
+		if (!vflag && WT_PREFIX_MATCH(key, "system:"))
 			continue;
 		if (cflag || vflag ||
 		    (strcmp(key, WT_METADATA_URI) != 0 &&


### PR DESCRIPTION
We added a "system:checkpoint" entry to the metadata to store the most recent timestamp at which a checkpoint completed.  Current versions of WiredTiger treat a missing entry as equivalent to a zero timestamp.

However, this metadata entry can confuse older versions of WiredTiger (specifically, opening a backup cursor fails when the new entry exists). Since MongoDB will always checkpoint without a timestamp as part of the downgrade process, remove the metadata entry in that case so that older versions of WiredTiger never see it.

Also, check for the "system:" previous generally rather than this specific entry.  Then if future versions of WiredTiger introduce new entries, they will be silently skipped when not expected.