### PR TITLE
WT-4039 Move row-store missing-value support into the cell unpack code.

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1051,7 +1051,6 @@ __debug_page_row_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 static int
 __debug_page_row_leaf(WT_DBG *ds, WT_PAGE *page)
 {
-	WT_CELL *cell;
 	WT_CELL_UNPACK *unpack, _unpack;
 	WT_DECL_ITEM(key);
 	WT_DECL_RET;
@@ -1077,13 +1076,9 @@ __debug_page_row_leaf(WT_DBG *ds, WT_PAGE *page)
 		WT_ERR(__wt_row_leaf_key(session, page, rip, key, false));
 		WT_ERR(__debug_item_key(ds, "K", key->data, key->size));
 
-		if ((cell = __wt_row_leaf_value_cell(page, rip, NULL)) == NULL)
-			WT_ERR(ds->f(ds, "\tV {}\n"));
-		else {
-			__wt_cell_unpack(cell, unpack);
-			WT_ERR(__debug_cell_data(
-			    ds, page, WT_PAGE_ROW_LEAF, "V", unpack));
-		}
+		__wt_row_leaf_value_cell(page, rip, NULL, unpack);
+		WT_ERR(__debug_cell_data(
+		    ds, page, WT_PAGE_ROW_LEAF, "V", unpack));
 
 		if ((upd = WT_ROW_UPDATE(page, rip)) != NULL)
 			WT_ERR(__debug_update(ds, upd, false));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -100,16 +100,8 @@ __value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 		if (__wt_row_leaf_value(page, rip, &cursor->value))
 			return (0);
 
-		/*
-		 * Take the value from the original page cell (which may be
-		 * empty).
-		 */
-		if ((cell =
-		    __wt_row_leaf_value_cell(page, rip, NULL)) == NULL) {
-			cursor->value.size = 0;
-			return (0);
-		}
-		__wt_cell_unpack(cell, &unpack);
+		/* Take the value from the original page cell. */
+		__wt_row_leaf_value_cell(page, rip, NULL, &unpack);
 		return (__wt_page_cell_data_ref(
 		    session, page, &unpack, &cursor->value));
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -2034,16 +2034,15 @@ err:		WT_TRET(__wt_page_release(session, ref, 0));
  * referenced.
  */
 static int
-__slvg_row_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL *cell)
+__slvg_row_ovfl_single(
+    WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL_UNPACK *unpack)
 {
-	WT_CELL_UNPACK unpack;
 	WT_TRACK *ovfl;
 	uint32_t i;
 
-	/* Unpack the cell, and check if it's an overflow record. */
-	__wt_cell_unpack(cell, &unpack);
-	if (unpack.type != WT_CELL_KEY_OVFL &&
-	    unpack.type != WT_CELL_VALUE_OVFL)
+	/* Check if it's an overflow record. */
+	if (unpack->type != WT_CELL_KEY_OVFL &&
+	    unpack->type != WT_CELL_VALUE_OVFL)
 		return (0);
 
 	/*
@@ -2052,8 +2051,8 @@ __slvg_row_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL *cell)
 	 */
 	for (i = 0; i < trk->trk_ovfl_cnt; ++i) {
 		ovfl = trk->ss->ovfl[trk->trk_ovfl_slot[i]];
-		if (unpack.size == ovfl->trk_addr_size &&
-		    memcmp(unpack.data, ovfl->trk_addr, unpack.size) == 0)
+		if (unpack->size == ovfl->trk_addr_size &&
+		    memcmp(unpack->data, ovfl->trk_addr, unpack->size) == 0)
 			return (__slvg_ovfl_ref(session, ovfl, true));
 	}
 
@@ -2070,6 +2069,7 @@ __slvg_row_ovfl(WT_SESSION_IMPL *session,
     WT_TRACK *trk, WT_PAGE *page, uint32_t start, uint32_t stop)
 {
 	WT_CELL *cell;
+	WT_CELL_UNPACK unpack;
 	WT_ROW *rip;
 	void *copy;
 
@@ -2081,11 +2081,12 @@ __slvg_row_ovfl(WT_SESSION_IMPL *session,
 		copy = WT_ROW_KEY_COPY(rip);
 		(void)__wt_row_leaf_key_info(
 		    page, copy, NULL, &cell, NULL, NULL);
-		if (cell != NULL)
-			WT_RET(__slvg_row_ovfl_single(session, trk, cell));
-		cell = __wt_row_leaf_value_cell(page, rip, NULL);
-		if (cell != NULL)
-			WT_RET(__slvg_row_ovfl_single(session, trk, cell));
+		WT_ASSERT(session, cell != NULL);
+		__wt_cell_unpack(cell, &unpack);
+		WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
+
+		__wt_row_leaf_value_cell(page, rip, NULL, &unpack);
+		WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
 	}
 	return (0);
 }

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -291,10 +291,11 @@ __stat_page_row_leaf(
 		    (upd->type != WT_UPDATE_RESERVE &&
 		    upd->type != WT_UPDATE_TOMBSTONE))
 			++entry_cnt;
-		if (upd == NULL && (cell =
-		    __wt_row_leaf_value_cell(page, rip, NULL)) != NULL &&
-		    __wt_cell_type(cell) == WT_CELL_VALUE_OVFL)
-			++ovfl_cnt;
+		if (upd == NULL) {
+			__wt_row_leaf_value_cell(page, rip, NULL, &unpack);
+			if (unpack.type == WT_CELL_VALUE_OVFL)
+				++ovfl_cnt;
+		}
 
 		/* Walk K/V pairs inserted after the on-page K/V pair. */
 		WT_SKIP_FOREACH(ins, WT_ROW_INSERT(page, rip))

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1013,11 +1013,11 @@ __wt_row_leaf_key(WT_SESSION_IMPL *session,
 
 /*
  * __wt_row_leaf_value_cell --
- *	Return a pointer to the value cell for a row-store leaf page key, or
- * NULL if there isn't one.
+ *	Return the unpacked value for a row-store leaf page key.
  */
-static inline WT_CELL *
-__wt_row_leaf_value_cell(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *kpack)
+static inline void
+__wt_row_leaf_value_cell(
+    WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *kpack, WT_CELL_UNPACK *vpack)
 {
 	WT_CELL *kcell, *vcell;
 	WT_CELL_UNPACK unpack;
@@ -1052,7 +1052,7 @@ __wt_row_leaf_value_cell(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *kpack)
 		}
 	}
 
-	return (__wt_cell_leaf_value_parse(page, vcell));
+	__wt_cell_unpack(__wt_cell_leaf_value_parse(page, vcell), vpack);
 }
 
 /*

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -717,28 +717,23 @@ done:	WT_CELL_LEN_CHK(cell, unpack->__len);
 static inline void
 __wt_cell_unpack(WT_CELL *cell, WT_CELL_UNPACK *unpack)
 {
-	(void)__wt_cell_unpack_safe(cell, unpack, NULL, NULL);
-}
-
-/*
- * __wt_cell_unpack_empty_value --
- *	Create an unpacked cell that looks like zero-length row-store value.
- */
-static inline void
-__wt_cell_unpack_empty_value(WT_CELL_UNPACK *unpack)
-{
 	/*
 	 * Row-store doesn't store zero-length values on pages, but this allows
 	 * us to pretend.
 	 */
-	unpack->cell = NULL;
-	unpack->v = 0;
-	unpack->data = "";
-	unpack->size = 0;
-	unpack->__len = 0;
-	unpack->prefix = 0;
-	unpack->raw = unpack->type = WT_CELL_VALUE;
-	unpack->ovfl = 0;
+	if (cell == NULL) {
+		unpack->cell = NULL;
+		unpack->v = 0;
+		unpack->data = "";
+		unpack->size = 0;
+		unpack->__len = 0;
+		unpack->prefix = 0;
+		unpack->raw = unpack->type = WT_CELL_VALUE;
+		unpack->ovfl = 0;
+		return;
+	}
+
+	(void)__wt_cell_unpack_safe(cell, unpack, NULL, NULL);
 }
 
 /*
@@ -786,7 +781,7 @@ __cell_data_ref(WT_SESSION_IMPL *session,
 	WT_ILLEGAL_VALUE(session);
 	}
 
-	return (huffman == NULL ? 0 :
+	return (huffman == NULL || store->size == 0 ? 0 :
 	    __wt_huffman_decode(
 	    session, huffman, store->data, store->size, store));
 }

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -376,7 +376,7 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 {
 	WT_BTREE *btree;
 	WT_CELL *cell;
-	WT_CELL_UNPACK *unpack, _unpack;
+	WT_CELL_UNPACK *kpack, _kpack, *vpack, _vpack;
 	WT_ITEM *kb, *vb;
 	WT_PAGE *page;
 	WT_SESSION_IMPL *session;
@@ -386,7 +386,8 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 	btree = S2BT(session);
 	page = cbt->ref->page;
 
-	unpack = NULL;
+	kpack = NULL;
+	vpack = &_vpack;
 
 	kb = &cbt->iface.key;
 	vb = &cbt->iface.value;
@@ -417,11 +418,11 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 	 * Inline building simple prefix-compressed keys from a previous key,
 	 * otherwise build from scratch.
 	 */
