### PR TITLE
WT-4520 prepare transactions fallout during cursor navigation.

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -305,6 +305,7 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage)
 		cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		cbt->ins = WT_SKIP_FIRST(cbt->ins_head);
 		cbt->row_iteration_slot = 1;
+		cbt->slot = 0;
 		cbt->rip_saved = NULL;
 		goto new_insert;
 	}

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -178,6 +178,7 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
+		cbt->slot = UINT32_MAX;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);
@@ -302,7 +303,7 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage)
 	 * Initialize for each new page.
 	 */
 	if (newpage) {
-		cbt->slot = 0;
+		cbt->slot = UINT32_MAX;
 		cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		cbt->ins = WT_SKIP_FIRST(cbt->ins_head);
 		cbt->row_iteration_slot = 1;

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -178,6 +178,7 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
+		cbt->slot = 0;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);
@@ -302,10 +303,10 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage)
 	 * Initialize for each new page.
 	 */
 	if (newpage) {
+		cbt->slot = 0;
 		cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		cbt->ins = WT_SKIP_FIRST(cbt->ins_head);
 		cbt->row_iteration_slot = 1;
-		cbt->slot = 0;
 		cbt->rip_saved = NULL;
 		goto new_insert;
 	}

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -178,7 +178,6 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
-		cbt->slot = 0;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -178,6 +178,10 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
+		/*
+		 * Be paranoid and set the slot out of bounds when moving to a
+		 * new page.
+		 */
 		cbt->slot = UINT32_MAX;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
@@ -303,6 +307,10 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage)
 	 * Initialize for each new page.
 	 */
 	if (newpage) {
+		/*
+		 * Be paranoid and set the slot out of bounds when moving to a
+		 * new page.
+		 */
 		cbt->slot = UINT32_MAX;
 		cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		cbt->ins = WT_SKIP_FIRST(cbt->ins_head);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -324,6 +324,10 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
+		/*
+		 * Be paranoid and set the slot out of bounds when moving to a
+		 * new page.
+		 */
 		cbt->slot = UINT32_MAX;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
@@ -456,13 +460,16 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 		if (!F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
 			WT_RET(__wt_row_leaf_keys(session, page));
 
+		/*
+		 * Be paranoid and set the slot out of bounds when moving to a
+		 * new page.
+		 */
 		cbt->slot = UINT32_MAX;
-		if (page->entries == 0) {
+		if (page->entries == 0)
 			cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
-		} else {
+		else
 			cbt->ins_head =
 			    WT_ROW_INSERT_SLOT(page, page->entries - 1);
-		}
 		cbt->ins = WT_SKIP_LAST(cbt->ins_head);
 		cbt->row_iteration_slot = page->entries * 2 + 1;
 		cbt->rip_saved = NULL;

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -455,11 +455,14 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 		if (!F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
 			WT_RET(__wt_row_leaf_keys(session, page));
 
-		if (page->entries == 0)
+		if (page->entries == 0) {
+			cbt->slot = 0;
 			cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
-		else
+		} else {
+			cbt->slot = page->entries - 1;
 			cbt->ins_head =
 			    WT_ROW_INSERT_SLOT(page, page->entries - 1);
+		}
 		cbt->ins = WT_SKIP_LAST(cbt->ins_head);
 		cbt->row_iteration_slot = page->entries * 2 + 1;
 		cbt->rip_saved = NULL;

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -324,6 +324,7 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 
 	/* Initialize for each new page. */
 	if (newpage) {
+		cbt->slot = UINT32_MAX;
 		cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
 		if (cbt->last_standard_recno == 0)
 			return (WT_NOTFOUND);
@@ -455,11 +456,10 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage)
 		if (!F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
 			WT_RET(__wt_row_leaf_keys(session, page));
 
+		cbt->slot = UINT32_MAX;
 		if (page->entries == 0) {
-			cbt->slot = 0;
 			cbt->ins_head = WT_ROW_INSERT_SMALLEST(page);
 		} else {
-			cbt->slot = page->entries - 1;
 			cbt->ins_head =
 			    WT_ROW_INSERT_SLOT(page, page->entries - 1);
 		}

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -305,7 +305,13 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *valid)
 		/* The search function doesn't check for empty pages. */
 		if (page->entries == 0)
 			return (0);
-		WT_ASSERT(session, cbt->slot < page->entries);
+		/*
+		 * In case of prepare conflict, the slot might not have a valid
+		 * value, if the update in the insert list of a new page
+		 * scanned is in prepared state.
+		 */
+		WT_ASSERT(session,
+		    cbt->slot == UINT32_MAX || cbt->slot < page->entries);
 
 		/*
 		 * Column-store updates are stored as "insert" objects. If
@@ -330,7 +336,13 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *valid)
 		/* The search function doesn't check for empty pages. */
 		if (page->entries == 0)
 			return (0);
-		WT_ASSERT(session, cbt->slot < page->entries);
+		/*
+		 * In case of prepare conflict, the slot might not have a valid
+		 * value, if the update in the insert list of a new page
+		 * scanned is in prepared state.
+		 */
+		WT_ASSERT(session,
+		    cbt->slot == UINT32_MAX || cbt->slot < page->entries);
 
 		/*
 		 * See above: for row-store, no insert object can have the same


### PR DESCRIPTION
When scanning a new page and prepared update is encountered, the cbt->slot is not being updated, it still represents the slot from the earlier page.