### PR TITLE
WT-4694 Throttle reads in wtperf to make readonly workload perform more consistently

### DIFF
--- a/bench/wtperf/runners/500m-btree-rdonly.wtperf
+++ b/bench/wtperf/runners/500m-btree-rdonly.wtperf
@@ -17,5 +17,5 @@ report_interval=10
 run_time=7200
 sample_interval=10
 sample_rate=1
-threads=((count=20,reads=1))
+threads=((count=20,reads=1,throttle=10000))
 warmup=120

--- a/bench/wtperf/runners/500m-btree-rdonly.wtperf
+++ b/bench/wtperf/runners/500m-btree-rdonly.wtperf
@@ -17,5 +17,5 @@ report_interval=10
 run_time=7200
 sample_interval=10
 sample_rate=1
-threads=((count=20,reads=1,throttle=10000))
+threads=((count=20,reads=1,throttle=500))
 warmup=120

--- a/bench/wtperf/runners/500m-btree-rdonly.wtperf
+++ b/bench/wtperf/runners/500m-btree-rdonly.wtperf
@@ -17,5 +17,5 @@ report_interval=10
 run_time=7200
 sample_interval=10
 sample_rate=1
-threads=((count=20,reads=1,throttle=500))
+threads=((count=20,reads=1,throttle=625))
 warmup=120


### PR DESCRIPTION
In our Jenkins testing, IO performance seems to vary a lot. This change is simply throttling the read workload so that variation in IO performance is less likely to affect the `500m-btree-rdonly` workload.