### PR TITLE
WT-5250 Stop relying on all entries for a given page being contiguous in the lookaside table

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -287,8 +287,6 @@ __wt_page_las_free(WT_SESSION_IMPL *session, WT_PAGE_LOOKASIDE **page_lasp)
             __wt_buf_free(session, &birthmarkp->key);
         __wt_free(session, page_las->birthmarks);
     }
-    __wt_buf_free(session, &page_las->max_las_key);
-    __wt_buf_free(session, &page_las->min_las_key);
     __wt_free(session, page_las);
     *page_lasp = NULL;
 }

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -115,7 +115,7 @@ __instantiate_birthmarks(WT_SESSION_IMPL *session, WT_REF *ref)
 
     for (i = 0, birthmarkp = page_las->birthmarks; i < page_las->birthmarks_cnt;
          i++, birthmarkp++) {
-        if (birthmarkp->instantiated)
+        if (birthmarkp->instantiated || birthmarkp->txnid == WT_TXN_ABORTED)
             continue;
 
         WT_ERR(__create_birthmark_upd(session, birthmarkp, &incr, &upd));
@@ -167,27 +167,25 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
         wt_timestamp_t timestamp;
         uint64_t txnid;
     } * las_preparep;
-    WT_BIRTHMARK_DETAILS *birthmarkp;
     WT_CACHE *cache;
     WT_CURSOR *las_cursor;
     WT_CURSOR_BTREE cbt;
     WT_DECL_ITEM(las_prepares);
     WT_DECL_RET;
-    WT_ITEM las_key, las_key_tmp, las_value, next_las_key;
+    WT_ITEM las_key, las_key_tmp, las_value;
     WT_MODIFY_VECTOR modifies;
     WT_PAGE *page;
     WT_PAGE_LOOKASIDE *page_las;
     WT_UPDATE *mod_upd, *upd;
     wt_timestamp_t durable_timestamp, durable_timestamp_tmp, las_timestamp, las_timestamp_tmp;
     size_t notused, size, total_incr;
-    uint64_t birthmark_cnt, instantiated_cnt, las_txnid, las_txnid_tmp, recno;
+    uint64_t instantiated_cnt, las_txnid, las_txnid_tmp, recno;
     uint32_t i, las_btree_id, las_prepare_cnt, mod_counter, session_flags;
     uint8_t prepare_state, upd_type;
     const uint8_t *p;
     int cmp, exact;
-    bool birthmark_record, first_scan, locked;
+    bool birthmark_record, locked;
 
-    birthmarkp = NULL;
     cache = S2C(session)->cache;
     las_cursor = NULL;
     WT_CLEAR(las_key);
@@ -197,7 +195,6 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
     page = ref->page;
     page_las = ref->page_las;
     mod_upd = upd = NULL;
-    birthmark_cnt = 0;
     recno = WT_RECNO_OOB;
     las_btree_id = S2BT(session)->id;
     las_prepare_cnt = mod_counter = 0;
@@ -255,89 +252,65 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
     __wt_las_cursor(session, &las_cursor, &session_flags);
 
     /*
-     * The lookaside records are in key and update order, that is, there will be a set of in-order
-     * updates for a key, then another set of in-order updates for a subsequent key. We find the
-     * most recent of the updates for a key and then insert that update into the page, then all the
-     * updates for the next key, and so on. If the birthmark record exists for that key, then insert
-     * birthmark record into the page.
+     * The lookaside records are in update order for a given key, that is, there will be a set of
+     * in-order updates for a key, then another set of in-order updates for a subsequent key. We
+     * find the most recent of the updates for a key and then insert that update into the page, then
+     * all the updates for the next key, and so on. If the birthmark record exists for that key,
+     * then insert birthmark record into the page.
      *
-     * The search starts with the minimum LAS key of the page until the maximum LAS key (both
-     * inclusive). We are going to instantiate only the most recent record for a key. To find out
-     * the most recent record for a key, we use the search_near cursor function with both the
-     * maximum timestamp and the transaction id as part of the key search. This search can return
-     * either the last record of the search key or the first record of the next key.
+     * An important point to note is that the keys for a given page are NOT necessarily next to each
+     * other in the lookaside table since we can specify our own ordering for a given table with a
+     * custom collator. Therefore, we need to make use of the keys that we have stored in-memory
+     * last time we evicted to instantiate each key.
      *
-     * Once we instantiate the most recent record for a key, the search continues to the next key.
-     * Since we're pointing at the max timestamp and transaction id pairing for a given key, the
-     * next entry is guaranteed to be for the next key in the LAS and again set the search for the
-     * next key with maximum timestamp and transaction id.
+     * During instantiation, we iterate over our set of keys from eviction. If the key momento has a
+     * specific txn id that isn't "aborted" then it indicates that birthmark update should be
+     * instantiated for that key. Otherwise it is just an indicator that we need to search the
+     * lookaside for that particular key.
      */
     cache->las_reader = true;
     __wt_readlock(session, &cache->las_sweepwalk_lock);
     cache->las_reader = false;
     notused = size = total_incr = 0;
