### PR TITLE
WT-5267 Store stop time pair in history store

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -180,11 +180,11 @@ __instantiate_lookaside(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_PAGE *page;
     WT_PAGE_LOOKASIDE *page_las;
     WT_UPDATE *mod_upd, *upd;
-    wt_timestamp_t durable_timestamp, durable_timestamp_tmp, las_stop_timestamp,
-      las_stop_timestamp_tmp, las_timestamp, las_timestamp_tmp;
+    wt_timestamp_t durable_timestamp, durable_timestamp_tmp, las_stop_timestamp;
+    wt_timestamp_t las_stop_timestamp_tmp, las_timestamp, las_timestamp_tmp;
     size_t notused, size, total_incr;
-    uint64_t birthmark_cnt, instantiated_cnt, las_stop_txnid, las_stop_txnid_tmp, las_txnid,
-      las_txnid_tmp, recno;
+    uint64_t birthmark_cnt, instantiated_cnt, las_stop_txnid, las_stop_txnid_tmp;
+    uint64_t las_txnid, las_txnid_tmp, recno;
     uint32_t i, las_btree_id, las_prepare_cnt, mod_counter, session_flags;
     uint8_t prepare_state, upd_type;
     const uint8_t *p;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -814,7 +814,7 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
             ++insert_cnt;
 
             /*
-             * Store the current update comit timestamp and transaction id, these are the stop
+             * Store the current update commit timestamp and transaction id, these are the stop
              * timestamp and transaction id's for the next record in the update list.
              */
             stop_ts = upd->start_ts;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -779,10 +779,10 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
                 birthmarks_cnt++;
 
                 /*
-                 * Store the current update durable timestamp and transaction id, these are the stop
+                 * Store the current update commit timestamp and transaction id, these are the stop
                  * timestamp and transaction id's for the next record in the update list.
                  */
-                stop_ts = upd->durable_ts;
+                stop_ts = upd->start_ts;
                 stop_txnid = upd->txnid;
 
                 /* Do not put birthmarks into the lookaside. */
@@ -814,10 +814,10 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
             ++insert_cnt;
 
             /*
-             * Store the current update durable timestamp and transaction id, these are the stop
+             * Store the current update comit timestamp and transaction id, these are the stop
              * timestamp and transaction id's for the next record in the update list.
              */
-            stop_ts = upd->durable_ts;
+            stop_ts = upd->start_ts;
             stop_txnid = upd->txnid;
 
             /*

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1123,8 +1123,8 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_ITEM las_key, las_value, remove_key;
     WT_ITEM *sweep_key;
-    wt_timestamp_t durable_timestamp, las_stop_timestamp, las_timestamp, remove_stop_timestamp,
-      remove_timestamp, saved_timestamp;
+    wt_timestamp_t durable_timestamp, las_stop_timestamp, las_timestamp;
+    wt_timestamp_t remove_stop_timestamp, remove_timestamp, saved_timestamp;
     uint64_t cnt, remove_cnt, pending_remove_cnt, visit_cnt;
     uint64_t las_stop_txnid, las_txnid, remove_stop_txnid, remove_txnid, saved_txnid;
     uint32_t las_btree_id, remove_btree_id, saved_btree_id, session_flags;
@@ -1449,8 +1449,8 @@ __wt_find_lookaside_upd(
     WT_MODIFY_VECTOR modifies;
     WT_TXN *txn;
     WT_UPDATE *birthmark_upd, *mod_upd, *upd;
-    wt_timestamp_t durable_timestamp, durable_timestamp_tmp, las_stop_timestamp,
-      las_stop_timestamp_tmp, las_timestamp, las_timestamp_tmp;
+    wt_timestamp_t durable_timestamp, durable_timestamp_tmp, las_stop_timestamp;
+    wt_timestamp_t las_stop_timestamp_tmp, las_timestamp, las_timestamp_tmp;
     wt_timestamp_t read_timestamp;
     size_t notused, size;
     uint64_t las_stop_txnid, las_stop_txnid_tmp, las_txnid, las_txnid_tmp, recno;

--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -779,10 +779,10 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
                 birthmarks_cnt++;
 
                 /*
-                 * Store the current update start timestamp and transaction id, these are the stop
+                 * Store the current update durable timestamp and transaction id, these are the stop
                  * timestamp and transaction id's for the next record in the update list.
                  */
-                stop_ts = upd->start_ts;
+                stop_ts = upd->durable_ts;
                 stop_txnid = upd->txnid;
 
                 /* Do not put birthmarks into the lookaside. */
@@ -814,10 +814,10 @@ __wt_las_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MU
             ++insert_cnt;
 
             /*
-             * Store the current update start timestamp and transaction id, these are the stop
+             * Store the current update durable timestamp and transaction id, these are the stop
              * timestamp and transaction id's for the next record in the update list.
              */
-            stop_ts = upd->start_ts;
+            stop_ts = upd->durable_ts;
             stop_txnid = upd->txnid;
 
             /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -218,10 +218,10 @@ struct __wt_ovfl_reuse {
 #else
 #define WT_LOOKASIDE_COMPRESSOR "none"
 #endif
-#define WT_LAS_CONFIG                                                             \
-    "key_format=" WT_UNCHECKED_STRING(IuQQ) ",value_format=" WT_UNCHECKED_STRING( \
-      QBBu) ",block_compressor=" WT_LOOKASIDE_COMPRESSOR                          \
-            ",leaf_value_max=64MB"                                                \
+#define WT_LAS_CONFIG                                                               \
+    "key_format=" WT_UNCHECKED_STRING(IuQQQQ) ",value_format=" WT_UNCHECKED_STRING( \
+      QBBu) ",block_compressor=" WT_LOOKASIDE_COMPRESSOR                            \
+            ",leaf_value_max=64MB"                                                  \
             ",prefix_compression=true"
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -122,9 +122,9 @@ __get_next_rec_upd(WT_SESSION_IMPL *session, WT_UPDATE **inmem_upd_pos, bool *la
 {
     WT_DECL_RET;
     WT_ITEM las_key, las_value;
-    wt_timestamp_t durable_timestamp, las_stop_timestamp, las_timestamp;
+    WT_TIME_PAIR las_start, las_stop;
+    wt_timestamp_t durable_timestamp;
     size_t not_used;
-    uint64_t las_stop_txnid, las_txnid;
     uint32_t las_btree_id;
     uint8_t prepare_state, upd_type;
     int cmp;
@@ -132,7 +132,8 @@ __get_next_rec_upd(WT_SESSION_IMPL *session, WT_UPDATE **inmem_upd_pos, bool *la
 
     WT_CLEAR(las_key);
     WT_CLEAR(las_value);
-    las_timestamp = las_txnid = 0;
+    las_start.timestamp = WT_TS_NONE;
+    las_start.txnid = WT_TXN_NONE;
     use_las_rec = false;
 
     /* Free any external update we're holding. */
@@ -142,8 +143,8 @@ __get_next_rec_upd(WT_SESSION_IMPL *session, WT_UPDATE **inmem_upd_pos, bool *la
     /* Determine whether to use lookaside or an in-memory update. */
     if (*las_positioned) {
         /* Check if lookaside cursor is still positioned on an update for the given key. */
-        WT_RET(las_cursor->get_key(las_cursor, &las_btree_id, &las_key, &las_timestamp, &las_txnid,
-          &las_stop_timestamp, &las_stop_txnid));
+        WT_RET(las_cursor->get_key(las_cursor, &las_btree_id, &las_key, &las_start.timestamp,
+          &las_start.txnid, &las_stop.timestamp, &las_stop.txnid));
         if (las_btree_id != btree_id) {
             *las_positioned = false;
             goto inmem;
@@ -159,10 +160,10 @@ __get_next_rec_upd(WT_SESSION_IMPL *session, WT_UPDATE **inmem_upd_pos, bool *la
             /* There are no more in-memory updates to consider. */
             use_las_rec = true;
         } else {
-            if (las_timestamp > (*inmem_upd_pos)->start_ts)
+            if (las_start.timestamp > (*inmem_upd_pos)->start_ts)
                 use_las_rec = true;
-            else if (las_timestamp == (*inmem_upd_pos)->start_ts) {
-                if (las_txnid > (*inmem_upd_pos)->txnid)
+            else if (las_start.timestamp == (*inmem_upd_pos)->start_ts) {
+                if (las_start.txnid > (*inmem_upd_pos)->txnid)
                     use_las_rec = true;
             }
         }
@@ -179,9 +180,9 @@ __get_next_rec_upd(WT_SESSION_IMPL *session, WT_UPDATE **inmem_upd_pos, bool *la
          * discarded when not needed.
          */
         WT_RET(__wt_update_alloc(session, &las_value, updp, &not_used, upd_type));
-        (*updp)->txnid = las_txnid;
+        (*updp)->txnid = las_start.txnid;
         (*updp)->durable_ts = durable_timestamp;
-        (*updp)->start_ts = las_timestamp;
+        (*updp)->start_ts = las_start.timestamp;
         (*updp)->prepare_state = prepare_state;
         (*updp)->ext = 1;
 
@@ -216,12 +217,13 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     WT_ITEM las_key, las_value;
     WT_MODIFY_VECTOR modifies;
     WT_PAGE *page;
+    WT_TIME_PAIR las_start, las_stop;
     WT_TXN_ISOLATION saved_isolation;
     WT_UPDATE *birthmark_upd, *first_txn_upd, *first_inmem_upd, *inmem_upd_pos, *last_inmem_upd;
     WT_UPDATE *tmp_upd, *upd;
-    wt_timestamp_t durable_ts, las_stop_ts, las_ts, max_ts, mod_upd_ts;
+    wt_timestamp_t durable_ts, max_ts, mod_upd_ts;
     size_t notused, upd_memsize;
-    uint64_t las_stop_txnid, las_txnid, max_txn, txnid;
+    uint64_t max_txn, txnid;
     uint32_t las_btree_id, session_flags;
     uint8_t *p, prepare_state, upd_type;
     int cmp;
@@ -381,8 +383,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         WT_CLEAR(las_key);
         WT_CLEAR(las_value);
         las_btree_id = 0;
-        las_ts = WT_TS_NONE;
-        las_txnid = WT_TXN_NONE;
+        las_start.timestamp = WT_TS_NONE;
+        las_start.txnid = WT_TXN_NONE;
 
         /* Find the birthmark update if one exists in the update list. */
         for (birthmark_upd = first_inmem_upd;
@@ -412,15 +414,16 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             WT_ERR_NOTFOUND_OK(ret);
             cmp = 0;
             if (ret != WT_NOTFOUND) {
-                WT_ERR(las_cursor->get_key(las_cursor, &las_btree_id, &las_key, &las_ts, &las_txnid,
-                  &las_stop_ts, &las_stop_txnid));
+                WT_ERR(las_cursor->get_key(las_cursor, &las_btree_id, &las_key,
+                  &las_start.timestamp, &las_start.txnid, &las_stop.timestamp, &las_stop.txnid));
                 /*
                  * If the birthmark update is more recent than the current lookaside record then we
                  * should use that as the base update instead.
                  */
-                if (birthmark_upd != NULL && las_ts < mod_upd_ts &&
-                  ((birthmark_upd->start_ts > las_ts) ||
-                      (birthmark_upd->start_ts == las_ts && birthmark_upd->txnid > las_txnid))) {
+                if (birthmark_upd != NULL && las_start.timestamp < mod_upd_ts &&
+                  ((birthmark_upd->start_ts > las_start.timestamp) ||
+                      (birthmark_upd->start_ts == las_start.timestamp &&
+                        birthmark_upd->txnid > las_start.txnid))) {
                     /*
                      * Normally we'd hit a base update in the lookaside which will set the update
                      * type to "standard". Since we're use the birthmark value, set it explicitly.
@@ -441,7 +444,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 WT_ERR(__wt_value_return_buf(cbt, cbt->ref, &las_value));
                 break;
             } else
-                WT_ASSERT(session, __wt_txn_visible(session, las_txnid, las_ts));
+                WT_ASSERT(session, __wt_txn_visible(session, las_start.txnid, las_start.timestamp));
             WT_ERR(las_cursor->get_value(
               las_cursor, &durable_ts, &prepare_state, &upd_type, &las_value));
         }


### PR DESCRIPTION
Stop time pair is required for every record in the history
store to represent the end of visibility of each record in
the history store. Store it in the key of the every history
record.