### PR TITLE
WT-4748 internal eviction flag handling could be simplified

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -224,7 +224,7 @@ __wt_compact(WT_SESSION_IMPL *session)
 	}
 
 err:	if (ref != NULL)
-		WT_TRET(__wt_page_release(session, ref, 0));
+		WT_TRET(__wt_page_release(session, ref, false));
 
 	return (ret);
 }

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,7 +81,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		}
 
 		(void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
-		ret = __wt_evict(session, ref, previous_state, 0);
+		ret = __wt_evict(session, ref, previous_state, false, false);
 		(void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);
 		WT_RET_BUSY_OK(ret);
 		ret = 0;

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -832,7 +832,7 @@ __btree_get_last_recno(WT_SESSION_IMPL *session)
 	btree->last_recno = page->type == WT_PAGE_COL_VAR ?
 	    __col_var_last_recno(next_walk) : __col_fix_last_recno(next_walk);
 
-	return (__wt_page_release(session, next_walk, 0));
+	return (__wt_page_release(session, next_walk, false));
 }
 
 /*

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -196,7 +196,8 @@ restart:	/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */
-		WT_RET(__wt_page_release(session, current, flags));
+		WT_RET(__wt_page_release(
+		    session, current, LF_ISSET(WT_READ_NO_SPLIT)));
 	}
 
 	/* Search the internal pages of the tree. */
@@ -250,7 +251,8 @@ restart:	/*
 			if (--retry > 0)
 				goto restart;
 
-			WT_RET(__wt_page_release(session, current, flags));
+			WT_RET(__wt_page_release(
+			    session, current, LF_ISSET(WT_READ_NO_SPLIT)));
 			return (WT_NOTFOUND);
 		}
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -774,7 +774,8 @@ read:			/*
 			if (force_attempts < 10 &&
 			    __evict_force_check(session, ref)) {
 				++force_attempts;
-				ret = __wt_page_release_evict(session, ref, 0);
+				ret =
+				__wt_page_release_evict(session, ref, false);
 				/* If forced eviction fails, stall. */
 				if (ret == EBUSY) {
 					WT_NOT_READ(ret, 0);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1299,13 +1299,13 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 	page->pg_var = save_col_var;
 	page->entries = save_entries;
 
-	ret = __wt_page_release(session, ref, 0);
+	ret = __wt_page_release(session, ref, false);
 	if (ret == 0)
 		ret = __wt_evict(session, ref, WT_REF_MEM,
 		    WT_EVICT_CALL_CLOSING);
 
 	if (0) {
-err:		WT_TRET(__wt_page_release(session, ref, 0));
+err:		WT_TRET(__wt_page_release(session, ref, false));
 	}
 
 	return (ret);
@@ -2029,13 +2029,13 @@ __slvg_row_build_leaf(
 	 * Discard our hazard pointer and evict the page, updating the
 	 * parent's reference.
 	 */
-	ret = __wt_page_release(session, ref, 0);
+	ret = __wt_page_release(session, ref, false);
 	if (ret == 0)
 		ret = __wt_evict(session, ref, WT_REF_MEM,
 		    WT_EVICT_CALL_CLOSING);
 
 	if (0) {
-err:		WT_TRET(__wt_page_release(session, ref, 0));
+err:		WT_TRET(__wt_page_release(session, ref, false));
 	}
 	__wt_scr_free(session, &key);
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -328,8 +328,8 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 	 */
 	if (ss->root_ref.page != NULL) {
 		btree->ckpt = ckptbase;
-		ret = __wt_evict(session, &ss->root_ref, WT_REF_MEM,
-		    WT_EVICT_CALL_CLOSING);
+		ret = __wt_evict(
+		    session, &ss->root_ref, WT_REF_MEM, true, false);
 		ss->root_ref.page = NULL;
 		btree->ckpt = NULL;
 	}
@@ -1301,8 +1301,7 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 
 	ret = __wt_page_release(session, ref, false);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, WT_REF_MEM,
-		    WT_EVICT_CALL_CLOSING);
+		ret = __wt_evict(session, ref, WT_REF_MEM, true, false);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, false));
@@ -2031,8 +2030,7 @@ __slvg_row_build_leaf(
 	 */
 	ret = __wt_page_release(session, ref, false);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, WT_REF_MEM,
-		    WT_EVICT_CALL_CLOSING);
+		ret = __wt_evict(session, ref, WT_REF_MEM, true, false);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, false));

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -144,7 +144,7 @@ __split_verify_root(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 		__split_verify_intl_key_order(session, ref->page);
 
-		WT_ERR(__wt_page_release(session, ref, read_flags));
+		WT_ERR(__wt_page_release(session, ref, false));
 	} WT_INTL_FOREACH_END;
 
 	return (0);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -67,14 +67,16 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_PAGE *page)
  *	Duplicate a tree walk point.
  */
 static inline int
