### PR TITLE
WT-4383 Update session statistics to reflect the operation statistics.

### DIFF
--- a/dist/s_stat
+++ b/dist/s_stat
@@ -30,6 +30,7 @@ lock_commit_timestamp_wait_application
 lock_commit_timestamp_wait_internal
 lock_commit_timestamp_write_count
 lock_dhandle_read_count
+lock_dhandle_wait
 lock_dhandle_wait_application
 lock_dhandle_wait_internal
 lock_dhandle_write_count
@@ -41,6 +42,7 @@ lock_read_timestamp_wait_application
 lock_read_timestamp_wait_internal
 lock_read_timestamp_write_count
 lock_schema_count
+lock_schema_wait
 lock_schema_wait_application
 lock_schema_wait_internal
 lock_table_read_count

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -145,6 +145,7 @@ __wt_bt_read(WT_SESSION_IMPL *session,
 		WT_STAT_DATA_INCR(session, compress_read);
 	WT_STAT_CONN_INCRV(session, cache_bytes_read, dsk->mem_size);
 	WT_STAT_DATA_INCRV(session, cache_bytes_read, dsk->mem_size);
+	WT_STAT_SESSION_INCRV(session, bytes_read, dsk->mem_size);
 	(void)__wt_atomic_add64(
 	    &S2C(session)->cache->bytes_read, dsk->mem_size);
 
@@ -185,7 +186,7 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 	WT_KEYED_ENCRYPTOR *kencryptor;
 	WT_PAGE_HEADER *dsk;
 	size_t dst_len, len, result_len, size, src_len;
-	uint64_t time_start, time_stop;
+	uint64_t time_diff, time_start, time_stop;
 	uint8_t *dst, *src;
 	int compression_failed;		/* Extension API, so not a bool. */
 	bool data_checksum, encrypted, timer;
@@ -388,15 +389,17 @@ __wt_bt_write(WT_SESSION_IMPL *session, WT_ITEM *buf,
 	/* Update some statistics now that the write is done */
 	if (timer) {
 		time_stop = __wt_clock(session);
+		time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 		WT_STAT_CONN_INCR(session, cache_write_app_count);
-		WT_STAT_CONN_INCRV(session, cache_write_app_time,
-		    WT_CLOCKDIFF_US(time_stop, time_start));
+		WT_STAT_CONN_INCRV(session, cache_write_app_time, time_diff);
+		WT_STAT_SESSION_INCRV(session, write_time, time_diff);
 	}
 
 	WT_STAT_CONN_INCR(session, cache_write);
 	WT_STAT_DATA_INCR(session, cache_write);
 	WT_STAT_CONN_INCRV(session, cache_bytes_write, dsk->mem_size);
 	WT_STAT_DATA_INCRV(session, cache_bytes_write, dsk->mem_size);
+	WT_STAT_SESSION_INCRV(session, bytes_write, dsk->mem_size);
 	(void)__wt_atomic_add64(
 	    &S2C(session)->cache->bytes_written, dsk->mem_size);
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -415,7 +415,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	WT_ITEM tmp;
 	WT_PAGE *notused;
 	size_t addr_size;
-	uint64_t time_start, time_stop;
+	uint64_t time_diff, time_start, time_stop;
 	uint32_t page_flags, final_state, new_state, previous_state;
 	const uint8_t *addr;
 	bool timer;
@@ -482,9 +482,10 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	WT_ERR(__wt_bt_read(session, &tmp, addr, addr_size));
 	if (timer) {
 		time_stop = __wt_clock(session);
+		time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 		WT_STAT_CONN_INCR(session, cache_read_app_count);
-		WT_STAT_CONN_INCRV(session, cache_read_app_time,
-		    WT_CLOCKDIFF_US(time_stop, time_start));
+		WT_STAT_CONN_INCRV(session, cache_read_app_time, time_diff);
+		WT_STAT_SESSION_INCRV(session, read_time, time_diff);
 	}
 
 	/*

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -57,11 +57,11 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
 	WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
 	WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
 	WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
-	WT_SPIN_INIT_TRACKED(session, &conn->schema_lock, schema);
+	WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
 	WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
 
 	/* Read-write locks */
-	WT_RWLOCK_INIT_TRACKED(session, &conn->dhandle_lock, dhandle);
+	WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->dhandle_lock, dhandle);
 	WT_RET(__wt_rwlock_init(session, &conn->hot_backup_lock));
 	WT_RWLOCK_INIT_TRACKED(session, &conn->table_lock, table);
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -270,6 +270,10 @@ __curstat_reset(WT_CURSOR *cursor)
 	cst->notinitialized = cst->notpositioned = true;
 	F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 
+	/* Reset the session statistics to zero. */
+	if (strcmp(cursor->uri, "statistics:session") == 0)
+		__wt_stat_session_clear_single(&session->stats);
+
 err:	API_END_RET(session, ret);
 }
 
