### PR TITLE
WT-4128 Skip creating checkpoints if the stable timestamp allows.

### DIFF
--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -101,37 +101,23 @@ __ckpt_server(void *arg)
 		if (!__ckpt_server_run_chk(session))
 			break;
 
-		/*
-		 * Checkpoint the database if the connection is marked dirty.
-		 * A connection is marked dirty whenever a btree gets marked
-		 * dirty, which reflects upon a change in the database that
-		 * needs to be checkpointed. Said that, there can be short
-		 * instances when a btree gets marked dirty and the connection
-		 * is yet to be. We might skip a checkpoint in that short
-		 * instance, which is okay because by the next time we get to
-		 * checkpoint, the connection would have been marked dirty and
-		 * hence the checkpoint will not be skipped this time.
-		 */
-		if (conn->modified) {
-			WT_ERR(wt_session->checkpoint(wt_session, NULL));
+		WT_ERR(wt_session->checkpoint(wt_session, NULL));
 
-			/* Reset. */
-			if (conn->ckpt_logsize) {
-				__wt_log_written_reset(session);
-				conn->ckpt_signalled = false;
+		/* Reset. */
+		if (conn->ckpt_logsize) {
+			__wt_log_written_reset(session);
+			conn->ckpt_signalled = false;
 
-				/*
-				 * In case we crossed the log limit during the
-				 * checkpoint and the condition variable was
-				 * already signalled, do a tiny wait to clear
-				 * it so we don't do another checkpoint
-				 * immediately.
-				 */
-				__wt_cond_wait(
-				    session, conn->ckpt_cond, 1, NULL);
-			}
-		} else
-			WT_STAT_CONN_INCR(session, txn_checkpoint_skipped);
+			/*
+			 * In case we crossed the log limit during the
+			 * checkpoint and the condition variable was
+			 * already signalled, do a tiny wait to clear
+			 * it so we don't do another checkpoint
+			 * immediately.
+			 */
+			__wt_cond_wait(
+			    session, conn->ckpt_cond, 1, NULL);
+		}
 	}
 
 	if (0) {

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -126,7 +126,7 @@ __checkpoint_update_generation(WT_SESSION_IMPL *session)
  */
 static int
 __checkpoint_apply_all(WT_SESSION_IMPL *session, const char *cfg[],
-    int (*op)(WT_SESSION_IMPL *, const char *[]), bool *fullp)
+    int (*op)(WT_SESSION_IMPL *, const char *[]))
 {
 	WT_CONFIG targetconf;
 	WT_CONFIG_ITEM cval, k, v;
@@ -195,9 +195,6 @@ __checkpoint_apply_all(WT_SESSION_IMPL *session, const char *cfg[],
 		    __wt_meta_apply_all(session, op, NULL, cfg) :
 		    __wt_conn_btree_apply(session, NULL, op, NULL, cfg));
 	}
-
-	if (fullp != NULL)
-		*fullp = !target_list;
 
 err:	__wt_scr_free(session, &tmp);
 	return (ret);
@@ -767,8 +764,84 @@ __checkpoint_prepare(
 	 */
 	WT_ASSERT(session, session->ckpt_handle_next == 0);
 	WT_WITH_TABLE_READ_LOCK(session, ret = __checkpoint_apply_all(
-	    session, cfg, __wt_checkpoint_get_handles, NULL));
+	    session, cfg, __wt_checkpoint_get_handles));
 	return (ret);
