### PR TITLE
WT-4352 Backport data corruption fixes to 3.6 (2nd attempt)

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -279,13 +279,14 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 	 * the page could switch to an in-memory state at any time.  Lock down
 	 * the structure, just to be safe.
 	 */
-	if (ref->page_del == NULL)
+	if (ref->page_del == NULL && ref->page_las == NULL)
 		return (true);
 
 	if (!__wt_atomic_casv32(&ref->state, WT_REF_DELETED, WT_REF_LOCKED))
 		return (false);
 
-	skip = !__wt_page_del_active(session, ref, visible_all);
+	skip = !__wt_page_del_active(session, ref, visible_all) &&
+	    !__wt_page_las_active(session, ref);
 
 	/*
 	 * The page_del structure can be freed as soon as the delete is stable:

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -115,6 +115,12 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 	/* Initialize and configure the WT_BTREE structure. */
 	WT_ERR(__btree_conf(session, &ckpt));
 
+	/*
+	 * We could be a re-open of a table that was put in the lookaside
+	 * dropped list. Remove our id from that list.
+	 */
+	__wt_las_remove_dropped(session);
+
 	/* Connect to the underlying block manager. */
 	filename = dhandle->name;
 	if (!WT_PREFIX_SKIP(filename, "file:"))

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -242,6 +242,16 @@ __wt_btree_close(WT_SESSION_IMPL *session)
 	F_SET(btree, WT_BTREE_CLOSED);
 
 	/*
+	 * If closing a tree let sweep drop lookaside entries for it.
+	 */
+	if (F_ISSET(S2C(session), WT_CONN_LOOKASIDE_OPEN) &&
+	    btree->lookaside_entries) {
+		WT_ASSERT(session, !WT_IS_METADATA(btree->dhandle) &&
+		    !F_ISSET(btree, WT_BTREE_LOOKASIDE));
+		WT_TRET(__wt_las_save_dropped(session));
+	}
+
+	/*
 	 * If we turned eviction off and never turned it back on, do that now,
 	 * otherwise the counter will be off.
 	 */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -415,6 +415,7 @@ __page_read_lookaside(WT_SESSION_IMPL *session,
 
 	WT_RET(__las_page_instantiate(session, ref));
 	ref->page_las->eviction_to_lookaside = false;
+	ref->page_las->resolved = true;
 	return (0);
 }
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -291,6 +291,13 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 		}
 	}
 
+	/*
+	 * Now the lookaside history has been read into cache there is no
+	 * further need to maintain a reference to it.
+	 */
+	ref->page_las->eviction_to_lookaside = false;
+	ref->page_las->resolved = true;
+
 err:	if (locked)
 		__wt_readunlock(session, &cache->las_sweepwalk_lock);
 	WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
@@ -414,8 +421,6 @@ __page_read_lookaside(WT_SESSION_IMPL *session,
 	}
 
 	WT_RET(__las_page_instantiate(session, ref));
-	ref->page_las->eviction_to_lookaside = false;
-	ref->page_las->resolved = true;
 	return (0);
 }
 
@@ -539,10 +544,8 @@ skip_read:
 		 * information), first update based on the lookaside table and
 		 * then apply the delete.
 		 */
-		if (ref->page_las != NULL) {
+		if (ref->page_las != NULL)
 			WT_ERR(__las_page_instantiate(session, ref));
-			ref->page_las->eviction_to_lookaside = false;
-		}
 
 		/* Move all records to a deleted state. */
 		WT_ERR(__wt_delete_page_instantiate(session, ref));

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -855,6 +855,9 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new,
 			}
 		}
 
