### PR TITLE
WT-4712 Add diagnostic logging. (#4572)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -456,6 +456,25 @@ connection_runtime_config = [
             above 0 configures periodic checkpoints''',
             min='0', max='100000'),
         ]),
+    Config('debug_mode', '', r'''
+        control the settings of various extended debugging features''',
+        type='category', subconfig=[
+        Config('checkpoint_retention', '0', r'''
+            adjust log archiving to retain the log records of this number
+            of checkpoints. Zero or one means perform normal archiving.''',
+            min='0', max='1024'),
+        Config('rollback_error', '0', r'''
+            return a WT_ROLLBACK error from a transaction operation about
+            every Nth operation to simulate a collision''',
+            min='0', max='10M'),
+        Config('table_logging', 'false', r'''
+            if true, write transaction related information to the log for all
+            operations, even operations for tables with logging turned off.
+            This setting introduces a log format change that may break older
+            versions of WiredTiger. These operations are informational and
+            skipped in recovery.''',
+            type='boolean'),
+        ]),
     Config('error_prefix', '', r'''
         prefix string for error messages'''),
     Config('eviction', '', r'''

--- a/dist/log.py
+++ b/dist/log.py
@@ -18,6 +18,9 @@ field_types = {
           'WT_ERR(__logrec_make_hex_str(session, &escaped, &arg));']),
     'recno' : ('uint64_t', 'r', '%" PRIu64 "', 'arg', [ '' ]),
     'uint32' : ('uint32_t', 'I', '%" PRIu32 "', 'arg', [ '' ]),
+    # The fileid may have the high bit set. Print in both decimal and hex.
+    'uint32_id' : ('uint32_t', 'I',
+        '%" PRIu32 " 0x%" PRIx32 "', 'arg, arg', [ '' ]),
     'uint64' : ('uint64_t', 'Q', '%" PRIu64 "', 'arg', [ '' ]),
 }
 

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -36,7 +36,7 @@ rectypes = [
     # the allocated LSN to reduce the amount of work recovery has to do, and
     # they are useful for debugging recovery.
     LogRecordType('file_sync', 'file sync', [
-        ('uint32', 'fileid'), ('int', 'start')]),
+        ('uint32_id', 'fileid'), ('int', 'start')]),
 
     # Debugging message in the log
     LogRecordType('message', 'message', [('string', 'message')]),
@@ -62,25 +62,39 @@ class LogOperationType:
 optypes = [
 # commit operations
     LogOperationType('col_modify', 'column modify',
-        [('uint32', 'fileid'), ('recno', 'recno'), ('item', 'value')]),
+        [('uint32_id', 'fileid'), ('recno', 'recno'), ('item', 'value')]),
     LogOperationType('col_put', 'column put',
-        [('uint32', 'fileid'), ('recno', 'recno'), ('item', 'value')]),
+        [('uint32_id', 'fileid'), ('recno', 'recno'), ('item', 'value')]),
     LogOperationType('col_remove', 'column remove',
-        [('uint32', 'fileid'), ('recno', 'recno')]),
+        [('uint32_id', 'fileid'), ('recno', 'recno')]),
     LogOperationType('col_truncate', 'column truncate',
-        [('uint32', 'fileid'), ('recno', 'start'), ('recno', 'stop')]),
+        [('uint32_id', 'fileid'), ('recno', 'start'), ('recno', 'stop')]),
     LogOperationType('row_modify', 'row modify',
-        [('uint32', 'fileid'), ('item', 'key'), ('item', 'value')]),
+        [('uint32_id', 'fileid'), ('item', 'key'), ('item', 'value')]),
     LogOperationType('row_put', 'row put',
-        [('uint32', 'fileid'), ('item', 'key'), ('item', 'value')]),
+        [('uint32_id', 'fileid'), ('item', 'key'), ('item', 'value')]),
     LogOperationType('row_remove', 'row remove',
-        [('uint32', 'fileid'), ('item', 'key')]),
+        [('uint32_id', 'fileid'), ('item', 'key')]),
     LogOperationType('row_truncate', 'row truncate',
-        [('uint32', 'fileid'), ('item', 'start'), ('item', 'stop'),
+        [('uint32_id', 'fileid'), ('item', 'start'), ('item', 'stop'),
             ('uint32', 'mode')]),
 
 # system operations
     LogOperationType('checkpoint_start', 'checkpoint start', []),
     LogOperationType('prev_lsn', 'previous LSN',
         [('WT_LSN', 'prev_lsn')]),
+
+# diagnostic operations
+# Operations used only for diagnostic purposes should be have their type
+# values in the diagnostic range in src/include/wiredtiger.in so that they
+# are always ignored by recovery.
+    #
+    # We need to know the base size/type of a 'struct timespec'. Cast its
+    # parts to uint64_t and split it into seconds and nanoseconds.
+    #
+    LogOperationType('txn_timestamp', 'txn_timestamp',
+        [('uint64', 'time_sec'), ('uint64', 'time_nsec'),
+            ('uint64', 'commit_ts'), ('uint64', 'durable_ts'),
+            ('uint64', 'first_ts'), ('uint64', 'prepare_ts'),
+            ('uint64', 'read_ts')]),
 ]

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -74,6 +74,16 @@ static const WT_CONFIG_CHECK
 };
 
 static const WT_CONFIG_CHECK
