### PR TITLE
Debug against log format branch

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -869,6 +869,9 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 			__wt_free(session, next_ref->page_del->update_list);
 			__wt_free(session, next_ref->page_del);
 		}
+		WT_ASSERT(session, next_ref->page_las == NULL ||
+		    __wt_txn_visible_all(session, next_ref->page_las->max_txn,
+		    next_ref->page_las->max_timestamp));
 		__wt_free(session, next_ref->page_las);
 
 		/* Free the backing block and address. */

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -618,7 +618,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 	WT_SAVE_UPD *list;
 	WT_SESSION_IMPL *session;
 	WT_TXN_ISOLATION saved_isolation;
-	WT_UPDATE *upd;
+	WT_UPDATE *first_upd, *upd;
 	wt_off_t las_size;
 	uint64_t insert_cnt, las_counter, las_pageid, prepared_insert_cnt;
 	uint32_t btree_id, i, slot;
@@ -698,7 +698,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			slot = page->type == WT_PAGE_ROW_LEAF ?
 			    WT_ROW_SLOT(page, list->ripcip) :
 			    WT_COL_SLOT(page, list->ripcip);
-		upd = list->ins == NULL ?
+		first_upd = upd = list->ins == NULL ?
 		    page->modify->mod_row_update[slot] : list->ins->upd;
 
 		/*
@@ -717,6 +717,8 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 				las_value.size = upd->size;
 				break;
 			case WT_UPDATE_BIRTHMARK:
+				WT_ASSERT(session, upd != first_upd || multi->page_las.skew_newest);
+				/* FALLTHROUGH */
 			case WT_UPDATE_TOMBSTONE:
 				las_value.size = 0;
 				break;
@@ -737,6 +739,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			    (upd->type == WT_UPDATE_STANDARD ||
 			    upd->type == WT_UPDATE_MODIFY)) {
 				las_value.size = 0;
+				WT_ASSERT(session, upd != first_upd || multi->page_las.skew_newest);
 				cursor->set_value(cursor, upd->txnid,
 				    upd->start_ts, upd->durable_ts,
 				    upd->prepare_state, WT_UPDATE_BIRTHMARK,

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -102,9 +102,9 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 		 * WT_ASSERT(session, btree->rec_max_txn >= btree->tmp_rec_max_txn);
 		WT_ASSERT(session, btree->rec_max_timestamp >= btree->tmp_rec_max_timestamp);
 		*/
+		__wt_epoch(session, &now);
 		if (btree->rec_max_timestamp < btree->tmp_rec_max_timestamp) {
-			__wt_epoch(session, &now);
-			WT_IGNORE_RET(__wt_log_printf(session, NULL,
+			WT_IGNORE_RET(__wt_log_printf(session,
 			    "[%" PRIu64 ":%" PRIu64 "] SWEEP ERROR:"
 			    " Missing data in %s"
 			    " rec_max_timestamp: %" PRIu64 " 0x%" PRIx64
@@ -122,6 +122,19 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 			    btree->rec_max_timestamp, btree->rec_max_timestamp,
 			    btree->tmp_rec_max_timestamp, btree->tmp_rec_max_timestamp));
 		}
+		WT_IGNORE_RET(__wt_log_printf(session,
+		    "[%" PRIu64 ":%" PRIu64 "] SWEEP:"
+		    " CLOSE %s"
+		    " rec_max_txn: %" PRIu64 " 0x%" PRIx64
+		    " tmp_rec_max_txn: %" PRIu64 " 0x%" PRIx64
+		    " rec_max_timestamp: %" PRIu64 " 0x%" PRIx64
+		    " tmp_rec_max_timestamp: %" PRIu64 " 0x%" PRIx64,
+		    (uint64_t)now.tv_sec, (uint64_t)now.tv_nsec,
+		    btree->dhandle->name,
+		    btree->rec_max_txn, btree->rec_max_txn,
+		    btree->tmp_rec_max_txn, btree->tmp_rec_max_txn,
+		    btree->rec_max_timestamp, btree->rec_max_timestamp,
+		    btree->tmp_rec_max_timestamp, btree->tmp_rec_max_timestamp));
 	}
 
 	/*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -656,7 +656,8 @@ __evict_review(
 		else if (!WT_IS_METADATA(session->dhandle)) {
 			LF_SET(WT_REC_UPDATE_RESTORE);
 
-			if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
+			if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB) ||
+			    __wt_random(&session->rnd) % 3 == 0)
 				LF_SET(WT_REC_SCRUB);
 
 			/*
@@ -665,8 +666,13 @@ __evict_review(
 			 * suggests trying the lookaside table.
 			 */
 			if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE) &&
-			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
+			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE)) {
+				if (__wt_random(&session->rnd) % 10 == 1) {
+					LF_CLR(WT_REC_SCRUB | WT_REC_UPDATE_RESTORE);
+					LF_SET(WT_REC_LOOKASIDE);
+				}
 				lookaside_retryp = &lookaside_retry;
+			}
 		}
 	}
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -167,6 +167,10 @@ struct __wt_btree {
 	uint64_t rec_max_txn;		/* Maximum txn seen (clean trees) */
 	wt_timestamp_t rec_max_timestamp;
 
+	/* The largest transaction seen on the page by reconciliation. */
+	uint64_t tmp_rec_max_txn;
+	wt_timestamp_t tmp_rec_max_timestamp;
+
 	uint64_t checkpoint_gen;	/* Checkpoint generation */
 	WT_SESSION_IMPL *sync_session;	/* Syncing session */
 	volatile enum {

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -922,6 +922,7 @@ __wt_row_leaf_key_set_cell(WT_PAGE *page, WT_ROW *rip, WT_CELL *cell)
 	 */
 	v = WT_CELL_ENCODE_OFFSET(WT_PAGE_DISK_OFFSET(page, cell)) |
 	    WT_CELL_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 
@@ -941,6 +942,7 @@ __wt_row_leaf_key_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *unpack)
 	v = WT_K_ENCODE_KEY_LEN(unpack->size) |
 	    WT_K_ENCODE_KEY_OFFSET(WT_PAGE_DISK_OFFSET(page, unpack->data)) |
 	    WT_K_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 
@@ -979,6 +981,7 @@ __wt_row_leaf_value_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *unpack)
 	    WT_KV_ENCODE_VALUE_LEN(unpack->size) |
 	    WT_KV_ENCODE_KEY_OFFSET(key_offset) |
 	    WT_KV_ENCODE_VALUE_OFFSET(value_offset) | WT_KV_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -358,7 +358,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	 * order), so we track the maximum transaction ID and the newest update
 	 * with a timestamp (if any).
 	 */
