### PR TITLE
WT-4043 Fix assertion failure while dumping the cache

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2666,9 +2666,9 @@ __verbose_dump_cache_apply(WT_SESSION_IMPL *session,
 		    ret = __verbose_dump_cache_single(
 		    session, total_bytesp, total_dirty_bytesp));
 		if (ret != 0)
-			break;
+			WT_RET(ret);
 	}
-	return (ret);
+	return (0);
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2668,9 +2668,7 @@ __verbose_dump_cache_apply(WT_SESSION_IMPL *session,
 		if (ret != 0)
 			break;
 	}
-	WT_RET(ret);
-
-	return (0);
+	return (ret);
 }
 
 /*


### PR DESCRIPTION
Acquire a read lock on the dhandle just before dumping cache information. This would prevent concurrent updates to dhandle state. Also prevent dumping the handle if it is already marked discarded.