### PR TITLE
WT-4286 Column store should skip end-of-table checks if there's an exact match.

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -834,6 +834,7 @@ retry:	WT_ERR(__cursor_func_init(cbt, true));
 		 * serialized append operation.
 		 */
 		cbt->iface.recno = WT_RECNO_OOB;
+		cbt->compare = 1;
 		WT_ERR(__cursor_col_search(session, cbt, NULL));
 		WT_ERR(__cursor_col_modify(session, cbt, WT_UPDATE_STANDARD));
 		cursor->recno = cbt->recno;

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -50,21 +50,22 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 				modify_type = WT_UPDATE_STANDARD;
 				value = &col_fix_remove;
 			}
-		} else {
-			/*
-			 * There's a chance the application specified a record
-			 * past the last record on the page.  If that's the
-			 * case, and we're inserting a new WT_INSERT/WT_UPDATE
-			 * pair, it goes on the append list, not the update
-			 * list. Also, an out-of-band recno implies an append
-			 * operation, we're allocating a new row.
-			 */
-			if (recno == WT_RECNO_OOB ||
-			    recno > (btree->type == BTREE_COL_VAR ?
-			    __col_var_last_recno(cbt->ref) :
-			    __col_fix_last_recno(cbt->ref)))
-				append = true;
 		}
+
+		/*
+		 * There's a chance the application specified a record past the
+		 * last record on the page. If that's the case and we're
+		 * inserting a new WT_INSERT/WT_UPDATE pair, it goes on the
+		 * append list, not the update list. Also, an out-of-band recno
+		 * implies an append operation, we're allocating a new row.
+		 */
+		WT_ASSERT(session, recno != WT_RECNO_OOB || cbt->compare != 0);
+		if (cbt->compare != 0 &&
+		    (recno == WT_RECNO_OOB ||
+		    recno > (btree->type == BTREE_COL_VAR ?
+		    __col_var_last_recno(cbt->ref) :
+		    __col_fix_last_recno(cbt->ref))))
+			append = true;
 	}
 
 	/* We're going to modify the page, we should have loaded history. */


### PR DESCRIPTION
In summary, the change in #4262 to clear `WT_CURSOR_BTREE.ins` in the case of finding a record past the end of the page breaks if there are already records past the end of the page and we found an exact match to one of those records.

I don't see any point in doing the work to check past the end of the page if we've already found an exact match, and I want to clear `WT_CURSOR_BTREE.ins` in the append case.

Two bits worth thinking about:

* I'm only checking `WT_CURSOR_BTREE.compare` to determine if an exact match exists, which means any search ending up past the tree is required to pass in a non-zero compare value. I reviewed the usage and I think it's correct (with one fix for `WT_RECNO_OOB`), regardless, I don't think we should be passing in a non-NULL `WT_CURSOR_BTREE.ins` if we didn't find an exact match.

* I split the test for `modify_type == WT_UPDATE_RESERVE || modify_type == WT_UPDATE_TOMBSTONE` from the test for a record past the end of the table. (The tests have always been joined that way, see: https://github.com/wiredtiger/wiredtiger/blame/897c1c89dc5b7670daa53fa3822905ebd72d423b/src/btree/col_modify.c.) Anyway, that code assumes a remove operation can't operate on a record that doesn't already exist. That's **probably** correct, but I wouldn't bet a lot on it, especially with implicit records, and I don't see any reason to make the assumption, it doesn't buy us anything that I can see.