### PR TITLE
WT-4724 Use /bin/bash for the script.

### DIFF
--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # wtperf_run.sh - run wtperf regression tests on the Jenkins platform.
 #


### PR DESCRIPTION
@ddanderson Please review this tiny change to use `bash` for this shell script instead of whatever system's default `sh`. The other scripts in the `runners` directory already did the same.