### PR TITLE
WT-4482 lint

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -4078,7 +4078,6 @@ __rec_col_var(WT_SESSION_IMPL *session,
 	WT_COL_FOREACH(page, cip, i) {
 		ovfl_state = OVFL_IGNORE;
 		if ((cell = WT_COL_PTR(page, cip)) == NULL) {
-			vpack = NULL;
 			nrepeat = 1;
 			ins = NULL;
 			orig_deleted = true;


### PR DESCRIPTION
Revert a commit in the #4407 branch, it's incorrect and can potentially lead to a column-store core dump.