### PR TITLE
WT-4916 Pre-formatting fixes

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -333,7 +333,7 @@ for optype in log_data.optypes:
 })
 
 tfile.write('''
-\tWT_ILLEGAL_VALUE(session, optype);
+\treturn (__wt_illegal_value(session, optype));
 \t}
 
 \treturn (0);

--- a/dist/log.py
+++ b/dist/log.py
@@ -333,7 +333,7 @@ for optype in log_data.optypes:
 })
 
 tfile.write('''
-\treturn (__wt_illegal_value(session, optype));
+\tdefault:\n\t\treturn (__wt_illegal_value(session, optype));
 \t}
 
 \treturn (0);

--- a/dist/s_function
+++ b/dist/s_function
@@ -23,7 +23,7 @@ file_parse()
 # where there's a jump to the error label after the error label.
 for f in `find bench examples ext src test -name '*.[ci]'`; do
 	file_parse $f |
-	egrep '(WT_ERR[_A-Z]*|WT_ILLEGAL_VALUE_ERR)\(.*(WT_ILLEGAL_VALUE|WT_RET[_A-Z]*)\(.*err:|[^a-z_]err:.*(WT_ERR|WT_ILLEGAL_VALUE_ERR)\(' |
+	egrep '(WT_ERR[_A-Z]*)\(.*(WT_RET[_A-Z]*)\(.*err:|[^a-z_]err:.*(WT_ERR)\(' |
 	sed 's/:.*//' > $t
 
 	test -s $t && {
@@ -37,7 +37,7 @@ done
 for f in `find bench examples ext src test -name '*.[ci]'`; do
 	file_parse $f | sed "s=^=$f:="
 done | python dist/s_function_loop.py |
-    egrep '\{@[^@]*(WT_ILLEGAL_VALUE|WT_RET[_A-Z]*)\([^@]*(WT_ERR[_A-Z]*|WT_ILLEGAL_VALUE_ERR)\(.*err:' |
+    egrep '\{@[^@]*(WT_RET[_A-Z]*)\([^@]*(WT_ERR[_A-Z]*)\(.*err:' |
     sed -e 's/^\([^:]*\): *\([^:]*\):.*/\1:\2: mix of returns and jump to the error label within a loop/'
 
 # Return of 0 in functions after a jump to the error label.

--- a/dist/s_void
+++ b/dist/s_void
@@ -147,7 +147,6 @@ for f in `find bench ext src test -name '*.[ci]'`; do
 	    -e '/WT_CURSOR_NEEDKEY(/d' \
 	    -e '/WT_CURSOR_NEEDVALUE(/d' \
 	    -e '/WT_ERR[A-Z_]*(/d' \
-	    -e '/WT_ILLEGAL_VALUE[A-Z_]*(/d' \
 	    -e '/WT_PANIC[A-Z_]*(/d' \
 	    -e '/WT_RET[A-Z_]*(/d' \
 	    -e '/WT_SIZE_CHECK_PACK(/d' \
@@ -176,7 +175,6 @@ for f in `find bench ext src test -name '*.[ci]'`; do
 	    -e '/WT_CURSOR_NEEDKEY/d' \
 	    -e '/WT_CURSOR_NEEDVALUE/d' \
 	    -e '/WT_ERR/d' \
-	    -e '/WT_ILLEGAL_VALUE_ERR/d' \
 	    -e '/WT_SYSCALL.*ret/d' \
 	    -e '/WT_TRET/d' \
 	    -e 's/^\([^(]*\).*/\1/' \

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -358,11 +358,6 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
 				break;
 			/* FALLTHROUGH */
 		default:
-			/*
-			 * Don't convert to WT_ILLEGAL_VALUE, it won't compile
-			 * on some gcc compilers because they don't understand
-			 * FALLTHROUGH as part of a macro.
-			 */
 			return (__wt_illegal_value(session, ckpt->flags));
 		}
 	return (0);

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -129,7 +129,8 @@ __wt_block_checkpoint_load(WT_SESSION_IMPL *session, WT_BLOCK *block,
 		WT_ERR(__wt_block_truncate(session, block, ci->file_size));
 
 	if (0) {
-err:		/*
+err:
+		/*
 		 * Don't call checkpoint-unload: unload does real work including
 		 * file truncation.  If we fail early enough that the checkpoint
 		 * information isn't correct, bad things would happen.  The only

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -668,7 +668,9 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 				ret = __cursor_var_append_next(
 				    cbt, newpage, restart);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, page->type);
+			default:
+				ret = __wt_illegal_value(session, page->type);
+				goto err;
 			}
 			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
@@ -686,7 +688,9 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_ROW_LEAF:
 				ret = __cursor_row_next(cbt, newpage, restart);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, page->type);
+			default:
+				ret = __wt_illegal_value(session, page->type);
+				goto err;
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -214,7 +214,8 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 		__cursor_set_recno(cbt, cbt->recno + 1);
 
 new_page:
-restart_read:	/* Find the matching WT_COL slot. */
+restart_read:
+		/* Find the matching WT_COL slot. */
 		if ((cip =
 		    __col_var_search(cbt->ref, cbt->recno, &rle_start)) == NULL)
 			return (WT_NOTFOUND);

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -670,8 +670,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 				    cbt, newpage, restart);
 				break;
 			default:
-				ret = __wt_illegal_value(session, page->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, page->type));
 			}
 			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
@@ -690,8 +689,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 				ret = __cursor_row_next(cbt, newpage, restart);
 				break;
 			default:
-				ret = __wt_illegal_value(session, page->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, page->type));
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -497,7 +497,8 @@ __wt_cursor_key_order_check(
 		return (__cursor_key_order_check_col(session, cbt, next));
 	case WT_PAGE_ROW_LEAF:
 		return (__cursor_key_order_check_row(session, cbt, next));
-	WT_ILLEGAL_VALUE(session, cbt->ref->page->type);
+	default:
+		return (__wt_illegal_value(session, cbt->ref->page->type));
 	}
 	/* NOTREACHED */
 }
@@ -522,7 +523,8 @@ __wt_cursor_key_order_init(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 	case WT_PAGE_ROW_LEAF:
 		return (__wt_buf_set(session,
 		    cbt->lastkey, cbt->iface.key.data, cbt->iface.key.size));
-	WT_ILLEGAL_VALUE(session, cbt->ref->page->type);
+	default:
+		return (__wt_illegal_value(session, cbt->ref->page->type));
 	}
 	/* NOTREACHED */
 }

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -360,7 +360,8 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 new_page:	if (cbt->recno < cbt->ref->ref_recno)
 			return (WT_NOTFOUND);
 
-restart_read:	/* Find the matching WT_COL slot. */
+restart_read:
+		/* Find the matching WT_COL slot. */
 		if ((cip =
 		    __col_var_search(cbt->ref, cbt->recno, &rle_start)) == NULL)
 			return (WT_NOTFOUND);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -629,7 +629,9 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 				ret = __cursor_var_append_prev(
 				    cbt, newpage, restart);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, page->type);
+			default:
+				ret = __wt_illegal_value(session, page->type);
+				goto err;
 			}
 			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
