### PR TITLE
WT-4760 Checkpoint should not read past a stable update (#4651) (Backport-4.0)

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -240,6 +240,9 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		 */
 		if (*updp == NULL)
 			*updp = upd;
+
+		if (!F_ISSET(r, WT_REC_EVICT))
+			break;
 	}
 
 	/* Keep track of the selected update. */


### PR DESCRIPTION
(cherry picked from commit 6b408028f0267ca26d8821a0be6925e5cb48eca2)