### PR TITLE
WT-4690 During checkpoints, make sure eviction does not split. (v4.0 backport)

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,7 +81,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 		}
 
 		(void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
-		ret = __wt_evict(session, ref, false, previous_state);
+		ret = __wt_evict(session, ref, previous_state, 0);
 		(void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);
 		WT_RET_BUSY_OK(ret);
 		ret = 0;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -776,7 +776,7 @@ read:			/*
 			if (force_attempts < 10 &&
 			    __evict_force_check(session, ref)) {
 				++force_attempts;
-				ret = __wt_page_release_evict(session, ref);
+				ret = __wt_page_release_evict(session, ref, 0);
 				/* If forced eviction fails, stall. */
 				if (ret == EBUSY) {
 					WT_NOT_READ(ret, 0);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -328,7 +328,8 @@ __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
 	 */
 	if (ss->root_ref.page != NULL) {
 		btree->ckpt = ckptbase;
-		ret = __wt_evict(session, &ss->root_ref, true, WT_REF_MEM);
+		ret = __wt_evict(session, &ss->root_ref, WT_REF_MEM,
+		    WT_EVICT_CALL_CLOSING);
 		ss->root_ref.page = NULL;
 		btree->ckpt = NULL;
 	}
@@ -1300,7 +1301,8 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, true, WT_REF_MEM);
+		ret = __wt_evict(session, ref, WT_REF_MEM,
+		    WT_EVICT_CALL_CLOSING);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));
@@ -2019,7 +2021,8 @@ __slvg_row_build_leaf(
 	 */
 	ret = __wt_page_release(session, ref, 0);
 	if (ret == 0)
-		ret = __wt_evict(session, ref, true, WT_REF_MEM);
+		ret = __wt_evict(session, ref, WT_REF_MEM,
+		    WT_EVICT_CALL_CLOSING);
 
 	if (0) {
 err:		WT_TRET(__wt_page_release(session, ref, 0));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -326,7 +326,7 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			    page->read_gen == WT_READGEN_WONT_NEED &&
 			    !tried_eviction) {
 				WT_ERR_BUSY_OK(
-				    __wt_page_release_evict(session, walk));
+				    __wt_page_release_evict(session, walk, 0));
 				walk = prev;
 				prev = NULL;
 				tried_eviction = true;

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -95,7 +95,8 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * Ensure the ref state is restored to the previous
 			 * value if eviction fails.
 			 */
-			WT_ERR(__wt_evict(session, ref, true, ref->state));
+			WT_ERR(__wt_evict(session, ref, ref->state,
+			    WT_EVICT_CALL_CLOSING));
 			break;
 		case WT_SYNC_DISCARD:
 			/*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2320,7 +2320,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 	__wt_cache_read_gen_bump(session, ref->page);
 
 	WT_WITH_BTREE(session, btree,
-	     ret = __wt_evict(session, ref, false, previous_state));
+	    ret = __wt_evict(session, ref, previous_state, 0));
 
 	(void)__wt_atomic_subv32(&btree->evict_busy, 1);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -8,9 +8,9 @@
 
 #include "wt_internal.h"
 
-static int __evict_page_clean_update(WT_SESSION_IMPL *, WT_REF *, bool);
-static int __evict_page_dirty_update(WT_SESSION_IMPL *, WT_REF *, bool);
-static int __evict_review(WT_SESSION_IMPL *, WT_REF *, bool, bool *);
+static int __evict_page_clean_update(WT_SESSION_IMPL *, WT_REF *, uint32_t);
+static int __evict_page_dirty_update(WT_SESSION_IMPL *, WT_REF *, uint32_t);
+static int __evict_review(WT_SESSION_IMPL *, WT_REF *, uint32_t, bool *);
 
 /*
  * __evict_exclusive_clear --
@@ -51,19 +51,20 @@ __evict_exclusive(WT_SESSION_IMPL *session, WT_REF *ref)
  *	Release a reference to a page, and attempt to immediately evict it.
  */
 int
-__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
+__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 {
 	WT_BTREE *btree;
 	WT_DECL_RET;
 	WT_PAGE *page;
 	uint64_t time_start, time_stop;
-	uint32_t previous_state;
+	uint32_t evict_flags, previous_state;
 	bool locked, too_big;
 
 	btree = S2BT(session);
 	locked = false;
 	page = ref->page;
 	time_start = __wt_clock(session);
+	evict_flags = LF_ISSET(WT_READ_NO_SPLIT) ? WT_EVICT_CALL_NO_SPLIT : 0;
 
 	/*
 	 * This function always releases the hazard pointer - ensure that's
@@ -89,7 +90,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * Track how long the call to evict took. If eviction is successful then
 	 * we have one of two pairs of stats to increment.
 	 */
-	ret = __wt_evict(session, ref, false, previous_state);
+	ret = __wt_evict(session, ref, previous_state, evict_flags);
 	time_stop = __wt_clock(session);
 	if (ret == 0) {
 		if (too_big) {
@@ -124,19 +125,24 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref)
  */
 int
 __wt_evict(WT_SESSION_IMPL *session,
-    WT_REF *ref, bool closing, uint32_t previous_state)
+    WT_REF *ref, uint32_t previous_state, uint32_t flags)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_PAGE *page;
-	bool clean_page, inmem_split, local_gen, tree_dead;
+	bool clean_page, closing, inmem_split, local_gen, tree_dead;
 
 	conn = S2C(session);
 	page = ref->page;
+	closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
 	local_gen = false;
 
 	__wt_verbose(session, WT_VERB_EVICT,
 	    "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
+
+	tree_dead = F_ISSET(session->dhandle, WT_DHANDLE_DEAD);
+	if (tree_dead)
+		LF_SET(WT_EVICT_CALL_NO_SPLIT);
 
 	/*
 	 * Enter the eviction generation. If we re-enter eviction, leave the
@@ -171,7 +177,7 @@ __wt_evict(WT_SESSION_IMPL *session,
 	 * Make this check for clean pages, too: while unlikely eviction would
 	 * choose an internal page with children, it's not disallowed.
 	 */
-	WT_ERR(__evict_review(session, ref, closing, &inmem_split));
+	WT_ERR(__evict_review(session, ref, flags, &inmem_split));
 
 	/*
 	 * If there was an in-memory split, the tree has been left in the state
@@ -208,7 +214,6 @@ __wt_evict(WT_SESSION_IMPL *session,
 	}
 
 	/* Update the reference and discard the page. */
-	tree_dead = F_ISSET(session->dhandle, WT_DHANDLE_DEAD);
 	if (__wt_ref_is_root(ref))
 		__wt_ref_out(session, ref);
 	else if ((clean_page && !F_ISSET(conn, WT_CONN_IN_MEMORY)) || tree_dead)
@@ -216,10 +221,9 @@ __wt_evict(WT_SESSION_IMPL *session,
 		 * Pages that belong to dead trees never write back to disk
 		 * and can't support page splits.
 		 */
-		WT_ERR(__evict_page_clean_update(
-		    session, ref, tree_dead || closing));
+		WT_ERR(__evict_page_clean_update(session, ref, flags));
 	else
-		WT_ERR(__evict_page_dirty_update(session, ref, closing));
+		WT_ERR(__evict_page_dirty_update(session, ref, flags));
 
 	if (clean_page) {
 		WT_STAT_CONN_INCR(session, cache_eviction_clean);
@@ -250,7 +254,7 @@ done:	/* Leave any local eviction generation. */
  *	split.
  */
 static int
-__evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
+__evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 {
 	WT_DECL_RET;
 	WT_PAGE *parent;
@@ -264,7 +268,7 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 	 * Avoid doing reverse splits when closing the file, it is wasted work
 	 * and some structures may have already been freed.
 	 */
-	if (!closing) {
+	if (!LF_ISSET(WT_EVICT_CALL_NO_SPLIT | WT_EVICT_CALL_CLOSING)) {
 		parent = ref->home;
 		WT_INTL_INDEX_GET(session, parent, pindex);
 		ndeleted = __wt_atomic_addv32(&pindex->deleted_entries, 1);
@@ -302,9 +306,12 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
  *	Update a clean page's reference on eviction.
  */
 static int
-__evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
+__evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 {
 	WT_DECL_RET;
+	bool closing;
+
+	closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
 
 	/*
 	 * Before discarding a page, assert that all updates are globally
@@ -334,7 +341,7 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		WT_REF_SET_STATE(ref, WT_REF_LOOKASIDE);
 	} else if (ref->addr == NULL) {
 		WT_WITH_PAGE_INDEX(session,
-		    ret = __evict_delete_ref(session, ref, closing));
+		    ret = __evict_delete_ref(session, ref, flags));
 		WT_RET_BUSY_OK(ret);
 	} else
 		WT_REF_SET_STATE(ref, WT_REF_DISK);
@@ -347,14 +354,17 @@ __evict_page_clean_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
  *	Update a dirty page's reference on eviction.
  */
 static int
-__evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
+__evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref,
+    uint32_t evict_flags)
 {
 	WT_ADDR *addr;
 	WT_DECL_RET;
 	WT_MULTI multi;
 	WT_PAGE_MODIFY *mod;
+	bool closing;
 
 	mod = ref->page->modify;
+	closing = FLD_ISSET(evict_flags, WT_EVICT_CALL_CLOSING);
 
 	WT_ASSERT(session, ref->addr == NULL);
 
@@ -370,7 +380,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
 		 */
 		__wt_ref_out(session, ref);
 		WT_WITH_PAGE_INDEX(session,
-		    ret = __evict_delete_ref(session, ref, closing));
+		    ret = __evict_delete_ref(session, ref, evict_flags));
 		WT_RET_BUSY_OK(ret);
 		break;
 	case WT_PM_REC_MULTIBLOCK:			/* Multiple blocks */
@@ -511,20 +521,22 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
  */
 static int
 __evict_review(
-    WT_SESSION_IMPL *session, WT_REF *ref, bool closing, bool *inmem_splitp)
+    WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags,
+	bool *inmem_splitp)
 {
 	WT_CACHE *cache;
 	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_PAGE *page;
 	uint32_t flags;
-	bool lookaside_retry, *lookaside_retryp, modified;
+	bool closing, lookaside_retry, *lookaside_retryp, modified;
 
 	*inmem_splitp = false;
 
 	conn = S2C(session);
 	page = ref->page;
 	flags = WT_REC_EVICT;
+	closing = FLD_ISSET(evict_flags, WT_EVICT_CALL_CLOSING);
 	if (!WT_SESSION_BTREE_SYNC(session))
 		LF_SET(WT_REC_VISIBLE_ALL);
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1516,7 +1516,8 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 				WT_IGNORE_RET(
 				    __wt_page_evict_urgent(session, ref));
 		} else {
-			WT_RET_BUSY_OK(__wt_page_release_evict(session, ref));
+			WT_RET_BUSY_OK(__wt_page_release_evict(session, ref,
+			    flags));
 			return (0);
 		}
 	}

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -290,3 +290,9 @@ struct __wt_cache_pool {
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 	uint8_t flags;
 };
+
+/* Flags used with __wt_evict */
+/* AUTOMATIC FLAG VALUE GENERATION START */
+#define	WT_EVICT_CALL_CLOSING  0x1u		/* Closing connection or tree */
+#define	WT_EVICT_CALL_NO_SPLIT 0x2u		/* Splits not allowed */
+/* AUTOMATIC FLAG VALUE GENERATION STOP */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -386,8 +386,8 @@ extern bool __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC
 extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool closing, uint32_t previous_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);


### PR DESCRIPTION
Clean cherrypick of commit 34c1ffa.