### PR TITLE
WT-5288 format.sh must distinguish format timeouts and kill child processes

### DIFF
--- a/test/format/t.c
+++ b/test/format/t.c
@@ -45,6 +45,7 @@ static void signal_timer(int signo) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 static void
 signal_timer(int signo)
 {
+    fprintf(stderr, "format alarm timed out\n");
     fprintf(stderr, "format caught signal %d, aborting the process\n", signo);
     fflush(stderr);
     __wt_abort(NULL);


### PR DESCRIPTION
@sueloverso, I liked your idea of using `SIGKILL`, it's a nice simplification.

While I was there, I realized we weren't treating timeouts as failures, and we weren't kill the process group.