### PR TITLE
WT-4409 Fix workgen throttling

### DIFF
--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -67,13 +67,15 @@ struct WorkgenException {
 
 struct Throttle {
     ThreadRunner &_runner;
-    double _throttle;
+    double _throttle;                          // operations per second
     double _burst;
     timespec _next_div;
     int64_t _ops_delta;
-    uint64_t _ops_prev;         // previously returned value
-    uint64_t _ops_per_div;      // statically calculated.
-    uint64_t _ms_per_div;       // statically calculated.
+    uint64_t _ops_prev;                        // previously returned value
+    uint64_t _ops_per_div;                     // statically calculated.
+    uint64_t _ms_per_div;                      // statically calculated.
+    double _ops_left_this_second;              // ops left to go this second
+    uint_t _div_pos;                           // count within THROTTLE_PER_SEC
     bool _started;
 
     Throttle(ThreadRunner &runner, double throttle, double burst);


### PR DESCRIPTION
Fix wtperf.py to not modify the throttling number of a thread to account for log-like operations, it was doing the wrong calculation before.

Fix workgen so that small throttle numbers, or generally numbers that aren't divisible by 20 (internal THROTTLE_PER_SEC constant) are still handled.