### PR TITLE
WT-4961 Checkpoints with cache overflow must keep history for reads. (Clang Format migration)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1436,8 +1436,8 @@ methods = {
         dropped while a hot backup is in progress or if open in
         a cursor''', type='list'),
     Config('force', 'false', r'''
-        by default, checkpoints may be skipped if the underlying object
-        has not been modified, this option forces the checkpoint''',
+        if false (the default), checkpoints may be skipped if the underlying object has not been
+        modified, if true, this option forces the checkpoint''',
         type='boolean'),
     Config('name', '', r'''
         if set, specify a name for the checkpoint (note that checkpoints
@@ -1445,10 +1445,9 @@ methods = {
     Config('target', '', r'''
         if non-empty, checkpoint the list of objects''', type='list'),
     Config('use_timestamp', 'true', r'''
-        by default, create the checkpoint as of the last stable timestamp
-        if timestamps are in use, or all current updates if there is no
-        stable timestamp set.  If false, this option generates a checkpoint
-        with all updates including those later than the timestamp''',
+        if true (the default), create the checkpoint as of the last stable timestamp if timestamps
+        are in use, or all current updates if there is no stable timestamp set. If false, this
+        option generates a checkpoint with all updates including those later than the timestamp''',
         type='boolean'),
 ]),
 

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -928,6 +928,8 @@ transaction_ops(WT_SESSION *session_arg)
     error_check(conn->set_timestamp(conn, "stable_timestamp=2a"));
     /*! [set stable timestamp] */
 
+    /* WT_CONNECTION.rollback_to_stable requires a timestamped checkpoint. */
+    error_check(session->checkpoint(session, NULL));
     /*! [rollback to stable] */
     error_check(conn->rollback_to_stable(conn, NULL));
     /*! [rollback to stable] */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -116,6 +116,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_DECL_RET;
     WT_ITEM las_key, las_value;
     WT_PAGE *page;
+    WT_PAGE_LOOKASIDE *page_las;
     WT_UPDATE *first_upd, *last_upd, *upd;
     wt_timestamp_t durable_timestamp, las_timestamp;
     size_t incr, total_incr;
@@ -131,7 +132,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     locked = false;
     total_incr = 0;
     current_recno = recno = WT_RECNO_OOB;
-    las_pageid = ref->page_las->las_pageid;
+    page_las = ref->page_las;
+    las_pageid = page_las->las_pageid;
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
     WT_CLEAR(las_key);
 
@@ -167,7 +169,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
          * Confirm the search using the unique prefix; if not a match, we're done searching for
          * records for this page.
          */
-        if (las_pageid != ref->page_las->las_pageid)
+        if (las_pageid != page_las->las_pageid)
             break;
 
         /* Allocate the WT_UPDATE structure. */
@@ -265,12 +267,11 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
 
         FLD_SET(page->modify->restore_state, WT_PAGE_RS_LOOKASIDE);
 
-        if (ref->page_las->skew_newest && !ref->page_las->has_prepares &&
+        if (page_las->min_skipped_ts == WT_TS_MAX && !page_las->has_prepares &&
           !S2C(session)->txn_global.has_stable_timestamp &&
-          __wt_txn_visible_all(
-              session, ref->page_las->unstable_txn, ref->page_las->unstable_durable_timestamp)) {
-            page->modify->rec_max_txn = ref->page_las->max_txn;
-            page->modify->rec_max_timestamp = ref->page_las->max_timestamp;
+          __wt_txn_visible_all(session, page_las->max_txn, page_las->max_ondisk_ts)) {
+            page->modify->rec_max_txn = page_las->max_txn;
+            page->modify->rec_max_timestamp = page_las->max_ondisk_ts;
             __wt_page_modify_clear(session, page);
         }
     }
@@ -279,8 +280,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
      * Now the lookaside history has been read into cache there is no further need to maintain a
      * reference to it.
      */
-    ref->page_las->eviction_to_lookaside = false;
-    ref->page_las->resolved = true;
+    page_las->eviction_to_lookaside = false;
+    page_las->resolved = true;
 
 err:
     if (locked)
@@ -543,7 +544,7 @@ skip_read:
      * Don't free WT_REF.page_las, there may be concurrent readers.
      */
     if (final_state == WT_REF_MEM && ref->page_las != NULL &&
-      (!ref->page_las->skew_newest || ref->page_las->has_prepares))
+      (ref->page_las->min_skipped_ts != WT_TS_MAX || ref->page_las->has_prepares))
         WT_ERR(__wt_las_remove_block(session, ref->page_las->las_pageid));
 
     WT_REF_SET_STATE(ref, final_state);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -299,21 +299,9 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * cache clean but with history that cannot be
              * discarded), that is not wasted effort because
              * checkpoint doesn't need to write the page again.
