### PR TITLE
WT-4179 Expose WiredTiger crc32c functions

### DIFF
--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -53,19 +53,6 @@ AM_CONDITIONAL([HAVE_BUILTIN_EXTENSION_ZSTD],
     [test "$wt_cv_with_builtin_extension_zstd" = "yes"])
 AC_MSG_RESULT($with_builtins)
 
-AH_TEMPLATE(
-    HAVE_CRC32_HARDWARE, [Define to 1 to configure CRC32 hardware support.])
-AC_MSG_CHECKING(if --enable-crc32-hardware option specified)
-AC_ARG_ENABLE(crc32-hardware,
-	AS_HELP_STRING([--enable-crc32-hardware],
-	    [Enable CRC32 hardware support.]), r=$enableval, r=yes)
-case "$r" in
-no)	wt_cv_enable_crc32_hardware=no;;
-*)	AC_DEFINE(HAVE_CRC32_HARDWARE)
-	wt_cv_enable_crc32_hardware=yes;;
-esac
-AC_MSG_RESULT($wt_cv_enable_crc32_hardware)
-
 AH_TEMPLATE(HAVE_DIAGNOSTIC, [Define to 1 for diagnostic tests.])
 AC_MSG_CHECKING(if --enable-diagnostic option specified)
 AC_ARG_ENABLE(diagnostic,

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -25,9 +25,6 @@
 /* Define to 1 if you have the `clock_gettime' function. */
 /* #undef HAVE_CLOCK_GETTIME */
 
-/* Define to 1 to enable CRC32 hardware support. */
-/* #undef HAVE_CRC32_HARDWARE */
-
 /* Define to 1 for diagnostic tests. */
 /* #undef HAVE_DIAGNOSTIC */
 

--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -29,7 +29,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
 
@@ -99,7 +99,7 @@ extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
-#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_CRC32)

--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -95,7 +95,7 @@ extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
-#if defined(HAVE_CRC32_HARDWARE)
+#if defined(__powerpc64__)
 	return (__wt_checksum_hw);
 #else
 	return (__wt_checksum_sw);

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -29,7 +29,6 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-#if defined(HAVE_CRC32_HARDWARE)
 #if (defined(__amd64) || defined(__x86_64))
 /*
  * __wt_checksum_hw --
@@ -117,7 +116,6 @@ __wt_checksum_hw(const void *chunk, size_t len)
 	return (~crc);
 }
 #endif
-#endif /* HAVE_CRC32_HARDWARE */
 
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
 #if defined(__GNUC__)
@@ -133,7 +131,6 @@ extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
-#if defined(HAVE_CRC32_HARDWARE)
 #if (defined(__amd64) || defined(__x86_64))
 	unsigned int eax, ebx, ecx, edx;
 
@@ -156,11 +153,8 @@ uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 	if (cpuInfo[2] & CPUID_ECX_HAS_SSE42)
 		return (__wt_checksum_hw);
 	return (__wt_checksum_sw);
+
 #else
 	return (__wt_checksum_sw);
 #endif
-
-#else /* !HAVE_CRC32_HARDWARE */
-	return (__wt_checksum_sw);
-#endif /* HAVE_CRC32_HARDWARE */
 }

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -12,7 +12,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__)
 #include <sys/auxv.h>
 
 /* RHEL 7 has kernel support, but does not define this constant in the lib c headers. */
@@ -107,7 +107,7 @@ extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
-#if defined(__linux__) && defined(HAVE_CRC32_HARDWARE)
+#if defined(__linux__)
 	unsigned long caps = getauxval(AT_HWCAP);
 
 	if (caps & HWCAP_S390_VX)


### PR DESCRIPTION
@agorrod, this change is probably worth consideration.

I missed it in the first round of changes, and what it means is we can no longer use autoconf configuration to turn off hardware checksum acceleration in WiredTiger. I went back through the original checksum tickets, and I didn't find any reason why we wanted that ability, but I wanted to call it out, just in case.