### PR TITLE
WT-4051 format configures too-small LSM caches.

### DIFF
--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -193,6 +193,13 @@ struct __wt_lsm_manager {
 #define	WT_LSM_AGGRESSIVE_THRESHOLD	2
 
 /*
+ * The minimum size for opening a tree: three chunks, plus one page for each
+ * participant in up to three concurrent merges.
+ */
+#define	WT_LSM_TREE_MINIMUM_SIZE(chunk_size, merge_max, maxleafpage)	\
+	(3 * (chunk_size) + 3 * ((merge_max) * (maxleafpage)))
+
+/*
  * WT_LSM_TREE --
  *	An LSM tree.
  */

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -311,7 +311,7 @@ config_cache(void)
 		required = WT_LSM_TREE_MINIMUM_SIZE(
 		    g.c_chunk_size * WT_MEGABYTE,
 		    g.c_threads * g.c_merge_max, g.c_threads * g.leaf_page_max);
-		required = WT_ALIGN(required, WT_MEGABYTE) / WT_MEGABYTE;
+		required = (required + (WT_MEGABYTE - 1)) / WT_MEGABYTE;
 		if (g.c_cache < required)
 			g.c_cache = required;
 	}

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -264,6 +264,9 @@ typedef struct {
 #define	ISOLATION_SNAPSHOT		4
 	u_int c_isolation_flag;			/* Isolation flag value */
 
+	uint32_t intl_page_max;			/* Maximum page sizes */
+	uint32_t leaf_page_max;
+
 	uint64_t key_cnt;			/* Keys loaded so far */
 	uint64_t rows;				/* Total rows */
 

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -368,22 +368,19 @@ wts_init(void)
 	    "internal_page_max=%" PRIu32 ",leaf_page_max=%" PRIu32,
 	    (g.type == ROW) ? "u" : "r",
 	    g.c_firstfit ? "block_allocation=first," : "",
-	    g.c_intl_page_max, g.c_leaf_page_max);
+	    g.intl_page_max, g.leaf_page_max);
 
 	/*
 	 * Configure the maximum key/value sizes, but leave it as the default
 	 * if we come up with something crazy.
 	 */
-	maxintlkey =
-	    mmrand(NULL, g.c_intl_page_max / 50, g.c_intl_page_max / 40);
+	maxintlkey = mmrand(NULL, g.intl_page_max / 50, g.intl_page_max / 40);
 	if (maxintlkey > 20)
 		CONFIG_APPEND(p, ",internal_key_max=%" PRIu32, maxintlkey);
-	maxleafkey =
-	    mmrand(NULL, g.c_leaf_page_max / 50, g.c_leaf_page_max / 40);
+	maxleafkey = mmrand(NULL, g.leaf_page_max / 50, g.leaf_page_max / 40);
 	if (maxleafkey > 20)
 		CONFIG_APPEND(p, ",leaf_key_max=%" PRIu32, maxleafkey);
-	maxleafvalue =
-	    mmrand(NULL, g.c_leaf_page_max * 10, g.c_leaf_page_max / 40);
+	maxleafvalue = mmrand(NULL, g.leaf_page_max * 10, g.leaf_page_max / 40);
 	if (maxleafvalue > 40 && maxleafvalue < 100 * 1024)
 		CONFIG_APPEND(p, ",leaf_value_max=%" PRIu32, maxleafvalue);
 


### PR DESCRIPTION
@sueloverso, I'm going to merge this once it passes PR testing to get general testing back on track, but if you'd take a look when you're back next week, I'd really appreciate it.

Thanks!