-             *
-             * Once the transaction has given up it's snapshot it
-             * is no longer safe to reconcile pages. That happens
-             * prior to the final metadata checkpoint.
-             *
-             * XXX Only attempt this eviction when there are no
-             * readers older than the checkpoint.  Otherwise, a bug
-             * in eviction can mark the page clean and discard
-             * history, causing those reads to incorrectly see
-             * newer versions of data than they should.
              */
             if (!WT_PAGE_IS_INTERNAL(page) && page->read_gen == WT_READGEN_WONT_NEED &&
-              !tried_eviction && F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT) &&
-              (!F_ISSET(txn, WT_TXN_HAS_TS_READ) ||
-                txn->read_timestamp == conn->txn_global.pinned_timestamp)) {
+              !tried_eviction) {
                 WT_ERR_BUSY_OK(__wt_page_release_evict(session, walk, 0));
                 walk = prev;
                 prev = NULL;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -396,7 +396,6 @@ bool
 __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_TXN *txn;
-    wt_timestamp_t unstable_timestamp;
 
     txn = &session->txn;
 
@@ -425,13 +424,17 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /*
      * If some of the page's history overlaps with the reader's snapshot then we have to read it.
-     * This is only relevant if we chose versions that were unstable when the page was written.
      */
-    if (ref->page_las->skew_newest && WT_TXNID_LE(txn->snap_min, ref->page_las->unstable_txn))
+    if (WT_TXNID_LE(txn->snap_min, ref->page_las->max_txn))
         return (false);
 
+    /*
+     * Otherwise, if not reading at a timestamp, the page's history is in the past, so the page
+     * image is correct if it contains the most recent versions of everything and nothing was
+     * prepared.
+     */
     if (!F_ISSET(txn, WT_TXN_HAS_TS_READ))
-        return (ref->page_las->skew_newest);
+        return (!ref->page_las->has_prepares && ref->page_las->min_skipped_ts == WT_TS_MAX);
 
     /*
      * Skip lookaside history if reading as of a timestamp, we evicted new
@@ -439,21 +442,18 @@ __wt_las_page_skip_locked(WT_SESSION_IMPL *session, WT_REF *ref)
      * possible for prepared updates, because the commit timestamp was not
      * known when the page was evicted.
      *
-     * Skip lookaside pages if reading as of a timestamp, we evicted old
-     * versions of data and all the unstable updates are in the future.
-     *
-     * Checkpoint should respect durable timestamps, other reads should
-     * respect ordinary visibility.  Checking for just the unstable updates
-     * during checkpoint would end up reading more content from lookaside
-     * than necessary.
+     * Otherwise, skip reading lookaside history if everything on the page
+     * is older than the read timestamp, and the oldest update in lookaside
+     * newer than the page is in the future of the reader.  This seems
+     * unlikely, but is exactly what eviction tries to do when a checkpoint
+     * is running.
      */
-    unstable_timestamp = WT_SESSION_IS_CHECKPOINT(session) ?
-      ref->page_las->unstable_durable_timestamp :
-      ref->page_las->unstable_timestamp;
-    if (ref->page_las->skew_newest && !ref->page_las->has_prepares &&
-      txn->read_timestamp > unstable_timestamp)
+    if (!ref->page_las->has_prepares && ref->page_las->min_skipped_ts == WT_TS_MAX &&
+      txn->read_timestamp >= ref->page_las->max_ondisk_ts)
         return (true);
-    if (!ref->page_las->skew_newest && txn->read_timestamp < unstable_timestamp)
+
+    if (txn->read_timestamp >= ref->page_las->max_ondisk_ts &&
+      txn->read_timestamp < ref->page_las->min_skipped_ts)
         return (true);
 
     return (false);
@@ -586,16 +586,15 @@ __las_insert_block_verbose(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_MULTI *
           "file ID %" PRIu32 ", page ID %" PRIu64
           ". "
           "Max txn ID %" PRIu64
-          ", unstable timestamp %s,"
-          " unstable durable timestamp %s, %s. "
+          ", max ondisk timestamp %s, "
+          "first skipped ts %s. "
           "Entries now in lookaside file: %" PRId64
           ", "
           "cache dirty: %2.3f%% , "
           "cache use: %2.3f%%",
           btree_id, multi->page_las.las_pageid, multi->page_las.max_txn,
-          __wt_timestamp_to_string(multi->page_las.unstable_timestamp, ts_string[0]),
-          __wt_timestamp_to_string(multi->page_las.unstable_durable_timestamp, ts_string[1]),
-          multi->page_las.skew_newest ? "newest" : "not newest",
+          __wt_timestamp_to_string(multi->page_las.max_ondisk_ts, ts_string[0]),
+          __wt_timestamp_to_string(multi->page_las.min_skipped_ts, ts_string[1]),
           WT_STAT_READ(conn->stats, cache_lookaside_entries), pct_dirty, pct_full);
     }
 
