### PR TITLE
WT-4183 Add verbose option to log more messages on error returns

### DIFF
--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1770,7 +1770,8 @@ __slvg_row_trk_update_start(
 	 * would have discarded it, we wouldn't be here.  Therefore, this test
 	 * is safe.  (But, it never hurts to check.)
 	 */
-	WT_ERR_TEST(!found, WT_ERROR);
+	if (!found)
+		WT_ERR_MSG(session, WT_ERROR, "expected on-page key not found");
 	WT_ERR(__slvg_key_copy(session, &trk->row_start, key));
 
 	/*

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -651,15 +651,17 @@ __curjoin_entry_member(WT_SESSION_IMPL *session, WT_CURSOR_JOIN_ENTRY *entry,
 		if (iter != NULL && entry == iter->entry)
 			WT_ITEM_SET(v, iter->idxkey);
 		else {
-			memset(&v, 0, sizeof(v));  /* Keep lint quiet. */
+			memset(&v, 0, sizeof(v));	/* Keep lint quiet. */
 			c = entry->main;
 			c->set_key(c, key);
 			entry->stats.main_access++;
 			if ((ret = c->search(c)) == 0)
 				ret = c->get_value(c, &v);
-			else if (ret == WT_NOTFOUND)
-				WT_ERR_MSG(session, WT_ERROR,
+			else if (ret == WT_NOTFOUND) {
+				__wt_err(session, ret,
 				    "main table for join is missing entry");
+				ret = WT_ERROR;
+			}
 			WT_TRET(c->reset(c));
 			WT_ERR(ret);
 		}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2158,7 +2158,8 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 	}
 	WT_ERR(__log_open_verify(session, start_lsn.l.file, &log_fh, &prev_lsn,
 	    NULL, &need_salvage));
-	WT_ERR_TEST(need_salvage, WT_ERROR);
+	if (need_salvage)
+		WT_ERR_MSG(session, WT_ERROR, "log file requires salvage");
 	WT_ERR(__wt_filesize(session, log_fh, &log_size));
 	rd_lsn = start_lsn;
 	if (LF_ISSET(WT_LOGSCAN_RECOVER))
@@ -2224,7 +2225,9 @@ advance:
 			WT_ERR(__log_open_verify(session,
 			    rd_lsn.l.file, &log_fh, &prev_lsn, &version,
 			    &need_salvage));
-			WT_ERR_TEST(need_salvage, WT_ERROR);
+			if (need_salvage)
+				WT_ERR_MSG(session, WT_ERROR,
+				    "log file requires salvage");
 			/*
 			 * Opening the log file reads with verify sets up the
 			 * previous LSN from the first record.  This detects

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -532,7 +532,7 @@ __wt_log_extract_lognum(
 
 	if (id == NULL || name == NULL)
 		WT_RET_MSG(session, EINVAL,
-		    "%s: unexpected usage: no id or no name", __func__);
+		    "unexpected usage: no id or no name");
 	if ((p = strrchr(name, '.')) == NULL ||
 	    sscanf(++p, "%" SCNu32, id) != 1)
 		WT_RET_MSG(session, WT_ERROR, "Bad log file name '%s'", name);
@@ -717,8 +717,7 @@ __log_decompress(WT_SESSION_IMPL *session, WT_ITEM *in, WT_ITEM *out)
 	compressor = conn->log_compressor;
 	if (compressor == NULL || compressor->decompress == NULL)
 		WT_RET_MSG(session, WT_ERROR,
-		    "%s: Compressed record with no configured compressor",
-		    __func__);
+		    "Compressed record with no configured compressor");
 	uncompressed_size = logrec->mem_len;
 	WT_RET(__wt_buf_initsize(session, out, uncompressed_size));
 	memcpy(out->mem, in->mem, skip);
@@ -735,7 +734,7 @@ __log_decompress(WT_SESSION_IMPL *session, WT_ITEM *in, WT_ITEM *out)
 	 */
 	if (result_len != uncompressed_size - WT_LOG_COMPRESS_SKIP)
 		WT_RET_MSG(session, WT_ERROR,
-		    "%s: decompression failed with incorrect size", __func__);
+		    "decompression failed with incorrect size");
 
 	return (0);
 }
