### PR TITLE
WT-4405 Fix cursor next & prev for prepared transactions.

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -603,7 +603,8 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 		WT_ERR(__cursor_check_prepared_update(cbt, &visible));
 		if (visible) {
 #ifdef HAVE_DIAGNOSTIC
-			ret = __wt_cursor_key_order_check(session, cbt, true);
+			WT_ERR(
+			    __wt_cursor_key_order_check(session, cbt, true));
 #endif
 			return (0);
 		}

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -603,8 +603,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 		WT_ERR(__cursor_check_prepared_update(cbt, &visible));
 		if (visible) {
 #ifdef HAVE_DIAGNOSTIC
-			WT_ERR(
-			    __wt_cursor_key_order_check(session, cbt, true));
+			WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
 #endif
 			return (0);
 		}

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -604,23 +604,24 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 	F_CLR(cbt, WT_CBT_RETRY_PREV);
 	if (F_ISSET(cbt, WT_CBT_RETRY_NEXT)) {
 		WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
-		if (!valid)
-			WT_ERR(WT_PREPARE_CONFLICT);
 
 		/* The update that returned prepared conflict is now visible. */
 		F_CLR(cbt, WT_CBT_RETRY_NEXT);
 
-		/*
-		 * The underlying key-return function uses a comparison value
-		 * of 0 to indicate the search function has pre-built the key
-		 * we want to return. That's not the case, don't take that path.
-		 */
-		cbt->compare = 1;
-		WT_ERR(__cursor_kv_return(session, cbt, upd));
+		if (valid) {
+			/*
+			 * The underlying key-return function uses a comparison
+			 * value of 0 to indicate the search function has
+			 * pre-built the key we want to return. That's not the
+			 * case, don't take that path.
+			 */
+			cbt->compare = 1;
+			WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
-		WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
+			WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
 #endif
-		return (0);
+			return (0);
+		}
 	}
 
 	WT_ERR(__cursor_func_init(cbt, false));

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -615,7 +615,6 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			 * pre-built the key we want to return. That's not the
 			 * case, don't take that path.
 			 */
