### PR TITLE
WT-4895 Avoid overriding the randomization of lookaside eviction (#4736) (v4.0 backport)

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -581,8 +581,7 @@ __rec_init(WT_SESSION_IMPL *session,
 	else
 		r->las_skew_newest =
 		    LF_ISSET(WT_REC_LOOKASIDE) && LF_ISSET(WT_REC_VISIBLE_ALL);
-	r->las_skew_newest =
-	    LF_ISSET(WT_REC_LOOKASIDE) && LF_ISSET(WT_REC_VISIBLE_ALL);
+
 	if (r->las_skew_newest &&
 	    !__wt_btree_immediately_durable(session) &&
 	    txn_global->has_stable_timestamp &&


### PR DESCRIPTION
Remove the override of the randomization that is choosen Under
WT_CACHE_EVICT_DEBUG_MODE flag.

(cherry picked from commit dccdc93ba1ca5efcdc2239617d9532f66fa4944e)