### PR TITLE
WT-4026 Add implementation for existing file extension configuration API

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -694,7 +694,8 @@ wiredtiger_open_log_configuration = [
             information'''),
         Config('file_max', '100MB', r'''
             the maximum size of log files''',
-            min='100KB', max='2GB'),
+            min='100KB',    # !!! Must match WT_LOG_FILE_MIN
+            max='2GB'),    # !!! Must match WT_LOG_FILE_MAX
         Config('path', '"."', r'''
             the name of a directory into which log files are written. The
             directory must already exist. If the value is not an absolute path,
@@ -848,9 +849,11 @@ wiredtiger_open_common =\
         file extension configuration.  If set, extend files of the set
         type in allocations of the set size, instead of a block at a
         time as each new block is written.  For example,
-        <code>file_extend=(data=16MB)</code>. If set to 0, disables the
-        file extension for the set type. For log files, default is to extend
-        in allocations of maximum log file size.''',
+        <code>file_extend=(data=16MB)</code>. If set to 0, disable the file
+        extension for the set type. For log files, the allowed range is
+        between 100KB and 2GB; values larger than configured maximum log size
+        and the default config would extend log files in allocations of
+        the maximum log file size.''',
         type='list', choices=['data', 'log']),
     Config('hazard_max', '1000', r'''
         maximum number of simultaneous hazard pointers per session

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -845,10 +845,13 @@ wiredtiger_open_common =\
         <code>extensions=(/path/ext.so={entry=my_entry})</code>)''',
         type='list'),
     Config('file_extend', '', r'''
-        file extension configuration.  If set, extend files of the set
-        type in allocations of the set size, instead of a block at a
-        time as each new block is written.  For example,
-        <code>file_extend=(data=16MB)</code>''',
+        file extension configuration.  If set for data files, extend
+        those in allocations of the set size, instead of a block at a
+        time as each new block is written. For example,
+        <code>file_extend=(data=16MB)</code>. Disables log file
+        extension when set to -1 for log file. The default is to extend
+        the log file in allocations of the <code>log_file_max</code>
+        size.''',
         type='list', choices=['data', 'log']),
     Config('hazard_max', '1000', r'''
         maximum number of simultaneous hazard pointers per session

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -845,13 +845,12 @@ wiredtiger_open_common =\
         <code>extensions=(/path/ext.so={entry=my_entry})</code>)''',
         type='list'),
     Config('file_extend', '', r'''
