### PR TITLE
WT-4768 Save the id for sweep dropping in btree_close instead of eviction.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -270,6 +270,16 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 	F_SET(btree, WT_BTREE_CLOSED);
 
 	/*
+	 * If closing a tree let sweep drop lookaside entries for it.
+	 */
+	if (F_ISSET(S2C(session), WT_CONN_LOOKASIDE_OPEN) &&
+	    btree->lookaside_entries) {
+		WT_ASSERT(session, !WT_IS_METADATA(btree->dhandle) &&
+		    !F_ISSET(btree, WT_BTREE_LOOKASIDE));
+		WT_TRET(__wt_las_save_dropped(session));
+	}
+
+	/*
 	 * If we turned eviction off and never turned it back on, do that now,
 	 * otherwise the counter will be off.
 	 */

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -104,7 +104,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 */
 			WT_ASSERT(session,
 			    F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
-			    F_ISSET(conn, WT_CONN_CLOSING) ||
+			    F_ISSET(S2C(session), WT_CONN_CLOSING) ||
 			    __wt_page_can_evict(session, ref, NULL));
 			__wt_ref_out(session, ref);
 			break;

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -41,24 +41,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	if (btree->root.page == NULL)
 		return (0);
 
-	/*
-	 * If discarding a dead tree, remove any lookaside entries.  This deals
-	 * with the case where a tree is dropped with "force=true".  It happens
-	 * that we also force-drop the lookaside table itself: it can never
-	 * participate in lookaside eviction, and we can't open a cursor on it
-	 * as we are discarding it.
-	 *
-	 * We use the special page ID zero so that all lookaside entries for
-	 * the tree are removed.
-	 */
-	if (F_ISSET(dhandle, WT_DHANDLE_DEAD) &&
-	    F_ISSET(conn, WT_CONN_LOOKASIDE_OPEN) && btree->lookaside_entries) {
-		WT_ASSERT(session, !WT_IS_METADATA(dhandle) &&
-		    !F_ISSET(btree, WT_BTREE_LOOKASIDE));
-
-		WT_RET(__wt_las_save_dropped(session));
-	}
-
 	/* Make sure the oldest transaction ID is up-to-date. */
 	WT_RET(__wt_txn_update_oldest(
 	    session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -16,7 +16,6 @@ int
 __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 {
 	WT_BTREE *btree;
-	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 	WT_PAGE *page;
@@ -25,7 +24,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
 	dhandle = session->dhandle;
 	btree = dhandle->handle;
-	conn = S2C(session);
 
 	/*
 	 * We need exclusive access to the file, we're about to discard the root


### PR DESCRIPTION
With this fix, I do not get any data mismatch failures with the test case. Prior to this fix, I was getting 100% failure with 20 parallel processes.

@michaelcahill I'm a bit concerned this undoes some of the fixes from WT-3715 and dropping the LAS entries for a dropped file with `force=true` by moving it. I also considered some path that would remove or avoid saving the id with the sweep dead versus discard phases if we reopened, but that felt messy pretty quickly.