### PR TITLE
WT-4775 Make the "bad file descriptor" test resilient against crashing.

### DIFF
--- a/test/suite/suite_subprocess.py
+++ b/test/suite/suite_subprocess.py
@@ -151,7 +151,8 @@ class suite_subprocess:
         return envvar + '=' + str(os.environ.get(envvar)) + '\n'
 
     def show_outputs(self, procargs, message, filenames):
-        out = 'ERROR: wt command ' + message + ': ' + str(procargs) + '\n' + \
+        out = message + ': ' + \
+              str(procargs) + '\n' + \
               self.verbose_env('PATH') + \
               self.verbose_env('LD_LIBRARY_PATH') + \
               self.verbose_env('DYLD_LIBRARY_PATH') + \
@@ -168,6 +169,48 @@ class suite_subprocess:
                     sepline = '*' * 50 + '\n'
                     out = sepline + filename + '\n' + sepline + contents
                     WiredTigerTestCase.prout(out)
+
+    # Run a method as a subprocess using the run.py machinery.
+    # Return the process exit status and the the WiredTiger
+    # home directory used by the subprocess.
+    def run_subprocess_function(self, directory, funcname):
+        testparts = funcname.split('.')
+        if len(testparts) != 3:
+            raise ValueError('bad function name "' + funcname +
+                '", should be three part dotted name')
+        topdir = os.path.dirname(self.buildDirectory())
+        runscript = os.path.join(topdir, 'test', 'suite', 'run.py')
+        procargs = [ sys.executable, runscript, '-p', '--dir', directory,
+            funcname]
+
+        # scenario_number is only set if we are running in a scenario
+        try:
+            scennum = self.scenario_number
+            procargs.append('-s')
+            procargs.append(str(scennum))
+        except:
+            scennum = 0
+
+        returncode = -1
+        os.makedirs(directory)
+
+        # We cannot put the output/error files in the subdirectory, as
+        # that will be cleared by the run.py script.
+        with open("subprocess.err", "w") as wterr:
+            with open("subprocess.out", "w") as wtout:
+                returncode = subprocess.call(
+                    procargs, stdout=wtout, stderr=wterr)
+                if returncode != 0:
+                    # This is not necessarily an error, the primary reason to
+                    # run in a subprocess is that it may crash.
+                    self.show_outputs(procargs,
+                        "Warning: run_subprocess_function " + funcname + \
+                        " returned error code " + str(returncode),
+                        [ "subprocess.out", "subprocess.err" ])
+
+        new_home_dir = os.path.join(directory,
+            testparts[1] + '.' + str(scennum))
+        return [ returncode, new_home_dir ]
 
     # Run the wt utility.
     def runWt(self, args, infilename=None,
@@ -230,15 +273,17 @@ class suite_subprocess:
                         procargs, stdout=wtout, stderr=wterr)
         if failure:
             if returncode == 0:
-                self.show_outputs(procargs, "expected failure, got success",
-                                  [wtoutname, wterrname])
+                self.show_outputs(procargs,
+                    "ERROR: wt command expected failure, got success",
+                    [wtoutname, wterrname])
             self.assertNotEqual(returncode, 0,
                 'expected failure: "' + \
                 str(procargs) + '": exited ' + str(returncode))
         else:
             if returncode != 0:
-                self.show_outputs(procargs, "expected success, got failure",
-                                  [wtoutname, wterrname])
+                self.show_outputs(procargs,
+                    "ERROR: wt command expected success, got failure",
+                    [wtoutname, wterrname])
             self.assertEqual(returncode, 0,
                 'expected success: "' + \
                 str(procargs) + '": exited ' + str(returncode))

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -101,10 +101,14 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
         # sync even though table 1 was successfully written and table 2
         # had an error on close.
         self.open_conn(new_home_dir)
-        c1 = self.session.open_cursor(self.uri1)
-        c2 = self.session.open_cursor(self.uri2)
-        results1 = list(c1)
-        results2 = list(c2)
+
+        # It's possible the second table can't even be opened,
+        # that's okay for our test.
+        results1 = list(self.session.open_cursor(self.uri1))
+        try:
+            results2 = list(self.session.open_cursor(self.uri2))
+        except:
+            results2 = []
         self.assertEqual(results1, results2)
 
 if __name__ == '__main__':

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -92,7 +92,6 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
         subdir = 'SUBPROCESS'
         [ignore_result, new_home_dir] = self.run_subprocess_function(subdir,
             'test_bug018.test_bug018.subprocess_bug018')
-        #os.system('ls -R ' + new_home_dir + '>/dev/tty')
 
         # Make a backup for forensics in case something goes wrong.
         backup_dir = 'BACKUP'
