### PR TITLE
WT-4899 WT-4940 WT-4943 backport v4.0

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -57,6 +57,7 @@ func_ok()
 	    -e '/int __wt_block_write_size$/d' \
 	    -e '/int __wt_buf_catfmt$/d' \
 	    -e '/int __wt_buf_fmt$/d' \
+	    -e '/int __wt_count_birthmarks$/d' \
 	    -e '/int __wt_curjoin_joined$/d' \
 	    -e '/int __wt_cursor_noop$/d' \
 	    -e '/int __wt_epoch$/d' \

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -26,7 +26,8 @@ __col_instantiate(
      *
      * Just free the memory: it hasn't been accounted for on the page yet.
      */
-    if (updlist->next != NULL && (upd = __wt_update_obsolete_check(session, page, updlist)) != NULL)
+    if (updlist->next != NULL &&
+      (upd = __wt_update_obsolete_check(session, page, updlist, false)) != NULL)
         __wt_free_update_list(session, upd);
 
     /* Search the page and add updates. */
@@ -53,7 +54,8 @@ __row_instantiate(
      *
      * Just free the memory: it hasn't been accounted for on the page yet.
      */
-    if (updlist->next != NULL && (upd = __wt_update_obsolete_check(session, page, updlist)) != NULL)
+    if (updlist->next != NULL &&
+      (upd = __wt_update_obsolete_check(session, page, updlist, false)) != NULL)
         __wt_free_update_list(session, upd);
 
     /* Search the page and add updates. */
@@ -221,7 +223,8 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ERR_NOTFOUND_OK(ret);
 
     /* Insert the last set of updates, if any. */
-    if (first_upd != NULL)
+    if (first_upd != NULL) {
+        WT_ASSERT(session, __wt_count_birthmarks(first_upd) <= 1);
         switch (page->type) {
         case WT_PAGE_COL_FIX:
         case WT_PAGE_COL_VAR:
@@ -235,6 +238,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
         default:
             WT_ERR(__wt_illegal_value(session, page->type));
         }
+    }
 
     /* Discard the cursor. */
     WT_ERR(__wt_las_cursor_close(session, &cursor, session_flags));

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1341,11 +1341,11 @@ err:
 
 #ifdef HAVE_DIAGNOSTIC
 /*
- * __check_upd_list --
+ * __wt_count_birthmarks --
  *     Sanity check an update list. In particular, make sure there no birthmarks.
  */
-static void
-__check_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd)
+int
+__wt_count_birthmarks(WT_UPDATE *upd)
 {
     int birthmark_count;
 
@@ -1353,7 +1353,7 @@ __check_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (upd->type == WT_UPDATE_BIRTHMARK)
             ++birthmark_count;
 
-    WT_ASSERT(session, birthmark_count <= 1);
+    return (birthmark_count);
 }
 #endif
 
@@ -1444,9 +1444,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
                 key->size = WT_INSERT_KEY_SIZE(supd->ins);
             }
 
-#ifdef HAVE_DIAGNOSTIC
-            __check_upd_list(session, upd);
-#endif
+            WT_ASSERT(session, __wt_count_birthmarks(upd) <= 1);
 
             /* Search the page. */
             WT_ERR(__wt_row_search(session, key, ref, &cbt, true, true));

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -288,10 +288,12 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
  *     Check for obsolete updates.
  */
 WT_UPDATE *
