### PR TITLE
WT-4016 Change lookaside skew heuristic.

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -978,9 +978,9 @@ __rec_init(WT_SESSION_IMPL *session,
 		WT_ORDERED_READ(las_skew_oldest,
 		    txn_global->has_stable_timestamp);
 		if (las_skew_oldest)
-			las_skew_oldest = r->ref->page_las != NULL &&
+			las_skew_oldest = ref->page_las != NULL &&
 			    !__wt_txn_visible_all(session, WT_TXN_NONE,
-			    &r->ref->page_las->min_timestamp);
+			    WT_TIMESTAMP_NULL(&ref->page_las->min_timestamp));
 	}
 	r->las_skew_newest = LF_ISSET(WT_REC_LOOKASIDE) &&
 	    LF_ISSET(WT_REC_VISIBLE_ALL) && !las_skew_oldest;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -958,15 +958,32 @@ __rec_init(WT_SESSION_IMPL *session,
 	 * uncommitted.
 	 */
 	txn_global = &S2C(session)->txn_global;
+	WT_ORDERED_READ(r->last_running, txn_global->last_running);
+
+	/*
+	 * Decide whether to skew on-page values towards newer or older
+	 * versions.  This is a heuristic attempting to minimize the number of
+	 * pages that need to be rewritten by future checkpoints.
+	 *
+	 * We usually prefer to skew to newer versions, the logic being that by
+	 * the time the next checkpoint runs, it is likely that all the updates
+	 * we choose will be stable.  However, if checkpointing with a
+	 * timestamp (indicated by a stable_timestamp being set), and the
+	 * timestamp hasn't changed since the last time this page was
+	 * reconciled, skew oldest instead.
+	 */
 	if (__wt_btree_immediately_durable(session))
 		las_skew_oldest = false;
-	else
+	else {
 		WT_ORDERED_READ(las_skew_oldest,
 		    txn_global->has_stable_timestamp);
+		if (las_skew_oldest)
+			las_skew_oldest = r->ref->page_las != NULL &&
+			    !__wt_txn_visible_all(session, WT_TXN_NONE,
+			    &r->ref->page_las->min_timestamp);
+	}
 	r->las_skew_newest = LF_ISSET(WT_REC_LOOKASIDE) &&
 	    LF_ISSET(WT_REC_VISIBLE_ALL) && !las_skew_oldest;
-
-	WT_ORDERED_READ(r->last_running, txn_global->last_running);
 
 	/*
 	 * When operating on the lookaside table, we should never try


### PR DESCRIPTION
This heuristic attempts to ensure that most pages evicted with lookaside history get the versions on-disk that will be chosen by the next checkpoint.  Even if a stable_timestamp is set, under normal circumstances it will be moving forward regularly, so the next checkpoint is likely to choose the most recent committed versions to write to the backing file.

Only skew towards choosing the oldest versions of records if a page is evicted twice without the pinned timestamp moving forward.