-__sync_dup_walk(WT_SESSION_IMPL *session, WT_REF *walk, WT_REF **dupp)
+__sync_dup_walk(
+    WT_SESSION_IMPL *session, WT_REF *walk, uint32_t flags, WT_REF **dupp)
 {
 	WT_REF *old;
 	bool busy;
 
 	if ((old = *dupp) != NULL) {
 		*dupp = NULL;
-		WT_RET(__wt_page_release(session, old, false));
+		WT_RET(__wt_page_release(
+		    session, old, LF_ISSET(WT_READ_NO_SPLIT)));
 	}
 
 	/* It is okay to duplicate a walk before it starts. */
@@ -254,7 +256,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		LF_SET(WT_READ_LOOKASIDE | WT_READ_WONT_NEED);
 
 		for (;;) {
-			WT_ERR(__sync_dup_walk(session, walk, &prev));
+			WT_ERR(__sync_dup_walk(session, walk, flags, &prev));
 			WT_ERR(__wt_tree_walk(session, &walk, flags));
 
 			if (walk == NULL)
@@ -371,8 +373,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	}
 
 err:	/* On error, clear any left-over tree walk. */
-	WT_TRET(__wt_page_release(session, walk, false));
-	WT_TRET(__wt_page_release(session, prev, false));
+	WT_TRET(__wt_page_release(session, walk, LF_ISSET(WT_READ_NO_SPLIT)));
+	WT_TRET(__wt_page_release(session, prev, LF_ISSET(WT_READ_NO_SPLIT)));
 
 	/*
 	 * If we got a snapshot in order to write pages, and there was no

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -560,7 +560,7 @@ celltype_err:		WT_RET_MSG(session, WT_ERROR,
 			++vs->depth;
 			WT_RET(__wt_page_in(session, child_ref, 0));
 			ret = __verify_tree(session, child_ref, unpack, vs);
-			WT_TRET(__wt_page_release(session, child_ref, 0));
+			WT_TRET(__wt_page_release(session, child_ref, false));
 			--vs->depth;
 			WT_RET(ret);
 
@@ -595,7 +595,7 @@ celltype_err:		WT_RET_MSG(session, WT_ERROR,
 			++vs->depth;
 			WT_RET(__wt_page_in(session, child_ref, 0));
 			ret = __verify_tree(session, child_ref, unpack, vs);
-			WT_TRET(__wt_page_release(session, child_ref, 0));
+			WT_TRET(__wt_page_release(session, child_ref, false));
 			--vs->depth;
 			WT_RET(ret);
 

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -284,12 +284,13 @@ __tree_walk_internal(WT_SESSION_IMPL *session,
 	WT_REF *couple, *ref, *ref_orig;
 	uint64_t restart_sleep, restart_yield, swap_sleep, swap_yield;
 	uint32_t current_state, slot;
-	bool empty_internal, prev, skip;
+	bool empty_internal, nosplit, prev, skip;
 
 	btree = S2BT(session);
 	pindex = NULL;
 	restart_sleep = restart_yield = swap_sleep = swap_yield = 0;
 	empty_internal = false;
+	nosplit = LF_ISSET(WT_READ_NO_SPLIT);
 
 	/*
 	 * We're not supposed to walk trees without root pages. As this has not
@@ -360,7 +361,7 @@ restart:		/*
 			 */
 			__wt_spin_backoff(&restart_yield, &restart_sleep);
 
-			WT_ERR(__wt_page_release(session, couple, flags));
+			WT_ERR(__wt_page_release(session, couple, nosplit));
 			couple = NULL;
 		}
 
@@ -581,8 +582,8 @@ descend:		/*
 
 done:
 err:
-	WT_TRET(__wt_page_release(session, couple, flags));
-	WT_TRET(__wt_page_release(session, ref_orig, flags));
+	WT_TRET(__wt_page_release(session, couple, nosplit));
+	WT_TRET(__wt_page_release(session, ref_orig, nosplit));
 	WT_LEAVE_PAGE_INDEX(session);
 	return (ret);
 }

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -121,7 +121,7 @@ restart:	/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */
-		WT_RET(__wt_page_release(session, current, 0));
+		WT_RET(__wt_page_release(session, current, false));
 	}
 
 	/* Search the internal pages of the tree. */

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -281,7 +281,7 @@ restart:	/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */
-		WT_RET(__wt_page_release(session, current, 0));
+		WT_RET(__wt_page_release(session, current, false));
 		skiphigh = skiplow = 0;
 	}
 
