### PR TITLE
WT-4794 Mark lookaside history resolved in all read paths.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -291,6 +291,13 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 		}
 	}
 
+	/*
+	 * Now the lookaside history has been read into cache there is no
+	 * further need to maintain a reference to it.
+	 */
+	ref->page_las->eviction_to_lookaside = false;
+	ref->page_las->resolved = true;
+
 err:	if (locked)
 		__wt_readunlock(session, &cache->las_sweepwalk_lock);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
@@ -414,8 +421,6 @@ __page_read_lookaside(WT_SESSION_IMPL *session, WT_REF *ref,
 	}
 
 	WT_RET(__las_page_instantiate(session, ref));
-	ref->page_las->eviction_to_lookaside = false;
-	ref->page_las->resolved = true;
 	return (0);
 }
 
@@ -541,10 +546,8 @@ skip_read:
 		 * information), first update based on the lookaside table and
 		 * then apply the delete.
 		 */
-		if (ref->page_las != NULL) {
+		if (ref->page_las != NULL)
 			WT_ERR(__las_page_instantiate(session, ref));
-			ref->page_las->eviction_to_lookaside = false;
-		}
 
 		/* Move all records to a deleted state. */
 		WT_ERR(__wt_delete_page_instantiate(session, ref));


### PR DESCRIPTION
When the `resolved` flag was first added to `ref->page_las`, it was only being set in the common case where lookaside history was re-instantiated in memory.  This change sets it consistently in all (currently both) paths.