### PR TITLE
WT-5046 Prepared transactions aren't properly cleared from global table with WT_CONN_LOG_DEBUG_MODE enabled

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -1254,6 +1254,12 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
 	txn_global = &S2C(session)->txn_global;
 
 	/*
+	 * Default to true - callers shouldn't rely on this if an error is
+	 * returned, but let's give them deterministic behaviour if they do.
+	 */
+	*txn_active = true;
+
+	/*
 	 * Ensure the oldest ID is as up to date as possible so we can use a
 	 * simple check to find if there are any running transactions.
 	 */

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1728,7 +1728,8 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
 		WT_TRET(__wt_txn_rollback(session, cfg));
 	}
 
-err:	API_END_RET(session, ret);
+err:	WT_ASSERT(session, WT_SESSION_TXN_STATE(session)->id == WT_TXN_NONE);
+	API_END_RET(session, ret);
 }
 
 /*
@@ -1762,7 +1763,8 @@ __session_prepare_transaction(WT_SESSION *wt_session, const char *config)
 
 	WT_ERR(__wt_txn_prepare(session, cfg));
 
-err:	API_END_RET(session, ret);
+err:	WT_ASSERT(session, WT_SESSION_TXN_STATE(session)->id == WT_TXN_NONE);
+	API_END_RET(session, ret);
 
 }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -621,6 +621,9 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 		 */
 		if (!F_ISSET(txn, WT_TXN_PREPARE))
 			__txn_remove_from_global_table(session);
+		else
+			WT_ASSERT(session,
+			    WT_SESSION_TXN_STATE(session)->id == WT_TXN_NONE);
 		txn->id = WT_TXN_NONE;
 	}
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -593,14 +593,13 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
 void
 __wt_txn_release(WT_SESSION_IMPL *session)
 {
-	WT_CONNECTION_IMPL *conn;
 	WT_TXN *txn;
 	WT_TXN_GLOBAL *txn_global;
 
-	conn = S2C(session);
 	txn = &session->txn;
-	txn_global = &conn->txn_global;
+	txn_global = &S2C(session)->txn_global;
 
+	WT_ASSERT(session, txn->mod_count == 0);
 	txn->notify = NULL;
 
 	/* Clear the transaction's ID from the global table. */
@@ -619,15 +618,8 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 		/*
 		 * If transaction is prepared, this would have been done in
 		 * prepare.
-		 *
-		 * If the logging debug mode is on, an empty prepared txn which
-		 * never gets an ID allocated to it will be allocated one at
-		 * commit time in order for it to be logged. If that happens, we
-		 * need to remove that ID from the global table now.
 		 */
-		if (!F_ISSET(txn, WT_TXN_PREPARE) ||
-		    (FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE) &&
-		    txn->mod_count == 0))
+		if (!F_ISSET(txn, WT_TXN_PREPARE))
 			__txn_remove_from_global_table(session);
 		txn->id = WT_TXN_NONE;
 	}
@@ -658,7 +650,6 @@ __wt_txn_release(WT_SESSION_IMPL *session)
 	 */
 	txn->flags = 0;
 	txn->prepare_timestamp = WT_TS_NONE;
-	txn->mod_count = 0;
 }
 
 /*
@@ -1038,6 +1029,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 	WT_STAT_CONN_INCRV(session, txn_prepared_updates_resolved,
 	    resolved_update_count);
 
+	txn->mod_count = 0;
+
 	/*
 	 * If durable is set, we'll try to update the global durable timestamp
 	 * with that value. If durable isn't set, durable is implied to be the
@@ -1342,6 +1335,8 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 	    resolved_update_count == visited_update_count);
 	WT_STAT_CONN_INCRV(session, txn_prepared_updates_resolved,
 	    resolved_update_count);
+
+	txn->mod_count = 0;
 
 	__wt_txn_release(session);
 	/*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -215,8 +215,10 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
 	 * are recording diagnostic information. In that case, allocate an id.
 	 */
 	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_DEBUG_MODE) &&