@@ -746,7 +745,6 @@ __wt_las_insert_block(
             if (upd == list->onpage_upd && upd->size > 0 &&
               (upd->type == WT_UPDATE_STANDARD || upd->type == WT_UPDATE_MODIFY)) {
                 las_value.size = 0;
-                WT_ASSERT(session, upd != first_upd || multi->page_las.skew_newest);
                 cursor->set_value(cursor, upd->txnid, upd->start_ts, upd->durable_ts,
                   upd->prepare_state, WT_UPDATE_BIRTHMARK, &las_value);
             } else

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -678,15 +678,8 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
 
     /* Reconcile the page. */
     ret = __wt_reconcile(session, ref, NULL, flags, lookaside_retryp);
-
-    /*
-     * If attempting eviction during a checkpoint, we may successfully reconcile but then find that
-     * there are updates on the page too new to evict. Give up evicting in that case: checkpoint
-     * will include the reconciled page when it visits the parent.
-     */
-    if (WT_SESSION_BTREE_SYNC(session) && !__wt_page_is_modified(page) &&
-      !__wt_txn_visible_all(session, page->modify->rec_max_txn, page->modify->rec_max_timestamp))
-        return (__wt_set_return(session, EBUSY));
+    WT_ASSERT(session, __wt_page_is_modified(page) ||
+        __wt_txn_visible_all(session, page->modify->rec_max_txn, page->modify->rec_max_timestamp));
 
     /*
      * If reconciliation fails but reports it might succeed if we use the lookaside table, try again

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -230,21 +230,31 @@ struct __wt_ovfl_reuse {
 
 /*
  * WT_PAGE_LOOKASIDE --
- *	Related information for on-disk pages with lookaside entries.
+ *	Information for on-disk pages with lookaside entries.
+ *
+ * This information is used to decide whether history evicted to lookaside is
+ * needed for a read, and when it is no longer needed at all. We track the
+ * newest update written to the disk image in `max_ondisk_ts`, and the oldest
+ * update skipped to choose the on-disk version in `min_skipped_ts`.  If no
+ * updates were skipped, then the disk image contains the newest versions of
+ * all updates and `min_skipped_ts == WT_TS_MAX`.
+ *
+ * For reads without a timestamp, we check that there are no skipped updates
+ * and that the reader's snapshot can see everything on disk.
+ *
+ * For readers with a timestamp, it is safe to ignore lookaside if either
+ * (a) there are no skipped updates and everything on disk is visible, or
+ * (b) everything on disk is visible, and the minimum skipped update is in
+ * the future of the reader.
  */
 struct __wt_page_lookaside {
-    uint64_t las_pageid;               /* Page ID in lookaside */
-    uint64_t max_txn;                  /* Maximum transaction ID */
-    uint64_t unstable_txn;             /* First transaction ID not on page */
-    wt_timestamp_t max_timestamp;      /* Maximum timestamp */
-    wt_timestamp_t unstable_timestamp; /* First timestamp not on page */
-    wt_timestamp_t unstable_durable_timestamp;
-    /* First durable timestamp not on
-     * page */
-    bool eviction_to_lookaside; /* Revert to lookaside on eviction */
-    bool has_prepares;          /* One or more updates are prepared */
-    bool resolved;              /* History has been read into cache */
-    bool skew_newest;           /* Page image has newest versions */
+    uint64_t las_pageid;           /* Page ID in lookaside */
+    uint64_t max_txn;              /* Maximum transaction ID */
+    wt_timestamp_t max_ondisk_ts;  /* Maximum timestamp on disk */
+    wt_timestamp_t min_skipped_ts; /* Skipped in favor of disk version */
+    bool eviction_to_lookaside;    /* Revert to lookaside on eviction */
+    bool has_prepares;             /* One or more updates are prepared */
+    bool resolved;                 /* History has been read into cache */
 };
 
 /*

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1160,12 +1160,10 @@ __wt_page_las_active(WT_SESSION_IMPL *session, WT_REF *ref)
         return (false);
     if (page_las->resolved)
         return (false);
-    if (!page_las->skew_newest || page_las->has_prepares)
+    if (page_las->min_skipped_ts != WT_TS_MAX || page_las->has_prepares)
         return (true);
-    if (__wt_txn_visible_all(session, page_las->max_txn, page_las->max_timestamp))
-        return (false);
 
-    return (true);
+    return (!__wt_txn_visible_all(session, page_las->max_txn, page_las->max_ondisk_ts));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1798,8 +1798,6 @@ static inline bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref
   WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_am_oldest(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible(WT_SESSION_IMPL *session, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -33,12 +33,9 @@ struct __wt_reconcile {
 
     /* Track the page's min/maximum transactions. */
     uint64_t max_txn;
-    wt_timestamp_t max_timestamp;
-
-    /* Lookaside boundary tracking. */
-    uint64_t unstable_txn;
-    wt_timestamp_t unstable_durable_timestamp;
-    wt_timestamp_t unstable_timestamp;
+    wt_timestamp_t max_ts;
+    wt_timestamp_t max_ondisk_ts;
+    wt_timestamp_t min_skipped_ts;
 
     u_int updates_seen;     /* Count of updates seen. */
     u_int updates_unstable; /* Count of updates not visible_all. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -794,19 +794,6 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 }
 
 /*
- * __wt_txn_upd_durable --
- *     Can the current transaction make the given update durable.
- */
-static inline bool
-__wt_txn_upd_durable(WT_SESSION_IMPL *session, WT_UPDATE *upd)
-{
-    /* If update is visible then check if it is durable. */
-    if (__wt_txn_upd_visible_type(session, upd) != WT_VISIBLE_TRUE)
-        return (false);
-    return (__wt_txn_visible(session, upd->txnid, upd->durable_ts));
-}
-
-/*
  * __wt_txn_upd_visible --
  *     Can the current transaction see the given update.
  */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2494,18 +2494,16 @@ struct __wt_connection {
 	/*!
 	 * Rollback in-memory non-logged state to an earlier point in time.
 	 *
-	 * This method uses a timestamp to define the rollback point, and thus
-	 * requires that the application uses timestamps and that the
-	 * stable_timestamp must have been set via a call to
-	 * WT_CONNECTION::set_timestamp. Any updates to checkpoint durable
-	 * tables that are more recent than the stable timestamp are removed.
+	 * This method uses a timestamp to define the rollback point, and requires the application
+	 * use timestamps, the stable_timestamp have been set via a call to
+	 * WT_CONNECTION::set_timestamp, and a checkpoint operating on the last stable timestamp
+	 * to have completed. Any updates to checkpoint durable tables that are more recent than
+	 * the stable timestamp are removed.
 	 *
-	 * This method requires that there are no active operations for the
-	 * duration of the call.
+	 * This method requires that there are no active operations for the duration of the call.
 	 *
-	 * Any updates made to logged tables will not be rolled back. Any
-	 * updates made without an associated timestamp will not be rolled
-	 * back. See @ref transaction_timestamps.
+	 * Any updates made to logged tables will not be rolled back. Any updates made without an
+	 * associated timestamp will not be rolled back. See @ref transaction_timestamps.
 	 *
 	 * @snippet ex_all.c rollback to stable
 	 *

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1906,16 +1906,17 @@ struct __wt_session {
 	 * "to=<checkpoint>" to drop all checkpoints before and including the named checkpoint.
 	 * Checkpoints cannot be dropped while a hot backup is in progress or if open in a cursor.,
 	 * a list of strings; default empty.}
-	 * @config{force, by default\, checkpoints may be skipped if the underlying object has not
-	 * been modified\, this option forces the checkpoint., a boolean flag; default \c false.}
+	 * @config{force, if false (the default)\, checkpoints may be skipped if the underlying
+	 * object has not been modified\, if true\, this option forces the checkpoint., a boolean
+	 * flag; default \c false.}
 	 * @config{name, if set\, specify a name for the checkpoint (note that checkpoints including
 	 * LSM trees may not be named)., a string; default empty.}
 	 * @config{target, if non-empty\, checkpoint the list of objects., a list of strings;
 	 * default empty.}
-	 * @config{use_timestamp, by default\, create the checkpoint as of the last stable timestamp
-	 * if timestamps are in use\, or all current updates if there is no stable timestamp set.
-	 * If false\, this option generates a checkpoint with all updates including those later than
-	 * the timestamp., a boolean flag; default \c true.}
+	 * @config{use_timestamp, if true (the default)\, create the checkpoint as of the last
+	 * stable timestamp if timestamps are in use\, or all current updates if there is no stable
+	 * timestamp set.  If false\, this option generates a checkpoint with all updates including
+	 * those later than the timestamp., a boolean flag; default \c true.}
 	 * @configend
 	 * @errors
 	 */

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -94,10 +94,7 @@ __rec_child_deleted(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *ref, WT_C
     if (F_ISSET(r, WT_REC_EVICT))
         return (__wt_set_return(session, EBUSY));
 
-    /*
-     * If there are deleted child pages we can't discard immediately, keep the page dirty so they
-     * are eventually freed.
-     */
+    /* If the page cannot be marked clean. */
     r->leave_dirty = true;
 
     /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -351,12 +351,10 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     }
 
     /*
-     * Check if all updates on the page are visible.  If not, it must stay
-     * dirty unless we are saving updates to the lookaside table.
+     * Check if all updates on the page are visible, if not, it must stay dirty.
      *
-     * Updates can be out of transaction ID order (but not out of timestamp
-     * order), so we track the maximum transaction ID and the newest update
-     * with a timestamp (if any).
+     * Updates can be out of transaction ID order (but not out of timestamp order), so we track the
+     * maximum transaction ID and the newest update with a timestamp (if any).
      */
     all_stable = upd == first_txn_upd && !list_prepared && !list_uncommitted &&
       __wt_txn_visible_all(session, max_txn, max_ts);
@@ -364,17 +362,12 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     if (all_stable)
         goto check_original_value;
 
-    if (!r->leave_dirty &&
-      (upd != first_txn_upd || list_prepared || list_uncommitted ||
-        F_ISSET(r, WT_REC_VISIBLE_ALL) || !__wt_txn_visible(session, max_txn, max_ts)))
-        r->leave_dirty = true;
+    r->leave_dirty = true;
 
     if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
         WT_PANIC_RET(session, EINVAL, "reconciliation error, update not visible");
 
-    /*
-     * If not trying to evict the page, we know what we'll write and we're done.
-     */
+    /* If not trying to evict the page, we know what we'll write and we're done. */
     if (!F_ISSET(r, WT_REC_EVICT))
         goto check_original_value;
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -9,6 +9,19 @@
 #include "wt_internal.h"
 
 /*
+ * __rec_update_durable --
+ *     Return whether an update is suitable for writing to a disk image.
+ */
+static bool
+__rec_update_durable(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *upd)
+{
+    return (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
+        __wt_txn_upd_visible_all(session, upd) :
+        __wt_txn_upd_visible_type(session, upd) == WT_VISIBLE_TRUE &&
+          __wt_txn_visible(session, upd->txnid, upd->durable_ts));
+}
+
+/*
  * __rec_update_save --
  *     Save a WT_UPDATE list for later restoration.
  */
@@ -111,11 +124,11 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
   WT_CELL_UNPACK *vpack, WT_UPDATE_SELECT *upd_select)
 {
     WT_PAGE *page;
-    WT_UPDATE *first_ts_upd, *first_txn_upd, *first_upd, *upd;
-    wt_timestamp_t timestamp, ts;
+    WT_UPDATE *first_txn_upd, *first_upd, *upd;
+    wt_timestamp_t max_ts;
     size_t upd_memsize;
     uint64_t max_txn, txnid;
-    bool all_visible, list_prepared, list_uncommitted, skipped_birthmark;
+    bool all_stable, list_prepared, list_uncommitted, skipped_birthmark;
 
     /*
      * The "saved updates" return value is used independently of returning an update we can write,
@@ -125,8 +138,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     upd_select->upd_saved = false;
 
     page = r->page;
-    first_ts_upd = first_txn_upd = NULL;
+    first_txn_upd = NULL;
     upd_memsize = 0;
+    max_ts = WT_TS_NONE;
     max_txn = WT_TXN_NONE;
     list_prepared = list_uncommitted = skipped_birthmark = false;
 
@@ -152,8 +166,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
          */
         if (first_txn_upd == NULL)
             first_txn_upd = upd;
-
-        /* Track the largest transaction ID seen. */
         if (WT_TXNID_LT(max_txn, txnid))
             max_txn = txnid;
 
@@ -170,21 +182,23 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
          * prepared transaction IDs are globally visible, need to check the update state as well.
          */
         if (F_ISSET(r, WT_REC_EVICT)) {
-            if (upd->prepare_state == WT_PREPARE_LOCKED ||
-              upd->prepare_state == WT_PREPARE_INPROGRESS) {
-                list_prepared = true;
-                continue;
-            }
             if (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
                                                  !__txn_visible_id(session, txnid)) {
                 r->update_uncommitted = list_uncommitted = true;
                 continue;
             }
+            if (upd->prepare_state == WT_PREPARE_LOCKED ||
+              upd->prepare_state == WT_PREPARE_INPROGRESS) {
+                list_prepared = true;
+                if (upd->start_ts > max_ts)
+                    max_ts = upd->start_ts;
+                continue;
+            }
         }
 
         /* Track the first update with non-zero timestamp. */
-        if (first_ts_upd == NULL && upd->start_ts != WT_TS_NONE)
-            first_ts_upd = upd;
+        if (upd->durable_ts > max_ts)
+            max_ts = upd->durable_ts;
 
         /*
          * Select the update to write to the disk image.
@@ -202,8 +216,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         if (upd_select->upd == NULL && r->las_skew_newest)
             upd_select->upd = upd;
 
-        if (F_ISSET(r, WT_REC_VISIBLE_ALL) ? !__wt_txn_upd_visible_all(session, upd) :
-                                             !__wt_txn_upd_durable(session, upd)) {
+        if (!__rec_update_durable(session, r, upd)) {
             if (F_ISSET(r, WT_REC_EVICT))
                 ++r->updates_unstable;
 
@@ -214,21 +227,29 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
              * discard an uncommitted update.
              */
             if (F_ISSET(r, WT_REC_UPDATE_RESTORE) && upd_select->upd != NULL &&
-              (list_prepared || list_uncommitted)) {
-                r->leave_dirty = true;
+              (list_prepared || list_uncommitted))
                 return (__wt_set_return(session, EBUSY));
-            }
 
             if (upd->type == WT_UPDATE_BIRTHMARK)
                 skipped_birthmark = true;
+
+            /*
+             * Track the oldest update not on the page.
+             *
+             * This is used to decide whether reads can use the
+             * page image, hence using the start rather than the
+             * durable timestamp.
+             */
+            if (upd_select->upd == NULL && upd->start_ts < r->min_skipped_ts)
+                r->min_skipped_ts = upd->start_ts;
 
             continue;
         }
 
         /*
          * Lookaside without stable timestamp was taken care of above
-         * (set to the first uncommitted transaction). Lookaside with
-         * stable timestamp always takes the first stable update.
+         * (set to the first uncommitted transaction). All other
+         * reconciliation takes the first stable update.
          */
         if (upd_select->upd == NULL)
             upd_select->upd = upd;
