### PR TITLE
WT-4160 Restore performance when timestamps are built but not in use.

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1357,13 +1357,11 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
 		return (true);
 
 #ifdef HAVE_TIMESTAMPS
-	if (!__wt_timestamp_iszero(&mod->last_eviction_timestamp)) {
-		__wt_txn_pinned_timestamp(session, &pinned_ts);
-		if (__wt_timestamp_cmp(
-		    &mod->last_eviction_timestamp,
-		    &pinned_ts) != 0)
-			return (true);
-	} else
+	if (__wt_timestamp_iszero(&mod->last_eviction_timestamp))
+		return (true);
+
+	__wt_txn_pinned_timestamp(session, &pinned_ts);
+	if (__wt_timestamp_cmp(&pinned_ts, &mod->last_eviction_timestamp) > 0)
 		return (true);
 #endif
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1361,9 +1361,10 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
 		__wt_txn_pinned_timestamp(session, &pinned_ts);
 		if (__wt_timestamp_cmp(
 		    &mod->last_eviction_timestamp,
-		    &txn_global->pinned_timestamp) != 0)
+		    &pinned_ts) != 0)
 			return (true);
-	}
+	} else
+		return (true);
 #endif
 
 	return (false);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -442,8 +442,9 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref,
 	if (LF_ISSET(WT_REC_EVICT)) {
 		mod->last_eviction_id = oldest_id;
 #ifdef HAVE_TIMESTAMPS
-		__wt_txn_pinned_timestamp(
-		    session, &mod->last_eviction_timestamp);
+		if (S2C(session)->txn_global.has_pinned_timestamp)
+			__wt_txn_pinned_timestamp(
+			    session, &mod->last_eviction_timestamp);
 #endif
 		mod->last_evict_pass_gen = S2C(session)->cache->evict_pass_gen;
 	}


### PR DESCRIPTION
@michaelcahill Please review this change that modifies some of the changes made in WT-4141 that resulted in a perf drop for the overflow test. These are things I saw eyeballing that diff in #4147 that can affect a timestamp build that is not actually using timestamps. Here are the things to know:
1. The change to `rec_write.c` does NOT impact performance, but it feels like a correct change and avoids calling the function when timestamps are built but not being used.
2. The real change is in `btree.i`. In particular, the pre-WT-4141 code would return `true` in the case that timestamps were not in use. Restoring that via the `else` restores performance in all my local tests.
3. The other change in `btree.i` is a bug in the original code, IMO. The code gets the `pinned_ts` in the line before, but then never uses it.