### PR TITLE
WT-4056 Add API to set minimum required file version. (#4092)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -443,14 +443,6 @@ connection_runtime_config = [
             above 0 configures periodic checkpoints''',
             min='0', max='100000'),
         ]),
-    Config('compatibility', '', r'''
-        set compatibility version of database.  Changing the compatibility
-        version requires that there are no active operations for the duration
-        of the call.''',
-        type='category', subconfig=[
-        Config('release', '', r'''
-            compatibility release version string'''),
-        ]),
     Config('error_prefix', '', r'''
         prefix string for error messages'''),
     Config('eviction', '', r'''
@@ -633,6 +625,34 @@ connection_runtime_config = [
             'write']),
 ]
 
+# wiredtiger_open and WT_CONNECTION.reconfigure compatibility configurations.
+compatibility_configuration_common = [
+    Config('release', '', r'''
+        compatibility release version string'''),
+]
+
+connection_reconfigure_compatibility_configuration = [
+    Config('compatibility', '', r'''
+        set compatibility version of database.  Changing the compatibility
+        version requires that there are no active operations for the duration
+        of the call.''',
+        type='category', subconfig=
+        compatibility_configuration_common)
+]
+wiredtiger_open_compatibility_configuration = [
+    Config('compatibility', '', r'''
+        set compatibility version of database.  Changing the compatibility
+        version requires that there are no active operations for the duration
+        of the call.''',
+        type='category', subconfig=
+        compatibility_configuration_common + [
+        Config('require_min', '', r'''
+            required minimum compatibility version of existing data files.
+            Must be less than or equal to any release version set in the
+            \c release setting. Has no effect if creating the database.'''),
+    ]),
+]
+
 # wiredtiger_open and WT_CONNECTION.reconfigure log configurations.
 log_configuration_common = [
     Config('archive', 'true', r'''
@@ -753,6 +773,7 @@ session_config = [
 
 wiredtiger_open_common =\
     connection_runtime_config +\
+    wiredtiger_open_compatibility_configuration +\
     wiredtiger_open_log_configuration +\
     wiredtiger_open_statistics_log_configuration + [
     Config('buffer_alignment', '-1', r'''
@@ -1353,6 +1374,7 @@ methods = {
         print global txn information''', type='boolean'),
 ]),
 'WT_CONNECTION.reconfigure' : Method(
+    connection_reconfigure_compatibility_configuration +\
     connection_reconfigure_log_configuration +\
     connection_reconfigure_statistics_log_configuration +\
     connection_runtime_config

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -68,7 +68,7 @@ static const WT_CONFIG_CHECK
 };
 
 static const WT_CONFIG_CHECK
-    confchk_wiredtiger_open_compatibility_subconfigs[] = {
+    confchk_WT_CONNECTION_reconfigure_compatibility_subconfigs[] = {
 	{ "release", "string", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };
@@ -145,7 +145,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	    confchk_wiredtiger_open_checkpoint_subconfigs, 2 },
 	{ "compatibility", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_compatibility_subconfigs, 1 },
+	    confchk_WT_CONNECTION_reconfigure_compatibility_subconfigs, 1 },
 	{ "error_prefix", "string", NULL, NULL, NULL, 0 },
 	{ "eviction", "category",
 	    NULL, NULL,
@@ -749,6 +749,13 @@ static const WT_CONFIG_CHECK confchk_table_meta[] = {
 };
 
 static const WT_CONFIG_CHECK
+    confchk_wiredtiger_open_compatibility_subconfigs[] = {
+	{ "release", "string", NULL, NULL, NULL, 0 },
+	{ "require_min", "string", NULL, NULL, NULL, 0 },
+	{ NULL, NULL, NULL, NULL, NULL, 0 }
+};
+
+static const WT_CONFIG_CHECK
     confchk_wiredtiger_open_encryption_subconfigs[] = {
 	{ "keyid", "string", NULL, NULL, NULL, 0 },
 	{ "name", "string", NULL, NULL, NULL, 0 },
@@ -806,7 +813,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "checkpoint_sync", "boolean", NULL, NULL, NULL, 0 },
 	{ "compatibility", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_compatibility_subconfigs, 1 },
+	    confchk_wiredtiger_open_compatibility_subconfigs, 2 },
 	{ "config_base", "boolean", NULL, NULL, NULL, 0 },
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
 	{ "direct_io", "list",
@@ -909,7 +916,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "checkpoint_sync", "boolean", NULL, NULL, NULL, 0 },
 	{ "compatibility", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_compatibility_subconfigs, 1 },
+	    confchk_wiredtiger_open_compatibility_subconfigs, 2 },
 	{ "config_base", "boolean", NULL, NULL, NULL, 0 },
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
 	{ "direct_io", "list",
@@ -1013,7 +1020,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "checkpoint_sync", "boolean", NULL, NULL, NULL, 0 },
 	{ "compatibility", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_compatibility_subconfigs, 1 },
+	    confchk_wiredtiger_open_compatibility_subconfigs, 2 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1111,7 +1118,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "checkpoint_sync", "boolean", NULL, NULL, NULL, 0 },
 	{ "compatibility", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_compatibility_subconfigs, 1 },
+	    confchk_wiredtiger_open_compatibility_subconfigs, 2 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1483,21 +1490,21 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
 	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=),config_base=true,"
-	  "create=false,direct_io=,encryption=(keyid=,name=,secretkey=),"
-	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
-	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
-	  "path=\".\"),readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,session_table_cache=true,"
-	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "checkpoint_sync=true,compatibility=(release=,require_min=),"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,"
+	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
+	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
@@ -1509,21 +1516,21 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
 	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=),config_base=true,"
-	  "create=false,direct_io=,encryption=(keyid=,name=,secretkey=),"
-	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
-	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
-	  "path=\".\"),readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,session_table_cache=true,"
-	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  "checkpoint_sync=true,compatibility=(release=,require_min=),"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,"
+	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
+	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
@@ -1535,8 +1542,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
 	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "checkpoint_sync=true,compatibility=(release=,require_min=),"
+	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
@@ -1559,8 +1566,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
 	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "checkpoint_sync=true,compatibility=(release=,require_min=),"
+	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2439,11 +2439,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_ERR(__conn_load_extensions(session, cfg, true));
 
 	/*
-	 * Set compatibility versions early so that any subsystem sees it.
-	 */
-	WT_ERR(__wt_conn_compat_config(session, cfg));
-
-	/*
 	 * If the application didn't configure its own file system, configure
 	 * one of ours. Check to ensure we have a valid file system.
 	 */
@@ -2462,6 +2457,13 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 
 	/* Make sure no other thread of control already owns this database. */
 	WT_ERR(__conn_single(session, cfg));
+
+	/*
+	 * Set compatibility versions early so that any subsystem sees it.
+	 * Call after we own the database so that we can know if the
+	 * database is new or not.
+	 */
+	WT_ERR(__wt_conn_compat_config(session, cfg, false));
 
 	/*
 	 * Capture the config_base setting file for later use. Again, if the

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -121,6 +121,18 @@ __logmgr_version(WT_SESSION_IMPL *session, bool reconfig)
 	}
 
 	/*
+	 * Set up the minimum log version required if needed.
+	 */
+	if (conn->compat_req_major != WT_CONN_COMPAT_NONE) {
+		if (conn->compat_req_major < WT_LOG_V2_MAJOR)
+			conn->log_req_version = 1;
+		else if (conn->compat_req_minor == WT_LOG_V2_MINOR)
+			conn->log_req_version = 2;
+		else
+			conn->log_req_version = WT_LOG_VERSION;
+	}
+
+	/*
 	 * If the version is the same, there is nothing to do.
 	 */
 	if (log->log_version == new_version)

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -9,15 +9,47 @@
 #include "wt_internal.h"
 
 /*
+ * __conn_compat_parse --
+ *	Parse a compatibility release string into its parts.
+ */
+static int
+__conn_compat_parse(WT_SESSION_IMPL *session,
+    WT_CONFIG_ITEM *cvalp, uint16_t *majorp, uint16_t *minorp)
+{
+	uint16_t unused_patch;
+
+	/*
+	 * Accept either a major.minor.patch release string or a major.minor
+	 * release string.  We ignore the patch value, but allow it in
+	 * the string.
+	 */
+	if (sscanf(cvalp->str,
+	    "%" SCNu16 ".%" SCNu16, majorp, minorp) != 2 &&
+	    sscanf(cvalp->str, "%" SCNu16 ".%" SCNu16 ".%" SCNu16,
+	    majorp, minorp, &unused_patch) != 3)
+		WT_RET_MSG(session, EINVAL,
+		    "illegal compatibility release");
+	if (*majorp > WIREDTIGER_VERSION_MAJOR)
+		WT_RET_MSG(session, ENOTSUP,
+		    "unsupported major version");
+	if (*majorp == WIREDTIGER_VERSION_MAJOR &&
+	    *minorp > WIREDTIGER_VERSION_MINOR)
+		WT_RET_MSG(session, ENOTSUP,
+		    "unsupported minor version");
+	return (0);
+}
+
+/*
  * __wt_conn_compat_config --
  *	Configure compatibility version.
  */
 int
-__wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg)
+__wt_conn_compat_config(
+    WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
 {
 	WT_CONFIG_ITEM cval;
 	WT_CONNECTION_IMPL *conn;
-	uint16_t major, minor, patch;
+	uint16_t major, minor;
 	bool txn_active;
 
 	conn = S2C(session);
@@ -25,34 +57,53 @@ __wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg)
 	if (cval.len == 0) {
 		conn->compat_major = WIREDTIGER_VERSION_MAJOR;
 		conn->compat_minor = WIREDTIGER_VERSION_MINOR;
-		return (0);
+	} else {
+		WT_RET(__conn_compat_parse(session, &cval, &major, &minor));
+
+		/*
+		 * We're doing an upgrade or downgrade, check whether
+		 * transactions are active.
+		 */
+		WT_RET(__wt_txn_activity_check(session, &txn_active));
+		if (txn_active)
+			WT_RET_MSG(session, ENOTSUP,
+			    "system must be quiescent"
+			    " for upgrade or downgrade");
+		conn->compat_major = major;
+		conn->compat_minor = minor;
 	}
 
 	/*
-	 * Accept either a major.minor release string or a major.minor.patch
-	 * release string.  We ignore the patch value, but allow it in the
-	 * string.
+	 * The required minimum cannot be set via reconfigure and it is
+	 * meaningless on a newly created database. We're done in those cases.
 	 */
-	if (sscanf(cval.str, "%" SCNu16 ".%" SCNu16, &major, &minor) != 2 &&
-	    sscanf(cval.str, "%" SCNu16 ".%" SCNu16 ".%" SCNu16,
-	    &major, &minor, &patch) != 3)
-		WT_RET_MSG(session, EINVAL, "illegal compatibility release");
-	if (major > WIREDTIGER_VERSION_MAJOR)
-		WT_RET_MSG(session, ENOTSUP, "unsupported major version");
-	if (major == WIREDTIGER_VERSION_MAJOR &&
-	    minor > WIREDTIGER_VERSION_MINOR)
-		WT_RET_MSG(session, ENOTSUP, "unsupported minor version");
+	if (reconfig || conn->is_new)
+		return (0);
 
 	/*
-	 * We're doing an upgrade or downgrade, check whether transactions are
-	 * active.
+	 * The minimum required version for existing files is only available
+	 * on opening the connection, not reconfigure.
 	 */
-	WT_RET(__wt_txn_activity_check(session, &txn_active));
-	if (txn_active)
+	WT_RET(__wt_config_gets(session,
+	    cfg, "compatibility.require_min", &cval));
+	if (cval.len == 0) {
+		conn->compat_req_major = WT_CONN_COMPAT_NONE;
+		conn->compat_req_minor = WT_CONN_COMPAT_NONE;
+		return (0);
+	}
+	WT_RET(__conn_compat_parse(session, &cval, &major, &minor));
+
+	/*
+	 * The minimum required must be less than or equal to the compatibility
+	 * release if one was set.
+	 */
+	if ((major > conn->compat_major) ||
+	    (major == conn->compat_major && minor > conn->compat_minor))
 		WT_RET_MSG(session, ENOTSUP,
-		    "system must be quiescent for upgrade or downgrade");
-	conn->compat_major = major;
-	conn->compat_minor = minor;
+		    "required min cannot be larger than compatibility release");
+	conn->compat_req_major = major;
+	conn->compat_req_minor = minor;
+
 	return (0);
 }
 
@@ -288,7 +339,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 	 * downgrade completes.
 	 */
 	WT_WITH_CHECKPOINT_LOCK(session,
-	    ret = __wt_conn_compat_config(session, cfg));
+	    ret = __wt_conn_compat_config(session, cfg, true));
 	WT_ERR(ret);
 	WT_ERR(__wt_conn_optrack_setup(session, cfg, true));
 	WT_ERR(__wt_conn_statistics_config(session, cfg));

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -177,6 +177,9 @@ struct __wt_connection_impl {
 
 	uint16_t compat_major;		/* Compatibility major version */
 	uint16_t compat_minor;		/* Compatibility minor version */
+#define	WT_CONN_COMPAT_NONE	UINT16_MAX
+	uint16_t compat_req_major;	/* Compatibility required major */
+	uint16_t compat_req_minor;	/* Compatibility required minor */
 
 	WT_EXTENSION_API extension_api;	/* Extension API */
 
@@ -338,6 +341,7 @@ struct __wt_connection_impl {
 	wt_off_t	 log_file_max;	/* Log file max size */
 	const char	*log_path;	/* Logging path format */
 	uint32_t	 log_prealloc;	/* Log file pre-allocation */
+	uint16_t	 log_req_version;/* Required log version */
 	uint32_t	 txn_logsync;	/* Log sync configuration */
 
 	WT_SESSION_IMPL *meta_ckpt_session;/* Metadata checkpoint session */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -287,7 +287,7 @@ extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIB
 extern int __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_connection_close(WT_CONNECTION_IMPL *conn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_optrack_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_optrack_teardown(WT_SESSION_IMPL *session, bool reconfig) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2740,6 +2740,10 @@ struct __wt_connection {
  * below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release
  * version string., a string; default empty.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;require_min, required minimum compatibility
+ * version of existing data files.  Must be less than or equal to any release
+ * version set in the \c release setting.  Has no effect if creating the
+ * database., a string; default empty.}
  * @config{ ),,}
  * @config{config_base, write the base configuration file if creating the
  * database.  If \c false in the config passed directly to ::wiredtiger_open\,

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -960,10 +960,21 @@ __log_open_verify(WT_SESSION_IMPL *session, uint32_t id, WT_FH **fhp,
 	 */
 	if (desc->version > WT_LOG_VERSION)
 		WT_ERR_MSG(session, WT_ERROR,
-		    "unsupported WiredTiger file version: this build "
+		    "unsupported WiredTiger file version: this build"
 		    " only supports versions up to %d,"
 		    " and the file is version %" PRIu16,
 		    WT_LOG_VERSION, desc->version);
+
+	/*
+	 * We error if the log version is less than the required minimum.
+	 */
+	if (conn->compat_req_major != WT_CONN_COMPAT_NONE &&
+	    desc->version < conn->log_req_version)
+		WT_ERR_MSG(session, WT_ERROR,
+		    "unsupported WiredTiger file version: this build"
+		    " requires a minimum version of %" PRIu16 ","
+		    " and the file is version %" PRIu16,
+		    conn->log_req_version, desc->version);
 
 	/*
 	 * Set up the return values if the magic number is valid.
@@ -1572,8 +1583,17 @@ __wt_log_open(WT_SESSION_IMPL *session)
 	if (firstlog == UINT32_MAX) {
 		WT_ASSERT(session, logcount == 0);
 		WT_INIT_LSN(&log->first_lsn);
-	} else
+	} else {
 		WT_SET_LSN(&log->first_lsn, firstlog, 0);
+		/*
+		 * If the user specified a required minimum version and we
+		 * have existing log files, check the last log now before
+		 * we create a new log file.
+		 */
+		if (conn->compat_req_major != WT_CONN_COMPAT_NONE)
+			WT_ERR(__log_open_verify(session,
+			    lastlog, NULL, NULL, &version));
+	}
 
 	/*
 	 * Start logging at the beginning of the next log file, no matter

--- a/test/suite/test_compat01.py
+++ b/test/suite/test_compat01.py
@@ -42,10 +42,11 @@ class test_compat01(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = "100K"
     tablename = 'test_compat01'
     uri = 'table:' + tablename
-    sync_list = [
-        '(method=fsync,enabled)',
-        '(method=none,enabled)',
-    ]
+    # Declare the log versions that do and do not have prevlsn.
+    # Log version 1 does not have the prevlsn record.
+    # Log version 2 introduced that record.
+    # Log version 3 continues to have that record.
+    min_logv = 2
 
     # The API uses only the major and minor numbers but accepts with
     # and without the patch number.  Test both.
@@ -80,13 +81,8 @@ class test_compat01(wttest.WiredTigerTestCase, suite_subprocess):
         return compat_str
 
     def conn_config(self):
-        # Cycle through the different transaction_sync values in a
-        # deterministic manner.
-        txn_sync = self.sync_list[
-            self.scenario_number % len(self.sync_list)]
         # Set archive false on the home directory.
-        log_str = 'log=(archive=false,enabled,file_max=%s),' % self.logmax + \
-            'transaction_sync="%s",' % txn_sync
+        log_str = 'log=(archive=false,enabled,file_max=%s),' % self.logmax
         compat_str = self.make_compat_str(True)
         self.pr("Conn config:" + log_str + compat_str)
         return log_str + compat_str

--- a/test/suite/test_compat02.py
+++ b/test/suite/test_compat02.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_compat02.py
+# Check compatibility API
+
+import fnmatch, os
+import wiredtiger, wttest
+from suite_subprocess import suite_subprocess
+from wtdataset import SimpleDataSet, simple_key
+from wtscenario import make_scenarios
+
+class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
+    # Add enough entries and use a small log size to generate more than
+    # one log file.
+    entries = 2000
+    logmax = "100K"
+    tablename = 'test_compat02'
+    uri = 'table:' + tablename
+    # Declare the log versions that do and do not have prevlsn.
+    # Log version 1 does not have the prevlsn record.
+    # Log version 2 introduced that record.
+    # Log version 3 continues to have that record.
+    min_logv = 2
+
+    # Test detecting a not-yet-existing log version. This should
+    # hold us for a couple years.
+    future_logv = 5
+    future_rel = "5.0"
+
+    # The API uses only the major and minor numbers but accepts with
+    # and without the patch number. Test one on release and the
+    # required minimum just for testing of parsing.
+    #
+    compat_create = [
+        ('def', dict(create_rel='none', log_create=3)),
+        ('31', dict(create_rel="3.1", log_create=3)),
+        ('30', dict(create_rel="3.0", log_create=2)),
+        ('26', dict(create_rel="2.6", log_create=1)),
+    ]
+    compat_release = [
+        ('def_rel', dict(rel='none', log_rel=3)),
+        ('31_rel', dict(rel="3.1", log_rel=3)),
+        ('30_rel', dict(rel="3.0", log_rel=2)),
+        ('26_rel', dict(rel="2.6", log_rel=1)),
+        ('26_patch_rel', dict(rel="2.6.1", log_rel=1)),
+    ]
+    compat_required = [
+        ('future_req', dict(req=future_rel, log_req=future_logv)),
+        ('31_req', dict(req="3.1", log_req=3)),
+        ('30_req', dict(req="3.0", log_req=2)),
+        ('26_req', dict(req="2.6", log_req=1)),
+        ('26_patch_req', dict(req="2.6.1", log_req=1)),
+    ]
+    base_config = [
+        ('basecfg_true', dict(basecfg='true')),
+        ('basecfg_false', dict(basecfg='false')),
+    ]
+    scenarios = make_scenarios(compat_create, compat_release, compat_required, base_config)
+
+    def conn_config(self):
+        # Set archive false on the home directory.
+        config_str = 'config_base=%s,' % self.basecfg
+        log_str = 'log=(archive=false,enabled,file_max=%s),' % self.logmax
+        compat_str = ''
+        if (self.create_rel != 'none'):
+            compat_str += 'compatibility=(release="%s"),' % self.create_rel
+        config_str += log_str + compat_str
+        self.pr("Conn config:" + config_str)
+        return config_str
+
+    def test_compat02(self):
+        #
+        # Create initial database at the compatibility level requested
+        # and a table with some data.
+        #
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        c = self.session.open_cursor(self.uri, None)
+        #
+        # Add some entries to generate log files.
+        #
+        for i in range(self.entries):
+            c[i] = i + 1
+        c.close()
+
+        # Close and reopen the connection with the required compatibility
+        # version. That configuration needs an existing database for it to be
+        # useful. Test for success or failure based on the relative versions
+        # configured.
+        compat_str = ''
+        if (self.req != 'none'):
+            #compat_str = 'verbose=(temporary),compatibility=(require_min="%s"),' % self.req
+            compat_str += 'compatibility=(require_min="%s"),' % self.req
+        if (self.rel != 'none'):
+            compat_str += 'compatibility=(release="%s"),' % self.rel
+        self.conn.close()
+        log_str = 'log=(enabled,file_max=%s,archive=false),' % self.logmax
+        restart_config = log_str + compat_str
+        self.pr("Restart conn " + restart_config)
+        #
+        # Open a connection with a minimum required database and a
+        # release compatibility setting.
+        #
+        msgunsup = "/unsupported major version/"
+        msglog = "/this build requires a minimum version/"
+        msgcompat = "/required min cannot be larger/"
+        if (self.log_req >= self.future_logv):
+            self.pr("EXPECT: " + msgunsup)
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.wiredtiger_open('.', restart_config), msgunsup)
+        elif (self.rel != 'none' and self.log_req > self.log_rel):
+            self.pr("EXPECT: " + msgcompat)
+            # If required minimum is larger than the compatibility
+            # setting we expect an error.
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.wiredtiger_open('.', restart_config), msgcompat)
+        elif (self.log_req > self.log_create):
+            self.pr("EXPECT: " + msglog)
+            # If required minimum is larger than the setting we created the
+            # database with, we expect an error.
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.wiredtiger_open('.', restart_config), msglog)
+        else:
+            # We expect success
+            self.pr("EXPECT: SUCCESS")
+            conn = self.wiredtiger_open('.', restart_config)
+            conn.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
* Add API to set minimum required file version.

* Move processing config into else clause.

* Whitespace in error message. Add test.

* Remove unused function

* Review comments and fixes for log file version bump.

(cherry picked from commit 3b1f623c2cd84e8df3b90adf2dc77a35c594d020)