### PR TITLE
WT-4300 setting the update timestamp can overwrite the WT_REF.addr field

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -279,7 +279,7 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 	 */
 	timestamp = op->type == WT_TXN_OP_REF_DELETE ?
 	    &op->u.ref->page_del->timestamp : &op->u.op_upd->timestamp;
-	needs_timestamp = 
+	needs_timestamp =
 	    __wt_timestamp_iszero(timestamp) || F_ISSET(txn, WT_TXN_PREPARE);
 	if (!needs_timestamp)
 		return;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -235,14 +235,11 @@ static inline void
 __wt_txn_unmodify(WT_SESSION_IMPL *session)
 {
 	WT_TXN *txn;
-	WT_TXN_OP *op;
 
 	txn = &session->txn;
 	if (F_ISSET(txn, WT_TXN_HAS_ID)) {
 		WT_ASSERT(session, txn->mod_count > 0);
-		op = txn->mod + txn->mod_count - 1;
-		__wt_txn_op_free(session, op);
-		txn->mod_count--;
+		__wt_txn_op_free(session, txn->mod + --txn->mod_count);
 	}
 }
 
@@ -262,9 +259,10 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 	wt_timestamp_t *timestamp;
 	bool needs_timestamp;
 
-	txn = &session->txn;
 	if (was_set != NULL)
 		*was_set = false;
+
+	txn = &session->txn;
 
 	/*
 	 * The timestamp is in the page deleted structure for truncates, or

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -336,7 +336,6 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 		return;
 
 	if (F_ISSET(txn, WT_TXN_PREPARE)) {
-                WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 		if (op->type == WT_TXN_OP_REF_DELETE)
 			__wt_txn_op_commit_page_del(session, op->u.ref);
 		else {
@@ -405,7 +404,6 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	upd->txnid = session->txn.id;
 
 #ifdef HAVE_TIMESTAMPS
-        WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 	__wt_txn_op_set_timestamp(session, op);
 	/*
 	 * Copy the key into the transaction op structure, so the update
@@ -455,7 +453,6 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
 	op->u.ref = ref;
 	ref->page_del->txnid = txn->id;
 #ifdef HAVE_TIMESTAMPS
-        WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 	__wt_txn_op_set_timestamp(session, op);
 #endif
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -263,7 +263,6 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 	bool needs_timestamp;
 
 	txn = &session->txn;
-	upd = op->u.op_upd;
 	if (was_set != NULL)
 		*was_set = false;
 
@@ -291,7 +290,7 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 	if (!needs_timestamp)
 		return;
 
-	if (for_prepare) {
+	if (for_prepare && op->type != WT_TXN_OP_REF_DELETE) {
 		/*
 		 * In case of a prepared transaction, the order
 		 * of modification of the prepare timestamp to
@@ -303,6 +302,7 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 		 * As updating timestamp might not be an atomic
 		 * operation, we will manage using state.
 		 */
+		upd = op->u.op_upd;
 		upd->prepare_state = WT_PREPARE_LOCKED;
 		WT_WRITE_BARRIER();
 		__wt_timestamp_set(timestamp, &txn->commit_timestamp);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -235,16 +235,18 @@ static inline void
 __wt_txn_unmodify(WT_SESSION_IMPL *session)
 {
 	WT_TXN *txn;
+	WT_TXN_OP *op;
 
 	txn = &session->txn;
 	if (F_ISSET(txn, WT_TXN_HAS_ID)) {
 		WT_ASSERT(session, txn->mod_count > 0);
-		__wt_txn_op_free(session, txn->mod + --txn->mod_count);
+		--txn->mod_count;
+		op = txn->mod + txn->mod_count;
+		__wt_txn_op_free(session, op);
 	}
 }
 
 #ifdef HAVE_TIMESTAMPS
-
 /*
  * __wt_txn_op_commit_page_del --
  *	Make the transaction ID and timestamp updates necessary to a ref that

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -277,14 +277,9 @@ __wt_txn_update_set_timestamp(WT_SESSION_IMPL *session,
 	 * The timestamp is in the page deleted structure for truncates, or
 	 * in the update for other operations.
 	 */
