### PR TITLE
WT-4898 Don't allow the eviction server to reconcile if it's busy

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1508,7 +1508,8 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * memory_page_max setting, when we see many deleted items, and when we
 	 * are attempting to scan without trashing the cache.
 	 *
-	 * Fast checks if eviction is disabled for this handle, operation or
+	 * Fast checks if flag indicates no evict, session can't perform slow
+	 * operation, eviction is disabled for this handle, operation or
 	 * tree, then perform a general check if eviction will be possible.
 	 *
 	 * Checkpoint should not queue pages for urgent eviction if it cannot
@@ -1517,7 +1518,9 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 	 * checkpointed, and no other thread can help with that.
 	 */
 	page = ref->page;
-	if (WT_READGEN_EVICT_SOON(page->read_gen) &&
+	if (!LF_ISSET(WT_READ_NO_EVICT) &&
+	    __wt_session_can_wait(session) &&
+	    WT_READGEN_EVICT_SOON(page->read_gen) &&
 	    btree->evict_disabled == 0 &&
 	    __wt_page_can_evict(session, ref, &inmem_split)) {
 		if (!__wt_page_evict_clean(page) &&


### PR DESCRIPTION
Don't allow reconcile a page refernce when flags indicate
no eviction, session can't perfom slow operation in addition
to the existing.