### PR TITLE
WT-5074 Fix "make check" on exotic architectures

### DIFF
--- a/build_posix/Make.base
+++ b/build_posix/Make.base
@@ -53,13 +53,6 @@ $(srcdir)/Makefile.am: $(srcdir)/build_posix/Make.base $(srcdir)/build_posix/mak
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
-$(srcdir)/src/include/extern.h: auto-includes.chk
-$(srcdir)/src/include/wt_internal.h: auto-includes.chk
-
-auto-includes.chk: $(libwiredtiger_la_SOURCES)
-	@(cd $(srcdir)/dist && \
-	    python prototypes.py && sh s_typedef -b) && touch $@
-
 $(srcdir)/docs/index.html:
 	@cd $(srcdir)/dist && sh s_docs
 

--- a/build_posix/reconf
+++ b/build_posix/reconf
@@ -22,7 +22,6 @@ clean()
 		Makefile.am \
 		Makefile.in \
 		aclocal.m4 \
-		auto-includes.chk \
 		autom4te.cache \
 		config.cache \
 		config.hin \

--- a/dist/s_clang-format
+++ b/dist/s_clang-format
@@ -4,10 +4,10 @@ set -o pipefail
 
 download_clang_format() {
 	if [ `uname` = "Linux" ]; then
-		wget https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-3.8-rhel55.tar.gz -O dist/clang-format.tar.gz
+		curl https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-3.8-rhel55.tar.gz -o dist/clang-format.tar.gz
 		tar --strip=2 -C dist/ -xf dist/clang-format.tar.gz build/bin/clang-format && rm dist/clang-format.tar.gz
 	elif [ `uname` = "Darwin" ]; then
-		wget https://s3.amazonaws.com/boxes.10gen.com/build/clang%2Bllvm-3.8.0-x86_64-apple-darwin.tar.xz -O dist/clang-format.tar.gz
+		curl https://s3.amazonaws.com/boxes.10gen.com/build/clang%2Bllvm-3.8.0-x86_64-apple-darwin.tar.xz -o dist/clang-format.tar.gz
 		tar --strip=2 -C dist/ -xf dist/clang-format.tar.gz clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang-format && rm dist/clang-format.tar.gz
 	else
 		echo "$0: unsupported environment $(uname)"


### PR DESCRIPTION
This PR is removing code generation from `make check`. Since we began using `clang-format` as part of our code generation process, this has become a problem on architectures such as ZSeries and PowerPC since we don't have the appropriate binaries for them (and maintaining them all would be untenable).

I think it's reasonable to remove this from the build process since I don't believe it belongs here anyway. To my way of thinking, this is unnecessarily making a development dependency also a build dependency. Just as an example, if you have a project that uses code generated by Protobuf, I wouldn't expect to need `protoc` to build it (although developers would need it).

Please let me know your thoughts on this.