### PR TITLE
WT-4943 Separate tracking per update list vs per page.

### DIFF
--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -51,7 +51,6 @@ struct __wt_reconcile {
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */
 
-	bool update_prepared;		/* An update was prepared. */
 	bool update_uncommitted;	/* An update was uncommitted. */
 	bool update_used;		/* An update could be used. */
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -365,7 +365,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	 */
 	timestamp = first_ts_upd == NULL ? 0 : first_ts_upd->durable_ts;
 	all_visible = upd == first_txn_upd &&
-	    !list_uncommitted && !list_prepared &&
+	    !list_prepared && !list_uncommitted &&
 	    (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
 	    __wt_txn_visible_all(session, max_txn, timestamp) :
 	    __wt_txn_visible(session, max_txn, timestamp));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -700,7 +700,7 @@ __rec_init(WT_SESSION_IMPL *session,
 
 	/* Track if updates were used and/or uncommitted. */
 	r->updates_seen = r->updates_unstable = 0;
-	r->update_prepared = r->update_uncommitted = r->update_used = false;
+	r->update_uncommitted = r->update_used = false;
 
 	/* Track if all the updates are with prepare in-progress state. */
 	r->all_upd_prepare_in_prog = true;


### PR DESCRIPTION
We've tried a few times to get this right, so I've renamed the variables to clarify.  Reconciliation as a whole needs to know whether there are any uncommitted updates on a page (to prevent lookaside eviction): that's tracked in `r->updates_uncommitted`.  Selecting a single update needs to know whether any updates *in the list* are prepared or uncommitted.  That's now tracked in `list_prepared` and `list_uncommitted`.