### PR TITLE
WT-4263 When copying a key for a lookaside write, use the right tree.

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -662,10 +662,12 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			key->size = WT_PTRDIFF(p, key->data);
 			break;
 		case WT_PAGE_ROW_LEAF:
-			if (list->ins == NULL)
-				WT_ERR(__wt_row_leaf_key(
+			if (list->ins == NULL) {
+				WT_WITH_BTREE(session, btree,
+				    ret = __wt_row_leaf_key(
 				    session, page, list->ripcip, key, false));
-			else {
+				WT_ERR(ret);
+			} else {
 				key->data = WT_INSERT_KEY(list->ins);
 				key->size = WT_INSERT_KEY_SIZE(list->ins);
 			}


### PR DESCRIPTION
Previously this code juggled two session handles, one of which referenced the original tree and the other was specific to the lookaside table.  Now that the code has been simplified to just use one session, we need to take care when we need to operate on the original tree.