### PR TITLE
WT-4037 Fix a bug where WT_REF structures are freed while still in use (v3.4 backport)

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -462,6 +462,9 @@ __split_ref_prepare(WT_SESSION_IMPL *session,
 	 * ascend into the created children, but eventually fail as that parent
 	 * page won't yet know about the created children pages. That's OK, we
 	 * spin there until the parent's page index is updated.
+	 *
+	 * Lock the newly created page to ensure it doesn't split until all
+	 * child pages have been updated.
 	 */
 	for (i = skip_first ? 1 : 0; i < pindex->entries; ++i) {
 		ref = pindex->index[i];
@@ -495,12 +498,14 @@ __split_ref_prepare(WT_SESSION_IMPL *session,
 		 * reading the child's page index structure is safe.
 		 */
 		j = 0;
+		WT_PAGE_LOCK(session, child);
 		WT_ENTER_PAGE_INDEX(session);
 		WT_INTL_FOREACH_BEGIN(session, child, child_ref) {
 			child_ref->home = child;
 			child_ref->pindex_hint = j++;
 		} WT_INTL_FOREACH_END;
 		WT_LEAVE_PAGE_INDEX(session);
+		WT_PAGE_UNLOCK(session, child);
 
 #ifdef HAVE_DIAGNOSTIC
 		WT_WITH_PAGE_INDEX(session,

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1219,19 +1219,12 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	/* Start making real changes to the tree, errors are fatal. */
 	complete = WT_ERR_PANIC;
 
-	/* Prepare the WT_REFs for the move. */
-	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, true));
-
-	/* Split into the parent. */
-	WT_ERR(__split_parent(session, page_ref, alloc_index->index,
-	    alloc_index->entries, parent_incr, false, false));
-
 	/*
 	 * Prepare the WT_REFs for the move: this requires a stable split
 	 * generation to block splits in newly created pages, so get one.
 	 */
 	WT_ENTER_PAGE_INDEX(session);
-	__split_ref_prepare(session, alloc_index, &locked, true);
+	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, true));
 
 	/* Split into the parent. */
 	if ((ret = __split_parent(session, page_ref, alloc_index->index,

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -616,7 +616,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	 * created pages are set to the current split generation and so can't be
 	 * evicted until all readers have left the old generation.
 	 */
-	split_gen = __wt_gen_next(session, WT_GEN_SPLIT);
+	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 	WT_ASSERT(session, root->pg_intl_split_gen < split_gen);
 
 	/* Allocate child pages, and connect them into the new page index. */
@@ -645,6 +645,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 
 		/* Initialize the child page. */
 		child->pg_intl_parent_ref = ref;
+		child->pg_intl_split_gen = split_gen;
 
 		/* Mark it dirty. */
 		WT_ERR(__wt_page_modify_init(session, child));
@@ -677,11 +678,8 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	complete = WT_ERR_PANIC;
 
 	/* Prepare the WT_REFs for the move. */
+	WT_ENTER_PAGE_INDEX(session);
 	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, false));
-
-	/* Encourage a race */
-	__page_split_timing_stress(session,
-	    WT_TIMING_STRESS_SPLIT_RACE_1, 100 * WT_THOUSAND);
 
 	/*
 	 * Confirm the root page's index hasn't moved, then update it, which
@@ -1160,7 +1158,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	 * created pages are set to the current split generation and so can't be
 	 * evicted until all readers have left the old generation.
 	 */
-	split_gen = __wt_gen_next(session, WT_GEN_SPLIT);
+	split_gen = __wt_atomic_addv64(&S2C(session)->split_gen, 1);
 	WT_ASSERT(session, page->pg_intl_split_gen < split_gen);
 
 	/* Allocate child pages, and connect them into the new page index. */
@@ -1189,6 +1187,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
 		/* Initialize the child page. */
 		child->pg_intl_parent_ref = ref;
+		child->pg_intl_split_gen = split_gen;
 
 		/* Mark it dirty. */
 		WT_ERR(__wt_page_modify_init(session, child));
@@ -1223,10 +1222,6 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	/* Prepare the WT_REFs for the move. */
 	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, true));
 
-	/* Encourage a race */
-	__page_split_timing_stress(session,
-	    WT_TIMING_STRESS_SPLIT_RACE_5, 100 * WT_THOUSAND);
-
 	/* Split into the parent. */
 	WT_ERR(__split_parent(session, page_ref, alloc_index->index,
 	    alloc_index->entries, parent_incr, false, false));
@@ -1236,7 +1231,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	 * generation to block splits in newly created pages, so get one.
 	 */
 	WT_ENTER_PAGE_INDEX(session);
-	__split_ref_prepare(session, alloc_index, session->split_gen, true);
+	__split_ref_prepare(session, alloc_index, &locked, true);
 
 	/* Split into the parent. */
 	if ((ret = __split_parent(session, page_ref, alloc_index->index,


### PR DESCRIPTION
This PR includes backport changes for both WT-3710 and WT-4037. 