-			cbt->compare = 1;
 			WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
 			WT_ERR(__wt_cursor_key_order_check(session, cbt, true));

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -609,12 +609,6 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 		F_CLR(cbt, WT_CBT_RETRY_NEXT);
 
 		if (valid) {
-			/*
-			 * The underlying key-return function uses a comparison
-			 * value of 0 to indicate the search function has
-			 * pre-built the key we want to return. That's not the
-			 * case, don't take that path.
-			 */
 			WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
 			WT_ERR(__wt_cursor_key_order_check(session, cbt, true));
@@ -653,7 +647,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 				break;
 			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
-			if (ret == 0)
+			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
 			F_CLR(cbt, WT_CBT_ITERATE_APPEND);
 			if (ret != WT_NOTFOUND)

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -563,15 +563,6 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 		F_CLR(cbt, WT_CBT_RETRY_PREV);
 
 		if (valid) {
-			/*
-			 * The update that returned prepared conflict is now
-			 * visible.
-			 *
-			 * The underlying key-return function uses a comparison
-			 * value of 0 to indicate the search function has
-			 * pre-built the key we want to return. That's not the
-			 * case, don't take that path.
-			 */
 			WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
 			WT_ERR(
@@ -621,7 +612,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 				break;
 			WT_ILLEGAL_VALUE_ERR(session, page->type);
 			}
-			if (ret == 0)
+			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
 			F_CLR(cbt, WT_CBT_ITERATE_APPEND);
 			if (ret != WT_NOTFOUND)

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -572,7 +572,6 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 			 * pre-built the key we want to return. That's not the
 			 * case, don't take that path.
 			 */
-			cbt->compare = 1;
 			WT_ERR(__cursor_kv_return(session, cbt, upd));
 #ifdef HAVE_DIAGNOSTIC
 			WT_ERR(

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -536,9 +536,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	WT_DECL_RET;
 	WT_PAGE *page;
 	WT_SESSION_IMPL *session;
-	WT_UPDATE *upd;
 	uint32_t flags;
-	bool newpage, valid;
+	bool newpage, visible;
 
 	cursor = &cbt->iface;
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
@@ -549,27 +548,12 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 
 	/*
-	 * When retrying an operation due to a prepare conflict, the cursor is
-	 * is at an update list which resulted in conflict. So, when retrying
-	 * we should examine the same update again instead of iterating to the
-	 * next object. We'll eventually find a valid update, return prepare-
-	 * conflict until successful.
+	 * Check if prepared update at current cursor position is resolved,
+	 * if any.
 	 */
-	if (F_ISSET(cbt, WT_CBT_RETRY_PREV)) {
-		WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
-
-		/* The update that returned prepared conflict is now visible. */
-		F_CLR(cbt, WT_CBT_RETRY_PREV);
-
-		if (valid) {
-			WT_ERR(__cursor_kv_return(session, cbt, upd));
-#ifdef HAVE_DIAGNOSTIC
-			WT_ERR(
-			    __wt_cursor_key_order_check(session, cbt, false));
-#endif
-			return (0);
-		}
-	}
+	WT_ERR(__cursor_check_prepared_update(cbt, false, &visible));
+	if (visible)
+		return (0);
 
 	WT_ERR(__cursor_func_init(cbt, false));
 

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -557,7 +557,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 		WT_ERR(__cursor_check_prepared_update(cbt, &visible));
 		if (visible) {
 #ifdef HAVE_DIAGNOSTIC
-			ret = __wt_cursor_key_order_check(session, cbt, false);
+			WT_ERR(
+			    __wt_cursor_key_order_check(session, cbt, false));
 #endif
 			return (0);
 		}

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -227,18 +227,18 @@ struct __wt_cursor_btree {
 #define	WT_CBT_ITERATE_APPEND	0x002u	/* Col-store: iterating append list */
 #define	WT_CBT_ITERATE_NEXT	0x004u	/* Next iteration configuration */
 #define	WT_CBT_ITERATE_PREV	0x008u	/* Prev iteration configuration */
-#define	WT_CBT_NO_TXN   	0x010u	/* Non-txn cursor (e.g. a checkpoint) */
-#define	WT_CBT_READ_ONCE	0x020u	/* Page in with WT_READ_WONT_NEED */
-#define	WT_CBT_RETRY_NEXT	0x040u	/* Next, resulted in prepare conflict */
-#define	WT_CBT_RETRY_PREV	0x080u	/* Prev, resulted in prepare conflict */
+#define	WT_CBT_ITERATE_RETRY_NEXT	0x010u	/* Prepare conflict by next. */
+#define	WT_CBT_ITERATE_RETRY_PREV	0x020u	/* Prepare conflict by prev. */
+#define	WT_CBT_NO_TXN   	0x040u	/* Non-txn cursor (e.g. a checkpoint) */
+#define	WT_CBT_READ_ONCE	0x080u	/* Page in with WT_READ_WONT_NEED */
 #define	WT_CBT_SEARCH_SMALLEST	0x100u	/* Row-store: small-key insert list */
 #define	WT_CBT_VAR_ONPAGE_MATCH	0x200u	/* Var-store: on-page recno match */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 
 #define	WT_CBT_POSITION_MASK		/* Flags associated with position */ \
 	(WT_CBT_ITERATE_APPEND | WT_CBT_ITERATE_NEXT | WT_CBT_ITERATE_PREV | \
-	WT_CBT_RETRY_NEXT | WT_CBT_RETRY_PREV | WT_CBT_SEARCH_SMALLEST |     \
-	WT_CBT_VAR_ONPAGE_MATCH)
+	WT_CBT_ITERATE_RETRY_NEXT | WT_CBT_ITERATE_RETRY_PREV |		     \
+	WT_CBT_SEARCH_SMALLEST | WT_CBT_VAR_ONPAGE_MATCH)
 
 	uint32_t flags;
 };

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -478,35 +478,25 @@ value:
  *	Return whether prepared update at current position is visible or not.
  */
 static inline int
-__cursor_check_prepared_update(WT_CURSOR_BTREE *cbt, bool next, bool *visible)
+__cursor_check_prepared_update(WT_CURSOR_BTREE *cbt, bool *visiblep)
 {
 	WT_SESSION_IMPL *session;
 	WT_UPDATE *upd;
-	bool valid;
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
 	/*
 	 * When retrying an operation due to a prepared conflict, the cursor is
 	 * at an update list which resulted in conflict. So, when retrying we
 	 * should examine the same update again instead of iterating to the next
-	 * object. We'll eventually find a valid update.
-	 *      return prepare-conflict until successful.
+	 * object. We'll eventually find a valid update, else return
+	 * prepare-conflict until resolved.
 	 */
-	*visible = false;
-	if ((next && F_ISSET(cbt, WT_CBT_RETRY_NEXT)) ||
-	    (!next && F_ISSET(cbt, WT_CBT_RETRY_PREV)))
-	{
-		WT_RET(__wt_cursor_valid(cbt, &upd, &valid));
+	WT_RET(__wt_cursor_valid(cbt, &upd, visiblep));
 
-		/* The update that returned prepared conflict is now visible. */
-		F_CLR(cbt, WT_CBT_RETRY_NEXT | WT_CBT_RETRY_PREV);
-		if (valid) {
-			WT_RET(__cursor_kv_return(session, cbt, upd));
-#ifdef HAVE_DIAGNOSTIC
-			WT_RET(__wt_cursor_key_order_check(session, cbt, next));
-#endif
-			*visible = true;
-		}
-	}
+	/* The update that returned prepared conflict is now visible. */
+	F_CLR(cbt, WT_CBT_ITERATE_RETRY_NEXT | WT_CBT_ITERATE_RETRY_PREV);
+	if (*visiblep)
+		WT_RET(__cursor_kv_return(session, cbt, upd));
+
 	return (0);
 }

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet, SimpleIndexDataSet
+from wtdataset import SimpleLSMDataSet, ComplexDataSet, ComplexLSMDataSet
+from wtscenario import make_scenarios
+
+# test_prepare_cursor01.py
+#    WT_CURSOR position tests with prepared transactions
+class test_prepare_cursor01(wttest.WiredTigerTestCase):
+
+    keyfmt = [
+        ('integer', dict(keyfmt='i')),
+    ]
+    types = [
+        ('table-simple', dict(uri='table', ds=SimpleDataSet)),
+    ]
+
+    iso_types = [
+        ('isolation_read_committed', dict(isolation='read-committed')),
+        ('isolation_snapshot', dict(isolation='snapshot'))
+    ]
+    scenarios = make_scenarios(types, keyfmt, iso_types)
+
+    def skip(self):
+        return self.keyfmt == 'r' and \
+            (self.ds.is_lsm() or self.uri == 'lsm')
+
+    # Do an insert and confirm no key, value or position remains.
+    def test_cursor_prepare_insert(self):
+        if self.skip():
+            return
+
+        # Build an object.
+        uri = self.uri + ':test_prepare_cursor01'
+        ds = self.ds(self, uri, 50, key_format=self.keyfmt)
+        ds.populate()
+        session = self.conn.open_session()
+        cursor = session.open_cursor(uri, None)
+
+        prep_session = self.conn.open_session()
+        prep_cursor = prep_session.open_cursor(uri, None)
+
+        # Scenario-1 : next / prev with insert as prepared updated.
+        # Begin of Scenario-1.
+        # Insert key 52, by leaving gap for 51, so that prev testing can
+        # use key 51.
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(52))
+        prep_cursor.set_value(ds.value(52))
+        prep_cursor.insert()
+        prep_session.prepare_transaction("prepare_timestamp=100")
+
+        # Cursor points to key 50.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(50))
+        self.assertEquals(cursor.search(), 0)
+        # Next key will be 52, in prepared state.
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.next())
+        prep_session.commit_transaction("commit_timestamp=100")
+
+        self.assertEquals(cursor.next(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(52))
+        session.commit_transaction()
+
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(51))
+        prep_cursor.set_value(ds.value(51))
+        prep_cursor.insert()
+        prep_session.prepare_transaction("prepare_timestamp=100")
+
+        # Cursor points to key 52.
+        # Search, so that new snapshot includes key 51.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(52))
+        self.assertEquals(cursor.search(), 0)
+        # Prev key will be 51, in prepared state.
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.prev())
+        prep_session.commit_transaction("commit_timestamp=100")
+
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(51))
+        session.commit_transaction()
+
+        # End of Scenario-1.
+
+        # Scenario-2 : next / prev with update as prepared updated.
+        # Begin of Scenario-2.
+        # Update key 52
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(52))
+        prep_cursor.set_value(ds.value(152))
+        prep_cursor.update()
+        prep_session.prepare_transaction("prepare_timestamp=200")
+
+        # Cursor points to key 51.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(51))
+        self.assertEquals(cursor.search(), 0)
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.next())
+        prep_session.commit_transaction("commit_timestamp=200")
+
+        self.assertEquals(cursor.next(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(52))
+        session.commit_transaction()
+
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(51))
+        prep_cursor.set_value(ds.value(151))
+        prep_cursor.update()
+        prep_session.prepare_transaction("prepare_timestamp=200")
+
+        # Cursor points to key 52.
+        # Search, so that new snapshot includes key 51.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(52))
+        self.assertEquals(cursor.search(), 0)
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.prev())
+        prep_session.commit_transaction("commit_timestamp=200")
+
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(51))
+        session.commit_transaction()
+
+        # End of Scenario-2.
+
+        # Scenario-3 : next / prev with remove as prepared updated.
+        # Begin of Scenario-3.
+        # Remove key 52
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(52))
+        prep_cursor.remove()
+        prep_session.prepare_transaction("prepare_timestamp=300")
+
+        # Cursor points to key 51.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(51))
+        self.assertEquals(cursor.search(), 0)
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.next())
+        prep_session.commit_transaction("commit_timestamp=300")
+
+        # Key 52 is deleted and it is the last one, so should get NOT FOUND.
+        self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
+        session.commit_transaction()
+
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(50))
+        prep_cursor.remove()
+        prep_session.prepare_transaction("prepare_timestamp=300")
+
+        # Cursor points to key 51.
+        # Search, so that new snapshot includes key 50, which is removed.
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(51))
+        self.assertEquals(cursor.search(), 0)
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: cursor.prev())
+        prep_session.commit_transaction("commit_timestamp=300")
+
+        # Key 50 is deleted, cursor was pointing to 50 now so should get 49.
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(49))
+        session.commit_transaction()
+
+        # End of Scenario-3.
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -124,6 +124,10 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertEquals(before_ts_c.next(), wiredtiger.WT_NOTFOUND)
         # As read is between, next will point to prepared update.
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
+        # Check to see prev works when a next returns prepare conflict.
+        self.assertEquals(between_ts_c.prev(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(50))
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
         # As read is after, next will point to prepared update.
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.next())
         # As read is non-timestamped, next will point to prepared update.
