### PR TITLE
WT-4481 Evergreen script cleanups

### DIFF
--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -1,7 +1,19 @@
 #! /bin/sh
 
+t=__wt.$$
+trap 'rm -f $t' 0 1 2 3 13 15
+
 toplevel_dir=$(git rev-parse --show-toplevel)
 program=${toplevel_dir}/test/evergreen/evg_cfg.py
 
 # Run checking program to identify missing tests in Evergreen configuration
-${program} check
+${program} check >$t 2>&1
+
+test -s $t && {
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	echo "$0: $program check"
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	cat $t
+	exit 1
+}
+exit 0

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -264,7 +264,7 @@ def evg_cfg(action, test_type):
     """
 
     # Make sure the program is run under a checkout of wiredtiger repository
-    if run('git config remote.origin.url') != WIREDTIGER_REPO:
+    if run('git config remote.origin.url') in WIREDTIGER_REPO:
         sys.exit("ERROR: need to run this script inside a wiredtiger repo")
 
     # Change directory to repo top level


### PR DESCRIPTION
@lukech, just minor stuff I ran into today.

I would suggest that all of the error messages in `evg_cfg.py` should print out the name of the script so it's easy to figure out where the error message is coming from, but I didn't make that change.