### PR TITLE
WT-5295 Disable remaining failing tests in durable history branch

### DIFF
--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -25,7 +25,8 @@ all_TESTS += test_rwlock
 
 test_schema_abort_SOURCES = schema_abort/main.c
 noinst_PROGRAMS += test_schema_abort
-all_TESTS += schema_abort/smoke.sh
+# Temporarily disabled
+# all_TESTS += schema_abort/smoke.sh
 
 test_scope_SOURCES = scope/main.c
 noinst_PROGRAMS += test_scope

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1611,29 +1611,31 @@ tasks:
   #         display_name: Coverage report
   #         remote_file: wiredtiger/${build_variant}/${revision}/coverage_report/coverage_report_${build_id}.html
 
-  - name: spinlock-gcc-test
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          posix_configure_flags: --enable-python --with-spinlock=gcc --enable-strict
-      - func: "make check all"
-      - func: "test format"
-        vars:
-          times: 3
-      - func: "unit test"
+  # Temporarily disabled
+  # - name: spinlock-gcc-test
+  #   commands:
+  #     - func: "get project"
+  #     - func: "compile wiredtiger"
+  #       vars:
+  #         posix_configure_flags: --enable-python --with-spinlock=gcc --enable-strict
+  #     - func: "make check all"
+  #     - func: "test format"
+  #       vars:
+  #         times: 3
+  #     - func: "unit test"
 
-  - name: spinlock-pthread-adaptive-test
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          posix_configure_flags: --enable-python --with-spinlock=pthread_adaptive --enable-strict
-      - func: "make check all"
-      - func: "test format"
-        vars:
-          times: 3
-      - func: "unit test"
+  # Temporarily disabled
+  # - name: spinlock-pthread-adaptive-test
+  #   commands:
+  #     - func: "get project"
+  #     - func: "compile wiredtiger"
+  #       vars:
+  #         posix_configure_flags: --enable-python --with-spinlock=pthread_adaptive --enable-strict
+  #     - func: "make check all"
+  #     - func: "test format"
+  #       vars:
+  #         times: 3
+  #     - func: "unit test"
 
   - name: wtperf-test
     depends_on:
@@ -1699,8 +1701,9 @@ buildvariants:
     # - name: checkpoint-filetypes-test
     # - name: coverage-report
     - name: unit-test-long
-    - name: spinlock-gcc-test
-    - name: spinlock-pthread-adaptive-test
+    # Temporarily disabled
+    # - name: spinlock-gcc-test
+    # - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf
     - name: wtperf-test
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -562,20 +562,21 @@ tasks:
 
             ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
 
-  - name: csuite-schema-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
+  # Temporarily disabled
+  # - name: csuite-schema-abort-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger/build_posix"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
 
-            ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
+  #           ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
 
   # Temporarily disabled
   # - name: csuite-timestamp-abort-test

--- a/test/suite/test_las06.py
+++ b/test/suite/test_las06.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import unittest, wiredtiger, wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
@@ -61,6 +61,7 @@ class test_las06(wttest.WiredTigerTestCase):
     def get_non_page_image_memory_usage(self):
         return self.get_stat(stat.conn.cache_bytes_other)
 
+    @unittest.skip("Temporarily disabled")
     def test_las_reads(self):
         # Create a small table.
         uri = "table:test_las06"


### PR DESCRIPTION
This PR is disabling `schema_abort` since we have a regression in the durable history feature branch.