### PR TITLE
WT-3756 Adjust pre-allocated file amount downward if we're not using them quickly enough

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -447,7 +447,14 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
 		__wt_verbose(session, WT_VERB_LOG,
 		    "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
 		    log->prep_missed, conn->log_prealloc);
-	}
+	} else if (reccount > conn->log_prealloc / 2)
+		/*
+		 * If we used less than half, then adjust how many we allocate
+		 * downward. Cut in half, plus 1 so that we always allocate
+		 * at least one.
+		 */
+		conn->log_prealloc = conn->log_prealloc / 2 + 1;
+
 	WT_STAT_CONN_SET(session, log_prealloc_max, conn->log_prealloc);
 	/*
 	 * Allocate up to the maximum number that we just computed and detected.

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -447,13 +447,17 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
 		__wt_verbose(session, WT_VERB_LOG,
 		    "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
 		    log->prep_missed, conn->log_prealloc);
-	} else if (reccount > conn->log_prealloc / 2)
+	} else if (reccount > conn->log_prealloc / 2 &&
+	    conn->log_prealloc > 2) {
 		/*
-		 * If we used less than half, then adjust how many we allocate
-		 * downward. Cut in half, plus 1 so that we always allocate
-		 * at least one.
+		 * If we used less than half, then start adjusting down.
 		 */
-		conn->log_prealloc = conn->log_prealloc / 2 + 1;
+		--conn->log_prealloc;
+		__wt_verbose(session, WT_VERB_LOG,
+		    "Adjust down. Did not use %" PRIu32
+		    ". Now pre-allocating %" PRIu32,
+		    reccount, conn->log_prealloc);
+	}
 
 	WT_STAT_CONN_SET(session, log_prealloc_max, conn->log_prealloc);
 	/*

--- a/test/suite/test_bug019.py
+++ b/test/suite/test_bug019.py
@@ -60,7 +60,7 @@ class test_bug019(wttest.WiredTigerTestCase):
         self.assertFalse(not f)
 
     def get_prealloc_stat(self):
-        stat_cursor = self.session.open_cursor('statistics:', None, None);
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
         prealloc = stat_cursor[stat.conn.log_prealloc_max][2]
         stat_cursor.close()
         return prealloc

--- a/test/suite/test_bug019.py
+++ b/test/suite/test_bug019.py
@@ -92,12 +92,8 @@ class test_bug019(wttest.WiredTigerTestCase):
 
         # Sleep for a few seconds and we should see the number of files we want
         # to pre-allocate drop as the log server thread sees an idle system.
-        #
-        # NOTE: there is a problem with auto-adjusting conditions such that
-        # waiting 3 seconds is not long enough for the log server thread to run.
-        # It appears to need over 5 seconds to run once when idle.
         prealloc = self.get_prealloc_stat()
-        time.sleep(6)
+        time.sleep(3)
         new_prealloc = self.get_prealloc_stat()
         self.assertTrue(new_prealloc < prealloc)
 


### PR DESCRIPTION
@sueloverso I created this new pull request using the old `wt-3756-prealloc` branch. The previous pull request #4356 was reverted due to the failures described in [WT-3756](https://jira.mongodb.org/browse/WT-3756?focusedCommentId=2064129&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2064129).