### PR TITLE
WT-4335 Don't fail rollback_to_stable due to sweep activity

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1473,6 +1473,8 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
 	WT_RET(__wt_msg(session, "current ID: %" PRIu64, txn_global->current));
 	WT_RET(__wt_msg(session,
 	    "last running ID: %" PRIu64, txn_global->last_running));
+	WT_RET(__wt_msg(session,
+	    "metadata_pinned ID: %" PRIu64, txn_global->metadata_pinned));
 	WT_RET(__wt_msg(session, "oldest ID: %" PRIu64, txn_global->oldest_id));
 
 #ifdef HAVE_TIMESTAMPS


### PR DESCRIPTION
Since the later phase of rollback_to_stable holds a lock to prevent sweep running concurrently, this check should use the same approach to avoid spurious failures.