### PR TITLE
WT-4955 Extend backup API to allow for efficient incremental copy (Clang Format migration)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1201,6 +1201,16 @@ methods = {
         characters are hexadecimal encoded.  These formats are compatible
         with the @ref util_dump and @ref util_load commands''',
         choices=['hex', 'json', 'print']),
+    Config('incremental_checkpoint', '', r'''
+        the starting checkpoint for an file offset based incremental backup;
+        valid only for a backup data source'''),
+    Config('incremental_file', '', r'''
+        the object for a file offset based incremental backup; valid only for "
+        "a backup data source'''),
+    Config('incremental_size', '16MB', r'''
+        the maximum block size returned for a file offset based incremental
+        backup; valid only for a backup data source''',
+        min='1MB'),
     Config('next_random', 'false', r'''
         configure the cursor to return a pseudo-random record from the
         object when the WT_CURSOR::next method is called; valid only for
@@ -1439,11 +1449,18 @@ methods = {
         by default, checkpoints may be skipped if the underlying object
         has not been modified, this option forces the checkpoint''',
         type='boolean'),
+    Config('lock', '', r'''
+        if set, specify the name of a checkpoint to lock (retain) for use in
+        subsequent incremental backups. No checkpoint is performed'''),
     Config('name', '', r'''
         if set, specify a name for the checkpoint (note that checkpoints
         including LSM trees may not be named)'''),
     Config('target', '', r'''
         if non-empty, checkpoint the list of objects''', type='list'),
+    Config('unlock', '', r'''
+        if set, specify the name of a checkpoint to unlock (discard), as it
+        is no longer needed for subsequent incremental backups. No checkpoint
+        is performed'''),
     Config('use_timestamp', 'true', r'''
         by default, create the checkpoint as of the last stable timestamp
         if timestamps are in use, or all current updates if there is no

--- a/dist/filelist
+++ b/dist/filelist
@@ -6,6 +6,7 @@ src/async/async_op.c
 src/async/async_worker.c
 src/block/block_addr.c
 src/block/block_ckpt.c
+src/block/block_ckpt_rewrite.c
 src/block/block_ckpt_scan.c
 src/block/block_compact.c
 src/block/block_ext.c
@@ -54,8 +55,8 @@ src/checksum/arm64/crc32-arm64.c	ARM64_HOST
 src/checksum/power8/crc32.sx		POWERPC_HOST
 src/checksum/power8/crc32_wrapper.c	POWERPC_HOST
 src/checksum/software/checksum.c
-src/checksum/x86/crc32-x86.c		X86_HOST
 src/checksum/x86/crc32-x86-alt.c	X86_HOST
+src/checksum/x86/crc32-x86.c		X86_HOST
 src/checksum/zseries/crc32-s390x.c	ZSERIES_HOST
 src/checksum/zseries/crc32le-vx.sx	ZSERIES_HOST
 src/config/config.c
@@ -81,6 +82,7 @@ src/conn/conn_reconfig.c
 src/conn/conn_stat.c
 src/conn/conn_sweep.c
 src/cursor/cur_backup.c
+src/cursor/cur_backup_incr.c
 src/cursor/cur_bulk.c
 src/cursor/cur_config.c
 src/cursor/cur_ds.c

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -560,6 +560,7 @@ checkkey
 checkpointed
 checkpointer
 checkpointing
+checkpointlock
 checksum
 checksums
 checksys
@@ -925,6 +926,7 @@ libdatasource
 libs
 libtool
 libwiredtiger
+lifecycle
 linkers
 llll
 llu
@@ -1126,6 +1128,7 @@ pvA
 pwrite
 py
 qdown
+qq
 qrrSS
 qsort
 quartile

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -263,11 +263,11 @@ err:
 }
 
 /*
- * __ckpt_extlist_read --
- *     Read a checkpoints extent lists and copy
+ * __wt_ckpt_extlist_read --
+ *     Read a checkpoints extent lists.
  */
-static int
-__ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
+int
+__wt_ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt, bool discard)
 {
     WT_BLOCK_CKPT *ci;
 
@@ -289,7 +289,8 @@ __ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
     WT_RET(__wt_block_ckpt_init(session, ci, ckpt->name));
     WT_RET(__wt_block_buffer_to_ckpt(session, block, ckpt->raw.data, ci));
     WT_RET(__wt_block_extlist_read(session, block, &ci->alloc, ci->file_size));
-    WT_RET(__wt_block_extlist_read(session, block, &ci->discard, ci->file_size));
+    if (discard)
+        WT_RET(__wt_block_extlist_read(session, block, &ci->discard, ci->file_size));
 
     return (0);
 }
@@ -446,7 +447,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
          * may have already read these extent blocks if there is more than one deleted checkpoint).
          */
         if (ckpt->bpriv == NULL)
-            WT_ERR(__ckpt_extlist_read(session, block, ckpt));
+            WT_ERR(__wt_ckpt_extlist_read(session, block, ckpt, true));
 
         for (next_ckpt = ckpt + 1;; ++next_ckpt)
             if (!F_ISSET(next_ckpt, WT_CKPT_FAKE))
@@ -456,7 +457,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
          * The "next" checkpoint may be the live tree which has no extent blocks to read.
          */
         if (next_ckpt->bpriv == NULL && !F_ISSET(next_ckpt, WT_CKPT_ADD))
-            WT_ERR(__ckpt_extlist_read(session, block, next_ckpt));
+            WT_ERR(__wt_ckpt_extlist_read(session, block, next_ckpt, true));
     }
 
     /*

--- a/src/block/block_ckpt_rewrite.c
+++ b/src/block/block_ckpt_rewrite.c
@@ -1,0 +1,88 @@
+/*-
+ * Copyright (c) 2014-2019 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __wt_block_checkpoint_rewrite --
+ *     Return the block/size pairs required to upgrade a file from one checkpoint to subsequent one.
+ */
+int
+__wt_block_checkpoint_rewrite(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase,
+  uint64_t **listp, uint64_t *list_countp)
+{
+    WT_BLOCK_CKPT *a, *b;
+    WT_CKPT *ckpt;
+    WT_EXT *ext;
+    uint64_t *list;
+    bool start, stop;
+
+    a = NULL;
+    start = stop = false;
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (F_ISSET(ckpt, WT_CKPT_FAKE))
+            continue;
+
+        /*
+         * Find the starting checkpoint. We don't care about its blocks, the backup already has
+         * those.
+         */
+        if (F_ISSET(ckpt, WT_CKPT_INCR_START)) {
+            start = true;
+            continue;
+        }
+        if (!start)
+            continue;
+
+        WT_RET(__wt_ckpt_extlist_read(session, block, ckpt, false));
+        if (a == NULL)
+            a = ckpt->bpriv;
+        else {
+            /*
+             * Once we've started, continue reading each allocation extent, aggregating them as we
+             * go.
+             */
+            b = ckpt->bpriv;
+            if (b->alloc.entries != 0)
+                WT_RET(__wt_block_extlist_merge(session, block, &a->alloc, &b->alloc));
+            __wt_block_ckpt_destroy(session, a);
+            a = b;
+        }
+
+        if (a->alloc.offset != WT_BLOCK_INVALID_OFFSET)
+            WT_RET(
+              __wt_block_insert_ext(session, block, &a->alloc, a->alloc.offset, a->alloc.size));
+        if (a->discard.offset != WT_BLOCK_INVALID_OFFSET)
+            WT_RET(
+              __wt_block_insert_ext(session, block, &a->alloc, a->discard.offset, a->discard.size));
+        if (a->avail.offset != WT_BLOCK_INVALID_OFFSET)
+            WT_RET(
+              __wt_block_insert_ext(session, block, &a->alloc, a->avail.offset, a->avail.size));
+
+        if (F_ISSET(ckpt, WT_CKPT_INCR_STOP)) {
+            stop = true;
+            break;
+        }
+    }
+
+    if (!start || !stop)
+        WT_RET_MSG(session, EINVAL, "missing or unmatched start/stop checkpoints specified");
+
+    WT_RET(__wt_calloc_def(session, a->alloc.entries * 2, &list));
+    *listp = list;
+    *list_countp = a->alloc.entries * 2;
+
+    WT_EXT_FOREACH (ext, a->alloc.off) {
+        *list++ = (uint64_t)ext->off;
+        *list++ = (uint64_t)ext->size;
+    }
+
+    __wt_block_ckpt_destroy(session, a);
+
+    return (0);
+}

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -144,6 +144,17 @@ __bm_checkpoint_resolve_readonly(WT_BM *bm, WT_SESSION_IMPL *session, bool faile
 }
 
 /*
+ * __bm_checkpoint_rewrite --
+ *     Return the block/size pairs required to upgrade a file from one checkpoint to subsequent one.
+ */
+static int
+__bm_checkpoint_rewrite(
+  WT_BM *bm, WT_SESSION_IMPL *session, WT_CKPT *ckpt, uint64_t **listp, uint64_t *list_countp)
+{
+    return (__wt_block_checkpoint_rewrite(session, bm->block, ckpt, listp, list_countp));
+}
+
+/*
  * __bm_checkpoint_start --
  *     Start the checkpoint.
  */
@@ -557,6 +568,7 @@ __bm_method_set(WT_BM *bm, bool readonly)
     bm->checkpoint_last = __bm_checkpoint_last;
     bm->checkpoint_load = __bm_checkpoint_load;
     bm->checkpoint_resolve = __bm_checkpoint_resolve;
+    bm->checkpoint_rewrite = __bm_checkpoint_rewrite;
     bm->checkpoint_start = __bm_checkpoint_start;
     bm->checkpoint_unload = __bm_checkpoint_unload;
     bm->close = __bm_close;
@@ -570,6 +582,7 @@ __bm_method_set(WT_BM *bm, bool readonly)
     bm->map_discard = __bm_map_discard;
     bm->preload = __wt_bm_preload;
     bm->read = __wt_bm_read;
+    bm->read_raw = __wt_bm_read_raw;
     bm->salvage_end = __bm_salvage_end;
     bm->salvage_next = __bm_salvage_next;
     bm->salvage_start = __bm_salvage_start;

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -9,6 +9,50 @@
 #include "wt_internal.h"
 
 /*
+ * __block_read --
+ *     Read a block using an offset/size pair.
+ */
+static int
+__block_read(
+  WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_off_t offset, uint32_t size)
+{
+    size_t bufsize;
+
+    WT_STAT_CONN_INCR(session, block_read);
+    WT_STAT_CONN_INCRV(session, block_byte_read, size);
+
+    /*
+     * Grow the buffer as necessary and read the block. Buffers should be aligned for reading, but
+     * there are lots of buffers (for example, file cursors have two buffers each, key and value),
+     * and it's difficult to be sure we've found all of them. If the buffer isn't aligned, it's an
+     * easy fix: set the flag and guarantee we reallocate it. (Most of the time on reads, the buffer
+     * memory has not yet been allocated, so we're not adding any additional processing time.)
+     */
+    if (F_ISSET(buf, WT_ITEM_ALIGNED))
+        bufsize = size;
+    else {
+        F_SET(buf, WT_ITEM_ALIGNED);
+        bufsize = WT_MAX(size, buf->memsize + 10);
+    }
+
+    /*
+     * Ensure we don't read information that isn't there. It shouldn't ever happen, but it's a cheap
+     * test.
+     */
+    if (size < block->allocsize)
+        WT_RET_MSG(session, EINVAL, "%s: impossibly small block size of %" PRIu32
+                                    "B, less than "
+                                    "allocation size of %" PRIu32,
+          block->name, size, block->allocsize);
+
+    WT_RET(__wt_buf_init(session, buf, bufsize));
+    WT_RET(__wt_read(session, block->fh, offset, size, buf->mem));
+    buf->size = size;
+
+    return (0);
+}
+
+/*
  * __wt_bm_preload --
  *     Pre-load a page.
  */
@@ -50,15 +94,52 @@ __wt_bm_preload(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t
 }
 
 /*
+ * __wt_bm_read_raw --
+ *     Map or read an offset/size referenced block into a buffer.
+ */
+int
+__wt_bm_read_raw(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, uint64_t offset, uint64_t size)
+{
+    WT_BLOCK *block;
+    WT_FILE_HANDLE *handle;
+    bool mapped;
+
+    block = bm->block;
+
+    /*
+     * Map the block if it's possible.
+     */
+    handle = block->fh->handle;
+    mapped = bm->map != NULL && offset + size <= bm->maplen;
+    if (mapped && handle->fh_map_preload != NULL) {
+        WT_STAT_CONN_INCR(session, block_map_read);
+        WT_STAT_CONN_INCRV(session, block_byte_map_read, size);
+
+        buf->data = (uint8_t *)bm->map + offset;
+        buf->size = size;
+        return (handle->fh_map_preload(
+          handle, (WT_SESSION *)session, buf->data, buf->size, bm->mapped_cookie));
+    }
+
+    /* Read the block. */
+    __wt_capacity_throttle(session, size, WT_THROTTLE_READ);
+    WT_RET(__block_read(session, block, buf, (wt_off_t)offset, (uint32_t)size));
+
+    /* Optionally discard blocks from the system's buffer cache. */
+    WT_RET(__wt_block_discard(session, block, (size_t)size));
+
+    return (0);
+}
+
+/*
  * __wt_bm_read --
- *     Map or read address cookie referenced block into a buffer.
+ *     Map or read a address cookie referenced block into a buffer.
  */
 int
 __wt_bm_read(
   WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, size_t addr_size)
 {
     WT_BLOCK *block;
-    WT_DECL_RET;
     WT_FILE_HANDLE *handle;
     wt_off_t offset;
     uint32_t checksum, size;
@@ -76,14 +157,13 @@ __wt_bm_read(
     handle = block->fh->handle;
     mapped = bm->map != NULL && offset + size <= (wt_off_t)bm->maplen;
     if (mapped && handle->fh_map_preload != NULL) {
-        buf->data = (uint8_t *)bm->map + offset;
-        buf->size = size;
-        ret = handle->fh_map_preload(
-          handle, (WT_SESSION *)session, buf->data, buf->size, bm->mapped_cookie);
-
         WT_STAT_CONN_INCR(session, block_map_read);
         WT_STAT_CONN_INCRV(session, block_byte_map_read, size);
-        return (ret);
+
+        buf->data = (uint8_t *)bm->map + offset;
+        buf->size = size;
+        return (handle->fh_map_preload(
+          handle, (WT_SESSION *)session, buf->data, buf->size, bm->mapped_cookie));
     }
 
 #ifdef HAVE_DIAGNOSTIC
@@ -204,48 +284,18 @@ err:
 
 /*
  * __wt_block_read_off --
- *     Read an addr/size pair referenced block into a buffer.
+ *     Read an offset/size/checksum triplet referenced block into a buffer.
  */
 int
 __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_off_t offset,
   uint32_t size, uint32_t checksum)
 {
     WT_BLOCK_HEADER *blk, swap;
-    size_t bufsize;
 
     __wt_verbose(session, WT_VERB_READ, "off %" PRIuMAX ", size %" PRIu32 ", checksum %#" PRIx32,
       (uintmax_t)offset, size, checksum);
 
-    WT_STAT_CONN_INCR(session, block_read);
-    WT_STAT_CONN_INCRV(session, block_byte_read, size);
-
-    /*
-     * Grow the buffer as necessary and read the block. Buffers should be aligned for reading, but
-     * there are lots of buffers (for example, file cursors have two buffers each, key and value),
-     * and it's difficult to be sure we've found all of them. If the buffer isn't aligned, it's an
-     * easy fix: set the flag and guarantee we reallocate it. (Most of the time on reads, the buffer
-     * memory has not yet been allocated, so we're not adding any additional processing time.)
-     */
-    if (F_ISSET(buf, WT_ITEM_ALIGNED))
-        bufsize = size;
-    else {
-        F_SET(buf, WT_ITEM_ALIGNED);
-        bufsize = WT_MAX(size, buf->memsize + 10);
-    }
-
-    /*
-     * Ensure we don't read information that isn't there. It shouldn't ever happen, but it's a cheap
-     * test.
-     */
-    if (size < block->allocsize)
-        WT_RET_MSG(session, EINVAL, "%s: impossibly small block size of %" PRIu32
-                                    "B, less than "
-                                    "allocation size of %" PRIu32,
-          block->name, size, block->allocsize);
-
-    WT_RET(__wt_buf_init(session, buf, bufsize));
-    WT_RET(__wt_read(session, block->fh, offset, size, buf->mem));
-    buf->size = size;
+    WT_RET(__block_read(session, block, buf, offset, size));
 
     /*
      * We incrementally read through the structure before doing a checksum, do little- to big-endian

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -199,7 +199,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_begin_transaction[] = {
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_checkpoint[] = {
   {"drop", "list", NULL, NULL, NULL, 0}, {"force", "boolean", NULL, NULL, NULL, 0},
-  {"name", "string", NULL, NULL, NULL, 0}, {"target", "list", NULL, NULL, NULL, 0},
+  {"lock", "string", NULL, NULL, NULL, 0}, {"name", "string", NULL, NULL, NULL, 0},
+  {"target", "list", NULL, NULL, NULL, 0}, {"unlock", "string", NULL, NULL, NULL, 0},
   {"use_timestamp", "boolean", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_commit_transaction[] = {
@@ -297,6 +298,9 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_open_cursor[] = {
   {"checkpoint", "string", NULL, NULL, NULL, 0},
   {"checkpoint_wait", "boolean", NULL, NULL, NULL, 0},
   {"dump", "string", NULL, "choices=[\"hex\",\"json\",\"print\"]", NULL, 0},
+  {"incremental_checkpoint", "string", NULL, NULL, NULL, 0},
+  {"incremental_file", "string", NULL, NULL, NULL, 0},
+  {"incremental_size", "int", NULL, "min=1MB", NULL, 0},
   {"next_random", "boolean", NULL, NULL, NULL, 0},
   {"next_random_sample_size", "string", NULL, NULL, NULL, 0},
   {"overwrite", "boolean", NULL, NULL, NULL, 0}, {"raw", "boolean", NULL, NULL, NULL, 0},
@@ -839,8 +843,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "ignore_prepare=false,isolation=,name=,priority=0,read_timestamp="
     ",roundup_timestamps=(prepared=false,read=false),snapshot=,sync=",
     confchk_WT_SESSION_begin_transaction, 8},
-  {"WT_SESSION.checkpoint", "drop=,force=false,name=,target=,use_timestamp=true",
-    confchk_WT_SESSION_checkpoint, 5},
+  {"WT_SESSION.checkpoint", "drop=,force=false,lock=,name=,target=,unlock=,use_timestamp=true",
+    confchk_WT_SESSION_checkpoint, 7},
   {"WT_SESSION.close", "", NULL, 0},
   {"WT_SESSION.commit_transaction", "commit_timestamp=,durable_timestamp=,sync=",
     confchk_WT_SESSION_commit_transaction, 3},
@@ -880,10 +884,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
   {"WT_SESSION.log_printf", "", NULL, 0},
   {"WT_SESSION.open_cursor",
     "append=false,bulk=false,checkpoint=,checkpoint_wait=true,dump=,"
+    "incremental_checkpoint=,incremental_file=,incremental_size=16MB,"
     "next_random=false,next_random_sample_size=0,overwrite=true,"
     "raw=false,read_once=false,readonly=false,skip_sort_check=false,"
     "statistics=,target=",
-    confchk_WT_SESSION_open_cursor, 14},
+    confchk_WT_SESSION_open_cursor, 17},
   {"WT_SESSION.prepare_transaction", "prepare_timestamp=", confchk_WT_SESSION_prepare_transaction,
     1},
   {"WT_SESSION.query_timestamp", "get=read", confchk_WT_SESSION_query_timestamp, 1},

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -132,10 +132,11 @@ __wt_connection_destroy(WT_CONNECTION_IMPL *conn)
 
     /* Free allocated memory. */
     __wt_free(session, conn->cfg);
-    __wt_free(session, conn->debug_ckpt);
-    __wt_free(session, conn->error_prefix);
     __wt_free(session, conn->home);
+    __wt_free(session, conn->error_prefix);
+    __wt_free(session, conn->debug_ckpt);
     __wt_free(session, conn->sessions);
+    __wt_free(session, conn->ckpt_locked);
     __wt_stat_connection_discard(session, conn);
 
     __wt_free(NULL, conn);

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -13,7 +13,8 @@ static int __backup_list_append(WT_SESSION_IMPL *, WT_CURSOR_BACKUP *, const cha
 static int __backup_list_uri_append(WT_SESSION_IMPL *, const char *, bool *);
 static int __backup_start(WT_SESSION_IMPL *, WT_CURSOR_BACKUP *, bool, const char *[]);
 static int __backup_stop(WT_SESSION_IMPL *, WT_CURSOR_BACKUP *);
-static int __backup_uri(WT_SESSION_IMPL *, const char *[], bool, bool *, bool *);
+static int __backup_config(
+  WT_SESSION_IMPL *, WT_CURSOR_BACKUP *, const char *[], bool, bool *, bool *);
 
 /*
  * __curbackup_next --
@@ -61,6 +62,8 @@ __curbackup_reset(WT_CURSOR *cursor)
     cb->next = 0;
     F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 
+/* XXX KEITH: incremental backup needs work */
+
 err:
     API_END_RET(session, ret);
 }
@@ -79,6 +82,8 @@ __backup_free(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
             __wt_free(session, cb->list[i]);
         __wt_free(session, cb->list);
     }
+
+    __wt_curbackup_free_incr(session, cb);
 }
 
 /*
@@ -152,6 +157,8 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
 
     WT_STATIC_ASSERT(offsetof(WT_CURSOR_BACKUP, iface) == 0);
 
+    WT_RET(__wt_inmem_unsupported_op(session, "backup cursor"));
+
     WT_RET(__wt_calloc_one(session, &cb));
     cursor = (WT_CURSOR *)cb;
     *cursor = iface;
@@ -169,7 +176,9 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
       session, WT_WITH_SCHEMA_LOCK(session, ret = __backup_start(session, cb, other != NULL, cfg)));
     WT_ERR(ret);
 
-    WT_ERR(__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));
+    WT_ERR(cb->incr_file == NULL ?
+        __wt_cursor_init(cursor, uri, NULL, cfg, cursorp) :
+        __wt_curbackup_open_incr(session, uri, other, cursor, cfg, cursorp));
 
     if (0) {
 err:
@@ -228,8 +237,6 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
     cb->list = NULL;
     cb->list_next = 0;
 
-    WT_RET(__wt_inmem_unsupported_op(session, "backup cursor"));
-
     /*
      * Single thread hot backups: we're holding the schema lock, so we know we'll serialize with
      * other attempts to start a hot backup.
@@ -264,10 +271,10 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
 
         /*
          * Create a temporary backup file. This must be opened before generating the list of targets
-         * in backup_uri. This file will later be renamed to the correct name depending on whether
-         * or not we're doing an incremental backup. We need a temp file so that if we fail or crash
-         * while filling it, the existence of a partial file doesn't confuse restarting in the
-         * source database.
+         * in backup_config. This file will later be renamed to the correct name depending on
+         * whether or not we're doing an incremental backup. We need a temp file so that if we fail
+         * or crash while filling it, the existence of a partial file doesn't confuse restarting in
+         * the source database.
          */
         WT_ERR(__wt_fopen(session, WT_BACKUP_TMP, WT_FS_OPEN_CREATE, WT_STREAM_WRITE, &cb->bfs));
     }
@@ -277,17 +284,13 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
      * database objects and log files to the list.
      */
     target_list = false;
-    WT_ERR(__backup_uri(session, cfg, is_dup, &target_list, &log_only));
-    /*
-     * For a duplicate cursor, all the work is done in backup_uri. The only usage accepted is
-     * "target=("log:")" so error if not log only.
-     */
+    WT_ERR(__backup_config(session, cb, cfg, is_dup, &target_list, &log_only));
+
+    /* For a duplicate cursor, all the work is done in backup_config. */
     if (is_dup) {
-        if (!log_only)
-            WT_ERR_MSG(session, EINVAL, "duplicate backup cursor must be for logs only");
         F_SET(cb, WT_CURBACKUP_DUP);
         F_SET(session, WT_SESSION_BACKUP_DUP);
-        goto done;
+        return (0);
     }
     if (!target_list) {
         /*
@@ -357,7 +360,6 @@ err:
     if (cb->bfs != NULL)
         WT_TRET(__wt_fclose(session, &cb->bfs));
 
-done:
     return (ret);
 }
 
@@ -378,6 +380,7 @@ __backup_stop(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
     /* If it's not a dup backup cursor, make sure one isn't open. */
     WT_ASSERT(session, !F_ISSET(session, WT_SESSION_BACKUP_DUP));
     WT_WITH_HOTBACKUP_WRITE_LOCK(session, conn->hot_backup_list = NULL);
+
     __backup_free(session, cb);
 
     /* Remove any backup specific file. */
@@ -402,20 +405,52 @@ __backup_all(WT_SESSION_IMPL *session)
 }
 
 /*
- * __backup_uri --
- *     Backup a list of objects.
+ * __backup_config --
+ *     Backup configuration.
  */
 static int
-__backup_uri(WT_SESSION_IMPL *session, const char *cfg[], bool is_dup, bool *foundp, bool *log_only)
+__backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[], bool is_dup,
+  bool *foundp, bool *log_only)
 {
     WT_CONFIG targetconf;
     WT_CONFIG_ITEM cval, k, v;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     const char *uri;
-    bool target_list;
+    bool incremental_config, log_config, target_list;
 
     *foundp = *log_only = false;
+
+    incremental_config = log_config = false;
+
+    /*
+     * Per-file offset incremental hot backup configurations take a starting checkpoint and the
+     * subsequent duplicate cursors take a file object.
+     */
+    WT_RET_NOTFOUND_OK(__wt_config_gets(session, cfg, "incremental_checkpoint", &cval));
+    if (cval.len != 0) {
+        if (is_dup)
+            WT_RET_MSG(session, EINVAL,
+              "file offset based incremental backup checkpoints "
+              "must be specified when opening the primary backup "
+              "cursor");
+        WT_RET(__wt_strndup(session, cval.str, cval.len, &cb->incr_checkpoint_start));
+
+        WT_RET(__wt_config_gets(session, cfg, "incremental_size", &cval));
+        cb->incr_size = (uint64_t)cval.val;
+
+        incremental_config = true;
+    }
+    WT_RET_NOTFOUND_OK(__wt_config_gets(session, cfg, "incremental_file", &cval));
+    if (cval.len != 0) {
+        if (!is_dup)
+            WT_RET_MSG(session, EINVAL,
+              "incremental file offset based backup objects are "
+              "specified when opening a duplicate backup cursor");
+        WT_RET(__wt_strndup(session, cval.str, cval.len, &cb->incr_file));
+
+        incremental_config = true;
+    }
 
     /*
      * If we find a non-empty target configuration string, we have a job, otherwise it's not our
@@ -441,14 +476,7 @@ __backup_uri(WT_SESSION_IMPL *session, const char *cfg[], bool is_dup, bool *fou
          * function to append them. Set log_only only if it is our only URI target.
          */
         if (WT_PREFIX_MATCH(uri, "log:")) {
-            /*
-             * Log archive cannot mix with incremental backup, don't let that happen. If we're a
-             * duplicate cursor archiving is already temporarily suspended.
-             */
-            if (!is_dup && FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ARCHIVE))
-                WT_ERR_MSG(session, EINVAL,
-                  "incremental backup not possible when "
-                  "automatic log archival configured");
+            log_config = true;
             *log_only = !target_list;
             WT_ERR(__backup_log_append(session, session->bkp_cursor, false));
         } else {
@@ -464,6 +492,30 @@ __backup_uri(WT_SESSION_IMPL *session, const char *cfg[], bool is_dup, bool *fou
         }
     }
     WT_ERR_NOTFOUND_OK(ret);
+
+    /*
+     * Compatibility checking.
+     *
+     * Log archive cannot mix with log-file based incremental backups (but
+     * if a duplicate cursor, archiving has been temporarily suspended).
+     *
+     * Duplicate backup cursors are only for log- and file-based incremental
+     * backups.
+     *
+     * Log targets don't make sense with incremental backup.
+     */
+    if (!is_dup && FLD_ISSET(S2C(session)->log_flags, WT_CONN_LOG_ARCHIVE))
+        WT_ERR_MSG(session, EINVAL,
+          "incremental log file backup not possible when automatic "
+          "log archival configured");
+    if (is_dup && (!incremental_config && !log_only))
+        WT_ERR_MSG(session, EINVAL,
+          "duplicate backup cursor must be for file- or log-based "
+          "incremental backup");
+    if (incremental_config && (log_config || target_list))
+        WT_ERR_MSG(session, EINVAL,
+          "incremental file offset backup incompatible with a list "
+          "of targets");
 
 err:
     __wt_scr_free(session, &tmp);
@@ -499,12 +551,16 @@ __wt_backup_file_remove(WT_SESSION_IMPL *session)
 static int
 __backup_list_uri_append(WT_SESSION_IMPL *session, const char *name, bool *skip)
 {
+    WT_CKPT *ckpt, *ckptbase;
+    WT_CURSOR *cursor;
     WT_CURSOR_BACKUP *cb;
     WT_DECL_RET;
     char *value;
 
-    cb = session->bkp_cursor;
     WT_UNUSED(skip);
+
+    cb = session->bkp_cursor;
+    value = NULL;
 
     /*
      * While reading the metadata file, check there are no data sources that can't support hot
@@ -523,22 +579,40 @@ __backup_list_uri_append(WT_SESSION_IMPL *session, const char *name, bool *skip)
 
     /* Add the metadata entry to the backup file. */
     WT_RET(__wt_metadata_search(session, name, &value));
-    ret = __wt_fprintf(session, cb->bfs, "%s\n%s\n", name, value);
-    __wt_free(session, value);
-    WT_RET(ret);
+    WT_ERR(__wt_fprintf(session, cb->bfs, "%s\n%s\n", name, value));
+
+    /* If this is the first file we've listed, get a checkpoint name. */
+    cursor = (WT_CURSOR *)cb;
+    if (cursor->checkpoint == NULL) {
+        WT_ERR(__wt_meta_ckptlist_get(session, name, false, &ckptbase));
+        WT_CKPT_FOREACH (ckptbase, ckpt)
+            if ((ckpt + 1)->name == NULL)
+                break;
+        if (ckpt->name == NULL)
+            WT_PANIC_ERR(session, WT_PANIC,
+              "%s: attempting hot backup of an object without a "
+              "checkpoint",
+              name);
+
+        cursor = (WT_CURSOR *)cb;
+        WT_ERR(__wt_strdup(session, ckpt->name, &cursor->checkpoint));
+        __wt_meta_ckptlist_free(session, &ckptbase);
+    }
 
     /*
      * We want to retain the system information in the backup metadata file above, but there is no
      * file object to copy so return now.
      */
     if (WT_PREFIX_MATCH(name, WT_SYSTEM_PREFIX))
-        return (0);
+        goto err;
 
     /* Add file type objects to the list of files to be copied. */
     if (WT_PREFIX_MATCH(name, "file:"))
-        WT_RET(__backup_list_append(session, cb, name));
+        WT_ERR(__backup_list_append(session, cb, name));
 
-    return (0);
+err:
+    __wt_free(session, value);
+    return (ret);
 }
 
 /*

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -1,0 +1,288 @@
+/*-
+ * Copyright (c) 2014-2019 MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+/*
+ * __curbackup_incr_get_key --
+ *     WT_CURSOR->get_key for incremental hot backup cursors.
+ */
+static int
+__curbackup_incr_get_key(WT_CURSOR *cursor, ...)
+{
+    WT_CURSOR_BACKUP *cb;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    uint64_t offset, size;
+    va_list ap;
+
+    va_start(ap, cursor);
+    cb = (WT_CURSOR_BACKUP *)cursor;
+    CURSOR_API_CALL(cursor, session, get_key, NULL);
+
+    WT_ERR(__cursor_needkey(cursor));
+
+    offset = cb->incr_list[cb->incr_list_offset];
+    size = WT_MIN(cb->incr_list[cb->incr_list_offset + 1], cb->incr_size);
+
+    *va_arg(ap, uint64_t *) = offset;
+    *va_arg(ap, uint64_t *) = size;
+
+err:
+    va_end(ap);
+    API_END_RET(session, ret);
+}
+
+/*
+ * __curbackup_incr_get_value --
+ *     WT_CURSOR->get_value for incremental hot backup cursors.
+ */
+static int
+__curbackup_incr_get_value(WT_CURSOR *cursor, ...)
+{
+    WT_BM *bm;
+    WT_BTREE *btree;
+    WT_CURSOR_BACKUP *cb;
+    WT_DECL_RET;
+    WT_FH *fh;
+    WT_ITEM *value;
+    WT_SESSION_IMPL *session;
+    uint64_t offset, size;
+    va_list ap;
+
+    fh = NULL;
+    va_start(ap, cursor);
+
+    cb = (WT_CURSOR_BACKUP *)cursor;
+    btree = cb->incr_cursor == NULL ? NULL : ((WT_CURSOR_BTREE *)cb->incr_cursor)->btree;
+    CURSOR_API_CALL(cursor, session, get_value, btree);
+
+    WT_ERR(__cursor_needvalue(cursor));
+
+    offset = cb->incr_list[cb->incr_list_offset];
+    size = WT_MIN(cb->incr_list[cb->incr_list_offset + 1], cb->incr_size);
+
+    if (btree == NULL) {
+        WT_ERR(__wt_open(
+          session, cb->incr_file, WT_FS_OPEN_FILE_TYPE_REGULAR, WT_FS_OPEN_READONLY, &fh));
+        WT_ERR(__wt_buf_init(session, cb->incr_block, size));
+        WT_ERR(__wt_read(session, fh, (wt_off_t)offset, (size_t)size, cb->incr_block->mem));
+        cb->incr_block->size = size;
+    } else {
+        bm = btree->bm;
+        WT_ERR(bm->read_raw(bm, session, cb->incr_block, offset, size));
+    }
+    value = va_arg(ap, WT_ITEM *);
+    value->data = cb->incr_block->data;
+    value->size = cb->incr_block->size;
+
+err:
+    va_end(ap);
+
+    WT_TRET(__wt_close(session, &fh));
+    API_END_RET(session, ret);
+}
+/*
+ * __curbackup_incr_next --
+ *     WT_CURSOR->next method for the btree cursor type when configured with incremental_backup.
+ */
+static int
+__curbackup_incr_next(WT_CURSOR *cursor)
+{
+    WT_BM *bm;
+    WT_BTREE *btree;
+    WT_CKPT *ckpt, *ckptbase;
+    WT_CURSOR_BACKUP *cb;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    wt_off_t size;
+    bool start, stop;
+
+    ckptbase = NULL;
+
+    cb = (WT_CURSOR_BACKUP *)cursor;
+    btree = cb->incr_cursor == NULL ? NULL : ((WT_CURSOR_BTREE *)cb->incr_cursor)->btree;
+    CURSOR_API_CALL(cursor, session, get_value, btree);
+
+    /*
+     * If we have this object's incremental information, step past the current offset, otherwise
+     * call the block manager to get it.
+     */
+    if (cb->incr_init) {
+        if (cb->incr_list_offset >= cb->incr_list_count - 2)
+            return (WT_NOTFOUND);
+
+        /*
+         * If we didn't manage to transfer all of the data, move to the next chunk.
+         */
+        if (cb->incr_list[cb->incr_list_offset + 1] <= cb->incr_size)
+            cb->incr_list_offset += 2;
+        else {
+            cb->incr_list[cb->incr_list_offset] += cb->incr_size;
+            cb->incr_list[cb->incr_list_offset + 1] -= cb->incr_size;
+        }
+    } else if (btree == NULL) {
+        WT_ERR(__wt_fs_size(session, cb->incr_file, &size));
+
+        WT_ERR(__wt_calloc_def(session, 2, &cb->incr_list));
+        cb->incr_list[0] = 0;
+        cb->incr_list[1] = (uint64_t)size;
+        cb->incr_list_count = 2;
+        cb->incr_list_offset = 0;
+        WT_ERR(__wt_scr_alloc(session, 0, &cb->incr_block));
+        cb->incr_init = true;
+
+        F_SET(cursor, WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
+    } else {
+        /*
+         * Get a list of the checkpoints available for the file and flag the starting/stopping ones.
+         * It shouldn't be possible to specify checkpoints that no longer exist, but paranoia is
+         * good.
+         */
+        ret = __wt_meta_ckptlist_get(session, cb->incr_file, false, &ckptbase);
+        WT_ERR(ret == WT_NOTFOUND ? ENOENT : ret);
+
+        start = stop = false;
+        WT_CKPT_FOREACH (ckptbase, ckpt) {
+            if (strcmp(ckpt->name, cb->incr_checkpoint_start) == 0) {
+                start = true;
+                F_SET(ckpt, WT_CKPT_INCR_START);
+            }
+            if (start == true && strcmp(ckpt->name, cb->incr_checkpoint_stop) == 0) {
+                stop = true;
+                F_SET(ckpt, WT_CKPT_INCR_STOP);
+            }
+        }
+        if (!start)
+            WT_PANIC_ERR(
+              session, ENOENT, "start checkpoint %s not found", cb->incr_checkpoint_start);
+        if (!stop)
+            WT_PANIC_ERR(session, ENOENT, "stop checkpoint %s not found", cb->incr_checkpoint_stop);
+
+        bm = btree->bm;
+        WT_ERR(bm->checkpoint_rewrite(bm, session, ckptbase, &cb->incr_list, &cb->incr_list_count));
+
+        if (cb->incr_list_count == 0)
+            WT_ERR(WT_NOTFOUND);
+        if (cb->incr_list_count % 2 != 0)
+            WT_PANIC_MSG(session, EINVAL,
+              "unexpected return from block manager checkpoint "
+              "rewrite API");
+
+        cb->incr_list_offset = 0;
+        WT_ERR(__wt_scr_alloc(session, 0, &cb->incr_block));
+        cb->incr_init = true;
+
+        F_SET(cursor, WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
+    }
+
+err:
+    __wt_meta_ckptlist_free(session, &ckptbase);
+    API_END_RET(session, ret);
+}
+
+/*
+ * __wt_curbackup_free_incr --
+ *     Free the duplicate backup cursor for a file-based incremental backup.
+ */
+void
+__wt_curbackup_free_incr(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
+{
+    __wt_free(session, cb->incr_file);
+    __wt_cursor_close(cb->incr_cursor);
+    __wt_free(session, cb->incr_checkpoint_start);
+    __wt_free(session, cb->incr_checkpoint_stop);
+    __wt_free(session, cb->incr_list);
+    __wt_scr_free(session, &cb->incr_block);
+}
+
+/*
+ * __wt_curbackup_open_incr --
+ *     Initialize the duplicate backup cursor for a file-based incremental backup.
+ */
+int
+__wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
+  WT_CURSOR *cursor, const char *cfg[], WT_CURSOR **cursorp)
+{
+    static const char *copy_entire[] = {WT_BASECONFIG, WT_METADATA_BACKUP, WT_WIREDTIGER, NULL};
+    WT_CURSOR_BACKUP *cb, *other_cb;
+    WT_DECL_ITEM(open_checkpoint);
+    WT_DECL_ITEM(open_uri);
+    WT_DECL_RET;
+    size_t i;
+    const char **p, **new_cfg;
+
+    cb = (WT_CURSOR_BACKUP *)cursor;
+    other_cb = (WT_CURSOR_BACKUP *)other;
+    new_cfg = NULL;
+
+    cursor->key_format = "qq";
+    cursor->value_format = "u";
+
+    cursor->next = __curbackup_incr_next;
+    cursor->get_key = __curbackup_incr_get_key;
+    cursor->get_value = __curbackup_incr_get_value;
+
+    /* We need a starting checkpoint. */
+    if (other_cb->incr_checkpoint_start == NULL)
+        WT_ERR_MSG(session, EINVAL,
+          "a starting checkpoint must be specified to open a hot "
+          "backup cursor for file-based incremental backups");
+
+    /* The two checkpoints aren't supposed to be the same. */
+    if (strcmp(other_cb->incr_checkpoint_start, other->checkpoint) == 0)
+        WT_ERR_MSG(session, EINVAL,
+          "incremental backup start and stop checkpoints are the "
+          "same: %s",
+          other_cb->incr_checkpoint_start);
+
+    /* Copy information from the primary cursor to the current file. */
+    WT_ERR(__wt_strdup(session, other_cb->incr_checkpoint_start, &cb->incr_checkpoint_start));
+    WT_ERR(__wt_strdup(session, other->checkpoint, &cb->incr_checkpoint_stop));
+    cb->incr_size = other_cb->incr_size;
+
+    /*
+     * Files that aren't underlying block-manager files have to be copied in their entirety. Catch
+     * them up front and don't try and read them.
+     */
+    for (p = copy_entire; *p != NULL; ++p)
+        if (strcmp(*p, cb->incr_file) == 0)
+            return (__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));
+
+    /*
+     * If doing a file-based incremental backup, we need an open cursor on the file. Open the backup
+     * checkpoint, confirming it exists.
+     */
+    WT_ERR(__wt_scr_alloc(session, 0, &open_uri));
+    WT_ERR(__wt_buf_fmt(session, open_uri, "file:%s", cb->incr_file));
+    __wt_free(session, cb->incr_file);
+    WT_ERR(__wt_strdup(session, open_uri->data, &cb->incr_file));
+
+    WT_ERR(__wt_scr_alloc(session, 0, &open_checkpoint));
+    WT_ERR(__wt_buf_fmt(session, open_checkpoint, "checkpoint=%s", cb->incr_checkpoint_start));
+    for (i = 0; cfg[i] != NULL; ++i)
+        ;
+    WT_ERR(__wt_calloc_def(session, i + 2, &new_cfg));
+    for (i = 0; cfg[i] != NULL; ++i)
+        new_cfg[i] = cfg[i];
+    new_cfg[i++] = open_checkpoint->data;
+    new_cfg[i] = NULL;
+
+    WT_ERR(__wt_curfile_open(session, cb->incr_file, NULL, new_cfg, &cb->incr_cursor));
+
+    WT_ERR(__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));
+
+    /* XXX KEITH */
+    WT_ERR(__wt_strdup(session, cb->incr_cursor->internal_uri, &cb->incr_cursor->internal_uri));
+
+err:
+    __wt_scr_free(session, &open_checkpoint);
+    __wt_scr_free(session, &open_uri);
+    __wt_free(session, new_cfg);
+    return (ret);
+}

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -721,6 +721,10 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_d
         if (cval.len != 0)
             return (WT_NOTFOUND);
 
+        WT_RET(__wt_config_gets_def(session, cfg, "incremental_backup", 0, &cval));
+        if (cval.val != 0)
+            return (WT_NOTFOUND);
+
         WT_RET(__wt_config_gets_def(session, cfg, "next_random", 0, &cval));
         if (cval.val != 0)
             return (WT_NOTFOUND);
@@ -821,6 +825,9 @@ __wt_cursor_close(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
+    if (cursor == NULL)
+        return;
+
     session = (WT_SESSION_IMPL *)cursor->session;
 
     if (F_ISSET(cursor, WT_CURSTD_OPEN)) {
@@ -831,9 +838,9 @@ __wt_cursor_close(WT_CURSOR *cursor)
     }
     __wt_buf_free(session, &cursor->key);
     __wt_buf_free(session, &cursor->value);
-
     __wt_free(session, cursor->internal_uri);
     __wt_free(session, cursor->uri);
+    __wt_free(session, cursor->checkpoint);
     __wt_overwrite_and_free(session, cursor);
 }
 

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -175,6 +175,7 @@ struct __wt_bm {
     int (*checkpoint_load)(
       WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t, uint8_t *, size_t *, bool);
     int (*checkpoint_resolve)(WT_BM *, WT_SESSION_IMPL *, bool);
+    int (*checkpoint_rewrite)(WT_BM *, WT_SESSION_IMPL *, WT_CKPT *, uint64_t **, uint64_t *);
     int (*checkpoint_start)(WT_BM *, WT_SESSION_IMPL *);
     int (*checkpoint_unload)(WT_BM *, WT_SESSION_IMPL *);
     int (*close)(WT_BM *, WT_SESSION_IMPL *);
@@ -188,6 +189,7 @@ struct __wt_bm {
     int (*map_discard)(WT_BM *, WT_SESSION_IMPL *, void *, size_t);
     int (*preload)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
     int (*read)(WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, const uint8_t *, size_t);
+    int (*read_raw)(WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, uint64_t, uint64_t);
     int (*salvage_end)(WT_BM *, WT_SESSION_IMPL *);
     int (*salvage_next)(WT_BM *, WT_SESSION_IMPL *, uint8_t *, size_t *, bool *);
     int (*salvage_start)(WT_BM *, WT_SESSION_IMPL *);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -282,6 +282,7 @@ struct __wt_connection_impl {
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */
+    char *ckpt_locked;     /* List of locked checkpoints */
 
     uint64_t ckpt_usecs;    /* Checkpoint timer */
     uint64_t ckpt_time_max; /* Checkpoint time min/max */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -15,6 +15,7 @@
     static const WT_CURSOR n = {                                                                \
       NULL, /* session */                                                                       \
       NULL, /* uri */                                                                           \
+      NULL, /* checkpoint */                                                                    \
       NULL, /* key_format */                                                                    \
       NULL, /* value_format */                                                                  \
       get_key, get_value, set_key, set_value, compare, equals, next, prev, reset, search,       \
@@ -42,6 +43,20 @@ struct __wt_cursor_backup {
     char **list; /* List of files to be copied. */
     size_t list_allocated;
     size_t list_next;
+
+    /* File offset-based incremental backup. */
+    char *incr_file;        /* File */
+    WT_CURSOR *incr_cursor; /* File cursor */
+    /* Start/stop checkpoints */
+    char *incr_checkpoint_start;
+    char *incr_checkpoint_stop;
+
+    bool incr_init;            /* Cursor traversal initialized */
+    uint64_t *incr_list;       /* List of file offset/size pairs */
+    uint64_t incr_list_count;  /* Count of file offset/size pairs */
+    uint64_t incr_list_offset; /* Current offset */
+    uint64_t incr_size;        /* Maximum transfer size */
+    WT_ITEM *incr_block;       /* Current block of data */
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CURBACKUP_DUP 0x1u    /* Duplicated backup cursor */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -109,6 +109,9 @@ extern int __wt_block_checkpoint_load(WT_SESSION_IMPL *session, WT_BLOCK *block,
   bool checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool failed)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_block_checkpoint_rewrite(WT_SESSION_IMPL *session, WT_BLOCK *block,
+  WT_CKPT *ckptbase, uint64_t **listp, uint64_t *list_countp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_checkpoint_unload(WT_SESSION_IMPL *session, WT_BLOCK *block, bool checkpoint)
@@ -244,6 +247,8 @@ extern int __wt_bm_preload(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *a
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bm_read(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bm_read_raw(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, uint64_t offset,
+  uint64_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bt_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
@@ -349,6 +354,8 @@ extern int __wt_checkpoint_server_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_checkpoint_sync(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt,
+  bool discard) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_close_connection_close(WT_SESSION_IMPL *session)
@@ -471,6 +478,9 @@ extern int __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const ch
 extern int __wt_count_birthmarks(WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
+  WT_CURSOR *cursor, const char *cfg[], WT_CURSOR **cursorp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curbulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool bitmap,
   bool skip_sort_check) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curconfig_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
@@ -1589,6 +1599,7 @@ extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);
 extern void __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
+extern void __wt_curbackup_free_incr(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb);
 extern void __wt_cursor_close(WT_CURSOR *cursor);
 extern void __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt);
 extern void __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -30,8 +30,9 @@
 #define WT_LAS_FILE "WiredTigerLAS.wt"     /* Lookaside table */
 #define WT_LAS_URI "file:WiredTigerLAS.wt" /* Lookaside table URI*/
 
-#define WT_SYSTEM_PREFIX "system:"             /* System URI prefix */
-#define WT_SYSTEM_CKPT_URI "system:checkpoint" /* Checkpoint URI */
+#define WT_SYSTEM_PREFIX "system:"                  /* System URI prefix */
+#define WT_SYSTEM_CKPT_URI "system:checkpoint"      /* Checkpoint URI */
+#define WT_SYSTEM_CKPT_LOCK "system:checkpointlock" /* Checkpoint lock */
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference the metadata file.
@@ -97,10 +98,12 @@ struct __wt_ckpt {
     void *bpriv; /* Block manager private */
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_CKPT_ADD 0x1u    /* Checkpoint to be added */
-#define WT_CKPT_DELETE 0x2u /* Checkpoint to be deleted */
-#define WT_CKPT_FAKE 0x4u   /* Checkpoint is a fake */
-#define WT_CKPT_UPDATE 0x8u /* Checkpoint requires update */
-                            /* AUTOMATIC FLAG VALUE GENERATION STOP */
+#define WT_CKPT_ADD 0x01u        /* Checkpoint to be added */
+#define WT_CKPT_DELETE 0x02u     /* Checkpoint to be deleted */
+#define WT_CKPT_FAKE 0x04u       /* Checkpoint is a fake */
+#define WT_CKPT_INCR_START 0x08u /* Checkpoint start incremental */
+#define WT_CKPT_INCR_STOP 0x10u  /* Checkpoint stop incremental */
+#define WT_CKPT_UPDATE 0x20u     /* Checkpoint requires update */
+                                 /* AUTOMATIC FLAG VALUE GENERATION STOP*/
     uint32_t flags;
 };

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -218,6 +218,13 @@ struct __wt_cursor {
 	const char *uri;
 
 	/*!
+	 * The name of the checkpoint for a hot backup cursor, or the checkpoint
+	 * within a data source, when it matches the \c checkpoint parameter to
+	 * WT_SESSION::open_cursor used to open the cursor.
+	 */
+	const char *checkpoint;
+
+	/*!
 	 * The format of the data packed into key items.  See @ref packing for
 	 * details.  If not set, a default value of "u" is assumed, and
 	 * applications must use WT_ITEM structures to manipulate untyped byte
@@ -1063,6 +1070,13 @@ struct __wt_session {
 	 * non-printing characters are hexadecimal encoded.  These formats are compatible with the
 	 * @ref util_dump and @ref util_load commands., a string\, chosen from the following
 	 * options: \c "hex"\, \c "json"\, \c "print"; default empty.}
+	 * @config{incremental_checkpoint, the starting checkpoint for an file offset based
+	 * incremental backup; valid only for a backup data source., a string; default empty.}
+	 * @config{incremental_file, the object for a file offset based incremental backup; valid
+	 * only for " "a backup data source., a string; default empty.}
+	 * @config{incremental_size, the maximum block size returned for a file offset based
+	 * incremental backup; valid only for a backup data source., an integer greater than or
+	 * equal to 1MB; default \c 16MB.}
 	 * @config{next_random, configure the cursor to return a pseudo-random record from the
 	 * object when the WT_CURSOR::next method is called; valid only for row-store cursors.  See
 	 * @ref cursor_random for details., a boolean flag; default \c false.}
@@ -1908,10 +1922,15 @@ struct __wt_session {
 	 * a list of strings; default empty.}
 	 * @config{force, by default\, checkpoints may be skipped if the underlying object has not
 	 * been modified\, this option forces the checkpoint., a boolean flag; default \c false.}
+	 * @config{lock, if set\, specify the name of a checkpoint to lock (retain) for use in
+	 * subsequent incremental backups.  No checkpoint is performed., a string; default empty.}
 	 * @config{name, if set\, specify a name for the checkpoint (note that checkpoints including
 	 * LSM trees may not be named)., a string; default empty.}
 	 * @config{target, if non-empty\, checkpoint the list of objects., a list of strings;
 	 * default empty.}
+	 * @config{unlock, if set\, specify the name of a checkpoint to unlock (discard)\, as it is
+	 * no longer needed for subsequent incremental backups.  No checkpoint is performed., a
+	 * string; default empty.}
 	 * @config{use_timestamp, by default\, create the checkpoint as of the last stable timestamp
 	 * if timestamps are in use\, or all current updates if there is no stable timestamp set.
 	 * If false\, this option generates a checkpoint with all updates including those later than

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -507,11 +507,16 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
      * When opening simple tables, the table code calls this function on the underlying data source,
      * in which case the application's URI has been copied.
      */
-    if ((*cursorp)->uri == NULL && (ret = __wt_strdup(session, uri, &(*cursorp)->uri)) != 0) {
-        WT_TRET((*cursorp)->close(*cursorp));
-        *cursorp = NULL;
-    }
+    if ((*cursorp)->uri == NULL)
+        WT_ERR(__wt_strdup(session, uri, &(*cursorp)->uri));
+    if ((*cursorp)->checkpoint == NULL && session->dhandle != NULL &&
+      session->dhandle->checkpoint != NULL)
+        WT_ERR(__wt_strdup(session, session->dhandle->checkpoint, &(*cursorp)->checkpoint));
+    return (0);
 
+err:
+    WT_TRET((*cursorp)->close(*cursorp));
+    *cursorp = NULL;
     return (ret);
 }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -649,6 +649,88 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
 }
 
 /*
+ * __txn_checkpoint_lock --
+ *     Lock/unlock a checkpoint.
+ */
+static int
+__txn_checkpoint_lock(WT_SESSION_IMPL *session, const char *cfg[], bool *can_skipp)
+{
+    WT_CONFIG_ITEM cval;
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_ITEM(tmp);
+    WT_DECL_RET;
+    char *remain, *token, *v;
+    bool first, match;
+
+    *can_skipp = false;
+
+    conn = S2C(session);
+    v = NULL;
+
+    WT_ERR(__wt_config_gets(session, cfg, "lock", &cval));
+    if (cval.len != 0) {
+        *can_skipp = true;
+
+        /* Add the newly locked checkpoint to the end of the list. */
+        WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+        WT_ERR(
+          __wt_buf_fmt(session, tmp, "%s%s%.*s", conn->ckpt_locked == NULL ? "" : conn->ckpt_locked,
+            conn->ckpt_locked == NULL ? "" : ",", (int)cval.len, cval.str));
+    }
+    WT_ERR(__wt_config_gets(session, cfg, "unlock", &cval));
+    if (cval.len != 0) {
+        *can_skipp = true;
+
+        if (conn->ckpt_locked == NULL)
+            goto nomatch;
+        if (tmp == NULL)
+            WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+
+        /*
+         * strtok_r will corrupt the string, make a copy to simplify error handling.
+         */
+        WT_ERR(__wt_strdup(session, conn->ckpt_locked, &v));
+
+        /* Walk the list, discarding any that are no longer locked. */
+        for (first = true, match = false, remain = v;
+             (token = strtok_r(remain, ",", &remain)) != NULL;)
+            if (WT_STRING_MATCH(token, cval.str, cval.len))
+                match = true;
+            else {
+                WT_ERR(__wt_buf_catfmt(session, tmp, "%s%s", first ? "" : ",", token));
+                first = false;
+            }
+        if (!match)
+            goto nomatch;
+    }
+
+    if (!*can_skipp)
+        return (0);
+
+    /*
+     * Update the in-memory copy. This is mildly tricky because we leave the in-memory list of
+     * locked checkpoints untouched until there is no possibility that replacing it will fail.
+     */
+    __wt_free(session, v);
+    WT_ERR(__wt_strdup(session, tmp->mem, &v));
+    __wt_free(session, conn->ckpt_locked);
+    conn->ckpt_locked = v;
+    v = NULL;
+
+    /* Update the metadata. */
+    WT_ERR(__wt_metadata_update(session, WT_SYSTEM_CKPT_LOCK, tmp->mem));
+
+    if (0) {
+nomatch:
+        WT_ERR_MSG(session, WT_NOTFOUND, "%.*s: not a locked checkpoint", (int)cval.len, cval.str);
+    }
+err:
+    __wt_free(session, v);
+    __wt_scr_free(session, &tmp);
+    return (ret);
+}
+
+/*
  * __txn_checkpoint_can_skip --
  *     Determine whether it's safe to skip taking a checkpoint.
  */
@@ -760,7 +842,14 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     saved_isolation = session->isolation;
     full = idle = logging = tracking = use_timestamp = false;
 
-    /* Avoid doing work if possible. */
+    /*
+     * Avoid doing work if possible. Lock/unlock doesn't do a checkpoint, some checkpoints can be
+     * skipped.
+     */
+    WT_RET(__txn_checkpoint_lock(session, cfg, &can_skip));
+    if (can_skip)
+        return (0);
+
     WT_RET(__txn_checkpoint_can_skip(session, cfg, &full, &use_timestamp, &can_skip));
     if (can_skip) {
         WT_STAT_CONN_INCR(session, txn_checkpoint_skipped);
@@ -1202,6 +1291,41 @@ __drop_to(WT_CKPT *ckptbase, const char *name, size_t len)
 }
 
 /*
+ * __retain_locked --
+ *     Don't drop any checkpoint that's currently locked.
+ */
+static int
+__retain_locked(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
+{
+    WT_CKPT *ckpt;
+    WT_CONNECTION_IMPL *conn;
+    char *remain, *token, *v;
+
+    conn = S2C(session);
+
+    /*
+     * We have an in-memory list of the locked checkpoints. It would be reasonable to instead
+     * store/retrieve from the metadata whenever we need it and avoid having two copies, but we
+     * create checkpoints both early and late in the lifecycle of the database, and there are times
+     * we're here when getting our hands on a metadata cursor is tricky, at best. So, two copies it
+     * is.
+     */
+    if (conn->ckpt_locked == NULL)
+        return (0);
+
+    /* strtok_r will corrupt the string, make a copy. */
+    WT_RET(__wt_strdup(session, conn->ckpt_locked, &v));
+
+    for (remain = v; (token = strtok_r(remain, ",", &remain)) != NULL;)
+        WT_CKPT_FOREACH (ckptbase, ckpt)
+            if (F_ISSET(ckpt, WT_CKPT_DELETE) && strcmp(ckpt->name, token) == 0)
+                F_CLR(ckpt, WT_CKPT_DELETE);
+
+    __wt_free(session, v);
+    return (0);
+}
+
+/*
  * __checkpoint_lock_dirty_tree_int --
  *     Helper for __checkpoint_lock_dirty_tree. Intended to be called while holding the hot backup
  *     lock.
@@ -1368,6 +1492,9 @@ __checkpoint_lock_dirty_tree(
 
     /* Drop checkpoints with the same name as the one we're taking. */
     __drop(ckptbase, name, strlen(name));
+
+    /* Except for locked checkpoints, they cannot be discarded. */
+    __retain_locked(session, ckptbase);
 
     /* Set the name of the new entry at the end of the list. */
     WT_CKPT_FOREACH (ckptbase, ckpt)


### PR DESCRIPTION
This is a migration of #4782.