### PR TITLE
WT-4906 wtperf.c integer overflow and dead code fixes (Coverity)

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1612,14 +1612,14 @@ scan_worker(void *arg)
 	 */
 	if (opts->scan_icount != 0) {
 		end_id = opts->scan_icount;
-		tot_items = (opts->scan_icount * pct) / 100;
-		incr = opts->scan_table_count * 1000 + 1;
+		tot_items = ((uint64_t)opts->scan_icount * pct) / 100;
+		incr = (uint64_t)opts->scan_table_count * 1000 + 1;
 		table_start = opts->table_count;
 		ntables = opts->scan_table_count;
 	} else {
 		end_id = opts->icount;
-		tot_items = (opts->icount * pct) / 100;
-		incr = opts->table_count * 1000 + 1;
+		tot_items = ((uint64_t)opts->icount * pct) / 100;
+		incr = (uint64_t)opts->table_count * 1000 + 1;
 		table_start = 0;
 		ntables = opts->table_count;
 	}
@@ -1678,13 +1678,7 @@ scan_worker(void *arg)
 			}
 		}
 		wtperf->scan = false;
-		if (ret == 0)
-			++thread->scan.ops;
-		else {
-			lprintf(wtperf, ret, 0, "Scan operation failed for %s.",
-			    uri);
-			goto err;
-		}
+		++thread->scan.ops;
 		__wt_epoch(NULL, &e);
 	}
 

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1577,7 +1577,6 @@ scan_worker(void *arg)
 	WT_CONNECTION *conn;
 	WT_CURSOR *cursor, **cursors;
 	WT_SESSION *session;
-	const char *uri;
 	char *key_buf;
 	struct timespec e, s;
 	uint32_t i, ntables, pct, table_start;
@@ -1592,7 +1591,6 @@ scan_worker(void *arg)
 	session = NULL;
 	cursors = NULL;
 	items = 0;
-	uri = NULL;
 
 	/*
 	 * Figure out how many items we should scan.


### PR DESCRIPTION
CID 113115, CID 113116, CID 113117 and CID 113119 (integer overflow)
Typecasted one of the variable to uint64_t to evaluate the arithmetic
using 64 bits instead of 32 bits.

CID 113118 (dead code)
Removed dead code