### PR TITLE
WT-3898 Keep prepared updates in lookaside until they are read.

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -258,7 +258,7 @@ __wt_compact_page_skip(
 	}
 
 	/* Reset the WT_REF state. */
-	WT_REF_SETSTATE(ref, WT_REF_DISK);
+	WT_REF_SET_STATE(ref, WT_REF_DISK);
 
 	return (ret);
 }

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -258,7 +258,7 @@ __wt_compact_page_skip(
 	}
 
 	/* Reset the WT_REF state. */
-	ref->state = WT_REF_DISK;
+	WT_REF_SETSTATE(ref, WT_REF_DISK);
 
 	return (ret);
 }

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -76,7 +76,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	if ((previous_state == WT_REF_MEM || previous_state == WT_REF_LIMBO) &&
 	    __wt_atomic_casv32(&ref->state, previous_state, WT_REF_LOCKED)) {
 		if (__wt_page_is_modified(ref->page)) {
-			ref->state = previous_state;
+			WT_REF_SETSTATE(ref, previous_state);
 			return (0);
 		}
 
@@ -155,13 +155,13 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	WT_STAT_DATA_INCR(session, rec_page_delete_fast);
 
 	/* Publish the page to its new state, ensuring visibility. */
-	WT_PUBLISH(ref->state, WT_REF_DELETED);
+	WT_REF_SETSTATE(ref, WT_REF_DELETED);
 	return (0);
 
 err:	__wt_free(session, ref->page_del);
 
 	/* Publish the page to its previous state, ensuring visibility. */
-	WT_PUBLISH(ref->state, previous_state);
+	WT_REF_SETSTATE(ref, previous_state);
 	return (ret);
 }
 
@@ -241,7 +241,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		for (; *updp != NULL; ++updp)
 			(*updp)->txnid = WT_TXN_ABORTED;
 
-	ref->state = current_state;
+	WT_REF_SETSTATE(ref, current_state);
 
 done:	/*
 	 * Now mark the truncate aborted: this must come last because after

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -76,7 +76,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	if ((previous_state == WT_REF_MEM || previous_state == WT_REF_LIMBO) &&
 	    __wt_atomic_casv32(&ref->state, previous_state, WT_REF_LOCKED)) {
 		if (__wt_page_is_modified(ref->page)) {
-			WT_REF_SETSTATE(ref, previous_state);
+			WT_REF_SET_STATE(ref, previous_state);
 			return (0);
 		}
 
@@ -155,13 +155,13 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 	WT_STAT_DATA_INCR(session, rec_page_delete_fast);
 
 	/* Publish the page to its new state, ensuring visibility. */
-	WT_REF_SETSTATE(ref, WT_REF_DELETED);
+	WT_REF_SET_STATE(ref, WT_REF_DELETED);
 	return (0);
 
 err:	__wt_free(session, ref->page_del);
 
 	/* Publish the page to its previous state, ensuring visibility. */
-	WT_REF_SETSTATE(ref, previous_state);
+	WT_REF_SET_STATE(ref, previous_state);
 	return (ret);
 }
 
@@ -241,7 +241,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		for (; *updp != NULL; ++updp)
 			(*updp)->txnid = WT_TXN_ABORTED;
 
