### PR TITLE
WT-4492 Add Evergreen compatibility tests for versioned data format

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -965,6 +965,18 @@ tasks:
             ulimit -c unlimited 
             largescale/run-million-collection-test.sh .
 
+  - name: compatibility-test-for-mongodb-releases
+    commands: 
+      - func: "fetch source"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: | 
+            set -o errexit
+            set -o verbose
+            test/evergreen/compatibility_test_for_mongodb_releases.sh
+
+
 buildvariants:
 - name: ubuntu1404
   display_name: Ubuntu 14.04
@@ -1040,6 +1052,14 @@ buildvariants:
     configure_env_vars: CC=/opt/mongodbtoolchain/bin/gcc CXX=/opt/mongodbtoolchain/bin/g++
   tasks:
     - name: million-collection-test
+
+- name: weekly-tests
+  display_name: Weekly run tests
+  batchtime: 10080 # 7 days
+  run_on:
+  - ubuntu1404-test
+  tasks:
+    - name: compatibility-test-for-mongodb-releases
 
 - name: windows-64
   display_name: Windows 64-bit

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -966,12 +966,12 @@ tasks:
             largescale/run-million-collection-test.sh .
 
   - name: compatibility-test-for-mongodb-releases
-    commands: 
+    commands:
       - func: "fetch source"
       - command: shell.exec
         params:
           working_dir: "wiredtiger"
-          script: | 
+          script: |
             set -o errexit
             set -o verbose
             test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -1053,8 +1053,8 @@ buildvariants:
   tasks:
     - name: million-collection-test
 
-- name: weekly-tests
-  display_name: Weekly run tests
+- name: compatibility-tests
+  display_name: Compatibility tests
   batchtime: 10080 # 7 days
   run_on:
   - ubuntu1404-test

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -7,12 +7,12 @@
 # Return the most recent version of the tagged release.
 ###########################################################################
 get_release()
-{ 
-	echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -n | sed -e '$p' -e d)"
+{
+	echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -V | sed -e '$p' -e d)"
 }
 
 #############################################################
-# This function will 
+# This function will
 #	- checkout git tree of the desired release and build it,
 #	- generate test objects.
 #
@@ -31,6 +31,8 @@ build_rel()
 	config+="--enable-snappy "
 
 	case "$1" in
+        # Please note 'develop' here is planned as the future MongoDB release 4.2 - the only release that supports
+        # both enabling and disabling of timestamps in data format. Once 4.2 is released, we need to update this script.
 	"develop")
 		branch="develop";;
 	"develop-timestamps")
@@ -42,7 +44,7 @@ build_rel()
 
 	git checkout --quiet -b $branch || return 1
 
-	(sh build_posix/reconf && ./configure $config && make -j 8) > /dev/null || return 1
+	(sh build_posix/reconf && ./configure $config && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null || return 1
 
 	cd test/format || return 1
 
@@ -69,7 +71,7 @@ build_rel()
 }
 
 #############################################################
-# This function will 
+# This function will
 #	- verify a pair of releases can verify each other's objects.
 #
 # arg1: release #1

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -53,7 +53,7 @@ build_rel()
 	args+="cache=80 "				# Medium cache so there's eviction
 	args+="checkpoints=1 "				# Force periodic writes
 	args+="compression=snappy "			# We only built with snappy, force the choice
