### PR TITLE
WT-4893 Fix a race between internal page child-page eviction checks a…

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -277,7 +277,7 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
         __wt_free(session, ref->page_del);
     }
 
-    __wt_overwrite_and_free(session, ref);
+    __wt_overwrite_and_free_len(session, ref, WT_REF_CLEAR_SIZE);
 }
 
 /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -446,11 +446,47 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
     WT_REF *child;
     bool active;
 
+    /*
+     * There may be cursors in the tree walking the list of child pages. The parent is locked, so
+     * all we care about is cursors already in the child pages, no thread can enter them. Any cursor
+     * moving through the child pages must be hazard pointer coupling between pages, where the page
+     * on which it currently has a hazard pointer must be in a state other than on-disk. Walk the
+     * child list forward, then backward, to ensure we don't race with a cursor walking in the
+     * opposite direction from our check.
+     */
+    WT_INTL_FOREACH_BEGIN (session, parent->page, child) {
+        switch (child->state) {
+        case WT_REF_DISK:      /* On-disk */
+        case WT_REF_DELETED:   /* On-disk, deleted */
+        case WT_REF_LOOKASIDE: /* On-disk, lookaside */
+            break;
+        default:
+            return (__wt_set_return(session, EBUSY));
+        }
+    }
+    WT_INTL_FOREACH_END;
+    WT_INTL_FOREACH_REVERSE_BEGIN(session, parent->page, child)
+    {
+        switch (child->state) {
+        case WT_REF_DISK:      /* On-disk */
+        case WT_REF_DELETED:   /* On-disk, deleted */
+        case WT_REF_LOOKASIDE: /* On-disk, lookaside */
+            break;
+        default:
+            return (__wt_set_return(session, EBUSY));
+        }
+    }
+    WT_INTL_FOREACH_END;
+
+    /*
+     * The fast check is done and there are no cursors in the child pages. Make sure the child
+     * WT_REF structures pages can be discarded.
+     */
     WT_INTL_FOREACH_BEGIN (session, parent->page, child) {
         switch (child->state) {
         case WT_REF_DISK: /* On-disk */
             break;
-        case WT_REF_DELETED: /* Deleted */
+        case WT_REF_DELETED: /* On-disk, deleted */
                              /*
                               * If the child page was part of a truncate,
                               * transaction rollback might switch this page into its
@@ -473,10 +509,11 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
             if (active)
                 return (__wt_set_return(session, EBUSY));
             break;
-        case WT_REF_LOOKASIDE:
-            /*
-             * If the lookaside history is obsolete, the reference can be ignored.
-             */
+        case WT_REF_LOOKASIDE: /* On-disk, lookaside */
+                               /*
+                                * If the lookaside history is obsolete, the reference can be
+                                * ignored.
+                                */
             if (__wt_page_las_active(session, child))
                 return (__wt_set_return(session, EBUSY));
             break;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -20,13 +20,13 @@ typedef enum {
  */
 static inline bool
 __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t old_state,
-  uint32_t new_state, const char *file, int line)
+  uint32_t new_state, const char *func, int line)
 {
     bool cas_result;
 
     /* Parameters that are used in a macro for diagnostic builds */
     WT_UNUSED(session);
-    WT_UNUSED(file);
+    WT_UNUSED(func);
     WT_UNUSED(line);
 
     cas_result = __wt_atomic_casv32(&ref->state, old_state, new_state);
@@ -37,7 +37,7 @@ __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t old_state
      * above but before the history has been updated.
      */
     if (cas_result)
-        WT_REF_SAVE_STATE(ref, new_state, file, line);
+        WT_REF_SAVE_STATE(ref, new_state, func, line);
 #endif
     return (cas_result);
 }

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -308,6 +308,10 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
     WT_SESSION_IMPL *s;
     uint32_t i, j, hazard_inuse, max, session_cnt, walk_cnt;
 
+    /* If a file can never be evicted, hazard pointers aren't required. */
+    if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+        return (NULL);
+
     conn = S2C(session);
 
     WT_STAT_CONN_INCR(session, cache_hazard_checks);


### PR DESCRIPTION
…nd cursors in the tree(#4749)

When checking if an internal page's children will block the internal page's
eviction, there may be cursors in the tree walking the list of child pages.
The parent is locked, so all we care about is cursors already in the child
pages, no thread can enter them. Any cursor moving through the child pages
must be hazard pointer coupling between pages, where the page on which it
currently has a hazard pointer must be in a state other than on-disk. Walk
the child list forward, then backward, to ensure we don't race with a cursor
walking in the opposite direction from our check.

Also:
* Skip work in __wt_hazard_check() and __wt_hazard_check_assert()
if we aren't maintaining hazard pointers on the tree.
* Don't clear the WT_REF history when we overwrite the WT_REF on
discard, it's useful diagnostic information.

(cherry picked from commit 82082debc5983bfc8e096bec4d812cb085cc026d)