### PR TITLE
WT-4282 Restructure __page_read and avoid moving from limbo to lookaside

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -369,6 +369,43 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __page_read_lookaside --
+ *	Figure out whether to instantiate content from lookaside on
+ *	page access.
+ */
+static inline int
+__page_read_lookaside(WT_SESSION_IMPL *session,
+    WT_REF *ref, uint32_t previous_state, uint32_t *final_statep)
+{
+	/*
+	 * Reading a lookaside ref for the first time, and not requiring the
+	 * history triggers a transition to WT_REF_LIMBO, if we are already
+	 * in limbo and still don't need the history - we are done.
+	 */
+	if (__wt_las_page_skip_locked(session, ref)) {
+		if (previous_state == WT_REF_LOOKASIDE) {
+			WT_STAT_CONN_INCR(
+			    session, cache_read_lookaside_skipped);
+			ref->page_las->eviction_to_lookaside = true;
+			*final_statep = WT_REF_LIMBO;
+		}
+		return (0);
+	}
+
+	/* Instantiate updates from the database's lookaside table. */
+	if (previous_state == WT_REF_LIMBO) {
+		WT_STAT_CONN_INCR(session, cache_read_lookaside_delay);
+		if (WT_SESSION_IS_CHECKPOINT(session))
+			WT_STAT_CONN_INCR(session,
+			    cache_read_lookaside_delay_checkpoint);
+	}
+
+	WT_RET(__las_page_instantiate(session, ref));
+	ref->page_las->eviction_to_lookaside = false;
+	return (0);
+}
+
+/*
  * __page_read --
  *	Read a page from the file.
  */
@@ -496,26 +533,10 @@ skip_read:
 		/* Move all records to a deleted state. */
 		WT_ERR(__wt_delete_page_instantiate(session, ref));
 		break;
-	case WT_REF_LOOKASIDE:
-		if (__wt_las_page_skip_locked(session, ref)) {
-			WT_STAT_CONN_INCR(
-			    session, cache_read_lookaside_skipped);
-			ref->page_las->eviction_to_lookaside = true;
-			final_state = WT_REF_LIMBO;
-			break;
-		}
-		/* FALLTHROUGH */
 	case WT_REF_LIMBO:
-		/* Instantiate updates from the database's lookaside table. */
-		if (previous_state == WT_REF_LIMBO) {
-			WT_STAT_CONN_INCR(session, cache_read_lookaside_delay);
-			if (WT_SESSION_IS_CHECKPOINT(session))
-				WT_STAT_CONN_INCR(session,
-				    cache_read_lookaside_delay_checkpoint);
-		}
-
-		WT_ERR(__las_page_instantiate(session, ref));
-		ref->page_las->eviction_to_lookaside = false;
+	case WT_REF_LOOKASIDE:
+		WT_ERR(__page_read_lookaside(
+		    session, ref, previous_state, &final_state));
 		break;
 	}
 


### PR DESCRIPTION
Sometimes it may be possible to avoid the transition.

It's likely the check in __wt_page_in avoids this transition - but it's not clear to me that the code always goes through that path - so I think we might as well be explicit in __page_read as well.