### PR TITLE
WT-4878 Disable random dhandle selection for eviction (#4716)

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1623,22 +1623,14 @@ __evict_push_candidate(WT_SESSION_IMPL *session,
  *	Calculate how many pages to queue for a given tree.
  */
 static uint32_t
-__evict_walk_target(WT_SESSION_IMPL *session, u_int max_entries)
+__evict_walk_target(WT_SESSION_IMPL *session)
 {
 	WT_CACHE *cache;
 	uint64_t btree_inuse, bytes_per_slot, cache_inuse;
 	uint32_t target_pages_clean, target_pages_dirty, target_pages;
-	uint32_t total_slots;
 
 	cache = S2C(session)->cache;
 	target_pages_clean = target_pages_dirty = 0;
-	total_slots = max_entries;
-
-	/*
-	 * The number of times we should fill the queue by the end of
-	 * considering all trees.
-	 */
-#define	QUEUE_FILLS_PER_PASS	10
 
 	/*
 	 * The minimum number of pages we should consider per tree.
@@ -1654,7 +1646,7 @@ __evict_walk_target(WT_SESSION_IMPL *session, u_int max_entries)
 	if (F_ISSET(cache, WT_CACHE_EVICT_CLEAN)) {
 		btree_inuse = __wt_btree_bytes_evictable(session);
 		cache_inuse = __wt_cache_bytes_inuse(cache);
-		bytes_per_slot = 1 + cache_inuse / total_slots;
+		bytes_per_slot = 1 + cache_inuse / cache->evict_slots;
 		target_pages_clean = (uint32_t)(
 		    (btree_inuse + bytes_per_slot / 2) / bytes_per_slot);
 	}
@@ -1662,20 +1654,12 @@ __evict_walk_target(WT_SESSION_IMPL *session, u_int max_entries)
 	if (F_ISSET(cache, WT_CACHE_EVICT_DIRTY)) {
 		btree_inuse = __wt_btree_dirty_leaf_inuse(session);
 		cache_inuse = __wt_cache_dirty_leaf_inuse(cache);
-		bytes_per_slot = 1 + cache_inuse / total_slots;
+		bytes_per_slot = 1 + cache_inuse / cache->evict_slots;
 		target_pages_dirty = (uint32_t)(
 		    (btree_inuse + bytes_per_slot / 2) / bytes_per_slot);
 	}
 
-	/*
-	 * Weight the number of target pages by the number of times we want to
-	 * fill the cache per pass through all the trees.  Note that we don't
-	 * build this into the calculation above because we don't want to favor
-	 * small trees, so round to a whole number of slots (zero for small
-	 * trees) before multiplying.
-	 */
-	target_pages = WT_MAX(target_pages_clean, target_pages_dirty) *
-	    QUEUE_FILLS_PER_PASS;
+	target_pages = WT_MAX(target_pages_clean, target_pages_dirty);
 
 	/*
 	 * Walk trees with a small fraction of the cache in case there are so
@@ -1739,12 +1723,10 @@ __evict_walk_tree(WT_SESSION_IMPL *session,
 	start = queue->evict_queue + *slotp;
 	remaining_slots = max_entries - *slotp;
 	if (btree->evict_walk_progress >= btree->evict_walk_target) {
-		btree->evict_walk_target =
-		    __evict_walk_target(session, max_entries);
+		btree->evict_walk_target = __evict_walk_target(session);
 		btree->evict_walk_progress = 0;
 	}
-	target_pages = WT_MIN(btree->evict_walk_target / QUEUE_FILLS_PER_PASS,
-	    btree->evict_walk_target - btree->evict_walk_progress);
+	target_pages = btree->evict_walk_target - btree->evict_walk_progress;
 
 	if (target_pages > remaining_slots)
 		target_pages = remaining_slots;

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -139,8 +139,10 @@ op(WT_SESSION *session, WT_RAND_STATE *rnd, WT_CURSOR **cpp)
 	/* Close the cursor half the time, otherwise cache it. */
 	if (__wt_random(rnd) % 2 == 0)
 		testutil_check(cursor->close(cursor));
-	else
+	else {
+		testutil_check(cursor->reset(cursor));
 		*cpp = cursor;
+	}
 
 	(void)__wt_atomic_add64(&worker, 1);
 }


### PR DESCRIPTION
This mostly goes back to the state before data handles were chosen
randomly to search for eviction candidates.  It also changes some of the
calculations for how many pages to enqueue per tree.

Also fix handle lock test to reset cursors before caching them.
Otherwise, for configurations with many threads it can end up in a state
where there is a cursor on every page, preventing the pages from
splitting, and ultimately blocking eviction.  This was exposed by
changes to eviction, but is a structural problem with the test case.

(cherry picked from commit 859c527b01143c0f3d1a064b4ae14592c65628d1)