@@ -649,7 +651,9 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 			case WT_PAGE_ROW_LEAF:
 				ret = __cursor_row_prev(cbt, newpage, restart);
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, page->type);
+			default:
+				ret = __wt_illegal_value(session, page->type);
+				goto err;
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -631,8 +631,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 				    cbt, newpage, restart);
 				break;
 			default:
-				ret = __wt_illegal_value(session, page->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, page->type));
 			}
 			if (ret == 0 || ret == WT_PREPARE_CONFLICT)
 				break;
@@ -653,8 +652,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 				ret = __cursor_row_prev(cbt, newpage, restart);
 				break;
 			default:
-				ret = __wt_illegal_value(session, page->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, page->type));
 			}
 			if (ret != WT_NOTFOUND)
 				break;

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1093,7 +1093,8 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned)
 		goto err;
 	}
 
-retry:	/*
+retry:
+	/*
 	 * Note these steps must be repeatable, we'll continue to take this path
 	 * as long as we encounter WT_RESTART.
 	 *
@@ -1215,7 +1216,8 @@ search_notfound:	ret = WT_NOTFOUND;
 		__cursor_state_restore(cursor, &state);
 	}
 
-done:	/*
+done:
+	/*
 	 * Upper level cursor removes don't expect the cursor value to be set
 	 * after a successful remove (and check in diagnostic mode). Error
 	 * handling may have converted failure to a success, do a final check.

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1376,7 +1376,8 @@ done:		switch (modify_type) {
 			break;
 		case WT_UPDATE_BIRTHMARK:
 		case WT_UPDATE_TOMBSTONE:
-		WT_ILLEGAL_VALUE(session, modify_type);
+		default:
+			return (__wt_illegal_value(session, modify_type));
 		}
 	}
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -459,8 +459,7 @@ __wt_debug_disk(
 		WT_ERR(ds->f(ds, ", datalen %" PRIu32, dsk->u.datalen));
 		break;
 	default:
-		ret = __wt_illegal_value(session, dsk->type);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, dsk->type));
 	}
 
 	if (F_ISSET(dsk, WT_PAGE_COMPRESSED))
@@ -1450,8 +1449,7 @@ __debug_cell_data(WT_DBG *ds,
 		WT_ERR(__debug_item_value(ds, tag, buf->data, buf->size));
 		break;
 	default:
-		ret = __wt_illegal_value(session, unpack->raw);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, unpack->raw));
 	}
 
 err:	__wt_scr_free(session, &buf);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -458,7 +458,9 @@ __wt_debug_disk(
 	case WT_PAGE_OVFL:
 		WT_ERR(ds->f(ds, ", datalen %" PRIu32, dsk->u.datalen));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, dsk->type);
+	default:
+		ret = __wt_illegal_value(session, dsk->type);
+		goto err;
 	}
 
 	if (F_ISSET(dsk, WT_PAGE_COMPRESSED))
@@ -1445,7 +1447,9 @@ __debug_cell_data(WT_DBG *ds,
 	case WT_CELL_VALUE_SHORT:
 		WT_ERR(__debug_item_value(ds, tag, buf->data, buf->size));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, unpack->raw);
+	default:
+		ret = __wt_illegal_value(session, unpack->raw);
+		goto err;
 	}
 
 err:	__wt_scr_free(session, &buf);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -790,7 +790,8 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
 		if (LF_ISSET(WT_DEBUG_TREE_LEAF))
 			WT_RET(__debug_page_row_leaf(ds, ref->page));
 		break;
-	WT_ILLEGAL_VALUE(session, ref->page->type);
+	default:
+		return (__wt_illegal_value(session, ref->page->type));
 	}
 
 	return (0);
@@ -840,7 +841,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 	case WT_PAGE_ROW_LEAF:
 		entries = page->entries;
 		break;
-	WT_ILLEGAL_VALUE(session, page->type);
+	default:
+		return (__wt_illegal_value(session, page->type));
 	}
 
 	WT_RET(ds->f(ds, ": %s\n", __wt_page_type_string(page->type)));
@@ -880,7 +882,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 			break;
 		case 0:
 			break;
-		WT_ILLEGAL_VALUE(session, mod->rec_result);
+		default:
+			return (__wt_illegal_value(session, mod->rec_result));
 		}
 	if (split_gen != 0)
 		WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -970,13 +970,14 @@ __debug_page_col_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 		WT_RET(__debug_ref(ds, ref));
 	} WT_INTL_FOREACH_END;
 
-	if (LF_ISSET(WT_DEBUG_TREE_WALK))
+	if (LF_ISSET(WT_DEBUG_TREE_WALK)) {
 		WT_INTL_FOREACH_BEGIN(session, page, ref) {
 			if (ref->state == WT_REF_MEM) {
 				WT_RET(ds->f(ds, "\n"));
 				WT_RET(__debug_page(ds, ref, flags));
 			}
 		} WT_INTL_FOREACH_END;
+	}
 
 	return (0);
 }
@@ -1044,13 +1045,14 @@ __debug_page_row_int(WT_DBG *ds, WT_PAGE *page, uint32_t flags)
 		WT_RET(__debug_ref(ds, ref));
 	} WT_INTL_FOREACH_END;
 
-	if (LF_ISSET(WT_DEBUG_TREE_WALK))
+	if (LF_ISSET(WT_DEBUG_TREE_WALK)) {
 		WT_INTL_FOREACH_BEGIN(session, page, ref) {
 			if (ref->state == WT_REF_MEM) {
 				WT_RET(ds->f(ds, "\n"));
 				WT_RET(__debug_page(ds, ref, flags));
 			}
 		} WT_INTL_FOREACH_END;
+	}
 	return (0);
 }
 

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -209,7 +209,8 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 		case WT_REF_LIMBO:
 		case WT_REF_LOOKASIDE:
 		case WT_REF_READING:
-		WT_ILLEGAL_VALUE(session, current_state);
+		default:
+			return (__wt_illegal_value(session, current_state));
 		}
 
 		if (locked)

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -244,7 +244,8 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	WT_REF_SET_STATE(ref, current_state);
 
-done:	/*
+done:
+	/*
 	 * Now mark the truncate aborted: this must come last because after
 	 * this point there is nothing preventing the page from being evicted.
 	 */
@@ -467,7 +468,8 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	return (0);
 
