### PR TITLE
WT-5128 Add script to run wtperf with XRay profiling

### DIFF
--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
 if test "$#" -lt "1"; then
-    echo "$0: must specify wtperf test to run"
-    exit 1
+	echo "$0: must specify wtperf test to run"
+	exit 1
 fi
 
 # Check symbols to ensure we've compiled with XRay.
 objdump_out=$(objdump -h -j xray_instr_map ./wtperf)
 if test -z "$objdump_out"; then
-    echo "$0: wtperf not compiled with xray"
-    exit 1
+	echo "$0: wtperf not compiled with xray"
+	exit 1
 fi
 
 rm xray-log.wtperf.* \
-   wtperf_account.txt \
-   wtperf_stack.txt \
-   wtperf_graph.svg \
-   wtperf_flame.svg
+	wtperf_account.txt \
+	wtperf_stack.txt \
+	wtperf_graph.svg \
+	wtperf_flame.svg
 
 export XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1"
 wtperf_out=$(./wtperf -O "$@")
@@ -24,32 +24,41 @@ wtperf_out=$(./wtperf -O "$@")
 xray_log=$(ls xray-log.wtperf.*)
 num_logs=$(echo "$xray_log" | wc -w)
 if test "$num_logs" -ne "1"; then
-    echo "$0: detected more than one xray log"
-    exit 1
+	echo "$0: detected more than one xray log"
+	exit 1
 fi
 
 if test -z "$XRAY_BINARY"; then
-    xray_bin="llvm-xray"
-    echo "$0: XRAY_BINARY is unset, defaulting to $xray_bin"
+	xray_bin="llvm-xray"
+	echo "$0: XRAY_BINARY is unset, defaulting to $xray_bin"
 else
-    xray_bin="$XRAY_BINARY"
+	xray_bin="$XRAY_BINARY"
 fi
 
-$xray_bin account $xray_log -top=10 -sortorder=dsc -instr_map ./wtperf > wtperf_account.txt
+$xray_bin account $xray_log \
+	-top=10 -sort=sum -sortorder=dsc -instr_map ./wtperf > \
+	wtperf_account.txt
 
-# Use the -aggregate-threads flag here so get the top stacks for all threads (omitting duplicates).
-# We could use the -per-thread-stacks option to get the top 10 stacks for each thread.
-$xray_bin stack -aggregate-threads $xray_log -instr_map ./wtperf > wtperf_stack.txt
+# Use the -per-thread-stacks option to get the top 10 stacks for each thread.
+# We could use the -aggregate-threads flag here so get the top stacks for all threads (omitting duplicates).
+$xray_bin stack -per-thread-stacks $xray_log \
+	-instr_map ./wtperf > \
+	wtperf_stack.txt
 
 # Generate a DOT graph.
-$xray_bin graph $xray_log -m ./wtperf -color-edges=sum -edge-label=sum | unflatten -f -l10 | dot -Tsvg -o wtperf_graph.svg
+$xray_bin graph $xray_log \
+	-m ./wtperf -color-edges=sum -edge-label=sum | \
+	unflatten -f -l10 | \
+	dot -Tsvg -o wtperf_graph.svg
 
 # This file can be inspected in the Google Chrome Trace Viewer.
 # It seems to take a long time to generate this so just disable it for now.
 # $xray_bin convert -symbolize -instr_map=./wtperf -output-format=trace_event $xray_log | gzip > wtperf_trace.txt.gz
 
 if test -z "$FLAME_GRAPH_PATH"; then
-    echo "$0: FLAME_GRAPH_PATH is unset, skipping flame graph generation"
+	echo "$0: FLAME_GRAPH_PATH is unset, skipping flame graph generation"
 else
-    $xray_bin stack $xray_log -instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | "$FLAME_GRAPH_PATH" > wtperf_flame.svg
+	$xray_bin stack $xray_log \
+		-instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | \
+		"$FLAME_GRAPH_PATH" > wtperf_flame.svg
 fi

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
 # wtperf_xray.sh - run wtperf regression tests with xray profiling and generate
-# profiling information
+# profiling information.
+#
+# This script assumes it is running in the directory with the wtperf executable.
 #
 # Usage
