### PR TITLE
WT-3879 Fix a race if checkpoint evicts a metadata page.

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -505,6 +505,10 @@ __wt_block_alloc(
 	WT_EXT *ext, **estack[WT_SKIP_MAXDEPTH];
 	WT_SIZE *szp, **sstack[WT_SKIP_MAXDEPTH];
 
+	/* If a sync is running, no other sessions can allocate blocks. */
+	WT_ASSERT(session, !WT_BTREE_SYNCING(S2BT(session)) ||
+	    WT_SESSION_TREE_SYNC(session));
+
 	/* Assert we're maintaining the by-size skiplist. */
 	WT_ASSERT(session, block->live.avail.track_size != 0);
 
@@ -622,8 +626,9 @@ __wt_block_off_free(
 {
 	WT_DECL_RET;
 
-	WT_ASSERT(session, S2BT(session)->checkpointing != WT_CKPT_RUNNING ||
-	   WT_SESSION_TREE_SYNC(session));
+	/* If a sync is running, no other sessions can free blocks. */
+	WT_ASSERT(session, !WT_BTREE_SYNCING(S2BT(session)) ||
+	    WT_SESSION_TREE_SYNC(session));
 
 	/*
 	 * Callers of this function are expected to have already acquired any

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -506,8 +506,7 @@ __wt_block_alloc(
 	WT_SIZE *szp, **sstack[WT_SKIP_MAXDEPTH];
 
 	/* If a sync is running, no other sessions can allocate blocks. */
-	WT_ASSERT(session, !WT_BTREE_SYNCING(S2BT(session)) ||
-	    WT_SESSION_TREE_SYNC(session));
+	WT_ASSERT(session, WT_SESSION_BTREE_SYNC_SAFE(session, S2BT(session)));
 
 	/* Assert we're maintaining the by-size skiplist. */
 	WT_ASSERT(session, block->live.avail.track_size != 0);
@@ -627,8 +626,7 @@ __wt_block_off_free(
 	WT_DECL_RET;
 
 	/* If a sync is running, no other sessions can free blocks. */
-	WT_ASSERT(session, !WT_BTREE_SYNCING(S2BT(session)) ||
-	    WT_SESSION_TREE_SYNC(session));
+	WT_ASSERT(session, WT_SESSION_BTREE_SYNC_SAFE(session, S2BT(session)));
 
 	/*
 	 * Callers of this function are expected to have already acquired any

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -622,6 +622,9 @@ __wt_block_off_free(
 {
 	WT_DECL_RET;
 
+	WT_ASSERT(session, S2BT(session)->checkpointing != WT_CKPT_RUNNING ||
+	   WT_SESSION_TREE_SYNC(session));
+
 	/*
 	 * Callers of this function are expected to have already acquired any
 	 * locks required to manipulate the extent lists.

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -521,7 +521,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 
 	btree->modified = false;			/* Clean */
 
-	btree->checkpointing = WT_CKPT_OFF;	/* Not checkpointing */
+	btree->syncing = WT_BTREE_SYNC_OFF;	/* Not syncing */
 	btree->write_gen = ckpt->write_gen;	/* Write generation */
 	btree->checkpoint_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -195,7 +195,7 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
 		 */
 		WT_ASSERT(session,
 		    S2BT(session)->checkpointing != WT_CKPT_RUNNING ||
-		    WT_SESSION_IS_CHECKPOINT(session));
+		    WT_SESSION_TREE_SYNC(session));
 
 		WT_RET(__wt_ovfl_discard(session, cell));
 	}

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -186,19 +186,8 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
 
 	cell = WT_PAGE_REF_OFFSET(page, cell_offset);
 	__wt_cell_unpack(cell, &kpack);
-	if (kpack.ovfl && kpack.raw != WT_CELL_KEY_OVFL_RM) {
-		/*
-		 * Eviction cannot free overflow items once a checkpoint is
-		 * running in a tree: that can corrupt the checkpoint's block
-		 * management.  Assert that checkpoints aren't running to make
-		 * sure we're catching all paths and to avoid regressions.
-		 */
-		WT_ASSERT(session,
-		    S2BT(session)->checkpointing != WT_CKPT_RUNNING ||
-		    WT_SESSION_TREE_SYNC(session));
-
+	if (kpack.ovfl && kpack.raw != WT_CELL_KEY_OVFL_RM)
 		WT_RET(__wt_ovfl_discard(session, cell));
-	}
 
 	return (0);
 }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -240,14 +240,13 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		 * Set the checkpointing flag to block such actions and wait for
 		 * any problematic eviction or page splits to complete.
 		 */
-		WT_ASSERT(session, btree->checkpointing == WT_CKPT_OFF);
+		WT_ASSERT(session, btree->syncing == WT_BTREE_SYNC_OFF &&
+		    btree->sync_session == NULL);
 
-		btree->checkpointing = WT_CKPT_PREPARE;
+		btree->sync_session = session;
+		btree->syncing = WT_BTREE_SYNC_WAIT;
 		(void)__wt_gen_next_drain(session, WT_GEN_EVICT);
-		btree->checkpointing = WT_CKPT_RUNNING;
-
-		/* Note in the session that we are syncing this tree. */
-		session->sync_dhandle = session->dhandle;
+		btree->syncing = WT_BTREE_SYNC_RUNNING;
 
 		/* Write all dirty in-cache pages. */
 		LF_SET(WT_READ_NO_EVICT);
@@ -388,8 +387,8 @@ err:	/* On error, clear any left-over tree walk. */
 		__wt_txn_release_snapshot(session);
 
 	/* Clear the checkpoint flag. */
-	btree->checkpointing = WT_CKPT_OFF;
-	session->sync_dhandle = NULL;
+	btree->syncing = WT_BTREE_SYNC_OFF;
+	btree->sync_session = NULL;
 
 	__wt_spin_unlock(session, &btree->flush_lock);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1442,7 +1442,7 @@ retry:	while (slot < max_entries) {
 		 * Skip files that are checkpointing if we are only looking for
 		 * dirty pages.
 		 */
-		if (btree->checkpointing != WT_CKPT_OFF &&
+		if (WT_BTREE_SYNCING(btree) &&
 		    !F_ISSET(cache, WT_CACHE_EVICT_CLEAN))
 			continue;
 
@@ -1910,7 +1910,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session,
 			continue;
 
 		/* Don't queue dirty pages in trees during checkpoints. */
-		if (modified && btree->checkpointing != WT_CKPT_OFF)
+		if (modified && WT_BTREE_SYNCING(btree))
 			continue;
 
 		/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -631,7 +631,7 @@ __evict_review(
 		if (F_ISSET(conn, WT_CONN_IN_MEMORY))
 			LF_SET(WT_REC_IN_MEMORY |
 			    WT_REC_SCRUB | WT_REC_UPDATE_RESTORE);
-		else if (WT_SESSION_TREE_SYNC(session))
+		else if (WT_SESSION_BTREE_SYNC(session))
 			LF_SET(WT_REC_LOOKASIDE);
 		else if (!WT_IS_METADATA(session->dhandle)) {
 			LF_SET(WT_REC_UPDATE_RESTORE);
@@ -659,7 +659,7 @@ __evict_review(
 	 * to evict.  Give up evicting in that case: checkpoint will include
 	 * the reconciled page when it visits the parent.
 	 */
-	if (WT_SESSION_TREE_SYNC(session) && !__wt_page_is_modified(page) &&
+	if (WT_SESSION_BTREE_SYNC(session) && !__wt_page_is_modified(page) &&
 	    !__wt_txn_visible_all(session, page->modify->rec_max_txn,
 	    WT_TIMESTAMP_NULL(&page->modify->rec_max_timestamp)))
 		return (__wt_set_return(session, EBUSY));
@@ -687,7 +687,7 @@ __evict_review(
 	 * very unlikely.  However, since checkpoint is partway through
 	 * reconciling the parent page, a split can corrupt the checkpoint.
 	 */
-	if (WT_SESSION_TREE_SYNC(session) &&
+	if (WT_SESSION_BTREE_SYNC(session) &&
 	    page->modify->rec_result == WT_PM_REC_MULTIBLOCK)
 		return (__wt_set_return(session, EBUSY));
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -574,15 +574,9 @@ __evict_review(
 		 * exclusive access. If an in-memory split completes, the page
 		 * stays in memory and the tree is left in the desired state:
 		 * avoid the usual cleanup.
-		 *
-		 * Note that checkpoints may not split pages in-memory, it can
-		 * lead to corruption when the parent internal page is updated.
 		 */
-		if (*inmem_splitp) {
-			 if (WT_SESSION_IS_CHECKPOINT(session))
-				return (__wt_set_return(session, EBUSY));
+		if (*inmem_splitp)
 			return (__wt_split_insert(session, ref));
-		}
 	}
 
 	/* If the page is clean, we're done and we can evict. */
@@ -637,7 +631,7 @@ __evict_review(
 		if (F_ISSET(conn, WT_CONN_IN_MEMORY))
 			LF_SET(WT_REC_IN_MEMORY |
 			    WT_REC_SCRUB | WT_REC_UPDATE_RESTORE);
-		else if (WT_SESSION_IS_CHECKPOINT(session))
+		else if (WT_SESSION_TREE_SYNC(session))
 			LF_SET(WT_REC_LOOKASIDE);
 		else if (!WT_IS_METADATA(session->dhandle)) {
 			LF_SET(WT_REC_UPDATE_RESTORE);
@@ -665,7 +659,7 @@ __evict_review(
 	 * to evict.  Give up evicting in that case: checkpoint will include
 	 * the reconciled page when it visits the parent.
 	 */
-	if (WT_SESSION_IS_CHECKPOINT(session) && !__wt_page_is_modified(page) &&
+	if (WT_SESSION_TREE_SYNC(session) && !__wt_page_is_modified(page) &&
 	    !__wt_txn_visible_all(session, page->modify->rec_max_txn,
 	    WT_TIMESTAMP_NULL(&page->modify->rec_max_timestamp)))
 		return (__wt_set_return(session, EBUSY));
@@ -693,7 +687,7 @@ __evict_review(
 	 * very unlikely.  However, since checkpoint is partway through
 	 * reconciling the parent page, a split can corrupt the checkpoint.
 	 */
-	if (WT_SESSION_IS_CHECKPOINT(session) &&
+	if (WT_SESSION_TREE_SYNC(session) &&
 	    page->modify->rec_result == WT_PM_REC_MULTIBLOCK)
 		return (__wt_set_return(session, EBUSY));
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -177,7 +177,7 @@ struct __wt_btree {
 	 * would conflict with the sync.
 	 * WT_SESSION_BTREE_SYNC indicates if the session is performing a sync
 	 * on its current tree.
-	 * WT_SESSION_BTREE_SYNC_SAFE checks whether it is safe to perfom an
+	 * WT_SESSION_BTREE_SYNC_SAFE checks whether it is safe to perform an
 	 * operation that would conflict with a sync.
 	 */
 #define	WT_BTREE_SYNCING(btree)						\

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -165,11 +165,26 @@ struct __wt_btree {
 	WT_DECL_TIMESTAMP(rec_max_timestamp)
 
 	uint64_t checkpoint_gen;	/* Checkpoint generation */
+	WT_SESSION_IMPL *sync_session;	/* Syncing session */
 	volatile enum {
-		WT_CKPT_OFF, WT_CKPT_PREPARE, WT_CKPT_RUNNING
-	} checkpointing;		/* Checkpoint in progress */
+		WT_BTREE_SYNC_OFF, WT_BTREE_SYNC_WAIT, WT_BTREE_SYNC_RUNNING
+	} syncing;			/* Sync status */
 
-	uint64_t    bytes_inmem;	/* Cache bytes in memory. */
+	/*
+	 * Helper macros: WT_BTREE_SYNC_ACTIVE indicates if a sync is either
+	 * waiting to start or already running (so no new operations should
+	 * start that would conflict with the sync).  WT_BTREE_SYNCING should
+	 * be used in assertions that operations do not conflict.
+	 */
+#define	WT_BTREE_SYNCING(btree)						\
+	(btree->syncing != WT_BTREE_SYNC_OFF)
+#define	WT_SESSION_BTREE_SYNC(session)					\
+	(S2BT(session)->sync_session == session)
+#define	WT_SESSION_BTREE_SYNC_SAFE(session, btree)			\
+	((btree)->syncing != WT_BTREE_SYNC_RUNNING ||			\
+	    (btree)->sync_session == session)
+
+	uint64_t    bytes_inmem;        /* Cache bytes in memory. */
 	uint64_t    bytes_dirty_intl;	/* Bytes in dirty internal pages. */
 	uint64_t    bytes_dirty_leaf;	/* Bytes in dirty leaf pages. */
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -171,10 +171,14 @@ struct __wt_btree {
 	} syncing;			/* Sync status */
 
 	/*
-	 * Helper macros: WT_BTREE_SYNC_ACTIVE indicates if a sync is either
-	 * waiting to start or already running (so no new operations should
-	 * start that would conflict with the sync).  WT_BTREE_SYNCING should
-	 * be used in assertions that operations do not conflict.
+	 * Helper macros:
+	 * WT_BTREE_SYNCING indicates if a sync is active (either waiting to
+	 * start or already running), so no new operations should start that
+	 * would conflict with the sync.
+	 * WT_SESSION_BTREE_SYNC indicates if the session is performing a sync
+	 * on its current tree.
+	 * WT_SESSION_BTREE_SYNC_SAFE checks whether it is safe to perfom an
+	 * operation that would conflict with a sync.
 	 */
 #define	WT_BTREE_SYNCING(btree)						\
 	(btree->syncing != WT_BTREE_SYNC_OFF)

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1218,7 +1218,7 @@ __wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
 	btree = S2BT(session);
 	return ((btree->checkpointing == WT_CKPT_OFF &&
 	    !F_ISSET(S2C(session), WT_CONN_CLOSING_TIMESTAMP)) ||
-	    WT_SESSION_IS_CHECKPOINT(session));
+	    WT_SESSION_TREE_SYNC(session));
 }
 
 /*
@@ -1235,6 +1235,14 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
 	int count;
 
 	btree = S2BT(session);
+
+	/*
+	 * Checkpoints can not do in-memory splits in the tree they are
+	 * walking: that can lead to corruption when the parent internal page
+	 * is updated.
+	 */
+	if (WT_SESSION_TREE_SYNC(session))
+		return (false);
 
 	/*
 	 * Only split a page once, otherwise workloads that update in the middle
@@ -1504,7 +1512,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 		if (!__wt_page_evict_clean(page) &&
 		    (LF_ISSET(WT_READ_NO_SPLIT) || (!inmem_split &&
 		    F_ISSET(session, WT_SESSION_NO_RECONCILE)))) {
-			if (!WT_SESSION_IS_CHECKPOINT(session))
+			if (!WT_SESSION_TREE_SYNC(session))
 				WT_IGNORE_RET(
 				    __wt_page_evict_urgent(session, ref));
 		} else {

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1216,8 +1216,8 @@ __wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
 	WT_BTREE *btree;
 
 	btree = S2BT(session);
-	return (F_ISSET(S2C(session), WT_CONN_CLOSING_TIMESTAMP) ||
-	    !WT_BTREE_SYNCING(btree) || WT_SESSION_BTREE_SYNC(session));
+	return ((!WT_BTREE_SYNCING(btree) || WT_SESSION_BTREE_SYNC(session)) &&
+            !F_ISSET(S2C(session), WT_CONN_CLOSING_TIMESTAMP));
 }
 
 /*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1217,7 +1217,7 @@ __wt_btree_can_evict_dirty(WT_SESSION_IMPL *session)
 
 	btree = S2BT(session);
 	return ((!WT_BTREE_SYNCING(btree) || WT_SESSION_BTREE_SYNC(session)) &&
-            !F_ISSET(S2C(session), WT_CONN_CLOSING_TIMESTAMP));
+	    !F_ISSET(S2C(session), WT_CONN_CLOSING_TIMESTAMP));
 }
 
 /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -66,6 +66,10 @@ struct __wt_session_impl {
 
 	WT_DATA_HANDLE *dhandle;	/* Current data handle */
 
+	WT_DATA_HANDLE *sync_dhandle;	/* Data handle being synced */
+#define	WT_SESSION_TREE_SYNC(session)					\
+	(session->dhandle == session->sync_dhandle)
+
 	/*
 	 * Each session keeps a cache of data handles. The set of handles can
 	 * grow quite large so we maintain both a simple list and a hash table

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -66,10 +66,6 @@ struct __wt_session_impl {
 
 	WT_DATA_HANDLE *dhandle;	/* Current data handle */
 
-	WT_DATA_HANDLE *sync_dhandle;	/* Data handle being synced */
-#define	WT_SESSION_TREE_SYNC(session)					\
-	(session->dhandle == session->sync_dhandle)
-
 	/*
 	 * Each session keeps a cache of data handles. The set of handles can
 	 * grow quite large so we maintain both a simple list and a hash table

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -307,12 +307,11 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 		 * should be included in the checkpoint.
 		 */
 		ckpt_session->txn.id = session->txn.id;
-		F_SET(ckpt_session, WT_SESSION_LOCKED_METADATA);
-		WT_WITH_METADATA_LOCK(session,
-		    WT_WITH_DHANDLE(ckpt_session,
-		    WT_SESSION_META_DHANDLE(session),
-		    ret = __wt_checkpoint(ckpt_session, NULL)));
-		F_CLR(ckpt_session, WT_SESSION_LOCKED_METADATA);
+		WT_ASSERT(session,
+		    !F_ISSET(session, WT_SESSION_LOCKED_METADATA));
+		WT_WITH_DHANDLE(ckpt_session, WT_SESSION_META_DHANDLE(session),
+		    WT_WITH_METADATA_LOCK(ckpt_session,
+			ret = __wt_checkpoint(ckpt_session, NULL)));
 		ckpt_session->txn.id = WT_TXN_NONE;
 		if (ret == 0)
 			WT_WITH_DHANDLE(session,

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -990,9 +990,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 		/* Disable metadata tracking during the metadata checkpoint. */
 		saved_meta_next = session->meta_track_next;
 		session->meta_track_next = NULL;
-		WT_WITH_METADATA_LOCK(session,
-		    WT_WITH_DHANDLE(session,
-			WT_SESSION_META_DHANDLE(session),
+		WT_WITH_DHANDLE(session, WT_SESSION_META_DHANDLE(session),
+		    WT_WITH_METADATA_LOCK(session,
 			ret = __wt_checkpoint(session, cfg)));
 		session->meta_track_next = saved_meta_next;
 		WT_ERR(ret);


### PR DESCRIPTION
The existing WT_SESSION_IS_CHECKPOINT macro is too broad: it allows a session-wide checkpoint to bypass the usual rules that make eviction of dirty pages safe.  Since we allow operations like WT_SESSION::create to run concurrent with a checkpoint and flush the metadata, we can't have the checkpoint being tapped for forced eviction in the metadata while it is being flushed.

Track the tree a checkpoint is currently flushing, and only allow checkpoint to bypass eviction rules in that tree.