-err:	/*
+err:
+	/*
 	 * The page-delete update structure may have existed before we were
 	 * called, and presumably might be in use by a running transaction.
 	 * The list of update structures cannot have been created before we

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -120,7 +120,7 @@ __wt_bt_read(WT_SESSION_IMPL *session,
 			fail_msg = "block decompression failed";
 			goto corrupt;
 		}
-	} else
+	} else {
 		/*
 		 * If we uncompressed above, the page is in the correct buffer.
 		 * If we get here the data may be in the wrong buffer and the
@@ -130,6 +130,7 @@ __wt_bt_read(WT_SESSION_IMPL *session,
 		if (ip != NULL)
 			WT_ERR(__wt_buf_set(
 			    session, buf, ip->data, dsk->mem_size));
+	}
 
 	/* If the handle is a verify handle, verify the physical page. */
 	if (F_ISSET(btree, WT_BTREE_VERIFY)) {

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -241,7 +241,8 @@ __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
 		__wt_cell_type_reset(session,
 		    unpack->cell, WT_CELL_VALUE_OVFL, WT_CELL_VALUE_OVFL_RM);
 		break;
-	WT_ILLEGAL_VALUE(session, unpack->raw);
+	default:
+		return (__wt_illegal_value(session, unpack->raw));
 	}
 
 	__wt_writeunlock(session, &btree->ovfl_lock);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -58,7 +58,8 @@ __wt_page_alloc(WT_SESSION_IMPL *session,
 		 */
 		size += alloc_entries * sizeof(WT_ROW);
 		break;
-	WT_ILLEGAL_VALUE(session, type);
+	default:
+		return (__wt_illegal_value(session, type));
 	}
 
 	WT_RET(__wt_calloc(session, 1, size, &page));
@@ -113,7 +114,8 @@ err:			if ((pindex = WT_INTL_INDEX_GET_SAFE(page)) != NULL) {
 		    NULL : (WT_ROW *)((uint8_t *)page + sizeof(WT_PAGE));
 		page->entries = alloc_entries;
 		break;
-	WT_ILLEGAL_VALUE(session, type);
+	default:
+		return (__wt_illegal_value(session, type));
 	}
 
 	/* Increment the cache statistics. */
@@ -190,7 +192,8 @@ __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref,
 			WT_RET(__inmem_row_leaf_entries(
 			    session, dsk, &alloc_entries));
 		break;
-	WT_ILLEGAL_VALUE(session, dsk->type);
+	default:
+		return (__wt_illegal_value(session, dsk->type));
 	}
 
 	/* Allocate and initialize a new WT_PAGE. */
@@ -561,7 +564,8 @@ __inmem_row_leaf_entries(
 		case WT_CELL_VALUE:
 		case WT_CELL_VALUE_OVFL:
 			break;
-		WT_ILLEGAL_VALUE(session, unpack.type);
+		default:
+			return (__wt_illegal_value(session, unpack.type));
 		}
 	} WT_CELL_FOREACH_END;
 
@@ -627,7 +631,8 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool check_unstable)
 				--page->entries;
 			}
 			break;
-		WT_ILLEGAL_VALUE(session, unpack.type);
+		default:
+			return (__wt_illegal_value(session, unpack.type));
 		}
 	} WT_CELL_FOREACH_END;
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -230,7 +230,9 @@ __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref,
 	case WT_PAGE_ROW_LEAF:
 		WT_ERR(__inmem_row_leaf(session, page, check_unstable));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, page->type);
+	default:
+		ret = __wt_illegal_value(session, page->type);
+		goto err;
 	}
 
 	/* Update the page's cache statistics. */
@@ -514,7 +516,9 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			ref->addr = unpack.cell;
 			++refp;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, unpack.type);
+		default:
+			ret = __wt_illegal_value(session, unpack.type);
+			goto err;
 		}
 	} WT_CELL_FOREACH_END;
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -231,8 +231,7 @@ __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref,
 		WT_ERR(__inmem_row_leaf(session, page, check_unstable));
 		break;
 	default:
-		ret = __wt_illegal_value(session, page->type);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, page->type));
 	}
 
 	/* Update the page's cache statistics. */
@@ -517,8 +516,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 			++refp;
 			break;
 		default:
-			ret = __wt_illegal_value(session, unpack.type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, unpack.type));
 		}
 	} WT_CELL_FOREACH_END;
 

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -192,7 +192,8 @@ __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags)
 	eviction = LF_ISSET(WT_READ_CACHE);
 
 	if (0) {
-restart:	/*
+restart:
+		/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -583,7 +583,8 @@ skip_read:
 	WT_REF_SET_STATE(ref, final_state);
 	return (ret);
 
-err:	/*
+err:
+	/*
 	 * If the function building an in-memory version of the page failed,
 	 * it discarded the page, but not the disk image.  Discard the page
 	 * and separately discard the disk image in all cases.
@@ -668,7 +669,8 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 			if (LF_ISSET(WT_READ_CACHE))
 				return (WT_NOTFOUND);
 
-read:			/*
+read:
+			/*
 			 * The page isn't in memory, read it. If this thread
 			 * respects the cache size, check for space in the
 			 * cache.
@@ -804,7 +806,8 @@ read:			/*
 				continue;
 			}
 
-skip_evict:		/*
+skip_evict:
+			/*
 			 * If we read the page and are configured to not trash
 			 * the cache, and no other thread has already used the
 			 * page, set the read generation so the page is evicted

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -222,7 +222,9 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			WT_ERR(__wt_buf_set(session,
 			    current_key, las_key.data, las_key.size));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, page->type);
+		default:
+			ret = __wt_illegal_value(session, page->type);
+			goto err;
 		}
 
 		/* Append the latest update to the list. */
@@ -252,7 +254,9 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			    current_key, ref, &cbt, first_upd));
 			first_upd = NULL;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, page->type);
+		default:
+			ret = __wt_illegal_value(session, page->type);
+			goto err;
 		}
 
 	/* Discard the cursor. */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -837,7 +837,8 @@ skip_evict:		/*
 			return (LF_ISSET(WT_READ_IGNORE_CACHE_SIZE) &&
 			    !F_ISSET(session, WT_SESSION_IGNORE_CACHE_SIZE) ?
 			    0 : __wt_txn_autocommit_check(session));
-		WT_ILLEGAL_VALUE(session, current_state);
+		default:
+			return (__wt_illegal_value(session, current_state));
 		}
 
 		/*

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -223,8 +223,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			    current_key, las_key.data, las_key.size));
 			break;
 		default:
-			ret = __wt_illegal_value(session, page->type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, page->type));
 		}
 
 		/* Append the latest update to the list. */
@@ -255,8 +254,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			first_upd = NULL;
 			break;
 		default:
-			ret = __wt_illegal_value(session, page->type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, page->type));
 		}
 
 	/* Discard the cursor. */

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -237,7 +237,9 @@ __rebalance_col_walk(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts,
 			WT_ERR(__rebalance_leaf_append(
 			    session, durable_ts, NULL, 0, &unpack, rs));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, unpack.type);
+		default:
+			ret = __wt_illegal_value(session, unpack.type);
+			goto err;
 		}
 	} WT_CELL_FOREACH_END;
 
@@ -384,7 +386,9 @@ __rebalance_row_walk(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts,
 
 			first_cell = false;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, unpack.type);
+		default:
+			ret = __wt_illegal_value(session, unpack.type);
+			goto err;
 		}
 	} WT_CELL_FOREACH_END;
 
@@ -445,7 +449,9 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_ERR(__rebalance_col_walk(
 		    session, WT_TS_MAX, ref->page->dsk, rs));
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, rs->type);
+	default:
+		ret = __wt_illegal_value(session, rs->type);
+		goto err;
 	}
 
 	/* Build a new root page. */

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -238,8 +238,7 @@ __rebalance_col_walk(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts,
 			    session, durable_ts, NULL, 0, &unpack, rs));
 			break;
 		default:
-			ret = __wt_illegal_value(session, unpack.type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, unpack.type));
 		}
 	} WT_CELL_FOREACH_END;
 
@@ -387,8 +386,7 @@ __rebalance_row_walk(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts,
 			first_cell = false;
 			break;
 		default:
-			ret = __wt_illegal_value(session, unpack.type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, unpack.type));
 		}
 	} WT_CELL_FOREACH_END;
 
@@ -450,8 +448,7 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 		    session, WT_TS_MAX, ref->page->dsk, rs));
 		break;
 	default:
-		ret = __wt_illegal_value(session, rs->type);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, rs->type));
 	}
 
 	/* Build a new root page. */

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -471,7 +471,8 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
 	ref->page = rs->root;
 	rs->root = NULL;
 
-err:	/* Discard any leftover root page we created. */
+err:
+	/* Discard any leftover root page we created. */
 	if (rs->root != NULL) {
 		__wt_page_modify_clear(session, rs->root);
 		__wt_page_out(session, &rs->root);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1037,7 +1037,8 @@ __slvg_col_range_overlap(
 	 * discard b_trk.
 	 */
 	if (a_trk->trk_gen > b_trk->trk_gen) {
-delete_b:	/*
+delete_b:
+		/*
 		 * After page and overflow reconciliation, one (and only one)
 		 * page can reference an overflow record.  But, if we split a
 		 * page into multiple chunks, any of the chunks might own any
@@ -1688,7 +1689,8 @@ __slvg_row_range_overlap(
 	 * discard b_trk.
 	 */
 	if (a_trk->trk_gen > b_trk->trk_gen) {
-delete_b:	/*
+delete_b:
+		/*
 		 * After page and overflow reconciliation, one (and only one)
 		 * page can reference an overflow record.  But, if we split a
 		 * page into multiple chunks, any of the chunks might own any

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -281,7 +281,9 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 		case WT_CELL_ADDR_LEAF_NO:
 			addr->type = WT_ADDR_LEAF_NO;
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, unpack.raw);
+		default:
+			ret = __wt_illegal_value(session, unpack.raw);
+			goto err;
 		}
 		if (__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr))
 			addr = NULL;
@@ -1601,7 +1603,9 @@ __split_multi_inmem(
 			WT_ERR(__wt_row_modify(session,
 			    &cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, orig->type);
+		default:
+			ret = __wt_illegal_value(session, orig->type);
+			goto err;
 		}
 	}
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -149,7 +149,8 @@ __split_verify_root(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 	return (0);
 
-err:	/* Something really bad just happened. */
+err:
+	/* Something really bad just happened. */
 	WT_PANIC_RET(session, ret, "fatal error during page split");
 }
 #endif
@@ -1633,7 +1634,8 @@ __split_multi_inmem(
 	mod->restore_state = orig->modify->restore_state;
 	FLD_SET(mod->restore_state, WT_PAGE_RS_RESTORED);
 
-err:	/* Free any resources that may have been cached in the cursor. */
+err:
+	/* Free any resources that may have been cached in the cursor. */
 	WT_TRET(__wt_btcur_close(&cbt, true));
 
 	__wt_scr_free(session, &key);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -283,8 +283,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home,
 			addr->type = WT_ADDR_LEAF_NO;
 			break;
 		default:
-			ret = __wt_illegal_value(session, unpack.raw);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, unpack.raw));
 		}
 		if (__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr))
 			addr = NULL;
@@ -1605,8 +1604,7 @@ __split_multi_inmem(
 			    &cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
 			break;
 		default:
-			ret = __wt_illegal_value(session, orig->type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, orig->type));
 		}
 	}
 

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -246,11 +246,12 @@ __stat_page_row_int(
 	 * the in-memory representation of the page doesn't necessarily contain
 	 * a reference to the original cell.
 	 */
-	if (page->dsk != NULL)
+	if (page->dsk != NULL) {
 		WT_CELL_FOREACH_BEGIN(session, btree, page->dsk, unpack) {
 			if (__wt_cell_type(unpack.cell) == WT_CELL_KEY_OVFL)
 				++ovfl_cnt;
 		} WT_CELL_FOREACH_END;
+	}
 
 	WT_STAT_INCRV(session, stats, btree_overflow, ovfl_cnt);
 }

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -130,7 +130,8 @@ __stat_page(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **stats)
 	case WT_PAGE_ROW_LEAF:
 		__stat_page_row_leaf(session, page, stats);
 		break;
-	WT_ILLEGAL_VALUE(session, page->type);
+	default:
+		return (__wt_illegal_value(session, page->type));
 	}
 	return (0);
 }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -371,7 +371,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 		    WT_CLOCKDIFF_MS(time_stop, time_start));
 	}
 
-err:	/* On error, clear any left-over tree walk. */
+err:
+	/* On error, clear any left-over tree walk. */
 	WT_TRET(__wt_page_release(session, walk, flags));
 	WT_TRET(__wt_page_release(session, prev, flags));
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -290,7 +290,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
 	}
 
 done:
-err:	/* Inform the underlying block manager we're done. */
+err:
+	/* Inform the underlying block manager we're done. */
 	if (bm_start)
 		WT_TRET(bm->verify_end(bm, session));
 

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -635,7 +635,8 @@ __verify_dsk_row(WT_SESSION_IMPL *session,
 			current->size = prefix + unpack->size;
 		}
 
