### PR TITLE
WT-4759 Save a copy when an old overflow value is discarded.

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -482,9 +482,13 @@ check_original_value:
 	 * Returning an update means the original on-page value might be lost,
 	 * and that's a problem if there's a reader that needs it.  This call
 	 * makes a copy of the on-page value and if there is a birthmark in the
-	 * update list, replaces it.
+	 * update list, replaces it.  We do that any time there are saved
+	 * updates and during reconciliation of a backing overflow record that
+	 * will be physically removed once it's no longer needed
 	 */
-	if (upd_select->upd != NULL && upd_select->upd_saved)
+	if (upd_select->upd != NULL && (upd_select->upd_saved ||
+	    (vpack != NULL && vpack->ovfl &&
+	    vpack->raw != WT_CELL_VALUE_OVFL_RM)))
 		WT_RET(
 		    __rec_append_orig_value(session, page, first_upd, vpack));
 


### PR DESCRIPTION
Reverts part of ace6f599762486eaf980d45c2337fce4660d5180 from WT-4352.