@@ -175,6 +179,10 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertEquals(before_ts_c.prev(), wiredtiger.WT_NOTFOUND)
         before_ts_s.commit_transaction()
         # As read is between, prev will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
+        # Check to see next works when a prev returns prepare conflict.
+        self.assertEquals(between_ts_c.next(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(2))
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
         # As read is after, prev will point to prepared update.
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.prev())

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -31,6 +31,9 @@ from wtdataset import SimpleDataSet, SimpleIndexDataSet
 from wtdataset import SimpleLSMDataSet, ComplexDataSet, ComplexLSMDataSet
 from wtscenario import make_scenarios
 
+def timestamp_str(t):
+    return '%x' %t
+
 # test_prepare_cursor01.py
 #    WT_CURSOR position tests with prepared transactions
 class test_prepare_cursor01(wttest.WiredTigerTestCase):
@@ -52,8 +55,13 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         return self.keyfmt == 'r' and \
             (self.ds.is_lsm() or self.uri == 'lsm')
 
-    # Do an insert and confirm no key, value or position remains.
-    def test_cursor_prepare_insert(self):
+    # Test cursor navigate (next/prev) with prepared transactions.
+    # Cursor navigate with timestamp reads and non-timestamped reads.
+    #   before cursor  : with timestamp earlier to prepare timestamp.
+    #   between cursor : with timestamp between prepare and commit timestamps.
+    #   after cursor   : with timestamp after commit timestamp.
+    # Cursor with out read timestamp behaviour should be same after cursor behavior.
+    def test_cursor_navigate_prepare_transaction(self):
         if self.skip():
             return
 