-	unpack = &_unpack;
-	__wt_cell_unpack(cell, unpack);
-	if (unpack->type == WT_CELL_KEY &&
+	kpack = &_kpack;
+	__wt_cell_unpack(cell, kpack);
+	if (kpack->type == WT_CELL_KEY &&
 	    cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {
-		WT_ASSERT(session, cbt->row_key->size >= unpack->prefix);
+		WT_ASSERT(session, cbt->row_key->size >= kpack->prefix);
 
 		/*
 		 * Grow the buffer as necessary as well as ensure data has been
@@ -431,12 +432,12 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 		 * Don't grow the buffer unnecessarily or copy data we don't
 		 * need, truncate the item's data length to the prefix bytes.
 		 */
-		cbt->row_key->size = unpack->prefix;
+		cbt->row_key->size = kpack->prefix;
 		WT_RET(__wt_buf_grow(
-		    session, cbt->row_key, cbt->row_key->size + unpack->size));
+		    session, cbt->row_key, cbt->row_key->size + kpack->size));
 		memcpy((uint8_t *)cbt->row_key->data + cbt->row_key->size,
-		    unpack->data, unpack->size);
-		cbt->row_key->size += unpack->size;
+		    kpack->data, kpack->size);
+		cbt->row_key->size += kpack->size;
 	} else {
 		/*
 		 * Call __wt_row_leaf_key_work instead of __wt_row_leaf_key: we
@@ -462,17 +463,7 @@ value:
 	if (__wt_row_leaf_value(page, rip, vb))
 		return (0);
 
-	/*
-	 * Else, take the value from the original page cell (which may be
-	 * empty).
-	 */
-	if ((cell = __wt_row_leaf_value_cell(page, rip, unpack)) == NULL) {
-		vb->data = "";
-		vb->size = 0;
-		return (0);
-	}
-
-	unpack = &_unpack;
-	__wt_cell_unpack(cell, unpack);
-	return (__wt_page_cell_data_ref(session, cbt->ref->page, unpack, vb));
+	/* Else, take the value from the original page cell. */
+	__wt_row_leaf_value_cell(page, rip, kpack, vpack);
+	return (__wt_page_cell_data_ref(session, cbt->ref->page, vpack, vb));
 }


### PR DESCRIPTION
@michaelcahill, I like your idea a lot, but the actual mechanics of it make me nervous.

I split this work into a different ticket from WT-4031 (#4049) because we don't need to backport this work to fix the bug, and second, I think we want to pound on this change hard before we let it out into the wild.