### PR TITLE
WT-4186 Log recovery/salvage now detects/reports corruption within log records

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2769,7 +2769,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	WT_LSN lsn;
 	WT_MYSLOT myslot;
 	int64_t release_size;
-	uint32_t force, rdup_len;
+	uint32_t fill_size, force, rdup_len;
 	bool free_slot;
 
 	conn = S2C(session);
@@ -2799,9 +2799,36 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	 * If the caller's record only partially fills the necessary
 	 * space, we need to zero-fill the remainder.
 	 */
-	if (record->size != rdup_len) {
-		memset((uint8_t *)record->mem + record->size, 0,
-		    rdup_len - record->size);
+	fill_size = rdup_len - record->size;
+	if (fill_size != 0) {
+		memset((uint8_t *)record->mem + record->size, 0, fill_size);
+		/*
+		 * Set the last byte of the log record to a non-zero value,
+		 * that allows us, on the input side, to tell that a log
+		 * record was completely written; there couldn't have been
+		 * a partial write. That means that any checksum mismatch
+		 * in those conditions is a log corruption.
+		 *
+		 * Without this changed byte, when we see a zeroed last byte,
+		 * we must always treat a checksum error as a possible partial
+		 * write. Since partial writes can happen as a result of an
+		 * interrupted process (for example, a shutdown), we must
+		 * treat a checksum error as a normal occurrence, and merely
+		 * the place where the log must be truncated. So any real
+		 * corruption within log records is hard to detect as such.
+		 *
+		 * However, we can only make this modification if there is
+		 * more than one byte being filled, as the first zero byte
+		 * past the actual record is needed to terminate the loop
+		 * in txn_commit_apply.
+		 *
+		 * This is not a log format change, as we only are changing a
+		 * byte in the padding portion of a record, and no logging code
+		 * has ever checked that it is any particular value up to now.
+		 */
+		if (fill_size > 1)
+			*((uint8_t *)record->mem + rdup_len - 1) =
+			    WT_DEBUG_BYTE;
 		record->size = rdup_len;
 	}
 	/*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2798,8 +2798,10 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp,
 	/*
 	 * If the caller's record only partially fills the necessary
 	 * space, we need to zero-fill the remainder.
+	 *
+	 * The cast is safe, we've already checked to make sure it's in range.
 	 */
-	fill_size = rdup_len - record->size;
+	fill_size = rdup_len - (uint32_t)record->size;
 	if (fill_size != 0) {
 		memset((uint8_t *)record->mem + record->size, 0, fill_size);
 		/*

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -236,9 +236,8 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
     # the file is mangled, that is always an unexpected corruption. Situations
     # where we cannot reliably detect corruption include:
     #  - removal of the last log
-    #  - corruption in the middle of a log record
-    #  - certain corruptions at the beginning of a log record (we don't have
-    #      specific tests for these)
+    #  - certain corruptions at the beginning of a log record (adding garbage
+    #      at the end of a log file can trigger this).
     def log_corrupt_but_valid(self):
         if self.corrupt_last_file() and self.kind == 'removal':
             return True
@@ -246,7 +245,6 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         if self.corrupt_hole_in_last_file():
             return False
         if self.kind == 'truncate-middle' or \
-           self.kind == 'garbage-middle' or \
            self.kind == 'garbage-end':
             return True
         return False


### PR DESCRIPTION
A small code change, with a big comment!  The test case has been updated accordingly.