-	WT_REF_SETSTATE(ref, current_state);
+	WT_REF_SET_STATE(ref, current_state);
 
 done:	/*
 	 * Now mark the truncate aborted: this must come last because after

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -669,7 +669,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 		ref->home = root;
 		ref->page = NULL;
 		ref->addr = NULL;
-		WT_REF_SETSTATE(ref, WT_REF_DELETED);
+		WT_REF_SET_STATE(ref, WT_REF_DELETED);
 		ref->ref_recno = 1;
 		break;
 	case BTREE_ROW:
@@ -682,7 +682,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 		ref->home = root;
 		ref->page = NULL;
 		ref->addr = NULL;
-		WT_REF_SETSTATE(ref, WT_REF_DELETED);
+		WT_REF_SET_STATE(ref, WT_REF_DELETED);
 		WT_ERR(__wt_row_ikey_incr(session, root, 0, "", 1, ref));
 		break;
 	}
@@ -691,7 +691,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 	if (F_ISSET(btree, WT_BTREE_BULK)) {
 		WT_ERR(__wt_btree_new_leaf_page(session, &leaf));
 		ref->page = leaf;
-		WT_REF_SETSTATE(ref, WT_REF_MEM);
+		WT_REF_SET_STATE(ref, WT_REF_MEM);
 		WT_ERR(__wt_page_modify_init(session, leaf));
 		__wt_page_only_modify_set(session, leaf);
 	}

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -669,7 +669,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 		ref->home = root;
 		ref->page = NULL;
 		ref->addr = NULL;
-		ref->state = WT_REF_DELETED;
+		WT_REF_SETSTATE(ref, WT_REF_DELETED);
 		ref->ref_recno = 1;
 		break;
 	case BTREE_ROW:
@@ -682,7 +682,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 		ref->home = root;
 		ref->page = NULL;
 		ref->addr = NULL;
-		ref->state = WT_REF_DELETED;
+		WT_REF_SETSTATE(ref, WT_REF_DELETED);
 		WT_ERR(__wt_row_ikey_incr(session, root, 0, "", 1, ref));
 		break;
 	}
@@ -691,7 +691,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
 	if (F_ISSET(btree, WT_BTREE_BULK)) {
 		WT_ERR(__wt_btree_new_leaf_page(session, &leaf));
 		ref->page = leaf;
-		ref->state = WT_REF_MEM;
+		WT_REF_SETSTATE(ref, WT_REF_MEM);
 		WT_ERR(__wt_page_modify_init(session, leaf));
 		__wt_page_only_modify_set(session, leaf);
 	}

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -482,7 +482,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			 * Re-create the state of a deleted page.
 			 */
 			ref->addr = cell;
-			ref->state = WT_REF_DELETED;
+			WT_REF_SETSTATE(ref, WT_REF_DELETED);
 			++refp;
 
 			/*

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -482,7 +482,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			 * Re-create the state of a deleted page.
 			 */
 			ref->addr = cell;
-			WT_REF_SETSTATE(ref, WT_REF_DELETED);
+			WT_REF_SET_STATE(ref, WT_REF_DELETED);
 			++refp;
 
 			/*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -554,11 +554,9 @@ skip_read:
 	 * Don't free WT_REF.page_las, there may be concurrent readers.
 	 */
 	if (final_state == WT_REF_MEM && ref->page_las != NULL &&
-	    (!ref->page_las->skew_newest || ref->page_las->has_prepares)) {
-		ret = __wt_las_remove_block(
-		    session, ref->page_las->las_pageid);
-		WT_ERR(ret);
-	}
+	    (!ref->page_las->skew_newest || ref->page_las->has_prepares))
+		WT_ERR(__wt_las_remove_block(
+		    session, ref->page_las->las_pageid));
 
 	WT_REF_SETSTATE(ref, final_state);
 	return (ret);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -113,7 +113,7 @@ __las_page_instantiate_verbose(WT_SESSION_IMPL *session, uint64_t las_pageid)
  *	Instantiate lookaside update records in a recently read page.
  */
 static int
-__las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, bool *preparedp)
+__las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_CACHE *cache;
 	WT_CURSOR *cursor;
@@ -166,7 +166,6 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, bool *preparedp)
 	__wt_readlock(session, &cache->las_sweepwalk_lock);
 	WT_PUBLISH(cache->las_reader, false);
 	locked = true;
-	*preparedp = false;
 	for (ret = __wt_las_cursor_position(cursor, las_pageid);
 	    ret == 0;
 	    ret = cursor->next(cursor)) {
@@ -189,8 +188,6 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, bool *preparedp)
 		total_incr += incr;
 		upd->txnid = las_txnid;
 		upd->prepare_state = prepare_state;
-		if (prepare_state == WT_PREPARE_INPROGRESS)
-			*preparedp = true;
 #ifdef HAVE_TIMESTAMPS
 		WT_ASSERT(session, las_timestamp.size == WT_TIMESTAMP_SIZE);
 		memcpy(&upd->timestamp, las_timestamp.data, las_timestamp.size);
