### PR TITLE
WT-4502 Assertion checking hazard pointers on page discard is too str…

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -216,16 +216,6 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
- * __free_page_int --
- *     Discard a WT_PAGE_COL_INT or WT_PAGE_ROW_INT page.
- */
-static void
-__free_page_int(WT_SESSION_IMPL *session, WT_PAGE *page)
-{
-    __wt_free_ref_index(session, page, WT_INTL_INDEX_GET_SAFE(page), false);
-}
-
-/*
  * __wt_free_ref --
  *     Discard the contents of a WT_REF structure (optionally including the pages it references).
  */
@@ -236,9 +226,6 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
 
     if (ref == NULL)
         return;
-
-    /* Assert there are no hazard pointers. */
-    WT_ASSERT(session, __wt_hazard_check_assert(session, ref, false));
 
     /*
      * Optionally free the referenced pages. (The path to free referenced page is used for error
@@ -281,19 +268,45 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
 }
 
 /*
+ * __free_page_int --
+ *     Discard a WT_PAGE_COL_INT or WT_PAGE_ROW_INT page.
+ */
+static void
+__free_page_int(WT_SESSION_IMPL *session, WT_PAGE *page)
+{
+    WT_PAGE_INDEX *pindex;
+    uint32_t i;
+
+    for (pindex = WT_INTL_INDEX_GET_SAFE(page), i = 0; i < pindex->entries; ++i)
+        __wt_free_ref(session, pindex->index[i], page->type, false);
+
+    __wt_free(session, pindex);
+}
+
+/*
  * __wt_free_ref_index --
  *     Discard a page index and its references.
  */
 void
 __wt_free_ref_index(WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pindex, bool free_pages)
 {
+    WT_REF *ref;
     uint32_t i;
 
     if (pindex == NULL)
         return;
 
-    for (i = 0; i < pindex->entries; ++i)
-        __wt_free_ref(session, pindex->index[i], page->type, free_pages);
+    for (i = 0; i < pindex->entries; ++i) {
+        ref = pindex->index[i];
+
+        /*
+         * Used when unrolling splits and other error paths where there should never have been a
+         * hazard pointer taken.
+         */
+        WT_ASSERT(session, __wt_hazard_check_assert(session, ref, false));
+
+        __wt_free_ref(session, ref, page->type, free_pages);
+    }
     __wt_free(session, pindex);
 }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1536,7 +1536,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_REF *ref)
     /*
      * We failed creating new in-memory pages. For error-handling reasons,
      * we've left the update chains referenced by both the original and
-     * new pages. Discard the new allocated WT_REF structures and their
+     * new pages. Discard the newly allocated WT_REF structures and their
      * pages (setting a flag so the discard code doesn't discard the updates
      * on the page).
      *

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -195,8 +195,7 @@ __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
             /*
              * We don't publish the hazard pointer clear in the general case. It's not required for
              * correctness; it gives an eviction thread faster access to the page were the page
-             * selected for eviction, but the generation number was just set, it's unlikely the page
-             * will be selected for eviction.
+             * selected for eviction.
              */
             hp->ref = NULL;
 


### PR DESCRIPTION
…ong (#4733)

Checking if there are hazard references when evicting a page requires spinning while walking the list of hazard pointers, it's relatively easy
to race with threads acquiring hazard pointers (but then releasing them
because we have the WT_REF locked). Don't repeat the check a second time
during eviction when freeing an internal page's WT_PAGE_INDEX referenced
WT_REF list, only do that check when freeing a WT_PAGE_INDEX from outside
the normal page eviction path.

Fix a couple of minor comments.

(cherry picked from commit 5cc7119f29a445e36c0e038b46baedbe2c7254a5)