-	    txn->id == WT_TXN_NONE)
+	    txn->id == WT_TXN_NONE) {
+		WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
 		WT_RET(__wt_txn_id_check(session));
+	}
 	else
 		WT_ASSERT(session, txn->id != WT_TXN_NONE);
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -215,10 +215,8 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
 	 * are recording diagnostic information. In that case, allocate an id.
 	 */
 	if (FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_DEBUG_MODE) &&
-	    txn->id == WT_TXN_NONE) {
-		WT_ASSERT(session, !F_ISSET(txn, WT_TXN_PREPARE));
+	    txn->id == WT_TXN_NONE)
 		WT_RET(__wt_txn_id_check(session));
-	}
 	else
 		WT_ASSERT(session, txn->id != WT_TXN_NONE);
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -408,6 +408,15 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
 	    !FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE))
 		return (0);
 
+	/*
+	 * There is a rare usage case of a prepared transaction that has no
+	 * modifications, but then commits and sets timestamps. If an empty
+	 * transaction has been prepared, don't bother writing a timestamp
+	 * operation record.
+	 */
+	if (F_ISSET(txn, WT_TXN_PREPARE) && txn->mod_count == 0)
+		return (0);
+
 	/* We'd better have a transaction running. */
 	WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -207,8 +207,10 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
 	rectype = WT_LOGREC_COMMIT;
 	fmt = WT_UNCHECKED_STRING(Iq);
 
-	if (txn->logrec != NULL)
+	if (txn->logrec != NULL) {
+		WT_ASSERT(session, F_ISSET(txn, WT_TXN_HAS_ID));
 		return (0);
+	}
 
 	/*
 	 * The only way we should ever get in here without a txn id is if we

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -474,6 +474,10 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
 	 */
 	__wt_writelock(session, &conn->cache->las_sweepwalk_lock);
 	ret = __wt_txn_activity_check(session, &txn_active);
+#if defined (HAVE_DIAGNOSTIC)
+	if (txn_active)
+		WT_TRET(__wt_verbose_dump_txn(session));
+#endif
 	__wt_writeunlock(session, &conn->cache->las_sweepwalk_lock);
 
 	if (ret == 0 && txn_active)

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -474,7 +474,7 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
 	 */
 	__wt_writelock(session, &conn->cache->las_sweepwalk_lock);
 	ret = __wt_txn_activity_check(session, &txn_active);
-#if defined (HAVE_DIAGNOSTIC)
+#ifdef HAVE_DIAGNOSTIC
 	if (txn_active)
 		WT_TRET(__wt_verbose_dump_txn(session));
 #endif

--- a/test/suite/test_debug_mode03.py
+++ b/test/suite/test_debug_mode03.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-# Public Domain 2034-2039 MongoDB, Inc.
-# Public Domain 2008-2034 WiredTiger, Inc.
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
 #
 # This is free and unencumbered software released into the public domain.
 #

--- a/test/suite/test_debug_mode04.py
+++ b/test/suite/test_debug_mode04.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-# Public Domain 2034-2039 MongoDB, Inc.
-# Public Domain 2008-2034 WiredTiger, Inc.
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
 #
 # This is free and unencumbered software released into the public domain.
 #

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-# Public Domain 2034-2039 MongoDB, Inc.
-# Public Domain 2008-2034 WiredTiger, Inc.
+# Public Domain 2014-2019 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
 #
 # This is free and unencumbered software released into the public domain.
 #

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -62,9 +62,9 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         self.conn.rollback_to_stable()
 
         # The original bug happened when we had a txn that:
-        # 1). Was prepared.
-        # 2). Did not cause anything to be written to the log before committing.
-        # 3). Was the last txn before the rollback to stable call.
+        # 1. Was prepared.
+        # 2. Did not cause anything to be written to the log before committing.
+        # 3. Was the last txn before the rollback to stable call.
         # Therefore, we're specifically not doing any operations here.
         self.session.begin_transaction()
         self.session.prepare_transaction(
@@ -75,6 +75,10 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
             'durable_timestamp=' + timestamp_str(400))
         self.session.commit_transaction()
 
+        # The aforementioned bug resulted in a failure in rollback to stable.
+        # This is because we failed to clear out a txn id from our global state
+        # which caused us to think that we had a running txn.
+        # Verify that we can rollback to stable without issues.
         self.conn.rollback_to_stable()
 
         self.session.begin_transaction()
