### PR TITLE
WT-4174 Only rollback lookaside if we're not an in-memory database.

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -466,7 +466,8 @@ __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[])
 	 * trees in cache populates a list that is used to check which
 	 * lookaside records should be removed.
 	 */
-	WT_ERR(__txn_rollback_to_stable_lookaside_fixup(session));
+	if (!F_ISSET(conn, WT_CONN_IN_MEMORY))
+		WT_ERR(__txn_rollback_to_stable_lookaside_fixup(session));
 
 err:	F_CLR(conn, WT_CONN_EVICTION_NO_LOOKASIDE);
 	__wt_free(session, conn->stable_rollback_bitstring);


### PR DESCRIPTION
@keithbostic Please review. I'll open a new ticket to add in-mem to timestamp testing where I originally reproduced this, but am pushing the code fix now because Dianna is blocked on this failure.