### PR TITLE
WT-5080 New wtperf workload modify_distribute option

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -220,7 +220,7 @@ config_threads(WTPERF *wtperf, const char *config, size_t len)
                     goto err;
                 continue;
             }
-            if (STRING_MATCH("distribute_changes", k.str, k.len)) {
+            if (STRING_MATCH("distribute_modifications", k.str, k.len)) {
                 if (v.type != WT_CONFIG_ITEM_BOOL)
                     goto err;
                 workp->distribute_modifications = v.val;

--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -220,6 +220,12 @@ config_threads(WTPERF *wtperf, const char *config, size_t len)
                     goto err;
                 continue;
             }
+            if (STRING_MATCH("distribute_changes", k.str, k.len)) {
+                if (v.type != WT_CONFIG_ITEM_BOOL)
+                    goto err;
+                workp->distribute_modifications = v.val;
+                continue;
+            }
             if (STRING_MATCH("modify", k.str, k.len)) {
                 if ((workp->modify = v.val) < 0)
                     goto err;

--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -220,12 +220,6 @@ config_threads(WTPERF *wtperf, const char *config, size_t len)
                     goto err;
                 continue;
             }
-            if (STRING_MATCH("distribute_modifications", k.str, k.len)) {
-                if (v.type != WT_CONFIG_ITEM_BOOL)
-                    goto err;
-                workp->distribute_modifications = v.val;
-                continue;
-            }
             if (STRING_MATCH("modify", k.str, k.len)) {
                 if ((workp->modify = v.val) < 0)
                     goto err;
@@ -245,6 +239,12 @@ config_threads(WTPERF *wtperf, const char *config, size_t len)
                     if (v.val < 0)
                         F_SET(wtperf, CFG_SHRINK);
                 }
+                continue;
+            }
+            if (STRING_MATCH("modify_distribute", k.str, k.len)) {
+                if (v.type != WT_CONFIG_ITEM_BOOL)
+                    goto err;
+                workp->modify_distribute = v.val;
                 continue;
             }
             if (STRING_MATCH("modify_force_update", k.str, k.len)) {

--- a/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
@@ -11,4 +11,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,modify=1,ops_per_txn=1,distribute_changes=true,modify_force_update=true))
+threads=((count=1,modify=1,ops_per_txn=1,distribute_modifications=true,modify_force_update=true))

--- a/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
@@ -11,4 +11,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,modify=1,ops_per_txn=1,distribute_modifications=true,modify_force_update=true))
+threads=((count=1,modify=1,ops_per_txn=1,modify_distribute=true,modify_force_update=true))

--- a/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
@@ -11,4 +11,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=4,modify=1,ops_per_txn=1,modify_force_update=true))
+threads=((count=1,modify=1,ops_per_txn=1,distribute_changes=true,modify_force_update=true))

--- a/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-force-update-large-record-btree.wtperf
@@ -8,7 +8,6 @@ key_sz=40
 value_sz=10000
 icount=500000
 report_interval=5
-random_value=true
 run_time=120
 populate_threads=1
 threads=((count=1,modify=1,ops_per_txn=1,modify_distribute=true,modify_force_update=true))

--- a/bench/wtperf/runners/modify-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-large-record-btree.wtperf
@@ -10,4 +10,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,modify=1,ops_per_txn=1,distribute_modifications=true))
+threads=((count=1,modify=1,ops_per_txn=1,modify_distribute=true))

--- a/bench/wtperf/runners/modify-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-large-record-btree.wtperf
@@ -10,4 +10,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,modify=1,ops_per_txn=1,distribute_changes=true))
+threads=((count=1,modify=1,ops_per_txn=1,distribute_modifications=true))

--- a/bench/wtperf/runners/modify-large-record-btree.wtperf
+++ b/bench/wtperf/runners/modify-large-record-btree.wtperf
@@ -7,7 +7,6 @@ key_sz=40
 value_sz=10000
 icount=500000
 report_interval=5
-random_value=true
 run_time=120
 populate_threads=1
 threads=((count=1,modify=1,ops_per_txn=1,modify_distribute=true))

--- a/bench/wtperf/runners/update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/update-large-record-btree.wtperf
@@ -10,4 +10,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,updates=1,ops_per_txn=1,distribute_changes=true))
+threads=((count=1,updates=1,ops_per_txn=1,distribute_modifications=true))

