### PR TITLE
WT-5169 WT_REF_LIMBO pages cannot support fast (leaf-page only) searches

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -16,6 +16,7 @@ __wt_config_getone
 __wt_cursor_get_raw_value
 __wt_debug_addr
 __wt_debug_addr_print
+__wt_debug_cursor_las
 __wt_debug_cursor_page
 __wt_debug_offset
 __wt_debug_set_verbose

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -101,17 +101,15 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
         return (false);
 
     /*
-     * If we are doing an update, we need a page with history, release the page so we get it again
-     * with history if required. Eviction may be locking the page, wait until we see a "normal"
-     * state and then test against that state (eviction may have already locked the page again).
+     * We need a page with history: updates need complete update lists and a read might be based on
+     * a different timestamp than the one that brought the page into memory. Release the page and
+     * read it again with history if required. Eviction may be locking the page, wait until we see a
+     * "normal" state and then test against that state (eviction may have already locked the page
+     * again).
      */
-    if (F_ISSET(&session->txn, WT_TXN_UPDATE)) {
-        while ((current_state = cbt->ref->state) == WT_REF_LOCKED)
-            __wt_yield();
-        return (current_state == WT_REF_MEM);
-    }
-
-    return (true);
+    while ((current_state = cbt->ref->state) == WT_REF_LOCKED)
+        __wt_yield();
+    return (current_state == WT_REF_MEM);
 }
 
 /*

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -109,6 +109,7 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
      */
     while ((current_state = cbt->ref->state) == WT_REF_LOCKED)
         __wt_yield();
+    WT_ASSERT(session, current_state == WT_REF_LIMBO || current_state == WT_REF_MEM);
     return (current_state == WT_REF_MEM);
 }
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -698,6 +698,28 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
 }
 
 /*
+ * __wt_debug_cursor_las --
+ *     Dump the LAS tree given a user cursor.
+ */
+int
+__wt_debug_cursor_las(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_SESSION_IMPL *las_session;
+
+    cursor = cursor_arg;
+    conn = S2C((WT_SESSION_IMPL *)cursor->session);
+    las_session = conn->cache->las_session[0];
+    if (las_session == NULL)
+        return (0);
+    cbt = (WT_CURSOR_BTREE *)las_session->las_cursor;
+    return (__wt_debug_tree_all(las_session, cbt->btree, NULL, ofile));
+}
+
+/*
  * __debug_tree --
  *     Dump the in-memory information for a tree.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -574,6 +574,8 @@ extern int __wt_debug_addr(WT_SESSION_IMPL *session, const uint8_t *addr, size_t
   const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_addr_print(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_cursor_las(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
+  (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_cursor_page(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_disk(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, const char *ofile)


### PR DESCRIPTION
@agorrod, @sulabhM, I'm uncertain on some of the possible `WT_REF_LIMBO` transitions, please consider if there's a better test we could use than turning off all fast searches of `WT_REF_LIMBO` pages.

I considered calling `__wt_las_page_skip()` from inside `__cursor_page_pinned()`, but that requires locking the page which might be too heavy-weight (and, as I said, I'm not completely sure that calling that function would be sufficient).