### PR TITLE
WT-5087 Add time tracking at start of reconciliation.

### DIFF
--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -187,7 +187,8 @@ __wt_row_leaf_key_work(
         WT_ERR_ASSERT(session, (current - start) < WT_MINUTE * 5, EINVAL,
           "Current function call taking too long: current %" PRIu32 " func started %" PRIu32,
           current, start);
-        WT_ERR_ASSERT(session, (current - session->op_start) < WT_MINUTE * 5, EINVAL,
+        WT_ERR_ASSERT(session,
+          session->op_start == 0 || ((current - session->op_start) < WT_MINUTE * 5), EINVAL,
           "Operation taking too long: current %" PRIu32 " started %" PRIu32, current,
           session->op_start);
 #endif

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -40,6 +40,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
         *lookaside_retryp = false;
 
     page = ref->page;
+    WT_TRACK_TIME(session);
 
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconcile %s (%s%s%s)", (void *)ref,
       __wt_page_type_string(page->type), LF_ISSET(WT_REC_EVICT) ? "evict" : "checkpoint",


### PR DESCRIPTION
@keithbostic please review. I missed some initialization for the debug timing. It hit on an LSM thread. I decided to initialize at the start of reconciliation as well as add in a conditional so that we don't trigger if there are other paths into this code from other places (like `cursor_row_slot_return`).