### PR TITLE
WT-4147 For log recovery/salvage, report/fix corruption outside of log records

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -317,9 +317,15 @@ struct __wt_log_record {
 	/*
 	 * No automatic generation: flag values cannot change, they're written
 	 * to disk.
+	 *
+	 * Unused bits in the flags, as well as the 'unused' padding,
+	 * are expected to be zeroed; we check that to help detect file
+	 * corruption.
 	 */
 #define	WT_LOG_RECORD_COMPRESSED	0x01u	/* Compressed except hdr */
 #define	WT_LOG_RECORD_ENCRYPTED		0x02u	/* Encrypted except hdr */
+#define	WT_LOG_RECORD_ALL_FLAGS					\
+	(WT_LOG_RECORD_COMPRESSED | WT_LOG_RECORD_ENCRYPTED)
 	uint16_t	flags;		/* 08-09: Flags */
 	uint8_t		unused[2];	/* 10-11: Padding */
 	uint32_t	mem_len;	/* 12-15: Uncompressed len if needed */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1088,27 +1088,31 @@ __log_record_verify(WT_SESSION_IMPL *session, WT_FH *log_fh, uint32_t offset,
 	if (F_ISSET(logrec, ~(WT_LOG_RECORD_ALL_FLAGS))) {
 		WT_RET(__wt_msg(session,
 		    "%s: log record at position %" PRIu32
-		    " has flag corruption", log_fh->name, offset));
+		    " has flag corruption %" PRIx16, log_fh->name, offset,
+		    logrec->flags));
 		*corrupt = true;
 	}
 	for (i = 0; i < sizeof(logrec->unused); i++)
 		if (logrec->unused[i] != 0) {
 			WT_RET(__wt_msg(session,
 			    "%s: log record at position %" PRIu32
-			    " has unused corruption", log_fh->name, offset));
+			    " has unused[%" WT_SIZET_FMT "] corruption %" PRIx8,
+			    log_fh->name, offset, i, logrec->unused[i]));
 			*corrupt = true;
 		}
 	if (logrec->mem_len != 0 && !F_ISSET(logrec,
 	    WT_LOG_RECORD_COMPRESSED | WT_LOG_RECORD_ENCRYPTED)) {
 		WT_RET(__wt_msg(session,
 		    "%s: log record at position %" PRIu32
-		    " has memory len corruption", log_fh->name, offset));
+		    " has memory len corruption %" PRIx32, log_fh->name,
+		    offset, logrec->mem_len));
 		*corrupt = true;
 	}
 	if (logrec->len <= offsetof(WT_LOG_RECORD, record)) {
 		WT_RET(__wt_msg(session,
 		    "%s: log record at position %" PRIu32
-		    " has record len corruption", log_fh->name, offset));
+		    " has record len corruption %" PRIx32, log_fh->name,
+		    offset, logrec->len));
 		*corrupt = true;
 	}
 	return (0);

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -43,13 +43,13 @@ import wiredtiger, wttest
 
 def corrupt(fname, truncate, offset, writeit):
     with open(fname, 'r+') as log:
-        if truncate:
-            log.truncate()
         if offset:
             if offset < 0:  # Negative offset means seek to the end
                 log.seek(0, 2)
             else:
                 log.seek(offset)
+        if truncate:
+            log.truncate()
         if writeit:
             log.write(writeit)
 
@@ -62,6 +62,8 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
             os.remove(fname))),
         ('truncate', dict(kind='truncate', f=lambda fname:
             corrupt(fname, True, 0, None))),
