### PR TITLE
WT-4940 Reconciliation should set prepared/uncommitted for each update (v4.0 backport)

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -169,14 +169,14 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 		 * globally visible, need to check the update state as well.
 		 */
 		if (F_ISSET(r, WT_REC_EVICT)) {
-			if (upd->prepare_state == WT_PREPARE_LOCKED ||
-			    upd->prepare_state == WT_PREPARE_INPROGRESS)
-				prepared = true;
-
-			if (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
+			prepared = upd->prepare_state == WT_PREPARE_LOCKED ||
+			    upd->prepare_state == WT_PREPARE_INPROGRESS;
+			uncommitted = !prepared &&
+			    (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
 			    WT_TXNID_LE(r->last_running, txnid) :
-			    !__txn_visible_id(session, txnid))
-				uncommitted = r->update_uncommitted = true;
+			    !__txn_visible_id(session, txnid));
+			if (uncommitted)
+				r->update_uncommitted = true;
 
 		       if (prepared || uncommitted)
 			       continue;


### PR DESCRIPTION

(cherry picked from commit 3e9b3318f2a3ce47707e14d7587dc3ecec1481a0)