### PR TITLE
WT-4602 Remove macro parentheses and suppress linter instead

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -36,7 +36,8 @@ extern "C" {
 #if defined(DOXYGEN) || defined(SWIG)
 #define	__F(func) func
 #else
-#define	__F(func) (*(func))
+/* NOLINTNEXTLINE(misc-macro-parentheses) */
+#define	__F(func) (*func)
 #endif
 
 /*


### PR DESCRIPTION
Looks like MongoDB builds WiredTiger with different compiler flags. So the extra parentheses around this macro that I added to please Clang Tidy is now creating an "unnecessary parentheses" warning in the MongoDB build.