@@ -520,15 +524,6 @@ __curstat_join_init(WT_SESSION_IMPL *session,
 static void
 __curstat_session_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 {
-	/* This is a stub at the moment, initialize the session stats to 0. */
-	session->stats.bytes_read = 0;
-	session->stats.bytes_write = 0;
-	session->stats.cache_time = 0;
-	session->stats.lock_dhandle_wait = 0;
-	session->stats.lock_schema_wait = 0;
-	session->stats.read_time = 0;
-	session->stats.write_time = 0;
-
 	/*
 	 * Copy stats from the session to the cursor. Optionally clear the
 	 * session's statistics.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2444,6 +2444,7 @@ err:	if (timer) {
 		time_stop = __wt_clock(session);
 		elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
 		WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+		WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
 		session->cache_wait_us += elapsed;
 		if (cache->cache_max_wait_us != 0 &&
 		    session->cache_wait_us > cache->cache_max_wait_us) {

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -53,6 +53,7 @@ struct __wt_rwlock {			/* Read/write lock */
 	int16_t stat_write_count_off;	/* write acquisitions offset */
 	int16_t stat_app_usecs_off;	/* waiting application threads offset */
 	int16_t stat_int_usecs_off;	/* waiting server threads offset */
+	int16_t stat_session_usecs_off;	/* waiting session offset */
 
 	WT_CONDVAR *cond_readers;	/* Blocking readers */
 	WT_CONDVAR *cond_writers;	/* Blocking writers */
@@ -65,17 +66,24 @@ struct __wt_rwlock {			/* Read/write lock */
  * Implemented as a macro so we can pass in a statistics field and convert
  * it into a statistics structure array offset.
  */
-#define	WT_RWLOCK_INIT_TRACKED(session, l, name) do {                   \
-	WT_RET(__wt_rwlock_init(session, l));                           \
-	(l)->stat_read_count_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(   \
-	    S2C(session)->stats, lock_##name##_read_count);             \
-	(l)->stat_write_count_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(  \
-	    S2C(session)->stats, lock_##name##_write_count);            \
-	(l)->stat_app_usecs_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(    \
-	    S2C(session)->stats, lock_##name##_wait_application);       \
-	(l)->stat_int_usecs_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(    \
-	    S2C(session)->stats, lock_##name##_wait_internal);          \
+#define	WT_RWLOCK_INIT_TRACKED(session, l, name) do {			\
+	WT_RET(__wt_rwlock_init(session, l));				\
+	(l)->stat_read_count_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(	\
+	    S2C(session)->stats, lock_##name##_read_count);		\
+	(l)->stat_write_count_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(	\
+	    S2C(session)->stats, lock_##name##_write_count);		\
+	(l)->stat_app_usecs_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(	\
+	    S2C(session)->stats, lock_##name##_wait_application);	\
+	(l)->stat_int_usecs_off = (int16_t)WT_STATS_FIELD_TO_OFFSET(	\
+	    S2C(session)->stats, lock_##name##_wait_internal);		\
 } while (0)
+
+#define	WT_RWLOCK_INIT_SESSION_TRACKED(session, l, name) {		\
+	WT_RWLOCK_INIT_TRACKED(session, l, name);			\
+	(l)->stat_session_usecs_off =					\
+	    (int16_t)WT_SESSION_STATS_FIELD_TO_OFFSET(			\
+	    &(session->stats), lock_##name##_wait);			\
+}
 
 /*
  * Spin locks:
@@ -112,6 +120,7 @@ struct __wt_spinlock {
 	int16_t stat_count_off;		/* acquisitions offset */
 	int16_t stat_app_usecs_off;	/* waiting application threads offset */
 	int16_t stat_int_usecs_off;	/* waiting server threads offset */
+	int16_t stat_session_usecs_off;	/* waiting session offset */
 
 	int8_t initialized;		/* Lock initialized, for cleanup */
 

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -78,12 +78,12 @@ struct __wt_rwlock {			/* Read/write lock */
 	    S2C(session)->stats, lock_##name##_wait_internal);		\
 } while (0)
 
-#define	WT_RWLOCK_INIT_SESSION_TRACKED(session, l, name) {		\
+#define	WT_RWLOCK_INIT_SESSION_TRACKED(session, l, name) do {		\
 	WT_RWLOCK_INIT_TRACKED(session, l, name);			\
 	(l)->stat_session_usecs_off =					\
 	    (int16_t)WT_SESSION_STATS_FIELD_TO_OFFSET(			\
 	    &(session->stats), lock_##name##_wait);			\
-}
+} while (0)
 
 /*
  * Spin locks:

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -286,12 +286,12 @@ __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 	    S2C(session)->stats, lock_##name##_wait_internal);		\
 } while (0)
 
-#define	WT_SPIN_INIT_SESSION_TRACKED(session, t, name) {                \
+#define	WT_SPIN_INIT_SESSION_TRACKED(session, t, name) do {                \
 	WT_SPIN_INIT_TRACKED(session, t, name);                         \
 	(t)->stat_session_usecs_off = \
 	    (int16_t)WT_SESSION_STATS_FIELD_TO_OFFSET(                  \
 	    &(session->stats), lock_##name##_wait);                     \
-}
+} while (0)
 
 /*
  * __wt_spin_lock_track --

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -300,25 +300,25 @@ __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 static inline void
 __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
-	uint64_t time_start, time_stop;
+	uint64_t time_diff, time_start, time_stop;
 	int64_t *session_stats, **stats;
 
 	if (t->stat_count_off != -1 && WT_STAT_ENABLED(session)) {
 		time_start = __wt_clock(session);
 		__wt_spin_lock(session, t);
 		time_stop = __wt_clock(session);
+		time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 		stats = (int64_t **)S2C(session)->stats;
 		session_stats = (int64_t *)&(session->stats);
 		stats[session->stat_bucket][t->stat_count_off]++;
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][t->stat_int_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
+			    (int64_t)time_diff;
 		else {
 			stats[session->stat_bucket][t->stat_app_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
-			session_stats[t->stat_session_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
+			    (int64_t)time_diff;
 		}
+		session_stats[t->stat_session_usecs_off] += (int64_t)time_diff;
 	} else
 		__wt_spin_lock(session, t);
 }

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -84,6 +84,9 @@
 #define	WT_STATS_FIELD_TO_OFFSET(stats, fld)				\
 	(int)(&(stats)[0]->fld - (int64_t *)(stats)[0])
 
+#define	WT_SESSION_STATS_FIELD_TO_OFFSET(stats, fld)			\
+	(int)(&(stats)->fld - (int64_t *)(stats))
+
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define	WT_STAT_CLEAR		0x01u
 #define	WT_STAT_JSON		0x02u
@@ -257,6 +260,12 @@ __wt_stats_clear(void *stats_arg, int slot)
 		WT_STAT_SET(						\
 		    session, (session)->dhandle->stats, fld, value);	\
 } while (0)
+
+/*
+ * Update per session statistics.
+ */
+#define	WT_STAT_SESSION_INCRV(session, fld, value)			\
+       WT_STAT_INCRV_BASE(session, &session->stats, fld, value)
 
 /*
  * Construct histogram increment functions to put the passed value into the

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -269,9 +269,8 @@ stall:			__wt_cond_wait(session,
 		else {
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
 			    (int64_t)time_diff;
-			session_stats[l->stat_session_usecs_off] +=
-			    (int64_t)time_diff;
 		}
+		session_stats[l->stat_session_usecs_off] += (int64_t)time_diff;
 	}
 
 	/*
@@ -445,12 +444,10 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][l->stat_int_usecs_off] +=
 			    (int64_t)time_diff;
-		else {
+		else
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
 			    (int64_t)time_diff;
-			session_stats[l->stat_session_usecs_off] +=
-			    (int64_t)time_diff;
-		}
+		session_stats[l->stat_session_usecs_off] += (int64_t)time_diff;
 	}
 
 	/*

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -171,13 +171,14 @@ void
 __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 {
 	WT_RWLOCK new, old;
-	uint64_t time_start, time_stop;
-	int64_t **stats;
+	uint64_t time_diff, time_start, time_stop;
+	int64_t *session_stats, **stats;
 	int16_t writers_active;
 	uint8_t ticket;
 	int pause_cnt;
 	bool set_stats;
 
+	session_stats = NULL;		/* -Wconditional-uninitialized */
 	stats = NULL;			/* -Wconditional-uninitialized */
 	time_start = time_stop = 0;	/* -Wconditional-uninitialized */
 
@@ -243,6 +244,7 @@ stall:			__wt_cond_wait(session,
 	if (set_stats) {
 		stats = (int64_t **)S2C(session)->stats;
 		stats[session->stat_bucket][l->stat_read_count_off]++;
+		session_stats = (int64_t *)&(session->stats);
 		time_start = __wt_clock(session);
 	}
 	/* Wait for our group to start. */
@@ -260,12 +262,16 @@ stall:			__wt_cond_wait(session,
 	}
 	if (set_stats) {
 		time_stop = __wt_clock(session);
+		time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][l->stat_int_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
-		else
+			    (int64_t)time_diff;
+		else {
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
+			    (int64_t)time_diff;
+			session_stats[l->stat_session_usecs_off] +=
+			    (int64_t)time_diff;
+		}
 	}
 
 	/*
@@ -371,12 +377,13 @@ void
 __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 {
 	WT_RWLOCK new, old;
-	uint64_t time_start, time_stop;
-	int64_t **stats;
+	uint64_t time_diff, time_start, time_stop;
+	int64_t *session_stats, **stats;
 	uint8_t ticket;
 	int pause_cnt;
 	bool set_stats;
 
+	session_stats = NULL;		/* -Wconditional-uninitialized */
 	stats = NULL;			/* -Wconditional-uninitialized */
 	time_start = time_stop = 0;	/* -Wconditional-uninitialized */
 
@@ -407,6 +414,7 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 	if (set_stats) {
 		stats = (int64_t **)S2C(session)->stats;
 		stats[session->stat_bucket][l->stat_write_count_off]++;
+		session_stats = (int64_t *)&(session->stats);
 		time_start = __wt_clock(session);
 	}
 	/*
@@ -433,12 +441,16 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 	}
 	if (set_stats) {
 		time_stop = __wt_clock(session);
+		time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 		if (F_ISSET(session, WT_SESSION_INTERNAL))
 			stats[session->stat_bucket][l->stat_int_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
-		else
+			    (int64_t)time_diff;
+		else {
 			stats[session->stat_bucket][l->stat_app_usecs_off] +=
-			    (int64_t)WT_CLOCKDIFF_US(time_stop, time_start);
+			    (int64_t)time_diff;
+			session_stats[l->stat_session_usecs_off] +=
+			    (int64_t)time_diff;
+		}
 	}
 
 	/*

--- a/test/suite/test_schema06.py
+++ b/test/suite/test_schema06.py
@@ -93,7 +93,8 @@ class test_schema06(wttest.WiredTigerTestCase):
         self.drop_index(1)
 
         # Test the session level schema lock wait statistic. The schema lock
-        # wait is seen for the lsm table only.
+        # wait is seen for the lsm table only. Concurrent lsm worker threads
+        # could require an in-memory chunk switch under a schema lock.
         if self.idx_config == ',type=lsm':
             found = False
             stat_cur = self.session.open_cursor('statistics:session', None, None)

--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# test_stat08.py
+#    Session statistics for cache writes, reads and wait.
+class test_stat08(wttest.WiredTigerTestCase):
+
+    nentries = 5200
+    # Small cache and stats colleciton enabled.
+    conn_config = 'cache_size=1MB,statistics=(all)'
+    # Make the values about 200 bytes. That's little more than 1MB of
+    # data for 5200 records, triggering writes to the disk and cache
+    # full wait.
+    entry_value = "abcde" * 40
+
+    def test_session_stats(self):
+        self.session = self.conn.open_session()
+        self.session.create("table:test_stat08",
+                            "key_format=i,value_format=S")
+        cursor =  self.session.open_cursor('table:test_stat08', None, None)
+        # Write the entries.
+        for i in range(0, self.nentries):
+            cursor[i] = self.entry_value
+        cursor.reset()
+
+        # Read the entries.
+        for key, value in cursor:
+            self.pr('read %d -> %s' % (key, value))
+        cursor.reset()
+
+        stat_cur = self.session.open_cursor('statistics:session', None, None)
+        while stat_cur.next() == 0:
+            [desc, pvalue, value] = stat_cur.get_values()
+            if desc == 'session: time waiting for cache (usecs)' or \
+               desc == 'session: bytes read into cache' or \
+               desc == 'session: bytes written from cache' or \
+               desc == 'session: page read from disk to cache time (usecs)' or \
+               desc == 'session: page write from cache to disk time (usecs)':
+                self.assertTrue(value > 0)
+
+        # Session stats cursor reset should set all the stats values to zero.
+        stat_cur.reset()
+        while stat_cur.next() == 0:
+            [desc, pvalue, value] = stat_cur.get_values()
+            self.assertTrue(value == 0)
+
+        stat_cur.reset()
+        # Write 10 more records to the disk.
+        for i in range(0, 10):
+            cursor[i + self.nentries] = self.entry_value
+        self.session.checkpoint()
+        while stat_cur.next() == 0:
+            [desc, pvalue, value] = stat_cur.get_values()
+            if desc == 'session: page write from cache to disk time (usecs)' or \
+               desc == 'session: bytes written from cache':
+                self.assertTrue(value > 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -82,8 +82,7 @@ class test_stat08(wttest.WiredTigerTestCase):
             [desc, pvalue, value] = stat_cur.get_values()
             self.printVerbose(2, '  stat: \'' + desc + '\', \'' +
                               pvalue + '\', ' + str(value))
-            if desc == 'session: page write from cache to disk time (usecs)' or \
-               desc == 'session: bytes written from cache':
+            if desc == 'session: bytes written from cache':
                 self.assertTrue(value > 0)
 
 if __name__ == '__main__':

--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -53,8 +53,7 @@ class test_stat08(wttest.WiredTigerTestCase):
         cur.set_key(k)
         cur.search()
         [desc, pvalue, value] = cur.get_values()
-        self.printVerbose(2, '  stat: \'' + desc + '\', \'' + pvalue + '\', ' +
-                          str(value))
+        self.pr('  stat: \'%s\', \'%s\', \'%s\'' % (desc, pvalue, str(value)))
         self.assertEqual(desc, exp_desc )
         self.assertTrue(value > 0)
 


### PR DESCRIPTION
This change set increments the new session statistics at the desired locations. It does not add any decrement macro yet because s_define complains about the unused macros.