### PR TITLE
WT-5142 Don't create huge root pages when rebalancing or bulk-loading objects with overflow keys

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1161,10 +1161,10 @@ extern int __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
   WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
+extern int __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool forced)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len,
+  bool forced) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_split_finish(WT_SESSION_IMPL *session, WT_RECONCILE *r)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_split_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page,

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -141,18 +141,19 @@ struct __wt_reconcile {
         WT_ITEM image; /* disk-image */
     } chunkA, chunkB, *cur_ptr, *prev_ptr;
 
+    size_t disk_img_buf_size; /* Base size needed for a chunk memory image */
+
     /*
      * We track current information about the current record number, the number of entries copied
      * into the disk image buffer, where we are in the buffer, how much memory remains, and the
      * current min/max of the timestamps. Those values are packaged here rather than passing
      * pointers to stack locations around the code.
      */
-    uint64_t recno;      /* Current record number */
-    uint32_t entries;    /* Current number of entries */
-    uint8_t *first_free; /* Current first free byte */
-    size_t space_avail;  /* Remaining space in this chunk */
-    /* Remaining space in this chunk to put a minimum size boundary */
-    size_t min_space_avail;
+    uint64_t recno;         /* Current record number */
+    uint32_t entries;       /* Current number of entries */
+    uint8_t *first_free;    /* Current first free byte */
+    size_t space_avail;     /* Remaining space in this chunk */
+    size_t min_space_avail; /* Remaining space in this chunk to put a minimum size boundary */
 
     /*
      * Saved update list, supporting the WT_REC_UPDATE_RESTORE and WT_REC_LOOKASIDE configurations.

--- a/src/include/reconcile.i
+++ b/src/include/reconcile.i
@@ -9,8 +9,6 @@
 #define WT_CROSSING_MIN_BND(r, next_len) \
     ((r)->cur_ptr->min_offset == 0 && (next_len) > (r)->min_space_avail)
 #define WT_CROSSING_SPLIT_BND(r, next_len) ((next_len) > (r)->space_avail)
-#define WT_CHECK_CROSSING_BND(r, next_len) \
-    (WT_CROSSING_MIN_BND(r, next_len) || WT_CROSSING_SPLIT_BND(r, next_len))
 
 /*
  * __wt_rec_need_split --
@@ -19,23 +17,8 @@
 static inline bool
 __wt_rec_need_split(WT_RECONCILE *r, size_t len)
 {
-    /*
-     * In the case of a row-store leaf page, trigger a split if a threshold number of saved updates
-     * is reached. This allows pages to split for update/restore and lookaside eviction when there
-     * is no visible data causing the disk image to grow.
-     *
-     * In the case of small pages or large keys, we might try to split when a page has no updates or
-     * entries, which isn't possible. To consider update/restore or lookaside information, require
-     * either page entries or updates that will be attached to the image. The limit is one of
-     * either, but it doesn't make sense to create pages or images with few entries or updates, even
-     * where page sizes are small (especially as updates that will eventually become overflow items
-     * can throw off our calculations). Bound the combination at something reasonable.
-     */
-    if (r->page->type == WT_PAGE_ROW_LEAF && r->entries + r->supd_next > 10)
-        len += r->supd_memsize;
-
     /* Check for the disk image crossing a boundary. */
-    return (WT_CHECK_CROSSING_BND(r, len));
+    return (WT_CROSSING_MIN_BND(r, len) || WT_CROSSING_SPLIT_BND(r, len));
 }
 
 /*

--- a/src/include/reconcile.i
+++ b/src/include/reconcile.i
@@ -9,6 +9,8 @@
 #define WT_CROSSING_MIN_BND(r, next_len) \
     ((r)->cur_ptr->min_offset == 0 && (next_len) > (r)->min_space_avail)
 #define WT_CROSSING_SPLIT_BND(r, next_len) ((next_len) > (r)->space_avail)
+#define WT_CHECK_CROSSING_BND(r, next_len) \
+    (WT_CROSSING_MIN_BND(r, next_len) || WT_CROSSING_SPLIT_BND(r, next_len))
 
 /*
  * __wt_rec_need_split --
@@ -17,8 +19,23 @@
 static inline bool
 __wt_rec_need_split(WT_RECONCILE *r, size_t len)
 {
+    /*
+     * In the case of a row-store leaf page, trigger a split if a threshold number of saved updates
+     * is reached. This allows pages to split for update/restore and lookaside eviction when there
+     * is no visible data causing the disk image to grow.
+     *
+     * In the case of small pages or large keys, we might try to split when a page has no updates or
+     * entries, which isn't possible. To consider update/restore or lookaside information, require
+     * either page entries or updates that will be attached to the image. The limit is one of
+     * either, but it doesn't make sense to create pages or images with few entries or updates, even
+     * where page sizes are small (especially as updates that will eventually become overflow items
+     * can throw off our calculations). Bound the combination at something reasonable.
+     */
+    if (r->page->type == WT_PAGE_ROW_LEAF && r->entries + r->supd_next > 10)
+        len += r->supd_memsize;
+
     /* Check for the disk image crossing a boundary. */
