### PR TITLE
WT-4607 Allow prepare timestamp to commit behind oldest timestamp.

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -860,7 +860,7 @@ extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, 
 extern int __wt_txn_query_timestamp(WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[], bool global_txn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool compare_stable) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool durable_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_prepare_timestamp(WT_SESSION_IMPL *session, const char *cfg[], wt_timestamp_t *timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -860,7 +860,7 @@ extern int __wt_txn_parse_timestamp(WT_SESSION_IMPL *session, const char *name, 
 extern int __wt_txn_query_timestamp(WT_SESSION_IMPL *session, char *hex_timestamp, const char *cfg[], bool global_txn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool durable_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool durable_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_prepare_timestamp(WT_SESSION_IMPL *session, const char *cfg[], wt_timestamp_t *timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -754,7 +754,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		 * For prepared transactions commit timestamp could be earlier
 		 * than stable timestamp.
 		 */
-		WT_ERR(__wt_commit_timestamp_validate(
+		WT_ERR(__wt_txn_commit_timestamp_validate(
 		    session, "commit", ts, &cval, !prepare));
 		txn->commit_timestamp = ts;
 		__wt_txn_set_commit_timestamp(session);
@@ -787,7 +787,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		/* Durable timestamp should be later than stable timestamp. */
 		F_SET(txn, WT_TXN_HAS_TS_DURABLE);
 		txn->durable_timestamp = ts;
-		WT_ERR(__wt_commit_timestamp_validate(
+		WT_ERR(__wt_txn_commit_timestamp_validate(
 		    session, "durable", ts, &cval, true));
 	}
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -576,11 +576,11 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 }
 
 /*
- * __txn_commit_timestamps_validate --
+ * __txn_commit_timestamps_assert --
  *	Validate that timestamps provided to commit are legal.
  */
 static inline int
-__txn_commit_timestamps_validate(WT_SESSION_IMPL *session)
+__txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 {
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
@@ -754,7 +754,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		 * For prepared transactions commit timestamp could be earlier
 		 * than stable timestamp.
 		 */
-		WT_ERR(__wt_timestamp_validate(
+		WT_ERR(__wt_commit_timestamp_validate(
 		    session, "commit", ts, &cval, !prepare));
 		txn->commit_timestamp = ts;
 		__wt_txn_set_commit_timestamp(session);
@@ -787,11 +787,11 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		/* Durable timestamp should be later than stable timestamp. */
 		F_SET(txn, WT_TXN_HAS_TS_DURABLE);
 		txn->durable_timestamp = ts;
-		WT_ERR(__wt_timestamp_validate(
+		WT_ERR(__wt_commit_timestamp_validate(
 		    session, "durable", ts, &cval, true));
 	}
 
-	WT_ERR(__txn_commit_timestamps_validate(session));
+	WT_ERR(__txn_commit_timestamps_assert(session));
 
 	/*
 	 * The default sync setting is inherited from the connection, but can

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -579,14 +579,15 @@ set:	__wt_writelock(session, &txn_global->rwlock);
 }
 
 /*
- * __wt_timestamp_validate --
- *	Validate a timestamp to be not older than the global oldest and global
- *	stable and running transaction commit timestamp and running transaction
- *	prepare timestamp.
+ * __wt_commit_timestamp_validate --
+ *	Validate a timestamp to be not older than running transaction commit
+ *	timestamp and running transaction prepare timestamp. Validate a durable
+ *	timestamp to be not older than the global oldest and global stable
+ *	timestamp.
  */
 int
-__wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
-    wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool compare_stable)
+__wt_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
+    wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool durable_ts)
 {
 	WT_TXN *txn = &session->txn;
 	WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
@@ -609,14 +610,14 @@ __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	if (has_stable_ts)
 		stable_ts = txn_global->stable_timestamp;
 
-	if (has_oldest_ts && ts < oldest_ts) {
+	if (durable_ts && has_oldest_ts && ts < oldest_ts) {
 		__wt_timestamp_to_string(
 		    oldest_ts, ts_string[0], sizeof(ts_string[0]));
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than oldest timestamp %s",
 		    name, (int)cval->len, cval->str, ts_string[0]);
 	}
-	if (compare_stable && has_stable_ts && ts < stable_ts) {
+	if (durable_ts && has_stable_ts && ts < stable_ts) {
 		__wt_timestamp_to_string(
 		    stable_ts, ts_string[0], sizeof(ts_string[0]));
 		WT_RET_MSG(session, EINVAL,
@@ -696,10 +697,10 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		 * than stable timestamp.
 		 */
 		if (prepare)
-			WT_RET(__wt_timestamp_validate(
+			WT_RET(__wt_commit_timestamp_validate(
 			    session, "commit", ts, &cval, false));
 		else
-			WT_RET(__wt_timestamp_validate(
+			WT_RET(__wt_commit_timestamp_validate(
 			    session, "commit", ts, &cval, true));
 		txn->commit_timestamp = ts;
 		__wt_txn_set_commit_timestamp(session);
@@ -727,7 +728,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	 * is required.
 	 */
 	if (ret == 0 && cval.len != 0)
-		WT_RET(__wt_timestamp_validate(
+		WT_RET(__wt_commit_timestamp_validate(
 		    session, "durable", txn->durable_timestamp, &cval, true));
 	/*
 	 * We allow setting the commit timestamp and durable timestamp after a

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -579,14 +579,14 @@ set:	__wt_writelock(session, &txn_global->rwlock);
 }
 
 /*
- * __wt_commit_timestamp_validate --
+ * __wt_txn_commit_timestamp_validate --
  *	Validate a timestamp to be not older than running transaction commit
  *	timestamp and running transaction prepare timestamp. Validate a durable
  *	timestamp to be not older than the global oldest and global stable
  *	timestamp.
  */
 int
-__wt_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
+__wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
     wt_timestamp_t ts, WT_CONFIG_ITEM *cval, bool durable_ts)
 {
 	WT_TXN *txn = &session->txn;
@@ -697,10 +697,10 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 		 * than stable timestamp.
 		 */
 		if (prepare)
-			WT_RET(__wt_commit_timestamp_validate(
+			WT_RET(__wt_txn_commit_timestamp_validate(
 			    session, "commit", ts, &cval, false));
 		else
-			WT_RET(__wt_commit_timestamp_validate(
+			WT_RET(__wt_txn_commit_timestamp_validate(
 			    session, "commit", ts, &cval, true));
 		txn->commit_timestamp = ts;
 		__wt_txn_set_commit_timestamp(session);
@@ -728,7 +728,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	 * is required.
 	 */
 	if (ret == 0 && cval.len != 0)
-		WT_RET(__wt_commit_timestamp_validate(
+		WT_RET(__wt_txn_commit_timestamp_validate(
 		    session, "durable", txn->durable_timestamp, &cval, true));
 	/*
 	 * We allow setting the commit timestamp and durable timestamp after a


### PR DESCRIPTION
Function name changes for less ambiguity.
Mask the check of commit timestamp < oldest timestamp.