### PR TITLE
WT-4643 Adding commit timestamp validitiy check into txn commit

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -776,6 +776,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	wt_timestamp_t prev_commit_timestamp, ts;
 	uint32_t fileid;
 	u_int i;
+	char ts_string[2][WT_TS_INT_STRING_SIZE];
 	bool locked, prepare, readonly, update_timestamp;
 
 	txn = &session->txn;
@@ -835,6 +836,23 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		txn->durable_timestamp = ts;
 		WT_ERR(__wt_txn_commit_timestamp_validate(
 		    session, "durable", ts, &cval, true));
+	}
+
+	/*
+	 * Confirm if the first commit timestamp is valid
+	 * with both prepared and unprepared transactions.
+	 */
+	if (txn_global->has_stable_timestamp &&
+	    (!prepare || (prepare && !F_ISSET(txn, WT_TXN_HAS_TS_DURABLE))) &&
+		F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
+		txn->first_commit_timestamp <= txn_global->stable_timestamp) {
+		__wt_timestamp_to_string(txn->first_commit_timestamp,
+		    ts_string[0]);
+		__wt_timestamp_to_string(txn_global->stable_timestamp,
+		    ts_string[1]);
+		WT_ERR_MSG(session, EINVAL,
+		    "first commit timestamp %s older than stable timestamp %s",
+		    ts_string[0], ts_string[1]);
 	}
 
 	WT_ERR(__txn_commit_timestamps_assert(session));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -839,20 +839,37 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	}
 
 	/*
-	 * Confirm if the first commit timestamp is valid
-	 * with both prepared and unprepared transactions.
+	 * Confirm if the is valid with both prepared and unprepared
+	 * transactions. This check is required as the stable timestamp
+	 * can be moved beyond the commit / durable timestamp after
+	 * they are set.
 	 */
-	if (txn_global->has_stable_timestamp &&
-	    (!prepare || (prepare && !F_ISSET(txn, WT_TXN_HAS_TS_DURABLE))) &&
-		F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
-		txn->first_commit_timestamp <= txn_global->stable_timestamp) {
-		__wt_timestamp_to_string(txn->first_commit_timestamp,
-		    ts_string[0]);
-		__wt_timestamp_to_string(txn_global->stable_timestamp,
-		    ts_string[1]);
-		WT_ERR_MSG(session, EINVAL,
-		    "first commit timestamp %s older than stable timestamp %s",
-		    ts_string[0], ts_string[1]);
+	if (txn_global->has_stable_timestamp) {
+		if (prepare && txn->durable_timestamp <=
+		    txn_global->stable_timestamp) {
+			__wt_timestamp_to_string(txn->durable_timestamp,
+			    ts_string[0]);
+			__wt_timestamp_to_string(txn_global->stable_timestamp,
+			    ts_string[1]);
+			WT_ERR_MSG(session, EINVAL,
+			    "commit timestamp %s older"
+			    " than stable timestamp %s",
+			    ts_string[0], ts_string[1]);
+		} else if (!prepare) {
+			if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
+			    txn->first_commit_timestamp <=
+			    txn_global->stable_timestamp) {
+				__wt_timestamp_to_string(
+				    txn->first_commit_timestamp,
+				    ts_string[0]);
+				__wt_timestamp_to_string(
+				    txn_global->stable_timestamp, ts_string[1]);
+				WT_ERR_MSG(session, EINVAL,
+				    "commit timestamp %s older"
+				    " than stable timestamp %s",
+				    ts_string[0], ts_string[1]);
+			}
+		}
 	}
 
 	WT_ERR(__txn_commit_timestamps_assert(session));

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -612,7 +612,7 @@ __wt_txn_commit_timestamp_validate(WT_SESSION_IMPL *session, const char *name,
 		    "%s timestamp %.*s older than oldest timestamp %s",
 		    name, (int)cval->len, cval->str, ts_string[0]);
 	}
