### PR TITLE
WT-4309 Increase the maximum expected LAS test reads

### DIFF
--- a/test/suite/test_las03.py
+++ b/test/suite/test_las03.py
@@ -96,7 +96,7 @@ class test_las03(wttest.WiredTigerTestCase):
             # Since we're dealing with eviction concurrent with checkpoints
             # and skewing is controlled by a heuristic, we can't put too tight
             # a bound on this.
-            self.assertLessEqual(las_reads, 100)
+            self.assertLessEqual(las_reads, 200)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
From my reading of the comment above, the failing assertion is a ballpark figure to ensure that the number of LAS reads is not out of control. The two test failures I've been able to inspect (the remaining ones have had their logs cleared) have failed with LAS reads of `120`, `130` and `166`. So `200` seems safe to me.

@michaelcahill 
- How did we arrive at `100` to begin with?
- Do you think that `200` is still tight enough to be a useful assertion? Or do you feel that this is unreasonably high.