+        ('truncate-middle', dict(kind='truncate-middle', f=lambda fname:
+            corrupt(fname, True, 1024 * 25, None))),
         ('zero-begin', dict(kind='zero', f=lambda fname:
             corrupt(fname, False, 0, '\0' * 4096))),
         ('zero-trunc', dict(kind='zero', f=lambda fname:
@@ -150,12 +152,6 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         # At any rate, we consider this particular corruption to be benign.
         if self.kind == 'zero-end':
             return False
-
-        # NOTE:
-        # If garbage is added to an otherwise valid log file, the invalid
-        # portion is effectively 'skipped over'.
-        if self.kind == 'garbage-end':
-            return False
         return True
 
     def show_logs(self, homedir, msg):
@@ -218,20 +214,41 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         if self.corruptpos2 != 0:
             self.f(self.log_number_to_file_name(homedir, self.corruptpos2))
 
-    # Return true iff the log has been damaged in a way that
-    # is not detected as a corruption.
-    # This includes:
+    def corrupt_last_file(self):
+        return self.corruptpos == self.record_to_logfile(self.nrecords)
+
+    # Corruption past the last written record in a log file can sometimes
+    # be detected. In our test case, the last log file zero or one large
+    # 60K record written into it, but it is presized to 100K.  Corruption
+    # at the end of this file creates a hole, and the corruption starts
+    # a new log record, where it can be detected as phony.  Similarly,
+    # corruption in the "middle" of the last file (actually the 25K point)
+    # can be detected if there aren't any of the insert records in the file.
+    def corrupt_hole_in_last_file(self):
+        return self.corrupt_last_file() and \
+            ((self.kind == 'garbage-middle' and self.nrecords % 2 == 0) or \
+             self.kind == 'garbage-end')
+
+    # Return true iff the log has been damaged in a way that is not detected
+    # as a corruption.  WiredTiger must be lenient about damage in any log
+    # file, because a partial log record written just before a crash is in
+    # most cases indistinguishable from a corruption.  If the beginning of
+    # the file is mangled, that is always an unexpected corruption. Situations
+    # where we cannot reliably detect corruption include:
     #  - removal of the last log
-    #  - corruption in the middle of a log file.
+    #  - corruption in the middle of a log record
+    #  - certain corruptions at the beginning of a log record (we don't have
+    #      specific tests for these)
     def log_corrupt_but_valid(self):
-        # NOTE:
-        # Currently, corruption in the middle of a log file is not yet
-        # detected.
-        if self.kind == 'garbage-middle':
+        if self.corrupt_last_file() and self.kind == 'removal':
             return True
-        if self.corruptpos == self.record_to_logfile(self.nrecords):
-            if self.kind == 'removal':
-                return True
+        # Certain corruptions in the last file can be detected.
+        if self.corrupt_hole_in_last_file():
+            return False
+        if self.kind == 'truncate-middle' or \
+           self.kind == 'garbage-middle' or \
+           self.kind == 'garbage-end':
+            return True
         return False
 
     # For this test, at least, salvage identifies and fixes all
@@ -247,7 +264,12 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
     def recovered_records(self):
         if not self.corrupted() or self.chkpt > self.corruptpos:
             return self.nrecords
-        return self.logfile_to_record(self.corruptpos)
+        if self.kind == 'garbage-end':
+            # All records in the corrupt file will be found.
+            found = self.logfile_to_record(self.corruptpos + 1)
+        else:
+            found = self.logfile_to_record(self.corruptpos)
+        return min(found, self.nrecords)
 
     def test_corrupt_log(self):
         ''' Corrupt the log and restart with different kinds of recovery '''

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -218,7 +218,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         return self.corruptpos == self.record_to_logfile(self.nrecords)
 
     # Corruption past the last written record in a log file can sometimes
-    # be detected. In our test case, the last log file zero or one large
+    # be detected. In our test case, the last log file has zero or one large
     # 60K record written into it, but it is presized to 100K.  Corruption
     # at the end of this file creates a hole, and the corruption starts
     # a new log record, where it can be detected as phony.  Similarly,


### PR DESCRIPTION
We do a conservative consistency check of log record headers, as well as
consistency checks of 'holes' in log files. This catches corruptions that
occur from appending junk to a valid log file, or inserting corruption
in the unused portion of the final log file.

Corruption errors are reported in a standard way that suggests using
salvage to fix.

Tests have been updated, along with extra commentary.