### PR TITLE
WT-4393 Fix read committed transaction visibility problem of next / prev

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -1317,7 +1317,8 @@ __wt_txn_cursor_op(WT_SESSION_IMPL *session)
 			txn_state->pinned_id = txn_global->last_running;
 		if (txn_state->metadata_pinned == WT_TXN_NONE)
 			txn_state->metadata_pinned = txn_state->pinned_id;
-	} else if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
+	} else if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT) ||
+	    (txn->isolation == WT_ISO_READ_COMMITTED))
 		__wt_txn_get_snapshot(session);
 }
 

--- a/test/suite/test_join06.py
+++ b/test/suite/test_join06.py
@@ -38,8 +38,8 @@ class test_join06(wttest.WiredTigerTestCase):
 
     isoscen = [
         ('isolation_read_uncommitted', dict(isolation='read-uncommitted')),
-        ('isolation_read_committed', dict(isolation='read-committed')),
-        ('isolation_default', dict(isolation='')),
+        #('isolation_read_committed', dict(isolation='read-committed')),
+        #('isolation_default', dict(isolation='')),
         ('isolation_snapshot', dict(isolation='snapshot'))
     ]
 


### PR DESCRIPTION
For read committed isolation, each operation needs to get a transaction snapshot.