-	timestamp = first_ts_upd == NULL ? 0 : first_ts_upd->durable_ts;
+	timestamp = first_ts_upd == NULL ? WT_TS_NONE : first_ts_upd->durable_ts;
 	all_visible = upd == first_txn_upd && !(uncommitted || prepared) &&
 	    (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
 	    __wt_txn_visible_all(session, max_txn, timestamp) :

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -679,6 +679,8 @@ __checkpoint_prepare(
 		 * Get a new one.
 		 */
 		__wt_txn_get_snapshot(session);
+		__wt_log_printf(session, "CKPT: txn id %" PRIu64 " read ts %"
+		    PRIu64, txn->id, txn->read_timestamp);
 	}
 
 	/*
@@ -870,6 +872,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	 */
 	generation = __wt_gen_next(session, WT_GEN_CHECKPOINT);
 	WT_STAT_CONN_SET(session, txn_checkpoint_generation, generation);
+	__wt_sleep(1, 0);
 
 	/*
 	 * We want to skip checkpointing clean handles whenever possible.  That
@@ -890,6 +893,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 	    ret = __checkpoint_prepare(session, &tracking, cfg));
 	WT_ERR(ret);
 
+	__wt_sleep(1, 0);
 	WT_ASSERT(session, txn->isolation == WT_ISO_SNAPSHOT);
 
 	/*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -38,6 +38,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	if (cbt->ins == NULL) {
 		session = (WT_SESSION_IMPL *)cbt->iface.session;
 		page = cbt->ref->page;
+		WT_ASSERT(session, cbt->slot < page->entries);
 		rip = &page->pg_row[cbt->slot];
 		WT_ASSERT(session,
 		    __wt_row_leaf_key(session, page, rip, &key, false) == 0);

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -29,8 +29,9 @@
 #include "test_checkpoint.h"
 
 static WT_THREAD_RET checkpointer(void *);
+static WT_THREAD_RET clock_thread(void *);
 static int compare_cursors(
-    WT_CURSOR *, const char *, WT_CURSOR *, const char *);
+    WT_CURSOR *, const char *, WT_CURSOR *, const char *, int);
 static int diagnose_key_error(WT_CURSOR *, int, WT_CURSOR *, int);
 static int real_checkpointer(void);
 static int verify_consistency(WT_SESSION *, bool);
@@ -42,8 +43,11 @@ static int verify_consistency(WT_SESSION *, bool);
 void
 start_checkpoints(void)
 {
+	testutil_check(__wt_rwlock_init(NULL, &g.clock_lock));
 	testutil_check(__wt_thread_create(NULL,
 	    &g.checkpoint_thread, checkpointer, NULL));
+	testutil_check(__wt_thread_create(NULL,
+	    &g.clock_thread, clock_thread, NULL));
 }
 
 /*
@@ -54,6 +58,43 @@ void
 end_checkpoints(void)
 {
 	testutil_check(__wt_thread_join(NULL, &g.checkpoint_thread));
+	testutil_check(__wt_thread_join(NULL, &g.clock_thread));
+	__wt_rwlock_destroy(NULL, &g.clock_lock);
+}
+
+/*
+ * clock_thread --
+ *	Clock thread: ticks up timestamps.
+ */
+static WT_THREAD_RET
+clock_thread(void *arg)
+{
+	WT_SESSION *wt_session;
+	WT_SESSION_IMPL *session;
+	char buf[128];
+
+	WT_UNUSED(arg);
+
+	testutil_check(g.conn->open_session(g.conn, NULL, NULL, &wt_session));
+	session = (WT_SESSION_IMPL *)wt_session;
+
+	g.ts = 0;
+	while (g.running) {
+		__wt_writelock(session, &g.clock_lock);
+		++g.ts;
+		testutil_check(__wt_snprintf(
+		    buf, sizeof(buf),
+		    "oldest_timestamp=%x,stable_timestamp=%x", g.ts, g.ts));
+		testutil_check(g.conn->set_timestamp(g.conn, buf));
+		if (g.ts % 997 == 0)
+			__wt_sleep(10, 0);
+		__wt_writeunlock(session, &g.clock_lock);
+		__wt_sleep(0, 10000);
+	}
+
+	testutil_check(wt_session->close(wt_session, NULL));
+
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -83,8 +124,8 @@ static int
 real_checkpointer(void)
 {
 	WT_SESSION *session;
-	int ret;
 	char buf[128], *checkpoint_config;
+	int ret;
 
 	if (g.running == 0)
 		return (log_print_err(
@@ -115,14 +156,17 @@ real_checkpointer(void)
 		    session, checkpoint_config)) != 0)
 			return (log_print_err("session.checkpoint", ret, 1));
 		printf("Finished a checkpoint\n");
++		fflush(stdout);
 
 		if (!g.running)
 			goto done;
 
 		/* Verify the content of the checkpoint. */
-		if ((ret = verify_consistency(session, true)) != 0)
+		if (0 && (ret = verify_consistency(session, true)) != 0)
 			return (log_print_err(
 			    "verify_consistency (offline)", ret, 1));
+
+		__wt_sleep(5, 0);
 	}
 
 done:	if ((ret = session->close(session, NULL)) != 0)
@@ -141,11 +185,12 @@ verify_consistency(WT_SESSION *session, bool use_checkpoint)
 {
 	WT_CURSOR **cursors;
 	uint64_t key_count;
-	int i, ret, t_ret;
+	int err, err_ret, i, ret, t_ret;
 	const char *ckpt, *type0, *typei;
 	char ckpt_buf[128], next_uri[128];
 
 	ret = t_ret = 0;
+	err = err_ret = 0;
 	key_count = 0;
 	cursors = calloc((size_t)g.ntables, sizeof(*cursors));
 	if (cursors == NULL)
@@ -221,19 +266,26 @@ verify_consistency(WT_SESSION *session, bool use_checkpoint)
 			type0 = type_to_string(g.cookies[0].type);
 			typei = type_to_string(g.cookies[i].type);
 			if ((ret = compare_cursors(
-			    cursors[0], type0, cursors[i], typei)) != 0) {
+			    cursors[0], type0, cursors[i], typei, i)) != 0) {
 				(void)diagnose_key_error(
 				    cursors[0], 0, cursors[i], i);
 				(void)log_print_err(
 				    "verify_consistency - mismatching data",
 				    EFAULT, 1);
+				err++;
+				if (err_ret == 0)
+					err_ret = ret;
+				ret = 0;
+#if 0
 				goto err;
+#endif
 			}
 		}
 	}
