### PR TITLE
WT-4769 Keep empty page references with active history.

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -279,13 +279,14 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 	 * the page could switch to an in-memory state at any time.  Lock down
 	 * the structure, just to be safe.
 	 */
-	if (ref->page_del == NULL)
+	if (ref->page_del == NULL && ref->page_las == NULL)
 		return (true);
 
 	if (!__wt_atomic_casv32(&ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 		return (false);
 
-	skip = !__wt_page_del_active(session, ref, visible_all);
+	skip = !__wt_page_del_active(session, ref, visible_all) &&
+	    !__wt_page_las_active(session, ref);
 
 	/*
 	 * The page_del structure can be freed as soon as the delete is stable:

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -415,6 +415,7 @@ __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
 
 	WT_RET(__las_page_instantiate(session, ref));
 	ref->page_las->eviction_to_lookaside = false;
+	ref->page_las->resolved = true;
 	return (0);
 }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -861,6 +861,10 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 			}
 		}
 
+		/* Check that we are not discarding active history. */
+		WT_ASSERT(session, (next_ref == ref && discard) ||
+		    !__wt_page_las_active(session, next_ref));
+
 		/*
 		 * The page-delete and lookaside memory weren't added to the
 		 * parent's footprint, ignore it here.

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -862,8 +862,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 		}
 
 		/* Check that we are not discarding active history. */
-		WT_ASSERT(session, (next_ref == ref && discard) ||
-		    !__wt_page_las_active(session, next_ref));
+		WT_ASSERT(session, !__wt_page_las_active(session, next_ref));
 
 		/*
 		 * The page-delete and lookaside memory weren't added to the

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -255,6 +255,7 @@ struct __wt_page_lookaside {
 					 * page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
+	bool resolved;			/* History has been read into cache */
 	bool skew_newest;		/* Page image has newest versions */
 };
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1198,6 +1198,8 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	if ((page_las = ref->page_las) == NULL)
 		return (false);
+	if (page_las->resolved)
+		return (false);
 	if (!page_las->skew_newest || page_las->has_prepares)
 		return (true);
 	if (__wt_txn_visible_all(session, page_las->max_txn,


### PR DESCRIPTION
It is only okay to discard a reference once its history is no longer required, even if reconciliation created an empty page image.