### PR TITLE
WT-4521 Change WiredTiger to format printed timestamps as 4B integer pairs

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -738,6 +738,7 @@ fdopen
 fextend
 ffc
 fff
+ffffffffffffffff
 fflush
 ffs
 fgetc

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -592,7 +592,7 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 %typemap(argout) (uint64_t *recnop) { $result = PyLong_FromUnsignedLongLong(*$1); }
 
 /* Handle returned hexadecimal timestamps. */
-%typemap(in,numinputs=0) (char *hex_timestamp) (char tsbuf[WT_TS_HEX_SIZE]) { $1 = tsbuf; }
+%typemap(in,numinputs=0) (char *hex_timestamp) (char tsbuf[WT_TS_HEX_STRING_SIZE]) { $1 = tsbuf; }
 %typemap(argout) (char *hex_timestamp) {
 	if (*$1)
 		$result = SWIG_FromCharPtr($1);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1169,7 +1169,7 @@ __debug_modify(WT_DBG *ds, WT_UPDATE *upd)
 static int
 __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 {
-	char hex_timestamp[WT_TS_HEX_SIZE];
+	char ts_string[WT_TS_INT_STRING_SIZE];
 
 	for (; upd != NULL; upd = upd->next) {
 		switch (upd->type) {
@@ -1204,8 +1204,9 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 			WT_RET(ds->f(ds, "\t" "txn id aborted"));
 		else
 			WT_RET(ds->f(ds, "\t" "txn id %" PRIu64, upd->txnid));
-		__wt_timestamp_to_hex_string(hex_timestamp, upd->timestamp);
-		WT_RET(ds->f(ds, ", ts %s", hex_timestamp));
+		__wt_timestamp_to_string(
+		    ts_string, sizeof(ts_string), upd->timestamp);
+		WT_RET(ds->f(ds, ", ts %s", ts_string));
 		WT_RET(ds->f(ds, "\n"));
 	}
 	return (0);
@@ -1267,8 +1268,7 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	WT_DECL_ITEM(buf);
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
-	char hex_ts[3][WT_TS_HEX_SIZE];
-	const char *type;
+	char ts_string[3][WT_TS_INT_STRING_SIZE];
 
 	session = ds->session;
 
@@ -1312,13 +1312,14 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_ADDR_INT:
 	case WT_CELL_ADDR_LEAF:
 	case WT_CELL_ADDR_LEAF_NO:
-		__wt_timestamp_to_hex_string(
-		    hex_ts[0], unpack->oldest_start_ts);
-		__wt_timestamp_to_hex_string(
-		    hex_ts[1], unpack->newest_start_ts);
-		__wt_timestamp_to_hex_string(hex_ts[2], unpack->newest_stop_ts);
+		__wt_timestamp_to_string(ts_string[0],
+		    sizeof(ts_string[0]), unpack->oldest_start_ts);
+		__wt_timestamp_to_string(ts_string[1],
+		    sizeof(ts_string[1]), unpack->newest_start_ts);
+		__wt_timestamp_to_string(ts_string[2],
+		    sizeof(ts_string[2]), unpack->newest_stop_ts);
 		WT_RET(ds->f(ds,
-		    ", ts %s,%s,%s", hex_ts[0], hex_ts[1], hex_ts[2]));
+		    ", ts %s,%s,%s", ts_string[0], ts_string[1], ts_string[2]));
 		break;
 	case WT_CELL_DEL:
 	case WT_CELL_VALUE:
@@ -1326,35 +1327,27 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_VALUE_OVFL:
 	case WT_CELL_VALUE_OVFL_RM:
 	case WT_CELL_VALUE_SHORT:
-		__wt_timestamp_to_hex_string(hex_ts[0], unpack->start_ts);
-		__wt_timestamp_to_hex_string(hex_ts[1], unpack->stop_ts);
-		WT_RET(ds->f(ds, ", ts %s-%s", hex_ts[0], hex_ts[1]));
+		__wt_timestamp_to_string(ts_string[0],
+		    sizeof(ts_string[0]), unpack->start_ts);
+		__wt_timestamp_to_string(ts_string[1],
+		    sizeof(ts_string[1]), unpack->stop_ts);
+		WT_RET(ds->f(ds, ", ts %s-%s", ts_string[0], ts_string[1]));
 		break;
 	}
 
 	/* Dump addresses. */
 	switch (unpack->raw) {
 	case WT_CELL_ADDR_DEL:
-		type = "addr/del";
-		goto addr;
 	case WT_CELL_ADDR_INT:
-		type = "addr/int";
-		goto addr;
 	case WT_CELL_ADDR_LEAF:
-		type = "addr/leaf";
-		goto addr;
 	case WT_CELL_ADDR_LEAF_NO:
-		type = "addr/leaf-no";
-		goto addr;
 	case WT_CELL_KEY_OVFL:
 	case WT_CELL_KEY_OVFL_RM:
 	case WT_CELL_VALUE_OVFL:
 	case WT_CELL_VALUE_OVFL_RM:
-		type = "ovfl";
-addr:		WT_RET(__wt_scr_alloc(session, 128, &buf));
-		ret = ds->f(ds, ", %s %s", type,
-		    __wt_addr_string(
-		    session, unpack->data, unpack->size, buf));
+		WT_RET(__wt_scr_alloc(session, 128, &buf));
+		ret = ds->f(ds, ", %s",
+		    __wt_addr_string(session, unpack->data, unpack->size, buf));
 		__wt_scr_free(session, &buf);
 		WT_RET(ret);
 		break;

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1205,7 +1205,7 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 		else
 			WT_RET(ds->f(ds, "\t" "txn id %" PRIu64, upd->txnid));
 		__wt_timestamp_to_string(
-		    ts_string, sizeof(ts_string), upd->timestamp);
+		    upd->timestamp, ts_string, sizeof(ts_string));
 		WT_RET(ds->f(ds, ", ts %s", ts_string));
 		WT_RET(ds->f(ds, "\n"));
 	}
