### PR TITLE
WT-5052 Enhance lookaside search functionality to handle WT_MODIFY records

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1558,8 +1558,7 @@ __wt_find_lookaside_upd(
 			}
 			WT_ASSERT(session, upd_type == WT_UPDATE_STANDARD);
 			while (i > 0) {
-				WT_ERR(__wt_modify_apply_item(
-				    (WT_SESSION_IMPL *)cursor->session,
+				WT_ERR(__wt_modify_apply_item(session,
 				    &las_value, listp[i - 1]->data, false));
 				__wt_free_update_list(session, listp[i - 1]);
 				--i;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1413,14 +1413,14 @@ __wt_find_lookaside_upd(
 	WT_ITEM *key, las_key, las_value;
 	WT_REF *ref;
 	WT_UPDATE *upd, *list[1000];
-	wt_timestamp_t durable_timestamp, las_timestamp;
 	wt_timestamp_t _durable_timestamp, _las_timestamp;
+	wt_timestamp_t durable_timestamp, las_timestamp;
 	size_t incr;
 	uint64_t las_counter, las_pageid, las_txnid, _las_txnid;
 	uint32_t las_id, session_flags;
 	uint8_t prepare_state, upd_type, _prepare_state;
-	int cmp;
 	u_int i;
+	int cmp;
 	bool upd_visible;
 
 	*updp = upd = NULL;
@@ -1506,8 +1506,8 @@ __wt_find_lookaside_upd(
 		 */
 		if (upd_type == WT_UPDATE_MODIFY) {
 			while (upd_type == WT_UPDATE_MODIFY) {
-				WT_ERR(__wt_update_alloc(
-				    session, &las_value, &upd, &incr, upd_type));
+				WT_ERR(__wt_update_alloc(session,
+				    &las_value, &upd, &incr, upd_type));
 				list[i++] = upd;
 				WT_ERR(cursor->next(cursor));
 #ifdef HAVE_DIAGNOSTIC
@@ -1519,7 +1519,7 @@ __wt_find_lookaside_upd(
 				WT_ERR(cursor->get_key(cursor, &las_pageid,
 				    &las_id, &las_counter, &las_key));
 				WT_ASSERT(session,
-				    las_pageid != ref->page_las->las_pageid);
+				    las_pageid == ref->page_las->las_pageid);
 #endif
 				/*
 				 * Make sure we use the underscore variants of
@@ -1533,7 +1533,6 @@ __wt_find_lookaside_upd(
 				WT_ASSERT(session, __wt_txn_visible(
 				    session, _las_txnid, _las_timestamp));
 			}
-
 			WT_ASSERT(session, upd_type == WT_UPDATE_STANDARD);
 
 			/*

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1557,15 +1557,6 @@ __wt_find_lookaside_upd(
 				    session, _las_txnid, _las_timestamp));
 			}
 			WT_ASSERT(session, upd_type == WT_UPDATE_STANDARD);
-
-			/*
-			 * This value is a pointer/size pair pointing at a spot
-			 * in the cursor's buffer. Our modify function needs to
-			 * know to allocate its own buffer when applying
-			 * modifications so explicitly unset these.
-			 */
-			las_value.mem = NULL;
-			las_value.memsize = 0;
 			while (i > 0) {
 				WT_ERR(__wt_modify_apply_item(
 				    (WT_SESSION_IMPL *)cursor->session,

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1508,7 +1508,6 @@ __wt_find_lookaside_upd(
 		 * It is okay to locate an older update in lookaside,
 		 * but we proceed only if we find a matching record.
 		 */
-		WT_ASSERT(session, start_ts >= las_timestamp);
 		if (start_ts != las_timestamp)
 			break;
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1541,6 +1541,10 @@ __wt_find_lookaside_upd(
 				    &las_id, &las_counter, &las_key));
 				WT_ASSERT(session,
 				    las_pageid == ref->page_las->las_pageid);
+				WT_ERR(__wt_compare(session,
+				    S2BT(session)->collator,
+				    &las_key, key, &cmp));
+				WT_ASSERT(session, cmp == 0);
 #endif
 				/*
 				 * Make sure we use the underscore variants of

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -506,7 +506,7 @@ extern int __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session) WT_GCC_FUNC_DE
 extern int __wt_metadata_update( WT_SESSION_IMPL *session, const char *key, const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply(WT_CURSOR *cursor, const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_modify_apply_buf(WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_modify_apply_item( WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_pack(WT_CURSOR *cursor, WT_ITEM **modifyp, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -506,6 +506,7 @@ extern int __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session) WT_GCC_FUNC_DE
 extern int __wt_metadata_update( WT_SESSION_IMPL *session, const char *key, const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply(WT_CURSOR *cursor, const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_modify_apply_buf(WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_pack(WT_CURSOR *cursor, WT_ITEM **modifyp, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format (printf, 2, 3))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -910,8 +910,8 @@ __wt_txn_read(WT_SESSION_IMPL *session,
 		 * If we located the correct record, the contents should
 		 * be the same and we can use the record from lookaside.
 		 */
-		/* WT_ASSERT(session, upd->size == tmp_upd->size && */
-		/*     memcmp(upd->data, tmp_upd->data, upd->size) == 0); */
+		WT_ASSERT(session, upd->size == tmp_upd->size &&
+		    memcmp(upd->data, tmp_upd->data, upd->size) == 0);
 		upd = tmp_upd;
 	}
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -910,8 +910,9 @@ __wt_txn_read(WT_SESSION_IMPL *session,
 		 * If we located the correct record, the contents should
 		 * be the same and we can use the record from lookaside.
 		 */
-		WT_ASSERT(session, upd->size == tmp_upd->size &&
-		    memcmp(upd->data, tmp_upd->data, upd->size) == 0);
+		WT_ASSERT(session, upd->type == WT_UPDATE_MODIFY ||
+		    (upd->size == tmp_upd->size &&
+		    memcmp(upd->data, tmp_upd->data, upd->size) == 0));
 		upd = tmp_upd;
 	}
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -910,8 +910,8 @@ __wt_txn_read(WT_SESSION_IMPL *session,
 		 * If we located the correct record, the contents should
 		 * be the same and we can use the record from lookaside.
 		 */
-		WT_ASSERT(session, upd->size == tmp_upd->size &&
-		    memcmp(upd->data, tmp_upd->data, upd->size) == 0);
+		/* WT_ASSERT(session, upd->size == tmp_upd->size && */
+		/*     memcmp(upd->data, tmp_upd->data, upd->size) == 0); */
 		upd = tmp_upd;
 	}
 

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -335,22 +335,32 @@ __modify_apply_no_overlap(WT_SESSION_IMPL *session, WT_ITEM *value,
 
 /*
  * __wt_modify_apply --
- *	Apply a single set of WT_MODIFY changes to a buffer.
+ *	Apply a single set of WT_MODIFY changes to a cursor buffer.
  */
 int
 __wt_modify_apply(WT_CURSOR *cursor, const void *modify)
 {
-	WT_ITEM *value;
-	WT_MODIFY mod;
 	WT_SESSION_IMPL *session;
-	size_t datasz, destsz, item_offset, tmp;
-	const size_t *p;
-	int napplied, nentries;
-	bool overlap, sformat;
+	bool sformat;
 
 	session = (WT_SESSION_IMPL *)cursor->session;
 	sformat = cursor->value_format[0] == 'S';
-	value = &cursor->value;
+
+	return __wt_modify_apply_buf(session, &cursor->value, modify, sformat);
+}
+
+/*
+ * __wt_modify_apply_buf --
+ *	Apply a single set of WT_MODIFY changes to a buffer.
+ */
+int
+__wt_modify_apply_buf(WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat)
+{
+	WT_MODIFY mod;
+	size_t datasz, destsz, item_offset, tmp;
+	const size_t *p;
+	int napplied, nentries;
+	bool overlap;
 
 	/*
 	 * Get the number of modify entries and set a second pointer to

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -346,7 +346,8 @@ __wt_modify_apply(WT_CURSOR *cursor, const void *modify)
 	session = (WT_SESSION_IMPL *)cursor->session;
 	sformat = cursor->value_format[0] == 'S';
 
-	return __wt_modify_apply_item(session, &cursor->value, modify, sformat);
+	return (__wt_modify_apply_item(
+	    session, &cursor->value, modify, sformat));
 }
 
 /*

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -346,15 +346,16 @@ __wt_modify_apply(WT_CURSOR *cursor, const void *modify)
 	session = (WT_SESSION_IMPL *)cursor->session;
 	sformat = cursor->value_format[0] == 'S';
 
-	return __wt_modify_apply_buf(session, &cursor->value, modify, sformat);
+	return __wt_modify_apply_item(session, &cursor->value, modify, sformat);
 }
 
 /*
- * __wt_modify_apply_buf --
- *	Apply a single set of WT_MODIFY changes to a buffer.
+ * __wt_modify_apply_item --
+ *	Apply a single set of WT_MODIFY changes to a WT_ITEM buffer.
  */
 int
-__wt_modify_apply_buf(WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat)
+__wt_modify_apply_item(
+    WT_SESSION_IMPL *session, WT_ITEM *value, const void *modify, bool sformat)
 {
 	WT_MODIFY mod;
 	size_t datasz, destsz, item_offset, tmp;

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -163,16 +163,6 @@ class test_las06(wttest.WiredTigerTestCase):
         #                             between on value1 to deduce value3.
         self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
         for i in range(1, 5000):
-            val = cursor[i]
-            #print(len(val))
-            for i in range(0, len(val) - 1):
-                c = val[i]
-                if c == 'B':
-                    pass
-                    # print('b found at {}'.format(i))
-                elif c == 'C':
-                    pass
-                    # print('c found at {}'.format(i))
             self.assertEqual(cursor[i], expected)
         self.session.rollback_transaction()
 

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -104,5 +104,67 @@ class test_las06(wttest.WiredTigerTestCase):
         # TODO: Uncomment this once the project work is done.
         # self.assertLessEqual(end_usage, (start_usage * 2))
 
+    def test_las_modify_reads_workload(self):
+        # Create a small table.
+        uri = "table:test_las06"
+        create_params = 'key_format=i,value_format=S,'
+        self.session.create(uri, create_params)
+
+        # Create initial large values.
+        value1 = 'a' * 500
+        value2 = 'b' * 500
+
+        # Load 5Mb of data.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, 5000):
+            cursor[i] = value1
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        # Load another a slight modification with a later timestamp.
+        self.session.begin_transaction()
+        for i in range(1, 5000):
+            cursor.set_key(i)
+            mods = [wiredtiger.Modify('b', 100, 1)]
+            self.assertEqual(cursor.modify(mods), 0)
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        # And another.
+        self.session.begin_transaction()
+        for i in range(1, 5000):
+            cursor.set_key(i)
+            mods = [wiredtiger.Modify('c', 200, 1)]
+            self.assertEqual(cursor.modify(mods), 0)
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+
+        # Now write something completely different.
+        self.session.begin_transaction()
+        for i in range(1, 5000):
+            cursor[i] = value2
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+
+        # Now the latest version will get written to the data file.
+        self.session.checkpoint()
+
+        expected = list(value1)
+        expected[100] = 'b'
+        expected[200] = 'c'
+        expected = str().join(expected)
+
+        # Whenever we request something of timestamp 4, this should be a modify
+        # op. We should keep looking backwards in lookaside until we find the
+        # newest whole update (timestamp 2).
+        #
+        # t5: value1 (full update)
+        # t4: (delta) <= We're querying for t4 so we begin here.
+        # t3: (delta)
+        # t2: value2 (full update) <= And finish here, applying all deltas in
+        #                             between on value1 to deduce value3.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
+        for i in range(1, 5000):
+            self.assertEqual(cursor[i], expected)
+        self.session.rollback_transaction()
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -112,7 +112,7 @@ class test_las06(wttest.WiredTigerTestCase):
 
         # Create initial large values.
         value1 = 'a' * 500
-        value2 = 'b' * 500
+        value2 = 'd' * 500
 
         # Load 5Mb of data.
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
@@ -126,7 +126,7 @@ class test_las06(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         for i in range(1, 5000):
             cursor.set_key(i)
-            mods = [wiredtiger.Modify('b', 100, 1)]
+            mods = [wiredtiger.Modify('B', 100, 1)]
             self.assertEqual(cursor.modify(mods), 0)
         self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
 
@@ -134,7 +134,7 @@ class test_las06(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         for i in range(1, 5000):
             cursor.set_key(i)
-            mods = [wiredtiger.Modify('c', 200, 1)]
+            mods = [wiredtiger.Modify('C', 200, 1)]
             self.assertEqual(cursor.modify(mods), 0)
         self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
 
@@ -148,8 +148,8 @@ class test_las06(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         expected = list(value1)
-        expected[100] = 'b'
-        expected[200] = 'c'
+        expected[100] = 'B'
+        expected[200] = 'C'
         expected = str().join(expected)
 
         # Whenever we request something of timestamp 4, this should be a modify
@@ -163,6 +163,16 @@ class test_las06(wttest.WiredTigerTestCase):
         #                             between on value1 to deduce value3.
         self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
         for i in range(1, 5000):
+            val = cursor[i]
+            #print(len(val))
+            for i in range(0, len(val) - 1):
+                c = val[i]
+                if c == 'B':
+                    pass
+                    # print('b found at {}'.format(i))
+                elif c == 'C':
+                    pass
+                    # print('c found at {}'.format(i))
             self.assertEqual(cursor[i], expected)
         self.session.rollback_transaction()
 

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -122,7 +122,7 @@ class test_las06(wttest.WiredTigerTestCase):
             cursor[i] = value1
         self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
 
-        # Load another a slight modification with a later timestamp.
+        # Load a slight modification with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 5000):
             cursor.set_key(i)


### PR DESCRIPTION
This PR is adding support for modify records with the new lookaside logic. When we search lookaside and find a modify update, we keep walking backwards until we find a regular update and squash all the modifies in between on top of that base update.