### PR TITLE
WT-5217 Write utility to generate operation tracking log from X-Ray trace

### DIFF
--- a/build_posix/Make.subdirs
+++ b/build_posix/Make.subdirs
@@ -47,3 +47,6 @@ test/thread
 # Benchmark programs.
 bench/workgen PYTHON HAVE_CXX
 bench/wtperf
+
+# Utility programs.
+tools/xray_to_optrack LLVM HAVE_CXX

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -275,4 +275,21 @@ no)	wt_cv_crc32_hardware=no
 	AC_MSG_RESULT(no);;
 esac
 
+AC_MSG_CHECKING(if --enable-llvm option specified)
+AC_ARG_ENABLE(llvm,
+	[AS_HELP_STRING([--enable-llvm],
+	    [Configure with LLVM.])], r=$enableval, r=no)
+case "$r" in
+no)	wt_cv_enable_llvm=no;;
+*)	wt_cv_enable_llvm=yes;;
+esac
+AC_MSG_RESULT($wt_cv_enable_llvm)
+AM_CONDITIONAL([LLVM], [test x$wt_cv_enable_llvm = xyes])
+
+AC_MSG_CHECKING(if --with-llvm-config option specified)
+AC_ARG_WITH(llvm-config,
+	[AS_HELP_STRING([--with-llvm-config=DIR],
+	    [Path to LLVM config.])])
+AC_MSG_RESULT($with_llvm_config)
+
 ])

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -284,12 +284,14 @@ no)	wt_cv_enable_llvm=no;;
 *)	wt_cv_enable_llvm=yes;;
 esac
 AC_MSG_RESULT($wt_cv_enable_llvm)
+if test "$wt_cv_enable_llvm" = "yes"; then
+	AC_CHECK_PROG(wt_cv_llvm_config, llvm-config, yes)
+	if test "$wt_cv_llvm_config" != "yes"; then
+		AC_MSG_ERROR([--enable-llvm requires llvm-config])
+	fi
+	if ! test $(llvm-config --version | grep "^8"); then
+		AC_MSG_ERROR([llvm-config must be version 8])
+	fi
+fi
 AM_CONDITIONAL([LLVM], [test x$wt_cv_enable_llvm = xyes])
-
-AC_MSG_CHECKING(if --with-llvm-config option specified)
-AC_ARG_WITH(llvm-config,
-	[AS_HELP_STRING([--with-llvm-config=DIR],
-	    [Path to LLVM config.])])
-AC_MSG_RESULT($with_llvm_config)
-
 ])

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -162,14 +162,6 @@ if test "$wt_cv_enable_python" = "yes"; then
 	AC_SUBST(PYTHON_INSTALL_ARG)
 fi
 
-LLVM_CONFIG=llvm-config
-if test "$wt_cv_enable_llvm" = "yes"; then
-	if test -n "$with_llvm_config"; then
-        	LLVM_CONFIG="$with_llvm_config"
-        fi
-fi
-AC_SUBST(LLVM_CONFIG)
-
 AM_TYPES
 
 AC_PROG_INSTALL

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -162,6 +162,14 @@ if test "$wt_cv_enable_python" = "yes"; then
 	AC_SUBST(PYTHON_INSTALL_ARG)
 fi
 
+LLVM_CONFIG=llvm-config
+if test "$wt_cv_enable_llvm" = "yes"; then
+	if test -n "$with_llvm_config"; then
+        	LLVM_CONFIG="$with_llvm_config"
+        fi
+fi
+AC_SUBST(LLVM_CONFIG)
+
 AM_TYPES
 
 AC_PROG_INSTALL

--- a/tools/xray_to_optrack/Makefile.am
+++ b/tools/xray_to_optrack/Makefile.am
@@ -1,0 +1,5 @@
+AM_CPPFLAGS = `$(LLVM_CONFIG) --cxxflags --libs core`
+AM_LDFLAGS = `$(LLVM_CONFIG) --ldflags --libs core`
+
+noinst_PROGRAMS = xray_to_optrack
+xray_to_optrack_SOURCES = xray_to_optrack.cxx

--- a/tools/xray_to_optrack/Makefile.am
+++ b/tools/xray_to_optrack/Makefile.am
@@ -1,5 +1,5 @@
-AM_CPPFLAGS = `$(LLVM_CONFIG) --cxxflags --libs core`
-AM_LDFLAGS = `$(LLVM_CONFIG) --ldflags --libs core`
+AM_CPPFLAGS = `llvm-config --cxxflags --libs core`
+AM_LDFLAGS = `llvm-config --ldflags --libs core`
 
 noinst_PROGRAMS = xray_to_optrack
 xray_to_optrack_SOURCES = xray_to_optrack.cxx

