### PR TITLE
WT-4678 Write the test workload for relevant history in cache

### DIFF
--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -1,0 +1,83 @@
+import wiredtiger, wttest
+from wiredtiger import stat
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_las06.py
+# Verify that triggering lookaside usage does not cause a spike in memory usage
+# to form an update chain from the lookaside contents.
+#
+# The required value should be fetched from lookaside and then passed straight
+# back to the user without putting together an update chain.
+#
+# TODO: Uncomment the checks after the main portion of the relevant history
+# project work is complete.
+class test_las06(wttest.WiredTigerTestCase):
+    # Force a small cache.
+    conn_config = 'cache_size=50MB,statistics=(fast)'
+    session_config = 'isolation=snapshot'
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def get_non_page_image_memory_usage(self):
+        return self.get_stat(stat.conn.cache_bytes_other)
+
+    def get_lookaside_usage(self):
+        return self.get_stat(stat.conn.cache_read_lookaside)
+
+    def test_checkpoint_las_reads(self):
+        # Create a small table.
+        uri = "table:test_las06"
+        create_params = 'key_format=i,value_format=S,'
+        self.session.create(uri, create_params)
+
+        value1 = b'a' * 500
+        value2 = b'b' * 500
+
+        # Fill up the cache with 50Mb of data.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, 10000):
+            cursor[i] = value1
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        # Load another 50Mb of data with a later timestamp.
+        self.session.begin_transaction()
+        for i in range(1, 10000):
+            cursor[i] = value2
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        # Now the latest version will get written to the data file.
+        self.session.checkpoint()
+
+        start_usage = self.get_non_page_image_memory_usage()
+
+        # We haven't used lookaside yet.
+        self.assertEqual(self.get_lookaside_usage(), 0)
+
+        # Whenever we request something out of cache of timestamp 2, we should
+        # be reading it straight from lookaside without initialising a full
+        # update chain of every version of the data.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(2))
+        for i in range(1, 10000):
+            self.assertEqual(cursor[i], value1)
+        self.session.rollback_transaction()
+
+        end_usage = self.get_non_page_image_memory_usage()
+
+        # We expect to have used lookaside when reading historical data.
+        self.assertNotEqual(self.get_lookaside_usage(), 0)
+
+        # Non-page related memory usage shouldn't spike significantly.
+        # Prior to this change, this type of workload would use a lot of memory
+        # to recreate update lists for each page.
+        # self.assertLessEqual(end_usage, (start_usage * 2))
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -74,8 +74,8 @@ class test_las06(wttest.WiredTigerTestCase):
         # We expect to have used lookaside when reading historical data.
         #
         # Prior to this change, this type of workload will cause every lookaside
-        # entry for a given page to get read in. Now that we're only reading the
-        # lookaside entry that we need, we expect to see comparatively fewer
+        # entry for a given value to get read in. Now that we're only reading
+        # the lookaside entry that we need, we expect to see comparatively fewer
         # reads from lookaside.
         #
         # TODO: Set the upper bound to something smaller once the project work

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -1,3 +1,31 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 import wiredtiger, wttest
 from wiredtiger import stat
 

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -33,8 +33,8 @@ class test_las06(wttest.WiredTigerTestCase):
         create_params = 'key_format=i,value_format=S,'
         self.session.create(uri, create_params)
 
-        value1 = b'a' * 500
-        value2 = b'b' * 500
+        value1 = 'a' * 500
+        value2 = 'b' * 500
 
         # Fill up the cache with 50Mb of data.
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -36,7 +36,7 @@ class test_las06(wttest.WiredTigerTestCase):
         value1 = 'a' * 500
         value2 = 'b' * 500
 
-        # Fill up the cache with 50Mb of data.
+        # Load 5Mb of data.
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
@@ -44,7 +44,7 @@ class test_las06(wttest.WiredTigerTestCase):
             cursor[i] = value1
         self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
 
-        # Load another 50Mb of data with a later timestamp.
+        # Load another 5Mb of data with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 10000):
             cursor[i] = value2

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -30,7 +30,7 @@ class test_las06(wttest.WiredTigerTestCase):
     def get_lookaside_usage(self):
         return self.get_stat(stat.conn.cache_read_lookaside)
 
-    def test_checkpoint_las_reads(self):
+    def test_las_reads_workload(self):
         # Create a small table.
         uri = "table:test_las06"
         create_params = 'key_format=i,value_format=S,'
@@ -58,8 +58,8 @@ class test_las06(wttest.WiredTigerTestCase):
 
         start_usage = self.get_non_page_image_memory_usage()
 
-        # We haven't used lookaside yet.
-        self.assertEqual(self.get_lookaside_usage(), 0)
+        # We haven't used much lookaside yet.
+        self.assertLess(self.get_lookaside_usage(), 100)
 
         # Whenever we request something out of cache of timestamp 2, we should
         # be reading it straight from lookaside without initialising a full


### PR DESCRIPTION
This PR is adding a test that exercises the new lookaside behaviour and makes some assertions on how the implementation should behave from a memory usage + perf perspective.