-	if (durable_ts && has_stable_ts && ts < stable_ts) {
+	if (durable_ts && has_stable_ts && ts <= stable_ts) {
 		__wt_timestamp_to_string(stable_ts, ts_string[0]);
 		WT_RET_MSG(session, EINVAL,
 		    "%s timestamp %.*s older than stable timestamp %s",

--- a/test/suite/test_las02.py
+++ b/test/suite/test_las02.py
@@ -79,17 +79,17 @@ class test_las02(wttest.WiredTigerTestCase):
             ',stable_timestamp=' + timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
-        self.large_updates(uri, bigvalue, ds, nrows / 3, 1)
+        self.large_updates(uri, bigvalue, ds, nrows / 3, 2)
 
         # Check that all updates are seen
-        self.check(bigvalue, uri, nrows / 3, 1)
+        self.check(bigvalue, uri, nrows / 3, 2)
 
         # Check to see lookaside working with old timestamp
         bigvalue2 = "ddddd" * 100
         self.large_updates(uri, bigvalue2, ds, nrows, 100)
 
         # Check that the new updates are only seen after the update timestamp
-        self.check(bigvalue, uri, nrows / 3, 1)
+        self.check(bigvalue, uri, nrows / 3, 2)
         self.check(bigvalue2, uri, nrows, 100)
 
         # Force out most of the pages by updating a different tree
@@ -107,7 +107,7 @@ class test_las02(wttest.WiredTigerTestCase):
         self.check(bigvalue2, uri, nrows / 2, 200)
 
         # Repeat earlier checks
-        self.check(bigvalue, uri, nrows / 3, 1)
+        self.check(bigvalue, uri, nrows / 3, 2)
         self.check(bigvalue2, uri, nrows, 100)
 
 if __name__ == '__main__':

--- a/test/suite/test_prepare_lookaside01.py
+++ b/test/suite/test_prepare_lookaside01.py
@@ -60,7 +60,7 @@ class test_prepare_lookaside01(wttest.WiredTigerTestCase):
         # Commit some updates to get eviction and lookaside fired up
         bigvalue1 = "bbbbb" * 100
         cursor = self.session.open_cursor(uri)
-        for i in range(1, nsessions * nkeys):
+        for i in range(2, nsessions * nkeys):
             self.session.begin_transaction()
             cursor.set_key(ds.key(nrows + i))
             cursor.set_value(bigvalue1)

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -149,17 +149,17 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # When explicitly set, commit timestamp for a transaction can be earlier
         # than the commit timestamp of an earlier transaction.
         self.session.begin_transaction()
-        c[6] = 6
+        c[7] = 7
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(6))
+            'commit_timestamp=' + timestamp_str(7))
+        self.session.begin_transaction()
+        c[9] = 9
+        self.session.commit_transaction(
+            'commit_timestamp=' + timestamp_str(9))
         self.session.begin_transaction()
         c[8] = 8
         self.session.commit_transaction(
             'commit_timestamp=' + timestamp_str(8))
-        self.session.begin_transaction()
-        c[7] = 7
-        self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(7))
 
         # Read timestamp >= Oldest timestamp
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(7) +
@@ -169,20 +169,20 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 timestamp_str(6)),
                 '/older than oldest timestamp/')
 
-        # c[8] is not visible at read_timestamp < 8
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(7))
-        self.assertEqual(c[6], 6)
+        # c[9] is not visible at read_timestamp < 9
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(8))
         self.assertEqual(c[7], 7)
-        c.set_key(8)
+        self.assertEqual(c[8], 8)
+        c.set_key(9)
         self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND)
         self.session.commit_transaction()
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(8))
-        self.assertEqual(c[6], 6)
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(9))
         self.assertEqual(c[7], 7)
         self.assertEqual(c[8], 8)
+        self.assertEqual(c[9], 9)
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(8))
+            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(9))
         self.session.commit_transaction()
 
         # We can move the oldest timestamp backwards with "force"

