### PR TITLE
WT-4943 Track uncommitted/prepared status through reconciliation.

### DIFF
--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -51,8 +51,9 @@ struct __wt_reconcile {
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */
 
-	bool update_uncommitted;	/* An update was uncommitted */
-	bool update_used;		/* An update could be used */
+	bool update_prepared;		/* An update was prepared. */
+	bool update_uncommitted;	/* An update was uncommitted. */
+	bool update_used;		/* An update could be used. */
 
 	/* All the updates are with prepare in-progress state. */
 	bool all_upd_prepare_in_prog;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -700,7 +700,7 @@ __rec_init(WT_SESSION_IMPL *session,
 
 	/* Track if updates were used and/or uncommitted. */
 	r->updates_seen = r->updates_unstable = 0;
-	r->update_uncommitted = r->update_used = false;
+	r->update_prepared = r->update_uncommitted = r->update_used = false;
 
 	/* Track if all the updates are with prepare in-progress state. */
 	r->all_upd_prepare_in_prog = true;


### PR DESCRIPTION
Don't skip selecting an update after seeing an uncommitted / prepared entry in an update list, but remember whether one has been seen when determining whether the page can be evicted.