### PR TITLE
WT-4573 Reducing calls to __wt_epoch from session reset.

### DIFF
--- a/src/include/session.h
+++ b/src/include/session.h
@@ -40,7 +40,7 @@ struct __wt_hazard {
 typedef TAILQ_HEAD(__wt_cursor_list, __wt_cursor)	WT_CURSOR_LIST;
 
 /* Number of cursors cached to trigger cursor sweep. */
-#define	WT_SESSION_CURSOR_SWEEP_COUNTDOWN	20
+#define	WT_SESSION_CURSOR_SWEEP_COUNTDOWN	40
 
 /* Minimum number of buckets to visit during cursor sweep. */
 #define	WT_SESSION_CURSOR_SWEEP_MIN		5

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1016,7 +1016,11 @@ __session_reset(WT_SESSION *wt_session)
 
 	WT_TRET(__wt_session_reset_cursors(session, true));
 
-	WT_TRET(__wt_session_cursor_cache_sweep(session));
+	if (--session->cursor_sweep_countdown == 0) {
+		session->cursor_sweep_countdown =
+		    WT_SESSION_CURSOR_SWEEP_COUNTDOWN;
+		WT_TRET(__wt_session_cursor_cache_sweep(session));
+	}
 
 	/* Release common session resources. */
 	WT_TRET(__wt_session_release_resources(session));


### PR DESCRIPTION
__wt_epoch is called everytime in __wt_session_cursor_cache_sweep
when session reset is called. This change is to set countdown to
call less often cursor cache sweep during session reset.