### PR TITLE
WT-4138 Add option to timeout operations waiting for cache.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -417,6 +417,11 @@ connection_runtime_config = [
         maximum heap memory to allocate for the cache. A database should
         configure either \c cache_size or \c shared_cache but not both''',
         min='1MB', max='10TB'),
+    Config('cache_max_wait', '0', r'''
+        the maximum number of milliseconds an application thread will wait
+        for space to be available in cache before giving up. Default will
+        wait forever''',
+        min=0),
     Config('cache_overhead', '8', r'''
         assume the heap allocator overhead is the specified percentage, and
         adjust the cache usage by that amount (for example, if there is 10GB

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -417,7 +417,7 @@ connection_runtime_config = [
         maximum heap memory to allocate for the cache. A database should
         configure either \c cache_size or \c shared_cache but not both''',
         min='1MB', max='10TB'),
-    Config('cache_max_wait', '0', r'''
+    Config('cache_max_wait_ms', '0', r'''
         the maximum number of milliseconds an application thread will wait
         for space to be available in cache before giving up. Default will
         wait forever''',

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -279,6 +279,7 @@ connection_stats = [
     CacheStat('cache_read_lookaside_delay_checkpoint', 'pages read into cache with skipped lookaside entries needed later by checkpoint'),
     CacheStat('cache_read_lookaside_skipped', 'pages read into cache skipping older lookaside entries'),
     CacheStat('cache_read_overflow', 'overflow pages read into cache'),
+    CacheStat('cache_timed_out_ops', 'operations timed out waiting for space in cache'),
     CacheStat('cache_write', 'pages written from cache'),
     CacheStat('cache_write_app_count', 'application threads page write from cache to disk count'),
     CacheStat('cache_write_app_time', 'application threads page write from cache to disk time (usecs)'),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -138,7 +138,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	{ "async", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
-	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
+	{ "cache_max_wait_ms", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -807,7 +807,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
-	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
+	{ "cache_max_wait_ms", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -911,7 +911,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
-	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
+	{ "cache_max_wait_ms", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1016,7 +1016,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
-	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
+	{ "cache_max_wait_ms", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1115,7 +1115,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
-	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
+	{ "cache_max_wait_ms", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1255,13 +1255,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  confchk_WT_CONNECTION_query_timestamp, 1
 	},
 	{ "WT_CONNECTION.reconfigure",
-	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait=0,"
-	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
-	  ",compatibility=(release=),error_prefix=,eviction=(threads_max=8,"
-	  "threads_min=1),eviction_checkpoint_target=5,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
+	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait_ms=0"
+	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
+	  "wait=0),compatibility=(release=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
+	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
+	  ",file_manager=(close_handle_minimum=250,close_idle_time=30,"
 	  "close_scan_interval=10),log=(archive=true,prealloc=true,"
 	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
 	  "lsm_merge=true,operation_tracking=(enabled=false,path=\".\"),"
@@ -1494,24 +1494,24 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
-	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
-	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),config_base=true,create=false,direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
-	  "eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
-	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
-	  "path=\".\"),readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,session_table_cache=true,"
-	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  ",builtin_extension_config=,cache_cursors=true,"
+	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "compatibility=(release=,require_max=,require_min=),"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,"
+	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
+	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
@@ -1521,24 +1521,24 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
-	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
-	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),config_base=true,create=false,direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
-	  "eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",exclusive=false,extensions=,file_extend=,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
-	  "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
-	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
-	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
-	  "path=\".\"),readonly=false,session_max=100,"
-	  "session_scratch_max=2MB,session_table_cache=true,"
-	  "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+	  ",builtin_extension_config=,cache_cursors=true,"
+	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "compatibility=(release=,require_max=,require_min=),"
+	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
+	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
+	  "threads_min=1),eviction_checkpoint_target=5,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
+	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
+	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
+	  "in_memory=false,log=(archive=true,compressor=,enabled=false,"
+	  "file_max=100MB,path=\".\",prealloc=true,recover=on,"
+	  "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+	  "lsm_merge=true,mmap=true,multiprocess=false,"
+	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
+	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
+	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
@@ -1548,11 +1548,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
-	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
-	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),direct_io=,encryption=(keyid=,name=,secretkey=),"
-	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
+	  ",builtin_extension_config=,cache_cursors=true,"
+	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "compatibility=(release=,require_max=,require_min=),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
@@ -1572,11 +1573,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
-	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
-	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),direct_io=,encryption=(keyid=,name=,secretkey=),"
-	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
+	  ",builtin_extension_config=,cache_cursors=true,"
+	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
+	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
+	  "compatibility=(release=,require_max=,require_min=),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -138,6 +138,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	{ "async", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_async_subconfigs, 3 },
+	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -806,6 +807,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
+	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -909,6 +911,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
+	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1013,6 +1016,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
+	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1111,6 +1115,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0 },
 	{ "builtin_extension_config", "string", NULL, NULL, NULL, 0 },
 	{ "cache_cursors", "boolean", NULL, NULL, NULL, 0 },
+	{ "cache_max_wait", "int", NULL, "min=0", NULL, 0 },
 	{ "cache_overhead", "int", NULL, "min=0,max=30", NULL, 0 },
 	{ "cache_size", "int", NULL, "min=1MB,max=10TB", NULL, 0 },
 	{ "checkpoint", "category",
@@ -1250,9 +1255,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  confchk_WT_CONNECTION_query_timestamp, 1
 	},
 	{ "WT_CONNECTION.reconfigure",
-	  "async=(enabled=false,ops_max=1024,threads=2),cache_overhead=8,"
-	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "compatibility=(release=),error_prefix=,eviction=(threads_max=8,"
+	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait=0,"
+	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
+	  ",compatibility=(release=),error_prefix=,eviction=(threads_max=8,"
 	  "threads_min=1),eviction_checkpoint_target=5,"
 	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
 	  "eviction_target=80,eviction_trigger=95,"
@@ -1264,7 +1269,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,verbose=",
-	  confchk_WT_CONNECTION_reconfigure, 22
+	  confchk_WT_CONNECTION_reconfigure, 23
 	},
 	{ "WT_CONNECTION.rollback_to_stable",
 	  "",
@@ -1489,9 +1494,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	},
 	{ "wiredtiger_open",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
-	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
+	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
+	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
+	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,direct_io=,"
 	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
@@ -1512,13 +1517,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),use_environment=true,use_environment_priv=false,"
 	  "verbose=,write_through=",
-	  confchk_wiredtiger_open, 45
+	  confchk_wiredtiger_open, 46
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
-	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
+	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
+	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
+	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,direct_io=,"
 	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
@@ -1539,13 +1544,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),use_environment=true,use_environment_priv=false,"
 	  "verbose=,version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_all, 46
+	  confchk_wiredtiger_open_all, 47
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
-	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
+	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
+	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
+	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),direct_io=,encryption=(keyid=,name=,secretkey=),"
 	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
@@ -1563,13 +1568,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_basecfg, 40
+	  confchk_wiredtiger_open_basecfg, 41
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
-	  ",builtin_extension_config=,cache_cursors=true,cache_overhead=8,"
-	  "cache_size=100MB,checkpoint=(log_size=0,wait=0),"
-	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
+	  ",builtin_extension_config=,cache_cursors=true,cache_max_wait=0,"
+	  "cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,wait=0)"
+	  ",checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),direct_io=,encryption=(keyid=,name=,secretkey=),"
 	  "error_prefix=,eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=5,eviction_dirty_target=5,"
@@ -1587,7 +1592,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,write_through=",
-	  confchk_wiredtiger_open_usercfg, 39
+	  confchk_wiredtiger_open_usercfg, 40
 	},
 	{ NULL, NULL, NULL, 0 }
 };

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -144,7 +144,7 @@ __cache_config_local(WT_SESSION_IMPL *session, bool shared, const char *cfg[])
 	conn->evict_threads_min = evict_threads_min;
 
 	/* Retrieve the wait time and convert from milliseconds */
-	WT_RET(__wt_config_gets(session, cfg, "cache_max_wait", &cval));
+	WT_RET(__wt_config_gets(session, cfg, "cache_max_wait_ms", &cval));
 	cache->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
 
 	return (0);

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -143,6 +143,11 @@ __cache_config_local(WT_SESSION_IMPL *session, bool shared, const char *cfg[])
 	conn->evict_threads_max = evict_threads_max;
 	conn->evict_threads_min = evict_threads_min;
 
+	/* Retrieve the wait time and convert from milliseconds */
+	WT_RET(__wt_config_gets(session,
+	    cfg, "cache_max_wait", &cval));
+	cache->cache_max_wait_us = (uint32_t)cval.val * WT_THOUSAND;
+
 	return (0);
 }
 

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -144,9 +144,8 @@ __cache_config_local(WT_SESSION_IMPL *session, bool shared, const char *cfg[])
 	conn->evict_threads_min = evict_threads_min;
 
 	/* Retrieve the wait time and convert from milliseconds */
-	WT_RET(__wt_config_gets(session,
-	    cfg, "cache_max_wait", &cval));
-	cache->cache_max_wait_us = (uint32_t)cval.val * WT_THOUSAND;
+	WT_RET(__wt_config_gets(session, cfg, "cache_max_wait", &cval));
+	cache->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
 
 	return (0);
 }

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -48,6 +48,9 @@
 	WT_TRACK_OP_INIT(s);						\
 	WT_SINGLE_THREAD_CHECK_START(s);				\
 	WT_ERR(WT_SESSION_CHECK_PANIC(s));				\
