### PR TITLE
WT-4486 Make test even more conservative.

### DIFF
--- a/test/suite/test_log03.py
+++ b/test/suite/test_log03.py
@@ -91,9 +91,10 @@ class test_log03(wttest.WiredTigerTestCase):
         baseline = self.with_log_sync(12, 0)
         #self.tty('baseline: ' + str(baseline))
 
-        for dirty_pct,increase in [50, 8], [33, 16], [25, 24], [20, 32]:
+        incr = 5
+        for dirty_pct,increase in [50, incr], [33, incr*2], [25, incr*3], [20, incr*4]:
             result = self.with_log_sync(12, dirty_pct)
-            #self.tty('tried: ' + str(dirty_pct) + ', got: ' + str(result))
+            #self.tty('tried: ' + str(dirty_pct) + ', got: ' + str(result) + ', expected: ' + str(baseline + increase))
             self.assertGreater(result, baseline + increase)
 
 if __name__ == '__main__':


### PR DESCRIPTION
@ddanderson this can be reviewed. It is an open question if we can figure out and fix in this PR whatever the issue is that caused the test directory not to be saved and the results saying `passed=True`. They're only sort of related to this, and would be easy to include if we want here.