@@ -1312,12 +1312,12 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_ADDR_INT:
 	case WT_CELL_ADDR_LEAF:
 	case WT_CELL_ADDR_LEAF_NO:
-		__wt_timestamp_to_string(ts_string[0],
-		    sizeof(ts_string[0]), unpack->oldest_start_ts);
-		__wt_timestamp_to_string(ts_string[1],
-		    sizeof(ts_string[1]), unpack->newest_start_ts);
-		__wt_timestamp_to_string(ts_string[2],
-		    sizeof(ts_string[2]), unpack->newest_stop_ts);
+		__wt_timestamp_to_string(unpack->oldest_start_ts,
+		    ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(unpack->newest_start_ts,
+		    ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(unpack->newest_stop_ts,
+		    ts_string[2], sizeof(ts_string[2]));
 		WT_RET(ds->f(ds,
 		    ", ts %s,%s,%s", ts_string[0], ts_string[1], ts_string[2]));
 		break;
@@ -1327,10 +1327,10 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_VALUE_OVFL:
 	case WT_CELL_VALUE_OVFL_RM:
 	case WT_CELL_VALUE_SHORT:
-		__wt_timestamp_to_string(ts_string[0],
-		    sizeof(ts_string[0]), unpack->start_ts);
-		__wt_timestamp_to_string(ts_string[1],
-		    sizeof(ts_string[1]), unpack->stop_ts);
+		__wt_timestamp_to_string(unpack->start_ts,
+		    ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(unpack->stop_ts,
+		    ts_string[1], sizeof(ts_string[1]));
 		WT_RET(ds->f(ds, ", ts %s-%s", ts_string[0], ts_string[1]));
 		break;
 	}

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -545,8 +545,7 @@ __las_insert_block_verbose(
 	double pct_dirty, pct_full;
 	uint64_t ckpt_gen_current, ckpt_gen_last;
 	uint32_t btree_id;
-	char hex_timestamp[WT_TS_HEX_SIZE];
-	const char *ts;
+	char ts_string[WT_TS_INT_STRING_SIZE];
 
 	btree_id = btree->id;
 
@@ -570,10 +569,9 @@ __las_insert_block_verbose(
 	    ckpt_gen_last, ckpt_gen_current))) {
 		(void)__wt_eviction_clean_needed(session, &pct_full);
 		(void)__wt_eviction_dirty_needed(session, &pct_dirty);
+		__wt_timestamp_to_string(ts_string, sizeof(ts_string),
+		    multi->page_las.unstable_timestamp);
 
-		__wt_timestamp_to_hex_string(
-		    hex_timestamp, multi->page_las.unstable_timestamp);
-		ts = hex_timestamp;
 		__wt_verbose(session,
 		    WT_VERB_LOOKASIDE | WT_VERB_LOOKASIDE_ACTIVITY,
 		    "Page reconciliation triggered lookaside write "
@@ -584,7 +582,7 @@ __las_insert_block_verbose(
 		    "cache use: %2.3f%%",
 		    btree_id, multi->page_las.las_pageid,
 		    multi->page_las.max_txn,
-		    ts,
+		    ts_string,
 		    multi->page_las.skew_newest ? "newest" : "not newest",
 		    WT_STAT_READ(conn->stats, cache_lookaside_entries),
 		    pct_dirty, pct_full);

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -569,8 +569,9 @@ __las_insert_block_verbose(
 	    ckpt_gen_last, ckpt_gen_current))) {
 		(void)__wt_eviction_clean_needed(session, &pct_full);
 		(void)__wt_eviction_dirty_needed(session, &pct_dirty);
-		__wt_timestamp_to_string(ts_string, sizeof(ts_string),
-		    multi->page_las.unstable_timestamp);
+		__wt_timestamp_to_string(
+		    multi->page_las.unstable_timestamp,
+		    ts_string, sizeof(ts_string));
 
 		__wt_verbose(session,
 		    WT_VERB_LOOKASIDE | WT_VERB_LOOKASIDE_ACTIVITY,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -845,6 +845,7 @@ extern int __wt_txn_named_snapshot_config(WT_SESSION_IMPL *session, const char *
 extern void __wt_txn_named_snapshot_destroy(WT_SESSION_IMPL *session);
 extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_timestamp_to_string(char *ts_string, size_t len, wt_timestamp_t ts);
 extern void __wt_timestamp_to_hex_string(char *hex_timestamp, wt_timestamp_t ts);
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *msg);
 extern int __wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -845,8 +845,8 @@ extern int __wt_txn_named_snapshot_config(WT_SESSION_IMPL *session, const char *
 extern void __wt_txn_named_snapshot_destroy(WT_SESSION_IMPL *session);
 extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_timestamp_to_string(char *ts_string, size_t len, wt_timestamp_t ts);
-extern void __wt_timestamp_to_hex_string(char *hex_timestamp, wt_timestamp_t ts);
+extern void __wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string, size_t len);
+extern void __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp);
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *msg);
 extern int __wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -44,8 +44,15 @@
 #define	WT_TS_NONE	0		/* Beginning of time */
 #define	WT_TS_MAX	UINT64_MAX	/* End of time */
 
-					/* Bytes to hold a hex timestamp */
-#define	WT_TS_HEX_SIZE	(2 * sizeof(wt_timestamp_t) + 1)
+/*
+ * We format timestamps in a couple of ways, declare appropriate sized buffers.
+ * Hexadecimal is 2x the size of the value. MongoDB format (high/low pairs of
+ * 4B unsigned integers, with surrounding parenthesis and dividing comma), is
+ * 2x the maximum digits from a 4B unsigned integer + 3. Both sizes include a
+ * trailing nul byte as well.
+ */
+#define	WT_TS_HEX_STRING_SIZE	(2 * sizeof(wt_timestamp_t) + 1)
+#define	WT_TS_INT_STRING_SIZE	(2 * 10 + 3 + 1)
 
 /*
  * Perform an operation at the specified isolation level.

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -514,7 +514,7 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 	 * or in recovery.
 	 */
 	__wt_timestamp_to_hex_string(
-	    hex_timestamp, S2C(session)->txn_global.meta_ckpt_timestamp);
+	    S2C(session)->txn_global.meta_ckpt_timestamp, hex_timestamp);
 
 	/*
 	 * Don't leave a zero entry in the metadata: remove it.  This avoids

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1411,13 +1411,13 @@ __wt_verbose_dump_txn_one(WT_SESSION_IMPL *session, WT_TXN *txn)
 		break;
 	}
 	__wt_timestamp_to_string(
-	    ts_string[0], sizeof(ts_string[0]), txn->commit_timestamp);
+	    txn->commit_timestamp, ts_string[0], sizeof(ts_string[0]));
 	__wt_timestamp_to_string(
-	    ts_string[1], sizeof(ts_string[1]), txn->durable_timestamp);
+	    txn->durable_timestamp, ts_string[1], sizeof(ts_string[1]));
 	__wt_timestamp_to_string(
-	    ts_string[2], sizeof(ts_string[2]), txn->first_commit_timestamp);
+	    txn->first_commit_timestamp, ts_string[2], sizeof(ts_string[2]));
 	__wt_timestamp_to_string(
-	    ts_string[3], sizeof(ts_string[3]), txn->read_timestamp);
+	    txn->read_timestamp, ts_string[3], sizeof(ts_string[3]));
 	WT_RET(__wt_msg(session,
 	    "mod count: %u"
 	    ", snap min: %" PRIu64
@@ -1469,16 +1469,16 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
 	WT_RET(__wt_msg(session, "oldest ID: %" PRIu64, txn_global->oldest_id));
 
 	__wt_timestamp_to_string(
-	    ts_string, sizeof(ts_string), txn_global->commit_timestamp);
+	    txn_global->commit_timestamp, ts_string, sizeof(ts_string));
 	WT_RET(__wt_msg(session, "commit timestamp: %s", ts_string));
 	__wt_timestamp_to_string(
-	    ts_string, sizeof(ts_string), txn_global->oldest_timestamp);
+	    txn_global->oldest_timestamp, ts_string, sizeof(ts_string));
 	WT_RET(__wt_msg(session, "oldest timestamp: %s", ts_string));
 	__wt_timestamp_to_string(
-	    ts_string, sizeof(ts_string), txn_global->pinned_timestamp);
+	    txn_global->pinned_timestamp, ts_string, sizeof(ts_string));
 	WT_RET(__wt_msg(session, "pinned timestamp: %s", ts_string));
 	__wt_timestamp_to_string(
-	    ts_string, sizeof(ts_string), txn_global->stable_timestamp);
+	    txn_global->stable_timestamp, ts_string, sizeof(ts_string));
 	WT_RET(__wt_msg(session, "stable timestamp: %s", ts_string));
 	WT_RET(__wt_msg(session, "has_commit_timestamp: %s",
 	    txn_global->has_commit_timestamp ? "yes" : "no"));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1395,8 +1395,8 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session)
 int
 __wt_verbose_dump_txn_one(WT_SESSION_IMPL *session, WT_TXN *txn)
 {
-	char hex_timestamp[4][WT_TS_HEX_SIZE];
 	const char *iso_tag;
+	char ts_string[4][WT_TS_INT_STRING_SIZE];
 
 	WT_NOT_READ(iso_tag, "INVALID");
 	switch (txn->isolation) {
@@ -1410,11 +1410,14 @@ __wt_verbose_dump_txn_one(WT_SESSION_IMPL *session, WT_TXN *txn)
 		iso_tag = "WT_ISO_SNAPSHOT";
 		break;
 	}
-	__wt_timestamp_to_hex_string(hex_timestamp[0], txn->commit_timestamp);
-	__wt_timestamp_to_hex_string(hex_timestamp[1], txn->durable_timestamp);
-	__wt_timestamp_to_hex_string(
-	    hex_timestamp[2], txn->first_commit_timestamp);
-	__wt_timestamp_to_hex_string(hex_timestamp[3], txn->read_timestamp);
+	__wt_timestamp_to_string(
+	    ts_string[0], sizeof(ts_string[0]), txn->commit_timestamp);
+	__wt_timestamp_to_string(
+	    ts_string[1], sizeof(ts_string[1]), txn->durable_timestamp);
+	__wt_timestamp_to_string(
+	    ts_string[2], sizeof(ts_string[2]), txn->first_commit_timestamp);
+	__wt_timestamp_to_string(
+	    ts_string[3], sizeof(ts_string[3]), txn->read_timestamp);
 	WT_RET(__wt_msg(session,
 	    "mod count: %u"
 	    ", snap min: %" PRIu64
@@ -1428,10 +1431,10 @@ __wt_verbose_dump_txn_one(WT_SESSION_IMPL *session, WT_TXN *txn)
 	    txn->mod_count,
 	    txn->snap_min,
 	    txn->snap_max,
-	    hex_timestamp[0],
-	    hex_timestamp[1],
-	    hex_timestamp[2],
-	    hex_timestamp[3],
+	    ts_string[0],
+	    ts_string[1],
+	    ts_string[2],
+	    ts_string[3],
 	    txn->flags,
 	    iso_tag));
 	return (0);
@@ -1450,7 +1453,7 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
 	WT_TXN_STATE *s;
 	uint64_t id;
 	uint32_t i, session_cnt;
-	char hex_timestamp[3][WT_TS_HEX_SIZE];
+	char ts_string[WT_TS_INT_STRING_SIZE];
 
 	conn = S2C(session);
 	txn_global = &conn->txn_global;
@@ -1465,18 +1468,18 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
 	    "metadata_pinned ID: %" PRIu64, txn_global->metadata_pinned));
 	WT_RET(__wt_msg(session, "oldest ID: %" PRIu64, txn_global->oldest_id));
 
-	__wt_timestamp_to_hex_string(
-	    hex_timestamp[0], txn_global->commit_timestamp);
-	WT_RET(__wt_msg(session, "commit timestamp: %s", hex_timestamp[0]));
-	__wt_timestamp_to_hex_string(
-	    hex_timestamp[0], txn_global->oldest_timestamp);
-	WT_RET(__wt_msg(session, "oldest timestamp: %s", hex_timestamp[0]));
-	__wt_timestamp_to_hex_string(
-	    hex_timestamp[0], txn_global->pinned_timestamp);
-	WT_RET(__wt_msg(session, "pinned timestamp: %s", hex_timestamp[0]));
-	__wt_timestamp_to_hex_string(
-	    hex_timestamp[0], txn_global->stable_timestamp);
-	WT_RET(__wt_msg(session, "stable timestamp: %s", hex_timestamp[0]));
+	__wt_timestamp_to_string(
+	    ts_string, sizeof(ts_string), txn_global->commit_timestamp);
+	WT_RET(__wt_msg(session, "commit timestamp: %s", ts_string));
+	__wt_timestamp_to_string(
+	    ts_string, sizeof(ts_string), txn_global->oldest_timestamp);
+	WT_RET(__wt_msg(session, "oldest timestamp: %s", ts_string));
+	__wt_timestamp_to_string(
+	    ts_string, sizeof(ts_string), txn_global->pinned_timestamp);
+	WT_RET(__wt_msg(session, "pinned timestamp: %s", ts_string));
+	__wt_timestamp_to_string(
+	    ts_string, sizeof(ts_string), txn_global->stable_timestamp);
+	WT_RET(__wt_msg(session, "stable timestamp: %s", ts_string));
 	WT_RET(__wt_msg(session, "has_commit_timestamp: %s",
 	    txn_global->has_commit_timestamp ? "yes" : "no"));
 	WT_RET(__wt_msg(session, "has_oldest_timestamp: %s",

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -360,7 +360,7 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 	WT_DECL_RET;
 	WT_SESSION_IMPL *session;
 	wt_timestamp_t ckpt_timestamp;
-	char hex_timestamp[WT_TS_HEX_SIZE], *sys_config;
+	char ts_string[WT_TS_INT_STRING_SIZE], *sys_config;
 
 	sys_config = NULL;
 
@@ -399,11 +399,11 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 
 	if (WT_VERBOSE_ISSET(session,
 	    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS)) {
-		__wt_timestamp_to_hex_string(
-		    hex_timestamp, conn->txn_global.recovery_timestamp);
+		__wt_timestamp_to_string(ts_string, sizeof(ts_string),
+		    conn->txn_global.recovery_timestamp);
 		__wt_verbose(session,
 		    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,
-		    "Set global recovery timestamp: %s", hex_timestamp);
+		    "Set global recovery timestamp: %s", ts_string);
 	}
 err:	__wt_free(session, sys_config);
 	return (ret);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -399,8 +399,9 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 
 	if (WT_VERBOSE_ISSET(session,
 	    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS)) {
-		__wt_timestamp_to_string(ts_string, sizeof(ts_string),
-		    conn->txn_global.recovery_timestamp);
+		__wt_timestamp_to_string(
+		    conn->txn_global.recovery_timestamp,
+		    ts_string, sizeof(ts_string));
 		__wt_verbose(session,
 		    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,
 		    "Set global recovery timestamp: %s", ts_string);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -40,6 +40,10 @@ __wt_timestamp_to_hex_string(char *hex_timestamp, wt_timestamp_t ts)
 		hex_timestamp[1] = '\0';
 		return;
 	}
+	if (ts == WT_TS_MAX) {
+		(void)strcpy(hex_timestamp, "ffffffffffffffff");
+		return;
+	}
 
 	for (p = hex_timestamp; ts != 0; ts >>= 4)
 		*p++ = (char)__wt_hex((u_char)(ts & 0x0f));

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -590,7 +590,7 @@ timestamp(void *arg)
 	WT_CONNECTION *conn;
 	WT_DECL_RET;
 	WT_SESSION *session;
-	char buf[64];
+	char buf[WT_TS_HEX_STRING_SIZE + 64];
 	bool done;
 
 	(void)(arg);

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -106,7 +106,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
                 timestamp_str(3) + ',stable_timestamp=' + timestamp_str(1)),
-                '/oldest timestamp 0*3 must not be later than stable timestamp 0*1/')
+                '/oldest timestamp \(0,3\) must not be later than stable timestamp \(0,1\)/')
 
         # Oldest timestamp is 3 at the moment, trying to set it to an earlier
         # timestamp is a no-op.
@@ -125,7 +125,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
                 timestamp_str(6)),
-                '/oldest timestamp 0*6 must not be later than stable timestamp 0*5/')
+                '/oldest timestamp \(0,6\) must not be later than stable timestamp \(0,5\)/')
 
         # Commit timestamp >= Stable timestamp.
         # Check both timestamp_transaction and commit_transaction APIs.


### PR DESCRIPTION
There are two interesting changes here:

* change af46378, switching most of our timestamp displays from hexadecimal to integers, making sure that I switched all of the ones I should have, and none of the ones I shouldn't,
* change 852f06c, shuffling some code in `__wt_txn_parse_read_timestamp()` so we don't format timestamps unless we need to, and we never hold a lock while formatting a timestamp.