@@ -61,139 +69,495 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         uri = self.uri + ':test_prepare_cursor01'
         ds = self.ds(self, uri, 50, key_format=self.keyfmt)
         ds.populate()
+
+        # Session for non-timestamped reads.
         session = self.conn.open_session()
         cursor = session.open_cursor(uri, None)
+        cursor.set_key(ds.key(1))
+        cursor.remove()
+
+        # Session for timestamped reads before prepare timestamp.
+        before_ts_s = self.conn.open_session()
+        before_ts_c = before_ts_s.open_cursor(uri, None)
+        # Session for timestamped reads between prepare timestamp and commit timestamp.
+        between_ts_s = self.conn.open_session()
+        between_ts_c = between_ts_s.open_cursor(uri, None)
+        # Session for timestamped reads after commit timestamp.
+        after_ts_s = self.conn.open_session()
+        after_ts_c = after_ts_s.open_cursor(uri, None)
 
         prep_session = self.conn.open_session()
         prep_cursor = prep_session.open_cursor(uri, None)
 
-        # Scenario-1 : next / prev with insert as prepared updated.
+        # Scenario-1 : Check cursor navigate with insert in prepared transaction.
         # Begin of Scenario-1.
-        # Insert key 52, by leaving gap for 51, so that prev testing can
-        # use key 51.
-        prep_session.begin_transaction()
-        prep_cursor.set_key(ds.key(52))
-        prep_cursor.set_value(ds.value(52))
-        prep_cursor.insert()
-        prep_session.prepare_transaction("prepare_timestamp=100")
-
-        # Cursor points to key 50.
-        session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(50))
-        self.assertEquals(cursor.search(), 0)
-        # Next key will be 52, in prepared state.
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.next())
-        prep_session.commit_transaction("commit_timestamp=100")
-
-        self.assertEquals(cursor.next(), 0)
-        self.assertEquals(cursor.get_key(), ds.key(52))
-        session.commit_transaction()
-
+        # Data set at start has keys {2,3,4 ... 50}
+        # Insert key 51 to check next operation.
+        # Insert key 1 to check prev operation.
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(51))
         prep_cursor.set_value(ds.value(51))
         prep_cursor.insert()
