### PR TITLE
WT-5100 Update test format to pass -R to disable readonly in wt util

### DIFF
--- a/test/format/rebalance.c
+++ b/test/format/rebalance.c
@@ -40,9 +40,9 @@ wts_rebalance(void)
 
     track("rebalance", 0ULL, NULL);
 
-    /* Dump the current object. */
+    /* Dump the current object. Pass -R flag to avoid readonly check while logging statistics */
     testutil_check(__wt_snprintf(cmd, sizeof(cmd), ".." DIR_DELIM_STR ".." DIR_DELIM_STR "wt"
-                                                   " -h %s dump -f %s/rebalance.orig %s",
+                                                   " -R -h %s dump -f %s/rebalance.orig %s",
       g.home, g.home, g.uri));
     testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 
@@ -59,9 +59,8 @@ wts_rebalance(void)
 
     wts_verify("post-rebalance verify");
     wts_close();
-
     testutil_check(__wt_snprintf(cmd, sizeof(cmd), ".." DIR_DELIM_STR ".." DIR_DELIM_STR "wt"
-                                                   " -h %s dump -f %s/rebalance.new %s",
+                                                   " -R -h %s dump -f %s/rebalance.new %s",
       g.home, g.home, g.uri));
     testutil_checkfmt(system(cmd), "command failed: %s", cmd);
 


### PR DESCRIPTION
The statistics_log configuration used by wiredtiger is not readonly, as such when we close the connection and then open it with any readonly wiredtiger util. e.g. dump it reads the config from the WiredTiger.basecfg file which tells it to begin statistic logging, which triggers this assertion:

`[1567488766:358842][30124:0x7f1ed3d3d700], wt, statlog-server: __wt_open, 248: lock_file || !LF_ISSET(WT_FS_OPEN_CREATE)`