### PR TITLE
WT-4956 Handle the case where 4 billion updates are made to a page without eviction

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1325,6 +1325,7 @@ unmodify
 unordered
 unpackv
 unpadded
+unreconciled
 unreferenced
 unregister
 unsized

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -889,7 +889,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 	if (split_gen != 0)
 		WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));
 	if (mod != NULL)
-		WT_RET(ds->f(ds, ", mod-state=%" PRIu32, mod->mod_state));
+		WT_RET(ds->f(ds, ", page-state=%" PRIu32, mod->page_state));
 	WT_RET(ds->f(ds,
 	    ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
 	WT_RET(ds->f(ds, "\n"));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -889,7 +889,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 	if (split_gen != 0)
 		WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));
 	if (mod != NULL)
-		WT_RET(ds->f(ds, ", write-gen=%" PRIu32, mod->write_gen));
+		WT_RET(ds->f(ds, ", mod-state=%" PRIu32, mod->mod_state));
 	WT_RET(ds->f(ds,
 	    ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
 	WT_RET(ds->f(ds, "\n"));

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -498,10 +498,9 @@ struct __wt_page_modify {
 	 * WT_PAGE_DIRTY --
 	 *	The page has 2 or more unreconciled updates.
 	 *
-	 * When we reconcile, we artificially set the state to
-	 * single and check afterwards that it hasn't changed
-	 * to determine whether reconciliation
-	 * was able to render the page clean.
+	 * When we reconcile, we artificially set the state to single and check
+	 * afterwards that it hasn't changed to determine whether reconciliation was
+	 * able to render the page clean.
 	 */
 #define	WT_PAGE_CLEAN		0
 #define	WT_PAGE_DIRTY_FIRST	1

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -500,7 +500,7 @@ struct __wt_page_modify {
 	 * to determine whether reconciliation was able to render the page
 	 * clean.
 	 *
-	 * Using write generation is a simple counter of the number of updates
+	 * Using write generation as a simple counter of the number of updates
 	 * is not acceptable as some workloads will get close to hitting
 	 * UINT32_MAX.
 	 */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -505,7 +505,7 @@ struct __wt_page_modify {
 #define	WT_PAGE_CLEAN		0
 #define	WT_PAGE_DIRTY_FIRST	1
 #define	WT_PAGE_DIRTY		2
-	uint8_t page_state;
+	uint32_t page_state;
 
 #define	WT_PM_REC_EMPTY		1	/* Reconciliation: no replacement */
 #define	WT_PM_REC_MULTIBLOCK	2	/* Reconciliation: multiple blocks */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -489,22 +489,28 @@ struct __wt_page_modify {
 	WT_SPINLOCK page_lock;		/* Page's spinlock */
 
 	/*
-	 * The write generation is incremented when a page is modified.
+	 * The mod state is incremented when a page is modified.
 	 *
-	 * 0: The page is clean.
-	 * 1: The page has 1 unreconciled update.
-	 * 2: The page has 2 or more unreconciled updates.
+	 * WT_MOD_STATE_CLEAN --
+	 *	The page is clean.
+	 * WT_MOD_STATE_SINGLE --
+	 *	The page has 1 unreconciled update.
+	 * WT_MOD_STATE_MANY --
+	 *	The page has 2 or more unreconciled updates.
 	 *
-	 * When we reconcile, we artificially set the write generation to 1 and
-	 * check afterwards that the write generation hasn't changed (incr to 2)
-	 * to determine whether reconciliation was able to render the page
-	 * clean.
+	 * When we reconcile, we artificially set the mod state to
+	 * WT_MOD_STATE_SINGLE and check afterwards that it hasn't changed
+	 * (increased to WT_MOD_STATE_MANY) to determine whether reconciliation
+	 * was able to render the page clean.
 	 *
-	 * Using write generation as a simple counter of the number of updates
-	 * is not acceptable as some workloads will get close to hitting
-	 * UINT32_MAX.
+	 * Using mod state as a simple counter of the number of updates is not
+	 * acceptable as some workloads will get close to hitting the max size
+	 * of whatever unsigned type we use.
 	 */
-	uint32_t write_gen;
+#define	WT_MOD_STATE_CLEAN	0
+#define	WT_MOD_STATE_SINGLE	1
+#define	WT_MOD_STATE_MANY	2
+	uint8_t mod_state;
 
 #define	WT_PM_REC_EMPTY		1	/* Reconciliation: no replacement */
 #define	WT_PM_REC_MULTIBLOCK	2	/* Reconciliation: multiple blocks */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -495,12 +495,14 @@ struct __wt_page_modify {
 	 * 1: The page has 1 unreconciled update.
 	 * 2: The page has 2 or more unreconciled updates.
 	 *
-	 * When we reconcile, we artifically set the write generation to 1 and
+	 * When we reconcile, we artificially set the write generation to 1 and
 	 * check afterwards that the write generation hasn't changed (incr to 2)
-	 * to determine whether reconciliation was able to render the page clean.
+	 * to determine whether reconciliation was able to render the page
+	 * clean.
 	 *
-	 * Using write generation is a simple counter of the number of updates is
-	 * not acceptable as some workloads will get close to hitting UINT32_MAX.
+	 * Using write generation is a simple counter of the number of updates
+	 * is not acceptable as some workloads will get close to hitting
+	 * UINT32_MAX.
 	 */
 	uint32_t write_gen;
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -491,26 +491,22 @@ struct __wt_page_modify {
 	/*
 	 * The mod state is incremented when a page is modified.
 	 *
-	 * WT_MOD_STATE_CLEAN --
+	 * WT_PAGE_CLEAN --
 	 *	The page is clean.
-	 * WT_MOD_STATE_SINGLE --
+	 * WT_PAGE_DIRTY_FIRST --
 	 *	The page has 1 unreconciled update.
-	 * WT_MOD_STATE_MANY --
+	 * WT_PAGE_DIRTY --
 	 *	The page has 2 or more unreconciled updates.
 	 *
-	 * When we reconcile, we artificially set the mod state to
-	 * WT_MOD_STATE_SINGLE and check afterwards that it hasn't changed
-	 * (increased to WT_MOD_STATE_MANY) to determine whether reconciliation
+	 * When we reconcile, we artificially set the state to
+	 * single and check afterwards that it hasn't changed
+	 * to determine whether reconciliation
 	 * was able to render the page clean.
-	 *
-	 * Using mod state as a simple counter of the number of updates is not
-	 * acceptable as some workloads will get close to hitting the max size
-	 * of whatever unsigned type we use.
 	 */
-#define	WT_MOD_STATE_CLEAN	0
-#define	WT_MOD_STATE_SINGLE	1
-#define	WT_MOD_STATE_MANY	2
-	uint8_t mod_state;
+#define	WT_PAGE_CLEAN		0
+#define	WT_PAGE_DIRTY_FIRST	1
+#define	WT_PAGE_DIRTY		2
+	uint8_t page_state;
 
 #define	WT_PM_REC_EMPTY		1	/* Reconciliation: no replacement */
 #define	WT_PM_REC_MULTIBLOCK	2	/* Reconciliation: multiple blocks */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -499,8 +499,8 @@ struct __wt_page_modify {
 	 *	The page has 2 or more unreconciled updates.
 	 *
 	 * When we reconcile, we artificially set the state to single and check
-	 * afterwards that it hasn't changed to determine whether reconciliation was
-	 * able to render the page clean.
+	 * afterwards that it hasn't changed to determine whether reconciliation
+	 * was able to render the page clean.
 	 */
 #define	WT_PAGE_CLEAN		0
 #define	WT_PAGE_DIRTY_FIRST	1

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -489,7 +489,7 @@ struct __wt_page_modify {
 	WT_SPINLOCK page_lock;		/* Page's spinlock */
 
 	/*
-	 * The mod state is incremented when a page is modified.
+	 * The page state is incremented when a page is modified.
 	 *
 	 * WT_PAGE_CLEAN --
 	 *	The page is clean.

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -489,8 +489,18 @@ struct __wt_page_modify {
 	WT_SPINLOCK page_lock;		/* Page's spinlock */
 
 	/*
-	 * The write generation is incremented when a page is modified, a page
-	 * is clean if the write generation is 0.
+	 * The write generation is incremented when a page is modified.
+	 *
+	 * 0: The page is clean.
+	 * 1: The page has 1 unreconciled update.
+	 * 2: The page has 2 or more unreconciled updates.
+	 *
+	 * When we reconcile, we artifically set the write generation to 1 and
+	 * check afterwards that the write generation hasn't changed (incr to 2)
+	 * to determine whether reconciliation was able to render the page clean.
+	 *
+	 * Using write generation is a simple counter of the number of updates is
+	 * not acceptable as some workloads will get close to hitting UINT32_MAX.
 	 */
 	uint32_t write_gen;
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -494,13 +494,11 @@ struct __wt_page_modify {
 	 * WT_PAGE_CLEAN --
 	 *	The page is clean.
 	 * WT_PAGE_DIRTY_FIRST --
-	 *	The page has 1 unreconciled update.
+	 *	The page is in this state after the first operation that marks a
+	 *	page dirty, or when reconciliation is checking to see if it has
+	 *	done enough work to be able to mark the page clean.
 	 * WT_PAGE_DIRTY --
-	 *	The page has 2 or more unreconciled updates.
-	 *
-	 * When we reconcile, we artificially set the state to single and check
-	 * afterwards that it hasn't changed to determine whether reconciliation
-	 * was able to render the page clean.
+	 *	Two or more updates have been added to the page.
 	 */
 #define	WT_PAGE_CLEAN		0
 #define	WT_PAGE_DIRTY_FIRST	1

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -588,13 +588,14 @@ __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 */
 	if (__wt_page_is_modified(page)) {
 		/*
-		 * The only parts where ordering matters is during
-		 * reconciliation when updates on other threads are updating the
-		 * page state.
+		 * The only part where ordering matters is during
+		 * reconciliation where updates on other threads are performing
+		 * writes to the page state that need to be visible to the
+		 * reconciliation thread.
 		 *
-		 * Since clearing is not going to be happening during
-		 * reconciliation on a separate thread, there's no write barrier
-		 * needed here.
+		 * Since clearing of the page state is not going to be happening
+		 * during reconciliation on a separate thread, there's no write
+		 * barrier needed here.
 		 */
 		page->modify->page_state = WT_PAGE_CLEAN;
 		__wt_cache_dirty_decr(session, page);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -511,7 +511,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * and transactional information.
 	 */
 	if (page->modify->page_state < WT_PAGE_DIRTY &&
-	    __wt_atomic_add32(&page->modify->page_state, 1) == WT_PAGE_DIRTY) {
+	    __wt_atomic_add32(&page->modify->page_state, 1) ==
+	    WT_PAGE_DIRTY_FIRST) {
 		__wt_cache_dirty_incr(session, page);
 
 		/*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -587,6 +587,15 @@ __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page)
 	 * Allow the call to be made on clean pages.
 	 */
 	if (__wt_page_is_modified(page)) {
+		/*
+		 * The only parts where ordering matters is during
+		 * reconciliation when updates on other threads are updating the
+		 * page state.
+		 *
+		 * Since clearing is not going to be happening during
+		 * reconciliation on a separate thread, there's no write barrier
+		 * needed here.
+		 */
 		page->modify->page_state = WT_PAGE_CLEAN;
 		__wt_cache_dirty_decr(session, page);
 	}

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -505,7 +505,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 	/*
 	 * We depend on atomic-cas being a write barrier, that is, a barrier to
 	 * ensure all changes to the page are flushed before updating the page
-	 * mod state and/or marking the tree dirty, otherwise checkpoints
+	 * page state and/or marking the tree dirty, otherwise checkpoints
 	 * and/or page reconciliation might be looking at a clean page/tree.
 	 *
 	 * Every time the page transitions from clean to dirty, update the cache

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -502,13 +502,17 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 		last_running = S2C(session)->txn_global.last_running;
 
 	/*
-	 * We depend on atomic-cas being a write barrier, that is, a barrier to
-	 * ensure all changes to the page are flushed before updating the page
-	 * page state and/or marking the tree dirty, otherwise checkpoints
+	 * We depend on the atomic operation being a write barrier, that is, a
+	 * barrier to ensure all changes to the page are flushed before updating
+	 * the page state and/or marking the tree dirty, otherwise checkpoints
 	 * and/or page reconciliation might be looking at a clean page/tree.
 	 *
 	 * Every time the page transitions from clean to dirty, update the cache
 	 * and transactional information.
+	 *
+	 * The page state can only ever be incremented above dirty by the number
+	 * of concurrently running threads, so the counter will never approach
+	 * the point where it would wrap.
 	 */
 	if (page->modify->page_state < WT_PAGE_DIRTY &&
 	    __wt_atomic_add32(&page->modify->page_state, 1) ==

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -20,12 +20,6 @@ struct __wt_reconcile {
 	uint32_t flags;			/* Caller's configuration */
 
 	/*
-	 * Track start/stop write generation to decide if all changes to the
-	 * page are written.
-	 */
-	uint32_t orig_write_gen;
-
-	/*
 	 * Track start/stop checkpoint generations to decide if lookaside table
 	 * records are correct.
 	 */

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -140,7 +140,7 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
+	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
 
 	/*
 	 * Acquire the page's spinlock unless we already have exclusive access.
@@ -191,7 +191,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
+	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
 
 	simple = true;
 	for (i = 0; i < skipdepth; i++)
@@ -247,7 +247,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	upd = *updp;
 	*updp = NULL;
 
-	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
+	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
 
 	/*
 	 * All structure setup must be flushed before the structure is entered

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -140,8 +140,6 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
-
 	/*
 	 * Acquire the page's spinlock unless we already have exclusive access.
 	 * Then call the worker function.
@@ -190,8 +188,6 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	/* Clear references to memory we now own and must free on error. */
 	new_ins = *new_insp;
 	*new_insp = NULL;
-
-	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
 
 	simple = true;
 	for (i = 0; i < skipdepth; i++)
@@ -246,8 +242,6 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	/* Clear references to memory we now own and must free on error. */
 	upd = *updp;
 	*updp = NULL;
-
-	WT_ASSERT(session, page->modify->page_state <= WT_PAGE_DIRTY);
 
 	/*
 	 * All structure setup must be flushed before the structure is entered

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -140,7 +140,7 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	WT_ASSERT(session, page->modify->write_gen <= 2);
+	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
 
 	/*
 	 * Acquire the page's spinlock unless we already have exclusive access.
@@ -191,7 +191,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	WT_ASSERT(session, page->modify->write_gen <= 2);
+	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
 
 	simple = true;
 	for (i = 0; i < skipdepth; i++)
@@ -247,7 +247,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	upd = *updp;
 	*updp = NULL;
 
-	WT_ASSERT(session, page->modify->write_gen <= 2);
+	WT_ASSERT(session, page->modify->mod_state <= WT_MOD_STATE_MANY);
 
 	/*
 	 * All structure setup must be flushed before the structure is entered

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -7,29 +7,6 @@
  */
 
 /*
- * __page_write_gen_wrapped_check --
- *	Confirm the page's write generation number won't wrap.
- */
-static inline int
-__page_write_gen_wrapped_check(WT_PAGE *page)
-{
-	/*
-	 * Check to see if the page's write generation is about to wrap (wildly
-	 * unlikely as it implies 4B updates between clean page reconciliations,
-	 * but technically possible), and fail the update.
-	 *
-	 * The check is outside of the serialization mutex because the page's
-	 * write generation is going to be a hot cache line, so technically it's
-	 * possible for the page's write generation to wrap between the test and
-	 * our subsequent modification of it.  However, the test is (4B-1M), and
-	 * there cannot be a million threads that have done the test but not yet
-	 * completed their modification.
-	 */
-	return (page->modify->write_gen >
-	    UINT32_MAX - WT_MILLION ? WT_RESTART : 0);
-}
-
-/*
  * __insert_simple_func --
  *	Worker function to add a WT_INSERT entry to the middle of a skiplist.
  */
@@ -163,8 +140,7 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
+	WT_ASSERT(session, page->modify->write_gen <= 2);
 
 	/*
 	 * Acquire the page's spinlock unless we already have exclusive access.
@@ -215,8 +191,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	new_ins = *new_insp;
 	*new_insp = NULL;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
+	WT_ASSERT(session, page->modify->write_gen <= 2);
 
 	simple = true;
 	for (i = 0; i < skipdepth; i++)
@@ -272,8 +247,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	upd = *updp;
 	*updp = NULL;
 
-	/* Check for page write generation wrap. */
-	WT_RET(__page_write_gen_wrapped_check(page));
+	WT_ASSERT(session, page->modify->write_gen <= 2);
 
 	/*
 	 * All structure setup must be flushed before the structure is entered

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -621,6 +621,7 @@ __rec_init(WT_SESSION_IMPL *session,
 	 * concurrent update, it'll remain marked as dirty.
 	 */
 	page->modify->mod_state = WT_MOD_STATE_SINGLE;
+	WT_WRITE_BARRIER();
 
 	/*
 	 * Cache the oldest running transaction ID.  This is used to check

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -456,7 +456,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		}
 
 		/*
-		 * We set the mod state to MOD_STATE_CLEAN prior to
+		 * We set the mod state to WT_MOD_STATE_SINGLE prior to
 		 * reconciliation. A failed atomic cas indicates that an update
 		 * has taken place during reconciliation.
 		 *

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -623,7 +623,7 @@ __rec_init(WT_SESSION_IMPL *session,
 	 * update will see this state change.
 	 */
 	page->modify->page_state = WT_PAGE_DIRTY_FIRST;
-	WT_WRITE_BARRIER();
+	WT_FULL_BARRIER();
 
 	/*
 	 * Cache the oldest running transaction ID.  This is used to check

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -461,10 +461,10 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		 * indicates that an update has taken place during
 		 * reconciliation.
 		 *
-		 * The page only might be clean; if the mod state is unchanged
+		 * The page only might be clean; if the page state is unchanged
 		 * since reconciliation started, it's clean.
 		 *
-		 * If the mod state changed, the page has been written since
+		 * If the page state changed, the page has been written since
 		 * reconciliation started and remains dirty (that can't happen
 		 * when evicting, the page is exclusively locked).
 		 */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -468,7 +468,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 		 * reconciliation started and remains dirty (that can't happen
 		 * when evicting, the page is exclusively locked).
 		 */
-		if (__wt_atomic_cas8(
+		if (__wt_atomic_cas32(
 		    &mod->page_state, WT_PAGE_DIRTY_FIRST, WT_PAGE_CLEAN))
 			__wt_cache_dirty_decr(session, page);
 		else


### PR DESCRIPTION
This PR is to handle the issue where we consistently have at least one update that doesn't get written to the data file by a checkpoint causing the `write_gen` to never get reset to 0. This type of workload causes the `write_gen` to continually increase until we hit the check in `__page_write_gen_wrapped_check` and begin stalling.

This new scheme involves capping the `write_gen` to 2 since we only need this value to determine whether the page is clean or dirty (or has been dirtied during reconciliation).