### PR TITLE
WT-4411 Added connection statistic for current total of cached cursors (v3.6 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -291,7 +291,8 @@ connection_stats = [
     ##########################################
     # Cursor operations
     ##########################################
-    CursorStat('cursor_cache', 'cursors cached on close'),
+    CursorStat('cursors_cached', 'cursors currently cached', 'no_clear,no_scale'),
+    CursorStat('cursor_cache', 'cursor close calls that result in cache'),
     CursorStat('cursor_create', 'cursor create calls'),
     CursorStat('cursor_insert', 'cursor insert calls'),
     CursorStat('cursor_modify', 'cursor modify calls'),
@@ -691,7 +692,7 @@ dsrc_stats = [
     ##########################################
     # Cursor operations
     ##########################################
-    CursorStat('cursor_cache', 'cursors cached on close'),
+    CursorStat('cursor_cache', 'close calls that result in cache'),
     CursorStat('cursor_create', 'create calls'),
     CursorStat('cursor_insert', 'insert calls'),
     CursorStat('cursor_insert_bulk', 'bulk-loaded cursor-insert calls'),
@@ -749,7 +750,7 @@ dsrc_stats = [
     # Session operations
     ##########################################
     SessionStat('session_compact', 'object compaction'),
-    SessionStat('session_cursor_cached', 'cached cursor count', 'no_clear,no_scale'),
+    SessionStat('session_cursors_cached', 'cached cursor count', 'no_clear,no_scale'),
     SessionStat('session_cursor_open', 'open cursor count', 'no_clear,no_scale'),
 
     ##########################################

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -621,7 +621,8 @@ __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
 
 	(void)__wt_atomic_sub32(&S2C(session)->open_cursor_count, 1);
 	WT_STAT_DATA_DECR(session, session_cursor_open);
-	WT_STAT_DATA_INCR(session, session_cursor_cached);
+	WT_STAT_DATA_INCR(session, session_cursors_cached);
+	WT_STAT_CONN_INCR(session, cursors_cached);
 	F_SET(cursor, WT_CURSTD_CACHED);
 	return (ret);
 }
@@ -646,7 +647,8 @@ __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
 	}
 	(void)__wt_atomic_add32(&S2C(session)->open_cursor_count, 1);
 	WT_STAT_DATA_INCR(session, session_cursor_open);
-	WT_STAT_DATA_DECR(session, session_cursor_cached);
+	WT_STAT_DATA_DECR(session, session_cursors_cached);
+	WT_STAT_CONN_DECR(session, cursors_cached);
 
 	bucket = cursor->uri_hash % WT_HASH_ARRAY_SIZE;
 	TAILQ_REMOVE(&session->cursor_cache[bucket], cursor, q);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -454,6 +454,7 @@ struct __wt_connection_stats {
 	int64_t fsync_io;
 	int64_t read_io;
 	int64_t write_io;
+	int64_t cursor_cache;
 	int64_t cursor_create;
 	int64_t cursor_insert;
 	int64_t cursor_modify;
@@ -470,7 +471,7 @@ struct __wt_connection_stats {
 	int64_t cursor_sweep_examined;
 	int64_t cursor_sweep;
 	int64_t cursor_update;
-	int64_t cursor_cache;
+	int64_t cursors_cached;
 	int64_t cursor_reopen;
 	int64_t cursor_truncate;
 	int64_t dh_conn_handle_count;
@@ -789,12 +790,12 @@ struct __wt_dsrc_stats {
 	int64_t compress_raw_fail;
 	int64_t compress_raw_ok;
 	int64_t cursor_insert_bulk;
+	int64_t cursor_cache;
 	int64_t cursor_create;
 	int64_t cursor_restart;
 	int64_t cursor_insert_bytes;
 	int64_t cursor_remove_bytes;
 	int64_t cursor_update_bytes;
-	int64_t cursor_cache;
 	int64_t cursor_reopen;
 	int64_t cursor_insert;
 	int64_t cursor_modify;
@@ -821,7 +822,7 @@ struct __wt_dsrc_stats {
 	int64_t rec_pages;
 	int64_t rec_pages_eviction;
 	int64_t rec_page_delete;
-	int64_t session_cursor_cached;
+	int64_t session_cursors_cached;
 	int64_t session_compact;
 	int64_t session_cursor_open;
 	int64_t txn_update_conflict;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5291,484 +5291,486 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_READ_IO				1139
 /*! connection: total write I/Os */
 #define	WT_STAT_CONN_WRITE_IO				1140
+/*! cursor: cursor close calls that result in cache */
+#define	WT_STAT_CONN_CURSOR_CACHE			1141
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1141
+#define	WT_STAT_CONN_CURSOR_CREATE			1142
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1142
+#define	WT_STAT_CONN_CURSOR_INSERT			1143
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1143
+#define	WT_STAT_CONN_CURSOR_MODIFY			1144
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1144
+#define	WT_STAT_CONN_CURSOR_NEXT			1145
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1145
+#define	WT_STAT_CONN_CURSOR_RESTART			1146
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1146
+#define	WT_STAT_CONN_CURSOR_PREV			1147
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1147
+#define	WT_STAT_CONN_CURSOR_REMOVE			1148
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1148
+#define	WT_STAT_CONN_CURSOR_RESERVE			1149
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1149
+#define	WT_STAT_CONN_CURSOR_RESET			1150
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1150
+#define	WT_STAT_CONN_CURSOR_SEARCH			1151
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1151
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1152
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1152
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1153
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1153
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1154
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1154
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1155
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1155
+#define	WT_STAT_CONN_CURSOR_SWEEP			1156
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1156
-/*! cursor: cursors cached on close */
-#define	WT_STAT_CONN_CURSOR_CACHE			1157
+#define	WT_STAT_CONN_CURSOR_UPDATE			1157
+/*! cursor: cursors currently cached */
+#define	WT_STAT_CONN_CURSORS_CACHED			1158
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1158
+#define	WT_STAT_CONN_CURSOR_REOPEN			1159
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1159
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1160
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1160
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1161
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1161
+#define	WT_STAT_CONN_DH_SWEEP_REF			1162
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1162
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1163
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1163
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1164
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1164
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1165
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1165
+#define	WT_STAT_CONN_DH_SWEEPS				1166
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1166
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1167
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1167
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1168
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1168
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1169
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1169
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1170
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1170
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1171
 /*!
  * lock: commit timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1171
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1172
 /*! lock: commit timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1172
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1173
 /*! lock: commit timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1173
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1174
 /*! lock: commit timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1174
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1175
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1175
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1176
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1176
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1177
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1177
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1178
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1178
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1179
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1179
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1180
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1180
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1181
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1181
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1182
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1182
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1183
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1183
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1184
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1184
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1185
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1185
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1186
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1186
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1187
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1187
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1188
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1188
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1189
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1189
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1190
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1190
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1191
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1191
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1192
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1192
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1193
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1193
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1194
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1194
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1195
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1195
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1196
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1196
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1197
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1197
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1198
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1198
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1199
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1199
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1200
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1200
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1201
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1201
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1202
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1202
+#define	WT_STAT_CONN_LOG_FLUSH				1203
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1203
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1204
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1204
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1205
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1205
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1206
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1206
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1207
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1207
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1208
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1208
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1209
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1209
+#define	WT_STAT_CONN_LOG_SCANS				1210
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1210
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1211
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1211
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1212
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1212
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1213
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1213
+#define	WT_STAT_CONN_LOG_SYNC				1214
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1214
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1215
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1215
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1216
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1216
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1217
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1217
+#define	WT_STAT_CONN_LOG_WRITES				1218
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1218
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1219
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1219
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1220
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1220
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1221
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1221
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1222
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1222
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1223
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1223
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1224
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1224
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1225
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1225
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1226
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1226
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1227
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1227
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1228
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1228
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1229
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1229
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1230
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1230
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1231
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1231
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1232
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1232
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1233
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1233
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1234
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1234
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1235
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1235
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1236
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1236
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1237
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1237
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1238
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1238
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1239
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1239
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1240
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1240
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1241
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1241
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1242
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1242
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1243
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1243
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1244
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1244
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1245
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1245
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1246
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1246
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1247
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1247
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1248
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1248
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1249
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1249
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1250
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1250
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1251
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1251
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1252
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1252
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1253
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1253
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1254
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1254
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1255
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1255
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1256
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1256
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1257
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1257
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1258
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1258
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1259
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1259
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1260
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1260
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1261
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1261
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1262
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1262
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1263
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1263
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1264
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1264
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1265
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1265
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1266
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1266
+#define	WT_STAT_CONN_REC_PAGES				1267
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1267
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1268
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1268
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1269
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1269
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1270
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1270
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1271
 /*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1271
+#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1272
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1272
+#define	WT_STAT_CONN_SESSION_OPEN			1273
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1273
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1274
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1274
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1275
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1275
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1276
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1276
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1277
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1277
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1278
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1278
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1279
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1279
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1280
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1280
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1281
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1281
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1282
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1282
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1283
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1283
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1284
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1284
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1285
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1285
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1286
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1286
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1287
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1287
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1288
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1288
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1289
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1289
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1290
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1290
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1291
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1291
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1292
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1292
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1293
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1293
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1294
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1294
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1295
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1295
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1296
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1296
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1297
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1297
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1298
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1298
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1299
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1299
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1300
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1300
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1301
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1301
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1302
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1302
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1303
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1303
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1304
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1304
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1305
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1305
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1306
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1306
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1307
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1307
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1308
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1308
+#define	WT_STAT_CONN_PAGE_SLEEP				1309
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1309
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1310
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1310
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1311
 /*! transaction: commit timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1311
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1312
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1312
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1313
 /*! transaction: commit timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1313
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1314
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1314
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1315
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1315
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1316
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1316
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1317
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1317
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1318
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1318
+#define	WT_STAT_CONN_TXN_PREPARE			1319
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1319
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1320
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1320
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1321
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1321
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1322
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1322
+#define	WT_STAT_CONN_TXN_QUERY_TS			1323
 /*! transaction: read timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1323
+#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1324
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1324
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1325
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1325
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1326
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1326
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1327
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1327
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1328
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1328
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1329
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1329
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1330
 /*! transaction: rollback to stable updates removed from cache overflow */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1330
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1331
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1331
+#define	WT_STAT_CONN_TXN_SET_TS				1332
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1332
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1333
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1333
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1334
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1334
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1335
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1335
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1336
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1336
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1337
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1337
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1338
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1338
+#define	WT_STAT_CONN_TXN_BEGIN				1339
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1339
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1340
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1340
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1341
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1341
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1342
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1342
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1343
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1343
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1344
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1344
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1345
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1345
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1346
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1346
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1347
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1347
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1348
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1348
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1349
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1349
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1350
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1350
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1351
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1351
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1352
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1352
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1353
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1353
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1354
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1354
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1355
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1355
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1356
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1356
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1357
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1357
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1358
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1358
+#define	WT_STAT_CONN_TXN_SYNC				1359
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1359
+#define	WT_STAT_CONN_TXN_COMMIT				1360
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1360
+#define	WT_STAT_CONN_TXN_ROLLBACK			1361
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1361
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1362
 
 /*!
  * @}
@@ -6093,18 +6095,18 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_COMPRESS_RAW_OK			2105
 /*! cursor: bulk-loaded cursor-insert calls */
 #define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2106
+/*! cursor: close calls that result in cache */
+#define	WT_STAT_DSRC_CURSOR_CACHE			2107
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2107
+#define	WT_STAT_DSRC_CURSOR_CREATE			2108
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2108
+#define	WT_STAT_DSRC_CURSOR_RESTART			2109
 /*! cursor: cursor-insert key and value bytes inserted */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2109
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2110
 /*! cursor: cursor-remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2110
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2111
 /*! cursor: cursor-update value bytes updated */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2111
-/*! cursor: cursors cached on close */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2112
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2112
 /*! cursor: cursors reused from cache */
 #define	WT_STAT_DSRC_CURSOR_REOPEN			2113
 /*! cursor: insert calls */
@@ -6161,7 +6163,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! reconciliation: pages deleted */
 #define	WT_STAT_DSRC_REC_PAGE_DELETE			2138
 /*! session: cached cursor count */
-#define	WT_STAT_DSRC_SESSION_CURSOR_CACHED		2139
+#define	WT_STAT_DSRC_SESSION_CURSORS_CACHED		2139
 /*! session: object compaction */
 #define	WT_STAT_DSRC_SESSION_COMPACT			2140
 /*! session: open cursor count */

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -110,12 +110,12 @@ static const char * const __stats_dsrc_desc[] = {
 	"compression: raw compression call failed, no additional data available",
 	"compression: raw compression call succeeded",
 	"cursor: bulk-loaded cursor-insert calls",
+	"cursor: close calls that result in cache",
 	"cursor: create calls",
 	"cursor: cursor operation restarted",
 	"cursor: cursor-insert key and value bytes inserted",
 	"cursor: cursor-remove key bytes removed",
 	"cursor: cursor-update value bytes updated",
-	"cursor: cursors cached on close",
 	"cursor: cursors reused from cache",
 	"cursor: insert calls",
 	"cursor: modify calls",
@@ -295,12 +295,12 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->compress_raw_fail = 0;
 	stats->compress_raw_ok = 0;
 	stats->cursor_insert_bulk = 0;
+	stats->cursor_cache = 0;
 	stats->cursor_create = 0;
 	stats->cursor_restart = 0;
 	stats->cursor_insert_bytes = 0;
 	stats->cursor_remove_bytes = 0;
 	stats->cursor_update_bytes = 0;
-	stats->cursor_cache = 0;
 	stats->cursor_reopen = 0;
 	stats->cursor_insert = 0;
 	stats->cursor_modify = 0;
@@ -327,7 +327,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->rec_pages = 0;
 	stats->rec_pages_eviction = 0;
 	stats->rec_page_delete = 0;
-		/* not clearing session_cursor_cached */
+		/* not clearing session_cursors_cached */
 	stats->session_compact = 0;
 		/* not clearing session_cursor_open */
 	stats->txn_update_conflict = 0;
@@ -481,12 +481,12 @@ __wt_stat_dsrc_aggregate_single(
 	to->compress_raw_fail += from->compress_raw_fail;
 	to->compress_raw_ok += from->compress_raw_ok;
 	to->cursor_insert_bulk += from->cursor_insert_bulk;
+	to->cursor_cache += from->cursor_cache;
 	to->cursor_create += from->cursor_create;
 	to->cursor_restart += from->cursor_restart;
 	to->cursor_insert_bytes += from->cursor_insert_bytes;
 	to->cursor_remove_bytes += from->cursor_remove_bytes;
 	to->cursor_update_bytes += from->cursor_update_bytes;
-	to->cursor_cache += from->cursor_cache;
 	to->cursor_reopen += from->cursor_reopen;
 	to->cursor_insert += from->cursor_insert;
 	to->cursor_modify += from->cursor_modify;
@@ -514,7 +514,7 @@ __wt_stat_dsrc_aggregate_single(
 	to->rec_pages += from->rec_pages;
 	to->rec_pages_eviction += from->rec_pages_eviction;
 	to->rec_page_delete += from->rec_page_delete;
-	to->session_cursor_cached += from->session_cursor_cached;
+	to->session_cursors_cached += from->session_cursors_cached;
 	to->session_compact += from->session_compact;
 	to->session_cursor_open += from->session_cursor_open;
 	to->txn_update_conflict += from->txn_update_conflict;
@@ -700,12 +700,12 @@ __wt_stat_dsrc_aggregate(
 	to->compress_raw_fail += WT_STAT_READ(from, compress_raw_fail);
 	to->compress_raw_ok += WT_STAT_READ(from, compress_raw_ok);
 	to->cursor_insert_bulk += WT_STAT_READ(from, cursor_insert_bulk);
+	to->cursor_cache += WT_STAT_READ(from, cursor_cache);
 	to->cursor_create += WT_STAT_READ(from, cursor_create);
 	to->cursor_restart += WT_STAT_READ(from, cursor_restart);
 	to->cursor_insert_bytes += WT_STAT_READ(from, cursor_insert_bytes);
 	to->cursor_remove_bytes += WT_STAT_READ(from, cursor_remove_bytes);
 	to->cursor_update_bytes += WT_STAT_READ(from, cursor_update_bytes);
-	to->cursor_cache += WT_STAT_READ(from, cursor_cache);
 	to->cursor_reopen += WT_STAT_READ(from, cursor_reopen);
 	to->cursor_insert += WT_STAT_READ(from, cursor_insert);
 	to->cursor_modify += WT_STAT_READ(from, cursor_modify);
@@ -739,8 +739,8 @@ __wt_stat_dsrc_aggregate(
 	to->rec_pages += WT_STAT_READ(from, rec_pages);
 	to->rec_pages_eviction += WT_STAT_READ(from, rec_pages_eviction);
 	to->rec_page_delete += WT_STAT_READ(from, rec_page_delete);
-	to->session_cursor_cached +=
-	    WT_STAT_READ(from, session_cursor_cached);
+	to->session_cursors_cached +=
+	    WT_STAT_READ(from, session_cursors_cached);
 	to->session_compact += WT_STAT_READ(from, session_compact);
 	to->session_cursor_open += WT_STAT_READ(from, session_cursor_open);
 	to->txn_update_conflict += WT_STAT_READ(from, txn_update_conflict);
@@ -888,6 +888,7 @@ static const char * const __stats_connection_desc[] = {
 	"connection: total fsync I/Os",
 	"connection: total read I/Os",
 	"connection: total write I/Os",
+	"cursor: cursor close calls that result in cache",
 	"cursor: cursor create calls",
 	"cursor: cursor insert calls",
 	"cursor: cursor modify calls",
@@ -904,7 +905,7 @@ static const char * const __stats_connection_desc[] = {
 	"cursor: cursor sweep cursors examined",
 	"cursor: cursor sweeps",
 	"cursor: cursor update calls",
-	"cursor: cursors cached on close",
+	"cursor: cursors currently cached",
 	"cursor: cursors reused from cache",
 	"cursor: truncate calls",
 	"data-handle: connection data handles currently active",
@@ -1292,6 +1293,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->fsync_io = 0;
 	stats->read_io = 0;
 	stats->write_io = 0;
+	stats->cursor_cache = 0;
 	stats->cursor_create = 0;
 	stats->cursor_insert = 0;
 	stats->cursor_modify = 0;
@@ -1308,7 +1310,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cursor_sweep_examined = 0;
 	stats->cursor_sweep = 0;
 	stats->cursor_update = 0;
-	stats->cursor_cache = 0;
+		/* not clearing cursors_cached */
 	stats->cursor_reopen = 0;
 	stats->cursor_truncate = 0;
 		/* not clearing dh_conn_handle_count */
@@ -1741,6 +1743,7 @@ __wt_stat_connection_aggregate(
 	to->fsync_io += WT_STAT_READ(from, fsync_io);
 	to->read_io += WT_STAT_READ(from, read_io);
 	to->write_io += WT_STAT_READ(from, write_io);
+	to->cursor_cache += WT_STAT_READ(from, cursor_cache);
 	to->cursor_create += WT_STAT_READ(from, cursor_create);
 	to->cursor_insert += WT_STAT_READ(from, cursor_insert);
 	to->cursor_modify += WT_STAT_READ(from, cursor_modify);
@@ -1758,7 +1761,7 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, cursor_sweep_examined);
 	to->cursor_sweep += WT_STAT_READ(from, cursor_sweep);
 	to->cursor_update += WT_STAT_READ(from, cursor_update);
-	to->cursor_cache += WT_STAT_READ(from, cursor_cache);
+	to->cursors_cached += WT_STAT_READ(from, cursors_cached);
 	to->cursor_reopen += WT_STAT_READ(from, cursor_reopen);
 	to->cursor_truncate += WT_STAT_READ(from, cursor_truncate);
 	to->dh_conn_handle_count += WT_STAT_READ(from, dh_conn_handle_count);

--- a/test/suite/test_cursor16.py
+++ b/test/suite/test_cursor16.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2018 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_cursor16.py
+#   Cursors: final close of cached cursors
+#
+
+import wttest
+from wiredtiger import stat
+
+class test_cursor16(wttest.WiredTigerTestCase):
+    tablename = 'test_cursor16'
+    uri_prefix = 'table:' + tablename
+    uri_count = 100
+    session_count = 100
+
+    conn_config = 'cache_cursors=true,statistics=(fast)'
+
+    # Returns the number of cursors cached
+    def cached_stats(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        cache = stat_cursor[stat.conn.cursors_cached][2]
+        stat_cursor.close()
+        return cache
+
+    def test_cursor16(self):
+        uris = []
+        cursors = []
+        #self.tty('begin cursors cached=' + str(self.cached_stats()))
+        for i in range(0, self.uri_count):
+            uri = self.uri_prefix + '-' + str(i)
+            uris.append(uri)
+            self.session.create(uri, 'key_format=S,value_format=S')
+            cursor = self.session.open_cursor(uri)
+            # We keep the cursors open in the main session, so there
+            # will always be a reference to their dhandle, and cached
+            # cursors won't get swept.
+            cursors.append(cursor)
+            for j in range(0, 10):
+                cursor[str(j)] = str(j)
+
+        self.assertEqual(0, self.cached_stats())
+
+        sessions = []
+        for i in range(0, self.session_count):
+            #if i % 10 == 0:
+            #    self.tty('session count=%d cursors cached=%d' %
+            #             (i, self.cached_stats()))
+            session = self.conn.open_session(self.session_config)
+            sessions.append(session)
+            for uri in uris:
+                cursor = session.open_cursor(uri)
+                # spot check, and leaves the cursor positioned
+                self.assertEqual(cursor['3'],'3')
+                cursor.close()
+
+        #self.tty('max cursors cached=' + str(self.cached_stats()))
+        i = 0
+        for session in sessions:
+            #if i % 10 == 0:
+            #    self.tty('session count=%d cursors cached=%d' %
+            #             (self.session_count - i, self.cached_stats()))
+            i += 1
+            session.close()
+
+        #self.tty('end cursors cached=' + str(self.cached_stats()))
+        self.assertEqual(0, self.cached_stats())
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Renamed data source statistic for current total.  Tweeked descriptions
of other cache cursor statistics.  Added test to verify new statistic.

(cherry picked from commit 660c2d688c6c04fb85fbf390f3bc7034cf13cb13)

@ddanderson Can you help to take a look of this v3.6 backport? Thanks.
Once this is merged, I'm going to backport WT-4438. 