### PR TITLE
WT-3929 Fix "pip install" to work with Python3.

### DIFF
--- a/lang/python/Makefile.am
+++ b/lang/python/Makefile.am
@@ -2,7 +2,7 @@ PYSRC = $(top_srcdir)/lang/python
 PYDIRS = -t $(abs_builddir) -I $(abs_top_srcdir):$(abs_top_builddir) -L $(abs_top_builddir)/.libs
 PYDST = $(abs_builddir)/wiredtiger
 PYFILES = $(PYDST)/fpacking.py $(PYDST)/intpacking.py $(PYDST)/packing.py \
-	$(PYDST)/__init__.py
+	$(PYDST)/packutil.py $(PYDST)/__init__.py
 PY_MAJOR_VERSION := $$($(PYTHON) -c \
 	'import sys; print(int(sys.version_info.major))')
 

--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -98,7 +98,7 @@ def check_needed_dependencies(builtins, inc_paths, lib_paths):
 #   Locate an executable in the PATH.
 def find_executable(exename, path):
     p = subprocess.Popen(['which', exename ], stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+                         stderr=subprocess.PIPE, universal_newlines=True)
     out, err = p.communicate('')
     out = str(out)  # needed for Python3
     if out == '':
@@ -146,7 +146,8 @@ def get_sources_curdir():
     DEVNULL = open(os.devnull, 'w')
     gitproc = subprocess.Popen(
         ['git', 'ls-tree', '-r', '--name-only', 'HEAD^{tree}'],
-        stdin=DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdin=DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True)
     sources = [line.rstrip() for line in gitproc.stdout.readlines()]
     err = gitproc.stderr.read()
     gitproc.wait()
@@ -176,6 +177,7 @@ def get_library_dirs():
     dirs.append("/usr/local/lib")
     dirs.append("/usr/local/lib64")
     dirs.append("/lib/x86_64-linux-gnu")
+    dirs.append("/usr/lib/x86_64-linux-gnu")
     dirs.append("/opt/local/lib")
     dirs.append("/usr/lib")
     dirs.append("/usr/lib64")
@@ -230,10 +232,6 @@ elif os.path.isfile(os.path.join(this_dir, 'LICENSE')):
     wt_dir = this_dir
 else:
     die('running from an unknown directory')
-
-python3 = (sys.version_info[0] > 2)
-if python3:
-    die('Python3 is not yet supported')
 
 # Ensure that Extensions won't be built for 32 bit,
 # that won't work with WiredTiger.

--- a/lang/python/wiredtiger/intpacking.py
+++ b/lang/python/wiredtiger/intpacking.py
@@ -28,8 +28,12 @@
 #
 
 from __future__ import print_function
-from wiredtiger.packutil import _chr, _ord, x00_entry, xff_entry
 import math, struct, sys
+try:
+    from wiredtiger.packutil import _chr, _ord, x00_entry, xff_entry
+except ImportError:
+    # When WiredTiger is installed as a package, python2 needs this
+    from .packutil import _chr, _ord, x00_entry, xff_entry
 
 # Variable-length integer packing
 # need: up to 64 bits, both signed and unsigned

--- a/lang/python/wiredtiger/intpacking.py
+++ b/lang/python/wiredtiger/intpacking.py
@@ -28,7 +28,7 @@
 #
 
 from __future__ import print_function
-from wiredtiger.packing import _chr, _ord
++from wiredtiger.packutil import _chr, _ord, x00_entry, xff_entry
 import math, struct, sys
 
 # Variable-length integer packing
@@ -63,14 +63,6 @@ POS_2BYTE_MAX = 2**13 + POS_1BYTE_MAX
 
 MINUS_BIT = -1 << 64
 UINT64_MASK = 0xffffffffffffffff
-
-_python3 = (sys.version_info >= (3, 0, 0))
-if _python3:
-    xff_entry = 0xff
-    x00_entry = 0x00
-else:
-    xff_entry = '\xff'
-    x00_entry = '\x00'
 
 def getbits(x, start, end=0):
     '''return the least significant bits of x, from start to end'''

--- a/lang/python/wiredtiger/intpacking.py
+++ b/lang/python/wiredtiger/intpacking.py
@@ -28,7 +28,7 @@
 #
 
 from __future__ import print_function
-+from wiredtiger.packutil import _chr, _ord, x00_entry, xff_entry
+from wiredtiger.packutil import _chr, _ord, x00_entry, xff_entry
 import math, struct, sys
 
 # Variable-length integer packing

