### PR TITLE
Revert "WT-4076 Discard obsolete lookaside history from cache."

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -300,16 +300,14 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 
 	/*
 	 * Discard the page and update the reference structure. If evicting a
-	 * WT_REF_LIMBO page with active history, transition back to
-	 * WT_REF_LOOKASIDE. Otherwise, a page with a disk address is an
-	 * on-disk page, and a page without a disk address is a re-instantiated
-	 * deleted page (for example, by searching), that was never
-	 * subsequently written.
+	 * WT_REF_LIMBO page, transition back to WT_REF_LOOKASIDE. Otherwise,
+	 * a page with a disk address is an on-disk page, and a page without
+	 * a disk address is a re-instantiated deleted page (for example, by
+	 * searching), that was never subsequently written.
 	 */
 	__wt_ref_out(session, ref);
 	if (!closing && ref->page_las != NULL &&
-	    ref->page_las->eviction_to_lookaside &&
-	    __wt_page_las_active(session, ref)) {
+	    ref->page_las->eviction_to_lookaside) {
 		ref->page_las->eviction_to_lookaside = false;
 		WT_PUBLISH(ref->state, WT_REF_LOOKASIDE);
 	} else if (ref->addr == NULL) {
@@ -453,14 +451,6 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 			 * page.
 			 */
 			if (__wt_page_del_active(session, child, true))
-				return (EBUSY);
-			break;
-		case WT_REF_LOOKASIDE:
-			/*
-			 * If the lookaside history is obsolete, the reference
-			 * can be ignored.
-			 */
-			if (__wt_page_las_active(session, child))
 				return (EBUSY);
 			break;
 		default:

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1180,28 +1180,6 @@ __wt_page_del_active(
 }
 
 /*
- * __wt_page_las_active --
- *	Return if lookaside data for a page is still required.
- */
-static inline bool
-__wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
-{
-	WT_PAGE_LOOKASIDE *page_las;
-
-	if ((page_las = ref->page_las) == NULL)
-		return (false);
-	if (page_las->invalid)
-		return (false);
-	if (!ref->page_las->las_skew_newest)
-		return (true);
-	if (__wt_txn_visible_all(session, page_las->las_max_txn,
-	    WT_TIMESTAMP_NULL(&page_las->onpage_timestamp)))
-		return (false);
-
-	return (true);
-}
-
-/*
  * __wt_btree_can_evict_dirty --
  *	Check whether eviction of dirty pages or splits are permitted in the
  *	current tree.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1814,21 +1814,17 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			break;
 
 		case WT_REF_LIMBO:
-			WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT));
-			/* FALLTHROUGH */
 		case WT_REF_LOOKASIDE:
 			/*
-			 * On disk or in cache with lookaside updates.
+			 * On disk, with lookaside updates.
 			 *
-			 * We should never be here during eviction: active
+			 * We should never be here during eviction, active
 			 * child pages in an evicted page's subtree fails the
 			 * eviction attempt.
 			 */
-			if (F_ISSET(r, WT_REC_EVICT) &&
-			    __wt_page_las_active(session, ref)) {
-				WT_ASSERT(session, false);
+			WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT));
+			if (F_ISSET(r, WT_REC_EVICT))
 				return (EBUSY);
-			}
 
 			/*
 			 * A page evicted with lookaside entries may not have
@@ -1840,6 +1836,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 				*statep = WT_CHILD_IGNORE;
 				WT_CHILD_RELEASE(session, *hazardp, ref);
 			}
+
 			goto done;
 
 		case WT_REF_MEM:


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#4111

The change caused some automated test failures.