### PR TITLE
WT-4858 Clang 8 and GCC 9 compatibility

### DIFF
--- a/build_posix/aclocal/strict.m4
+++ b/build_posix/aclocal/strict.m4
@@ -134,9 +134,9 @@ AC_DEFUN([AM_CLANG_WARNINGS], [
 		w="$w -Wno-unused-command-line-argument";;
 	esac
 
-        # We occasionally use an extra semicolon to indicate an empty loop or
-        # conditional body.
-        w="$w -Wno-extra-semi-stmt"
+	# We occasionally use an extra semicolon to indicate an empty loop or
+	# conditional body.
+	w="$w -Wno-extra-semi-stmt"
 
 	# Ignore unrecognized options.
 	w="$w -Wno-unknown-warning-option"

--- a/build_posix/aclocal/strict.m4
+++ b/build_posix/aclocal/strict.m4
@@ -134,6 +134,10 @@ AC_DEFUN([AM_CLANG_WARNINGS], [
 		w="$w -Wno-unused-command-line-argument";;
 	esac
 
+        # We occasionally use an extra semicolon to indicate an empty loop or
+        # conditional body.
+        w="$w -Wno-extra-semi-stmt"
+
 	# Ignore unrecognized options.
 	w="$w -Wno-unknown-warning-option"
 

--- a/examples/c/ex_async.c
+++ b/examples/c/ex_async.c
@@ -37,7 +37,7 @@ static const char *home;
 #elif defined(_WIN32)
 #define	ATOMIC_ADD(v, val)      (_InterlockedExchangeAdd(&(v), val) + val)
 #else
-#define	ATOMIC_ADD(v, val)      __sync_add_and_fetch(&(v), val)
+#define	ATOMIC_ADD(v, val)      __atomic_add_fetch(&(v), val, __ATOMIC_SEQ_CST)
 #endif
 
 static int global_error = 0;

--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -160,8 +160,7 @@ retry:
 	WT_RET(__async_get_format(conn, uri, config, op));
 	op->unique_id = __wt_atomic_add64(&async->op_id, 1);
 	op->optype = WT_AOP_NONE;
-	__wt_atomic_store32(
-	    &async->ops_index, (i + 1) % conn->async_size);
+	async->ops_index = (i + 1) % conn->async_size;
 	*opp = op;
 	return (0);
 }

--- a/src/async/async_api.c
+++ b/src/async/async_api.c
@@ -160,7 +160,7 @@ retry:
 	WT_RET(__async_get_format(conn, uri, config, op));
 	op->unique_id = __wt_atomic_add64(&async->op_id, 1);
 	op->optype = WT_AOP_NONE;
-	(void)__wt_atomic_store32(
+	__wt_atomic_store32(
 	    &async->ops_index, (i + 1) % conn->async_size);
 	*opp = op;
 	return (0);

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -270,7 +270,7 @@ __capacity_reserve(uint64_t *reservation, uint64_t bytes, uint64_t capacity,
 			 * If the reservation clock is out of date, bring it
 			 * to within a second of a current time.
 			 */
-			(void)__wt_atomic_store64(reservation,
+			__wt_atomic_store64(reservation,
 			    (now_ns - WT_BILLION) + res_len);
 	} else
 		res_value = now_ns;

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -270,8 +270,7 @@ __capacity_reserve(uint64_t *reservation, uint64_t bytes, uint64_t capacity,
 			 * If the reservation clock is out of date, bring it
 			 * to within a second of a current time.
 			 */
-			__wt_atomic_store64(reservation,
-			    (now_ns - WT_BILLION) + res_len);
+			*reservation = (now_ns - WT_BILLION) + res_len;
 	} else
 		res_value = now_ns;
 

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -135,11 +135,6 @@ __wt_atomic_fetch_add##name(vp_arg, v_arg)				\
 {									\
 	return (__atomic_fetch_add(vp, v, __ATOMIC_SEQ_CST));		\
 }									\
-static inline void							\
-__wt_atomic_store##name(vp_arg, v_arg)					\
-{									\
-	__atomic_store_n(vp, v, __ATOMIC_SEQ_CST);			\
-}									\
 static inline ret							\
 __wt_atomic_sub##name(vp_arg, v_arg)					\
 {									\

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -90,11 +90,11 @@
  */
 
 #define	WT_ATOMIC_CAS(ptr, oldp, new)					\
-	__atomic_compare_exchange_n(						\
+	__atomic_compare_exchange_n(					\
 	    ptr, oldp, new, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
-#define	WT_ATOMIC_CAS_FUNC(name, vp_arg, old_arg, new_arg) \
+#define	WT_ATOMIC_CAS_FUNC(name, vp_arg, old_arg, new_arg)		\
 static inline bool							\
-__wt_atomic_cas##name(vp_arg, old_arg, new_arg)			\
+__wt_atomic_cas##name(vp_arg, old_arg, new_arg)				\
 {									\
 	return (WT_ATOMIC_CAS(vp, &old, new));				\
 }

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -89,6 +89,17 @@
  * swap) operations.
  */
 
+/*
+ * We've hit optimization bugs with Clang 3.5 in the past when using the atomic
+ * builtins. See http://llvm.org/bugs/show_bug.cgi?id=21499 for details.
+ */
+#if defined(__clang__) && \
+	defined(__clang_major__) && defined(__clang_minor__) && \
+	(((__clang_major__ == 3) && (__clang_minor__ <= 5)) || \
+	 (__clang_major__ < 3))
+#error "Clang versions 3.5 and earlier are unsupported by WiredTiger"
+#endif
+
 #define	WT_ATOMIC_CAS(ptr, oldp, new)					\
 	__atomic_compare_exchange_n(					\
 	    ptr, oldp, new, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -89,38 +89,29 @@
  * swap) operations.
  */
 
-#ifdef __clang__
-/*
- * We avoid __sync_bool_compare_and_swap with due to problems with optimization
- * with some versions of clang. See http://llvm.org/bugs/show_bug.cgi?id=21499
- * for details.
- */
-#define	WT_ATOMIC_CAS(ptr, old, new)					\
-	(__sync_val_compare_and_swap(ptr, old, new) == (old))
-#else
-#define	WT_ATOMIC_CAS(ptr, old, new)					\
-	__sync_bool_compare_and_swap(ptr, old, new)
-#endif
-#define	WT_ATOMIC_CAS_FUNC(name, vp_arg, old_arg, new_arg)		\
+#define	WT_ATOMIC_CAS(ptr, oldp, new)					\
+	__atomic_compare_exchange_n(						\
+	    ptr, oldp, new, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+#define	WT_ATOMIC_CAS_FUNC(name, vp_arg, old_arg, new_arg) \
 static inline bool							\
-__wt_atomic_cas##name(vp_arg, old_arg, new_arg)				\
+__wt_atomic_cas##name(vp_arg, old_arg, new_arg)			\
 {									\
-	return (WT_ATOMIC_CAS(vp, old, new));				\
+	return (WT_ATOMIC_CAS(vp, &old, new));				\
 }
 WT_ATOMIC_CAS_FUNC(8, uint8_t *vp, uint8_t old, uint8_t new)
 WT_ATOMIC_CAS_FUNC(16, uint16_t *vp, uint16_t old, uint16_t new)
 WT_ATOMIC_CAS_FUNC(32, uint32_t *vp, uint32_t old, uint32_t new)
 WT_ATOMIC_CAS_FUNC(v32,							\
-    volatile uint32_t *vp, volatile uint32_t old, volatile uint32_t new)
+    volatile uint32_t *vp, uint32_t old, volatile uint32_t new)
 WT_ATOMIC_CAS_FUNC(i32, int32_t *vp, int32_t old, int32_t new)
 WT_ATOMIC_CAS_FUNC(iv32,						\
-    volatile int32_t *vp, volatile int32_t old, volatile int32_t new)
+    volatile int32_t *vp, int32_t old, volatile int32_t new)
 WT_ATOMIC_CAS_FUNC(64, uint64_t *vp, uint64_t old, uint64_t new)
 WT_ATOMIC_CAS_FUNC(v64,							\
-    volatile uint64_t *vp, volatile uint64_t old, volatile uint64_t new)
+    volatile uint64_t *vp, uint64_t old, volatile uint64_t new)
 WT_ATOMIC_CAS_FUNC(i64, int64_t *vp, int64_t old, int64_t new)
 WT_ATOMIC_CAS_FUNC(iv64,						\
-    volatile int64_t *vp, volatile int64_t old, volatile int64_t new)
+    volatile int64_t *vp, int64_t old, volatile int64_t new)
 WT_ATOMIC_CAS_FUNC(size, size_t *vp, size_t old, size_t new)
 
 /*
@@ -130,29 +121,29 @@ WT_ATOMIC_CAS_FUNC(size, size_t *vp, size_t old, size_t new)
 static inline bool
 __wt_atomic_cas_ptr(void *vp, void *old, void *new)
 {
-	return (WT_ATOMIC_CAS((void **)vp, old, new));
+	return (WT_ATOMIC_CAS((void **)vp, &old, new));
 }
 
 #define	WT_ATOMIC_FUNC(name, ret, vp_arg, v_arg)			\
 static inline ret							\
 __wt_atomic_add##name(vp_arg, v_arg)					\
 {									\
-	return (__sync_add_and_fetch(vp, v));				\
+	return (__atomic_add_fetch(vp, v, __ATOMIC_SEQ_CST));		\
 }									\
 static inline ret							\
 __wt_atomic_fetch_add##name(vp_arg, v_arg)				\
 {									\
-	return (__sync_fetch_and_add(vp, v));				\
+	return (__atomic_fetch_add(vp, v, __ATOMIC_SEQ_CST));		\
 }									\
-static inline ret							\
+static inline void							\
 __wt_atomic_store##name(vp_arg, v_arg)					\
 {									\
-	return (__sync_lock_test_and_set(vp, v));			\
+	__atomic_store_n(vp, v, __ATOMIC_SEQ_CST);			\
 }									\
 static inline ret							\
 __wt_atomic_sub##name(vp_arg, v_arg)					\
 {									\
-	return (__sync_sub_and_fetch(vp, v));				\
+	return (__atomic_sub_fetch(vp, v, __ATOMIC_SEQ_CST));		\
 }
 WT_ATOMIC_FUNC(8, uint8_t, uint8_t *vp, uint8_t v)
 WT_ATOMIC_FUNC(16, uint16_t, uint16_t *vp, uint16_t v)

--- a/src/include/lint.h
+++ b/src/include/lint.h
@@ -35,15 +35,6 @@ __wt_atomic_fetch_add##name(type *vp, type v)				\
 	return (orig);							\
 }									\
 static inline ret							\
-__wt_atomic_store##name(type *vp, type v)				\
-{									\
-	type orig;							\
-									\
-	orig = *vp;							\
-	*vp = v;							\
-	return (orig);							\
-}									\
-static inline ret							\
 __wt_atomic_sub##name(type *vp, type v)					\
 {									\
 	*vp -= v;							\

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -45,11 +45,6 @@ __wt_atomic_fetch_add##name(type *vp, type v)				\
 	return (_InterlockedExchangeAdd ## s((t *)(vp), (t)(v)));	\
 }									\
 static inline ret							\
-__wt_atomic_store##name(type *vp, type v)				\
-{									\
-	return (_InterlockedExchange ## s((t *)(vp), (t)(v)));		\
-}									\
-static inline ret							\
 __wt_atomic_sub##name(type *vp, type v)					\
 {									\
 	return (_InterlockedExchangeAdd ## s((t *)(vp), - (t)v) - (v));	\

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -68,7 +68,7 @@ __wt_spin_trylock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
 	WT_UNUSED(session);
 
-	return (__sync_lock_test_and_set(&t->lock, 1) == 0 ? 0 : EBUSY);
+	return (__atomic_test_and_set(&t->lock, __ATOMIC_ACQUIRE) ? 0 : EBUSY);
 }
 
 /*
@@ -82,7 +82,7 @@ __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 
 	WT_UNUSED(session);
 
-	while (__sync_lock_test_and_set(&t->lock, 1)) {
+	while (__atomic_test_and_set(&t->lock, __ATOMIC_ACQUIRE)) {
 		for (i = 0; t->lock && i < WT_SPIN_COUNT; i++)
 			WT_PAUSE();
 		if (t->lock)
@@ -99,7 +99,7 @@ __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
 	WT_UNUSED(session);
 
-	__sync_lock_release(&t->lock);
+	__atomic_clear(&t->lock, __ATOMIC_RELEASE);
 }
 
 #elif SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX ||			\


### PR DESCRIPTION
This PR is to get WiredTiger to compile with the newest Clang and GCC releases.

I had a look at the new flags introduced in both releases but all of the interesting ones are either on by default or are part of `-Wextra`.

The main change here is to move away from the legacy `__sync` compiler intrinsics and towards the `__atomic` ones. These new functions allow us to specify memory order so we could potentially use one of the weaker orderings for performance reasons. I think for our purposes, we want the strongest ordering (sequentially consistent ordering which is what you get by default with a C++ `std::atomic`).