### PR TITLE
WT-4812 Fix the Python distribution script for Python3 changes.

### DIFF
--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -195,6 +195,7 @@ def source_filter(sources):
     movers = dict()
     py_dir = os.path.join('lang', 'python')
     pywt_dir = os.path.join(py_dir, 'wiredtiger')
+    pywt_build_dir = os.path.join('build_posix', py_dir, 'wiredtiger')
     pywt_prefix = pywt_dir + os.path.sep
     for f in sources:
         if not re.match(source_regex, f):
@@ -211,7 +212,7 @@ def source_filter(sources):
         result.append(dest)
     # Add SWIG generated files
     result.append('wiredtiger.py')
-    movers['wiredtiger.py'] = os.path.join(pywt_dir, '__init__.py')
+    movers['wiredtiger.py'] = os.path.join(pywt_build_dir, '__init__.py')
     result.append(os.path.join(py_dir, 'wiredtiger_wrap.c'))
     return result, movers
 

--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -303,6 +303,17 @@ cppflags, cflags, ldflags = get_compile_flags(inc_paths, lib_paths)
 # If we are creating a source distribution, create a staging directory
 # with just the right sources. Put the result in the python dist directory.
 if pip_command == 'sdist':
+
+    # Technically, this script can run under Python2, and will do the
+    # right thing. But if we're running with Python2, chances are we built
+    # WiredTiger using Python2, and a distribution built that way will
+    # only run under Python2, not Python3.  If we do the WiredTiger configure,
+    # build and this script all using Python3, we'll end up with a distribution
+    # that installs and runs under either Python2 or Python3.
+    python2 = (sys.version_info[0] <= 2)
+    if python2:
+        die('Python3 should be used to create a source distribution')
+
     sources, movers = source_filter(get_sources_curdir())
     stage_dir = os.path.join(python_rel_dir, 'stage')
     shutil.rmtree(stage_dir, True)

--- a/test/py_install/testbase.py
+++ b/test/py_install/testbase.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A quick sanity test of an installation via 'pip install wiredtiger'.
+
+import wiredtiger, shutil, os
+from wiredtiger import wiredtiger_open, wiredtiger_version
+
+wthome = "WTPY_TEST"
+shutil.rmtree(wthome, ignore_errors=True)
+os.mkdir(wthome)
+conn = wiredtiger_open(wthome, "create")
+session = conn.open_session()
+session.create('table:foo', 'key_format=S,value_format=i')
+c = session.open_cursor('table:foo')
+c['A'] = 100
+c['B'] = 200
+c['C'] = 300
+print('Expect 200 = ' + str(c['B']))
+if c['B'] != 200:
+    raise Exception('BAD RESULT')
+c.close()
+session.close()
+conn.close()
+
+print(wiredtiger_version())
+print('testbase success.')

--- a/test/py_install/testpack.py
+++ b/test/py_install/testpack.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A quick sanity test of an installation via 'pip install wiredtiger'.
+# This program only uses the packing API.
+
+import sys
+from wiredtiger.packing import unpack, pack
+
+testval = '8281e420f2fa4a8381e40c5855ca808080808080e22fc0e20fc0'
+# Jump through hoops to make code work for Py2 + Py3
+x = bytes(bytearray.fromhex(testval))
+
+unpacked = unpack('iiiiiiiiiiiiii',x)
+unexpect = [2, 1, 552802954, 3, 1, 207123978, 0, 0, 0, 0, 0, 0, 20480, 12288]
+#print(str(unpacked)))
+if unpacked != unexpect:
+    raise Exception('BAD RESULT FOR UNPACK')
+
+packed = pack('iiii', 1, 2, 3, 4)
+expect = b'\x81\x82\x83\x84'
+#print(str(packed)))
+if packed != expect:
+    raise Exception('BAD RESULT FOR PACK')
+
+print('testpack success.')


### PR DESCRIPTION
SWIG generated Python files are now installed in build_posix, so the script needed to be adjusted.