### PR TITLE
WT-4791 Guard against deference null return (coverity)

### DIFF
--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -49,8 +49,7 @@ restart:
 	 * with a search.
 	 */
 	recno = WT_INSERT_RECNO(cbt->ins);
-	while (((current = cbt->ins) != PREV_INS(cbt, 0)) &&
-	    (current != NULL)) {
+	while ((current = cbt->ins) != PREV_INS(cbt, 0)) {
 		if (cbt->btree->type == BTREE_ROW) {
 			key.data = WT_INSERT_KEY(current);
 			key.size = WT_INSERT_KEY_SIZE(current);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -47,7 +47,8 @@ restart:
 	 * If the search stack does not point at the current item, fill it in
 	 * with a search.
 	 */
-	while (((current = cbt->ins) != PREV_INS(cbt, 0)) && (current != NULL)) {
+	while (((current = cbt->ins) != PREV_INS(cbt, 0)) &&
+	    (current != NULL)) {
 		if (cbt->btree->type == BTREE_ROW) {
 			key.data = WT_INSERT_KEY(current);
 			key.size = WT_INSERT_KEY_SIZE(current);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -38,6 +38,7 @@ __cursor_skip_prev(WT_CURSOR_BTREE *cbt)
 	WT_INSERT *current, *ins;
 	WT_ITEM key;
 	WT_SESSION_IMPL *session;
+	uint64_t recno;
 	int i;
 
 	session = (WT_SESSION_IMPL *)cbt->iface.session;
@@ -47,6 +48,7 @@ restart:
 	 * If the search stack does not point at the current item, fill it in
 	 * with a search.
 	 */
+	recno = WT_INSERT_RECNO(cbt->ins);
 	while (((current = cbt->ins) != PREV_INS(cbt, 0)) &&
 	    (current != NULL)) {
 		if (cbt->btree->type == BTREE_ROW) {
@@ -56,8 +58,7 @@ restart:
 			    session, cbt, cbt->ins_head, &key));
 		} else
 			cbt->ins = __col_insert_search(cbt->ins_head,
-			    cbt->ins_stack, cbt->next_stack,
-			    WT_INSERT_RECNO(current));
+			    cbt->ins_stack, cbt->next_stack, recno);
 	}
 
 	/*

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -46,8 +46,11 @@ restart:
 	/*
 	 * If the search stack does not point at the current item, fill it in
 	 * with a search.
+	 *
+	 * current pointer is not NULL, when it enters into the loop, but
+	 * Coverity is unconvinced; a test for NULL check isn't a bad idea.
 	 */
-	while ((current = cbt->ins) != PREV_INS(cbt, 0)) {
+	while (((current = cbt->ins) != PREV_INS(cbt, 0)) && (current != NULL)) {
 		if (cbt->btree->type == BTREE_ROW) {
 			key.data = WT_INSERT_KEY(current);
 			key.size = WT_INSERT_KEY_SIZE(current);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -46,9 +46,6 @@ restart:
 	/*
 	 * If the search stack does not point at the current item, fill it in
 	 * with a search.
-	 *
-	 * current pointer is not NULL, when it enters into the loop, but
-	 * Coverity is unconvinced; a test for NULL check isn't a bad idea.
 	 */
 	while (((current = cbt->ins) != PREV_INS(cbt, 0)) && (current != NULL)) {
 		if (cbt->btree->type == BTREE_ROW) {


### PR DESCRIPTION
CID 112861 (#1 of 1): Deference null return

The reported coverity problem is not possible, but in the same
flow with a different branch flow the issue can happen, so added
a NULL check.