### PR TITLE
WT-4700 Python3: use the Python version to build from a single source with Python2/Python3.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -333,7 +333,7 @@ if GetOption("lang-python"):
             "-O",
             "-nodefaultctor",
             "-nodefaultdtor",
-            "-DPY_MAJOR_VERSION=" + pythonMajorVersion
+            "-DPY_MAJOR_VERSION=" + str(pythonMajorVersion)
             ])
     # Ignore warnings in swig-generated code.
     pythonEnv['CFLAGS'].remove("/WX")

--- a/SConstruct
+++ b/SConstruct
@@ -325,6 +325,7 @@ if GetOption("lang-python"):
         print "The Python Interpreter must be 64-bit in order to build the python bindings"
         Exit(1)
 
+    pythonMajorVersion = sys.version_info.major
     pythonEnv = env.Clone()
     pythonEnv.Append(SWIGFLAGS=[
             "-python",
@@ -332,6 +333,7 @@ if GetOption("lang-python"):
             "-O",
             "-nodefaultctor",
             "-nodefaultdtor",
+            "-DPY_MAJOR_VERSION=" + pythonMajorVersion
             ])
     # Ignore warnings in swig-generated code.
     pythonEnv['CFLAGS'].remove("/WX")

--- a/lang/python/Makefile.am
+++ b/lang/python/Makefile.am
@@ -3,6 +3,8 @@ PYDIRS = -t $(abs_builddir) -I $(abs_top_srcdir):$(abs_top_builddir) -L $(abs_to
 PYDST = $(abs_builddir)/wiredtiger
 PYFILES = $(PYDST)/fpacking.py $(PYDST)/intpacking.py $(PYDST)/packing.py \
 	$(PYDST)/__init__.py
+PY_MAJOR_VERSION := $$($(PYTHON) -c \
+	'import sys; print(int(sys.version_info.major))')
 
 all-local: _wiredtiger.so pyfiles
 
@@ -10,7 +12,9 @@ all-local: _wiredtiger.so pyfiles
 # in release packages.
 $(PYSRC)/wiredtiger_wrap.c $(PYSRC)/wiredtiger.py: $(top_srcdir)/src/include/wiredtiger.in $(PYSRC)/wiredtiger.i
 	(cd $(PYSRC) && \
-	    $(SWIG) -python -threads -O -Wall -nodefaultctor -nodefaultdtor -I$(abs_top_builddir) wiredtiger.i)
+	    $(SWIG) -python -DPY_MAJOR_VERSION=$(PY_MAJOR_VERSION) \
+	    -threads -O -Wall -nodefaultctor -nodefaultdtor \
+	    -I$(abs_top_builddir) wiredtiger.i)
 
 _wiredtiger.so: $(top_builddir)/libwiredtiger.la $(PYSRC)/wiredtiger_wrap.c
 	(cd $(PYSRC) && \

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -612,12 +612,12 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, compare, (self, other))
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, equals, (self, other))
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 
-/*
- * SWIG magic to turn Python byte strings into data / size.
- * For Python3, we need to use it like this:
- *   %apply (char *STRING, int LENGTH) { (char *data, int size) };
- */
+/* SWIG magic to turn Python byte strings into data / size. */
+#if PY_MAJOR_VERSION >= 3
+	%apply (char *STRING, int LENGTH) { (char *data, int size) };
+#else
 %apply (char *STRING, int LENGTH) { (void *data, int size) };
+#endif
 
 /* Handle binary data returns from get_key/value -- avoid cstring.i: it creates a list of returns. */
 %typemap(in,numinputs=0) (char **datap, int *sizep) (char *data, int size) { $1 = &data; $2 = &size; }


### PR DESCRIPTION
Builds using whatever the current python is.  On *nix, uses the python found in configuration; on Windows, uses the python used to run SConstruct.