### PR TITLE
WT-5098 Simplify the __wt_update_alloc() code, stop passing an empty WT_ITEM

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -71,14 +71,12 @@ __row_instantiate(
 static int
 __create_birthmark_upd(WT_SESSION_IMPL *session, WT_BIRTHMARK_DETAILS *birthmarkp, WT_UPDATE **updp)
 {
-    WT_ITEM empty_item;
     WT_UPDATE *upd;
     size_t not_used;
 
     *updp = NULL;
-    empty_item.size = 0;
 
-    WT_RET(__wt_update_alloc(session, &empty_item, &upd, &not_used, WT_UPDATE_BIRTHMARK));
+    WT_RET(__wt_update_alloc(session, NULL, &upd, &not_used, WT_UPDATE_BIRTHMARK));
     upd->txnid = birthmarkp->txnid;
     upd->durable_ts = birthmarkp->durable_ts;
     upd->start_ts = birthmarkp->start_ts;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -260,18 +260,11 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
      */
     WT_ASSERT(session, modify_type != WT_UPDATE_INVALID);
 
-    /*
-     * Allocate the WT_UPDATE structure and room for the value, then copy the value into place.
-     */
-    if (modify_type == WT_UPDATE_BIRTHMARK || modify_type == WT_UPDATE_RESERVE ||
-      modify_type == WT_UPDATE_TOMBSTONE)
-        WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE, &upd));
-    else {
-        WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE + value->size, &upd));
-        if (value->size != 0) {
-            upd->size = WT_STORE_SIZE(value->size);
-            memcpy(upd->data, value->data, value->size);
-        }
+    /* Allocate the WT_UPDATE structure and room for the value, then copy any value into place. */
+    WT_RET(__wt_calloc(session, 1, WT_UPDATE_SIZE + (value == NULL ? 0 : value->size), &upd));
+    if (value != NULL && value->size != 0) {
+        upd->size = WT_STORE_SIZE(value->size);
+        memcpy(upd->data, value->data, value->size);
     }
     upd->type = (uint8_t)modify_type;
 


### PR DESCRIPTION
structure when allocating a birthmark update.