### PR TITLE
WT-5176 Group pull request tasks using Evergreen task tags

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -982,7 +982,7 @@ tasks:
   # End of Python unit test tasks
 
   - name: compile-windows-alt
-    tags: ["pull_request", "windows"]
+    tags: ["pull_request", "windows_only"]
     depends_on:
     - name: compile
     commands:
@@ -1016,7 +1016,7 @@ tasks:
             fi
 
   - name: format
-    tags: ["pull_request", "windows"]
+    tags: ["pull_request", "windows_only"]
     depends_on:
     - name: compile
     commands:
@@ -1190,7 +1190,7 @@ buildvariants:
     configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
   tasks:
-    - name: ".pull_request !.windows"
+    - name: ".pull_request !.windows_only"
 
 - name: ubuntu1804-python3
   display_name: Ubuntu 18.04 (Python3)

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -114,11 +114,13 @@ post:
 tasks:
 ## Base compile task on posix flavours
   - name: compile
+    tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
 
   - name: compile-asan
+    tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -144,6 +146,7 @@ tasks:
   # Start of normal make check test tasks
 
   - name: lang-python-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -154,6 +157,7 @@ tasks:
           directory: lang/python
 
   - name: examples-c-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -163,7 +167,8 @@ tasks:
         vars:
           directory: examples/c
 
-  - name: examples-c-test-asan
+  - name: examples-c-asan-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile-asan
     commands:
@@ -179,6 +184,7 @@ tasks:
           directory: examples/c
 
   - name: bloom-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -189,6 +195,7 @@ tasks:
           directory: test/bloom
 
   - name: checkpoint-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -199,6 +206,7 @@ tasks:
           directory: test/checkpoint
 
   - name: cursor-order-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -209,6 +217,7 @@ tasks:
           directory: test/cursor_order
 
   - name: fops-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -219,6 +228,7 @@ tasks:
           directory: test/fops
 
   - name: format-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -229,6 +239,7 @@ tasks:
           directory: test/format
 
   - name: huge-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -239,6 +250,7 @@ tasks:
           directory: test/huge
 
   - name: manydbs-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -249,6 +261,7 @@ tasks:
           directory: test/manydbs
 
   - name: packing-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -259,6 +272,7 @@ tasks:
           directory: test/packing
 
   - name: readonly-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -269,6 +283,7 @@ tasks:
           directory: test/readonly
 
   - name: salvage-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -279,6 +294,7 @@ tasks:
           directory: test/salvage
 
   - name: thread-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -289,6 +305,7 @@ tasks:
           directory: test/thread
 
   - name: bench-wtperf-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -303,11 +320,11 @@ tasks:
   # Start of csuite test tasks
 
   - name: csuite-import-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      - func: "compile wiredtiger"
       - command: shell.exec
         params:
           working_dir: "wiredtiger/build_posix"
