### PR TITLE
WT-4154 Surface the oldest read timestamp.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1441,14 +1441,14 @@ methods = {
         specify which timestamp to query: \c all_committed returns the largest
         timestamp such that all timestamps up to that value have committed,
         \c oldest returns the most recent \c oldest_timestamp set with
-        WT_CONNECTION::set_timestamp, \c oldest_active_reader returns the
+        WT_CONNECTION::set_timestamp, \c oldest_reader returns the
         minimum of the read timestamps of all active readers including the
         checkpoint \c pinned returns the minimum of the\c oldest_timestamp and
         the read timestamps of all active readers, and \c stable returns the
         most recent \c stable_timestamp set with WT_CONNECTION::set_timestamp.
         See @ref transaction_timestamps''',
         choices=['all_committed','last_checkpoint',
-            'oldest','oldest_active_reader','pinned','recovery','stable']),
+            'oldest','oldest_reader','pinned','recovery','stable']),
 ]),
 
 'WT_CONNECTION.set_timestamp' : Method([

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1441,12 +1441,14 @@ methods = {
         specify which timestamp to query: \c all_committed returns the largest
         timestamp such that all timestamps up to that value have committed,
         \c oldest returns the most recent \c oldest_timestamp set with
-        WT_CONNECTION::set_timestamp, \c pinned returns the minimum of the
-        \c oldest_timestamp and the read timestamps of all active readers, and
-        \c stable returns the most recent \c stable_timestamp set with
-        WT_CONNECTION::set_timestamp.  See @ref transaction_timestamps''',
+        WT_CONNECTION::set_timestamp, \c oldest_active_reader returns the
+        minimum of the read timestamps of all active readers including the
+        checkpoint \c pinned returns the minimum of the\c oldest_timestamp and
+        the read timestamps of all active readers, and \c stable returns the
+        most recent \c stable_timestamp set with WT_CONNECTION::set_timestamp.
+        See @ref transaction_timestamps''',
         choices=['all_committed','last_checkpoint',
-            'oldest','pinned','recovery','stable']),
+            'oldest','oldest_active_reader','pinned','recovery','stable']),
 ]),
 
 'WT_CONNECTION.set_timestamp' : Method([

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1442,11 +1442,11 @@ methods = {
         timestamp such that all timestamps up to that value have committed,
         \c oldest returns the most recent \c oldest_timestamp set with
         WT_CONNECTION::set_timestamp, \c oldest_reader returns the
-        minimum of the read timestamps of all active readers including the
-        checkpoint \c pinned returns the minimum of the\c oldest_timestamp and
-        the read timestamps of all active readers, and \c stable returns the
-        most recent \c stable_timestamp set with WT_CONNECTION::set_timestamp.
-        See @ref transaction_timestamps''',
+        minimum of the read timestamps of all active readers \c pinned returns
+        the minimum of the\c oldest_timestamp and the read timestamps of all
+        active readers, and \c stable returns the most recent
+        \c stable_timestamp set with WT_CONNECTION::set_timestamp. See
+        @ref transaction_timestamps''',
         choices=['all_committed','last_checkpoint',
             'oldest','oldest_reader','pinned','recovery','stable']),
 ]),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -47,7 +47,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_open_session[] = {
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_query_timestamp[] = {
 	{ "get", "string",
 	    NULL, "choices=[\"all_committed\",\"last_checkpoint\",\"oldest\""
-	    ",\"pinned\",\"recovery\",\"stable\"]",
+	    ",\"oldest_active_reader\",\"pinned\",\"recovery\",\"stable\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -47,7 +47,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_open_session[] = {
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_query_timestamp[] = {
 	{ "get", "string",
 	    NULL, "choices=[\"all_committed\",\"last_checkpoint\",\"oldest\""
-	    ",\"oldest_active_reader\",\"pinned\",\"recovery\",\"stable\"]",
+	    ",\"oldest_reader\",\"pinned\",\"recovery\",\"stable\"]",
 	    NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
 };

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2486,14 +2486,13 @@ struct __wt_connection {
 	 * value have committed\, \c oldest returns the most recent \c
 	 * oldest_timestamp set with WT_CONNECTION::set_timestamp\, \c
 	 * oldest_reader returns the minimum of the read timestamps of all
-	 * active readers including the checkpoint \c pinned returns the minimum
-	 * of the\c oldest_timestamp and the read timestamps of all active
-	 * readers\, and \c stable returns the most recent \c stable_timestamp
-	 * set with WT_CONNECTION::set_timestamp.  See @ref
-	 * transaction_timestamps., a string\, chosen from the following
-	 * options: \c "all_committed"\, \c "last_checkpoint"\, \c "oldest"\, \c
-	 * "oldest_reader"\, \c "pinned"\, \c "recovery"\, \c "stable"; default
-	 * \c all_committed.}
+	 * active readers \c pinned returns the minimum of the\c
+	 * oldest_timestamp and the read timestamps of all active readers\, and
+	 * \c stable returns the most recent \c stable_timestamp set with
+	 * WT_CONNECTION::set_timestamp.  See @ref transaction_timestamps., a
+	 * string\, chosen from the following options: \c "all_committed"\, \c
+	 * "last_checkpoint"\, \c "oldest"\, \c "oldest_reader"\, \c "pinned"\,
+	 * \c "recovery"\, \c "stable"; default \c all_committed.}
 	 * @configend
 	 * @errors
 	 * If there is no matching timestamp (e.g., if this method is called

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2485,15 +2485,15 @@ struct __wt_connection {
 	 * returns the largest timestamp such that all timestamps up to that
 	 * value have committed\, \c oldest returns the most recent \c
 	 * oldest_timestamp set with WT_CONNECTION::set_timestamp\, \c
-	 * oldest_active_reader returns the minimum of the read timestamps of
-	 * all active readers including the checkpoint \c pinned returns the
-	 * minimum of the\c oldest_timestamp and the read timestamps of all
-	 * active readers\, and \c stable returns the most recent \c
-	 * stable_timestamp set with WT_CONNECTION::set_timestamp.  See @ref
+	 * oldest_reader returns the minimum of the read timestamps of all
+	 * active readers including the checkpoint \c pinned returns the minimum
+	 * of the\c oldest_timestamp and the read timestamps of all active
+	 * readers\, and \c stable returns the most recent \c stable_timestamp
+	 * set with WT_CONNECTION::set_timestamp.  See @ref
 	 * transaction_timestamps., a string\, chosen from the following
 	 * options: \c "all_committed"\, \c "last_checkpoint"\, \c "oldest"\, \c
-	 * "oldest_active_reader"\, \c "pinned"\, \c "recovery"\, \c "stable";
-	 * default \c all_committed.}
+	 * "oldest_reader"\, \c "pinned"\, \c "recovery"\, \c "stable"; default
+	 * \c all_committed.}
 	 * @configend
 	 * @errors
 	 * If there is no matching timestamp (e.g., if this method is called

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2484,14 +2484,16 @@ struct __wt_connection {
 	 * @config{get, specify which timestamp to query: \c all_committed
 	 * returns the largest timestamp such that all timestamps up to that
 	 * value have committed\, \c oldest returns the most recent \c
-	 * oldest_timestamp set with WT_CONNECTION::set_timestamp\, \c pinned
-	 * returns the minimum of the \c oldest_timestamp and the read
-	 * timestamps of all active readers\, and \c stable returns the most
-	 * recent \c stable_timestamp set with WT_CONNECTION::set_timestamp.
-	 * See @ref transaction_timestamps., a string\, chosen from the
-	 * following options: \c "all_committed"\, \c "last_checkpoint"\, \c
-	 * "oldest"\, \c "pinned"\, \c "recovery"\, \c "stable"; default \c
-	 * all_committed.}
+	 * oldest_timestamp set with WT_CONNECTION::set_timestamp\, \c
+	 * oldest_active_reader returns the minimum of the read timestamps of
+	 * all active readers including the checkpoint \c pinned returns the
+	 * minimum of the\c oldest_timestamp and the read timestamps of all
+	 * active readers\, and \c stable returns the most recent \c
+	 * stable_timestamp set with WT_CONNECTION::set_timestamp.  See @ref
+	 * transaction_timestamps., a string\, chosen from the following
+	 * options: \c "all_committed"\, \c "last_checkpoint"\, \c "oldest"\, \c
+	 * "oldest_active_reader"\, \c "pinned"\, \c "recovery"\, \c "stable";
+	 * default \c all_committed.}
 	 * @configend
 	 * @errors
 	 * If there is no matching timestamp (e.g., if this method is called

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -202,7 +202,7 @@ __txn_get_pinned_timestamp(
    bool include_oldest)
 {
 	WT_CONNECTION_IMPL *conn;
-	WT_DECL_TIMESTAMP(tmp_ts);
+	WT_DECL_TIMESTAMP(tmp_ts)
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -194,7 +194,7 @@ __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name,
 
 /*
  * __txn_get_pinned_timestamp --
- * 	Calculate the current pinned timestamp.
+ *	Calculate the current pinned timestamp.
  */
 static int
 __txn_get_pinned_timestamp(

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -207,7 +207,6 @@ __txn_get_pinned_timestamp(
 
 	conn = S2C(session);
 	txn_global = &conn->txn_global;
-	__wt_timestamp_set_zero(tsp);
 
 	if (include_oldest && !txn_global->has_oldest_timestamp)
 		return (WT_NOTFOUND);
@@ -215,6 +214,8 @@ __txn_get_pinned_timestamp(
 	__wt_readlock(session, &txn_global->rwlock);
 	if (include_oldest)
 		__wt_timestamp_set(tsp, &txn_global->oldest_timestamp);
+	else
+		__wt_timestamp_set_zero(tsp);
 
 	/* Check for a running checkpoint */
 	if (include_checkpoint &&
@@ -307,7 +308,7 @@ __txn_global_query_timestamp(
 			return (WT_NOTFOUND);
 		WT_WITH_TIMESTAMP_READLOCK(session, &txn_global->rwlock,
 		    __wt_timestamp_set(&ts, &txn_global->oldest_timestamp));
-	} else if (WT_STRING_MATCH("oldest_active_reader", cval.str, cval.len))
+	} else if (WT_STRING_MATCH("oldest_reader", cval.str, cval.len))
 		WT_RET(__txn_get_pinned_timestamp(session, &ts, true, false));
 	else if (WT_STRING_MATCH("pinned", cval.str, cval.len))
 		WT_RET(__txn_get_pinned_timestamp(session, &ts, true, true));

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -184,6 +184,9 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(c[6], 6)
         self.assertEqual(c[7], 7)
         self.assertEqual(c[8], 8)
+        self.assertTimestampsEqual(
+            self.conn.query_timestamp('get=oldest_active_reader'),
+            timestamp_str(8))
         self.session.commit_transaction()
 
         # We can move the oldest timestamp backwards with "force"
@@ -194,6 +197,9 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 timestamp_str(4)),
                 '/older than oldest timestamp/')
         self.session.begin_transaction('read_timestamp=' + timestamp_str(6))
+        self.assertTimestampsEqual(
+            self.conn.query_timestamp('get=oldest_active_reader'),
+            timestamp_str(6))
         self.session.commit_transaction()
 
 if __name__ == '__main__':

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -185,8 +185,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(c[7], 7)
         self.assertEqual(c[8], 8)
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=oldest_active_reader'),
-            timestamp_str(8))
+            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(8))
         self.session.commit_transaction()
 
         # We can move the oldest timestamp backwards with "force"
@@ -198,8 +197,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 '/older than oldest timestamp/')
         self.session.begin_transaction('read_timestamp=' + timestamp_str(6))
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=oldest_active_reader'),
-            timestamp_str(6))
+            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(6))
         self.session.commit_transaction()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a new option `oldest_reader` to the `query_timestamp` API. When `query_timestamp` is used with this option, WT will return the minimum of the read timestamps of all the active transactions which includes the checkpoint transaction. If there are no active readers at the time of issuing this API, WT will return WT_NOTFOUND.
@bvpvamsikrishna please review.