### PR TITLE
WT-4259 Restore ref to previous state rather than MEM when eviction fails

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,7 +81,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		}
 
 		(void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
-		ret = __wt_evict(session, ref, false);
+		ret = __wt_evict(session, ref, false, previous_state);
 		(void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);
 		WT_RET_BUSY_OK(ret);
 		ret = 0;

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -328,7 +328,7 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 	 */
 	if (ss->root_ref.page != NULL) {
 		btree->ckpt = ckptbase;
-		ret = __wt_evict(session, &ss->root_ref, true);
+		ret = __wt_evict(session, &ss->root_ref, true, WT_REF_MEM);
 		ss->root_ref.page = NULL;
 		btree->ckpt = NULL;
 	}
@@ -1300,7 +1300,7 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, true);
+		ret = __wt_evict(session, ref, true, WT_REF_MEM);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));
@@ -2019,7 +2019,7 @@ __slvg_row_build_leaf(
 	 */
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, true);
+		ret = __wt_evict(session, ref, true, WT_REF_MEM);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -111,8 +111,12 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		case WT_SYNC_CLOSE:
 			/*
 			 * Evict the page.
+			 *
+			 * We are closing a tree, if the eviction of a page in
+			 * WT_REF_LIMBO state fails due to some reason, retain
+			 * that page state after the failure.
 			 */
-			WT_ERR(__wt_evict(session, ref, true, WT_REF_MEM));
+			WT_ERR(__wt_evict(session, ref, true, ref->state));
 			break;
 		case WT_SYNC_DISCARD:
 			/*

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -112,7 +112,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			/*
 			 * Evict the page.
 			 */
-			WT_ERR(__wt_evict(session, ref, true));
+			WT_ERR(__wt_evict(session, ref, true, WT_REF_MEM));
 			break;
 		case WT_SYNC_DISCARD:
 			/*

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -112,9 +112,8 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			/*
 			 * Evict the page.
 			 *
-			 * We are closing a tree, if the eviction of a page in
-			 * WT_REF_LIMBO state fails due to some reason, retain
-			 * that page state after the failure.
+			 * Ensure the ref state is restored to the previous
+			 * value if eviction fails.
 			 */
 			WT_ERR(__wt_evict(session, ref, true, ref->state));
 			break;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2087,9 +2087,8 @@ fast:		/* If the page can't be evicted, give up. */
  *	Get a page for eviction.
  */
 static int
-__evict_get_ref(
-    WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_REF **refp,
-    uint32_t *previous_statep)
+__evict_get_ref(WT_SESSION_IMPL *session,
+    bool is_server, WT_BTREE **btreep, WT_REF **refp, uint32_t *previous_statep)
 {
 	WT_CACHE *cache;
 	WT_EVICT_ENTRY *evict;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2275,6 +2275,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 
 	WT_TRACK_OP_INIT(session);
 
+	previous_state = WT_REF_MEM;
 	WT_RET_TRACK(__evict_get_ref(
 	    session, is_server, &btree, &ref, &previous_state));
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2274,6 +2274,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 
 	WT_TRACK_OP_INIT(session);
 
+	previous_state = WT_REF_MEM;
 	WT_RET_TRACK(__evict_get_ref(
 	    session, is_server, &btree, &ref, &previous_state));
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2097,6 +2097,11 @@ __evict_get_ref(WT_SESSION_IMPL *session,
 	bool is_app, server_only, urgent_ok;
 
 	*btreep = NULL;
+	/*
+	 * It is polite to initialize output variables, but it isn't safe for
+	 * callers to use the previous state if we don't return a locked ref.
+	 */
+	*previous_statep = WT_REF_MEM;
 	*refp = NULL;
 
 	cache = S2C(session)->cache;
@@ -2273,7 +2278,6 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	bool app_timer;
 
 	WT_TRACK_OP_INIT(session);
-	previous_state = WT_REF_MEM;	/* -Werror=maybe-uninitialized */
 
 	WT_RET_TRACK(__evict_get_ref(
 	    session, is_server, &btree, &ref, &previous_state));

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2274,8 +2274,8 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	bool app_timer;
 
 	WT_TRACK_OP_INIT(session);
+	previous_state = WT_REF_MEM;	/* -Werror=maybe-uninitialized */
 
-	previous_state = WT_REF_MEM;
 	WT_RET_TRACK(__evict_get_ref(
 	    session, is_server, &btree, &ref, &previous_state));
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -58,25 +58,27 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_PAGE *page;
 	uint64_t time_start, time_stop;
 	uint32_t previous_state;
-	bool too_big;
+	bool locked, too_big;
 
 	btree = S2BT(session);
+	locked = false;
 	page = ref->page;
 	time_start = __wt_clock(session);
 
 	/*
-	 * Take some care with order of operations: if we release the hazard
-	 * reference without first locking the page, it could be evicted in
-	 * between.
+	 * This function always releases the hazard pointer - ensure that's
+	 * done regardless of whether we can get exclusive access.  Take some
+	 * care with order of operations: if we release the hazard pointer
+	 * without first locking the page, it could be evicted in between.
 	 */
 	previous_state = ref->state;
-	if ((previous_state != WT_REF_MEM && previous_state != WT_REF_LIMBO) ||
-	    !__wt_atomic_casv32(&ref->state, previous_state, WT_REF_LOCKED))
-		return (EBUSY);
-
-	if ((ret = __wt_hazard_clear(session, ref)) != 0) {
-		ref->state = previous_state;
-		return (ret);
+	if ((previous_state == WT_REF_MEM || previous_state == WT_REF_LIMBO) &&
+	    __wt_atomic_casv32(&ref->state, previous_state, WT_REF_LOCKED))
+		locked = true;
+	if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
+		if (locked)
+			ref->state = previous_state;
+		return (ret == 0 ? EBUSY : ret);
 	}
 
 	(void)__wt_atomic_addv32(&btree->evict_busy, 1);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -21,10 +21,7 @@ __evict_exclusive_clear(
     WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state)
 {
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED && ref->page != NULL);
-	/*
-	 * If we were evicting a page that is not an ordinary in-memory page
-	 * (i.e. WT_REF_LIMBO), restore the previous state.
-	 */
+
 	ref->state = previous_state;
 }
 
@@ -121,7 +118,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
  */
 int
 __wt_evict(WT_SESSION_IMPL *session,
-    WT_REF *ref, bool closing, uint32_t prev_state)
+    WT_REF *ref, bool closing, uint32_t previous_state)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
@@ -229,7 +226,7 @@ __wt_evict(WT_SESSION_IMPL *session,
 	if (0) {
 err:		if (!closing)
 			__evict_exclusive_clear(
-			    session, ref, prev_state);
+			    session, ref, previous_state);
 
 		WT_STAT_CONN_INCR(session, cache_eviction_fail);
 		WT_STAT_DATA_INCR(session, cache_eviction_fail);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -382,7 +382,7 @@ extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing, uint32_t prev_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing, uint32_t previous_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -382,7 +382,7 @@ extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing, uint32_t prev_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);


### PR DESCRIPTION
During eviction we could move a page from WT_REF_LIMBO to WT_REF_LOCKED. But if the page eviction fails due to some reason we would call __evict_exclusive_clear which used to transition the ref->state from WT_REF_LOCKED to WT_REF_MEM which is undesired. This change set restores the page ref state to the previous state rather than WT_REF_MEM when eviction fails.