+    confchk_wiredtiger_open_debug_mode_subconfigs[] = {
+	{ "checkpoint_retention", "int",
+	    NULL, "min=0,max=1024",
+	    NULL, 0 },
+	{ "rollback_error", "int", NULL, "min=0,max=10M", NULL, 0 },
+	{ "table_logging", "boolean", NULL, NULL, NULL, 0 },
+	{ NULL, NULL, NULL, NULL, NULL, 0 }
+};
+
+static const WT_CONFIG_CHECK
     confchk_wiredtiger_open_eviction_subconfigs[] = {
 	{ "threads_max", "int", NULL, "min=1,max=20", NULL, 0 },
 	{ "threads_min", "int", NULL, "min=1,max=20", NULL, 0 },
@@ -156,6 +166,9 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
 	{ "compatibility", "category",
 	    NULL, NULL,
 	    confchk_WT_CONNECTION_reconfigure_compatibility_subconfigs, 1 },
+	{ "debug_mode", "category",
+	    NULL, NULL,
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
 	{ "error_prefix", "string", NULL, NULL, NULL, 0 },
 	{ "eviction", "category",
 	    NULL, NULL,
@@ -850,6 +863,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
 	{ "config_base", "boolean", NULL, NULL, NULL, 0 },
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
+	{ "debug_mode", "category",
+	    NULL, NULL,
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -959,6 +975,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
 	{ "config_base", "boolean", NULL, NULL, NULL, 0 },
 	{ "create", "boolean", NULL, NULL, NULL, 0 },
+	{ "debug_mode", "category",
+	    NULL, NULL,
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1067,6 +1086,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "compatibility", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
+	{ "debug_mode", "category",
+	    NULL, NULL,
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1171,6 +1193,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "compatibility", "category",
 	    NULL, NULL,
 	    confchk_wiredtiger_open_compatibility_subconfigs, 3 },
+	{ "debug_mode", "category",
+	    NULL, NULL,
+	    confchk_wiredtiger_open_debug_mode_subconfigs, 3 },
 	{ "direct_io", "list",
 	    NULL, "choices=[\"checkpoint\",\"data\",\"log\"]",
 	    NULL, 0 },
@@ -1308,11 +1333,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	{ "WT_CONNECTION.reconfigure",
 	  "async=(enabled=false,ops_max=1024,threads=2),cache_max_wait_ms=0"
 	  ",cache_overhead=8,cache_size=100MB,checkpoint=(log_size=0,"
-	  "wait=0),compatibility=(release=),error_prefix=,"
-	  "eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
-	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
-	  ",file_manager=(close_handle_minimum=250,close_idle_time=30,"
+	  "wait=0),compatibility=(release=),"
+	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
+	  "table_logging=false),error_prefix=,eviction=(threads_max=8,"
+	  "threads_min=1),eviction_checkpoint_target=1,"
+	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
+	  "eviction_target=80,eviction_trigger=95,"
+	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
 	  "close_scan_interval=10),io_capacity=(total=0),log=(archive=true,"
 	  "os_cache_dirty_pct=0,prealloc=true,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
@@ -1321,7 +1348,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,verbose=",
-	  confchk_WT_CONNECTION_reconfigure, 24
+	  confchk_WT_CONNECTION_reconfigure, 25
 	},
 	{ "WT_CONNECTION.rollback_to_stable",
 	  "",
@@ -1559,16 +1586,18 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
 	  "compatibility=(release=,require_max=,require_min=),"
-	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
-	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
-	  "threads_min=1),eviction_checkpoint_target=1,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
-	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
-	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
-	  "in_memory=false,io_capacity=(total=0),log=(archive=true,"
-	  "compressor=,enabled=false,file_max=100MB,os_cache_dirty_pct=0,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
+	  "config_base=true,create=false,debug_mode=(checkpoint_retention=0"
+	  ",rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
+	  ",exclusive=false,extensions=,file_extend=,"
+	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
+	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
+	  "io_capacity=(total=0),log=(archive=true,compressor=,"
+	  "enabled=false,file_max=100MB,os_cache_dirty_pct=0,path=\".\","
+	  "prealloc=true,recover=on,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
 	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
 	  "path=\".\"),readonly=false,salvage=false,session_max=100,"
@@ -1579,7 +1608,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),use_environment=true,use_environment_priv=false,"
 	  "verbose=,write_through=",
-	  confchk_wiredtiger_open, 48
+	  confchk_wiredtiger_open, 49
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
@@ -1587,16 +1616,18 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
 	  "compatibility=(release=,require_max=,require_min=),"
-	  "config_base=true,create=false,direct_io=,encryption=(keyid=,"
-	  "name=,secretkey=),error_prefix=,eviction=(threads_max=8,"
-	  "threads_min=1),eviction_checkpoint_target=1,"
-	  "eviction_dirty_target=5,eviction_dirty_trigger=20,"
-	  "eviction_target=80,eviction_trigger=95,exclusive=false,"
-	  "extensions=,file_extend=,file_manager=(close_handle_minimum=250,"
-	  "close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
-	  "in_memory=false,io_capacity=(total=0),log=(archive=true,"
-	  "compressor=,enabled=false,file_max=100MB,os_cache_dirty_pct=0,"
-	  "path=\".\",prealloc=true,recover=on,zero_fill=false),"
+	  "config_base=true,create=false,debug_mode=(checkpoint_retention=0"
+	  ",rollback_error=0,table_logging=false),direct_io=,"
+	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
+	  "eviction=(threads_max=8,threads_min=1),"
+	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
+	  ",exclusive=false,extensions=,file_extend=,"
+	  "file_manager=(close_handle_minimum=250,close_idle_time=30,"
+	  "close_scan_interval=10),hazard_max=1000,in_memory=false,"
+	  "io_capacity=(total=0),log=(archive=true,compressor=,"
+	  "enabled=false,file_max=100MB,os_cache_dirty_pct=0,path=\".\","
+	  "prealloc=true,recover=on,zero_fill=false),"
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
 	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
 	  "path=\".\"),readonly=false,salvage=false,session_max=100,"
@@ -1607,17 +1638,18 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),use_environment=true,use_environment_priv=false,"
 	  "verbose=,version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_all, 49
+	  confchk_wiredtiger_open_all, 50
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,"
 	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
-	  "compatibility=(release=,require_max=,require_min=),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
-	  "eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "compatibility=(release=,require_max=,require_min=),"
+	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
+	  "table_logging=false),direct_io=,encryption=(keyid=,name=,"
+	  "secretkey=),error_prefix=,eviction=(threads_max=8,threads_min=1)"
+	  ",eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
@@ -1633,17 +1665,18 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_basecfg, 43
+	  confchk_wiredtiger_open_basecfg, 44
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
 	  ",builtin_extension_config=,cache_cursors=true,"
 	  "cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
 	  "checkpoint=(log_size=0,wait=0),checkpoint_sync=true,"
-	  "compatibility=(release=,require_max=,require_min=),direct_io=,"
-	  "encryption=(keyid=,name=,secretkey=),error_prefix=,"
-	  "eviction=(threads_max=8,threads_min=1),"
-	  "eviction_checkpoint_target=1,eviction_dirty_target=5,"
+	  "compatibility=(release=,require_max=,require_min=),"
+	  "debug_mode=(checkpoint_retention=0,rollback_error=0,"
+	  "table_logging=false),direct_io=,encryption=(keyid=,name=,"
+	  "secretkey=),error_prefix=,eviction=(threads_max=8,threads_min=1)"
+	  ",eviction_checkpoint_target=1,eviction_dirty_target=5,"
 	  "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
 	  ",extensions=,file_extend=,file_manager=(close_handle_minimum=250"
 	  ",close_idle_time=30,close_scan_interval=10),hazard_max=1000,"
@@ -1659,7 +1692,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,write_through=",
-	  confchk_wiredtiger_open_usercfg, 42
+	  confchk_wiredtiger_open_usercfg, 43
 	},
 	{ NULL, NULL, NULL, 0 }
 };

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1816,6 +1816,48 @@ err:	/*
 	return (ret);
 }
 
+/*
+ * __wt_debug_mode_config --
+ *	Set debugging configuration.
+ */
+int
+__wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
+{
+	WT_CONFIG_ITEM cval;
+	WT_CONNECTION_IMPL *conn;
+	WT_TXN_GLOBAL *txn_global;
+
+	conn = S2C(session);
+	txn_global = &conn->txn_global;
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.rollback_error", &cval));
+	txn_global->debug_rollback = (uint64_t)cval.val;
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.table_logging", &cval));
+	if (cval.val)
+		FLD_SET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
+	else
+		FLD_CLR(conn->log_flags, WT_CONN_LOG_DEBUG_MODE);
+
+	WT_RET(__wt_config_gets(session,
+	    cfg, "debug_mode.checkpoint_retention", &cval));
+	conn->debug_ckpt_cnt = (uint32_t)cval.val;
+	if (cval.val == 0) {
+		if (conn->debug_ckpt != NULL)
+			__wt_free(session, conn->debug_ckpt);
+		conn->debug_ckpt = NULL;
+	} else if (conn->debug_ckpt != NULL)
+		WT_RET(__wt_realloc(session, NULL,
+		    conn->debug_ckpt_cnt, &conn->debug_ckpt));
+	else
+		WT_RET(__wt_calloc_def(session,
+		    conn->debug_ckpt_cnt, &conn->debug_ckpt));
+
+	return (0);
+}
+
 /* Simple structure for name and flag configuration searches. */
 typedef struct {
 	const char *name;
@@ -2584,6 +2626,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 		    session, cval.str, cval.len, &conn->error_prefix));
 	}
 	WT_ERR(__wt_verbose_config(session, cfg));
