### PR TITLE
WT-4499 Fix prepare transactions key order check failure.

### DIFF
--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -495,8 +495,23 @@ __cursor_check_prepared_update(WT_CURSOR_BTREE *cbt, bool *visiblep)
 
 	/* The update that returned prepared conflict is now visible. */
 	F_CLR(cbt, WT_CBT_ITERATE_RETRY_NEXT | WT_CBT_ITERATE_RETRY_PREV);
-	if (*visiblep)
-		WT_RET(__cursor_kv_return(session, cbt, upd));
+	if (*visiblep) {
+		/*
+		 * The underlying key-return function uses a comparison value
+		 * of 0 to indicate the search function has pre-built the key
+		 * we want to return. That's not the case, don't take that path.
+		 */
+		cbt->compare = 1;
+		/*
+		 * If a prepared delete operation is resolved, it will be
+		 * visible, but key is not valid. The update will be null in
+		 * that case and we continue with cursor navigation.
+		 */
+		if (upd != NULL)
+			WT_RET(__cursor_kv_return(session, cbt, upd));
+		else
+			*visiblep = false;
+	}
 
 	return (0);
 }


### PR DESCRIPTION
This PR has two changes.
1.A prepared delete operation after resolution will be visible, but should not use the key and value.

2.cbt->compare to be set to non-zero to indicate that key is not pre-built.