-	printf("Finished verifying a %s with %d tables and %" PRIu64
+	printf("Finished verifying a %s (%d errors) with %d tables and %" PRIu64
 	    " keys\n", use_checkpoint ? "checkpoint" : "snapshot",
-	    g.ntables, key_count);
+	    err, g.ntables, key_count);
+	fflush(stdout);
 
 err:	for (i = 0; i < g.ntables; i++) {
 		if (cursors[i] != NULL &&
@@ -244,7 +296,7 @@ err:	for (i = 0; i < g.ntables; i++) {
 	if (!use_checkpoint)
 		testutil_check(session->commit_transaction(session, NULL));
 	free(cursors);
-	return (ret);
+	return (err_ret);
 }
 
 /*
@@ -254,19 +306,21 @@ err:	for (i = 0; i < g.ntables; i++) {
 static int
 compare_cursors(
     WT_CURSOR *cursor1, const char *type1,
-    WT_CURSOR *cursor2, const char *type2)
+    WT_CURSOR *cursor2, const char *type2, int i)
 {
 	uint64_t key1, key2;
 	int ret;
-	char buf[128], *val1, *val2;
+	char buf[128], *k1, *k2, *val1, *val2;
 
 	ret = 0;
 	memset(buf, 0, 128);
 
-	if (cursor1->get_key(cursor1, &key1) != 0 ||
-	    cursor2->get_key(cursor2, &key2) != 0)
+	if (cursor1->get_key(cursor1, &k1) != 0 ||
+	    cursor2->get_key(cursor2, &k2) != 0)
 		return (log_print_err("Error getting keys", EINVAL, 1));
 
+	sscanf(k1, "%" SCNu64, &key1);
+	sscanf(k2, "%" SCNu64, &key2);
 	if (cursor1->get_value(cursor1, &val1) != 0 ||
 	    cursor2->get_value(cursor2, &val2) != 0)
 		return (log_print_err("Error getting values", EINVAL, 1));
@@ -283,8 +337,12 @@ compare_cursors(
 		return (0);
 
 	printf("Key/value mismatch: %" PRIu64 "/%s from a %s table is not %"
-	    PRIu64 "/%s from a %s table\n",
-	    key1, val1, type1, key2, val2, type2);
+	    PRIu64 "/%s from a %s table %d)\n",
+	    key1, val1, type1, key2, val2, type2, i);
+	if (key1 < key2)
+		cursor1->next(cursor1);
+	else
+		cursor2->next(cursor2);
 
 	return (ret);
 }
@@ -303,7 +361,7 @@ diagnose_key_error(
 	WT_SESSION *session;
 	uint64_t key1, key1_orig, key2, key2_orig;
 	int ret;
-	char ckpt[128], next_uri[128];
+	char ckpt[128], keybuf[16], next_uri[128], *k1, *k2;
 
 	/* Hack to avoid passing session as parameter. */
 	session = cursor1->session;
@@ -313,11 +371,13 @@ diagnose_key_error(
 	    ckpt, sizeof(ckpt), "checkpoint=%s", g.checkpoint_name));
 
 	/* Save the failed keys. */
-	if (cursor1->get_key(cursor1, &key1_orig) != 0 ||
-	    cursor2->get_key(cursor2, &key2_orig) != 0) {
+	if (cursor1->get_key(cursor1, &k1) != 0 ||
+	    cursor2->get_key(cursor2, &k2) != 0) {
 		(void)log_print_err("Error retrieving key.", EINVAL, 0);
 		goto live_check;
 	}
+	sscanf(k1, "%" SCNu64, &key1_orig);
+	sscanf(k2, "%" SCNu64, &key2_orig);
 
 	if (key1_orig == key2_orig)
 		goto live_check;
@@ -325,28 +385,40 @@ diagnose_key_error(
 	/* See if previous values are still valid. */
 	if (cursor1->prev(cursor1) != 0 || cursor2->prev(cursor2) != 0)
 		return (1);
-	if (cursor1->get_key(cursor1, &key1) != 0 ||
-	    cursor2->get_key(cursor2, &key2) != 0)
+	if (cursor1->get_key(cursor1, &k1) != 0 ||
+	    cursor2->get_key(cursor2, &k2) != 0)
 		(void)log_print_err("Error decoding key", EINVAL, 1);
-	else if (key1 != key2)
-		(void)log_print_err("Now previous keys don't match", EINVAL, 0);
+	else {
+		sscanf(k1, "%" SCNu64, &key1);
+		sscanf(k2, "%" SCNu64, &key2);
+		if (key1 != key2)
+			(void)log_print_err("Now previous keys don't match", EINVAL, 0);
+	}
 
 	if (cursor1->next(cursor1) != 0 || cursor2->next(cursor2) != 0)
 		return (1);
-	if (cursor1->get_key(cursor1, &key1) != 0 ||
-	    cursor2->get_key(cursor2, &key2) != 0)
+	if (cursor1->get_key(cursor1, &k1) != 0 ||
+	    cursor2->get_key(cursor2, &k2) != 0)
 		(void)log_print_err("Error decoding key", EINVAL, 1);
-	else if (key1 == key2)
-		(void)log_print_err("After prev/next keys match", EINVAL, 0);
+	else  {
+		sscanf(k1, "%" SCNu64, &key1);
+		sscanf(k2, "%" SCNu64, &key2);
+		if (key1 == key2)
+			(void)log_print_err("After prev/next keys match", EINVAL, 0);
+	}
 
 	if (cursor1->next(cursor1) != 0 || cursor2->next(cursor2) != 0)
 		return (1);
-	if (cursor1->get_key(cursor1, &key1) != 0 ||
-	    cursor2->get_key(cursor2, &key2) != 0)
+	if (cursor1->get_key(cursor1, &k1) != 0 ||
+	    cursor2->get_key(cursor2, &k2) != 0)
 		(void)log_print_err("Error decoding key", EINVAL, 1);
-	else if (key1 == key2)
-		(void)log_print_err(
-		    "After prev/next/next keys match", EINVAL, 0);
+	else {
+		sscanf(k1, "%" SCNu64, &key1);
+		sscanf(k2, "%" SCNu64, &key2);
+		if (key1 == key2)
+			(void)log_print_err(
+			    "After prev/next/next keys match", EINVAL, 0);
+	}
 
 	/*
 	 * Now try opening new cursors on the checkpoints and see if we
@@ -356,10 +428,14 @@ diagnose_key_error(
 	    next_uri, sizeof(next_uri), "table:__wt%04d", index1));
 	if (session->open_cursor(session, next_uri, NULL, ckpt, &c) != 0)
 		return (1);
-	c->set_key(c, key1_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key1_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
 		(void)log_print_err("1st cursor didn't find 1st key", ret, 0);
-	c->set_key(c, key2_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key2_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
 		(void)log_print_err("1st cursor didn't find 2nd key", ret, 0);
 	if (c->close(c) != 0)
@@ -369,10 +445,14 @@ diagnose_key_error(
 	    next_uri, sizeof(next_uri), "table:__wt%04d", index2));
 	if (session->open_cursor(session, next_uri, NULL, ckpt, &c) != 0)
 		return (1);
-	c->set_key(c, key1_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key1_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
 		(void)log_print_err("2nd cursor didn't find 1st key", ret, 0);
-	c->set_key(c, key2_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key2_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
 		(void)log_print_err("2nd cursor didn't find 2nd key", ret, 0);
 	if (c->close(c) != 0)
@@ -387,9 +467,11 @@ live_check:
 	    next_uri, sizeof(next_uri), "table:__wt%04d", index1));
 	if (session->open_cursor(session, next_uri, NULL, NULL, &c) != 0)
 		return (1);
-	c->set_key(c, key1_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key1_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
-		(void)log_print_err("1st cursor didn't find 1st key", ret, 0);
+		(void)log_print_err("LIVE: 1st cursor didn't find 1st key", ret, 0);
 	if (c->close(c) != 0)
 		return (1);
 
@@ -397,9 +479,11 @@ live_check:
 	    next_uri, sizeof(next_uri), "table:__wt%04d", index2));
 	if (session->open_cursor(session, next_uri, NULL, NULL, &c) != 0)
 		return (1);
-	c->set_key(c, key2_orig);
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", key2_orig));
+	c->set_key(c, keybuf);
 	if ((ret = c->search(c)) != 0)
-		(void)log_print_err("2nd cursor didn't find 2nd key", ret, 0);
+		(void)log_print_err("LIVE: 2nd cursor didn't find 2nd key", ret, 0);
 	if (c->close(c) != 0)
 		return (1);
 

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -34,7 +34,7 @@ static int  handle_error(WT_EVENT_HANDLER *, WT_SESSION *, int, const char *);
 static int  handle_message(WT_EVENT_HANDLER *, WT_SESSION *, const char *);
 static void onint(int)
     WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
-static void cleanup(void);
+static void cleanup(bool);
 static int  usage(void);
 static int  wt_connect(const char *);
 static int  wt_shutdown(void);
@@ -130,11 +130,12 @@ main(int argc, char *argv[])
 	testutil_work_dir_from_path(g.home, 512, working_dir);
 
 	printf("%s: process %" PRIu64 "\n", progname, (uint64_t)getpid());
+
 	for (cnt = 1; (runs == 0 || cnt <= runs) && g.status == 0; ++cnt) {
+		cleanup(cnt == 1);		/* Clean up previous runs */
+
 		printf("    %d: %d workers, %d tables\n",
 		    cnt, g.nworkers, g.ntables);
-
-		cleanup();			/* Clean up previous runs */
 
 		/* Setup a fresh set of cookies in the global array. */
 		if ((g.cookies = calloc(
@@ -189,12 +190,10 @@ wt_connect(const char *config_open)
 		NULL	/* Close handler. */
 	};
 	int ret;
-	char config[128];
-
-	testutil_make_work_dir(g.home);
+	char config[512];
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
-	    "create,statistics=(fast),error_prefix=\"%s\",cache_size=1GB%s%s",
+	    "create,cache_cursors=false,statistics=(fast),statistics_log=(json,wait=1),error_prefix=\"%s\",file_manager=(close_handle_minimum=1,close_idle_time=1,close_scan_interval=1),timing_stress_for_test=(aggressive_sweep),log=(enabled),cache_size=1GB%s%s,diagnostic=(checkpoint_retention=100,table_logging=true)",
 	    progname,
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));
@@ -230,12 +229,14 @@ wt_shutdown(void)
  *	Clean up from previous runs.
  */
 static void
-cleanup(void)
+cleanup(bool remove_dir)
 {
 	g.running = 0;
 	g.ntables_created = 0;
+	g.ts = 0;
 
-	testutil_clean_work_dir(g.home);
+	if (remove_dir)
+		testutil_make_work_dir(g.home);
 }
 
 static int
@@ -271,7 +272,7 @@ onint(int signo)
 {
 	WT_UNUSED(signo);
 
-	cleanup();
+	cleanup(false);
 
 	fprintf(stderr, "\n");
 	exit(EXIT_FAILURE);

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -63,8 +63,11 @@ typedef struct {
 	int ntables_created;			/* Number tables opened */
 	int running;				/* Whether to stop */
 	int status;				/* Exit status */
+	u_int ts;				/* Current timestamp */
 	COOKIE *cookies;			/* Per-thread info */
+	WT_RWLOCK clock_lock;			/* Clock synchronization */
 	wt_thread_t checkpoint_thread;		/* Checkpoint thread */
+	wt_thread_t clock_thread;		/* Clock thread */
 } GLOBAL;
 extern GLOBAL g;
 

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -39,11 +39,11 @@ static int
 create_table(WT_SESSION *session, COOKIE *cookie)
 {
 	int ret;
-	char config[128];
+	char config[256];
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
-	    "key_format=%s,value_format=S,%s",
-	    cookie->type == COL ? "r" : "q",
+	    "key_format=%s,value_format=S,allocation_size=512,leaf_page_max=1KB,internal_page_max=1KB,memory_page_max=64KB,log=(enabled=false),%s",
+	    cookie->type == COL ? "r" : "S",
 	    cookie->type == LSM ? ",type=lsm" : ""));
 
 	if ((ret = session->create(session, cookie->uri, config)) != 0)
@@ -94,6 +94,8 @@ start_workers(table_type type)
 			goto err;
 	}
 
+	testutil_check(session->close(session, NULL));
+
 	(void)gettimeofday(&start, NULL);
 
 	/* Create threads. */
@@ -122,20 +124,49 @@ err:	free(tids);
 static inline int
 worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
 {
-	int ret;
-	char valuebuf[64];
+	int cmp, ret;
+	char keybuf[16], valuebuf[64];
 
-	cursor->set_key(cursor, keyno);
-	/* Roughly 5% removes. */
-	if (new_val % 19 == 0) {
-		if ((ret = cursor->remove(cursor)) != 0) {
+	testutil_check(__wt_snprintf(
+	    keybuf, sizeof(keybuf), "%08u", keyno));
+	cursor->set_key(cursor, keybuf);
+	/* Roughly half inserts, then balanced inserts / range removes. */
+	if (new_val > g.nops / 2 && new_val % 39 == 0) {
+		if ((ret = cursor->search_near(cursor, &cmp)) != 0) {
+			if (ret == WT_NOTFOUND)
+				return (0);
+			return (log_print_err("cursor.search_near", ret, 1));
+		}
+		if (cmp < 0) {
+			if ((ret = cursor->next(cursor)) != 0) {
+				if (ret == WT_NOTFOUND)
+					return (0);
+				return (log_print_err("cursor.next", ret, 1));
+			}
+		}
+		for (int i = 10; i > 0; i--) {
+			if ((ret = cursor->remove(cursor)) != 0) {
+				if (ret == WT_ROLLBACK)
+					return (WT_ROLLBACK);
+				return (log_print_err("cursor.remove", ret, 1));
+			}
+			if ((ret = cursor->next(cursor)) != 0) {
+				if (ret == WT_NOTFOUND)
+					return (0);
+				return (log_print_err("cursor.next", ret, 1));
+			}
+		}
+		testutil_check(cursor->reset(cursor));
+	} else if (new_val % 39 < 10) {
+		if ((ret = cursor->search(cursor)) != 0 && ret != WT_NOTFOUND) {
 			if (ret == WT_ROLLBACK)
 				return (WT_ROLLBACK);
-			return (log_print_err("cursor.remove", ret, 1));
+			return (log_print_err("cursor.search", ret, 1));
 		}
+		testutil_check(cursor->reset(cursor));
 	} else {
 		testutil_check(__wt_snprintf(
-		    valuebuf, sizeof(valuebuf), "%037u", new_val));
+		    valuebuf, sizeof(valuebuf), "%052u", new_val));
 		cursor->set_value(cursor, valuebuf);
 		if ((ret = cursor->insert(cursor)) != 0) {
 			if (ret == WT_ROLLBACK)
@@ -143,6 +174,7 @@ worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
 			return (log_print_err("cursor.insert", ret, 1));
 		}
 	}
+
 	return (0);
 }
 
@@ -177,10 +209,10 @@ real_worker(void)
 	WT_SESSION *session;
 	u_int i, keyno;
 	int j, ret, t_ret;
+	char buf[128];
+	bool has_cursors;
 
 	ret = t_ret = 0;
-
-	__wt_random_init(&rnd);
 
 	if ((cursors = calloc(
 	    (size_t)(g.ntables), sizeof(WT_CURSOR *))) == NULL)
@@ -192,41 +224,91 @@ real_worker(void)
 		goto err;
 	}
 
+	__wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+
 	for (j = 0; j < g.ntables; j++)
 		if ((ret = session->open_cursor(session,
 		    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
 			(void)log_print_err("session.open_cursor", ret, 1);
 			goto err;
 		}
+	has_cursors = true;
 
 	for (i = 0; i < g.nops && g.running; ++i, __wt_yield()) {
-		if ((ret = session->begin_transaction(session, NULL)) != 0) {
+		if ((ret = session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)")) != 0) {
 			(void)log_print_err(
 			    "real_worker:begin_transaction", ret, 1);
 			goto err;
 		}
 		keyno = __wt_random(&rnd) % g.nkeys + 1;
-		for (j = 0; j < g.ntables; j++) {
-			if ((ret = worker_op(cursors[j], keyno, i)) != 0)
-				break;
+		if (i % 23 == 0) {
+			if (__wt_try_readlock((WT_SESSION_IMPL *)session, &g.clock_lock) != 0) {
+				testutil_check(session->commit_transaction(session, NULL));
+				for (j = 0; j < g.ntables; j++)
+					testutil_check(cursors[j]->close(cursors[j]));
+				has_cursors = false;
+				__wt_readlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+				testutil_check(session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)"));
+			}
+			testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%x", g.ts + 1));
+			testutil_check(session->timestamp_transaction(session, buf));
+			__wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+
+			for (j = 0; !has_cursors && j < g.ntables; j++)
+				if ((ret = session->open_cursor(session,
+				    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
+					(void)log_print_err("session.open_cursor", ret, 1);
+					goto err;
+				}
+			has_cursors = true;
 		}
-		if (ret == 0) {
+		for (j = 0; ret == 0 && j < g.ntables; j++) {
+			ret = worker_op(cursors[j], keyno, i);
+		}
+#if 0
+		if (i % 23 == 0) {
+			if (__wt_try_readlock((WT_SESSION_IMPL *)session, &g.clock_lock) != 0) {
+				testutil_check(session->commit_transaction(session, NULL));
+				for (j = 0; j < g.ntables; j++)
+					testutil_check(cursors[j]->close(cursors[j]));
+				has_cursors = false;
+				__wt_readlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+				testutil_check(session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)"));
+			}
+
+			testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%x", g.ts + 1));
+			testutil_check(session->timestamp_transaction(session, buf));
+			__wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+
+			for (j = 0; !has_cursors && j < g.ntables; j++)
+				if ((ret = session->open_cursor(session,
+				    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
+					(void)log_print_err("session.open_cursor", ret, 1);
+					goto err;
+				}
+			has_cursors = true;
+		}
+		for (j = 0; ret == 0 && j < g.ntables; j++) {
+			ret = worker_op(cursors[j], keyno, i + 1);
+		}
+#endif
+		if (ret != 0 && ret != WT_ROLLBACK) {
+			(void)log_print_err("worker op failed", ret, 1);
+			goto err;
+		} else if (ret == 0 && __wt_random(&rnd) % 7 != 0) {
 			if ((ret = session->commit_transaction(
 			    session, NULL)) != 0) {
 				(void)log_print_err(
 				    "real_worker:commit_transaction", ret, 1);
 				goto err;
 			}
-		} else if (ret == WT_ROLLBACK) {
+		} else {
 			if ((ret = session->rollback_transaction(
 			    session, NULL)) != 0) {
 				(void)log_print_err(
 				    "real_worker:rollback_transaction", ret, 1);
 				goto err;
-			    }
-		} else {
-			(void)log_print_err("worker op failed", ret, 1);
-			goto err;
+			}
 		}
 	}
 

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -235,7 +235,11 @@ real_worker(void)
 	has_cursors = true;
 
 	for (i = 0; i < g.nops && g.running; ++i, __wt_yield()) {
+#if 0
 		if ((ret = session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)")) != 0) {
+#else
+		if ((ret = session->begin_transaction(session, NULL)) != 0) {
+#endif
 			(void)log_print_err(
 			    "real_worker:begin_transaction", ret, 1);
 			goto err;
@@ -248,10 +252,18 @@ real_worker(void)
 					testutil_check(cursors[j]->close(cursors[j]));
 				has_cursors = false;
 				__wt_readlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+#if 0
 				testutil_check(session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)"));
+#else
+				testutil_check(session->begin_transaction(session, NULL));
+#endif
 			}
+#if 0
 			testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%x", g.ts + 1));
 			testutil_check(session->timestamp_transaction(session, buf));
+#else
+			testutil_check(session->timestamp_transaction(session, NULL));
+#endif
 			__wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
 
 			for (j = 0; !has_cursors && j < g.ntables; j++)

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -136,7 +136,8 @@ thread_ts_run(void *arg)
 
 	td = (THREAD_DATA *)arg;
 
-	testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+	testutil_check(td->conn->open_session(td->conn,
+	    NULL, "isolation=snapshot", &session));
 	/* Update the oldest timestamp every 1 millisecond. */
 	for (;;) {
 		/*
@@ -191,7 +192,8 @@ thread_ckpt_run(void *arg)
 	 * Keep a separate file with the records we wrote for checking.
 	 */
 	(void)unlink(ckpt_file);
-	testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+	testutil_check(td->conn->open_session(td->conn,
+	    NULL, "isolation=snapshot", &session));
 	first_ckpt = true;
 	for (i = 0; ;++i) {
 		sleep_time = __wt_random(&rnd) % MAX_CKPT_INVL;
@@ -275,10 +277,11 @@ thread_run(void *arg)
 	 * that modify a table that is logged. But we also want to test mixed
 	 * logged and not-logged transactions.
 	 */
-	testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+	testutil_check(td->conn->open_session(td->conn,
+	    NULL, "isolation=snapshot", &session));
 	if (use_prep)
 		testutil_check(td->conn->open_session(
-		    td->conn, NULL, NULL, &prepared_session));
+		    td->conn, NULL, "isolation=snapshot", &prepared_session));
 	/*
 	 * Open a cursor to each table.
 	 */
@@ -463,7 +466,8 @@ run_workload(uint32_t nth)
 		strcat(envconf, ENV_CONFIG_COMPAT);
 
 	testutil_check(wiredtiger_open(NULL, NULL, envconf, &conn));
-	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(conn->open_session(conn,
+	    NULL, "isolation=snapshot", &session));
 	/*
 	 * Create all the tables.
 	 */
@@ -756,7 +760,8 @@ main(int argc, char *argv[])
 	 * Open the connection which forces recovery to be run.
 	 */
 	testutil_check(wiredtiger_open(NULL, NULL, ENV_CONFIG_REC, &conn));
-	testutil_check(conn->open_session(conn, NULL, NULL, &session));
+	testutil_check(conn->open_session(conn,
+	    NULL, "isolation=snapshot", &session));
 	/*
 	 * Open a cursor on all the tables.
 	 */


### PR DESCRIPTION
@michaelcahill and @dgottlieb this branch is (clearly) not for merge. But I applied Michael's changes to the 4712 branch with the log format change so that it is easier to see commits to non-logged tables and added some log printf calls to see where they fall in the stream of operations. There are a few changes to `test/checkpoint` as well:
* I've made the key format always 'S' for easier printlog viewing.
* I modified the test `verify` function to keep going after it hits a mismatch error so that we can see all of the errors not just the first one.