+		/* Check that we are not discarding active history. */
+		WT_ASSERT(session, !__wt_page_las_active(session, next_ref));
+
 		/*
 		 * The page-delete and lookaside memory weren't added to the
 		 * parent's footprint, ignore it here.

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -886,6 +886,33 @@ __wt_las_remove_block(
 }
 
 /*
+ * __wt_las_remove_dropped --
+ *	Remove an opened btree ID if it is in the dropped table.
+ */
+void
+__wt_las_remove_dropped(WT_SESSION_IMPL *session)
+{
+	WT_BTREE *btree;
+	WT_CACHE *cache;
+	u_int i, j;
+
+	btree = S2BT(session);
+	cache = S2C(session)->cache;
+
+	__wt_spin_lock(session, &cache->las_sweep_lock);
+	for (i = 0; i < cache->las_dropped_next &&
+	    cache->las_dropped[i] != btree->id; i++)
+		;
+
+	if (i < cache->las_dropped_next) {
+		cache->las_dropped_next--;
+		for (j = i; j < cache->las_dropped_next; j++)
+			cache->las_dropped[j] = cache->las_dropped[j + 1];
+	}
+	__wt_spin_unlock(session, &cache->las_sweep_lock);
+}
+
+/*
  * __wt_las_save_dropped --
  *	Save a dropped btree ID to be swept from the lookaside table.
  */
@@ -961,6 +988,19 @@ __las_sweep_init(WT_SESSION_IMPL *session)
 			ret = WT_NOTFOUND;
 		goto err;
 	}
+
+	/*
+	 * Record the current page ID: sweep will stop after this point.
+	 *
+	 * Since the btree IDs we're scanning are closed, any eviction must
+	 * have already completed, so we won't miss anything with this
+	 * approach.
+	 *
+	 * Also, if a tree is reopened and there is lookaside activity before
+	 * this sweep completes, it will have a higher page ID and should not
+	 * be removed.
+	 */
+	cache->las_sweep_max_pageid = cache->las_pageid;
 
 	/* Scan the btree IDs to find min/max. */
 	cache->las_sweep_dropmin = UINT32_MAX;
@@ -1062,7 +1102,7 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		 * table. Searching for the same key could leave us stuck at
 		 * the end of the table, repeatedly checking the same rows.
 		 */
-		sweep_key->size = 0;
+		__wt_buf_free(session, sweep_key);
 	} else
 		ret = __las_sweep_init(session);
 	if (ret != 0)
@@ -1090,6 +1130,17 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
 		 */
 		if (__wt_cache_stuck(session))
 			cnt = 0;
+
+		/*
+		 * Don't go past the end of lookaside from when sweep started.
+		 * If a file is reopened, its ID may be reused past this point
+		 * so the bitmap we're using is not valid.
+		 */
+		if (las_pageid > cache->las_sweep_max_pageid) {
+			__wt_buf_free(session, sweep_key);
+			ret = WT_NOTFOUND;
+			break;
+		}
 
 		/*
 		 * We only want to break between key blocks. Stop if we've

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -16,7 +16,6 @@ int
 __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 {
 	WT_BTREE *btree;
-	WT_CONNECTION_IMPL *conn;
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
 	WT_PAGE *page;
@@ -25,7 +24,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
 	dhandle = session->dhandle;
 	btree = dhandle->handle;
-	conn = S2C(session);
 
 	/*
 	 * We need exclusive access to the file, we're about to discard the root
@@ -40,24 +38,6 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	 */
 	if (btree->root.page == NULL)
 		return (0);