--- a/test/suite/test_timestamp15.py
+++ b/test/suite/test_timestamp15.py
@@ -56,7 +56,7 @@ class test_timestamp15(wttest.WiredTigerTestCase, suite_subprocess):
         cur1[1] = 1
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(),
-                '/first commit timestamp \(0,2\) older ' +
+                '/commit timestamp \(0,2\) older ' +
                     'than stable timestamp \(0,3\)/')
 
         # Scenario 2:
@@ -69,7 +69,7 @@ class test_timestamp15(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.timestamp_transaction('commit_timestamp=6')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(),
-                '/first commit timestamp \(0,4\) older ' +
+                '/commit timestamp \(0,4\) older ' +
                     'than stable timestamp \(0,5\)/')
 
         # Scenario 3:
@@ -103,7 +103,7 @@ class test_timestamp15(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.timestamp_transaction('commit_timestamp=4')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(),
-                '/first commit timestamp \(0,4\) older ' +
+                '/commit timestamp \(0,4\) older ' +
                     'than stable timestamp \(0,5\)/')
 
 if __name__ == '__main__':

--- a/test/suite/test_timestamp15.py
+++ b/test/suite/test_timestamp15.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_timestamp15.py
+#   Test various timestamp scenarios for active txns
+#
+
+import random
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_timestamp15(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_timestamp15'
+    uri = 'table:' + tablename
+
+    def test_commit_timestamp_before_stable(self):
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        cur1 = self.session.open_cursor(self.uri)
+        self.conn.set_timestamp('stable_timestamp=1')
+
+        # Scenario 1: A simple case where we start a transaction
+        # specify a commit timestamp then the move the stable timestamp
+        # past the commit timestamp, then attempt to commit.
+        self.session.begin_transaction()
+        self.session.timestamp_transaction('commit_timestamp=2')
+        self.conn.set_timestamp('stable_timestamp=3')
+        cur1[1] = 1
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(),
+                '/first commit timestamp \(0,2\) older ' +
+                    'than stable timestamp \(0,3\)/')
+
+        # Scenario 2:
+        # Specify multiple commit timestamps some being after
+        # the stable timestamp.
+        self.session.begin_transaction()
+        self.session.timestamp_transaction('commit_timestamp=4')
+        self.conn.set_timestamp('stable_timestamp=5')
+        cur1[2] = 2
+        self.session.timestamp_transaction('commit_timestamp=6')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(),
+                '/first commit timestamp \(0,4\) older ' +
+                    'than stable timestamp \(0,5\)/')
+
+        # Scenario 3:
+        # Specify a commit timestamp equal to a stable timestamp.
+        # This is also not legal.
+        self.session.begin_transaction()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.timestamp_transaction('commit_timestamp=5'),
+                '/commit timestamp 5 older than stable timestamp \(0,5\)/')
+        self.session.commit_transaction()
+
+        # Scenario 4:
+        # Ensure that if the transaction is prepared it is not
+        # going to be rejected if a durable timestamp that is
+        # older than the stable timestamp is provided.
+        self.session.begin_transaction()
+        cur1[3] = 3
+        self.session.prepare_transaction('prepare_timestamp=3')
+        self.session.timestamp_transaction('commit_timestamp=4')
+        self.session.timestamp_transaction('durable_timestamp=6')
+        self.session.commit_transaction()
+
+        # Scenario 5:
+        # Given a prepared transaction ensure that first commit
+        # timestamp provided is newer than the stable timestamp
+        # as we are not specifying a durable
+        # timestamp.
+        self.session.begin_transaction()
+        cur1[4] = 4
+        self.session.prepare_transaction('prepare_timestamp=3')
+        self.session.timestamp_transaction('commit_timestamp=4')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(),
+                '/first commit timestamp \(0,4\) older ' +
+                    'than stable timestamp \(0,5\)/')
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
This PR fixes the scenario described in WT-4643, it additionally fixes a bug where the commit timestamp can be set at the stable timestamp. These fixes are tested in the provided python test file.