+	WT_ERR(__wt_debug_mode_config(session, cfg));
 	WT_ERR(__wt_timing_stress_config(session, cfg));
 
 	/* Set up operation tracking if configured. */

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -132,8 +132,9 @@ __wt_connection_destroy(WT_CONNECTION_IMPL *conn)
 
 	/* Free allocated memory. */
 	__wt_free(session, conn->cfg);
-	__wt_free(session, conn->home);
+	__wt_free(session, conn->debug_ckpt);
 	__wt_free(session, conn->error_prefix);
+	__wt_free(session, conn->home);
 	__wt_free(session, conn->sessions);
 	__wt_stat_connection_discard(session, conn);
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -372,9 +372,19 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
 	 */
 	if (backup_file != 0)
 		min_lognum = WT_MIN(log->ckpt_lsn.l.file, backup_file);
-	else
-		min_lognum = WT_MIN(
-		    log->ckpt_lsn.l.file, log->sync_lsn.l.file);
+	else {
+		/*
+		 * Figure out the minimum log file to archive. Use the
+		 * LSN in the debugging array if necessary.
+		 */
+		if (conn->debug_ckpt_cnt == 0)
+			min_lognum = WT_MIN(
+			    log->ckpt_lsn.l.file, log->sync_lsn.l.file);
+		else
+			min_lognum = WT_MIN(
+			    conn->debug_ckpt[conn->debug_ckpt_cnt - 1].l.file,
+			    log->sync_lsn.l.file);
+	}
 	__wt_verbose(session, WT_VERB_LOG,
 	    "log_archive: archive to log number %" PRIu32, min_lognum);
 

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -488,6 +488,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 	WT_ERR(__wt_cache_config(session, true, cfg));
 	WT_ERR(__wt_capacity_server_create(session, cfg));
 	WT_ERR(__wt_checkpoint_server_create(session, cfg));
