### PR TITLE
WT-4623 Remove barriers from transaction ID allocation.

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -129,8 +129,6 @@ struct __wt_txn_global {
 	bool oldest_is_pinned;
 	bool stable_is_pinned;
 
-	WT_SPINLOCK id_lock;
-
 	/* Protects the active transaction states. */
 	WT_RWLOCK rwlock;
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -994,11 +994,11 @@ __wt_txn_id_alloc(WT_SESSION_IMPL *session, bool publish)
 	 * increment here.
 	 */
 	if (publish) {
-		WT_PUBLISH(txn_state->is_allocating, true);
+		txn_state->is_allocating = true;
 		WT_PUBLISH(txn_state->id, txn_global->current);
 		id = __wt_atomic_addv64(&txn_global->current, 1) - 1;
 		session->txn.id = id;
-		WT_PUBLISH(txn_state->id, id);
+		txn_state->id = id;
 		WT_PUBLISH(txn_state->is_allocating, false);
 	} else
 		id = __wt_atomic_addv64(&txn_global->current, 1) - 1;


### PR DESCRIPTION
Also try yielding after spinning, evidence suggests this can help on some single-socket servers.