### PR TITLE
WT-4418 Don't keep key/value memory buffers allocated for cached cursor (v3.6 backport)

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -598,6 +598,10 @@ __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
 
 	WT_TRET(cursor->reset(cursor));
 
+	/* Don't keep buffers allocated for cached cursors. */
+	__wt_buf_free(session, &cursor->key);
+	__wt_buf_free(session, &cursor->value);
+
 	/*
 	 * Acquire a reference while decrementing the in-use counter.
 	 * After this point, the dhandle may be marked dead, but the


### PR DESCRIPTION

(cherry picked from commit ed2bf5948e433eaf9efe62093a9de77026d711be)

This is a clean cherry-pick. @ddanderson, can you help to take a look? Cheers.