@@ -627,6 +627,6 @@ leaf_match:	cbt->compare = 0;
 
 	return (0);
 
-err:	WT_TRET(__wt_page_release(session, current, 0));
+err:	WT_TRET(__wt_page_release(session, current, false));
 	return (ret);
 }

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -138,8 +138,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	if (0) {
 err:		/* On error, clear any left-over tree walk. */
 		if (next_ref != NULL)
-			WT_TRET(__wt_page_release(
-			    session, next_ref, walk_flags));
+			WT_TRET(__wt_page_release(session, next_ref, false));
 	}
 
 	return (ret);

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -115,8 +115,8 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * Ensure the ref state is restored to the previous
 			 * value if eviction fails.
 			 */
-			WT_ERR(__wt_evict(session, ref, ref->state,
-			    WT_EVICT_CALL_CLOSING));
+			WT_ERR(__wt_evict(
+			    session, ref, ref->state, true, false));
 			break;
 		case WT_SYNC_DISCARD:
 			/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2317,7 +2317,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	__wt_cache_read_gen_bump(session, ref->page);
 
 	WT_WITH_BTREE(session, btree,
-	    ret = __wt_evict(session, ref, previous_state, 0));
+	    ret = __wt_evict(session, ref, previous_state, false, false));
 
 	(void)__wt_atomic_subv32(&btree->evict_busy, 1);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -825,7 +825,8 @@ __evict_clear_walk(WT_SESSION_IMPL *session)
 	btree->evict_ref = NULL;
 
 	WT_WITH_DHANDLE(cache->walk_session, session->dhandle,
-	    (ret = __wt_page_release(cache->walk_session, ref, false)));
+	    (ret = __wt_page_release(cache->walk_session,
+	    ref, WT_READ_NO_EVICT)));
 	return (ret);
 }
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -825,8 +825,7 @@ __evict_clear_walk(WT_SESSION_IMPL *session)
 	btree->evict_ref = NULL;
 
 	WT_WITH_DHANDLE(cache->walk_session, session->dhandle,
-	    (ret = __wt_page_release(cache->walk_session,
-	    ref, WT_READ_NO_EVICT)));
+	    (ret = __wt_page_release(cache->walk_session, ref, false)));
 	return (ret);
 }
 
