### PR TITLE
WT-5286 Enable data format to store time pair

### DIFF
--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -191,7 +191,7 @@ AC_MSG_CHECKING(if --enable-page-version-ts option specified)
 AC_ARG_ENABLE(page-version-ts,
 	[AS_HELP_STRING([--enable-page-version-ts],
 	    [Configure for timestamp version page formats])],
-	    r=$enableval, r=no)
+	    r=$enableval, r=yes)
 case "$r" in
 no)	wt_cv_enable_page_version_ts=no;;
 *)	AC_DEFINE(HAVE_PAGE_VERSION_TS)


### PR DESCRIPTION
Change the default value of the WT build to store the time pair
data in the WT_CELL structure whenever a record is reconciled
into a disk image.