### PR TITLE
WT-4532 Fix shared access to the default session.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1051,6 +1051,9 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
 
 	CONNECTION_API_CALL(conn, session, close, config, cfg);
 
+	/* The default session is used to access data handles during close. */
+	F_CLR(session, WT_SESSION_NO_DATA_HANDLES);
+
 	WT_TRET(__wt_config_gets(session, cfg, "leak_memory", &cval));
 	if (cval.val != 0)
 		F_SET(conn, WT_CONN_LEAK_MEMORY);
@@ -2312,6 +2315,11 @@ wiredtiger_dummy_session_init(
 	 * use the WT_CONNECTION_IMPL's default session and its strerror method.
 	 */
 	session->iface.strerror = __wt_session_strerror;
+
+	/*
+	 * The dummy session should never be used to access data handles.
+	 */
+	F_SET(session, WT_SESSION_NO_DATA_HANDLES);
 }
 
 /*
@@ -2757,10 +2765,15 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	if (F_ISSET(conn, WT_CONN_SALVAGE))
 		WT_ERR(__wt_metadata_salvage(session));
 
-	WT_ERR(__wt_metadata_cursor(session, NULL));
-
 	/* Start the worker threads and run recovery. */
 	WT_ERR(__wt_connection_workers(session, cfg));
+
+	/*
+	 * The default session should not open data handles after this point:
+	 * since it can be shared between threads, relying on session->dhandle
+	 * is not safe.
+	 */
+	F_SET(session, WT_SESSION_NO_DATA_HANDLES);
 
 	WT_STATIC_ASSERT(offsetof(WT_CONNECTION_IMPL, iface) == 0);
 	*connectionp = &conn->iface;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2765,6 +2765,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	if (F_ISSET(conn, WT_CONN_SALVAGE))
 		WT_ERR(__wt_metadata_salvage(session));
 
+	WT_ERR(__wt_metadata_cursor(session, NULL));
+
 	/* Start the worker threads and run recovery. */
 	WT_ERR(__wt_connection_workers(session, cfg));
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -487,6 +487,8 @@ __txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[])
 
 	WT_ERR(__txn_rollback_to_stable_check(session));
 
+	F_CLR(conn, WT_CONN_EVICTION_NO_LOOKASIDE);
+
 	/*
 	 * Allocate a non-durable btree bitstring.  We increment the global
 	 * value before using it, so the current value is already in use, and
@@ -507,7 +509,8 @@ __txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[])
 	if (!F_ISSET(conn, WT_CONN_IN_MEMORY))
 		WT_ERR(__txn_rollback_to_stable_lookaside_fixup(session));
 
-err:	__wt_free(session, conn->stable_rollback_bitstring);
+err:	F_CLR(conn, WT_CONN_EVICTION_NO_LOOKASIDE);
+	__wt_free(session, conn->stable_rollback_bitstring);
 	return (ret);
 }
 


### PR DESCRIPTION
In particular, `WT_CONNECTION::rollback_to_stable` can run for long enough that other periodic tasks (e.g., calls to `WT_CONNECTION::query_timestamp`) are called concurrently.  Disallow any access to data handles via the default session (outside open / close connection), and use a temporary internal session for rollback_to_stable.