### PR TITLE
WT-4233 Change log corruption errors to warnings and truncate log

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -45,7 +45,6 @@ func_ok()
 	    -e '/int __im_file_sync$/d' \
 	    -e '/int __im_fs_directory_list_free$/d' \
 	    -e '/int __im_fs_exist$/d' \
-	    -e '/int __log_salvage_message$/d' \
 	    -e '/int __page_write_gen_wrapped_check$/d' \
 	    -e '/int __posix_terminate$/d' \
 	    -e '/int __rec_destroy_session$/d' \

--- a/dist/s_void
+++ b/dist/s_void
@@ -45,6 +45,7 @@ func_ok()
 	    -e '/int __im_file_sync$/d' \
 	    -e '/int __im_fs_directory_list_free$/d' \
 	    -e '/int __im_fs_exist$/d' \
+	    -e '/int __log_salvage_message$/d' \
 	    -e '/int __page_write_gen_wrapped_check$/d' \
 	    -e '/int __posix_terminate$/d' \
 	    -e '/int __rec_destroy_session$/d' \

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1081,7 +1081,7 @@ err:	__wt_scr_free(session, &buf);
  *	Check that values of the log record header are valid.
  *	No byteswap of the header has been done at this point.
  */
-static int
+static void
 __log_record_verify(WT_SESSION_IMPL *session, WT_FH *log_fh, uint32_t offset,
     WT_LOG_RECORD *logrecp, bool *corrupt)
 {
@@ -1098,36 +1098,35 @@ __log_record_verify(WT_SESSION_IMPL *session, WT_FH *log_fh, uint32_t offset,
 	__wt_log_record_byteswap(&logrec);
 
 	if (F_ISSET(&logrec, ~(WT_LOG_RECORD_ALL_FLAGS))) {
-		WT_RET(__wt_msg(session,
+		__wt_verbose(session, WT_VERB_RECOVERY,
 		    "%s: log record at position %" PRIu32
 		    " has flag corruption 0x%" PRIx16, log_fh->name, offset,
-		    logrec.flags));
+		    logrec.flags);
 		*corrupt = true;
 	}
 	for (i = 0; i < sizeof(logrec.unused); i++)
 		if (logrec.unused[i] != 0) {
-			WT_RET(__wt_msg(session,
+			__wt_verbose(session, WT_VERB_RECOVERY,
 			    "%s: log record at position %" PRIu32
 			    " has unused[%" WT_SIZET_FMT "] corruption 0x%"
-			    PRIx8, log_fh->name, offset, i, logrec.unused[i]));
+			    PRIx8, log_fh->name, offset, i, logrec.unused[i]);
 			*corrupt = true;
 		}
 	if (logrec.mem_len != 0 && !F_ISSET(&logrec,
 	    WT_LOG_RECORD_COMPRESSED | WT_LOG_RECORD_ENCRYPTED)) {
-		WT_RET(__wt_msg(session,
+		__wt_verbose(session, WT_VERB_RECOVERY,
 		    "%s: log record at position %" PRIu32
 		    " has memory len corruption 0x%" PRIx32, log_fh->name,
-		    offset, logrec.mem_len));
+		    offset, logrec.mem_len);
 		*corrupt = true;
 	}
 	if (logrec.len <= offsetof(WT_LOG_RECORD, record)) {
-		WT_RET(__wt_msg(session,
+		__wt_verbose(session, WT_VERB_RECOVERY,
 		    "%s: log record at position %" PRIu32
 		    " has record len corruption 0x%" PRIx32, log_fh->name,
-		    offset, logrec.len));
+		    offset, logrec.len);
 		*corrupt = true;
 	}
-	return (0);
 }
 
 /*
@@ -1930,8 +1929,8 @@ __log_has_hole(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t log_size,
 				logrec = (WT_LOG_RECORD *)p;
 				if (buf_left >= sizeof(WT_LOG_RECORD)) {
 					off += p - buf;
-					WT_ERR(__log_record_verify(session, fh,
-					    (uint32_t)off, logrec, &corrupt));
+					__log_record_verify(session, fh,
+					    (uint32_t)off, logrec, &corrupt);
 					if (corrupt)
 						*error_offset = off;
 				}
@@ -2145,18 +2144,16 @@ err:	if (locked)
 }
 
 /*
- * __log_salvageable_error --
- *	Show error messages consistently for a salvageable error.
+ * __log_salvage_message --
+ *	Show verbose messages consistently for a salvageable error.
  */
 static int
-__log_salvageable_error(WT_SESSION_IMPL *session, const char *log_name,
+__log_salvage_message(WT_SESSION_IMPL *session, const char *log_name,
     const char *extra_msg, wt_off_t offset)
 {
-	if (!FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_RECOVER_SALVAGE))
-		WT_PANIC_RET(session, WT_ERROR,
-		    "log file %s corrupted%s at position %" PRIuMAX
-		    ", use salvage to fix", log_name, extra_msg,
-		    (uintmax_t)offset);
+	__wt_verbose(session, WT_VERB_RECOVERY,
+	    "log file %s corrupted%s at position %" PRIuMAX
+	    ", truncated", log_name, extra_msg, (uintmax_t)offset);
 	return (WT_ERROR);
 }
 
@@ -2324,7 +2321,7 @@ advance:
 				    &partial_record));
 				if (bad_offset != 0) {
 					need_salvage = true;
-					WT_ERR(__log_salvageable_error(session,
+					WT_ERR(__log_salvage_message(session,
 					    log_fh->name, "", bad_offset));
 				}
 			}
@@ -2440,7 +2437,7 @@ advance:
 			    &bad_offset, &eol));
 			if (bad_offset != 0) {
 				need_salvage = true;
-				WT_ERR(__log_salvageable_error(session,
+				WT_ERR(__log_salvage_message(session,
 				    log_fh->name, "", bad_offset));
 			}
 			if (eol)
@@ -2494,18 +2491,20 @@ advance:
 				ret = WT_NOTFOUND;
 
 			/*
-			 * When we have a checksum mismatch, we determine
-			 * whether it may be the result of:
+			 * When we have a checksum mismatch, we would like
+			 * to determine whether it may be the result of:
 			 *  1) some expected corruption that can occur during
 			 *     backups
 			 *  2) a partial write that can naturally occur when
 			 *     an application crashes
 			 *  3) some other corruption
-			 *
-			 * As the first and second happen commonly in normal
-			 * operations, we will silently truncate the log when
-			 * it occurs. The third will result in an error during
-			 * recovery, and requires salvage to fix.
+			 * so that we can (in case 3) flag cases of file system
+			 * or hardware failures. Unfortunately, we have found
+			 * on some systems that file system writes may in fact
+			 * be lost, and this can readily be triggered with
+			 * normal operations. Rather than force users to
+			 * salvage in these situations, we merely truncate the
+			 * log at this point and issue a verbose message.
 			 */
 			if (F_ISSET(conn, WT_CONN_WAS_BACKUP))
 				break;
@@ -2517,7 +2516,7 @@ advance:
 				 * must be salvaged.
 				 */
 				need_salvage = true;
-				WT_ERR(__log_salvageable_error(session,
+				WT_ERR(__log_salvage_message(session,
 				    log_fh->name, ", bad checksum",
 				    rd_lsn.l.offset));
 			} else {
@@ -2526,11 +2525,11 @@ advance:
 				 * that the header is corrupt.  Make a sanity
 				 * check of the log record header.
 				 */
-				WT_ERR(__log_record_verify(session, log_fh,
-				    rd_lsn.l.offset, logrec, &corrupt));
+				__log_record_verify(session, log_fh,
+				    rd_lsn.l.offset, logrec, &corrupt);
 				if (corrupt) {
 					need_salvage = true;
-					WT_ERR(__log_salvageable_error(session,
+					WT_ERR(__log_salvage_message(session,
 					    log_fh->name, "", rd_lsn.l.offset));
 				}
 			}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2146,7 +2146,7 @@ err:	if (locked)
 
 /*
  * __log_salvage_message --
- *	Show verbose messages consistently for a salvageable error.
+ *	Show messages consistently for a salvageable error.
  */
 static int
 __log_salvage_message(WT_SESSION_IMPL *session, const char *log_name,

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -247,9 +247,8 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
             return True
         return False
 
-    # In certain cases, we detect log corruption, but only report it on
-    # verbose output.
-    def expect_verbose_corruption(self):
+    # In certain cases, we detect log corruption, but just issue warnings.
+    def expect_warning_corruption(self):
         if self.kind == 'garbage-middle' and self.chkpt <= self.corruptpos:
             return True
         if self.corrupt_hole_in_last_file():
@@ -313,7 +312,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
             ['/log file.*corrupted/', 'WT_ERROR: non-specific WiredTiger error'])
         else:
             self.check_empty_file(errfile)
-            if self.expect_verbose_corruption():
+            if self.expect_warning_corruption():
                 self.check_file_contains(outfile, '/log file .* corrupted/')
             self.check_file_contains(outfile, self.uri)
 

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -296,9 +296,6 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         outfile = 'list.out'
         expect_fail = self.expect_recovery_failure()
 
-        # Certain corruptions are only reported as verbose output.
-        verbose_config = self.base_config + ',verbose=[recovery]'
-
         # In cases of corruption, we cannot always call wiredtiger_open
         # directly, because there may be a panic, and abort() is called
         # in diagnostic mode which terminates the Python interpreter.
@@ -307,7 +304,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         # us to observe the failure or success safely.
         # Use -R to force recover=on, which is the default for
         # wiredtiger_open, (wt utilities normally have recover=error)
-        self.runWt(['-h', newdir, '-C', verbose_config, '-R', 'list'],
+        self.runWt(['-h', newdir, '-C', self.base_config, '-R', 'list'],
             errfilename=errfile, outfilename=outfile, failure=expect_fail,
             closeconn=False)
 


### PR DESCRIPTION
Most reports of log corruption will now be reported as messages,
and they will not stop recovery from succeeding.