### PR TITLE
WT-4470 Minimize testing that requires TESTUTIL_ENABLE_LONG_TESTS

### DIFF
--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -6,9 +6,6 @@ set -e
 echo "checkpoint: 3 mixed tables"
 $TEST_WRAPPER ./t -T 3 -t m
 
-# We are done unless long tests are enabled.
-test "$TESTUTIL_ENABLE_LONG_TESTS" = "1" || exit 0
-
 echo "checkpoint: 6 column-store tables"
 $TEST_WRAPPER ./t -T 6 -t c
 

--- a/test/csuite/time_shift_test.sh
+++ b/test/csuite/time_shift_test.sh
@@ -11,9 +11,6 @@ set -e
 # assumption that other factors of the environment will influence the execution
 # time by less than 20%.
 
-# We will run only when long tests are enabled.
-test "$TESTUTIL_ENABLE_LONG_TESTS" = "1" || exit 0
-
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
 

--- a/test/csuite/time_shift_test.sh
+++ b/test/csuite/time_shift_test.sh
@@ -11,10 +11,6 @@ set -e
 # assumption that other factors of the environment will influence the execution
 # time by less than 20%.
 
-
-# need to enable long tests to run test_rwlock 
-export TESTUTIL_ENABLE_LONG_TESTS=1
-
 # We will run only when long tests are enabled.
 test "$TESTUTIL_ENABLE_LONG_TESTS" = "1" || exit 0
 

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -79,9 +79,6 @@ page_init(uint64_t n)
 	}
 }
 