--- a/bench/wtperf/runners/update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/update-large-record-btree.wtperf
@@ -7,7 +7,6 @@ key_sz=40
 value_sz=10000
 icount=500000
 report_interval=5
-random_value=true
 run_time=120
 populate_threads=1
 threads=((count=1,updates=1,ops_per_txn=1,modify_distribute=true))

--- a/bench/wtperf/runners/update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/update-large-record-btree.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: btree with updates. The goal here is to have a workload
-# of large documents that uses a lot of transaction IDs for modify operations
+# of large documents that uses a lot of transaction IDs for update operations
 conn_config="cache_size=20G"
 sess_config="isolation=snapshot"
 table_config="type=file"
@@ -10,4 +10,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,modify=1,ops_per_txn=1,distribute_changes=true))
+threads=((count=1,updates=1,ops_per_txn=1,distribute_changes=true))

--- a/bench/wtperf/runners/update-large-record-btree.wtperf
+++ b/bench/wtperf/runners/update-large-record-btree.wtperf
@@ -10,4 +10,4 @@ report_interval=5
 random_value=true
 run_time=120
 populate_threads=1
-threads=((count=1,updates=1,ops_per_txn=1,distribute_modifications=true))
+threads=((count=1,updates=1,ops_per_txn=1,modify_distribute=true))

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -726,12 +726,6 @@ worker(void *arg)
 
                 if (delta != 0)
                     update_value_delta(thread, delta);
-                if (value_buf[0] == 'a')
-                    value_buf[0] = 'b';
-                else
-                    value_buf[0] = 'a';
-                if (opts->random_value)
-                    randomize_value(thread, value_buf, delta);
 
                 value_len = strlen(value);
                 total_modify_size = value_len;
@@ -742,7 +736,7 @@ worker(void *arg)
                  * the maximum number of modifications and modify up to the maximum percent of the
                  * record size.
                  */