@@ -261,6 +282,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     /* If no updates were skipped, record that we're making progress. */
     if (upd == first_txn_upd)
         r->update_used = true;
+
+    if (upd != NULL && upd->durable_ts > r->max_ondisk_ts)
+        r->max_ondisk_ts = upd->durable_ts;
 
     /*
      * TIMESTAMP-FIXME The start timestamp is determined by the commit timestamp when the key is
@@ -308,8 +332,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         r->max_txn = max_txn;
 
     /* Update the maximum timestamp. */
-    if (first_ts_upd != NULL && r->max_timestamp < first_ts_upd->durable_ts)
-        r->max_timestamp = first_ts_upd->durable_ts;
+    if (max_ts > r->max_ts)
+        r->max_ts = max_ts;
 
     /*
      * If the update we chose was a birthmark, or we are doing update-restore and we skipped a
@@ -334,15 +358,16 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      * order), so we track the maximum transaction ID and the newest update
      * with a timestamp (if any).
      */
-    timestamp = first_ts_upd == NULL ? 0 : first_ts_upd->durable_ts;
-    all_visible = upd == first_txn_upd && !list_prepared && !list_uncommitted &&
-      (F_ISSET(r, WT_REC_VISIBLE_ALL) ? __wt_txn_visible_all(session, max_txn, timestamp) :
-                                        __wt_txn_visible(session, max_txn, timestamp));
+    all_stable = upd == first_txn_upd && !list_prepared && !list_uncommitted &&
+      __wt_txn_visible_all(session, max_txn, max_ts);
 
