### PR TITLE
WT-4144 Fix rollback_to_stable with lookaside history.

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -394,9 +394,6 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * We also need to instantiate a lookaside page if this is an update
 	 * operation in progress.
 	 */
-	if (ref->page_las->invalid)
-		return (false);
-
 	if (F_ISSET(txn, WT_TXN_UPDATE))
 		return (false);
 
@@ -470,18 +467,23 @@ __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref)
  *	Remove all records for a given page from the lookaside store.
  */
 static int
-__las_remove_block(WT_SESSION_IMPL *session,
+__las_remove_block(
     WT_CURSOR *cursor, uint64_t pageid, bool lock_wait, uint64_t *remove_cntp)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_ITEM las_key;
+	WT_SESSION_IMPL *session;
+	WT_TXN_ISOLATION saved_isolation;
 	uint64_t las_counter, las_pageid;
 	uint32_t las_id;
+	bool local_txn;
 
 	*remove_cntp = 0;
 
+	session = (WT_SESSION_IMPL *)cursor->session;
 	conn = S2C(session);
+	local_txn = false;
 
 	/* Prevent the sweep thread from removing the block. */
 	if (lock_wait)
@@ -489,6 +491,10 @@ __las_remove_block(WT_SESSION_IMPL *session,
 	else
 		WT_RET(__wt_try_writelock(
 		    session, &conn->cache->las_sweepwalk_lock));
+
+	__las_set_isolation(session, &saved_isolation);
+	WT_ERR(__wt_txn_begin(session, NULL));
+	local_txn = true;
 
 	/*
 	 * Search for the block's unique btree ID and page ID prefix and step
@@ -508,7 +514,15 @@ __las_remove_block(WT_SESSION_IMPL *session,
 	}
 	WT_ERR_NOTFOUND_OK(ret);
 
-err:	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
+err:	if (local_txn) {
+		if (ret == 0)
+			ret = __wt_txn_commit(session, NULL);
+		else
+			WT_TRET(__wt_txn_rollback(session, NULL));
+	}
+
+	__las_restore_isolation(session, saved_isolation);
+	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
 	return (ret);
 }
 
@@ -518,7 +532,8 @@ err:	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
  *	cache state when performing a lookaside table write.
  */
 static int
-__las_insert_block_verbose(WT_SESSION_IMPL *session, WT_MULTI *multi)
+__las_insert_block_verbose(
+    WT_SESSION_IMPL *session, WT_BTREE *btree, WT_MULTI *multi)
 {
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
@@ -530,7 +545,7 @@ __las_insert_block_verbose(WT_SESSION_IMPL *session, WT_MULTI *multi)
 #endif
 	const char *ts;
 
-	btree_id = S2BT(session)->id;
+	btree_id = btree->id;
 
 	if (!WT_VERBOSE_ISSET(session,
 	    WT_VERB_LOOKASIDE | WT_VERB_LOOKASIDE_ACTIVITY))
@@ -587,15 +602,14 @@ __las_insert_block_verbose(WT_SESSION_IMPL *session, WT_MULTI *multi)
  *	Copy one set of saved updates into the database's lookaside table.
  */
 int
-__wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
-    WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key)
+__wt_las_insert_block(WT_CURSOR *cursor,
+    WT_BTREE *btree, WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key)
 {
-	WT_BTREE *btree;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_ITEM las_timestamp, las_value;
 	WT_SAVE_UPD *list;
-	WT_SESSION_IMPL *las_session;
+	WT_SESSION_IMPL *session;
 	WT_TXN_ISOLATION saved_isolation;
 	WT_UPDATE *upd;
 	uint64_t insert_cnt;
@@ -604,7 +618,7 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	uint8_t *p;
 	bool local_txn;
 
-	btree = S2BT(session);
+	session = (WT_SESSION_IMPL *)cursor->session;
 	conn = S2C(session);
 	WT_CLEAR(las_timestamp);
 	WT_CLEAR(las_value);
@@ -617,12 +631,6 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	if (!btree->lookaside_entries)
 		btree->lookaside_entries = true;
 
-	/* Wrap all the updates in a transaction. */
-	las_session = (WT_SESSION_IMPL *)cursor->session;
-	__las_set_isolation(las_session, &saved_isolation);
-	WT_ERR(__wt_txn_begin(las_session, NULL));
-	local_txn = true;
-
 #ifdef HAVE_DIAGNOSTIC
 	{
 	uint64_t remove_cnt;
@@ -630,11 +638,16 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 	 * There should never be any entries with the page ID we are about to
 	 * use.
 	 */
-	WT_ERR_BUSY_OK(__las_remove_block(
-	    session, cursor, las_pageid, false, &remove_cnt));
+	WT_ERR_BUSY_OK(
+	    __las_remove_block(cursor, las_pageid, false, &remove_cnt));
 	WT_ASSERT(session, remove_cnt == 0);
 	}
 #endif
+
+	/* Wrap all the updates in a transaction. */
+	__las_set_isolation(session, &saved_isolation);
+	WT_ERR(__wt_txn_begin(session, NULL));
+	local_txn = true;
 
 	/* Enter each update in the boundary's list into the lookaside store. */
 	for (las_counter = 0, i = 0,
@@ -742,9 +755,9 @@ __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
 err:	/* Resolve the transaction. */
 	if (local_txn) {
 		if (ret == 0)
-			WT_TRET(__wt_txn_commit(las_session, NULL));
+			WT_TRET(__wt_txn_commit(session, NULL));
 		else
-			WT_TRET(__wt_txn_rollback(las_session, NULL));
+			WT_TRET(__wt_txn_rollback(session, NULL));
 
 		/* Adjust the entry count. */
 		if (ret == 0)
@@ -752,11 +765,11 @@ err:	/* Resolve the transaction. */
 			    &conn->cache->las_insert_count, insert_cnt);
 	}
 
-	__las_restore_isolation(las_session, saved_isolation);
+	__las_restore_isolation(session, saved_isolation);
 
 	if (ret == 0 && insert_cnt > 0) {
 		multi->page_las.las_pageid = las_pageid;
-		ret = __las_insert_block_verbose(session, multi);
+		ret = __las_insert_block_verbose(session, btree, multi);
 	}
 
 	return (ret);
@@ -832,8 +845,6 @@ __wt_las_remove_block(
 	WT_CONNECTION_IMPL *conn;
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
-	WT_SESSION_IMPL *las_session;
-	WT_TXN_ISOLATION saved_isolation;
 	uint64_t remove_cnt;
 	uint32_t session_flags;
 
@@ -847,24 +858,12 @@ __wt_las_remove_block(
 	 */
 	__wt_las_cursor(session, &cursor, &session_flags);
 
-	las_session = (WT_SESSION_IMPL *)cursor->session;
-	__las_set_isolation(las_session, &saved_isolation);
-
-	WT_ERR(__wt_txn_begin(las_session, NULL));
-
-	ret = __las_remove_block(
-	    las_session, cursor, pageid, lock_wait, &remove_cnt);
-	if (ret == 0)
-		ret = __wt_txn_commit(las_session, NULL);
-	else
-		WT_TRET(__wt_txn_rollback(las_session, NULL));
-	if (ret == 0)
+	if ((ret = __las_remove_block(
+	    cursor, pageid, lock_wait, &remove_cnt)) == 0)
 		(void)__wt_atomic_add64(
 		    &conn->cache->las_remove_count, remove_cnt);
 
-err:	__las_restore_isolation(las_session, saved_isolation);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
-
 	return (ret);
 }
 
@@ -1008,6 +1007,12 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	saved_pageid = 0;
 
 	/*
+	 * Prevent other threads removing entries from underneath the sweep.
+	 */
+	__wt_writelock(session, &cache->las_sweepwalk_lock);
+	locked = true;
+
+	/*
 	 * Allocate a cursor and wrap all the updates in a transaction.
 	 * We should have our own lookaside cursor.
 	 */
@@ -1016,12 +1021,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	__las_set_isolation(session, &saved_isolation);
 	WT_ERR(__wt_txn_begin(session, NULL));
 	local_txn = true;
-
-	/*
-	 * Prevent other threads removing entries from underneath the sweep.
-	 */
-	__wt_writelock(session, &cache->las_sweepwalk_lock);
-	locked = true;
 
 	/* Encourage a race */
 	__wt_timing_stress(session, WT_TIMING_STRESS_LOOKASIDE_SWEEP);
@@ -1193,11 +1192,12 @@ err:		__wt_buf_free(session, sweep_key);
 			(void)__wt_atomic_add64(
 			    &cache->las_remove_count, remove_cnt);
 	}
+
+	__las_restore_isolation(session, saved_isolation);
+	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
+
 	if (locked)
 		__wt_writeunlock(session, &cache->las_sweepwalk_lock);
-
-	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
-	__las_restore_isolation(session, saved_isolation);
 
 	__wt_scr_free(session, &saved_key);
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -755,7 +755,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 err:	/* Resolve the transaction. */
 	if (local_txn) {
 		if (ret == 0)
-			WT_TRET(__wt_txn_commit(session, NULL));
+			ret = __wt_txn_commit(session, NULL);
 		else
 			WT_TRET(__wt_txn_rollback(session, NULL));
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -638,7 +638,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 	 * There should never be any entries with the page ID we are about to
 	 * use.
 	 */
-	WT_ERR_BUSY_OK(
+	WT_RET_BUSY_OK(
 	    __las_remove_block(cursor, las_pageid, false, &remove_cnt));
 	WT_ASSERT(session, remove_cnt == 0);
 	}

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -628,11 +628,10 @@ __evict_update_work(WT_SESSION_IMPL *session)
 	 * (3) the cache is more than half way from the dirty target to the
 	 *     dirty trigger.
 	 */
-	if (!F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE) &&
-	    (__wt_cache_stuck(session) ||
+	if (__wt_cache_stuck(session) ||
 	    (__wt_cache_lookaside_score(cache) > 80 &&
 	    dirty_inuse >
-	    (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200)))
+	    (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200))
 		F_SET(cache, WT_CACHE_EVICT_LOOKASIDE);
 
 	/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -631,7 +631,8 @@ __evict_review(
 			 * that can't be evicted, check if reconciliation
 			 * suggests trying the lookaside table.
 			 */
-			if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE))
+			if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE) &&
+			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
 				lookaside_retryp = &lookaside_retry;
 		}
 	}

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -239,7 +239,6 @@ struct __wt_page_lookaside {
 	WT_DECL_TIMESTAMP(max_timestamp)/* Maximum timestamp */
 	WT_DECL_TIMESTAMP(unstable_timestamp)/* First timestamp not on page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
-	bool invalid;			/* History is required correct reads */
 	bool skew_newest;		/* Page image has newest versions */
 };
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1189,7 +1189,7 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	if ((page_las = ref->page_las) == NULL)
 		return (false);
