### PR TITLE
WT-5062 Adjust the record size to consume less size in Jenkins perf machine

### DIFF
--- a/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
@@ -5,7 +5,7 @@ conn_config="cache_size=20G"
 sess_config="isolation=snapshot"
 table_config="type=file"
 key_sz=40
-value_sz=100000
+value_sz=10000
 icount=500000
 report_interval=5
 random_value=true

--- a/bench/wtperf/runners/modify-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-large-record-btree.wtperf
@@ -4,7 +4,7 @@ conn_config="cache_size=20G"
 sess_config="isolation=snapshot"
 table_config="type=file"
 key_sz=40
-value_sz=100000
+value_sz=10000
 icount=500000
 report_interval=5
 random_value=true


### PR DESCRIPTION
The record size is reduced to consume less disk space for the test
as part of the performance tests. Earlier it used to take around
60GB, now it is reduced to 12GB.