### PR TITLE
WT-4438 Use accurate statistics for cursor cache totals in connection (v3.6 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -291,7 +291,8 @@ connection_stats = [
     ##########################################
     # Cursor operations
     ##########################################
-    CursorStat('cursors_cached', 'cursors currently cached', 'no_clear,no_scale'),
+    CursorStat('cursor_open_count', 'open cursor count', 'no_clear,no_scale'),
+    CursorStat('cursor_cached_count', 'cached cursor count', 'no_clear,no_scale'),
     CursorStat('cursor_cache', 'cursor close calls that result in cache'),
     CursorStat('cursor_create', 'cursor create calls'),
     CursorStat('cursor_insert', 'cursor insert calls'),
@@ -464,7 +465,6 @@ connection_stats = [
     ##########################################
     # Session operations
     ##########################################
-    SessionStat('session_cursor_open', 'open cursor count', 'no_clear,no_scale'),
     SessionStat('session_open', 'open session count', 'no_clear,no_scale'),
     SessionStat('session_query_ts', 'session query timestamp calls'),
     SessionStat('session_table_alter_fail', 'table alter failed calls', 'no_clear,no_scale'),
@@ -692,6 +692,7 @@ dsrc_stats = [
     ##########################################
     # Cursor operations
     ##########################################
+    CursorStat('cursor_open_count', 'open cursor count', 'no_clear,no_scale'),
     CursorStat('cursor_cache', 'close calls that result in cache'),
     CursorStat('cursor_create', 'create calls'),
     CursorStat('cursor_insert', 'insert calls'),
@@ -750,8 +751,6 @@ dsrc_stats = [
     # Session operations
     ##########################################
     SessionStat('session_compact', 'object compaction'),
-    SessionStat('session_cursors_cached', 'cached cursor count', 'no_clear,no_scale'),
-    SessionStat('session_cursor_open', 'open cursor count', 'no_clear,no_scale'),
 
     ##########################################
     # Transaction statistics

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -80,7 +80,7 @@ __wt_conn_stat_init(WT_SESSION_IMPL *session)
 
 	WT_STAT_SET(session, stats, file_open, conn->open_file_count);
 	WT_STAT_SET(session,
-	    stats, session_cursor_open, conn->open_cursor_count);
+	    stats, cursor_open_count, conn->open_cursor_count);
 	WT_STAT_SET(session, stats, dh_conn_handle_count, conn->dhandle_count);
 	WT_STAT_SET(session,
 	    stats, rec_split_stashed_objects, conn->stashed_objects);

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -620,9 +620,8 @@ __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
 	TAILQ_INSERT_HEAD(&session->cursor_cache[bucket], cursor, q);
 
 	(void)__wt_atomic_sub32(&S2C(session)->open_cursor_count, 1);
-	WT_STAT_DATA_DECR(session, session_cursor_open);
-	WT_STAT_DATA_INCR(session, session_cursors_cached);
-	WT_STAT_CONN_INCR(session, cursors_cached);
+	WT_STAT_CONN_INCR_ATOMIC(session, cursor_cached_count);
+	WT_STAT_DATA_DECR(session, cursor_open_count);
 	F_SET(cursor, WT_CURSTD_CACHED);
 	return (ret);
 }
@@ -646,9 +645,8 @@ __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
 		WT_DHANDLE_RELEASE(dhandle);
 	}
 	(void)__wt_atomic_add32(&S2C(session)->open_cursor_count, 1);
-	WT_STAT_DATA_INCR(session, session_cursor_open);
-	WT_STAT_DATA_DECR(session, session_cursors_cached);
-	WT_STAT_CONN_DECR(session, cursors_cached);
+	WT_STAT_CONN_DECR_ATOMIC(session, cursor_cached_count);
+	WT_STAT_DATA_INCR(session, cursor_open_count);
 
 	bucket = cursor->uri_hash % WT_HASH_ARRAY_SIZE;
 	TAILQ_REMOVE(&session->cursor_cache[bucket], cursor, q);
@@ -871,7 +869,7 @@ __wt_cursor_close(WT_CURSOR *cursor)
 		TAILQ_REMOVE(&session->cursors, cursor, q);
 
 		(void)__wt_atomic_sub32(&S2C(session)->open_cursor_count, 1);
-		WT_STAT_DATA_DECR(session, session_cursor_open);
+		WT_STAT_DATA_DECR(session, cursor_open_count);
 	}
 	__wt_buf_free(session, &cursor->key);
 	__wt_buf_free(session, &cursor->value);
@@ -1143,7 +1141,7 @@ __wt_cursor_init(WT_CURSOR *cursor,
 
 	F_SET(cursor, WT_CURSTD_OPEN);
 	(void)__wt_atomic_add32(&S2C(session)->open_cursor_count, 1);
-	WT_STAT_DATA_INCR(session, session_cursor_open);
+	WT_STAT_DATA_INCR(session, cursor_open_count);
 
 	*cursorp = (cdump != NULL) ? cdump : cursor;
 	return (0);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -454,6 +454,7 @@ struct __wt_connection_stats {
 	int64_t fsync_io;
 	int64_t read_io;
 	int64_t write_io;
+	int64_t cursor_cached_count;
 	int64_t cursor_cache;
 	int64_t cursor_create;
 	int64_t cursor_insert;
@@ -471,8 +472,8 @@ struct __wt_connection_stats {
 	int64_t cursor_sweep_examined;
 	int64_t cursor_sweep;
 	int64_t cursor_update;
-	int64_t cursors_cached;
 	int64_t cursor_reopen;
+	int64_t cursor_open_count;
 	int64_t cursor_truncate;
 	int64_t dh_conn_handle_count;
 	int64_t dh_sweep_ref;
@@ -585,7 +586,6 @@ struct __wt_connection_stats {
 	int64_t rec_page_delete;
 	int64_t rec_split_stashed_bytes;
 	int64_t rec_split_stashed_objects;
-	int64_t session_cursor_open;
 	int64_t session_open;
 	int64_t session_query_ts;
 	int64_t session_table_alter_fail;
@@ -800,6 +800,7 @@ struct __wt_dsrc_stats {
 	int64_t cursor_insert;
 	int64_t cursor_modify;
 	int64_t cursor_next;
+	int64_t cursor_open_count;
 	int64_t cursor_prev;
 	int64_t cursor_remove;
 	int64_t cursor_reserve;
@@ -822,9 +823,7 @@ struct __wt_dsrc_stats {
 	int64_t rec_pages;
 	int64_t rec_pages_eviction;
 	int64_t rec_page_delete;
-	int64_t session_cursors_cached;
 	int64_t session_compact;
-	int64_t session_cursor_open;
 	int64_t txn_update_conflict;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5291,282 +5291,282 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_READ_IO				1139
 /*! connection: total write I/Os */
 #define	WT_STAT_CONN_WRITE_IO				1140
+/*! cursor: cached cursor count */
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1141
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1141
+#define	WT_STAT_CONN_CURSOR_CACHE			1142
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1142
+#define	WT_STAT_CONN_CURSOR_CREATE			1143
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1143
+#define	WT_STAT_CONN_CURSOR_INSERT			1144
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1144
+#define	WT_STAT_CONN_CURSOR_MODIFY			1145
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1145
+#define	WT_STAT_CONN_CURSOR_NEXT			1146
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1146
+#define	WT_STAT_CONN_CURSOR_RESTART			1147
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1147
+#define	WT_STAT_CONN_CURSOR_PREV			1148
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1148
+#define	WT_STAT_CONN_CURSOR_REMOVE			1149
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1149
+#define	WT_STAT_CONN_CURSOR_RESERVE			1150
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1150
+#define	WT_STAT_CONN_CURSOR_RESET			1151
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1151
+#define	WT_STAT_CONN_CURSOR_SEARCH			1152
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1152
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1153
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1153
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1154
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1154
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1155
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1155
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1156
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1156
+#define	WT_STAT_CONN_CURSOR_SWEEP			1157
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1157
-/*! cursor: cursors currently cached */
-#define	WT_STAT_CONN_CURSORS_CACHED			1158
+#define	WT_STAT_CONN_CURSOR_UPDATE			1158
 /*! cursor: cursors reused from cache */
 #define	WT_STAT_CONN_CURSOR_REOPEN			1159
+/*! cursor: open cursor count */
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1160
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1160
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1161
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1161
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1162
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1162
+#define	WT_STAT_CONN_DH_SWEEP_REF			1163
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1163
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1164
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1164
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1165
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1165
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1166
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1166
+#define	WT_STAT_CONN_DH_SWEEPS				1167
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1167
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1168
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1168
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1169
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1169
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1170
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1170
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1171
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1171
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1172
 /*!
  * lock: commit timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1172
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1173
 /*! lock: commit timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1173
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1174
 /*! lock: commit timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1174
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1175
 /*! lock: commit timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1175
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1176
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1176
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1177
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1177
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1178
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1178
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1179
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1179
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1180
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1180
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1181
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1181
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1182
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1182
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1183
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1183
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1184
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1184
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1185
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1185
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1186
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1186
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1187
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1187
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1188
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1188
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1189
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1189
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1190
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1190
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1191
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1191
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1192
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1192
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1193
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1193
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1194
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1194
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1195
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1195
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1196
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1196
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1197
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1197
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1198
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1198
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1199
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1199
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1200
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1200
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1201
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1201
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1202
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1202
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1203
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1203
+#define	WT_STAT_CONN_LOG_FLUSH				1204
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1204
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1205
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1205
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1206
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1206
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1207
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1207
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1208
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1208
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1209
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1209
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1210
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1210
+#define	WT_STAT_CONN_LOG_SCANS				1211
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1211
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1212
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1212
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1213
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1213
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1214
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1214
+#define	WT_STAT_CONN_LOG_SYNC				1215
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1215
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1216
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1216
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1217
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1217
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1218
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1218
+#define	WT_STAT_CONN_LOG_WRITES				1219
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1219
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1220
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1220
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1221
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1221
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1222
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1222
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1223
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1223
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1224
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1224
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1225
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1225
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1226
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1226
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1227
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1227
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1228
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1228
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1229
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1229
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1230
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1230
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1231
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1231
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1232
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1232
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1233
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1233
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1234
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1234
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1235
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1235
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1236
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1236
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1237
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1237
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1238
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1238
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1239
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1239
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1240
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1240
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1241
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1241
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1242
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1242
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1243
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1243
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1244
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1244
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1245
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1245
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1246
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1246
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1247
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1247
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1248
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1248
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1249
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1249
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1250
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1250
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1251
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1251
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1252
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1252
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1253
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1253
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1254
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1254
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1255
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1255
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1256
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1256
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1257
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1257
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1258
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1258
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1259
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1259
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1260
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1260
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1261
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1261
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1262
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1262
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1263
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1263
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1264
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1264
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1265
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1265
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1266
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1266
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1267
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1267
+#define	WT_STAT_CONN_REC_PAGES				1268
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1268
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1269
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1269
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1270
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1270
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1271
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1271
-/*! session: open cursor count */
-#define	WT_STAT_CONN_SESSION_CURSOR_OPEN		1272
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1272
 /*! session: open session count */
 #define	WT_STAT_CONN_SESSION_OPEN			1273
 /*! session: session query timestamp calls */
@@ -6115,61 +6115,59 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_CURSOR_MODIFY			2115
 /*! cursor: next calls */
 #define	WT_STAT_DSRC_CURSOR_NEXT			2116
+/*! cursor: open cursor count */
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2117
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2117
+#define	WT_STAT_DSRC_CURSOR_PREV			2118
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2118
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2119
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2119
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2120
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2120
+#define	WT_STAT_DSRC_CURSOR_RESET			2121
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2121
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2122
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2122
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2123
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2123
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2124
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2124
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2125
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2125
+#define	WT_STAT_DSRC_REC_DICTIONARY			2126
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2126
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2127
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2127
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2128
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2128
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2129
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2129
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2130
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2130
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2131
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2131
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2132
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2132
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2133
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2133
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2134
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2134
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2135
 /*! reconciliation: page checksum matches */
-#define	WT_STAT_DSRC_REC_PAGE_MATCH			2135
+#define	WT_STAT_DSRC_REC_PAGE_MATCH			2136
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2136
+#define	WT_STAT_DSRC_REC_PAGES				2137
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2137
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2138
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2138
-/*! session: cached cursor count */
-#define	WT_STAT_DSRC_SESSION_CURSORS_CACHED		2139
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2139
 /*! session: object compaction */
 #define	WT_STAT_DSRC_SESSION_COMPACT			2140
-/*! session: open cursor count */
-#define	WT_STAT_DSRC_SESSION_CURSOR_OPEN		2141
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2142
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2141
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -120,6 +120,7 @@ static const char * const __stats_dsrc_desc[] = {
 	"cursor: insert calls",
 	"cursor: modify calls",
 	"cursor: next calls",
+	"cursor: open cursor count",
 	"cursor: prev calls",
 	"cursor: remove calls",
 	"cursor: reserve calls",
@@ -142,9 +143,7 @@ static const char * const __stats_dsrc_desc[] = {
 	"reconciliation: page reconciliation calls",
 	"reconciliation: page reconciliation calls for eviction",
 	"reconciliation: pages deleted",
-	"session: cached cursor count",
 	"session: object compaction",
-	"session: open cursor count",
 	"transaction: update conflicts",
 };
 
@@ -305,6 +304,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->cursor_insert = 0;
 	stats->cursor_modify = 0;
 	stats->cursor_next = 0;
+		/* not clearing cursor_open_count */
 	stats->cursor_prev = 0;
 	stats->cursor_remove = 0;
 	stats->cursor_reserve = 0;
@@ -327,9 +327,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->rec_pages = 0;
 	stats->rec_pages_eviction = 0;
 	stats->rec_page_delete = 0;
-		/* not clearing session_cursors_cached */
 	stats->session_compact = 0;
-		/* not clearing session_cursor_open */
 	stats->txn_update_conflict = 0;
 }
 
@@ -491,6 +489,7 @@ __wt_stat_dsrc_aggregate_single(
 	to->cursor_insert += from->cursor_insert;
 	to->cursor_modify += from->cursor_modify;
 	to->cursor_next += from->cursor_next;
+	to->cursor_open_count += from->cursor_open_count;
 	to->cursor_prev += from->cursor_prev;
 	to->cursor_remove += from->cursor_remove;
 	to->cursor_reserve += from->cursor_reserve;
@@ -514,9 +513,7 @@ __wt_stat_dsrc_aggregate_single(
 	to->rec_pages += from->rec_pages;
 	to->rec_pages_eviction += from->rec_pages_eviction;
 	to->rec_page_delete += from->rec_page_delete;
-	to->session_cursors_cached += from->session_cursors_cached;
 	to->session_compact += from->session_compact;
-	to->session_cursor_open += from->session_cursor_open;
 	to->txn_update_conflict += from->txn_update_conflict;
 }
 
@@ -710,6 +707,7 @@ __wt_stat_dsrc_aggregate(
 	to->cursor_insert += WT_STAT_READ(from, cursor_insert);
 	to->cursor_modify += WT_STAT_READ(from, cursor_modify);
 	to->cursor_next += WT_STAT_READ(from, cursor_next);
+	to->cursor_open_count += WT_STAT_READ(from, cursor_open_count);
 	to->cursor_prev += WT_STAT_READ(from, cursor_prev);
 	to->cursor_remove += WT_STAT_READ(from, cursor_remove);
 	to->cursor_reserve += WT_STAT_READ(from, cursor_reserve);
@@ -739,10 +737,7 @@ __wt_stat_dsrc_aggregate(
 	to->rec_pages += WT_STAT_READ(from, rec_pages);
 	to->rec_pages_eviction += WT_STAT_READ(from, rec_pages_eviction);
 	to->rec_page_delete += WT_STAT_READ(from, rec_page_delete);
-	to->session_cursors_cached +=
-	    WT_STAT_READ(from, session_cursors_cached);
 	to->session_compact += WT_STAT_READ(from, session_compact);
-	to->session_cursor_open += WT_STAT_READ(from, session_cursor_open);
 	to->txn_update_conflict += WT_STAT_READ(from, txn_update_conflict);
 }
 
@@ -888,6 +883,7 @@ static const char * const __stats_connection_desc[] = {
 	"connection: total fsync I/Os",
 	"connection: total read I/Os",
 	"connection: total write I/Os",
+	"cursor: cached cursor count",
 	"cursor: cursor close calls that result in cache",
 	"cursor: cursor create calls",
 	"cursor: cursor insert calls",
@@ -905,8 +901,8 @@ static const char * const __stats_connection_desc[] = {
 	"cursor: cursor sweep cursors examined",
 	"cursor: cursor sweeps",
 	"cursor: cursor update calls",
-	"cursor: cursors currently cached",
 	"cursor: cursors reused from cache",
+	"cursor: open cursor count",
 	"cursor: truncate calls",
 	"data-handle: connection data handles currently active",
 	"data-handle: connection sweep candidate became referenced",
@@ -1019,7 +1015,6 @@ static const char * const __stats_connection_desc[] = {
 	"reconciliation: pages deleted",
 	"reconciliation: split bytes currently awaiting free",
 	"reconciliation: split objects currently awaiting free",
-	"session: open cursor count",
 	"session: open session count",
 	"session: session query timestamp calls",
 	"session: table alter failed calls",
@@ -1293,6 +1288,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->fsync_io = 0;
 	stats->read_io = 0;
 	stats->write_io = 0;
+		/* not clearing cursor_cached_count */
 	stats->cursor_cache = 0;
 	stats->cursor_create = 0;
 	stats->cursor_insert = 0;
@@ -1310,8 +1306,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cursor_sweep_examined = 0;
 	stats->cursor_sweep = 0;
 	stats->cursor_update = 0;
-		/* not clearing cursors_cached */
 	stats->cursor_reopen = 0;
+		/* not clearing cursor_open_count */
 	stats->cursor_truncate = 0;
 		/* not clearing dh_conn_handle_count */
 	stats->dh_sweep_ref = 0;
@@ -1424,7 +1420,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->rec_page_delete = 0;
 		/* not clearing rec_split_stashed_bytes */
 		/* not clearing rec_split_stashed_objects */
-		/* not clearing session_cursor_open */
 		/* not clearing session_open */
 	stats->session_query_ts = 0;
 		/* not clearing session_table_alter_fail */
@@ -1743,6 +1738,7 @@ __wt_stat_connection_aggregate(
 	to->fsync_io += WT_STAT_READ(from, fsync_io);
 	to->read_io += WT_STAT_READ(from, read_io);
 	to->write_io += WT_STAT_READ(from, write_io);
+	to->cursor_cached_count += WT_STAT_READ(from, cursor_cached_count);
 	to->cursor_cache += WT_STAT_READ(from, cursor_cache);
 	to->cursor_create += WT_STAT_READ(from, cursor_create);
 	to->cursor_insert += WT_STAT_READ(from, cursor_insert);
@@ -1761,8 +1757,8 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, cursor_sweep_examined);
 	to->cursor_sweep += WT_STAT_READ(from, cursor_sweep);
 	to->cursor_update += WT_STAT_READ(from, cursor_update);
-	to->cursors_cached += WT_STAT_READ(from, cursors_cached);
 	to->cursor_reopen += WT_STAT_READ(from, cursor_reopen);
+	to->cursor_open_count += WT_STAT_READ(from, cursor_open_count);
 	to->cursor_truncate += WT_STAT_READ(from, cursor_truncate);
 	to->dh_conn_handle_count += WT_STAT_READ(from, dh_conn_handle_count);
 	to->dh_sweep_ref += WT_STAT_READ(from, dh_sweep_ref);
@@ -1934,7 +1930,6 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, rec_split_stashed_bytes);
 	to->rec_split_stashed_objects +=
 	    WT_STAT_READ(from, rec_split_stashed_objects);
-	to->session_cursor_open += WT_STAT_READ(from, session_cursor_open);
 	to->session_open += WT_STAT_READ(from, session_open);
 	to->session_query_ts += WT_STAT_READ(from, session_query_ts);
 	to->session_table_alter_fail +=

--- a/test/suite/test_cursor16.py
+++ b/test/suite/test_cursor16.py
@@ -44,7 +44,7 @@ class test_cursor16(wttest.WiredTigerTestCase):
     # Returns the number of cursors cached
     def cached_stats(self):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
-        cache = stat_cursor[stat.conn.cursors_cached][2]
+        cache = stat_cursor[stat.conn.cursor_cached_count][2]
         stat_cursor.close()
         return cache
 


### PR DESCRIPTION
(cherry picked from commit dfd4f021aca05e62200454c564ecdfce1924478c)

@ddanderson Please help to take a look. There were merge conflicts while cherry-picking the commit from mongodb-4.0. The `SessionOpStat()` function was introduced by WT-4378, which was not backported to mongodb-3.6. So I kept using `SessionStat()` for this v3.6 backporting change. 