### PR TITLE
WT-3637 Fix a heap use after free from evicting of a page that just split (v3.4 backport)

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -391,6 +391,18 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref,
 	 */
 	WT_PAGE_LOCK(session, page);
 
+	/*
+	 * Now that the page is locked, if attempting to evict it, check again
+	 * whether eviction is permitted. The page's state could have changed
+	 * while we were waiting to acquire the lock (e.g., the page could have
+	 * split).
+	 */
+	if (LF_ISSET(WT_REC_EVICT) &&
+	    !__wt_page_can_evict(session, ref, NULL)) {
+		WT_PAGE_UNLOCK(session, page);
+		return (EBUSY);
+	}
+
 	oldest_id = __wt_txn_oldest_id(session);
 	if (LF_ISSET(WT_EVICTING))
 		mod->last_eviction_id = oldest_id;


### PR DESCRIPTION
(cherry picked from commit a86638be657f647ce1656d24d8f653e72a9e6eee)