### PR TITLE
WT-4706 Add a statistic to track the lookaside table size (v3.6 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -264,6 +264,7 @@ connection_stats = [
     CacheStat('cache_lookaside_cursor_wait_internal', 'cache overflow cursor internal thread wait time (usecs)'),
     CacheStat('cache_lookaside_entries', 'cache overflow table entries', 'no_clear,no_scale'),
     CacheStat('cache_lookaside_insert', 'cache overflow table insert calls'),
+    CacheStat('cache_lookaside_ondisk', 'cache overflow table on-disk size', 'no_clear,no_scale,size'),
     CacheStat('cache_lookaside_remove', 'cache overflow table remove calls'),
     CacheStat('cache_lookaside_score', 'cache overflow score', 'no_clear,no_scale'),
     CacheStat('cache_overhead', 'percentage overhead', 'no_clear,no_scale'),

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -622,6 +622,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 	WT_SESSION_IMPL *session;
 	WT_TXN_ISOLATION saved_isolation;
 	WT_UPDATE *upd;
+	wt_off_t las_size;
 	uint64_t insert_cnt;
 	uint64_t las_counter, las_pageid;
 	uint32_t btree_id, i, slot;
@@ -765,6 +766,9 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			++insert_cnt;
 		} while ((upd = upd->next) != NULL);
 	}
