### PR TITLE
WT-4525 Don't run test in valgrind. Too many threads.

### DIFF
--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -338,6 +338,12 @@ main(int argc, char *argv[])
 	u_int i, n;
 	int ch;
 
+	/*
+	 * Bypass this test for valgrind. It has a fairly low thread limit.
+	 */
+	if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
+		return (EXIT_SUCCESS);
+
 	(void)testutil_set_progname(argv);
 	__wt_random_init_seed(NULL, &rnd);
 


### PR DESCRIPTION
@keithbostic For this one I decided to ignore the test in valgrind. Please review.