### PR TITLE
WT-5196 data mismatch with las sweep

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1032,7 +1032,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
     cache = S2C(session)->cache;
     cursor = NULL;
     sweep_key = &cache->las_sweep_key;
-    saved_isolation = 0; /*[-Wconditional-uninitialized] */
     remove_cnt = 0;
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
     local_txn = locked = removing_key_block = false;
@@ -1052,8 +1051,8 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
      */
     __wt_las_cursor(session, &cursor, &session_flags);
     WT_ASSERT(session, cursor->session == &session->iface);
-    WT_ERR(__wt_txn_begin(session, NULL));
     __las_set_isolation(session, &saved_isolation);
+    WT_ERR(__wt_txn_begin(session, NULL));
     local_txn = true;
 
     /* Encourage a race */
@@ -1230,11 +1229,11 @@ err:
             ret = __wt_txn_commit(session, NULL);
         else
             WT_TRET(__wt_txn_rollback(session, NULL));
-        __las_restore_isolation(session, saved_isolation);
         if (ret == 0)
             (void)__wt_atomic_add64(&cache->las_remove_count, remove_cnt);
     }
 
+    __las_restore_isolation(session, saved_isolation);
     WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
 
     if (locked)

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1020,7 +1020,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_ITEM las_key, las_value;
     WT_ITEM *sweep_key;
-    WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t durable_timestamp, las_timestamp;
     uint64_t cnt, remove_cnt, las_pageid, saved_pageid, visit_cnt;
     uint64_t las_counter, las_txnid;
@@ -1051,7 +1050,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
      */
     __wt_las_cursor(session, &cursor, &session_flags);
     WT_ASSERT(session, cursor->session == &session->iface);
-    __las_set_isolation(session, &saved_isolation);
     WT_ERR(__wt_txn_begin(session, NULL));
     local_txn = true;
 
@@ -1233,7 +1231,6 @@ err:
             (void)__wt_atomic_add64(&cache->las_remove_count, remove_cnt);
     }
 
-    __las_restore_isolation(session, saved_isolation);
     WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
 
     if (locked)


### PR DESCRIPTION
Let the LAS sweep work under "read committed" isolation

Earlier, LAS sweep working under "read uncommitted" isolation can find the
LAS records that are even not committed. The LAS sweep does the
cleanup based on the first record that is present for the key.
As the LAS sweep operates in "read uncommitted" mode, sometimes
even when the entire record chain for the key is not finished
insertion, the LAS sweep may clean the part of the update chain
as it finds them as obsolete. This leads to missing update chain
records and that leads to record miss.

To solve this problem, let the LAS sweep to work under "read committed"
isolation level, that leads to non-visibility of records from a running transaction.