### PR TITLE
WT-4823 Add check for uninitialised lookaside resources

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -75,11 +75,15 @@ __wt_las_config(WT_SESSION_IMPL *session, const char **cfg)
 		    "max cache overflow size %" PRId64 " below minimum %d",
 		    cval.val, WT_LAS_FILE_MIN);
 
+	/* This is expected for in-memory configurations. */
+	las_session = S2C(session)->cache->las_session[0];
+	if (las_session == NULL)
+		return (0);
+
 	/*
 	 * We need to set file_max on the btree associated with one of the
 	 * lookaside sessions.
 	 */
-	las_session = S2C(session)->cache->las_session[0];
 	las_cursor = (WT_CURSOR_BTREE *)las_session->las_cursor;
 	las_cursor->btree->file_max = (uint64_t)cval.val;
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -77,6 +77,9 @@ __wt_las_config(WT_SESSION_IMPL *session, const char **cfg)
 
 	/* This is expected for in-memory configurations. */
 	las_session = S2C(session)->cache->las_session[0];
+	WT_ASSERT(session,
+	    las_session != NULL || F_ISSET(S2C(session), WT_CONN_IN_MEMORY));
+
 	if (las_session == NULL)
 		return (0);
 

--- a/test/suite/test_las04.py
+++ b/test/suite/test_las04.py
@@ -40,8 +40,8 @@ class test_las04(wttest.WiredTigerTestCase):
     uri = 'table:las_04'
     in_memory_values = [
         ('false', dict(in_memory=False)),
-        ('true', dict(in_memory=True)),
-        ('none', dict(in_memory=None))
+        ('none', dict(in_memory=None)),
+        ('true', dict(in_memory=True))
     ]
     init_file_max_values = [
         ('default', dict(init_file_max=None, init_stat_val=0)),
@@ -75,6 +75,8 @@ class test_las04(wttest.WiredTigerTestCase):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 
         if self.in_memory:
+            # For in-memory configurations, we simply ignore any lookaside
+            # related configuration.
             self.assertEqual(
                 self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
                 0)

--- a/test/suite/test_las04.py
+++ b/test/suite/test_las04.py
@@ -38,6 +38,11 @@ WT_MB = 1048576
 
 class test_las04(wttest.WiredTigerTestCase):
     uri = 'table:las_04'
+    in_memory_values = [
+        ('false', dict(in_memory=False)),
+        ('true', dict(in_memory=True)),
+        ('none', dict(in_memory=None))
+    ]
     init_file_max_values = [
         ('default', dict(init_file_max=None, init_stat_val=0)),
         ('non-zero', dict(init_file_max='100MB', init_stat_val=(WT_MB * 100))),
@@ -49,12 +54,15 @@ class test_las04(wttest.WiredTigerTestCase):
         ('too-low', dict(reconfig_file_max='99MB', reconfig_stat_val=None)),
         ('zero', dict(reconfig_file_max='0', reconfig_stat_val=0))
     ]
-    scenarios = make_scenarios(init_file_max_values, reconfig_file_max_values)
+    scenarios = make_scenarios(init_file_max_values, reconfig_file_max_values,
+                               in_memory_values)
 
     def conn_config(self):
         config = 'statistics=(fast)'
         if self.init_file_max is not None:
             config += ',cache_overflow=(file_max={})'.format(self.init_file_max)
+        if self.in_memory is not None:
+            config += ',in_memory=' + ('true' if self.in_memory else 'false')
         return config
 
     def get_stat(self, stat):
@@ -66,9 +74,14 @@ class test_las04(wttest.WiredTigerTestCase):
     def test_las(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 
-        self.assertEqual(
-            self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
-            self.init_stat_val)
+        if self.in_memory:
+            self.assertEqual(
+                self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
+                0)
+        else:
+            self.assertEqual(
+                self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
+                self.init_stat_val)
 
         reconfigure = lambda: self.conn.reconfigure(
             'cache_overflow=(file_max={})'.format(self.reconfig_file_max))
@@ -82,9 +95,14 @@ class test_las04(wttest.WiredTigerTestCase):
 
         reconfigure()
 
-        self.assertEqual(
-            self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
-            self.reconfig_stat_val)
+        if self.in_memory:
+            self.assertEqual(
+                self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
+                0)
+        else:
+            self.assertEqual(
+                self.get_stat(wiredtiger.stat.conn.cache_lookaside_ondisk_max),
+                self.reconfig_stat_val)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
For in-memory configurations, the lookaside session isn't allocated so we need to add a `NULL` check here.

I've amended the `test_las04` tests to include in-memory configuration. When I remove the check, this test causes a segmentation fault in the same spot as the reported issue so I believe that this is the correct fix.

After discussing with @agorrod, we elected to simply ignore lookaside configuration for in-memory setups.