-    if (all_visible)
+    if (all_stable)
         goto check_original_value;
 
-    r->leave_dirty = true;
+    if (!r->leave_dirty &&
+      (upd != first_txn_upd || list_prepared || list_uncommitted ||
+        F_ISSET(r, WT_REC_VISIBLE_ALL) || !__wt_txn_visible(session, max_txn, max_ts)))
+        r->leave_dirty = true;
 
     if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
         WT_PANIC_RET(session, EINVAL, "reconciliation error, update not visible");
@@ -381,54 +406,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      */
     WT_RET(__rec_update_save(session, r, ins, ripcip, upd_select->upd, upd_memsize));
     upd_select->upd_saved = true;
-
-    /*
-     * Track the first off-page update when saving history in the lookaside table. When skewing
-     * newest, we want the first (non-aborted) update after the one stored on the page. Otherwise,
-     * we want the update before the on-page update.
-     */
-    if (F_ISSET(r, WT_REC_LOOKASIDE) && r->las_skew_newest) {
-        if (WT_TXNID_LT(r->unstable_txn, first_upd->txnid))
-            r->unstable_txn = first_upd->txnid;
-        if (first_ts_upd != NULL) {
-            WT_ASSERT(session, first_ts_upd->prepare_state == WT_PREPARE_INPROGRESS ||
-                first_ts_upd->start_ts <= first_ts_upd->durable_ts);
-
-            if (r->unstable_timestamp < first_ts_upd->start_ts)
-                r->unstable_timestamp = first_ts_upd->start_ts;
-
-            if (r->unstable_durable_timestamp < first_ts_upd->durable_ts)
-                r->unstable_durable_timestamp = first_ts_upd->durable_ts;
-        }
-    } else if (F_ISSET(r, WT_REC_LOOKASIDE)) {
-        for (upd = first_upd; upd != upd_select->upd; upd = upd->next) {
-            if (upd->txnid == WT_TXN_ABORTED)
-                continue;
-
-            if (upd->txnid != WT_TXN_NONE && WT_TXNID_LT(upd->txnid, r->unstable_txn))
-                r->unstable_txn = upd->txnid;
-
-            /*
-             * The durable timestamp is always set by commit, and usually the same as the start
-             * timestamp, which makes it OK to use the two independently and be confident both will
-             * be set.
-             */
-            WT_ASSERT(session,
-              upd->prepare_state == WT_PREPARE_INPROGRESS || upd->durable_ts >= upd->start_ts);
-
-            if (r->unstable_timestamp > upd->start_ts)
-                r->unstable_timestamp = upd->start_ts;
-
-            /*
-             * An in-progress prepared update will always have a zero durable timestamp. Checkpoints
-             * can only skip reading lookaside history if all updates are in the future, including
-             * the prepare, so including the prepare timestamp instead.
-             */
-            ts = upd->prepare_state == WT_PREPARE_INPROGRESS ? upd->start_ts : upd->durable_ts;
-            if (r->unstable_durable_timestamp > ts)
-                r->unstable_durable_timestamp = ts;
-        }
-    }
 
 check_original_value:
     /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -618,7 +618,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
         } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = txn_global->recovery_timestamp;
     } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
