### PR TITLE
WT-5283 Write newest version to disk for eviction and checkpoint

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -34,6 +34,7 @@ __wt_stat_join_aggregate
 __wt_stat_join_clear_all
 __wt_stream_set_no_buffer
 __wt_try_readlock
+__wt_rec_upd_select_new
 wiredtiger_calc_modify
 wiredtiger_config_parser_open
 wiredtiger_config_validate

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1180,6 +1180,9 @@ extern int __wt_rec_split_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAG
 extern int __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
   void *ripcip, WT_CELL_UNPACK *vpack, WT_UPDATE_SELECT *upd_select)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_upd_select_new(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
+  void *ripcip, WT_CELL_UNPACK *vpack, WT_UPDATE_SELECT *upd_select)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage,
   uint32_t flags, bool *lookaside_retryp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name, bool durable)

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -843,16 +843,6 @@ __wt_rec_upd_select_new(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *in
             if (F_ISSET(r, WT_REC_EVICT))
                 ++r->updates_unstable;
 
-            /*
-             * Rare case: when applications run at low isolation levels, update/restore eviction may
-             * see a stable update followed by an uncommitted update. Give up in that case: we need
-             * to discard updates from the stable update and older for correctness and we can't
-             * discard an uncommitted update.
-             */
-            if (F_ISSET(r, WT_REC_UPDATE_RESTORE) && upd_select->upd != NULL &&
-              (list_prepared || list_uncommitted))
-                return (__wt_set_return(session, EBUSY));
-
             continue;
         }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -964,7 +964,7 @@ __wt_rec_upd_select_new(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *in
 
     /* If not trying to evict the page, we know what we'll write and we're done. */
     if (!F_ISSET(r, WT_REC_EVICT))
-        goto check_original_value;
+        goto save_and_check_original;
 
     /*
      * We are attempting eviction with changes that are not yet stable (i.e. globally visible).
@@ -983,7 +983,7 @@ __wt_rec_upd_select_new(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *in
     if (list_uncommitted && !F_ISSET(r, WT_REC_UPDATE_RESTORE))
         return (__wt_set_return(session, EBUSY));
 
-check_original_value:
+save_and_check_original:
     WT_ASSERT(session, r->max_txn != WT_TXN_NONE);
 
     WT_RET(__rec_update_save(session, r, ins, ripcip, upd_select->upd, upd_memsize));

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -945,7 +945,7 @@ __wt_rec_upd_select_new(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *in
       !list_prepared && !list_uncommitted && __wt_txn_visible_all(session, max_txn, max_ts);
 
     if (all_stable)
-        goto check_original_value;
+        goto save_and_check_original;
 
     r->leave_dirty = true;
 


### PR DESCRIPTION
As discussed with Vamsi, we plan to write new functions for the eviction module and then replace the old module with the new module when we are ready for testing.

This is the function in the new eviction module for selecting the version to write for both eviction and checkpoint. Since we are overhauling the whole module, I think it's better to simply this function and move as much logic as possible outside this function. I'm not sure if it's still necessary for us to maintain the list of pointers and counters in this function. If we can remove some of them, it would be great. Also I keep the time pair logic and save update logic in this function for now but we may also move them outside the function later.