### PR TITLE
WT-5263 format incorrectly attempting to repeat reads before transaction resolution

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -523,6 +523,8 @@ prepare_transaction(TINFO *tinfo)
     testutil_check(__wt_snprintf(buf, sizeof(buf), "prepare_timestamp=%" PRIx64, ts));
     ret = session->prepare_transaction(session, buf);
 
+    logop(session, "prepare ts=%" PRIu64, ts);
+
     testutil_check(pthread_rwlock_unlock(&g.ts_lock));
 
     return (ret);

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -403,6 +403,17 @@ snap_repeat_txn(WT_CURSOR *cursor, TINFO *tinfo)
         if (current->opid != tinfo->opid)
             break;
 
+        /*
+         * First, reads may simply not be repeatable because the read timestamp chosen wasn't older
+         * than all concurrently running uncommitted updates.
+         */
+        if (!tinfo->repeatable_reads && current->op == READ)
+            continue;
+
+        /*
+         * Second, as we have not yet resolved the transaction, the rules are as if the transaction
+         * committed successfully.
+         */
         if (snap_repeat_ok_commit(tinfo, current))
             WT_RET(snap_verify(cursor, tinfo, current));
     }


### PR DESCRIPTION
@agorrod, @bvpvamsikrishna, I think this may be a test bug.

After a transaction has resolved, `format` won't repeat reads unless the read timestamp selected is at least as old as the oldest resolved commit timestamp in any thread. However, if the transaction has not yet been resolved, `format` will attempt to repeat reads where the read timestamp selected was simply the next available timestamp. I've been looking at the code, and I don't think that's safe, it seems to me it doesn't matter whether or not the transaction has been resolved, the read will or will not be repeatable based on the timestamp chosen. Is that correct?