### PR TITLE
WT-4340 the cursor caching layer can incorrectly release too many handle locks.

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -567,7 +567,7 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 	 * state disqualifies the cache.
 	 */
 	ret = __wt_session_lock_dhandle(session, 0, &is_dead);
-	if (ret == 0 && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+	if (!is_dead && ret == 0 && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
 		WT_RET(__wt_session_release_dhandle(session));
 		ret = __wt_set_return(session, EBUSY);
 	}

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -555,7 +555,6 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 	cbt = (WT_CURSOR_BTREE *)cursor;
 	dhandle = cbt->dhandle;
 	session = (WT_SESSION_IMPL *)cursor->session;
-	is_dead = false;
 
 	if (check_only)
 		return (WT_DHANDLE_CAN_REOPEN(dhandle) ? 0 : WT_NOTFOUND);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -119,7 +119,7 @@ __wt_session_lock_dhandle(
 	WT_DECL_RET;
 	bool is_open, lock_busy, want_exclusive;
 
-	*is_deadp = 0;
+	*is_deadp = false;
 
 	dhandle = session->dhandle;
 	btree = dhandle->handle;
@@ -158,7 +158,7 @@ __wt_session_lock_dhandle(
 	for (;;) {
 		/* If the handle is dead, give up. */
 		if (F_ISSET(dhandle, WT_DHANDLE_DEAD)) {
-			*is_deadp = 1;
+			*is_deadp = true;
 			return (0);
 		}
 
@@ -182,7 +182,7 @@ __wt_session_lock_dhandle(
 		    (!want_exclusive || lock_busy)) {
 			__wt_readlock(session, &dhandle->rwlock);
 			if (F_ISSET(dhandle, WT_DHANDLE_DEAD)) {
-				*is_deadp = 1;
+				*is_deadp = true;
 				__wt_readunlock(session, &dhandle->rwlock);
 				return (0);
 			}
@@ -203,7 +203,7 @@ __wt_session_lock_dhandle(
 		if ((ret =
 		    __wt_try_writelock(session, &dhandle->rwlock)) == 0) {
 			if (F_ISSET(dhandle, WT_DHANDLE_DEAD)) {
-				*is_deadp = 1;
+				*is_deadp = true;
 				__wt_writeunlock(session, &dhandle->rwlock);
 				return (0);
 			}


### PR DESCRIPTION
@ddanderson, I introduced a bug in #4292, __wt_session_lock_dhandle() returns 0 with is_dead set, and we're not holding a lock in those cases.