### PR TITLE
WT-5141 Handle multiple modifies for the same key on lookaside eviction

### DIFF
--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -112,13 +112,6 @@ __value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
 }
 
 /*
- * When threads race modifying a record, we can end up with more than the usual maximum number of
- * modifications in an update list. We'd prefer not to allocate memory in a return path, so add a
- * few additional slots to the array we use to build up a list of modify records to apply.
- */
-#define WT_MODIFY_ARRAY_SIZE (WT_MAX_MODIFY_UPDATE + 10)
-
-/*
  * __wt_value_return_upd --
  *     Change the cursor to reference an internal update structure return value.
  */

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -792,6 +792,14 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
             ++insert_cnt;
             if (upd->prepare_state == WT_PREPARE_INPROGRESS)
                 ++prepared_insert_cnt;
+
+            /*
+             * If we encounter subsequent updates with the same timestamp, skip them to avoid
+             * clobbering the entry that we just wrote to lookaside. Only the last thing in the
+             * update list for that timestamp matters anyway.
+             */
+            while (upd->next != NULL && upd->start_ts == upd->next->start_ts)
+                upd = upd->next;
         } while ((upd = upd->next) != NULL);
     }
 

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -786,9 +786,10 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
             /*
              * If we encounter subsequent updates with the same timestamp, skip them to avoid
              * clobbering the entry that we just wrote to lookaside. Only the last thing in the
-             * update list for that timestamp matters anyway.
+             * update list for that timestamp and transaction id matters anyway.
              */
-            while (upd->next != NULL && upd->start_ts == upd->next->start_ts)
+            while (upd->next != NULL && upd->start_ts == upd->next->start_ts &&
+              upd->txnid == upd->next->txnid)
                 upd = upd->next;
         } while ((upd = upd->next) != NULL);
     }

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -543,17 +543,6 @@ __las_insert_updates_verbose(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_MULTI
 }
 
 /*
- * When threads race modifying a record, we can end up with more than the max
- * number of modifications in an update list.
- *
- * Leave space for double the maximum number on the stack as a best attempt to
- * avoid heap allocation.
- *
- * TODO: Look into reusing code from __wt_value_return_upd.
- */
-#define WT_MODIFY_ARRAY_SIZE (WT_MAX_MODIFY_UPDATE * 2)
-
-/*
  * __las_squash_modifies --
  *     Squash multiple modify operations for the same key and timestamp into a standard update and
  *     insert it into lookaside. This is necessary since multiple updates on the same key/timestamp

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1130,16 +1130,20 @@ struct __wt_update {
 #define WT_UPDATE_MEMSIZE(upd) WT_ALIGN(WT_UPDATE_SIZE + (upd)->size, 32)
 
 /*
- * WT_MAX_MODIFY_UPDATE --
- *	Limit update chains value to avoid penalizing reads and
- *	permit truncation. Having a smaller value will penalize the cases
- *	when history has to be maintained, resulting in multiplying cache
- *	pressure.
+ * WT_MAX_MODIFY_UPDATE, WT_MODIFY_ARRAY_SIZE
+ *	Limit update chains value to avoid penalizing reads and permit truncation. Having a smaller
+ * value will penalize the cases when history has to be maintained, resulting in multiplying cache
+ * pressure.
+ *
+ * When threads race modifying a record, we can end up with more than the usual maximum number of
+ * modifications in an update list. We use arrays of updates in a couple of places to avoid heap
+ * allocation, add a few additional slots to that array.
  */
 #define WT_MAX_MODIFY_UPDATE 10
+#define WT_MODIFY_ARRAY_SIZE (WT_MAX_MODIFY_UPDATE + 10)
 
 /*
- * WT_MODIFY_MEM_FACTOR	--
+ * WT_MODIFY_MEM_FRACTION
  *	Limit update chains to a fraction of the base document size.
  */
 #define WT_MODIFY_MEM_FRACTION 10

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -225,6 +225,45 @@ class test_las06(wttest.WiredTigerTestCase):
             self.assertEquals(value2, cursor[i])
         self.session.rollback_transaction()
 
+    def test_multiple_updates_workload(self):
+        # Create a small table.
+        uri = "table:test_las06"
+        create_params = 'key_format={},value_format=S'.format(self.key_format)
+        self.session.create(uri, create_params)
+
+        value1 = 'a' * 500
+        value2 = 'b' * 500
+        value3 = 'c' * 500
+        value4 = 'd' * 500
+
+        # Load 5Mb of data.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[i] = value1
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        # Do two different updates to the same key with the same timestamp.
+        # We want to make sure that the second value is the one that is visible even after eviction.
+        for i in range(1, 11):
+            self.session.begin_transaction()
+            cursor[i] = value2
+            cursor[i] = value3
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        # Write a newer value on top.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[i] = value4
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+
+        # Ensure that we see the last of the two updates that got applied.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
+        for i in range(1, 11):
+            self.assertEquals(cursor[i], value3)
+        self.session.rollback_transaction()
+
     def test_multiple_modifies_workload(self):
         # Create a small table.
         uri = "table:test_las06"

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -244,7 +244,7 @@ class test_las06(wttest.WiredTigerTestCase):
 
         # Apply three sets of modifies.
         # They specifically need to be in separate modify calls.
-        for i in range(1, 10000):
+        for i in range(1, 11):
             self.session.begin_transaction()
             cursor.set_key(i)
             self.assertEqual(cursor.modify([wiredtiger.Modify('B', 100, 1)]), 0)
@@ -266,7 +266,7 @@ class test_las06(wttest.WiredTigerTestCase):
 
         # Go back and read. We should get the initial value with the 3 modifies applied on top.
         self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
-        for i in range(1, 10000):
+        for i in range(1, 11):
             self.assertEqual(cursor[i], expected)
         self.session.rollback_transaction()
 

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -225,5 +225,50 @@ class test_las06(wttest.WiredTigerTestCase):
             self.assertEquals(value2, cursor[i])
         self.session.rollback_transaction()
 
+    def test_multiple_modifies_workload(self):
+        # Create a small table.
+        uri = "table:test_las06"
+        create_params = 'key_format={},value_format=S'.format(self.key_format)
+        self.session.create(uri, create_params)
+
+        value1 = 'a' * 500
+        value2 = 'b' * 500
+
+        # Load 5Mb of data.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[i] = value1
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        # Apply three sets of modifies.
+        # They specifically need to be in separate modify calls.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(i)
+            self.assertEqual(cursor.modify([wiredtiger.Modify('B', 100, 1)]), 0)
+            self.assertEqual(cursor.modify([wiredtiger.Modify('C', 200, 1)]), 0)
+            self.assertEqual(cursor.modify([wiredtiger.Modify('D', 300, 1)]), 0)
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        expected = list(value1)
+        expected[100] = 'B'
+        expected[200] = 'C'
+        expected[300] = 'D'
+        expected = str().join(expected)
+
+        # Write a newer value on top.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[i] = value2
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+
+        # Go back and read. We should get the initial value with the 3 modifies applied on top.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
+        for i in range(1, 10000):
+            self.assertEqual(cursor[i], expected)
+        self.session.rollback_transaction()
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
As it stands, if we open a transaction and apply multiple modifies at the same timestamp, lookaside eviction will cause all but one of these modifies to be lost. This is because they occupy the same key in lookaside (`btree_id, key, timestamp, txnid`).

This PR adds some logic to detect this situation and squash the modifies into a single standard update upon lookaside eviction.