-        txn_global->meta_ckpt_timestamp = 0;
+        txn_global->meta_ckpt_timestamp = WT_TS_NONE;
 
     __wt_writeunlock(session, &txn_global->rwlock);
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -949,12 +949,18 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
         __checkpoint_stats(session);
 
         /*
-         * If timestamps were used to define the content of the checkpoint update the saved last
-         * checkpoint timestamp, otherwise leave it alone. If a checkpoint is taken without
-         * timestamps, it's likely a bug, but we don't want to clear the saved last checkpoint
-         * timestamp regardless.
+         * If timestamps defined the checkpoint's content, set the saved last checkpoint timestamp,
+         * otherwise clear it. We clear it for a couple of reasons: applications can query it and we
+         * don't want to lie, and we use it to decide if WT_CONNECTION.rollback_to_stable is an
+         * allowed operation. For the same reason, don't set it to WT_TS_NONE when the checkpoint
+         * timestamp is WT_TS_NONE, set it to 1 so we can tell the difference.
          */
-        conn->txn_global.last_ckpt_timestamp = use_timestamp ? ckpt_tmp_ts : WT_TS_NONE;
+        if (use_timestamp) {
+            conn->txn_global.last_ckpt_timestamp = use_timestamp ? ckpt_tmp_ts : WT_TS_NONE;
+            if (conn->txn_global.last_ckpt_timestamp == WT_TS_NONE)
+                conn->txn_global.last_ckpt_timestamp = WT_TS_NONE + 1;
+        } else
+            conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
     }
 
 err:

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -607,7 +607,9 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
         /*
          * If the user wants timestamps then set the metadata checkpoint timestamp based on whether
          * or not a stable timestamp is actually in use. Only set it when we're not running recovery
-         * because recovery doesn't set the recovery timestamp until its checkpoint is complete.
+         * because recovery doesn't set the recovery timestamp until its checkpoint is complete. If
+         * recovery has never been run, set it to something other than WT_TS_NONE, because it has to
+         * be set in order for rollback-to-stable to be allowed.
          */
         if (txn_global->has_stable_timestamp) {
             txn->read_timestamp = txn_global->stable_timestamp;
@@ -615,8 +617,11 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
             F_SET(txn, WT_TXN_HAS_TS_READ);
             if (!F_ISSET(conn, WT_CONN_RECOVERING))
                 txn_global->meta_ckpt_timestamp = txn->read_timestamp;
-        } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
+        } else if (!F_ISSET(conn, WT_CONN_RECOVERING)) {
             txn_global->meta_ckpt_timestamp = txn_global->recovery_timestamp;
+            if (txn_global->meta_ckpt_timestamp == WT_TS_NONE)
+                txn_global->meta_ckpt_timestamp = 1;
+        }
     } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
         txn_global->meta_ckpt_timestamp = WT_TS_NONE;
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -607,9 +607,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
         /*
          * If the user wants timestamps then set the metadata checkpoint timestamp based on whether
          * or not a stable timestamp is actually in use. Only set it when we're not running recovery
-         * because recovery doesn't set the recovery timestamp until its checkpoint is complete. If
-         * recovery has never been run, set it to something other than WT_TS_NONE, because it has to
-         * be set in order for rollback-to-stable to be allowed.
+         * because recovery doesn't set the recovery timestamp until its checkpoint is complete.
          */
         if (txn_global->has_stable_timestamp) {
             txn->read_timestamp = txn_global->stable_timestamp;
@@ -617,11 +615,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
             F_SET(txn, WT_TXN_HAS_TS_READ);
             if (!F_ISSET(conn, WT_CONN_RECOVERING))
                 txn_global->meta_ckpt_timestamp = txn->read_timestamp;
-        } else if (!F_ISSET(conn, WT_CONN_RECOVERING)) {
+        } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = txn_global->recovery_timestamp;
-            if (txn_global->meta_ckpt_timestamp == WT_TS_NONE)
-                txn_global->meta_ckpt_timestamp = 1;
-        }
     } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
         txn_global->meta_ckpt_timestamp = WT_TS_NONE;
 