-__wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd)
+__wt_update_obsolete_check(
+  WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd, bool update_accounting)
 {
     WT_TXN_GLOBAL *txn_global;
-    WT_UPDATE *first, *next;
+    WT_UPDATE *first, *next, *prev;
+    size_t size;
     u_int count;
 
     txn_global = &S2C(session)->txn_global;
@@ -306,13 +308,21 @@ __wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *u
      *
      * Only updates with globally visible, self-contained data can terminate
      * update chains.
+     *
+     * Birthmarks are a special case: once a birthmark becomes obsolete, it
+     * can be discarded and subsequent reads will see the on-page value (as
+     * expected).  Inserting updates into the lookaside table relies on
+     * this behavior to avoid creating update chains with multiple
+     * birthmarks.
      */
-    for (first = NULL, count = 0; upd != NULL; upd = upd->next, count++) {
+    for (first = prev = NULL, count = 0; upd != NULL; prev = upd, upd = upd->next, count++) {
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
         if (!__wt_txn_upd_visible_all(session, upd))
             first = NULL;
-        else if (first == NULL && (WT_UPDATE_DATA_VALUE(upd) || upd->type == WT_UPDATE_BIRTHMARK))
+        else if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
+            first = prev;
+        else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
             first = upd;
     }
 
@@ -322,8 +332,19 @@ __wt_update_obsolete_check(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *u
      * reference to the list we will discard, and terminate the list.
      */
     if (first != NULL && (next = first->next) != NULL &&
-      __wt_atomic_cas_ptr(&first->next, next, NULL))
+      __wt_atomic_cas_ptr(&first->next, next, NULL)) {
+        /*
+         * Decrement the dirty byte count while holding the page lock, else we can race with
+         * checkpoints cleaning a page.
+         */
+        if (update_accounting) {
+            for (size = 0, upd = next; upd != NULL; upd = upd->next)
+                size += WT_UPDATE_MEMSIZE(upd);
+            if (size != 0)
+                __wt_cache_page_inmem_decr(session, page, size);
+        }
         return (next);
+    }
 
     /*
      * If the list is long, don't retry checks on this page until the transaction state has moved

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -681,7 +681,24 @@ __wt_las_insert_block(
         if (list->ripcip != NULL)
             slot = page->type == WT_PAGE_ROW_LEAF ? WT_ROW_SLOT(page, list->ripcip) :
                                                     WT_COL_SLOT(page, list->ripcip);
-        first_upd = upd = list->ins == NULL ? page->modify->mod_row_update[slot] : list->ins->upd;
+        first_upd = list->ins == NULL ? page->modify->mod_row_update[slot] : list->ins->upd;
+
+        /*
+         * Trim any updates before writing to lookaside. This saves wasted work, but is also
+         * necessary because the reconciliation only resolves existing birthmarks if they aren't
+         * obsolete.
+         */
+        WT_WITH_BTREE(
+          session, btree, upd = __wt_update_obsolete_check(session, page, first_upd, true));
+        if (upd != NULL)
+            __wt_free_update_list(session, upd);
+        upd = first_upd;
+
+        /*
+         * It's not OK for the update list to contain a birthmark on entry - we will generate one
+         * below if necessary.
+         */
+        WT_ASSERT(session, __wt_count_birthmarks(first_upd) == 0);
 
         /*
          * Walk the list of updates, storing each key/value pair into the lookaside table. Skip

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -326,6 +326,7 @@ extern int __wt_value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_count_birthmarks(WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi,
   WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
@@ -385,7 +386,7 @@ extern int __wt_row_insert_alloc(WT_SESSION_IMPL *session, const WT_ITEM *key, u
 extern int __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **updp,
   size_t *sizep, u_int modify_type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern WT_UPDATE *__wt_update_obsolete_check(
-  WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd);
+  WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd, bool update_accounting);
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf,

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -44,7 +44,6 @@ typedef struct {
     u_int updates_seen;     /* Count of updates seen. */
     u_int updates_unstable; /* Count of updates not visible_all. */
 
-    bool update_prepared;    /* An update was prepared. */
     bool update_uncommitted; /* An update was uncommitted. */
     bool update_used;        /* An update could be used. */
 

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -44,8 +44,9 @@ typedef struct {
     u_int updates_seen;     /* Count of updates seen. */
     u_int updates_unstable; /* Count of updates not visible_all. */
 
-    bool update_uncommitted; /* An update was uncommitted */
-    bool update_used;        /* An update could be used */
+    bool update_prepared;    /* An update was prepared. */
+    bool update_uncommitted; /* An update was uncommitted. */
+    bool update_used;        /* An update could be used. */
 
     /*
      * When we can't mark the page clean (for example, checkpoint found some uncommitted updates),

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -227,7 +227,6 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE **srch_upd
     WT_DECL_RET;
     WT_UPDATE *obsolete, *upd;
     wt_timestamp_t obsolete_timestamp;
-    size_t size;
     uint64_t txn;
 
     /* Clear references to memory we now own and must free on error. */
@@ -286,16 +285,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE **srch_upd
     if (WT_PAGE_TRYLOCK(session, page) != 0)
         return (0);
 
-    obsolete = __wt_update_obsolete_check(session, page, upd->next);
-
-    /*
-     * Decrement the dirty byte count while holding the page lock, else we can race with checkpoints
-     * cleaning a page.
-     */
-    for (size = 0, upd = obsolete; upd != NULL; upd = upd->next)
-        size += WT_UPDATE_MEMSIZE(upd);
-    if (size != 0)
-        __wt_cache_page_inmem_decr(session, page, size);
+    obsolete = __wt_update_obsolete_check(session, page, upd->next, true);
 
     WT_PAGE_UNLOCK(session, page);
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -160,13 +160,13 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
          * prepared transaction id's are globally visible, need to check the update state as well.
          */
         if (F_ISSET(r, WT_REC_EVICT)) {
-            if (upd->prepare_state == WT_PREPARE_LOCKED ||
-              upd->prepare_state == WT_PREPARE_INPROGRESS)
-                prepared = true;
-
-            if (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
-                                                 !__txn_visible_id(session, txnid))
-                uncommitted = r->update_uncommitted = true;
+            prepared = upd->prepare_state == WT_PREPARE_LOCKED ||
+              upd->prepare_state == WT_PREPARE_INPROGRESS;
+            uncommitted =
+              !prepared && (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
+                                                             !__txn_visible_id(session, txnid));
+            if (uncommitted)
+                r->update_uncommitted = true;
 
             if (prepared || uncommitted)
                 continue;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -114,7 +114,7 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
     wt_timestamp_t timestamp;
     size_t upd_memsize;
     uint64_t max_txn, txnid;
-    bool all_visible, prepared, skipped_birthmark, uncommitted, upd_saved;
+    bool all_visible, skipped_birthmark, upd_saved;
 
     if (upd_savedp != NULL)
         *upd_savedp = false;
@@ -124,7 +124,7 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
     first_ts_upd = first_txn_upd = NULL;
     upd_memsize = 0;
     max_txn = WT_TXN_NONE;
-    prepared = skipped_birthmark = uncommitted = upd_saved = false;
+    skipped_birthmark = upd_saved = false;
 
     /*
      * If called with a WT_INSERT item, use its WT_UPDATE list (which must
@@ -160,16 +160,16 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
          * prepared transaction id's are globally visible, need to check the update state as well.
          */
         if (F_ISSET(r, WT_REC_EVICT)) {
-            prepared = upd->prepare_state == WT_PREPARE_LOCKED ||
-              upd->prepare_state == WT_PREPARE_INPROGRESS;
-            uncommitted =
-              !prepared && (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
-                                                             !__txn_visible_id(session, txnid));
-            if (uncommitted)
-                r->update_uncommitted = true;
-
-            if (prepared || uncommitted)
+            if (upd->prepare_state == WT_PREPARE_LOCKED ||
+              upd->prepare_state == WT_PREPARE_INPROGRESS) {
+                r->update_prepared = true;
                 continue;
+            }
+            if (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
+                                                 !__txn_visible_id(session, txnid)) {
+                r->update_uncommitted = true;
+                continue;
+            }
         }
 
         /* Track the first update with non-zero timestamp. */
@@ -208,7 +208,8 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
              * to discard updates from the stable update and older for correctness and we can't
              * discard an uncommitted update.
              */
-            if (F_ISSET(r, WT_REC_UPDATE_RESTORE) && *updp != NULL && (uncommitted || prepared)) {
+            if (F_ISSET(r, WT_REC_UPDATE_RESTORE) && *updp != NULL &&
+              (r->update_uncommitted || r->update_prepared)) {
                 r->leave_dirty = true;
                 return (__wt_set_return(session, EBUSY));
             }
@@ -292,7 +293,7 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
      * with a timestamp (if any).
      */
     timestamp = first_ts_upd == NULL ? 0 : first_ts_upd->timestamp;
-    all_visible = upd == first_txn_upd && !(uncommitted || prepared) &&
+    all_visible = upd == first_txn_upd && !r->update_uncommitted && !r->update_prepared &&
       (F_ISSET(r, WT_REC_VISIBLE_ALL) ? __wt_txn_visible_all(session, max_txn, timestamp) :
                                         __wt_txn_visible(session, max_txn, timestamp));
 
@@ -327,7 +328,7 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
      */
     if (!F_ISSET(r, WT_REC_LOOKASIDE | WT_REC_UPDATE_RESTORE))
         return (__wt_set_return(session, EBUSY));
-    if (uncommitted && !F_ISSET(r, WT_REC_UPDATE_RESTORE))
+    if (r->update_uncommitted && !F_ISSET(r, WT_REC_UPDATE_RESTORE))
         return (__wt_set_return(session, EBUSY));
 
     WT_ASSERT(session, r->max_txn != WT_TXN_NONE);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -668,7 +668,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
 
     /* Track if updates were used and/or uncommitted. */
     r->updates_seen = r->updates_unstable = 0;
-    r->update_uncommitted = r->update_used = false;
+    r->update_prepared = r->update_uncommitted = r->update_used = false;
 
     /* Track if the page can be marked clean. */
     r->leave_dirty = false;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -668,7 +668,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
 
     /* Track if updates were used and/or uncommitted. */
     r->updates_seen = r->updates_unstable = 0;
-    r->update_prepared = r->update_uncommitted = r->update_used = false;
+    r->update_uncommitted = r->update_used = false;
 
     /* Track if the page can be marked clean. */
     r->leave_dirty = false;


### PR DESCRIPTION
Backport WT-4899 WT-4940 WT-4943 to mongodb-4.0

There are no test cases associated with the change, not really giving me any confidence that I'm doing the right thing. :(