-
-	/*
-	 * If discarding a dead tree, remove any lookaside entries.  This deals
-	 * with the case where a tree is dropped with "force=true".  It happens
-	 * that we also force-drop the lookaside table itself: it can never
-	 * participate in lookaside eviction, and we can't open a cursor on it
-	 * as we are discarding it.
-	 *
-	 * We use the special page ID zero so that all lookaside entries for
-	 * the tree are removed.
-	 */
-	if (F_ISSET(dhandle, WT_DHANDLE_DEAD) &&
-	    F_ISSET(conn, WT_CONN_LOOKASIDE_OPEN) && btree->lookaside_entries) {
-		WT_ASSERT(session, !WT_IS_METADATA(dhandle) &&
-		    !F_ISSET(btree, WT_BTREE_LOOKASIDE));
-
-		WT_RET(__wt_las_save_dropped(session));
-	}
 
 	/* Make sure the oldest transaction ID is up-to-date. */
 	WT_RET(__wt_txn_update_oldest(
@@ -123,7 +103,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 */
 			WT_ASSERT(session,
 			    F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
-			    F_ISSET(conn, WT_CONN_CLOSING) ||
+			    F_ISSET(S2C(session), WT_CONN_CLOSING) ||
 			    __wt_page_can_evict(session, ref, NULL));
 			__wt_ref_out(session, ref);
 			break;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -239,6 +239,7 @@ struct __wt_page_lookaside {
 	WT_DECL_TIMESTAMP(max_timestamp)/* Maximum timestamp */
 	WT_DECL_TIMESTAMP(unstable_timestamp)/* First timestamp not on page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
+	bool resolved;			/* History has been read into cache */
 	bool skew_newest;		/* Page image has newest versions */
 };
 

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1189,6 +1189,8 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	if ((page_las = ref->page_las) == NULL)
 		return (false);
+	if (page_las->resolved)
+		return (false);
 	if (!page_las->skew_newest)
 		return (true);
 	if (__wt_txn_visible_all(session, page_las->max_txn,

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -210,6 +210,7 @@ struct __wt_cache {
 	uint32_t las_sweep_dropmin;	/* Minimum btree ID in current set. */
 	uint8_t *las_sweep_dropmap;	/* Bitmap of dropped btree IDs. */
 	uint32_t las_sweep_dropmax;	/* Maximum btree ID in current set. */
+	uint64_t las_sweep_max_pageid;	/* Maximum page ID for sweep. */
 
 	uint32_t *las_dropped;		/* List of dropped btree IDs. */
 	size_t las_dropped_next;	/* Next index into drop list. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -213,6 +213,7 @@ extern bool __wt_las_page_skip(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUN
 extern int __wt_las_insert_block(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MULTI *multi, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_cursor_position(WT_CURSOR *cursor, uint64_t pageid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_remove_block(WT_SESSION_IMPL *session, uint64_t pageid, bool lock_wait) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_las_remove_dropped(WT_SESSION_IMPL *session);
 extern int __wt_las_save_dropped(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_sweep(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1299,7 +1299,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	wt_timestamp_t *timestampp;
 	size_t upd_memsize;
 	uint64_t max_txn, txnid;
-	bool all_visible, prepared, skipped_birthmark, uncommitted;
+	bool all_visible, prepared, skipped_birthmark, uncommitted, upd_saved;
 
 #ifdef HAVE_TIMESTAMPS
 	WT_UPDATE *first_ts_upd;
@@ -1314,7 +1314,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	first_txn_upd = NULL;
 	upd_memsize = 0;
 	max_txn = WT_TXN_NONE;
-	prepared = skipped_birthmark = uncommitted = false;
+	prepared = skipped_birthmark = uncommitted = upd_saved = false;
 
 	/*
 	 * If called with a WT_INSERT item, use its WT_UPDATE list (which must
@@ -1557,6 +1557,7 @@ __rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	 * unresolved updates, move the entire update list.
 	 */
 	WT_RET(__rec_update_save(session, r, ins, ripcip, *updp, upd_memsize));
+	upd_saved = true;
 	if (upd_savedp != NULL)
 		*upd_savedp = true;
 
@@ -1602,18 +1603,11 @@ check_original_value:
 
 	/*
 	 * Returning an update means the original on-page value might be lost,
-	 * and that's a problem if there's a reader that needs it. There are
-	 * several cases:
-	 * - any update from a modify operation (because the modify has to be
-	 *   applied to a stable update, not the new on-page update),
-	 * - any lookaside table eviction (because the backing disk image is
-	 *   rewritten),
-	 * - or any reconciliation of a backing overflow record that will be
-	 *   physically removed once it's no longer needed.
+	 * and that's a problem if there's a reader that needs it.  This call
+	 * makes a copy of the on-page value and if there is a birthmark in the
+	 * update list, replaces it.
 	 */
-	if (*updp != NULL && (!WT_UPDATE_DATA_VALUE(*updp) ||
-	    F_ISSET(r, WT_REC_LOOKASIDE) || (vpack != NULL &&
-	    vpack->ovfl && vpack->raw != WT_CELL_VALUE_OVFL_RM)))
+	if (*updp != NULL && upd_saved)
 		WT_RET(
 		    __rec_append_orig_value(session, page, first_upd, vpack));
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1605,9 +1605,13 @@ check_original_value:
 	 * Returning an update means the original on-page value might be lost,
 	 * and that's a problem if there's a reader that needs it.  This call
 	 * makes a copy of the on-page value and if there is a birthmark in the
-	 * update list, replaces it.
+	 * update list, replaces it.  We do that any time there are saved
+	 * updates and during reconciliation of a backing overflow record that
+	 * will be physically removed once it's no longer needed.
 	 */
-	if (*updp != NULL && upd_saved)
+	if (*updp != NULL && (upd_saved ||
+	    (vpack != NULL && vpack->ovfl &&
+	    vpack->raw != WT_CELL_VALUE_OVFL_RM)))
 		WT_RET(
 		    __rec_append_orig_value(session, page, first_upd, vpack));
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -250,19 +250,47 @@ __txn_abort_newer_updates(
 	 * dirty.  Otherwise, the history we need could be swept from the
 	 * lookaside table before the page is read because the lookaside sweep
 	 * code has no way to tell that the page image is invalid.
+	 *
+	 * So, if there is lookaside history for a page, first check if the
+	 * history needs to be rolled back make sure that history is loaded
+	 * into cache.  That is, if skew_newest is true, so the disk image
+	 * potentially contained unstable updates, and the history is more
+	 * recent than the rollback timestamp.
+	 *
+	 * Also, we have separately discarded any lookaside history more recent
+	 * than the rollback timestamp.  For page_las structures in cache,
+	 * reset any future timestamps back to the rollback timestamp.  This
+	 * allows those structures to be discarded once the rollback timestamp
+	 * is stable (crucially for tests, they can be discarded if the
+	 * connection is closed right after a rollback_to_stable call).
 	 */
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
-	if (ref->page_las != NULL && ref->page_las->skew_newest &&
-	    __wt_timestamp_cmp(rollback_timestamp,
-	    &ref->page_las->unstable_timestamp) < 0) {
-		/* Make sure get back a page with history, not limbo page */
-		WT_ASSERT(session,
-		    !F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT));
-		WT_RET(__wt_page_in(session, ref, read_flags));
-		WT_ASSERT(session, ref->state != WT_REF_LIMBO &&
-		    ref->page != NULL && __wt_page_is_modified(ref->page));
-		local_read = true;
+	if (ref->page_las != NULL) {
+		if (ref->page_las->skew_newest &&
+		    __wt_timestamp_cmp(rollback_timestamp,
+		    &ref->page_las->unstable_timestamp) < 0) {
+			/*
+			 * Make sure we get back a page with history, not a
+			 * limbo page.
+			 */
+			WT_ASSERT(session,
+			    !F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT));
+			WT_RET(__wt_page_in(session, ref, read_flags));
+			WT_ASSERT(session, ref->state != WT_REF_LIMBO &&
+			    ref->page != NULL &&
+			    __wt_page_is_modified(ref->page));
+			local_read = true;
+		}
+		if (__wt_timestamp_cmp(&ref->page_las->max_timestamp,
+		    rollback_timestamp) > 0)
+			ref->page_las->max_timestamp = *rollback_timestamp;
+		if (__wt_timestamp_cmp(&ref->page_las->unstable_timestamp,
+		    rollback_timestamp) > 0)
+			ref->page_las->unstable_timestamp = *rollback_timestamp;
+		if (__wt_timestamp_cmp(&ref->page_las->unstable_timestamp,
+		    rollback_timestamp) > 0)
+			ref->page_las->unstable_timestamp = *rollback_timestamp;
 	}
 
 	/* Review deleted page saved to the ref */


### PR DESCRIPTION
This is the 2nd attempt of backporting the set of data corruption fixes to 3.6, hoping to make a clean commit history easy for non-squash merge.

Please note the only diff with the 1st attempt (#4693) is the removal of `has_prepares` field in the `__wt_page_lookaside` structure, as the field is not meant to be used in 3.6. 