### PR TITLE
WT-4045 Don't retry fsync calls after EIO failure. (v3.6 backport)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -146,6 +146,7 @@ Fprintf
 FreeBSD
 FreeBSD's
 FreeLibrary
+Fsync
 Fuerst
 GCC
 GIDs
@@ -213,6 +214,7 @@ LSM
 LSN
 LSNs
 LTE
+LWN
 LZ
 LZO
 LeafGreen
@@ -293,6 +295,7 @@ Pandis
 Phong
 PlatformSDK
 Posix
+PostgreSQL
 PowerPC
 Pre
 Preload


### PR DESCRIPTION
(cherry picked from commit ae8bccce3d8a8248afa0e4e0cf67674a43dede96)