### PR TITLE
WT-5150 Fix the check to find out whethere LAS is empty

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -973,11 +973,8 @@ __las_sweep_init(WT_SESSION_IMPL *session)
     /*
      * If no files have been dropped and the lookaside file is empty, there's nothing to do.
      */
-    if (cache->las_dropped_next == 0) {
-        if (__wt_las_empty(session))
-            ret = WT_NOTFOUND;
-        goto err;
-    }
+    if (cache->las_dropped_next == 0 && __wt_las_empty(session))
+        WT_ERR(WT_NOTFOUND);
 
     /*
      * Record the current page ID: sweep will stop after this point.


### PR DESCRIPTION
Sweep server should periodically clean the LAS obsolete
entries when there as any tables are dropped or if the LAS
not empty. Fix the check that leads to not to remove the
obsolete entries when there are no tables dropped.