### PR TITLE
WT-5160 Stop requiring a checkpoint before calling rollback_to_stable

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -433,8 +433,7 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     txn_global = &conn->txn_global;
 
     if (!txn_global->has_stable_timestamp)
-        WT_RET_MSG(
-          session, EINVAL, "rollback_to_stable requires a stable timestamp");
+        WT_RET_MSG(session, EINVAL, "rollback_to_stable requires a stable timestamp");
 
     /*
      * Help the user comply with the requirement that there are no concurrent operations. Protect

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -432,9 +432,9 @@ __txn_rollback_to_stable_check(WT_SESSION_IMPL *session)
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    if (!txn_global->has_stable_timestamp || txn_global->last_ckpt_timestamp == WT_TS_NONE)
+    if (!txn_global->has_stable_timestamp)
         WT_RET_MSG(
-          session, EINVAL, "rollback_to_stable requires a checkpoint with a stable timestamp");
+          session, EINVAL, "rollback_to_stable requires a stable timestamp");
 
     /*
      * Help the user comply with the requirement that there are no concurrent operations. Protect


### PR DESCRIPTION
We recently introduced this constraint, but it's not acceptable.