### PR TITLE
WT-4575 Review usages of __wt_errx vs __wt_err

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -639,12 +639,12 @@ __wt_btree_tree_open(
 	 * Try to provide a helpful failure message.
 	 */
 	if (ret != 0 && WT_IS_METADATA(session->dhandle)) {
-		__wt_errx(session,
+		__wt_err(session, ret,
 		    "WiredTiger has failed to open its metadata");
-		__wt_errx(session, "This may be due to the database"
+		__wt_err(session, ret, "This may be due to the database"
 		    " files being encrypted, being from an older"
 		    " version or due to corruption on disk");
-		__wt_errx(session, "You should confirm that you have"
+		__wt_err(session, ret, "You should confirm that you have"
 		    " opened the database with the correct options including"
 		    " all encryption and compression options");
 	}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2605,12 +2605,12 @@ err:	WT_STAT_CONN_INCR(session, log_scans);
 	 * a helpful failure message.
 	 */
 	if (ret != 0 && firstrecord && LF_ISSET(WT_LOGSCAN_RECOVER)) {
-		__wt_errx(session,
+		__wt_err(session, ret,
 		    "WiredTiger is unable to read the recovery log.");
-		__wt_errx(session, "This may be due to the log"
+		__wt_err(session, ret, "This may be due to the log"
 		    " files being encrypted, being from an older"
 		    " version or due to corruption on disk");
-		__wt_errx(session, "You should confirm that you have"
+		__wt_err(session, ret, "You should confirm that you have"
 		    " opened the database with the correct options including"
 		    " all encryption and compression options");
 	}

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -348,7 +348,8 @@ err:	/*
 		WT_ASSERT(session, unroll || saved_ret != 0 ||
 		    session->txn.mod_count == 0);
 #ifdef WT_ENABLE_SCHEMA_TXN
-		__wt_errx(session, "TRACK: Abort internal schema txn");
+		__wt_err(session, saved_ret,
+		    "TRACK: Abort internal schema txn");
 		WT_TRET(__wt_txn_rollback(session, NULL));
 #endif
 	}

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -299,9 +299,9 @@ __handle_close(WT_SESSION_IMPL *session, WT_FH *fh, bool locked)
 	conn = S2C(session);
 
 	if (fh->ref != 0) {
-		__wt_errx(session,
-		    "Closing a file handle with open references: %s", fh->name);
 		WT_TRET(EBUSY);
+		__wt_err(session, ret,
+		    "Closing a file handle with open references: %s", fh->name);
 	}
 
 	/* Remove from the list. */

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -299,8 +299,7 @@ __handle_close(WT_SESSION_IMPL *session, WT_FH *fh, bool locked)
 	conn = S2C(session);
 
 	if (fh->ref != 0) {
-		WT_TRET(EBUSY);
-		__wt_err(session, ret,
+		__wt_errx(session,
 		    "Closing a file handle with open references: %s", fh->name);
 	}
 

--- a/src/os_win/os_dir.c
+++ b/src/os_win/os_dir.c
@@ -53,10 +53,11 @@ __directory_list_worker(WT_FILE_SYSTEM *file_system,
 	findhandle = FindFirstFileW(pathbuf_wide->data, &finddata);
 	if (findhandle == INVALID_HANDLE_VALUE) {
 		windows_error = __wt_getlasterror();
-		__wt_errx(session,
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret,
 		    "%s: directory-list: FindFirstFile: %s",
 		    pathbuf->data, __wt_formatmessage(session, windows_error));
-		WT_ERR(__wt_map_windows_error(windows_error));
+		WT_ERR(ret);
 	}
 
 	for (count = 0;;) {
@@ -89,10 +90,11 @@ skip:		if (FindNextFileW(findhandle, &finddata) != 0)
 		windows_error = __wt_getlasterror();
 		if (windows_error == ERROR_NO_MORE_FILES)
 			break;
-		__wt_errx(session,
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret,
 		    "%s: directory-list: FindNextFileW: %s",
 		    pathbuf->data, __wt_formatmessage(session, windows_error));
-		WT_ERR(__wt_map_windows_error(windows_error));
+		WT_ERR(ret);
 	}
 
 	*dirlistp = entries;
@@ -101,12 +103,12 @@ skip:		if (FindNextFileW(findhandle, &finddata) != 0)
 err:	if (findhandle != INVALID_HANDLE_VALUE)
 		if (FindClose(findhandle) == 0) {
 			windows_error = __wt_getlasterror();
-			__wt_errx(session,
+			if (ret == 0)
+				ret = __wt_map_windows_error(windows_error);
+			__wt_err(session, ret,
 			    "%s: directory-list: FindClose: %s",
 			    pathbuf->data,
 			    __wt_formatmessage(session, windows_error));
-			if (ret == 0)
-				ret = __wt_map_windows_error(windows_error);
 		}
 
 	__wt_free(session, dir_copy);

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -17,7 +17,7 @@
 			ret = __wt_map_windows_error(windows_error);	\
 			if (windows_error == ERROR_ACCESS_DENIED) {	\
 				if (__retry == 0)			\
-					__wt_errx(session,		\
+					__wt_err(session, ret,		\
 	"Access denied to a file owned by WiredTiger."			\
 	" It will attempt a few more times. You should confirm"		\
 	" no other processes, such as virus scanners, are"		\

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -17,7 +17,7 @@
 			ret = __wt_map_windows_error(windows_error);	\
 			if (windows_error == ERROR_ACCESS_DENIED) {	\
 				if (__retry == 0)			\
-					__wt_err(session, ret,		\
+					__wt_errx(session,		\
 	"Access denied to a file owned by WiredTiger."			\
 	" It will attempt a few more times. You should confirm"		\
 	" no other processes, such as virus scanners, are"		\

--- a/src/os_win/os_getenv.c
+++ b/src/os_win/os_getenv.c
@@ -15,6 +15,7 @@
 int
 __wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
 {
+	WT_DECL_RET;
 	DWORD size, windows_error;
 
 	*envp = NULL;
@@ -29,8 +30,9 @@ __wt_getenv(WT_SESSION_IMPL *session, const char *variable, const char **envp)
 		return (0);
 
 	windows_error = __wt_getlasterror();
-	__wt_errx(session,
+	ret = __wt_map_windows_error(windows_error);
+	__wt_err(session, ret,
 	    "GetEnvironmentVariableA: %s: %s",
 	    variable, __wt_formatmessage(session, windows_error));
-	return (__wt_map_windows_error(windows_error));
+	return (ret);
 }

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -120,7 +120,9 @@ skipping:		*signalled = false;
 	if (sleepret != 0)
 		return;
 
-	__wt_errx(session, "SleepConditionVariableCS: %s: %s",
+	__wt_err(session,
+	    __wt_map_windows_error(windows_error),
+	    "SleepConditionVariableCS: %s: %s",
 	    cond->name, __wt_formatmessage(session, windows_error));
 	WT_PANIC_MSG(session, __wt_map_windows_error(windows_error),
 	    "SleepConditionVariableCS: %s", cond->name);

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -58,7 +58,8 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t *tid)
 	    WaitForSingleObject(tid->id, INFINITE)) != WAIT_OBJECT_0) {
 		if (windows_error == WAIT_FAILED)
 			windows_error = __wt_getlasterror();
-		__wt_errx(session, "thread join: WaitForSingleObject: %s",
+		__wt_err(session, __wt_map_windows_error(windows_error),
+		    "thread join: WaitForSingleObject: %s",
 		    __wt_formatmessage(session, windows_error));
 
 		/* If we fail to wait, we will leak handles, do not continue. */
@@ -67,9 +68,10 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t *tid)
 
 	if (CloseHandle(tid->id) == 0) {
 		windows_error = __wt_getlasterror();
-		__wt_errx(session, "thread join: CloseHandle: %s",
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret, "thread join: CloseHandle: %s",
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return (ret);
 	}
 
 	return (0);

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -40,6 +40,7 @@ __wt_thread_create(WT_SESSION_IMPL *session,
 int
 __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t *tid)
 {
+	WT_DECL_RET;
 	DWORD windows_error;
 
 	/* Only attempt to join if thread was created successfully */

--- a/src/os_win/os_utf8.c
+++ b/src/os_win/os_utf8.c
@@ -16,6 +16,7 @@ int
 __wt_to_utf16_string(
     WT_SESSION_IMPL *session, const char *utf8, WT_ITEM **outbuf)
 {
+	WT_DECL_RET;
 	DWORD windows_error;
 	int bufferSize;
 
@@ -23,9 +24,10 @@ __wt_to_utf16_string(
 	windows_error = __wt_getlasterror();
 
 	if (bufferSize == 0 && windows_error != ERROR_INSUFFICIENT_BUFFER) {
-		__wt_errx(session, "MultiByteToWideChar: %s",
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret, "MultiByteToWideChar: %s",
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return (ret);
 	}
 
 	WT_RET(__wt_scr_alloc(session, bufferSize * sizeof(wchar_t), outbuf));
@@ -35,9 +37,10 @@ __wt_to_utf16_string(
 	if (bufferSize == 0) {
 		windows_error = __wt_getlasterror();
 		__wt_scr_free(session, outbuf);
-		__wt_errx(session, "MultiByteToWideChar: %s",
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret, "MultiByteToWideChar: %s",
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return (ret);
 	}
 
 	(*outbuf)->size = bufferSize;
@@ -52,6 +55,7 @@ int
 __wt_to_utf8_string(
     WT_SESSION_IMPL *session, const wchar_t *wide, WT_ITEM **outbuf)
 {
+	WT_DECL_RET;
 	DWORD windows_error;
 	int bufferSize;
 
@@ -60,9 +64,10 @@ __wt_to_utf8_string(
 	windows_error = __wt_getlasterror();
 
 	if (bufferSize == 0 && windows_error != ERROR_INSUFFICIENT_BUFFER) {
-		__wt_errx(session, "WideCharToMultiByte: %s",
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret, "WideCharToMultiByte: %s",
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return (ret);
 	}
 
 	WT_RET(__wt_scr_alloc(session, bufferSize, outbuf));
@@ -72,9 +77,10 @@ __wt_to_utf8_string(
 	if (bufferSize == 0) {
 		windows_error = __wt_getlasterror();
 		__wt_scr_free(session, outbuf);
-		__wt_errx(session, "WideCharToMultiByte: %s",
+		ret = __wt_map_windows_error(windows_error);
+		__wt_err(session, ret, "WideCharToMultiByte: %s",
 		    __wt_formatmessage(session, windows_error));
-		return (__wt_map_windows_error(windows_error));
+		return (ret);
 	}
 
 	(*outbuf)->size = bufferSize;


### PR DESCRIPTION
I did a quick review of places where we use `__wt_errx` and switched them over to `__wt_err` and supplied an error code when applicable.