-	args+="data_source=table "		
+	args+="data_source=table "
 	args+="in_memory=0 "				# Interested in the on-disk format
 	args+="leak_memory=1 "				# Faster runs
 	args+="logging_compression=snappy "		# We only built with snappy, force the choice

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+##############################################################################################
+# Check releases to ensure forward and backward compatibility.
+##############################################################################################
+
+###########################################################################
+# Return the most recent version of the tagged release.
+###########################################################################
+get_release()
+{ 
+	echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -n | sed -e '$p' -e d)"
+}
+
+#############################################################
+# This function will 
+#	- checkout git tree of the desired release and build it,
+#	- generate test objects.
+#
+# arg1: MongoDB tagged release number or develop branch identifier.
+#############################################################
+build_rel()
+{
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	echo "Building release: \"$1\""
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+
+	git clone --quiet https://github.com/wiredtiger/wiredtiger.git "wt.$1" > /dev/null || return 1
+	cd "wt.$1" || return 1
+
+	config=""
+	config+="--enable-snappy "
+
+	case "$1" in
+	"develop")
+		branch="develop";;
+	"develop-timestamps")
+		branch="develop"
+		config+="--enable-page-version-ts";;
+	*)
+		branch=$(get_release "$1");;
+	esac
+
+	git checkout --quiet -b $branch || return 1
+
+	(sh build_posix/reconf && ./configure $config && make -j 8) > /dev/null || return 1
+
+	cd test/format || return 1
+
+	# Run a configuration and generate some on-disk files.
+	args=""
+	args+="cache=80 "				# Medium cache so there's eviction
+	args+="checkpoints=1 "				# Force periodic writes
+	args+="compression=snappy "			# We only built with snappy, force the choice
+	args+="data_source=table "		
+	args+="in_memory=0 "				# Interested in the on-disk format
+	args+="leak_memory=1 "				# Faster runs
+	args+="logging_compression=snappy "		# We only built with snappy, force the choice
+	args+="quiet=1 "
+	args+="rebalance=0 "				# Faster runs
+	args+="rows=1000000 "
+	args+="salvage=0 "				# Faster runs
+	args+="timer=4 "
+	args+="verify=0 "				# Faster runs
+	for am in fix row var; do
+		./t -h "RUNDIR.$am" -1 "file_type=$am" $args || return 1
+	done
+
+	return 0
+}
+
+#############################################################
+# This function will 
+#	- verify a pair of releases can verify each other's objects.
+#
+# arg1: release #1
+# arg2: release #2
+#############################################################
+verify()
+{
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	echo "Verifying release \"$1\" and \"$2\""
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	a="wt.$1"
+	b="wt.$2"
+
+	EXT="extensions=["
+	EXT+="ext/compressors/snappy/.libs/libwiredtiger_snappy.so,"
+	EXT+="ext/collators/reverse/.libs/libwiredtiger_reverse_collator.so, "
+	EXT+="ext/encryptors/rotn/.libs/libwiredtiger_rotn.so, "
+	EXT+="]"
+	
+	cd $a || return 1
+	for am in fix row var; do
+		echo "$a/wt verifying $b/test/format/RUNDIR.$am..."
+		WIREDTIGER_CONFIG="$EXT" \
+		    ./wt -h ../$b/test/format/RUNDIR.$am verify table:wt || return 1
+	done
+
+	cd ../$b || return 1
+	for am in fix row var; do
+		echo "$b/wt verifying $a/test/format/RUNDIR.$am..."
+		WIREDTIGER_CONFIG="$EXT" \
+		    ./wt -h ../$a/test/format/RUNDIR.$am verify table:wt || return 1
+	done
+
+	return 0
+}
+
+run()
+{
+	# Build test files from each release.
+	(build_rel 3.4) || return 1
+	(build_rel 3.6) || return 1
+	(build_rel 4.0) || return 1
+	(build_rel develop) || return 1
+	(build_rel develop-timestamps) || return 1
+
+	# Verify forward/backward compatibility.
+	(verify 3.4 3.6) || return 1
+	(verify 3.6 4.0) || return 1
+	(verify 4.0 develop) || return 1
+	(verify 4.0 develop-timestamps) || return 1
+	(verify develop develop-timestamps) || return 1
+
+	return 0
+}
+
+# Create a directory in which to do the work.
+top="test-compatibility-run"
+rm -rf $top && mkdir $top && cd $top || {
+	echo "$0: unable to create $top working directory"
+	exit 1
+}
+
+run
+exit $?


### PR DESCRIPTION
Add a new Evergreen test (task) to verify backward and forward compatibility for a set of mongodb release pairs, to make sure the newer release wt binary is able to read objects generated by older release, and vice versa. The recent data format changes (PM-1309, targeting for MongoDB 4.2) will also be covered by this new test.