-        prep_session.prepare_transaction("prepare_timestamp=100")
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
 
-        # Cursor points to key 52.
-        # Search, so that new snapshot includes key 51.
+        # Point all cursors to key 50.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(50))
+        before_ts_c.set_key(ds.key(50))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(150))
+        between_ts_c.set_key(ds.key(50))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        after_ts_c.set_key(ds.key(50))
+        self.assertEquals(after_ts_c.search(), 0)
+
         session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(52))
+        cursor.set_key(ds.key(50))
         self.assertEquals(cursor.search(), 0)
-        # Prev key will be 51, in prepared state.
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.prev())
-        prep_session.commit_transaction("commit_timestamp=100")
 
-        self.assertEquals(cursor.prev(), 0)
+        # Check the visibility of newly inserted, prepared update.
+
+        # As read is before prepare timestamp, next is not found.
+        self.assertEquals(before_ts_c.next(), wiredtiger.WT_NOTFOUND)
+        # As read is between, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
+        # As read is after, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.next())
+        # As read is non-timestamped, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(200))
+
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), next is not found.
+        self.assertEquals(between_ts_c.next(), wiredtiger.WT_NOTFOUND)
+        between_ts_s.commit_transaction()
+        # As read is after, next will point to new key 51
+        self.assertEquals(after_ts_c.next(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(51))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 51.
+        self.assertEquals(cursor.next(), 0)
         self.assertEquals(cursor.get_key(), ds.key(51))
+        session.commit_transaction()
+
+        # Insert key 1 to check prev operation.
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(1))
+        prep_cursor.set_value(ds.value(1))
+        prep_cursor.insert()
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
+
+        # Point all cursors to key 2.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(50))
+        before_ts_c.set_key(ds.key(2))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(150))
+        between_ts_c.set_key(ds.key(2))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        after_ts_c.set_key(ds.key(2))
+        self.assertEquals(after_ts_c.search(), 0)
+
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(2))
+        self.assertEquals(cursor.search(), 0)
+
+        # Check the visibility of newly inserted, prepared update.
+
+        # As read is before prepare timestamp, prev is not found.
+        self.assertEquals(before_ts_c.prev(), wiredtiger.WT_NOTFOUND)
+        before_ts_s.commit_transaction()
+        # As read is between, prev will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
+        # As read is after, prev will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.prev())
+        # As read is non-timestamped, prev will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(200))
+
+        # As read is between(i.e before commit), prev is not found.
+        self.assertEquals(between_ts_c.prev(), wiredtiger.WT_NOTFOUND)
+        between_ts_s.commit_transaction()
+        # As read is after, prev will point to new key 1.
+        self.assertEquals(after_ts_c.prev(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(1))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 1.
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(1))
         session.commit_transaction()
 
         # End of Scenario-1.
 