-    return (WT_CROSSING_MIN_BND(r, len) || WT_CROSSING_SPLIT_BND(r, len));
+    return (WT_CHECK_CROSSING_BND(r, len));
 }
 
 /*

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -35,7 +35,7 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
              */
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
-            WT_RET(__wt_rec_split(session, r, 0));
+            WT_RET(__wt_rec_split(session, r, 0, false));
         }
         cbulk->entry = 0;
         cbulk->nrecs = WT_FIX_BYTES_TO_ENTRIES(btree, r->space_avail);
@@ -131,7 +131,7 @@ __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
 
     /* Boundary: split or write the page. */
     if (WT_CROSSING_SPLIT_BND(r, val->len))
-        WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len));
+        WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len, false));
 
     /* Copy the value onto the page. */
     if (btree->dictionary)
@@ -174,7 +174,7 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
         /* Boundary: split or write the page. */
         if (__wt_rec_need_split(r, val->len))
-            WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len));
+            WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len, false));
 
         /* Copy the value onto the page. */
         __wt_rec_image_copy(session, r, val);
@@ -298,7 +298,7 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
 
         /* Boundary: split or write the page. */
         if (__wt_rec_need_split(r, val->len))
-            WT_ERR(__wt_rec_split_crossing_bnd(session, r, val->len));
+            WT_ERR(__wt_rec_split_crossing_bnd(session, r, val->len, false));
 
         /* Copy the value onto the page. */
         __wt_rec_image_copy(session, r, val);
@@ -410,7 +410,7 @@ __wt_rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
              * last, allowing it to grow in the future.
              */
             __wt_rec_incr(session, r, entry, __bitstr_size((size_t)entry * btree->bitcnt));
-            WT_RET(__wt_rec_split(session, r, 0));
+            WT_RET(__wt_rec_split(session, r, 0, false));
 
             /* Calculate the number of entries per page. */
             entry = 0;
@@ -554,7 +554,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_SALVAGE_COOKI
 
     /* Boundary: split or write the page. */
     if (__wt_rec_need_split(r, val->len))
-        WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len));
+        WT_RET(__wt_rec_split_crossing_bnd(session, r, val->len, false));
 
     /* Copy the value onto the page. */
     if (!deleted && !overflow_type && btree->dictionary)

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -340,7 +340,6 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     r->cell_zero = true;
 
     page_image = 0;
-    key_onpage_ovfl = false;
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
@@ -500,10 +499,8 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
              * actual key. In that case, we have to build the key now because we are about to
              * promote it.
              */
-            if (key_onpage_ovfl) {
+            if (key_onpage_ovfl)
                 WT_ERR(__wt_buf_set(session, r->cur, WT_IKEY_DATA(ikey), ikey->size));
-                key_onpage_ovfl = false;
-            }
 
             WT_ERR(__wt_rec_split_crossing_bnd(session, r, key->len + val->len, force));
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -912,8 +912,7 @@ __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
  *     Initialize a single chunk structure.
  */
 static int
