### PR TITLE
WT-4840 WT_CURSOR.modify must require explicit, snapshot-isolation transaction (v4.0 backport)(2nd attempt after revert)

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1465,9 +1465,11 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	 * the update if the update chain is too long; third, there's a check
 	 * if the updated value is too large to store; fourth, to simplify the
 	 * count of bytes being added/removed; fifth, we can get into serious
-	 * trouble if we attempt to modify a value that doesn't exist. For the
-	 * fifth reason, verify we're not in a read-uncommitted transaction,
-	 * that implies a value that might disappear out from under us.
+	 * trouble if we attempt to modify a value that doesn't exist or read
+	 * a value that might not exist in the future. For the fifth reason,
+	 * fail if in anything other than a snapshot transaction, read-committed
+	 * and read-uncommitted imply values that might disappear out from under
+	 * us or an inability to repeat point-in-time reads.
 	 *
 	 * Also, an application might read a value outside of a transaction and
 	 * then call modify. For that to work, the read must be part of the
@@ -1478,9 +1480,10 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 	 * because it will work most of the time and the failure is unlikely to
 	 * be detected. Require explicit transactions for modify operations.
 	 */
-	if (session->txn.isolation == WT_ISO_READ_UNCOMMITTED)
+	if (session->txn.isolation != WT_ISO_SNAPSHOT)
 		WT_ERR_MSG(session, ENOTSUP,
-		    "not supported in read-uncommitted transactions");
+		    "not supported in read-committed or read-uncommitted "
+		    "transactions");
 	if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
 		WT_ERR_MSG(session, ENOTSUP,
 		    "not supported in implicit transactions");

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -919,11 +919,16 @@ __cursor_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
 	/*
 	 * The underlying btree code cannot support WT_CURSOR.modify within
-	 * a read-uncommitted transaction. Disallow it here for consistency.
+	 * a read-committed or read-uncommitted transaction, or outside of
+	 * an explicit transaction. Disallow here as well, for consistency.
 	 */
-	if (session->txn.isolation == WT_ISO_READ_UNCOMMITTED)
+	if (session->txn.isolation != WT_ISO_SNAPSHOT)
 		WT_ERR_MSG(session, ENOTSUP,
-		    "not supported in read-uncommitted transactions");
+		    "not supported in read-committed or read-uncommitted "
+		    "transactions");
+	if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
+		WT_ERR_MSG(session, ENOTSUP,
+		    "not supported in implicit transactions");
 
 	WT_ERR(__cursor_checkkey(cursor));
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -497,11 +497,7 @@ struct __wt_cursor {
 	 * format type \c u).
 	 *
 	 * The WT_CURSOR::modify method can only be called from within an
-	 * explicit transaction configured at a higher isolation level than
-	 * \c read-uncommitted. Using \c read-committed isolation is allowed,
-	 * but requires caution: reading a value, re-positioning the cursor
-	 * and then modifying the value based on the initial read could lead
-	 * to unexpected results. Using \c snapshot isolation is recommended.
+	 * explicit transaction configured at the snapshot isolation level.
 	 *
 	 * The WT_CURSOR::modify method stores a change record in cache and
 	 * writes a change record to the log instead of the usual complete

--- a/test/csuite/scope/main.c
+++ b/test/csuite/scope/main.c
@@ -91,8 +91,12 @@ cursor_scope_ops(WT_SESSION *session, const char *uri)
 	int exact;
 	bool recno, vstring;
 