-        # Scenario-2 : next / prev with update as prepared updated.
+        # Scenario-2 : Check cursor navigate with update in prepared transaction.
         # Begin of Scenario-2.
-        # Update key 52
-        prep_session.begin_transaction()
-        prep_cursor.set_key(ds.key(52))
-        prep_cursor.set_value(ds.value(152))
-        prep_cursor.update()
-        prep_session.prepare_transaction("prepare_timestamp=200")
-
-        # Cursor points to key 51.
-        session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(51))
-        self.assertEquals(cursor.search(), 0)
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.next())
-        prep_session.commit_transaction("commit_timestamp=200")
-
-        self.assertEquals(cursor.next(), 0)
-        self.assertEquals(cursor.get_key(), ds.key(52))
-        session.commit_transaction()
-
+        # Data set at start has keys {1,2,3,4 ... 50,51}
+        # Update key 51 to check next operation.
+        # Update key 1 to check prev operation.
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(51))
         prep_cursor.set_value(ds.value(151))
         prep_cursor.update()
-        prep_session.prepare_transaction("prepare_timestamp=200")
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(300))
 
-        # Cursor points to key 52.
-        # Search, so that new snapshot includes key 51.
+        # Point all cursors to key 51.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        before_ts_c.set_key(ds.key(50))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(350))
+        between_ts_c.set_key(ds.key(50))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        after_ts_c.set_key(ds.key(50))
+        self.assertEquals(after_ts_c.search(), 0)
+
         session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(52))
+        cursor.set_key(ds.key(50))
         self.assertEquals(cursor.search(), 0)
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.prev())
-        prep_session.commit_transaction("commit_timestamp=200")
 
-        self.assertEquals(cursor.prev(), 0)
+        # Check the visibility of newly inserted, prepared update.
+
+        # As read is before prepare timestamp, next is found with previous value.
+        self.assertEquals(before_ts_c.next(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(51))
+        self.assertEquals(before_ts_c.get_value(), ds.value(51))
+        # As read is between, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
+        # As read is after, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.next())
+        # As read is non-timestamped, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(400))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(51))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(51))
+        self.assertEquals(before_ts_c.get_value(), ds.value(51))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), next is not found.
+        self.assertEquals(between_ts_c.next(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(51))
+        self.assertEquals(between_ts_c.get_value(), ds.value(51))
+        between_ts_s.commit_transaction()
+        # As read is after, next will point to new key 51.
+        self.assertEquals(after_ts_c.next(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(51))
+        self.assertEquals(after_ts_c.get_value(), ds.value(151))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 51.
+        self.assertEquals(cursor.next(), 0)
         self.assertEquals(cursor.get_key(), ds.key(51))
+        self.assertEquals(cursor.get_value(), ds.value(151))
+        session.commit_transaction()
+
+        # Update key 1 to check prev operation.
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(1))
+        prep_cursor.set_value(ds.value(111))
+        prep_cursor.update()
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(300))
+
+        # Point all cursors to key 2.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        before_ts_c.set_key(ds.key(2))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(350))
+        between_ts_c.set_key(ds.key(2))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        after_ts_c.set_key(ds.key(2))
+        self.assertEquals(after_ts_c.search(), 0)
+
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(2))
+        self.assertEquals(cursor.search(), 0)
+
+        # Check the visibility of new update of prepared transaction.
+
+        # As read is before prepare timestamp, prev is not found.
+        self.assertEquals(before_ts_c.prev(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(1))
+        self.assertEquals(before_ts_c.get_value(), ds.value(1))
+        # As read is between, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
+        # As read is after, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.prev())
+        # As read is non-timestamped, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(400))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(1))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(1))
+        self.assertEquals(before_ts_c.get_value(), ds.value(1))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), prev should get old value.
+        self.assertEquals(between_ts_c.prev(), 0)
+        self.assertEquals(between_ts_c.get_value(), ds.value(1))
+        between_ts_s.commit_transaction()
+        # As read is after, prev should get new value.
+        self.assertEquals(after_ts_c.prev(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(1))
+        self.assertEquals(after_ts_c.get_value(), ds.value(111))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 1.
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(1))
+        self.assertEquals(cursor.get_value(), ds.value(111))
         session.commit_transaction()
 
         # End of Scenario-2.
 
