### PR TITLE
WT-4829 Fix broken filenames in operation tracking.

### DIFF
--- a/tools/optrack/find-latency-spikes.py
+++ b/tools/optrack/find-latency-spikes.py
@@ -864,7 +864,7 @@ def generateTSSlicesForBuckets():
                               numBuckets, "Generating timeline charts");
 
     for i, fname in returnValues.items():
-        bucketFilenames.append(str(fname.value));
+        bucketFilenames.append(fname.value.decode("ascii"));
     print(color.END);
 
     return bucketFilenames;

--- a/tools/optrack/find-latency-spikes.py
+++ b/tools/optrack/find-latency-spikes.py
@@ -864,7 +864,7 @@ def generateTSSlicesForBuckets():
                               numBuckets, "Generating timeline charts");
 
     for i, fname in returnValues.items():
-        bucketFilenames.append(fname.value.decode("ascii"));
+        bucketFilenames.append(fname.value.decode());
     print(color.END);
 
     return bucketFilenames;


### PR DESCRIPTION
After conversion to python 3, file names were encoded as byte arrays and not decoded. As a result the filenames used at HTML links were not properly formed and we could not click on these links. Add proper decoding to fix that.