### PR TITLE
WT-4857 Use a local variable to access the insert structure.

### DIFF
--- a/src/include/column.i
+++ b/src/include/column.i
@@ -29,7 +29,7 @@ __col_insert_search_gt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 	 * go as far as possible at each level before stepping down to the next.
 	 */
 	ins = NULL;
-	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;)
+	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;) {
 		/*
 		 * Use a local variable to access the insert because the skip
 		 * list can change across references.
@@ -42,6 +42,7 @@ __col_insert_search_gt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 			--i;		/* LT: drop down a level */
 			--insp;
 		}
+        }
 
 	/*
 	 * If we didn't find any records smaller than the target, we never set
@@ -83,7 +84,7 @@ __col_insert_search_lt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 	 * The insert list is a skip list: start at the highest skip level, then
 	 * go as far as possible at each level before stepping down to the next.
 	 */
-	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;)
+	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;) {
 		/*
 		 * Use a local variable to access the insert because the skip
 		 * list can change across references.
@@ -96,6 +97,7 @@ __col_insert_search_lt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 			--i;		/* LTE: drop down a level */
 			--insp;
 		}
+        }
 
 	return (ins);
 }

--- a/src/include/column.i
+++ b/src/include/column.i
@@ -42,7 +42,7 @@ __col_insert_search_gt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 			--i;		/* LT: drop down a level */
 			--insp;
 		}
-        }
+	}
 
 	/*
 	 * If we didn't find any records smaller than the target, we never set
@@ -97,7 +97,7 @@ __col_insert_search_lt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 			--i;		/* LTE: drop down a level */
 			--insp;
 		}
-        }
+	}
 
 	return (ins);
 }

--- a/src/include/column.i
+++ b/src/include/column.i
@@ -122,13 +122,18 @@ __col_insert_search_match(WT_INSERT_HEAD *ins_head, uint64_t recno)
 			continue;
 		}
 
-		ins_recno = WT_INSERT_RECNO(*insp);
+		/*
+		 * Use a local variable to access the insert because the skip
+		 * list can change across references.
+		 */
+		ret_ins = *insp;
+		ins_recno = WT_INSERT_RECNO(ret_ins);
 		cmp = (recno == ins_recno) ? 0 : (recno < ins_recno) ? -1 : 1;
 
 		if (cmp == 0)			/* Exact match: return */
-			return (*insp);
+			return (ret_ins);
 		if (cmp > 0)			/* Keep going at this level */
-			insp = &(*insp)->next[i];
+			insp = &ret_ins->next[i];
 		else {				/* Drop down a level */
 			--i;
 			--insp;

--- a/src/include/column.i
+++ b/src/include/column.i
@@ -31,7 +31,7 @@ __col_insert_search_gt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 	ins = NULL;
 	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;)
 		if ((local_ins = *insp) != NULL &&
-		    recno >= WT_INSERT_RECNO(*insp)) {
+		    recno >= WT_INSERT_RECNO(local_ins)) {
 			/* GTE: keep going at this level */
 			ins = local_ins;
 			insp = &local_ins->next[i];
@@ -82,7 +82,7 @@ __col_insert_search_lt(WT_INSERT_HEAD *ins_head, uint64_t recno)
 	 */
 	for (i = WT_SKIP_MAXDEPTH - 1, insp = &ins_head->head[i]; i >= 0;)
 		if ((local_ins = *insp) != NULL &&
-		    recno > WT_INSERT_RECNO(*insp)) {
+		    recno > WT_INSERT_RECNO(local_ins)) {
 			/* GT: keep going at this level */
 			ins = local_ins;
 			insp = &local_ins->next[i];


### PR DESCRIPTION
This is the simple change that has (so far) fixed the column store mismatch issue. Please review.