### PR TITLE
WT-5122 the sweep server can close handles the final checkpoint is in the process of using

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1073,13 +1073,21 @@ err:
     WT_TRET(__wt_lsm_manager_destroy(session));
 
     /*
-     * After the async and LSM threads have exited, we shouldn't opening any more files.
+     * After the async and LSM threads have exited, we won't open more files for the application.
+     * However, the sweep server is still running and it can close file handles at the same time the
+     * final checkpoint is reviewing open data handles (forcing checkpoint to reopen handles). Shut
+     * down the sweep server and then flag the system should not open anything new.
      */
+    WT_TRET(__wt_sweep_destroy(session));
     F_SET(conn, WT_CONN_CLOSING_NO_MORE_OPENS);
     WT_FULL_BARRIER();
 
-    /* The default session is used to access data handles during close. */
-    F_CLR(session, WT_SESSION_NO_DATA_HANDLES);
+    /*
+     * Shut down the checkpoint and capacity server threads: we don't want to throttle writes and
+     * we're about to do a final checkpoint separately from the checkpoint server.
+     */
+    WT_TRET(__wt_capacity_server_destroy(session));
+    WT_TRET(__wt_checkpoint_server_destroy(session));
 
     /* Perform a final checkpoint and shut down the global transaction state. */
     WT_TRET(__wt_txn_global_shutdown(session, config, cfg));

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -82,10 +82,12 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
     F_SET(conn, WT_CONN_CLOSING);
     WT_FULL_BARRIER();
 
+    /* The default session is used to access data handles during close. */
+    F_CLR(session, WT_SESSION_NO_DATA_HANDLES);
+
     /*
-     * Shut down server threads other than the eviction server, which is needed later to close btree
-     * handles. Some of these threads access btree handles, so take care in ordering shutdown to
-     * make sure they exit before files are closed.
+     * Shut down server threads. Some of these threads access btree handles and eviction, shut them
+     * down before the eviction server, and shut all servers down before closing open data handles.
      */
     WT_TRET(__wt_capacity_server_destroy(session));
     WT_TRET(__wt_checkpoint_server_destroy(session));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1423,6 +1423,8 @@ extern int __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const char **cfg)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[])
@@ -1724,7 +1726,6 @@ extern void __wt_txn_clear_timestamp_queues(WT_SESSION_IMPL *session);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);
 extern void __wt_txn_get_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_global_destroy(WT_SESSION_IMPL *session);
-extern void __wt_txn_global_shutdown(WT_SESSION_IMPL *session);
 extern void __wt_txn_named_snapshot_destroy(WT_SESSION_IMPL *session);
 extern void __wt_txn_op_free(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 extern void __wt_txn_publish_read_timestamp(WT_SESSION_IMPL *session);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1501,19 +1501,59 @@ __wt_txn_activity_drain(WT_SESSION_IMPL *session)
  * __wt_txn_global_shutdown --
  *     Shut down the global transaction state.
  */
-void
-__wt_txn_global_shutdown(WT_SESSION_IMPL *session)
+int
+__wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const char **cfg)
 {
+    WT_CONFIG_ITEM cval;
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_SESSION *wt_session;
+    WT_SESSION_IMPL *s;
+    const char *ckpt_cfg;
+
+    conn = S2C(session);
+
     /*
-     * All application transactions have completed, ignore the pinned
-     * timestamp so that updates can be evicted from the cache during
-     * connection close.
-     *
-     * Note that we are relying on a special case in __wt_txn_visible_all
-     * that returns true during close when there is no pinned timestamp
-     * set.
+     * Perform a system-wide checkpoint so that all tables are consistent with each other. All
+     * transactions are resolved but ignore timestamps to make sure all data gets to disk. Do this
+     * before shutting down all the subsystems. We have shut down all user sessions, but send in
+     * true for waiting for internal races.
      */
-    S2C(session)->txn_global.has_pinned_timestamp = false;
+    WT_TRET(__wt_config_gets(session, cfg, "use_timestamp", &cval));
+    ckpt_cfg = "use_timestamp=false";
+    if (cval.val != 0) {
+        ckpt_cfg = "use_timestamp=true";
+        if (conn->txn_global.has_stable_timestamp)
+            F_SET(conn, WT_CONN_CLOSING_TIMESTAMP);
+    }
+    if (!F_ISSET(conn, WT_CONN_IN_MEMORY | WT_CONN_READONLY)) {
+        s = NULL;
+        WT_TRET(__wt_open_internal_session(conn, "close_ckpt", true, 0, &s));
+        if (s != NULL) {
+            const char *checkpoint_cfg[] = {
+              WT_CONFIG_BASE(session, WT_SESSION_checkpoint), ckpt_cfg, NULL};
+            wt_session = &s->iface;
+            WT_TRET(__wt_txn_checkpoint(s, checkpoint_cfg, true));
+
+            /*
+             * Mark the metadata dirty so we flush it on close, allowing recovery to be skipped.
+             */
+            WT_WITH_DHANDLE(s, WT_SESSION_META_DHANDLE(s), __wt_tree_modify_set(s));
+
+            WT_TRET(wt_session->close(wt_session, config));
+        }
+    }
+
+    /*
+     * All application transactions have completed, ignore the pinned timestamp so that updates can
+     * be evicted from the cache during connection close.
+     *
+     * Note that we are relying on a special case in __wt_txn_visible_all that returns true during
+     * close when there is no pinned timestamp set.
+     */
+    conn->txn_global.has_pinned_timestamp = false;
+
+    return (ret);
 }
 
 /*


### PR DESCRIPTION
@agorrod, the interesting work is in 1231279 (fbb894c just moves the final checkpoint code out of the connection-close source and into the transaction subsystem source).

I moved the shutdown of the capacity, checkpoint and sweep servers to earlier in the shutdown process (it didn't seem useful to let them continue to run during shutdown), but that means we shut them down in two places rather than one, which is obviously more complicated. An alternative would be to not set the `WT_CONN_CLOSING_NO_MORE_OPENS` flag before doing the final checkpoint. That means the sweep server can race with the final checkpoint, but that's been true for a long time without any adverse effects.