### PR TITLE
WT-5220 Re-enable LAS dropped table change from WT-5150

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -967,11 +967,8 @@ __las_sweep_init(WT_SESSION_IMPL *session)
     /*
      * If no files have been dropped and the lookaside file is empty, there's nothing to do.
      */
-    if (cache->las_dropped_next == 0) {
-        if (__wt_las_empty(session))
-            ret = WT_NOTFOUND;
-        goto err;
-    }
+    if (cache->las_dropped_next == 0 && __wt_las_empty(session))
+        WT_ERR(WT_NOTFOUND);
 
     /*
      * Record the current page ID: sweep will stop after this point.


### PR DESCRIPTION

This reverts commit fb527a54117f3865aae8a25557849f1228d48205.

WT-5193 has reverted the change in WT-5150 as it leads to data mismatch
problems with checkpoint. WT-5196 addresses the data mismatch problem
even when the las sweep is enabled. Reenable the LAS sweep.