### PR TITLE
WT-4419 big-endian machines incorrectly configure little-endian crc32c support

### DIFF
--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -292,4 +292,18 @@ if test "$wt_cv_enable_zstd" = "yes"; then
 fi
 AM_CONDITIONAL([ZSTD], [test "$wt_cv_enable_zstd" = "yes"])
 
+AH_TEMPLATE(HAVE_NO_CRC32_HARDWARE,
+    [Define to 1 to disable any crc32 hardware support.])
+AC_MSG_CHECKING(if --disable-crc32-hardware option specified)
+AC_ARG_ENABLE(crc32-hardware,
+	[AS_HELP_STRING([--disable-crc32-hardware],
+	    [Disable any crc32 hardware support.])], r=$enableval, r=yes)
+case "$r" in
+no)	wt_cv_crc32_hardware=no
+	AC_DEFINE(HAVE_NO_CRC32_HARDWARE)
+	AC_MSG_RESULT(yes);;
+*)	wt_cv_crc32_hardware=yes
+	AC_MSG_RESULT(no);;
+esac
+
 ])

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -76,6 +76,9 @@
 /* Define to 1 if you have the <memory.h> header file. */
 /* #undef HAVE_MEMORY_H */
 
+/* Define to 1 to disable any crc32 hardware support. */
+/* #undef HAVE_NO_CRC32_HARDWARE */
+
 /* Define to 1 if pthread condition variables support monotonic clocks. */
 /* #undef HAVE_PTHREAD_COND_MONOTONIC */
 

--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -26,15 +26,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <wiredtiger_config.h>
 #include <inttypes.h>
 #include <stddef.h>
 
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
 #if defined(__linux__) && !defined(HAVE_NO_CRC32_HARDWARE)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>

--- a/src/checksum/power8/crc32.sx
+++ b/src/checksum/power8/crc32.sx
@@ -1,9 +1,4 @@
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
+#include <wiredtiger_config.h>
 #if defined(__powerpc64__) && !defined(HAVE_NO_CRC32_HARDWARE)
 
 /*

--- a/src/checksum/power8/crc32_wrapper.c
+++ b/src/checksum/power8/crc32_wrapper.c
@@ -1,12 +1,7 @@
+#include <wiredtiger_config.h>
 #include <inttypes.h>
 #include <stddef.h>
 
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
 #if defined(__powerpc64__) && !defined(HAVE_NO_CRC32_HARDWARE)
 #define CRC_TABLE
 #include "crc32_constants.h"

--- a/src/checksum/software/checksum.c
+++ b/src/checksum/software/checksum.c
@@ -38,6 +38,7 @@
  * little endian.
  */
 
+#include <wiredtiger_config.h>
 #include <inttypes.h>
 #include <stddef.h>
 

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -26,15 +26,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <wiredtiger_config.h>
 #include <inttypes.h>
 #include <stddef.h>
 
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
 #if !defined(HAVE_NO_CRC32_HARDWARE)
 #if (defined(__amd64) || defined(__x86_64))
 /*

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -7,17 +7,12 @@
  *
  */
 
+#include <wiredtiger_config.h>
 #include <sys/types.h>
 #include <endian.h>
 #include <inttypes.h>
 #include <stddef.h>
 
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
 #if defined(__linux__) && !defined(HAVE_NO_CRC32_HARDWARE)
 #include <sys/auxv.h>
 

--- a/src/checksum/zseries/crc32le-vx.sx
+++ b/src/checksum/zseries/crc32le-vx.sx
@@ -1,9 +1,4 @@
-/*
- * The checksum code doesn't include WiredTiger configuration or include files.
- * This means the HAVE_NO_CRC32_HARDWARE #define isn't configurable as part of
- * standalone WiredTiger configuration, there's no way to turn off the checksum
- * hardware.
- */
+#include <wiredtiger_config.h>
 #if !defined(HAVE_NO_CRC32_HARDWARE)
 
 /*


### PR DESCRIPTION
Replacement for #4362.