-__rec_split_chunk_init(
-  WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk, size_t memsize)
+__rec_split_chunk_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk)
 {
     chunk->recno = WT_RECNO_OOB;
     /* Don't touch the key item memory, that memory is reused. */
@@ -940,8 +939,9 @@ __rec_split_chunk_init(
      * In the case of fixed-length column-store, clear the entire buffer: fixed-length column-store
      * sets bits in bytes, where the bytes are assumed to initially be 0.
      */
-    WT_RET(__wt_buf_init(session, &chunk->image, memsize));
-    memset(chunk->image.mem, 0, r->page->type == WT_PAGE_COL_FIX ? memsize : WT_PAGE_HEADER_SIZE);
+    WT_RET(__wt_buf_init(session, &chunk->image, r->disk_img_buf_size));
+    memset(chunk->image.mem, 0,
+      r->page->type == WT_PAGE_COL_FIX ? r->disk_img_buf_size : WT_PAGE_HEADER_SIZE);
 
     return (0);
 }
@@ -958,7 +958,7 @@ __wt_rec_split_init(
     WT_BTREE *btree;
     WT_REC_CHUNK *chunk;
     WT_REF *ref;
-    size_t corrected_page_size, disk_img_buf_size;
+    size_t corrected_page_size;
 
     btree = S2BT(session);
     bm = btree->bm;
@@ -1030,10 +1030,10 @@ __wt_rec_split_init(
      */
     corrected_page_size = r->page_size;
     WT_RET(bm->write_size(bm, session, &corrected_page_size));
-    disk_img_buf_size = WT_ALIGN(WT_MAX(corrected_page_size, r->split_size), btree->allocsize);
+    r->disk_img_buf_size = WT_ALIGN(WT_MAX(corrected_page_size, r->split_size), btree->allocsize);
 
     /* Initialize the first split chunk. */
-    WT_RET(__rec_split_chunk_init(session, r, &r->chunkA, disk_img_buf_size));
+    WT_RET(__rec_split_chunk_init(session, r, &r->chunkA));
     r->cur_ptr = &r->chunkA;
     r->prev_ptr = NULL;
 
@@ -1226,16 +1226,13 @@ __rec_split_grow(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t add_len)
  *     in a row? Sweet-tooth does, too.)
  */
 int
-__wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
+__wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool forced)
 {
     WT_BTREE *btree;
     WT_REC_CHUNK *tmp;
     size_t inuse;
 
     btree = S2BT(session);
-
-    /* Fixed length col store can call with next_len 0 */
-    WT_ASSERT(session, next_len == 0 || __wt_rec_need_split(r, next_len));
 
     /*
      * We should never split during salvage, and we're about to drop core because there's no parent
@@ -1245,14 +1242,12 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
         WT_PANIC_RET(session, WT_PANIC, "%s page too large, attempted split during salvage",
           __wt_page_type_string(r->page->type));
 
-    inuse = WT_PTRDIFF(r->first_free, r->cur_ptr->image.mem);
-
     /*
-     * We can get here if the first key/value pair won't fit. Additionally, grow the buffer to
-     * contain the current item if we haven't already consumed a reasonable portion of a split
-     * chunk.
+     * We can get here if the first key/value pair won't fit. Grow the buffer to contain the current
+     * item if we haven't already consumed a reasonable portion of a split chunk.
      */
-    if (inuse < r->split_size / 2 && !__wt_rec_need_split(r, 0))
+    inuse = WT_PTRDIFF(r->first_free, r->cur_ptr->image.mem);
+    if (!forced && inuse < r->split_size / 2)
         goto done;
 
     /* All page boundaries reset the dictionary. */
@@ -1263,27 +1258,33 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
     r->cur_ptr->image.size = inuse;
 
     /*
-     * In case of bulk load, write out chunks as we get them. Otherwise we keep two chunks in memory
-     * at a given time. So, if there is a previous chunk, write it out, making space in the buffer
-     * for the next chunk to be written.
+     * Normally we keep two chunks in memory at a given time, and we write the previous chunk at
+     * each boundary, switching the previous and current check references. The exception is when
+     * doing a bulk load or a forced split, where we write out the chunks as we get them.
      */
     if (r->is_bulk_load)
         WT_RET(__rec_split_write(session, r, r->cur_ptr, NULL, false));
     else {
-        if (r->prev_ptr == NULL) {
-            WT_RET(__rec_split_chunk_init(session, r, &r->chunkB, r->cur_ptr->image.memsize));
-            r->prev_ptr = &r->chunkB;
-        } else
+        if (r->prev_ptr != NULL)
             WT_RET(__rec_split_write(session, r, r->prev_ptr, NULL, false));
 
-        /* Switch chunks. */
-        tmp = r->prev_ptr;
-        r->prev_ptr = r->cur_ptr;
-        r->cur_ptr = tmp;
+        if (forced) {
+            WT_RET(__rec_split_write(session, r, r->cur_ptr, NULL, false));
+            r->prev_ptr = NULL;
+            r->cur_ptr = &r->chunkA;
+        } else {
+            if (r->prev_ptr == NULL) {
+                WT_RET(__rec_split_chunk_init(session, r, &r->chunkB));
+                r->prev_ptr = &r->chunkB;
+            }
+            tmp = r->prev_ptr;
+            r->prev_ptr = r->cur_ptr;
+            r->cur_ptr = tmp;
+        }
     }
 
     /* Initialize the next chunk, including the key. */
-    WT_RET(__rec_split_chunk_init(session, r, r->cur_ptr, 0));
+    WT_RET(__rec_split_chunk_init(session, r, r->cur_ptr));
     r->cur_ptr->recno = r->recno;
     if (btree->type == BTREE_ROW)
         WT_RET(__rec_split_row_promote(session, r, &r->cur_ptr->key, r->page->type));
@@ -1321,16 +1322,14 @@ done:
  *     Save the details for the minimum split size boundary or call for a split.
  */
 int
-__wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
+__wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool forced)
 {
-    WT_ASSERT(session, __wt_rec_need_split(r, next_len));
-
     /*
      * If crossing the minimum split size boundary, store the boundary details at the current
      * location in the buffer. If we are crossing the split boundary at the same time, possible when
      * the next record is large enough, just split at this point.
      */
-    if (WT_CROSSING_MIN_BND(r, next_len) && !WT_CROSSING_SPLIT_BND(r, next_len) &&
+    if (!forced && WT_CROSSING_MIN_BND(r, next_len) && !WT_CROSSING_SPLIT_BND(r, next_len) &&
       !__wt_rec_need_split(r, 0)) {
         /*
          * If the first record doesn't fit into the minimum split size, we end up here. Write the
@@ -1361,7 +1360,7 @@ __wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t ne
     }
 
     /* We are crossing a split boundary */
-    return (__wt_rec_split(session, r, next_len));
+    return (__wt_rec_split(session, r, next_len, forced));
 }
 
 /*
@@ -1417,7 +1416,7 @@ __rec_split_finish_process_prev(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         tmp = r->prev_ptr;
         r->prev_ptr = r->cur_ptr;
         r->cur_ptr = tmp;
-        return (__rec_split_chunk_init(session, r, r->prev_ptr, 0));
+        return (__rec_split_chunk_init(session, r, r->prev_ptr));
     }
 
     if (prev_ptr->min_offset != 0 && cur_ptr->image.size < r->min_split_size) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1247,7 +1247,7 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool 
      * item if we haven't already consumed a reasonable portion of a split chunk.
      */
     inuse = WT_PTRDIFF(r->first_free, r->cur_ptr->image.mem);
-    if (!forced && inuse < r->split_size / 2)
+    if (!forced && inuse < r->split_size / 2 && !__wt_rec_need_split(r, 0))
         goto done;
 
     /* All page boundaries reset the dictionary. */


### PR DESCRIPTION
@agorrod, I ended up drilling the hole that allows callers of the reconciliation split code to force a split regardless of the current disk image size. I found a path I don't think is too ugly, and so avoid the retry logic we discussed (and which neither of us particularly liked). I like this approach better because I think it's reasonable for future work to want to force a split in a similar way, and this moves reconciliation in a more generally useful direction than the retry implementation would.

@sulabhM, these changes are primarily in the split code you & I wrote awhile back. The idea is that a caller can force the underlying code to split regardless of the current size of the disk image.

One relatively subtle change is [at line 1255 in rec_write.c](https://github.com/wiredtiger/wiredtiger/blob/develop/src/reconcile/rec_write.c#L1255):
I removed the `!__wt_rec_need_split(r, 0)` clause because I couldn't think of any reason it could be needed. Please review that change carefully.

EDIT:
I have restored the `!__wt_rec_need_split(r, 0)` clause, removing it fundamentally changed eviction characteristics, which isn't the point of this ticket.