### PR TITLE
WT-4595 Coverity "null pointer dereference" complaints

### DIFF
--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -382,7 +382,7 @@ err:
 	if (cindex->child != NULL)
 		WT_TRET(cindex->child->close(cindex->child));
 
-	WT_TRET(__wt_schema_release_table(session, cindex->table));
+	WT_TRET(__wt_schema_release_table(session, &cindex->table));
 	/* The URI is owned by the index. */
 	cursor->internal_uri = NULL;
 	__wt_cursor_close(cursor);
@@ -489,7 +489,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session,
 
 	if ((ret = __wt_schema_open_index(
 	    session, table, idxname, namesize, &idx)) != 0) {
-		WT_TRET(__wt_schema_release_table(session, table));
+		WT_TRET(__wt_schema_release_table(session, &table));
 		return (ret);
 	}
 	WT_RET(__wt_calloc_one(session, &cindex));

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -327,7 +327,7 @@ __curjoin_close(WT_CURSOR *cursor)
 	JOINABLE_CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, NULL);
 err:
 
-	WT_TRET(__wt_schema_release_table(session, cjoin->table));
+	WT_TRET(__wt_schema_release_table(session, &cjoin->table));
 
 	/* This is owned by the table */
 	cursor->key_format = NULL;

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -839,7 +839,7 @@ err:
 	__wt_free(session, ctable->cg_valcopy);
 	__wt_free(session, ctable->idx_cursors);
 
-	WT_TRET(__wt_schema_release_table(session, ctable->table));
+	WT_TRET(__wt_schema_release_table(session, &ctable->table));
 	/* The URI is owned by the table. */
 	cursor->internal_uri = NULL;
 	__wt_cursor_close(cursor);
@@ -999,7 +999,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session,
 		ret = __wt_open_cursor(session,
 		    table->cgroups[0]->source, NULL, cfg, cursorp);
 