-# ./wtperf_xray.sh <TEST> <TEST_ARGS>
+# wtperf_xray.sh <wtperf-config-file> [wtperf other args]
 #
 # Environment variables
 # XRAY_BINARY: The binary to use to inspect the xray log. (default: llvm-xray)
 # FLAME_GRAPH_PATH: The path to your copy of Brendan Gregg's FlameGraph script.
-
+#
+# When this is complete you can find information in the following files:
+# XXX
+#
 if test "$#" -lt "1"; then
-	echo "$0: must specify wtperf test to run"
+	echo "$0: must specify wtperf configuration to run"
 	exit 1
 fi
+
+# XXX add conditional to check existence of ./wtperf here.
 
 # Check symbols to ensure we've compiled with XRay.
 objdump_out=$(objdump -h -j xray_instr_map ./wtperf)
@@ -64,7 +71,6 @@ $xray_bin graph "$xray_log" \
 # This file can be inspected in the Google Chrome Trace Viewer.
 # It seems to take a long time to generate this so just disable it for now.
 # $xray_bin convert -symbolize -instr_map=./wtperf -output-format=trace_event $xray_log | gzip > wtperf_trace.txt.gz
-
 if test -z "$FLAME_GRAPH_PATH"; then
 	echo "$0: FLAME_GRAPH_PATH is unset, skipping flame graph generation"
 else

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -63,6 +63,11 @@ if test -z "$objdump_out"; then
 	exit 1
 fi
 
+if ! test -d "$xray_home"; then
+	echo "$0: creating directory $xray_home"
+	mkdir "$xray_home"
+fi
+
 xray_account_path="${xray_home}/wtperf_account.txt"
 xray_stack_path="${xray_home}/wtperf_stack.txt"
 xray_graph_path="${xray_home}/wtperf_graph.svg"

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -9,18 +9,36 @@
 # wtperf_xray.sh <wtperf-config-file> [wtperf other args]
 #
 # Environment variables
-# XRAY_BINARY: The binary to use to inspect the xray log. (default: llvm-xray)
-# FLAME_GRAPH_PATH: The path to your copy of Brendan Gregg's FlameGraph script.
+# XRAY_BINARY --
+#	The binary to use to inspect the xray log. (default: llvm-xray)
+# FLAME_GRAPH_PATH --
+#	The path to your copy of Brendan Gregg's FlameGraph script. (optional)
 #
 # When this is complete you can find information in the following files:
-# XXX
+# wtperf_account.txt --
+#	The top 10 functions where the workload is spending the most time along
+#	with a count, min, max and some percentiles for each one.
+# wtperf_stacks.txt --
+#	The top 10 stack traces where the workload is spending the most time.
+#	This calculation is done separately per thread.
+# wtperf_graph.svg --
+#	A function call graph showing what functions call each other. The edges
+#	are labelled and coloured proportionally to represent the ratio of time
+#	spent in each function call.
+# wtperf_flame.svg --
+#	A graph visualising stack traces and the time spent within each stack
+#	frame. If FLAME_GRAPH_PATH is not specified, this graph won't be
+#	generated.
 #
 if test "$#" -lt "1"; then
 	echo "$0: must specify wtperf configuration to run"
 	exit 1
 fi
 
