### PR TITLE
WT-5277 Cursor key out-of-order detected in the lookaside file

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1232,6 +1232,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     /* If our caller configures for a local search and we have a page pinned, do that search. */
     if (F_ISSET(cursor, WT_CURSTD_UPDATE_LOCAL) && __cursor_page_pinned(cbt, true)) {
         __wt_txn_cursor_op(session);
+	WT_ERR(__wt_txn_autocommit_check(session));
 
         WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, cbt->ref, &leaf_found) :
                                           __cursor_col_search(cbt, cbt->ref, &leaf_found));
@@ -1763,6 +1764,8 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
     session = (WT_SESSION_IMPL *)start->iface.session;
     btree = start->btree;
     WT_STAT_DATA_INCR(session, cursor_truncate);
+
+    WT_ERR(__wt_txn_autocommit_check(session));
 
     /*
      * For recovery, log the start and stop keys for a truncate operation, not the individual

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1232,7 +1232,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     /* If our caller configures for a local search and we have a page pinned, do that search. */
     if (F_ISSET(cursor, WT_CURSTD_UPDATE_LOCAL) && __cursor_page_pinned(cbt, true)) {
         __wt_txn_cursor_op(session);
-	WT_ERR(__wt_txn_autocommit_check(session));
+        WT_ERR(__wt_txn_autocommit_check(session));
 
         WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, cbt->ref, &leaf_found) :
                                           __cursor_col_search(cbt, cbt->ref, &leaf_found));
@@ -1765,7 +1765,7 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
     btree = start->btree;
     WT_STAT_DATA_INCR(session, cursor_truncate);
 
-    WT_ERR(__wt_txn_autocommit_check(session));
+    WT_RET(__wt_txn_autocommit_check(session));
 
     /*
      * For recovery, log the start and stop keys for a truncate operation, not the individual

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -658,11 +658,11 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
         WT_ERR(__cursor_row_search(cbt, true, cbt->ref, &leaf_found));
 
         /*
-         * If searching an already pinned page doesn't find an exact match and returns the first or
-         * last page slots, discard the results and search the full tree as the neighbor pages might
-         * offer better matches. This test is simplistic as we're ignoring append lists (there may
-         * be no page slots or we might be legitimately positioned after the last page slot). Ignore
-         * those cases, it makes things too complicated.
+         * Only use the pinned page search results if search returns an exact match or a slot other
+         * than the page's boundary slots, if that's not the case, a neighbor page might offer a
+         * better match. This test is simplistic as we're ignoring append lists (there may be no
+         * page slots or we might be legitimately positioned after the last page slot). Ignore those
+         * cases, it makes things too complicated.
          */
         if (leaf_found &&
           (cbt->compare == 0 || (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)))
@@ -1237,11 +1237,11 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
         WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, cbt->ref, &leaf_found) :
                                           __cursor_col_search(cbt, cbt->ref, &leaf_found));
         /*
-         * If searching an already pinned page doesn't find an exact match and returns the first or
-         * last page slots, discard the results and search the full tree, a non-existent record
-         * might belong on an entirely different page. This test is simplistic as we're ignoring
-         * append lists (there may be no page slots or we might be legitimately positioned after the
-         * last page slot). Ignore those cases, it makes things too complicated.
+         * Only use the pinned page search results if search returns an exact match or a slot other
+         * than the page's boundary slots, if that's not the case, the record might belong on an
+         * entirely different page. This test is simplistic as we're ignoring append lists (there
+         * may be no page slots or we might be legitimately positioned after the last page slot).
+         * Ignore those cases, it makes things too complicated.
          */
         if (leaf_found &&
           (cbt->compare == 0 || (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)))


### PR DESCRIPTION
@sueloverso, @tetsuo-cpp, I misread the code when I made the changes for WT-5120.

The row-search code doesn't abandon the leaf-page search in cases where it can't be sure the search is safe, it continues with the search and relies on its caller to use the `WT_CURSOR_BTREE.compare` value to decide if a match was found. That's fine for searches, but inserts quite likely don't have an exact match, and so we have to ignore any leaf page results where we don't get an exact match and we're at the edge of the page, as the item might belong on a different page entirely.

I have not re-run the WT-5120 tests to confirm this fix still works, but it seems like it would have minimal impact.