### PR TITLE
WT-4270 Add an operation field to know where threads hang.

### DIFF
--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -105,16 +105,16 @@ typedef struct {
 	const char *op;
 } THREAD_DATA;
 
-#define	NOOP		"NOOP"
-#define	BULK		"BULK"
-#define	BULK_UNQ	"BULK_UNIQUE"
-#define	CREATE		"CREATE"
-#define	CREATE_UNQ	"CREATE_UNIQUE"
-#define	CURSOR		"CURSOR"
-#define	DROP		"DROP"
-#define	REBALANCE	"REBALANCE"
-#define	UPGRADE		"UPGRADE"
-#define	VERIFY		"VERIFY"
+#define	NOOP		"noop"
+#define	BULK		"bulk"
+#define	BULK_UNQ	"bulk_unique"
+#define	CREATE		"create"
+#define	CREATE_UNQ	"create_unique"
+#define	CURSOR		"cursor"
+#define	DROP		"drop"
+#define	REBALANCE	"rebalance"
+#define	UPGRADE		"upgrade"
+#define	VERIFY		"verify"
 
 static void sig_handler(int)
     WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -76,7 +76,11 @@ static const char * const ckpt_file = "checkpoint_done";
 static bool compat, inmem, stable_set, use_ts, use_txn;
 static volatile uint64_t global_ts = 1;
 static volatile uint64_t uid = 1;
-static volatile uint64_t th_ts[MAX_TH];
+typedef struct {
+	uint64_t ts;
+	const char *op;
+} THREAD_TS;
+static volatile THREAD_TS th_ts[MAX_TH];
 
 #define	ENV_CONFIG_COMPAT	",compatibility=(release=\"2.9\")"
 #define	ENV_CONFIG_DEF						\
@@ -98,7 +102,19 @@ typedef struct {
 	WT_CONNECTION *conn;
 	uint64_t start;
 	uint32_t info;
+	const char *op;
 } THREAD_DATA;
+
+#define	NOOP		"NOOP"
+#define	BULK		"BULK"
+#define	BULK_UNQ	"BULK_UNIQUE"
+#define	CREATE		"CREATE"
+#define	CREATE_UNQ	"CREATE_UNIQUE"
+#define	CURSOR		"CURSOR"
+#define	DROP		"DROP"
+#define	REBALANCE	"REBALANCE"
+#define	UPGRADE		"UPGRADE"
+#define	VERIFY		"VERIFY"
 
 static void sig_handler(int)
     WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
@@ -155,8 +171,8 @@ dump_ts(uint64_t nth)
 	uint64_t i;
 
 	for (i = 0; i < nth; ++i)
-		fprintf(stderr, "THREAD %" PRIu64 ": ts: %" PRIu64 "\n",
-		    i, th_ts[i]);
+		fprintf(stderr, "THREAD %" PRIu64 ": ts: %" PRIu64
+		    " op %s\n", i, th_ts[i].ts, th_ts[i].op);
 }
 
 /*
@@ -477,7 +493,7 @@ thread_ts_run(void *arg)
 			 * any thread still with a zero timestamp we go to
 			 * sleep.
 			 */
-			this_ts = th_ts[i];
+			this_ts = th_ts[i].ts;
 			if (this_ts == 0)
 				goto ts_wait;
 			else if (this_ts < oldest_ts)
@@ -676,6 +692,7 @@ thread_run(void *arg)
 		 * Allow some threads to skip schema operations so that they
 		 * are generating sufficient dirty data.
 		 */
+		WT_PUBLISH(th_ts[td->info].op, NOOP);
 		if (td->info != 0 && td->info != 1)
 			/*
 			 * Do a schema operation about 50% of the time by having
@@ -683,30 +700,39 @@ thread_run(void *arg)
 			 */
 			switch (__wt_random(&rnd) % 20) {
 			case 0:
+				WT_PUBLISH(th_ts[td->info].op, BULK);
 				test_bulk(td);
 				break;
 			case 1:
+				WT_PUBLISH(th_ts[td->info].op, BULK_UNQ);
 				test_bulk_unique(td, __wt_random(&rnd) & 1);
 				break;
 			case 2:
+				WT_PUBLISH(th_ts[td->info].op, CREATE);
 				test_create(td);
 				break;
 			case 3:
+				WT_PUBLISH(th_ts[td->info].op, CREATE_UNQ);
 				test_create_unique(td, __wt_random(&rnd) & 1);
 				break;
 			case 4:
+				WT_PUBLISH(th_ts[td->info].op, CURSOR);
 				test_cursor(td);
 				break;
 			case 5:
+				WT_PUBLISH(th_ts[td->info].op, DROP);
 				test_drop(td, __wt_random(&rnd) & 1);
 				break;
 			case 6:
+				WT_PUBLISH(th_ts[td->info].op, REBALANCE);
 				test_rebalance(td);
 				break;
 			case 7:
+				WT_PUBLISH(th_ts[td->info].op, UPGRADE);
 				test_upgrade(td);
 				break;
 			case 8:
+				WT_PUBLISH(th_ts[td->info].op, VERIFY);
 				test_verify(td);
 				break;
 			}
@@ -772,7 +798,7 @@ thread_run(void *arg)
 			 * if we were to race with the timestamp thread, it
 			 * might see our thread update before the commit.
 			 */
-			WT_PUBLISH(th_ts[td->info], stable_ts);
+			WT_PUBLISH(th_ts[td->info].ts, stable_ts);
 		} else {
 			testutil_check(
 			    session->commit_transaction(session, NULL));


### PR DESCRIPTION
@agorrod This is a branch to add debugging for schema_abort when threads hang. This will give us some more information if it fails on a sanitizer build. We still need a core dump to know exactly where they're all hanging. But this is a step forward.