### PR TITLE
WT-5113 Add new test format run to smoke config

### DIFF
--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -9,3 +9,5 @@ $TEST_WRAPPER ./t $args file_type=fix
 $TEST_WRAPPER ./t $args file_type=row
 $TEST_WRAPPER ./t $args file_type=row data_source=lsm
 $TEST_WRAPPER ./t $args file_type=var
+# Force a rebalance to occur with statistics logging to test the utility
+$TEST_WRAPPER ./t $args file_type=row statistics_server=1 rebalance=1


### PR DESCRIPTION
smoke.sh is run during PR testing when we call `make check` this change simply adds a specific config that forces rebalance to run while also turning statistics logging on, which had we had would've caught the bug introduced by WT-4535. 