### PR TITLE
WT-4249 Attempt to discard dirty page during verify operation.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -86,8 +86,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 	/* Set the data handle first, our called functions reasonably use it. */
 	btree->dhandle = dhandle;
 
-	/* Checkpoint files are readonly. */
-	if (dhandle->checkpoint != NULL ||
+	/* Checkpoint and verify files are readonly. */
+	if (dhandle->checkpoint != NULL || F_ISSET(btree, WT_BTREE_VERIFY) ||
 	    F_ISSET(S2C(session), WT_CONN_READONLY))
 		F_SET(btree, WT_BTREE_READONLY);
 


### PR DESCRIPTION
This is fall out from WT-4104 fix, where handles opened by verify are
missed to mark as read-only.