### PR TITLE
WT-4105 restore max modify update value and tune to run as short test.

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1076,7 +1076,7 @@ struct __wt_update {
  *	when history has to be maintained, resulting in multiplying cache
  *	pressure.
  */
-#define	WT_MAX_MODIFY_UPDATE	10000
+#define	WT_MAX_MODIFY_UPDATE	10
 
 /*
  * WT_MODIFY_MEM_FACTOR	--

--- a/test/csuite/wt4105_large_doc_small_upd/main.c
+++ b/test/csuite/wt4105_large_doc_small_upd/main.c
@@ -140,8 +140,8 @@ main(int argc, char *argv[])
 		for (i = 0; i < NUM_DOCS; i++) {
 			/* Position the cursor. */
 			c->set_key(c, i);
-			modify_entry.data.data = 
-			    "wiredtigerwiredtigerwiredtiger";
+			modify_entry.data.data =
+			    "abcdefghijklmnopqrstuvwxyz";
 			modify_entry.data.size = strlen(modify_entry.data.data);
 			modify_entry.offset = offset;
 			modify_entry.size = modify_entry.data.size;


### PR DESCRIPTION
Restored the max modify update value back to 10.
Tune the test to run as short test instead of long test.
print test statements are masked with verbose flag.