### PR TITLE
WT-4035 page-delete information discarded before it was globally visible

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1665,16 +1665,7 @@ __rec_child_deleted(WT_SESSION_IMPL *session,
 	 * read into this part of the name space again, the cache read function
 	 * instantiates an entirely new page.)
 	 */
-	if (ref->addr != NULL && !__wt_page_del_active(session, ref, true))
-		WT_RET(__wt_ref_block_free(session, ref));
-
-	/*
-	 * If the original page is gone, we can skip the slot on the internal
-	 * page.
-	 */
-	if (ref->addr == NULL) {
-		*statep = WT_CHILD_IGNORE;
-
+	if (ref->addr != NULL && !__wt_page_del_active(session, ref, true)) {
 		/*
 		 * Minor memory cleanup: if a truncate call deleted this page
 		 * and we were ever forced to instantiate the page in memory,
@@ -1687,6 +1678,15 @@ __rec_child_deleted(WT_SESSION_IMPL *session,
 			__wt_free(session, ref->page_del);
 		}
 
+		WT_RET(__wt_ref_block_free(session, ref));
+	}
+
+	/*
+	 * If the original page is gone, we can skip the slot on the internal
+	 * page.
+	 */
+	if (ref->addr == NULL) {
+		*statep = WT_CHILD_IGNORE;
 		return (0);
 	}
 


### PR DESCRIPTION
Michael, what happened was AddressSanitizer failed in `__wt_delete_page_rollback()`, with a `WT_REF` in the `WT_REF_DELETED` state but `ref.page_del == NULL`, which is a core dump.

The only path I could find where I thought that might happen is `__rec_child_deleted()`, and I was able to make the free of `ref.page_del` assert with a not-yet-globally visible transaction there, with this stack:
```
#3  0x0000000000496ba1 in __wt_assert (session=0x7f62cf8ed498, error=0, 
    file_name=0x5b6210 <__func__.16654> "__rec_child_deleted", 
    line_number=1691, fmt=0x5b54fa "%s") at src/support/err.c:512
#4  0x000000000046995f in __rec_child_deleted (session=0x7f62cf8ed498, 
    r=0x7f6224009b20, ref=0x7f627c0a3ec0, statep=0x7f62617f98bc)
    at src/reconcile/rec_write.c:1691
#5  0x0000000000469aaf in __rec_child_modify (session=0x7f62cf8ed498, 
    r=0x7f6224009b20, ref=0x7f627c0a3ec0, hazardp=0x7f62617f98af, 
    statep=0x7f62617f98bc) at src/reconcile/rec_write.c:1777
#6  0x000000000047085b in __rec_row_int (session=0x7f62cf8ed498, 
    r=0x7f6224009b20, page=0x7f62840e7830) at src/reconcile/rec_write.c:5099
#7  0x00000000004672bf in __wt_reconcile (session=0x7f62cf8ed498, 
    ref=0x7f62840ed740, salvage=0x0, flags=1, lookaside_retryp=0x0)
    at src/reconcile/rec_write.c:470
#8  0x00000000004f4e0c in __sync_file (session=0x7f62cf8ed498, 
    syncop=WT_SYNC_CHECKPOINT) at src/btree/bt_sync.c:320
#9  0x00000000004f5187 in __wt_cache_op (session=0x7f62cf8ed498, 
    op=WT_SYNC_CHECKPOINT) at src/btree/bt_sync.c:414
#10 0x00000000004b1164 in __checkpoint_tree (session=0x7f62cf8ed498, 
    is_checkpoint=true, cfg=0x7f62617f9e10) at src/txn/txn_ckpt.c:1611
``` 
I stared at it a little while, but I'm not clear on what execution path leads us to a `ref.addr == NULL` and a state of `WT_REF_DELETED`.  It's either a chunk that never had a backing block, or was instantiated somehow without a backing block, and reconciliation does that enough now that I'm not sure what all the cases are.

Regardless, it clearly can happen, and this fix looks correct to me.

There are repro details in the ticket if you want to look at this further.