-	/* Reserve requires a running transaction. */
-	testutil_check(session->begin_transaction(session, NULL));
+	/*
+	 * Modify and reserve require a transaction, modify requires snapshot
+	 * isolation.
+	 */
+	testutil_check(
+	    session->begin_transaction(session, "isolation=snapshot"));
 
 	cursor = NULL;
 	for (op = ops; op->op != NULL; op++) {

--- a/test/csuite/wt4105_large_doc_small_upd/main.c
+++ b/test/csuite/wt4105_large_doc_small_upd/main.c
@@ -136,8 +136,8 @@ main(int argc, char *argv[])
 	while (++j < MODIFY_COUNT) {
 		for (i = 0; i < NUM_DOCS; i++) {
 			/* Position the cursor. */
-			testutil_check(
-			    session2->begin_transaction(session2, NULL));
+			testutil_check(session2->begin_transaction(
+			    session2, "isolation=snapshot"));
 			c->set_key(c, i);
 			modify_entry.data.data =
 			    "abcdefghijklmnopqrstuvwxyz";

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -879,11 +879,11 @@ ops(void *arg)
 			break;
 		case MODIFY:
 			/*
-			 * Change modify into update if not in a transaction
-			 * or in a read-uncommitted transaction, modify isn't
-			 * supported in those cases.
+			 * Change modify into update if not part of a snapshot
+			 * isolation transaction, modify isn't supported in
+			 * those cases.
 			 */
-			if (!intxn || iso_config == ISOLATION_READ_UNCOMMITTED)
+			if (!intxn || iso_config != ISOLATION_SNAPSHOT)
 				goto update_instead_of_chosen_op;
 
 			++tinfo->update;

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -194,7 +194,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
             self.assertEquals(c.update(), 0)
             c.reset()
 
-            self.session.begin_transaction()
+            self.session.begin_transaction("isolation=snapshot")
             c.set_key(ds.key(row))
             mods = []
             for j in i['mods']:
@@ -228,6 +228,34 @@ class test_cursor12(wttest.WiredTigerTestCase):
             if not single:
                 row = row + 1
         c.close()
+
+    # Smoke-test the modify API, anything other than an explicit transaction
+    # in snapshot isolation fails.
+    def test_modify_txn_api(self):
+        ds = SimpleDataSet(self, self.uri, 100, key_format=self.keyfmt, value_format=self.valuefmt)
+        ds.populate()
+
+        c = self.session.open_cursor(self.uri, None)
+        c.set_key(ds.key(10))
+        msg = '/not supported/'
+
+        self.session.begin_transaction()
+        mods = []
+        mods.append(wiredtiger.Modify('-', 1, 1))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c.modify(mods), msg)
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction("isolation=read-uncommitted")
+        mods = []
+        mods.append(wiredtiger.Modify('-', 1, 1))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c.modify(mods), msg)
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction("isolation=read-committed")
+        mods = []
+        mods.append(wiredtiger.Modify('-', 1, 1))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c.modify(mods), msg)
+        self.session.rollback_transaction()
 
     # Smoke-test the modify API, operating on a group of records.
     def test_modify_smoke(self):
@@ -290,7 +318,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         ds.populate()
 
         c = self.session.open_cursor(self.uri, None)
-        self.session.begin_transaction()
+        self.session.begin_transaction("isolation=snapshot")
         c.set_key(ds.key(10))
         orig = 'abcdefghijklmnopqrstuvwxyz'
         c.set_value(orig)
@@ -318,7 +346,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         c.set_key(ds.key(10))
         self.assertEquals(c.remove(), 0)
 
-        self.session.begin_transaction()
+        self.session.begin_transaction("isolation=snapshot")
         mods = []
         mod = wiredtiger.Modify('ABCD', 3, 3)
         mods.append(mod)
@@ -335,7 +363,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         ds.populate()
 
         # Start a transaction.
-        self.session.begin_transaction()
+        self.session.begin_transaction("isolation=snapshot")
 
         # Insert a new record.
         c = self.session.open_cursor(self.uri, None)
@@ -353,7 +381,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         # Test that another transaction cannot modify our uncommitted record.
         xs = self.conn.open_session()
         xc = xs.open_cursor(self.uri, None)
-        xs.begin_transaction()
+        xs.begin_transaction("isolation=snapshot")
         xc.set_key(ds.key(30))
         xc.set_value(ds.value(30))
         mods = []
@@ -367,7 +395,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         self.session.rollback_transaction()
 
         # Test that we can't modify our aborted insert.
-        self.session.begin_transaction()
+        self.session.begin_transaction("isolation=snapshot")
         mods = []
         mod = wiredtiger.Modify('ABCD', 3, 3)
         mods.append(mod)

--- a/test/suite/test_las01.py
+++ b/test/suite/test_las01.py
@@ -37,8 +37,8 @@ def timestamp_str(t):
 # Smoke tests to ensure lookaside tables are working.
 class test_las01(wttest.WiredTigerTestCase):
     # Force a small cache.
-    def conn_config(self):
-        return 'cache_size=50MB'
+    conn_config = 'cache_size=50MB'
+    session_config = 'isolation=snapshot'
 
     def large_updates(self, session, uri, value, ds, nrows, timestamp=False):
         # Update a large number of records, we'll hang if the lookaside table


### PR DESCRIPTION
Disallow WT_CURSOR.modify in anything other than an explicit transaction
at snapshot isolation.

Add tests that other transaction configurations fail.

(cherry picked from commit 7c486eb1d4aecb67a635e06cdd74d179d69638f1)