### PR TITLE
WT-5050 Don't allow checkpoints to evict without a snapshot

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -322,6 +322,10 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			 * discarded), that is not wasted effort because
 			 * checkpoint doesn't need to write the page again.
 			 *
+			 * Once the transaction has given up it's snapshot it
+			 * is no longer safe to reconcile pages. That happens
+			 * prior to the final metadata checkpoint.
+			 *
 			 * XXX Only attempt this eviction when there are no
 			 * readers older than the checkpoint.  Otherwise, a bug
 			 * in eviction can mark the page clean and discard
@@ -331,6 +335,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 			if (!WT_PAGE_IS_INTERNAL(page) &&
 			    page->read_gen == WT_READGEN_WONT_NEED &&
 			    !tried_eviction &&
+			    F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT) &&
 			    (!F_ISSET(txn, WT_TXN_HAS_TS_READ) ||
 			    txn->read_timestamp ==
 			    conn->txn_global.pinned_timestamp)) {


### PR DESCRIPTION
Checkpoint gives up it's snapshot prior to checkpointing the metadata.
Once the snapshot is given up, it's not OK for checkpoint to try eviction prior to doing reconciliation.