### PR TITLE
WT-4179 Expose WiredTiger crc32c functions

### DIFF
--- a/build_win/wiredtiger.def
+++ b/build_win/wiredtiger.def
@@ -1,8 +1,8 @@
 LIBRARY WIREDTIGER
 EXPORTS
-    wiredtiger_checksum_crc32c
     wiredtiger_config_parser_open
     wiredtiger_config_validate
+    wiredtiger_crc32c_func
     wiredtiger_open
     wiredtiger_pack_close
     wiredtiger_pack_int

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -1,7 +1,7 @@
 # List of OK external symbols.
-wiredtiger_checksum_crc32c
 wiredtiger_config_parser_open
 wiredtiger_config_validate
+wiredtiger_crc32c_func
 wiredtiger_open
 wiredtiger_pack_close
 wiredtiger_pack_int

--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -33,7 +33,6 @@ __wt_stat_join_aggregate
 __wt_stat_join_clear_all
 __wt_stream_set_no_buffer
 __wt_try_readlock
-wiredtiger_checksum_crc32c
 wiredtiger_config_parser_open
 wiredtiger_config_validate
 wiredtiger_pack_int

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1356,8 +1356,9 @@ main(int argc, char *argv[])
 	const char *buffer = "some string";
 	size_t len = strlen(buffer);
 	/*! [Checksum a buffer] */
-	uint32_t crc32c;
-	crc32c = wiredtiger_checksum_crc32c(buffer, len);
+	uint32_t crc32c, (*func)(const void *, size_t);
+	func = wiredtiger_crc32c_func();
+	crc32c = func(buffer, len);
 	/*! [Checksum a buffer] */
 	(void)crc32c;
 	}

--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -86,7 +86,12 @@ __wt_checksum_hw(const void *chunk, size_t len)
 #endif
 
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+#if defined(__GNUC__)
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
+    __attribute__((visibility("default")));
+#else
 extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+#endif
 
 /*
  * wiredtiger_crc32c_func --

--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -26,7 +26,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "wt_internal.h"
+#include <inttypes.h>
+#include <stddef.h>
 
 #if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 #include <asm/hwcap.h>
@@ -84,23 +85,23 @@ __wt_checksum_hw(const void *chunk, size_t len)
 }
 #endif
 
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+
 /*
- * __wt_checksum_init --
- *	WiredTiger: detect CRC hardware and set the checksum function.
+ * wiredtiger_crc32c_func --
+ *	WiredTiger: detect CRC hardware and return the checksum function.
  */
-void
-__wt_checksum_init(void)
-    WT_GCC_FUNC_ATTRIBUTE((cold))
+uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
 #if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_CRC32)
-		__wt_process.checksum = __wt_checksum_hw;
-	else
-		__wt_process.checksum = __wt_checksum_sw;
+		return (__wt_checksum_hw);
+	return (__wt_checksum_sw);
 
 #else
-	__wt_process.checksum = __wt_checksum_sw;
+	return (__wt_checksum_sw);
 #endif
 }

--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -82,7 +82,12 @@ __wt_checksum_hw(const void *chunk, size_t len)
 }
 
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+#if defined(__GNUC__)
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
+    __attribute__((visibility("default")));
+#else
 extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+#endif
 
 /*
  * wiredtiger_crc32c_func --

--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -1,5 +1,6 @@
 #if defined(__powerpc64__)
-#include "wt_internal.h"
+#include <inttypes.h>
+#include <stddef.h>
 
 #define CRC_TABLE
 #include "crc32_constants.h"
@@ -80,17 +81,17 @@ __wt_checksum_hw(const void *chunk, size_t len)
 	return (crc32_vpmsum(0, chunk, len));
 }
 
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+
 /*
- * __wt_checksum_init --
- *	WiredTiger: detect CRC hardware and set the checksum function.
+ * wiredtiger_crc32c_func --
+ *	WiredTiger: detect CRC hardware and return the checksum function.
  */
-void
-__wt_checksum_init(void)
-    WT_GCC_FUNC_ATTRIBUTE((cold))
-{
+uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 #if defined(HAVE_CRC32_HARDWARE)
-	__wt_process.checksum = __wt_checksum_hw;
+	return (__wt_checksum_hw);
 #else
-	__wt_process.checksum = __wt_checksum_sw;
+	return (__wt_checksum_sw);
 #endif
 }

--- a/src/checksum/software/checksum.c
+++ b/src/checksum/software/checksum.c
@@ -38,7 +38,8 @@
  * little endian.
  */
 
-#include "wt_internal.h"
+#include <inttypes.h>
+#include <stddef.h>
 
 /*
  * The CRC slicing tables.
@@ -1095,13 +1096,14 @@ static const uint32_t g_crc_slicing[8][256] = {
 #endif
 };
 
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+
 /*
  * __wt_checksum_sw --
  *	Return a checksum for a chunk of memory, computed in software.
  */
 uint32_t
 __wt_checksum_sw(const void *chunk, size_t len)
-    WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	uint32_t crc, next;
 	size_t nqwords;

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -26,7 +26,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "wt_internal.h"
+#include <inttypes.h>
+#include <stddef.h>
 
 #if defined(HAVE_CRC32_HARDWARE)
 #if (defined(__amd64) || defined(__x86_64))
@@ -118,13 +119,14 @@ __wt_checksum_hw(const void *chunk, size_t len)
 #endif
 #endif /* HAVE_CRC32_HARDWARE */
 
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+
 /*
- * __wt_checksum_init --
- *	WiredTiger: detect CRC hardware and set the checksum function.
+ * wiredtiger_crc32c_func --
+ *	WiredTiger: detect CRC hardware and return the checksum function.
  */