@@ -106,7 +105,6 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
         c2 = self.session.open_cursor(self.uri2)
         results1 = list(c1)
         results2 = list(c2)
-        #self.assertGreater(len(results1), 0)
         self.assertEqual(results1, results2)
 
 if __name__ == '__main__':

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 from helper import copy_wiredtiger_home
+from suite_subprocess import suite_subprocess
 import os
 import wiredtiger, wttest
 
@@ -34,10 +35,14 @@ import wiredtiger, wttest
 #   JIRA WT-3590: if writing table data fails during close then tables
 # that were updated within the same transaction could get out of sync with
 # each other.
-class test_bug018(wttest.WiredTigerTestCase):
+class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
     '''Test closing/reopening/recovering tables when writes fail'''
 
     conn_config = 'log=(enabled)'
+    basename = 'bug018.'
+    baseuri = 'file:' + basename
+    uri1 = baseuri + '01.wt'
+    uri2 = baseuri + '02.wt'
 
     def setUp(self):
         # This test uses Linux-specific code so skip on any other system.
@@ -49,12 +54,10 @@ class test_bug018(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format=S,value_format=S')
         return self.session.open_cursor(uri)
 
-    def test_bug018(self):
+    def subprocess_bug018(self):
         '''Test closing multiple tables'''
-        basename = 'bug018.'
-        baseuri = 'file:' + basename
-        c1 = self.create_table(baseuri + '01.wt')
-        c2 = self.create_table(baseuri + '02.wt')
+        c1 = self.create_table(self.uri1)
+        c2 = self.create_table(self.uri2)
 
         self.session.begin_transaction()
         c1['key'] = 'value'
@@ -70,7 +73,7 @@ class test_bug018(wttest.WiredTigerTestCase):
         # This is Linux-specific code to figure out the file descriptor.
         for f in os.listdir('/proc/self/fd'):
             try:
-                if os.readlink('/proc/self/fd/' + f).endswith(basename + '02.wt'):
+                if os.readlink('/proc/self/fd/' + f).endswith(self.basename + '02.wt'):
                     os.close(int(f))
             except OSError:
                 pass
@@ -82,17 +85,29 @@ class test_bug018(wttest.WiredTigerTestCase):
             except wiredtiger.WiredTigerError:
                 self.conn = None
 
+    def test_bug018(self):
+        '''Test closing multiple tables'''
+
+        self.close_conn()
+        subdir = 'SUBPROCESS'
+        [ignore_result, new_home_dir] = self.run_subprocess_function(subdir,
+            'test_bug018.test_bug018.subprocess_bug018')
+        #os.system('ls -R ' + new_home_dir + '>/dev/tty')
+
         # Make a backup for forensics in case something goes wrong.
         backup_dir = 'BACKUP'
-        copy_wiredtiger_home('.', backup_dir, True)
+        copy_wiredtiger_home(new_home_dir, backup_dir, True)
 
         # After reopening and running recovery both tables should be in
         # sync even though table 1 was successfully written and table 2
         # had an error on close.
-        self.open_conn()
-        c1 = self.session.open_cursor(baseuri + '01.wt')
-        c2 = self.session.open_cursor(baseuri + '02.wt')
-        self.assertEqual(list(c1), list(c2))
+        self.open_conn(new_home_dir)
+        c1 = self.session.open_cursor(self.uri1)
+        c2 = self.session.open_cursor(self.uri2)
+        results1 = list(c1)
+        results2 = list(c2)
+        #self.assertGreater(len(results1), 0)
+        self.assertEqual(results1, results2)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -102,12 +102,18 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
         # had an error on close.
         self.open_conn(new_home_dir)
 
-        # It's possible the second table can't even be opened,
-        # that's okay for our test.
         results1 = list(self.session.open_cursor(self.uri1))
+
+        # It's possible the second table can't even be opened.
+        # That can happen only if the root page was not pushed out.
+        # So if we get an error, make sure we're getting the right
+        # error message.
+
+        self.captureerr.check(self)     # check error messages until now
         try:
             results2 = list(self.session.open_cursor(self.uri2))
         except:
+            self.captureerr.checkAdditionalPattern(self, 'unable to read root page')
             results2 = []
         self.assertEqual(results1, results2)
 

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -247,6 +247,9 @@ class WiredTigerTestCase(unittest.TestCase):
         return "%s.%s.%s" %  (self.__module__,
                               self.className(), self._testMethodName)
 
+    def buildDirectory(self):
+        return self._builddir
+
     # Return the wiredtiger_open extension argument for
     # any needed shared library.
     def extensionsConfig(self):


### PR DESCRIPTION
As part of this change, a function is made available that allows a specialized test method to run in a subprocess.