### PR TITLE
WT-4853 standalone recovery code cannot handle deleted checkpoints

### DIFF
--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -73,11 +73,11 @@ __bm_checkpoint(WT_BM *bm, WT_SESSION_IMPL *session,
  *	Return information for the last known file checkpoint.
  */
 static int
-__bm_checkpoint_last(
-    WT_BM *bm, WT_SESSION_IMPL *session, char **metadatap, WT_ITEM *checkpoint)
+__bm_checkpoint_last(WT_BM *bm, WT_SESSION_IMPL *session,
+    char **metadatap, char **checkpoint_listp, WT_ITEM *checkpoint)
 {
 	return (__wt_block_checkpoint_last(
-	    session, bm->block, metadatap, checkpoint));
+	    session, bm->block, metadatap, checkpoint_listp, checkpoint));
 }
 
 /*

--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -25,19 +25,19 @@ __wt_import(WT_SESSION_IMPL *session, const char *uri)
 	WT_KEYED_ENCRYPTOR *kencryptor;
 	const char *filename;
 	const char *filecfg[] = {
-	   WT_CONFIG_BASE(session, file_meta), NULL, NULL, };
-	char *fileconf, *metadata;
+	   WT_CONFIG_BASE(session, file_meta), NULL, NULL, NULL, NULL, NULL };
+	char *checkpoint_list, *fileconf, *metadata, fileid[64];
 
 	ckptbase = NULL;
-	fileconf = metadata = NULL;
-
-	WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:"));
-	filename = uri;
-	WT_PREFIX_SKIP(filename, "file:");
+	checkpoint_list = fileconf = metadata = NULL;
 
 	WT_ERR(__wt_scr_alloc(session, 0, &a));
 	WT_ERR(__wt_scr_alloc(session, 0, &b));
 	WT_ERR(__wt_scr_alloc(session, 0, &checkpoint));
+
+	WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:"));
+	filename = uri;
+	WT_PREFIX_SKIP(filename, "file:");
 
 	/*
 	 * Open the file, request block manager checkpoint information.
@@ -46,11 +46,14 @@ __wt_import(WT_SESSION_IMPL *session, const char *uri)
 	 */
 	WT_ERR(__wt_block_manager_open(
 	    session, filename, filecfg, false, true, 512, &bm));
-	ret = bm->checkpoint_last(bm, session, &metadata, checkpoint);
+	ret = bm->checkpoint_last(
+	    bm, session, &metadata, &checkpoint_list, checkpoint);
 	WT_TRET(bm->close(bm, session));
 	WT_ERR(ret);
-	__wt_verbose(
-	    session, WT_VERB_CHECKPOINT, "import metadata: %s", metadata);
+	__wt_verbose(session,
+	    WT_VERB_CHECKPOINT, "import metadata: %s", metadata);
+	__wt_verbose(session,
+	    WT_VERB_CHECKPOINT, "import checkpoint-list: %s", checkpoint_list);
 
 	/*
 	 * The metadata may have been encrypted, in which case it's also
@@ -86,34 +89,78 @@ __wt_import(WT_SESSION_IMPL *session, const char *uri)
 		WT_ERR(__wt_decrypt(session, kencryptor->encryptor, 0, b, a));
 		((uint8_t *)a->data)[a->size] = '\0';
 	}
-	filecfg[1] = a->data;
 
 	/*
-	 * Build and flatten the complete configuration string (including the
-	 * returned metadata), then update the database metadata.
+	 * OK, we've now got three chunks of data: the file's metadata from when
+	 * the last checkpoint started, the array of checkpoints as of when the
+	 * last checkpoint was almost complete (everything written but the avail
+	 * list), and fixed-up checkpoint information from the last checkpoint.
+	 *
+	 * Build and flatten the metadata and the checkpoint list, then insert
+	 * it into the metadata for this file.
+	 *
+	 * Strip out the checkpoint-LSN, an imported file isn't associated
+	 * with any log files.
+	 * Assign a unique file ID.
 	 */
