### PR TITLE
WT-4620 Assert a uint64_t can hold a time_t, maintain seconds as uint64_t

### DIFF
--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -84,7 +84,7 @@ struct __wt_data_handle {
 	uint32_t session_ref;		/* Sessions referencing this handle */
 	int32_t	 session_inuse;		/* Sessions using this handle */
 	uint32_t excl_ref;		/* Refs of handle by excl_session */
-	time_t	 timeofdeath;		/* Use count went to 0 */
+	uint64_t timeofdeath;		/* Use count went to 0 */
 	WT_SESSION_IMPL *excl_session;	/* Session with exclusive use, if any */
 
 	WT_DATA_SOURCE *dsrc;		/* Data source for this handle */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -803,7 +803,7 @@ extern int __wt_thread_group_destroy(WT_SESSION_IMPL *session, WT_THREAD_GROUP *
 extern void __wt_thread_group_start_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, bool is_locked);
 extern void __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group);
 extern void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_seconds(WT_SESSION_IMPL *session, time_t *timep);
+extern void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 extern uint64_t __wt_clock_to_nsec(uint64_t end, uint64_t begin);
 extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -70,7 +70,7 @@ struct __wt_ckpt {
 
 	int64_t	 order;			/* Checkpoint order */
 
-	uintmax_t sec;			/* Wall clock time */
+	uint64_t sec;                   /* Wall clock time */
 
 	uint64_t size;			/* Checkpoint size */
 

--- a/src/include/os_windows.h
+++ b/src/include/os_windows.h
@@ -54,8 +54,5 @@ typedef unsigned long	u_long;
 typedef int ssize_t;
 #endif
 
-/* Provide a custom version of localtime_r */
-struct tm *localtime_r(const time_t* timer, struct tm* result);
-
 /* Windows does not provide fsync */
 #define	fsync	_commit

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -75,13 +75,13 @@ struct __wt_session_impl {
 	 */
 					/* Session handle reference list */
 	TAILQ_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
-	time_t last_sweep;		/* Last sweep for dead handles */
+	uint64_t last_sweep;		/* Last sweep for dead handles */
 	struct timespec last_epoch;	/* Last epoch time returned */
 
 	WT_CURSOR_LIST cursors;		/* Cursors closed with the session */
 	uint32_t cursor_sweep_position;	/* Position in cursor_cache for sweep */
 	uint32_t cursor_sweep_countdown;/* Countdown to cursor sweep */
-	time_t last_cursor_sweep;	/* Last sweep for dead cursors */
+	uint64_t last_cursor_sweep;	/* Last sweep for dead cursors */
 
 	WT_CURSOR_BACKUP *bkp_cursor;	/* Hot backup cursor */
 

--- a/src/include/verify_build.h
+++ b/src/include/verify_build.h
@@ -84,4 +84,10 @@ __wt_verify_build(void)
 	 * disallow them for now.
 	 */
 	WT_STATIC_ASSERT(sizeof(wt_off_t) == 8);
+
+	/*
+	 * We require a time_t be an integral type and fit into a uint64_t for
+	 * simplicity.
+	 */
+	WT_STATIC_ASSERT(sizeof(time_t) <= sizeof(uint64_t));
 }

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -340,7 +340,7 @@ __ckpt_load(WT_SESSION_IMPL *session,
 		goto format;
 	memcpy(timebuf, a.str, a.len);
 	timebuf[a.len] = '\0';
-	if (sscanf(timebuf, "%" SCNuMAX, &ckpt->sec) != 1)
+	if (sscanf(timebuf, "%" SCNu64, &ckpt->sec) != 1)
 		goto format;
 
 	WT_RET(__wt_config_subgets(session, v, "size", &a));
@@ -384,7 +384,6 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 	WT_CKPT *ckpt;
 	WT_DECL_ITEM(buf);
 	WT_DECL_RET;
-	time_t secs;
 	int64_t maxorder;
 	const char *sep;
 
@@ -430,14 +429,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 			if (F_ISSET(ckpt, WT_CKPT_ADD))
 				ckpt->order = ++maxorder;
 
-			/*
-			 * XXX
-			 * Assumes a time_t fits into a uintmax_t, which isn't
-			 * guaranteed, a time_t has to be an arithmetic type,
-			 * but not an integral type.
-			 */
-			__wt_seconds(session, &secs);
-			ckpt->sec = (uintmax_t)secs;
+			__wt_seconds(session, &ckpt->sec);
 		}
 
 		__wt_timestamp_addr_check(session, ckpt->oldest_start_ts,
@@ -456,7 +448,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 		 */
 		WT_ERR(__wt_buf_catfmt(session, buf,
 		    "=(addr=\"%.*s\",order=%" PRId64
-		    ",time=%" PRId64
+		    ",time=%" PRIu64
 		    ",size=%" PRId64
 		    ",oldest_start_ts=%" PRId64
 		    ",newest_start_ts=%" PRId64
@@ -464,7 +456,7 @@ __wt_meta_ckptlist_set(WT_SESSION_IMPL *session,
 		    ",write_gen=%" PRId64 ")",
 		    (int)ckpt->addr.size, (char *)ckpt->addr.data,
 		    ckpt->order,
-		    (int64_t)ckpt->sec,
+		    ckpt->sec,
 		    (int64_t)ckpt->size,
 		    (int64_t)ckpt->oldest_start_ts,
 		    (int64_t)ckpt->newest_start_ts,

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -59,7 +59,7 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 	WT_CURSOR *cursor, *cursor_tmp;
 	WT_CURSOR_LIST *cached_list;
 	WT_DECL_RET;
-	time_t now;
+	uint64_t now;
 	uint32_t position;
 	int i, t_ret, nbuckets, nexamined, nclosed;
 	bool productive;
@@ -72,7 +72,7 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 	 * do it again.
 	 */
 	__wt_seconds(session, &now);
-	if (difftime(now, session->last_cursor_sweep) < 1)
+	if (now - session->last_cursor_sweep < 1)
 		return (0);
 	session->last_cursor_sweep = now;
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -392,7 +392,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
 	WT_DATA_HANDLE_CACHE *dhandle_cache, *dhandle_cache_tmp;
-	time_t now;
+	uint64_t now;
 
 	conn = S2C(session);
 
@@ -401,7 +401,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 	 * do it again.
 	 */
 	__wt_seconds(session, &now);
-	if (difftime(now, session->last_sweep) < conn->sweep_interval)
+	if (now - session->last_sweep < conn->sweep_interval)
 		return;
 	session->last_sweep = now;
 
@@ -414,8 +414,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 		    dhandle->session_inuse == 0 &&
 		    (WT_DHANDLE_INACTIVE(dhandle) ||
 		    (dhandle->timeofdeath != 0 &&
-		    difftime(now, dhandle->timeofdeath) >
-		    conn->sweep_idle_time))) {
+		    now - dhandle->timeofdeath > conn->sweep_idle_time))) {
 			WT_STAT_CONN_INCR(session, dh_session_handles);
 			WT_ASSERT(session, !WT_IS_METADATA(dhandle));
 			__session_discard_dhandle(session, dhandle_cache);

--- a/src/support/time.c
+++ b/src/support/time.c
@@ -63,13 +63,17 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
  *	Return the seconds since the Epoch.
  */
 void
-__wt_seconds(WT_SESSION_IMPL *session, time_t *timep)
+__wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp)
 {
 	struct timespec t;
 
 	__wt_epoch(session, &t);
 
-	*timep = t.tv_sec;
+	/*
+	 * A time_t isn't guaranteed to fit into a uint64_t, but it's asserted
+	 * when WiredTiger builds.
+	 */
+	*secondsp = (uint64_t)t.tv_sec;
 }
 
 /*


### PR DESCRIPTION
@sueloverso, would you please do the detailed review?
@michaelcahill, I can't think of any reason not to make this change, but wanted to run it by you for sanity.   Thanks!