-                if (workload->distribute_modifications) {
+                if (workload->modify_distribute) {
                     /*
                      * The maximum that will be modified is a fixed percentage of the total record
                      * size.
@@ -776,6 +770,13 @@ worker(void *arg)
                     for (iter = (size_t)nmodify; iter > 0; iter--)
                         memmove(&value_buf[(iter * modify_offset) - modify_offset],
                           &value_buf[(iter * modify_offset) - modify_size], modify_size);
+                } else {
+                    if (value_buf[0] == 'a')
+                        value_buf[0] = 'b';
+                    else
+                        value_buf[0] = 'a';
+                    if (opts->random_value)
+                        randomize_value(thread, value_buf, delta);
                 }
 
                 if (*op == WORKER_UPDATE) {

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -735,15 +735,14 @@ worker(void *arg)
 
                 value_len = strlen(value);
                 total_modify_size = value_len;
+                nmodify = MAX_MODIFY_NUM;
 
+                /*
+                 * Distribute the modifications across the whole document. We randomly choose up to
+                 * the maximum number of modifications and modify up to the maximum percent of the
+                 * record size.
+                 */
                 if (workload->distribute_modifications) {
-                    /*
-                     * Distribute the modifications across the whole document. We randomly choose up
-                     * to the maximum number of modifications and modify up to the maximum percent
-                     * of the record size.
-                     */
-                    nmodify = MAX_MODIFY_NUM;
-
                     /*
                      * The maximum that will be modified is a fixed percentage of the total record
                      * size.

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -529,7 +529,6 @@ worker(void *arg)
     ops = 0;
     ops_per_txn = workload->ops_per_txn;
     session = NULL;
-    total_modify_size = 0;
     trk = NULL;
 
     if ((ret = conn->open_session(conn, NULL, opts->sess_config, &session)) != 0) {
@@ -735,6 +734,7 @@ worker(void *arg)
                     randomize_value(thread, value_buf, delta);
 
                 value_len = strlen(value);
+                total_modify_size = value_len;
 
                 if (workload->distribute_modifications) {
                     /*

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -66,17 +66,16 @@ typedef struct {
     uint64_t throttle; /* Maximum operations/second */
                        /* Number of operations per transaction. Zero for autocommit */
     int64_t ops_per_txn;
-    int64_t pause;                 /* Time between scans */
-    int64_t read_range;            /* Range of reads */
-    int32_t table_index;           /* Table to focus ops on */
-    int64_t truncate;              /* Truncate ratio */
-    uint64_t truncate_pct;         /* Truncate Percent */
-    uint64_t truncate_count;       /* Truncate Count */
-    int64_t modify_delta;          /* Value size change on modify */
-    int64_t update_delta;          /* Value size change on update */
-    bool distribute_modifications; /* Distribute the change of modifications across the whole new
-                                      record */
-    bool modify_force_update;      /* Do force update instead of modify */
+    int64_t pause;           /* Time between scans */
+    int64_t read_range;      /* Range of reads */
+    int32_t table_index;     /* Table to focus ops on */
+    int64_t truncate;        /* Truncate ratio */
+    uint64_t truncate_pct;   /* Truncate Percent */
+    uint64_t truncate_count; /* Truncate Count */
+    int64_t modify_delta;    /* Value size change on modify */
+    int64_t update_delta;    /* Value size change on update */
+    bool modify_distribute; /* Distribute the change of modifications across the whole new record */
+    bool modify_force_update; /* Do force update instead of modify */
 
 #define WORKER_INSERT 1     /* Insert */
 #define WORKER_INSERT_RMW 2 /* Insert with read-modify-write */

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -66,15 +66,17 @@ typedef struct {
     uint64_t throttle; /* Maximum operations/second */
                        /* Number of operations per transaction. Zero for autocommit */
     int64_t ops_per_txn;
-    int64_t pause;            /* Time between scans */
-    int64_t read_range;       /* Range of reads */
-    int32_t table_index;      /* Table to focus ops on */
-    int64_t truncate;         /* Truncate ratio */
-    uint64_t truncate_pct;    /* Truncate Percent */
-    uint64_t truncate_count;  /* Truncate Count */
-    int64_t modify_delta;     /* Value size change on modify */
-    int64_t update_delta;     /* Value size change on update */
-    bool modify_force_update; /* Do force update instead of modify */
+    int64_t pause;                 /* Time between scans */
+    int64_t read_range;            /* Range of reads */
+    int32_t table_index;           /* Table to focus ops on */
+    int64_t truncate;              /* Truncate ratio */
+    uint64_t truncate_pct;         /* Truncate Percent */
+    uint64_t truncate_count;       /* Truncate Count */
+    int64_t modify_delta;          /* Value size change on modify */
+    int64_t update_delta;          /* Value size change on update */
+    bool distribute_modifications; /* Distribute the change of modifications across the whole new
+                                      record */
+    bool modify_force_update;      /* Do force update instead of modify */
 
 #define WORKER_INSERT 1     /* Insert */
 #define WORKER_INSERT_RMW 2 /* Insert with read-modify-write */

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -65,6 +65,10 @@ typedef struct {
     int64_t update;    /* Update ratio */
     uint64_t throttle; /* Maximum operations/second */
                        /* Number of operations per transaction. Zero for autocommit */
+
+    int64_t modify_delta;   /* Value size change on modify */
+    bool modify_distribute; /* Distribute the change of modifications across the whole new record */
+    bool modify_force_update; /* Do force update instead of modify */
     int64_t ops_per_txn;
     int64_t pause;           /* Time between scans */
     int64_t read_range;      /* Range of reads */
@@ -72,10 +76,7 @@ typedef struct {
     int64_t truncate;        /* Truncate ratio */
     uint64_t truncate_pct;   /* Truncate Percent */
     uint64_t truncate_count; /* Truncate Count */
-    int64_t modify_delta;    /* Value size change on modify */
     int64_t update_delta;    /* Value size change on update */
-    bool modify_distribute; /* Distribute the change of modifications across the whole new record */
-    bool modify_force_update; /* Do force update instead of modify */
 
 #define WORKER_INSERT 1     /* Insert */
 #define WORKER_INSERT_RMW 2 /* Insert with read-modify-write */

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -153,7 +153,7 @@ DEF_OPT_AS_BOOL(
   reopen_connection, 1, "close and reopen the connection between populate and workload phases")
 DEF_OPT_AS_UINT32(
   report_interval, 2, "output throughput information every interval seconds, 0 to disable")
-DEF_OPT_AS_UINT32(run_ops, 0, "total insert, modify, insert and update workload operations")
+DEF_OPT_AS_UINT32(run_ops, 0, "total insert, modify, read and update workload operations")
 DEF_OPT_AS_UINT32(run_time, 0, "total workload seconds")
 DEF_OPT_AS_UINT32(sample_interval, 0, "performance logging every interval seconds, 0 to disable")
 DEF_OPT_AS_UINT32(sample_rate, 50,
@@ -203,10 +203,10 @@ DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
 DEF_OPT_AS_STRING(table_name, "test", "table name")
 DEF_OPT_AS_BOOL(
   truncate_single_ops, 0, "Implement truncate via cursor remove instead of session API")
-DEF_OPT_AS_UINT32(
-  value_sz_max, 1000, "maximum value size when delta updates/modify are present. Default disabled")
-DEF_OPT_AS_UINT32(
-  value_sz_min, 1, "minimum value size when delta updates/modify are present. Default disabled")
+DEF_OPT_AS_UINT32(value_sz_max, 1000,
+  "maximum value size when delta updates/modify operations are present. Default disabled")
+DEF_OPT_AS_UINT32(value_sz_min, 1,
+  "minimum value size when delta updates/modify operations are present. Default disabled")
 DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(verbose, 1, "verbosity")
 DEF_OPT_AS_UINT32(warmup, 0, "How long to run the workload phase before starting measurements")

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -153,7 +153,7 @@ DEF_OPT_AS_BOOL(
   reopen_connection, 1, "close and reopen the connection between populate and workload phases")
 DEF_OPT_AS_UINT32(
   report_interval, 2, "output throughput information every interval seconds, 0 to disable")
-DEF_OPT_AS_UINT32(run_ops, 0, "total read, insert and update workload operations")
+DEF_OPT_AS_UINT32(run_ops, 0, "total insert, modify, insert and update workload operations")
 DEF_OPT_AS_UINT32(run_time, 0, "total workload seconds")
 DEF_OPT_AS_UINT32(sample_interval, 0, "performance logging every interval seconds, 0 to disable")
 DEF_OPT_AS_UINT32(sample_rate, 50,
@@ -183,8 +183,8 @@ DEF_OPT_AS_UINT32(
   table_count_idle, 0, "number of tables to create, that won't be populated. Default 0.")
 DEF_OPT_AS_STRING(threads, "",
   "workload configuration: each 'count' "
-  "entry is the total number of threads, and the 'insert', 'read' and "
-  "'update' entries are the ratios of insert, read and update operations "
+  "entry is the total number of threads, and the 'insert', 'modify', 'read' and "
+  "'update' entries are the ratios of insert, modify, read and update operations "
   "done by each worker thread; If a throttle value is provided each thread "
   "will do a maximum of that number of operations per second; multiple "
   "workload configurations may be specified per threads configuration; "
@@ -192,8 +192,9 @@ DEF_OPT_AS_STRING(threads, "",
   "'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))' "
   "which would create 2 threads doing nothing but reads and 8 threads "
   "each doing 50% inserts and 25% reads and updates.  Allowed configuration "
-  "values are 'count', 'throttle', 'update_delta', 'reads', 'read_range', "
-  "'inserts', 'updates', 'truncate', 'truncate_pct' and 'truncate_count'. "
+  "values are 'count', 'throttle', 'inserts', 'reads', 'read_range', 'modify', "
+  "'modify_delta', 'modify_distribute', 'modify_force_update', 'updates', 'update_delta', "
+  "'truncate', 'truncate_pct' and 'truncate_count'. "
   "There are also behavior modifiers, supported modifiers are "
   "'ops_per_txn'")
 DEF_OPT_AS_CONFIG_STRING(transaction_config, "",
@@ -203,9 +204,9 @@ DEF_OPT_AS_STRING(table_name, "test", "table name")
 DEF_OPT_AS_BOOL(
   truncate_single_ops, 0, "Implement truncate via cursor remove instead of session API")
 DEF_OPT_AS_UINT32(
-  value_sz_max, 1000, "maximum value size when delta updates are present. Default disabled")
+  value_sz_max, 1000, "maximum value size when delta updates/modify are present. Default disabled")
 DEF_OPT_AS_UINT32(
-  value_sz_min, 1, "minimum value size when delta updates are present. Default disabled")
+  value_sz_min, 1, "minimum value size when delta updates/modify are present. Default disabled")
 DEF_OPT_AS_UINT32(value_sz, 100, "value size")
 DEF_OPT_AS_UINT32(verbose, 1, "verbosity")
 DEF_OPT_AS_UINT32(warmup, 0, "How long to run the workload phase before starting measurements")

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -195,7 +195,7 @@ close and reopen the connection between populate and workload phases
 @par report_interval (unsigned int, default=2)
 output throughput information every interval seconds, 0 to disable
 @par run_ops (unsigned int, default=0)
-total insert, modify, insert and update workload operations
+total insert, modify, read and update workload operations
 @par run_time (unsigned int, default=0)
 total workload seconds
 @par sample_interval (unsigned int, default=0)
@@ -229,9 +229,9 @@ table name
 @par truncate_single_ops (boolean, default=false)
 Implement truncate via cursor remove instead of session API
 @par value_sz_max (unsigned int, default=1000)
-maximum value size when delta updates/modify are present. Default disabled
+maximum value size when delta updates/modify operations are present. Default disabled
 @par value_sz_min (unsigned int, default=1)
-minimum value size when delta updates/modify are present. Default disabled
+minimum value size when delta updates/modify operations are present. Default disabled
 @par value_sz (unsigned int, default=100)
 value size
 @par verbose (unsigned int, default=1)

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -195,7 +195,7 @@ close and reopen the connection between populate and workload phases
 @par report_interval (unsigned int, default=2)
 output throughput information every interval seconds, 0 to disable
 @par run_ops (unsigned int, default=0)
-total read, insert and update workload operations
+total insert, modify, insert and update workload operations
 @par run_time (unsigned int, default=0)
 total workload seconds
 @par sample_interval (unsigned int, default=0)
@@ -221,7 +221,7 @@ number of tables to run operations over. Keys are divided evenly  over the table
 @par table_count_idle (unsigned int, default=0)
 number of tables to create, that won't be populated. Default 0.
 @par threads (string, default="")
-workload configuration: each 'count'  entry is the total number of threads, and the 'insert', 'read' and  'update' entries are the ratios of insert, read and update operations  done by each worker thread; If a throttle value is provided each thread  will do a maximum of that number of operations per second; multiple  workload configurations may be specified per threads configuration;  for example, a more complex threads configuration might be  'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))'  which would create 2 threads doing nothing but reads and 8 threads  each doing 50% inserts and 25% reads and updates.  Allowed configuration  values are 'count', 'throttle', 'update_delta', 'reads', 'read_range',  'inserts', 'updates', 'truncate', 'truncate_pct' and 'truncate_count'.  There are also behavior modifiers, supported modifiers are  'ops_per_txn'
+workload configuration: each 'count'  entry is the total number of threads, and the 'insert', 'modify', 'read' and  'update' entries are the ratios of insert, modify, read and update operations  done by each worker thread; If a throttle value is provided each thread  will do a maximum of that number of operations per second; multiple  workload configurations may be specified per threads configuration;  for example, a more complex threads configuration might be  'threads=((count=2,reads=1)(count=8,reads=1,inserts=2,updates=1))'  which would create 2 threads doing nothing but reads and 8 threads  each doing 50% inserts and 25% reads and updates.  Allowed configuration  values are 'count', 'throttle', 'inserts', 'reads', 'read_range', 'modify',  'modify_delta', 'modify_distribute', 'modify_force_update', 'updates', 'update_delta',  'truncate', 'truncate_pct' and 'truncate_count'.  There are also behavior modifiers, supported modifiers are  'ops_per_txn'
 @par transaction_config (string, default="")
 WT_SESSION.begin_transaction configuration string, applied during the  populate phase when populate_ops_per_txn is nonzero
 @par table_name (string, default="test")
@@ -229,9 +229,9 @@ table name
 @par truncate_single_ops (boolean, default=false)
 Implement truncate via cursor remove instead of session API
 @par value_sz_max (unsigned int, default=1000)
-maximum value size when delta updates are present. Default disabled
+maximum value size when delta updates/modify are present. Default disabled
 @par value_sz_min (unsigned int, default=1)
-minimum value size when delta updates are present. Default disabled
+minimum value size when delta updates/modify are present. Default disabled
 @par value_sz (unsigned int, default=100)
 value size
 @par verbose (unsigned int, default=1)


### PR DESCRIPTION
The newly added workload configuration parameter can be used for
both modify/update operations where the new value record is formed
with a set of modifications distributed evenly across the whole
old record.