-	if (op->type == WT_TXN_OP_REF_DELETE)
-		timestamp = op->u.ref == NULL || op->u.ref->page_del == NULL ?
-		    NULL : &op->u.ref->page_del->timestamp;
-	else
-		timestamp = op->u.op_upd == NULL ?
-		    NULL : &op->u.op_upd->timestamp;
-
-	needs_timestamp = timestamp == NULL ||
+	timestamp = op->type == WT_TXN_OP_REF_DELETE ?
+	    &op->u.ref->page_del->timestamp : &op->u.op_upd->timestamp;
+	needs_timestamp = 
 	    __wt_timestamp_iszero(timestamp) || F_ISSET(txn, WT_TXN_PREPARE);
 	if (!needs_timestamp)
 		return;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -336,6 +336,7 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 		return;
 
 	if (F_ISSET(txn, WT_TXN_PREPARE)) {
+                WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 		if (op->type == WT_TXN_OP_REF_DELETE)
 			__wt_txn_op_commit_page_del(session, op->u.ref);
 		else {
@@ -363,7 +364,7 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 		 */
 		timestamp = op->type == WT_TXN_OP_REF_DELETE ?
 		    &op->u.ref->page_del->timestamp : &op->u.op_upd->timestamp;
-		if (!__wt_timestamp_iszero(timestamp))
+		if (__wt_timestamp_iszero(timestamp))
 			__wt_timestamp_set(timestamp, &txn->commit_timestamp);
 	}
 }
@@ -404,6 +405,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	upd->txnid = session->txn.id;
 
 #ifdef HAVE_TIMESTAMPS
+        WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 	__wt_txn_op_set_timestamp(session, op);
 	/*
 	 * Copy the key into the transaction op structure, so the update
@@ -453,6 +455,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
 	op->u.ref = ref;
 	ref->page_del->txnid = txn->id;
 #ifdef HAVE_TIMESTAMPS
+        WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 	__wt_txn_op_set_timestamp(session, op);
 #endif
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -692,11 +692,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	u_int i;
 	bool locked, readonly;
 #ifdef HAVE_TIMESTAMPS
-	WT_REF *ref;
-	WT_UPDATE **updp;
 	wt_timestamp_t prev_commit_timestamp, ts;
-	uint32_t previous_state;
-	bool prepared_transaction, timestamp_set, update_timestamp;
+	bool update_timestamp;
 #endif
 
 	txn = &session->txn;
@@ -814,9 +811,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
 	/* Note: we're going to commit: nothing can fail after this point. */
 
-#ifdef HAVE_TIMESTAMPS
-	prepared_transaction = F_ISSET(txn, WT_TXN_PREPARE);
-#endif
 	/* Process and free updates. */
 	for (i = 0, op = txn->mod; i < txn->mod_count; i++, op++) {
 		fileid = op->btree->id;
@@ -848,71 +842,10 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 				upd->txnid = WT_TXN_NONE;
 				break;
 			}
-
-#ifdef HAVE_TIMESTAMPS
-			__wt_txn_update_set_timestamp(
-			    session, op, prepared_transaction, NULL);
-#endif
-			break;
-
+			/* FALLTHROUGH */
 		case WT_TXN_OP_REF_DELETE:
 #ifdef HAVE_TIMESTAMPS
-			__wt_txn_update_set_timestamp(
-			    session, op, prepared_transaction, &timestamp_set);
-			if (!timestamp_set)
-				break;
-
-			ref = op->u.ref;
-			/*
-			 * The page-deleted list can be discarded by eviction,
-			 * lock the WT_REF to ensure we don't race.
-			 */
-			if (ref->page_del->update_list == NULL)
-				break;
-
-			for (;; __wt_yield()) {
-				previous_state = ref->state;
-				if (previous_state != WT_REF_LOCKED &&
-				    __wt_atomic_casv32(
-				    &ref->state, previous_state, WT_REF_LOCKED))
-					break;
-			}
-
-			if ((updp = ref->page_del->update_list) == NULL) {
-				/*
-				 * Publish to ensure we don't let the page be
-				 * evicted and the updates discarded before
-				 * being written.
-				 */
-				WT_PUBLISH(ref->state, previous_state);
-				break;
-			}
-
-			for (; *updp != NULL; ++updp) {
-				if (prepared_transaction) {
-					/*
-					 * As ref state is LOCKED, timestamp
-					 * and prepare state are updated in
-					 * exclusive access, hence no need for
-					 * temporary state WT_PREPARE_LOCKED
-					 * and BARRIER.
-					 */
-					__wt_timestamp_set(
-					    &(*updp)->timestamp,
-					    &txn->commit_timestamp);
-					(*updp)->prepare_state =
-					    WT_PREPARE_RESOLVED;
-				} else
-					__wt_timestamp_set(
-					    &(*updp)->timestamp,
-					    &txn->commit_timestamp);
-			}
-
-			/*
-			 * Publish to ensure we don't let the page be evicted
-			 * and the updates discarded before being written.
-			 */
-			WT_PUBLISH(ref->state, previous_state);
+			__wt_txn_op_set_timestamp(session, op);
 #endif
 			break;
 		case WT_TXN_OP_TRUNCATE_COL:


### PR DESCRIPTION
@bvpvamsikrishna, @agorrod, I'm not sure this fix is correct, but hopefully 2551e61 points out where the problem is.