### PR TITLE
WT-4793 Extend test/checkpoint to use timestamps and more

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1370,6 +1370,7 @@ vw
 vxr
 vxz
 vz
+wW
 waitpid
 waker
 wakeup
@@ -1397,7 +1398,6 @@ wtperf
 wtperf's
 wts
 wtstats
-wW
 xF
 xff
 xxxx

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1370,7 +1370,6 @@ vw
 vxr
 vxz
 vz
-wW
 waitpid
 waker
 wakeup

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1397,6 +1397,7 @@ wtperf
 wtperf's
 wts
 wtstats
+wW
 xF
 xff
 xxxx

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -29,6 +29,7 @@
 #include "test_checkpoint.h"
 
 static WT_THREAD_RET checkpointer(void *);
+static WT_THREAD_RET clock_thread(void *);
 static int compare_cursors(
     WT_CURSOR *, const char *, WT_CURSOR *, const char *);
 static int diagnose_key_error(WT_CURSOR *, int, WT_CURSOR *, int);
@@ -42,8 +43,11 @@ static int verify_consistency(WT_SESSION *, bool);
 void
 start_checkpoints(void)
 {
+	testutil_check(__wt_rwlock_init(NULL, &g.clock_lock));
 	testutil_check(__wt_thread_create(NULL,
 	    &g.checkpoint_thread, checkpointer, NULL));
+	testutil_check(__wt_thread_create(NULL,
+	    &g.clock_thread, clock_thread, NULL));
 }
 
 /*
@@ -54,6 +58,43 @@ void
 end_checkpoints(void)
 {
 	testutil_check(__wt_thread_join(NULL, &g.checkpoint_thread));
+	testutil_check(__wt_thread_join(NULL, &g.clock_thread));
+	__wt_rwlock_destroy(NULL, &g.clock_lock);
+}
+
+/*
+ * clock_thread --
+ *	Clock thread: ticks up timestamps.
+ */
+static WT_THREAD_RET
+clock_thread(void *arg)
+{
+	WT_SESSION *wt_session;
+	WT_SESSION_IMPL *session;
+	char buf[128];
+
+	WT_UNUSED(arg);
+
+	testutil_check(g.conn->open_session(g.conn, NULL, NULL, &wt_session));
+	session = (WT_SESSION_IMPL *)wt_session;
+
+	g.ts = 0;
+	while (g.running) {
+		__wt_writelock(session, &g.clock_lock);
+		++g.ts;
+		testutil_check(__wt_snprintf(
+		    buf, sizeof(buf),
+		    "oldest_timestamp=%x,stable_timestamp=%x", g.ts, g.ts));
+		testutil_check(g.conn->set_timestamp(g.conn, buf));
+		if (g.ts % 997 == 0)
+			__wt_sleep(10, 0);
+		__wt_writeunlock(session, &g.clock_lock);
+		__wt_sleep(0, 10000);
+	}
+
+	testutil_check(wt_session->close(wt_session, NULL));
+
+	return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -115,6 +156,7 @@ real_checkpointer(void)
 		    session, checkpoint_config)) != 0)
 			return (log_print_err("session.checkpoint", ret, 1));
 		printf("Finished a checkpoint\n");
+		fflush(stdout);
 
 		if (!g.running)
 			goto done;
@@ -123,6 +165,8 @@ real_checkpointer(void)
 		if ((ret = verify_consistency(session, true)) != 0)
 			return (log_print_err(
 			    "verify_consistency (offline)", ret, 1));
+
+		__wt_sleep(5, 0);
 	}
 
 done:	if ((ret = session->close(session, NULL)) != 0)
@@ -234,6 +278,7 @@ verify_consistency(WT_SESSION *session, bool use_checkpoint)
 	printf("Finished verifying a %s with %d tables and %" PRIu64
 	    " keys\n", use_checkpoint ? "checkpoint" : "snapshot",
 	    g.ntables, key_count);
