### PR TITLE
WT-4529 Update lookaside schema to store durable timestamp

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -727,12 +727,13 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			    upd->type == WT_UPDATE_MODIFY)) {
 				las_value.size = 0;
 				cursor->set_value(cursor, upd->txnid,
-				    upd->timestamp, upd->prepare_state,
-				    WT_UPDATE_BIRTHMARK, &las_value);
+				    upd->timestamp, upd->durable_timestamp,
+				    upd->prepare_state, WT_UPDATE_BIRTHMARK,
+				    &las_value);
 			} else
 				cursor->set_value(cursor, upd->txnid,
-				    upd->timestamp, upd->prepare_state,
-				    upd->type, &las_value);
+				    upd->timestamp, upd->durable_timestamp,
+				    upd->prepare_state, upd->type, &las_value);
 
 			/*
 			 * Using update looks a little strange because the keys
@@ -978,7 +979,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 	WT_ITEM las_key, las_value;
 	WT_ITEM *sweep_key;
 	WT_TXN_ISOLATION saved_isolation;
-	wt_timestamp_t las_timestamp;
+	wt_timestamp_t durable_timestamp, las_timestamp;
 	uint64_t cnt, remove_cnt, las_pageid, saved_pageid, visit_cnt;
 	uint64_t las_counter, las_txnid;
 	uint32_t las_id, session_flags;
@@ -1102,8 +1103,9 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		 * Remove all entries for a key once they have aged out and are
 		 * no longer needed.
 		 */
-		WT_ERR(cursor->get_value(cursor, &las_txnid,
-		    &las_timestamp, &prepare_state, &upd_type, &las_value));
+		WT_ERR(cursor->get_value(
+		    cursor, &las_txnid, &las_timestamp,
+		    &durable_timestamp, &prepare_state, &upd_type, &las_value));
 
 		/*
 		 * Check to see if the page or key has changed this iteration,

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -209,8 +209,13 @@ struct __wt_ovfl_reuse {
  * this way so that overall the lookaside table is append-mostly), a counter
  * (used to ensure the update records remain in the original order), and the
  * record's key (byte-string for row-store, record number for column-store).
- * The value is the WT_UPDATE structure's transaction ID, timestamp, update's
- * prepare state, update type and value.
+ * The value is the WT_UPDATE structure's:
+ * 	- transaction ID
+ * 	- timestamp
+ * 	- durable timestamp
+ * 	- update's prepare state
+ *	- update type
+ *	- value.
  *
  * As the key for the lookaside table is different for row- and column-store, we
  * store both key types in a WT_ITEM, building/parsing them in the code, because
@@ -227,7 +232,7 @@ struct __wt_ovfl_reuse {
 #endif
 #define	WT_LAS_CONFIG							\
     "key_format=" WT_UNCHECKED_STRING(QIQu)				\
-    ",value_format=" WT_UNCHECKED_STRING(QQBBu)				\
+    ",value_format=" WT_UNCHECKED_STRING(QQQBBu)			\
     ",block_compressor=" WT_LOOKASIDE_COMPRESSOR			\
     ",leaf_value_max=64MB"						\
     ",prefix_compression=true"

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -20,7 +20,7 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 	WT_DECL_RET;
 	WT_ITEM las_key, las_value;
 	WT_TXN_GLOBAL *txn_global;
-	wt_timestamp_t las_timestamp, rollback_timestamp;
+	wt_timestamp_t durable_timestamp, las_timestamp, rollback_timestamp;
 	uint64_t las_counter, las_pageid, las_total, las_txnid;
 	uint32_t las_id, session_flags;
 	uint8_t prepare_state, upd_type;
@@ -59,8 +59,9 @@ __txn_rollback_to_stable_lookaside_fixup(WT_SESSION_IMPL *session)
 		if (__bit_test(conn->stable_rollback_bitstring, las_id))
 			continue;
 
-		WT_ERR(cursor->get_value(cursor, &las_txnid,
-		    &las_timestamp, &prepare_state, &upd_type, &las_value));
+		WT_ERR(cursor->get_value(
+		    cursor, &las_txnid, &las_timestamp,
+		    &durable_timestamp, &prepare_state, &upd_type, &las_value));
 
 		/*
 		 * Entries with no timestamp will have a timestamp of zero,

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from helper import copy_wiredtiger_home
+import wiredtiger, wttest
+
+def timestamp_str(t):
+    return '%x' %t
+
+# test_durable_ts03.py
+#    Check that the updates with durable timestamp newer than the stable
+#    timestamp fill up the cache and leave it stuck.
+class test_durable_ts03(wttest.WiredTigerTestCase):
+    # Reducing the cache size to 10MB to will generate a stuck cache. This
+    # has been kept to a higher size to avoid pull request failure.
+    def conn_config(self):
+        return 'cache_size=50MB'
+
+    def test_durable_ts03(self):
+        # Create a table.
+        uri = 'table:test_durable_ts03'
+        nrows = 300000
+        self.session.create(uri, 'key_format=i,value_format=u')
+        value1 = "aaaaa" * 100
+        value2 = "bbbbb" * 100
+
+        # Start with setting a stable and oldest timestamp.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1) + \
+                                ',oldest_timestamp=' + timestamp_str(1))
+
+        # Load the data into the table.
+        session = self.conn.open_session()
+        cursor = session.open_cursor(uri, None)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor[i] = value1
+            session.commit_transaction('commit_timestamp=' + timestamp_str(50))
+        cursor.close()
+
+        # Set the stable and the oldest timestamp to checkpoint initial data.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100) + \
+                                ',oldest_timestamp=' + timestamp_str(100))
+        self.session.checkpoint()
+
+        # Update all the values within transaction. Commit the transaction with
+        # a durable timestamp newer than the stable timestamp.
+        cursor = session.open_cursor(uri, None)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor[i] = value2
+            session.prepare_transaction('prepare_timestamp=' + timestamp_str(150))
+            session.commit_transaction('commit_timestamp=' + timestamp_str(200) + \
+                                       ',durable_timestamp=' + timestamp_str(220))
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
This brings back the changes in the lookaside schema for the durable timestamp.