-/*
- * TODO: Platform specific?
- */
 static void
 onsig(int signo)
 {
@@ -100,10 +97,6 @@ main(int argc, char *argv[])
 	pthread_t idlist[100];
 	uint64_t i, id;
 	char buf[100];
-
-	/* Ignore unless requested */
-	if (!testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
 
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -92,10 +92,6 @@ main(int argc, char *argv[])
 	TEST_OPTS *opts, _opts;
 	const char *tablename;
 
-	/* Ignore unless requested */
-	if (!testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
-
 	opts = &_opts;
 	sharedopts = &_sharedopts;
 	memset(opts, 0, sizeof(*opts));
@@ -318,7 +314,8 @@ thread_insert(void *arg)
 	return (NULL);
 }
 
-static void *thread_join(void *arg)
+static void *
+thread_join(void *arg)
 {
 	SHARED_OPTS *sharedopts;
 	TEST_OPTS *opts;

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -38,6 +38,8 @@
 
 void *thread_insert_race(void *);
 
+static uint64_t ready_counter;
+
 int
 main(int argc, char *argv[])
 {
@@ -49,14 +51,10 @@ main(int argc, char *argv[])
 	uint64_t current_value;
 	int i;
 
-	/* Ignore unless requested */
-	if (!testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
-
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
-	opts->nthreads = 10;
-	opts->nrecords = 1000;
+	opts->nthreads = 20;
+	opts->nrecords = 100000;
 	opts->table_type = TABLE_ROW;
 	testutil_check(testutil_parse_opts(argc, argv, opts));
 	testutil_make_work_dir(opts->home);
@@ -119,16 +117,25 @@ thread_insert_race(void *arg)
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
 	WT_SESSION *session;
-	uint64_t i, value;
+	uint64_t i, value, ready_counter_local;
 
 	opts = (TEST_OPTS *)arg;
 	conn = opts->conn;
+
+	printf("Running insert thread\n");
 
 	testutil_check(conn->open_session(conn, NULL, NULL, &session));
 	testutil_check(session->open_cursor(
 	    session, opts->uri, NULL, NULL, &cursor));
 
-	printf("Running insert thread\n");
+	/* Wait until all the threads are ready to go. */
+	(void)__wt_atomic_add64(&ready_counter, 1);
+	for (;; __wt_yield()) {
+		WT_ORDERED_READ(ready_counter_local, ready_counter);
+		if (ready_counter_local >= opts->nthreads)
+			break;
+	}
+
 	for (i = 0; i < opts->nrecords; ++i) {
 		testutil_check(
 		    session->begin_transaction(session, "isolation=snapshot"));

--- a/test/csuite/wt2834_join_bloom_fix/main.c
+++ b/test/csuite/wt2834_join_bloom_fix/main.c
@@ -59,10 +59,6 @@ main(int argc, char *argv[])
 	char posturi[256];
 	const char *tablename;
 
-	/* Ignore unless requested */
-	if (!testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
-
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
 	testutil_check(testutil_parse_opts(argc, argv, opts));

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -82,10 +82,6 @@ main(int argc, char *argv[])
 	int i, nfail;
 	const char *tablename;
 
-	/* Ignore unless requested */
-	if (!testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
-
 	opts = &_opts;
 	sharedopts = &_sharedopts;
 	memset(opts, 0, sizeof(*opts));

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -315,62 +315,51 @@ main(int argc, char *argv[])
 	static const struct {
 		u_int workers;
 		u_int uris;
+		bool  cache_cursors;
 	} runs[] = {
-		{  1,   1},
-		{  8,   1},
-		{ 16,   1},
-		{ 16,   WT_ELEMENTS(uri_list)},
-		{200, 100},
-		{300, 100},
-		{200, WT_ELEMENTS(uri_list)},
-		{600, WT_ELEMENTS(uri_list)},
+		{  1,   1, false},
+		{  1,   1, true},
+		{  8,   1, false},
+		{  8,   1, true},
+		{ 16,   1, false},
+		{ 16,   1, true},
+		{ 16,   WT_ELEMENTS(uri_list), false},
+		{ 16,   WT_ELEMENTS(uri_list), true},
+		{200, 100, false},
+		{200, 100, true},
+		{200, WT_ELEMENTS(uri_list), false},
+		{200, WT_ELEMENTS(uri_list), true},
+		{300, 100, false},
+		{300, 100, true},
+		{600, WT_ELEMENTS(uri_list), false},
+		{600, WT_ELEMENTS(uri_list), true},
 	};
+	WT_RAND_STATE rnd;
 	u_int i, n;
 	int ch;
-	bool run_long;
 
 	(void)testutil_set_progname(argv);
+	__wt_random_init_seed(NULL, &rnd);
 
-	run_long = false;
-	while ((ch = __wt_getopt(argv[0], argc, argv, "av")) != EOF) {
+	while ((ch = __wt_getopt(argv[0], argc, argv, "v")) != EOF) {
 		switch (ch) {
-		case 'a':
-			run_long = true;
-			break;
 		case 'v':
 			verbose = true;
 			break;
 		default:
-			fprintf(stderr, "usage: %s -a", argv[0]);
+			fprintf(stderr, "usage: %s -v\n", argv[0]);
 			return (EXIT_FAILURE);
 		}
 	}
 
-	/* Ignore unless requested */
-	if (!run_long &&
-	    !testutil_is_flag_set("TESTUTIL_ENABLE_LONG_TESTS"))
-		return (EXIT_SUCCESS);
-
 	(void)signal(SIGALRM, on_alarm);
 
-	/*
-	 * This test takes 2 minutes per slot in the runs table, only do the
-	 * first 2 and last 2 slots, unless specifically requested.
-	 */
-	n = WT_ELEMENTS(runs);
-	for (i = 0; i < 2; ++i) {
-		workers = runs[i].workers;
-		uris = runs[i].uris;
-		run(true);
-		run(false);
-	}
-	if (!run_long)
-		i = n - 2;
-	for (; i < n; ++i) {
-		workers = runs[i].workers;
-		uris = runs[i].uris;
-		run(true);
-		run(false);
+	/* Each test in the table runs for a minute, run 5 tests at random. */
+	for (i = 0; i < 5; ++i) {
+		n = __wt_random(&rnd) % WT_ELEMENTS(runs);
+		workers = runs[n].workers;
+		uris = runs[n].uris;
+		run(runs[n].cache_cursors);
 	}
 
 	uri_teardown();

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -621,7 +621,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_rwlock 2>&1
+            ${test_env_vars|} $(pwd)/test_rwlock 2>&1
 
   - name: csuite-wt2246-col-append-test
     depends_on:
@@ -635,7 +635,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2246_col_append 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2246_col_append 2>&1
 
   - name: csuite-wt2323-join-visibility-test
     depends_on:
@@ -649,7 +649,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2323_join_visibility 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2323_join_visibility 2>&1
 
   - name: csuite-wt2535-insert-race-test
     depends_on:
@@ -663,7 +663,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2535_insert_race 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2535_insert_race 2>&1
 
   - name: csuite-wt2834-join-bloom-fix-test
     depends_on:
@@ -677,7 +677,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2834_join_bloom_fix 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2834_join_bloom_fix 2>&1
 
   - name: csuite-wt2853-perf-test
     depends_on:
@@ -691,7 +691,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2853_perf 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2853_perf 2>&1
 
   - name: csuite-wt2909-checkpoint-integrity-test
     depends_on:
@@ -705,7 +705,7 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} TESTUTIL_ENABLE_LONG_TESTS=1 $(pwd)/test_wt2909_checkpoint_integrity 2>&1
+            ${test_env_vars|} $(pwd)/test_wt2909_checkpoint_integrity 2>&1
 
   - name: csuite-wt3338-partial-update-test
     depends_on:


### PR DESCRIPTION
@lukech, @agorrod, with these changes, I think we're close to getting rid of `TESTUTIL_ENABLE_LONG_TESTS`.

The only remaining uses of `TESTUTIL_ENABLE_LONG_TESTS` are:
```
test/evergreen.yml
test/csuite/time_shift_test.sh
```

@bvpvamsikrishna, I'm not sure what's going on with `time_shift_test.sh`. I can't find any place in the system that runs that shell script, and when I tried to run it, it hung on me.

Most of the commits simply remove checks for `TESTUTIL_ENABLE_LONG_TESTS`, because the tests involved were almost always reasonably fast, there wasn't any point in limiting the tests to "long" runs.

There were two tests I changed in other ways:

* 675b0c8: I increased the run-time of `wt2535_insert_race`, and changed it so the threads were queued behind a gate and didn't start until all of them were ready to run, to avoid them executing serially. This is more of a bug fix than anything else, the test wasn't really doing anything useful.

* 50519a3: I reworked `wt2909_checkpoint_integrity` in a couple of ways, first to reduce the amount of testing done to find a midpoint, and second, to only do a single test run per value near the midpoint. @ddanderson, this probably deserves real review.