-	if (!ref->page_las->skew_newest)
+	if (!page_las->skew_newest)
 		return (true);
 	if (__wt_txn_visible_all(session, page_las->max_txn,
 	    WT_TIMESTAMP_NULL(&page_las->max_timestamp)))

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1189,7 +1189,7 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	if ((page_las = ref->page_las) == NULL)
 		return (false);
-	if (page_las->invalid || !ref->page_las->skew_newest)
+	if (!ref->page_las->skew_newest)
 		return (true);
 	if (__wt_txn_visible_all(session, page_las->max_txn,
 	    WT_TIMESTAMP_NULL(&page_las->max_timestamp)))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -210,7 +210,7 @@ extern void __wt_las_cursor(WT_SESSION_IMPL *session, WT_CURSOR **cursorp, uint3
 extern int __wt_las_cursor_close(WT_SESSION_IMPL *session, WT_CURSOR **cursorp, uint32_t session_flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_las_insert_block(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_las_insert_block(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_remove_block(WT_SESSION_IMPL *session, uint64_t pageid, bool lock_wait) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_save_dropped(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -901,8 +901,8 @@ __wt_txn_update_check(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 		return (0);
 
 	/*
-	 * Clear the ignore prepare setting of txn, as it is not supposed, to
-	 * affect the visibility for update operations.
+	 * Always include prepared transactions in this check: they are not
+	 * supposed to affect visibility for update operations.
 	 */
 	ignore_prepare_set = F_ISSET(txn, WT_TXN_IGNORE_PREPARE);
 	F_CLR(txn, WT_TXN_IGNORE_PREPARE);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -6236,7 +6236,7 @@ __rec_las_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 	for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
 		if (multi->supd != NULL) {
 			WT_ERR(__wt_las_insert_block(
-			    session, cursor, r->page, multi, key));
+			    cursor, S2BT(session), r->page, multi, key));
 
 			__wt_free(session, multi->supd);
 			multi->supd_entries = 0;

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -117,12 +117,10 @@ __txn_abort_newer_update(WT_SESSION_IMPL *session,
 			__wt_timestamp_set_zero(&next_upd->timestamp);
 
 			/*
-			* If any updates are aborted, all newer updates
-			* better be aborted as well.
-			*/
-			if (!aborted_one)
-				WT_ASSERT(session,
-				    !aborted_one || upd == next_upd);
+			 * If any updates are aborted, all newer updates
+			 * better be aborted as well.
+			 */
+			WT_ASSERT(session, !aborted_one || upd == next_upd);
 			aborted_one = true;
 		}
 	}
@@ -230,9 +228,47 @@ static int
 __txn_abort_newer_updates(
     WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t *rollback_timestamp)
 {
+	WT_DECL_RET;
 	WT_PAGE *page;
+	uint32_t read_flags;
+	bool local_read;
 
-	page = ref->page;
+	local_read = false;
+	read_flags = WT_READ_WONT_NEED;
+	if (ref->page_las != NULL && ref->page_las->skew_newest &&
+	    __wt_timestamp_cmp(rollback_timestamp,
+	    &ref->page_las->unstable_timestamp) < 0) {
+		/* Make sure get back a page with history, not limbo page */
+		WT_ASSERT(session,
+		    !F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT));
+		WT_RET(__wt_page_in(session, ref, read_flags));
+		WT_ASSERT(session, ref->state != WT_REF_LIMBO &&
+		    ref->page != NULL && __wt_page_is_modified(ref->page));
+		local_read = true;
+	}
+
+	/* Review deleted page saved to the ref */
+	if (ref->page_del != NULL && __wt_timestamp_cmp(
+	    rollback_timestamp, &ref->page_del->timestamp) < 0)
+		WT_ERR(__wt_delete_page_rollback(session, ref));
+
+	/*
+	 * If we have a ref with no page, or the page is clean, there is
+	 * nothing to roll back.
+	 *
+	 * This check for a clean page is partly an optimization (checkpoint
+	 * only marks pages clean when they have no unwritten updates so
+	 * there's no point visiting them again), but also covers a corner case
+	 * of a checkpoint with use_timestamp=false.  Such a checkpoint
+	 * effectively moves the stable timestamp forward, because changes that
+	 * are written in the checkpoint cannot be reliably rolled back.  The
+	 * actual stable timestamp doesn't change, though, so if we try to roll
+	 * back clean pages the in-memory tree can get out of sync with the
+	 * on-disk tree.
+	 */
+	if ((page = ref->page) == NULL || !__wt_page_is_modified(page))
+		goto err;
+
 	switch (page->type) {
 	case WT_PAGE_COL_FIX:
 		__txn_abort_newer_col_fix(session, page, rollback_timestamp);
@@ -252,10 +288,12 @@ __txn_abort_newer_updates(
 	case WT_PAGE_ROW_LEAF:
 		__txn_abort_newer_row_leaf(session, page, rollback_timestamp);
 		break;
-	WT_ILLEGAL_VALUE(session, page->type);
+	WT_ILLEGAL_VALUE_ERR(session, page->type);
 	}
 
-	return (0);
+err:	if (local_read)
+		WT_TRET(__wt_page_release(session, ref, read_flags));
+	return (ret);
 }
 
 /*
@@ -267,29 +305,21 @@ __txn_rollback_to_stable_btree_walk(
     WT_SESSION_IMPL *session, wt_timestamp_t *rollback_timestamp)
 {
 	WT_DECL_RET;
-	WT_REF *ref;
+	WT_REF *child_ref, *ref;
 
 	/* Walk the tree, marking commits aborted where appropriate. */
 	ref = NULL;
 	while ((ret = __wt_tree_walk(session, &ref,
-	    WT_READ_CACHE | WT_READ_LOOKASIDE | WT_READ_NO_EVICT)) == 0 &&
+	    WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_WONT_NEED)) == 0 &&
 	    ref != NULL) {
-		if (ref->page_las != NULL &&
-		    ref->page_las->skew_newest &&
-		    __wt_timestamp_cmp(rollback_timestamp,
-		    &ref->page_las->unstable_timestamp) < 0)
-			ref->page_las->invalid = true;
-
-		/* Review deleted page saved to the ref */
-		if (ref->page_del != NULL && __wt_timestamp_cmp(
-		    rollback_timestamp, &ref->page_del->timestamp) < 0)
-			WT_RET(__wt_delete_page_rollback(session, ref));
-
-		if (!__wt_page_is_modified(ref->page))
-			continue;
-
-		WT_RET(__txn_abort_newer_updates(
-		    session, ref, rollback_timestamp));
+		if (WT_PAGE_IS_INTERNAL(ref->page)) {
+			WT_INTL_FOREACH_BEGIN(session, ref->page, child_ref) {
+				WT_RET(__txn_abort_newer_updates(
+				    session, child_ref, rollback_timestamp));
+			} WT_INTL_FOREACH_END;
+		} else
+			WT_RET(__txn_abort_newer_updates(
+			    session, ref, rollback_timestamp));
 	}
 	return (ret);
 }
@@ -373,8 +403,8 @@ __txn_rollback_to_stable_btree(WT_SESSION_IMPL *session, const char *cfg[])
 	 * be in.
 	 */
 	WT_RET(__wt_evict_file_exclusive_on(session));
-	ret = __txn_rollback_to_stable_btree_walk(
-	    session, &rollback_timestamp);
+	WT_WITH_PAGE_INDEX(session, ret = __txn_rollback_to_stable_btree_walk(
+	    session, &rollback_timestamp));
 	__wt_evict_file_exclusive_off(session);
 
 	return (ret);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -120,7 +120,8 @@ __txn_abort_newer_update(WT_SESSION_IMPL *session,
 			 * If any updates are aborted, all newer updates
 			 * better be aborted as well.
 			 */
-			WT_ASSERT(session, !aborted_one || upd == next_upd);
+			if (!aborted_one)
+				WT_ASSERT(session, upd == next_upd);
 			aborted_one = true;
 		}
 	}

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -234,6 +234,13 @@ __txn_abort_newer_updates(
 	uint32_t read_flags;
 	bool local_read;
 
+	/*
+	 * If we created a page image with updates the need to be rolled back,
+	 * read the history into cache now and make sure the page is marked
+	 * dirty.  Otherwise, the history we need could be swept from the
+	 * lookaside table before the page is read because the lookaside sweep
+	 * code has no way to tell that the page image is invalid.
+	 */
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
 	if (ref->page_las != NULL && ref->page_las->skew_newest &&

--- a/test/suite/test_timestamp04.py
+++ b/test/suite/test_timestamp04.py
@@ -70,8 +70,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         if missing == False:
             actual = dict((k, v) for k, v in cur if v != 0)
             if actual != expected:
-                print "missing: ", sorted(set(expected) - set(actual))
-                print "extras: ", sorted(set(actual) - set(expected))
+                print "missing: ", sorted(set(expected.items()) - set(actual.items()))
+                print "extras: ", sorted(set(actual.items()) - set(expected.items()))
             self.assertTrue(actual == expected)
 
         # Search for the expected items as well as iterating.
@@ -167,7 +167,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         self.conn.rollback_to_stable()
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rollback_to_stable][2]
-        upd_aborted = stat_cursor[stat.conn.txn_rollback_upd_aborted][2]
+        upd_aborted = (stat_cursor[stat.conn.txn_rollback_upd_aborted][2] +
+            stat_cursor[stat.conn.txn_rollback_las_removed][2])
         stat_cursor.close()
         self.assertEqual(calls, 1)
         self.assertTrue(upd_aborted >= key_range/2)
@@ -237,7 +238,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         self.conn.rollback_to_stable()
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rollback_to_stable][2]
-        upd_aborted = stat_cursor[stat.conn.txn_rollback_upd_aborted][2]
+        upd_aborted = (stat_cursor[stat.conn.txn_rollback_upd_aborted][2] +
+            stat_cursor[stat.conn.txn_rollback_las_removed][2])
         stat_cursor.close()
         self.assertEqual(calls, 2)
         #