+	fflush(stdout);
 
 err:	for (i = 0; i < g.ntables; i++) {
 		if (cursors[i] != NULL &&

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -23,3 +23,12 @@ $TEST_WRAPPER ./t -T 6 -t r
 
 echo "checkpoint: 6 row-store tables, named checkpoint"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r
+
+echo "checkpoint: row-store tables, stress LAS. Sweep and timestamps"
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -w -p -n 100000 -k 100000 -C cache_size=100MB
+
+echo "checkpoint: 3 mixed tables, with sweep"
+$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -w -n 100000 -k 100000
+
+echo "checkpoint: 3 mixed tables, with timestamps"
+$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -p -n 100000 -k 100000

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -25,10 +25,10 @@ echo "checkpoint: 6 row-store tables, named checkpoint"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r
 
 echo "checkpoint: row-store tables, stress LAS. Sweep and timestamps"
-$TEST_WRAPPER ./t -t r -W 3 -r 2 -s -p -n 100000 -k 100000 -C cache_size=100MB
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -s -x -n 100000 -k 100000 -C cache_size=100MB
 
 echo "checkpoint: 3 mixed tables, with sweep"
 $TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -s -n 100000 -k 100000
 
 echo "checkpoint: 3 mixed tables, with timestamps"
-$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -p -n 100000 -k 100000
+$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -x -n 100000 -k 100000

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -25,10 +25,10 @@ echo "checkpoint: 6 row-store tables, named checkpoint"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r
 
 echo "checkpoint: row-store tables, stress LAS. Sweep and timestamps"
-$TEST_WRAPPER ./t -t r -W 3 -r 2 -w -p -n 100000 -k 100000 -C cache_size=100MB
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -s -p -n 100000 -k 100000 -C cache_size=100MB
 
 echo "checkpoint: 3 mixed tables, with sweep"
-$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -w -n 100000 -k 100000
+$TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -s -n 100000 -k 100000
 
 echo "checkpoint: 3 mixed tables, with timestamps"
 $TEST_WRAPPER ./t -T 3 -t m -W 3 -r 2 -p -n 100000 -k 100000

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 	runs = 1;
 
 	while ((ch = __wt_getopt(
-	    progname, argc, argv, "C:c:h:k:l:n:pr:T:t:wW:")) != EOF)
+	    progname, argc, argv, "C:c:h:k:l:n:pr:sT:t:W:")) != EOF)
 		switch (ch) {
 		case 'c':
 			g.checkpoint_name = __wt_optarg;
@@ -96,6 +96,9 @@ main(int argc, char *argv[])
 		case 'r':			/* runs */
 			runs = atoi(__wt_optarg);
 			break;
+		case 's':
+			g.sweep_stress = true;
+			break;
 		case 't':
 			switch (__wt_optarg[0]) {
 			case 'c':
@@ -116,9 +119,6 @@ main(int argc, char *argv[])
 			break;
 		case 'T':
 			g.ntables = atoi(__wt_optarg);
-			break;
-		case 'w':
-			g.sweep_stress = true;
 			break;
 		case 'W':
 			g.nworkers = atoi(__wt_optarg);

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -34,7 +34,7 @@ static int  handle_error(WT_EVENT_HANDLER *, WT_SESSION *, int, const char *);
 static int  handle_message(WT_EVENT_HANDLER *, WT_SESSION *, const char *);
 static void onint(int)
     WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
-static void cleanup(void);
+static void cleanup(bool);
 static int  usage(void);
 static int  wt_connect(const char *);
 static int  wt_shutdown(void);
@@ -130,11 +130,12 @@ main(int argc, char *argv[])
 	testutil_work_dir_from_path(g.home, 512, working_dir);
 
 	printf("%s: process %" PRIu64 "\n", progname, (uint64_t)getpid());
+
 	for (cnt = 1; (runs == 0 || cnt <= runs) && g.status == 0; ++cnt) {
+		cleanup(cnt == 1);		/* Clean up previous runs */
+
 		printf("    %d: %d workers, %d tables\n",
 		    cnt, g.nworkers, g.ntables);
-
-		cleanup();			/* Clean up previous runs */
 
 		/* Setup a fresh set of cookies in the global array. */
 		if ((g.cookies = calloc(
@@ -189,12 +190,10 @@ wt_connect(const char *config_open)
 		NULL	/* Close handler. */
 	};
 	int ret;
-	char config[128];
-
-	testutil_make_work_dir(g.home);
+	char config[512];
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
-	    "create,statistics=(fast),error_prefix=\"%s\",cache_size=1GB%s%s",
+	    "create,cache_cursors=false,statistics=(fast),statistics_log=(json,wait=1),error_prefix=\"%s\",file_manager=(close_handle_minimum=1,close_idle_time=1,close_scan_interval=1),timing_stress_for_test=(aggressive_sweep),log=(enabled),cache_size=1GB%s%s",
 	    progname,
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));
@@ -230,12 +229,14 @@ wt_shutdown(void)
  *	Clean up from previous runs.
  */
 static void
-cleanup(void)
+cleanup(bool remove_dir)
 {
 	g.running = 0;
 	g.ntables_created = 0;
+	g.ts = 0;
 
-	testutil_clean_work_dir(g.home);
+	if (remove_dir)
+		testutil_make_work_dir(g.home);
 }
 
 static int
@@ -271,7 +272,7 @@ onint(int signo)
 {
 	WT_UNUSED(signo);
 
-	cleanup();
+	cleanup(false);
 
 	fprintf(stderr, "\n");
 	exit(EXIT_FAILURE);

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 	runs = 1;
 
 	while ((ch = __wt_getopt(
-	    progname, argc, argv, "C:c:h:k:l:n:pr:sT:t:W:")) != EOF)
+	    progname, argc, argv, "C:c:h:k:l:n:r:sT:t:W:x")) != EOF)
 		switch (ch) {
 		case 'c':
 			g.checkpoint_name = __wt_optarg;
@@ -89,9 +89,6 @@ main(int argc, char *argv[])
 			break;
 		case 'n':			/* operations */
 			g.nops = (u_int)atoi(__wt_optarg);
-			break;
-		case 'p':
-			g.use_timestamps = true;
 			break;
 		case 'r':			/* runs */
 			runs = atoi(__wt_optarg);
@@ -122,6 +119,9 @@ main(int argc, char *argv[])
 			break;
 		case 'W':
 			g.nworkers = atoi(__wt_optarg);
+			break;
+		case 'x':
+			g.use_timestamps = true;
 			break;
 		default:
 			return (usage());

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -193,7 +193,11 @@ wt_connect(const char *config_open)
 	char config[512];
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
-	    "create,cache_cursors=false,statistics=(fast),statistics_log=(json,wait=1),error_prefix=\"%s\",file_manager=(close_handle_minimum=1,close_idle_time=1,close_scan_interval=1),timing_stress_for_test=(aggressive_sweep),log=(enabled),cache_size=1GB%s%s",
+	    "create,cache_cursors=false,statistics=(fast),"		\
+	    "statistics_log=(json,wait=1),error_prefix=\"%s\","		\
+	    "file_manager=(close_handle_minimum=1,close_idle_time=1,"	\
+	    "close_scan_interval=1),log=(enabled),cache_size=1GB,"	\
+	    "timing_stress_for_test=(aggressive_sweep)%s%s",
 	    progname,
 	    config_open == NULL ? "" : ",",
 	    config_open == NULL ? "" : config_open));

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -65,7 +65,7 @@ typedef struct {
 	int status;				/* Exit status */
 	bool sweep_stress;			/* Sweep stress test */
 	u_int ts;				/* Current timestamp */
-	bool use_timestamps;			/* Use timestamps */
+	bool use_timestamps;			/* Use txn timestamps */
 	COOKIE *cookies;			/* Per-thread info */
 	WT_RWLOCK clock_lock;			/* Clock synchronization */
 	wt_thread_t checkpoint_thread;		/* Checkpoint thread */

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -63,8 +63,11 @@ typedef struct {
 	int ntables_created;			/* Number tables opened */
 	int running;				/* Whether to stop */
 	int status;				/* Exit status */
+	u_int ts;				/* Current timestamp */
 	COOKIE *cookies;			/* Per-thread info */
+	WT_RWLOCK clock_lock;			/* Clock synchronization */
 	wt_thread_t checkpoint_thread;		/* Checkpoint thread */
+	wt_thread_t clock_thread;		/* Clock thread */
 } GLOBAL;
 extern GLOBAL g;
 

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -63,7 +63,9 @@ typedef struct {
 	int ntables_created;			/* Number tables opened */
 	int running;				/* Whether to stop */
 	int status;				/* Exit status */
+	bool sweep_stress;			/* Sweep stress test */
 	u_int ts;				/* Current timestamp */
+	bool use_timestamps;			/* Use timestamps */
 	COOKIE *cookies;			/* Per-thread info */
 	WT_RWLOCK clock_lock;			/* Clock synchronization */
 	wt_thread_t checkpoint_thread;		/* Checkpoint thread */

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -39,10 +39,10 @@ static int
 create_table(WT_SESSION *session, COOKIE *cookie)
 {
 	int ret;
-	char config[128];
+	char config[256];
 
 	testutil_check(__wt_snprintf(config, sizeof(config),
-	    "key_format=%s,value_format=S,%s",
+	    "key_format=%s,value_format=S,allocation_size=512,leaf_page_max=1KB,internal_page_max=1KB,memory_page_max=64KB,log=(enabled=false),%s",
 	    cookie->type == COL ? "r" : "q",
 	    cookie->type == LSM ? ",type=lsm" : ""));
 
@@ -94,6 +94,8 @@ start_workers(table_type type)
 			goto err;
 	}
 
+	testutil_check(session->close(session, NULL));
+
 	(void)gettimeofday(&start, NULL);
 
 	/* Create threads. */
@@ -122,20 +124,53 @@ err:	free(tids);
 static inline int
 worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
 {
-	int ret;
+	int cmp, ret;
 	char valuebuf[64];
 
 	cursor->set_key(cursor, keyno);
-	/* Roughly 5% removes. */
-	if (new_val % 19 == 0) {
-		if ((ret = cursor->remove(cursor)) != 0) {
+	/* Roughly half inserts, then balanced inserts / range removes. */
+	if (new_val > g.nops / 2 && new_val % 39 == 0) {
+		if ((ret = cursor->search_near(cursor, &cmp)) != 0) {
+			if (ret == WT_NOTFOUND)
+				return (0);
 			if (ret == WT_ROLLBACK)
 				return (WT_ROLLBACK);
-			return (log_print_err("cursor.remove", ret, 1));
+			return (log_print_err("cursor.search_near", ret, 1));
 		}
+		if (cmp < 0) {
+			if ((ret = cursor->next(cursor)) != 0) {
+				if (ret == WT_NOTFOUND)
+					return (0);
+				if (ret == WT_ROLLBACK)
+					return (WT_ROLLBACK);
+				return (log_print_err("cursor.next", ret, 1));
+			}
+		}
+		for (int i = 10; i > 0; i--) {
+			if ((ret = cursor->remove(cursor)) != 0) {
+				if (ret == WT_ROLLBACK)
+					return (WT_ROLLBACK);
+				return (log_print_err("cursor.remove", ret, 1));
+			}
+			if ((ret = cursor->next(cursor)) != 0) {
+				if (ret == WT_NOTFOUND)
+					return (0);
+				if (ret == WT_ROLLBACK)
+					return (WT_ROLLBACK);
+				return (log_print_err("cursor.next", ret, 1));
+			}
+		}
+		testutil_check(cursor->reset(cursor));
+	} else if (new_val % 39 < 10) {
+		if ((ret = cursor->search(cursor)) != 0 && ret != WT_NOTFOUND) {
+			if (ret == WT_ROLLBACK)
+				return (WT_ROLLBACK);
+			return (log_print_err("cursor.search", ret, 1));
+		}
+		testutil_check(cursor->reset(cursor));
 	} else {
 		testutil_check(__wt_snprintf(
-		    valuebuf, sizeof(valuebuf), "%037u", new_val));
+		    valuebuf, sizeof(valuebuf), "%052u", new_val));
 		cursor->set_value(cursor, valuebuf);
 		if ((ret = cursor->insert(cursor)) != 0) {
 			if (ret == WT_ROLLBACK)
@@ -143,6 +178,7 @@ worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
 			return (log_print_err("cursor.insert", ret, 1));
 		}
 	}
+
 	return (0);
 }
 
@@ -177,10 +213,10 @@ real_worker(void)
 	WT_SESSION *session;
 	u_int i, keyno;
 	int j, ret, t_ret;
+	char buf[128];
+	bool has_cursors;
 
 	ret = t_ret = 0;
-
-	__wt_random_init(&rnd);
 
 	if ((cursors = calloc(
 	    (size_t)(g.ntables), sizeof(WT_CURSOR *))) == NULL)
@@ -192,41 +228,91 @@ real_worker(void)
 		goto err;
 	}
 
+	__wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+
 	for (j = 0; j < g.ntables; j++)
 		if ((ret = session->open_cursor(session,
 		    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
 			(void)log_print_err("session.open_cursor", ret, 1);
 			goto err;
 		}
+	has_cursors = true;
 
 	for (i = 0; i < g.nops && g.running; ++i, __wt_yield()) {
-		if ((ret = session->begin_transaction(session, NULL)) != 0) {
+		if ((ret = session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)")) != 0) {
 			(void)log_print_err(
 			    "real_worker:begin_transaction", ret, 1);
 			goto err;
 		}
 		keyno = __wt_random(&rnd) % g.nkeys + 1;
-		for (j = 0; j < g.ntables; j++) {
-			if ((ret = worker_op(cursors[j], keyno, i)) != 0)
-				break;
+		if (i % 23 == 0) {
+			if (__wt_try_readlock((WT_SESSION_IMPL *)session, &g.clock_lock) != 0) {
+				testutil_check(session->commit_transaction(session, NULL));
+				for (j = 0; j < g.ntables; j++)
+					testutil_check(cursors[j]->close(cursors[j]));
+				has_cursors = false;
+				__wt_readlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+				testutil_check(session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)"));
+			}
+			testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%x", g.ts + 1));
+			testutil_check(session->timestamp_transaction(session, buf));
+			__wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+
+			for (j = 0; !has_cursors && j < g.ntables; j++)
+				if ((ret = session->open_cursor(session,
+				    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
+					(void)log_print_err("session.open_cursor", ret, 1);
+					goto err;
+				}
+			has_cursors = true;
 		}
-		if (ret == 0) {
+		for (j = 0; ret == 0 && j < g.ntables; j++) {
+			ret = worker_op(cursors[j], keyno, i);
+		}
+#if 0
+		if (i % 23 == 0) {
+			if (__wt_try_readlock((WT_SESSION_IMPL *)session, &g.clock_lock) != 0) {
+				testutil_check(session->commit_transaction(session, NULL));
+				for (j = 0; j < g.ntables; j++)
+					testutil_check(cursors[j]->close(cursors[j]));
+				has_cursors = false;
+				__wt_readlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+				testutil_check(session->begin_transaction(session, "read_timestamp=1,roundup_timestamps=(read=true)"));
+			}
+
+			testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%x", g.ts + 1));
+			testutil_check(session->timestamp_transaction(session, buf));
+			__wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
+
+			for (j = 0; !has_cursors && j < g.ntables; j++)
+				if ((ret = session->open_cursor(session,
+				    g.cookies[j].uri, NULL, NULL, &cursors[j])) != 0) {
+					(void)log_print_err("session.open_cursor", ret, 1);
+					goto err;
+				}
+			has_cursors = true;
+		}
+		for (j = 0; ret == 0 && j < g.ntables; j++) {
+			ret = worker_op(cursors[j], keyno, i + 1);
+		}
+#endif
+		if (ret != 0 && ret != WT_ROLLBACK) {
+			(void)log_print_err("worker op failed", ret, 1);
+			goto err;
+		} else if (ret == 0 && __wt_random(&rnd) % 7 != 0) {
 			if ((ret = session->commit_transaction(
 			    session, NULL)) != 0) {
 				(void)log_print_err(
 				    "real_worker:commit_transaction", ret, 1);
 				goto err;
 			}
-		} else if (ret == WT_ROLLBACK) {
+		} else {
 			if ((ret = session->rollback_transaction(
 			    session, NULL)) != 0) {
 				(void)log_print_err(
 				    "real_worker:rollback_transaction", ret, 1);
 				goto err;
-			    }
-		} else {
-			(void)log_print_err("worker op failed", ret, 1);
-			goto err;
+			}
 		}
 	}
 

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -226,7 +226,8 @@ real_worker(void)
 	WT_SESSION *session;
 	u_int i, keyno;
 	int j, ret, t_ret;
-	char *begin_cfg, buf[128];
+	const char *begin_cfg;
+	char buf[128];
 	bool has_cursors;
 
 	ret = t_ret = 0;


### PR DESCRIPTION
Add options to encourage seeing conditions related to lookaside usage,
handle sweep, checkpoints and different types of data access patterns.

This is the first step, subsequently will make the new functionality
configurable.