### PR TITLE
WT-4899 Fix bugs that could allow more than one birthmark in an update chain (#4763) (v4.0 backport)

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -57,6 +57,7 @@ func_ok()
 	    -e '/int __wt_block_write_size$/d' \
 	    -e '/int __wt_buf_catfmt$/d' \
 	    -e '/int __wt_buf_fmt$/d' \
+	    -e '/int __wt_count_birthmarks$/d' \
 	    -e '/int __wt_curjoin_joined$/d' \
 	    -e '/int __wt_cursor_noop$/d' \
 	    -e '/int __wt_epoch$/d' \

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -27,7 +27,8 @@ __col_instantiate(WT_SESSION_IMPL *session,
 	 * Just free the memory: it hasn't been accounted for on the page yet.
 	 */
 	if (updlist->next != NULL &&
-	    (upd = __wt_update_obsolete_check(session, page, updlist)) != NULL)
+	    (upd = __wt_update_obsolete_check(
+	    session, page, updlist, false)) != NULL)
 		__wt_free_update_list(session, upd);
 
 	/* Search the page and add updates. */
@@ -56,7 +57,8 @@ __row_instantiate(WT_SESSION_IMPL *session,
 	 * Just free the memory: it hasn't been accounted for on the page yet.
 	 */
 	if (updlist->next != NULL &&
-	    (upd = __wt_update_obsolete_check(session, page, updlist)) != NULL)
+	    (upd = __wt_update_obsolete_check(
+	    session, page, updlist, false)) != NULL)
 		__wt_free_update_list(session, upd);
 
 	/* Search the page and add updates. */
@@ -238,7 +240,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 	WT_ERR_NOTFOUND_OK(ret);
 
 	/* Insert the last set of updates, if any. */
-	if (first_upd != NULL)
+	if (first_upd != NULL) {
+		WT_ASSERT(session, __wt_count_birthmarks(first_upd) <= 1);
 		switch (page->type) {
 		case WT_PAGE_COL_FIX:
 		case WT_PAGE_COL_VAR:
@@ -253,6 +256,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 			break;
 		WT_ILLEGAL_VALUE_ERR(session, page->type);
 		}
+	}
 
 	/* Discard the cursor. */
 	WT_ERR(__wt_las_cursor_close(session, &cursor, session_flags));

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1408,12 +1408,12 @@ err:	if (parent != NULL)
 
 #ifdef HAVE_DIAGNOSTIC
 /*
- * __check_upd_list --
+ * __wt_count_birthmarks --
  *	Sanity check an update list.
  *	In particular, make sure there no birthmarks.
  */
-static void
-__check_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd)
+int
+__wt_count_birthmarks(WT_UPDATE *upd)
 {
 	int birthmark_count;
 
@@ -1421,7 +1421,7 @@ __check_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 		if (upd->type == WT_UPDATE_BIRTHMARK)
 			++birthmark_count;
 
-	WT_ASSERT(session, birthmark_count <= 1);
+	return (birthmark_count);
 }
 #endif
 
@@ -1520,9 +1520,7 @@ __split_multi_inmem(
 				key->size = WT_INSERT_KEY_SIZE(supd->ins);
 			}
 
