### PR TITLE
WT-5167 Fix the missing pieces of page instantiation from las

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -255,7 +255,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     cache->las_reader = true;
     __wt_readlock(session, &cache->las_sweepwalk_lock);
     cache->las_reader = false;
-    incr = total_incr = 0;
+    total_incr = 0;
     first_scan = true;
     locked = true;
     cursor->set_key(cursor, las_btree_id, &page_las->min_las_key, WT_TS_MAX, WT_TXN_MAX);
@@ -377,8 +377,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Instantiate the remaining birthmark entries. */
     WT_ERR(__instantiate_birthmarks(session, ref));
 
-    if (total_incr != 0)
-        __wt_cache_page_inmem_incr(session, page, total_incr);
+    __wt_cache_page_inmem_incr(session, page, total_incr);
 
     /*
      * If the updates in lookaside are newer than the versions on the page, it must be included in

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -255,7 +255,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     cache->las_reader = true;
     __wt_readlock(session, &cache->las_sweepwalk_lock);
     cache->las_reader = false;
-    total_incr = 0;
+    incr = total_incr = 0;
     first_scan = true;
     locked = true;
     cursor->set_key(cursor, las_btree_id, &page_las->min_las_key, WT_TS_MAX, WT_TXN_MAX);

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -263,7 +263,6 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
     WT_UPDATE *upd;
 
     *updp = NULL;
-    *sizep = 0;
 
     /*
      * The code paths leading here are convoluted: assert we never attempt to allocate an update

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -263,6 +263,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
     WT_UPDATE *upd;
 
     *updp = NULL;
+    *sizep = 0;
 
     /*
      * The code paths leading here are convoluted: assert we never attempt to allocate an update

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -557,6 +557,7 @@ __las_squash_modifies(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_UPDATE **u
     size_t allocated_bytes;
     u_int i;
 
+    WT_CLEAR(las_value);
     listp = list;
     start_upd = upd = *updp;
     next_upd = start_upd->next;
@@ -589,7 +590,6 @@ __las_squash_modifies(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_UPDATE **u
             WT_PANIC_ERR(session, WT_PANIC,
               "found modify update but no corresponding standard update in the update list");
     }
-    WT_CLEAR(las_value);
     WT_ERR(__wt_buf_set(session, &las_value, upd->data, upd->size));
     while (i > 0)
         WT_ERR(__wt_modify_apply_item(session, &las_value, listp[--i]->data, false));

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -149,6 +149,9 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
+    if (size == 0)
+        return;
+
     (void)__wt_atomic_add64(&btree->bytes_inmem, size);
     (void)__wt_atomic_add64(&cache->bytes_inmem, size);
     (void)__wt_atomic_addsize(&page->memory_footprint, size);

--- a/test/suite/test_las03.py
+++ b/test/suite/test_las03.py
@@ -89,9 +89,9 @@ class test_las03(wttest.WiredTigerTestCase):
             # Now just update one record and checkpoint again.
             self.large_updates(self.session, uri, bigvalue2, ds, nrows, 1)
 
-            las_reads_start = self.get_stat(stat.conn.cache_read_lookaside)
+            las_reads_start = self.get_stat(stat.conn.cache_lookaside_read)
             self.session.checkpoint()
-            las_reads = self.get_stat(stat.conn.cache_read_lookaside) - las_reads_start
+            las_reads = self.get_stat(stat.conn.cache_lookaside_read) - las_reads_start
 
             # Since we're dealing with eviction concurrent with checkpoints
             # and skewing is controlled by a heuristic, we can't put too tight


### PR DESCRIPTION
Update various memory allocations that are done during the page
instantiation for the tracking stats variables.

Set the page modify restore_state with proper value once the page
is successfully instantiated.

If LAS updates are newer than the disk image, set the flag to include
these updates in the next checkpoint.

Otherwise, if the page image contains newest versions of data than
LAS updates, check whether the page that is marked as dirtly can
be cleared under some conditions.