-# XXX add conditional to check existence of ./wtperf here.
+if ! test -f ./wtperf; then
+	echo "$0: could not find wtperf in current working directory"
+	exit 1
+fi
 
 # Check symbols to ensure we've compiled with XRay.
 objdump_out=$(objdump -h -j xray_instr_map ./wtperf)

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if test "$#" -lt "1"; then
+    echo "$0: must specify wtperf test to run"
+    exit 1
+fi
+
+# Check symbols to ensure we've compiled with XRay.
+objdump_out=$(objdump -h -j xray_instr_map ./wtperf)
+if test -z "$objdump_out"; then
+    echo "$0: wtperf not compiled with xray"
+    exit 1
+fi
+
+rm xray-log.wtperf.*
+
+export XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1"
+wtperf_out=$(./wtperf -O "$@")
+
+xray_log=$(ls xray-log.wtperf.*)
+num_logs=$(wc -w "$xray_log")
+if test "$num_logs" -ne "1"; then
+    echo "$0: detected more than one xray log"
+    exit 1
+fi
+
+llvm-xray-8 account $xray_log -top=10 -sortorder=dsc -instr_map ./wtperf > wtperf_account.txt
+
+# Use the -per-thread-stacks option to get the top 10 stacks for each thread.
+# We could use -aggregate-threads flag here so get the top stacks for all threads (omitting duplicates).
+llvm-xray-8 stack $xray_log -instr_map -per-thread-stacks ./wtperf > wtperf_stack.txt
+
+# Generate a DOT graph.
+llvm-xray-8 graph $xray_log -m ./wtperf -color-edges=sum -edge-label=sum | unflatten -f -l10 | dot -Tsvg -o wtperf_graph.svg
+llvm-xray-8 convert -symbolize -instr_map=./wtperf -output-format=trace_event $xray_log | gzip > wtperf_trace.txt.gz
+llvm-xray-8 stack $xray_log -instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | ~/work/FlameGraph/flamegraph.pl > wtperf_flame.svg

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -18,19 +18,31 @@ export XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1"
 wtperf_out=$(./wtperf -O "$@")
 
 xray_log=$(ls xray-log.wtperf.*)
-num_logs=$(wc -w "$xray_log")
+num_logs=$(echo "$xray_log" | wc -w)
 if test "$num_logs" -ne "1"; then
     echo "$0: detected more than one xray log"
     exit 1
 fi
 
-llvm-xray-8 account $xray_log -top=10 -sortorder=dsc -instr_map ./wtperf > wtperf_account.txt
+if test -z "$XRAY_BINARY"; then
+    xray_bin="llvm-xray"
+    echo "$0: XRAY_BINARY is unset, defaulting to $xray_bin"
+else
+    xray_bin="$XRAY_BINARY"
+fi
+
+$xray_bin account $xray_log -top=10 -sortorder=dsc -instr_map ./wtperf > wtperf_account.txt
 
 # Use the -per-thread-stacks option to get the top 10 stacks for each thread.
 # We could use -aggregate-threads flag here so get the top stacks for all threads (omitting duplicates).
-llvm-xray-8 stack $xray_log -instr_map -per-thread-stacks ./wtperf > wtperf_stack.txt
+$xray_bin stack -per-thread-stacks $xray_log -instr_map ./wtperf > wtperf_stack.txt
 
 # Generate a DOT graph.
-llvm-xray-8 graph $xray_log -m ./wtperf -color-edges=sum -edge-label=sum | unflatten -f -l10 | dot -Tsvg -o wtperf_graph.svg
-llvm-xray-8 convert -symbolize -instr_map=./wtperf -output-format=trace_event $xray_log | gzip > wtperf_trace.txt.gz
-llvm-xray-8 stack $xray_log -instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | ~/work/FlameGraph/flamegraph.pl > wtperf_flame.svg
+$xray_bin graph $xray_log -m ./wtperf -color-edges=sum -edge-label=sum | unflatten -f -l10 | dot -Tsvg -o wtperf_graph.svg
+$xray_bin convert -symbolize -instr_map=./wtperf -output-format=trace_event $xray_log | gzip > wtperf_trace.txt.gz
+
+if test -z "$FLAME_GRAPH_PATH"; then
+    echo "$0: FLAME_GRAPH_PATH is unset, skipping flame graph generation"
+else
+    $xray_bin stack $xray_log -instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | "$FLAME_GRAPH_PATH" > wtperf_flame.svg
+fi

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# wtperf_xray.sh - run wtperf regression tests with xray profiling and generate
+# profiling information
+#
+# Usage
+# ./wtperf_xray.sh <TEST> <TEST_ARGS>
+#
+# Environment variables
+# XRAY_BINARY: The binary to use to inspect the xray log. (default: llvm-xray)
+# FLAME_GRAPH_PATH: The path to your copy of Brendan Gregg's FlameGraph scripts.
+
 if test "$#" -lt "1"; then
 	echo "$0: must specify wtperf test to run"
 	exit 1
