### PR TITLE
WT-4650 Fix incorrect WT_ASSERT identified by Coverity

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1142,11 +1142,13 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 			    session, saved_key, las_key.data, las_key.size));
 
 			/*
-			 * Never expect an entry with prepare locked state or
-			 * with durable timestamp as max timestamp or with
-			 * in-progress prepare state and non-zero durable
-			 * timestamp. In all other cases the durable timestamp
-			 * is higher or same as the las timestamp.
+			 * Expect an update entry with:
+			 *	1. not in a prepare locked state
+			 *	2. durable timestamp as not max timestamp.
+			 *	3. for an in-progress prepared update, durable
+			 *	timestamp should be zero.
+			 *	4. no restriction on durable timestamp value
+			 *	for other updates.
 			 */
 			WT_ASSERT(session,
 			    prepare_state != WT_PREPARE_LOCKED &&

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1149,8 +1149,8 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 			 * is higher or same as the las timestamp.
 			 */
 			WT_ASSERT(session,
-			    prepare_state != WT_PREPARE_LOCKED ||
-			    durable_timestamp != WT_TS_MAX ||
+			    prepare_state != WT_PREPARE_LOCKED &&
+			    durable_timestamp != WT_TS_MAX &&
 			    (prepare_state != WT_PREPARE_INPROGRESS ||
 			    durable_timestamp == 0));
 


### PR DESCRIPTION
This expression would previously always evaluate to `true` meaning that the assertion was not checking anything. I don't have enough context of the surrounding code to understand what is happening here but I deduced what the assertion should be based on the comment above it.