+	filecfg[1] = a->data;
+	filecfg[2] = checkpoint_list;
+	filecfg[3] = "checkpoint_lsn=";
+	WT_WITH_SCHEMA_LOCK(session, ret =
+	    __wt_snprintf(fileid, sizeof(fileid),
+	    "id=%" PRIu32, ++S2C(session)->next_file_id));
+	WT_ERR(ret);
+	filecfg[4] = fileid;
 	WT_ERR(__wt_config_collapse(session, filecfg, &fileconf));
+	WT_ERR(__wt_metadata_insert(session, uri, fileconf));
 	__wt_verbose(session,
 	    WT_VERB_CHECKPOINT, "import configuration: %s/%s", uri, fileconf);
-	WT_ERR(__wt_metadata_insert(session, uri, fileconf));
 
 	/*
-	 * We have the checkpoint information from immediately before the final
-	 * checkpoint (we just updated the file's metadata), the block manager
-	 * returned the corrected final checkpoint, put it all together.
+	 * The just inserted metadata was correct as of immediately before the
+	 * before the final checkpoint, but it's not quite right. The block
+	 * manager returned the corrected final checkpoint, put it all together.
 	 *
 	 * Get the checkpoint information from the file's metadata as an array
-	 * of WT_CKPT structures. We're going to add a new entry for the final
-	 * checkpoint at the end, move to that entry.
+	 * of WT_CKPT structures.
+	 *
+	 * Clear durability information, everything from an imported file must
+	 * be durable.
+	 *
+	 * XXX
+	 * There's a problem here. If a file is imported from our future (leaf
+	 * pages with unstable entries that have write-generations ahead of the
+	 * current database's base write generation), we'll read the values and
+	 * treat them as stable. A restart will fix this: when we added the
+	 * imported file to our metadata, the write generation in the imported
+	 * file's checkpoints updated our database's maximum write generation,
+	 * and so a restart will have a maximum generation newer than the
+	 * imported file's write generation. An alternative solution is to add
+	 * a "base write generation" value to the imported file's metadata, and
+	 * use that value instead of the connection's base write generation when
+	 * deciding what page items should be read. Since all future writes to
+	 * the imported file would be ahead of that write generation, it would
+	 * have the effect we want.
+	 *
+	 * Update the last checkpoint with the corrected information.
+	 * Update the file's metadata with the new checkpoint information.
 	 */
-	WT_ERR(__wt_meta_ckptlist_get(session, uri, true, &ckptbase));
-	WT_CKPT_FOREACH(ckptbase, ckpt)
-		if (ckpt->name == NULL)
+	WT_ERR(__wt_meta_ckptlist_get(session, uri, false, &ckptbase));
+	WT_CKPT_FOREACH(ckptbase, ckpt) {
+		if (ckpt->name == NULL || (ckpt + 1)->name == NULL)
 			break;
+		ckpt->newest_durable_ts = WT_TS_NONE;
+		ckpt->oldest_start_ts = WT_TS_NONE;
+		ckpt->oldest_start_txn = WT_TXN_NONE;
+		ckpt->newest_stop_ts = WT_TS_MAX;
+		ckpt->newest_stop_txn = WT_TXN_MAX;
+	}
+	if (ckpt->name == NULL)
+		WT_ERR_MSG(session, EINVAL,
+		    "no checkpoint information available to import");
+	F_SET(ckpt, WT_CKPT_UPDATE);
 	WT_ERR(__wt_buf_set(
 	    session, &ckpt->raw, checkpoint->data, checkpoint->size));
-
-	/* Update the file's metadata with the new checkpoint information. */
 	WT_ERR(__wt_meta_ckptlist_set(session, uri, ckptbase, NULL));
 
 err:
@@ -121,6 +168,7 @@ err:
 
 	__wt_free(session, fileconf);
 	__wt_free(session, metadata);
