### PR TITLE
WT-4767 Temporary fix for compatibility tests

### DIFF
--- a/test/suite/test_compat02.py
+++ b/test/suite/test_compat02.py
@@ -59,13 +59,13 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
     #
     compat_create = [
         ('def', dict(create_rel='none', log_create=3)),
-        ('31', dict(create_rel="3.1", log_create=3)),
+        ('32', dict(create_rel="3.2", log_create=3)),
         ('30', dict(create_rel="3.0", log_create=2)),
         ('26', dict(create_rel="2.6", log_create=1)),
     ]
     compat_release = [
         ('def_rel', dict(rel='none', log_rel=3)),
-        ('31_rel', dict(rel="3.1", log_rel=3)),
+        ('32_rel', dict(rel="3.2", log_rel=3)),
         ('30_rel', dict(rel="3.0", log_rel=2)),
         ('26_rel', dict(rel="2.6", log_rel=1)),
         ('26_patch_rel', dict(rel="2.6.1", log_rel=1)),
@@ -73,7 +73,7 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
     compat_max = [
         ('future_max', dict(max_req=future_rel, log_max=future_logv)),
         ('def_max', dict(max_req='none', log_max=3)),
-        ('31_max', dict(max_req="3.1", log_max=3)),
+        ('32_max', dict(max_req="3.2", log_max=3)),
         ('30_max', dict(max_req="3.0", log_max=2)),
         ('26_max', dict(max_req="2.6", log_max=1)),
         ('26_patch_max', dict(max_req="2.6.1", log_max=1)),
@@ -81,7 +81,7 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
     compat_min = [
         ('future_min', dict(min_req=future_rel, log_min=future_logv)),
         ('def_min', dict(min_req='none', log_min=3)),
-        ('31_min', dict(min_req="3.1", log_min=3)),
+        ('32_min', dict(min_req="3.2", log_min=3)),
         ('30_min', dict(min_req="3.0", log_min=2)),
         ('26_min', dict(min_req="2.6", log_min=1)),
         ('26_patch_min', dict(min_req="2.6.1", log_min=1)),

--- a/test/suite/test_compat03.py
+++ b/test/suite/test_compat03.py
@@ -60,7 +60,7 @@ class test_compat03(wttest.WiredTigerTestCase, suite_subprocess):
     compat_release = [
         ('def_rel', dict(rel='none', log_rel=3)),
         ('future_rel', dict(rel=future_rel, log_rel=future_logv)),
-        ('31_rel', dict(rel="3.1", log_rel=3)),
+        ('32_rel', dict(rel="3.2", log_rel=3)),
         ('30_rel', dict(rel="3.0", log_rel=2)),
         ('26_rel', dict(rel="2.6", log_rel=1)),
         ('26_patch_rel', dict(rel="2.6.1", log_rel=1)),
@@ -68,7 +68,7 @@ class test_compat03(wttest.WiredTigerTestCase, suite_subprocess):
     compat_max = [
         ('def_max', dict(max_req='none', log_max=3)),
         ('future_max', dict(max_req=future_rel, log_max=future_logv)),
-        ('31_max', dict(max_req="3.1", log_max=3)),
+        ('32_max', dict(max_req="3.2", log_max=3)),
         ('30_max', dict(max_req="3.0", log_max=2)),
         ('26_max', dict(max_req="2.6", log_max=1)),
         ('26_patch_max', dict(max_req="2.6.1", log_max=1)),
@@ -76,7 +76,7 @@ class test_compat03(wttest.WiredTigerTestCase, suite_subprocess):
     compat_min = [
         ('def_min', dict(min_req='none', log_min=3)),
         ('future_min', dict(min_req=future_rel, log_min=future_logv)),
-        ('31_min', dict(min_req="3.1", log_min=3)),
+        ('32_min', dict(min_req="3.2", log_min=3)),
         ('30_min', dict(min_req="3.0", log_min=2)),
         ('26_min', dict(min_req="2.6", log_min=1)),
         ('26_patch_min', dict(min_req="2.6.1", log_min=1)),


### PR DESCRIPTION
Cutting a 3.2.0 WiredTiger release broke the Python compatibility
tests, this change fixes the build failures, but means we no
longer test against the 3.1 release. I suspect it's not the
correct final fix.