--- a/test/suite/test_timestamp06.py
+++ b/test/suite/test_timestamp06.py
@@ -65,17 +65,15 @@ class test_timestamp06(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Check that a cursor (optionally started in a new transaction), sees the
     # expected values.
-    def check(self, session, txn_config, tablename, expected, prn=False):
+    def check(self, session, txn_config, tablename, expected):
         if txn_config:
             session.begin_transaction(txn_config)
 
         cur = session.open_cursor(tablename, None)
         actual = dict((k, v) for k, v in cur if v != 0)
-        if prn == True:
-            print "CHECK : Expected"
-            print expected
-            print "CHECK : Actual"
-            print actual
+        if actual != expected:
+            print "missing: ", sorted(set(expected.items()) - set(actual.items()))
+            print "extras: ", sorted(set(actual.items()) - set(expected.items()))
         self.assertTrue(actual == expected)
         # Search for the expected items as well as iterating
         for k, v in expected.iteritems():


### PR DESCRIPTION
There were several bugs, resulting in incorrect data after a rollback_to_stable call in the presence of lookaside history.

The main issue was with pages images containing updates newer than the stable timestamp (which is a common case because WiredTiger evicts optimistically, assuming the stable timestamp will move forward by the time the next checkpoint starts).  Since rollback_to_stable doesn't modify page images, it instead was marking such pages "invalid" so the history would always be loaded before the pages could be read correctly.  However, the required history to make sense of such pages could be removed by a lookaside sweep, which makes decisions solely on the contents of the lookaside table without access to the "invalid" flag.

The solution here is to read the history into cache for such pages during rollback_to_stable.  The page is marked dirty, with updates newer than the stable timestamp rolled back, then it can be evicted or rewritten in memory.  This eliminates the special "invalid" flag.

In the process of finding that bug, a number of other issues were found and fixed, including:
* don't read all lookaside content into cache during rollback_to_stable;
* avoid races between eviction threads and rollback_to_stable (fix nesting of locks and transactions, use an explicit flag check during eviction rather than relying on the eviction server thread to update cache-wide flags); and
* simplify functions accessing the lookaside table so each function has a single session.