### PR TITLE
WT-4654 Split task for Evergreen Windows build variant to reduce makespan

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1069,7 +1069,14 @@ buildvariants:
   tasks:
     - name: compile
     - name: compile-windows-alt
-    - name: unit-test
+    - name: unit-test-bucket00
+    - name: unit-test-bucket01
+    - name: unit-test-bucket02
+    - name: unit-test-bucket03
+    - name: unit-test-bucket04
+    - name: unit-test-bucket05
+    - name: unit-test-bucket06
+    - name: unit-test-bucket07
     #- name: format  - Enable when we have a solution for hangs and crashses
     - name: fops
 


### PR DESCRIPTION
This change is to split the unit-test (python test suite) into 8 buckets for Windows build variant, the same as what we did for the Ubuntu build variant before. With this change, the longest running task in the Windows variant finished within 10 mins (used to be over 40 mins). Patch build is [here](https://evergreen.mongodb.com/build/wiredtiger_windows_64_patch_07a346d2d683cc8a42c0a29753619476cd09314c_5c92e2fc3627e071fa07bd1f_19_03_21_01_03_57).