### PR TITLE
WT-5119 Add debugging for difficult data mismatch failures.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -210,6 +210,7 @@ Kanowski's
 Kounavis
 LANGID
 LAS
+LASdump
 LF
 LLLLLL
 LLLLLLL

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -175,7 +175,7 @@ __las_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Allocate the WT_UPDATE structure. */
         WT_ERR(cursor->get_value(cursor, &las_txnid, &las_timestamp, &durable_timestamp,
           &prepare_state, &upd_type, &las_value));
-        WT_ERR(__wt_update_alloc(session, &las_value, &upd, &incr, upd_type));
+        WT_ERR(__wt_update_alloc(session, &las_value, &upd, &incr, upd_type, 0x3ad01));
         total_incr += incr;
         upd->txnid = las_txnid;
         upd->durable_ts = durable_timestamp;

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -128,7 +128,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
         WT_ERR(__wt_txn_update_check(session, old_upd = cbt->ins->upd));
 
         /* Allocate a WT_UPDATE structure and transaction ID. */
-        WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type));
+        WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type, 0xc01));
         WT_ERR(__wt_txn_modify(session, upd));
         logged = true;
 
@@ -179,7 +179,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
             (recno != WT_RECNO_OOB && mod->mod_col_split_recno > recno));
 
         if (upd_arg == NULL) {
-            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type));
+            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type, 0xc02));
             WT_ERR(__wt_txn_modify(session, upd));
             logged = true;
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -91,7 +91,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
             WT_ERR(__wt_txn_update_check(session, old_upd = *upd_entry));
 
             /* Allocate a WT_UPDATE structure and transaction ID. */
-            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type));
+            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type, 0xadd01));
             WT_ERR(__wt_txn_modify(session, upd));
             logged = true;
 
@@ -152,7 +152,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
         cbt->ins = ins;
 
         if (upd_arg == NULL) {
-            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type));
+            WT_ERR(__wt_update_alloc(session, value, &upd, &upd_size, modify_type, 0xadd02));
             WT_ERR(__wt_txn_modify(session, upd));
             logged = true;
 
@@ -247,7 +247,7 @@ __wt_row_insert_alloc(WT_SESSION_IMPL *session, const WT_ITEM *key, u_int skipde
  */
 int
 __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **updp, size_t *sizep,
-  u_int modify_type)
+  u_int modify_type, uint32_t alloc_id)
 {
     WT_UPDATE *upd;
 
@@ -273,6 +273,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
         }
     }
     upd->type = (uint8_t)modify_type;
