### PR TITLE
WT-3943 Display full error message on python test failure

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -101,7 +101,7 @@ class CapturedFd(object):
                                      ' unexpected ' + self.desc +
                                      ', contains:\n"' + contents + '"')
             testcase.fail('unexpected ' + self.desc + ', contains: "' +
-                      shortenWithEllipsis(contents, 1000) + '"')
+                      contents + '"')
         self.expectpos = filesize
 
     def checkAdditional(self, testcase, expect):

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -101,7 +101,7 @@ class CapturedFd(object):
                                      ' unexpected ' + self.desc +
                                      ', contains:\n"' + contents + '"')
             testcase.fail('unexpected ' + self.desc + ', contains: "' +
-                      shortenWithEllipsis(contents,100) + '"')
+                      shortenWithEllipsis(contents, 1000) + '"')
         self.expectpos = filesize
 
     def checkAdditional(self, testcase, expect):


### PR DESCRIPTION
When there is an unexpected content in stderr, python test treats it
as a test failure and displays the content of stderr on console.
This content on console used to be truncated. This change elongates
the stderr content displayed on console to ease failure triage.