### PR TITLE
WT-4855 WiredTiger recovery should detect files without unique IDs.

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -457,6 +457,11 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 		r->nfiles = fileid + 1;
 	}
 
+	if (r->files[fileid].uri != NULL)
+		WT_PANIC_RET(r->session, WT_PANIC,
+		    "metadata corruption: files %s and %s have the same "
+		    "file ID %u",
+		    uri, r->files[fileid].uri, fileid);
 	WT_RET(__wt_strdup(r->session, uri, &r->files[fileid].uri));
 	WT_RET(
 	    __wt_config_getones(r->session, config, "checkpoint_lsn", &cval));


### PR DESCRIPTION
@sueloverso, I hit this when debugging a different problem (the symptom was leaking the allocated memory), so I figured I'd add in a check. I don't think it can happen absent corruption, but it might save us some debugging if we ever start importing objects in a significant way.