### PR TITLE
WT-4195 when encountering an illegal value, log the value that failed

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -331,7 +331,7 @@ for optype in log_data.optypes:
 })
 
 tfile.write('''
-\tWT_ILLEGAL_VALUE(session);
+\tWT_ILLEGAL_VALUE(session, optype);
 \t}
 
 \treturn (0);

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -373,7 +373,7 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
 			 * on some gcc compilers because they don't understand
 			 * FALLTHROUGH as part of a macro.
 			 */
-			return (__wt_illegal_value(session));
+			return (__wt_illegal_value(session, ckpt->flags));
 		}
 	return (0);
 }

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -373,8 +373,7 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
 			 * on some gcc compilers because they don't understand
 			 * FALLTHROUGH as part of a macro.
 			 */
-			return (
-			    __wt_illegal_value(session, "checkpoint array"));
+			return (__wt_illegal_value(session));
 		}
 	return (0);
 }

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -278,18 +278,20 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 
 		if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
 			__wt_errx(session,
-			    "read checksum error for %" PRIu32 "B block at "
+			    "%s: read checksum error for %" PRIu32 "B block at "
 			    "offset %" PRIuMAX ": calculated block checksum "
 			    "of %" PRIu32 " doesn't match expected checksum "
 			    "of %" PRIu32,
+			    block->name,
 			    size, (uintmax_t)offset, page_checksum, checksum);
 	} else
 		if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
 			__wt_errx(session,
-			    "read checksum error for %" PRIu32 "B block at "
+			    "%s: read checksum error for %" PRIu32 "B block at "
 			    "offset %" PRIuMAX ": block header checksum "
 			    "of %" PRIu32 " doesn't match expected checksum "
 			    "of %" PRIu32,
+			    block->name,
 			    size, (uintmax_t)offset, swap.checksum, checksum);
 
 	if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
@@ -297,7 +299,7 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 		    __wt_bm_corrupt_dump(session, buf, offset, size, checksum));
 
 	/* Panic if a checksum fails during an ordinary read. */
-	return (block->verify ||
-	    F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE) ?
-	    WT_ERROR : __wt_illegal_value(session, block->name));
+	if (block->verify || F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
+		return (WT_ERROR);
+	WT_PANIC_RET(session, WT_ERROR, "%s: fatal read error", block->name);
 }

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -457,7 +457,7 @@ __wt_cursor_key_order_check(
 		return (__cursor_key_order_check_col(session, cbt, next));
 	case WT_PAGE_ROW_LEAF:
 		return (__cursor_key_order_check_row(session, cbt, next));
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, cbt->ref->page->type);
 	}
 	/* NOTREACHED */
 }
@@ -482,7 +482,7 @@ __wt_cursor_key_order_init(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	case WT_PAGE_ROW_LEAF:
 		return (__wt_buf_set(session,
 		    cbt->lastkey, cbt->iface.key.data, cbt->iface.key.size));
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, cbt->ref->page->type);
 	}
 	/* NOTREACHED */
 }
@@ -642,7 +642,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_COL_VAR:
 				ret = __cursor_var_append_next(cbt, newpage);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
 			if (ret == 0)
 				break;
@@ -660,7 +660,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_ROW_LEAF:
 				ret = __cursor_row_next(cbt, newpage);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -606,7 +606,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_COL_VAR:
 				ret = __cursor_var_append_prev(cbt, newpage);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
 			if (ret == 0)
 				break;
@@ -626,7 +626,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_ROW_LEAF:
 				ret = __cursor_row_prev(cbt, newpage);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1321,7 +1321,7 @@ done:		switch (modify_type) {
 			break;
 		case WT_UPDATE_BIRTHMARK:
 		case WT_UPDATE_TOMBSTONE:
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, modify_type);
 		}
 	}
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -457,7 +457,7 @@ __wt_debug_disk(
 	case WT_PAGE_OVFL:
 		WT_ERR(ds->f(ds, ", datalen %" PRIu32, dsk->u.datalen));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, dsk->type);
 	}
 
 	if (F_ISSET(dsk, WT_PAGE_COMPRESSED))
@@ -791,7 +791,7 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
 		if (LF_ISSET(WT_DEBUG_TREE_LEAF))
 			WT_RET(__debug_page_row_leaf(ds, ref->page));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, ref->page->type);
 	}
 
 	return (0);
@@ -841,7 +841,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 	case WT_PAGE_ROW_LEAF:
 		entries = page->entries;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, page->type);
 	}
 
 	WT_RET(ds->f(ds, ": %s\n", __wt_page_type_string(page->type)));
@@ -881,7 +881,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 			break;
 		case 0:
 			break;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, mod->rec_result);
 		}
 	if (split_gen != 0)
 		WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));
@@ -1401,7 +1401,7 @@ __debug_cell_data(WT_DBG *ds,
 	case WT_CELL_VALUE_SHORT:
 		WT_ERR(__debug_item_value(ds, tag, buf->data, buf->size));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, unpack->raw);
 	}
 
 err:	__wt_scr_free(session, &buf);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -209,7 +209,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		case WT_REF_LIMBO:
 		case WT_REF_LOOKASIDE:
 		case WT_REF_READING:
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, current_state);
 		}
 
 		if (locked)

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -209,9 +209,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		case WT_REF_LIMBO:
 		case WT_REF_LOOKASIDE:
 		case WT_REF_READING:
-		default:
-			return (__wt_illegal_value(session,
-			    "illegal WT_REF.state rolling back deleted page"));
+		WT_ILLEGAL_VALUE(session);
 		}
 
 		if (locked)

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -153,10 +153,10 @@ corrupt:	if (ret == 0)
 			ret = WT_ERROR;
 		if (!F_ISSET(btree, WT_BTREE_VERIFY) &&
 		    !F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE)) {
-			__wt_err(session, ret, "%s", fail_msg);
 			WT_TRET(bm->corrupt(bm, session, addr, addr_size));
-			WT_TRET(
-			    __wt_illegal_value(session, btree->dhandle->name));
+			WT_PANIC_ERR(session, ret,
+			    "%s: fatal read error: %s",
+			    btree->dhandle->name, fail_msg);
 		}
 	}
 

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -241,7 +241,7 @@ __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_CELL *cell)
 		__wt_cell_type_reset(session,
 		    unpack->cell, WT_CELL_VALUE_OVFL, WT_CELL_VALUE_OVFL_RM);
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, unpack->raw);
 	}
 
 	__wt_writeunlock(session, &btree->ovfl_lock);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -57,7 +57,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session,
 		 */
 		size += alloc_entries * sizeof(WT_ROW);
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, type);
 	}
 
 	WT_RET(__wt_calloc(session, 1, size, &page));
@@ -112,7 +112,7 @@ err:			if ((pindex = WT_INTL_INDEX_GET_SAFE(page)) != NULL) {
 		    NULL : (WT_ROW *)((uint8_t *)page + sizeof(WT_PAGE));
 		page->entries = alloc_entries;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, type);
 	}
 
 	/* Increment the cache statistics. */
@@ -186,7 +186,7 @@ __wt_page_inmem(WT_SESSION_IMPL *session,
 			WT_RET(__inmem_row_leaf_entries(
 			    session, dsk, &alloc_entries));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, dsk->type);
 	}
 
 	/* Allocate and initialize a new WT_PAGE. */
@@ -222,7 +222,7 @@ __wt_page_inmem(WT_SESSION_IMPL *session,
 	case WT_PAGE_ROW_LEAF:
 		WT_ERR(__inmem_row_leaf(session, page));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, page->type);
 	}
 
 	/* Update the page's cache statistics. */
@@ -503,7 +503,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			ref->addr = cell;
 			++refp;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, unpack->type);
 		}
 	}
 
@@ -556,7 +556,7 @@ __inmem_row_leaf_entries(
 		case WT_CELL_VALUE:
 		case WT_CELL_VALUE_OVFL:
 			break;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, unpack->type);
 		}
 	}
 
@@ -614,7 +614,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 			break;
 		case WT_CELL_VALUE_OVFL:
 			break;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, unpack->type);
 		}
 	}
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -221,7 +221,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			WT_ERR(__wt_buf_set(session,
 			    current_key, las_key.data, las_key.size));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, page->type);
 		}
 
 		/* Append the latest update to the list. */
@@ -251,7 +251,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			    current_key, ref, &cbt, first_upd));
 			first_upd = NULL;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, page->type);
 		}
 
 	/* Discard the cursor. */
@@ -788,7 +788,7 @@ skip_evict:		/*
 			return (LF_ISSET(WT_READ_IGNORE_CACHE_SIZE) &&
 			    !F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE) ?
 			    0 : __wt_txn_autocommit_check(session));
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, current_state);
 		}
 
 		/*

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -235,7 +235,7 @@ __rebalance_col_walk(
 			    unpack.type == WT_CELL_ADDR_LEAF ?
 			    WT_ADDR_LEAF : WT_ADDR_LEAF_NO, rs));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, unpack.type);
 		}
 	}
 
@@ -386,7 +386,7 @@ __rebalance_row_walk(
 
 			first_cell = false;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, unpack.type);
 		}
 	}
 
@@ -440,7 +440,7 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_ERR(
 		    __rebalance_col_walk(session, btree->root.page->dsk, rs));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, rs->type);
 	}
 
 	/* Build a new root page. */

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -287,7 +287,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 		case WT_CELL_ADDR_LEAF_NO:
 			addr->type = WT_ADDR_LEAF_NO;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, unpack.raw);
 		}
 		if (__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr))
 			addr = NULL;
@@ -1513,7 +1513,7 @@ __split_multi_inmem(
 			WT_ERR(__wt_row_modify(session,
 			    &cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, orig->type);
 		}
 	}
 

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -122,7 +122,7 @@ __stat_page(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **stats)
 	case WT_PAGE_ROW_LEAF:
 		__stat_page_row_leaf(session, page, stats);
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, page->type);
 	}
 	return (0);
 }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -354,7 +354,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		break;
 	case WT_SYNC_CLOSE:
 	case WT_SYNC_DISCARD:
-		WT_ERR(__wt_illegal_value(session));
+		WT_ERR(__wt_illegal_value(session, syncop));
 		break;
 	}
 

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -354,7 +354,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		break;
 	case WT_SYNC_CLOSE:
 	case WT_SYNC_DISCARD:
-		WT_ERR(__wt_illegal_value(session, NULL));
+		WT_ERR(__wt_illegal_value(session));
 		break;
 	}
 

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -166,7 +166,7 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session,
 	case WT_PAGE_BLOCK_MANAGER:
 	case WT_PAGE_OVFL:
 		return (__verify_dsk_chunk(session, tag, dsk, dsk->u.datalen));
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, dsk->type);
 	}
 	/* NOTREACHED */
 }

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -657,7 +657,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 				key->size = WT_INSERT_KEY_SIZE(list->ins);
 			}
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, page->type);
 		}
 
 		/*
@@ -699,7 +699,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 			case WT_UPDATE_TOMBSTONE:
 				las_value.size = 0;
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, upd->type);
 			}
 
 			cursor->set_key(cursor,

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -143,7 +143,8 @@ __wt_conn_dhandle_alloc(
 		dhandle = &table->iface;
 		dhandle->type = WT_DHANDLE_TYPE_TABLE;
 	} else
-		return (__wt_illegal_value(session, NULL));
+		WT_PANIC_RET(session, EINVAL,
+		    "illegal handle allocation URI %s", uri);
 
 	/* Btree handles keep their data separate from the interface. */
 	if (dhandle->type == WT_DHANDLE_TYPE_BTREE) {

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -500,7 +500,7 @@ __curjoin_entry_in_range(WT_SESSION_IMPL *session, WT_CURSOR_JOIN_ENTRY *entry,
 			passed = (cmp < 0);
 			break;
 
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, WT_CURJOIN_END_RANGE(end));
 		}
 
 		if (!passed) {

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -801,7 +801,8 @@ __curjoin_init_bloom(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin,
 				goto done;
 			WT_ERR(ret);
 		} else
-			WT_ERR(__wt_illegal_value(session, NULL));
+			WT_PANIC_ERR(session, EINVAL,
+			    "fatal error in join cursor position state");
 	}
 	collator = (entry->index == NULL) ? NULL : entry->index->collator;
 	while (ret == 0) {

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -53,7 +53,7 @@ static int __json_pack_size(WT_SESSION_IMPL *, const char *, WT_CONFIG_ITEM *,
 		(pv).type = 'K';					\
 		break;							\
 	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session);					\
+	WT_ILLEGAL_VALUE(session, (pv).type);				\
 	}								\
 } while (0)
 
@@ -922,7 +922,7 @@ __wt_json_strncpy(WT_SESSION *wt_session,
 			case '\\':
 				*dst++ = ch;
 				break;
-			WT_ILLEGAL_VALUE(session);
+			WT_ILLEGAL_VALUE(session, ch);
 			}
 		else
 			*dst++ = ch;

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -126,7 +126,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			break;
 		case WT_SYNC_CHECKPOINT:
 		case WT_SYNC_WRITE_LEAVES:
-			WT_ERR(__wt_illegal_value(session));
+			WT_ERR(__wt_illegal_value(session, syncop));
 			break;
 		}
 	}

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -126,7 +126,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			break;
 		case WT_SYNC_CHECKPOINT:
 		case WT_SYNC_WRITE_LEAVES:
-			WT_ERR(__wt_illegal_value(session, NULL));
+			WT_ERR(__wt_illegal_value(session));
 			break;
 		}
 	}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -424,7 +424,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		}
 
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, mod->rec_result);
 	}
 
 	return (0);

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -778,7 +778,7 @@ __cell_data_ref(WT_SESSION_IMPL *session,
 			return (0);
 		huffman = btree->huffman_value;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, unpack->type);
 	}
 
 	return (huffman == NULL || store->size == 0 ? 0 :

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -97,16 +97,16 @@
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Called on unexpected code path: locate the failure. */
-#define	__wt_illegal_value(session)					\
-	__wt_illegal_value_func(session, __func__, __LINE__)
+#define	__wt_illegal_value(session, v)					\
+	__wt_illegal_value_func(session, (uintmax_t)v, __func__, __LINE__)
 
 /* Return and branch-to-err-label cases for switch statements. */
-#define	WT_ILLEGAL_VALUE(session)					\
+#define	WT_ILLEGAL_VALUE(session, v)					\
 	default:							\
-		return (__wt_illegal_value(session))
-#define	WT_ILLEGAL_VALUE_ERR(session)					\
+		return (__wt_illegal_value(session, v))
+#define	WT_ILLEGAL_VALUE_ERR(session, v)				\
 	default:							\
-		ret = __wt_illegal_value(session);			\
+		ret = __wt_illegal_value(session, v);			\
 		goto err
 
 #define	WT_PANIC_MSG(session, v, ...) do {				\

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -96,6 +96,10 @@
 #define	WT_TRET_BUSY_OK(a)	WT_TRET_ERROR_OK(a, EBUSY)
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
+/* Called on unexpected code path: locate the failure. */
+#define	__wt_illegal_value(session, msg)				\
+	__wt_illegal_value_func(session, msg, __func__, __LINE__)
+
 /* Return and branch-to-err-label cases for switch statements. */
 #define	WT_ILLEGAL_VALUE(session)					\
 	default:							\

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -97,21 +97,17 @@
 #define	WT_TRET_NOTFOUND_OK(a)	WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Called on unexpected code path: locate the failure. */
-#define	__wt_illegal_value(session, msg)				\
-	__wt_illegal_value_func(session, msg, __func__, __LINE__)
+#define	__wt_illegal_value(session)					\
+	__wt_illegal_value_func(session, __func__, __LINE__)
 
 /* Return and branch-to-err-label cases for switch statements. */
 #define	WT_ILLEGAL_VALUE(session)					\
 	default:							\
-		return (__wt_illegal_value(session, NULL))
+		return (__wt_illegal_value(session))
 #define	WT_ILLEGAL_VALUE_ERR(session)					\
 	default:							\
-		ret = __wt_illegal_value(session, NULL);		\
+		ret = __wt_illegal_value(session);			\
 		goto err
-#define	WT_ILLEGAL_VALUE_SET(session)					\
-	default:							\
-		ret = __wt_illegal_value(session, NULL);		\
-		break
 
 #define	WT_PANIC_MSG(session, v, ...) do {				\
 	__wt_err(session, v, __VA_ARGS__);				\

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -685,7 +685,7 @@ extern int __wt_ext_msg_printf(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session,
 extern const char *__wt_ext_strerror(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, int error);
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_illegal_value_func(WT_SESSION_IMPL *session, const char *func, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_illegal_value_func(WT_SESSION_IMPL *session, uintmax_t v, const char *func, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_inmem_unsupported_op(WT_SESSION_IMPL *session, const char *tag) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_object_unsupported(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bad_object_type(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -685,7 +685,7 @@ extern int __wt_ext_msg_printf(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session,
 extern const char *__wt_ext_strerror(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, int error);
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_illegal_value_func(WT_SESSION_IMPL *session, const char *tag, const char *file, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_illegal_value_func(WT_SESSION_IMPL *session, const char *func, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_inmem_unsupported_op(WT_SESSION_IMPL *session, const char *tag) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_object_unsupported(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bad_object_type(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -308,10 +308,6 @@ typedef void wt_timestamp_t;
 	__wt_page_swap_func(session, held, want, flags)
 #endif
 
-/* Called on unexpected code path: locate the failure. */
-#define	__wt_illegal_value(session, msg)				\
-	__wt_illegal_value_func(session, msg, __func__, __LINE__)
-
 /* Random number generator state. */
 union __wt_rand_state {
 	uint64_t v;

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -245,7 +245,7 @@ next:	if (pack->cur == pack->end)
 		(pv).u.u = va_arg(ap, uint64_t);			\
 		break;							\
 	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session);					\
+	WT_ILLEGAL_VALUE(session, (pv).type);				\
 	}								\
 } while (0)
 
@@ -612,7 +612,7 @@ __unpack_read(WT_SESSION_IMPL *session,
 		*va_arg(ap, uint64_t *) = (pv).u.u;			\
 		break;							\
 	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session);					\
+	WT_ILLEGAL_VALUE(session, (pv).type);				\
 	}								\
 } while (0)
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -852,7 +852,7 @@ __wt_txn_op_printlog(WT_SESSION_IMPL *session,
 		WT_RET(__wt_logop_prev_lsn_print(session, pp, end, flags));
 		break;
 
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, optype);
 	}
 
 	return (0);

--- a/src/packing/pack_stream.c
+++ b/src/packing/pack_stream.c
@@ -95,7 +95,7 @@ wiredtiger_pack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 
 	return (0);
@@ -128,7 +128,7 @@ wiredtiger_pack_int(WT_PACK_STREAM *ps, int64_t i)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 
 	return (0);
@@ -158,7 +158,7 @@ wiredtiger_pack_str(WT_PACK_STREAM *ps, const char *s)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 
 	return (0);
@@ -194,7 +194,7 @@ wiredtiger_pack_uint(WT_PACK_STREAM *ps, uint64_t u)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 
 	return (0);
@@ -225,7 +225,7 @@ wiredtiger_unpack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 		item->data = pv.u.item.data;
 		item->size = pv.u.item.size;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 
 	return (0);
@@ -258,7 +258,7 @@ wiredtiger_unpack_int(WT_PACK_STREAM *ps, int64_t *ip)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*ip = pv.u.i;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 	return (0);
 }
@@ -287,7 +287,7 @@ wiredtiger_unpack_str(WT_PACK_STREAM *ps, const char **sp)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*sp = pv.u.s;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 	return (0);
 }
@@ -322,7 +322,7 @@ wiredtiger_unpack_uint(WT_PACK_STREAM *ps, uint64_t *up)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*up = pv.u.u;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, pv.type);
 	}
 	return (0);
 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -481,7 +481,9 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref,
 	case WT_PAGE_ROW_LEAF:
 		ret = __rec_row_leaf(session, r, page, salvage);
 		break;
-	WT_ILLEGAL_VALUE_SET(session);
+	default:
+		ret = __wt_illegal_value(session);
+		break;
 	}
 
 	/*
@@ -4161,11 +4163,10 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 			break;
 		case WT_CHILD_PROXY:
 			/*
-			 * Deleted child where we write a proxy cell, not
-			 * yet supported for column-store.
+			 * Deleted child where we write a proxy cell, not yet
+			 * supported for column-store.
 			 */
-			ret = __wt_illegal_value(session, NULL);
-			goto err;
+			WT_ERR(__wt_illegal_value(session));
 		}
 
 		/*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -482,7 +482,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref,
 		ret = __rec_row_leaf(session, r, page, salvage);
 		break;
 	default:
-		ret = __wt_illegal_value(session);
+		ret = __wt_illegal_value(session, page->type);
 		break;
 	}
 
@@ -770,7 +770,7 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 		return (0);
 	case WT_PM_REC_MULTIBLOCK:			/* Multiple blocks */
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, mod->rec_result);
 	}
 
 	__wt_verbose(session, WT_VERB_SPLIT,
@@ -1899,7 +1899,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			WT_ASSERT(session, WT_REF_SPLIT != WT_REF_SPLIT);
 			return (__wt_set_return(session, EBUSY));
 
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, r->tested_ref_state);
 		}
 		WT_STAT_CONN_INCR(session, child_modify_blocked_page);
 	}
@@ -2922,7 +2922,7 @@ __rec_split_raw(WT_SESSION_IMPL *session,
 			}
 			r->raw_entries[slots] = entry;
 			continue;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, unpack->type);
 		}
 
 		/*
@@ -3641,7 +3641,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	case WT_PAGE_ROW_INT:
 		multi->addr.type = WT_ADDR_INT;
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, page->type);
 	}
 	multi->size = WT_STORE_SIZE(chunk->image.size);
 	multi->checksum = 0;
@@ -4155,7 +4155,8 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 			case WT_PM_REC_REPLACE:
 				addr = &child->modify->mod_replace;
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(
+			    session, child->modify->rec_result);
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -4166,7 +4167,7 @@ __rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 			 * Deleted child where we write a proxy cell, not yet
 			 * supported for column-store.
 			 */
-			WT_ERR(__wt_illegal_value(session));
+			WT_ERR(__wt_illegal_value(session, state));
 		}
 
 		/*
@@ -4705,7 +4706,7 @@ record_loop:	/*
 				case WT_UPDATE_TOMBSTONE:
 					deleted = true;
 					break;
-				WT_ILLEGAL_VALUE_ERR(session);
+				WT_ILLEGAL_VALUE_ERR(session, upd->type);
 				}
 			} else if (vpack->raw == WT_CELL_VALUE_OVFL_RM) {
 				/*
@@ -4950,7 +4951,7 @@ compare:		/*
 				case WT_UPDATE_TOMBSTONE:
 					deleted = true;
 					break;
-				WT_ILLEGAL_VALUE_ERR(session);
+				WT_ILLEGAL_VALUE_ERR(session, upd->type);
 				}
 
 			/*
@@ -5168,7 +5169,8 @@ __rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				 */
 				addr = &child->modify->mod_replace;
 				break;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(
+			    session, child->modify->rec_result);
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -5553,7 +5555,7 @@ __rec_row_leaf(WT_SESSION_IMPL *session,
 
 				/* Proceed with appended key/value pairs. */
 				goto leaf_insert;
-			WT_ILLEGAL_VALUE_ERR(session);
+			WT_ILLEGAL_VALUE_ERR(session, upd->type);
 			}
 		}
 
@@ -5763,7 +5765,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 			break;
 		case WT_UPDATE_TOMBSTONE:
 			continue;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, upd->type);
 		}
 
 		/* Build key cell. */
@@ -5973,7 +5975,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		mod->mod_replace.size = 0;
 		__wt_free(session, mod->mod_disk_image);
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, mod->rec_result);
 	}
 
 	/* Reset the reconciliation state. */

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -546,12 +546,14 @@ __wt_panic(WT_SESSION_IMPL *session)
  *	A standard error message when we detect an illegal value.
  */
 int
-__wt_illegal_value_func(WT_SESSION_IMPL *session, const char *func, int line)
+__wt_illegal_value_func(
+    WT_SESSION_IMPL *session, uintmax_t v, const char *func, int line)
     WT_GCC_FUNC_ATTRIBUTE((cold))
     WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 	__wt_err_func(session, EINVAL,
-	    func, line, "encountered an illegal file format or internal value");
+	    func, line, "%s: 0x%" PRIxMAX,
+	    "encountered an illegal file format or internal value", v);
 	return (__wt_panic(session));
 }
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -546,17 +546,12 @@ __wt_panic(WT_SESSION_IMPL *session)
  *	A standard error message when we detect an illegal value.
  */
 int
-__wt_illegal_value_func(
-    WT_SESSION_IMPL *session, const char *tag, const char *file, int line)
+__wt_illegal_value_func(WT_SESSION_IMPL *session, const char *func, int line)
     WT_GCC_FUNC_ATTRIBUTE((cold))
     WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-	__wt_errx(session, "%s%s%s: (%s, %d)",
-	    tag == NULL ? "" : tag,
-	    tag == NULL ? "" : ": ",
-	    "encountered an illegal file format or internal value",
-	    file, line);
-
+	__wt_err_func(session, EINVAL,
+	    func, line, "encountered an illegal file format or internal value");
 	return (__wt_panic(session));
 }
 

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -179,7 +179,7 @@ __wt_buf_set_printable_format(WT_SESSION_IMPL *session,
 			    session, buf, "%s%" PRIu64, sep, pv.u.u));
 			sep = ",";
 			break;
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, pv.type);
 		}
 	}
 	WT_ERR_NOTFOUND_OK(ret);

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -99,7 +99,7 @@ __txn_op_log(WT_SESSION_IMPL *session,
 			WT_RET(__wt_logop_row_remove_pack(
 			    session, logrec, op->fileid, &cursor->key));
 			break;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, upd->type);
 		}
 	} else {
 		recno = WT_INSERT_RECNO(cbt->ins);
@@ -118,7 +118,7 @@ __txn_op_log(WT_SESSION_IMPL *session,
 			WT_RET(__wt_logop_col_remove_pack(
 			    session, logrec, op->fileid, recno));
 			break;
-		WT_ILLEGAL_VALUE(session);
+		WT_ILLEGAL_VALUE(session, upd->type);
 		}
 	}
 
@@ -498,7 +498,7 @@ __wt_txn_checkpoint_log(
 		__wt_scr_free(session, &txn->ckpt_snapshot);
 		txn->full_ckpt = false;
 		break;
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, flags);
 	}
 
 err:	__wt_logrec_free(session, &logrec);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -247,7 +247,7 @@ __txn_op_apply(
 			stop = cursor;
 			break;
 
-		WT_ILLEGAL_VALUE_ERR(session);
+		WT_ILLEGAL_VALUE_ERR(session, mode);
 		}
 
 		/* Set the keys. */
@@ -264,7 +264,7 @@ __txn_op_apply(
 		WT_ERR(ret);
 		break;
 
-	WT_ILLEGAL_VALUE_ERR(session);
+	WT_ILLEGAL_VALUE_ERR(session, optype);
 	}
 
 	/* Reset the cursor so it doesn't block eviction. */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -252,7 +252,7 @@ __txn_abort_newer_updates(
 	case WT_PAGE_ROW_LEAF:
 		__txn_abort_newer_row_leaf(session, page, rollback_timestamp);
 		break;
-	WT_ILLEGAL_VALUE(session);
+	WT_ILLEGAL_VALUE(session, page->type);
 	}
 
 	return (0);


### PR DESCRIPTION
@agorrod, here are a set of changes to clean up and enhance our use of `__wt_illegal_value()`.

The first set are all cleaning up places where we called `__wt_illegal_value()` and it didn't make a lot of sense, basically, places that passed an additional message to `__wt_illegal_value()` so an error message could be logged. For most of those, I replaced the call with some variant of the `WT_PANIC` macro with an error message. I did those as separate commits so it would be easier to review the changes, that is, each change that needed a different fix got its own commit.

Once that was done, I removed the additional message being passed to `__wt_illegal_value()`, and added a "failing value" argument that's now displayed by the function.