### PR TITLE
WT-4539 Set the durable timestamp of the update structure

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -324,6 +324,7 @@ __tombstone_update_alloc(WT_SESSION_IMPL *session,
 	if (page_del != NULL) {
 		upd->txnid = page_del->txnid;
 		upd->timestamp = page_del->timestamp;
+		upd->durable_timestamp = page_del->timestamp;
 		upd->prepare_state = page_del->prepare_state;
 	}
 	*updp = upd;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1158,6 +1158,7 @@ __rec_append_orig_value(WT_SESSION_IMPL *session,
 	if (upd->type == WT_UPDATE_BIRTHMARK) {
 		append->txnid = upd->txnid;
 		append->timestamp = upd->timestamp;
+		append->durable_timestamp = upd->durable_timestamp;
 		append->next = upd->next;
 	}
 


### PR DESCRIPTION
The durable timestamp of an update structure should be set in congruence with
it's commit timestamp setting. There were couple of functions that were setting
the commit timestamp but not the durable timestamp. This change sets the durable
timestamp in those places.