+	WT_ERR(__wt_debug_mode_config(session, cfg));
 	WT_ERR(__wt_logmgr_reconfig(session, cfg));
 	WT_ERR(__wt_lsm_manager_reconfig(session, cfg));
 	WT_ERR(__wt_statlog_create(session, cfg));

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -193,6 +193,9 @@ struct __wt_connection_impl {
 	WT_SPINLOCK optrack_map_spinlock; /* Translation file spinlock. */
 	uintmax_t optrack_pid;		/* Cache the process ID. */
 
+	WT_LSN		*debug_ckpt;	/* Debug mode checkpoint LSNs. */
+	uint32_t	 debug_ckpt_cnt;/* Checkpoint retention number */
+
 	void  **foc;			/* Free-on-close array */
 	size_t  foc_cnt;		/* Array entries */
 	size_t  foc_size;		/* Array size */
@@ -321,15 +324,16 @@ struct __wt_connection_impl {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define	WT_CONN_LOG_ARCHIVE		0x001u	/* Archive is enabled */
-#define	WT_CONN_LOG_DOWNGRADED		0x002u	/* Running older version */
-#define	WT_CONN_LOG_ENABLED		0x004u	/* Logging is enabled */
-#define	WT_CONN_LOG_EXISTED		0x008u	/* Log files found */
-#define	WT_CONN_LOG_FORCE_DOWNGRADE	0x010u	/* Force downgrade */
-#define	WT_CONN_LOG_RECOVER_DIRTY	0x020u	/* Recovering unclean */
-#define	WT_CONN_LOG_RECOVER_DONE	0x040u	/* Recovery completed */
-#define	WT_CONN_LOG_RECOVER_ERR		0x080u	/* Error if recovery required */
-#define	WT_CONN_LOG_RECOVER_FAILED	0x100u	/* Recovery failed */
-#define	WT_CONN_LOG_ZERO_FILL		0x200u	/* Manually zero files */
+#define	WT_CONN_LOG_DEBUG_MODE		0x002u	/* Debug-mode logging enabled */
+#define	WT_CONN_LOG_DOWNGRADED		0x004u	/* Running older version */
+#define	WT_CONN_LOG_ENABLED		0x008u	/* Logging is enabled */
+#define	WT_CONN_LOG_EXISTED		0x010u	/* Log files found */
+#define	WT_CONN_LOG_FORCE_DOWNGRADE	0x020u	/* Force downgrade */
+#define	WT_CONN_LOG_RECOVER_DIRTY	0x040u	/* Recovering unclean */
+#define	WT_CONN_LOG_RECOVER_DONE	0x080u	/* Recovery completed */
+#define	WT_CONN_LOG_RECOVER_ERR		0x100u	/* Error if recovery required */
+#define	WT_CONN_LOG_RECOVER_FAILED	0x200u	/* Recovery failed */
+#define	WT_CONN_LOG_ZERO_FILL		0x400u	/* Manually zero files */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 	uint32_t	 log_flags;	/* Global logging configuration */
 	WT_CONDVAR	*log_cond;	/* Log server wait mutex */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -254,6 +254,7 @@ extern int __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval,
 extern int __wt_conn_remove_encryptor(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_extractor_config(WT_SESSION_IMPL *session, const char *uri, const char *config, WT_EXTRACTOR **extractorp, int *ownp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_remove_extractor(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_verbose_dump_sessions(WT_SESSION_IMPL *session, bool show_cursors) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_timing_stress_config(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -390,7 +391,7 @@ extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32
 extern int __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t previous_state, uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn);
+extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn);
 extern int __wt_log_flush_lsn(WT_SESSION_IMPL *session, WT_LSN *lsn, bool start) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_background(WT_SESSION_IMPL *session, WT_LSN *lsn);
 extern int __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -446,6 +447,9 @@ extern int __wt_logop_checkpoint_start_print(WT_SESSION_IMPL *session, const uin
 extern int __wt_logop_prev_lsn_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *prev_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_prev_lsn_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_LSN *prev_lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_prev_lsn_print(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_t time_sec, uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts, uint64_t first_ts, uint64_t prepare_ts, uint64_t read_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp, uint64_t *durable_tsp, uint64_t *first_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_logop_txn_timestamp_print(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_op_printlog(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern int __wt_log_slot_switch(WT_SESSION_IMPL *session, WT_MYSLOT *myslot, bool retry, bool forced, bool *did_work) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -857,6 +861,7 @@ extern void __wt_txn_op_free(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 extern int __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_checkpoint_logread(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_LSN *ckpt_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_ts_log(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_LSN *lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_truncate_log(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_truncate_end(WT_SESSION_IMPL *session);
@@ -878,7 +883,7 @@ extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *c
 extern int __wt_timestamp_validate(WT_SESSION_IMPL *session, const char *name, wt_timestamp_t ts, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_parse_prepare_timestamp(WT_SESSION_IMPL *session, const char *cfg[], wt_timestamp_t *timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_parse_read_timestamp(WT_SESSION_IMPL *session, const char *cfg[], bool *set_tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_clear_commit_timestamp(WT_SESSION_IMPL *session);
 extern void __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -21,6 +21,9 @@
 #define	WT_LOG_SYNC_ENABLED	0x10u
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 
+#define	WT_LOGOP_IGNORE	0x80000000
+#define	WT_LOGOP_IS_IGNORED(val)	(val & WT_LOGOP_IGNORE)
+
 /*
  * WT_LSN --
  *	A log sequence number, representing a position in the transaction log.

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -153,6 +153,8 @@ struct __wt_txn_global {
 	WT_TXN_STATE	  checkpoint_state;	/* Checkpoint's txn state */
 	wt_timestamp_t	  checkpoint_timestamp;	/* Checkpoint's timestamp */
 
+	volatile uint64_t debug_ops;		/* Debug mode op counter */
+	uint64_t	  debug_rollback;	/* Debug mode rollback */
 	volatile uint64_t metadata_pinned;	/* Oldest ID for metadata */
 
 	/* Named snapshot state. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -1075,13 +1075,19 @@ static inline int
 __wt_txn_update_check(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 {
 	WT_TXN *txn;
+	WT_TXN_GLOBAL *txn_global;
 	bool ignore_prepare_set;
 
 	txn = &session->txn;
+	txn_global = &S2C(session)->txn_global;
 
 	if (txn->isolation != WT_ISO_SNAPSHOT)
 		return (0);
 
+	if (txn_global->debug_rollback != 0 &&
+	    ++txn_global->debug_ops % txn_global->debug_rollback == 0)
+		return (__wt_txn_rollback_required(session,
+		    "debug mode simulated conflict"));
 	/*
 	 * Always include prepared transactions in this check: they are not
 	 * supposed to affect visibility for update operations.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2228,6 +2228,23 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release
 	 * version string., a string; default empty.}
 	 * @config{ ),,}
+	 * @config{debug_mode = (, control the settings of various extended
+	 * debugging features., a set of related configuration options defined
+	 * below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust
+	 * log archiving to retain the log records of this number of
+	 * checkpoints.  Zero or one means perform normal archiving., an integer
+	 * between 0 and 1024; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a WT_ROLLBACK
+	 * error from a transaction operation about every Nth operation to
+	 * simulate a collision., an integer between 0 and 10M; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write
+	 * transaction related information to the log for all operations\, even
+	 * operations for tables with logging turned off.  This setting
+	 * introduces a log format change that may break older versions of
+	 * WiredTiger.  These operations are informational and skipped in
+	 * recovery., a boolean flag; default \c false.}
+	 * @config{ ),,}
 	 * @config{error_prefix, prefix string for error messages., a string;
 	 * default empty.}
 	 * @config{eviction = (, eviction configuration options., a set of
@@ -2843,6 +2860,20 @@ struct __wt_connection {
  * true.}
  * @config{create, create the database if it does not exist., a boolean flag;
  * default \c false.}
+ * @config{debug_mode = (, control the settings of various extended debugging
+ * features., a set of related configuration options defined below.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_retention, adjust log archiving to
+ * retain the log records of this number of checkpoints.  Zero or one means
+ * perform normal archiving., an integer between 0 and 1024; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a WT_ROLLBACK error
+ * from a transaction operation about every Nth operation to simulate a
+ * collision., an integer between 0 and 10M; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write transaction
+ * related information to the log for all operations\, even operations for
+ * tables with logging turned off.  This setting introduces a log format change
+ * that may break older versions of WiredTiger.  These operations are
+ * informational and skipped in recovery., a boolean flag; default \c false.}
+ * @config{ ),,}
  * @config{direct_io, Use \c O_DIRECT on POSIX systems\, and \c
  * FILE_FLAG_NO_BUFFERING on Windows to access files.  Options are given as a
  * list\, such as <code>"direct_io=[data]"</code>. Configuring \c direct_io
@@ -4921,6 +4952,12 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_LOGOP_COL_MODIFY	9
 /*! row-store modify */
 #define	WT_LOGOP_ROW_MODIFY	10
+/*
+ * NOTE: Diagnostic-only log operations should have values in
+ * the ignore range.
+ */
+/*! Diagnostic: transaction timestamps */
+#define	WT_LOGOP_TXN_TIMESTAMP	(WT_LOGOP_IGNORE | 11)
 /*! @} */
 
 /*******************************************

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -236,16 +236,26 @@ __log_fs_write(WT_SESSION_IMPL *session,
  *	thread as needed.
  */
 void
-__wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn)
+__wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
 {
 	WT_CONNECTION_IMPL *conn;
 	WT_LOG *log;
+	int i;
 
 	conn = S2C(session);
 	log = conn->log;
-	log->ckpt_lsn = *ckp_lsn;
+	log->ckpt_lsn = *ckpt_lsn;
 	if (conn->log_cond != NULL)
 		__wt_cond_signal(session, conn->log_cond);
+	/*
+	 * If we are storing debugging LSNs to retain additional log files
+	 * from archiving, then rotate the newest LSN into the array.
+	 */
+	if (conn->debug_ckpt_cnt != 0) {
+		for (i = (int)conn->debug_ckpt_cnt - 1; i >= 0; --i)
+			conn->debug_ckpt[i] = conn->debug_ckpt[i-1];
+		conn->debug_ckpt[0] = *ckpt_lsn;
+	}
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -485,7 +485,7 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 	if (cval.val)
 		F_SET(txn, WT_TXN_IGNORE_PREPARE);
 
-	WT_RET(__wt_txn_parse_read_timestamp(session, cfg));
+	WT_RET(__wt_txn_parse_read_timestamp(session, cfg, NULL));
 
 	return (0);
 }
@@ -933,8 +933,12 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 
 	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 	WT_ASSERT(session, !F_ISSET(txn, WT_TXN_ERROR) || txn->mod_count == 0);
-	/* Transaction should not have updated any of the logged tables. */
-	WT_ASSERT(session, txn->logrec == NULL);
+	/*
+	 * A transaction should not have updated any of the logged tables,
+	 * if debug mode logging is not turned on.
+	 */
+	if (!FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_DEBUG_MODE))
+		WT_ASSERT(session, txn->logrec == NULL);
 
 	WT_RET(__wt_txn_context_check(session, true));
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -59,19 +59,15 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
  *	Log an operation for the current transaction.
  */
 static int
-__txn_op_log(WT_SESSION_IMPL *session,
-    WT_ITEM *logrec, WT_TXN_OP *op, WT_CURSOR_BTREE *cbt)
+__txn_op_log(WT_SESSION_IMPL *session, WT_ITEM *logrec,
+    WT_TXN_OP *op, WT_CURSOR_BTREE *cbt, uint32_t fileid)
 {
 	WT_CURSOR *cursor;
 	WT_ITEM value;
 	WT_UPDATE *upd;
 	uint64_t recno;
-	uint32_t fileid;
 
 	cursor = &cbt->iface;
-
-	fileid = op->btree->id;
-
 	upd = op->u.op_upd;
 	value.data = upd->data;
 	value.size = upd->size;
@@ -210,7 +206,16 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
 	if (txn->logrec != NULL)
 		return (0);
 
-	WT_ASSERT(session, txn->id != WT_TXN_NONE);
+	/*
+	 * The only way we should ever get in here without a txn id is if we
+	 * are recording diagnostic information. In that case, allocate an id.
+	 */
+	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_DEBUG_MODE) &&
+	    txn->id == WT_TXN_NONE)
+		WT_RET(__wt_txn_id_check(session));
+	else
+		WT_ASSERT(session, txn->id != WT_TXN_NONE);
+
 	WT_RET(__wt_struct_size(session, &header_size, fmt, rectype, txn->id));
 	WT_RET(__wt_logrec_alloc(session, header_size, &logrec));
 
@@ -233,6 +238,7 @@ err:		__wt_logrec_free(session, &logrec);
 int
 __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 {
+	WT_CONNECTION_IMPL *conn;
 	WT_DECL_RET;
 	WT_ITEM *logrec;
 	WT_TXN *txn;
@@ -240,11 +246,13 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 
 	uint32_t fileid;
 
+	conn = S2C(session);
 	txn = &session->txn;
 
-	if (!FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ENABLED) ||
+	if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ||
 	    F_ISSET(session, WT_SESSION_NO_LOGGING) ||
-	    F_ISSET(S2BT(session), WT_BTREE_NO_LOGGING))
+	    (F_ISSET(S2BT(session), WT_BTREE_NO_LOGGING) &&
+	    !FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE)))
 		return (0);
 
 	/* We'd better have a transaction. */
@@ -254,6 +262,14 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	WT_ASSERT(session, txn->mod_count > 0);
 	op = txn->mod + txn->mod_count - 1;
 	fileid = op->btree->id;
+
+	/*
+	 * If this operation is diagnostic only, set the ignore bit on the
+	 * fileid so that recovery can skip it.
+	 */
+	if (F_ISSET(S2BT(session), WT_BTREE_NO_LOGGING) &&
+	    FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE))
+		FLD_SET(fileid, WT_LOGOP_IGNORE);
 
 	WT_RET(__txn_logrec_init(session));
 	logrec = txn->logrec;
@@ -267,7 +283,7 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 		break;
 	case WT_TXN_OP_BASIC_COL:
 	case WT_TXN_OP_BASIC_ROW:
-		ret = __txn_op_log(session, logrec, op, cbt);
+		ret = __txn_op_log(session, logrec, op, cbt, fileid);
 		break;
 	case WT_TXN_OP_TRUNCATE_COL:
 		ret = __wt_logop_col_truncate_pack(session, logrec, fileid,
@@ -363,6 +379,47 @@ __wt_txn_checkpoint_logread(WT_SESSION_IMPL *session,
 	WT_SET_LSN(ckpt_lsn, ckpt_file, ckpt_offset);
 	*pp = end;
 	return (0);
+}
+
+/*
+ * __wt_txn_ts_log --
+ *	Write a log record recording timestamps in the transaction.
+ */
+int
+__wt_txn_ts_log(WT_SESSION_IMPL *session)
+{
+	struct timespec t;
+	WT_CONNECTION_IMPL *conn;
+	WT_ITEM *logrec;
+	WT_TXN *txn;
+	wt_timestamp_t commit, durable, first, prepare, read;
+
+	conn = S2C(session);
+	txn = &session->txn;
+
+	if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ||
+	    F_ISSET(session, WT_SESSION_NO_LOGGING) ||
+	    !FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE))
+		return (0);
+
+	/* We'd better have a transaction running. */
+	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
+
+	WT_RET(__txn_logrec_init(session));
+	logrec = txn->logrec;
+	commit = durable = first = prepare = read = WT_TS_NONE;
+	if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT)) {
+		commit = txn->commit_timestamp;
+		first = txn->first_commit_timestamp;
+	}
+	prepare = txn->prepare_timestamp;
+	if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
+		read = txn->read_timestamp;
+
+	__wt_epoch(session, &t);
+	return (__wt_logop_txn_timestamp_pack(session, logrec,
+	    (uint64_t)t.tv_sec, (uint64_t)t.tv_nsec,
+	    commit, durable, first, prepare, read));
 }
 
 /*

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -71,9 +71,10 @@ static char home[1024];			/* Program working dir */
 #define	SESSION_MAX	(MAX_TH + 3 + MAX_TH * PREPARE_PCT)
 
 static const char * table_pfx = "table";
+static const char * const uri_collection = "collection";
 static const char * const uri_local = "local";
 static const char * const uri_oplog = "oplog";
-static const char * const uri_collection = "collection";
+static const char * const uri_shadow = "shadow";
 
 static const char * const ckpt_file = "checkpoint_done";
 
@@ -82,9 +83,13 @@ static volatile uint64_t global_ts = 1;
 
 #define	ENV_CONFIG_COMPAT	",compatibility=(release=\"2.9\")"
 #define	ENV_CONFIG_DEF						\
-    "create,log=(archive=false,file_max=10M,enabled),session_max=%" PRIu32
+    "cache_size=20M,create,log=(archive=true,file_max=10M,enabled),"	\
+    "debug_mode=(table_logging=true,checkpoint_retention=5),"		\
+    "statistics=(fast),statistics_log=(wait=1,json=true),session_max=%" PRIu32
 #define	ENV_CONFIG_TXNSYNC					\
-    "create,log=(archive=false,file_max=10M,enabled),"		\
+    "cache_size=20M,create,log=(archive=true,file_max=10M,enabled),"	\
+    "debug_mode=(table_logging=true,checkpoint_retention=5),"		\
+    "statistics=(fast),statistics_log=(wait=1,json=true),"		\
     "transaction_sync=(enabled,method=none),session_max=%" PRIu32
 #define	ENV_CONFIG_REC "log=(archive=false,recover=on)"
 
@@ -225,7 +230,7 @@ static WT_THREAD_RET
 thread_run(void *arg)
 {
 	FILE *fp;
-	WT_CURSOR *cur_coll, *cur_local, *cur_oplog;
+	WT_CURSOR *cur_coll, *cur_local, *cur_oplog, *cur_shadow;
 	WT_ITEM data;
 	WT_RAND_STATE rnd;
 	WT_SESSION *prepared_session, *session;
@@ -286,6 +291,15 @@ thread_run(void *arg)
 		testutil_check(session->open_cursor(session,
 		    uri, NULL, NULL, &cur_coll));
 	testutil_check(__wt_snprintf(
+	    uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow));
+	if (use_prep)
+		testutil_check(prepared_session->open_cursor(prepared_session,
+		    uri, NULL, NULL, &cur_shadow));
+	else
+		testutil_check(session->open_cursor(session,
+		    uri, NULL, NULL, &cur_shadow));
+
+	testutil_check(__wt_snprintf(
 	    uri, sizeof(uri), "%s:%s", table_pfx, uri_local));
 	if (use_prep)
 		testutil_check(prepared_session->open_cursor(prepared_session,
@@ -315,7 +329,7 @@ thread_run(void *arg)
 
 		if (use_ts) {
 			testutil_check(pthread_rwlock_rdlock(&ts_lock));
-			active_ts = __wt_atomic_addv64(&global_ts, 1);
+			active_ts = __wt_atomic_addv64(&global_ts, 2);
 			testutil_check(__wt_snprintf(tscfg,
 			    sizeof(tscfg), "commit_timestamp=%" PRIx64,
 			    active_ts));
@@ -334,6 +348,7 @@ thread_run(void *arg)
 		cur_coll->set_key(cur_coll, kname);
 		cur_local->set_key(cur_local, kname);
 		cur_oplog->set_key(cur_oplog, kname);
+		cur_shadow->set_key(cur_shadow, kname);
 		/*
 		 * Put an informative string into the value so that it
 		 * can be viewed well in a binary dump.
@@ -351,6 +366,20 @@ thread_run(void *arg)
 		data.data = cbuf;
 		cur_coll->set_value(cur_coll, &data);
 		testutil_check(cur_coll->insert(cur_coll));
+		cur_shadow->set_value(cur_shadow, &data);
+		if (use_ts) {
+			/*
+			 * Change the timestamp in the middle of the
+			 * transaction so that we simulate a secondary.
+			 */
+			++active_ts;
+			testutil_check(__wt_snprintf(tscfg,
+			    sizeof(tscfg), "commit_timestamp=%" PRIx64,
+			    active_ts));
+			testutil_check(session->timestamp_transaction(
+			    session, tscfg));
+		}
+		testutil_check(cur_shadow->insert(cur_shadow));
 		data.size = __wt_random(&rnd) % MAX_VAL;
 		data.data = obuf;
 		cur_oplog->set_value(cur_oplog, &data);
@@ -434,6 +463,10 @@ run_workload(uint32_t nth)
 	 */
 	testutil_check(__wt_snprintf(
 	    uri, sizeof(uri), "%s:%s", table_pfx, uri_collection));
+	testutil_check(session->create(session, uri,
+		"key_format=S,value_format=u,log=(enabled=false)"));
+	testutil_check(__wt_snprintf(
+	    uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow));
 	testutil_check(session->create(session, uri,
 		"key_format=S,value_format=u,log=(enabled=false)"));
 	testutil_check(__wt_snprintf(
@@ -548,7 +581,7 @@ main(int argc, char *argv[])
 	FILE *fp;
 	REPORT c_rep[MAX_TH], l_rep[MAX_TH], o_rep[MAX_TH];
 	WT_CONNECTION *conn;
-	WT_CURSOR *cur_coll, *cur_local, *cur_oplog;
+	WT_CURSOR *cur_coll, *cur_local, *cur_oplog, *cur_shadow;
 	WT_RAND_STATE rnd;
 	WT_SESSION *session;
 	pid_t pid;
@@ -725,6 +758,10 @@ main(int argc, char *argv[])
 	testutil_check(session->open_cursor(session,
 	    buf, NULL, NULL, &cur_coll));
 	testutil_check(__wt_snprintf(
+	    buf, sizeof(buf), "%s:%s", table_pfx, uri_shadow));
+	testutil_check(session->open_cursor(session,
+	    buf, NULL, NULL, &cur_shadow));
+	testutil_check(__wt_snprintf(
 	    buf, sizeof(buf), "%s:%s", table_pfx, uri_local));
 	testutil_check(session->open_cursor(session,
 	    buf, NULL, NULL, &cur_local));
@@ -798,13 +835,20 @@ main(int argc, char *argv[])
 			cur_coll->set_key(cur_coll, kname);
 			cur_local->set_key(cur_local, kname);
 			cur_oplog->set_key(cur_oplog, kname);
+			cur_shadow->set_key(cur_shadow, kname);
 			/*
 			 * The collection table should always only have the
-			 * data as of the checkpoint.
+			 * data as of the checkpoint. The shadow table should
+			 * always have the exact same data (or not) as the
+			 * collection table.
 			 */
 			if ((ret = cur_coll->search(cur_coll)) != 0) {
 				if (ret != WT_NOTFOUND)
 					testutil_die(ret, "search");
+				if ((ret = cur_shadow->search(cur_shadow)) == 0)
+					testutil_die(ret,
+					   "shadow search success");
+
 				/*
 				 * If we don't find a record, the stable
 				 * timestamp written to our file better be
@@ -841,7 +885,10 @@ main(int argc, char *argv[])
 				    " > stable ts %" PRIu64 "\n",
 				    fname, key, stable_fp, stable_val);
 				fatal = true;
-			}
+			} else if ((ret = cur_shadow->search(cur_shadow)) != 0)
+				/* Collection and shadow both have the data. */
+				testutil_die(ret, "shadow search failure");
+
 			/*
 			 * The local table should always have all data.
 			 */

--- a/test/suite/test_debug_mode01.py
+++ b/test/suite/test_debug_mode01.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# test_debug_mode01.py
+#    Test the debug mode settings. Test rollback_error in this one.
+class test_debug_mode01(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled=true),debug_mode=(rollback_error=5)'
+    session_config = 'isolation=snapshot'
+    uri = 'file:test_debug'
+
+    entries = 22
+    min_error = entries // 5
+
+    def rollback_error(self, val, insert=True):
+        keys = range(1, self.entries)
+        c = self.session.open_cursor(self.uri, None)
+        # We expect some operations to return an exception so we cannot
+        # use the simple 'c[k] = 1'. But we must explicitly set the key
+        # and value and then use the insert or update primitives.
+        #
+        # Look for a generic 'WT_ROLLBACK' string not the specific
+        # simulated reason string.
+        msg = '/WT_ROLLBACK/'
+        rollback = 0
+        for k in keys:
+            self.session.begin_transaction()
+            c.set_key(k)
+            c.set_value(val)
+            # Execute the insert or update. It will return true if the simulated
+            # conflict exception is raised, false if no exception occurred.
+            if insert:
+                conflict = self.assertRaisesException(wiredtiger.WiredTigerError, \
+                    lambda:c.insert(), msg, True)
+            else:
+                conflict = self.assertRaisesException(wiredtiger.WiredTigerError, \
+                    lambda:c.update(), msg, True)
+
+            if conflict:
+                rollback += 1
+                self.pr("Key: " + str(k) + " Rolled back")
+                self.session.rollback_transaction()
+            else:
+                self.session.commit_transaction()
+        c.close()
+        return rollback
+
+    def test_rollback_error(self):
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        rollback = self.rollback_error(1)
+        rollback += self.rollback_error(2, False)
+        self.pr("Rollback: " + str(rollback))
+        self.pr("Minimum: " + str(self.min_error))
+        self.assertTrue(rollback >= self.min_error)
+
+    def test_rollback_error_off(self):
+        # The setting is added in to wiredtiger_open via the config above.
+        # Test that we can properly turn the setting off via reconfigure.
+        # There should then be no rollback errors.
+        self.conn.reconfigure("debug_mode=(rollback_error=0)")
+
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        rollback = self.rollback_error(1)
+        rollback += self.rollback_error(2)
+        self.assertTrue(rollback == 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_debug_mode02.py
+++ b/test/suite/test_debug_mode02.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Public Domain 2024-2029 MongoDB, Inc.
+# Public Domain 2008-2024 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import fnmatch, os, time, wiredtiger, wttest
+
+# test_debug_mode02.py
+#    Test the debug mode settings. Test checkpoint_retention use.
+class test_debug_mode02(wttest.WiredTigerTestCase):
+    uri = 'file:test_debug'
+
+    entries = 100
+    loop = 0
+    retain = 5
+    log1 = 'WiredTigerLog.0000000001'
+    log2 = 'WiredTigerLog.0000000002'
+
+    def conn_config(self):
+        return 'log=(enabled=true,file_max=100K),debug_mode=(checkpoint_retention=%d)' % self.retain
+
+    def log_set(self):
+        logs = fnmatch.filter(os.listdir(self.home), "*gerLog*")
+        return set(logs)
+
+    def check_archive(self, logfile):
+        archived = False
+        for i in range(1,90):
+            # Sleep and then see if archive ran. We do this in a loop
+            # for slow machines. Max out at 90 seconds.
+            time.sleep(1.0)
+            if not os.path.exists(logfile):
+                archived = True
+                break
+        self.assertTrue(archived)
+
+    def advance_log_checkpoint(self):
+        # Advance the log file to the next file and write a checkpoint.
+        keys = range(1, self.entries)
+        cur_set = self.log_set()
+        c = self.session.open_cursor(self.uri, None)
+        new_set = cur_set
+        # Write data in small chunks until we switch log files.
+        while cur_set == new_set:
+            for k in keys:
+                c[k + (self.loop * self.entries)] = 1
+            self.loop += 1
+            new_set = self.log_set()
+        c.close()
+        # Write a checkpoint into the new log file.
+        self.session.checkpoint()
+
+    def test_checkpoint_retain(self):
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        # No log files should be archived while we have fewer than the
+        # retention number of logs. Make sure each iteration the new
+        # logs are a proper superset of the previous time.
+        for i in range(1, self.retain):
+            cur_set = self.log_set()
+            self.advance_log_checkpoint()
+            # We don't accomodate slow machines here because we don't expect
+            # the files the change and there is no way to know if archive ran
+            # otherwise.
+            time.sleep(1.0)
+            new_set = self.log_set()
+            self.assertTrue(new_set.issuperset(cur_set))
+
+        self.assertTrue(os.path.exists(self.log1))
+        self.advance_log_checkpoint()
+        self.check_archive(self.log1)
+
+    # Test that both zero and one archive as usual. And test reconfigure.
+    def test_checkpoint_retain_off(self):
+        self.conn.reconfigure("debug_mode=(checkpoint_retention=0)")
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+
+        self.advance_log_checkpoint()
+        self.check_archive(self.log1)
+
+        self.conn.reconfigure("debug_mode=(checkpoint_retention=1)")
+        self.advance_log_checkpoint()
+        self.check_archive(self.log2)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_debug_mode03.py
+++ b/test/suite/test_debug_mode03.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Public Domain 2034-2039 MongoDB, Inc.
+# Public Domain 2008-2034 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# test_debug_mode03.py
+#    Test the debug mode settings. Test table_logging use.
+class test_debug_mode03(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled=true,file_max=100K),debug_mode=(table_logging=true)'
+    uri = 'file:test_debug'
+    entries = 100
+    value = b'\x01\x02abcd\x03\x04'
+
+    def add_data(self):
+        # Add a binary value we can search for in the log.
+        keys = range(0, self.entries)
+        c = self.session.open_cursor(self.uri, None)
+        for k in keys:
+            c[k] = self.value
+        c.close()
+
+    def find_log_recs(self):
+        # Open a log cursor. We should find log records that have
+        # the value we inserted.
+        c = self.session.open_cursor("log:", None)
+        count = 0
+        while c.next() == 0:
+            # lsn.file, lsn.offset, opcount
+            keys = c.get_key()
+            # txnid, rectype, optype, fileid, logrec_key, logrec_value
+            values = c.get_value()
+            # Look for log records that have a key/value pair.
+            if values[4] != b'':
+                if self.value in values[5]:  # logrec_value
+                    count += 1
+        c.close()
+        return count
+
+    def test_table_logging(self):
+        self.session.create(self.uri, 'key_format=i,value_format=u,log=(enabled=false)')
+        self.add_data()
+        count = self.find_log_recs()
+        self.assertEqual(count, self.entries)
+
+    # Test that both zero and one archive as usual. And test reconfigure.
+    def test_table_logging_off(self):
+        self.conn.reconfigure("debug_mode=(table_logging=false)")
+        self.session.create(self.uri, 'key_format=i,value_format=u,log=(enabled=false)')
+        self.add_data()
+        count = self.find_log_recs()
+        self.assertEqual(count, 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_timestamp17.py
+++ b/test/suite/test_timestamp17.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_timestamp17.py
+#   Test unintended timestamp usage on an update and ensure behavior
+#   matches expectations. Additionally, move the timestamp to ensure
+#   that values read are still consistent after those timestamps are
+#   moved.
+#
+
+import random
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_timestamp17(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_timestamp17'
+    uri = 'table:' + tablename
+    session_config = 'isolation=snapshot'
+
+    def test_inconsistent_timestamping(self):
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+        self.session.begin_transaction()
+        cur1 = self.session.open_cursor(self.uri)
+        cur1[1] = 1
+        self.session.commit_transaction('commit_timestamp=25')
+
+        self.session.begin_transaction()
+        cur1[1] = 2
+        self.session.commit_transaction('commit_timestamp=50')
+
+        self.session.begin_transaction()
+        cur1[1] = 3
+        self.session.commit_transaction('commit_timestamp=200')
+
+        self.session.begin_transaction()
+        cur1.set_key(1)
+        cur1.remove()
+        self.session.commit_transaction('commit_timestamp=100')
+
+        # Read before any updates and ensure we cannot find the key or value.
+        self.session.begin_transaction('read_timestamp=20')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Read at 25 and we should see 1.
+        self.session.begin_transaction('read_timestamp=25')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, 0)
+        value1 = cur1.get_value()
+        self.session.commit_transaction()
+        self.assertEqual(1, value1)
+
+        # Read at 50 and we should see 2.
+        self.session.begin_transaction('read_timestamp=50')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, 0)
+        value1 = cur1.get_value()
+        self.session.commit_transaction()
+        self.assertEqual(2, value1)
+
+        # Read at 100 and we should not find anything.
+        self.session.begin_transaction('read_timestamp=100')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Read at 200 and we should still not find anything.
+        self.session.begin_transaction('read_timestamp=200')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Read at 300 for further validation.
+        self.session.begin_transaction('read_timestamp=300')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Move oldest timestamp forward and
+        # confirm we see the correct numbers.
+        self.conn.set_timestamp('oldest_timestamp=49')
+
+        # Read at 49 and we should see 1.
+        self.session.begin_transaction('read_timestamp=49')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, 0)
+        value1 = cur1.get_value()
+        self.session.commit_transaction()
+        self.assertEqual(1, value1)
+
+        self.conn.set_timestamp('oldest_timestamp=99')
+
+        # Read at 99 and we should see 2.
+        self.session.begin_transaction('read_timestamp=99')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, 0)
+        value1 = cur1.get_value()
+        self.session.commit_transaction()
+        self.assertEqual(2, value1)
+
+        # Move oldest to the point at which we deleted.
+        self.conn.set_timestamp('oldest_timestamp=100')
+
+        # Read at 100 and we should not find anything.
+        self.session.begin_transaction('read_timestamp=100')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Read at 200 and we should not find anything.
+        self.session.begin_transaction('read_timestamp=200')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        # Move oldest timestamp to 200 to ensure history
+        # works as expected and we do not see the value 3.
+        self.conn.set_timestamp('oldest_timestamp=200')
+
+        self.session.begin_transaction('read_timestamp=200')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+        self.session.begin_transaction('read_timestamp=250')
+        cur1.set_key(1)
+        search_success = cur1.search()
+        self.assertEqual(search_success, wiredtiger.WT_NOTFOUND)
+        self.session.commit_transaction()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -508,8 +508,9 @@ class WiredTigerTestCase(unittest.TestCase):
         """
         Like TestCase.assertRaises(), with some additional options.
         If the exceptionString argument is used, the exception's string
-        must match it. If optional is set, then no assertion occurs
-        if the exception doesn't occur.
+        must match it, or its pattern if the string starts and ends with
+        a slash. If optional is set, then no assertion occurs if the
+        exception doesn't occur.
         Returns true if the assertion is raised.
         """
         raised = False
@@ -519,9 +520,19 @@ class WiredTigerTestCase(unittest.TestCase):
             if not isinstance(err, exceptionType):
                 self.fail('Exception of incorrect type raised, got type: ' + \
                     str(type(err)))
-            if exceptionString != None and exceptionString != str(err):
-                self.fail('Exception with incorrect string raised, got: "' + \
-                    str(err) + '"')
+            if exceptionString != None:
+                # Match either a pattern or an exact string.
+                fail = False
+                self.pr('Expecting string msg: ' + exceptionString)
+                if len(exceptionString) > 2 and \
+                  exceptionString[0] == '/' and exceptionString[-1] == '/' :
+                      if re.search(exceptionString[1:-1], str(err)) == None:
+                        fail = True
+                elif exceptionString != str(err):
+                        fail = True
+                if fail:
+                    self.fail('Exception with incorrect string raised, got: "' + \
+                        str(err) + '" Expected: ' + exceptionString)
             raised = True
         if not raised and not optional:
             self.fail('no assertion raised')


### PR DESCRIPTION
* WT-4712 Add diagnostic logging.

* We may not have a btree here, don't check it.

* Add bit field on fileid to ignore operation and remove ignore flag
from the record.

* Allocate a txn id in diagnostic mode if needed.

* Only call logging of timestamp setting if one is set.

* Skip timestamp operation in recovery. Add diagnostic to timestamp_abort.

* Need to unpack timestamp operation to move pointers to next operation.

* Correctly set bit to ignore the fileid. Remove verbose from test.

* Remove debug line.

* Conditionalize assertion that is no longer always true.

* Add support for durable and prepare timestamps.

* Whitespace and spelling.

* Add clock time to txn_timestamp log record.

* Add in support for checkpoint retention (i.e. archiving changes).

* Remove verbose setting from test.

* Move diagnostic free to general connection code.

* Ignore reconfigure while debugging.

* Fix off by one bug.

* Add special uint32_id type for fileids so they are printed in both
decimal and hex in printlog.

* Minor wordsmithing.

* Fix wording for long line.

* Commit auto-generated file.

* Reinstate code supporting reconfigure.

* Remove accidentally committed code.

* Check the flag, not just the bit value.

* Remove extra arg.

* Add diagnostic operation range usage to make it easier to ignore
those operation records.

* Add some comments to log_data.py file about diagnostic operations.

* Wordsmithing.

* Account for size of record we skip.

* Rename the config string to debug_mode and related changes.

* Fix editing error.

* Add test for rollback_error debug mode setting.

* Add test for checkpoint_retention.

* Fix minor test issue.

* Add debug print line.

* Use // for integer division for python3.

* Add test for table_logging.

* Whitespace

* Accomodate slow machines in sleep/archive test.

* Review comments.

* Fix typo

* Modify description.

* Turn on verbose=(log) on slow systems.

* Simplify archive checking to (hopefully) alleviate timing issues.

(cherry picked from commit a610f847393f5d21923f92e38a7e1aa7258f7d47)