### PR TITLE
WT-4711 Dist tools should ignore generated file wiredtiger.py.

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -146,7 +146,7 @@ EOF
 	}
 
 	# Add optional extras
-	EXTRAS="../lang/java/src/com/wiredtiger/db ../lang/python/wiredtiger.py"
+	EXTRAS="../lang/java/src/com/wiredtiger/db"
 	EXTRA_INPUT=""
 	for f in $EXTRAS ; do
 		[ -e "$f" ] && EXTRA_INPUT="$EXTRA_INPUT ../$f"

--- a/dist/s_python
+++ b/dist/s_python
@@ -10,6 +10,7 @@ cd ..
 egrep '	' `find . -name '*.py'` |
     sed -e 's/:.*//' \
 	-e '/__init__.py/d' \
+	-e '/\/wiredtiger.py/d' \
 	-e '/src\/docs\/tools\/doxypy.py/d' |
     sort -u |
     sed 's/^/	/' > $t

--- a/src/docs/tools/fixlinks.py
+++ b/src/docs/tools/fixlinks.py
@@ -59,8 +59,8 @@ def process(source):
           (m.group(0), m.group(1), m.group(1), m.group(2))), source)
 
     # Replace "self, handle" with "self" -- these are typedef'ed away
-    source = re.sub(r'(\s+#.*self),
-                    (?:connection|cursor|session)', r'\1', source)
+    source = re.sub(r'(\s+#.*self),' +
+                    r'(?:connection|cursor|session)', r'\1', source)
     return source
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed error in fixlinks, called by pyfilter.