### PR TITLE
WT-5233 Perform a full lookaside instantiation for a page if it has prepared updates

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -206,8 +206,11 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
     birthmark_record = false;
     locked = false;
 
-    /* Check whether the disk image contains all the newest versions of the page. */
-    if (page_las->min_skipped_ts == WT_TS_MAX) {
+    /*
+     * Check whether the disk image contains all the newest versions of the page. If the lookaside
+     * contains prepared updates for this page, we need to check it regardless.
+     */
+    if (page_las->min_skipped_ts == WT_TS_MAX && !page_las->has_prepares) {
         WT_RET(__instantiate_birthmarks(session, ref));
 
         if (page->modify != NULL) {
@@ -223,7 +226,7 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
              * all older and we could consider marking it clean (i.e., the next checkpoint can use
              * the version already on disk).
              */
-            if (!page_las->has_prepares && !S2C(session)->txn_global.has_stable_timestamp &&
+            if (!S2C(session)->txn_global.has_stable_timestamp &&
               __wt_txn_visible_all(session, page_las->max_txn, page_las->max_ondisk_ts)) {
                 page->modify->rec_max_txn = page_las->max_txn;
                 page->modify->rec_max_timestamp = page_las->max_ondisk_ts;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1815,8 +1815,9 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
     WT_PAGE_LOOKASIDE *orig_page_las;
     size_t addr_size, compressed_size;
     uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
+    bool block_las_evict;
 #ifdef HAVE_DIAGNOSTIC
-    bool block_las_evict, verify_image;
+    bool verify_image;
 #endif
 
     btree = S2BT(session);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1823,7 +1823,6 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
     btree = S2BT(session);
     page = r->page;
     orig_page_las = r->ref->page_las;
-    block_las_evict = false;
 #ifdef HAVE_DIAGNOSTIC
     verify_image = true;
 #endif


### PR DESCRIPTION
The reason we were not getting a `WT_PREPARE_CONFLICT` is because the `min_skipped_ts` doesn't get written to for prepared updates on eviction. Therefore in the case where we have a single prepared update in lookaside, we don't bother doing a full instantiation because we (incorrectly) think that the on-disk value is the newest.

@sulabhM In `cache_las.c`, I see the condition `ref->page_las->has_prepares && ref->page_las->min_skipped_ts == WT_TS_MAX` a few times which makes me think that this is the correct spot for the fix (as opposed to writing to `min_skipped_ts` even in the prepare case which I was considering).