### PR TITLE
WT-4698 Fixes for modify tests to work with Python3.

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -234,7 +234,8 @@ from .packing import pack, unpack
 			SWIG_exception_fail(SWIG_AttributeError,
 			    "Modify.data bad value");
 		}
-		if (__wt_malloc(NULL, datasize, &modarray[i].data.data) != 0) {
+		if (datasize != 0 &&
+		    __wt_malloc(NULL, datasize, &modarray[i].data.data) != 0) {
 			Py_DECREF(dataobj);
 			Py_DECREF(modobj);
 			freeModifyArray(modarray);

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -234,7 +234,13 @@ from .packing import pack, unpack
 			SWIG_exception_fail(SWIG_AttributeError,
 			    "Modify.data bad value");
 		}
-		modarray[i].data.data = malloc(datasize);
+		if (__wt_malloc(NULL, datasize, &modarray[i].data.data) != 0) {
+			Py_DECREF(dataobj);
+			Py_DECREF(modobj);
+			freeModifyArray(modarray);
+			SWIG_exception_fail(SWIG_AttributeError,
+			    "Modify.data failed malloc");
+		}
 		memcpy(modarray[i].data.data, datadata, datasize);
 		modarray[i].data.size = datasize;
 		Py_DECREF(dataobj);
@@ -1198,6 +1204,7 @@ static int unpackBytesOrString(PyObject *obj, void **datap, size_t *sizep)
 
 	if (PyBytes_AsStringAndSize(obj, &data, &sz) < 0) {
 #if PY_VERSION_HEX >= 0x03000000
+		PyErr_Clear();
 		if ((data = PyUnicode_AsUTF8AndSize(obj, &sz)) != 0)
 			*sizep = strlen((char *)data) + 1;
 		else


### PR DESCRIPTION
- clear Python error code if we guess wrong on what type we are decoding
- fix malloc failure condition
- fixed modify and calc_modify tests to use bytes type for 'u'
- changed calc_modify test to test both 'u' and 'S' types.