@@ -757,8 +756,7 @@ __log_decrypt(WT_SESSION_IMPL *session, WT_ITEM *in, WT_ITEM *out)
 	    (encryptor = kencryptor->encryptor) == NULL ||
 	    encryptor->decrypt == NULL)
 		WT_RET_MSG(session, WT_ERROR,
-		    "%s: Encrypted record with no configured decrypt method",
-		    __func__);
+		    "Encrypted record with no configured decrypt method");
 
 	return (__wt_decrypt(session, encryptor, WT_LOG_ENCRYPT_SKIP, in, out));
 }
@@ -2084,7 +2082,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
 				start_lsn = log->ckpt_lsn;
 			else if (!LF_ISSET(WT_LOGSCAN_FIRST))
 				WT_RET_MSG(session, WT_ERROR,
-				    "%s: WT_LOGSCAN_FIRST not set", __func__);
+				    "WT_LOGSCAN_FIRST not set");
 		}
 		lastlog = log->fileid;
 	} else {

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -21,12 +21,15 @@ __wt_optrack_record_funcid(
 	WT_DECL_ITEM(tmp);
 	WT_DECL_RET;
 	wt_off_t fsize;
+	bool locked;
 
 	conn = S2C(session);
+	locked = false;
 
 	WT_ERR(__wt_scr_alloc(session, strlen(func) + 32, &tmp));
 
 	__wt_spin_lock(session, &conn->optrack_map_spinlock);
+	locked = true;
 	if (*func_idp == 0) {
 		*func_idp = ++optrack_uid;
 
@@ -38,10 +41,12 @@ __wt_optrack_record_funcid(
 	}
 
 	if (0) {
-err:		WT_PANIC_MSG(session, ret, "%s", __func__);
+err:		WT_PANIC_MSG(session, ret,
+		    "operation tracking initialization failure");
 	}
 
-	__wt_spin_unlock(session, &conn->optrack_map_spinlock);
+	if (locked)
+		__wt_spin_unlock(session, &conn->optrack_map_spinlock);
 	__wt_scr_free(session, &tmp);
 }
 

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -66,8 +66,7 @@ __optrack_open_file(WT_SESSION_IMPL *session)
 	conn = S2C(session);
 
 	if (!F_ISSET(conn, WT_CONN_OPTRACK))
-		WT_RET_MSG(session, WT_ERROR,
-		    "%s: WT_CONN_OPTRACK not set", __func__);
+		WT_RET_MSG(session, WT_ERROR, "WT_CONN_OPTRACK not set");
 
 	WT_RET(__wt_scr_alloc(session, 0, &buf));
 	WT_ERR(__wt_filename_construct(session, conn->optrack_path,

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -189,7 +189,7 @@ err:	__wt_scr_free(session, &tmp);
 		return ((const char *)buf->data);
 
 	retp = "failed to create printable output";
-	__wt_err(session, ret, "%s: %s", __func__, retp);
+	__wt_err(session, ret, "%s", retp);
 	return (retp);
 }
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -659,7 +659,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 		if (F_ISSET(conn, WT_CONN_READONLY))
 			WT_ERR_MSG(session, WT_RUN_RECOVERY,
 			    "Read-only database needs recovery");
-		WT_ERR(WT_RUN_RECOVERY);
+		WT_ERR_MSG(session, WT_RUN_RECOVERY, "Database needs recovery");
 	}
 
 	if (F_ISSET(conn, WT_CONN_READONLY)) {


### PR DESCRIPTION
Review WiredTiger error returns for `WT_ERROR`, `WT_PANIC` and `WT_RUN_RECOVERY`, ensure the appropriate places include verbose error messages.