### PR TITLE
WT-4306 Fix mode if metadata pages need eviction.

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -526,7 +526,7 @@ __evict_review(
 	conn = S2C(session);
 	page = ref->page;
 	flags = WT_REC_EVICT;
-	if (!WT_SESSION_IS_CHECKPOINT(session))
+	if (!WT_SESSION_BTREE_SYNC(session))
 		LF_SET(WT_REC_VISIBLE_ALL);
 
 	/*


### PR DESCRIPTION
Specifically, as a checkpoint is running, it writes updates to the metadata table, which can cause pages to exceed maximum sizes.  It's fine to attempt eviction in that situation, but it should be ordinary eviction that respects the usual visibility rules.