### PR TITLE
WT-4143 Use WiredTiger.turtle.set if it exists but WiredTiger.turtle does not.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1775,8 +1775,27 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 	 * thing we do during initialization is rename a turtle file into place,
 	 * and there's never a database home after that point without a turtle
 	 * file. If the turtle file doesn't exist, it's a create.
+	 *	That said, we re-write the turtle file at checkpoint end, first
+	 * creating the "set" file and then renaming it into place. Renames on
+	 * Windows aren't guaranteed to be atomic, a power failure could leave
+	 * us with only the set file. The turtle file is the file we regularly
+	 * rename when WiredTiger is running, so if we're going to get caught,
+	 * the turtle file is where it will happen. If we have a set file and no
+	 * turtle file, rename the set file into place. We don't know what went
+	 * wrong for sure, so this can theoretically make it worse, but there
+	 * aren't any alternatives other than human intervention.
 	 */
 	WT_ERR(__wt_fs_exist(session, WT_METADATA_TURTLE, &exist));
+	if (!exist) {
+		WT_ERR(__wt_fs_exist(session, WT_METADATA_TURTLE_SET, &exist));
+		if (exist) {
+			__wt_errx(session,
+			    "wiredtiger_open: renaming %s into place as %s",
+			    WT_METADATA_TURTLE_SET, WT_METADATA_TURTLE);
+			WT_ERR(__wt_fs_rename(session,
+			    WT_METADATA_TURTLE_SET, WT_METADATA_TURTLE, true));
+		}
+	}
 	conn->is_new = exist ? 0 : 1;
 
 	if (conn->is_new) {

--- a/test/suite/test_bug020.py
+++ b/test/suite/test_bug020.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+
+# test_bug019.py
+#    Test that an existing set file will replace a  missing turtle file.
+class test_bug020(wttest.WiredTigerTestCase):
+    def test_bug020(self):
+        SimpleDataSet(self, "table:bug020", 1000).populate()
+        self.close_conn()
+        os.rename("WiredTiger.turtle", "WiredTiger.turtle.set")
+        expectMessage = 'renaming WiredTiger.turtle.set into place'
+        with self.expectedStderrPattern(expectMessage):
+            self.open_conn()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
I don't see any reason we can't use WiredTiger.turtle.set if it exists but WiredTiger.turtle does not. There are probably other paths that can lead to the problem (imagine removal of the  `WiredTiger.turtle` file during filesystem checks), but we're already dead in the water, so it's not unreasonable to try.

@sueloverso, I'm doing the rename at  a high-enough level that I don't think hot backup is affected, but I'd appreciate your agreement with that.