+	/* Reset wait time if this isn't an API re entry. */		\
+	if (__oldname == NULL)						\
+		(s)->cache_wait_us = 0;					\
 	__wt_verbose((s), WT_VERB_API, "%s", "CALL: " #h ":" #n)
 
 #define	API_CALL_NOCONF(s, h, n, dh) do {				\

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -125,6 +125,8 @@ struct __wt_cache {
 					   scrubs */
 
 	u_int overhead_pct;	        /* Cache percent adjustment */
+	uint64_t cache_max_wait_us;	/* Maximum time an operation waits for
+					 * space in cache */
 
 	/*
 	 * Eviction thread tuning information.

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -141,6 +141,8 @@ struct __wt_session_impl {
 	u_int   ckpt_handle_next;	/* Next empty slot */
 	size_t  ckpt_handle_allocated;	/* Bytes allocated */
 
+	uint64_t cache_wait_us; /* Wait time for cache for current operation */
+
 	/*
 	 * Operations acting on handles.
 	 *

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -406,6 +406,7 @@ struct __wt_connection_stats {
 	int64_t cache_eviction_maximum_page_size;
 	int64_t cache_eviction_dirty;
 	int64_t cache_eviction_app_dirty;
+	int64_t cache_timed_out_ops;
 	int64_t cache_read_overflow;
 	int64_t cache_eviction_deepen;
 	int64_t cache_write_lookaside;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2128,7 +2128,7 @@ struct __wt_connection {
 	 * thread uses a session from the configured session_max., an integer
 	 * between 1 and 20; default \c 2.}
 	 * @config{ ),,}
-	 * @config{cache_max_wait, the maximum number of milliseconds an
+	 * @config{cache_max_wait_ms, the maximum number of milliseconds an
 	 * application thread will wait for space to be available in cache
 	 * before giving up.  Default will wait forever., an integer greater
 	 * than or equal to 0; default \c 0.}
@@ -2712,7 +2712,7 @@ struct __wt_connection {
  * default value for any sessions created\, and can be overridden in configuring
  * \c cache_cursors in WT_CONNECTION.open_session., a boolean flag; default \c
  * true.}
- * @config{cache_max_wait, the maximum number of milliseconds an application
+ * @config{cache_max_wait_ms, the maximum number of milliseconds an application
  * thread will wait for space to be available in cache before giving up.
  * Default will wait forever., an integer greater than or equal to 0; default \c
  * 0.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2128,6 +2128,10 @@ struct __wt_connection {
 	 * thread uses a session from the configured session_max., an integer
 	 * between 1 and 20; default \c 2.}
 	 * @config{ ),,}
+	 * @config{cache_max_wait, the maximum number of milliseconds an
+	 * application thread will wait for space to be available in cache
+	 * before giving up.  Default will wait forever., an integer greater
+	 * than or equal to 0; default \c 0.}
 	 * @config{cache_overhead, assume the heap allocator overhead is the
 	 * specified percentage\, and adjust the cache usage by that amount (for
 	 * example\, if there is 10GB of data in cache\, a percentage of 10
@@ -2708,6 +2712,10 @@ struct __wt_connection {
  * default value for any sessions created\, and can be overridden in configuring
  * \c cache_cursors in WT_CONNECTION.open_session., a boolean flag; default \c
  * true.}
+ * @config{cache_max_wait, the maximum number of milliseconds an application
+ * thread will wait for space to be available in cache before giving up.
+ * Default will wait forever., an integer greater than or equal to 0; default \c
+ * 0.}
  * @config{cache_overhead, assume the heap allocator overhead is the specified
  * percentage\, and adjust the cache usage by that amount (for example\, if
  * there is 10GB of data in cache\, a percentage of 10 means WiredTiger treats
@@ -5103,596 +5111,598 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1091
 /*! cache: modified pages evicted by application threads */
 #define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1092
+/*! cache: operations timed out waiting for space in cache */
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1093
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1093
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1094
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1094
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1095
 /*! cache: page written requiring lookaside records */
-#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1095
+#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1096
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1096
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1097
 /*! cache: pages evicted because they exceeded the in-memory maximum count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1097
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1098
 /*!
  * cache: pages evicted because they exceeded the in-memory maximum time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1098
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1099
 /*! cache: pages evicted because they had chains of deleted items count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1099
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1100
 /*!
  * cache: pages evicted because they had chains of deleted items time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1101
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1101
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1102
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1103
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1104
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1105
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1105
+#define	WT_STAT_CONN_CACHE_READ				1106
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1106
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1107
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1107
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1108
 /*! cache: pages read into cache requiring lookaside entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1108
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1109
 /*! cache: pages read into cache requiring lookaside for checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1109
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1110
 /*! cache: pages read into cache skipping older lookaside entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1110
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1111
 /*!
  * cache: pages read into cache with skipped lookaside entries needed
  * later
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1111
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1112
 /*!
  * cache: pages read into cache with skipped lookaside entries needed
  * later by checkpoint
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1112
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1113
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1113
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1114
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1114
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1115
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1115
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1116
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1116
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1117
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1117
+#define	WT_STAT_CONN_CACHE_WRITE			1118
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1118
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1119
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1119
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1120
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1120
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1121
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1121
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1122
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1122
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1123
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1123
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1124
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1124
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1125
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1125
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1126
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1126
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1127
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1127
+#define	WT_STAT_CONN_TIME_TRAVEL			1128
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1128
+#define	WT_STAT_CONN_FILE_OPEN				1129
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1129
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1130
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1130
+#define	WT_STAT_CONN_MEMORY_FREE			1131
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1131
+#define	WT_STAT_CONN_MEMORY_GROW			1132
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1132
+#define	WT_STAT_CONN_COND_WAIT				1133
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1133
+#define	WT_STAT_CONN_RWLOCK_READ			1134
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1134
+#define	WT_STAT_CONN_RWLOCK_WRITE			1135
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1135
+#define	WT_STAT_CONN_FSYNC_IO				1136
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1136
+#define	WT_STAT_CONN_READ_IO				1137
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1137
+#define	WT_STAT_CONN_WRITE_IO				1138
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1138
+#define	WT_STAT_CONN_CURSOR_CREATE			1139
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1139
+#define	WT_STAT_CONN_CURSOR_INSERT			1140
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1140
+#define	WT_STAT_CONN_CURSOR_MODIFY			1141
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1141
+#define	WT_STAT_CONN_CURSOR_NEXT			1142
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1142
+#define	WT_STAT_CONN_CURSOR_PREV			1143
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1143
+#define	WT_STAT_CONN_CURSOR_REMOVE			1144
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1144
+#define	WT_STAT_CONN_CURSOR_RESERVE			1145
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1145
+#define	WT_STAT_CONN_CURSOR_RESET			1146
 /*! cursor: cursor restarted searches */
-#define	WT_STAT_CONN_CURSOR_RESTART			1146
+#define	WT_STAT_CONN_CURSOR_RESTART			1147
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1147
+#define	WT_STAT_CONN_CURSOR_SEARCH			1148
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1148
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1149
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1149
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1150
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1150
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1151
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1151
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1152
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1152
+#define	WT_STAT_CONN_CURSOR_SWEEP			1153
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1153
+#define	WT_STAT_CONN_CURSOR_UPDATE			1154
 /*! cursor: cursors cached on close */
-#define	WT_STAT_CONN_CURSOR_CACHE			1154
+#define	WT_STAT_CONN_CURSOR_CACHE			1155
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1155
+#define	WT_STAT_CONN_CURSOR_REOPEN			1156
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1156
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1157
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1157
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1158
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1158
+#define	WT_STAT_CONN_DH_SWEEP_REF			1159
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1159
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1160
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1160
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1161
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1161
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1162
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1162
+#define	WT_STAT_CONN_DH_SWEEPS				1163
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1163
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1164
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1164
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1165
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1165
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1166
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1166
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1167
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1167
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1168
 /*!
  * lock: commit timestamp queue lock application thread time waiting for
  * the dhandle lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1168
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1169
 /*!
  * lock: commit timestamp queue lock internal thread time waiting for the
  * dhandle lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1169
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1170
 /*! lock: commit timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1170
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1171
 /*! lock: commit timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1171
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1172
 /*!
  * lock: dhandle lock application thread time waiting for the dhandle
  * lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1172
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1173
 /*!
  * lock: dhandle lock internal thread time waiting for the dhandle lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1173
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1174
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1174
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1175
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1175
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1176
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1176
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1177
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1177
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1178
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1178
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1179
 /*!
  * lock: read timestamp queue lock application thread time waiting for
  * the dhandle lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1179
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1180
 /*!
  * lock: read timestamp queue lock internal thread time waiting for the
  * dhandle lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1180
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1181
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1181
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1182
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1182
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1183
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1183
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1184
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1184
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1185
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1185
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1186
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1186
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1187
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1187
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1188
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1188
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1189
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1189
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1190
 /*!
  * lock: txn global lock application thread time waiting for the dhandle
  * lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1190
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1191
 /*!
  * lock: txn global lock internal thread time waiting for the dhandle
  * lock (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1191
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1192
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1192
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1193
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1193
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1194
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1194
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1195
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1195
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1196
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1196
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1197
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1197
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1198
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1198
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1199
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1199
+#define	WT_STAT_CONN_LOG_FLUSH				1200
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1200
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1201
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1201
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1202
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1202
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1203
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1203
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1204
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1204
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1205
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1205
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1206
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1206
+#define	WT_STAT_CONN_LOG_SCANS				1207
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1207
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1208
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1208
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1209
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1209
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1210
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1210
+#define	WT_STAT_CONN_LOG_SYNC				1211
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1211
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1212
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1212
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1213
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1213
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1214
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1214
+#define	WT_STAT_CONN_LOG_WRITES				1215
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1215
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1216
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1216
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1217
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1217
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1218
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1218
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1219
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1219
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1220
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1220
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1221
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1221
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1222
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1222
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1223
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1223
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1224
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1224
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1225
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1225
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1226
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1226
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1227
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1227
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1228
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1228
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1229
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1229
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1230
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1230
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1231
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1231
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1232
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1232
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1233
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1233
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1234
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1234
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1235
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1235
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1236
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1236
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1237
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1237
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1238
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1238
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1239
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1239
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1240
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1240
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1241
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1241
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1242
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1242
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1243
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1243
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1244
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1244
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1245
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1245
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1246
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1246
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1247
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1247
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1248
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1248
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1249
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1249
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1250
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1250
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1251
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1251
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1252
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1252
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1253
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1253
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1254
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1254
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1255
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1255
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1256
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1256
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1257
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1257
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1258
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1258
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1259
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1259
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1260
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1260
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1261
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1261
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1262
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1262
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1263
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1263
+#define	WT_STAT_CONN_REC_PAGES				1264
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1264
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1265
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1265
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1266
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1266
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1267
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1267
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1268
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1268
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1269
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1269
+#define	WT_STAT_CONN_SESSION_OPEN			1270
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1270
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1271
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1271
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1272
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1272
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1273
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1273
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1274
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1274
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1275
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1275
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1276
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1276
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1277
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1277
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1278
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1278
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1279
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1279
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1280
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1280
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1281
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1281
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1282
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1282
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1283
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1283
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1284
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1284
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1285
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1285
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1286
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1286
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1287
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1287
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1288
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1288
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1289
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1289
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1290
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1290
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1291
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1291
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1292
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1292
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1293
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1293
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1294
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1294
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1295
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1295
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1296
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1296
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1297
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1297
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1298
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1298
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1299
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1299
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1300
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1300
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1301
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1301
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1302
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1302
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1303
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1303
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1304
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1304
+#define	WT_STAT_CONN_PAGE_SLEEP				1305
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1305
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1306
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1306
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1307
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1307
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1308
 /*! transaction: commit timestamp queue inserts to tail */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_TAIL		1308
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_TAIL		1309
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1309
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1310
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1310
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1311
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1311
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1312
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1312
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1313
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1313
+#define	WT_STAT_CONN_TXN_PREPARE			1314
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1314
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1315
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1315
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1316
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1316
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1317
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1317
+#define	WT_STAT_CONN_TXN_QUERY_TS			1318
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1318
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1319
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1319
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1320
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1320
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1321
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1321
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1322
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1322
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1323
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1323
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1324
 /*! transaction: rollback to stable updates removed from lookaside */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1324
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1325
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1325
+#define	WT_STAT_CONN_TXN_SET_TS				1326
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1326
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1327
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1327
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1328
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1328
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1329
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1329
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1330
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1330
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1331
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1331
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1332
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1332
+#define	WT_STAT_CONN_TXN_BEGIN				1333
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1333
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1334
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1334
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1335
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1335
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1336
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1336
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1337
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1337
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1338
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1338
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1339
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1339
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1340
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1340
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1341
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1341
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1342
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1342
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1343
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1343
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1344
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1344
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1345
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1345
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1346
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1346
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1347
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1347
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1348
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1348
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1349
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1349
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1350
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1350
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1351
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1351
+#define	WT_STAT_CONN_TXN_SYNC				1352
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1352
+#define	WT_STAT_CONN_TXN_COMMIT				1353
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1353
+#define	WT_STAT_CONN_TXN_ROLLBACK			1354
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1354
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1355
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -840,6 +840,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: maximum page size at eviction",
 	"cache: modified pages evicted",
 	"cache: modified pages evicted by application threads",
+	"cache: operations timed out waiting for space in cache",
 	"cache: overflow pages read into cache",
 	"cache: page split during eviction deepened the tree",
 	"cache: page written requiring lookaside records",
@@ -1237,6 +1238,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 		/* not clearing cache_eviction_maximum_page_size */
 	stats->cache_eviction_dirty = 0;
 	stats->cache_eviction_app_dirty = 0;
+	stats->cache_timed_out_ops = 0;
 	stats->cache_read_overflow = 0;
 	stats->cache_eviction_deepen = 0;
 	stats->cache_write_lookaside = 0;
@@ -1662,6 +1664,7 @@ __wt_stat_connection_aggregate(
 	to->cache_eviction_dirty += WT_STAT_READ(from, cache_eviction_dirty);
 	to->cache_eviction_app_dirty +=
 	    WT_STAT_READ(from, cache_eviction_app_dirty);
+	to->cache_timed_out_ops += WT_STAT_READ(from, cache_timed_out_ops);
 	to->cache_read_overflow += WT_STAT_READ(from, cache_read_overflow);
 	to->cache_eviction_deepen +=
 	    WT_STAT_READ(from, cache_eviction_deepen);

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -116,7 +116,8 @@ lrt(void *arg)
 			 * pinned so it should succeed eventually.
 			 */
 			while ((ret = session->begin_transaction(
-			    session, "snapshot=test")) == WT_CACHE_FULL) {}
+			    session, "snapshot=test")) == WT_CACHE_FULL)
+				;
 			testutil_check(ret);
 			testutil_check(session->snapshot(
 			    session, "drop=(all)"));
