### PR TITLE
WT-4817 Fix off-by-one error.

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -252,8 +252,8 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
 	 * from archiving, then rotate the newest LSN into the array.
 	 */
 	if (conn->debug_ckpt_cnt != 0) {
-		for (i = (int)conn->debug_ckpt_cnt - 1; i >= 0; --i)
-			conn->debug_ckpt[i] = conn->debug_ckpt[i-1];
+		for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
+			conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
 		conn->debug_ckpt[0] = *ckpt_lsn;
 	}
 }


### PR DESCRIPTION
@ddanderson can you do a quick review of this? All sanitizer builds will fail until this is merged. With this change it passes, prior to this sanitizer catches the bug all the time.