### PR TITLE
WT-4717 Remove usages of "round_to_oldest" configuration

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -532,11 +532,6 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 	if (cval.val)
 		F_SET(txn, WT_TXN_IGNORE_PREPARE);
 
-	/* Check if read timestamp to be rounded up to the oldest timestamp. */
-	WT_RET(__wt_config_gets_def(session, cfg, "round_to_oldest", 0, &cval));
-	if (cval.val)
-		F_SET(txn, WT_TXN_TS_ROUND_READ);
-
 	/*
 	 * Check if the prepare timestamp and the commit timestamp of a
 	 * prepared transaction need to be rounded up.

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -950,7 +950,6 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 {
 	WT_CONFIG_ITEM cval;
 	WT_DECL_RET;
-	WT_TXN *txn = &session->txn;
 	wt_timestamp_t ts;
 
 	WT_TRET(__wt_txn_context_check(session, true));

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -955,11 +955,6 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
 
 	WT_TRET(__wt_txn_context_check(session, true));
 
-	/* Look for round_to_oldest configuration. */
-	ret = __wt_config_gets_def(session, cfg, "round_to_oldest", 0, &cval);
-	if (cval.val)
-		F_SET(txn, WT_TXN_TS_ROUND_READ);
-
 	/* Look for a commit timestamp. */
 	ret = __wt_config_gets_def(session, cfg, "commit_timestamp", 0, &cval);
 	WT_RET_NOTFOUND_OK(ret);


### PR DESCRIPTION
Coverity was complaining about the invocation in `txn_timestamp.c` due to not reading the value of `ret`. This configuration was removed as part of #4550, so I believe the correct solution is to just remove all references to this config item.