### PR TITLE
WT-4477 Add in asserts from data inconsistency checking.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -491,16 +491,16 @@ connection_runtime_config = [
     Config('debug_mode', '', r'''
         control the settings of various extended debugging features''',
         type='category', subconfig=[
-        Config('aggressive_lookaside', 'false', r'''
+        Config('checkpoint_retention', '0', r'''
+            adjust log archiving to retain the log records of this number
+            of checkpoints. Zero or one means perform normal archiving.''',
+            min='0', max='1024'),
+        Config('eviction', 'false', r'''
             if true, modify internal algorithms to change skew to force
             lookaside eviction to happen more aggressively. This includes but
             is not limited to not skewing newest, not favoring leaf pages,
             and modifying the eviction score mechanism.''',
             type='boolean'),
-        Config('checkpoint_retention', '0', r'''
-            adjust log archiving to retain the log records of this number
-            of checkpoints. Zero or one means perform normal archiving.''',
-            min='0', max='1024'),
         Config('rollback_error', '0', r'''
             return a WT_ROLLBACK error from a transaction operation about
             every Nth operation to simulate a collision''',

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -491,6 +491,12 @@ connection_runtime_config = [
     Config('debug_mode', '', r'''
         control the settings of various extended debugging features''',
         type='category', subconfig=[
+        Config('aggressive_lookaside', 'false', r'''
+            if true, modify internal algorithms to change skew to force
+            lookaside eviction to happen more aggressively. This includes but
+            is not limited to not skewing newest, not favoring leaf pages,
+            and modifying the eviction score mechanism.''',
+            type='boolean'),
         Config('checkpoint_retention', '0', r'''
             adjust log archiving to retain the log records of this number
             of checkpoints. Zero or one means perform normal archiving.''',

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -105,6 +105,7 @@ DeadStores
 Decrement
 Decrypt
 DeleteFileW
+Dh
 EACCES
 EAGAIN
 EB

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1412,6 +1412,25 @@ err:	if (parent != NULL)
 	return (0);
 }
 
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __check_upd_list --
+ *	Sanity check an update list.
+ *	In particular, make sure there no birthmarks.
+ */
+static void
+__check_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd)
+{
+	int birthmark_count;
+
+	for (birthmark_count = 0; upd != NULL; upd = upd->next)
+		if (upd->type == WT_UPDATE_BIRTHMARK)
+			++birthmark_count;
+
+	WT_ASSERT(session, birthmark_count <= 1);
+}
+#endif
+
 /*
  * __split_multi_inmem --
  *	Instantiate a page from a disk image.
@@ -1510,6 +1529,10 @@ __split_multi_inmem(
 				key->data = WT_INSERT_KEY(supd->ins);
 				key->size = WT_INSERT_KEY_SIZE(supd->ins);
 			}
+
+#ifdef HAVE_DIAGNOSTIC
+			__check_upd_list(session, upd);
+#endif
 
 			/* Search the page. */
 			WT_ERR(__wt_row_search(
@@ -1817,9 +1840,11 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 		    WT_SKIP_FIRST(WT_ROW_INSERT_SMALLEST(page))) != NULL) {
 			key->data = WT_INSERT_KEY(ins);
 			key->size = WT_INSERT_KEY_SIZE(ins);
-		} else
+		} else {
+			WT_ASSERT(session, page->entries > 0);
 			WT_ERR(__wt_row_leaf_key(
 			    session, page, &page->pg_row[0], key, true));
+		}
 		WT_ERR(__wt_row_ikey(session, 0, key->data, key->size, child));
 		parent_incr += sizeof(WT_IKEY) + key->size;
 		__wt_scr_free(session, &key);

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -840,6 +840,7 @@ err:	/* Resolve the transaction. */
 		__las_insert_block_verbose(session, btree, multi);
 	}
 
+	WT_UNUSED(first_upd);
 	return (ret);
 }
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -660,7 +660,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 	WT_SAVE_UPD *list;
 	WT_SESSION_IMPL *session;
 	WT_TXN_ISOLATION saved_isolation;
-	WT_UPDATE *upd;
+	WT_UPDATE *first_upd, *upd;
 	wt_off_t las_size;
 	uint64_t insert_cnt, las_counter, las_pageid, max_las_size;
 	uint64_t prepared_insert_cnt;
@@ -741,7 +741,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			slot = page->type == WT_PAGE_ROW_LEAF ?
 			    WT_ROW_SLOT(page, list->ripcip) :
 			    WT_COL_SLOT(page, list->ripcip);
-		upd = list->ins == NULL ?
+		first_upd = upd = list->ins == NULL ?
 		    page->modify->mod_row_update[slot] : list->ins->upd;
 
 		/*
@@ -760,6 +760,9 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 				las_value.size = upd->size;
 				break;
 			case WT_UPDATE_BIRTHMARK:
+				WT_ASSERT(session, upd != first_upd ||
+				    multi->page_las.skew_newest);
+				/* FALLTHROUGH */
 			case WT_UPDATE_TOMBSTONE:
 				las_value.size = 0;
 				break;
@@ -780,6 +783,8 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			    (upd->type == WT_UPDATE_STANDARD ||
 			    upd->type == WT_UPDATE_MODIFY)) {
 				las_value.size = 0;
+				WT_ASSERT(session, upd != first_upd ||
+				    multi->page_las.skew_newest);
 				cursor->set_value(cursor, upd->txnid,
 				    upd->start_ts, upd->durable_ts,
 				    upd->prepare_state, WT_UPDATE_BIRTHMARK,

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -81,10 +81,10 @@ static const WT_CONFIG_CHECK
 
 static const WT_CONFIG_CHECK
     confchk_wiredtiger_open_debug_mode_subconfigs[] = {
-	{ "aggressive_lookaside", "boolean", NULL, NULL, NULL, 0 },
 	{ "checkpoint_retention", "int",
 	    NULL, "min=0,max=1024",
 	    NULL, 0 },
+	{ "eviction", "boolean", NULL, NULL, NULL, 0 },
 	{ "rollback_error", "int", NULL, "min=0,max=10M", NULL, 0 },
 	{ "table_logging", "boolean", NULL, NULL, NULL, 0 },
 	{ NULL, NULL, NULL, NULL, NULL, 0 }
@@ -1373,7 +1373,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait_ms=0"
 	  ",cache_overflow=(file_max=0),cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),compatibility=(release=),"
-	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "debug_mode=(checkpoint_retention=0,eviction=false,"
 	  "rollback_error=0,table_logging=false),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
@@ -1628,7 +1628,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,"
-	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "debug_mode=(checkpoint_retention=0,eviction=false,"
 	  "rollback_error=0,table_logging=false),direct_io=,"
 	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
@@ -1659,7 +1659,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,"
-	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "debug_mode=(checkpoint_retention=0,eviction=false,"
 	  "rollback_error=0,table_logging=false),direct_io=,"
 	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
@@ -1689,9 +1689,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overflow=(file_max=0),cache_overhead=8"
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),debug_mode=(aggressive_lookaside=false,"
-	  "checkpoint_retention=0,rollback_error=0,table_logging=false),"
-	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "require_min=),debug_mode=(checkpoint_retention=0,eviction=false,"
+	  "rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
@@ -1717,9 +1717,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overflow=(file_max=0),cache_overhead=8"
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),debug_mode=(aggressive_lookaside=false,"
-	  "checkpoint_retention=0,rollback_error=0,table_logging=false),"
-	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "require_min=),debug_mode=(checkpoint_retention=0,eviction=false,"
+	  "rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -81,6 +81,7 @@ static const WT_CONFIG_CHECK
 
 static const WT_CONFIG_CHECK
     confchk_wiredtiger_open_debug_mode_subconfigs[] = {
+	{ "aggressive_lookaside", "boolean", NULL, NULL, NULL, 0 },
 	{ "checkpoint_retention", "int",
 	    NULL, "min=0,max=1024",
 	    NULL, 0 },
@@ -177,7 +178,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	    confchk_WT_CONNECTION_reconfigure_compatibility_subconfigs, 1 },
 	{ "debug_mode", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 4 },
 	{ "error_prefix", "string", NULL, NULL, NULL, 0 },
 	{ "eviction", "category",
 	    NULL, NULL,
@@ -894,7 +895,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
 	{ "debug_mode", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 4 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1009,7 +1010,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
 	{ "debug_mode", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 4 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1123,7 +1124,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
 	{ "debug_mode", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 4 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1233,7 +1234,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
 	{ "debug_mode", "category",
 	    NULL, NULL,
-	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 4 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1372,12 +1373,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait_ms=0"
 	  ",cache_overflow=(file_max=0),cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),compatibility=(release=),"
-	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
-	  "table_logging=false),error_prefix=,eviction=(threads_max=8,"
-	  "threads_min=1),eviction_checkpoint_target=1,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,"
-	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
+	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "rollback_error=0,table_logging=false),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
+	  ",file_manager=(close_handle_minimum=250,close_idle_time=30,"
 	  "close_scan_interval=10),io_capacity=(total=0),log=(archive=true,"
 	  "os_cache_dirty_pct=0,prealloc=true,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
@@ -1627,10 +1628,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,"
-	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
-	  "table_logging=false),direct_io=,encryption=(keyid=,name=,"
-	  "secretkey=),error_prefix=,eviction=(threads_max=8,threads_min=1)"
-	  ",eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",exclusive=false,extensions=,file_extend=,"
 	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
@@ -1657,10 +1659,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
 	  "require_min=),config_base=true,create=false,"
-	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
-	  "table_logging=false),direct_io=,encryption=(keyid=,name=,"
-	  "secretkey=),error_prefix=,eviction=(threads_max=8,threads_min=1)"
-	  ",eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "debug_mode=(aggressive_lookaside=false,checkpoint_retention=0,"
+	  "rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",exclusive=false,extensions=,file_extend=,"
 	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
@@ -1686,9 +1689,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overflow=(file_max=0),cache_overhead=8"
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),debug_mode=(checkpoint_retention=0,"
-	  "rollback_error=0,table_logging=false),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "require_min=),debug_mode=(aggressive_lookaside=false,"
+	  "checkpoint_retention=0,rollback_error=0,table_logging=false),"
+	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
@@ -1714,9 +1717,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overflow=(file_max=0),cache_overhead=8"
 	  ",cache_size=100MB,checkpoint=(log_size=0,wait=0),"
 	  "checkpoint_sync=true,compatibility=(release=,require_max=,"
-	  "require_min=),debug_mode=(checkpoint_retention=0,"
-	  "rollback_error=0,table_logging=false),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "require_min=),debug_mode=(aggressive_lookaside=false,"
+	  "checkpoint_retention=0,rollback_error=0,table_logging=false),"
+	  "direct_io=,encryption=(keyid=,name=,secretkey=),error_prefix=,"
 	  "eviction=(threads_max=8,threads_min=1),"
 	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2646,7 +2646,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 		    session, cval.str, cval.len, &conn->error_prefix));
 	}
 	WT_ERR(__wt_verbose_config(session, cfg));
-	WT_ERR(__wt_debug_mode_config(session, cfg));
 	WT_ERR(__wt_timing_stress_config(session, cfg));
 	__wt_btree_page_version_config(session);
 
@@ -2769,6 +2768,12 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	 */
 	WT_ERR(__wt_connection_open(conn, cfg));
 	session = conn->default_session;
+
+	/*
+	 * This function expects the cache to be created so parse this after
+	 * the rest of the connection is set up.
+	 */
+	WT_ERR(__wt_debug_mode_config(session, cfg));
 
 	/*
 	 * Load the extensions after initialization completes; extensions expect

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1840,13 +1840,6 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 	txn_global = &conn->txn_global;
 
 	WT_RET(__wt_config_gets(session,
-	    cfg, "debug_mode.aggressive_lookaside", &cval));
-	if (cval.val)
-		F_SET(cache, WT_CACHE_EVICT_DEBUG_MODE);
-	else
-		F_CLR(cache, WT_CACHE_EVICT_DEBUG_MODE);
-
-	WT_RET(__wt_config_gets(session,
 	    cfg, "debug_mode.checkpoint_retention", &cval));
 	conn->debug_ckpt_cnt = (uint32_t)cval.val;
 	if (cval.val == 0) {
@@ -1859,6 +1852,13 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 	else
 		WT_RET(__wt_calloc_def(session,
 		    conn->debug_ckpt_cnt, &conn->debug_ckpt));
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.eviction", &cval));
+	if (cval.val)
+		F_SET(cache, WT_CACHE_EVICT_DEBUG_MODE);
+	else
+		F_CLR(cache, WT_CACHE_EVICT_DEBUG_MODE);
 
 	WT_RET(__wt_config_gets(session,
 	    cfg, "debug_mode.rollback_error", &cval));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1830,23 +1830,21 @@ err:	/*
 int
 __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 {
+	WT_CACHE *cache;
 	WT_CONFIG_ITEM cval;
 	WT_CONNECTION_IMPL *conn;
 	WT_TXN_GLOBAL *txn_global;
 
 	conn = S2C(session);
+	cache = conn->cache;
 	txn_global = &conn->txn_global;
 
 	WT_RET(__wt_config_gets(session,
-	    cfg, "debug_mode.rollback_error", &cval));
-	txn_global->debug_rollback = (uint64_t)cval.val;
-
-	WT_RET(__wt_config_gets(session,
-	    cfg, "debug_mode.table_logging", &cval));
+	    cfg, "debug_mode.aggressive_lookaside", &cval));
 	if (cval.val)
-		FLD_SET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
+		F_SET(cache, WT_CACHE_EVICT_DEBUG_MODE);
 	else
-		FLD_CLR(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
+		F_CLR(cache, WT_CACHE_EVICT_DEBUG_MODE);
 
 	WT_RET(__wt_config_gets(session,
 	    cfg, "debug_mode.checkpoint_retention", &cval));
@@ -1861,6 +1859,17 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 	else
 		WT_RET(__wt_calloc_def(session,
 		    conn->debug_ckpt_cnt, &conn->debug_ckpt));
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.rollback_error", &cval));
+	txn_global->debug_rollback = (uint64_t)cval.val;
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.table_logging", &cval));
+	if (cval.val)
+		FLD_SET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
+	else
+		FLD_CLR(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
 
 	return (0);
 }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -109,7 +109,7 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
 /*
  * __evict_lru_cmp_debug --
  *	Qsort function: sort the eviction array.
- *	Debug mode version for aggressive lookaside.
+ *	Version for eviction debug mode.
  */
 static int WT_CDECL
 __evict_lru_cmp_debug(const void *a_arg, const void *b_arg)
@@ -2087,7 +2087,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue,
 		 *
 		 * Also skip internal page unless we get aggressive, the tree
 		 * is idle (indicated by the tree being skipped for walks),
-		 * or we are in debug mode for aggressive lookaside.
+		 * or we are in eviction debug mode.
 		 * The goal here is that if trees become completely idle, we
 		 * eventually push them out of cache completely.
 		 */

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -107,6 +107,25 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __evict_lru_cmp_debug --
+ *	Qsort function: sort the eviction array.
+ *	Debug mode version for aggressive lookaside.
+ */
+static int WT_CDECL
+__evict_lru_cmp_debug(const void *a_arg, const void *b_arg)
+{
+	const WT_EVICT_ENTRY *a, *b;
+	uint64_t a_score, b_score;
+
+	a = a_arg;
+	b = b_arg;
+	a_score = (a->ref == NULL ? UINT64_MAX : 0);
+	b_score = (b->ref == NULL ? UINT64_MAX : 0);
+
+	return ((a_score < b_score) ? -1 : (a_score == b_score) ? 0 : 1);
+}
+
+/*
  * __evict_lru_cmp --
  *	Qsort function: sort the eviction array.
  */
@@ -1257,8 +1276,17 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		queue->evict_current = NULL;
 
 	entries = queue->evict_entries;
-	__wt_qsort(queue->evict_queue,
-	    entries, sizeof(WT_EVICT_ENTRY), __evict_lru_cmp);
+	/*
+	 * Style note: __wt_qsort is a macro that can leave a dangling
+	 * else. Full curly braces are needed here for the compiler.
+	 */
+	if (F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE)) {
+		__wt_qsort(queue->evict_queue,
+		    entries, sizeof(WT_EVICT_ENTRY), __evict_lru_cmp_debug);
+	} else {
+		__wt_qsort(queue->evict_queue,
+		    entries, sizeof(WT_EVICT_ENTRY), __evict_lru_cmp);
+	}
 
 	/* Trim empty entries from the end. */
 	while (entries > 0 && queue->evict_queue[entries - 1].ref == NULL)
@@ -2057,12 +2085,14 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue,
 		 * cache (indicated by seeing an internal page that is the
 		 * parent of the last page we saw).
 		 *
-		 * Also skip internal page unless we get aggressive or the tree
-		 * is idle (indicated by the tree being skipped for walks).
+		 * Also skip internal page unless we get aggressive, the tree
+		 * is idle (indicated by the tree being skipped for walks),
+		 * or we are in debug mode for aggressive lookaside.
 		 * The goal here is that if trees become completely idle, we
 		 * eventually push them out of cache completely.
 		 */
-		if (WT_PAGE_IS_INTERNAL(page)) {
+		if (!F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE) &&
+		    WT_PAGE_IS_INTERNAL(page)) {
 			if (page == last_parent)
 				continue;
 			if (btree->evict_walk_period == 0 &&

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -656,7 +656,13 @@ __evict_review(
 		else if (!WT_IS_METADATA(session->dhandle)) {
 			LF_SET(WT_REC_UPDATE_RESTORE);
 
-			if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB))
+			/*
+			 * Scrub if we're supposed to or toss it in sometimes
+			 * if we are in debugging mode.
+			 */
+			if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB) ||
+			    (F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE &&
+			    __wt_random(&session->rnd) % 3 == 0)))
 				LF_SET(WT_REC_SCRUB);
 
 			/*
@@ -665,8 +671,14 @@ __evict_review(
 			 * suggests trying the lookaside table.
 			 */
 			if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE) &&
-			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE))
+			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE)) {
+				if (__wt_random(&session->rnd) % 10 == 1) {
+					LF_CLR(WT_REC_SCRUB |
+					    WT_REC_UPDATE_RESTORE);
+					LF_SET(WT_REC_LOOKASIDE);
+				}
 				lookaside_retryp = &lookaside_retry;
+			}
 		}
 	}
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -674,7 +674,7 @@ __evict_review(
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE)) {
 				if (F_ISSET(cache,
 				    WT_CACHE_EVICT_DEBUG_MODE) &&
-				    __wt_random(&session->rnd) % 10 == 1) {
+				    __wt_random(&session->rnd) % 10 == 0) {
 					LF_CLR(WT_REC_SCRUB |
 					    WT_REC_UPDATE_RESTORE);
 					LF_SET(WT_REC_LOOKASIDE);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -661,8 +661,8 @@ __evict_review(
 			 * if we are in debugging mode.
 			 */
 			if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB) ||
-			    (F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE &&
-			    __wt_random(&session->rnd) % 3 == 0)))
+			    (F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE) &&
+			    __wt_random(&session->rnd) % 3 == 0))
 				LF_SET(WT_REC_SCRUB);
 
 			/*
@@ -672,7 +672,9 @@ __evict_review(
 			 */
 			if (F_ISSET(cache, WT_CACHE_EVICT_LOOKASIDE) &&
 			    !F_ISSET(conn, WT_CONN_EVICTION_NO_LOOKASIDE)) {
-				if (__wt_random(&session->rnd) % 10 == 1) {
+				if (F_ISSET(cache,
+				    WT_CACHE_EVICT_DEBUG_MODE) &&
+				    __wt_random(&session->rnd) % 10 == 1) {
 					LF_CLR(WT_REC_SCRUB |
 					    WT_REC_UPDATE_RESTORE);
 					LF_SET(WT_REC_LOOKASIDE);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -922,6 +922,7 @@ __wt_row_leaf_key_set_cell(WT_PAGE *page, WT_ROW *rip, WT_CELL *cell)
 	 */
 	v = WT_CELL_ENCODE_OFFSET(WT_PAGE_DISK_OFFSET(page, cell)) |
 	    WT_CELL_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 
@@ -941,6 +942,7 @@ __wt_row_leaf_key_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *unpack)
 	v = WT_K_ENCODE_KEY_LEN(unpack->size) |
 	    WT_K_ENCODE_KEY_OFFSET(WT_PAGE_DISK_OFFSET(page, unpack->data)) |
 	    WT_K_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 
@@ -979,6 +981,7 @@ __wt_row_leaf_value_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK *unpack)
 	    WT_KV_ENCODE_VALUE_LEN(unpack->size) |
 	    WT_KV_ENCODE_KEY_OFFSET(key_offset) |
 	    WT_KV_ENCODE_VALUE_OFFSET(value_offset) | WT_KV_FLAG;
+	WT_ASSERT(NULL, WT_ROW_SLOT(page, rip) < page->entries);
 	WT_ROW_KEY_SET(rip, v);
 }
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -170,7 +170,7 @@ struct __wt_cache {
 	 * Score of how aggressive eviction should be about selecting eviction
 	 * candidates. If eviction is struggling to make progress, this score
 	 * rises (up to a maximum of 100), at which point the cache is "stuck"
-	 * and transaction will be rolled back.
+	 * and transactions will be rolled back.
 	 */
 	uint32_t evict_aggressive_score;
 
@@ -250,11 +250,12 @@ struct __wt_cache {
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define	WT_CACHE_EVICT_CLEAN	  0x01u	/* Evict clean pages */
 #define	WT_CACHE_EVICT_CLEAN_HARD 0x02u	/* Clean % blocking app threads */
-#define	WT_CACHE_EVICT_DIRTY	  0x04u	/* Evict dirty pages */
-#define	WT_CACHE_EVICT_DIRTY_HARD 0x08u	/* Dirty % blocking app threads */
-#define	WT_CACHE_EVICT_LOOKASIDE  0x10u	/* Try lookaside eviction */
-#define	WT_CACHE_EVICT_SCRUB	  0x20u	/* Scrub dirty pages */
-#define	WT_CACHE_EVICT_URGENT	  0x40u	/* Pages are in the urgent queue */
+#define	WT_CACHE_EVICT_DEBUG_MODE 0x04u	/* Aggressive debugging mode */
+#define	WT_CACHE_EVICT_DIRTY	  0x08u	/* Evict dirty pages */
+#define	WT_CACHE_EVICT_DIRTY_HARD 0x10u	/* Dirty % blocking app threads */
+#define	WT_CACHE_EVICT_LOOKASIDE  0x20u	/* Try lookaside eviction */
+#define	WT_CACHE_EVICT_SCRUB	  0x40u	/* Scrub dirty pages */
+#define	WT_CACHE_EVICT_URGENT	  0x80u	/* Pages are in the urgent queue */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 #define	WT_CACHE_EVICT_ALL	(WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_DIRTY)
 	uint32_t flags;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2279,27 +2279,28 @@ struct __wt_connection {
 	 * @config{debug_mode = (, control the settings of various extended
 	 * debugging features., a set of related configuration options defined
 	 * below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;aggressive_lookaside, if
-	 * true\, modify internal algorithms to change skew to force lookaside
-	 * eviction to happen more aggressively.  This includes but is not
-	 * limited to not skewing newest\, not favoring leaf pages\, and
-	 * modifying the eviction score mechanism., a boolean flag; default \c
-	 * false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust
 	 * log archiving to retain the log records of this number of
 	 * checkpoints.  Zero or one means perform normal archiving., an integer
 	 * between 0 and 1024; default \c 0.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * rollback_error, return a WT_ROLLBACK error from a transaction
-	 * operation about every Nth operation to simulate a collision., an
-	 * integer between 0 and 10M; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write
-	 * transaction related information to the log for all operations\, even
-	 * operations for tables with logging turned off.  This setting
-	 * introduces a log format change that may break older versions of
-	 * WiredTiger.  These operations are informational and skipped in
-	 * recovery., a boolean flag; default \c false.}
-	 * @config{ ),,}
+	 * eviction, if true\, modify internal algorithms to change skew to
+	 * force lookaside eviction to happen more aggressively.  This includes
+	 * but is not limited to not skewing newest\, not favoring leaf pages\,
+	 * and modifying the eviction score mechanism., a boolean flag; default
+	 * \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a
+	 * WT_ROLLBACK error from a transaction operation about every Nth
+	 * operation to simulate a collision., an integer between 0 and 10M;
+	 * default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if
+	 * true\, write transaction related information to the log for all
+	 * operations\, even operations for tables with logging turned off.
+	 * This setting introduces a log format change that may break older
+	 * versions of WiredTiger.  These operations are informational and
+	 * skipped in recovery., a boolean flag; default \c false.}
+	 * @config{
+	 * ),,}
 	 * @config{error_prefix, prefix string for error messages., a string;
 	 * default empty.}
 	 * @config{eviction = (, eviction configuration options., a set of
@@ -2931,19 +2932,18 @@ struct __wt_connection {
  * default \c false.}
  * @config{debug_mode = (, control the settings of various extended debugging
  * features., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;aggressive_lookaside, if true\, modify
- * internal algorithms to change skew to force lookaside eviction to happen more
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust log archiving to
+ * retain the log records of this number of checkpoints.  Zero or one means
+ * perform normal archiving., an integer between 0 and 1024; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if true\, modify internal
+ * algorithms to change skew to force lookaside eviction to happen more
  * aggressively.  This includes but is not limited to not skewing newest\, not
  * favoring leaf pages\, and modifying the eviction score mechanism., a boolean
  * flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * checkpoint_retention, adjust log archiving to retain the log records of this
- * number of checkpoints.  Zero or one means perform normal archiving., an
- * integer between 0 and 1024; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * rollback_error, return a WT_ROLLBACK error from a transaction operation about
- * every Nth operation to simulate a collision., an integer between 0 and 10M;
- * default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error,
+ * return a WT_ROLLBACK error from a transaction operation about every Nth
+ * operation to simulate a collision., an integer between 0 and 10M; default \c
+ * 0.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write
  * transaction related information to the log for all operations\, even
  * operations for tables with logging turned off.  This setting introduces a log

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2279,6 +2279,12 @@ struct __wt_connection {
 	 * @config{debug_mode = (, control the settings of various extended
 	 * debugging features., a set of related configuration options defined
 	 * below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;aggressive_lookaside, if
+	 * true\, modify internal algorithms to change skew to force lookaside
+	 * eviction to happen more aggressively.  This includes but is not
+	 * limited to not skewing newest\, not favoring leaf pages\, and
+	 * modifying the eviction score mechanism., a boolean flag; default \c
+	 * false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust
 	 * log archiving to retain the log records of this number of
 	 * checkpoints.  Zero or one means perform normal archiving., an integer
@@ -2925,17 +2931,25 @@ struct __wt_connection {
  * default \c false.}
  * @config{debug_mode = (, control the settings of various extended debugging
  * features., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust log archiving to
- * retain the log records of this number of checkpoints.  Zero or one means
- * perform normal archiving., an integer between 0 and 1024; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a WT_ROLLBACK error
- * from a transaction operation about every Nth operation to simulate a
- * collision., an integer between 0 and 10M; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write transaction
- * related information to the log for all operations\, even operations for
- * tables with logging turned off.  This setting introduces a log format change
- * that may break older versions of WiredTiger.  These operations are
- * informational and skipped in recovery., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;aggressive_lookaside, if true\, modify
+ * internal algorithms to change skew to force lookaside eviction to happen more
+ * aggressively.  This includes but is not limited to not skewing newest\, not
+ * favoring leaf pages\, and modifying the eviction score mechanism., a boolean
+ * flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * checkpoint_retention, adjust log archiving to retain the log records of this
+ * number of checkpoints.  Zero or one means perform normal archiving., an
+ * integer between 0 and 1024; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * rollback_error, return a WT_ROLLBACK error from a transaction operation about
+ * every Nth operation to simulate a collision., an integer between 0 and 10M;
+ * default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write
+ * transaction related information to the log for all operations\, even
+ * operations for tables with logging turned off.  This setting introduces a log
+ * format change that may break older versions of WiredTiger.  These operations
+ * are informational and skipped in recovery., a boolean flag; default \c
+ * false.}
  * @config{ ),,}
  * @config{direct_io, Use \c O_DIRECT on POSIX systems\, and \c
  * FILE_FLAG_NO_BUFFERING on Windows to access files.  Options are given as a

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -575,7 +575,8 @@ __rec_init(WT_SESSION_IMPL *session,
 	 * history, or the stable timestamp hasn't changed since last time this
 	 * page was successfully, skew oldest instead.
 	 */
-	if (F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_DEBUG_MODE))
+	if (F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_DEBUG_MODE) &&
+	    __wt_random(&session->rnd) % 3 == 0)
 		r->las_skew_newest = false;
 	else
 		r->las_skew_newest =

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -575,6 +575,11 @@ __rec_init(WT_SESSION_IMPL *session,
 	 * history, or the stable timestamp hasn't changed since last time this
 	 * page was successfully, skew oldest instead.
 	 */
+	if (F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_DEBUG_MODE))
+		r->las_skew_newest = false;
+	else
+		r->las_skew_newest =
+		    LF_ISSET(WT_REC_LOOKASIDE) && LF_ISSET(WT_REC_VISIBLE_ALL);
 	r->las_skew_newest =
 	    LF_ISSET(WT_REC_LOOKASIDE) && LF_ISSET(WT_REC_VISIBLE_ALL);
 	if (r->las_skew_newest &&

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -38,6 +38,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	if (cbt->ins == NULL) {
 		session = (WT_SESSION_IMPL *)cbt->iface.session;
 		page = cbt->ref->page;
+		WT_ASSERT(session, cbt->slot < page->entries);
 		rip = &page->pg_row[cbt->slot];
 		WT_ASSERT(session,
 		    __wt_row_leaf_key(session, page, rip, &key, false) == 0);

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -25,6 +25,9 @@ echo "checkpoint: 6 row-store tables, named checkpoint"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r
 
 echo "checkpoint: row-store tables, stress LAS. Sweep and timestamps"
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -D -s -x -n 100000 -k 100000 -C cache_size=100MB
+
+echo "checkpoint: row-store tables, Sweep and timestamps"
 $TEST_WRAPPER ./t -t r -W 3 -r 2 -s -x -n 100000 -k 100000 -C cache_size=100MB
 
 echo "checkpoint: 3 mixed tables, with sweep"

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -186,6 +186,7 @@ main(int argc, char *argv[])
 	return (g.status);
 }
 
+#define	DEBUG_MODE_CFG	",debug_mode=(aggressive_lookaside=true,table_logging=true)"
 /*
  * wt_connect --
  *	Configure the WiredTiger connection.
@@ -212,23 +213,20 @@ wt_connect(const char *config_open)
 		    "statistics_log=(json,wait=1),error_prefix=\"%s\","	\
 		    "file_manager=(close_handle_minimum=1,close_idle_time=1,"\
 		    "close_scan_interval=1),log=(enabled),cache_size=1GB,"\
-		    "timing_stress_for_test=(aggressive_sweep)%s%s",
+		    "timing_stress_for_test=(aggressive_sweep)%s%s%s",
 		    progname,
+		    g.debug_mode ? DEBUG_MODE_CFG : "",
 		    config_open == NULL ? "" : ",",
 		    config_open == NULL ? "" : config_open));
 	else
 		testutil_check(__wt_snprintf(config, sizeof(config),
 		    "create,cache_cursors=false,statistics=(fast),"	\
 		    "statistics_log=(json,wait=1),error_prefix=\"%s\""	\
-		    "%s%s",
+		    "%s%s%s",
 		    progname,
+		    g.debug_mode ? DEBUG_MODE_CFG : "",
 		    config_open == NULL ? "" : ",",
 		    config_open == NULL ? "" : config_open));
-
-	if (g.debug_mode)
-		testutil_check(__wt_snprintf(config, sizeof(config),
-		    "%s,debug_mode=(aggressive_lookaside=true,"		\
-		    "table_logging=true)", config));
 
 	if ((ret = wiredtiger_open(
 	    g.home, &event_handler, config, &g.conn)) != 0)

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -186,7 +186,8 @@ main(int argc, char *argv[])
 	return (g.status);
 }
 
-#define	DEBUG_MODE_CFG	",debug_mode=(aggressive_lookaside=true,table_logging=true)"
+#define	DEBUG_MODE_CFG						\
+",debug_mode=(aggressive_lookaside=true,table_logging=true)"
 /*
  * wt_connect --
  *	Configure the WiredTiger connection.

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -57,6 +57,7 @@ main(int argc, char *argv[])
 	working_dir = NULL;
 	ttype = MIX;
 	g.checkpoint_name = "WiredTigerCheckpoint";
+	g.debug_mode = false;
 	g.home = dmalloc(512);
 	g.nkeys = 10000;
 	g.nops = 100000;
@@ -66,13 +67,16 @@ main(int argc, char *argv[])
 	runs = 1;
 
 	while ((ch = __wt_getopt(
-	    progname, argc, argv, "C:c:h:k:l:n:r:sT:t:W:x")) != EOF)
+	    progname, argc, argv, "C:c:Dh:k:l:n:r:sT:t:W:x")) != EOF)
 		switch (ch) {
 		case 'c':
 			g.checkpoint_name = __wt_optarg;
 			break;
 		case 'C':			/* wiredtiger_open config */
 			config_open = __wt_optarg;
+			break;
+		case 'D':
+			g.debug_mode = true;
 			break;
 		case 'h':			/* wiredtiger_open config */
 			working_dir = __wt_optarg;
@@ -220,6 +224,11 @@ wt_connect(const char *config_open)
 		    progname,
 		    config_open == NULL ? "" : ",",
 		    config_open == NULL ? "" : config_open));
+
+	if (g.debug_mode)
+		testutil_check(__wt_snprintf(config, sizeof(config),
+		    "%s,debug_mode=(aggressive_lookaside=true,"		\
+		    "table_logging=true)", config));
 
 	if ((ret = wiredtiger_open(
 	    g.home, &event_handler, config, &g.conn)) != 0)

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -187,7 +187,7 @@ main(int argc, char *argv[])
 }
 
 #define	DEBUG_MODE_CFG						\
-",debug_mode=(aggressive_lookaside=true,table_logging=true)"
+",debug_mode=(eviction=true,table_logging=true)"
 /*
  * wt_connect --
  *	Configure the WiredTiger connection.

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -55,6 +55,7 @@ typedef struct {
 	char *home;				/* Home directory */
 	const char *checkpoint_name;		/* Checkpoint name */
 	WT_CONNECTION *conn;			/* WiredTiger connection */
+	bool debug_mode;			/* Lookaside stress test */
 	u_int nkeys;				/* Keys to load */
 	u_int nops;				/* Operations per thread */
 	FILE *logfp;				/* Message log file. */

--- a/test/suite/test_debug_mode04.py
+++ b/test/suite/test_debug_mode04.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Public Domain 2034-2039 MongoDB, Inc.
+# Public Domain 2008-2034 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# test_debug_mode04.py
+#    Test the debug mode settings. Test eviction use.
+class test_debug_mode04(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled=true,file_max=100K),debug_mode=(eviction=true)'
+    uri = 'file:test_debug'
+    entries = 100
+    value = b'\x01\x02abcd\x03\x04'
+
+    def add_data(self):
+        keys = range(0, self.entries)
+        c = self.session.open_cursor(self.uri, None)
+        for k in keys:
+            c[k] = self.value
+        c.close()
+
+    # Just test turning it on and off. There really isn't something
+    # specific to verify.
+    def test_table_logging(self):
+        self.session.create(self.uri, 'key_format=i,value_format=u')
+        self.add_data()
+
+    def test_table_logging_off(self):
+        self.conn.reconfigure("debug_mode=(eviction=false)")
+        self.session.create(self.uri, 'key_format=i,value_format=u')
+        self.add_data()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
This branch pulls in the assertions from the original WT-4750 branch for the data inconsistency reproducer. This branch does not include the assertions in sweep that were commented out on that branch because they were triggering a lot.