### PR TITLE
WT-4341 Support million collection test in Evergreen

### DIFF
--- a/test/mciproject.yml
+++ b/test/mciproject.yml
@@ -16,6 +16,11 @@ functions:
         remote_file: wiredtiger/${build_variant}/${revision}/binaries/${build_id}.tgz
         bucket: build_external
         extract_to: wiredtiger
+  "fetch mongo-tests repo" :
+    command: shell.exec
+    params:
+      script: | 
+        git clone https://github.com/wiredtiger/mongo-tests -b million-collect-test-evg
 
 pre:
   - command: shell.exec
@@ -156,6 +161,20 @@ tasks:
             # format assumes we run it from the format directory
             cmd.exe /c "cd test\\format && ..\\..\\t_format.exe reverse=0 encryption=none logging_compression=none runs=20"
 
+  - name: million-collection-test
+    depends_on: []
+    run_on: 
+      - rhel62-large
+    commands: 
+      - func: "fetch mongo-tests repo"
+      - command: shell.exec
+        params:
+          working_dir: mongo-tests
+          script: | 
+            set -o errexit
+            set -o verbose
+            largescale/run-million-collection-test.sh .
+
 buildvariants:
 - name: ubuntu1404
   display_name: Ubuntu 14.04
@@ -170,6 +189,15 @@ buildvariants:
     - name: compile
     - name: unit-test
     - name: fops
+
+- name: large-scale-test
+  display_name: Large scale testing
+  run_on:
+  - rhel62-large
+  expansions:
+    configure_env_vars: CC=/opt/mongodbtoolchain/bin/gcc CXX=/opt/mongodbtoolchain/bin/g++
+  tasks:
+    - name: million-collection-test
 
 - name: windows-64
   display_name: Windows 64-bit


### PR DESCRIPTION
This part of the change is about Evergreen yaml configuration in order to support million collection testing in Evergreen CI system. 

The solution is to put the new `million-collect-test` task into a new `large-scale-test' build variant in the existing `WiredTiger` project.

The related script changes for `largescale/run-million-collection-test.sh` within `mongo-tests` repo will be covered by BUILD-6194.