@@ -284,6 +281,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref, bool *preparedp)
 		FLD_SET(page->modify->restore_state, WT_PAGE_RS_LOOKASIDE);
 
 		if (ref->page_las->skew_newest &&
+		    !ref->page_las->has_prepares &&
 		    !S2C(session)->txn_global.has_stable_timestamp &&
 		    __wt_txn_visible_all(session, ref->page_las->unstable_txn,
 		    WT_TIMESTAMP_NULL(&ref->page_las->unstable_timestamp))) {
@@ -378,7 +376,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
  */
 static inline int
 __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
-    uint32_t previous_state, uint32_t *final_statep, bool *preparedp)
+    uint32_t previous_state, uint32_t *final_statep)
 {
 	/*
 	 * Reading a lookaside ref for the first time, and not requiring the
@@ -390,8 +388,8 @@ __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
 			WT_STAT_CONN_INCR(
 			    session, cache_read_lookaside_skipped);
 			ref->page_las->eviction_to_lookaside = true;
-			*final_statep = WT_REF_LIMBO;
 		}
+		*final_statep = WT_REF_LIMBO;
 		return (0);
 	}
 
@@ -403,7 +401,7 @@ __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
 			    cache_read_lookaside_delay_checkpoint);
 	}
 
-	WT_RET(__las_page_instantiate(session, ref, preparedp));
+	WT_RET(__las_page_instantiate(session, ref));
 	ref->page_las->eviction_to_lookaside = false;
 	return (0);
 }
@@ -422,7 +420,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	uint64_t time_start, time_stop;
 	uint32_t page_flags, final_state, new_state, previous_state;
 	const uint8_t *addr;
-	bool prepared, timer;
+	bool timer;
 
 	time_start = time_stop = 0;
 
@@ -520,7 +518,6 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	    F_ISSET(ref->page->dsk, WT_PAGE_LAS_UPDATE));
 
 skip_read:
-	prepared = false;
 	switch (previous_state) {
 	case WT_REF_DELETED:
 		/*
@@ -530,7 +527,7 @@ skip_read:
 		 * then apply the delete.
 		 */
 		if (ref->page_las != NULL) {
-			WT_ERR(__las_page_instantiate(session, ref, &prepared));
+			WT_ERR(__las_page_instantiate(session, ref));
 			ref->page_las->eviction_to_lookaside = false;
 		}
 
@@ -540,7 +537,7 @@ skip_read:
 	case WT_REF_LIMBO:
 	case WT_REF_LOOKASIDE:
 		WT_ERR(__page_read_lookaside(
-		    session, ref, previous_state, &final_state, &prepared));
+		    session, ref, previous_state, &final_state));
 		break;
 	}
 
@@ -556,12 +553,14 @@ skip_read:
 	 *
 	 * Don't free WT_REF.page_las, there may be concurrent readers.
 	 */
-	if (final_state == WT_REF_MEM &&
-	    ref->page_las != NULL && (prepared || !ref->page_las->skew_newest))
-		WT_ERR(__wt_las_remove_block(
-		    session, ref->page_las->las_pageid));
+	if (final_state == WT_REF_MEM && ref->page_las != NULL &&
+	    (!ref->page_las->skew_newest || ref->page_las->has_prepares)) {
+		ret = __wt_las_remove_block(
+		    session, ref->page_las->las_pageid);
+		WT_ERR(ret);
+	}
 
-	WT_PUBLISH(ref->state, final_state);
+	WT_REF_SETSTATE(ref, final_state);
 	return (ret);
 
 err:	/*
@@ -571,7 +570,7 @@ err:	/*
 	 */
 	if (ref->page != NULL && previous_state != WT_REF_LIMBO)
 		__wt_ref_out(session, ref);
-	WT_PUBLISH(ref->state, previous_state);
+	WT_REF_SETSTATE(ref, previous_state);
 
 	__wt_buf_free(session, &tmp);
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -388,8 +388,8 @@ __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
 			WT_STAT_CONN_INCR(
 			    session, cache_read_lookaside_skipped);
 			ref->page_las->eviction_to_lookaside = true;
+			*final_statep = WT_REF_LIMBO;
 		}
-		*final_statep = WT_REF_LIMBO;
 		return (0);
 	}
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -558,7 +558,7 @@ skip_read:
 		WT_ERR(__wt_las_remove_block(
 		    session, ref->page_las->las_pageid));
 
-	WT_REF_SETSTATE(ref, final_state);
+	WT_REF_SET_STATE(ref, final_state);
 	return (ret);
 
 err:	/*
@@ -568,7 +568,7 @@ err:	/*
 	 */
 	if (ref->page != NULL && previous_state != WT_REF_LIMBO)
 		__wt_ref_out(session, ref);
