### PR TITLE
WT-5136 Fix reading freed memory due to birthmark after uncommitted updates freed 

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -309,11 +309,11 @@ __wt_update_obsolete_check(
      * Only updates with globally visible, self-contained data can terminate update chains.
      *
      * Birthmarks are a special case: once a birthmark becomes obsolete, it can be discarded if
-     * there is an update visible to all sessions before it and subsequent reads will see the
-     * on-page value (as expected). Inserting updates into the lookaside table relies on this
-     * behavior to avoid creating update chains with multiple birthmarks. We cannot discard the
-     * birthmark if it's the first globally visible update as the previous updates can be aborted
-     * and be freed as well causing the entire update chain being removed.
+     * there is a globally visible update before it and subsequent reads will see the on-page value
+     * (as expected). Inserting updates into the lookaside table relies on this behavior to avoid
+     * creating update chains with multiple birthmarks. We cannot discard the birthmark if it's the
+     * first globally visible update as the previous updates can be aborted and be freed causing the
+     * entire update chain being removed.
      */
     for (first = prev = NULL, visible_all_before = false, count = 0; upd != NULL;
          prev = upd, upd = upd->next, count++) {

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -330,10 +330,13 @@ __wt_update_obsolete_check(
             if (upd->start_ts != WT_TS_NONE && upd->start_ts >= oldest && upd->start_ts < stable)
                 ++upd_unstable;
         } else {
-            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
+            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK) {
                 first = seen_upd_visible_all ? prev : upd;
-            else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
+                break;
+            } else if (first == NULL && WT_UPDATE_DATA_VALUE(upd)) {
                 first = upd;
+                break;
+            }
 
             seen_upd_visible_all = true;
         }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -338,9 +338,8 @@ __wt_update_obsolete_check(
                 if (upd_visible_all_seen && upd->type == WT_UPDATE_BIRTHMARK)
                     first = prev;
                 /*
-                 * We cannot discard the birthmark if it is the first globally visible update as
-                 * the previous updates can be aborted resulting the entire update chain being
-                 * removed.
+                 * We cannot discard the birthmark if it is the first globally visible update as the
+                 * previous updates can be aborted resulting the entire update chain being removed.
                  */
                 else if (upd->type == WT_UPDATE_BIRTHMARK || WT_UPDATE_DATA_VALUE(upd))
                     first = upd;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -292,7 +292,7 @@ __wt_update_obsolete_check(
     size_t size;
     uint64_t oldest, stable;
     u_int count, upd_seen, upd_unstable;
-    bool visible_all_before;
+    bool seen_upd_visible_all;
 
     txn_global = &S2C(session)->txn_global;
 
@@ -315,7 +315,7 @@ __wt_update_obsolete_check(
      * first globally visible update as the previous updates can be aborted and be freed causing the
      * entire update chain being removed.
      */
-    for (first = prev = NULL, visible_all_before = false, count = 0; upd != NULL;
+    for (first = prev = NULL, seen_visible_all = false, count = 0; upd != NULL;
          prev = upd, upd = upd->next, count++) {
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
@@ -331,11 +331,11 @@ __wt_update_obsolete_check(
                 ++upd_unstable;
         } else {
             if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
-                first = visible_all_before ? prev : upd;
+                first = seen_upd_visible_all ? prev : upd;
             else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
                 first = upd;
 
-            visible_all_before = true;
+            seen_upd_visible_all = true;
         }
     }
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -330,13 +330,10 @@ __wt_update_obsolete_check(
             if (upd->start_ts != WT_TS_NONE && upd->start_ts >= oldest && upd->start_ts < stable)
                 ++upd_unstable;
         } else {
-            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK) {
+            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
                 first = upd_visible_all_seen ? prev : upd;
-                break;
-            } else if (first == NULL && WT_UPDATE_DATA_VALUE(upd)) {
+            else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
                 first = upd;
-                break;
-            }
 
             upd_visible_all_seen = true;
         }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -292,6 +292,7 @@ __wt_update_obsolete_check(
     size_t size;
     uint64_t oldest, stable;
     u_int count, upd_seen, upd_unstable;
+    bool visible_all_before;
 
     txn_global = &S2C(session)->txn_global;
 
@@ -307,14 +308,18 @@ __wt_update_obsolete_check(
      *
      * Only updates with globally visible, self-contained data can terminate update chains.
      *
-     * Birthmarks are a special case: once a birthmark becomes obsolete, it can be discarded and
-     * subsequent reads will see the on-page value (as expected). Inserting updates into the
-     * lookaside table relies on this behavior to avoid creating update chains with multiple
-     * birthmarks.
+     * Birthmarks are a special case: once a birthmark becomes obsolete, it can be discarded if
+     * there is an update visible to all sessions before it and subsequent reads will see the
+     * on-page value (as expected). Inserting updates into the lookaside table relies on this
+     * behavior to avoid creating update chains with multiple birthmarks. We cannot discard the
+     * birthmark if it's the first globally visible update as the previous updates can be aborted
+     * and be freed as well causing the entire update chain being removed.
      */
-    for (first = prev = NULL, count = 0; upd != NULL; prev = upd, upd = upd->next, count++) {
+    for (first = prev = NULL, visible_all_before = false, count = 0; upd != NULL;
+         prev = upd, upd = upd->next, count++) {
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
+
         ++upd_seen;
         if (!__wt_txn_upd_visible_all(session, upd)) {
             first = NULL;
@@ -324,10 +329,13 @@ __wt_update_obsolete_check(
              */
             if (upd->start_ts != WT_TS_NONE && upd->start_ts >= oldest && upd->start_ts < stable)
                 ++upd_unstable;
-        } else if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
-            first = prev;
-        else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
-            first = upd;
+        } else {
+            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK && visible_all_before)
+                first = prev;
+            else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
+                first = upd;
+            visible_all_before = true;
+        }
     }
 
     __wt_cache_update_lookaside_score(session, upd_seen, upd_unstable);

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -315,7 +315,7 @@ __wt_update_obsolete_check(
      * first globally visible update as the previous updates can be aborted and be freed causing the
      * entire update chain being removed.
      */
-    for (first = prev = NULL, seen_visible_all = false, count = 0; upd != NULL;
+    for (first = prev = NULL, seen_upd_visible_all = false, count = 0; upd != NULL;
          prev = upd, upd = upd->next, count++) {
         if (upd->txnid == WT_TXN_ABORTED)
             continue;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -330,10 +330,11 @@ __wt_update_obsolete_check(
             if (upd->start_ts != WT_TS_NONE && upd->start_ts >= oldest && upd->start_ts < stable)
                 ++upd_unstable;
         } else {
-            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK && visible_all_before)
-                first = prev;
+            if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK)
+                first = visible_all_before ? prev : upd;
             else if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
                 first = upd;
+
             visible_all_before = true;
         }
     }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -338,7 +338,7 @@ __wt_update_obsolete_check(
                 if (upd_visible_all_seen && upd->type == WT_UPDATE_BIRTHMARK)
                     first = prev;
                 /*
-                 * We cannot discard the birthemark if it is the first golbally visible update as
+                 * We cannot discard the birthmark if it is the first globally visible update as
                  * the previous updates can be aborted resulting the entire update chain being
                  * removed.
                  */

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -292,7 +292,7 @@ __wt_update_obsolete_check(
     size_t size;
     uint64_t oldest, stable;
     u_int count, upd_seen, upd_unstable;
-    bool seen_upd_visible_all;
+    bool upd_visible_all_seen;
 
     txn_global = &S2C(session)->txn_global;
 
@@ -315,7 +315,7 @@ __wt_update_obsolete_check(
      * first globally visible update as the previous updates can be aborted and be freed causing the
      * entire update chain being removed.
      */
-    for (first = prev = NULL, seen_upd_visible_all = false, count = 0; upd != NULL;
+    for (first = prev = NULL, upd_visible_all_seen = false, count = 0; upd != NULL;
          prev = upd, upd = upd->next, count++) {
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
@@ -331,14 +331,14 @@ __wt_update_obsolete_check(
                 ++upd_unstable;
         } else {
             if (first == NULL && upd->type == WT_UPDATE_BIRTHMARK) {
-                first = seen_upd_visible_all ? prev : upd;
+                first = upd_visible_all_seen ? prev : upd;
                 break;
             } else if (first == NULL && WT_UPDATE_DATA_VALUE(upd)) {
                 first = upd;
                 break;
             }
 
-            seen_upd_visible_all = true;
+            upd_visible_all_seen = true;
         }
     }
 


### PR DESCRIPTION
Obsolete birthmark cannot be freed if it follows a set of uncommitted
updates as the uncommitted updates can be aborted and freed causing the
entire update chain being removed in this case.

Birthmark can be discarded only if there is an update that is globally visible before it.