### PR TITLE
WT-4530 get_key and get_value example format corrections

### DIFF
--- a/examples/c/ex_stat.c
+++ b/examples/c/ex_stat.c
@@ -179,7 +179,7 @@ print_derived_stats(WT_SESSION *session)
 	percent = 0;
 	if (file_size != 0)
 		percent = 100 * ((file_size - ckpt_size) / file_size);
-	printf("Table is %" PRIu64 "%% fragmented\n", percent);
+	printf("Table is %" PRId64 "%% fragmented\n", percent);
 	/*! [statistics calculate table fragmentation] */
 	}
 

--- a/examples/c/ex_stat.c
+++ b/examples/c/ex_stat.c
@@ -30,7 +30,7 @@
  */
 #include <test_util.h>
 
-void get_stat(WT_CURSOR *cursor, int stat_field, uint64_t *valuep);
+void get_stat(WT_CURSOR *cursor, int stat_field, int64_t *valuep);
 void print_cursor(WT_CURSOR *);
 void print_database_stats(WT_SESSION *);
 void print_derived_stats(WT_SESSION *);
@@ -46,7 +46,7 @@ void
 print_cursor(WT_CURSOR *cursor)
 {
 	const char *desc, *pvalue;
-	uint64_t value;
+	int64_t value;
 	int ret;
 
 	while ((ret = cursor->next(cursor)) == 0) {
@@ -134,7 +134,7 @@ print_overflow_pages(WT_SESSION *session)
 	/*! [statistics retrieve by key] */
 	WT_CURSOR *cursor;
 	const char *desc, *pvalue;
-	uint64_t value;
+	int64_t value;
 
 	error_check(session->open_cursor(session,
 	    "statistics:table:access", NULL, NULL, &cursor));
@@ -150,7 +150,7 @@ print_overflow_pages(WT_SESSION *session)
 
 /*! [statistics calculation helper function] */
 void
-get_stat(WT_CURSOR *cursor, int stat_field, uint64_t *valuep)
+get_stat(WT_CURSOR *cursor, int stat_field, int64_t *valuep)
 {
 	const char *desc, *pvalue;
 
@@ -172,7 +172,7 @@ print_derived_stats(WT_SESSION *session)
 
 	{
 	/*! [statistics calculate table fragmentation] */
-	uint64_t ckpt_size, file_size, percent;
+	int64_t ckpt_size, file_size, percent;
 	get_stat(cursor, WT_STAT_DSRC_BLOCK_CHECKPOINT_SIZE, &ckpt_size);
 	get_stat(cursor, WT_STAT_DSRC_BLOCK_SIZE, &file_size);
 
@@ -185,7 +185,7 @@ print_derived_stats(WT_SESSION *session)
 
 	{
 	/*! [statistics calculate write amplification] */
-	uint64_t app_insert, app_remove, app_update, fs_writes;
+	int64_t app_insert, app_remove, app_update, fs_writes;
 
 	get_stat(cursor, WT_STAT_DSRC_CURSOR_INSERT_BYTES, &app_insert);
 	get_stat(cursor, WT_STAT_DSRC_CURSOR_REMOVE_BYTES, &app_remove);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -711,7 +711,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session,
 
 	/*
 	 * We return the statistics field's offset as the key, and a string
-	 * description, a string value, and a uint64_t value as the value
+	 * description, a string value, and a int64_t value as the value
 	 * columns.
 	 */
 	cursor->key_format = "i";

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -247,8 +247,8 @@ struct __wt_cursor {
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold key fields corresponding to
 	 * WT_CURSOR::key_format.
-	 * The API don't have a way to validate the argument types passed in,
-	 * caller is responsible to pass proper argument types according to
+	 * The API will not validate the argument types passed in, caller is
+	 * responsible to pass proper argument types according to
 	 * WT_CURSOR::key_format.
 	 * @errors
 	 */
@@ -264,8 +264,8 @@ struct __wt_cursor {
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold value fields corresponding to
 	 * WT_CURSOR::value_format.
-	 * The API don't have a way to validate the argument types passed in,
-	 * caller is responsible to pass proper argument types according to
+	 * The API will not validate the argument types passed in, caller is
+	 * responsible to pass proper argument types according to
 	 * WT_CURSOR::value_format.
 	 * @errors
 	 */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -247,8 +247,8 @@ struct __wt_cursor {
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold key fields corresponding to
 	 * WT_CURSOR::key_format.
-	 * The API will not validate the argument types passed in, caller is
-	 * responsible to pass proper argument types according to
+	 * The API does not validate the argument types passed in, the caller is
+	 * responsible for passing the correct argument types according to
 	 * WT_CURSOR::key_format.
 	 * @errors
 	 */
@@ -264,8 +264,8 @@ struct __wt_cursor {
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold value fields corresponding to
 	 * WT_CURSOR::value_format.
-	 * The API will not validate the argument types passed in, caller is
-	 * responsible to pass proper argument types according to
+	 * The API does not validate the argument types passed in, the caller is
+	 * responsible for passing the correct argument types according to
 	 * WT_CURSOR::value_format.
 	 * @errors
 	 */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -247,6 +247,9 @@ struct __wt_cursor {
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold key fields corresponding to
 	 * WT_CURSOR::key_format.
+	 * The API don't have a way to validate the argument types passed in,
+	 * caller is responsible to pass proper argument types according to
+	 * WT_CURSOR::key_format.
 	 * @errors
 	 */
 	int __F(get_key)(WT_CURSOR *cursor, ...);
@@ -260,6 +263,9 @@ struct __wt_cursor {
 	 *
 	 * @param cursor the cursor handle
 	 * @param ... pointers to hold value fields corresponding to
+	 * WT_CURSOR::value_format.
+	 * The API don't have a way to validate the argument types passed in,
+	 * caller is responsible to pass proper argument types according to
 	 * WT_CURSOR::value_format.
 	 * @errors
 	 */


### PR DESCRIPTION
WiredTiger example codes are corrected to follow proper
format types of the cursors. Also updated the documentation
of these two API's are they can't check the passed argument
types.