--- a/lang/python/wiredtiger/packing.py
+++ b/lang/python/wiredtiger/packing.py
@@ -49,49 +49,8 @@ Format  Python  Notes
   u     str     raw byte array
 """
 
-import sys
-
-# In the Python3 world, we pack into the bytes type, which like a list of ints.
-# In Python2, we pack into a string.  Create a set of constants and methods
-# to hide the differences from the main code.
-if sys.version_info[0] >= 3:
-    x00 = b'\x00'
-    xff = b'\xff'
-    empty_pack = b''
-    def _ord(b):
-        return b
-
-    def _chr(x, y=None):
-        a = [x]
-        if y != None:
-            a.append(y)
-        return bytes(a)
-
-    def _is_string(s):
-        return type(s) is str
-
-    def _string_result(s):
-        return s.decode()
-
-else:
-    x00 = '\x00'
-    xff = '\xff'
-    empty_pack = ''
-    def _ord(b):
-        return ord(b)
-
-    def _chr(x, y=None):
-        s = chr(x)
-        if y != None:
-            s += chr(y)
-        return s
-
-    def _is_string(s):
-        return type(s) is unicode
-
-    def _string_result(s):
-        return s
-
+from wiredtiger.packutil import _chr, _is_string, _ord, _string_result, \
+    x00, empty_pack
 from wiredtiger.intpacking import pack_int, unpack_int
 
 def __get_type(fmt):

--- a/lang/python/wiredtiger/packing.py
+++ b/lang/python/wiredtiger/packing.py
@@ -49,9 +49,15 @@ Format  Python  Notes
   u     str     raw byte array
 """
 
-from wiredtiger.packutil import _chr, _is_string, _ord, _string_result, \
-    x00, empty_pack
-from wiredtiger.intpacking import pack_int, unpack_int
+try:
+    from wiredtiger.packutil import _chr, _is_string, _ord, _string_result, \
+        empty_pack, x00
+    from wiredtiger.intpacking import pack_int, unpack_int
+except ImportError:
+    # When WiredTiger is installed as a package, python2 needs this
+    from .packutil import _chr, _is_string, _ord, _string_result, \
+        empty_pack, x00
+    from intpacking import pack_int, unpack_int
 
 def __get_type(fmt):
     if not fmt:

--- a/lang/python/wiredtiger/packutil.py
+++ b/lang/python/wiredtiger/packutil.py
@@ -26,23 +26,50 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# WiredTiger packing and unpacking utility functions and constants
 
-# pip_init.py
-#      This is installed as __init__.py, and imports the file created by SWIG.
-# This is needed because SWIG's import helper code created by certain SWIG
-# versions may be broken, see: https://github.com/swig/swig/issues/769 .
-# Importing indirectly seems to avoid these issues.
-import os, sys
-fname = os.path.basename(__file__)
-if fname != '__init__.py' and fname != '__init__.pyc':
-    print(__file__ + ': this file is not yet installed')
-    sys.exit(1)
+import sys
 
-# After importing the SWIG-generated file, copy all symbols from from it
-# to this module so they will appear in the wiredtiger namespace.
-me = sys.modules[__name__]
-sys.path.append(os.path.dirname(__file__))
-import wiredtiger.wiredtiger as swig_wiredtiger
-for name in dir(swig_wiredtiger):
-    value = getattr(swig_wiredtiger, name)
-    setattr(me, name, value)
+# In the Python3 world, we pack into the bytes type, which like a list of ints.
+# In Python2, we pack into a string.  Create a set of constants and methods
+# to hide the differences from the main code.
+
+# all bits on or off, expressed as a bytes type
+x00 = b'\x00'
+xff = b'\xff'
+x00_entry = x00[0]
+xff_entry = xff[0]
+empty_pack = b''
+
+_python3 = (sys.version_info >= (3, 0, 0))
+if _python3:
+    def _ord(b):
+        return b
+
+    def _chr(x, y=None):
+        a = [x]
+        if y != None:
+            a.append(y)
+        return bytes(a)
+
+    def _is_string(s):
+        return type(s) is str
+
+    def _string_result(s):
+        return s.decode()
+
+else:
+    def _ord(b):
+        return ord(b)
+
+    def _chr(x, y=None):
+        s = chr(x)
+        if y != None:
+            s += chr(y)
+        return s
+
+    def _is_string(s):
+        return type(s) is unicode
+
+    def _string_result(s):
+        return s

--- a/lang/python/wiredtiger/pip_init.py
+++ b/lang/python/wiredtiger/pip_init.py
@@ -42,7 +42,11 @@ if fname != '__init__.py' and fname != '__init__.pyc':
 # to this module so they will appear in the wiredtiger namespace.
 me = sys.modules[__name__]
 sys.path.append(os.path.dirname(__file__))
-import wiredtiger.wiredtiger as swig_wiredtiger
+try:
+    import wiredtiger.wiredtiger as swig_wiredtiger
+except ImportError:
+    # for Python2
+    import wiredtiger as swig_wiredtiger
 for name in dir(swig_wiredtiger):
     value = getattr(swig_wiredtiger, name)
     setattr(me, name, value)


### PR DESCRIPTION
- avoid the use of relative imports, it doesn't work well with
  installed packages.
- introduce packutil.py, to remove a circular dependency that causes
  trouble with installed packages.
- minor changes to setup_pip.py for Python3.
- add a new library directory to check for standard compression libs.