@@ -130,7 +131,8 @@ lrt(void *arg)
 			 * a new snapshot will be allocated.
 			 */
 			while ((ret = session->begin_transaction(
-			    session, "snapshot=snapshot")) == WT_CACHE_FULL) {}
+			    session, "snapshot=snapshot")) == WT_CACHE_FULL)
+				;
 			testutil_check(ret);
 
 			/* Read a record at the end of the table. */

--- a/test/format/lrt.c
+++ b/test/format/lrt.c
@@ -110,8 +110,14 @@ lrt(void *arg)
 			 */
 			testutil_check(session->snapshot(session, "name=test"));
 			__wt_sleep(1, 0);
-			testutil_check(session->begin_transaction(
-			    session, "snapshot=test"));
+			/*
+			 * Keep trying to start a new transaction if it's
+			 * timing out - we know there aren't any resources
+			 * pinned so it should succeed eventually.
+			 */
+			while ((ret = session->begin_transaction(
+			    session, "snapshot=test")) == WT_CACHE_FULL) {}
+			testutil_check(ret);
 			testutil_check(session->snapshot(
 			    session, "drop=(all)"));
 			testutil_check(session->commit_transaction(
@@ -123,8 +129,9 @@ lrt(void *arg)
 			 * positioned. As soon as the cursor loses its position
 			 * a new snapshot will be allocated.
 			 */
-			testutil_check(session->begin_transaction(
-			    session, "isolation=snapshot"));
+			while ((ret = session->begin_transaction(
+			    session, "snapshot=snapshot")) == WT_CACHE_FULL) {}
+			testutil_check(ret);
 
 			/* Read a record at the end of the table. */
 			do {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -529,8 +529,9 @@ begin_transaction(TINFO *tinfo, WT_SESSION *session, u_int *iso_configp)
 	 * know there aren't any resources pinned so it should succeed
 	 * eventually.
 	 */
-	while ((ret = session->begin_transaction(
-	    session, config)) == WT_CACHE_FULL) {}
+	while ((ret =
+	    session->begin_transaction(session, config)) == WT_CACHE_FULL)
+		;
 	testutil_check(ret);
 
 	if (v == ISOLATION_SNAPSHOT && g.c_txn_timestamps) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -498,6 +498,7 @@ static void
 begin_transaction(TINFO *tinfo, WT_SESSION *session, u_int *iso_configp)
 {
 	u_int v;
+	int ret;
 	const char *config;
 	char config_buf[64];
 	bool locked;
@@ -523,7 +524,14 @@ begin_transaction(TINFO *tinfo, WT_SESSION *session, u_int *iso_configp)
 	}
 	*iso_configp = v;
 
-	testutil_check(session->begin_transaction(session, config));
+	/*
+	 * Keep trying to start a new transaction if it's timing out - we
+	 * know there aren't any resources pinned so it should succeed
+	 * eventually.
+	 */
+	while ((ret = session->begin_transaction(
+	    session, config)) == WT_CACHE_FULL) {}
+	testutil_check(ret);
 
 	if (v == ISOLATION_SNAPSHOT && g.c_txn_timestamps) {
 		/* Avoid starting a new reader when a prepare is in progress. */


### PR DESCRIPTION
The option is to wiredtiger_open called cache_max_wait, and applies per operation on a session.

Also:
Fixup error reporting in bloom filter code.
Enhance test/format to work with new timeout code.