### PR TITLE
WT-4104 keys reappear after fast truncate.

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -357,10 +357,9 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	/*
 	 * Give the page a modify structure.
 	 *
-	 * If the tree is already dirty and so will be written, mark the page
-	 * dirty.  (We'd like to free the deleted pages, but if the handle is
-	 * read-only or if the application never modifies the tree, we're not
-	 * able to do so.)
+	 * Mark tree dirty, unless the handle is read-only.
+	 * (We'd like to free the deleted pages, but if the handle is read-only,
+	 * we're not able to do so.)
 	 */
 	WT_RET(__wt_page_modify_init(session, page));
 	if (!F_ISSET(btree, WT_BTREE_READONLY))

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -337,6 +337,7 @@ __tombstone_update_alloc(WT_SESSION_IMPL *session,
 int
 __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 {
+	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_INSERT *ins;
 	WT_INSERT_HEAD *insert;
@@ -347,6 +348,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	size_t size;
 	uint32_t count, i;
 
+	btree = S2BT(session);
 	page = ref->page;
 
 	WT_STAT_CONN_INCR(session, cache_read_deleted);
@@ -361,7 +363,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * able to do so.)
 	 */
 	WT_RET(__wt_page_modify_init(session, page));
-	if (session->dhandle->checkpoint == NULL)
+	if (!F_ISSET(btree, WT_BTREE_READONLY))
 		__wt_page_modify_set(session, page);
 
 	if (ref->page_del != NULL &&

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -337,7 +337,6 @@ __tombstone_update_alloc(WT_SESSION_IMPL *session,
 int
 __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 {
-	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_INSERT *ins;
 	WT_INSERT_HEAD *insert;
@@ -348,7 +347,6 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	size_t size;
 	uint32_t count, i;
 
-	btree = S2BT(session);
 	page = ref->page;
 
 	WT_STAT_CONN_INCR(session, cache_read_deleted);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -363,7 +363,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * able to do so.)
 	 */
 	WT_RET(__wt_page_modify_init(session, page));
-	if (btree->modified)
+	if (session->dhandle->checkpoint == NULL)
 		__wt_page_modify_set(session, page);
 
 	if (ref->page_del != NULL &&

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -68,7 +68,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 	size_t root_addr_size;
 	uint8_t root_addr[WT_BTREE_MAX_ADDR_COOKIE];
 	const char *filename;
-	bool creation, forced_salvage, readonly;
+	bool creation, forced_salvage;
 
 	btree = S2BT(session);
 	dhandle = session->dhandle;
@@ -87,8 +87,9 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 	btree->dhandle = dhandle;
 
 	/* Checkpoint files are readonly. */
-	readonly = dhandle->checkpoint != NULL ||
-	    F_ISSET(S2C(session), WT_CONN_READONLY);
+	if (dhandle->checkpoint != NULL ||
+	    F_ISSET(S2C(session), WT_CONN_READONLY))
+		F_SET(btree, WT_BTREE_READONLY);
 
 	/* Get the checkpoint information for this name/checkpoint pair. */
 	WT_CLEAR(ckpt);
@@ -120,7 +121,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 		WT_ERR_MSG(session, EINVAL, "expected a 'file:' URI");
 
 	WT_ERR(__wt_block_manager_open(session, filename, dhandle->cfg,
-	    forced_salvage, readonly, btree->allocsize, &btree->bm));
+	    forced_salvage, F_ISSET(btree, WT_BTREE_READONLY),
+	    btree->allocsize, &btree->bm));
 	bm = btree->bm;
 
 	/*
@@ -150,7 +152,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 		 */
 		WT_ERR(bm->checkpoint_load(bm, session,
 		    ckpt.raw.data, ckpt.raw.size,
-		    root_addr, &root_addr_size, readonly));
+		    root_addr, &root_addr_size,
+		    F_ISSET(btree, WT_BTREE_READONLY)));
 		if (creation || root_addr_size == 0)
 			WT_ERR(__btree_tree_open_empty(session, creation));
 		else {

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -220,11 +220,12 @@ struct __wt_btree {
 #define	WT_BTREE_LOOKASIDE	0x002000u	/* Look-aside table */
 #define	WT_BTREE_NO_CHECKPOINT	0x004000u	/* Disable checkpoints */
 #define	WT_BTREE_NO_LOGGING	0x008000u	/* Disable logging */
-#define	WT_BTREE_REBALANCE	0x010000u	/* Handle is for rebalance */
-#define	WT_BTREE_SALVAGE	0x020000u	/* Handle is for salvage */
-#define	WT_BTREE_SKIP_CKPT	0x040000u	/* Handle skipped checkpoint */
-#define	WT_BTREE_UPGRADE	0x080000u	/* Handle is for upgrade */
-#define	WT_BTREE_VERIFY		0x100000u	/* Handle is for verify */
+#define	WT_BTREE_READONLY	0x010000u	/* Handle is readonly */
+#define	WT_BTREE_REBALANCE	0x020000u	/* Handle is for rebalance */
+#define	WT_BTREE_SALVAGE	0x040000u	/* Handle is for salvage */
+#define	WT_BTREE_SKIP_CKPT	0x080000u	/* Handle skipped checkpoint */
+#define	WT_BTREE_UPGRADE	0x100000u	/* Handle is for upgrade */
+#define	WT_BTREE_VERIFY		0x200000u	/* Handle is for verify */
 	uint32_t flags;
 };
 


### PR DESCRIPTION
As per my understanding, checkpoint is marking the btree as clean, which is resulting in not constructing the update chain when fast truncate page is read back from disk.