-    first_scan = true;
     locked = true;
-    las_cursor->set_key(las_cursor, las_btree_id, &page_las->min_las_key, WT_TS_MAX, WT_TXN_MAX);
-    for (; ret == 0; ret = las_cursor->next(las_cursor)) {
-        if (!first_scan) {
-            WT_ERR(las_cursor->get_key(
-              las_cursor, &las_btree_id, &next_las_key, &las_timestamp, &las_txnid));
+    for (i = 0; i < page_las->birthmarks_cnt; ++i) {
+        if (page_las->birthmarks[i].txnid != WT_TXN_ABORTED) {
+            WT_ERR(__create_birthmark_upd(session, &page_las->birthmarks[i], &size, &upd));
+            WT_ERR(__wt_buf_set(session, &las_key, page_las->birthmarks[i].key.data,
+              page_las->birthmarks[i].key.size));
+            birthmark_record = true;
+        } else {
+            las_cursor->set_key(
+              las_cursor, las_btree_id, &page_las->birthmarks[i].key, WT_TS_MAX, WT_TXN_MAX);
+            WT_ERR(las_cursor->search_near(las_cursor, &exact));
 
-            /* Set the key to check with maximum timestamp and transaction id. */
-            las_cursor->set_key(las_cursor, las_btree_id, &next_las_key, WT_TS_MAX, WT_TXN_MAX);
+            /*
+             * Check whether the search_near returned the same key. If it returns the next key,
+             * continue with the previous record.
+             */
+            if (exact > 0)
+                WT_ERR(las_cursor->prev(las_cursor));
+            WT_ERR(
+              las_cursor->get_key(las_cursor, &las_btree_id, &las_key, &las_timestamp, &las_txnid));
+
+            /*
+             * Verify that our search_near has given us the right key.
+             *
+             * If it hasn't, this means that there are no longer any lookaside entries for that key.
+             * This is possible if the sweep server cleans some things up while the page was out of
+             * cache.
+             */
+            if (las_btree_id != S2BT(session)->id)
+                continue;
+            WT_ERR(__wt_compare(session, NULL, &las_key, &page_las->birthmarks[i].key, &cmp));
+            if (cmp != 0)
+                continue;
         }
-        first_scan = false;
-
-        WT_ERR(las_cursor->search_near(las_cursor, &exact));
-        /*
-         * Check whether the search_near returned the same key. If it returns the next key, continue
-         * with the previous record.
-         */
-        if (exact > 0)
-            WT_ERR(las_cursor->prev(las_cursor));
-
-        WT_ERR(
-          las_cursor->get_key(las_cursor, &las_btree_id, &las_key, &las_timestamp, &las_txnid));
-
-        /* Stop before crossing over to the next btree. */
-        if (las_btree_id != S2BT(session)->id)
-            break;
-
-        WT_ERR(__wt_compare(session, NULL, &las_key, &page_las->min_las_key, &cmp));
-        /* We got a key that is less than the minimum key of the page. */
-        if (cmp < 0)
-            break;
-
-        WT_ERR(__wt_compare(session, NULL, &las_key, &page_las->max_las_key, &cmp));
-        /* We reached the end of the key of the LAS records related to the current page. */
-        if (cmp > 0)
-            break;
 
         instantiated_cnt++;
-        if (page_las->birthmarks_cnt > 0) {
-            for (birthmarkp = page_las->birthmarks + birthmark_cnt;
-                 birthmark_cnt < page_las->birthmarks_cnt; birthmark_cnt++, birthmarkp++) {
-                if (birthmarkp->instantiated)
-                    continue;
-
-                WT_ERR(__wt_compare(session, NULL, &las_key, &birthmarkp->key, &cmp));
-                if (cmp == 0) {
-                    WT_ERR(__create_birthmark_upd(session, birthmarkp, &size, &upd));
-                    birthmark_record = true;
-                    break;
-                } else if (cmp < 0)
-                    /* LAS key is less than birthmark key, so no birthmark record for that key. */
-                    break;
-                else
-                    /*
-                     * LAS key is greater than birthmark key, check next set of birthmark records.
-                     */
-                    continue;
-            }
-        }
-
         if (upd == NULL) {
+            WT_ASSERT(session, !birthmark_record);
+
             /* Allocate the WT_UPDATE structure. */
             WT_ERR(las_cursor->get_value(
               las_cursor, &durable_timestamp, &prepare_state, &upd_type, &las_value));
@@ -431,11 +404,8 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
             las_prepare_cnt++;
         }
 
-        if (birthmark_record) {
-            birthmarkp->instantiated = true;
-            birthmark_record = false;
-        }
-
+        page_las->birthmarks[i].instantiated = true;
+        birthmark_record = false;
         upd = NULL;
     }
 
@@ -486,9 +456,8 @@ err:
             __wt_buf_free(session, &las_preparep->key);
 
     __wt_scr_free(session, &las_prepares);
-    for (birthmark_cnt = 0, birthmarkp = page_las->birthmarks;
-         birthmark_cnt < page_las->birthmarks_cnt; birthmark_cnt++, birthmarkp++)
-        birthmarkp->instantiated = false;
+    for (i = 0; i < page_las->birthmarks_cnt; ++i)
+        page_las->birthmarks[i].instantiated = false;
 
     if (locked)
         __wt_readunlock(session, &cache->las_sweepwalk_lock);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -248,16 +248,12 @@ struct __wt_page_lookaside {
     wt_timestamp_t max_ondisk_ts;  /* Maximum timestamp on disk */
     wt_timestamp_t min_skipped_ts; /* Skipped in favor of disk version */
     bool has_prepares;             /* One or more updates are prepared */
-    // Delete max/min keys, not needed anymore
-    WT_ITEM max_las_key; /* The maximum key in the LAS for the page */
-    WT_ITEM min_las_key; /* The minimum key in the LAS for the page */
     struct __wt_birthmark_details {
         WT_ITEM key;
         uint64_t txnid;
         wt_timestamp_t durable_ts;
         wt_timestamp_t start_ts;
         uint8_t prepare_state;
-        bool instantiated;
     } * birthmarks;          /* Birthmark details for a record */
     uint32_t birthmarks_cnt; /* Count of birthmark records */
 };

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -248,8 +248,9 @@ struct __wt_page_lookaside {
     wt_timestamp_t max_ondisk_ts;  /* Maximum timestamp on disk */
     wt_timestamp_t min_skipped_ts; /* Skipped in favor of disk version */
     bool has_prepares;             /* One or more updates are prepared */
-    WT_ITEM max_las_key;           /* The maximum key in the LAS for the page */
-    WT_ITEM min_las_key;           /* The minimum key in the LAS for the page */
+    // Delete max/min keys, not needed anymore
+    WT_ITEM max_las_key; /* The maximum key in the LAS for the page */
+    WT_ITEM min_las_key; /* The minimum key in the LAS for the page */
     struct __wt_birthmark_details {
         WT_ITEM key;
         uint64_t txnid;
@@ -258,7 +259,7 @@ struct __wt_page_lookaside {
         uint8_t prepare_state;
         bool instantiated;
     } * birthmarks;          /* Birthmark details for a record */
-    uint64_t birthmarks_cnt; /* Count of birthmark records */
+    uint32_t birthmarks_cnt; /* Count of birthmark records */
 };
 
 /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2452,8 +2452,6 @@ __rec_las_wrapup_err(WT_SESSION_IMPL *session, WT_RECONCILE *r)
                     __wt_buf_free(session, &birthmarkp->key);
             }
             __wt_free(session, multi->page_las.birthmarks);
-            __wt_buf_free(session, &multi->page_las.max_las_key);
-            __wt_buf_free(session, &multi->page_las.min_las_key);
         }
 }
 


### PR DESCRIPTION
This patch is adding functionality to store all keys for a page in memory when lookaside evicting and to use this information to instantiate when reading the page back into cache. On instantiation, we iterate over our stored keys and do a `search_near` to find the newest record for that key unless it is a birthmark which is indicated by an "aborted" transaction id.

This was originally going to be part of #4973 however we've been having trouble chasing down bugs in that branch and we know for a fact that this change works by itself.