-#ifdef HAVE_DIAGNOSTIC
-			__check_upd_list(session, upd);
-#endif
+			WT_ASSERT(session, __wt_count_birthmarks(upd) <= 1);
 
 			/* Search the page. */
 			WT_ERR(__wt_row_search(

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -732,8 +732,26 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 			slot = page->type == WT_PAGE_ROW_LEAF ?
 			    WT_ROW_SLOT(page, list->ripcip) :
 			    WT_COL_SLOT(page, list->ripcip);
-		first_upd = upd = list->ins == NULL ?
+		first_upd = list->ins == NULL ?
 		    page->modify->mod_row_update[slot] : list->ins->upd;
+
+		/*
+		 * Trim any updates before writing to lookaside. This saves
+		 * wasted work, but is also necessary because the
+		 * reconciliation only resolves existing birthmarks if they
+		 * aren't obsolete.
+		 */
+		WT_WITH_BTREE(session, btree, upd =
+		    __wt_update_obsolete_check(session, page, first_upd, true));
+		if (upd != NULL)
+			__wt_free_update_list(session, upd);
+		upd = first_upd;
+
+		/*
+		 * It's not OK for the update list to contain a birthmark on
+		 * entry - we will generate one below if necessary.
+		 */
+		WT_ASSERT(session, __wt_count_birthmarks(first_upd) == 0);
 
 		/*
 		 * Walk the list of updates, storing each key/value pair into
@@ -750,14 +768,15 @@ __wt_las_insert_block(WT_CURSOR *cursor,
 				las_value.data = upd->data;
 				las_value.size = upd->size;
 				break;
-			case WT_UPDATE_BIRTHMARK:
-				WT_ASSERT(session, upd != first_upd ||
-				    multi->page_las.skew_newest);
-				/* FALLTHROUGH */
 			case WT_UPDATE_TOMBSTONE:
 				las_value.size = 0;
 				break;
-			WT_ILLEGAL_VALUE_ERR(session, upd->type);
+			default:
+				/*
+				 * It is never OK to see a birthmark here - it
+				 * would be referring to the wrong page image.
+				 */
+				WT_ERR(__wt_illegal_value(session, upd->type));
 			}
 
 			cursor->set_key(cursor,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -172,6 +172,7 @@ extern int __wt_value_return_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
 extern int __wt_key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_count_birthmarks(WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -199,7 +200,7 @@ extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page) WT_GC
 extern int __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, WT_UPDATE *upd_arg, u_int modify_type, bool exclusive) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_insert_alloc(WT_SESSION_IMPL *session, const WT_ITEM *key, u_int skipdepth, WT_INSERT **insp, size_t *ins_sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **updp, size_t *sizep, u_int modify_type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
+extern WT_UPDATE *__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd, bool update_accounting);
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt, bool insert, bool restore) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_config(WT_SESSION_IMPL *session, const char **cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -266,7 +266,6 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	WT_DECL_RET;
 	WT_UPDATE *obsolete, *upd;
 	wt_timestamp_t obsolete_timestamp;
-	size_t size;
 	uint64_t txn;
 
 	/* Clear references to memory we now own and must free on error. */
@@ -331,16 +330,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page,
 	if (WT_PAGE_TRYLOCK(session, page) != 0)
 		return (0);
 
-	obsolete = __wt_update_obsolete_check(session, page, upd->next);
-
-	/*
-	 * Decrement the dirty byte count while holding the page lock, else we
-	 * can race with checkpoints cleaning a page.
-	 */
-	for (size = 0, upd = obsolete; upd != NULL; upd = upd->next)
-		size += WT_UPDATE_MEMSIZE(upd);
-	if (size != 0)
-		__wt_cache_page_inmem_decr(session, page, size);
+	obsolete = __wt_update_obsolete_check(session, page, upd->next, true);
 
 	WT_PAGE_UNLOCK(session, page);
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -291,8 +291,17 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r,
 	 */
 	if (upd != NULL &&
 	    (upd->type == WT_UPDATE_BIRTHMARK ||
-	    (F_ISSET(r, WT_REC_UPDATE_RESTORE) && skipped_birthmark)))
+	    (F_ISSET(r, WT_REC_UPDATE_RESTORE) && skipped_birthmark))) {
+		/*
+		 * Resolve the birthmark now regardless of whether the
+		 * update being written to the data file is the same as it
+		 * was the previous reconciliation. Otherwise lookaside can
+		 * end up with two birthmark records in the same update chain.
+		 */
+		WT_RET(
+		    __rec_append_orig_value(session, page, first_upd, vpack));
 		*updp = NULL;
+	}
 
 	/*
 	 * Check if all updates on the page are visible.  If not, it must stay


### PR DESCRIPTION
Specifically there were cases where writing a page to lookaside multiple times would result in an update chain with multiple birthmarks, which isn't right. A birthmark refers to the on-page value, and there should only ever be one update in a chain that refers to it.

There were two issues:
* Sometimes birthmarks weren't being resolved during reconciliation. This would mean that they would be re-written in subsequent lookaside evictions. This would only be a problem if reconciliation had chosen a different record to put in the data file the second time, and it should not have been doing that.
* Sometimes obsolete updates were being written to lookaside, and we never resolve values for obsolete updates. A birthmark could be written, but it would never have been visible.

(cherry picked from commit a9a9857e32181befc4cba4541325dc36008749d6)