### PR TITLE
WT-4483 Improve caching of small updates to large values. (#4403)

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1425,10 +1425,11 @@ __cursor_chain_exceeded(WT_CURSOR_BTREE *cbt)
 		upd_size += WT_UPDATE_MEMSIZE(upd);
 		if (upd_size >= WT_MODIFY_MEM_FACTOR * cursor->value.size)
 			return (true);
-		if (__wt_txn_upd_visible_all(session, upd) &&
-		    i >= WT_MAX_MODIFY_UPDATE)
-			return (true);
 	}
+	if (upd != NULL && upd->type == WT_UPDATE_STANDARD &&
+	    __wt_txn_upd_visible_all(session, upd) &&
+	    i >= WT_MAX_MODIFY_UPDATE)
+		return (true);
 	return (false);
 }
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -316,6 +316,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_BTREE *btree;
 	WT_PAGE *page;
+	size_t footprint;
 
 	btree = S2BT(session);
 	page = ref->page;
@@ -331,8 +332,20 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	if (__wt_page_evict_clean(page))
 		return (false);
 
+	/*
+	 * Exclude the disk image size from the footprint checks.  Usually the
+	 * disk image size is small compared with the in-memory limit (e.g.
+	 * 16KB vs 5MB), so this doesn't make a big difference.  Where it is
+	 * important is for pages with a small number of large values, where
+	 * the disk image size takes into account large values that have
+	 * already been written and should not trigger forced eviction.
+	 */
+	footprint = page->memory_footprint;
+	if (page->dsk != NULL)
+		footprint -= page->dsk->mem_size;
+
 	/* Pages are usually small enough, check that first. */
-	if (page->memory_footprint < btree->splitmempage)
+	if (footprint < btree->splitmempage)
 		return (false);
 
 	/*
@@ -345,7 +358,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 	/* If we can do an in-memory split, do it. */
 	if (__wt_leaf_page_can_split(session, page))
 		return (true);
-	if (page->memory_footprint < btree->maxmempage)
+	if (footprint < btree->maxmempage)
 		return (false);
 
 	/* Bump the oldest ID, we're about to do some visibility checks. */


### PR DESCRIPTION
Be less aggressive about creating full copies of a value, especially when the values are large.

(cherry picked from commit 42865162b40203367904627e5fc39d3274665cc4)