### PR TITLE
WT-5038 format heap use after free in __txn_commit_timestamps_assert

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -232,8 +232,6 @@ __wt_txn_resolve_prepared_op(
 			continue;
 		if (upd->txnid != txn->id)
 			break;
-		if (op->u.op_upd == NULL)
-			op->u.op_upd = upd;
 
 		++(*resolved_update_countp);
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -655,12 +655,6 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 /*
  * __txn_commit_timestamps_assert --
  *	Validate that timestamps provided to commit are legal.
- *
- *	For prepared transactions, this function will open cursors to mutate the
- *	update list with pointers to uncommitted data. After they are finished
- *	with the update list, the caller is responsible for closing every
- *	non-null cursor pointer in the cursors array and freeing the underlying
- *	buffer.
  */
 static inline int
 __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -672,6 +672,7 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 
 	txn = &session->txn;
 	cursor = NULL;
+	durable_op_timestamp = prev_op_timestamp = WT_TS_NONE;
 
 	/*
 	 * Debugging checks on timestamps, if user requested them.
@@ -753,11 +754,10 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 			 * first valid update in the chain. They're in
 			 * most recent order.
 			 */
-			if (upd == NULL)
-				continue;
-
-			prev_op_timestamp = upd->start_ts;
-			durable_op_timestamp = upd->durable_ts;
+			if (upd != NULL) {
+				prev_op_timestamp = upd->start_ts;
+				durable_op_timestamp = upd->durable_ts;
+			}
 
 			/*
 			 * We no longer need to access the update structure so
@@ -769,6 +769,9 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 				WT_RET(cursor->close(cursor));
 				cursor = NULL;
 			}
+
+			if (upd == NULL)
+				continue;
 
 			/*
 			 * Check for consistent per-key timestamp usage.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -737,7 +737,6 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 				upd = op->u.op_upd;
 
 			WT_ASSERT(session, upd != NULL);
-
 			op_timestamp = upd->start_ts;
 
 			/*
@@ -772,7 +771,6 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 
 			if (upd == NULL)
 				continue;
-
 			/*
 			 * Check for consistent per-key timestamp usage.
 			 * If timestamps are or are not used originally then

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -662,8 +662,7 @@ __wt_txn_release(WT_SESSION_IMPL *session)
  *	non-null cursor pointer in the cursors array.
  */
 static inline int
-__txn_commit_timestamps_assert(
-    WT_SESSION_IMPL *session, WT_CURSOR **cursors)
+__txn_commit_timestamps_assert(WT_SESSION_IMPL *session, WT_CURSOR **cursors)
 {
 	WT_CURSOR *cursor;
 	WT_DECL_RET;
@@ -827,7 +826,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	cursors = NULL;
 	if (txn->mod_count != 0)
 		WT_ERR(__wt_calloc(
-		    session, sizeof(WT_CURSOR*), txn->mod_count, &cursors));
+		    session, sizeof(WT_CURSOR *), txn->mod_count, &cursors));
 
 	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 	WT_ASSERT(session, !F_ISSET(txn, WT_TXN_ERROR) ||
@@ -876,8 +875,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		WT_ASSERT(session,
 		    txn->commit_timestamp <= txn->durable_timestamp);
 
-	WT_ERR(__txn_commit_timestamps_assert(
-	    session, cursors));
+	WT_ERR(__txn_commit_timestamps_assert(session, cursors));
 
 	/*
 	 * The default sync setting is inherited from the connection, but can
@@ -1047,6 +1045,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 		if (cursor != NULL)
 			WT_IGNORE_RET(cursor->close(cursor));
 	}
+	__wt_free(session, cursors);
 
 	txn->mod_count = 0;
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1044,9 +1044,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 
 	for (i = 0; i < txn->mod_count; ++i) {
 		cursor = cursors[i];
-		if (cursor == NULL)
-			break;
-		WT_IGNORE_RET(cursor->close(cursor));
+		if (cursor != NULL)
+			WT_IGNORE_RET(cursor->close(cursor));
 	}
 
 	txn->mod_count = 0;


### PR DESCRIPTION
This PR is to address the use after free issue exposed by WT-4957. Since `__txn_commit_timestamps_assert` actually populates the update list with pointers to data from a given cursor, that cursor needs to stay open until we're finished with the update list.