-	WT_REF_SETSTATE(ref, previous_state);
+	WT_REF_SET_STATE(ref, previous_state);
 
 	__wt_buf_free(session, &tmp);
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1186,7 +1186,7 @@ __slvg_col_build_internal(
 		addr = NULL;
 
 		ref->ref_recno = trk->col_start;
-		ref->state = WT_REF_DISK;
+		WT_REF_SETSTATE(ref, WT_REF_DISK);
 
 		/*
 		 * If the page's key range is unmodified from when we read it
@@ -1844,7 +1844,7 @@ __slvg_row_build_internal(
 		addr = NULL;
 
 		__wt_ref_key_clear(ref);
-		ref->state = WT_REF_DISK;
+		WT_REF_SETSTATE(ref, WT_REF_DISK);
 
 		/*
 		 * If the page's key range is unmodified from when we read it

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1186,7 +1186,7 @@ __slvg_col_build_internal(
 		addr = NULL;
 
 		ref->ref_recno = trk->col_start;
-		WT_REF_SETSTATE(ref, WT_REF_DISK);
+		WT_REF_SET_STATE(ref, WT_REF_DISK);
 
 		/*
 		 * If the page's key range is unmodified from when we read it
@@ -1844,7 +1844,7 @@ __slvg_row_build_internal(
 		addr = NULL;
 
 		__wt_ref_key_clear(ref);
-		WT_REF_SETSTATE(ref, WT_REF_DISK);
+		WT_REF_SET_STATE(ref, WT_REF_DISK);
 
 		/*
 		 * If the page's key range is unmodified from when we read it

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -495,7 +495,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 			root_incr += sizeof(WT_IKEY) + size;
 		} else
 			ref->ref_recno = (*root_refp)->ref_recno;
-		ref->state = WT_REF_MEM;
+		WT_REF_SETSTATE(ref, WT_REF_MEM);
 
 		/*
 		 * Initialize the child page.
@@ -784,7 +784,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 		 * Set the discarded WT_REF state to split, ensuring we don't
 		 * race with any discard of the WT_REF deleted fields.
 		 */
-		WT_PUBLISH(ref->state, WT_REF_SPLIT);
+		WT_REF_SETSTATE(ref, WT_REF_SPLIT);
 
 		/*
 		 * Push out the change: not required for correctness, but stops
@@ -903,7 +903,7 @@ err:	__wt_scr_free(session, &scr);
 		for (i = 0; i < parent_entries; ++i) {
 			next_ref = pindex->index[i];
 			if (next_ref->state == WT_REF_SPLIT)
-				next_ref->state = WT_REF_DELETED;
+				WT_REF_SETSTATE(next_ref, WT_REF_DELETED);
 		}
 
 		__wt_free_ref_index(session, NULL, alloc_index, false);
@@ -1060,7 +1060,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 			parent_incr += sizeof(WT_IKEY) + size;
 		} else
 			ref->ref_recno = (*page_refp)->ref_recno;
-		ref->state = WT_REF_MEM;
+		WT_REF_SETSTATE(ref, WT_REF_MEM);
 
 		/*
 		 * Initialize the child page.
@@ -1675,7 +1675,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		WT_RET(__wt_memdup(session,
 		    multi->addr.addr, addr->size, &addr->addr));
 
-		ref->state = WT_REF_DISK;
+		WT_REF_SETSTATE(ref, WT_REF_DISK);
 	}
 
 	/*
@@ -1693,7 +1693,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		WT_RET(__wt_calloc_one(session, &ref->page_las));
 		*ref->page_las = multi->page_las;
 		WT_ASSERT(session, ref->page_las->max_txn != WT_TXN_NONE);
-		ref->state = WT_REF_LOOKASIDE;
+		WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
 	}
 
 	/*
@@ -1704,7 +1704,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	 */
 	if (multi->disk_image != NULL && !closing) {
 		WT_RET(__split_multi_inmem(session, page, multi, ref));
-		ref->state = WT_REF_MEM;
+		WT_REF_SETSTATE(ref, WT_REF_MEM);
 	}
 	__wt_free(session, multi->disk_image);
 
@@ -2303,7 +2303,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 	/* Swap the new page into place. */
 	ref->page = new->page;
 
-	WT_PUBLISH(ref->state, WT_REF_MEM);
+	WT_REF_SETSTATE(ref, WT_REF_MEM);
 
 	__wt_free(session, new);
 	return (0);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -495,7 +495,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 			root_incr += sizeof(WT_IKEY) + size;
 		} else
 			ref->ref_recno = (*root_refp)->ref_recno;
