### PR TITLE
WT-4140 Cursor walk limits quick eviction page selection unnecessarily.

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -356,7 +356,7 @@ restart:	/*
 			 * all of the child pages were deleted, mark it for
 			 * eviction.
 			 */
-			if (empty_internal && pindex->entries > 1) {
+			if (empty_internal) {
 				__wt_page_evict_soon(session, ref);
 				empty_internal = false;
 			}


### PR DESCRIPTION
Alex, what I think happened here is that in commit [68138e2](https://github.com/wiredtiger/wiredtiger/commit/68138e21d0fe1529d7f65cebd2556699e3fa854b), this code was changed from:
```
			/*
			 * If we got all the way through an internal page and
			 * all of the child pages were deleted, evict it.
			 */
			if (empty_internal) {
				__wt_page_evict_soon(ref->page);
				empty_internal = false;
			}
```
to:
```
			/*
			 * If we got all the way through an internal page and
			 * all of the child pages were deleted, mark it for
			 * eviction.  If we see enough deleted refs at either
			 * end, try a reverse split immediately.
			 */
			if (empty_internal && pindex->entries > 1) {
				__wt_page_evict_soon(ref->page);
				empty_internal = false;
			} else if (delete_count > 0)
				WT_ERR(__wt_split_reverse(session, ref));
```
then at some point, the call to `__wt_split_reverse()` call was removed and the `pindex->entries > 1` check wasn't removed along with it.

I'm still confused by this, because it seems to me the right check would have been `pindex->entries < 2`, that is, don't try and reverse split anything without enough entries to split.

Hoping you or @michaelcahill know.

Just discard out of hand if I'm reading this whole thing wrong.