### PR TITLE
WT-4547 Remove redundant os_cache_dirty field.

### DIFF
--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -351,9 +351,9 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block,
 	 * cache, but only if the current session can wait.
 	 */
 	if (block->os_cache_dirty_max != 0 &&
-	    (block->os_cache_dirty += align_size) > block->os_cache_dirty_max &&
+	    fh->written > block->os_cache_dirty_max &&
 	    __wt_session_can_wait(session)) {
-		block->os_cache_dirty = 0;
+		fh->written = 0;
 		if ((ret = __wt_fsync(session, fh, false)) != 0) {
 			 /*
 			  * Ignore ENOTSUP, but don't try again.

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -234,7 +234,6 @@ struct __wt_block {
 	uint32_t allocsize;		/* Allocation size */
 	size_t	 os_cache;		/* System buffer cache flush max */
 	size_t	 os_cache_max;
-	size_t	 os_cache_dirty;	/* System buffer cache write max */
 	size_t	 os_cache_dirty_max;
 
 	u_int	 block_header;		/* Header length */


### PR DESCRIPTION
@keithbostic Please review this small fix to remove the redundant field in the block structure now that we have the same information in the file handle. I cannot remove the similar `os_cache` field as that has a different purpose. 