### PR TITLE
WT-4305 Avoid key copy for txn operations with timestamps as they cannot be prepared.

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -381,3 +381,10 @@ union __wt_rand_state {
 		    session, buf, (buf)->size + __len + 1));		\
 	}								\
 } while (0)
+
+/*
+ * HAVE_LONG_RUNNING_PREPARE
+ * 	To enable functionality of evicting prepared transactions using
+ * cache overflow mechanism.
+ */
+#define	HAVE_LONG_RUNNING_PREPARE 0

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -387,4 +387,4 @@ union __wt_rand_state {
  * 	To enable functionality of evicting prepared transactions using
  * cache overflow mechanism.
  */
-#define	HAVE_LONG_RUNNING_PREPARE 0
+#undef	HAVE_LONG_RUNNING_PREPARE

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -392,6 +392,14 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	__wt_txn_op_set_timestamp(session, op);
 
 	/*
+	 * TODO:
+	 * Following code block is under #ifdef temporarily, to avoid
+	 * performance penalty. This block will be enabled, once an alternative
+	 * is figured out, or we have to live with this penalty.
+	 */
+#define	DISABLE_LOOKASIDE_FOR_PREPARED
+#ifdef DISABLE_LOOKASIDE_FOR_PREPARED
+	/*
 	 * Transaction operation with timestamp cannot be prepared.
 	 * Copy the key into the transaction op structure, so the update
 	 * can be evicted to lookaside, and we have a chance of finding it
@@ -413,11 +421,14 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 		} else
 			op->u.op_col.recno = cbt->recno;
 	}
-#else
+#endif
+#undef DISABLE_LOOKASIDE_FOR_PREPARED
+
+#endif
 	WT_UNUSED(btree);
 	WT_UNUSED(cbt);
 	WT_UNUSED(key);
-#endif
+
 	return (0);
 }
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -354,7 +354,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	__wt_txn_update_set_timestamp(session, op, false, &timestamp_set);
 
 	/*
-	 * Transactions with timestamped operations cannot be prepared.
+	 * Transaction operation with timestamp cannot be prepared.
 	 * Copy the key into the transaction op structure, so the update
 	 * can be evicted to lookaside, and we have a chance of finding it
 	 * again. This is only possible for transactions that are in the

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -397,8 +397,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 	 * performance penalty. This block will be enabled, once an alternative
 	 * is figured out, or we have to live with this penalty.
 	 */
-#define	DISABLE_LOOKASIDE_FOR_PREPARED
-#ifdef DISABLE_LOOKASIDE_FOR_PREPARED
+#ifdef HAVE_LONG_RUNNING_PREPARE
 	/*
 	 * Transaction operation with timestamp cannot be prepared.
 	 * Copy the key into the transaction op structure, so the update
@@ -422,7 +421,6 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 			op->u.op_col.recno = cbt->recno;
 	}
 #endif
-#undef DISABLE_LOOKASIDE_FOR_PREPARED
 
 #endif
 	WT_UNUSED(btree);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1360,14 +1360,12 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 			* together to enable the feature, remove this temporary
 			* code.
 			*/
-#define	DISABLE_LOOKASIDE_FOR_PREPARED
-#ifdef DISABLE_LOOKASIDE_FOR_PREPARED
+#ifndef HAVE_LONG_RUNNING_PREPARE
 		       if (prepared) {
 			       prepared = false;
 			       uncommitted = r->update_uncommitted = true;
 		       }
 #endif
-#undef DISABLE_LOOKASIDE_FOR_PREPARED
 
 		       if (prepared || uncommitted)
 			       continue;


### PR DESCRIPTION
If txn operations have timestamp, then that transaction cannot be prepared, so we avoid making a copy of the key.