+}
+
+/*
+ * __txn_checkpoint_can_skip --
+ *	Determine whether it's safe to skip taking a checkpoint.
+ */
+static int
+__txn_checkpoint_can_skip(WT_SESSION_IMPL *session,
+    const char *cfg[], bool *fullp, bool *can_skipp)
+{
+	WT_CONFIG targetconf;
+	WT_CONFIG_ITEM cval, k, v;
+	WT_CONNECTION_IMPL *conn;
+	WT_TXN_GLOBAL *txn_global;
+	bool full;
+
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+	/* Default to not skipping. */
+	*can_skipp = false;
+
+	/*
+	 * Determine if this is going to be a full checkpoint, that is a
+	 * checkpoint that applies to all data tables in a database.
+	 */
+	WT_RET(__wt_config_gets(session, cfg, "target", &cval));
+	__wt_config_subinit(session, &targetconf, &cval);
+	full = __wt_config_next(&targetconf, &k, &v) != 0;
+	if (fullp != NULL)
+		*fullp = full;
+
+	/* Never skip non-full checkpoints */
+	if (!full)
+		return (0);
+
+	/* Never skip if force is configured. */
+	WT_RET(__wt_config_gets_def(session, cfg, "force", 0, &cval));
+	if (cval.val != 0)
+		return (0);
+
+	/* Never skip named checkpoints. */
+	WT_RET(__wt_config_gets(session, cfg, "name", &cval));
+	if (cval.val != 0)
+		return (0);
+
+	/*
+	 * Skip checkpointing the database if nothing has been dirtied since
+	 * the last checkpoint. That said there can be short instances when a
+	 * btree gets marked dirty and the connection is yet to be. We might
+	 * skip a checkpoint in that short instance, which is okay because by
+	 * the next time we get to checkpoint, the connection would have been
+	 * marked dirty and hence the checkpoint will not be skipped this time.
+	 */
+	if (!conn->modified) {
+		*can_skipp = true;
+		return (0);
+	}
+
+#ifdef HAVE_TIMESTAMPS
+	/*
+	 * If the checkpoint is using timestamps, and the stable timestamp
+	 * hasn't been updated since the last checkpoint there is nothing
+	 * more that could be written.
+	 */
+	WT_RET(__wt_config_gets(session, cfg, "use_timestamp", &cval));
+	if (cval.val != 0 &&
+	    txn_global->has_stable_timestamp &&
+	    !__wt_timestamp_iszero(&txn_global->last_ckpt_timestamp) &&
+	    __wt_timestamp_cmp(&txn_global->last_ckpt_timestamp,
+	    &txn_global->stable_timestamp) == 0) {
+		*can_skipp = true;
+		return (0);
+	}
+#endif
+
+	return (0);
 }
 
 /*
@@ -787,7 +860,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_TXN_ISOLATION saved_isolation;
 	uint64_t fsync_duration_usecs, generation, time_start, time_stop;
 	u_int i;
-	bool failed, full, idle, logging, tracking;
+	bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
 	void *saved_meta_next;
 
 	conn = S2C(session);
@@ -795,13 +868,20 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	txn = &session->txn;
 	txn_global = &conn->txn_global;
 	saved_isolation = session->isolation;
-	full = idle = logging = tracking = false;
+	full = idle = logging = tracking = use_timestamp = false;
+
+	/* Avoid doing work if possible. */
+	WT_RET(__txn_checkpoint_can_skip(session, cfg, &full, &can_skip));
+	if (can_skip) {
+		WT_STAT_CONN_INCR(session, txn_checkpoint_skipped);
+		return (0);
+	}
 
 	/*
 	 * Do a pass over the configuration arguments and figure out what kind
 	 * of checkpoint this is.
 	 */
-	WT_RET(__checkpoint_apply_all(session, cfg, NULL, &full));
+	WT_RET(__checkpoint_apply_all(session, cfg, NULL));
 
 	/* Configure logging only if doing a full checkpoint. */
 	logging = FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED);
@@ -994,8 +1074,17 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	if (full) {
 		__checkpoint_stats(session);
 #ifdef HAVE_TIMESTAMPS
-		__wt_timestamp_set(
-		    &conn->txn_global.last_ckpt_timestamp, &ckpt_tmp_ts);
+		/*
+		 * If timestamps were used to define the content of the
+		 * checkpoint update the saved last checkpoint timestamp,
+		 * otherwise leave it alone. If a checkpoint is taken without
+		 * timestamps, it's likely a bug, but we don't want to clear
+		 * the saved last checkpoint timestamp regardless.
+		 */
+		if (use_timestamp)
+			__wt_timestamp_set(
+			    &conn->txn_global.last_ckpt_timestamp,
+			    &ckpt_tmp_ts);
 #endif
 	}
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -839,6 +839,8 @@ __txn_checkpoint_can_skip(WT_SESSION_IMPL *session,
 		*can_skipp = true;
 		return (0);
 	}
+#else
+	WT_UNUSED(txn_global);
 #endif
 
 	return (0);


### PR DESCRIPTION
If the stable timestamp doesn't move between checkpoints, their content would be identical.
Also move the similar existing check for clean databases from the checkpoint server into the checkpoint code itself.