@@ -8,7 +18,7 @@ fi
 # Check symbols to ensure we've compiled with XRay.
 objdump_out=$(objdump -h -j xray_instr_map ./wtperf)
 if test -z "$objdump_out"; then
-	echo "$0: wtperf not compiled with xray"
+	echo "$0: wtperf not compiled with xray, add '-fxray-instrument' to your CFLAGS"
 	exit 1
 fi
 

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -8,7 +8,7 @@
 #
 # Environment variables
 # XRAY_BINARY: The binary to use to inspect the xray log. (default: llvm-xray)
-# FLAME_GRAPH_PATH: The path to your copy of Brendan Gregg's FlameGraph scripts.
+# FLAME_GRAPH_PATH: The path to your copy of Brendan Gregg's FlameGraph script.
 
 if test "$#" -lt "1"; then
 	echo "$0: must specify wtperf test to run"
@@ -29,7 +29,7 @@ rm xray-log.wtperf.* \
 	wtperf_flame.svg
 
 export XRAY_OPTIONS="patch_premain=true xray_mode=xray-basic verbosity=1"
-wtperf_out=$(./wtperf -O "$@")
+./wtperf -O "$@"
 
 xray_log=$(ls xray-log.wtperf.*)
 num_logs=$(echo "$xray_log" | wc -w)
@@ -45,18 +45,18 @@ else
 	xray_bin="$XRAY_BINARY"
 fi
 
-$xray_bin account $xray_log \
+$xray_bin account "$xray_log" \
 	-top=10 -sort=sum -sortorder=dsc -instr_map ./wtperf > \
 	wtperf_account.txt
 
 # Use the -per-thread-stacks option to get the top 10 stacks for each thread.
 # We could use the -aggregate-threads flag here so get the top stacks for all threads (omitting duplicates).
-$xray_bin stack -per-thread-stacks $xray_log \
+$xray_bin stack -per-thread-stacks "$xray_log" \
 	-instr_map ./wtperf > \
 	wtperf_stack.txt
 
 # Generate a DOT graph.
-$xray_bin graph $xray_log \
+$xray_bin graph "$xray_log" \
 	-m ./wtperf -color-edges=sum -edge-label=sum | \
 	unflatten -f -l10 | \
 	dot -Tsvg -o wtperf_graph.svg
@@ -68,7 +68,7 @@ $xray_bin graph $xray_log \
 if test -z "$FLAME_GRAPH_PATH"; then
 	echo "$0: FLAME_GRAPH_PATH is unset, skipping flame graph generation"
 else
-	$xray_bin stack $xray_log \
+	$xray_bin stack "$xray_log" \
 		-instr_map ./wtperf -stack-format=flame -aggregation-type=time -all-stacks | \
 		"$FLAME_GRAPH_PATH" > wtperf_flame.svg
 fi

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -6,7 +6,12 @@
 # This script assumes it is running in the directory with the wtperf executable.
 #
 # Usage
-# wtperf_xray.sh [-h output-directory] <wtperf-config-file> [wtperf other args]
+# wtperf_xray.sh <wtperf-config-file> [-h output-directory] [wtperf other args]
+#
+# This script checks the first argument after the wtperf configuration to see
+# whether a home directory is being specified with the -h flag. If so, this
+# script will write its output files to that directory. Otherwise it will
+# default to WT_TEST (wtperf's default).
 #
 # Environment variables
 # XRAY_BINARY --
@@ -35,26 +40,17 @@ if ! test -f ./wtperf; then
 	exit 1
 fi
 
-xray_home="."
-if test "$#" -ne "0"; then
-	opt="$1"
-	case "$opt" in
-	-h )
-		shift
-		if test "$#" -eq "0"; then
-			echo "$0: the -h flag must be followed by a valid directory"
-			exit 1
-		fi
-		xray_home="$1"
-		shift
-		;;
-	esac
-fi
-
 if test "$#" -lt "1"; then
 	echo "$0: must specify wtperf configuration to run"
 	exit 1
 fi
+
+# By default, wtperf uses WT_TEST as its home directory.
+xray_home="WT_TEST"
+if test "$2" = "-h"; then
+	xray_home="$3"
+fi
+echo "$0: using $xray_home as home directory"
 
 # Check symbols to ensure we've compiled with XRay.
 objdump_out=$(objdump -h -j xray_instr_map ./wtperf)

