### PR TITLE
WT-4844 Only log an informational message when a set read-timestamp is older than the oldest timestamp.

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1939,8 +1939,6 @@ struct __wt_session {
 	 * transaction_timestamps., a string; default empty.}
 	 * @configend
 	 * @errors
-	 * If the \c read_timestamp is newer than the current oldest timestamp,
-	 * \c EINVAL will be returned.
 	 */
 	int __F(timestamp_transaction)(WT_SESSION *session, const char *config);
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1939,6 +1939,8 @@ struct __wt_session {
 	 * transaction_timestamps., a string; default empty.}
 	 * @configend
 	 * @errors
+	 * If the \c read_timestamp is newer than the current oldest timestamp,
+	 * \c EINVAL will be returned.
 	 */
 	int __F(timestamp_transaction)(WT_SESSION *session, const char *config);
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -928,6 +928,21 @@ __wt_txn_set_read_timestamp(
 			did_roundup_to_oldest = true;
 		} else {
 			__wt_readunlock(session, &txn_global->rwlock);
+
+			/*
+			 * In some cases, MongoDB sets a read timestamp older
+			 * than the oldest timestamp, relying on WiredTiger's
+			 * concurrency to detect and fail the set. In other
+			 * cases it's a bug and MongoDB wants error context to
+			 * make it easier to find those problems. Don't output
+			 * an error message because that logs a MongoDB error,
+			 * use an informational message to provide the context
+			 * instead.
+			 */
+			WT_RET(__wt_msg(session, "read timestamp "
+			    "%s less than the oldest timestamp %s",
+			    __wt_timestamp_to_string(read_ts, ts_string[0]),
+			    __wt_timestamp_to_string(ts_oldest, ts_string[1])));
 			return (EINVAL);
 		}
 	} else

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -928,6 +928,8 @@ __wt_txn_set_read_timestamp(
 			did_roundup_to_oldest = true;
 		} else {
 			__wt_readunlock(session, &txn_global->rwlock);
+			if (!WT_VERBOSE_ISSET(session, WT_VERB_TIMESTAMP))
+				return (EINVAL);
 			WT_RET_MSG(session, EINVAL, "read timestamp "
 			    "%s less than the oldest timestamp %s",
 			    __wt_timestamp_to_string(read_ts, ts_string[0]),

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -928,12 +928,7 @@ __wt_txn_set_read_timestamp(
 			did_roundup_to_oldest = true;
 		} else {
 			__wt_readunlock(session, &txn_global->rwlock);
-			if (!WT_VERBOSE_ISSET(session, WT_VERB_TIMESTAMP))
-				return (EINVAL);
-			WT_RET_MSG(session, EINVAL, "read timestamp "
-			    "%s less than the oldest timestamp %s",
-			    __wt_timestamp_to_string(read_ts, ts_string[0]),
-			    __wt_timestamp_to_string(ts_oldest, ts_string[1]));
+			return (EINVAL);
 		}
 	} else
 		txn->read_timestamp = read_ts;

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -165,10 +165,8 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # Read timestamp >= Oldest timestamp
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(7) +
             ',stable_timestamp=' + timestamp_str(7))
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.begin_transaction('read_timestamp=' +
-                timestamp_str(6)),
-                '/less than the oldest timestamp/')
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(6)))
 
         # c[8] is not visible at read_timestamp < 8
         self.session.begin_transaction('read_timestamp=' + timestamp_str(7))
@@ -189,10 +187,8 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # We can move the oldest timestamp backwards with "force"
         self.conn.set_timestamp(
             'oldest_timestamp=' + timestamp_str(5) + ',force')
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.begin_transaction('read_timestamp=' +
-                timestamp_str(4)),
-                '/less than the oldest timestamp/')
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(4)))
         self.session.begin_transaction('read_timestamp=' + timestamp_str(6))
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=oldest_reader'), timestamp_str(6))

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -165,8 +165,9 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # Read timestamp >= Oldest timestamp
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(7) +
             ',stable_timestamp=' + timestamp_str(7))
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(6)))
+        with self.expectedStdoutPattern('less than the oldest timestamp'):
+            self.assertRaisesException(wiredtiger.WiredTigerError,
+                lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(6)))
 
         # c[8] is not visible at read_timestamp < 8
         self.session.begin_transaction('read_timestamp=' + timestamp_str(7))
@@ -187,8 +188,9 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # We can move the oldest timestamp backwards with "force"
         self.conn.set_timestamp(
             'oldest_timestamp=' + timestamp_str(5) + ',force')
-        self.assertRaisesException(wiredtiger.WiredTigerError,
-            lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(4)))
+        with self.expectedStdoutPattern('less than the oldest timestamp'):
+            self.assertRaisesException(wiredtiger.WiredTigerError,
+                lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(4)))
         self.session.begin_transaction('read_timestamp=' + timestamp_str(6))
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=oldest_reader'), timestamp_str(6))


### PR DESCRIPTION
Alex, this is a change already queued up in WT-4733 (#4610), to not log an error message if the application specifies a timestamp older than the current oldest timestamp.

The argument is an application will hit this unless it explicitly synchronizes the read and oldest timestamps, and it's not an error so much as an alert the application's read timestamp likely needs to move forward.

The `test/format` PR #4610 requires this change, and MongoDB is running into it as well (SERVER-40591), which is why I'll pulled it out into its own PR.

@bvpvamsikrishna, @michaelcahill: is this OK with you?