-		WT_REF_SETSTATE(ref, WT_REF_MEM);
+		WT_REF_SET_STATE(ref, WT_REF_MEM);
 
 		/*
 		 * Initialize the child page.
@@ -784,7 +784,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 		 * Set the discarded WT_REF state to split, ensuring we don't
 		 * race with any discard of the WT_REF deleted fields.
 		 */
-		WT_REF_SETSTATE(ref, WT_REF_SPLIT);
+		WT_REF_SET_STATE(ref, WT_REF_SPLIT);
 
 		/*
 		 * Push out the change: not required for correctness, but stops
@@ -903,7 +903,7 @@ err:	__wt_scr_free(session, &scr);
 		for (i = 0; i < parent_entries; ++i) {
 			next_ref = pindex->index[i];
 			if (next_ref->state == WT_REF_SPLIT)
-				WT_REF_SETSTATE(next_ref, WT_REF_DELETED);
+				WT_REF_SET_STATE(next_ref, WT_REF_DELETED);
 		}
 
 		__wt_free_ref_index(session, NULL, alloc_index, false);
@@ -1060,7 +1060,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 			parent_incr += sizeof(WT_IKEY) + size;
 		} else
 			ref->ref_recno = (*page_refp)->ref_recno;
-		WT_REF_SETSTATE(ref, WT_REF_MEM);
+		WT_REF_SET_STATE(ref, WT_REF_MEM);
 
 		/*
 		 * Initialize the child page.
@@ -1675,7 +1675,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		WT_RET(__wt_memdup(session,
 		    multi->addr.addr, addr->size, &addr->addr));
 
-		WT_REF_SETSTATE(ref, WT_REF_DISK);
+		WT_REF_SET_STATE(ref, WT_REF_DISK);
 	}
 
 	/*
@@ -1693,7 +1693,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 		WT_RET(__wt_calloc_one(session, &ref->page_las));
 		*ref->page_las = multi->page_las;
 		WT_ASSERT(session, ref->page_las->max_txn != WT_TXN_NONE);
-		WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
+		WT_REF_SET_STATE(ref, WT_REF_LOOKASIDE);
 	}
 
 	/*
@@ -1704,7 +1704,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session,
 	 */
 	if (multi->disk_image != NULL && !closing) {
 		WT_RET(__split_multi_inmem(session, page, multi, ref));
-		WT_REF_SETSTATE(ref, WT_REF_MEM);
+		WT_REF_SET_STATE(ref, WT_REF_MEM);
 	}
 	__wt_free(session, multi->disk_image);
 
@@ -2303,7 +2303,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 	/* Swap the new page into place. */
 	ref->page = new->page;
 
-	WT_REF_SETSTATE(ref, WT_REF_MEM);
+	WT_REF_SET_STATE(ref, WT_REF_MEM);
 
 	__wt_free(session, new);
 	return (0);

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -403,7 +403,7 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * We also need to instantiate a lookaside page if this is an update
 	 * operation in progress.
 	 */
-	if (F_ISSET(txn, WT_TXN_UPDATE))
+	if (F_ISSET(txn, WT_TXN_PREPARE | WT_TXN_UPDATE))
 		return (false);
 
 	if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
@@ -465,7 +465,7 @@ __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 	skip = __wt_las_page_skip_locked(session, ref);
 
 	/* Restore the state and push the change. */
-	ref->state = previous_state;
+	WT_REF_SETSTATE(ref, previous_state);
 	WT_FULL_BARRIER();
 
 	return (skip);
@@ -789,6 +789,7 @@ err:	/* Resolve the transaction. */
 
 	if (ret == 0 && insert_cnt > 0) {
 		multi->page_las.las_pageid = las_pageid;
+		multi->page_las.has_prepares = prepared_insert_cnt > 0;
 		ret = __las_insert_block_verbose(session, btree, multi);
 	}
 
@@ -829,26 +830,23 @@ __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid)
 		cursor->set_key(cursor,
 		    pageid, (uint32_t)0, (uint64_t)0, &las_key);
 		WT_RET(cursor->search_near(cursor, &exact));
