### PR TITLE
WT-4366 Fix how test/format handles prepare conflict errors

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -276,6 +276,44 @@ wts_ops(int lastrun)
 	free(tinfo_list);
 }
 
+typedef enum { NEXT, PREV, SEARCH, SEARCH_NEAR } read_operation;
+
+/*
+ * read_op --
+ *	Perform a read operation, waiting out prepare conflicts.
+ */
+static inline int
+read_op(WT_CURSOR *cursor, read_operation op, int *exactp)
+{
+	WT_DECL_RET;
+
+	/*
+	 * Read operations wait out prepare-conflicts. (As part of the snapshot
+	 * isolation checks, we repeat reads that succeeded before, they should
+	 * be repeatable.)
+	 */
+	switch (op) {
+	case NEXT:
+		while ((ret = cursor->next(cursor)) == WT_PREPARE_CONFLICT)
+			__wt_yield();
+		break;
+	case PREV:
+		while ((ret = cursor->prev(cursor)) == WT_PREPARE_CONFLICT)
+			__wt_yield();
+		break;
+	case SEARCH:
+		while ((ret = cursor->search(cursor)) == WT_PREPARE_CONFLICT)
+			__wt_yield();
+		break;
+	case SEARCH_NEAR:
+		while ((ret =
+		    cursor->search_near(cursor, exactp)) == WT_PREPARE_CONFLICT)
+			__wt_yield();
+		break;
+	}
+	return (ret);
+}
+
 typedef enum { INSERT, MODIFY, READ, REMOVE, TRUNCATE, UPDATE } thread_op;
 typedef struct {
 	thread_op op;			/* Operation */
@@ -401,7 +439,7 @@ snap_check(WT_CURSOR *cursor,
 			}
 		}
 
-		switch (ret = cursor->search(cursor)) {
+		switch (ret = read_op(cursor, SEARCH, NULL)) {
 		case 0:
 			if (g.type == FIX) {
 				testutil_check(
@@ -634,12 +672,22 @@ prepare_transaction(TINFO *tinfo, WT_SESSION *session)
  */
 #define	OP_FAILED(notfound_ok) do {					\
 	positioned = false;						\
-	if (intxn && (ret == WT_CACHE_FULL ||				\
-	    ret == WT_PREPARE_CONFLICT || ret == WT_ROLLBACK))		\
+	if (intxn && (ret == WT_CACHE_FULL || ret == WT_ROLLBACK))	\
 		goto rollback;						\
 	testutil_assert((notfound_ok && ret == WT_NOTFOUND) ||		\
-	    ret == WT_CACHE_FULL ||					\
-	    ret == WT_PREPARE_CONFLICT || ret == WT_ROLLBACK);		\
+	    ret == WT_CACHE_FULL || ret == WT_ROLLBACK);		\
+} while (0)
+
+/*
+ * Rollback updates returning prepare-conflict, they're unlikely to succeed
+ * unless the prepare aborts. Reads wait out the error, so it's unexpected.
+ */
+#define	READ_OP_FAILED(notfound_ok)					\
+	OP_FAILED(notfound_ok)
+#define	WRITE_OP_FAILED(notfound_ok) do {				\
+	if (ret == WT_PREPARE_CONFLICT)					\
+		ret = WT_ROLLBACK;					\
+	OP_FAILED(notfound_ok);						\
 } while (0)
 
 /*
@@ -826,7 +874,7 @@ ops(void *arg)
 				positioned = true;
 				SNAP_TRACK(READ, tinfo);
 			} else
-				OP_FAILED(true);
+				READ_OP_FAILED(true);
 		}
 
 		/* Optionally reserve a row. */
@@ -845,7 +893,7 @@ ops(void *arg)
 
 				__wt_yield();	/* Let other threads proceed. */
 			} else
-				OP_FAILED(true);
+				WRITE_OP_FAILED(true);
 		}
 
 		/* Perform the operation. */
@@ -875,7 +923,7 @@ ops(void *arg)
 				++tinfo->insert;
 				SNAP_TRACK(INSERT, tinfo);
 			} else
