### PR TITLE
WT-5042 Avoid calling config functions during checkpoint. (#4936)

### DIFF
--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -56,9 +56,8 @@ __wt_config_collapse(WT_SESSION_IMPL *session, const char **cfg, char **config_r
         goto err;
 
     /*
-     * If the caller passes us no valid configuration strings, we get here
-     * with no bytes to copy -- that's OK, the underlying string copy can
-     * handle empty strings.
+     * If the caller passes us no valid configuration strings, we get here with no bytes to copy --
+     * that's OK, the underlying string copy can handle empty strings.
      *
      * Strip any trailing comma.
      */

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -69,6 +69,7 @@ struct __wt_data_handle {
     uint64_t name_hash;     /* Hash of name */
     const char *checkpoint; /* Checkpoint name (or NULL) */
     const char **cfg;       /* Configuration information */
+    const char *meta_base;  /* Base metadata configuration */
 
     /*
      * Sessions holding a connection's data handle will have a non-zero reference count; sessions

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -12,7 +12,7 @@ static int __ckpt_last(WT_SESSION_IMPL *, const char *, WT_CKPT *);
 static int __ckpt_last_name(WT_SESSION_IMPL *, const char *, const char **);
 static int __ckpt_load(WT_SESSION_IMPL *, WT_CONFIG_ITEM *, WT_CONFIG_ITEM *, WT_CKPT *);
 static int __ckpt_named(WT_SESSION_IMPL *, const char *, const char *, WT_CKPT *);
-static int __ckpt_set(WT_SESSION_IMPL *, const char *, const char *);
+static int __ckpt_set(WT_SESSION_IMPL *, const char *, const char *, bool);
 static int __ckpt_version_chk(WT_SESSION_IMPL *, const char *, const char *);
 
 /*
@@ -92,7 +92,7 @@ __wt_meta_checkpoint_clear(WT_SESSION_IMPL *session, const char *fname)
      * If we are unrolling a failed create, we may have already removed the metadata entry. If no
      * entry is found to update and we're trying to clear the checkpoint, just ignore it.
      */
-    WT_RET_NOTFOUND_OK(__ckpt_set(session, fname, NULL));
+    WT_RET_NOTFOUND_OK(__ckpt_set(session, fname, NULL, false));
 
     return (0);
 }
@@ -102,25 +102,40 @@ __wt_meta_checkpoint_clear(WT_SESSION_IMPL *session, const char *fname)
  *     Set a file's checkpoint.
  */
 static int
-__ckpt_set(WT_SESSION_IMPL *session, const char *fname, const char *v)
+__ckpt_set(WT_SESSION_IMPL *session, const char *fname, const char *v, bool use_base)
 {
+    WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     char *config, *newcfg;
-    const char *cfg[3];
+    const char *cfg[3], *str;
 
+    /*
+     * If the caller knows we're on a path like checkpoints where we have a valid checkpoint and
+     * checkpoint LSN and should use the base, then use that faster path. Some paths don't have a
+     * dhandle or want to have the older value retained from the existing metadata. In those cases,
+     * use the slower path through configuration parsing functions.
+     */
     config = newcfg = NULL;
-
-    /* Retrieve the metadata for this file. */
-    WT_ERR(__wt_metadata_search(session, fname, &config));
-
-    /* Replace the checkpoint entry. */
-    cfg[0] = config;
-    cfg[1] = v == NULL ? "checkpoint=()" : v;
-    cfg[2] = NULL;
-    WT_ERR(__wt_config_collapse(session, cfg, &newcfg));
-    WT_ERR(__wt_metadata_update(session, fname, newcfg));
+    str = v == NULL ? "checkpoint=(),checkpoint_lsn=" : v;
+    if (use_base && session->dhandle != NULL) {
+        WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+        WT_ASSERT(session, strcmp(session->dhandle->name, fname) == 0);
+        /* Concatenate the metadata base string with the checkpoint string. */
+        WT_ERR(__wt_buf_fmt(session, tmp, "%s,%s", session->dhandle->meta_base, str));
+        WT_ERR(__wt_metadata_update(session, fname, tmp->mem));
+    } else {
+        /* Retrieve the metadata for this file. */
+        WT_ERR(__wt_metadata_search(session, fname, &config));
+        /* Replace the checkpoint entry. */
+        cfg[0] = config;
+        cfg[1] = str;
+        cfg[2] = NULL;
+        WT_ERR(__wt_config_collapse(session, cfg, &newcfg));
+        WT_ERR(__wt_metadata_update(session, fname, newcfg));
+    }
 
 err:
+    __wt_scr_free(session, &tmp);
     __wt_free(session, config);
     __wt_free(session, newcfg);
     return (ret);
@@ -368,6 +383,7 @@ __wt_meta_ckptlist_set(
     time_t secs;
     int64_t maxorder;
     const char *sep;
+    bool has_lsn;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
     maxorder = 0;
@@ -426,10 +442,13 @@ __wt_meta_ckptlist_set(
         sep = ",";
     }
     WT_ERR(__wt_buf_catfmt(session, buf, ")"));
+
+    has_lsn = ckptlsn != NULL;
     if (ckptlsn != NULL)
         WT_ERR(__wt_buf_catfmt(session, buf, ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
           ckptlsn->l.file, (uintmax_t)ckptlsn->l.offset));
-    WT_ERR(__ckpt_set(session, fname, buf->mem));
+
+    WT_ERR(__ckpt_set(session, fname, buf->mem, has_lsn));
 
 err:
     __wt_scr_free(session, &buf);

--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -131,9 +131,6 @@ pwrite64(wt, ""..., 0x1000, 0x3000);
 #ifdef __linux__
 fdatasync(wt);
 #endif /* __linux__ */
-fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
-
-close(fd);
 fd = open("./WiredTiger.turtle.set", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666);
 pwrite64(fd, "WiredTiger version string\nWiredTiger"..., ...);
 #ifdef __linux__


### PR DESCRIPTION
This is to backport WT-5042 and WT-5239.

When doing this, I found the syscall test on mongodb is broken and created a separate ticket WT-5297.

Since I cannot verify the change using syscall test, I manually verified that the change generates the expected change in stderr.txt outputted by syscall test. So I think the backport is good to go.