### PR TITLE
WT-4284 Print a verbose message in recovery on error too.

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -91,12 +91,14 @@ __recovery_cursor(WT_SESSION_IMPL *session, WT_RECOVERY *r,
  * Helper to a cursor if this operation is to be applied during recovery.
  */
 #define	GET_RECOVERY_CURSOR(session, r, lsnp, fileid, cp)		\
-	WT_ERR(__recovery_cursor(session, r, lsnp, fileid, false, cp));	\
+	ret = __recovery_cursor(session, r, lsnp, fileid, false, cp);	\
 	__wt_verbose(session, WT_VERB_RECOVERY,				\
 	    "%s op %" PRIu32 " to file %" PRIu32 " at LSN %" PRIu32	\
 	    "/%" PRIu32,						\
+	    ret != 0 ? "Error" :					\
 	    cursor == NULL ? "Skipping" : "Applying",			\
 	    optype, fileid, (lsnp)->l.file, (lsnp)->l.offset);		\
+	WT_ERR(ret);							\
 	if (cursor == NULL)						\
 		break
 


### PR DESCRIPTION
@ddanderson  Here's a minor change to the verbose error message in recovery. I needed this when debugging WT-4284 since the call to `recovery_cursor` was failing.