@@ -959,8 +954,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
          * timestamps, it's likely a bug, but we don't want to clear the saved last checkpoint
          * timestamp regardless.
          */
-        if (use_timestamp)
-            conn->txn_global.last_ckpt_timestamp = ckpt_tmp_ts;
+        conn->txn_global.last_ckpt_timestamp = use_timestamp ? ckpt_tmp_ts : WT_TS_NONE;
     }
 
 err:

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -966,10 +966,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
              * two calls to determine last stable recovery timestamp.
              */
             if (conn->txn_global.last_ckpt_timestamp == WT_TS_NONE)
-                conn->txn_global.last_ckpt_timestamp =
-                  (conn->txn_global.recovery_timestamp != WT_TS_NONE) ?
-                  conn->txn_global.recovery_timestamp :
-                  (WT_TS_NONE + 1);
+                conn->txn_global.last_ckpt_timestamp = conn->txn_global.recovery_timestamp;
         } else
             conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
     }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -536,7 +536,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     r.session = session;
     WT_MAX_LSN(&r.max_ckpt_lsn);
     WT_MAX_LSN(&r.max_rec_lsn);
-    conn->txn_global.recovery_timestamp = conn->txn_global.meta_ckpt_timestamp = 0;
+    conn->txn_global.recovery_timestamp = conn->txn_global.meta_ckpt_timestamp = WT_TS_NONE;
 
     F_SET(conn, WT_CONN_RECOVERING);
     WT_ERR(__wt_metadata_search(session, WT_METAFILE_URI, &config));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -432,9 +432,8 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    if (!txn_global->has_stable_timestamp || txn_global->last_ckpt_timestamp == WT_TS_NONE)
