### PR TITLE
WT-4056 Add log file version statistic

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -367,6 +367,7 @@ connection_stats = [
     LogStat('log_compress_small', 'log records too small to compress'),
     LogStat('log_compress_write_fails', 'log records not compressed'),
     LogStat('log_compress_writes', 'log records compressed'),
+    LogStat('log_file_version', 'most recent log file version number'),
     LogStat('log_flush', 'log flush operations'),
     LogStat('log_force_ckpt_sleep', 'force checkpoint calls slept'),
     LogStat('log_force_write', 'log force write operations'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -528,6 +528,7 @@ struct __wt_connection_stats {
 	int64_t log_writes;
 	int64_t log_slot_consolidated;
 	int64_t log_max_filesize;
+	int64_t log_file_version;
 	int64_t log_prealloc_max;
 	int64_t log_prealloc_missed;
 	int64_t log_prealloc_files;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5355,306 +5355,308 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1213
 /*! log: maximum log file size */
 #define	WT_STAT_CONN_LOG_MAX_FILESIZE			1214
+/*! log: most recent log file version number */
+#define	WT_STAT_CONN_LOG_FILE_VERSION			1215
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1215
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1216
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1216
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1217
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1217
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1218
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1218
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1219
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1219
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1220
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1220
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1221
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1221
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1222
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1222
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1223
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1223
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1224
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1224
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1225
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1225
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1226
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1226
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1227
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1227
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1228
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1228
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1229
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1229
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1230
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1230
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1231
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1231
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1232
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1232
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1233
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1233
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1234
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1234
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1235
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1235
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1236
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1236
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1237
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1237
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1238
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1238
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1239
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1239
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1240
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1240
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1241
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1241
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1242
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1242
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1243
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1243
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1244
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1244
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1245
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1245
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1246
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1246
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1247
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1247
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1248
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1248
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1249
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1249
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1250
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1250
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1251
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1251
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1252
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1252
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1253
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1253
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1254
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1254
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1255
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1255
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1256
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1256
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1257
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1257
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1258
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1258
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1259
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1259
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1260
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1260
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1261
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1261
+#define	WT_STAT_CONN_REC_PAGES				1262
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1262
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1263
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1263
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1264
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1264
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1265
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1265
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1266
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1266
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1267
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1267
+#define	WT_STAT_CONN_SESSION_OPEN			1268
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1268
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1269
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1269
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1270
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1270
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1271
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1271
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1272
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1272
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1273
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1273
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1274
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1274
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1275
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1275
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1276
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1276
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1277
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1277
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1278
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1278
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1279
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1279
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1280
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1280
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1281
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1281
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1282
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1282
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1283
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1283
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1284
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1284
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1285
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1285
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1286
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1286
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1287
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1287
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1288
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1288
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1289
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1289
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1290
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1290
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1291
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1291
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1292
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1292
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1293
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1293
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1294
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1294
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1295
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1295
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1296
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1296
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1297
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1297
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1298
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1298
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1299
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1299
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1300
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1300
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1301
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1301
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1302
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1302
+#define	WT_STAT_CONN_PAGE_SLEEP				1303
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1303
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1304
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1304
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1305
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1305
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1306
 /*! transaction: commit timestamp queue inserts to tail */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_TAIL		1306
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_TAIL		1307
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1307
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1308
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1308
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1309
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1309
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1310
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1310
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1311
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1311
+#define	WT_STAT_CONN_TXN_PREPARE			1312
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1312
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1313
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1313
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1314
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1314
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1315
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1315
+#define	WT_STAT_CONN_TXN_QUERY_TS			1316
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1316
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1317
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1317
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1318
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1318
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1319
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1319
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1320
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1320
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1321
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1321
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1322
 /*! transaction: rollback to stable updates removed from lookaside */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1322
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1323
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1323
+#define	WT_STAT_CONN_TXN_SET_TS				1324
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1324
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1325
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1325
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1326
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1326
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1327
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1327
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1328
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1328
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1329
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1329
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1330
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1330
+#define	WT_STAT_CONN_TXN_BEGIN				1331
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1331
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1332
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1332
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1333
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1333
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1334
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1334
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1335
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1335
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1336
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1336
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1337
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1337
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1338
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1338
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1339
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1339
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1340
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1340
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1341
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1341
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1342
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1342
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1343
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1343
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1344
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1344
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1345
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1345
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1346
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1346
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1347
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1347
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1348
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1348
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1349
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1349
+#define	WT_STAT_CONN_TXN_SYNC				1350
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1350
+#define	WT_STAT_CONN_TXN_COMMIT				1351
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1351
+#define	WT_STAT_CONN_TXN_ROLLBACK			1352
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1352
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1353
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -962,6 +962,7 @@ static const char * const __stats_connection_desc[] = {
 	"log: log write operations",
 	"log: logging bytes consolidated",
 	"log: maximum log file size",
+	"log: most recent log file version number",
 	"log: number of pre-allocated log files to create",
 	"log: pre-allocated log files not ready and missed",
 	"log: pre-allocated log files prepared",
@@ -1357,6 +1358,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->log_writes = 0;
 	stats->log_slot_consolidated = 0;
 		/* not clearing log_max_filesize */
+	stats->log_file_version = 0;
 		/* not clearing log_prealloc_max */
 	stats->log_prealloc_missed = 0;
 	stats->log_prealloc_files = 0;
@@ -1825,6 +1827,7 @@ __wt_stat_connection_aggregate(
 	to->log_slot_consolidated +=
 	    WT_STAT_READ(from, log_slot_consolidated);
 	to->log_max_filesize += WT_STAT_READ(from, log_max_filesize);
+	to->log_file_version += WT_STAT_READ(from, log_file_version);
 	to->log_prealloc_max += WT_STAT_READ(from, log_prealloc_max);
 	to->log_prealloc_missed += WT_STAT_READ(from, log_prealloc_missed);
 	to->log_prealloc_files += WT_STAT_READ(from, log_prealloc_files);


### PR DESCRIPTION
@agorrod Here is one fairly easy way to get the information needed by MongoDB to determine a database is an illegal 3.4-based without corrupting the database, if opened read-only.  I did run a test on a 3.4-based database directory, opening it read-only, grabbing the version and checking it, and then running `wt list -v` on the 3.4 directory after to make sure it is still usable. Again, there are no good ways to test it other than manually.

Also note that this branch is based off the WT-4029 branch.

@dgottlieb FYI.