### PR TITLE
WT-4395 Use WT_TRET so error return is not overwritten.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2501,6 +2501,8 @@ advance:
 			 * the first pass through recovery.  In the second pass
 			 * where we truncate the log, this is where it should
 			 * end.
+			 * Continue processing where possible, so remember any
+			 * error returns, but don't skip to the error handler.
 			 */
 			if (log != NULL)
 				log->trunc_lsn = rd_lsn;
@@ -2603,7 +2605,8 @@ advance:
 		__wt_verbose(session, WT_VERB_LOG,
 		    "End of recovery truncate end of log %" PRIu32 "/%" PRIu32,
 		    rd_lsn.l.file, rd_lsn.l.offset);
-		WT_ERR(__log_truncate(session, &rd_lsn, false, false));
+		/* Preserve prior error and fall through to error handling. */
+		WT_TRET(__log_truncate(session, &rd_lsn, false, false));
 	}
 
 err:	WT_STAT_CONN_INCR(session, log_scans);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2537,7 +2537,7 @@ advance:
 				 * must be salvaged.
 				 */
 				need_salvage = true;
-				WT_ERR(__log_salvage_message(session,
+				WT_TRET(__log_salvage_message(session,
 				    log_fh->name, ", bad checksum",
 				    rd_lsn.l.offset));
 			} else {
@@ -2546,11 +2546,11 @@ advance:
 				 * that the header is corrupt.  Make a sanity
 				 * check of the log record header.
 				 */
-				WT_ERR(__log_record_verify(session, log_fh,
+				WT_TRET(__log_record_verify(session, log_fh,
 				    rd_lsn.l.offset, logrec, &corrupt));
 				if (corrupt) {
 					need_salvage = true;
-					WT_ERR(__log_salvage_message(session,
+					WT_TRET(__log_salvage_message(session,
 					    log_fh->name, "", rd_lsn.l.offset));
 				}
 			}
@@ -2623,7 +2623,7 @@ err:	WT_STAT_CONN_INCR(session, log_scans);
 	 * an error recovery is likely going to fail.  Try to provide
 	 * a helpful failure message.
 	 */
-	if (ret != 0 && firstrecord) {
+	if (ret != 0 && firstrecord && LF_ISSET(WT_LOGSCAN_RECOVER)) {
 		__wt_errx(session,
 		    "WiredTiger is unable to read the recovery log.");
 		__wt_errx(session, "This may be due to the log"


### PR DESCRIPTION
@ddanderson Please review this small change. The code path changed slightly with the log corruption/salvage work a couple months ago and in the specific case of a log cursor getting an error, that error return would get overwritten and lost.