### PR TITLE
WT-5037 Remove wrong assert of las transaction rollback

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1261,10 +1261,6 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Rollback and free updates. */
     for (i = 0, op = txn->mod; i < txn->mod_count; i++, op++) {
-        /* Assert it's not an update to the lookaside file. */
-        WT_ASSERT(
-          session, S2C(session)->cache->las_fileid == 0 || !F_ISSET(op->btree, WT_BTREE_LOOKASIDE));
-
         /* Metadata updates should never be rolled back. */
         WT_ASSERT(session, !WT_IS_METADATA(op->btree->dhandle));
         if (WT_IS_METADATA(op->btree->dhandle))


### PR DESCRIPTION
Remove the assert that checks that no lookaside operations
can rollback. It is possible that las transaction can rollback.
it is a rare scenario, but better to avoid it.