### PR TITLE
WT-4721 Add verbose output for failures in the wt2853_perf test.

### DIFF
--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -202,7 +202,7 @@ main(int argc, char *argv[])
 		    "ERROR: %d failures when a single commit"
 		    " took more than %d seconds.\n"
 		    "This may indicate a real problem or a"
-		    " particularly slow machine\n", nfail, MAX_GAP);
+		    " particularly slow machine.\n", nfail, MAX_GAP);
 	testutil_assert(nfail == 0);
 	testutil_progress(opts, "cleanup starting");
 	testutil_cleanup(opts);

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -193,6 +193,16 @@ main(int argc, char *argv[])
 		nfail += get_args[i].nfail;
 	}
 
+	/*
+	 * Note that slow machines can be skipped for this test.
+	 * See the bypass code earlier.
+	 */
+	if (nfail != 0)
+		fprintf(stderr,
+		    "ERROR: %d failures when a single commit"
+		    " took more than %d seconds.\n"
+		    "This may indicate a real problem or a"
+		    " particularly slow machine\n", nfail, MAX_GAP);
 	testutil_assert(nfail == 0);
 	testutil_progress(opts, "cleanup starting");
 	testutil_cleanup(opts);


### PR DESCRIPTION
This is helpful since failures may naturally occur with slow machines.