### PR TITLE
WT-4583 Collect read/write stats in throttling even if not using capacity.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -301,11 +301,11 @@ connection_stats = [
     ##########################################
     # Capacity statistics
     ##########################################
-    CapacityStat('capacity_bytes_ckpt', 'throttled bytes written for checkpoint'),
-    CapacityStat('capacity_bytes_evict', 'throttled bytes written for eviction'),
-    CapacityStat('capacity_bytes_log', 'throttled bytes written for log'),
-    CapacityStat('capacity_bytes_read', 'throttled bytes read'),
-    CapacityStat('capacity_bytes_written', 'throttled bytes written total'),
+    CapacityStat('capacity_bytes_ckpt', 'bytes written for checkpoint'),
+    CapacityStat('capacity_bytes_evict', 'bytes written for eviction'),
+    CapacityStat('capacity_bytes_log', 'bytes written for log'),
+    CapacityStat('capacity_bytes_read', 'bytes read'),
+    CapacityStat('capacity_bytes_written', 'bytes written total'),
     CapacityStat('capacity_threshold', 'threshold to call fsync'),
     CapacityStat('capacity_time_ckpt', 'time waiting during checkpoint (usecs)'),
     CapacityStat('capacity_time_evict', 'time waiting during eviction (usecs)'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -456,12 +456,12 @@ struct __wt_connection_stats {
 	int64_t fsync_all_fh_total;
 	int64_t fsync_all_fh;
 	int64_t fsync_all_time;
-	int64_t capacity_threshold;
 	int64_t capacity_bytes_read;
 	int64_t capacity_bytes_ckpt;
 	int64_t capacity_bytes_evict;
 	int64_t capacity_bytes_log;
 	int64_t capacity_bytes_written;
+	int64_t capacity_threshold;
 	int64_t capacity_time_total;
 	int64_t capacity_time_ckpt;
 	int64_t capacity_time_evict;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5244,18 +5244,18 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_FSYNC_ALL_FH			1130
 /*! capacity: background fsync time (msecs) */
 #define	WT_STAT_CONN_FSYNC_ALL_TIME			1131
+/*! capacity: bytes read */
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1132
+/*! capacity: bytes written for checkpoint */
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1133
+/*! capacity: bytes written for eviction */
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1134
+/*! capacity: bytes written for log */
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1135
+/*! capacity: bytes written total */
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1136
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1132
-/*! capacity: throttled bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1133
-/*! capacity: throttled bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1134
-/*! capacity: throttled bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1135
-/*! capacity: throttled bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1136
-/*! capacity: throttled bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1137
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1137
 /*! capacity: time waiting due to total capacity (usecs) */
 #define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1138
 /*! capacity: time waiting during checkpoint (usecs) */

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -885,12 +885,12 @@ static const char * const __stats_connection_desc[] = {
 	"capacity: background fsync file handles considered",
 	"capacity: background fsync file handles synced",
 	"capacity: background fsync time (msecs)",
+	"capacity: bytes read",
+	"capacity: bytes written for checkpoint",
+	"capacity: bytes written for eviction",
+	"capacity: bytes written for log",
+	"capacity: bytes written total",
 	"capacity: threshold to call fsync",
-	"capacity: throttled bytes read",
-	"capacity: throttled bytes written for checkpoint",
-	"capacity: throttled bytes written for eviction",
-	"capacity: throttled bytes written for log",
-	"capacity: throttled bytes written total",
 	"capacity: time waiting due to total capacity (usecs)",
 	"capacity: time waiting during checkpoint (usecs)",
 	"capacity: time waiting during eviction (usecs)",
@@ -1316,12 +1316,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->fsync_all_fh_total = 0;
 	stats->fsync_all_fh = 0;
 		/* not clearing fsync_all_time */
-	stats->capacity_threshold = 0;
 	stats->capacity_bytes_read = 0;
 	stats->capacity_bytes_ckpt = 0;
 	stats->capacity_bytes_evict = 0;
 	stats->capacity_bytes_log = 0;
 	stats->capacity_bytes_written = 0;
+	stats->capacity_threshold = 0;
 	stats->capacity_time_total = 0;
 	stats->capacity_time_ckpt = 0;
 	stats->capacity_time_evict = 0;
@@ -1793,13 +1793,13 @@ __wt_stat_connection_aggregate(
 	to->fsync_all_fh_total += WT_STAT_READ(from, fsync_all_fh_total);
 	to->fsync_all_fh += WT_STAT_READ(from, fsync_all_fh);
 	to->fsync_all_time += WT_STAT_READ(from, fsync_all_time);
-	to->capacity_threshold += WT_STAT_READ(from, capacity_threshold);
 	to->capacity_bytes_read += WT_STAT_READ(from, capacity_bytes_read);
 	to->capacity_bytes_ckpt += WT_STAT_READ(from, capacity_bytes_ckpt);
 	to->capacity_bytes_evict += WT_STAT_READ(from, capacity_bytes_evict);
 	to->capacity_bytes_log += WT_STAT_READ(from, capacity_bytes_log);
 	to->capacity_bytes_written +=
 	    WT_STAT_READ(from, capacity_bytes_written);
+	to->capacity_threshold += WT_STAT_READ(from, capacity_threshold);
 	to->capacity_time_total += WT_STAT_READ(from, capacity_time_total);
 	to->capacity_time_ckpt += WT_STAT_READ(from, capacity_time_ckpt);
 	to->capacity_time_evict += WT_STAT_READ(from, capacity_time_evict);


### PR DESCRIPTION
@ddanderson Please review. Note the textual change in the stats. I felt that 'throttled bytes' was a bit misleading, as in it was a count of the subset of all bytes read/written that only applied when we actually throttled/slept, not a total number. I simply deleted the `throttled` prefix. If adding some other prefix is clearer, let me know.