### PR TITLE
Revert "WT-4460 Optimize for in-order, non-overlapping modifications"

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1506,11 +1506,8 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) ||
 	    !F_ISSET(cursor, WT_CURSTD_VALUE_INT))
 		WT_ERR(__wt_btcur_search(cbt));
-
-	WT_ERR(__wt_modify_pack(cursor, &modify, entries, nentries));
-
 	orig = cursor->value.size;
-	WT_ERR(__wt_modify_apply(cursor, modify->data));
+	WT_ERR(__wt_modify_apply_api(session, cursor, entries, nentries));
 	new = cursor->value.size;
 	WT_ERR(__cursor_size_chk(session, &cursor->value));
 
@@ -1530,7 +1527,8 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	F_CLR(cursor, WT_CURSTD_OVERWRITE);
 	if (cursor->value.size <= 64 || __cursor_chain_exceeded(cbt))
 		ret = __btcur_update(cbt, &cursor->value, WT_UPDATE_STANDARD);
-	else
+	else if ((ret =
+	    __wt_modify_pack(session, &modify, entries, nentries)) == 0)
 		ret = __btcur_update(cbt, modify, WT_UPDATE_MODIFY);
 	if (overwrite)
 	       F_SET(cursor, WT_CURSTD_OVERWRITE);

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -250,7 +250,7 @@ __wt_value_return_upd(WT_SESSION_IMPL *session,
 	 * updates.
 	 */
 	while (i > 0)
-		WT_ERR(__wt_modify_apply(cursor, listp[--i]->data));
+		WT_ERR(__wt_modify_apply(session, cursor, listp[--i]->data));
 
 err:	if (allocated_bytes != 0)
 		__wt_free(session, listp);

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -931,7 +931,7 @@ __cursor_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
 	/* Get the current value, apply the modifications. */
 	WT_ERR(cursor->search(cursor));
-	WT_ERR(__wt_modify_apply_api(cursor, entries, nentries));
+	WT_ERR(__wt_modify_apply_api(session, cursor, entries, nentries));
 
 	/* We know both key and value are set, "overwrite" doesn't matter. */
 	ret = cursor->update(cursor);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -503,9 +503,9 @@ extern int __wt_metadata_search(WT_SESSION_IMPL *session, const char *key, char 
 extern int __wt_metadata_set_base_write_gen(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_update( WT_SESSION_IMPL *session, const char *key, const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_modify_apply(WT_CURSOR *cursor, const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_modify_pack(WT_CURSOR *cursor, WT_ITEM **modifyp, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_modify_apply( WT_SESSION_IMPL *session, WT_CURSOR *cursor, const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_modify_apply_api(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_modify_pack(WT_SESSION_IMPL *session, WT_ITEM **modifyp, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_name_check(WT_SESSION_IMPL *session, const char *str, size_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -844,7 +844,6 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 
 	return (WT_VISIBLE_TRUE);
 }
-
 /*
  * __wt_txn_upd_durable --
  *	Can the current transaction make the given update durable.

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -8,49 +8,18 @@
 
 #include "wt_internal.h"
 
-#define	WT_MODIFY_FOREACH_BEGIN(mod, p, nentries, napplied) do {	\
-	const size_t *__p = p;						\
-	const uint8_t *__data =						\
-	    (const uint8_t *)(__p + (size_t)(nentries) * 3);		\
-	int __i;							\
-	for (__i = 0; __i < (nentries); ++__i) {			\
-		memcpy(&(mod).data.size, __p++, sizeof(size_t));	\
-		memcpy(&(mod).offset, __p++, sizeof(size_t));		\
-		memcpy(&(mod).size, __p++, sizeof(size_t));		\
-		(mod).data.data = __data;				\
-		__data += (mod).data.size;				\
-		if (__i < (napplied))					\
-			continue;
-
-#define	WT_MODIFY_FOREACH_REVERSE(mod, p, nentries, napplied, datasz) do {\
-	const size_t *__p = (p) + (size_t)(nentries) * 3;		\
-	const uint8_t *__data = (const uint8_t *)__p + datasz;		\
-	int __i;							\
-	for (__i = (napplied); __i < (nentries); ++__i) {		\
-		memcpy(&(mod).size, --__p, sizeof(size_t));		\
-		memcpy(&(mod).offset, --__p, sizeof(size_t));		\
-		memcpy(&(mod).data.size, --__p, sizeof(size_t));	\
-		(mod).data.data = (__data -= (mod).data.size);
-
-#define	WT_MODIFY_FOREACH_END						\
-	}								\
-} while (0)
-
 /*
  * __wt_modify_pack --
  *	Pack a modify structure into a buffer.
  */
 int
-__wt_modify_pack(WT_CURSOR *cursor,
+__wt_modify_pack(WT_SESSION_IMPL *session,
     WT_ITEM **modifyp, WT_MODIFY *entries, int nentries)
 {
 	WT_ITEM *modify;
-	WT_SESSION_IMPL *session;
-	size_t diffsz, len, *p;
+	size_t len, *p;
 	uint8_t *data;
 	int i;
-
-	session = (WT_SESSION_IMPL *)cursor->session;
 
 	/*
 	 * Build the in-memory modify value. It's the entries count, followed
@@ -58,10 +27,9 @@ __wt_modify_pack(WT_CURSOR *cursor,
 	 * data (data at the end to minimize unaligned reads/writes).
 	 */
 	len = sizeof(size_t);                           /* nentries */
-	for (i = 0, diffsz = 0; i < nentries; ++i) {
+	for (i = 0; i < nentries; ++i) {
 		len += 3 * sizeof(size_t);              /* WT_MODIFY fields */
 		len += entries[i].data.size;            /* data */
-		diffsz += entries[i].size;		/* bytes touched */
 	}
 
 	WT_RET(__wt_scr_alloc(session, len, &modify));
@@ -80,18 +48,6 @@ __wt_modify_pack(WT_CURSOR *cursor,
 	}
 	modify->size = WT_PTRDIFF(data, modify->data);
 	*modifyp = modify;
-
-	/*
-	 * Update statistics. This is the common path called by
-	 * WT_CURSOR::modify implementations.
-	 */
-	WT_STAT_CONN_INCR(session, cursor_modify);
-	WT_STAT_DATA_INCR(session, cursor_modify);
-	WT_STAT_CONN_INCRV(session, cursor_modify_bytes, cursor->value.size);
-	WT_STAT_DATA_INCRV(session, cursor_modify_bytes, cursor->value.size);
-	WT_STAT_CONN_INCRV(session, cursor_modify_bytes_touch, diffsz);
-	WT_STAT_DATA_INCRV(session, cursor_modify_bytes_touch, diffsz);
-
 	return (0);
 }
 
@@ -100,26 +56,25 @@ __wt_modify_pack(WT_CURSOR *cursor,
  *	Apply a single modify structure change to the buffer.
  */
 static int
-__modify_apply_one(
-    WT_SESSION_IMPL *session, WT_ITEM *value, WT_MODIFY *modify, bool sformat)
+__modify_apply_one(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
+    size_t data_size, size_t offset, size_t size, const uint8_t *data)
 {
-	size_t data_size, len, offset, size;
-	const uint8_t *data, *from;
-	uint8_t *to;
+	WT_ITEM *value;
+	size_t len;
+	uint8_t *from, *to;
+	bool sformat;
 
-	data = modify->data.data;
-	data_size = modify->data.size;
-	offset = modify->offset;
-	size = modify->size;
+	value = &cursor->value;
+	sformat = cursor->value_format[0] == 'S';
 
 	/*
 	 * Grow the buffer to the maximum size we'll need. This is pessimistic
 	 * because it ignores replacement bytes, but it's a simpler calculation.
 	 *
-	 * Grow the buffer first. This function is often called using a cursor
-	 * buffer referencing on-page memory and it's easy to overwrite a page.
-	 * A side-effect of growing the buffer is to ensure the buffer's value
-	 * is in buffer-local memory.
+	 * Grow the buffer before we fast-path the expected case. This function
+	 * is often called using a cursor buffer referencing on-page memory and
+	 * it's easy to overwrite a page. A side-effect of growing the buffer is
+	 * to ensure the buffer's value is in buffer-local memory.
 	 *
 	 * Because the buffer may reference an overflow item, the data may not
 	 * start at the start of the buffer's memory and we have to correct for
@@ -130,26 +85,35 @@ __modify_apply_one(
 	    len + WT_MAX(value->size, offset) + data_size + (sformat ? 1 : 0)));
 
 	/*
-	 * Fast-path the common case, where we're overwriting a set of bytes
+	 * Fast-path the expected case, where we're overwriting a set of bytes
 	 * that already exist in the buffer.
 	 */
 	if (value->size > offset + data_size && data_size == size) {
-		memcpy((uint8_t *)value->mem + offset, data, data_size);
+		memmove((uint8_t *)value->data + offset, data, data_size);
 		return (0);
 	}
+
+	/*
+	 * Decrement the size to discard the trailing nul (done after growing
+	 * the buffer to ensure it can be restored without further checking).
+	 */
+	if (sformat)
+		--value->size;
 
 	/*
 	 * If appending bytes past the end of the value, initialize gap bytes
 	 * and copy the new bytes into place.
 	 */
 	if (value->size <= offset) {
-		WT_ASSERT(session,
-		    offset + data_size + (sformat ? 1 : 0) <= value->memsize);
 		if (value->size < offset)
-			memset((uint8_t *)value->mem + value->size,
+			memset((uint8_t *)value->data + value->size,
 			    sformat ? ' ' : 0, offset - value->size);
-		memcpy((uint8_t *)value->mem + offset, data, data_size);
+		memmove((uint8_t *)value->data + offset, data, data_size);
 		value->size = offset + data_size;
+
+		/* Restore the trailing nul. */
+		if (sformat)
+			((char *)value->data)[value->size++] = '\0';
 		return (0);
 	}
 
@@ -161,12 +125,9 @@ __modify_apply_one(
 	if (value->size < offset + size)
 		size = value->size - offset;
 
-	WT_ASSERT(session, value->size + (data_size - size) +
-	    (sformat ? 1 : 0) <= value->memsize);
-
 	if (data_size == size) {			/* Overwrite */
 		/* Copy in the new data. */
-		memcpy((uint8_t *)value->mem + offset, data, data_size);
+		memmove((uint8_t *)value->data + offset, data, data_size);
 
 		/*
 		 * The new data must overlap the buffer's end (else, we'd use
@@ -176,18 +137,18 @@ __modify_apply_one(
 		value->size = offset + data_size;
 	} else {					/* Shrink or grow */
 		/* Move trailing data forward/backward to its new location. */
-		from = (const uint8_t *)value->data + (offset + size);
+		from = (uint8_t *)value->data + (offset + size);
 		WT_ASSERT(session, WT_DATA_IN_ITEM(value) &&
 		    from + (value->size - (offset + size)) <=
 		    (uint8_t *)value->mem + value->memsize);
-		to = (uint8_t *)value->mem + (offset + data_size);
+		to = (uint8_t *)value->data + (offset + data_size);
 		WT_ASSERT(session, WT_DATA_IN_ITEM(value) &&
 		    to + (value->size - (offset + size)) <=
 		    (uint8_t *)value->mem + value->memsize);
 		memmove(to, from, value->size - (offset + size));
 
 		/* Copy in the new data. */
-		memcpy((uint8_t *)value->mem + offset, data, data_size);
+		memmove((uint8_t *)value->data + offset, data, data_size);
 
 		/*
 		 * Correct the size. This works because of how the C standard
@@ -204,197 +165,7 @@ __modify_apply_one(
 		 value->size += (data_size - size);
 	}
 
-	return (0);
-}
-
-/*
- * __modify_fast_path --
- *	Process a set of modifications, applying any that can be made in place,
- *	and check if the remaining ones are sorted and non-overlapping.
- */
-static void
-__modify_fast_path(
-    WT_ITEM *value, const size_t *p, int nentries,
-    int *nappliedp, bool *overlapp, size_t *dataszp, size_t *destszp)
-{
-	WT_MODIFY current, prev;
-	size_t datasz, destoff;
-	bool fastpath, first;
-
-	*overlapp = true;
-	datasz = destoff = 0;
-	WT_CLEAR(current);
-
-	/*
-	 * If the modifications are sorted and don't overlap in the old or new
-	 * values, we can do a fast application of all the modifications
-	 * modifications in a single pass.
-	 *
-	 * The requirement for ordering is unfortunate, but modifications are
-	 * performed in order, and applications specify byte offsets based on
-	 * that. In other words, byte offsets are cumulative, modifications
-	 * that shrink or grow the data affect subsequent modification's byte
-	 * offsets.
-	 */
-	fastpath = first = true;
-	*nappliedp = 0;
-	WT_MODIFY_FOREACH_BEGIN(current, p, nentries, 0) {
-		datasz += current.data.size;
-
-		if (fastpath && current.data.size == current.size &&
-		    current.offset + current.size <= value->size) {
-			memcpy((uint8_t *)value->mem + current.offset,
-			    current.data.data, current.data.size);
-			++(*nappliedp);
-			continue;
-		}
-		fastpath = false;
-
-		/* Step over the bytes before the current block. */
-		if (first)
-			destoff = current.offset;
-		else {
-			/* Check that entries are sorted and non-overlapping. */
-			if (current.offset < prev.offset + prev.size ||
-			    current.offset < prev.offset + prev.data.size)
-				return;
-			destoff += current.offset - (prev.offset + prev.size);
-		}
-
-		/*
-		 * If the source is past the end of the current value, we have
-		 * to deal with padding bytes.  Don't try to fast-path padding
-		 * bytes; it's not common and adds branches to the loop
-		 * applying the changes.
-		 */
-		if (current.offset + current.size > value->size)
-			return;
-
-		/*
-		 * If copying this block overlaps with the next one, we can't
-		 * build the value in reverse order.
-		 */
-		if (current.size != current.data.size &&
-		    current.offset + current.size > destoff)
-			return;
-
-		/* Step over the current modification. */
-		destoff += current.data.size;
-
-		prev = current;
-		first = false;
-	} WT_MODIFY_FOREACH_END;
-
-	/* Step over the final unmodified block. */
-	destoff += value->size - (current.offset + current.size);
-
-	*overlapp = false;
-	*dataszp = datasz;
-	*destszp = destoff;
-	return;
-}
-
-/*
- * __modify_apply_no_overlap --
- *	Apply a single set of WT_MODIFY changes to a buffer, where the changes
- *	are in sorted order and none of the changes overlap.
- */
-static void
-__modify_apply_no_overlap(WT_SESSION_IMPL *session, WT_ITEM *value,
-    const size_t *p, int nentries, int napplied, size_t datasz, size_t destsz)
-{
-	WT_MODIFY current;
-	size_t sz;
-	const uint8_t *from;
-	uint8_t *to;
-
-	from = (const uint8_t *)value->data + value->size;
-	to = (uint8_t *)value->mem + destsz;
-	WT_MODIFY_FOREACH_REVERSE(current, p, nentries, napplied, datasz) {
-		/* Move the current unmodified block into place if necessary. */
-		sz = WT_PTRDIFF(to, value->mem) -
-		    (current.offset + current.data.size);
-		from -= sz;
-		to -= sz;
-		WT_ASSERT(session, from >= (const uint8_t *)value->data &&
-		    to >= (uint8_t *)value->mem);
-		WT_ASSERT(session,
-		    from + sz <= (const uint8_t *)value->data + value->size);
-
-		if (to != from)
-			memmove(to, from, sz);
-
-		from -= current.size;
-		to -= current.data.size;
-		memcpy(to, current.data.data, current.data.size);
-	} WT_MODIFY_FOREACH_END;
-
-	value->size = destsz;
-}
-
-/*
- * __wt_modify_apply --
- *	Apply a single set of WT_MODIFY changes to a buffer.
- */
-int
-__wt_modify_apply(WT_CURSOR *cursor, const void *modify)
-{
-	WT_ITEM *value;
-	WT_MODIFY mod;
-	WT_SESSION_IMPL *session;
-	size_t datasz, destsz, tmp;
-	const size_t *p;
-	int napplied, nentries;
-	bool overlap, sformat;
-
-	session = (WT_SESSION_IMPL *)cursor->session;
-	sformat = cursor->value_format[0] == 'S';
-	value = &cursor->value;
-
-	/*
-	 * Get the number of modify entries and set a second pointer to
-	 * reference the replacement data.
-	 */
-	p = modify;
-	memcpy(&tmp, p++, sizeof(size_t));
-	nentries = (int)tmp;
-
-	/*
-	 * Grow the buffer first. This function is often called using a cursor
-	 * buffer referencing on-page memory and it's easy to overwrite a page.
-	 * A side-effect of growing the buffer is to ensure the buffer's value
-	 * is in buffer-local memory.
-	 */
-	WT_RET(__wt_buf_grow(session, value, value->size));
-
-	/*
-	 * Decrement the size to discard the trailing nul (done after growing
-	 * the buffer to ensure it can be restored without further checking).
-	 */
-	if (sformat)
-		--value->size;
-
-	__modify_fast_path(
-	    value, p, nentries, &napplied, &overlap, &datasz, &destsz);
-
-	if (napplied == nentries)
-		goto done;
-
-	if (!overlap) {
-		/* Grow the buffer first. */
-		WT_RET(__wt_buf_grow(session, value,
-		    WT_MAX(destsz, value->size) + (sformat ? 1 : 0)));
-
-		__modify_apply_no_overlap(
-		    session, value, p, nentries, napplied, datasz, destsz);
-		goto done;
-	}
-
-	WT_MODIFY_FOREACH_BEGIN(mod, p, nentries, napplied) {
-		WT_RET(__modify_apply_one(session, value, &mod, sformat));
-	} WT_MODIFY_FOREACH_END;
-
-done:	/* Restore the trailing nul. */
+	/* Restore the trailing nul. */
 	if (sformat)
 		((char *)value->data)[value->size++] = '\0';
 
@@ -404,18 +175,71 @@ done:	/* Restore the trailing nul. */
 /*
  * __wt_modify_apply_api --
  *	Apply a single set of WT_MODIFY changes to a buffer, the cursor API
- *	interface.
+ * interface.
  */
 int
-__wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
+__wt_modify_apply_api(WT_SESSION_IMPL *session,
+    WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-	WT_DECL_ITEM(modify);
-	WT_DECL_RET;
+	size_t modified;
+	int i;
 
-	WT_ERR(__wt_modify_pack(cursor, &modify, entries, nentries));
-	WT_ERR(__wt_modify_apply(cursor, modify->data));
+	for (modified = 0, i = 0; i < nentries; ++i) {
+		modified += entries[i].size;
+		WT_RET(__modify_apply_one(session, cursor, entries[i].data.size,
+		    entries[i].offset, entries[i].size, entries[i].data.data));
+	}
+	/*
+	 * This API is used by some external test functions with a NULL
+	 * session pointer - they don't expect statistics to be incremented.
+	 */
+	if (session != NULL) {
+		WT_STAT_CONN_INCR(session, cursor_modify);
+		WT_STAT_DATA_INCR(session, cursor_modify);
+		WT_STAT_CONN_INCRV(session,
+		    cursor_modify_bytes, cursor->value.size);
+		WT_STAT_DATA_INCRV(session,
+		    cursor_modify_bytes, cursor->value.size);
+		WT_STAT_CONN_INCRV(session,
+		    cursor_modify_bytes_touch, modified);
+		WT_STAT_DATA_INCRV(session,
+		    cursor_modify_bytes_touch, modified);
+	}
 
-err:	__wt_scr_free((WT_SESSION_IMPL *)cursor->session, &modify);
-	return (ret);
+	return (0);
+}
+
+/*
+ * __wt_modify_apply --
+ *	Apply a single set of WT_MODIFY changes to a buffer.
+ */
+int
+__wt_modify_apply(
+    WT_SESSION_IMPL *session, WT_CURSOR *cursor, const void *modify)
+{
+	size_t data_size, nentries, offset, size;
+	const size_t *p;
+	const uint8_t *data;
+
+	/*
+	 * Get the number of entries, and set a second pointer to reference the
+	 * change data. The modify string isn't necessarily aligned for size_t
+	 * access, copy to be sure.
+	 */
+	p = modify;
+	memcpy(&nentries, p++, sizeof(size_t));
+	data = (uint8_t *)modify +
+	    sizeof(size_t) + (nentries * 3 * sizeof(size_t));
+
+	/* Step through the list of entries, applying them in order. */
+	for (; nentries-- > 0; data += data_size) {
+		memcpy(&data_size, p++, sizeof(size_t));
+		memcpy(&offset, p++, sizeof(size_t));
+		memcpy(&size, p++, sizeof(size_t));
+		WT_RET(__modify_apply_one(
+		    session, cursor, data_size, offset, size, data));
+	}
+
+	return (0);
 }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -155,7 +155,7 @@ __txn_op_apply(
 			 * than using cursor modify to create a partial update
 			 * (for no particular reason than simplicity).
 			 */
-			WT_ERR(__wt_modify_apply(cursor, value.data));
+			WT_ERR(__wt_modify_apply(session, cursor, value.data));
 			WT_ERR(cursor->insert(cursor));
 		}
 		break;
@@ -222,7 +222,7 @@ __txn_op_apply(
 			 * than using cursor modify to create a partial update
 			 * (for no particular reason than simplicity).
 			 */
-			WT_ERR(__wt_modify_apply(cursor, value.data));
+			WT_ERR(__wt_modify_apply(session, cursor, value.data));
 			WT_ERR(cursor->insert(cursor));
 		}
 		break;


### PR DESCRIPTION
This reverts commit 2a43429ebff0b8c4f8d27130cfcf009b98d9b7e6.