### PR TITLE
WT-4776 Modify operations should be equivalent to updates. (v3.6 backport)

### DIFF
--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -201,6 +201,13 @@ __wt_value_return_upd(WT_SESSION_IMPL *session,
 					memcpy(listp, list, sizeof(list));
 			}
 			listp[i++] = upd;
+
+			/*
+			 * Once a modify is found, all previously committed
+			 * modifications should be applied regardless of
+			 * visibility.
+			 */
+			ignore_visibility = true;
 		}
 	}
 


### PR DESCRIPTION
If modifies are created with out-of-order timestamps, WiredTiger should use apply all previous modifications until it finds a complete copy of the document. Once a modify is identified as the most recent visible version for a value WT should not apply normal visibility rules to the prior versions - they were visible when the modify was performed, so should be included in the read.

(cherry picked from commit 8eb2d9c36c5c23da09f75e16dff982f0be52d34f)
(cherry picked from commit 4738e7c66f59517d9d9c4a0daa291f53f11bf209)