@@ -318,6 +335,7 @@ tasks:
             ${test_env_vars|} $(pwd)/../test/csuite/import/smoke.sh 2>&1
 
   - name: csuite-random-abort-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -332,6 +350,7 @@ tasks:
             ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
 
   - name: csuite-random-directio-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -346,6 +365,7 @@ tasks:
             ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
 
   - name: csuite-schema-abort-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -360,6 +380,7 @@ tasks:
             ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
 
   - name: csuite-timestamp-abort-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -374,6 +395,7 @@ tasks:
             ${test_env_vars|} $(pwd)/../test/csuite/timestamp_abort/smoke.sh 2>&1
 
   - name: csuite-scope-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -388,6 +410,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_scope 2>&1
 
   - name: csuite-truncated-log-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -402,6 +425,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_truncated_log 2>&1
 
   - name: csuite-wt1965-col-efficiency-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -416,6 +440,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt1965_col_efficiency 2>&1
 
   - name: csuite-wt2403-lsm-workload-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -430,6 +455,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2403_lsm_workload 2>&1
 
   - name: csuite-wt2447-join-main-table-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -444,6 +470,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2447_join_main_table 2>&1
 
   - name: csuite-wt2695-checksum-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -458,6 +485,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2695_checksum 2>&1
 
   - name: csuite-wt2592-join-schema-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -472,6 +500,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2592_join_schema 2>&1
 
   - name: csuite-wt2719-reconfig-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -486,6 +515,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2719_reconfig 2>&1
 
   - name: csuite-wt2999-join-extractor-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -500,6 +530,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2999_join_extractor 2>&1
 
   - name: csuite-wt3120-filesys-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -514,6 +545,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3120_filesys 2>&1
 
   - name: csuite-wt3135-search-near-collator-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -528,6 +560,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3135_search_near_collator 2>&1
 
   - name: csuite-wt3184-dup-index-collator-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -542,6 +575,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3184_dup_index_collator 2>&1
 
   - name: csuite-wt3363-checkpoint-op-races-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -556,6 +590,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3363_checkpoint_op_races 2>&1
 
   - name: csuite-wt3874-pad-byte-collator-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -570,6 +605,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3874_pad_byte_collator 2>&1
 
   - name: csuite-wt4105-large-doc-small-upd-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -584,6 +620,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4105_large_doc_small_upd 2>&1
 
   - name: csuite-wt4117-checksum-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -598,6 +635,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4117_checksum 2>&1
 
   - name: csuite-wt4156-metadata-salvage-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -612,6 +650,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4156_metadata_salvage 2>&1
 
   - name: csuite-wt4699-json-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -626,6 +665,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4699_json 2>&1
 
   - name: csuite-wt4803-cache-overflow-abort-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -640,6 +680,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4803_cache_overflow_abort 2>&1
 
   - name: csuite-wt4891-meta-ckptlist-get-alloc-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -654,6 +695,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4891_meta_ckptlist_get_alloc 2>&1
 
   - name: csuite-rwlock-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -668,6 +710,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_rwlock 2>&1
 
   - name: csuite-wt2246-col-append-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -682,6 +725,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2246_col_append 2>&1
 
   - name: csuite-wt2323-join-visibility-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -696,6 +740,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2323_join_visibility 2>&1
 
   - name: csuite-wt2535-insert-race-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -710,6 +755,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2535_insert_race 2>&1
 
   - name: csuite-wt2834-join-bloom-fix-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -724,6 +770,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2834_join_bloom_fix 2>&1
 
   - name: csuite-wt2853-perf-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -738,6 +785,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
 
   - name: csuite-wt2909-checkpoint-integrity-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -752,6 +800,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2909_checkpoint_integrity 2>&1
 
   - name: csuite-wt3338-partial-update-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -766,6 +815,7 @@ tasks:
             ${test_env_vars|} $(pwd)/test/csuite/test_wt3338_partial_update 2>&1
 
   - name: csuite-wt4333-handle-locks-test
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -810,6 +860,7 @@ tasks:
   # "test/suite/run.py [ab]" will be translated to testing "test_a*.py" and "test_b*.py"
 
   - name: unit-test-bucket00
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -824,6 +875,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [ab] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket01
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -838,6 +890,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [c] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket02
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -852,6 +905,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [defg] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket03
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -866,6 +920,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [hijk] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket04
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -880,6 +935,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [lmnopq] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket05
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -894,6 +950,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [rs] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket06
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -908,6 +965,7 @@ tasks:
             ${test_env_vars|} ${python_binary|python} ../test/suite/run.py [t] -v 2 ${smp_command|} 2>&1
 
   - name: unit-test-bucket07
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -924,6 +982,7 @@ tasks:
   # End of Python unit test tasks
 
   - name: compile-windows-alt
+    tags: ["pull_request", "windows"]
     depends_on:
     - name: compile
     commands:
@@ -939,6 +998,7 @@ tasks:
             scons-3.1.1.bat ${smp_command|} "CFLAGS=/Gv /wd4090 /wd4996 /we4047 /we4024 /TC /we4100 /we4133" wiredtiger.dll libwiredtiger.lib
 
   - name: fops
