### PR TITLE
WT-4840 WT_CURSOR.modify must require explicit, snapshot-isolation transaction

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1477,9 +1477,11 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	 * the update if the update chain is too long; third, there's a check
 	 * if the updated value is too large to store; fourth, to simplify the
 	 * count of bytes being added/removed; fifth, we can get into serious
-	 * trouble if we attempt to modify a value that doesn't exist. For the
-	 * fifth reason, verify we're not in a read-uncommitted transaction,
-	 * that implies a value that might disappear out from under us.
+	 * trouble if we attempt to modify a value that doesn't exist or read
+	 * a value that might not exist in the future. For the fifth reason,
+	 * fail if in anything other than a snapshot transaction, read-committed
+	 * and read-uncommitted imply values that might disappear out from under
+	 * us or an inability to repeat point-in-time reads.
 	 *
 	 * Also, an application might read a value outside of a transaction and
 	 * then call modify. For that to work, the read must be part of the
@@ -1490,9 +1492,10 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	 * because it will work most of the time and the failure is unlikely to
 	 * be detected. Require explicit transactions for modify operations.
 	 */
-	if (session->txn.isolation == WT_ISO_READ_UNCOMMITTED)
+	if (session->txn.isolation != WT_ISO_SNAPSHOT)
 		WT_ERR_MSG(session, ENOTSUP,
-		    "not supported in read-uncommitted transactions");
+		    "not supported in read-committed or read-uncommitted "
+		    "transactions");
 	if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
 		WT_ERR_MSG(session, ENOTSUP,
 		    "not supported in implicit transactions");

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -916,11 +916,16 @@ __cursor_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
 	/*
 	 * The underlying btree code cannot support WT_CURSOR.modify within
-	 * a read-uncommitted transaction. Disallow it here for consistency.
+	 * a read-committed or read-uncommitted transaction, or outside of
+	 * an explicit transaction. Disallow here as well, for consistency.
 	 */
-	if (session->txn.isolation == WT_ISO_READ_UNCOMMITTED)
+	if (session->txn.isolation != WT_ISO_SNAPSHOT)
 		WT_ERR_MSG(session, ENOTSUP,
-		    "not supported in read-uncommitted transactions");
+		    "not supported in read-committed or read-uncommitted "
+		    "transactions");
+	if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
+		WT_ERR_MSG(session, ENOTSUP,
+		    "not supported in implicit transactions");
 
 	WT_ERR(__cursor_checkkey(cursor));
 

--- a/src/docs/upgrading.dox
+++ b/src/docs/upgrading.dox
@@ -1,6 +1,19 @@
 /*! @page upgrading Upgrading WiredTiger applications
 
 </dl><hr>
+@section version_321 Upgrading to Version 3.2.1
+<dl>
+
+<dt>WT_CURSOR::modify transaction requirements</dt>
+<dd>
+In previous releases of WiredTiger, WT_CURSOR::modify operations could be
+performed within <code>read-committed</code> transactions. This implies
+point-in-time reads that cannot be repeated. In the 3.2.1 release,
+WT_CURSOR::modify operations must be performed in an explicit transaction
+at snapshot isolation, and will fail if that's not the case.
+</dd>
+
+</dl><hr>
 @section version_320 Upgrading to Version 3.2.0
 <dl>
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -498,11 +498,7 @@ struct __wt_cursor {
 	 * format type \c u).
 	 *
 	 * The WT_CURSOR::modify method can only be called from within an
-	 * explicit transaction configured at a higher isolation level than
-	 * \c read-uncommitted. Using \c read-committed isolation is allowed,
-	 * but requires caution: reading a value, re-positioning the cursor
-	 * and then modifying the value based on the initial read could lead
-	 * to unexpected results. Using \c snapshot isolation is recommended.
+	 * explicit transaction configured at the snapshot isolation level.
 	 *
 	 * The WT_CURSOR::modify method stores a change record in cache and
 	 * writes a change record to the log instead of the usual complete

--- a/test/csuite/scope/main.c
+++ b/test/csuite/scope/main.c
@@ -91,8 +91,12 @@ cursor_scope_ops(WT_SESSION *session, const char *uri)
 	int exact;
 	bool recno, vstring;
 
-	/* Reserve requires a running transaction. */
-	testutil_check(session->begin_transaction(session, NULL));
+	/*
+	 * Modify and reserve require a transaction, modify requires snapshot
+	 * isolation.
+	 */
+	testutil_check(
+	    session->begin_transaction(session, "isolation=snapshot"));
 
 	cursor = NULL;
 	for (op = ops; op->op != NULL; op++) {

--- a/test/csuite/wt4105_large_doc_small_upd/main.c
+++ b/test/csuite/wt4105_large_doc_small_upd/main.c
@@ -136,8 +136,8 @@ main(int argc, char *argv[])
 	while (++j < MODIFY_COUNT) {
 		for (i = 0; i < NUM_DOCS; i++) {
 			/* Position the cursor. */
-			testutil_check(
-			    session2->begin_transaction(session2, NULL));
+			testutil_check(session2->begin_transaction(
+			    session2, "isolation=snapshot"));
 			c->set_key(c, i);
 			modify_entry.data.data =
 			    "abcdefghijklmnopqrstuvwxyz";

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -629,20 +629,22 @@ config_pct(void)
 	}
 
 	/*
-	 * Cursor modify isn't possible for read-uncommitted transactions.
-	 * If both forced, it's an error, else, prefer the forced one, else,
-	 * prefer modify operations.
+	 * Cursor modify isn't possible for anything besides snapshot isolation
+	 * transactions. If both forced, it's an error. The run-time operations
+	 * code converts modify operations into updates if we're in some other
+	 * transaction type, but if we're never going to be able to do a modify,
+	 * turn it off in the CONFIG output to avoid misleading debuggers.
 	 */
-	if (g.c_isolation_flag == ISOLATION_READ_UNCOMMITTED) {
-		if (config_is_perm("isolation")) {
-			if (config_is_perm("modify_pct") && g.c_modify_pct != 0)
-				testutil_die(EINVAL,
-				    "WT_CURSOR.modify not supported with "
-				    "read-uncommitted transactions");
-			list[CONFIG_MODIFY_ENTRY].order = 0;
-			*list[CONFIG_MODIFY_ENTRY].vp = 0;
-		} else
-			config_single("isolation=random", false);
+	if (g.c_isolation_flag == ISOLATION_READ_COMMITTED ||
+	    g.c_isolation_flag == ISOLATION_READ_UNCOMMITTED) {
+		if (config_is_perm("isolation") &&
+		    config_is_perm("modify_pct") && g.c_modify_pct != 0)
+			testutil_die(EINVAL,
+			    "WT_CURSOR.modify only supported with "
+			    "snapshot isolation transactions");
+
+		list[CONFIG_MODIFY_ENTRY].order = 0;
+		*list[CONFIG_MODIFY_ENTRY].vp = 0;
 	}
 
 	/*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -819,11 +819,11 @@ ops(void *arg)
 			break;
 		case MODIFY:
 			/*
-			 * Change modify into update if not in a transaction
-			 * or in a read-uncommitted transaction, modify isn't
-			 * supported in those cases.
+			 * Change modify into update if not part of a snapshot
+			 * isolation transaction, modify isn't supported in
+			 * those cases.
 			 */
-			if (!intxn || iso_config == ISOLATION_READ_UNCOMMITTED)
+			if (!intxn || iso_config != ISOLATION_SNAPSHOT)
 				goto update_instead_of_chosen_op;
 
 			++tinfo->update;


### PR DESCRIPTION
at snapshot isolation.