### PR TITLE
WT-4410 Split 'unit-test' task to reduce Evergreen Ubuntu build variant runtime

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -808,7 +808,7 @@ tasks:
             set -o verbose
 
             cd .libs
-            ${python_test_env_vars|} python ../test/suite/run.py [de] -v 2 ${smp_command|} 2>&1
+            ${python_test_env_vars|} python ../test/suite/run.py [defg] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket03
     depends_on:
@@ -823,7 +823,7 @@ tasks:
             set -o verbose
 
             cd .libs
-            ${python_test_env_vars|} python ../test/suite/run.py [hij] -v 2 ${smp_command|} 2>&1
+            ${python_test_env_vars|} python ../test/suite/run.py [hijk] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket04
     depends_on:
@@ -838,7 +838,7 @@ tasks:
             set -o verbose
 
             cd .libs
-            ${python_test_env_vars|} python ../test/suite/run.py [lmnop] -v 2 ${smp_command|} 2>&1
+            ${python_test_env_vars|} python ../test/suite/run.py [lmnopq] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket05
     depends_on:
@@ -883,7 +883,7 @@ tasks:
             set -o verbose
 
             cd .libs
-            ${python_test_env_vars|} python ../test/suite/run.py [uv] -v 2 ${smp_command|} 2>&1
+            ${python_test_env_vars|} python ../test/suite/run.py [uvwxyz] -v 2 ${smp_command|} 2>&1
 
   # End of Python unit test tasks
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -737,6 +737,8 @@ tasks:
 
   # End of csuite test tasks
 
+  # Start of Python unit test tasks
+
   - name: unit-test
     depends_on:
     - name: compile
@@ -749,21 +751,141 @@ tasks:
             set -o errexit
             set -o verbose
 
-            if [ "Windows_NT" = "$OS" ]; then
-              ${test_env_vars|} python ./test/suite/run.py -v 2 ${smp_command|} 2>&1
-            elif [ "$(uname -s)" == "Darwin" ]; then
-              # Avoid /usr/bin/python, at least on macOS: with System Integrity
-              # Protection enabled, it ignores DYLD_LIBRARY_PATH and hence
-              # doesn't find the WiredTiger library in the local tree.
-              ${test_env_vars|} python ./test/suite/run.py -v 2 ${smp_command|} 2>&1
-            else # Ubuntu
-              # Change directory to where the local installed 'wt' binary is located, 
-              # to avoid libtool generated 'wt' script from being selected by run.py,
-              # which invokes relink_command that tries to changing to a non-existed 
-              # /data/mci/<uniq> directory, as 'make' is done by a separate 'compile' task.
-              cd .libs
-              ${python_test_env_vars|} python ../test/suite/run.py -v 2 ${smp_command|} 2>&1
-            fi
+            # Only Windows and OS X variants are expected to run this task
+            #
+            # Avoid /usr/bin/python, at least on macOS: with System Integrity
+            # Protection enabled, it ignores DYLD_LIBRARY_PATH and hence
+            # doesn't find the WiredTiger library in the local tree.
+            ${test_env_vars|} python ./test/suite/run.py -v 2 ${smp_command|} 2>&1
+
+  # Break out Python unit tests into multiple buckets/tasks based on test name and runtime
+  # The test/suite/run.py script can work out test names by casting each command argument
+  # with "test_" prefix and "*.py" postfix. 
+  #
+  # One example: 
+  # "test/suite/run.py [ab]" will be translated to testing "test_a*.py" and "test_b*.py"
+
+  - name: unit-test-bucket00
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [ab] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket01
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [c] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket02
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [de] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket03
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [hij] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket04
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [lmnop] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket05
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [rs] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket06
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [t] -v 2 ${smp_command|} 2>&1
+
+  - name: unit-test-bucket07
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+
+            cd .libs
+            ${python_test_env_vars|} python ../test/suite/run.py [uv] -v 2 ${smp_command|} 2>&1
+
+  # End of Python unit test tasks
 
   - name: compile-windows-alt
     depends_on:
@@ -884,7 +1006,14 @@ buildvariants:
     - name: csuite-wt2909-checkpoint-integrity-test
     - name: csuite-wt3338-partial-update-test
     - name: csuite-wt4333-handle-locks-test
-    - name: unit-test
+    - name: unit-test-bucket00
+    - name: unit-test-bucket01
+    - name: unit-test-bucket02
+    - name: unit-test-bucket03
+    - name: unit-test-bucket04
+    - name: unit-test-bucket05
+    - name: unit-test-bucket06
+    - name: unit-test-bucket07
     - name: fops
 
 - name: large-scale-test

--- a/test/suite/README
+++ b/test/suite/README
@@ -1,0 +1,13 @@
+The test/suite directory includes a collection of Python unit tests 
+that are expected to be executed when code change is introduced in this repo.  
+
+These Python tests are broken down and grouped into multiple buckets/tasks
+in Evergreen (CI system) configuration. See test/evergreen.yml for details.
+
+There is a plan to implement a mechanism to auto-group tests into buckets/tasks
+based on history runtime of each test, and generate the Evergreen configuration
+dynamically before each Evergreen build variant run, so that no mental overhead
+is required when new tests is introduced into test/suite. (WT-4441)
+
+Before the above mentioned mechansim is put into place, please double check
+test/evergreen.yml and test run logs to make sure new test are covered.


### PR DESCRIPTION
Split 'unit-test' Evergreen task (Python test/suite) into 8 buckets/tasks to reduce Makespan for the WiredTiger Ubuntu build variant. The split was based on test name (alphabetic order for the 1st letter after 'test_' prefix) and test runtime, a few alphabetics were grouped together to get them 'relatively' evenly-distributed runtime for each bucket/task. 

There's a plan to implement a mechanism to auto-group and auto-generate buckets/tasks based on historic runtime for each tests, which would be covered later in WT-4441. Added a REAME under test/suite to describe the situation and plan. 

A patch build of the change is [here](https://evergreen.mongodb.com/version/5bf745092a60ed72f37df437). 