### PR TITLE
WT-4049 Adjust restarted search backoff algorithm.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -474,6 +474,7 @@ autocommit
 autoconf
 automake
 bInheritHandle
+backoff
 bal
 basecfg
 basho

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -443,7 +443,7 @@ static void
 __cursor_restart(
     WT_SESSION_IMPL *session, uint64_t *yield_count, uint64_t *sleep_usecs)
 {
-	__wt_state_yield_sleep(yield_count, sleep_usecs);
+	__wt_spin_backoff(yield_count, sleep_usecs);
 
 	WT_STAT_CONN_INCR(session, cursor_restart);
 	WT_STAT_DATA_INCR(session, cursor_restart);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -222,7 +222,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		 * and if we've yielded enough times, start sleeping so we
 		 * don't burn CPU to no purpose.
 		 */
-		__wt_state_yield_sleep(&yield_count, &sleep_usecs);
+		__wt_spin_backoff(&yield_count, &sleep_usecs);
 		WT_STAT_CONN_INCRV(session,
 		    page_del_rollback_blocked, sleep_usecs);
 	}

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -810,7 +810,7 @@ skip_evict:		/*
 			if (cache_work)
 				continue;
 		}
-		__wt_state_yield_sleep(&yield_cnt, &sleep_usecs);
+		__wt_spin_backoff(&yield_cnt, &sleep_usecs);
 		WT_STAT_CONN_INCRV(session, page_sleep, sleep_usecs);
 	}
 }

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -70,7 +70,7 @@ __ref_index_slot(WT_SESSION_IMPL *session,
 		 * before retrying, and if we've yielded enough times, start
 		 * sleeping so we don't burn CPU to no purpose.
 		 */
-		__wt_state_yield_sleep(&yield_count, &sleep_usecs);
+		__wt_spin_backoff(&yield_count, &sleep_usecs);
 		WT_STAT_CONN_INCRV(session, page_index_slot_ref_blocked,
 		    sleep_usecs);
 	}
@@ -476,7 +476,7 @@ restart:	/*
 				 * enough times, start sleeping so we don't burn
 				 * CPU to no purpose.
 				 */
-				__wt_state_yield_sleep(
+				__wt_spin_backoff(
 				    &yield_count, &sleep_usecs);
 
 				/*

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -226,10 +226,10 @@ __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
 
 /*
  * __wt_spin_backoff --
- *	Backoff spinning for a resource. This is used to avoid busy waiting
- *      loops that can consume enough CPU to block real work being done.
- *      The algorithm spins a few times, then yields for a while, then falls
- *      back to sleeping.
+ *	Back off while spinning for a resource. This is used to avoid busy
+ *	waiting loops that can consume enough CPU to block real work being
+ *	done. The algorithm spins a few times, then yields for a while, then
+ *	falls back to sleeping.
  */
 static inline void
 __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -225,16 +225,20 @@ __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
 }
 
 /*
- * __wt_state_yield_sleep --
- *	Sleep while waiting, after a thousand yields.
+ * __wt_spin_backoff --
+ *	Backoff spinning for a resource. This is used to avoid busy waiting
+ *      loops that can consume enough CPU to block real work being done.
+ *      The algorithm spins a few times, then yields for a while, then falls
+ *      back to sleeping.
  */
 static inline void
-__wt_state_yield_sleep(uint64_t *yield_count, uint64_t *sleep_usecs)
+__wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
 {
-	/*
-	 * We yield before retrying, and if we've yielded enough times, start
-	 * sleeping so we don't burn CPU to no purpose.
-	 */
+	if ((*yield_count) < 10) {
+		(*yield_count)++;
+		return;
+	}
+
 	if ((*yield_count) < WT_THOUSAND) {
 		(*yield_count)++;
 		__wt_yield();


### PR DESCRIPTION
If we backoff too aggressively it makes page splits less effective in some workloads.