-key_compare:	/*
+key_compare:
+		/*
 		 * Compare the current key against the last key.
 		 *
 		 * Be careful about the 0th key on internal pages: we only store

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -195,7 +195,8 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag,
 	case WT_PAGE_BLOCK_MANAGER:
 	case WT_PAGE_OVFL:
 		return (__verify_dsk_chunk(session, tag, dsk, dsk->u.datalen));
-	WT_ILLEGAL_VALUE(session, dsk->type);
+	default:
+		return (__wt_illegal_value(session, dsk->type));
 	}
 	/* NOTREACHED */
 }

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -353,7 +353,8 @@ __tree_walk_internal(WT_SESSION_IMPL *session,
 	/* If no page is active, begin a walk from the start/end of the tree. */
 	if ((ref = ref_orig) == NULL) {
 		if (0) {
-restart:		/*
+restart:
+			/*
 			 * Yield before retrying, and if we've yielded enough
 			 * times, start sleeping so we don't burn CPU to no
 			 * purpose.
@@ -460,7 +461,8 @@ restart:		/*
 			++*walkcntp;
 
 		for (;;) {
-descend:		/*
+descend:
+			/*
 			 * Get a reference, setting the reference hint if it's
 			 * wrong (used when we continue the walk). We don't
 			 * always update the hints when splitting, it's expected

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -258,7 +258,8 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	}
 
 	if (0) {
-err:		/*
+err:
+		/*
 		 * Remove the update from the current transaction, so we don't
 		 * try to modify it on rollback.
 		 */

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -117,7 +117,8 @@ __wt_col_search(WT_SESSION_IMPL *session,
 	}
 
 	if (0) {
-restart:	/*
+restart:
+		/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */
@@ -162,7 +163,8 @@ restart:	/*
 			base = indx + 1;
 			--limit;
 		}
-descend:	/*
+descend:
+		/*
 		 * Reference the slot used for next step down the tree.
 		 *
 		 * Base is the smallest index greater than recno and may be the

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -166,7 +166,8 @@ __wt_row_leaf_key_work(WT_SESSION_IMPL *session,
 	direction = BACKWARD;
 	for (slot_offset = 0;;) {
 		if (0) {
-switch_and_jump:	/* Switching to a forward roll. */
+switch_and_jump:
+			/* Switching to a forward roll. */
 			WT_ASSERT(session, direction == BACKWARD);
 			direction = FORWARD;
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -216,7 +216,8 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 	}
 
 	if (0) {
-err:		/*
+err:
+		/*
 		 * Remove the update from the current transaction, so we don't
 		 * try to modify it on rollback.
 		 */

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -277,7 +277,8 @@ __wt_row_search(WT_SESSION_IMPL *session,
 	}
 
 	if (0) {
-restart:	/*
+restart:
+		/*
 		 * Discard the currently held page and restart the search from
 		 * the root.
 		 */
@@ -431,7 +432,8 @@ append:			if (__wt_split_descent_race(
 				goto restart;
 		}
 
-descend:	/* Encourage races. */
+descend:
+		/* Encourage races. */
 		WT_DIAGNOSTIC_YIELD;
 
 		/*

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -724,8 +724,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			}
 			break;
 		default:
-			ret = __wt_illegal_value(session, page->type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, page->type));
 		}
 
 		/*
@@ -771,8 +770,7 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 				las_value.size = 0;
 				break;
 			default:
-				ret = __wt_illegal_value(session, upd->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, upd->type));
 			}
 
 			cursor->set_key(cursor,

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -723,7 +723,9 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 				key->size = WT_INSERT_KEY_SIZE(list->ins);
 			}
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, page->type);
+		default:
+			ret = __wt_illegal_value(session, page->type);
+			goto err;
 		}
 
 		/*
@@ -768,7 +770,9 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			case WT_UPDATE_TOMBSTONE:
 				las_value.size = 0;
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, upd->type);
+			default:
+				ret = __wt_illegal_value(session, upd->type);
+				goto err;
 			}
 
 			cursor->set_key(cursor,

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -821,7 +821,8 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 		    "WiredTigerLAS: file size of %" PRIu64 " exceeds maximum "
 		    "size %" PRIu64, (uint64_t)las_size, max_las_size);
 
-err:	/* Resolve the transaction. */
+err:
+	/* Resolve the transaction. */
 	if (local_txn) {
 		if (ret == 0)
 			ret = __wt_txn_commit(session, NULL);

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -557,7 +557,8 @@ __config_process_value(WT_CONFIG_ITEM *value)
 	}
 
 	if (0) {
-nonum:		/*
+nonum:
+		/*
 		 * We didn't get a well-formed number.  That might be okay, the
 		 * required type will be checked by __wt_config_check.
 		 */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1830,7 +1830,8 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 			    "option configured");
 	}
 
-err:	/*
+err:
+	/*
 	 * We ignore the connection's lock file handle on error, it will be
 	 * closed when the connection structure is destroyed.
 	 */
@@ -2868,7 +2869,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 	WT_STATIC_ASSERT(offsetof(WT_CONNECTION_IMPL, iface) == 0);
 	*connectionp = &conn->iface;
 
-err:	/* Discard the scratch buffers. */
+err:
+	/* Discard the scratch buffers. */
 	__wt_scr_free(session, &encbuf);
 	__wt_scr_free(session, &i1);
 	__wt_scr_free(session, &i2);

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -356,7 +356,8 @@ __backup_start(WT_SESSION_IMPL *session,
 		WT_ERR(__backup_list_append(session, cb, WT_WIREDTIGER));
 	}
 
-err:	/* Close the hot backup file. */
+err:
+	/* Close the hot backup file. */
 	if (srcfs != NULL)
 		WT_TRET(__wt_fclose(session, &srcfs));
 	/*

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -747,7 +747,8 @@ __curfile_create(WT_SESSION_IMPL *session,
 	WT_STAT_DATA_INCR(session, cursor_create);
 
 	if (0) {
-err:		/*
+err:
+		/*
 		 * Our caller expects to release the data handle if we fail.
 		 * Disconnect it from the cursor before closing.
 		 */
@@ -833,7 +834,8 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri,
 
 	return (0);
 
-err:	/* If the cursor could not be opened, release the handle. */
+err:
+	/* If the cursor could not be opened, release the handle. */
 	WT_TRET(__wt_session_release_dhandle(session));
 	return (ret);
 }

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -500,7 +500,9 @@ __curjoin_entry_in_range(WT_SESSION_IMPL *session, WT_CURSOR_JOIN_ENTRY *entry,
 			passed = (cmp < 0);
 			break;
 
-		WT_ILLEGAL_VALUE(session, WT_CURJOIN_END_RANGE(end));
+		default:
+			return (__wt_illegal_value(
+			    session, WT_CURJOIN_END_RANGE(end)));
 		}
 
 		if (!passed) {

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -52,8 +52,9 @@ static int __json_pack_size(WT_SESSION_IMPL *, const char *, WT_CONFIG_ITEM *,
 		WT_RET(json_string_arg(session, &(jstr), &(pv).u.item));\
 		(pv).type = 'K';					\
 		break;							\
-	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session, (pv).type);				\
+	default:							\
+		/* User format strings have already been validated. */	\
+		return (__wt_illegal_value(session, (pv).type));	\
 	}								\
 } while (0)
 
@@ -934,7 +935,8 @@ __wt_json_strncpy(WT_SESSION *wt_session,
 			case '\\':
 				*dst++ = ch;
 				break;
-			WT_ILLEGAL_VALUE(session, ch);
+			default:
+				return (__wt_illegal_value(session, ch));
 			}
 		else
 			*dst++ = ch;

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -116,7 +116,8 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 	}
 
 	if (0) {
-err:		/* On error, clear any left-over tree walk. */
+err:
+		/* On error, clear any left-over tree walk. */
 		if (next_ref != NULL)
 			WT_TRET(__wt_page_release(
 			    session, next_ref, walk_flags));

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2098,7 +2098,8 @@ __evict_walk_tree(WT_SESSION_IMPL *session,
 		    !__txn_visible_all_id(session, page->modify->update_txn)))
 			continue;
 
-fast:		/* If the page can't be evicted, give up. */
+fast:
+		/* If the page can't be evicted, give up. */
 		if (!__wt_page_can_evict(session, ref, NULL))
 			continue;
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -454,7 +454,8 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref,
 		}
 
 		break;
-	WT_ILLEGAL_VALUE(session, mod->rec_result);
+	default:
+		return (__wt_illegal_value(session, mod->rec_result));
 	}
 
 	return (0);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -241,7 +241,8 @@ err:		if (!closing)
 		WT_STAT_DATA_INCR(session, cache_eviction_fail);
 	}
 