-        WT_RET_MSG(
-          session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
+    if (!txn_global->has_stable_timestamp)
+        WT_RET_MSG(session, EINVAL, "rollback_to_stable requires a stable timestamp");
 
     /*
      * Help the user comply with the requirement that there are no concurrent operations. Protect

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -227,14 +227,14 @@ __txn_abort_newer_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t 
     bool local_read;
 
     /*
-     * If we created a page image with updates the need to be rolled back,
+     * If we created a page image with updates that need to be rolled back,
      * read the history into cache now and make sure the page is marked
      * dirty.  Otherwise, the history we need could be swept from the
      * lookaside table before the page is read because the lookaside sweep
      * code has no way to tell that the page image is invalid.
      *
      * So, if there is lookaside history for a page, first check if the
-     * history needs to be rolled back make sure that history is loaded
+     * history needs to be rolled back then ensure the history is loaded
      * into cache.
      *
      * Also, we have separately discarded any lookaside history more recent

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -433,7 +433,7 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     txn_global = &conn->txn_global;
 
     if (txn_global->has_stable_timestamp == WT_TS_NONE ||
-      txn_global->meta_ckpt_timestamp == WT_TS_NONE)
+      txn_global->last_ckpt_timestamp == WT_TS_NONE)
         WT_RET_MSG(
           session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -432,8 +432,9 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    if (!txn_global->has_stable_timestamp)
-        WT_RET_MSG(session, EINVAL, "rollback_to_stable requires a stable timestamp");
+    if (!txn_global->has_stable_timestamp || txn_global->last_ckpt_timestamp == WT_TS_NONE)
+        WT_RET_MSG(
+          session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
 
     /*
      * Help the user comply with the requirement that there are no concurrent operations. Protect

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -431,8 +431,11 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
     txn_global = &conn->txn_global;
-    if (!txn_global->has_stable_timestamp)
-        WT_RET_MSG(session, EINVAL, "rollback_to_stable requires a stable timestamp");
+
+    if (txn_global->has_stable_timestamp == WT_TS_NONE ||
+      txn_global->meta_ckpt_timestamp == WT_TS_NONE)
+        WT_RET_MSG(
+          session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
 
     /*
      * Help the user comply with the requirement that there are no concurrent operations. Protect

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -432,8 +432,7 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    if (txn_global->has_stable_timestamp == WT_TS_NONE ||
-      txn_global->last_ckpt_timestamp == WT_TS_NONE)
+    if (!txn_global->has_stable_timestamp || txn_global->last_ckpt_timestamp == WT_TS_NONE)
         WT_RET_MSG(
           session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
 

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -43,11 +43,11 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
 
     def test_table_logging_rollback_to_stable(self):
         self.session.create(self.uri, 'key_format=i,value_format=u')
-        self.session.checkpoint()
 
         cursor = self.session.open_cursor(self.uri, None)
 
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))
+        self.session.checkpoint()
 
         # Try doing a normal prepared txn and then rollback to stable.
         self.session.begin_transaction()

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -43,6 +43,8 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
 
     def test_table_logging_rollback_to_stable(self):
         self.session.create(self.uri, 'key_format=i,value_format=u')
+        self.session.checkpoint()
+
         cursor = self.session.open_cursor(self.uri, None)
 
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))

--- a/test/suite/test_las01.py
+++ b/test/suite/test_las01.py
@@ -83,10 +83,11 @@ class test_las01(wttest.WiredTigerTestCase):
         # Skip the initial rows, which were not updated
         for i in range(0, nrows+1):
             self.assertEqual(cursor.next(), 0)
-        if (check_value != cursor.get_value()):
-            print("Check value : " + str(check_value))
-            print("value : " + str(cursor.get_value()))
-        self.assertTrue(check_value == cursor.get_value())
+        if check_value != cursor.get_value():
+            session.breakpoint()
+        self.assertTrue(check_value == cursor.get_value(),
+            "for key " + str(i) + ", expected " + str(check_value) +
+            ", got " + str(cursor.get_value()))
         cursor.close()
         session.close()
         conn.close()

--- a/test/suite/test_timestamp04.py
+++ b/test/suite/test_timestamp04.py
@@ -78,7 +78,8 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         # Search for the expected items as well as iterating.
         for k, v in expected.items():
             if missing == False:
-                self.assertEqual(cur[k], v, "for key " + str(k))
+                self.assertEqual(cur[k], v, "for key " + str(k) +
+                    " expected " + str(v) + ", got " + str(cur[k]))
             else:
                 cur.set_key(k)
                 if self.empty:

--- a/test/suite/test_timestamp04.py
+++ b/test/suite/test_timestamp04.py
@@ -131,6 +131,9 @@ class test_timestamp04(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.create(self.table_nots_nolog, config_default + config_nolog + self.extra_config)
         cur_nots_nolog = self.session.open_cursor(self.table_nots_nolog)
 
+        # We're about to test rollback-to-stable which requires a checkpoint to which we can roll back.
+        self.session.checkpoint()
+
         # Insert keys each with timestamp=key, in some order.
         key_range = 10000
         keys = list(range(1, key_range + 1))

--- a/test/suite/test_timestamp11.py
+++ b/test/suite/test_timestamp11.py
@@ -43,7 +43,6 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         base = 'timestamp11'
         uri = 'file:' + base
         self.session.create(uri, 'key_format=S,value_format=S')
-        self.session.checkpoint()
 
         # Test that mixed timestamp usage where some transactions use timestamps
         # and others don't behave in the expected way.
@@ -84,6 +83,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         #
         stable_ts = timestamp_str(2)
         self.conn.set_timestamp('stable_timestamp=' + stable_ts)
+        self.session.checkpoint()
         self.conn.rollback_to_stable()
 
         c = self.session.open_cursor(uri)

--- a/test/suite/test_timestamp11.py
+++ b/test/suite/test_timestamp11.py
@@ -43,6 +43,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         base = 'timestamp11'
         uri = 'file:' + base
         self.session.create(uri, 'key_format=S,value_format=S')
+        self.session.checkpoint()
 
         # Test that mixed timestamp usage where some transactions use timestamps
         # and others don't behave in the expected way.

--- a/test/suite/test_timestamp16.py
+++ b/test/suite/test_timestamp16.py
@@ -50,25 +50,21 @@ class test_timestamp16(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction('read_timestamp=100')
         self.session.rollback_transaction()
         self.session.checkpoint('use_timestamp=true')
-        self.assertTimestampsEqual('0',
-            self.conn.query_timestamp('get=last_checkpoint'))
+        self.assertTimestampsEqual('1', self.conn.query_timestamp('get=last_checkpoint'))
 
-        # Set a stable and make sure that we still checkpoint at
-        # the stable.
-        self.conn.set_timestamp('stable_timestamp=1')
+        # Set a stable and make sure that we still checkpoint at the stable.
+        self.conn.set_timestamp('stable_timestamp=2')
         self.session.begin_transaction('read_timestamp=100')
         self.session.rollback_transaction()
         self.session.checkpoint('use_timestamp=true')
-        self.assertTimestampsEqual('1',
-            self.conn.query_timestamp('get=last_checkpoint'))
+        self.assertTimestampsEqual('2', self.conn.query_timestamp('get=last_checkpoint'))
 
         # Finally make sure that commit also resets the read timestamp.
         self.session.create(self.uri, 'key_format=i,value_format=i')
         self.session.begin_transaction('read_timestamp=150')
         self.session.commit_transaction()
         self.session.checkpoint('use_timestamp=true')
-        self.assertTimestampsEqual('1',
-            self.conn.query_timestamp('get=last_checkpoint'))
+        self.assertTimestampsEqual('2', self.conn.query_timestamp('get=last_checkpoint'))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_timestamp16.py
+++ b/test/suite/test_timestamp16.py
@@ -50,7 +50,7 @@ class test_timestamp16(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction('read_timestamp=100')
         self.session.rollback_transaction()
         self.session.checkpoint('use_timestamp=true')
-        self.assertTimestampsEqual('1', self.conn.query_timestamp('get=last_checkpoint'))
+        self.assertTimestampsEqual('0', self.conn.query_timestamp('get=last_checkpoint'))
 
         # Set a stable and make sure that we still checkpoint at the stable.
         self.conn.set_timestamp('stable_timestamp=2')


### PR DESCRIPTION
This is a migration of #4786.