### PR TITLE
WT-4627 Coverity #111405: out-of-bounds overrun

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1207,15 +1207,12 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
 		else
 			WT_RET(ds->f(ds, "\t" "txn id %" PRIu64, upd->txnid));
 
-		__wt_timestamp_to_string(
-		    upd->start_ts, ts_string, sizeof(ts_string));
+		__wt_timestamp_to_string(upd->start_ts, ts_string);
 		WT_RET(ds->f(ds, ", start_ts %s", ts_string));
-		__wt_timestamp_to_string(
-		    upd->stop_ts, ts_string, sizeof(ts_string));
+		__wt_timestamp_to_string(upd->stop_ts, ts_string);
 		WT_RET(ds->f(ds, ", stop_ts %s", ts_string));
 		if (upd->durable_ts != WT_TS_NONE) {
-			__wt_timestamp_to_string(upd->durable_ts,
-			    ts_string, sizeof(ts_string));
+			__wt_timestamp_to_string(upd->durable_ts, ts_string);
 			WT_RET(ds->f(ds, ", durable-ts %s", ts_string));
 		}
 
@@ -1341,12 +1338,9 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_ADDR_INT:
 	case WT_CELL_ADDR_LEAF:
 	case WT_CELL_ADDR_LEAF_NO:
-		__wt_timestamp_to_string(unpack->oldest_start_ts,
-		    ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(unpack->newest_start_ts,
-		    ts_string[1], sizeof(ts_string[1]));
-		__wt_timestamp_to_string(unpack->newest_stop_ts,
-		    ts_string[2], sizeof(ts_string[2]));
+		__wt_timestamp_to_string(unpack->oldest_start_ts, ts_string[0]);
+		__wt_timestamp_to_string(unpack->newest_start_ts, ts_string[1]);
+		__wt_timestamp_to_string(unpack->newest_stop_ts, ts_string[2]);
 		WT_RET(ds->f(ds,
 		    ", ts %s,%s,%s", ts_string[0], ts_string[1], ts_string[2]));
 		break;
@@ -1356,10 +1350,8 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 	case WT_CELL_VALUE_OVFL:
 	case WT_CELL_VALUE_OVFL_RM:
 	case WT_CELL_VALUE_SHORT:
-		__wt_timestamp_to_string(unpack->start_ts,
-		    ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(unpack->stop_ts,
-		    ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(unpack->start_ts, ts_string[0]);
+		__wt_timestamp_to_string(unpack->stop_ts, ts_string[1]);
 		WT_RET(ds->f(ds, ", ts %s-%s", ts_string[0], ts_string[1]));
 		break;
 	}

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -582,11 +582,9 @@ __las_insert_block_verbose(
 		(void)__wt_eviction_clean_needed(session, &pct_full);
 		(void)__wt_eviction_dirty_needed(session, &pct_dirty);
 		__wt_timestamp_to_string(
-		    multi->page_las.unstable_timestamp,
-		    ts_string[0], sizeof(ts_string));
+		    multi->page_las.unstable_timestamp, ts_string[0]);
 		__wt_timestamp_to_string(
-		    multi->page_las.unstable_durable_timestamp,
-		    ts_string[1], sizeof(ts_string));
+		    multi->page_las.unstable_durable_timestamp, ts_string[1]);
 
 		__wt_verbose(session,
 		    WT_VERB_LOOKASIDE | WT_VERB_LOOKASIDE_ACTIVITY,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -852,7 +852,7 @@ extern int __wt_txn_named_snapshot_config(WT_SESSION_IMPL *session, const char *
 extern void __wt_txn_named_snapshot_destroy(WT_SESSION_IMPL *session);
 extern int __wt_txn_recover(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string, size_t len);
+extern void __wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string);
 extern void __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp);
 extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *msg);
 extern int __wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1500,14 +1500,10 @@ __wt_verbose_dump_txn_one(WT_SESSION_IMPL *session, WT_TXN *txn)
 		iso_tag = "WT_ISO_SNAPSHOT";
 		break;
 	}
-	__wt_timestamp_to_string(
-	    txn->commit_timestamp, ts_string[0], sizeof(ts_string[0]));
-	__wt_timestamp_to_string(
-	    txn->durable_timestamp, ts_string[1], sizeof(ts_string[1]));
-	__wt_timestamp_to_string(
-	    txn->first_commit_timestamp, ts_string[2], sizeof(ts_string[2]));
-	__wt_timestamp_to_string(
-	    txn->read_timestamp, ts_string[3], sizeof(ts_string[3]));
+	__wt_timestamp_to_string(txn->commit_timestamp, ts_string[0]);
+	__wt_timestamp_to_string(txn->durable_timestamp, ts_string[1]);
+	__wt_timestamp_to_string(txn->first_commit_timestamp, ts_string[2]);
+	__wt_timestamp_to_string(txn->read_timestamp, ts_string[3]);
 	WT_RET(__wt_msg(session,
 	    "mod count: %u"
 	    ", snap min: %" PRIu64
@@ -1558,17 +1554,13 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
 	    "metadata_pinned ID: %" PRIu64, txn_global->metadata_pinned));
 	WT_RET(__wt_msg(session, "oldest ID: %" PRIu64, txn_global->oldest_id));
 
