### PR TITLE
WT-4745 Update upgrading doc for 3.2.0 WiredTiger release

### DIFF
--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -1,12 +1,12 @@
 /*! @page upgrading Upgrading WiredTiger applications
 
 </dl><hr>
-@section version_311 Upgrading to Version 3.1.1
+@section version_320 Upgrading to Version 3.2.0
 <dl>
 
 <dt>Raw compression</dt>
 <dd>
-Support for "raw compression" has been removed in the 3.1.1 release.  Only
+Support for "raw compression" has been removed in the 3.2.0 release.  Only
 applications configuring their own compressors will require modification,
 those applications should remove their initialization of the \c WT_COMPRESSOR
 structure's \c WT_COMPRESSOR::compress_raw field. Applications configuring
@@ -20,7 +20,7 @@ see different compression ratios from previous releases.
 In previous releases of WiredTiger, it was possible to disable timestamp
 support as well as to configure a timestamp size different from the 64-bit
 default, using the <code>--with-timestamp-size=X</code> configuration option.
-That is no longer the case, in the 3.1.1 release, timestamps are always
+That is no longer the case, in the 3.2.0 release, timestamps are always
 configured, and are always 64-bit unsigned integers.
 </dd>
 
@@ -30,7 +30,7 @@ In previous releases of WiredTiger, it was possible to use implicit
 transactions in combination with WT_CURSOR::modify operations. This
 requires applications be extraordinarily careful to avoid multiple
 threads which are changing the same values racing with each other. In
-the 3.1.1 release, WT_CURSOR::modify operations must be performed in an
+the 3.2.0 release, WT_CURSOR::modify operations must be performed in an
 explicit transaction, and will fail if that's not the case.
 </dd>
 


### PR DESCRIPTION
The changes of below tickets were identified to worth a description in the upgrading doc, which had been covered by the WT tickets. Just need to replace 3.1.1 with 3.2.0 since we decided to use 3.2.0 as the new release version. 
- WT-4192 Remove WiredTiger raw compression support
- WT-4427 Make WiredTiger timestamps always on and 8 bytes
- WT-4193 Make WT_CURSOR.modify require explicit transactions

Please note WT-4283 (together with WT-4156) introduced a new top level API (salvage), which did not exist in the previous WT release 3.1.0. Won't mention it in the upgrading doc, instead will cover it in the release note. 