--- a/bench/wtperf/runners/wtperf_xray.sh
+++ b/bench/wtperf/runners/wtperf_xray.sh
@@ -48,7 +48,9 @@ fi
 # By default, wtperf uses WT_TEST as its home directory.
 xray_home="WT_TEST"
 if test "$2" = "-h"; then
-	xray_home="$3"
+	if ! test -z "$3"; then
+		xray_home="$3"
+	fi
 fi
 echo "$0: using $xray_home as home directory"
 


### PR DESCRIPTION
This is a script to run `wtperf` with XRay profiling enabled and generate some interesting information using the logs. I'm invoking like so:
```
XRAY_BINARY=llvm-xray-8 FLAME_GRAPH_PATH=~/work/FlameGraph/flamegraph.pl bash ../../../bench/wtperf/runners/wtperf_xray.sh ../../../bench/wtperf/runners/small-btree.wtperf
```
`wtperf_account.txt`: A breakdown of the top 10 functions where the workload is spending most of its time.
```
Functions with latencies: 308
   funcid      count [      min,       med,       90p,       99p,       max]       sum  function
      258        504 [ 0.001050,  0.731710,  7.316153,  7.316191,  7.316230] 939.480654  os_mtx_cond.c:58:0: __wt_cond_wait_signal
      471         16 [ 5.624216, 88.403520, 88.404453, 88.404574, 88.404574] 752.231184  thread_group.c:17:0: __thread_run
       43          8 [87.809180, 87.809375, 87.809592, 87.809592, 87.809592] 702.474963  wtperf.c:501:0: worker
      898   20483363 [ 0.000011,  0.000030,  0.000031,  0.000042,  0.013131] 610.765654  cur_file.c:184:0: __curfile_search
      578   20483363 [ 0.000009,  0.000028,  0.000030,  0.000040,  0.013127] 582.309584  bt_cursor.c:509:0: __wt_btcur_search
      801   20483369 [ 0.000005,  0.000020,  0.000021,  0.000028,  0.013104] 412.661116  row_srch.c:213:0: __wt_row_search
      166        234 [ 0.000006,  0.731754,  0.731768,  0.731808,  0.731854] 147.538713  evict_lru.c:271:0: __wt_evict_thread_run
       21          1 [94.929063, 94.929063, 94.929063, 94.929063, 94.929063] 94.929063  wtperf.c:2543:0: main
       22          1 [94.689410, 94.689410, 94.689410, 94.689410, 94.689410] 94.689410  wtperf.c:2298:0: start_all_runs
       24          1 [94.689407, 94.689407, 94.689407, 94.689407, 94.689407] 94.689407  wtperf.c:2371:0: start_run
```
`wtperf_stack.txt`: The top 10 stack traces per thread. Here are a few stacks for a given thread.
```
Sum: 150608443030
lvl   function                                                            count              sum
#0    worker                                                                  1     263428775618
#1    __curfile_search                                                  2556560     229082313916
#2    __wt_btcur_search                                                 2556564     218432977048
#3    __wt_row_search                                                   2519298     150608443030

Sum: 738365164
lvl   function                                                            count              sum
#0    worker                                                                  1     263428775618
#1    __curfile_search                                                  2556560     229082313916
#2    __wt_btcur_search                                                 2556564     218432977048
#3    __wt_row_search                                                     37266       4124255246
#4    __wt_lex_compare_skip                                               21889        738365164
```
`wtperf_graph.svg`: A function call graph showing which functions call which. The edges are coloured and labelled to show what ratio of time is spent in each function.
<img width="898" alt="Screen Shot 2019-09-17 at 6 52 07 pm" src="https://user-images.githubusercontent.com/30496335/65085523-67134900-d97c-11e9-8b19-bb201813a969.png">
`wtperf_flame.svg`: A flame graph. You've all seen this before since we were generating these with `perf_events` data previously.

These commands are mostly copied from the documentation. I think it will take a bit of trial and error to see what sticks so this is just a starting point! @fedorova has mentioned the possibility of parsing the XRay logs into the operation tracking format or something that `t2` can understand.