-		if (exact < 0) {
+		if (exact < 0)
 			WT_RET(cursor->next(cursor));
 
-			/*
-			 * Because of the special visibility rules for
-			 * lookaside, a new block can appear in between our
-			 * search and the block of interest.  Keep trying while
-			 * we have a key lower than we expect.
-			 *
-			 * There may be no block of lookaside entries if they
-			 * have been removed by
-			 * WT_CONNECTION::rollback_to_stable.
-			 */
-			WT_RET(cursor->get_key(cursor,
-			    &las_pageid, &las_id, &las_counter, &las_key));
-			if (las_pageid < pageid)
-				continue;
-		}
-
-		return (0);
+		/*
+		 * Because of the special visibility rules for
+		 * lookaside, a new block can appear in between our
+		 * search and the block of interest.  Keep trying while
+		 * we have a key lower than we expect.
+		 *
+		 * There may be no block of lookaside entries if they
+		 * have been removed by
+		 * WT_CONNECTION::rollback_to_stable.
+		 */
+		WT_RET(cursor->get_key(cursor,
+		    &las_pageid, &las_id, &las_counter, &las_key));
+		if (las_pageid >= pageid)
+			return (0);
 	}
 
 	/* NOTREACHED */

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -465,7 +465,7 @@ __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 	skip = __wt_las_page_skip_locked(session, ref);
 
 	/* Restore the state and push the change. */
-	WT_REF_SETSTATE(ref, previous_state);
+	WT_REF_SET_STATE(ref, previous_state);
 	WT_FULL_BARRIER();
 
 	return (skip);
@@ -834,14 +834,13 @@ __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid)
 			WT_RET(cursor->next(cursor));
 
 		/*
-		 * Because of the special visibility rules for
-		 * lookaside, a new block can appear in between our
-		 * search and the block of interest.  Keep trying while
-		 * we have a key lower than we expect.
+		 * Because of the special visibility rules for lookaside, a new
+		 * block can appear in between our search and the block of
+		 * interest. Keep trying while we have a key lower than we
+		 * expect.
 		 *
-		 * There may be no block of lookaside entries if they
-		 * have been removed by
-		 * WT_CONNECTION::rollback_to_stable.
+		 * There may be no block of lookaside entries if they have been
+		 * removed by WT_CONNECTION::rollback_to_stable.
 		 */
 		WT_RET(cursor->get_key(cursor,
 		    &las_pageid, &las_id, &las_counter, &las_key));

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -401,7 +401,7 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * image with updates in the future of the checkpoint.
 	 *
 	 * We also need to instantiate a lookaside page if this is an update