-	__wt_timestamp_to_string(
-	    txn_global->commit_timestamp, ts_string, sizeof(ts_string));
+	__wt_timestamp_to_string(txn_global->commit_timestamp, ts_string);
 	WT_RET(__wt_msg(session, "commit timestamp: %s", ts_string));
-	__wt_timestamp_to_string(
-	    txn_global->oldest_timestamp, ts_string, sizeof(ts_string));
+	__wt_timestamp_to_string(txn_global->oldest_timestamp, ts_string);
 	WT_RET(__wt_msg(session, "oldest timestamp: %s", ts_string));
-	__wt_timestamp_to_string(
-	    txn_global->pinned_timestamp, ts_string, sizeof(ts_string));
+	__wt_timestamp_to_string(txn_global->pinned_timestamp, ts_string);
 	WT_RET(__wt_msg(session, "pinned timestamp: %s", ts_string));
-	__wt_timestamp_to_string(
-	    txn_global->stable_timestamp, ts_string, sizeof(ts_string));
+	__wt_timestamp_to_string(txn_global->stable_timestamp, ts_string);
 	WT_RET(__wt_msg(session, "stable timestamp: %s", ts_string));
 	WT_RET(__wt_msg(session, "has_commit_timestamp: %s",
 	    txn_global->has_commit_timestamp ? "yes" : "no"));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -400,8 +400,7 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 	if (WT_VERBOSE_ISSET(session,
 	    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS)) {
 		__wt_timestamp_to_string(
-		    conn->txn_global.recovery_timestamp,
-		    ts_string, sizeof(ts_string));
+		    conn->txn_global.recovery_timestamp, ts_string);
 		__wt_verbose(session,
 		    WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,
 		    "Set global recovery timestamp: %s", ts_string);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -19,9 +19,9 @@
  *	Convert a timestamp to the MongoDB string representation.
  */
 void
