### PR TITLE
WT-4766 Make wt_ckpt_decode script work with both python2 and python3

### DIFF
--- a/tools/wt_ckpt_decode.py
+++ b/tools/wt_ckpt_decode.py
@@ -81,7 +81,7 @@ def decode_arg(arg, allocsize):
     print(arg + ': ')
     if version != 1:
         print('**** ERROR: unknown version ' + str(version))
-    addr = addr[1:]
+    addr = bytes(addr[1:])
     result = unpack('iiiiiiiiiiiiii',addr)
     if len(result) != 14:
         print('**** ERROR: result len unexpected: ' + str(len(result)))


### PR DESCRIPTION
The change is needed because the WT unpack routine now takes a bytes object.  It was working previously for Python3 because a bytearray object behaves like a bytes object in Python3.  In Python2, they are not the same at all, but an explicit conversion will solve the problem.