### PR TITLE
WT-5211 Print mismatch information before dumping page and LAS, which

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -210,6 +210,7 @@ Kanowski's
 Kounavis
 LANGID
 LAS
+LASdump
 LF
 LLLLLL
 LLLLLLL

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -63,6 +63,7 @@ typedef struct {
     char *home_backup_init;  /* Initialize backup command */
     char *home_config;       /* Run CONFIG file path */
     char *home_init;         /* Initialize home command */
+    char *home_lasdump;      /* LAS dump filename */
     char *home_log;          /* Operation log file path */
     char *home_pagedump;     /* Page dump filename */
     char *home_rand;         /* RNG log file path */

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -191,7 +191,7 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
             return (0);
     }
 
-/* Things went pear-shaped. */
+    /* Things went pear-shaped. */
     switch (g.type) {
     case FIX:
         fprintf(stderr, "snapshot-isolation: %" PRIu64

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -192,7 +192,6 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
     }
 
 /* Things went pear-shaped. */
-#ifdef HAVE_DIAGNOSTIC
     switch (g.type) {
     case FIX:
         fprintf(stderr, "snapshot-isolation: %" PRIu64
@@ -229,6 +228,8 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
 
         break;
     }
+
+#ifdef HAVE_DIAGNOSTIC
     /*
      * We have a mismatch. Try to print out as much information as we can. In doing so, we are
      * calling into the debug code directly and that does not take locks. So it is possible that the

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -197,9 +197,9 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
     case FIX:
         fprintf(stderr, "snapshot-isolation: %" PRIu64
                         " search: "
-                        "expected {0x%02x}, found {0x%02x}",
-          keyno, snap->op == REMOVE ? 0 : *(uint8_t *)snap->vdata,
-          ret == WT_NOTFOUND ? 0 : *(uint8_t *)value->data);
+                        "expected {0x%02x}, found {0x%02x}\n",
+          keyno, snap->op == REMOVE ? 0U : *(uint8_t *)snap->vdata,
+          ret == WT_NOTFOUND ? 0U : *(uint8_t *)value->data);
         break;
     case ROW:
         fprintf(

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -194,10 +194,9 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
     /* Things went pear-shaped. */
     switch (g.type) {
     case FIX:
-        fprintf(stderr, "snapshot-isolation: %" PRIu64
-                        " search: "
-                        "expected {0x%02x}, found {0x%02x}\n",
-          keyno, snap->op == REMOVE ? 0U : *(uint8_t *)snap->vdata,
+        fprintf(stderr,
+          "snapshot-isolation: %" PRIu64 " search: expected {0x%02x}, found {0x%02x}\n", keyno,
+          snap->op == REMOVE ? 0U : *(uint8_t *)snap->vdata,
           ret == WT_NOTFOUND ? 0U : *(uint8_t *)value->data);
         break;
     case ROW:
@@ -212,7 +211,6 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
             fprintf(stderr, "   found {deleted}\n");
         else
             print_item_data("   found", value->data, value->size);
-
         break;
     case VAR:
         fprintf(stderr, "snapshot-isolation %" PRIu64 " search mismatch\n", keyno);
@@ -225,7 +223,6 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
             fprintf(stderr, "   found {deleted}\n");
         else
             print_item_data("   found", value->data, value->size);
-
         break;
     }
 

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -237,7 +237,7 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
      * The most important information is the key/value mismatch information. Then try to dump out
      * the other information. Right now we dump the entire lookaside table including what is on
      * disk. That can potentially be very large. If it becomes a problem, this can be modified to
-     * just dump out the page this key is on. 
+     * just dump out the page this key is on.
      */
     fprintf(stderr, "snapshot-isolation error: Dumping page to %s\n", g.home_pagedump);
     testutil_check(__wt_debug_cursor_page(cursor, g.home_pagedump));

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -193,17 +193,14 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
 
 /* Things went pear-shaped. */
 #ifdef HAVE_DIAGNOSTIC
-    fprintf(stderr, "snapshot-isolation error: Dumping page to %s\n", g.home_pagedump);
-    testutil_check(__wt_debug_cursor_page(cursor, g.home_pagedump));
-#endif
     switch (g.type) {
     case FIX:
-        testutil_die(ret, "snapshot-isolation: %" PRIu64
-                          " search: "
-                          "expected {0x%02x}, found {0x%02x}",
+        fprintf(stderr, "snapshot-isolation: %" PRIu64
+                        " search: "
+                        "expected {0x%02x}, found {0x%02x}",
           keyno, snap->op == REMOVE ? 0 : *(uint8_t *)snap->vdata,
           ret == WT_NOTFOUND ? 0 : *(uint8_t *)value->data);
-    /* NOTREACHED */
+        break;
     case ROW:
         fprintf(
           stderr, "snapshot-isolation %.*s search mismatch\n", (int)key->size, (char *)key->data);
@@ -217,9 +214,7 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
         else
             print_item_data("   found", value->data, value->size);
 
-        testutil_die(
-          ret, "snapshot-isolation: %.*s search mismatch", (int)key->size, (char *)key->data);
-    /* NOTREACHED */
+        break;
     case VAR:
         fprintf(stderr, "snapshot-isolation %" PRIu64 " search mismatch\n", keyno);
 
@@ -232,7 +227,33 @@ snap_verify(WT_CURSOR *cursor, TINFO *tinfo, SNAP_OPS *snap)
         else
             print_item_data("   found", value->data, value->size);
 
+        break;
+    }
+    /*
+     * We have a mismatch. Try to print out as much information as we can. In doing so, we are
+     * calling into the debug code directly and that does not take locks. So it is possible that the
+     * calls may crash in some way.
+     *
+     * The most important information is the key/value mismatch information. Then try to dump out
+     * the other information. Right now we dump the entire lookaside table including what is on
+     * disk. That can potentially be very large. If it becomes a problem, this can be modified to
+     * just dump out the page this key is on. 
+     */
+    fprintf(stderr, "snapshot-isolation error: Dumping page to %s\n", g.home_pagedump);
+    testutil_check(__wt_debug_cursor_page(cursor, g.home_pagedump));
+    fprintf(stderr, "snapshot-isolation error: Dumping LAS to %s\n", g.home_lasdump);
+    testutil_check(__wt_debug_cursor_las(cursor, g.home_lasdump));
+    if (g.logging)
+        testutil_check(cursor->session->log_flush(cursor->session, "sync=off"));
+#endif
+    switch (g.type) {
+    case FIX:
+    case VAR:
         testutil_die(ret, "snapshot-isolation: %" PRIu64 " search mismatch", keyno);
+    /* NOTREACHED */
+    case ROW:
+        testutil_die(
+          ret, "snapshot-isolation: %.*s search mismatch", (int)key->size, (char *)key->data);
         /* NOTREACHED */
     }
 

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -329,6 +329,11 @@ path_setup(const char *home)
     g.home_log = dmalloc(len);
     testutil_check(__wt_snprintf(g.home_log, len, "%s/%s", g.home, "log"));
 
+    /* LAS dump file. */
+    len = strlen(g.home) + strlen("LASdump") + 2;
+    g.home_lasdump = dmalloc(len);
+    testutil_check(__wt_snprintf(g.home_lasdump, len, "%s/%s", g.home, "LASdump"));
+
     /* Page dump file. */
     len = strlen(g.home) + strlen("pagedump") + 2;
     g.home_pagedump = dmalloc(len);


### PR DESCRIPTION
can potentially crash.