-__wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string, size_t len)
+__wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string)
 {
-	WT_IGNORE_RET(__wt_snprintf(ts_string, len,
+	WT_IGNORE_RET(__wt_snprintf(ts_string, WT_TS_INT_STRING_SIZE,
 	    "(%" PRIu32 ",%" PRIu32 ")",
 	    (uint32_t)((ts >> 32) & 0xffffffff), (uint32_t)(ts & 0xffffffff)));
 }
@@ -72,7 +72,7 @@ __wt_verbose_timestamp(
 	if (!WT_VERBOSE_ISSET(session, WT_VERB_TIMESTAMP))
 		return;
 
-	__wt_timestamp_to_string(ts, ts_string, sizeof(ts_string));
+	__wt_timestamp_to_string(ts, ts_string);
 	__wt_verbose(session,
 	    WT_VERB_TIMESTAMP, "Timestamp %s : %s", ts_string, msg);
 }
@@ -481,10 +481,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	if (has_commit && (has_oldest ||
 	    txn_global->has_oldest_timestamp) && oldest_ts > commit_ts) {
 		__wt_readunlock(session, &txn_global->rwlock);
-		__wt_timestamp_to_string(
-		    oldest_ts, ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(
-		    commit_ts, ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(oldest_ts, ts_string[0]);
+		__wt_timestamp_to_string(commit_ts, ts_string[1]);
 		WT_RET_MSG(session, EINVAL,
 		    "set_timestamp: oldest timestamp %s must not be later than "
 		    "commit timestamp %s", ts_string[0], ts_string[1]);
@@ -493,10 +491,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	if (has_commit && (has_stable ||
 	    txn_global->has_stable_timestamp) && stable_ts > commit_ts) {
 		__wt_readunlock(session, &txn_global->rwlock);
-		__wt_timestamp_to_string(
-		    stable_ts, ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(
-		    commit_ts, ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(stable_ts, ts_string[0]);
+		__wt_timestamp_to_string(commit_ts, ts_string[1]);
 		WT_RET_MSG(session, EINVAL,
 		    "set_timestamp: stable timestamp %s must not be later than "
 		    "commit timestamp %s", ts_string[0], ts_string[1]);
@@ -511,10 +507,8 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 	    (has_stable ||
 	    txn_global->has_stable_timestamp) && oldest_ts > stable_ts) {
 		__wt_readunlock(session, &txn_global->rwlock);
-		__wt_timestamp_to_string(
-		    oldest_ts, ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(
-		    stable_ts, ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(oldest_ts, ts_string[0]);
+		__wt_timestamp_to_string(stable_ts, ts_string[1]);
 		WT_RET_MSG(session, EINVAL,
 		    "set_timestamp: oldest timestamp %s must not be later than "
 		    "stable timestamp %s", ts_string[0], ts_string[1]);
@@ -613,15 +607,13 @@ __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 		stable_ts = txn_global->stable_timestamp;
 
 	if (durable_ts && has_oldest_ts && ts < oldest_ts) {
-		__wt_timestamp_to_string(
-		    oldest_ts, ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(oldest_ts, ts_string[0]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than oldest timestamp %s",
 		    name, (int)cval->len, cval->str, ts_string[0]);
 	}
 	if (durable_ts && has_stable_ts && ts < stable_ts) {
-		__wt_timestamp_to_string(
-		    stable_ts, ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(stable_ts, ts_string[0]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than stable timestamp %s",
 		    name, (int)cval->len, cval->str, ts_string[0]);
@@ -634,8 +626,8 @@ __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	 */
 	if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
 	    ts < txn->first_commit_timestamp) {
-		__wt_timestamp_to_string(txn->first_commit_timestamp,
-		    ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(
+		    txn->first_commit_timestamp, ts_string[0]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than the first "
 		    "commit timestamp %s for this transaction",
@@ -648,8 +640,7 @@ __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 	 * timestamp.
 	 */
 	if (F_ISSET(txn, WT_TXN_PREPARE) && ts < txn->prepare_timestamp) {
-		__wt_timestamp_to_string(
-		    txn->prepare_timestamp, ts_string[0], sizeof(ts_string[0]));
+		__wt_timestamp_to_string(txn->prepare_timestamp, ts_string[0]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than the prepare timestamp %s "
 		    "for this transaction",
@@ -658,10 +649,8 @@ __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 
 	if (F_ISSET(txn, WT_TXN_HAS_TS_DURABLE) &&
 	    txn->durable_timestamp < txn->commit_timestamp) {
-		__wt_timestamp_to_string(
-		    txn->durable_timestamp, ts_string[0], sizeof(ts_string[0]));
-		__wt_timestamp_to_string(
-		    txn->commit_timestamp, ts_string[1], sizeof(ts_string[1]));
+		__wt_timestamp_to_string(txn->durable_timestamp, ts_string[0]);
+		__wt_timestamp_to_string(txn->commit_timestamp, ts_string[1]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %s older than the commit timestamp %s "
 		    "for this transaction",
@@ -791,8 +780,8 @@ __wt_txn_parse_prepare_timestamp(
 			if (prev->read_timestamp >= *timestamp) {
 				__wt_readunlock(session,
 				    &txn_global->read_timestamp_rwlock);
-				__wt_timestamp_to_string(prev->read_timestamp,
-				    ts_string, sizeof(ts_string));
+				__wt_timestamp_to_string(
+				    prev->read_timestamp, ts_string);
 				WT_RET_MSG(session, EINVAL,
 				    "prepare timestamp %.*s not later than "
 				    "an active read timestamp %s ",
@@ -810,8 +799,7 @@ __wt_txn_parse_prepare_timestamp(
 			oldest_ts = txn_global->oldest_timestamp;
 
 			if (*timestamp < oldest_ts) {
-				__wt_timestamp_to_string(
-				    oldest_ts, ts_string, sizeof(ts_string));
+				__wt_timestamp_to_string(oldest_ts, ts_string);
 				WT_RET_MSG(session, EINVAL,
 				    "prepare timestamp %.*s is older than the "
 				    "oldest timestamp %s ", (int)cval.len,
@@ -882,10 +870,9 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 				txn->read_timestamp = ts_oldest;
 			else {
 				__wt_readunlock(session, &txn_global->rwlock);
+				__wt_timestamp_to_string(ts, ts_string[0]);
 				__wt_timestamp_to_string(
-				    ts, ts_string[0], sizeof(ts_string[0]));
-				__wt_timestamp_to_string(ts_oldest,
-				    ts_string[1], sizeof(ts_string[1]));
+				    ts_oldest, ts_string[1]);
 				WT_RET_MSG(session, EINVAL, "read timestamp "
 				    "%s older than oldest timestamp %s",
 				    ts_string[0], ts_string[1]);
@@ -907,10 +894,8 @@ __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 			 * This message is generated here to reduce the span of
 			 * critical section.
 			 */
-			__wt_timestamp_to_string(
-			    ts, ts_string[0], sizeof(ts_string[0]));
-			__wt_timestamp_to_string(
-			    ts_oldest, ts_string[1], sizeof(ts_string[1]));
+			__wt_timestamp_to_string(ts, ts_string[0]);
+			__wt_timestamp_to_string(ts_oldest, ts_string[1]);
 			__wt_verbose(session, WT_VERB_TIMESTAMP, "Read "
 			    "timestamp %s : Rounded to oldest timestamp %s",
 			    ts_string[0], ts_string[1]);


### PR DESCRIPTION
@nehakhatri5, I removed the `sizeof` argument to  `__wt_timestamp_to_string()`, it's always the same value and it's just something to get wrong.

If you can think of a way to get back error checking on this call, I'm open to suggestions, but absent passing in a `WT_SESSION_IMPL *` argument and asserting it, I don't see anything.