### PR TITLE
WT-4961 Checkpoints with cache overflow must keep history for reads.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -124,6 +124,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_DECL_RET;
 	WT_ITEM las_key, las_value;
 	WT_PAGE *page;
+	WT_PAGE_LOOKASIDE *page_las;
 	WT_UPDATE *first_upd, *last_upd, *upd;
 	wt_timestamp_t durable_timestamp, las_timestamp;
 	size_t incr, total_incr;
@@ -139,7 +140,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	locked = false;
 	total_incr = 0;
 	current_recno = recno = WT_RECNO_OOB;
-	las_pageid = ref->page_las->las_pageid;
+	page_las = ref->page_las;
+	las_pageid = page_las->las_pageid;
 	session_flags = 0;		/* [-Werror=maybe-uninitialized] */
 	WT_CLEAR(las_key);
 
@@ -179,7 +181,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 		 * Confirm the search using the unique prefix; if not a match,
 		 * we're done searching for records for this page.
 		 */
-		if (las_pageid != ref->page_las->las_pageid)
+		if (las_pageid != page_las->las_pageid)
 			break;
 
 		/* Allocate the WT_UPDATE structure. */
@@ -285,14 +287,13 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
 		FLD_SET(page->modify->restore_state, WT_PAGE_RS_LOOKASIDE);
 
-		if (ref->page_las->skew_newest &&
-		    !ref->page_las->has_prepares &&
+		if (page_las->max_ts == page_las->max_onpage_ts &&
+		    !page_las->has_prepares &&
 		    !S2C(session)->txn_global.has_stable_timestamp &&
-		    __wt_txn_visible_all(session, ref->page_las->unstable_txn,
-		    ref->page_las->unstable_durable_timestamp)) {
-			page->modify->rec_max_txn = ref->page_las->max_txn;
-			page->modify->rec_max_timestamp =
-			    ref->page_las->max_timestamp;
+		    __wt_txn_visible_all(session, page_las->max_txn,
+		    page_las->max_ts)) {
+			page->modify->rec_max_txn = page_las->max_txn;
+			page->modify->rec_max_timestamp = page_las->max_ts;
 			__wt_page_modify_clear(session, page);
 		}
 	}
@@ -301,8 +302,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * Now the lookaside history has been read into cache there is no
 	 * further need to maintain a reference to it.
 	 */
-	ref->page_las->eviction_to_lookaside = false;
-	ref->page_las->resolved = true;
+	page_las->eviction_to_lookaside = false;
+	page_las->resolved = true;
 
 err:	if (locked)
 		__wt_readunlock(session, &cache->las_sweepwalk_lock);
@@ -578,9 +579,10 @@ skip_read:
 	 * Don't free WT_REF.page_las, there may be concurrent readers.
 	 */
 	if (final_state == WT_REF_MEM && ref->page_las != NULL &&
-	    (!ref->page_las->skew_newest || ref->page_las->has_prepares))
-		WT_ERR(__wt_las_remove_block(
-		    session, ref->page_las->las_pageid));
+	    (ref->page_las->max_ts > ref->page_las->max_onpage_ts ||
+	    ref->page_las->has_prepares))
+		WT_ERR(
+		    __wt_las_remove_block(session, ref->page_las->las_pageid));
 
 	WT_REF_SET_STATE(ref, final_state);
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -287,13 +287,14 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
 		FLD_SET(page->modify->restore_state, WT_PAGE_RS_LOOKASIDE);
 
-		if (page_las->max_ts == page_las->max_onpage_ts &&
+		if (page_las->min_skipped_ts == WT_TS_MAX &&
 		    !page_las->has_prepares &&
 		    !S2C(session)->txn_global.has_stable_timestamp &&
-		    __wt_txn_visible_all(session, page_las->max_txn,
-		    page_las->max_ts)) {
+		    __wt_txn_visible_all(
+		    session, page_las->max_txn, page_las->max_ondisk_ts)) {
 			page->modify->rec_max_txn = page_las->max_txn;
-			page->modify->rec_max_timestamp = page_las->max_ts;
+			page->modify->rec_max_timestamp =
+			    page_las->max_ondisk_ts;
 			__wt_page_modify_clear(session, page);
 		}
 	}
@@ -579,7 +580,7 @@ skip_read:
 	 * Don't free WT_REF.page_las, there may be concurrent readers.
 	 */
 	if (final_state == WT_REF_MEM && ref->page_las != NULL &&
-	    (ref->page_las->max_ts > ref->page_las->max_onpage_ts ||
+	    (ref->page_las->min_skipped_ts != WT_TS_MAX ||
 	    ref->page_las->has_prepares))
 		WT_ERR(
 		    __wt_las_remove_block(session, ref->page_las->las_pageid));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -321,19 +321,10 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * cache clean but with history that cannot be
 			 * discarded), that is not wasted effort because
 			 * checkpoint doesn't need to write the page again.