-        # Scenario-3 : next / prev with remove as prepared updated.
+        # Scenario-3 : Check cursor navigate with remove in prepared transaction.
         # Begin of Scenario-3.
-        # Remove key 52
+        # Data set at start has keys {1,2,3,4 ... 50,51}
+        # Remove key 51 to check next operation.
+        # Remove key 1 to check prev operation.
         prep_session.begin_transaction()
-        prep_cursor.set_key(ds.key(52))
+        prep_cursor.set_key(ds.key(51))
         prep_cursor.remove()
-        prep_session.prepare_transaction("prepare_timestamp=300")
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(500))
 
-        # Cursor points to key 51.
+        # Point all cursors to key 51.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        before_ts_c.set_key(ds.key(50))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(550))
+        between_ts_c.set_key(ds.key(50))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        after_ts_c.set_key(ds.key(50))
+        self.assertEquals(after_ts_c.search(), 0)
+
         session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(51))
+        cursor.set_key(ds.key(50))
         self.assertEquals(cursor.search(), 0)
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.next())
-        prep_session.commit_transaction("commit_timestamp=300")
 
-        # Key 52 is deleted and it is the last one, so should get NOT FOUND.
+        # Check the visibility of removed prepared update.
+
+        # As read is before prepare timestamp, next is found with key 51.
+        self.assertEquals(before_ts_c.next(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(51))
+        # As read is between, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
+        # As read is after, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.next())
+        # As read is non-timestamped, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(600))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(51))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(51))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), next is not found.
+        self.assertEquals(between_ts_c.next(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(51))
+        between_ts_s.commit_transaction()
+        # As read is after, next will point beyond end.
+        self.assertEquals(after_ts_c.next(), wiredtiger.WT_NOTFOUND)
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should not find a key.
         self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
         session.commit_transaction()
 
+        # Remove key 1 to check prev operation.
         prep_session.begin_transaction()
-        prep_cursor.set_key(ds.key(50))
+        prep_cursor.set_key(ds.key(1))
         prep_cursor.remove()
-        prep_session.prepare_transaction("prepare_timestamp=300")
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(500))
 
-        # Cursor points to key 51.
-        # Search, so that new snapshot includes key 50, which is removed.
+        # Point all cursors to key 2.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        before_ts_c.set_key(ds.key(2))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(550))
+        between_ts_c.set_key(ds.key(2))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        after_ts_c.set_key(ds.key(2))
+        self.assertEquals(after_ts_c.search(), 0)
+
         session.begin_transaction('isolation=' + self.isolation)
-        cursor.set_key(ds.key(51))
+        cursor.set_key(ds.key(2))
         self.assertEquals(cursor.search(), 0)
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: cursor.prev())
-        prep_session.commit_transaction("commit_timestamp=300")
 