+	__wt_free(session, checkpoint_list);
 
 	__wt_scr_free(session, &a);
 	__wt_scr_free(session, &b);

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -178,7 +178,8 @@ struct __wt_bm {
 	u_int (*block_header)(WT_BM *);
 	int (*checkpoint)
 	    (WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, WT_CKPT *, bool);
-	int (*checkpoint_last)(WT_BM *, WT_SESSION_IMPL *, char **, WT_ITEM *);
+	int (*checkpoint_last)
+	    (WT_BM *, WT_SESSION_IMPL *, char **, char **, WT_ITEM *);
 	int (*checkpoint_load)(WT_BM *, WT_SESSION_IMPL *,
 	    const uint8_t *, size_t, uint8_t *, size_t *, bool);
 	int (*checkpoint_resolve)(WT_BM *, WT_SESSION_IMPL *, bool);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -25,7 +25,7 @@ extern int __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block
 extern int __wt_block_checkpoint(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, WT_CKPT *ckptbase, bool data_checksum) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool failed) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_checkpoint_final(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, uint8_t **file_sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **metadatap, WT_ITEM *checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **metadatap, char **checkpoint_listp, WT_ITEM *checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -87,7 +87,8 @@ struct __wt_ckpt {
 
 	uint64_t write_gen;		/* Write generation */
 
-	char	*metadata;		/* Checkpoint metadata */
+	char	*block_metadata;	/* Block-stored metadata */
+	char	*block_checkpoint;	/* Block-stored checkpoint */
 
 					/* Validity window */
 	wt_timestamp_t	newest_durable_ts;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -296,7 +296,7 @@ __wt_meta_block_metadata(
 	    "block_metadata_encrypted=%s,block_metadata=[%.*s]",
 	    (int)cval.len, cval.str, kencryptor == NULL ? "false" : "true",
 	    (int)metadata_len, metadata));
-	WT_ERR(__wt_strndup(session, b->data, b->size, &ckpt->metadata));
+	WT_ERR(__wt_strndup(session, b->data, b->size, &ckpt->block_metadata));
 
 err:
 	__wt_free(session, min_config);
@@ -676,7 +676,8 @@ __wt_meta_checkpoint_free(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
 		return;
 
 	__wt_free(session, ckpt->name);
-	__wt_free(session, ckpt->metadata);
+	__wt_free(session, ckpt->block_metadata);
+	__wt_free(session, ckpt->block_checkpoint);
 	__wt_buf_free(session, &ckpt->addr);
 	__wt_buf_free(session, &ckpt->raw);
 	__wt_free(session, ckpt->bpriv);

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -172,6 +172,27 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 }
 
 /*
+ * list_print_size --
+ *	List a size found in the checkpoint information.
+ */
+static void
+list_print_size(uint64_t v)
+{
+	if (v >= WT_PETABYTE)
+		printf("%" PRIu64 " PB", v / WT_PETABYTE);
+	else if (v >= WT_TERABYTE)
+		printf("%" PRIu64 " TB", v / WT_TERABYTE);
+	else if (v >= WT_GIGABYTE)
+		printf("%" PRIu64 " GB", v / WT_GIGABYTE);
+	else if (v >= WT_MEGABYTE)
+		printf("%" PRIu64 " MB", v / WT_MEGABYTE);
+	else if (v >= WT_KILOBYTE)
+		printf("%" PRIu64 " KB", v / WT_KILOBYTE);
+	else
+		printf("%" PRIu64 " B", v);
+}
+
+/*
  * list_print_checkpoint --
  *	List the checkpoint information.
  */
@@ -183,7 +204,6 @@ list_print_checkpoint(WT_SESSION *session, const char *key)
 	WT_DECL_RET;
 	size_t allocsize, len;
 	time_t t;
-	uint64_t v;
 
 	/*
 	 * We may not find any checkpoints for this file, in which case we don't
@@ -210,38 +230,55 @@ list_print_checkpoint(WT_SESSION *session, const char *key)
 		 * Call ctime, not ctime_r; ctime_r has portability problems,
 		 * the Solaris version is different from the POSIX standard.
 		 */
+		if (ckpt != ckptbase)
+			printf("\n");
 		t = (time_t)ckpt->sec;
 		printf("\t%*s: %.24s", (int)len, ckpt->name, ctime(&t));
 
-		v = ckpt->size;
-		if (v >= WT_PETABYTE)
-			printf(" (%" PRIu64 " PB)\n", v / WT_PETABYTE);
-		else if (v >= WT_TERABYTE)
-			printf(" (%" PRIu64 " TB)\n", v / WT_TERABYTE);
-		else if (v >= WT_GIGABYTE)
-			printf(" (%" PRIu64 " GB)\n", v / WT_GIGABYTE);
-		else if (v >= WT_MEGABYTE)
-			printf(" (%" PRIu64 " MB)\n", v / WT_MEGABYTE);
-		else if (v >= WT_KILOBYTE)
-			printf(" (%" PRIu64 " KB)\n", v / WT_KILOBYTE);
-		else
-			printf(" (%" PRIu64 " B)\n", v);
+		printf(" (size ");
+		list_print_size(ckpt->size);
+		printf(")\n");
 
 		/* Decode the checkpoint block. */
 		if (ckpt->raw.data == NULL)
 			continue;
 		if ((ret = __wt_block_ckpt_decode(
 		    session, allocsize, ckpt->raw.data, &ci)) == 0) {
-			printf("\t\t" "root offset: %" PRIuMAX
-			    " (0x%" PRIxMAX ")\n",
+			printf("\t\t" "file-size: ");
+			list_print_size((uint64_t)ci.file_size);
+			printf(", checkpoint-size: ");
+			list_print_size(ci.ckpt_size);
+			printf("\n\n");
+
+			printf("\t\t" "          offset, size, checksum\n");
+			printf(
+			    "\t\t" "root    "
+			    ": %" PRIuMAX
+			    ", %" PRIu32
+			    ", %" PRIu32 "\n",
 			    (uintmax_t)ci.root_offset,
-			    (uintmax_t)ci.root_offset);
-			printf("\t\t" "root size: %" PRIu32
-			    " (0x%" PRIx32 ")\n",
-			    ci.root_size, ci.root_size);
-			printf("\t\t" "root checksum: %" PRIu32
-			    " (0x%" PRIx32 ")\n",
-			    ci.root_checksum, ci.root_checksum);
+			    ci.root_size, ci.root_checksum);
+			printf(
+			    "\t\t" "alloc   "
+			    ": %" PRIuMAX
+			    ", %" PRIu32
+			    ", %" PRIu32 "\n",
+			    (uintmax_t)ci.alloc.offset,
+			    ci.alloc.size, ci.alloc.checksum);
+			printf(
+			    "\t\t" "discard "
+			    ": %" PRIuMAX
+			    ", %" PRIu32
+			    ", %" PRIu32 "\n",
+			    (uintmax_t)ci.discard.offset,
+			    ci.discard.size, ci.discard.checksum);
+			printf(
+			    "\t\t" "avail   "
+			    ": %" PRIuMAX
+			    ", %" PRIu32
+			    ", %" PRIu32 "\n",
+			    (uintmax_t)ci.avail.offset,
+			    ci.avail.size, ci.avail.checksum);
 		} else {
 			/* Ignore the error and continue if damaged. */
 			(void)util_err(session, ret, "__wt_block_ckpt_decode");

--- a/test/csuite/import/smoke.sh
+++ b/test/csuite/import/smoke.sh
@@ -12,14 +12,20 @@ top_builddir=${top_builddir:-../../build_posix}
 top_srcdir=${top_srcdir:-../..}
 
 dir=WT_TEST.import
-rm -rf $dir && mkdir $dir
 
 rundir=$dir/RUNDIR
 foreign=$dir/FOREIGN
 
+mo=$dir/metadata.orig
+mi=$dir/metadata.import
+co=$dir/ckpt.orig
+ci=$dir/ckpt.import
+
 EXT="extensions=[\
 $top_builddir/ext/encryptors/rotn/.libs/libwiredtiger_rotn.so,\
 $top_builddir/ext/collators/reverse/.libs/libwiredtiger_reverse_collator.so]"
+
+wt="$top_builddir/wt"
 
 # Run test/format to create an object.
 format()
@@ -37,23 +43,77 @@ format()
 	    ops=0 \
 	    rebalance=0 \
 	    salvage=0 \
+	    threads=4 \
 	    timer=2 \
-	    verify=1 || exit 1
+	    verify=1
+}
+
+import()
+{
+	# Update the extensions if the run included encryption.
+	egrep 'encryption=none' $rundir/CONFIG > /dev/null ||
+	    EXT="encryption=(name=rotn,keyid=7),$EXT"
+
+	# Dump the original metadata.
+	echo; echo 'dumping the original metadata'
+	$wt -C "$EXT" -h $rundir list -cv file:wt
+	$wt -C "$EXT" -h $rundir list -v file:wt | sed 1d > $mo
+
+	# Create a stub datbase and copy in the table.
+	rm -rf $foreign && mkdir $foreign || exit 1
+	$wt -C "$EXT" -h $foreign create file:xxx || exit 1
+	cp $rundir/wt $foreign/yyy || exit 1
+
+	# Import the table.
+	$wt -C "$EXT" -h $foreign import file:yyy
+
+
+	# Dump the imported metadata.
+	echo; echo 'dumping the imported metadata'
+	$wt -C "$EXT" -h $foreign list -cv file:yyy
+	$wt -C "$EXT" -h $foreign list -v file:yyy | sed 1d > $mi
+}
+
+compare_checkpoints()
+{
+	echo 'comparing the original and imported checkpoints'
+	sed -e 's/.*\(checkpoint=.*))\).*/\1/' < $mo > $co
+	sed -e 's/.*\(checkpoint=.*))\).*/\1/' < $mi > $ci
+	echo; echo 'original checkpoint'
+	cat $co
+	echo; echo 'imported checkpoint'
+	cat $ci
+	cmp $co $ci
 }
 
 verify()
 {
-	# Import and verify the object.
-	egrep 'encryption=none' $rundir/CONFIG > /dev/null ||
-	    EXT="encryption=(name=rotn,keyid=7),$EXT"
-	wt="$top_builddir/wt"
-
-	rm -rf $foreign && mkdir $foreign || exit 1
-	$wt -C "$EXT" -h $foreign create file:xxx || exit 1
-	mv $rundir/wt $foreign/yyy || exit 1
-	$wt -C "$EXT" -h $foreign import file:yyy || exit 1
+	echo; echo 'verifying the imported file'
+	$wt -C "$EXT" -h $foreign verify file:yyy || exit 1
 }
 
-format
+# The checkpoints will differ in some ways, for example, the import clears the
+# durable timestamp/transaction information in the checkpoint. If verify fails,
+# you can repeatedly run the import and verify process using the -c option for
+# debugging.
+compare=0
+while :
+	do case "$1" in
+	-c)
+		compare=1
+		shift;;
+	*)
+		break;;
+	esac
+done
+
+if test $compare -eq 0; then
+	rm -rf $dir && mkdir $dir
+	format
+fi
+import
+if test $compare -eq 1; then
+	compare_checkpoints
+fi
 verify
 exit 0


### PR DESCRIPTION
@agorrod, @michaelcahill, this is a significant change to the standalone recovery code Michael merged. In summary, the previous code tried to repair the most recent checkpoint found in the metadata, and that doesn't work in all cases. The reason I didn't see it was I had a bug in my test harness, and was only testing the import process, instead of doing a full verification after the import.

In this branch, instead of just storing the base file metadata and the corrected checkpoint information in the file, the block manager now constructs the complete, almost-correct, file checkpoint metadata entry, and copies it into the file's avail list along with the base metadata and the corrected checkpoint information.

Additionally, I've pushed changes into the test program to do a full verify after the import.

The new layering is a little uglier than before (but not that much), and almost all of the changes are in the block-scan and btree-import code, so the added risk in merging this code is minimal.