### PR TITLE
WT-4961 part 2: rewrite of reconciliation visibility checks.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -287,14 +287,13 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
 		FLD_SET(page->modify->restore_state, WT_PAGE_RS_LOOKASIDE);
 
-		if (page_las->max_timestamp <= page_las->rec_timestamp &&
+		if (page_las->max_ts == page_las->max_onpage_ts &&
 		    !page_las->has_prepares &&
 		    !S2C(session)->txn_global.has_stable_timestamp &&
 		    __wt_txn_visible_all(session, page_las->max_txn,
-		    page_las->max_timestamp)) {
+		    page_las->max_ts)) {
 			page->modify->rec_max_txn = page_las->max_txn;
-			page->modify->rec_max_timestamp =
-			    page_las->max_timestamp;
+			page->modify->rec_max_timestamp = page_las->max_ts;
 			__wt_page_modify_clear(session, page);
 		}
 	}
@@ -580,7 +579,7 @@ skip_read:
 	 * Don't free WT_REF.page_las, there may be concurrent readers.
 	 */
 	if (final_state == WT_REF_MEM && ref->page_las != NULL &&
-	    (ref->page_las->max_timestamp > ref->page_las->rec_timestamp ||
+	    (ref->page_las->max_ts > ref->page_las->max_onpage_ts ||
 	    ref->page_las->has_prepares))
 		WT_ERR(
 		    __wt_las_remove_block(session, ref->page_las->las_pageid));

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -247,16 +247,11 @@ struct __wt_ovfl_reuse {
 struct __wt_page_lookaside {
 	uint64_t las_pageid;		/* Page ID in lookaside */
 	uint64_t max_txn;		/* Maximum transaction ID */
-	uint64_t unstable_txn;		/* First transaction ID not on page */
 	wt_timestamp_t max_timestamp;	/* Maximum timestamp */
-	wt_timestamp_t unstable_timestamp;/* First timestamp not on page */
-	wt_timestamp_t unstable_durable_timestamp;
-					/* First durable timestamp not on
-					 * page */
+	wt_timestamp_t rec_timestamp;	/* Timestamp when reconciliation ran */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
 	bool resolved;			/* History has been read into cache */
-	bool skew_newest;		/* Page image has newest versions */
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -247,8 +247,9 @@ struct __wt_ovfl_reuse {
 struct __wt_page_lookaside {
 	uint64_t las_pageid;		/* Page ID in lookaside */
 	uint64_t max_txn;		/* Maximum transaction ID */
-	wt_timestamp_t max_timestamp;	/* Maximum timestamp */
-	wt_timestamp_t rec_timestamp;	/* Timestamp when reconciliation ran */
+	wt_timestamp_t max_onpage_ts;	/* Maximum timestamp on page */
+	wt_timestamp_t max_ts;		/* Maximum timestamp seen */
+	wt_timestamp_t min_newer_ts;	/* Update newer than on-page */
 	bool eviction_to_lookaside;	/* Revert to lookaside on eviction */
 	bool has_prepares;		/* One or more updates are prepared */
 	bool resolved;			/* History has been read into cache */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1203,13 +1203,12 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 		return (false);
 	if (page_las->resolved)
 		return (false);
-	if (!page_las->skew_newest || page_las->has_prepares)
+	if (page_las->max_timestamp > page_las->rec_timestamp ||
+	    page_las->has_prepares)
 		return (true);
-	if (__wt_txn_visible_all(session, page_las->max_txn,
-	    page_las->max_timestamp))
-		return (false);
 
-	return (true);
+	return (!__wt_txn_visible_all(
+	    session, page_las->max_txn, page_las->max_timestamp));
 }
 
 /*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1203,12 +1203,12 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
 		return (false);
 	if (page_las->resolved)
 		return (false);
-	if (page_las->max_timestamp > page_las->rec_timestamp ||
+	if (page_las->max_ts > page_las->max_onpage_ts ||
 	    page_las->has_prepares)
 		return (true);
 
 	return (!__wt_txn_visible_all(
-	    session, page_las->max_txn, page_las->max_timestamp));
+	    session, page_las->max_txn, page_las->max_ts));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -935,7 +935,6 @@ static inline bool __wt_row_leaf_value(WT_PAGE *page, WT_ROW *rip, WT_ITEM *valu
 static inline bool __wt_session_can_wait(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_split_descent_race( WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_am_oldest(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_visible( WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -33,20 +33,17 @@ struct __wt_reconcile {
 	uint64_t orig_txn_checkpoint_gen;
 
 	/*
-	 * Track the oldest running transaction and whether to skew lookaside
-	 * to the newest update.
+	 * Track the timestamp reconciliation will use for reads, the oldest
+	 * running transaction and whether to skew lookaside to the newest
+	 * update.
 	 */
-	bool las_skew_newest;
+	wt_timestamp_t rec_timestamp;
 	uint64_t last_running;
+	bool las_skew_newest;
 
 	/* Track the page's min/maximum transactions. */
 	uint64_t max_txn;
 	wt_timestamp_t max_timestamp;
-
-	/* Lookaside boundary tracking. */
-	uint64_t unstable_txn;
-	wt_timestamp_t unstable_durable_timestamp;
-	wt_timestamp_t unstable_timestamp;
 
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -33,17 +33,17 @@ struct __wt_reconcile {
 	uint64_t orig_txn_checkpoint_gen;
 
 	/*
-	 * Track the timestamp reconciliation will use for reads, the oldest
-	 * running transaction and whether to skew lookaside to the newest
-	 * update.
+	 * Track the oldest running transaction and whether to skew lookaside
+	 * to the newest update.
 	 */
-	wt_timestamp_t rec_timestamp;
 	uint64_t last_running;
 	bool las_skew_newest;
 
 	/* Track the page's min/maximum transactions. */
 	uint64_t max_txn;
-	wt_timestamp_t max_timestamp;
+	wt_timestamp_t min_newer_ts;
+	wt_timestamp_t max_ts;
+	wt_timestamp_t max_onpage_ts;
 
 	u_int updates_seen;		/* Count of updates seen. */
 	u_int updates_unstable;		/* Count of updates not visible_all. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -844,18 +844,6 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 
 	return (WT_VISIBLE_TRUE);
 }
-/*
- * __wt_txn_upd_durable --
- *	Can the current transaction make the given update durable.
- */
-static inline bool
-__wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd)
-{
-	/* If update is visible then check if it is durable. */
-	if (__wt_txn_upd_visible_type(session, upd) != WT_VISIBLE_TRUE)
-		return (false);
-	return (__wt_txn_visible(session, upd->txnid, upd->durable_ts));
-}
 
 /*
  * __wt_txn_upd_visible --

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -17,6 +17,7 @@ __rec_update_durable(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *upd)
 {
 	return (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
 	    __wt_txn_upd_visible_all(session, upd) :
+	    __wt_txn_upd_visible_type(session, upd) == WT_VISIBLE_TRUE &&
 	    __wt_txn_visible(session, upd->txnid, upd->durable_ts));
 }
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -263,8 +263,8 @@ __txn_abort_newer_updates(
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
 	if ((page_las = ref->page_las) != NULL) {
-		if (page_las->max_timestamp <= page_las->rec_timestamp &&
-		    rollback_timestamp < page_las->max_timestamp) {
+		if (page_las->max_ts == page_las->max_onpage_ts &&
+		    rollback_timestamp < page_las->max_ts) {
 			/*
 			 * Make sure we get back a page with history, not a
 			 * limbo page.
@@ -277,8 +277,10 @@ __txn_abort_newer_updates(
 			    __wt_page_is_modified(ref->page));
 			local_read = true;
 		}
-		if (page_las->max_timestamp > rollback_timestamp)
-			page_las->max_timestamp = rollback_timestamp;
+		if (page_las->max_onpage_ts > rollback_timestamp)
+			page_las->max_onpage_ts = rollback_timestamp;
+		if (page_las->max_ts > rollback_timestamp)
+			page_las->max_ts = rollback_timestamp;
 	}
 
 	/* Review deleted page saved to the ref */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -236,6 +236,7 @@ __txn_abort_newer_updates(
 {
 	WT_DECL_RET;
 	WT_PAGE *page;
+	WT_PAGE_LOOKASIDE *page_las;
 	uint32_t read_flags;
 	bool local_read;
 
@@ -261,9 +262,9 @@ __txn_abort_newer_updates(
 	 */
 	local_read = false;
 	read_flags = WT_READ_WONT_NEED;
-	if (ref->page_las != NULL) {
-		if (ref->page_las->skew_newest && rollback_timestamp <
-		    ref->page_las->unstable_durable_timestamp) {
+	if ((page_las = ref->page_las) != NULL) {
+		if (page_las->max_timestamp <= page_las->rec_timestamp &&
+		    rollback_timestamp < page_las->max_timestamp) {
 			/*
 			 * Make sure we get back a page with history, not a
 			 * limbo page.
@@ -276,14 +277,8 @@ __txn_abort_newer_updates(
 			    __wt_page_is_modified(ref->page));
 			local_read = true;
 		}
-		if (ref->page_las->max_timestamp > rollback_timestamp)
-			ref->page_las->max_timestamp = rollback_timestamp;
-		if (ref->page_las->unstable_durable_timestamp >
-		    rollback_timestamp)
-			ref->page_las->unstable_durable_timestamp =
-			    rollback_timestamp;
-		if (ref->page_las->unstable_timestamp > rollback_timestamp)
-			ref->page_las->unstable_timestamp = rollback_timestamp;
+		if (page_las->max_timestamp > rollback_timestamp)
+			page_las->max_timestamp = rollback_timestamp;
 	}
 
 	/* Review deleted page saved to the ref */

--- a/test/suite/test_las01.py
+++ b/test/suite/test_las01.py
@@ -83,10 +83,11 @@ class test_las01(wttest.WiredTigerTestCase):
         # Skip the initial rows, which were not updated
         for i in range(0, nrows+1):
             self.assertEqual(cursor.next(), 0)
-        if (check_value != cursor.get_value()):
-            print("Check value : " + str(check_value))
-            print("value : " + str(cursor.get_value()))
-        self.assertTrue(check_value == cursor.get_value())
+        if check_value != cursor.get_value():
+            session.breakpoint()
+        self.assertTrue(check_value == cursor.get_value(),
+            "for key " + str(i) + ", expected " + str(check_value) +
+            ", got " + str(cursor.get_value()))
         cursor.close()
         session.close()
         conn.close()

--- a/test/suite/test_timestamp04.py
+++ b/test/suite/test_timestamp04.py
@@ -78,7 +78,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         # Search for the expected items as well as iterating.
         for k, v in expected.items():
             if missing == False:
-                self.assertEqual(cur[k], v, "for key " + str(k))
+                self.assertEqual(cur[k], v, "for key " + str(k) +
+                    " expected " + str(v) + ", got " + str(cur[k]))
             else:
                 cur.set_key(k)
                 if self.empty:


### PR DESCRIPTION
This branch attempts to fix some problems in the base branch, improve efficiency of lookaside evictions and subsequent reads, and simplify the information being tracked for pages with history in lookaside.