-	 * operation in progress.
+	 * operation in progress or transaction is in prepared state.
 	 */
 	if (F_ISSET(txn, WT_TXN_PREPARE | WT_TXN_UPDATE))
 		return (false);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -22,7 +22,7 @@ __evict_exclusive_clear(
 {
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED && ref->page != NULL);
 
-	WT_REF_SETSTATE(ref, previous_state);
+	WT_REF_SET_STATE(ref, previous_state);
 }
 
 /*
@@ -77,7 +77,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 		locked = true;
 	if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
 		if (locked)
-			WT_REF_SETSTATE(ref, previous_state);
+			WT_REF_SET_STATE(ref, previous_state);
 		return (ret == 0 ? EBUSY : ret);
 	}
 
@@ -294,7 +294,7 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		}
 	}
 
-	WT_REF_SETSTATE(ref, WT_REF_DELETED);
+	WT_REF_SET_STATE(ref, WT_REF_DELETED);
 	return (0);
 }
 
@@ -332,13 +332,13 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	    ref->page_las->eviction_to_lookaside &&
 	    __wt_page_las_active(session, ref)) {
 		ref->page_las->eviction_to_lookaside = false;
-		WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
+		WT_REF_SET_STATE(ref, WT_REF_LOOKASIDE);
 	} else if (ref->addr == NULL) {
 		WT_WITH_PAGE_INDEX(session,
 		    ret = __evict_delete_ref(session, ref, closing));
 		WT_RET_BUSY_OK(ret);
 	} else
-		WT_REF_SETSTATE(ref, WT_REF_DISK);
+		WT_REF_SET_STATE(ref, WT_REF_DISK);
 
 	return (0);
 }
@@ -428,10 +428,10 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 				*ref->page_las = mod->mod_page_las;
 				__wt_page_modify_clear(session, ref->page);
 				__wt_ref_out(session, ref);
-				WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
+				WT_REF_SET_STATE(ref, WT_REF_LOOKASIDE);
 			} else {
 				__wt_ref_out(session, ref);
-				WT_REF_SETSTATE(ref, WT_REF_DISK);
+				WT_REF_SET_STATE(ref, WT_REF_DISK);
 			}
 		} else {
 			/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -22,7 +22,7 @@ __evict_exclusive_clear(
 {
 	WT_ASSERT(session, ref->state == WT_REF_LOCKED && ref->page != NULL);
 
-	ref->state = previous_state;
+	WT_REF_SETSTATE(ref, previous_state);
 }
 
 /*
@@ -77,7 +77,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 		locked = true;
 	if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
 		if (locked)
-			ref->state = previous_state;
+			WT_REF_SETSTATE(ref, previous_state);
 		return (ret == 0 ? EBUSY : ret);
 	}
 
@@ -294,7 +294,7 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		}
 	}
 
-	WT_PUBLISH(ref->state, WT_REF_DELETED);
+	WT_REF_SETSTATE(ref, WT_REF_DELETED);
 	return (0);
 }
 
@@ -332,13 +332,13 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	    ref->page_las->eviction_to_lookaside &&
 	    __wt_page_las_active(session, ref)) {
 		ref->page_las->eviction_to_lookaside = false;
-		WT_PUBLISH(ref->state, WT_REF_LOOKASIDE);
+		WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
 	} else if (ref->addr == NULL) {
 		WT_WITH_PAGE_INDEX(session,
 		    ret = __evict_delete_ref(session, ref, closing));
 		WT_RET_BUSY_OK(ret);
 	} else
-		WT_PUBLISH(ref->state, WT_REF_DISK);
+		WT_REF_SETSTATE(ref, WT_REF_DISK);
 
 	return (0);
 }
@@ -428,10 +428,10 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 				*ref->page_las = mod->mod_page_las;
 				__wt_page_modify_clear(session, ref->page);
 				__wt_ref_out(session, ref);
-				WT_PUBLISH(ref->state, WT_REF_LOOKASIDE);
+				WT_REF_SETSTATE(ref, WT_REF_LOOKASIDE);
 			} else {
 				__wt_ref_out(session, ref);
-				WT_PUBLISH(ref->state, WT_REF_DISK);
+				WT_REF_SETSTATE(ref, WT_REF_DISK);
 			}
 		} else {
 			/*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -867,7 +867,7 @@ struct __wt_ref {
 		uint32_t state;
 	} hist[3];
 	int histoff;
-#define	WT_REF_SETSTATE(ref, s) do {					\
+#define	WT_REF_SET_STATE(ref, s) do {					\
 	ref->hist[ref->histoff].session = session;			\
 	ref->hist[ref->histoff].name = session->name;			\
 	ref->hist[ref->histoff].file = __FILE__;			\
@@ -877,7 +877,7 @@ struct __wt_ref {
 	WT_PUBLISH(ref->state, s);					\
 } while (0)
 #else
-#define	WT_REF_SETSTATE(ref, s) WT_PUBLISH(ref->state, s)
+#define	WT_REF_SET_STATE(ref, s) WT_PUBLISH(ref->state, s)
 #endif
 
 	/*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -239,6 +239,7 @@ struct __wt_page_lookaside {
 	WT_DECL_TIMESTAMP(max_timestamp)/* Maximum timestamp */
 	WT_DECL_TIMESTAMP(unstable_timestamp)/* First timestamp not on page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
+	bool has_prepares;		/* One or more updates are prepared */
 	bool skew_newest;		/* Page image has newest versions */
 };
 
@@ -856,6 +857,24 @@ struct __wt_ref {
 #define	WT_REF_SPLIT	 7		/* Parent page split (WT_REF dead) */
 	volatile uint32_t state;	/* Page state */
 
+	struct {
+		WT_SESSION_IMPL *session;
+		const char *name;
+		const char *file;
+		int line;
+		uint32_t state;
+	} hist[3];
+	int histoff;
+#define	WT_REF_SETSTATE(ref, s) do {					\
+	ref->hist[ref->histoff].session = session;			\
+	ref->hist[ref->histoff].name = session->name;			\
+	ref->hist[ref->histoff].file = __FILE__;			\
+	ref->hist[ref->histoff].line = __LINE__;			\
+	ref->hist[ref->histoff].state = s;				\
+	ref->histoff = (ref->histoff + 1) % (int)WT_ELEMENTS(ref->hist);\
+	WT_PUBLISH(ref->state, s);					\
+} while (0)
+
 	/*
 	 * Address: on-page cell if read from backing block, off-page WT_ADDR
 	 * if instantiated in-memory, or NULL if page created in-memory.
@@ -882,7 +901,7 @@ struct __wt_ref {
  * WT_REF_SIZE is the expected structure size -- we verify the build to ensure
  * the compiler hasn't inserted padding which would break the world.
  */