+    upd->alloc_id = alloc_id;
 
     *updp = upd;
     *sizep = WT_UPDATE_MEMSIZE(upd);

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -741,11 +741,28 @@ __wt_las_insert_block(
             if (upd == list->onpage_upd && upd->size > 0 &&
               (upd->type == WT_UPDATE_STANDARD || upd->type == WT_UPDATE_MODIFY)) {
                 las_value.size = 0;
+                __wt_errx(session, "LAS_INS: birthmark ZERO txn id %" PRIu64 " start_ts %" PRIu64
+                                   " type %d"
+                                   " key pg_id %" PRIu64,
+                  " btree %" PRIu32, " LAS cnt %" PRIu64, upd->txnid, upd->start_ts, (int)upd->type,
+                  las_pageid, btree_id, las_counter);
                 cursor->set_value(cursor, upd->txnid, upd->start_ts, upd->durable_ts,
                   upd->prepare_state, WT_UPDATE_BIRTHMARK, &las_value);
-            } else
+            } else {
+                if (upd->size == 0 && upd->txnid != WT_TXN_NONE)
+                    __wt_errx(session,
+                      "LAS_INS: ZERO txn id %" PRIu64 " start_ts %" PRIu64 " type %d",
+                      " key pg_id %" PRIu64, " btree %" PRIu32, " LAS cnt %" PRIu64, upd->txnid,
+                      upd->start_ts, (int)upd->type, las_pageid, btree_id, las_counter);
+                else
+                    __wt_errx(session,
+                      "LAS_INS: txn id %" PRIu64 " start_ts %" PRIu64 " type %d size %d",
+                      " key pg_id %" PRIu64, " btree %" PRIu32, " LAS cnt %" PRIu64, upd->txnid,
+                      upd->start_ts, (int)upd->type, (int)upd->size, las_pageid, btree_id,
+                      las_counter);
                 cursor->set_value(cursor, upd->txnid, upd->start_ts, upd->durable_ts,
                   upd->prepare_state, upd->type, &las_value);
+            }
 
             /*
              * Using update instead of insert so the page stays pinned and can be searched before

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1069,14 +1069,16 @@ struct __wt_ikey {
  *	formed into a forward-linked list.
  */
 struct __wt_update {
-    volatile uint64_t txnid; /* transaction ID */
+    volatile uint64_t txnid;      /* transaction ID */
+    volatile uint64_t orig_txnid; /* transaction ID */
 
     wt_timestamp_t durable_ts; /* timestamps */
     wt_timestamp_t start_ts;
 
     WT_UPDATE *next; /* forward-linked list */
 
-    uint32_t size; /* data length */
+    uint32_t size;     /* data length */
+    uint32_t alloc_id; /* allocation location */
 
 #define WT_UPDATE_INVALID 0   /* diagnostic check */
 #define WT_UPDATE_BIRTHMARK 1 /* transaction for on-page value */
@@ -1107,7 +1109,11 @@ struct __wt_update {
  * WT_UPDATE_SIZE is the expected structure size excluding the payload data -- we verify the build
  * to ensure the compiler hasn't inserted padding.
  */
+#if 0
 #define WT_UPDATE_SIZE 38
+#else
+#define WT_UPDATE_SIZE 50
+#endif
 
 /*
  * The memory size of an update: include some padding because this is such a common case that

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -572,6 +572,8 @@ extern int __wt_debug_addr(WT_SESSION_IMPL *session, const uint8_t *addr, size_t
   const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_addr_print(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_cursor_las(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
+  (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_cursor_page(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_disk(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, const char *ofile)
@@ -1483,7 +1485,8 @@ extern int __wt_unexpected_object_type(
   WT_SESSION_IMPL *session, const char *uri, const char *expect) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **updp,
-  size_t *sizep, u_int modify_type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  size_t *sizep, u_int modify_type, uint32_t alloc_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_upgrade(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_value_return(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -531,16 +531,30 @@ static bool
 __rec_row_zero_len(WT_SESSION_IMPL *session, wt_timestamp_t start_ts, uint64_t start_txn,
   wt_timestamp_t stop_ts, uint64_t stop_txn)
 {
+    bool vis;
+
     /* Before timestamps were stored on pages, it was always possible. */
     if (!__wt_process.page_version_ts)
         return (true);
 
-    /*
-     * The item must be globally visible because we're not writing anything on the page.
-     */
+/*
+ * The item must be globally visible because we're not writing anything on the page.
+ */
+#if 0
+    return ((stop_ts == WT_TS_MAX && stop_txn == WT_TXN_MAX) &&
+      ((start_ts == WT_TS_NONE && start_txn == WT_TXN_NONE) || vis));
+#else
+    if (stop_ts == WT_TS_MAX && stop_txn == WT_TXN_MAX) {
+        if (!(start_ts == WT_TS_NONE && start_txn == WT_TXN_NONE)) {
+            vis = __wt_txn_visible_all(session, start_txn, start_ts);
+            __wt_errx(session, "ZERO: start_txn %" PRIu64 " start_ts %" PRIu64 " vis %d", start_txn,
+              (uint64_t)start_ts, vis);
+        }
+    }
     return ((stop_ts == WT_TS_MAX && stop_txn == WT_TXN_MAX) &&
       ((start_ts == WT_TS_NONE && start_txn == WT_TXN_NONE) ||
               __wt_txn_visible_all(session, start_txn, start_ts)));
+#endif
 }
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -77,11 +77,11 @@ __rec_append_orig_value(
     append = NULL; /* -Wconditional-uninitialized */
     size = 0;      /* -Wconditional-uninitialized */
     if (unpack == NULL || unpack->type == WT_CELL_DEL)
-        WT_RET(__wt_update_alloc(session, NULL, &append, &size, WT_UPDATE_TOMBSTONE));
+        WT_RET(__wt_update_alloc(session, NULL, &append, &size, WT_UPDATE_TOMBSTONE, 0xec01));
     else {
         WT_RET(__wt_scr_alloc(session, 0, &tmp));
         WT_ERR(__wt_page_cell_data_ref(session, page, unpack, tmp));
-        WT_ERR(__wt_update_alloc(session, tmp, &append, &size, WT_UPDATE_STANDARD));
+        WT_ERR(__wt_update_alloc(session, tmp, &append, &size, WT_UPDATE_STANDARD, 0xec02));
     }
 
     /*
@@ -104,6 +104,7 @@ __rec_append_orig_value(
 
     if (upd->type == WT_UPDATE_BIRTHMARK) {
         upd->type = WT_UPDATE_STANDARD;
+        upd->orig_txnid = upd->txnid;
         upd->txnid = WT_TXN_ABORTED;
     }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -689,6 +689,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit)
             break;
 
         if (!commit) {
+	    upd->orig_txnid = upd->txnid;
             upd->txnid = WT_TXN_ABORTED;
             continue;
         }
@@ -1014,6 +1015,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                  * Switch reserved operations to abort to simplify obsolete update list truncation.
                  */
                 if (upd->type == WT_UPDATE_RESERVE) {
+                    upd->orig_txnid = upd->txnid;
                     upd->txnid = WT_TXN_ABORTED;
                     break;
                 }
@@ -1180,6 +1182,7 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
              * again: it can be discarded.
              */
             if (upd->type == WT_UPDATE_RESERVE) {
+                upd->orig_txnid = upd->txnid;
                 upd->txnid = WT_TXN_ABORTED;
                 __wt_txn_op_free(session, op);
                 break;
@@ -1280,6 +1283,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 
             if (!prepare) {
                 WT_ASSERT(session, upd->txnid == txn->id || upd->txnid == WT_TXN_ABORTED);
+                upd->orig_txnid = upd->txnid;
                 upd->txnid = WT_TXN_ABORTED;
             } else {
                 /*

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -115,6 +115,7 @@ __txn_abort_newer_update(
                 upd == first_upd);
             first_upd = upd->next;
 
+            upd->orig_txnid = upd->txnid;
             upd->txnid = WT_TXN_ABORTED;
             WT_STAT_CONN_INCR(session, txn_rollback_upd_aborted);
             upd->durable_ts = upd->start_ts = WT_TS_NONE;

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -63,6 +63,7 @@ typedef struct {
     char *home_backup_init;  /* Initialize backup command */
     char *home_config;       /* Run CONFIG file path */
     char *home_init;         /* Initialize home command */
+    char *home_lasdump;      /* LAS dump filename */
     char *home_log;          /* Operation log file path */
     char *home_pagedump;     /* Page dump filename */
     char *home_rand;         /* RNG log file path */
@@ -352,7 +353,7 @@ void snap_init(TINFO *, uint64_t, bool);
 void snap_repeat_single(WT_CURSOR *, TINFO *);
 int snap_repeat_txn(WT_CURSOR *, TINFO *);
 void snap_repeat_update(TINFO *, bool);
-void snap_track(TINFO *, thread_op);
+void snap_track(WT_CURSOR *, TINFO *, thread_op);
 WT_THREAD_RET timestamp(void *);
 void track(const char *, uint64_t, TINFO *);
 void val_gen(WT_RAND_STATE *, WT_ITEM *, uint64_t);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -523,7 +523,7 @@ prepare_transaction(TINFO *tinfo)
 #define SNAP_TRACK(tinfo, op)                                          \
     do {                                                               \
         if (intxn && !ckpt_handle && iso_config == ISOLATION_SNAPSHOT) \
-            snap_track(tinfo, op);                                     \
+            snap_track(cursor, tinfo, op);                             \
     } while (0)
 
 /*
@@ -974,6 +974,7 @@ ops(void *arg)
             snap_repeat_update(tinfo, true);
             break;
         case 5: /* 10% */
+        case 6: /* 20% */
 rollback:
             rollback_transaction(tinfo);
             snap_repeat_update(tinfo, false);

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -246,7 +246,7 @@ val_gen(WT_RAND_STATE *rnd, WT_ITEM *value, uint64_t keyno)
      * WiredTiger doesn't store zero-length data items in row-store files, test that by inserting a
      * zero-length data item every so often.
      */
-    if (keyno % 63 == 0) {
+    if (keyno % 5 == 0) {
         p[0] = '\0';
         value->size = 0;
         return;
@@ -328,6 +328,11 @@ path_setup(const char *home)
     len = strlen(g.home) + strlen("log") + 2;
     g.home_log = dmalloc(len);
     testutil_check(__wt_snprintf(g.home_log, len, "%s/%s", g.home, "log"));
+
+    /* LAS dump file. */
+    len = strlen(g.home) + strlen("LASdump") + 2;
+    g.home_lasdump = dmalloc(len);
+    testutil_check(__wt_snprintf(g.home_lasdump, len, "%s/%s", g.home, "LASdump"));
 
     /* Page dump file. */
     len = strlen(g.home) + strlen("pagedump") + 2;


### PR DESCRIPTION
@keithbostic Here's a branch we can add debugging to and share. It is not yet ready for merge but please push anything additional you add for WT-5169 too. This contains all the latest changes I am running with, including a fix in the `5119.Nov18.diff` that I put in the ticket. (That fix was printing out the allocation location in hex instead of decimal.)