-		WT_TRET(__wt_schema_release_table(session, table));
+		WT_TRET(__wt_schema_release_table(session, &table));
 		if (ret == 0) {
 			/* Fix up the public URI to match what was passed in. */
 			cursor = *cursorp;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -621,7 +621,7 @@ extern int __wt_schema_create(WT_SESSION_IMPL *session, const char *uri, const c
 extern int __wt_schema_drop(WT_SESSION_IMPL *session, const char *uri, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_get_table_uri(WT_SESSION_IMPL *session, const char *uri, bool ok_incomplete, uint32_t flags, WT_TABLE **tablep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_get_table(WT_SESSION_IMPL *session, const char *name, size_t namelen, bool ok_incomplete, uint32_t flags, WT_TABLE **tablep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_schema_release_table(WT_SESSION_IMPL *session, WT_TABLE *table) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_schema_release_table(WT_SESSION_IMPL *session, WT_TABLE **tablep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern int __wt_schema_destroy_index(WT_SESSION_IMPL *session, WT_INDEX **idxp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_close_table(WT_SESSION_IMPL *session, WT_TABLE *table) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -278,7 +278,7 @@ err:	__wt_free(session, cgconf);
 	__wt_buf_free(session, &namebuf);
 
 	if (!tracked)
-		WT_TRET(__wt_schema_release_table(session, table));
+		WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }
 
@@ -415,7 +415,7 @@ __create_index(WT_SESSION_IMPL *session,
 		WT_RET_MSG(session, ret,
 		    "Can't create an index for table: %.*s",
 		    (int)tlen, tablename);
-	WT_RET(__wt_schema_release_table(session, table));
+	WT_RET(__wt_schema_release_table(session, &table));
 
 	if ((ret = __wt_schema_get_table(
 	    session, tablename, tlen, true, 0, &table)) != 0)
@@ -565,7 +565,7 @@ err:	__wt_free(session, idxconf);
 	__wt_buf_free(session, &fmt);
 	__wt_buf_free(session, &namebuf);
 
-	WT_TRET(__wt_schema_release_table(session, table));
+	WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }
 
@@ -636,8 +636,7 @@ __create_table(WT_SESSION_IMPL *session,
 		table = NULL;
 	}
 
-err:	if (table != NULL)
-		WT_TRET(__wt_schema_release_table(session, table));
+err:	WT_TRET(__wt_schema_release_table(session, &table));
 	__wt_free(session, cgname);
 	__wt_free(session, tableconf);
 	return (ret);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -162,7 +162,7 @@ __drop_table(
 	}
 
 	/* Make sure the table data handle is closed. */
-	WT_TRET(__wt_schema_release_table(session, table));
+	WT_ERR(__wt_schema_release_table(session, table));
 	WT_ERR(__wt_schema_get_table_uri(
 	    session, uri, true, WT_DHANDLE_EXCLUSIVE, &table));
 	F_SET(&table->iface, WT_DHANDLE_DISCARD);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -131,7 +131,7 @@ __drop_table(
 	 */
 	WT_ERR(__wt_schema_get_table_uri(session, uri, true,
 	    WT_DHANDLE_EXCLUSIVE, &table));
-	WT_ERR(__wt_schema_release_table(session, table));
+	WT_ERR(__wt_schema_release_table(session, &table));
 	WT_ERR(__wt_schema_get_table_uri(session, uri, true, 0, &table));
 
 	/* Drop the column groups. */
@@ -162,7 +162,7 @@ __drop_table(
 	}
 
 	/* Make sure the table data handle is closed. */
-	WT_ERR(__wt_schema_release_table(session, table));
+	WT_ERR(__wt_schema_release_table(session, &table));
 	WT_ERR(__wt_schema_get_table_uri(
 	    session, uri, true, WT_DHANDLE_EXCLUSIVE, &table));
 	F_SET(&table->iface, WT_DHANDLE_DISCARD);
@@ -176,8 +176,8 @@ __drop_table(
 	/* Remove the metadata entry (ignore missing items). */
 	WT_ERR(__wt_metadata_remove(session, uri));
 
-err:	if (table != NULL && !tracked)
-		WT_TRET(__wt_schema_release_table(session, table));
+err:	if (!tracked)
+		WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }
 

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -27,8 +27,8 @@ __wt_schema_get_table_uri(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_session_get_dhandle(session, uri, NULL, NULL, flags));
 	table = (WT_TABLE *)session->dhandle;
 	if (!ok_incomplete && !table->cg_complete) {
+		WT_ERR(__wt_session_release_dhandle(session));
 		ret = __wt_set_return(session, EINVAL);
-		WT_TRET(__wt_session_release_dhandle(session));
 		WT_ERR_MSG(session, ret, "'%s' cannot be used "
 		    "until all column groups are created",
 		    table->iface.name);

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -67,9 +67,14 @@ err:	__wt_scr_free(session, &namebuf);
  *	Release a table handle.
  */
 int
-__wt_schema_release_table(WT_SESSION_IMPL *session, WT_TABLE *table)
+__wt_schema_release_table(WT_SESSION_IMPL *session, WT_TABLE **tablep)
 {
 	WT_DECL_RET;
+	WT_TABLE *table;
+
+	if ((table = *tablep) == NULL)
+		return (0);
+	*tablep = NULL;
 
 	WT_WITH_DHANDLE(session, &table->iface,
 	    ret = __wt_session_release_dhandle(session));

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -14,16 +14,15 @@
  */
 int
 __wt_schema_get_table_uri(WT_SESSION_IMPL *session,
-    const char *uri, bool ok_incomplete, uint32_t flags,
-    WT_TABLE **tablep)
+    const char *uri, bool ok_incomplete, uint32_t flags, WT_TABLE **tablep)
 {
 	WT_DATA_HANDLE *saved_dhandle;
 	WT_DECL_RET;
 	WT_TABLE *table;
 
-	saved_dhandle = session->dhandle;
-
 	*tablep = NULL;
+
+	saved_dhandle = session->dhandle;
 
 	WT_ERR(__wt_session_get_dhandle(session, uri, NULL, NULL, flags));
 	table = (WT_TABLE *)session->dhandle;

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -525,12 +525,12 @@ __wt_schema_get_colgroup(WT_SESSION_IMPL *session,
 				*tablep = table;
 			else
 				WT_RET(
-				    __wt_schema_release_table(session, table));
+				    __wt_schema_release_table(session, &table));
 			return (0);
 		}
 	}
 
-	WT_RET(__wt_schema_release_table(session, table));
+	WT_RET(__wt_schema_release_table(session, &table));
 	if (quiet)
 		WT_RET(ENOENT);
 	WT_RET_MSG(session, ENOENT, "%s not found in table", uri);
@@ -576,7 +576,7 @@ __wt_schema_get_index(WT_SESSION_IMPL *session,
 done:	if (invalidate)
 		table->idx_complete = false;
 
-err:	WT_TRET(__wt_schema_release_table(session, table));
+err:	WT_TRET(__wt_schema_release_table(session, &table));
 	WT_RET(ret);
 
 	if (*indexp != NULL)

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -236,7 +236,7 @@ __rename_table(WT_SESSION_IMPL *session,
 		    table->indices[i]->name, cfg));
 
 	/* Make sure the table data handle is closed. */
-	WT_TRET(__wt_schema_release_table(session, table));
+	WT_ERR(__wt_schema_release_table(session, table));
 	WT_ERR(__wt_schema_get_table_uri(
 	    session, uri, true, WT_DHANDLE_EXCLUSIVE, &table));
 	F_SET(&table->iface, WT_DHANDLE_DISCARD);

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -236,7 +236,7 @@ __rename_table(WT_SESSION_IMPL *session,
 		    table->indices[i]->name, cfg));
 
 	/* Make sure the table data handle is closed. */
-	WT_ERR(__wt_schema_release_table(session, table));
+	WT_ERR(__wt_schema_release_table(session, &table));
 	WT_ERR(__wt_schema_get_table_uri(
 	    session, uri, true, WT_DHANDLE_EXCLUSIVE, &table));
 	F_SET(&table->iface, WT_DHANDLE_DISCARD);
@@ -251,7 +251,7 @@ __rename_table(WT_SESSION_IMPL *session,
 	ret = __metadata_rename(session, uri, newuri);
 
 err:	if (!tracked)
-		WT_TRET(__wt_schema_release_table(session, table));
+		WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }
 

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -184,7 +184,7 @@ __wt_curstat_table_init(WT_SESSION_IMPL *session,
 
 	__wt_curstat_dsrc_final(cst);
 
-err:	WT_TRET(__wt_schema_release_table(session, table));
+err:	WT_TRET(__wt_schema_release_table(session, &table));
 
 	__wt_scr_free(session, &buf);
 	return (ret);

--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -34,7 +34,7 @@ __truncate_table(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 		WT_ERR(__wt_schema_truncate(
 		    session, table->indices[i]->source, cfg));
 
-err:	WT_TRET(__wt_schema_release_table(session, table));
+err:	WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -152,7 +152,6 @@ __wt_schema_worker(WT_SESSION_IMPL *session,
 	} else
 		WT_ERR(__wt_bad_object_type(session, uri));
 
-err:	if (table != NULL)
-		WT_TRET(__wt_schema_release_table(session, table));
+err:	WT_TRET(__wt_schema_release_table(session, &table));
 	return (ret);
 }


### PR DESCRIPTION
@agorrod, I don't see any problems in the Coverity "null pointer dereference" complaints themselves ([https://coverity.corp.mongodb.com/reports.htm#v10632/p10001](https://coverity.corp.mongodb.com/reports.htm#v10632/p10001)), but whoever reviews this branch should double check me.

This branch cleans up some minor problems in the table get/release code paths that I noticed while reviewing the Coverity complaints.

EDIT: We triaged the Coverity reports, so they're a bit harder to find. Here's a link to one of them: [https://coverity.corp.mongodb.com/reports.htm#v11943/p10001/fileInstanceId=24060345&defectInstanceId=17273195&mergedDefectId=104925&fileStart=251&fileEnd=318](https://coverity.corp.mongodb.com/reports.htm#v11943/p10001/fileInstanceId=24060345&defectInstanceId=17273195&mergedDefectId=104925&fileStart=251&fileEnd=318)

