### PR TITLE
WT-4792 Add stat to track pages queued for eviction after LRU sorting

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -235,6 +235,7 @@ connection_stats = [
     CacheStat('cache_eviction_maximum_page_size', 'maximum page size at eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_pages_queued', 'pages queued for eviction'),
     CacheStat('cache_eviction_pages_queued_oldest', 'pages queued for urgent eviction during walk'),
+    CacheStat('cache_eviction_pages_queued_post_lru', 'pages queued for eviction post lru sorting'),
     CacheStat('cache_eviction_pages_queued_urgent', 'pages queued for urgent eviction'),
     CacheStat('cache_eviction_pages_seen', 'pages seen by eviction walk'),
     CacheStat('cache_eviction_queue_empty', 'eviction server candidate queue empty when topping up'),

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1313,7 +1313,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		__evict_list_clear(session, &queue->evict_queue[--entries]);
 
 	queue->evict_entries = entries;
-	WT_STAT_CONN_SET(
+	WT_STAT_CONN_INCRV(
 	    session, cache_eviction_pages_queued_post_lru, entries);
 
 	if (entries == 0) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1313,8 +1313,6 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		__evict_list_clear(session, &queue->evict_queue[--entries]);
 
 	queue->evict_entries = entries;
-	WT_STAT_CONN_INCRV(
-	    session, cache_eviction_pages_queued_post_lru, entries);
 
 	if (entries == 0) {
 		/*
@@ -1375,6 +1373,8 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		}
 	}
 
+	WT_STAT_CONN_INCRV(session,
+	    cache_eviction_pages_queued_post_lru, queue->evict_candidates);
 	queue->evict_current = queue->evict_queue;
 	__wt_spin_unlock(session, &queue->evict_lock);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1313,6 +1313,8 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
 		__evict_list_clear(session, &queue->evict_queue[--entries]);
 
 	queue->evict_entries = entries;
+	WT_STAT_CONN_SET(
+	    session, cache_eviction_pages_queued_post_lru, entries);
 
 	if (entries == 0) {
 		/*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -433,6 +433,7 @@ struct __wt_connection_stats {
 	int64_t cache_eviction_force_delete_time;
 	int64_t cache_eviction_app;
 	int64_t cache_eviction_pages_queued;
+	int64_t cache_eviction_pages_queued_post_lru;
 	int64_t cache_eviction_pages_queued_urgent;
 	int64_t cache_eviction_pages_queued_oldest;
 	int64_t cache_read;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5304,623 +5304,625 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_APP			1107
 /*! cache: pages queued for eviction */
 #define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1108
+/*! cache: pages queued for eviction post lru sorting */
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1109
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1109
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1110
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1110
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1111
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1111
+#define	WT_STAT_CONN_CACHE_READ				1112
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1112
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1113
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1113
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1114
 /*! cache: pages read into cache requiring cache overflow entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1114
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE		1115
 /*! cache: pages read into cache requiring cache overflow for checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1115
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_CHECKPOINT	1116
 /*! cache: pages read into cache skipping older cache overflow entries */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1116
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_SKIPPED	1117
 /*!
  * cache: pages read into cache with skipped cache overflow entries
  * needed later
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1117
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY		1118
 /*!
  * cache: pages read into cache with skipped cache overflow entries
  * needed later by checkpoint
  */
-#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1118
+#define	WT_STAT_CONN_CACHE_READ_LOOKASIDE_DELAY_CHECKPOINT	1119
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1119
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1120
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1120
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1121
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1121
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1122
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1122
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1123
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1123
+#define	WT_STAT_CONN_CACHE_WRITE			1124
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1124
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1125
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1125
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1126
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1126
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1127
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1127
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1128
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1128
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1129
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1129
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1130
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1130
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1131
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1131
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1132
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1132
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1133
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1133
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1134
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1134
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1135
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1135
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1136
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1136
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1137
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1137
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1138
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1138
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1139
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1139
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1140
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1140
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1141
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1141
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1142
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1142
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1143
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1143
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1144
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1144
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1145
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1145
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1146
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1146
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1147
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1147
+#define	WT_STAT_CONN_TIME_TRAVEL			1148
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1148
+#define	WT_STAT_CONN_FILE_OPEN				1149
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1149
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1150
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1150
+#define	WT_STAT_CONN_MEMORY_FREE			1151
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1151
+#define	WT_STAT_CONN_MEMORY_GROW			1152
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1152
+#define	WT_STAT_CONN_COND_WAIT				1153
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1153
+#define	WT_STAT_CONN_RWLOCK_READ			1154
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1154
+#define	WT_STAT_CONN_RWLOCK_WRITE			1155
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1155
+#define	WT_STAT_CONN_FSYNC_IO				1156
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1156
+#define	WT_STAT_CONN_READ_IO				1157
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1157
+#define	WT_STAT_CONN_WRITE_IO				1158
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1158
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1159
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1159
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1160
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1160
+#define	WT_STAT_CONN_CURSOR_CACHE			1161
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1161
+#define	WT_STAT_CONN_CURSOR_CREATE			1162
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1162
+#define	WT_STAT_CONN_CURSOR_INSERT			1163
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1163
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1164
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1164
+#define	WT_STAT_CONN_CURSOR_MODIFY			1165
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1165
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1166
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1166
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1167
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1167
+#define	WT_STAT_CONN_CURSOR_NEXT			1168
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1168
+#define	WT_STAT_CONN_CURSOR_RESTART			1169
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1169
+#define	WT_STAT_CONN_CURSOR_PREV			1170
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1170
+#define	WT_STAT_CONN_CURSOR_REMOVE			1171
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1171
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1172
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1172
+#define	WT_STAT_CONN_CURSOR_RESERVE			1173
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1173
+#define	WT_STAT_CONN_CURSOR_RESET			1174
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1174
+#define	WT_STAT_CONN_CURSOR_SEARCH			1175
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1175
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1176
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1176
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1177
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1177
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1178
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1178
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1179
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1179
+#define	WT_STAT_CONN_CURSOR_SWEEP			1180
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1180
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1181
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1181
+#define	WT_STAT_CONN_CURSOR_UPDATE			1182
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1182
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1183
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1183
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1184
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1184
+#define	WT_STAT_CONN_CURSOR_REOPEN			1185
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1185
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1186
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1186
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1187
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1187
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1188
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1188
+#define	WT_STAT_CONN_DH_SWEEP_REF			1189
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1189
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1190
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1190
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1191
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1191
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1192
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1192
+#define	WT_STAT_CONN_DH_SWEEPS				1193
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1193
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1194
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1194
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1195
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1195
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1196
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1196
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1197
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1197
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1198
 /*!
  * lock: commit timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1198
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_APPLICATION	1199
 /*! lock: commit timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1199
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WAIT_INTERNAL	1200
 /*! lock: commit timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1200
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_READ_COUNT	1201
 /*! lock: commit timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1201
+#define	WT_STAT_CONN_LOCK_COMMIT_TIMESTAMP_WRITE_COUNT	1202
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1202
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1203
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1203
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1204
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1204
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1205
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1205
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1206
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1206
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1207
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1207
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1208
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1208
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1209
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1209
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1210
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1210
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1211
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1211
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1212
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1212
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1213
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1213
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1214
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1214
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1215
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1215
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1216
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1216
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1217
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1217
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1218
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1218
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1219
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1219
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1220
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1220
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1221
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1221
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1222
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1222
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1223
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1223
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1224
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1224
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1225
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1225
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1226
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1226
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1227
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1227
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1228
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1228
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1229
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1229
+#define	WT_STAT_CONN_LOG_FLUSH				1230
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1230
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1231
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1231
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1232
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1232
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1233
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1233
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1234
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1234
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1235
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1235
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1236
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1236
+#define	WT_STAT_CONN_LOG_SCANS				1237
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1237
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1238
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1238
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1239
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1239
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1240
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1240
+#define	WT_STAT_CONN_LOG_SYNC				1241
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1241
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1242
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1242
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1243
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1243
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1244
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1244
+#define	WT_STAT_CONN_LOG_WRITES				1245
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1245
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1246
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1246
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1247
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1247
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1248
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1248
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1249
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1249
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1250
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1250
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1251
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1251
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1252
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1252
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1253
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1253
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1254
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1254
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1255
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1255
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1256
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1256
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1257
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1257
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1258
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1258
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1259
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1259
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1260
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1260
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1261
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1261
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1262
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1262
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1263
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1263
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1264
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1264
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1265
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1265
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1266
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1266
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1267
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1267
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1268
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1268
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1269
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1269
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1270
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1270
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1271
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1271
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1272
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1272
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1273
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1273
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1274
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1274
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1275
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1275
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1276
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1276
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1277
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1277
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1278
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1278
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1279
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1279
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1280
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1280
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1281
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1281
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1282
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1282
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1283
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1283
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1284
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1284
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1285
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1285
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1286
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1286
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1287
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1287
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1288
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1288
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1289
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1289
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1290
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1290
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1291
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1291
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1292
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1292
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1293
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1293
+#define	WT_STAT_CONN_REC_PAGES				1294
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1294
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1295
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1295
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1296
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1296
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1297
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1297
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1298
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1298
+#define	WT_STAT_CONN_SESSION_OPEN			1299
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1299
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1300
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1300
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1301
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1301
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1302
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1302
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1303
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1303
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1304
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1304
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1305
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1305
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1306
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1306
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1307
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1307
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1308
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1308
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1309
 /*! session: table import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_IMPORT_FAIL		1309
+#define	WT_STAT_CONN_SESSION_TABLE_IMPORT_FAIL		1310
 /*! session: table import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_IMPORT_SUCCESS	1310
+#define	WT_STAT_CONN_SESSION_TABLE_IMPORT_SUCCESS	1311
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1311
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1312
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1312
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1313
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1313
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1314
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1314
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1315
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1315
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1316
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1316
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1317
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1317
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1318
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1318
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1319
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1319
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1320
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1320
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1321
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1321
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1322
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1322
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1323
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1323
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1324
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1324
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1325
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1325
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1326
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1326
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1327
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1327
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1328
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1328
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1329
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1329
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1330
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1330
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1331
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1331
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1332
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1332
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1333
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1333
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1334
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1334
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1335
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1335
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1336
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1336
+#define	WT_STAT_CONN_PAGE_SLEEP				1337
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1337
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1338
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1338
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1339
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COUNT		1339
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COUNT		1340
 /*! transaction: Number of prepared updates added to cache overflow */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_LOOKASIDE_INSERTS	1340
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_LOOKASIDE_INSERTS	1341
 /*! transaction: Number of prepared updates resolved */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_RESOLVED	1341
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_RESOLVED	1342
 /*! transaction: commit timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1342
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1343
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1343
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1344
 /*! transaction: commit timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1344
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1345
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1345
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1346
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1346
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1347
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1347
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1348
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1348
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1349
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1349
+#define	WT_STAT_CONN_TXN_PREPARE			1350
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1350
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1351
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1351
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1352
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1352
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1353
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1353
+#define	WT_STAT_CONN_TXN_QUERY_TS			1354
 /*! transaction: read timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1354
+#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1355
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1355
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1356
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1356
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1357
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1357
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1358
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1358
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1359
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1359
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1360
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1360
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1361
 /*! transaction: rollback to stable updates removed from cache overflow */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1361
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1362
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1362
+#define	WT_STAT_CONN_TXN_SET_TS				1363
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1363
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1364
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1364
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1365
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1365
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1366
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1366
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1367
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1367
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1368
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1368
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1369
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1369
+#define	WT_STAT_CONN_TXN_BEGIN				1370
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1370
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1371
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1371
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1372
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1372
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1373
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1373
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1374
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1374
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1375
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1375
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1376
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1376
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1377
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1377
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1378
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1378
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1379
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1379
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1380
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1380
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1381
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1381
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1382
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1382
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1383
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1383
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1384
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1384
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1385
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1385
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1386
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1386
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1387
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1387
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1388
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1388
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1389
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1389
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1390
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1390
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1391
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1391
+#define	WT_STAT_CONN_TXN_SYNC				1392
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1392
+#define	WT_STAT_CONN_TXN_COMMIT				1393
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1393
+#define	WT_STAT_CONN_TXN_ROLLBACK			1394
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1394
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1395
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -874,6 +874,7 @@ static const char * const __stats_connection_desc[] = {
 	"cache: pages evicted because they had chains of deleted items time (usecs)",
 	"cache: pages evicted by application threads",
 	"cache: pages queued for eviction",
+	"cache: pages queued for eviction post lru sorting",
 	"cache: pages queued for urgent eviction",
 	"cache: pages queued for urgent eviction during walk",
 	"cache: pages read into cache",
@@ -1311,6 +1312,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 	stats->cache_eviction_force_delete_time = 0;
 	stats->cache_eviction_app = 0;
 	stats->cache_eviction_pages_queued = 0;
+	stats->cache_eviction_pages_queued_post_lru = 0;
 	stats->cache_eviction_pages_queued_urgent = 0;
 	stats->cache_eviction_pages_queued_oldest = 0;
 	stats->cache_read = 0;
@@ -1787,6 +1789,8 @@ __wt_stat_connection_aggregate(
 	to->cache_eviction_app += WT_STAT_READ(from, cache_eviction_app);
 	to->cache_eviction_pages_queued +=
 	    WT_STAT_READ(from, cache_eviction_pages_queued);
+	to->cache_eviction_pages_queued_post_lru +=
+	    WT_STAT_READ(from, cache_eviction_pages_queued_post_lru);
 	to->cache_eviction_pages_queued_urgent +=
 	    WT_STAT_READ(from, cache_eviction_pages_queued_urgent);
 	to->cache_eviction_pages_queued_oldest +=


### PR DESCRIPTION
At the moment, we have a stat called `cache_eviction_pages_queued` which tracks the amount of pages initially queued. Afterwards, we do an LRU sort of the pages and trim some entries off the end of the queue. This PR is adding a statistic to track the size of the queue after this processing.