-void
-__wt_checksum_init(void)
-    WT_GCC_FUNC_ATTRIBUTE((cold))
+uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
 #if defined(HAVE_CRC32_HARDWARE)
 #if (defined(__amd64) || defined(__x86_64))
@@ -137,9 +139,8 @@ __wt_checksum_init(void)
 
 #define	CPUID_ECX_HAS_SSE42	(1 << 20)
 	if (ecx & CPUID_ECX_HAS_SSE42)
-		__wt_process.checksum = __wt_checksum_hw;
-	else
-		__wt_process.checksum = __wt_checksum_sw;
+		return (__wt_checksum_hw);
+	return (__wt_checksum_sw);
 
 #elif defined(_M_AMD64)
 	int cpuInfo[4];
@@ -148,14 +149,13 @@ __wt_checksum_init(void)
 
 #define	CPUID_ECX_HAS_SSE42	(1 << 20)
 	if (cpuInfo[2] & CPUID_ECX_HAS_SSE42)
-		__wt_process.checksum = __wt_checksum_hw;
-	else
-		__wt_process.checksum = __wt_checksum_sw;
+		return (__wt_checksum_hw);
+	return (__wt_checksum_sw);
 #else
-	__wt_process.checksum = __wt_checksum_sw;
+	return (__wt_checksum_sw);
 #endif
 
 #else /* !HAVE_CRC32_HARDWARE */
-	__wt_process.checksum = __wt_checksum_sw;
+	return (__wt_checksum_sw);
 #endif /* HAVE_CRC32_HARDWARE */
 }

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -120,7 +120,12 @@ __wt_checksum_hw(const void *chunk, size_t len)
 #endif /* HAVE_CRC32_HARDWARE */
 
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+#if defined(__GNUC__)
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
+    __attribute__((visibility("default")));
+#else
 extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+#endif
 
 /*
  * wiredtiger_crc32c_func --

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -94,7 +94,12 @@ __wt_checksum_hw(const void *chunk, size_t len)
 #endif
 
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+#if defined(__GNUC__)
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
+    __attribute__((visibility("default")));
+#else
 extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+#endif
 
 /*
  * wiredtiger_crc32c_func --

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -6,10 +6,11 @@
  * Author(s): Hendrik Brueckner <brueckner@linux.vnet.ibm.com>
  *
  */
-#include "wt_internal.h"
 
 #include <sys/types.h>
 #include <endian.h>
+#include <inttypes.h>
+#include <stddef.h>
 
 #if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 #include <sys/auxv.h>
@@ -92,23 +93,24 @@ __wt_checksum_hw(const void *chunk, size_t len)
 
 #endif
 
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
+extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
+
 /*
- * __wt_checksum_init --
- *      WiredTiger: detect CRC hardware and set the checksum function.
+ * wiredtiger_crc32c_func --
+ *	WiredTiger: detect CRC hardware and return the checksum function.
  */
-void
-__wt_checksum_init(void)
-    WT_GCC_FUNC_ATTRIBUTE((cold))
+uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
 #if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_S390_VX)
-		__wt_process.checksum = __wt_checksum_hw;
+		return (__wt_checksum_hw);
 	else
-		__wt_process.checksum = __wt_checksum_sw;
+		return (__wt_checksum_sw);
 
 #else
-	__wt_process.checksum = __wt_checksum_sw;
+	return (__wt_checksum_sw);
 #endif
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2751,15 +2751,3 @@ err:	/* Discard the scratch buffers. */
 
 	return (ret);
 }
-
-/*
- * wiredtiger_checksum_crc32c --
- *	CRC32C checksum function entry point.
- */
-uint32_t
-wiredtiger_checksum_crc32c(const void *buffer, size_t len)
-{
-	if (__wt_process.checksum == NULL)
-		__wt_checksum_init();
-	return (__wt_process.checksum(buffer, len));
-}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -215,8 +215,7 @@ extern int __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid) WT_GCC_F
 extern int __wt_las_remove_block(WT_SESSION_IMPL *session, uint64_t pageid, bool lock_wait) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_save_dropped(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_sweep(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern uint32_t __wt_checksum_sw(const void *chunk, size_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_checksum_init(void) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
+extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
 extern void __wt_config_initn(WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str, size_t len);
 extern void __wt_config_init(WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str);
 extern void __wt_config_subinit(WT_SESSION_IMPL *session, WT_CONFIG *conf, WT_CONFIG_ITEM *item);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3550,18 +3550,17 @@ struct __wt_config_parser {
  */
 
 /*!
- * Return a buffer's CRC32C checksum.
+ * Return a pointer to a function that calculates a CRC32C checksum.
  *
  * The WiredTiger library CRC32C checksum function uses hardware support where
  * available, else it falls back to a software implementation.
  *
  * @snippet ex_all.c Checksum a buffer
  *
- * @param buffer a pointer to a buffer
- * @param len the number of valid bytes in the buffer
- * @returns the buffer's CRC32C checksum
+ * @returns a pointer to a function that takes a buffer and length and returns
+ * the CRC32C checksum
  */
-uint32_t wiredtiger_checksum_crc32c(const void *buffer, size_t len)
+uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
     WT_ATTRIBUTE_LIBRARY_VISIBLE;
 
 /*! @} */

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -117,7 +117,7 @@ __wt_global_once(void)
 		return;
 	}
 
-	__wt_checksum_init();
+	__wt_process.checksum = wiredtiger_crc32c_func();
 	__global_calibrate_ticks();
 
 	TAILQ_INIT(&__wt_process.connqh);


### PR DESCRIPTION
@agorrod, this approach is intended to make it possible to build the checksum functions in a separate library from the WiredTiger library: in short, we don't use any WiredTiger include files or structures.

Returning a pointer to a function is intended to minimize the wrapping required for C++.