@@ -2063,7 +2062,7 @@ fast:		/* If the page can't be evicted, give up. */
 				WT_STAT_CONN_INCR(
 				    session, cache_eviction_walks_abandoned);
 			WT_RET(__wt_page_release(
-			    cache->walk_session, ref, walk_flags));
+			    cache->walk_session, ref, false));
 			ref = NULL;
 		} else
 			while (ref != NULL && (ref->state != WT_REF_MEM ||

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -51,20 +51,19 @@ __evict_exclusive(WT_SESSION_IMPL *session, WT_REF *ref)
  *	Release a reference to a page, and attempt to immediately evict it.
  */
 int
-__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
+__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool nosplit)
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_PAGE *page;
 	uint64_t time_start, time_stop;
-	uint32_t evict_flags, previous_state;
+	uint32_t previous_state;
 	bool locked, too_big;
 
 	btree = S2BT(session);
 	locked = false;
 	page = ref->page;
 	time_start = __wt_clock(session);
-	evict_flags = LF_ISSET(WT_READ_NO_SPLIT) ? WT_EVICT_CALL_NO_SPLIT : 0;
 
 	/*
 	 * This function always releases the hazard pointer - ensure that's
@@ -90,7 +89,8 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * Track how long the call to evict took. If eviction is successful then
 	 * we have one of two pairs of stats to increment.
 	 */
-	ret = __wt_evict(session, ref, previous_state, evict_flags);
+	ret = __wt_evict(session,
+	    ref, previous_state, nosplit ? WT_EVICT_CALL_NO_SPLIT : 0);
 	time_stop = __wt_clock(session);
 	if (ret == 0) {
 		if (too_big) {

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -89,8 +89,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool nosplit)
 	 * Track how long the call to evict took. If eviction is successful then
 	 * we have one of two pairs of stats to increment.
 	 */
-	ret = __wt_evict(session,
-	    ref, previous_state, nosplit ? WT_EVICT_CALL_NO_SPLIT : 0);
+	ret = __wt_evict(session, ref, previous_state, false, nosplit);
 	time_stop = __wt_clock(session);
 	if (ret == 0) {
 		if (too_big) {
@@ -125,12 +124,12 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool nosplit)
  */
 int
 __wt_evict(WT_SESSION_IMPL *session,
-    WT_REF *ref, uint32_t previous_state, uint32_t flags)
+    WT_REF *ref, uint32_t previous_state, bool closing, bool nosplit)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_PAGE *page;
-	bool clean_page, closing, inmem_split, local_gen, nosplit, tree_dead;
+	bool clean_page, inmem_split, local_gen, tree_dead;
 
 	conn = S2C(session);
 	page = ref->page;
@@ -139,8 +138,6 @@ __wt_evict(WT_SESSION_IMPL *session,
 	__wt_verbose(session, WT_VERB_EVICT,
 	    "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
 
-	closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
-	nosplit = LF_ISSET(WT_EVICT_CALL_NO_SPLIT);
 	tree_dead = F_ISSET(session->dhandle, WT_DHANDLE_DEAD);
 	if (tree_dead)
 		nosplit = true;

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -287,9 +287,3 @@ struct __wt_cache_pool {
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 	uint8_t flags;
 };
-
-/* Flags used with __wt_evict */
-/* AUTOMATIC FLAG VALUE GENERATION START */
-#define	WT_EVICT_CALL_CLOSING  0x1u		/* Closing connection or tree */
-#define	WT_EVICT_CALL_NO_SPLIT 0x2u		/* Splits not allowed */
-/* AUTOMATIC FLAG VALUE GENERATION STOP */

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -211,7 +211,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
 	 *
 	 * Clear the reference regardless, so we don't try the release twice.
 	 */
-	ret = __wt_page_release(session, cbt->ref, 0);
+	ret = __wt_page_release(session, cbt->ref, false);
 	cbt->ref = NULL;
 
 	return (ret);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -386,7 +386,7 @@ extern bool __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC
 extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool nosplit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -387,7 +387,7 @@ extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool nosplit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state, bool closing, bool nosplit) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1610,8 +1610,7 @@ check_original_value:
 #define	WT_CHILD_RELEASE(session, hazard, ref) do {			\
 	if (hazard) {							\
 		(hazard) = false;					\
-		WT_TRET(						\
-		    __wt_page_release(session, ref, WT_READ_NO_EVICT));	\
+		WT_TRET(__wt_page_release(session, ref, false));	\
 	}								\
 } while (0)
 #define	WT_CHILD_RELEASE_ERR(session, hazard, ref) do {			\

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1610,7 +1610,8 @@ check_original_value:
 #define	WT_CHILD_RELEASE(session, hazard, ref) do {			\
 	if (hazard) {							\
 		(hazard) = false;					\
-		WT_TRET(__wt_page_release(session, ref, false));	\
+		WT_TRET(						\
+		    __wt_page_release(session, ref, WT_READ_NO_EVICT));	\
 	}								\
 } while (0)
 #define	WT_CHILD_RELEASE_ERR(session, hazard, ref) do {			\

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -305,7 +305,7 @@ __txn_abort_newer_updates(
 	}
 
 err:	if (local_read)
-		WT_TRET(__wt_page_release(session, ref, read_flags));
+		WT_TRET(__wt_page_release(session, ref, false));
 	return (ret);
 }
 


### PR DESCRIPTION
@michaelcahill, would you comment on whether or not  you like this change?

When I was reviewing Don's changes for WT-4690, I thought about simplifying our eviction flag handling and this is the result.

The root change is to not pass `WT_READ_XXX` flags to the `__wt_page_release()` and `__wt_page_release_evict()` functions, replacing the flag handling from there down through `__wt_evict() and `__evict_review()` with boolean arguments.

I can think of reasons this is a bad idea:

* We might want to pay attention to additional `WT_READ_XXX` flags in the eviction code in the future, as we have in the past, and we'd have to go back to passing the read flags through the `__wt_page_release` calls.
* If someone adds `WT_READ_NO_SPLIT` to a tree-walk flag set in the future, they can't rely on that automatically being passed through to eviction, they'll need to pay attention to the `__wt_page_release` calls, so this change might be an invitation to add a subtle bug.

There were two places we passed the `WT_READ_NO_EVICT` flags to `__wt_page_release()`, and I can't see that was having any effect at all.

Anyway, don't hesitate to discard this change without further discussion if this isn't a way you want to go.

@ddanderson, if Michael approves the change, can you please do the review?

In eb0e8b0 I replaced the two flags you added with two booleans -- I don't feel strongly about that change, feel free to discard that change if you prefer the flags.