-done:	/* Leave any local eviction generation. */
+done:
+	/* Leave any local eviction generation. */
 	if (local_gen)
 		__wt_session_gen_leave(session, WT_GEN_EVICT);
 

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -1046,7 +1046,8 @@ __cell_data_ref(WT_SESSION_IMPL *session,
 			return (0);
 		huffman = btree->huffman_value;
 		break;
-	WT_ILLEGAL_VALUE(session, unpack->type);
+	default:
+		return (__wt_illegal_value(session, unpack->type));
 	}
 
 	return (huffman == NULL || store->size == 0 ? 0 :

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -100,12 +100,6 @@
 #define	__wt_illegal_value(session, v)					\
 	__wt_illegal_value_func(session, (uintmax_t)(v), __func__, __LINE__)
 
-/* Return and branch-to-err-label cases for switch statements. */
-#define	WT_ILLEGAL_VALUE_ERR(session, v)				\
-	default:							\
-		ret = __wt_illegal_value(session, v);			\
-		goto err
-
 #define	WT_PANIC_MSG(session, v, ...) do {				\
 	__wt_err(session, v, __VA_ARGS__);				\
 	WT_IGNORE_RET(__wt_panic(session));				\

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -101,9 +101,6 @@
 	__wt_illegal_value_func(session, (uintmax_t)(v), __func__, __LINE__)
 
 /* Return and branch-to-err-label cases for switch statements. */
-#define	WT_ILLEGAL_VALUE(session, v)					\
-	default:							\
-		return (__wt_illegal_value(session, v))
 #define	WT_ILLEGAL_VALUE_ERR(session, v)				\
 	default:							\
 		ret = __wt_illegal_value(session, v);			\

--- a/src/include/packing.i
+++ b/src/include/packing.i
@@ -244,8 +244,9 @@ next:	if (pack->cur == pack->end)
 	case 'R':							\
 		(pv).u.u = va_arg(ap, uint64_t);			\
 		break;							\
-	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session, (pv).type);				\
+	default:							\
+		/* User format strings have already been validated. */	\
+		return (__wt_illegal_value(session, (pv).type));	\
 	}								\
 } while (0)
 
@@ -611,8 +612,9 @@ __unpack_read(WT_SESSION_IMPL *session,
 	case 'R':							\
 		*va_arg(ap, uint64_t *) = (pv).u.u;			\
 		break;							\
-	/* User format strings have already been validated. */		\
-	WT_ILLEGAL_VALUE(session, (pv).type);				\
+	default:							\
+		/* User format strings have already been validated. */	\
+		return (__wt_illegal_value(session, (pv).type));	\
 	}								\
 } while (0)
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -928,7 +928,8 @@ __wt_txn_op_printlog(WT_SESSION_IMPL *session,
 		WT_RET(__wt_logop_txn_timestamp_print(session, pp, end, args));
 		break;
 
-	return (__wt_illegal_value(session, optype));
+	default:
+		return (__wt_illegal_value(session, optype));
 	}
 
 	return (0);

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -928,7 +928,7 @@ __wt_txn_op_printlog(WT_SESSION_IMPL *session,
 		WT_RET(__wt_logop_txn_timestamp_print(session, pp, end, args));
 		break;
 
-	WT_ILLEGAL_VALUE(session, optype);
+	return (__wt_illegal_value(session, optype));
 	}
 
 	return (0);

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -959,7 +959,8 @@ __clsm_next(WT_CURSOR *cursor)
 		if (clsm->current != NULL)
 			goto retry;
 	} else {
-retry:		/*
+retry:
+		/*
 		 * If there are multiple cursors on that key, move them
 		 * forward.
 		 */
@@ -1122,7 +1123,8 @@ __clsm_prev(WT_CURSOR *cursor)
 		if (clsm->current != NULL)
 			goto retry;
 	} else {
-retry:		/*
+retry:
+		/*
 		 * If there are multiple cursors on that key, move them
 		 * backwards.
 		 */

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -795,7 +795,8 @@ __lsm_free_chunks(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 		cookie.chunk_array[i] = NULL;
 	}
 
-err:	/* Flush the metadata unless the system is in panic */
+err:
+	/* Flush the metadata unless the system is in panic */
 	if (flush_metadata && ret != WT_PANIC) {
 		__wt_lsm_tree_writelock(session, lsm_tree);
 		WT_TRET(__wt_lsm_meta_write(session, lsm_tree, NULL));

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -320,7 +320,8 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 			    ret = __wt_checkpoint_sync(session, NULL));
 	}
 
-err:	/*
+err:
+	/*
 	 * Undo any tracked operations on failure.
 	 * Apply any tracked operations post-commit.
 	 */

--- a/src/packing/pack_stream.c
+++ b/src/packing/pack_stream.c
@@ -95,7 +95,8 @@ wiredtiger_pack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 
 	return (0);
@@ -128,7 +129,8 @@ wiredtiger_pack_int(WT_PACK_STREAM *ps, int64_t i)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 
 	return (0);
@@ -158,7 +160,8 @@ wiredtiger_pack_str(WT_PACK_STREAM *ps, const char *s)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 
 	return (0);
@@ -194,7 +197,8 @@ wiredtiger_pack_uint(WT_PACK_STREAM *ps, uint64_t u)
 		WT_RET(__pack_write(
 		    session, &pv, &ps->p, (size_t)(ps->end - ps->p)));
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 
 	return (0);
@@ -225,7 +229,8 @@ wiredtiger_unpack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 		item->data = pv.u.item.data;
 		item->size = pv.u.item.size;
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 
 	return (0);
@@ -258,7 +263,8 @@ wiredtiger_unpack_int(WT_PACK_STREAM *ps, int64_t *ip)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*ip = pv.u.i;
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 	return (0);
 }
@@ -287,7 +293,8 @@ wiredtiger_unpack_str(WT_PACK_STREAM *ps, const char **sp)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*sp = pv.u.s;
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 	return (0);
 }
@@ -322,7 +329,8 @@ wiredtiger_unpack_uint(WT_PACK_STREAM *ps, uint64_t *up)
 		    &pv, (const uint8_t **)&ps->p, (size_t)(ps->end - ps->p)));
 		*up = pv.u.u;
 		break;
-	WT_ILLEGAL_VALUE(session, pv.type);
+	default:
+		return (__wt_illegal_value(session, pv.type));
 	}
 	return (0);
 }

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -289,7 +289,9 @@ __wt_rec_child_modify(WT_SESSION_IMPL *session,
 			WT_ASSERT(session, WT_REF_SPLIT != WT_REF_SPLIT);
 			return (__wt_set_return(session, EBUSY));
 
-		WT_ILLEGAL_VALUE(session, r->tested_ref_state);
+		default:
+			return (__wt_illegal_value(
+			    session, r->tested_ref_state));
 		}
 		WT_STAT_CONN_INCR(session, child_modify_blocked_page);
 	}

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -273,8 +273,8 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 				addr = &child->modify->mod_replace;
 				break;
 			default:
-			ret = __wt_illegal_value(
-			    session, child->modify->rec_result);
+				ret = __wt_illegal_value(
+				    session, child->modify->rec_result);
 			goto err;
 			}
 			break;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -804,7 +804,8 @@ __wt_rec_col_var(WT_SESSION_IMPL *session,
 		WT_ERR(__wt_dsk_cell_data_ref(
 		    session, WT_PAGE_COL_VAR, vpack, orig));
 
-record_loop:	/*
+record_loop:
+		/*
 		 * Generate on-page entries: loop repeat records, looking for
 		 * WT_INSERT entries matching the record number.  The WT_INSERT
 		 * lists are in sorted order, so only need check the next one.
@@ -977,7 +978,8 @@ record_loop:	/*
 				}
 			}
 
-compare:		/*
+compare:
+			/*
 			 * If we have a record against which to compare, and
 			 * the records compare equal, increment the rle counter
 			 * and continue.  If the records don't compare equal,

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -272,8 +272,10 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 			case WT_PM_REC_REPLACE:
 				addr = &child->modify->mod_replace;
 				break;
-			WT_ILLEGAL_VALUE_ERR(
+			default:
+			ret = __wt_illegal_value(
 			    session, child->modify->rec_result);
+			goto err;
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -864,7 +866,10 @@ record_loop:	/*
 				case WT_UPDATE_TOMBSTONE:
 					deleted = true;
 					break;
-				WT_ILLEGAL_VALUE_ERR(session, upd->type);
+				default:
+					ret = __wt_illegal_value(
+					    session, upd->type);
+					goto err;
 				}
 			} else if (vpack->raw == WT_CELL_VALUE_OVFL_RM) {
 				/*
@@ -1172,7 +1177,10 @@ compare:		/*
 				case WT_UPDATE_TOMBSTONE:
 					deleted = true;
 					break;
-				WT_ILLEGAL_VALUE_ERR(session, upd->type);
+				default:
+					ret = __wt_illegal_value(
+					    session, upd->type);
+					goto err;
 				}
 			}
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -273,9 +273,8 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 				addr = &child->modify->mod_replace;
 				break;
 			default:
-				ret = __wt_illegal_value(
-				    session, child->modify->rec_result);
-			goto err;
+				WT_ERR(__wt_illegal_value(
+				    session, child->modify->rec_result));
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -868,9 +867,8 @@ record_loop:
 					deleted = true;
 					break;
 				default:
-					ret = __wt_illegal_value(
-					    session, upd->type);
-					goto err;
+					WT_ERR(__wt_illegal_value(
+					    session, upd->type));
 				}
 			} else if (vpack->raw == WT_CELL_VALUE_OVFL_RM) {
 				/*
@@ -1180,9 +1178,8 @@ compare:
 					deleted = true;
 					break;
 				default:
-					ret = __wt_illegal_value(
-					    session, upd->type);
-					goto err;
+					WT_ERR(__wt_illegal_value(
+					    session, upd->type));
 				}
 			}
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -457,8 +457,8 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				addr = &child->modify->mod_replace;
 				break;
 			default:
-			ret = __wt_illegal_value(
-			    session, child->modify->rec_result);
+				ret = __wt_illegal_value(
+				    session, child->modify->rec_result);
 			goto err;
 			}
 			break;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -657,7 +657,8 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 			break;
 		case WT_UPDATE_TOMBSTONE:
 			continue;
-		WT_ILLEGAL_VALUE(session, upd->type);
+		default:
+			return (__wt_illegal_value(session, upd->type));
 		}
 
 		/* Build key cell. */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1104,7 +1104,8 @@ build:
 		/* Update compression state. */
 		__rec_key_state_update(r, ovfl_key);
 
-leaf_insert:	/* Write any K/V pairs inserted into the page after this key. */
+leaf_insert:
+		/* Write any K/V pairs inserted into the page after this key. */
 		if ((ins = WT_SKIP_FIRST(WT_ROW_INSERT(page, rip))) != NULL)
 			WT_ERR(__rec_row_leaf_insert(session, r, ins));
 	}

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -457,9 +457,8 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				addr = &child->modify->mod_replace;
 				break;
 			default:
-				ret = __wt_illegal_value(
-				    session, child->modify->rec_result);
-			goto err;
+				WT_ERR(__wt_illegal_value(
+				    session, child->modify->rec_result));
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -980,8 +979,7 @@ __wt_rec_row_leaf(WT_SESSION_IMPL *session,
 				/* Proceed with appended key/value pairs. */
 				goto leaf_insert;
 			default:
-				ret = __wt_illegal_value(session, upd->type);
-				goto err;
+				WT_ERR(__wt_illegal_value(session, upd->type));
 			}
 		}
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -456,8 +456,10 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 				 */
 				addr = &child->modify->mod_replace;
 				break;
-			WT_ILLEGAL_VALUE_ERR(
+			default:
+			ret = __wt_illegal_value(
 			    session, child->modify->rec_result);
+			goto err;
 			}
 			break;
 		case WT_CHILD_ORIGINAL:
@@ -977,7 +979,9 @@ __wt_rec_row_leaf(WT_SESSION_IMPL *session,
 
 				/* Proceed with appended key/value pairs. */
 				goto leaf_insert;
-			WT_ILLEGAL_VALUE_ERR(session, upd->type);
+			default:
+				ret = __wt_illegal_value(session, upd->type);
+				goto err;
 			}
 		}
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -500,7 +500,8 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
 		return (0);
 	case WT_PM_REC_MULTIBLOCK:			/* Multiple blocks */
 		break;
-	WT_ILLEGAL_VALUE(session, mod->rec_result);
+	default:
+		return (__wt_illegal_value(session, mod->rec_result));
 	}
 
 	__wt_verbose(session, WT_VERB_SPLIT,
@@ -2023,7 +2024,8 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	case WT_PAGE_ROW_INT:
 		multi->addr.type = WT_ADDR_INT;
 		break;
-	WT_ILLEGAL_VALUE(session, page->type);
+	default:
+		return (__wt_illegal_value(session, page->type));
 	}
 	multi->size = WT_STORE_SIZE(chunk->image.size);
 	multi->checksum = 0;
@@ -2412,7 +2414,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 		mod->mod_replace.size = 0;
 		__wt_free(session, mod->mod_disk_image);
 		break;
-	WT_ILLEGAL_VALUE(session, mod->rec_result);
+	default:
+		return (__wt_illegal_value(session, mod->rec_result));
 	}
 
 	/* Reset the reconciliation state. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1402,7 +1402,8 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 	r->min_space_avail =
 	    r->min_split_size - WT_PAGE_HEADER_BYTE_SIZE(btree);
 
-done:  	/*
+done:
+	/*
 	 * Overflow values can be larger than the maximum page size but still be
 	 * "on-page". If the next key/value pair is larger than space available
 	 * after a split has happened (in other words, larger than the maximum

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1481,7 +1481,8 @@ __wt_session_range_truncate(WT_SESSION_IMPL *session,
 	WT_ERR(__wt_schema_range_truncate(session, start, stop));
 
 done:
-err:	/*
+err:
+	/*
 	 * Close any locally-opened start cursor.
 	 *
 	 * Reset application cursors, they've possibly moved and the

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -374,7 +374,8 @@ __wt_hazard_check(WT_SESSION_IMPL *session,
 	WT_STAT_CONN_INCRV(session, cache_hazard_walks, walk_cnt);
 	hp = NULL;
 
-done:	/* Leave the current resource generation. */
+done:
+	/* Leave the current resource generation. */
 	__wt_session_gen_leave(session, WT_GEN_HAZARD);
 
 	return (hp);

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -180,8 +180,7 @@ __wt_buf_set_printable_format(WT_SESSION_IMPL *session,
 			sep = ",";
 			break;
 		default:
-			ret = __wt_illegal_value(session, pv.type);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, pv.type));
 		}
 	}
 	WT_ERR_NOTFOUND_OK(ret);

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -179,7 +179,9 @@ __wt_buf_set_printable_format(WT_SESSION_IMPL *session,
 			    session, buf, "%s%" PRIu64, sep, pv.u.u));
 			sep = ",";
 			break;