+    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -956,6 +1016,7 @@ tasks:
             fi
 
   - name: format
+    tags: ["pull_request", "windows"]
     depends_on:
     - name: compile
     commands:
@@ -1124,70 +1185,12 @@ buildvariants:
   run_on:
   - ubuntu1804-test
   expansions:
-    # It's ugly, but we need the absolute path here, not the relative
     test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
   tasks:
-    - name: compile
-    - name: lang-python-test
-    - name: examples-c-test
-    - name: bloom-test
-    - name: checkpoint-test
-    - name: cursor-order-test
-    - name: fops-test
-    - name: format-test
-    - name: huge-test
-    - name: manydbs-test
-    - name: packing-test
-    - name: readonly-test
-    - name: salvage-test
-    - name: thread-test
-    - name: bench-wtperf-test
-    - name: csuite-import-test
-    - name: csuite-random-abort-test
-    - name: csuite-random-directio-test
-    - name: csuite-schema-abort-test
-    - name: csuite-timestamp-abort-test
-    - name: csuite-scope-test
-    - name: csuite-truncated-log-test
-    - name: csuite-wt1965-col-efficiency-test
-    - name: csuite-wt2403-lsm-workload-test
-    - name: csuite-wt2447-join-main-table-test
-    - name: csuite-wt2695-checksum-test
-    - name: csuite-wt2592-join-schema-test
-    - name: csuite-wt2719-reconfig-test
-    - name: csuite-wt2999-join-extractor-test
-    - name: csuite-wt3120-filesys-test
-    - name: csuite-wt3135-search-near-collator-test
-    - name: csuite-wt3184-dup-index-collator-test
-    - name: csuite-wt3363-checkpoint-op-races-test
-    - name: csuite-wt3874-pad-byte-collator-test
-    - name: csuite-wt4105-large-doc-small-upd-test
-    - name: csuite-wt4117-checksum-test
-    - name: csuite-wt4156-metadata-salvage-test
-    - name: csuite-wt4699-json-test
-    - name: csuite-rwlock-test
-    - name: csuite-wt2246-col-append-test
-    - name: csuite-wt2323-join-visibility-test
-    - name: csuite-wt2535-insert-race-test
-    - name: csuite-wt2834-join-bloom-fix-test
-    - name: csuite-wt2853-perf-test
-    - name: csuite-wt2909-checkpoint-integrity-test
-    - name: csuite-wt3338-partial-update-test
-    - name: csuite-wt4333-handle-locks-test
-    - name: unit-test-bucket00
-    - name: unit-test-bucket01
-    - name: unit-test-bucket02
-    - name: unit-test-bucket03
-    - name: unit-test-bucket04
-    - name: unit-test-bucket05
-    - name: unit-test-bucket06
-    - name: unit-test-bucket07
-    - name: fops
-    - name: compile-asan
-    - name: examples-c-test-asan
+    - name: ".pull_request !.windows"
 
 - name: ubuntu1804-python3
   display_name: Ubuntu 18.04 (Python3)

--- a/test/evergreen/csuite_test_evg_task.template
+++ b/test/evergreen/csuite_test_evg_task.template
@@ -1,4 +1,5 @@
   - name: {{task_name}}
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:

--- a/test/evergreen/make_check_test_evg_task.template
+++ b/test/evergreen/make_check_test_evg_task.template
@@ -1,15 +1,10 @@
  - name: {{task_name}}
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
       - func: "fetch artifacts"
       - func: "compile wiredtiger"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger"
-          script: |
-            set -o errexit
-            set -o verbose
-
-            ${test_env_vars|} ${make_command|make} VERBOSE=1 check -C {{test_dir}} ${smp_command|} 2>&1
-
+      - func: "make check directory"
+        vars:
+          directory: {{test_dir}}


### PR DESCRIPTION
Changes include:
- tagging all applicable tasks as `pull_request`
- tagging Windows only tasks as `windows`
- simplifying listing tasks in `ubuntu1804` build variant
- updating task templates to fit recent retro code

@quchenhao Can you help to take a look? Thanks.