### PR TITLE
WT-4190 Decrease shutdown time by doing multi-threaded cache flush

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1064,6 +1064,13 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
 			F_SET(conn, WT_CONN_CLOSING_TIMESTAMP);
 	}
 
+	/*
+	 * Ramp the eviction dirty target down to encourage eviction threads to
+	 * clear dirty content out of cache.
+	 */
+	conn->cache->eviction_dirty_trigger = 1.0;
+	conn->cache->eviction_dirty_target = 0.1;
+
 err:	/*
 	 * Rollback all running transactions.
 	 * We do this as a separate pass because an active transaction in one


### PR DESCRIPTION
This PR is artificially bringing the dirty target down to encourage the eviction threads to help reconcile prior to shutdown.

I reproduced similar results to those recorded by @agorrod in the ticket. Bringing the target value down even further doesn't seem to yield any real improvement. And again, this doesn't help much for when we have a single table.