### PR TITLE
WT-4048 Extend timing_stress_for_test split options

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -31,24 +31,6 @@ typedef enum {
 } WT_SPLIT_ERROR_PHASE;
 
 /*
- * __page_split_timing_stress --
- *	Optionally add delay to simulate the race conditions in page split for
- * debug purposes. The purpose is to uncover the race conditions in page split.
- */
-static void
-__page_split_timing_stress(
-    WT_SESSION_IMPL *session, uint64_t flag, uint64_t micro_seconds)
-{
-	WT_CONNECTION_IMPL *conn;
-
-	conn = S2C(session);
-
-	/* We only want to sleep when page split race flag is set. */
-	if (FLD_ISSET(conn->timing_stress_flags, flag))
-		__wt_sleep(0, micro_seconds);
-}
-
-/*
  * __split_safe_free --
  *	Free a buffer if we can be sure no thread is accessing it, or schedule
  *	it to be freed otherwise.
@@ -566,8 +548,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, false));
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_1, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_1);
 
 	/*
 	 * Confirm the root page's index hasn't moved, then update it, which
@@ -578,8 +559,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 	alloc_index = NULL;
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_2, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_2);
 
 	/*
 	 * Get a generation for this split, mark the root page.  This must be
@@ -772,8 +752,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	WT_NOT_READ(complete, WT_ERR_PANIC);
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_3, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_3);
 
 	/*
 	 * Confirm the parent page's index hasn't moved then update it, which
@@ -784,8 +763,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 	alloc_index = NULL;
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_4, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_4);
 
 	/*
 	 * Get a generation for this split, mark the page.  This must be after
@@ -1125,8 +1103,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	WT_ERR(__split_ref_prepare(session, alloc_index, &locked, true));
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_5, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_5);
 
 	/* Split into the parent. */
 	WT_ERR(__split_parent(session, page_ref, alloc_index->index,
@@ -1140,8 +1117,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 	WT_INTL_INDEX_SET(page, replace_index);
 
 	/* Encourage a race */
-	__page_split_timing_stress(
-	    session, WT_TIMING_STRESS_SPLIT_6, TIMING_STRESS_TEST_SLEEP);
+	__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_6);
 
 	/*
 	 * Get a generation for this split, mark the parent page.  This must be
@@ -1259,8 +1235,7 @@ __split_internal_lock(
 		parent = ref->home;
 
 		/* Encourage races. */
-		__page_split_timing_stress(
-		    session, WT_TIMING_STRESS_SPLIT_7, WT_THOUSAND);
+		__wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_7);
 
 		/* Page locks live in the modify structure. */
 		WT_RET(__wt_page_modify_init(session, parent));

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -19,24 +19,6 @@
 	WT_SESSION_NO_RECONCILE)
 
 /*
- * __las_timing_stress --
- *	Optionally add delay to simulate the race conditions in lookaside
- * sweep for debug purposes.
- */
-static void
-__las_timing_stress(WT_SESSION_IMPL *session)
-{
-	WT_CONNECTION_IMPL *conn;
-
-	conn = S2C(session);
-
-	/* Only sleep when lookaside sweep race flag is set. */
-	if (FLD_ISSET(conn->timing_stress_flags,
-	    WT_TIMING_STRESS_LOOKASIDE_SWEEP))
-		__wt_sleep(0, TIMING_STRESS_TEST_SLEEP);
-}
-
-/*
  * __las_set_isolation --
  *	Switch to read-uncommitted.
  */
@@ -1052,7 +1034,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	locked = true;
 
 	/* Encourage a race */
-	__las_timing_stress(session);
+	__wt_timing_stress(session, WT_TIMING_STRESS_LOOKASIDE_SWEEP);
 
 	/*
 	 * When continuing a sweep, position the cursor using the key from the

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -336,6 +336,3 @@ union __wt_rand_state {
 			continue;					\
 		}
 #define	WT_TAILQ_SAFE_REMOVE_END }
-
-/* Sleep time to uncover race conditions during timing stress test. */
-#define	TIMING_STRESS_TEST_SLEEP	(100 * WT_THOUSAND)

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -248,3 +248,26 @@ __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
 	(*sleep_usecs) = WT_MIN((*sleep_usecs) + 100, WT_THOUSAND);
 	__wt_sleep(0, (*sleep_usecs));
 }
+
+				/* Maximum stress delay is 1/10 of a second. */
+#define	WT_TIMING_STRESS_MAX_DELAY	(100000)
+
+/*
+ * __wt_timing_stress --
+ *	Optionally add delay to stress code paths.
+ */
+static inline void
+__wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
+{
+	WT_CONNECTION_IMPL *conn;
+	uint64_t sleep_usecs;
+
+	conn = S2C(session);
+
+	/* Only sleep when the specified configuration flag is set. */
+	if (!FLD_ISSET(conn->timing_stress_flags, flag))
+		return;
+
+	sleep_usecs = __wt_random(&session->rnd) % WT_TIMING_STRESS_MAX_DELAY;
+	__wt_sleep(0, sleep_usecs);
+}


### PR DESCRIPTION
Make the timing stress function generally available.
Insert a random delay, up to 1/10th of a second, always delaying that long significantly slows down some applications which could lead to less useful testing.