### PR TITLE
WT-4850 __slvg_checkpoint() metadata memory leak

### DIFF
--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -170,6 +170,7 @@ __slvg_checkpoint(WT_SESSION_IMPL *session, WT_REF *root)
 	char *config;
 
 	btree = S2BT(session);
+	ckptbase = NULL;
 	dhandle = session->dhandle;
 	config = NULL;
 
@@ -219,6 +220,7 @@ __slvg_checkpoint(WT_SESSION_IMPL *session, WT_REF *root)
 		WT_ERR(__wt_meta_checkpoint_clear(session, dhandle->name));
 
 err:	__wt_meta_ckptlist_free(session, &ckptbase);
+	__wt_free(session, config);
 	return (ret);
 }
 


### PR DESCRIPTION
Memory allocated into `config` was never freed.

I also explicitly initialized `ckptbase`, just for clarity.