-				OP_FAILED(false);
+				WRITE_OP_FAILED(false);
 			break;
 		case MODIFY:
 			/*
@@ -899,7 +947,7 @@ ops(void *arg)
 				positioned = true;
 				SNAP_TRACK(MODIFY, tinfo);
 			} else
-				OP_FAILED(true);
+				WRITE_OP_FAILED(true);
 			break;
 		case READ:
 			++tinfo->search;
@@ -908,7 +956,7 @@ ops(void *arg)
 				positioned = true;
 				SNAP_TRACK(READ, tinfo);
 			} else
-				OP_FAILED(true);
+				READ_OP_FAILED(true);
 			break;
 		case REMOVE:
 remove_instead_of_truncate:
@@ -929,7 +977,7 @@ remove_instead_of_truncate:
 				 */
 				SNAP_TRACK(REMOVE, tinfo);
 			} else
-				OP_FAILED(true);
+				WRITE_OP_FAILED(true);
 			break;
 		case TRUNCATE:
 			/*
@@ -992,14 +1040,15 @@ remove_instead_of_truncate:
 				ret = col_truncate(tinfo, cursor);
 				break;
 			}
-			positioned = false;
 			(void)__wt_atomic_subv64(&g.truncate_cnt, 1);
 
+			/* Truncate never leaves the cursor positioned. */
+			positioned = false;
 			if (ret == 0) {
 				++tinfo->truncate;
 				SNAP_TRACK(TRUNCATE, tinfo);
 			} else
-				OP_FAILED(false);
+				WRITE_OP_FAILED(false);
 			break;
 		case UPDATE:
 update_instead_of_chosen_op:
@@ -1017,7 +1066,7 @@ update_instead_of_chosen_op:
 				positioned = true;
 				SNAP_TRACK(UPDATE, tinfo);
 			} else
-				OP_FAILED(false);
+				WRITE_OP_FAILED(false);
 			break;
 		}
 
@@ -1033,7 +1082,7 @@ update_instead_of_chosen_op:
 				if ((ret = nextprev(tinfo, cursor, next)) == 0)
 					continue;
 
-				OP_FAILED(true);
+				READ_OP_FAILED(true);
 				break;
 			}
 		}
@@ -1193,11 +1242,11 @@ read_row_worker(
 	}
 
 	if (sn) {
-		ret = cursor->search_near(cursor, &exact);
+		ret = read_op(cursor, SEARCH_NEAR, &exact);
 		if (ret == 0 && exact != 0)
 			ret = WT_NOTFOUND;
 	} else
-		ret = cursor->search(cursor);
+		ret = read_op(cursor, SEARCH, NULL);
 	switch (ret) {
 	case 0:
 		if (g.type == FIX) {
@@ -1288,7 +1337,7 @@ nextprev(TINFO *tinfo, WT_CURSOR *cursor, bool next)
 	keyno = 0;
 	which = next ? "WT_CURSOR.next" : "WT_CURSOR.prev";
 
-	switch (ret = (next ? cursor->next(cursor) : cursor->prev(cursor))) {
+	switch (ret = read_op(cursor, next ? NEXT : PREV, NULL)) {
 	case 0:
 		switch (g.type) {
 		case FIX:
@@ -2019,7 +2068,7 @@ row_remove(TINFO *tinfo, WT_CURSOR *cursor, bool positioned)
 	}
 
 	/* We use the cursor in overwrite mode, check for existence. */
-	if ((ret = cursor->search(cursor)) == 0)
+	if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
 		ret = cursor->remove(cursor);
 
 	if (ret != 0 && ret != WT_NOTFOUND)
@@ -2053,7 +2102,7 @@ col_remove(TINFO *tinfo, WT_CURSOR *cursor, bool positioned)
 		cursor->set_key(cursor, tinfo->keyno);
 
 	/* We use the cursor in overwrite mode, check for existence. */
-	if ((ret = cursor->search(cursor)) == 0)
+	if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
 		ret = cursor->remove(cursor);
 
 	if (ret != 0 && ret != WT_NOTFOUND)


### PR DESCRIPTION
There was fallout from the initial merge of #4325 regarding cursor out-of-order:
http://build.wiredtiger.com:8080/job/wiredtiger-test-race-condition-stress-sanitizer/27811/
http://build.wiredtiger.com:8080/job/wiredtiger-test-format-stress/68652/

@keithbostic @agorrod I recreated the PR based on the old `wt-4366-format-prepare-conflict2`  branch for further work. 