--- a/tools/xray_to_optrack/xray_to_optrack.cxx
+++ b/tools/xray_to_optrack/xray_to_optrack.cxx
@@ -1,3 +1,31 @@
+/*-
+ * Public Domain 2014-2019 MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
 #include <llvm/XRay/InstrumentationMap.h>

--- a/tools/xray_to_optrack/xray_to_optrack.cxx
+++ b/tools/xray_to_optrack/xray_to_optrack.cxx
@@ -1,0 +1,153 @@
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/DebugInfo/Symbolize/Symbolize.h>
+#include <llvm/XRay/InstrumentationMap.h>
+#include <llvm/XRay/Trace.h>
+
+#include <fstream>
+#include <sstream>
+
+namespace xray_to_optrack {
+
+/*
+ * make_error --
+ *     Helper for creating LLVM StringErrors.
+ */
+static llvm::Error
+make_error(const std::string &msg)
+{
+    return llvm::make_error<llvm::StringError>(msg, llvm::inconvertibleErrorCode());
+}
+
+/*
+ * xray_to_optrack_record_type --
+ *     Convert from an XRay log record type to an OpTrack log record type.
+ */
+static llvm::Expected<int>
+xray_to_optrack_record_type(const llvm::xray::RecordTypes record_type)
+{
+    switch (record_type) {
+    case llvm::xray::RecordTypes::ENTER:
+        return 0;
+    case llvm::xray::RecordTypes::EXIT:
+    case llvm::xray::RecordTypes::TAIL_EXIT:
+        return 1;
+    default: {
+        std::stringstream ss;
+        ss << "Unexpected record type \"" << static_cast<unsigned>(record_type) << "\"";
+        return make_error(ss.str());
+    }
+    }
+}
+
+/*
+ * write_optrack_record --
+ *     Write an OpTrack record to a log file.
+ */
+static void
+write_optrack_record(std::ofstream &os, int record_type, const std::string &func_name, uint64_t tsc)
+{
+    os << record_type << " " << func_name << " " << tsc << "\n";
+}
+
+/*
+ * symbolize_func_id --
+ *    Symbolize the full function name for a given XRay function id.
+ */
+static llvm::Expected<std::string>
+symbolize_func_id(uint32_t func_id, const std::string &instr_map,
+  llvm::symbolize::LLVMSymbolizer &symbolizer,
+  const std::unordered_map<int32_t, uint64_t> &address_map,
+  llvm::DenseMap<uint32_t, std::string> &cache)
+{
+    const auto cache_iter = cache.find(func_id);
+    if (cache_iter != cache.end())
+        return cache_iter->second;
+    const auto iter = address_map.find(func_id);
+    if (iter == address_map.end()) {
+        std::stringstream ss;
+        ss << "Found function id \"" << func_id << "\" without a corresponding address";
+        return make_error(ss.str());
+    }
+    auto res = symbolizer.symbolizeCode(instr_map, iter->second);
+    if (!res)
+        return res.takeError();
+    if (res->FunctionName == "<invalid>") {
+        std::stringstream ss;
+        ss << "Could not symbolize id \"" << func_id << "\", address \"" << iter->second << "\"";
+        return make_error(ss.str());
+    }
+    cache.try_emplace(func_id, res->FunctionName);
+    return res->FunctionName;
+}
+
+/*
+ * generate_optrack_log_name --
+ *     Create a filename for an OpTrack log given its process id and thread id. The filename is in
+ *     the format "optrack_<pid>_<tid>".
+ */
+static std::string
+generate_optrack_log_name(uint32_t process_id, uint32_t thread_id)
+{
+    std::stringstream ss;
+    ss << "optrack_" << process_id << "_" << thread_id;
+    return ss.str();
+}
+
+/*
+ * xray_to_optrack --
+ *     Write an OpTrack log for each thread given an XRay log and instrumentation map.
+ */
+static llvm::Error
+xray_to_optrack(const std::string &instr_map, const std::string &input)
+{
+    auto map = llvm::xray::loadInstrumentationMap(instr_map);
+    if (!map)
+        return map.takeError();
+    auto trace = llvm::xray::loadTraceFile(input);
+    if (!trace)
+        return trace.takeError();
+    llvm::symbolize::LLVMSymbolizer symbolizer;
+    llvm::DenseMap<uint32_t, std::string> cache;
+    llvm::DenseMap<uint32_t, std::ofstream> files;
+    for (const llvm::xray::XRayRecord &record : *trace) {
+        auto file_iter = files.find(record.TId);
+        if (file_iter == files.end()) {
+            std::ofstream file(generate_optrack_log_name(record.PId, record.TId));
+            if (!file) {
+                std::stringstream ss;
+                ss << "Failed to write OpTrack log for process id \"" << record.PId
+                   << "\", thread id \"" << record.TId << "\"";
+                return make_error(ss.str());
+            }
+            auto res = files.try_emplace(record.TId, std::move(file));
+            file_iter = res.first;
+        }
+        assert(file_iter != files.end());
+        auto record_type = xray_to_optrack_record_type(record.Type);
+        if (!record_type)
+            return record_type.takeError();
+        auto func_name = symbolize_func_id(
+          record.FuncId, instr_map, symbolizer, map->getFunctionAddresses(), cache);
+        if (!func_name)
+            return func_name.takeError();
+        write_optrack_record(file_iter->second, *record_type, *func_name, record.TSC);
+    }
+    return llvm::Error::success();
+}
+
+} // namespace xray_to_optrack
+
+int
+main(int argc, char **argv)
+{
+    if (argc != 3) {
+        llvm::errs() << "Usage: xray_to_optrack <instr_map> <xray_log>\n";
+        return EXIT_FAILURE;
+    }
+    auto error = xray_to_optrack::xray_to_optrack(argv[1], argv[2]);
+    if (error) {
+        llvm::errs() << "Error: " << error << ".\n";
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Added an `xray_to_optrack` utility program to convert from XRay logs to the OpTrack format. I'm currently building with `../configure --enable-llvm --with-llvm-config=llvm-config-8`.

One issue that I'm seeing is that `xray_to_optrack` generates very big OpTrack logs. The `find-latency-spikes.py` seemed to handle it ok despite taking a while but `optrack_to_t2.py` never finished for me and I waited quite a while. This makes sense to me since I think OpTrack logs have historically been used to instrument a few functions of interest whereas by default, XRay will instrument anything that compiles down to more than 200 instructions. To make this more manageable, we might have to manually choose a set of functions to instrument when building with XRay. We can do it either with function attributes or with a special case file.

<img width="1545" alt="Screen Shot 2019-11-09 at 2 00 52 am" src="https://user-images.githubusercontent.com/30496335/68486994-6325e800-0296-11ea-879e-2c458dace7f1.png">