### PR TITLE
WT-4251 Prepared updates cannot be discarded.

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -510,6 +510,10 @@ __wt_txn_visible_all(
 static inline bool
 __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 {
+	if (upd->prepare_state == WT_PREPARE_LOCKED ||
+	    upd->prepare_state == WT_PREPARE_INPROGRESS)
+		return (false);
+
 	return (__wt_txn_visible_all(
 	    session, upd->txnid, WT_TIMESTAMP_NULL(&upd->timestamp)));
 }


### PR DESCRIPTION
We have a check in ordinary eviction that prepared updates are not discarded, but not in other places (e.g., the code that garbage collects obsolete updates).  Rather than find all of the places, this change checks for prepared updates as part of the "visible all" check for updates.