-			 *
-			 * XXX Only attempt this eviction when there are no
-			 * readers older than the checkpoint.  Otherwise, a bug
-			 * in eviction can mark the page clean and discard
-			 * history, causing those reads to incorrectly see
-			 * newer versions of data than they should.
 			 */
 			if (!WT_PAGE_IS_INTERNAL(page) &&
 			    page->read_gen == WT_READGEN_WONT_NEED &&
-			    !tried_eviction &&
-			    (!F_ISSET(txn, WT_TXN_HAS_TS_READ) ||
-			    txn->read_timestamp ==
-			    conn->txn_global.pinned_timestamp)) {
+			    !tried_eviction) {
 				WT_ERR_BUSY_OK(
 				    __wt_page_release_evict(session, walk, 0));
 				walk = prev;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -805,8 +805,6 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			    (upd->type == WT_UPDATE_STANDARD ||
 			    upd->type == WT_UPDATE_MODIFY)) {
 				las_value.size = 0;
-				WT_ASSERT(session, upd != first_upd ||
-				    multi->page_las.skew_newest);
 				cursor->set_value(cursor, upd->txnid,
 				    upd->start_ts, upd->durable_ts,
 				    upd->prepare_state, WT_UPDATE_BIRTHMARK,

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -418,14 +418,13 @@ __wt_las_cursor_close(
 
 /*
  * __wt_las_page_skip_locked --
- *	 Check if we can skip reading a page with lookaside entries, where
- * the page is already locked.
+ *	Check if we can skip reading a page with lookaside entries, where the
+ *	page is already locked.
  */
 bool
 __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 {
 	WT_TXN *txn;
-	wt_timestamp_t unstable_timestamp;
 
 	txn = &session->txn;
 
@@ -454,15 +453,19 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 
 	/*
 	 * If some of the page's history overlaps with the reader's snapshot
-	 * then we have to read it.  This is only relevant if we chose versions
-	 * that were unstable when the page was written.
+	 * then we have to read it.
 	 */
-	if (ref->page_las->skew_newest &&
-	    WT_TXNID_LE(txn->snap_min, ref->page_las->unstable_txn))
+	if (WT_TXNID_LE(txn->snap_min, ref->page_las->max_txn))
 		return (false);
 
+	/*
+	 * Otherwise, if not reading at a timestamp, the page's history is in
+	 * the past, so the page image is correct if it contains the most
+	 * recent versions of everything and nothing was prepared.
+	 */
 	if (!F_ISSET(txn, WT_TXN_HAS_TS_READ))
-		return (ref->page_las->skew_newest);
+		return (!ref->page_las->has_prepares &&
+		    ref->page_las->max_ts == ref->page_las->max_onpage_ts);
 
 	/*
 	 * Skip lookaside history if reading as of a timestamp, we evicted new
@@ -470,22 +473,19 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 	 * possible for prepared updates, because the commit timestamp was not
 	 * known when the page was evicted.
 	 *
-	 * Skip lookaside pages if reading as of a timestamp, we evicted old
-	 * versions of data and all the unstable updates are in the future.
-	 *
-	 * Checkpoint should respect durable timestamps, other reads should
-	 * respect ordinary visibility.  Checking for just the unstable updates
-	 * during checkpoint would end up reading more content from lookaside
-	 * than necessary.
+	 * Otherwise, skip reading lookaside history if everything on the page
+	 * is older than the read timestamp, and the oldest update in lookaside
+	 * newer than the page is in the future of the reader.  This seems
+	 * unlikely, but is exactly what eviction tries to do when a checkpoint
+	 * is running.
 	 */
-	unstable_timestamp = WT_SESSION_IS_CHECKPOINT(session) ?
-	    ref->page_las->unstable_durable_timestamp :
-	    ref->page_las->unstable_timestamp;
-	if (ref->page_las->skew_newest && !ref->page_las->has_prepares &&
-	    txn->read_timestamp > unstable_timestamp)
+	if (!ref->page_las->has_prepares &&
+	    ref->page_las->max_ts == ref->page_las->max_onpage_ts &&
+	    txn->read_timestamp >= ref->page_las->max_ts)
 		return (true);
-	if (!ref->page_las->skew_newest &&
-	    txn->read_timestamp < unstable_timestamp)
+
+	if (txn->read_timestamp >= ref->page_las->max_onpage_ts &&
+	    txn->read_timestamp < ref->page_las->min_newer_ts)
 		return (true);
 
 	return (false);
@@ -596,7 +596,7 @@ __las_insert_block_verbose(
 	double pct_dirty, pct_full;
 	uint64_t ckpt_gen_current, ckpt_gen_last;
 	uint32_t btree_id;
-	char ts_string[2][WT_TS_INT_STRING_SIZE];
+	char ts_string[WT_TS_INT_STRING_SIZE];
 
 	btree_id = btree->id;
 
@@ -627,18 +627,17 @@ __las_insert_block_verbose(
 		    WT_VERB_LOOKASIDE | WT_VERB_LOOKASIDE_ACTIVITY,
 		    "Page reconciliation triggered lookaside write "
 		    "file ID %" PRIu32 ", page ID %" PRIu64 ". "
-		    "Max txn ID %" PRIu64 ", unstable timestamp %s,"
-		    " unstable durable timestamp %s, %s. "
+		    "Max txn ID %" PRIu64 ", max timestamp %s. "
+		    "page image contains %s. "
 		    "Entries now in lookaside file: %" PRId64 ", "
 		    "cache dirty: %2.3f%% , "
 		    "cache use: %2.3f%%",
 		    btree_id, multi->page_las.las_pageid,
 		    multi->page_las.max_txn,
 		    __wt_timestamp_to_string(
-		    multi->page_las.unstable_timestamp, ts_string[0]),
-		    __wt_timestamp_to_string(
-		    multi->page_las.unstable_durable_timestamp, ts_string[1]),
-		    multi->page_las.skew_newest ? "newest" : "not newest",
+		    multi->page_las.max_ts, ts_string),
+		    multi->page_las.max_ts == multi->page_las.max_onpage_ts ?
+		    "newest" : "not newest",
 		    WT_STAT_READ(conn->stats, cache_lookaside_entries),
 		    pct_dirty, pct_full);
 	}

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -724,6 +724,17 @@ __evict_review(WT_SESSION_IMPL *session,
 	ret = __wt_reconcile(session, ref, NULL, flags, lookaside_retryp);
 
 	/*
+	 * If attempting eviction during a checkpoint, we may successfully
+	 * reconcile but then find that there are updates on the page too new
+	 * to evict.  Give up evicting in that case: checkpoint will include
+	 * the reconciled page when it visits the parent.
+	 */
+	if (WT_SESSION_BTREE_SYNC(session) && !__wt_page_is_modified(page) &&
+	    !__wt_txn_visible_all(session, page->modify->rec_max_txn,
+	    page->modify->rec_max_timestamp))
+		return (__wt_set_return(session, EBUSY));
+
+	/*
 	 * If reconciliation fails but reports it might succeed if we use the
 	 * lookaside table, try again with the lookaside table, allowing the
 	 * eviction of pages we'd otherwise have to retain in cache to support

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -724,17 +724,6 @@ __evict_review(WT_SESSION_IMPL *session,
 	ret = __wt_reconcile(session, ref, NULL, flags, lookaside_retryp);
 
 	/*
-	 * If attempting eviction during a checkpoint, we may successfully
-	 * reconcile but then find that there are updates on the page too new
-	 * to evict.  Give up evicting in that case: checkpoint will include
-	 * the reconciled page when it visits the parent.
-	 */
-	if (WT_SESSION_BTREE_SYNC(session) && !__wt_page_is_modified(page) &&
-	    !__wt_txn_visible_all(session, page->modify->rec_max_txn,
-	    page->modify->rec_max_timestamp))
-		return (__wt_set_return(session, EBUSY));
-
-	/*
 	 * If reconciliation fails but reports it might succeed if we use the
 	 * lookaside table, try again with the lookaside table, allowing the
 	 * eviction of pages we'd otherwise have to retain in cache to support

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -247,16 +247,12 @@ struct __wt_ovfl_reuse {
 struct __wt_page_lookaside {
 	uint64_t las_pageid;		/* Page ID in lookaside */
 	uint64_t max_txn;		/* Maximum transaction ID */
-	uint64_t unstable_txn;		/* First transaction ID not on page */
-	wt_timestamp_t max_timestamp;	/* Maximum timestamp */
-	wt_timestamp_t unstable_timestamp;/* First timestamp not on page */
-	wt_timestamp_t unstable_durable_timestamp;
-					/* First durable timestamp not on
-					 * page */
+	wt_timestamp_t max_onpage_ts;	/* Maximum timestamp on page */
+	wt_timestamp_t max_ts;		/* Maximum timestamp seen */
+	wt_timestamp_t min_newer_ts;	/* Update newer than on-page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
 	bool resolved;			/* History has been read into cache */
-	bool skew_newest;		/* Page image has newest versions */
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -242,13 +242,28 @@ struct __wt_ovfl_reuse {
 
 /*
  * WT_PAGE_LOOKASIDE --
- *	Related information for on-disk pages with lookaside entries.
+ *	Information for on-disk pages with lookaside entries.
+ *
+ * This information is used to decide whether history evicted to lookaside is
+ * needed for a read, and when it is no longer needed at all. We track the
+ * newest update written to the disk image in `max_ondisk_ts`, and the oldest
+ * update skipped to choose the on-disk version in `min_skipped_ts`.  If no
+ * updates were skipped, then the disk image contains the newest versions of
+ * all updates and `min_skipped_ts == WT_TS_MAX`.
+ *
+ * For reads without a timestamp, we check that there are no skipped updates
+ * and that the reader's snapshot can see everything on disk.
+ *
+ * For readers with a timestamp, it is safe to ignore lookaside if either
+ * (a) there are no skipped updates and everything on disk is visible, or
+ * (b) everything on disk is visible, and the minimum skipped update is in
+ * the future of the reader.
  */
 struct __wt_page_lookaside {
 	uint64_t las_pageid;		/* Page ID in lookaside */
 	uint64_t max_txn;		/* Maximum transaction ID */
-	wt_timestamp_t max_ondisk_ts;	/* Maximum timestamp on page */
-	wt_timestamp_t min_skipped_ts;	/* Update newer than on-page */
+	wt_timestamp_t max_ondisk_ts;	/* Maximum timestamp on disk */
+	wt_timestamp_t min_skipped_ts;	/* Skipped in favor of disk version */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
 	bool resolved;			/* History has been read into cache */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -247,9 +247,8 @@ struct __wt_ovfl_reuse {
 struct __wt_page_lookaside {
 	uint64_t las_pageid;		/* Page ID in lookaside */
 	uint64_t max_txn;		/* Maximum transaction ID */
-	wt_timestamp_t max_onpage_ts;	/* Maximum timestamp on page */
-	wt_timestamp_t max_ts;		/* Maximum timestamp seen */
-	wt_timestamp_t min_newer_ts;	/* Update newer than on-page */
+	wt_timestamp_t max_ondisk_ts;	/* Maximum timestamp on page */
+	wt_timestamp_t min_skipped_ts;	/* Update newer than on-page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
 	bool resolved;			/* History has been read into cache */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1203,13 +1203,12 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 		return (false);
 	if (page_las->resolved)
 		return (false);
-	if (!page_las->skew_newest || page_las->has_prepares)
+	if (page_las->max_ts > page_las->max_onpage_ts ||
+	    page_las->has_prepares)
 		return (true);
-	if (__wt_txn_visible_all(session, page_las->max_txn,
-	    page_las->max_timestamp))
-		return (false);
 
-	return (true);
+	return (!__wt_txn_visible_all(
+	    session, page_las->max_txn, page_las->max_ts));
 }
 
 /*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1203,12 +1203,12 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 		return (false);
 	if (page_las->resolved)
 		return (false);
-	if (page_las->max_ts > page_las->max_onpage_ts ||
+	if (page_las->min_skipped_ts != WT_TS_MAX ||
 	    page_las->has_prepares)
 		return (true);
 
 	return (!__wt_txn_visible_all(
-	    session, page_las->max_txn, page_las->max_ts));
+	    session, page_las->max_txn, page_las->max_ondisk_ts));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -935,7 +935,6 @@ static inline bool __wt_row_leaf_value(WT_PAGE *page, WT_ROW *rip, WT_ITEM *valu
 static inline bool __wt_session_can_wait(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_split_descent_race( WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_am_oldest(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_visible( WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -36,17 +36,14 @@ struct __wt_reconcile {
 	 * Track the oldest running transaction and whether to skew lookaside
 	 * to the newest update.
 	 */
-	bool las_skew_newest;
 	uint64_t last_running;
+	bool las_skew_newest;
 
 	/* Track the page's min/maximum transactions. */
 	uint64_t max_txn;
-	wt_timestamp_t max_timestamp;
-
-	/* Lookaside boundary tracking. */
-	uint64_t unstable_txn;
-	wt_timestamp_t unstable_durable_timestamp;
-	wt_timestamp_t unstable_timestamp;
+	wt_timestamp_t min_newer_ts;
+	wt_timestamp_t max_ts;
+	wt_timestamp_t max_onpage_ts;
 
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -36,14 +36,14 @@ struct __wt_reconcile {
 	 * Track the oldest running transaction and whether to skew lookaside
 	 * to the newest update.
 	 */
-	uint64_t last_running;
 	bool las_skew_newest;
+	uint64_t last_running;
 
 	/* Track the page's min/maximum transactions. */
 	uint64_t max_txn;
-	wt_timestamp_t min_newer_ts;
 	wt_timestamp_t max_ts;
-	wt_timestamp_t max_onpage_ts;
+	wt_timestamp_t max_ondisk_ts;
+	wt_timestamp_t min_skipped_ts;
 
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -844,18 +844,6 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 
 	return (WT_VISIBLE_TRUE);
 }
-/*
- * __wt_txn_upd_durable --
- *	Can the current transaction make the given update durable.
- */
-static inline bool
-__wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd)
-{
-	/* If update is visible then check if it is durable. */
-	if (__wt_txn_upd_visible_type(session, upd) != WT_VISIBLE_TRUE)
-		return (false);
-	return (__wt_txn_visible(session, upd->txnid, upd->durable_ts));
-}
 
 /*
  * __wt_txn_upd_visible --

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -398,9 +398,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	if (all_stable)
 		goto check_original_value;
 
-	if (upd != first_txn_upd ||
-	    list_prepared || list_uncommitted ||
-		F_ISSET(r, WT_REC_VISIBLE_ALL) ||
+	if (upd != first_txn_upd || list_prepared || list_uncommitted ||
+	    F_ISSET(r, WT_REC_VISIBLE_ALL) ||
 	    !__wt_txn_visible(session, max_txn, max_ts))
 		r->leave_dirty = true;
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -396,7 +396,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 
 	if (upd != first_txn_upd || list_prepared || list_uncommitted ||
 	    F_ISSET(r, WT_REC_VISIBLE_ALL) ||
-	    !__wt_txn_visible(session, max_txn, max_ts))
+	    !(WT_SESSION_BTREE_SYNC(session) ?
+	    __wt_txn_visible_all(session, max_txn, max_ts) :
+	    __wt_txn_visible(session, max_txn, max_ts)))
 		r->leave_dirty = true;
 
 	if (F_ISSET(r, WT_REC_VISIBILITY_ERR))

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -394,9 +394,10 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	if (all_stable)
 		goto check_original_value;
 
-	if (upd != first_txn_upd || list_prepared || list_uncommitted ||
+	if (!r->leave_dirty &&
+	    (upd != first_txn_upd || list_prepared || list_uncommitted ||
 	    F_ISSET(r, WT_REC_VISIBLE_ALL) ||
-	    !__wt_txn_visible(session, max_txn, max_ts))
+	    !__wt_txn_visible(session, max_txn, max_ts)))
 		r->leave_dirty = true;
 
 	if (F_ISSET(r, WT_REC_VISIBILITY_ERR))

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -172,8 +172,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 		 */
 		if (first_txn_upd == NULL)
 			first_txn_upd = upd;
-
-		/* Track the largest transaction ID seen. */
 		if (WT_TXNID_LT(max_txn, txnid))
 			max_txn = txnid;
 
@@ -242,10 +240,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 			 */
 			if (F_ISSET(r, WT_REC_UPDATE_RESTORE) &&
 			    upd_select->upd != NULL &&
-			    (list_prepared || list_uncommitted)) {
-				r->leave_dirty = true;
+			    (list_prepared || list_uncommitted))
 				return (__wt_set_return(session, EBUSY));
-			}
 
 			if (upd->type == WT_UPDATE_BIRTHMARK)
 				skipped_birthmark = true;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -258,8 +258,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 			 * durable timestamp.
 			 */
 			if (upd_select->upd == NULL &&
-			    upd->start_ts < r->min_newer_ts)
-				r->min_newer_ts = upd->start_ts;
+			    upd->start_ts < r->min_skipped_ts)
+				r->min_skipped_ts = upd->start_ts;
 
 			continue;
 		}
@@ -302,8 +302,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	if (upd == first_txn_upd)
 		r->update_used = true;
 
-	if (upd != NULL && upd->durable_ts > r->max_onpage_ts)
-		r->max_onpage_ts = upd->durable_ts;
+	if (upd != NULL && upd->durable_ts > r->max_ondisk_ts)
+		r->max_ondisk_ts = upd->durable_ts;
 
 	/*
 	 * TIMESTAMP-FIXME

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -396,9 +396,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 
 	if (upd != first_txn_upd || list_prepared || list_uncommitted ||
 	    F_ISSET(r, WT_REC_VISIBLE_ALL) ||
-	    !(WT_SESSION_BTREE_SYNC(session) ?
-	    __wt_txn_visible_all(session, max_txn, max_ts) :
-	    __wt_txn_visible(session, max_txn, max_ts)))
+	    !__wt_txn_visible(session, max_txn, max_ts))
 		r->leave_dirty = true;
 
 	if (F_ISSET(r, WT_REC_VISIBILITY_ERR))

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -9,6 +9,19 @@
 #include "wt_internal.h"
 
 /*
+ * __rec_update_durable --
+ *	Return whether an update is suitable for writing to a disk image.
+ */
+static bool
+__rec_update_durable(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *upd)
+{
+	return (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
+	    __wt_txn_upd_visible_all(session, upd) :
+	    __wt_txn_upd_visible_type(session, upd) == WT_VISIBLE_TRUE &&
+	    __wt_txn_visible(session, upd->txnid, upd->durable_ts));
+}
+
+/*
  * __rec_update_save --
  *	Save a WT_UPDATE list for later restoration.
  */
@@ -116,8 +129,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
     void *ripcip, WT_CELL_UNPACK *vpack, WT_UPDATE_SELECT *upd_select)
 {
 	WT_PAGE *page;
-	WT_UPDATE *first_ts_upd, *first_txn_upd, *first_upd, *upd;
-	wt_timestamp_t timestamp, ts;
+	WT_UPDATE *first_txn_upd, *first_upd, *upd;
+	wt_timestamp_t max_ts;
 	size_t upd_memsize;
 	uint64_t max_txn, txnid;
 	bool all_stable, list_prepared, list_uncommitted, skipped_birthmark;
@@ -130,8 +143,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	upd_select->upd_saved = false;
 
 	page = r->page;
-	first_ts_upd = first_txn_upd = NULL;
+	first_txn_upd = NULL;
 	upd_memsize = 0;
+	max_ts = WT_TS_NONE;
 	max_txn = WT_TXN_NONE;
 	list_prepared = list_uncommitted = skipped_birthmark = false;
 
@@ -179,22 +193,24 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 		 * globally visible, need to check the update state as well.
 		 */
 		if (F_ISSET(r, WT_REC_EVICT)) {
-			if (upd->prepare_state == WT_PREPARE_LOCKED ||
-			    upd->prepare_state == WT_PREPARE_INPROGRESS) {
-				list_prepared = true;
-				continue;
-			}
 			if (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
 			    WT_TXNID_LE(r->last_running, txnid) :
 			    !__txn_visible_id(session, txnid)) {
 				r->update_uncommitted = list_uncommitted = true;
 				continue;
 			}
+			if (upd->prepare_state == WT_PREPARE_LOCKED ||
+			    upd->prepare_state == WT_PREPARE_INPROGRESS) {
+				list_prepared = true;
+				if (upd->start_ts > max_ts)
+					max_ts = upd->start_ts;
+				continue;
+			}
 		}
 
 		/* Track the first update with non-zero timestamp. */
-		if (first_ts_upd == NULL && upd->start_ts != WT_TS_NONE)
-			first_ts_upd = upd;
+		if (upd->durable_ts > max_ts)
+			max_ts = upd->durable_ts;
 
 		/*
 		 * Select the update to write to the disk image.
@@ -212,9 +228,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 		if (upd_select->upd == NULL && r->las_skew_newest)
 			upd_select->upd = upd;
 
-		if (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
-		    !__wt_txn_upd_visible_all(session, upd) :
-		    !__wt_txn_upd_durable(session, upd)) {
+		if (!__rec_update_durable(session, r, upd)) {
 			if (F_ISSET(r, WT_REC_EVICT))
 				++r->updates_unstable;
 
@@ -236,13 +250,24 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 			if (upd->type == WT_UPDATE_BIRTHMARK)
 				skipped_birthmark = true;
 
+			/*
+			 * Track the oldest update not on the page.
+			 *
+			 * This is used to decide whether reads can use the
+			 * page image, hence using the start rather than the
+			 * durable timestamp.
+			 */
+			if (upd_select->upd == NULL &&
+			    upd->start_ts < r->min_newer_ts)
+				r->min_newer_ts = upd->start_ts;
+
 			continue;
 		}
 
 		/*
 		 * Lookaside without stable timestamp was taken care of above
-		 * (set to the first uncommitted transaction). Lookaside with
-		 * stable timestamp always takes the first stable update.
+		 * (set to the first uncommitted transaction). All other
+		 * reconciliation takes the first stable update.
 		 */
 		if (upd_select->upd == NULL)
 			upd_select->upd = upd;
@@ -276,6 +301,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	/* If no updates were skipped, record that we're making progress. */
 	if (upd == first_txn_upd)
 		r->update_used = true;
+
+	if (upd != NULL && upd->durable_ts > r->max_onpage_ts)
+		r->max_onpage_ts = upd->durable_ts;
 
 	/*
 	 * TIMESTAMP-FIXME
@@ -333,8 +361,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 		r->max_txn = max_txn;
 
 	/* Update the maximum timestamp. */
-	if (first_ts_upd != NULL && r->max_timestamp < first_ts_upd->durable_ts)
-		r->max_timestamp = first_ts_upd->durable_ts;
+	if (max_ts > r->max_ts)
+		r->max_ts = max_ts;
 
 	/*
 	 * If the update we chose was a birthmark, or we are doing
@@ -363,17 +391,17 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	 * order), so we track the maximum transaction ID and the newest update
 	 * with a timestamp (if any).
 	 */
-	timestamp = first_ts_upd == NULL ?
-	    WT_TS_NONE : first_ts_upd->durable_ts;
 	all_stable = upd == first_txn_upd &&
 	    !list_prepared && !list_uncommitted &&
-	    __wt_txn_visible_all(session, max_txn, timestamp);
+	    __wt_txn_visible_all(session, max_txn, max_ts);
 
 	if (all_stable)
 		goto check_original_value;
 
-	if (F_ISSET(r, WT_REC_VISIBLE_ALL) ||
-	    !__wt_txn_visible(session, max_txn, timestamp))
+	if (upd != first_txn_upd ||
+	    list_prepared || list_uncommitted ||
+		F_ISSET(r, WT_REC_VISIBLE_ALL) ||
+	    !__wt_txn_visible(session, max_txn, max_ts))
 		r->leave_dirty = true;
 
 	if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
@@ -416,65 +444,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
 	WT_RET(__rec_update_save(
 	    session, r, ins, ripcip, upd_select->upd, upd_memsize));
 	upd_select->upd_saved = true;
-
-	/*
-	 * Track the first off-page update when saving history in the lookaside
-	 * table.  When skewing newest, we want the first (non-aborted) update
-	 * after the one stored on the page.  Otherwise, we want the update
-	 * before the on-page update.
-	 */
-	if (F_ISSET(r, WT_REC_LOOKASIDE) && r->las_skew_newest) {
-		if (WT_TXNID_LT(r->unstable_txn, first_upd->txnid))
-			r->unstable_txn = first_upd->txnid;
-		if (first_ts_upd != NULL) {
-			WT_ASSERT(session,
-			    first_ts_upd->prepare_state ==
-			    WT_PREPARE_INPROGRESS ||
-			    first_ts_upd->start_ts <= first_ts_upd->durable_ts);
-
-			if (r->unstable_timestamp < first_ts_upd->start_ts)
-				r->unstable_timestamp = first_ts_upd->start_ts;
-
-			if (r->unstable_durable_timestamp <
-			    first_ts_upd->durable_ts)
-				r->unstable_durable_timestamp =
-				    first_ts_upd->durable_ts;
-		}
-	} else if (F_ISSET(r, WT_REC_LOOKASIDE)) {
-		for (upd = first_upd; upd != NULL; upd = upd->next) {
-			if (upd->txnid == WT_TXN_ABORTED)
-				continue;
-
-			if (upd->txnid != WT_TXN_NONE &&
-			    WT_TXNID_LT(upd->txnid, r->unstable_txn))
-				r->unstable_txn = upd->txnid;
-
-			/*
-			 * The durable timestamp is always set by commit, and
-			 * usually the same as the start timestamp, which makes
-			 * it OK to use the two independently and be confident
-			 * both will be set.
-			 */
-			WT_ASSERT(session,
-			    upd->prepare_state == WT_PREPARE_INPROGRESS ||
-			    upd->durable_ts >= upd->start_ts);
-
-			if (r->unstable_timestamp > upd->start_ts)
-				r->unstable_timestamp = upd->start_ts;
-
-			/*
-			 * An in-progress prepared update will always have a
-			 * zero durable timestamp.  Checkpoints can only skip
-			 * reading lookaside history if all updates are in the
-			 * future, including the prepare, so including the
-			 * prepare timestamp instead.
-			 */
-			ts = upd->prepare_state == WT_PREPARE_INPROGRESS ?
-			    upd->start_ts : upd->durable_ts;
-			if (r->unstable_durable_timestamp > ts)
-				r->unstable_durable_timestamp = ts;
-		}
-	}
 
 check_original_value:
 	/*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2093,9 +2093,13 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 			 * entries were used, there's no disk image to write.
 			 * There's no more work to do in this case, lookaside
 			 * eviction doesn't copy disk images.
+			 *
+			 * Note we can't mark such a page clean because there
+			 * would be no page to reference a lookaside record.
 			 */
 			if (chunk->entries == 0)
-				return (0);
+				return (r->leave_dirty ?
+				    0 : __wt_set_return(session, EBUSY));
 		} else {
 			r->cache_write_restore = true;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2093,13 +2093,9 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 			 * entries were used, there's no disk image to write.
 			 * There's no more work to do in this case, lookaside
 			 * eviction doesn't copy disk images.
-			 *
-			 * Note we can't mark such a page clean because there
-			 * would be no page to reference a lookaside record.
 			 */
 			if (chunk->entries == 0)
-				return (r->leave_dirty ?
-				    0 : __wt_set_return(session, EBUSY));
+				return (0);
 		} else {
 			r->cache_write_restore = true;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -438,7 +438,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		 * we can evict a clean page and discard its history).
 		 */
 		mod->rec_max_txn = r->max_txn;
-		mod->rec_max_timestamp = r->max_timestamp;
+		mod->rec_max_timestamp = r->max_ts;
 
 		/*
 		 * Track the tree's maximum transaction ID (used to decide if
@@ -451,8 +451,8 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		if (!F_ISSET(r, WT_REC_EVICT)) {
 			if (WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
 				btree->rec_max_txn = r->max_txn;
-			if (btree->rec_max_timestamp < r->max_timestamp)
-				btree->rec_max_timestamp = r->max_timestamp;
+			if (btree->rec_max_timestamp < r->max_ts)
+				btree->rec_max_timestamp = r->max_ts;
 		}
 
 		/*
@@ -680,23 +680,8 @@ __rec_init(WT_SESSION_IMPL *session,
 
 	/* Track the page's min/maximum transaction */
 	r->max_txn = WT_TXN_NONE;
-	r->max_timestamp = 0;
-
-	/*
-	 * Track the first unstable transaction (when skewing newest this is
-	 * the newest update, otherwise the newest update not on the page).
-	 * This is the boundary between the on-page information and the history
-	 * stored in the lookaside table.
-	 */
-	if (r->las_skew_newest) {
-		r->unstable_txn = WT_TXN_NONE;
-		r->unstable_timestamp = WT_TS_NONE;
-		r->unstable_durable_timestamp = WT_TS_NONE;
-	} else {
-		r->unstable_txn = WT_TXN_ABORTED;
-		r->unstable_timestamp = WT_TS_MAX;
-		r->unstable_durable_timestamp = WT_TS_MAX;
-	}
+	r->max_onpage_ts = r->max_ts = WT_TS_NONE;
+	r->min_newer_ts = WT_TS_MAX;
 
 	/* Track if updates were used and/or uncommitted. */
 	r->updates_seen = r->updates_unstable = 0;
@@ -1746,18 +1731,10 @@ __rec_split_write_supd(WT_SESSION_IMPL *session,
 
 done:	if (F_ISSET(r, WT_REC_LOOKASIDE)) {
 		/* Track the oldest lookaside timestamp seen so far. */
-		multi->page_las.skew_newest = r->las_skew_newest;
 		multi->page_las.max_txn = r->max_txn;
-		multi->page_las.unstable_txn = r->unstable_txn;
-		WT_ASSERT(session, r->unstable_txn != WT_TXN_NONE);
-		multi->page_las.max_timestamp = r->max_timestamp;
-
-		WT_ASSERT(session, r->all_upd_prepare_in_prog == true ||
-		    r->unstable_durable_timestamp >= r->unstable_timestamp);
-
-		multi->page_las.unstable_timestamp = r->unstable_timestamp;
-		multi->page_las.unstable_durable_timestamp =
-		    r->unstable_durable_timestamp;
+		multi->page_las.max_onpage_ts = r->max_onpage_ts;
+		multi->page_las.max_ts = r->max_ts;
+		multi->page_las.min_newer_ts = r->min_newer_ts;
 	}
 
 err:	__wt_scr_free(session, &key);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -680,8 +680,8 @@ __rec_init(WT_SESSION_IMPL *session,
 
 	/* Track the page's min/maximum transaction */
 	r->max_txn = WT_TXN_NONE;
-	r->max_onpage_ts = r->max_ts = WT_TS_NONE;
-	r->min_newer_ts = WT_TS_MAX;
+	r->max_ondisk_ts = r->max_ts = WT_TS_NONE;
+	r->min_skipped_ts = WT_TS_MAX;
 
 	/* Track if updates were used and/or uncommitted. */
 	r->updates_seen = r->updates_unstable = 0;
@@ -1732,9 +1732,8 @@ __rec_split_write_supd(WT_SESSION_IMPL *session,
 done:	if (F_ISSET(r, WT_REC_LOOKASIDE)) {
 		/* Track the oldest lookaside timestamp seen so far. */
 		multi->page_las.max_txn = r->max_txn;
-		multi->page_las.max_onpage_ts = r->max_onpage_ts;
-		multi->page_las.max_ts = r->max_ts;
-		multi->page_las.min_newer_ts = r->min_newer_ts;
+		multi->page_las.max_ondisk_ts = r->max_ondisk_ts;
+		multi->page_las.min_skipped_ts = r->min_skipped_ts;
 	}
 
 err:	__wt_scr_free(session, &key);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -273,10 +273,9 @@ __txn_abort_newer_updates(
 			    ref->page != NULL &&
 			    __wt_page_is_modified(ref->page));
 			local_read = true;
-		}
-		if (page_las->max_ondisk_ts > rollback_timestamp)
 			page_las->max_ondisk_ts = rollback_timestamp;
-		if (page_las->min_skipped_ts > rollback_timestamp)
+		}
+		if (rollback_timestamp < page_las->min_skipped_ts)
 			page_las->min_skipped_ts = rollback_timestamp;
 	}
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -249,9 +249,7 @@ __txn_abort_newer_updates(
 	 *
 	 * So, if there is lookaside history for a page, first check if the
 	 * history needs to be rolled back make sure that history is loaded
-	 * into cache.  That is, if skew_newest is true, so the disk image
-	 * potentially contained unstable updates, and the history is more
-	 * recent than the rollback timestamp.
+	 * into cache.
 	 *
 	 * Also, we have separately discarded any lookaside history more recent
 	 * than the rollback timestamp.  For page_las structures in cache,
@@ -263,8 +261,7 @@ __txn_abort_newer_updates(
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
 	if ((page_las = ref->page_las) != NULL) {
-		if (page_las->max_ts == page_las->max_onpage_ts &&
-		    rollback_timestamp < page_las->max_ts) {
+		if (rollback_timestamp < page_las->max_ondisk_ts) {
 			/*
 			 * Make sure we get back a page with history, not a
 			 * limbo page.
@@ -277,10 +274,10 @@ __txn_abort_newer_updates(
 			    __wt_page_is_modified(ref->page));
 			local_read = true;
 		}
-		if (page_las->max_onpage_ts > rollback_timestamp)
-			page_las->max_onpage_ts = rollback_timestamp;
-		if (page_las->max_ts > rollback_timestamp)
-			page_las->max_ts = rollback_timestamp;
+		if (page_las->max_ondisk_ts > rollback_timestamp)
+			page_las->max_ondisk_ts = rollback_timestamp;
+		if (page_las->min_skipped_ts > rollback_timestamp)
+			page_las->min_skipped_ts = rollback_timestamp;
 	}
 
 	/* Review deleted page saved to the ref */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -236,6 +236,7 @@ __txn_abort_newer_updates(
 {
 	WT_DECL_RET;
 	WT_PAGE *page;
+	WT_PAGE_LOOKASIDE *page_las;
 	uint32_t read_flags;
 	bool local_read;
 
@@ -261,9 +262,9 @@ __txn_abort_newer_updates(
 	 */
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
-	if (ref->page_las != NULL) {
-		if (ref->page_las->skew_newest && rollback_timestamp <
-		    ref->page_las->unstable_durable_timestamp) {
+	if ((page_las = ref->page_las) != NULL) {
+		if (page_las->max_ts == page_las->max_onpage_ts &&
+		    rollback_timestamp < page_las->max_ts) {
 			/*
 			 * Make sure we get back a page with history, not a
 			 * limbo page.
@@ -276,14 +277,10 @@ __txn_abort_newer_updates(
 			    __wt_page_is_modified(ref->page));
 			local_read = true;
 		}
-		if (ref->page_las->max_timestamp > rollback_timestamp)
-			ref->page_las->max_timestamp = rollback_timestamp;
-		if (ref->page_las->unstable_durable_timestamp >
-		    rollback_timestamp)
-			ref->page_las->unstable_durable_timestamp =
-			    rollback_timestamp;
-		if (ref->page_las->unstable_timestamp > rollback_timestamp)
-			ref->page_las->unstable_timestamp = rollback_timestamp;
+		if (page_las->max_onpage_ts > rollback_timestamp)
+			page_las->max_onpage_ts = rollback_timestamp;
+		if (page_las->max_ts > rollback_timestamp)
+			page_las->max_ts = rollback_timestamp;
 	}
 
 	/* Review deleted page saved to the ref */

--- a/test/suite/test_las01.py
+++ b/test/suite/test_las01.py
@@ -83,10 +83,11 @@ class test_las01(wttest.WiredTigerTestCase):
         # Skip the initial rows, which were not updated
         for i in range(0, nrows+1):
             self.assertEqual(cursor.next(), 0)
-        if (check_value != cursor.get_value()):
-            print("Check value : " + str(check_value))
-            print("value : " + str(cursor.get_value()))
-        self.assertTrue(check_value == cursor.get_value())
+        if check_value != cursor.get_value():
+            session.breakpoint()
+        self.assertTrue(check_value == cursor.get_value(),
+            "for key " + str(i) + ", expected " + str(check_value) +
+            ", got " + str(cursor.get_value()))
         cursor.close()
         session.close()
         conn.close()

--- a/test/suite/test_timestamp04.py
+++ b/test/suite/test_timestamp04.py
@@ -78,7 +78,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         # Search for the expected items as well as iterating.
         for k, v in expected.items():
             if missing == False:
-                self.assertEqual(cur[k], v, "for key " + str(k))
+                self.assertEqual(cur[k], v, "for key " + str(k) +
+                    " expected " + str(v) + ", got " + str(cur[k]))
             else:
                 cur.set_key(k)
                 if self.empty:


### PR DESCRIPTION
When cache overflow has been active, checkpoints may need to pull pages into cache in order to rewrite the correct versions.  These pages must be evicted as soon as possible to avoid checkpoint filling the cache with pages that other threads cannot evict (until checkpoint has moved on to another tree).

This leads to the unusual case of attempting eviction of pages while writing disk images that are correct as of the checkpoint's transaction.  In other words, `__wt_txn_visible` is used to select the versions of updates written to the disk image.  However, it is not okay in this case to discard history because everything happens to be visible to a checkpoint: snapshot readers may need an earlier version (back to the oldest timestamp).