-        file extension configuration.  If set for data files, extend
-        those in allocations of the set size, instead of a block at a
-        time as each new block is written. For example,
-        <code>file_extend=(data=16MB)</code>. Disables log file
-        extension when set to -1 for log file. The default is to extend
-        the log file in allocations of the <code>log_file_max</code>
-        size.''',
+        file extension configuration.  If set, extend files of the set
+        type in allocations of the set size, instead of a block at a
+        time as each new block is written.  For example,
+        <code>file_extend=(data=16MB)</code>. If set to 0, disables the
+        file extension for the set type. For log files, default is to extend
+        in allocations of maximum log file size.''',
         type='list', choices=['data', 'log']),
     Config('hazard_max', '1000', r'''
         maximum number of simultaneous hazard pointers per session

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -851,8 +851,8 @@ wiredtiger_open_common =\
         time as each new block is written.  For example,
         <code>file_extend=(data=16MB)</code>. If set to 0, disable the file
         extension for the set type. For log files, the allowed range is
-        between 100KB and 2GB; values larger than configured maximum log size
-        and the default config would extend log files in allocations of
+        between 100KB and 2GB; values larger than the configured maximum log
+        size and the default config would extend log files in allocations of
         the maximum log file size.''',
         type='list', choices=['data', 'log']),
     Config('hazard_max', '1000', r'''

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2636,8 +2636,20 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 				conn->log_extend_len = sval.val;
 				break;
 			}
-		} else
+		} else {
+			/*
+			 * Set the default log extend length to -1 as an
+			 * indicator that the default for log files is to extend
+			 * by configured maximum log file size. Update the
+			 * extend length with actual desired size when maximum
+			 * log file size gets initialized as part log server
+			 * initialization.
+			 */
+			if (ft->name == "log")
+				conn->log_extend_len = -1;
+
 			WT_ERR_NOTFOUND_OK(ret);
+		}
 	}
 
 	WT_ERR(__wt_config_gets(session, cfg, "mmap", &cval));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2645,7 +2645,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 			 * log file size gets initialized as part log server
 			 * initialization.
 			 */
-			if (ft->name == "log")
+			if (ft->flag == WT_DIRECT_IO_LOG)
 				conn->log_extend_len = -1;
 
 			WT_ERR_NOTFOUND_OK(ret);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2652,8 +2652,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 					conn->log_extend_len = sval.val;
 				else
 					WT_ERR_MSG(session, EINVAL,
-					    "invalid log extend length: %ld",
-					    sval.val);
+					    "invalid log extend length: %"
+					    PRId64, sval.val);
 				break;
 			}
 		} else

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -277,6 +277,16 @@ __logmgr_config(
 	if (!reconfig) {
 		WT_RET(__wt_config_gets(session, cfg, "log.file_max", &cval));
 		conn->log_file_max = (wt_off_t)cval.val;
+
+		/*
+		 * With default log file extend configuration i.e. when log file
+		 * extend configuration is not provided or config string is like
+		 * this "file_extend=(log=)", extend the log files by configured
+		 * maximum log file size.
+		 */
+		if (conn->log_extend_len == -1 || conn->log_extend_len == 1)
+			conn->log_extend_len = conn->log_file_max;
+
 		WT_STAT_CONN_SET(session, log_max_filesize, conn->log_file_max);
 	}
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -280,7 +280,7 @@ __logmgr_config(
 		/*
 		 * With the default log file extend configuration or log file
 		 * extension size larger than configured maximum log file size,
-		 * set the log file extension size to configured maximum log
+		 * set the log file extension size to the configured maximum log
 		 * file size.
 		 */
 		if (conn->log_extend_len == WT_CONFIG_UNSET ||

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -277,16 +277,15 @@ __logmgr_config(
 	if (!reconfig) {
 		WT_RET(__wt_config_gets(session, cfg, "log.file_max", &cval));
 		conn->log_file_max = (wt_off_t)cval.val;
-
 		/*
-		 * With default log file extend configuration i.e. when log file
-		 * extend configuration is not provided or config string is like
-		 * this "file_extend=(log=)", extend the log files by configured
-		 * maximum log file size.
+		 * With the default log file extend configuration or log file
+		 * extension size larger than configured maximum log file size,
+		 * set the log file extension size to configured maximum log
+		 * file size.
 		 */
-		if (conn->log_extend_len == -1 || conn->log_extend_len == 1)
+		if (conn->log_extend_len == WT_CONFIG_UNSET ||
+		    conn->log_extend_len > conn->log_file_max)
 			conn->log_extend_len = conn->log_file_max;
-
 		WT_STAT_CONN_SET(session, log_max_filesize, conn->log_file_max);
 	}
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -278,10 +278,10 @@ __logmgr_config(
 		WT_RET(__wt_config_gets(session, cfg, "log.file_max", &cval));
 		conn->log_file_max = (wt_off_t)cval.val;
 		/*
-		 * With the default log file extend configuration or log file
-		 * extension size larger than configured maximum log file size,
-		 * set the log file extension size to the configured maximum log
-		 * file size.
+		 * With the default log file extend configuration or if the log
+		 * file extension size is larger than the configured maximum log
+		 * file size, set the log file extension size to the configured
+		 * maximum log file size.
 		 */
 		if (conn->log_extend_len == WT_CONFIG_UNSET ||
 		    conn->log_extend_len > conn->log_file_max)

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -50,6 +50,7 @@ struct __wt_config_parser_impl {
 		"", 0, 0, WT_CONFIG_ITEM_NUM				\
 	}
 
+#define	WT_CONFIG_UNSET	-1
 /*
  * DO NOT EDIT: automatically built by dist/api_config.py.
  * configuration section: BEGIN

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -90,7 +90,7 @@ union __wt_lsn {
 /*
  * Size range for the log files.
  */
-#define	WT_LOG_FILE_MAX ((uint64_t)2 * WT_GIGABYTE)
+#define	WT_LOG_FILE_MAX ((int64_t)2 * WT_GIGABYTE)
 #define	WT_LOG_FILE_MIN (100 * WT_KILOBYTE)
 
 #define	WT_LOG_SKIP_HEADER(data)					\

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -91,7 +91,7 @@ union __wt_lsn {
  * Size range for the log files.
  */
 #define	WT_LOG_FILE_MAX ((uint64_t)2 * WT_GIGABYTE)
-#define	WT_LOG_FILE_MIN (100 * 1024)
+#define	WT_LOG_FILE_MIN (100 * WT_KILOBYTE)
 
 #define	WT_LOG_SKIP_HEADER(data)					\
     ((const uint8_t *)(data) + offsetof(WT_LOG_RECORD, record))

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -87,6 +87,12 @@ union __wt_lsn {
 #define	WT_LOGC_KEY_FORMAT	WT_UNCHECKED_STRING(III)
 #define	WT_LOGC_VALUE_FORMAT	WT_UNCHECKED_STRING(qIIIuu)
 
+/*
+ * Size range for the log files.
+ */
+#define	WT_LOG_FILE_MAX ((uint64_t)2 * WT_GIGABYTE)
+#define	WT_LOG_FILE_MIN (100 * 1024)
+
 #define	WT_LOG_SKIP_HEADER(data)					\
     ((const uint8_t *)(data) + offsetof(WT_LOG_RECORD, record))
 #define	WT_LOG_REC_SIZE(size)						\

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2840,10 +2840,12 @@ struct __wt_connection {
  * @config{file_extend, file extension configuration.  If set\, extend files of
  * the set type in allocations of the set size\, instead of a block at a time as
  * each new block is written.  For example\,
- * <code>file_extend=(data=16MB)</code>. If set to 0\, disables the file
- * extension for the set type.  For log files\, default is to extend in
- * allocations of maximum log file size., a list\, with values chosen from the
- * following options: \c "data"\, \c "log"; default empty.}
+ * <code>file_extend=(data=16MB)</code>. If set to 0\, disable the file
+ * extension for the set type.  For log files\, the allowed range is between
+ * 100KB and 2GB; values larger than configured maximum log size and the default
+ * config would extend log files in allocations of the maximum log file size., a
+ * list\, with values chosen from the following options: \c "data"\, \c "log";
+ * default empty.}
  * @config{file_manager = (, control how file handles are managed., a set of
  * related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_handle_minimum, number of handles open

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2837,12 +2837,12 @@ struct __wt_connection {
  * WT_CONNECTION::load_extension as the \c config parameter (for example\,
  * <code>extensions=(/path/ext.so={entry=my_entry})</code>)., a list of strings;
  * default empty.}
- * @config{file_extend, file extension configuration.  If set for data files\,
- * extend those in allocations of the set size\, instead of a block at a time as
+ * @config{file_extend, file extension configuration.  If set\, extend files of
+ * the set type in allocations of the set size\, instead of a block at a time as
  * each new block is written.  For example\,
- * <code>file_extend=(data=16MB)</code>. Disables log file extension when set to
- * -1 for log file.  The default is to extend the log file in allocations of the
- * <code>log_file_max</code> size., a list\, with values chosen from the
+ * <code>file_extend=(data=16MB)</code>. If set to 0\, disables the file
+ * extension for the set type.  For log files\, default is to extend in
+ * allocations of maximum log file size., a list\, with values chosen from the
  * following options: \c "data"\, \c "log"; default empty.}
  * @config{file_manager = (, control how file handles are managed., a set of
  * related configuration options defined below.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2842,10 +2842,10 @@ struct __wt_connection {
  * each new block is written.  For example\,
  * <code>file_extend=(data=16MB)</code>. If set to 0\, disable the file
  * extension for the set type.  For log files\, the allowed range is between
- * 100KB and 2GB; values larger than configured maximum log size and the default
- * config would extend log files in allocations of the maximum log file size., a
- * list\, with values chosen from the following options: \c "data"\, \c "log";
- * default empty.}
+ * 100KB and 2GB; values larger than the configured maximum log size and the
+ * default config would extend log files in allocations of the maximum log file
+ * size., a list\, with values chosen from the following options: \c "data"\, \c
+ * "log"; default empty.}
  * @config{file_manager = (, control how file handles are managed., a set of
  * related configuration options defined below.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_handle_minimum, number of handles open

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2837,10 +2837,12 @@ struct __wt_connection {
  * WT_CONNECTION::load_extension as the \c config parameter (for example\,
  * <code>extensions=(/path/ext.so={entry=my_entry})</code>)., a list of strings;
  * default empty.}
- * @config{file_extend, file extension configuration.  If set\, extend files of
- * the set type in allocations of the set size\, instead of a block at a time as
+ * @config{file_extend, file extension configuration.  If set for data files\,
+ * extend those in allocations of the set size\, instead of a block at a time as
  * each new block is written.  For example\,
- * <code>file_extend=(data=16MB)</code>., a list\, with values chosen from the
+ * <code>file_extend=(data=16MB)</code>. Disables log file extension when set to
+ * -1 for log file.  The default is to extend the log file in allocations of the
+ * <code>log_file_max</code> size., a list\, with values chosen from the
  * following options: \c "data"\, \c "log"; default empty.}
  * @config{file_manager = (, control how file handles are managed., a set of
  * related configuration options defined below.}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -674,14 +674,14 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
 		    WT_LOG_END_HEADER, conn->log_file_max));
 
 	/* If configured to not extend the file, we're done. */
-	if (conn->log_extend_len == -1)
+	if (conn->log_extend_len == 0)
 		return (0);
 
 	/*
 	 * We have exclusive access to the log file and there are no other
 	 * writes happening concurrently, so there are no locking issues.
 	 */
-	ret = __wt_fextend(session, fh, conn->log_file_max);
+	ret = __wt_fextend(session, fh, conn->log_extend_len);
 	return (ret == EBUSY || ret == ENOTSUP ? 0 : ret);
 }
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -673,6 +673,10 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
 		return (__log_zero(session, fh,
 		    WT_LOG_END_HEADER, conn->log_file_max));
 
+	/* If configured to not extend the file, we're done. */
+	if (conn->log_extend_len == -1)
+		return (0);
+
 	/*
 	 * We have exclusive access to the log file and there are no other
 	 * writes happening concurrently, so there are no locking issues.

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -605,7 +605,7 @@ directory_open:
 	file_handle->fh_sync = __win_file_sync;
 
 	/* Extend and truncate share the same implementation. */
-	file_handle->fh_extend = NULL;
+	file_handle->fh_extend = __win_file_set_end;
 	file_handle->fh_truncate = __win_file_set_end;
 
 	file_handle->fh_write = __win_file_write;

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -605,7 +605,7 @@ directory_open:
 	file_handle->fh_sync = __win_file_sync;
 
 	/* Extend and truncate share the same implementation. */
-	file_handle->fh_extend = __win_file_set_end;
+	file_handle->fh_extend = NULL;
 	file_handle->fh_truncate = __win_file_set_end;
 
 	file_handle->fh_write = __win_file_write;

--- a/test/suite/test_config07.py
+++ b/test/suite/test_config07.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import fnmatch, os
+import wiredtiger, wttest
+
+# test_config07.py
+#    Test that log files extend as configured and as documented.
+class test_config07(wttest.WiredTigerTestCase):
+    uri = "table:test"
+    entries = 100000
+    K = 1024
+
+    def populate(self):
+        cur = self.session.open_cursor(self.uri, None, None)
+        for i in range(0, self.entries):
+            cur[i] = i
+        cur.close()
+
+    def checkLogFileSize(self, size):
+        logs = fnmatch.filter(os.listdir('.'), "*Prep*")
+        f = logs[-1]
+        file_size = os.stat(f).st_size
+        self.assertEqual(size, file_size)
+
+    def log_extend_test(self, config, size):
+        self.conn.close()
+        # Create a table, insert data in it to trigger log file writes.
+        configarg = 'create,statistics=(fast)' + ',' + config
+        self.conn = self.wiredtiger_open('.', configarg)
+        self.session = self.conn.open_session(None)
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        self.populate()
+        self.session.checkpoint()
+
+        self.checkLogFileSize(size)
+
+    def test_log_extend_default(self):
+        conn_config = 'log=(enabled,file_max=100K),file_extend=(log=)'
+        self.log_extend_test(conn_config, 100 * self.K)
+
+    def test_log_extend_empty(self):
+        conn_config = 'log=(enabled,file_max=100K),file_extend=(log=)'
+        self.log_extend_test(conn_config, 100 * self.K)
+
+    def test_log_extend_disable(self):
+        conn_config = 'log=(enabled,file_max=100K),file_extend=(log=0)'
+        self.log_extend_test(conn_config, 128)
+
+    def test_log_extend_by_size(self):
+        conn_config = 'log=(enabled,file_max=100K),file_extend=(log=20K)'
+        self.log_extend_test(conn_config, 20 * self.K)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
File extend API on Windows(setEndOfFile) could be slow at times based on MSDN API
documentation hence disable it.