### PR TITLE
WT-4884 Test for recovery correctness with all WAL operation types

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -544,14 +544,16 @@ recover_and_verify(uint32_t nthreads)
                     if (strncmp(file_value, search_value.data, search_value.size) == 0)
                         continue;
 
-                    /*
-                     * Once the key exist in the database, there is no way that fetched data can
-                     * mismatch with saved.
-                     */
-                    printf("%s: modified record with data mismatch key %" PRIu64 "\n",
-                      fname[MODIFY_RECORD_FILE_ID], key);
-                    fatal = true;
-                    break;
+                    if (!inmem)
+                        /*
+                         * Once the key exist in the database, there is no way that fetched data can
+                         * mismatch with saved.
+                         */
+                        printf("%s: modified record with data mismatch key %" PRIu64 "\n",
+                          fname[MODIFY_RECORD_FILE_ID], key);
+
+                    absent++;
+                    middle = key;
                 }
             } else
                 /* Dead code. To catch any op type misses */

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -121,9 +121,7 @@ thread_run(void *arg)
     columnar_table = false;
 
     td = (WT_THREAD_DATA *)arg;
-    /*
-     * The value is the name of the record file with our id appended.
-     */
+
     testutil_check(__wt_snprintf(fname[DELETE_RECORD_FILE_ID], sizeof(fname[DELETE_RECORD_FILE_ID]),
       DELETE_RECORDS_FILE, td->id));
     testutil_check(__wt_snprintf(fname[INSERT_RECORD_FILE_ID], sizeof(fname[INSERT_RECORD_FILE_ID]),
@@ -174,6 +172,9 @@ thread_run(void *arg)
         if (i == 0)
             i++;
 
+        /*
+         * The value is the insert- with key appended.
+         */
         testutil_check(__wt_snprintf(buf, sizeof(buf), "insert-%" PRIu64, i));
 
         if (columnar_table)

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -169,7 +169,7 @@ thread_run(void *arg)
      */
     printf("Thread %" PRIu32 " starts at %" PRIu64 "\n", td->id, td->start);
     for (i = td->start;; ++i) {
-        /* Recno 0 is invalid for columnar store */
+        /* Record number 0 is invalid for columnar store, check it. */
         if (i == 0)
             i++;
 


### PR DESCRIPTION
The row store operations like row_put(insert, update), row_modify(modify)
and row_remove(remove) cursor operations are covered in the test.

The test creates 3 set of files per worker (insert, modify and delete).
Insert file contains all the records that are inserted, followed by
either the record is modified or deleted those will be in their corresponding
files.

After a successful recovery, the main thread verifies the records based
on the file the key is present.
	- insert, the record must present
	- delete, the record must not present
	- modify, the record must present with modified data