+
+	WT_ERR(__wt_block_manager_named_size(session, WT_LAS_FILE, &las_size));
+	WT_STAT_CONN_SET(session, cache_lookaside_ondisk, las_size);
 
 err:	/* Resolve the transaction. */
 	if (local_txn) {

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -27,6 +27,7 @@
 #define	WT_METAFILE_SLVG	"WiredTiger.wt.orig"	/* Metadata copy */
 #define	WT_METAFILE_URI		"file:WiredTiger.wt"	/* Metadata table URI */
 
+#define	WT_LAS_FILE		"WiredTigerLAS.wt"	/* Lookaside table */
 #define	WT_LAS_URI		"file:WiredTigerLAS.wt"	/* Lookaside table URI*/
 
 #define	WT_SYSTEM_PREFIX	"system:"		/* System URI prefix */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -359,6 +359,7 @@ struct __wt_connection_stats {
 	int64_t cache_lookaside_score;
 	int64_t cache_lookaside_entries;
 	int64_t cache_lookaside_insert;
+	int64_t cache_lookaside_ondisk;
 	int64_t cache_lookaside_remove;
 	int64_t cache_eviction_checkpoint;
 	int64_t cache_eviction_get_ref;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5074,703 +5074,705 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_LOOKASIDE_ENTRIES		1044
 /*! cache: cache overflow table insert calls */
 #define	WT_STAT_CONN_CACHE_LOOKASIDE_INSERT		1045
+/*! cache: cache overflow table on-disk size */
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_ONDISK		1046
 /*! cache: cache overflow table remove calls */
-#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1046
+#define	WT_STAT_CONN_CACHE_LOOKASIDE_REMOVE		1047
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1047
+#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1048
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1048
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1049
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1049
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1050
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1050
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1051
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1051
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1052
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1052
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1053
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1053
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1054
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1054
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1055
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1055
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1056
 /*! cache: eviction server evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1056
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1057
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1057
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1058
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1058
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1059
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1059
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1060
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1060
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1061
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1061
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1062
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1062
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1063
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1063
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1064
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1064
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1065
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1065
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1066
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1066
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1067
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1067
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1068
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1068
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1069
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1069
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1070
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1070
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1071
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1071
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1072
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1072
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1073
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1073
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1074
 /*! cache: eviction worker thread evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1074
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1075
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1075
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1076
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1076
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1077
 /*!
  * cache: failed eviction of pages that exceeded the in-memory maximum
  * count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1077
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1078
 /*!
  * cache: failed eviction of pages that exceeded the in-memory maximum
  * time (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1078
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1079
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1079
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1080
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1080
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1081
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1081
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1082
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1082
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1083
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1083
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1084
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1084
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1085
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1085
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1086
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1086
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1087
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1087
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1088
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1088
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1089
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1089
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1090
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1090
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1091
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1091
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1092
 /*! cache: maximum page size at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1093
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1093
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1094
 /*! cache: modified pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1094
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1095
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1095
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1096
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1096
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1097
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1097
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1098
 /*! cache: page written requiring cache overflow records */
-#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1098
+#define	WT_STAT_CONN_CACHE_WRITE_LOOKASIDE		1099
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1099
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1100
 /*! cache: pages evicted because they exceeded the in-memory maximum count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1100
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1101
 /*!
  * cache: pages evicted because they exceeded the in-memory maximum time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1101
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_TIME		1102
 /*! cache: pages evicted because they had chains of deleted items count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1103
 /*!
  * cache: pages evicted because they had chains of deleted items time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE_TIME	1104
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1104
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1105
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1105
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1106
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1107
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1108
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1108
+#define	WT_STAT_CONN_CACHE_READ				1109
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1109
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1110
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1110
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1111
 /*! cache: pages read into cache requiring cache overflow entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1111
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1112
 /*! cache: pages read into cache requiring cache overflow for checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1112
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1113
 /*! cache: pages read into cache skipping older cache overflow entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1113
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1114
 /*!
  * cache: pages read into cache with skipped cache overflow entries
  * needed later
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1114
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1115
 /*!
  * cache: pages read into cache with skipped cache overflow entries
  * needed later by checkpoint
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1115
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1116
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1116
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1117
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1117
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1118
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1118
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1119
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1119
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1120
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1120
+#define	WT_STAT_CONN_CACHE_WRITE			1121
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1121
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1122
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1122
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1123
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1123
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1124
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1124
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1125
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1125
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1126
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1126
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1127
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1127
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1128
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1128
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1129
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1129
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1130
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1130
+#define	WT_STAT_CONN_TIME_TRAVEL			1131
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1131
+#define	WT_STAT_CONN_FILE_OPEN				1132
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1132
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1133
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1133
+#define	WT_STAT_CONN_MEMORY_FREE			1134
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1134
+#define	WT_STAT_CONN_MEMORY_GROW			1135
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1135
+#define	WT_STAT_CONN_COND_WAIT				1136
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1136
+#define	WT_STAT_CONN_RWLOCK_READ			1137
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1137
+#define	WT_STAT_CONN_RWLOCK_WRITE			1138
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1138
+#define	WT_STAT_CONN_FSYNC_IO				1139
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1139
+#define	WT_STAT_CONN_READ_IO				1140
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1140
+#define	WT_STAT_CONN_WRITE_IO				1141
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1141
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1142
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1142
+#define	WT_STAT_CONN_CURSOR_CACHE			1143
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1143
+#define	WT_STAT_CONN_CURSOR_CREATE			1144
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1144
+#define	WT_STAT_CONN_CURSOR_INSERT			1145
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1145
+#define	WT_STAT_CONN_CURSOR_MODIFY			1146
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1146
+#define	WT_STAT_CONN_CURSOR_NEXT			1147
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1147
+#define	WT_STAT_CONN_CURSOR_RESTART			1148
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1148
+#define	WT_STAT_CONN_CURSOR_PREV			1149
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1149
+#define	WT_STAT_CONN_CURSOR_REMOVE			1150
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1150
+#define	WT_STAT_CONN_CURSOR_RESERVE			1151
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1151
+#define	WT_STAT_CONN_CURSOR_RESET			1152
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1152
+#define	WT_STAT_CONN_CURSOR_SEARCH			1153
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1153
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1154
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1154
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1155
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1155
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1156
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1156
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1157
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1157
+#define	WT_STAT_CONN_CURSOR_SWEEP			1158
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1158
+#define	WT_STAT_CONN_CURSOR_UPDATE			1159
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1159
+#define	WT_STAT_CONN_CURSOR_REOPEN			1160
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1160
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1161
 /*! cursor: truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1161
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1162
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1162
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1163
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1163
+#define	WT_STAT_CONN_DH_SWEEP_REF			1164
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1164
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1165
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1165
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1166
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1166
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1167
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1167
+#define	WT_STAT_CONN_DH_SWEEPS				1168
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1168
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1169
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1169
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1170
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1170
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1171
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1171
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1172
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1172
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1173
 /*!
  * lock: commit timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1173
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1174
 /*! lock: commit timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1174
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1175
 /*! lock: commit timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1175
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1176
 /*! lock: commit timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1176
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1177
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1177
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1178
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1178
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1179
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1179
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1180
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1180
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1181
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1181
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1182
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1182
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1183
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1183
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1184
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1184
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1185
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1185
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1186
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1186
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1187
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1187
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1188
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1188
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1189
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1189
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1190
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1190
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1191
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1191
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1192
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1192
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1193
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1193
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1194
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1194
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1195
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1195
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1196
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1196
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1197
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1197
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1198
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1198
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1199
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1199
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1200
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1200
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1201
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1201
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1202
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1202
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1203
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1203
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1204
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1204
+#define	WT_STAT_CONN_LOG_FLUSH				1205
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1205
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1206
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1206
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1207
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1207
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1208
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1208
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1209
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1209
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1210
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1210
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1211
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1211
+#define	WT_STAT_CONN_LOG_SCANS				1212
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1212
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1213
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1213
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1214
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1214
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1215
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1215
+#define	WT_STAT_CONN_LOG_SYNC				1216
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1216
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1217
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1217
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1218
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1218
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1219
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1219
+#define	WT_STAT_CONN_LOG_WRITES				1220
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1220
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1221
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1221
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1222
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1222
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1223
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1223
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1224
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1224
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1225
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1225
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1226
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1226
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1227
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1227
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1228
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1228
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1229
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1229
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1230
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1230
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1231
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1231
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1232
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1232
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1233
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1233
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1234
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1234
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1235
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1235
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1236
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1236
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1237
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1237
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1238
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1238
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1239
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1239
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1240
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1240
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1241
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1241
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1242
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1242
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1243
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1243
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1244
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1244
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1245
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1245
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1246
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1246
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1247
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1247
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1248
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1248
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1249
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1249
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1250
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1250
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1251
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1251
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1252
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1252
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1253
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1253
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1254
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1254
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1255
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1255
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1256
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1256
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1257
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1257
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1258
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1258
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1259
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1259
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1260
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1260
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1261
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1261
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1262
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1262
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1263
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1263
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1264
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1264
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1265
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1265
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1266
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1266
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1267
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1267
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1268
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1268
+#define	WT_STAT_CONN_REC_PAGES				1269
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1269
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1270
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1270
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1271
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1271
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1272
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1272
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1273
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1273
+#define	WT_STAT_CONN_SESSION_OPEN			1274
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1274
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1275
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1275
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1276
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1276
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1277
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1277
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1278
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1278
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1279
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1279
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1280
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1280
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1281
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1281
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1282
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1282
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1283
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1283
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1284
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1284
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1285
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1285
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1286
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1286
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1287
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1287
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1288
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1288
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1289
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1289
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1290
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1290
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1291
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1291
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1292
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1292
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1293
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1293
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1294
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1294
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1295
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1295
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1296
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1296
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1297
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1297
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1298
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1298
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1299
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1299
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1300
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1300
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1301
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1301
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1302
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1302
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1303
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1303
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1304
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1304
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1305
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1305
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1306
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1306
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1307
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1307
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1308
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1308
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1309
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1309
+#define	WT_STAT_CONN_PAGE_SLEEP				1310
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1310
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1311
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1311
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1312
 /*! transaction: commit timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1312
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1313
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1313
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1314
 /*! transaction: commit timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1314
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1315
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1315
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1316
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1316
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1317
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1317
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1318
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1318
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1319
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1319
+#define	WT_STAT_CONN_TXN_PREPARE			1320
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1320
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1321
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1321
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1322
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1322
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1323
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1323
+#define	WT_STAT_CONN_TXN_QUERY_TS			1324
 /*! transaction: read timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1324
+#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1325
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1325
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1326
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1326
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1327
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1327
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1328
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1328
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1329
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1329
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1330
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1330
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1331
 /*! transaction: rollback to stable updates removed from cache overflow */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1331
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1332
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1332
+#define	WT_STAT_CONN_TXN_SET_TS				1333
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1333
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1334
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1334
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1335
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1335
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1336
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1336
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1337
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1337
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1338
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1338
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1339
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1339
+#define	WT_STAT_CONN_TXN_BEGIN				1340
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1340
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1341
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1341
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1342
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1342
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1343
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1343
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1344
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1344
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1345
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1345
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1346
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1346
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1347
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1347
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1348
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1348
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1349
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1349
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1350
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1350
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1351
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1351
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1352
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1352
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1353
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1353
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1354
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1354
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1355
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1355
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1356
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1356
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1357
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1357
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1358
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1358
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1359
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1359
+#define	WT_STAT_CONN_TXN_SYNC				1360
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1360
+#define	WT_STAT_CONN_TXN_COMMIT				1361
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1361
+#define	WT_STAT_CONN_TXN_ROLLBACK			1362
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1362
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1363
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -788,6 +788,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: cache overflow score",
 	"cache: cache overflow table entries",
 	"cache: cache overflow table insert calls",
+	"cache: cache overflow table on-disk size",
 	"cache: cache overflow table remove calls",
 	"cache: checkpoint blocked page eviction",
 	"cache: eviction calls to get a page",
@@ -1193,6 +1194,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 		/* not clearing cache_lookaside_score */
 		/* not clearing cache_lookaside_entries */
 	stats->cache_lookaside_insert = 0;
+		/* not clearing cache_lookaside_ondisk */
 	stats->cache_lookaside_remove = 0;
 	stats->cache_eviction_checkpoint = 0;
 	stats->cache_eviction_get_ref = 0;
@@ -1586,6 +1588,8 @@ __wt_stat_connection_aggregate(
 	    WT_STAT_READ(from, cache_lookaside_entries);
 	to->cache_lookaside_insert +=
 	    WT_STAT_READ(from, cache_lookaside_insert);
+	to->cache_lookaside_ondisk +=
+	    WT_STAT_READ(from, cache_lookaside_ondisk);
 	to->cache_lookaside_remove +=
 	    WT_STAT_READ(from, cache_lookaside_remove);
 	to->cache_eviction_checkpoint +=


### PR DESCRIPTION
Unclean cherry-pick of the backport commit (b89fdd5) from the `mongodb-4.0` branch.