### PR TITLE
WT-4385 Prepare-conflict during a cursor scan can return the wrong key

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -603,7 +603,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 	 */
 	F_CLR(cbt, WT_CBT_RETRY_PREV);
 	if (F_ISSET(cbt, WT_CBT_RETRY_NEXT)) {
-		WT_RET(__wt_cursor_valid(cbt, &upd, &valid));
+		WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
 		F_CLR(cbt, WT_CBT_RETRY_NEXT);
 		if (valid) {
 			/*
@@ -616,11 +616,15 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			 * make sure we don't take that path.
 			 */
 			cbt->compare = 1;
-			return (__cursor_kv_return(session, cbt, upd));
+			WT_ERR(__cursor_kv_return(session, cbt, upd));
+#ifdef HAVE_DIAGNOSTIC
+			WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
+#endif
+			return (0);
 		}
 	}
 
-	WT_RET(__cursor_func_init(cbt, false));
+	WT_ERR(__cursor_func_init(cbt, false));
 
 	/*
 	 * If we aren't already iterating in the right direction, there's
@@ -702,13 +706,13 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 		WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
 		WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND);
 	}
-#ifdef HAVE_DIAGNOSTIC
-	if (ret == 0)
-		WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
-#endif
+
 err:	switch (ret) {
 	case 0:
 		F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
+#ifdef HAVE_DIAGNOSTIC
+		ret = __wt_cursor_key_order_check(session, cbt, true);
+#endif
 		break;
 	case WT_PREPARE_CONFLICT:
 		/*

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -609,7 +609,13 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			/*
 			 * If the update, which returned prepared conflict is
 			 * visible, return the value.
+			 *
+			 * The underlying key-return function uses a comparison
+			 * of 0 to indicate the search function has pre-built
+			 * the key we want to return. That's not the case here,
+			 * make sure we don't take that path.
 			 */
+			cbt->compare = 1;
 			return (__cursor_kv_return(session, cbt, upd));
 		}
 	}

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -558,25 +558,24 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	F_CLR(cbt, WT_CBT_RETRY_NEXT);
 	if (F_ISSET(cbt, WT_CBT_RETRY_PREV)) {
 		WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
+		WT_ASSERT(session, valid == true);
+
+		/* The update that returned prepared conflict is now visible. */
 		F_CLR(cbt, WT_CBT_RETRY_PREV);
-		if (valid) {
-			/*
-			 * If the update, which returned prepared conflict is
-			 * visible, return the value.
-			 *
-			 * The underlying key-return function uses a comparison
-			 * of 0 to indicate the search function has pre-built
-			 * the key we want to return. That's not the case here,
-			 * make sure we don't take that path.
-			 */
-			cbt->compare = 1;
-			WT_ERR(__cursor_kv_return(session, cbt, upd));
+
+		/*
+		 * The update that returned prepared conflict is now visible.
+		 *
+		 * The underlying key-return function uses a comparison value
+		 * of 0 to indicate the search function has pre-built the key
+		 * we want to return. That's not the case, don't take that path.
+		 */
+		cbt->compare = 1;
+		WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
-			WT_ERR(
-			    __wt_cursor_key_order_check(session, cbt, false));
+		WT_ERR(__wt_cursor_key_order_check(session, cbt, false));
 #endif
-			return (0);
-		}
+		return (0);
 	}
 
 	WT_ERR(__cursor_func_init(cbt, false));

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -563,7 +563,13 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 			/*
 			 * If the update, which returned prepared conflict is
 			 * visible, return the value.
+			 *
+			 * The underlying key-return function uses a comparison
+			 * of 0 to indicate the search function has pre-built
+			 * the key we want to return. That's not the case here,
+			 * make sure we don't take that path.
 			 */
+			cbt->compare = 1;
 			return (__cursor_kv_return(session, cbt, upd));
 		}
 	}

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -427,10 +427,9 @@ random_page_entry:
 	 */
 	WT_ERR(__wt_row_random_leaf(session, cbt));
 	WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
-	if (valid) {
-		WT_ERR(__wt_key_return(session, cbt));
-		WT_ERR(__wt_value_return(session, cbt, upd));
-	} else {
+	if (valid)
+		WT_ERR(__cursor_kv_return(session, cbt, upd));
+	else {
 		if ((ret = __wt_btcur_next(cbt, false)) == WT_NOTFOUND)
 			ret = __wt_btcur_prev(cbt, false);
 		WT_ERR(ret);

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -417,8 +417,14 @@ __cursor_row_slot_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_UPDATE *upd)
 	 * Unpack the cell and deal with overflow and prefix-compressed keys.
 	 * Inline building simple prefix-compressed keys from a previous key,
 	 * otherwise build from scratch.
+	 *
+	 * Clear the key cell structure. It shouldn't be necessary (as far as I
+	 * can tell, and we don't do it in lots of other places), but disabling
+	 * shared builds (--disable-shared) results in the compiler complaining
+	 * about uninitialized field use.
 	 */
 	kpack = &_kpack;
+	memset(kpack, 0, sizeof(*kpack));
 	__wt_cell_unpack(cell, kpack);
 	if (kpack->type == WT_CELL_KEY &&
 	    cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {


### PR DESCRIPTION
@bvpvamsikrishna, the core bug fix is 96a3059.

I think 7ae8a03 probably needs close review. If I'm wrong in my assertion, we'll still need some kind of change there because it must be wrong to fall into the iteration code.