### PR TITLE
WT-5157 Fix atomics usage in spinlock impl

### DIFF
--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -100,6 +100,7 @@ struct __wt_spinlock {
 #if SPINLOCK_TYPE == SPINLOCK_GCC
     WT_CACHE_LINE_PAD_BEGIN
     volatile bool lock;
+    uint8_t unused[7];
 #elif SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX || \
   SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX_ADAPTIVE || SPINLOCK_TYPE == SPINLOCK_MSVC
     wt_mutex_t lock;

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -99,7 +99,7 @@ struct __wt_rwlock { /* Read/write lock */
 struct __wt_spinlock {
 #if SPINLOCK_TYPE == SPINLOCK_GCC
     WT_CACHE_LINE_PAD_BEGIN
-    volatile int lock;
+    volatile bool lock;
 #elif SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX || \
   SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX_ADAPTIVE || SPINLOCK_TYPE == SPINLOCK_MSVC
     wt_mutex_t lock;

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -67,7 +67,7 @@ __wt_spin_trylock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
     WT_UNUSED(session);
 
-    return (__atomic_test_and_set(&t->lock, __ATOMIC_ACQUIRE) ? 0 : EBUSY);
+    return (!__atomic_test_and_set(&t->lock, __ATOMIC_ACQUIRE) ? 0 : EBUSY);
 }
 
 /*


### PR DESCRIPTION
This bug was introduced in #4740. I didn't notice the deadlock at the time since I didn't run the Python test suite with `--with-spinlock=gcc`.

> The byte is set to some implementation defined nonzero “set” value and the return value is true if and only if the previous contents were “set”

The `__atomic_test_and_set` compiler intrinsic is similar to its `__sync_*` counterpart in that it returns a `bool` for the previous value before the call took place (not for success like I thought). So actually a successful acquisition should return `false` since no other thread should have set it to its "on" value.