### PR TITLE
WT-4075 Allow timestamp_transaction after prepare.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1785,7 +1785,8 @@ __session_timestamp_transaction(WT_SESSION *wt_session, const char *config)
 	SESSION_API_CALL_PREPARE_ALLOWED(session,
 	    timestamp_transaction, config, cfg);
 #else
-	SESSION_API_CALL(session, timestamp_transaction, NULL, cfg);
+	SESSION_API_CALL_PREPARE_ALLOWED(session,
+	    timestamp_transaction, NULL, cfg);
 	cfg[1] = config;
 #endif
 	WT_TRET(__wt_txn_set_timestamp(session, cfg));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1782,7 +1782,8 @@ __session_timestamp_transaction(WT_SESSION *wt_session, const char *config)
 
 	session = (WT_SESSION_IMPL *)wt_session;
 #ifdef HAVE_DIAGNOSTIC
-	SESSION_API_CALL(session, timestamp_transaction, config, cfg);
+	SESSION_API_CALL_PREPARE_ALLOWED(session,
+	    timestamp_transaction, config, cfg);
 #else
 	SESSION_API_CALL(session, timestamp_transaction, NULL, cfg);
 	cfg[1] = config;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -713,7 +713,9 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_ERR_MSG(session, EINVAL, "commit_timestamp requires a "
 		    "version of WiredTiger built with timestamp support");
 #endif
-	} else if (F_ISSET(txn, WT_TXN_PREPARE))
+	}
+	if (F_ISSET(txn, WT_TXN_PREPARE) &&
+	    !F_ISSET(txn, WT_TXN_HAS_TS_COMMIT))
 		WT_ERR_MSG(session, EINVAL,
 		    "commit_timestamp is required for a prepared transaction");
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -657,6 +657,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 
 	/* Look for a commit timestamp. */
 	ret = __wt_config_gets_def(session, cfg, "commit_timestamp", 0, &cval);
+	WT_RET_NOTFOUND_OK(ret);
 	if (ret == 0 && cval.len != 0) {
 #ifdef HAVE_TIMESTAMPS
 		WT_TXN *txn = &session->txn;
@@ -677,8 +678,6 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		 * but no other timestamp.
 		 */
 		WT_RET(__wt_txn_context_prepare_check(session));
-
-	WT_RET_NOTFOUND_OK(ret);
 
 	/* Look for a read timestamp. */
 	WT_RET(__wt_txn_parse_read_timestamp(session, cfg));

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -671,7 +671,13 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_RET_MSG(session, ENOTSUP, "commit_timestamp requires a "
 		    "version of WiredTiger built with timestamp support");
 #endif
-	}
+	} else
+		/*
+		 * We allow setting the commit timestamp after a prepare
+		 * but no other timestamp.
+		 */
+		WT_RET(__wt_txn_context_prepare_check(session));
+
 	WT_RET_NOTFOUND_OK(ret);
 
 	/* Look for a read timestamp. */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -581,39 +581,30 @@ set_commit_timestamp(TINFO *tinfo)
  *     Commit a transaction.
  */
 static void
-commit_transaction(TINFO *tinfo, WT_SESSION *session, bool prepared)
+commit_transaction(TINFO *tinfo, WT_SESSION *session)
 {
 	uint64_t ts;
-	char *config, config_buf[64];
+	char config_buf[64];
 
 	++tinfo->commit;
 
-	config = NULL;
 	if (g.c_txn_timestamps) {
 		ts = set_commit_timestamp(tinfo);
 		testutil_check(__wt_snprintf(
 		    config_buf, sizeof(config_buf),
 		    "commit_timestamp=%" PRIx64, ts));
-		config = config_buf;
-	}
-
-	if (prepared)
-		testutil_check(session->commit_transaction(session, config));
-
-	if (!prepared)
-		testutil_check(session->timestamp_transaction(session, config));
-
-	/*
-	 * Clear the thread's active timestamp: it no longer needs to be pinned.
-	 * Don't let the compiler re-order this statement, if we were to race
-	 * with the timestamp thread, it might see our thread update before the
-	 * commit_timestamp is set for the transaction.
-	 */
-	if (g.c_txn_timestamps)
+		testutil_check(
+		    session->timestamp_transaction(session, config_buf));
+		/*
+		 * Clear the thread's active timestamp: it no longer needs to
+		 * be pinned.  Don't let the compiler re-order this statement,
+		 * if we were to race with the timestamp thread, it might see
+		 * our thread update before the commit_timestamp is set for the
+		 * transaction.
+		 */
 		WT_PUBLISH(tinfo->commit_timestamp, 0);
-
-	if (!prepared)
-		testutil_check(session->commit_transaction(session, NULL));
+	}
+	testutil_check(session->commit_transaction(session, NULL));
 }
 
 /*
@@ -708,7 +699,7 @@ ops(void *arg)
 	uint64_t reset_op, session_op, truncate_op;
 	uint32_t range, rnd;
 	u_int i, j, iso_config;
-	bool greater_than, intxn, next, positioned, prepared, readonly;
+	bool greater_than, intxn, next, positioned, readonly;
 
 	tinfo = arg;
 
@@ -749,7 +740,7 @@ ops(void *arg)
 			 * resolve any running transaction.
 			 */
 			if (intxn) {
-				commit_transaction(tinfo, session, false);
+				commit_transaction(tinfo, session);
 				intxn = false;
 			}
 
@@ -1112,14 +1103,12 @@ update_instead_of_chosen_op:
 		 * If prepare configured, prepare the transaction 10% of the
 		 * time.
 		 */
-		prepared = false;
 		if (g.c_prepare && mmrand(&tinfo->rnd, 1, 10) == 1) {
 			ret = prepare_transaction(tinfo, session);
 			testutil_assert(ret == 0 || ret == WT_PREPARE_CONFLICT);
 			if (ret == WT_PREPARE_CONFLICT)
 				goto rollback;
 
-			prepared = true;
 			__wt_yield();		/* Let other threads proceed. */
 		}
 
@@ -1129,7 +1118,7 @@ update_instead_of_chosen_op:
 		 */
 		switch (rnd) {
 		case 1: case 2: case 3: case 4:			/* 40% */
-			commit_transaction(tinfo, session, prepared);
+			commit_transaction(tinfo, session);
 			break;
 		case 5:						/* 10% */
 rollback:		rollback_transaction(tinfo, session);

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -99,7 +99,7 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
             lambda:self.session.prepare_transaction("prepare_timestamp=2a"), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                "commit_timestamp=2a"), msg)
+                "read_timestamp=2a"), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda:self.session.checkpoint(), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
@@ -113,6 +113,14 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
         c1 = self.session.open_cursor("table:mytable", None)
         self.session.prepare_transaction("prepare_timestamp=2a")
         self.session.commit_transaction("commit_timestamp=2b")
+
+        # Setting commit timestamp via timestamp_transaction after
+        # prepare is also permitted.
+        self.session.begin_transaction()
+        c1 = self.session.open_cursor("table:mytable", None)
+        self.session.prepare_transaction("prepare_timestamp=2a")
+        self.session.timestamp_transaction("commit_timestamp=2b")
+        self.session.commit_transaction()
 
         # Rollback after prepare is permitted.
         self.session.begin_transaction()


### PR DESCRIPTION
I made these modifications. @keithbostic please review the reversion (discussed in the ticket) to `test/format` for this. I ran this with the CONFIG from WT-3698 and it has run some iterations.

@michaelcahill or @bvpvamsikrishna please review the code and unit test changes.