@@ -84,3 +88,6 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
             'commit_timestamp=' + timestamp_str(450))
 
         self.conn.rollback_to_stable()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Public Domain 2034-2039 MongoDB, Inc.
+# Public Domain 2008-2034 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+def timestamp_str(t):
+    return '%x' %t
+
+# test_debug_mode05.py
+#     As per WT-5046, the debug table logging settings prevent rollback to
+#     stable in the presence of prepared transactions.
+#
+#     This test is to confirm the fix and prevent similar regressions.
+class test_debug_mode05(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled),debug_mode=(table_logging=true)'
+    session_config = 'isolation=snapshot'
+    uri = 'file:test_debug_mode05'
+
+    def test_table_logging_rollback_to_stable(self):
+        self.session.create(self.uri, 'key_format=i,value_format=u')
+        cursor = self.session.open_cursor(self.uri, None)
+
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))
+
+        self.session.begin_transaction()
+        for i in range(1, 50):
+            cursor[i] = 'a' * 100
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + timestamp_str(150))
+        self.session.timestamp_transaction(
+            'commit_timestamp=' + timestamp_str(200))
+        self.session.timestamp_transaction(
+            'durable_timestamp=' + timestamp_str(250))
+        self.session.commit_transaction()
+
+        # The original bug happened when we had a transaction that:
+        # a). Was prepared.
+        # b). Did not cause anything to be written to the log before committing.
+        # Therefore, we're specifically not doing anything here.
+        self.session.begin_transaction()
+        # for i in range(1, 50):
+        #     cursor.set_key(i)
+        #     cursor.remove()
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + timestamp_str(300))
+        self.session.timestamp_transaction(
+            'commit_timestamp=' + timestamp_str(350))
+        self.session.timestamp_transaction(
+            'durable_timestamp=' + timestamp_str(400))
+        self.session.commit_transaction()
+
+        self.session.begin_transaction()
+        for i in range(1, 50):
+            cursor[i] = 'b' * 100
+        self.session.commit_transaction(
+            'commit_timestamp=' + timestamp_str(450))
+
+        self.conn.rollback_to_stable()

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -50,7 +50,7 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         # Try doing a normal prepared txn and then rollback to stable.
         self.session.begin_transaction()
         for i in range(1, 50):
-            cursor[i] = 'a' * 100
+            cursor[i] = b'a' * 100
         self.session.prepare_transaction(
             'prepare_timestamp=' + timestamp_str(150))
         self.session.timestamp_transaction(
@@ -79,7 +79,7 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
 
         self.session.begin_transaction()
         for i in range(1, 50):
-            cursor[i] = 'b' * 100
+            cursor[i] = b'b' * 100
         self.session.commit_transaction(
             'commit_timestamp=' + timestamp_str(450))
 


### PR DESCRIPTION
This PR is adding some additional logic to clear txn IDs from the global table when we have table logging on. To give a bit of background on what this is solving:

The lifecycle for a normal prepared txn is:
1. Begin txn.
2. Do operations. The first one will alloc a txn ID and a write to the log.
3. Prepare the txn. Here we clear the txn ID from the global table.
4. Commit the txn. We purposely don't clear the txn ID since we did it at the prepare stage.

When a txn has no operations, it gets neither a txn ID nor a log record allocated for it. When we have table logging turned on, an empty prepared txn will have its log record initialised (and a txn ID allocated) at commit time in order to write it to the log. With our existing logic, this causes the txn ID to not get cleared from the global table and prevents rollback to stable.

The lifecycle for an empty prepared txn is:
1. Begin txn.
2. Do no operations. We won't get a txn ID allocated or any log initialised.
3. Prepare the txn. We have no txn ID to clear from the global table so nothing special happens in that regard.
4. Commit the txn. Since we haven't initialised the log yet, we do it here and allocate a txn ID as part of this process. We purposely don't clear the txn ID since we supposedly did it at the prepare stage (!!!).

So this PR is modifying the clearing logic at the commit stage to clear the txn ID from the global table for not only non-prepared txns but ALSO prepared txns that have no modifications if table logging is on.