### PR TITLE
WT-4856 format should test LSM and timestamp configurations.

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -104,14 +104,8 @@ config_setup(void)
 			 *
 			 * Configuring truncation or timestamps results in LSM
 			 * cache problems, don't configure LSM if those set.
-			 *
-			 * XXX
-			 * Remove the timestamp test when WT-4067 resolved.
 			 */
 			if (g.type != ROW || g.c_in_memory)
-				break;
-			if (config_is_perm(
-			    "transaction_timestamps") && g.c_txn_timestamps)
 				break;
 			if (config_is_perm("truncate") && g.c_truncate)
 				break;
@@ -558,19 +552,6 @@ config_lsm_reset(void)
 	 */
 	if (!config_is_perm("truncate"))
 		config_single("truncate=off", 0);
-
-	/*
-	 * LSM doesn't currently play nicely with timestamps, don't choose the
-	 * pair unless forced to. If we turn off timestamps, make sure we turn
-	 * off prepare as well, it requires timestamps. Remove this code with
-	 * WT-4067.
-	 *
-	 */
-	if (!config_is_perm("prepare") &&
-	    !config_is_perm("transaction_timestamps")) {
-		config_single("prepare=off", 0);
-		config_single("transaction_timestamps=off", 0);
-	}
 }
 
 /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1399,7 +1399,7 @@ nextprev(TINFO *tinfo, WT_CURSOR *cursor, bool next)
 		/* Check that keys are never returned out-of-order. */
 		/*
 		 * XXX
-		 * WT-3889
+		 * WT-3889, WT-3907
 		 * LSM has a bug that prevents cursor order checks from
 		 * working, skip the test for now.
 		 */


### PR DESCRIPTION
@agorrod, @sueloverso, this turns LSM and timestamp configurations back on in test/format.

I'm running LSM with timestamps on a test box, I'll let it run for a few hours and see how it goes.