-        # Key 50 is deleted, cursor was pointing to 50 now so should get 49.
-        self.assertEquals(cursor.prev(), 0)
-        self.assertEquals(cursor.get_key(), ds.key(49))
+        # Check the visibility of new update of prepared transaction.
+
+        # As read is before prepare timestamp, prev is not found.
+        self.assertEquals(before_ts_c.prev(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(1))
+        # As read is between, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
+        # As read is after, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.prev())
+        # As read is non-timestamped, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(600))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(1))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(1))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), prev should get old value.
+        self.assertEquals(between_ts_c.prev(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(1))
+        between_ts_s.commit_transaction()
+        # As read is after, prev should get new value.
+        self.assertEquals(after_ts_c.prev(), wiredtiger.WT_NOTFOUND)
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 1.
+        self.assertEquals(cursor.prev(), wiredtiger.WT_NOTFOUND)
         session.commit_transaction()
 
         # End of Scenario-3.
+
+        # Scenario-4 : Check cursor navigate with remove in prepared transaction.
+        # remove keys not in the ends.
+        # Begin of Scenario-4.
+        # Data set at start has keys {2,3,4 ... 50}
+        # Remove key 49 to check next operation.
+        # Remove key 3 to check prev operation.
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(49))
+        prep_cursor.remove()
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(700))
+
+        # Point all cursors to key 48.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        before_ts_c.set_key(ds.key(48))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(750))
+        between_ts_c.set_key(ds.key(48))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(850))
+        after_ts_c.set_key(ds.key(48))
+        self.assertEquals(after_ts_c.search(), 0)
+
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(48))
+        self.assertEquals(cursor.search(), 0)
+
+        # Check the visibility of removed prepared update.
+
+        # As read is before prepare timestamp, next is found with key 49.
+        self.assertEquals(before_ts_c.next(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(49))
+        # As read is between, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.next())
+        # As read is after, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.next())
+        # As read is non-timestamped, next will point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(800))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(49))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(49))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), next is not found.
+        self.assertEquals(between_ts_c.next(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(49))
+        between_ts_s.commit_transaction()
+        # As read is after, next will point beyond end.
+        self.assertEquals(after_ts_c.next(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(50))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should not find a key.
+        self.assertEquals(cursor.next(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(50))
+        session.commit_transaction()
+
+        # Remove key 3 to check prev operation.
+        prep_session.begin_transaction()
+        prep_cursor.set_key(ds.key(3))
+        prep_cursor.remove()
+        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(700))
+
+        # Point all cursors to key 4.
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        before_ts_c.set_key(ds.key(4))
+        self.assertEquals(before_ts_c.search(), 0)
+
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(750))
+        between_ts_c.set_key(ds.key(4))
+        self.assertEquals(between_ts_c.search(), 0)
+
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(850))
+        after_ts_c.set_key(ds.key(4))
+        self.assertEquals(after_ts_c.search(), 0)
+
+        session.begin_transaction('isolation=' + self.isolation)
+        cursor.set_key(ds.key(4))
+        self.assertEquals(cursor.search(), 0)
+
+        # Check the visibility of new update of prepared transaction.
+
+        # As read is before prepare timestamp, prev is not found.
+        self.assertEquals(before_ts_c.prev(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(3))
+        # As read is between, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: between_ts_c.prev())
+        # As read is after, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: after_ts_c.prev())
+        # As read is non-timestamped, prev should point to prepared update.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+
+        # Commit the prepared transaction.
+        prep_session.commit_transaction('commit_timestamp=' + timestamp_str(800))
+
+        # Check to see before cursor still gets the old value.
+        before_ts_c.set_key(ds.key(3))
+        self.assertEquals(before_ts_c.search(), 0)
+        self.assertEquals(before_ts_c.get_key(), ds.key(3))
+        before_ts_s.commit_transaction()
+        # As read is between(i.e before commit), prev should get old value.
+        self.assertEquals(between_ts_c.prev(), 0)
+        self.assertEquals(between_ts_c.get_key(), ds.key(3))
+        between_ts_s.commit_transaction()
+        # As read is after, prev should get new value.
+        self.assertEquals(after_ts_c.prev(), 0)
+        self.assertEquals(after_ts_c.get_key(), ds.key(2))
+        after_ts_s.commit_transaction()
+        # Non-timestamped read should find new key 2.
+        self.assertEquals(cursor.prev(), 0)
+        self.assertEquals(cursor.get_key(), ds.key(2))
+        session.commit_transaction()
+
+        # End of Scenario-4.
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -35,11 +35,12 @@ def timestamp_str(t):
     return '%x' %t
 
 # test_prepare_cursor01.py
-#    WT_CURSOR position tests with prepared transactions
+#    WT_CURSOR navigation (next/prev) tests with prepared transactions
 class test_prepare_cursor01(wttest.WiredTigerTestCase):
 
     keyfmt = [
-        ('integer', dict(keyfmt='i')),
+        ('row-store', dict(keyfmt='i')),
+        ('column-store', dict(keyfmt='r')),
     ]
     types = [
         ('table-simple', dict(uri='table', ds=SimpleDataSet)),


### PR DESCRIPTION
I have added a python test to test the cursor next / prev behaviour with respect to prepared transactions.
I have made some code changes as well.

