### PR TITLE
WT-4064 Relax checking of lookaside entry count.

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -42,17 +42,29 @@ __las_restore_isolation(
 }
 
 /*
- * __wt_las_nonempty --
+ * __wt_las_entry_count --
+ *	Return when there are entries in the lookaside table.
+ */
+uint64_t
+__wt_las_entry_count(WT_CACHE *cache)
+{
+	uint64_t insert_cnt, remove_cnt;
+
+	insert_cnt = cache->las_insert_count;
+	remove_cnt = cache->las_remove_count;
+	WT_READ_BARRIER();
+
+	return (insert_cnt > remove_cnt ? insert_cnt - remove_cnt : 0);
+}
+
+/*
+ * __wt_las_empty --
  *	Return when there are entries in the lookaside table.
  */
 bool
-__wt_las_nonempty(WT_SESSION_IMPL *session)
+__wt_las_empty(WT_SESSION_IMPL *session)
 {
-	WT_CACHE *cache;
-
-	cache = S2C(session)->cache;
-
-	return (cache->las_entry_count > 0);
+	return (__wt_las_entry_count(S2C(session)->cache) == 0);
 }
 
 /*
@@ -81,8 +93,9 @@ __wt_las_stats_update(WT_SESSION_IMPL *session)
 
 	/* Set the connection-wide statistics. */
 	cstats = conn->stats;
-	WT_STAT_SET(
-	    session, cstats, cache_lookaside_entries, cache->las_entry_count);
+
+	WT_STAT_SET(session, cstats,
+	    cache_lookaside_entries, __wt_las_entry_count(cache));
 
 	/*
 	 * We have a cursor, and we need the underlying data handle; we can get
@@ -726,24 +739,15 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 
 err:	/* Resolve the transaction. */
 	if (local_txn) {
-		if (ret == 0) {
-			/*
-			 * Adjust the entry count.
-			 *
-			 * For inserts, we increment before committing.  As
-			 * soon as we commit, sweep could catch up and remove
-			 * the block, and we don't want the count to underflow.
-			 * In the unlikely event that the commit fails, roll
-			 * back the increment.
-			 */
-			__wt_atomic_add64(
-			    &conn->cache->las_entry_count, insert_cnt);
-			if ((ret = __wt_txn_commit(las_session, NULL)) != 0)
-				__wt_cache_decr_check_uint64(session,
-				    &conn->cache->las_entry_count,
-				    insert_cnt, "lookaside entry count");
-		} else
+		if (ret == 0)
+			WT_TRET(__wt_txn_commit(las_session, NULL));
+		else
 			WT_TRET(__wt_txn_rollback(las_session, NULL));
+
+		/* Adjust the entry count. */
+		if (ret == 0)
+			__wt_atomic_add64(
+			    &conn->cache->las_insert_count, insert_cnt);
 	}
 
 	__las_restore_isolation(las_session, saved_isolation);
@@ -853,9 +857,7 @@ __wt_las_remove_block(
 	else
 		WT_TRET(__wt_txn_rollback(las_session, NULL));
 	if (ret == 0)
-		__wt_cache_decr_check_uint64(session,
-		    &conn->cache->las_entry_count,
-		    remove_cnt, "lookaside entry count");
+		__wt_atomic_add64(&conn->cache->las_remove_count, remove_cnt);
 
 err:	__las_restore_isolation(las_session, saved_isolation);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
@@ -908,8 +910,8 @@ __las_sweep_count(WT_CACHE *cache)
 	 * with lookaside entries are blocked during sweep, make sure we do
 	 * some work but don't block reads for too long.
 	 */
-	return ((uint64_t)WT_MAX(100,
-	    cache->las_entry_count / (WT_MINUTE * 5 / WT_LAS_SWEEP_SEC)));
+	return ((uint64_t)WT_MAX(100, __wt_las_entry_count(cache) /
+	     (5 * WT_MINUTE / WT_LAS_SWEEP_SEC)));
 }
 
 /*
@@ -932,7 +934,7 @@ __las_sweep_init(WT_SESSION_IMPL *session)
 	 * there's nothing to do.
 	 */
 	if (cache->las_dropped_next == 0) {
-		if (cache->las_entry_count == 0)
+		if (__wt_las_empty(session))
 			ret = WT_NOTFOUND;
 		goto err;
 	}
@@ -1188,9 +1190,8 @@ err:		__wt_buf_free(session, sweep_key);
 		else
 			WT_TRET(__wt_txn_rollback(session, NULL));
 		if (ret == 0)
-			__wt_cache_decr_check_uint64(session,
-			    &S2C(session)->cache->las_entry_count,
-			    remove_cnt, "lookaside entry count");
+			__wt_atomic_add64(
+			    &cache->las_remove_count, remove_cnt);
 	}
 	if (locked)
 		__wt_writeunlock(session, &cache->las_sweepwalk_lock);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -313,7 +313,7 @@ __sweep_server(void *arg)
 		 * which will stop the cache from moving into the stuck state.
 		 */
 		if (now - last >= WT_LAS_SWEEP_SEC &&
-		    __wt_las_nonempty(session) &&
+		    !__wt_las_empty(session) &&
 		    !__wt_cache_stuck(session)) {
 			oldest_id = __wt_txn_oldest_id(session);
 			if (WT_TXNID_LT(last_las_sweep_id, oldest_id)) {

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -200,7 +200,8 @@ struct __wt_cache {
 	bool las_session_inuse[WT_LAS_NUM_SESSIONS];
 
 	uint32_t las_fileid;            /* Lookaside table file ID */
-	uint64_t las_entry_count;       /* Count of entries in lookaside */
+	uint64_t las_insert_count;      /* Count of inserts to lookaside */
+	uint64_t las_remove_count;      /* Count of removes from lookaside */
 	uint64_t las_pageid;		/* Lookaside table page ID counter */
 
 	bool las_reader;		/* Indicate an LAS reader to sweep */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -201,7 +201,8 @@ extern int __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_
 extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt, bool insert, bool restore) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wt_las_nonempty(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint64_t __wt_las_entry_count(WT_CACHE *cache);
+extern bool __wt_las_empty(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_las_stats_update(WT_SESSION_IMPL *session);
 extern int __wt_las_create(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -201,7 +201,6 @@ extern int __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_
 extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt, bool insert, bool restore) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern uint64_t __wt_las_entry_count(WT_CACHE *cache);
 extern bool __wt_las_empty(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_las_stats_update(WT_SESSION_IMPL *session);
 extern int __wt_las_create(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -79,8 +79,10 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 		}
 	}
 	WT_ERR_NOTFOUND_OK(ret);
-err:	if (ret == 0)
-		conn->cache->las_entry_count = las_total;
+err:	if (ret == 0) {
+		conn->cache->las_insert_count = las_total;
+		conn->cache->las_remove_count = 0;
+	}
 	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
 


### PR DESCRIPTION
If there is a race between inserting and removing lookaside records (or some bug where the entry count is not updated correctly), treat underflow the same as a zero entry count (i.e., treat the lookaside table as empty).

At worst, this will leave some data in the lookaside table that could potentially be swept.  It should avoid assertion failures during tests while we search for the source of the underflow.