### PR TITLE
WT-4317 Zero the end of the file if we don't have ftruncate.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -627,6 +627,7 @@ dsrc_stats = [
     BlockStat('block_minor', 'minor version number', 'max_aggregate,no_scale'),
     BlockStat('block_reuse_bytes', 'file bytes available for reuse', 'no_scale,size'),
     BlockStat('block_size', 'file size in bytes', 'no_scale,size'),
+    BlockStat('block_zero', 'number of times zero truncated the file'),
 
     ##########################################
     # Btree statistics

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -572,6 +572,7 @@ extern int __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp) WT_GCC_FUNC_DECL_AT
 extern bool __wt_fsync_background_chk(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_fsync_background(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_close_connection_close(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size, bool is_log) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_os_inmemory(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_fopen(WT_SESSION_IMPL *session, const char *name, uint32_t open_flags, uint32_t flags, WT_FSTREAM **fstrp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -742,6 +742,7 @@ struct __wt_dsrc_stats {
 	int64_t block_major;
 	int64_t block_size;
 	int64_t block_minor;
+	int64_t block_zero;
 	int64_t btree_checkpoint_generation;
 	int64_t btree_column_fix;
 	int64_t btree_column_internal;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5850,356 +5850,358 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BLOCK_SIZE				2020
 /*! block-manager: minor version number */
 #define	WT_STAT_DSRC_BLOCK_MINOR			2021
+/*! block-manager: number of times zero truncated the file */
+#define	WT_STAT_DSRC_BLOCK_ZERO				2022
 /*! btree: btree checkpoint generation */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2022
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2023
 /*!
  * btree: column-store fixed-size leaf pages, only reported if tree_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2023
+#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2024
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2024
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2025
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2025
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2026
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2026
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2027
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2027
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2028
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2028
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2029
 /*! btree: maximum internal page key size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLKEY			2029
+#define	WT_STAT_DSRC_BTREE_MAXINTLKEY			2030
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2030
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2031
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2031
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2032
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2032
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2033
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2033
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2034
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2034
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2035
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2035
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2036
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2036
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2037
 /*! btree: pages rewritten by compaction */
-#define	WT_STAT_DSRC_BTREE_COMPACT_REWRITE		2037
+#define	WT_STAT_DSRC_BTREE_COMPACT_REWRITE		2038
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2038
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2039
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2039
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2040
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2040
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2041
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2041
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2042
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2042
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2043
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2043
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2044
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2044
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2045
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2045
+#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2046
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2046
+#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2047
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2047
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2048
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2048
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2049
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2049
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2050
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2051
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2052
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2053
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2054
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2054
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2055
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2055
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2056
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2056
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2057
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2057
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2058
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2059
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2060
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2061
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2061
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2062
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2062
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2063
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2064
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2065
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2066
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2067
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2067
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2068
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2069
 /*! cache: page written requiring cache overflow records */
-#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2069
+#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2070
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2070
+#define	WT_STAT_DSRC_CACHE_READ				2071
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2071
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2072
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2072
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2073
 /*! cache: pages read into cache requiring cache overflow entries */
-#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2073
+#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2074
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2074
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2075
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2076
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2076
+#define	WT_STAT_DSRC_CACHE_WRITE			2077
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2077
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2078
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2078
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2079
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2080
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2080
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2081
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2081
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2082
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2082
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2083
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2083
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2084
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2084
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2085
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2085
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2086
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2086
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2087
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2087
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2088
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2088
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2089
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2089
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2090
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2090
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2091
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2091
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2092
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2092
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2093
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2093
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2094
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2094
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2095
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2095
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2096
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2096
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2097
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2097
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2098
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2098
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2099
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2099
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2100
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2100
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2101
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2101
+#define	WT_STAT_DSRC_COMPRESS_READ			2102
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2102
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2103
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2103
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2104
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2104
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2105
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2105
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2106
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2106
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2107
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2107
+#define	WT_STAT_DSRC_CURSOR_CACHE			2108
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2108
+#define	WT_STAT_DSRC_CURSOR_CREATE			2109
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2109
+#define	WT_STAT_DSRC_CURSOR_INSERT			2110
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2110
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2111
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2111
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2112
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2112
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2113
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2113
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2114
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2114
+#define	WT_STAT_DSRC_CURSOR_NEXT			2115
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2115
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2116
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2116
+#define	WT_STAT_DSRC_CURSOR_RESTART			2117
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2117
+#define	WT_STAT_DSRC_CURSOR_PREV			2118
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2118
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2119
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2119
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2120
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2120
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2121
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2121
+#define	WT_STAT_DSRC_CURSOR_RESET			2122
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2122
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2123
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2123
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2124
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2124
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2125
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2125
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2126
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2126
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2127
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2127
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2128
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2128
+#define	WT_STAT_DSRC_REC_DICTIONARY			2129
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2129
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2130
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2130
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2131
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2131
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2132
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2132
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2133
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2133
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2134
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2134
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2135
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2135
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2136
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2136
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2137
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2137
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2138
 /*! reconciliation: page checksum matches */
-#define	WT_STAT_DSRC_REC_PAGE_MATCH			2138
+#define	WT_STAT_DSRC_REC_PAGE_MATCH			2139
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2139
+#define	WT_STAT_DSRC_REC_PAGES				2140
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2140
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2141
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2141
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2142
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2142
+#define	WT_STAT_DSRC_SESSION_COMPACT			2143
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2143
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2144
 
 /*!
  * @}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -629,68 +629,6 @@ err:	WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
 }
 
 /*
- * __log_zero --
- *	Zero a log file.
- */
-static int
-__log_zero(WT_SESSION_IMPL *session,
-    WT_FH *fh, wt_off_t start_off, wt_off_t len)
-{
-	WT_CONNECTION_IMPL *conn;
-	WT_DECL_ITEM(zerobuf);
-	WT_DECL_RET;
-	WT_LOG *log;
-	uint32_t allocsize, bufsz, off, partial, wrlen;
-
-	conn = S2C(session);
-	log = conn->log;
-	allocsize = log->allocsize;
-	zerobuf = NULL;
-	if (allocsize < WT_MEGABYTE)
-		bufsz = WT_MEGABYTE;
-	else
-		bufsz = allocsize;
-	/*
-	 * If they're using smaller log files, cap it at the file size.
-	 */
-	if (conn->log_file_max < bufsz)
-		bufsz = (uint32_t)conn->log_file_max;
-	WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
-	memset(zerobuf->mem, 0, zerobuf->memsize);
-	WT_STAT_CONN_INCR(session, log_zero_fills);
-
-	/*
-	 * Read in a chunk starting at the end of the file.  Keep going until
-	 * we reach the beginning or we find a chunk that contains any non-zero
-	 * bytes.  Compare against a known zero byte chunk.
-	 */
-	off = (uint32_t)start_off;
-	while (off < (uint32_t)len) {
-		/*
-		 * Typically we start to zero the file after the log header
-		 * and the bufsz is a sector-aligned size.  So we want to
-		 * align our writes when we can.
-		 */
-		partial = off % bufsz;
-		if (partial != 0)
-			wrlen = bufsz - partial;
-		else
-			wrlen = bufsz;
-		/*
-		 * Check if we're writing a partial amount at the end too.
-		 */
-		if ((uint32_t)len - off < bufsz)
-			wrlen = (uint32_t)len - off;
-		__wt_capacity_throttle(session, wrlen, WT_THROTTLE_LOG);
-		WT_ERR(__wt_write(session,
-		    fh, (wt_off_t)off, wrlen, zerobuf->mem));
-		off += wrlen;
-	}
-err:	__wt_scr_free(session, &zerobuf);
-	return (ret);
-}
-
-/*
  * __log_prealloc --
  *	Pre-allocate a log file.
  */
@@ -710,8 +648,8 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
 	 * and zero the log file based on what is available.
 	 */
 	if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ZERO_FILL))
-		return (__log_zero(session, fh,
-		    log->first_record, conn->log_file_max));
+		return (__wt_file_zero(session, fh,
+		    log->first_record, conn->log_file_max, true));
 
 	/* If configured to not extend the file, we're done. */
 	if (conn->log_extend_len == 0)
@@ -1534,7 +1472,8 @@ __log_truncate_file(WT_SESSION_IMPL *session, WT_FH *log_fh, wt_off_t offset)
 		}
 	}
 
-	return (__log_zero(session, log_fh, offset, conn->log_file_max));
+	return (__wt_file_zero(session,
+	    log_fh, offset, conn->log_file_max, true));
 }
 
 /*

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -500,3 +500,54 @@ __wt_close_connection_close(WT_SESSION_IMPL *session)
 	} WT_TAILQ_SAFE_REMOVE_END
 	return (ret);
 }
+
+/*
+ * __wt_file_zero --
+ *	Zero out the file from offset for size bytes.
+ */
+int
+__wt_file_zero(WT_SESSION_IMPL *session,
+    WT_FH *fh, wt_off_t start_off, wt_off_t size, bool is_log)
+{
+	WT_DECL_ITEM(zerobuf);
+	WT_DECL_RET;
+	WT_THROTTLE_TYPE type;
+	uint64_t bufsz, off, partial, wrlen;
+
+	zerobuf = NULL;
+	bufsz = WT_MIN((uint64_t)size, WT_MEGABYTE);
+	if (is_log) {
+		type = WT_THROTTLE_LOG;
+		WT_STAT_CONN_INCR(session, log_zero_fills);
+	} else {
+		type = WT_THROTTLE_CKPT;
+		WT_STAT_DATA_INCR(session, block_zero);
+	}
+	WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
+	memset(zerobuf->mem, 0, zerobuf->memsize);
+	off = (uint64_t)start_off;
+	while (off < (uint64_t)size) {
+		/*
+		 * We benefit from aligning our writes when we can. Log files
+		 * will typically want to start to zero after the log header
+		 * and the bufsz is a sector-aligned size. So align when
+		 * we can.
+		 */
+		partial = off % bufsz;
+		if (partial != 0)
+			wrlen = bufsz - partial;
+		else
+			wrlen = bufsz;
+		/*
+		 * Check if we're writing a partial amount at the end too.
+		 */
+		if ((uint64_t)size - off < bufsz)
+			wrlen = (uint64_t)size - off;
+		__wt_capacity_throttle(session, wrlen, type);
+		WT_ERR(__wt_write(session,
+		    fh, (wt_off_t)off, (size_t)wrlen, zerobuf->mem));
+		off += wrlen;
+	}
+err:	__wt_scr_free(session, &zerobuf);
+	return (ret);
+}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -25,6 +25,7 @@ static const char * const __stats_dsrc_desc[] = {
 	"block-manager: file major version number",
 	"block-manager: file size in bytes",
 	"block-manager: minor version number",
+	"block-manager: number of times zero truncated the file",
 	"btree: btree checkpoint generation",
 	"btree: column-store fixed-size leaf pages",
 	"btree: column-store internal pages",
@@ -211,6 +212,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
 	stats->block_major = 0;
 	stats->block_size = 0;
 	stats->block_minor = 0;
+	stats->block_zero = 0;
 		/* not clearing btree_checkpoint_generation */
 	stats->btree_column_fix = 0;
 	stats->btree_column_internal = 0;
@@ -375,6 +377,7 @@ __wt_stat_dsrc_aggregate_single(
 	to->block_size += from->block_size;
 	if (from->block_minor > to->block_minor)
 		to->block_minor = from->block_minor;
+	to->block_zero += from->block_zero;
 	to->btree_checkpoint_generation += from->btree_checkpoint_generation;
 	to->btree_column_fix += from->btree_column_fix;
 	to->btree_column_internal += from->btree_column_internal;
@@ -559,6 +562,7 @@ __wt_stat_dsrc_aggregate(
 	to->block_size += WT_STAT_READ(from, block_size);
 	if ((v = WT_STAT_READ(from, block_minor)) > to->block_minor)
 		to->block_minor = v;
+	to->block_zero += WT_STAT_READ(from, block_zero);
 	to->btree_checkpoint_generation +=
 	    WT_STAT_READ(from, btree_checkpoint_generation);
 	to->btree_column_fix += WT_STAT_READ(from, btree_column_fix);


### PR DESCRIPTION
Here's a branch that avoids the salvage problem and zeroes out the end of a table that we wanted to ftruncate but it's not available.