### PR TITLE
WT-4506 Bypass some csuite tests for valgrind

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -400,6 +400,7 @@ UnmapViewOfFile
 Unmarshall
 Unordered
 Uryyb
+VALGRIND
 VARCHAR
 VLDB
 VMSG

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Bypass this test for valgrind
+test "$TESTUTIL_BYPASS_VALGRIND" = "1" && exit 0
+
 # Smoke-test checkpoints as part of running "make check".
 echo "checkpoint: 3 mixed tables"
 $TEST_WRAPPER ./t -T 3 -t m

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -98,6 +98,10 @@ main(int argc, char *argv[])
 	uint64_t i, id;
 	char buf[100];
 
+	/* Bypass this test for valgrind */
+	if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
 	memset(opts, 0, sizeof(*opts));
 	opts->table_type = TABLE_ROW;

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -92,6 +92,10 @@ main(int argc, char *argv[])
 	TEST_OPTS *opts, _opts;
 	const char *tablename;
 
+	/* Bypass this test for valgrind */
+	if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
+		return (EXIT_SUCCESS);
+
 	opts = &_opts;
 	sharedopts = &_sharedopts;
 	memset(opts, 0, sizeof(*opts));

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -199,7 +199,7 @@ bool
 testutil_is_flag_set(const char *flag)
 {
 	const char *res;
-	bool enable_long_tests;
+	bool flag_being_set;
 
 	if (__wt_getenv(NULL, flag, &res) != 0 || res == NULL)
 		return (false);
@@ -208,11 +208,11 @@ testutil_is_flag_set(const char *flag)
 	 * This is a boolean test. So if the environment variable is set to any
 	 * value other than 0, we return success.
 	 */
-	enable_long_tests = res[0] != '0';
+	flag_being_set = res[0] != '0';
 
 	free((void *)res);
 
-	return (enable_long_tests);
+	return (flag_being_set);
 }
 
 /*


### PR DESCRIPTION
Use the new env variable 'TESTUTIL_BYPASS_VALGRIND' to bypass below 3 long-running tests for valgrind:
- test/checkpoint
- test/csuite/test_wt2246_col_append
- test/csuite/test_wt2323_join_visibility
Verified this feature branch on `wiredtiger-valgrind` job, the [build](http://build.wiredtiger.com:8080/job/wiredtiger-valgrind/3046/) concluded/failed in 4h41m (with a known issue), instead of keep running for over 3 days without finishing without the changes. 

@keithbostic @agorrod Could you help to take a look? Thanks.