### PR TITLE
WT-4343 Unlock when sleeping to allow other log threads to make progress.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -58,16 +58,17 @@ static char home[1024];			/* Program working dir */
  */
 #define	INVALID_KEY	UINT64_MAX
 #define	MAX_CKPT_INVL	5	/* Maximum interval between checkpoints */
-#define	MAX_DEFAULT_TH	12
 #define	MAX_TH		200	/* Maximum configurable threads */
 #define	MAX_TIME	40
 #define	MAX_VAL		1024
 #define	MIN_TH		5
 #define	MIN_TIME	10
 #define	PREPARE_FREQ	5
+#define	PREPARE_PCT	10
 #define	PREPARE_YIELD	(PREPARE_FREQ * 10)
 #define	RECORDS_FILE	"records-%" PRIu32
-#define	SESSION_MAX	MAX_TH + 3	/* Include program worker threads */
+/* Include worker threads and prepare extra sessions */
+#define	SESSION_MAX	MAX_TH + 3 + MAX_TH * PREPARE_PCT
 
 static const char * table_pfx = "table";
 static const char * const uri_local = "local";
@@ -260,7 +261,7 @@ thread_run(void *arg)
 	 * are in use. Thread numbers start at 0 so we're always guaranteed
 	 * that at least one thread is using prepared transactions.
 	 */
-	use_prep = (use_ts && td->info % 10 == 0) ? true : false;
+	use_prep = (use_ts && td->info % PREPARE_PCT == 0) ? true : false;
 
 	/*
 	 * For the prepared case we have two sessions so that the oplog session
@@ -649,7 +650,7 @@ main(int argc, char *argv[])
 				timeout = MIN_TIME;
 		}
 		if (rand_th) {
-			nth = __wt_random(&rnd) % MAX_DEFAULT_TH;
+			nth = __wt_random(&rnd) % MAX_TH;
 			if (nth < MIN_TH)
 				nth = MIN_TH;
 		}


### PR DESCRIPTION
@agorrod here's a lighter version of the same fix from the other branch. I found that simply releasing and re-acquiring the locks allows threads to make progress and I am unable to reproduce the many-thread failure with these smaller changes (well over 500 iterations). On develop I can reproduce usually in under 30 iterations.

I also moved the Jenkins log perf test to this branch and it avoids the issues the original branch showed. The min/max throughput is back where it was and the performance of the logging variants is within normal variations.

I believe this branch will have less impact on MongoDB. If you agree, this should be reviewed and merged and the other one closed.