-#define	WT_REF_SIZE	56
+#define	WT_REF_SIZE	56 + 3*32 + 8
 
 /*
  * WT_ROW --

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -857,6 +857,8 @@ struct __wt_ref {
 #define	WT_REF_SPLIT	 7		/* Parent page split (WT_REF dead) */
 	volatile uint32_t state;	/* Page state */
 
+#ifdef HAVE_DIAGNOSTIC
+	/* Capture history of ref state changes. */
 	struct {
 		WT_SESSION_IMPL *session;
 		const char *name;
@@ -874,6 +876,9 @@ struct __wt_ref {
 	ref->histoff = (ref->histoff + 1) % (int)WT_ELEMENTS(ref->hist);\
 	WT_PUBLISH(ref->state, s);					\
 } while (0)
+#else
+#define	WT_REF_SETSTATE(ref, s) WT_PUBLISH(ref->state, s)
+#endif
 
 	/*
 	 * Address: on-page cell if read from backing block, off-page WT_ADDR
@@ -901,7 +906,11 @@ struct __wt_ref {
  * WT_REF_SIZE is the expected structure size -- we verify the build to ensure
  * the compiler hasn't inserted padding which would break the world.
  */
+#ifdef HAVE_DIAGNOSTIC
 #define	WT_REF_SIZE	56 + 3*32 + 8
+#else
+#define	WT_REF_SIZE	56
+#endif
 
 /*
  * WT_ROW --

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1189,7 +1189,7 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	if ((page_las = ref->page_las) == NULL)
 		return (false);
-	if (!page_las->skew_newest)
+	if (!page_las->skew_newest || page_las->has_prepares)
 		return (true);
 	if (__wt_txn_visible_all(session, page_las->max_txn,
 	    WT_TIMESTAMP_NULL(&page_las->max_timestamp)))

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -550,7 +550,7 @@ __wt_txn_op_commit_page_del(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * Publish to ensure we don't let the page be evicted and the updates
 	 * discarded before being written.
 	 */
-	WT_REF_SETSTATE(ref, previous_state);
+	WT_REF_SET_STATE(ref, previous_state);
 }
 
 /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -550,7 +550,7 @@ __wt_txn_op_commit_page_del(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * Publish to ensure we don't let the page be evicted and the updates
 	 * discarded before being written.
 	 */
-	WT_PUBLISH(ref->state, previous_state);
+	WT_REF_SETSTATE(ref, previous_state);
 }
 
 /*
@@ -1339,7 +1339,7 @@ __wt_txn_am_oldest(WT_SESSION_IMPL *session)
 	txn = &session->txn;
 	txn_global = &conn->txn_global;
 
-	if (txn->id == WT_TXN_NONE)
+	if (txn->id == WT_TXN_NONE || F_ISSET(txn, WT_TXN_PREPARE))
 		return (false);
 
 	WT_ORDERED_READ(session_cnt, conn->session_cnt);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1780,7 +1780,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			    &ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 				break;
 			ret = __rec_child_deleted(session, r, ref, statep);
-			WT_REF_SETSTATE(ref, WT_REF_DELETED);
+			WT_REF_SET_STATE(ref, WT_REF_DELETED);
 			goto done;
 
 		case WT_REF_LOCKED:

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1780,7 +1780,7 @@ __rec_child_modify(WT_SESSION_IMPL *session,
 			    &ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 				break;
 			ret = __rec_child_deleted(session, r, ref, statep);
-			WT_PUBLISH(ref->state, WT_REF_DELETED);
+			WT_REF_SETSTATE(ref, WT_REF_DELETED);
 			goto done;
 
 		case WT_REF_LOCKED:


### PR DESCRIPTION
We need to consider a lookaside block with prepared updates "active" until they are read back into cache (as part of commit or rollback).  Otherwise we can decide that the history is no longer relevant and transition a page to the WT_REF_MEM state, ignoring its history.