### PR TITLE
WT-4293 WT_CURSOR.remove can lose a cursor position

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1025,6 +1025,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned)
 	uint64_t yield_count, sleep_usecs;
 	bool iterating, valid;
 
+	search = NONE;
 	btree = cbt->btree;
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cursor->session;

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1185,7 +1185,8 @@ err:	if (ret == WT_RESTART) {
 		 * can succeed, we cannot return success.)
 		 */
 		if (0) {
-search_notfound:	if (!iterating && !positioned &&
+search_notfound:	ret = WT_NOTFOUND;
+			if (!iterating && !positioned &&
 			    F_ISSET(cursor, WT_CURSTD_OVERWRITE))
 				ret = 0;
 		}

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -107,7 +107,7 @@ extern int __wt_btcur_search(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((w
 extern int __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btcur_insert(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btcur_insert_check(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_btcur_remove(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btcur_reserve(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btcur_update(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
@michaelcahill, the simplest solution I could find was to maintain the "positioned" status of the cursor in the upper-level cursor code. That's arguably a layering violation, let me know if you see something better.

I also reworked error handling in the Btree cursor remove code, there were paths were we could lose errors.