### PR TITLE
WT-4528 Move remove/rename retry into Windows fs code.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -922,7 +922,7 @@ __log_server(void *arg)
 	WT_DECL_RET;
 	WT_LOG *log;
 	WT_SESSION_IMPL *session;
-	uint64_t retry, time_start, time_stop, timediff;
+	uint64_t time_start, time_stop, timediff;
 	bool did_work, signalled;
 
 	session = arg;
@@ -949,7 +949,6 @@ __log_server(void *arg)
 	 * takes to sync out an earlier file.
 	 */
 	did_work = true;
-	retry = 0;
 	while (F_ISSET(conn, WT_CONN_SERVER_LOG)) {
 		/*
 		 * Slots depend on future activity.  Force out buffered
@@ -994,24 +993,7 @@ __log_server(void *arg)
 					ret = __log_archive_once(session, 0);
 					__wt_writeunlock(
 					    session, &log->log_archive_lock);
-					/*
-					 * It is possible that an external
-					 * process on some systems may prevent
-					 * removal. If we get a permission
-					 * error, retry a few times.
-					 */
-					if (ret == EACCES &&
-					    retry < WT_RETRY_MAX) {
-						retry++;
-						WT_NOT_READ(ret, 0);
-					} else {
-						/*
-						 * Return the error if there is
-						 * one or reset on success.
-						 */
-						WT_ERR(ret);
-						retry = 0;
-					}
+					WT_ERR(ret);
 				} else
 					__wt_verbose(session, WT_VERB_LOG, "%s",
 					    "log_archive: Blocked due to open "

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -22,11 +22,9 @@
 					__wt_errx(session,		\
 	"WiredTiger could not access a database file.");		\
 					__wt_errx(session,		\
-	"It will attempt a few more times. You should confirm");	\
-					__wt_errx(session,		\
-	"no other processes, for example virus scanners, are");		\
-					__wt_errx(session,		\
-	"accessing the WiredTiger files.");				\
+	"It will attempt a few more times. You should confirm"		\
+	" no other processes, for example virus scanners, are"		\
+	" accessing the WiredTiger files.");				\
 					__first = false;		\
 				}					\
 				__wt_sleep(0L, 50000L);			\

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -10,23 +10,18 @@
 
 #define	WT_WINCALL_RETRY(call, ret) do {				\
 	int __retry;							\
-	bool __first;							\
-	__first = true;							\
 	for (__retry = 0; __retry < WT_RETRY_MAX; ++__retry) {		\
 		ret = 0;						\
 		if ((call) == FALSE) {					\
 			windows_error = __wt_getlasterror();		\
 			ret = __wt_map_windows_error(windows_error);	\
 			if (windows_error == ERROR_ACCESS_DENIED) {	\
-				if (__first) {				\
+				if (__retry == 0)			\
 					__wt_errx(session,		\
-	"WiredTiger could not access a database file.");		\
-					__wt_errx(session,		\
-	"It will attempt a few more times. You should confirm"		\
-	" no other processes, for example virus scanners, are"		\
+	"Access denied to a file owned by WiredTiger."			\
+	" It will attempt a few more times. You should confirm"		\
+	" no other processes, such as virus scanners, are"		\
 	" accessing the WiredTiger files.");				\
-					__first = false;		\
-				}					\
 				__wt_sleep(0L, 50000L);			\
 				continue;				\
 			}						\

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -64,7 +64,7 @@ retry:
 		 * may prevent removal. If we get a permission error, retry
 		 * a few times.
 		 */
-		if (ret == EACCESS && retry < WT_RETRY_MAX) {
+		if (ret == EACCES && retry < WT_RETRY_MAX) {
 			retry++;
 			ret = 0;
 			goto retry;
@@ -121,7 +121,7 @@ retry:
 		 * may prevent renaming. If we get a permission error, retry
 		 * a few times.
 		 */
-		if (ret == EACCESS && retry < WT_RETRY_MAX) {
+		if (ret == EACCES && retry < WT_RETRY_MAX) {
 			retry++;
 			ret = 0;
 			goto retry;

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -10,12 +10,25 @@
 
 #define	WT_WINCALL_RETRY(call, ret) do {				\
 	int __retry;							\
+	bool __first;							\
+	__first = true;							\
 	for (__retry = 0; __retry < WT_RETRY_MAX; ++__retry) {		\
 		ret = 0;						\
 		if ((call) == FALSE) {					\
 			windows_error = __wt_getlasterror();		\
 			ret = __wt_map_windows_error(windows_error);	\
 			if (windows_error == ERROR_ACCESS_DENIED) {	\
+				if (__first) {				\
+					__wt_errx(session,		\
+	"WiredTiger could not access a database file.");		\
+					__wt_errx(session,		\
+	"It will attempt a few more times. You should confirm");	\
+					__wt_errx(session,		\
+	"no other processes, for example virus scanners, are");		\
+					__wt_errx(session,		\
+	"accessing the WiredTiger files.");				\
+					__first = false;		\
+				}					\
 				__wt_sleep(0L, 50000L);			\
 				continue;				\
 			}						\


### PR DESCRIPTION
Please review this diff. I made the windows-specific remove and rename code retry on access issues up to 10 times. One thing is that I retry in a loop with no pause in between. I also removed the similar code from log archiving. This may help other windows access BF failures as well.