-		WT_ILLEGAL_VALUE_ERR(session, pv.type);
+		default:
+			ret = __wt_illegal_value(session, pv.type);
+			goto err;
 		}
 	}
 	WT_ERR_NOTFOUND_OK(ret);

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -225,7 +225,8 @@ __thread_group_resize(
 		__wt_thread_group_start_one(session, group, true);
 	return (0);
 
-err:	/*
+err:
+	/*
 	 * An error resizing a thread array is currently fatal, it should only
 	 * happen in an out of memory situation. Do real cleanup just in case
 	 * that changes in the future.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1078,7 +1078,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		    __wt_cache_eviction_check(session, false, false, NULL));
 	return (0);
 
-err:	/*
+err:
+	/*
 	 * If anything went wrong, roll back.
 	 *
 	 * !!!

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1012,7 +1012,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 			conn->txn_global.last_ckpt_timestamp = ckpt_tmp_ts;
 	}
 
-err:	/*
+err:
+	/*
 	 * Reset the timer so that next checkpoint tracks the progress only if
 	 * configured.
 	 */
@@ -1678,7 +1679,8 @@ __checkpoint_tree(
 	else
 		WT_ERR(__wt_evict_file(session, WT_SYNC_CLOSE));
 
-fake:	/*
+fake:
+	/*
 	 * If we're faking a checkpoint and logging is enabled, recovery should
 	 * roll forward any changes made between now and the next checkpoint,
 	 * so set the checkpoint LSN to the beginning of time.
@@ -1727,7 +1729,8 @@ fake:	/*
 		WT_ERR(__wt_txn_checkpoint_log(
 		    session, false, WT_TXN_LOG_CKPT_STOP, NULL));
 
-err:	/* Resolved the checkpoint for the block manager in the error path. */
+err:
+	/* Resolved the checkpoint for the block manager in the error path. */
 	if (resolve_bm)
 		WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -576,7 +576,9 @@ __wt_txn_checkpoint_log(
 		__wt_scr_free(session, &txn->ckpt_snapshot);
 		txn->full_ckpt = false;
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, flags);
+	default:
+		ret = __wt_illegal_value(session, flags);
+		goto err;
 	}
 
 err:	__wt_logrec_free(session, &logrec);

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -94,7 +94,8 @@ __txn_op_log(WT_SESSION_IMPL *session, WT_ITEM *logrec,
 			WT_RET(__wt_logop_row_remove_pack(
 			    session, logrec, fileid, &cursor->key));
 			break;
-		WT_ILLEGAL_VALUE(session, upd->type);
+		default:
+			return (__wt_illegal_value(session, upd->type));
 		}
 	} else {
 		recno = WT_INSERT_RECNO(cbt->ins);
@@ -113,7 +114,8 @@ __txn_op_log(WT_SESSION_IMPL *session, WT_ITEM *logrec,
 			WT_RET(__wt_logop_col_remove_pack(
 			    session, logrec, fileid, recno));
 			break;
-		WT_ILLEGAL_VALUE(session, upd->type);
+		default:
+			return (__wt_illegal_value(session, upd->type));
 		}
 	}
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -577,8 +577,7 @@ __wt_txn_checkpoint_log(
 		txn->full_ckpt = false;
 		break;
 	default:
-		ret = __wt_illegal_value(session, flags);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, flags));
 	}
 
 err:	__wt_logrec_free(session, &logrec);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -266,8 +266,7 @@ __txn_op_apply(
 			stop = cursor;
 			break;
 		default:
-			ret = __wt_illegal_value(session, mode);
-			goto err;
+			WT_ERR(__wt_illegal_value(session, mode));
 		}
 
 		/* Set the keys. */
@@ -293,8 +292,7 @@ __txn_op_apply(
 		    &t_nsec, &commit, &durable, &first, &prepare, &read));
 		break;
 	default:
-		ret = __wt_illegal_value(session, optype);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, optype));
 	}
 
 done:

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -265,8 +265,9 @@ __txn_op_apply(
 		case WT_TXN_TRUNC_STOP:
 			stop = cursor;
 			break;
-
-		WT_ILLEGAL_VALUE_ERR(session, mode);
+		default:
+			ret = __wt_illegal_value(session, mode);
+			goto err;
 		}
 
 		/* Set the keys. */
@@ -291,8 +292,9 @@ __txn_op_apply(
 		WT_ERR(__wt_logop_txn_timestamp_unpack(session, pp, end, &t_sec,
 		    &t_nsec, &commit, &durable, &first, &prepare, &read));
 		break;
-
-	WT_ILLEGAL_VALUE_ERR(session, optype);
+	default:
+		ret = __wt_illegal_value(session, optype);
+		goto err;
 	}
 
 done:

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -328,8 +328,7 @@ __txn_abort_newer_updates(
 		__txn_abort_newer_row_leaf(session, page, rollback_timestamp);
 		break;
 	default:
-		ret = __wt_illegal_value(session, page->type);
-		goto err;
+		WT_ERR(__wt_illegal_value(session, page->type));
 	}
 
 err:	if (local_read)

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -327,7 +327,9 @@ __txn_abort_newer_updates(
 	case WT_PAGE_ROW_LEAF:
 		__txn_abort_newer_row_leaf(session, page, rollback_timestamp);
 		break;
-	WT_ILLEGAL_VALUE_ERR(session, page->type);
+	default:
+		ret = __wt_illegal_value(session, page->type);
+		goto err;
 	}
 
 err:	if (local_read)

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -147,7 +147,8 @@ load_dump(WT_SESSION *session)
 	} else
 		ret = insert(cursor, uri);
 
-err:	/*
+err:
+	/*
 	 * Technically, we don't have to close the cursor because the session
 	 * handle will do it for us, but I'd like to see the flush to disk and
 	 * the close succeed, it's better to fail early when loading files.


### PR DESCRIPTION
This PR is to address some formatting issues identified in the past two Clang Format review PRs. I'd like to merge this before applying Clang Format to make the output as nice as possible.
The changes are:
- Remove `WT_ILLEGAL_VALUE` macros. We expect these to be indented at the same level as `case` label however, the formatter has no way of knowing it's not just a regular function call.
- Don't allow comments to trail after a `goto` label. It means we can use `s_goto` in its current state and also it is more consistent since Clang Format will not let code trail after a `goto` label like we do now.
- Wrap a few things with braces that don't get formatted well.