### PR TITLE
WT-4067 Enhance LSM to allow eviction in chunks pinned by history

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -498,6 +498,7 @@ extern int __wt_lsm_work_switch(WT_SESSION_IMPL *session, WT_LSM_WORK_UNIT **ent
 extern int __wt_lsm_work_bloom(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_lsm_chunk_visible_all(WT_SESSION_IMPL *session, WT_LSM_CHUNK *chunk) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LSM_CHUNK *chunk) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_lsm_work_enable_evict(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_free_chunks(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_worker_start(WT_SESSION_IMPL *session, WT_LSM_WORKER_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_lsm_worker_stop(WT_SESSION_IMPL *session, WT_LSM_WORKER_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -107,7 +107,8 @@ struct __wt_lsm_chunk {
 	uint32_t id;			/* ID used to generate URIs */
 	uint32_t generation;		/* Merge generation */
 	uint32_t refcnt;		/* Number of worker thread references */
-	uint32_t bloom_busy;		/* Number of worker thread references */
+	uint32_t bloom_busy;		/* Currently creating bloom filter */
+	uint32_t evict_enabled;		/* Eviction allowed on the chunk */
 
 	int8_t empty;			/* 1/0: checkpoint missing */
 	int8_t evicted;			/* 1/0: in-memory chunk was evicted */
@@ -129,12 +130,18 @@ struct __wt_lsm_chunk {
  * is required.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START */
-#define	WT_LSM_WORK_BLOOM	0x01u	/* Create a bloom filter */
-#define	WT_LSM_WORK_DROP	0x02u	/* Drop unused chunks */
-#define	WT_LSM_WORK_FLUSH	0x04u	/* Flush a chunk to disk */
-#define	WT_LSM_WORK_MERGE	0x08u	/* Look for a tree merge */
-#define	WT_LSM_WORK_SWITCH	0x10u	/* Switch to new in-memory chunk */
+#define	WT_LSM_WORK_BLOOM		0x01u	/* Create a bloom filter */
+#define	WT_LSM_WORK_DROP		0x02u	/* Drop unused chunks */
+#define	WT_LSM_WORK_ENABLE_EVICT	0x04u	/* Create a bloom filter */
+#define	WT_LSM_WORK_FLUSH		0x08u	/* Flush a chunk to disk */
+#define	WT_LSM_WORK_MERGE		0x10u	/* Look for a tree merge */
+#define	WT_LSM_WORK_SWITCH		0x20u	/* Switch the in-memory chunk */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
+
+/* Work units that are serviced by general worker threads. */
+#define	WT_LSM_WORK_GENERAL_OPS	 					\
+	(WT_LSM_WORK_BLOOM | WT_LSM_WORK_DROP | WT_LSM_WORK_ENABLE_EVICT |\
+	WT_LSM_WORK_FLUSH | WT_LSM_WORK_SWITCH)
 
 /*
  * WT_LSM_WORK_UNIT --

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -381,7 +381,7 @@ __clsm_close_cursors(
 
 	__wt_verbose(session, WT_VERB_LSM,
 	    "LSM closing cursor session(%p):clsm(%p), start: %u, end: %u",
-	    session, clsm, start, end);
+	    (void *)session, (void *)clsm, start, end);
 
 	if (clsm->chunks == NULL || clsm->nchunks == 0)
 		return (0);
@@ -640,7 +640,8 @@ retry:	if (F_ISSET(clsm, WT_CLSM_MERGE)) {
 	/* Open the cursors for chunks that have changed. */
 	__wt_verbose(session, WT_VERB_LSM,
 	    "LSM opening cursor session(%p):clsm(%p)%s, chunks: %u, good: %u",
-	    session, clsm, update ? ", update" : "", nchunks, ngood);
+	    (void *)session, (void *)clsm,
+	    update ? ", update" : "", nchunks, ngood);
 	for (i = ngood; i != nchunks; i++) {
 		chunk = lsm_tree->chunk[i + start_chunk];
 		/* Copy the maximum transaction ID. */

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -72,11 +72,7 @@ __lsm_general_worker_start(WT_SESSION_IMPL *session)
 			worker_args->type =
 			    WT_LSM_WORK_DROP | WT_LSM_WORK_SWITCH;
 		else {
-			worker_args->type =
-			    WT_LSM_WORK_BLOOM |
-			    WT_LSM_WORK_DROP |
-			    WT_LSM_WORK_FLUSH |
-			    WT_LSM_WORK_SWITCH;
+			worker_args->type = WT_LSM_WORK_GENERAL_OPS;
 			/*
 			 * Only allow half of the threads to run merges to
 			 * avoid all all workers getting stuck in long-running
@@ -422,9 +418,10 @@ __lsm_manager_run_server(WT_SESSION_IMPL *session)
 				fillms = 10000;
 			/*
 			 * If the tree appears to not be triggering enough
-			 * LSM maintenance, help it out. Additional work units
-			 * don't hurt, and can be necessary if some work
-			 * units aren't completed for some reason.
+			 * LSM maintenance, help it out. Some types of
+			 * additional work units don't hurt, and can be
+			 * necessary if some work units aren't completed for
+			 * some reason.
 			 * If the tree hasn't been modified, and there are
 			 * more than 1 chunks - try to get the tree smaller
 			 * so queries run faster.

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -331,16 +331,15 @@ __lsm_set_chunk_evictable(
 		if (need_handle)
 			WT_RET(__wt_session_get_dhandle(
 			    session, chunk->uri, NULL, NULL, 0));
-		/* Get a handle to the chunk */
 		btree = session->dhandle->handle;
 		if (btree->evict_disabled_open) {
 			btree->evict_disabled_open = false;
 			__wt_evict_file_exclusive_off(session);
 		}
-	}
 
-	if (need_handle)
-		WT_TRET(__wt_session_release_dhandle(session));
+		if (need_handle)
+			WT_TRET(__wt_session_release_dhandle(session));
+	}
 	return (ret);
 }
 

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -313,6 +313,38 @@ __wt_lsm_chunk_visible_all(
 }
 
 /*
+ * __lsm_set_chunk_evictable --
+ *	Enable eviction in an LSM chunk.
+ */
+static int
+__lsm_set_chunk_evictable(
+    WT_SESSION_IMPL *session, WT_LSM_CHUNK *chunk, bool need_handle)
+{
+	WT_BTREE *btree;
+	WT_DECL_RET;
+
+	if (chunk->evict_enabled != 0)
+		return (0);
+
+	/* See if we win the race to enable eviction. */
+	if (__wt_atomic_cas32(&chunk->evict_enabled, 0, 1)) {
+		if (need_handle)
+			WT_RET(__wt_session_get_dhandle(
+			    session, chunk->uri, NULL, NULL, 0));
+		/* Get a handle to the chunk */
+		btree = session->dhandle->handle;
+		if (btree->evict_disabled_open) {
+			btree->evict_disabled_open = false;
+			__wt_evict_file_exclusive_off(session);
+		}
+	}
+
+	if (need_handle)
+		WT_TRET(__wt_session_release_dhandle(session));
+	return (ret);
+}
+
+/*
  * __lsm_checkpoint_chunk --
  *	Checkpoint an LSM chunk, separated out to make locking easier.
  */
@@ -340,7 +372,6 @@ int
 __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
     WT_LSM_TREE *lsm_tree, WT_LSM_CHUNK *chunk)
 {
-	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_TXN_ISOLATION saved_isolation;
 	bool flush_set, release_dhandle;
@@ -375,6 +406,14 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	WT_RET(__wt_txn_update_oldest(
 	    session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 	if (!__wt_lsm_chunk_visible_all(session, chunk)) {
+		/*
+		 * If there is cache pressure consider making a chunk evictable
+		 * to avoid the cache getting stuck when history is required.
+		 */
+		if (__wt_eviction_needed(session, false, false, NULL))
+			WT_ERR(__wt_lsm_manager_push_entry(
+			    session, WT_LSM_WORK_ENABLE_EVICT, 0, lsm_tree));
+
 		__wt_verbose(session, WT_VERB_LSM,
 		    "LSM worker %s: running transaction, return",
 		    chunk->uri);
@@ -446,11 +485,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session,
 	 * Enable eviction on the live chunk so it doesn't block the cache.
 	 * Future reads should direct to the on-disk chunk anyway.
 	 */
-	btree = session->dhandle->handle;
-	if (btree->evict_disabled_open) {
-		btree->evict_disabled_open = false;
-		__wt_evict_file_exclusive_off(session);
-	}
+	WT_ERR(__lsm_set_chunk_evictable(session, chunk, false));
 
 	release_dhandle = false;
 	WT_ERR(__wt_session_release_dhandle(session));
@@ -477,6 +512,54 @@ err:	if (flush_set)
 	if (release_dhandle)
 		WT_TRET(__wt_session_release_dhandle(session));
 
+	return (ret);
+}
+
+/*
+ * __wt_lsm_work_enable_evict --
+ *	LSM usually pins live chunks in memory - preferring to force them
+ *	out via a checkpoint when they are no longer required. For applications
+ *	that keep data pinned for a long time this can lead to the cache
+ *	being pinned full. This work unit detects that case, and enables
+ *	regular eviction in chunks that can be correctly evicted.
+ */
+int
+__wt_lsm_work_enable_evict(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
+{
+	WT_DECL_RET;
+	WT_LSM_CHUNK *chunk;
+	WT_LSM_WORKER_COOKIE cookie;
+	u_int i;
+
+	WT_CLEAR(cookie);
+
+	/* Only do this if there is cache pressure */
+	if (!__wt_eviction_needed(session, false, false, NULL))
+		return (0);
+
+	WT_RET(__lsm_copy_chunks(session, lsm_tree, &cookie, false));
+
+	/*
+	 * Turn on eviction in chunks that have had some chance to
+	 * checkpoint if there is cache pressure.
+	 */
+	for (i = 0; cookie.nchunks > 2 && i < cookie.nchunks - 2; i++) {
+		chunk = cookie.chunk_array[i];
+
+		/*
+		 * Skip if the chunk isn't on disk yet, or if it's still in
+		 * cache for a reason other than transaction visibility.
+		 */
+		if (!F_ISSET(chunk, WT_LSM_CHUNK_ONDISK) ||
+		    chunk->evict_enabled != 0 ||
+		    __wt_lsm_chunk_visible_all(session, chunk))
+			continue;
+
+		WT_ERR(__lsm_set_chunk_evictable(session, chunk, true));
+	}
+
+err:	__lsm_unpin_chunks(session, &cookie);
+	__wt_free(session, cookie.chunk_array);
 	return (ret);
 }
 

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -57,9 +57,6 @@ __lsm_worker_general_op(
 
 	*completed = false;
 
-	/*
-	 * Return if this thread cannot process a bloom, drop or flush.
-	 */
 	if (!FLD_ISSET(cookie->type, WT_LSM_WORK_GENERAL_OPS))
 		return (WT_NOTFOUND);
 

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -42,7 +42,9 @@ __wt_lsm_worker_stop(WT_SESSION_IMPL *session, WT_LSM_WORKER_ARGS *args)
 
 /*
  * __lsm_worker_general_op --
- *	Execute a single bloom, drop or flush work unit.
+ *	Execute a single medium importance maintenance operation that should
+ *	not be super long running. That includes bloom creation, drop or flush
+ *	work unit types.
  */
 static int
 __lsm_worker_general_op(
@@ -58,8 +60,7 @@ __lsm_worker_general_op(
 	/*
 	 * Return if this thread cannot process a bloom, drop or flush.
 	 */
-	if (!FLD_ISSET(cookie->type,
-	    WT_LSM_WORK_BLOOM | WT_LSM_WORK_DROP | WT_LSM_WORK_FLUSH))
+	if (!FLD_ISSET(cookie->type, WT_LSM_WORK_GENERAL_OPS))
 		return (WT_NOTFOUND);
 
 	if ((ret = __wt_lsm_manager_pop_entry(session,
@@ -88,6 +89,8 @@ __lsm_worker_general_op(
 		WT_ERR(__wt_lsm_free_chunks(session, entry->lsm_tree));
 	else if (entry->type == WT_LSM_WORK_BLOOM)
 		WT_ERR(__wt_lsm_work_bloom(session, entry->lsm_tree));
+	else if (entry->type == WT_LSM_WORK_ENABLE_EVICT)
+		WT_ERR(__wt_lsm_work_enable_evict(session, entry->lsm_tree));
 	*completed = true;
 
 err:	__wt_lsm_manager_free_work_unit(session, entry);


### PR DESCRIPTION
If the transaction ID or timestamp lags in LSM, it currently causes chunks to be pinned in memory, which can lead to the cache becoming full of un-evictable pages.

The change here looks for such situations and "unpins" chunks in that case - allowing eviction and hopefully progress. This is only useful if applications aren't holding a cursor open on the active chunks (i.e: if there isn't a cursor doing a range scan).