### PR TITLE
Add warning if the open file limit is too small.

### DIFF
--- a/tools/optrack/find-latency-spikes.py
+++ b/tools/optrack/find-latency-spikes.py
@@ -39,6 +39,7 @@ import multiprocessing
 import numpy as np
 import os
 import pandas as pd
+import subprocess
 import sys
 import traceback
 import time
@@ -1241,6 +1242,22 @@ def parseConfigFile(fname):
 
     return True;
 
+# With Python3 this script fails if the number of open files
+# is limited to 256, because the multiprocessing package does
+# not appear to properly clean up processes that exited.
+#
+def checkOpenFileLimit():
+
+    targetLimit = 512;
+    openFileLimit = int(subprocess.check_output("ulimit -n",
+                                            shell=True).decode());
+
+    if (openFileLimit < targetLimit):
+        print(color.BOLD + color.RED + "Open file limit is " +
+              str(openFileLimit) + ". Please increase to " + str(targetLimit) +
+              " by running `ulimit -n " + str(targetLimit) + "`." +
+              color.END);
+        sys.exit(-1);
 
 def main():
 
@@ -1274,6 +1291,8 @@ def main():
     if (len(args.files) == 0):
         parser.print_help();
         sys.exit(1);
+
+    checkOpenFileLimit();
 
     # Determine the target job parallelism
     if (args.jobParallelism > 0):


### PR DESCRIPTION
After conversion to Python3, a script that visualizes operation tracking logs begin to fail on systems where the open file limit is set to 256. The culprit is the multiprocessing module, which appears to not clean up the open files right away after the processes exit. Others are reporting similar issues online. This is affecting us only on OSX. The workaround is simple: the user only needs to bump the open file limit. To keep things simple, I print a warning to the user and terminate the script if the open file limit is too small. 