### PR TITLE
WT-4837 Don't sleep in timing_stress if the cache is totally full.

### DIFF
--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -255,10 +255,22 @@ __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
 static inline void
 __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
 {
-	uint64_t i;
+	double pct;
+	uint64_t i, max;
 
 	/* Optionally only sleep when a specified configuration flag is set. */
 	if (flag != 0 && !FLD_ISSET(S2C(session)->timing_stress_flags, flag))
+		return;
+
+	/*
+	 * If there is a lot of cache pressure, don't let the sleep time
+	 * get too large. If the cache is totally full, return.
+	 */
+	if (__wt_eviction_needed(session, false, false, &pct))
+		max = 5;
+	else
+		max = 9;
+	if (pct > 100.0)
 		return;
 
 	/*
@@ -269,7 +281,7 @@ __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
 	 * That means we'll hit the maximum roughly every 1K calls.
 	 */
 	for (i = 0;;)
-		if (__wt_random(&session->rnd) & 0x1 || ++i > 9)
+		if (__wt_random(&session->rnd) & 0x1 || ++i > max)
 			break;
 
 	if (i == 0)

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -266,6 +266,7 @@ __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
 	 * If there is a lot of cache pressure, don't let the sleep time
 	 * get too large. If the cache is totally full, return.
 	 */
+        pct = 0.0;
 	if (__wt_eviction_needed(session, false, false, &pct))
 		max = 5;
 	else

--- a/src/include/misc.i
+++ b/src/include/misc.i
@@ -266,7 +266,7 @@ __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
 	 * If there is a lot of cache pressure, don't let the sleep time
 	 * get too large. If the cache is totally full, return.
 	 */
-        pct = 0.0;
+	pct = 0.0;
 	if (__wt_eviction_needed(session, false, false, &pct))
 		max = 5;
 	else

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -407,12 +407,12 @@ typedef uint64_t wt_timestamp_t;
 #endif
 #include "verify_build.h"
 
+#include "cache.i"			/* required by misc.i */
 #include "ctype.i"			/* required by packing.i */
 #include "intpack.i"			/* required by cell.i, packing.i */
 #include "misc.i"			/* required by mutex.i */
 
 #include "buf.i"                        /* required by cell.i */
-#include "cache.i"			/* required by txn.i */
 #include "cell.i"			/* required by btree.i */
 #include "mutex.i"			/* required by btree.i */
 #include "txn.i"			/* required by btree.i */


### PR DESCRIPTION
With this change the LSM + timing stress stuck cache failure does not happen. @keithbostic let me know what you think of these tweaks to the timing stress function.