### PR TITLE
WT-4164 Evict clean internal pages where possible when there is cache pressure

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -122,7 +122,7 @@ extern int __wt_debug_addr(WT_SESSION_IMPL *session, const uint8_t *addr, size_t
 extern int __wt_debug_offset_blind(WT_SESSION_IMPL *session, wt_off_t offset, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size, uint32_t checksum, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_disk(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_debug_tree_shape(WT_SESSION_IMPL *session, WT_PAGE *page, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_tree_shape(WT_SESSION_IMPL *session, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_tree_all(void *session_arg, WT_BTREE *btree, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_tree(void *session_arg, WT_BTREE *btree, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_page(void *session_arg, WT_BTREE *btree, WT_REF *ref, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -296,8 +296,7 @@ config_cache(void)
 	 * are lots of threads, it grows the cache to N megabytes per thread.
 	 */
 	v = 2 * g.c_threads * MEGABYTE(g.c_memory_page_max);
-	g.c_cache = WT_MAX(g.c_cache, (v + (WT_MEGABYTE - 1)) / WT_MEGABYTE);
-	v = ((g.c_cache * WT_MEGABYTE) / 10) * 4;
+	v = (v / 4) * 10;
 	g.c_cache = WT_MAX(g.c_cache, (v + (WT_MEGABYTE - 1)) / WT_MEGABYTE);
 
 	/*

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -250,6 +250,10 @@ static CONFIG c[] = {
 	  "the number of LSM worker threads",
 	  0x0, 3, 4, 20, &g.c_lsm_worker_threads, NULL },
 
+	{ "memory_page_max",
+	  "maximum size of in-memory pages",
+	  0x0, 1, 10, 128, &g.c_memory_page_max, NULL },
+
 	{ "merge_max",
 	  "the maximum number of chunks to include in a merge operation",
 	  0x0, 4, 20, 100, &g.c_merge_max, NULL },

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -65,11 +65,11 @@
 #define	LZO_PATH	".libs/lzo_compress.so"
 
 #undef	M
-#define	M(v)		((v) * 1000000)		/* Million */
+#define	M(v)		((v) * WT_MILLION)	/* Million */
 #undef	KILOBYTE
-#define	KILOBYTE(v)	((v) * 1024)
+#define	KILOBYTE(v)	((v) * WT_KILOBYTE)
 #undef	MEGABYTE
-#define	MEGABYTE(v)	((v) * 1048576)
+#define	MEGABYTE(v)	((v) * WT_MEGABYTE)
 
 #define	WT_NAME	"wt"				/* Object name */
 
@@ -201,6 +201,7 @@ typedef struct {
 	uint32_t c_logging_prealloc;
 	uint32_t c_long_running_txn;
 	uint32_t c_lsm_worker_threads;
+	uint32_t c_memory_page_max;
 	uint32_t c_merge_max;
 	uint32_t c_mmap;
 	uint32_t c_modify_pct;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -367,12 +367,15 @@ wts_init(void)
 	max = sizeof(config);
 
 	CONFIG_APPEND(p,
-	    "key_format=%s,"
-	    "allocation_size=512,%s"
-	    "internal_page_max=%" PRIu32 ",leaf_page_max=%" PRIu32,
+	    "key_format=%s"
+	    ",allocation_size=512"
+	    ",%s"
+	    ",internal_page_max=%" PRIu32
+	    ",leaf_page_max=%" PRIu32
+	    ",memory_page_max=%" PRIu32,
 	    (g.type == ROW) ? "u" : "r",
-	    g.c_firstfit ? "block_allocation=first," : "",
-	    g.intl_page_max, g.leaf_page_max);
+	    g.c_firstfit ? "block_allocation=first" : "",
+	    g.intl_page_max, g.leaf_page_max, MEGABYTE(g.c_memory_page_max));
 
 	/*
 	 * Configure the maximum key/value sizes, but leave it as the default


### PR DESCRIPTION
@michaelcahill, this change takes the in-memory page maximum size into account when sizing the cache, guaranteeing every worker thread can pin two maximum-sized pages into memory without blowing out the cache. This change significantly increases the memory that format will allocate to a cache in the presence of larger numbers of threads and so has an outsized impact on our small-cache testing.

On the other hand, this should resolve the category of small-cache problems where we're simply filling the cache.

I don't like it, but I like playing whack-a-mole even less, and I think that's where we've ended up.