### PR TITLE
WT-5309 update format script add prefix command

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -18,7 +18,7 @@ trap 'onintr' 2
 
 usage() {
 	echo "usage: $0 [-aFSv] [-c config] "
-	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [-p prefix-command][format-configuration]"
+	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-p prefix-command] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -c config    format configuration file (defaults to CONFIG.stress)"

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -21,8 +21,8 @@ usage() {
 	echo "    [-b format-binary-cmd] [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
-	echo "    -c config    format configuration file (defaults to CONFIG.stress)"
 	echo "    -b binary    format binary command (defaults to "./t")"
+	echo "    -c config    format configuration file (defaults to CONFIG.stress)"
 	echo "    -F           quit on first failure (defaults to off)"
 	echo "    -h home      run directory (defaults to .)"
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
@@ -82,11 +82,11 @@ while :; do
 	-a)
 		abort_test=1
 		shift ;;
-	-c)
-		config="$2"
-		shift ; shift ;;
 	-b)
 		format_binary_cmd="$2"
+		shift ; shift ;;
+	-c)
+		config="$2"
 		shift ; shift ;;
 	-F)
 		first_failure=1

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -18,7 +18,7 @@ trap 'onintr' 2
 
 usage() {
 	echo "usage: $0 [-aFSv] [-c config] "
-	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
+	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [-p prefix-command][format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -c config    format configuration file (defaults to CONFIG.stress)"
@@ -29,6 +29,7 @@ usage() {
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"
+	echo "    -p           prefix command to prepend before executable (defaults to empty)"
 	echo "    --           separates $name arguments from format arguments"
 
 	exit 1
@@ -74,6 +75,7 @@ parallel_jobs=8
 smoke_test=0
 total_jobs=0
 verbose=0
+prefix_cmd=""
 
 while :; do
 	case "$1" in
@@ -116,6 +118,9 @@ while :; do
 	-v)
 		verbose=1
 		shift ;;
+	-p)
+		prefix_cmd="$2"
+		shift; shift;;
 	--)
 		shift; break;;
 	-*)
@@ -368,7 +373,7 @@ format()
 		echo "$name: starting job in $dir"
 	fi
 
-	cmd="$format_binary -c "$config" -h "$dir" -1 $args quiet=1"
+	cmd="$prefix_cmd $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
 	verbose "$name: $cmd"
 
 	# Disassociate the command from the shell script so we can exit and let the command

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -18,10 +18,10 @@ trap 'onintr' 2
 
 usage() {
 	echo "usage: $0 [-aFSv] [-c config] "
-	echo "    [-b format-binary-cmd] [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
+	echo "    [-b format-binary] [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
-	echo "    -b binary    format binary command (defaults to "./t")"
+	echo "    -b binary    format binary (defaults to "./t")"
 	echo "    -c config    format configuration file (defaults to CONFIG.stress)"
 	echo "    -F           quit on first failure (defaults to off)"
 	echo "    -h home      run directory (defaults to .)"

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -26,7 +26,7 @@ usage() {
 	echo "    -h home      run directory (defaults to .)"
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
-	echo "    -p           prefix command to prepend before binary (defaults to empty)"
+	echo "    -p           pre settings to prepend before binary (defaults to empty)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"
@@ -75,7 +75,7 @@ parallel_jobs=8
 smoke_test=0
 total_jobs=0
 verbose=0
-prefix_cmd=""
+pre_setting=""
 
 while :; do
 	case "$1" in
@@ -106,7 +106,7 @@ while :; do
 		}
 		shift ; shift ;;
 	-p)
-		prefix_cmd="$2"
+		pre_setting="$2"
 		shift; shift;;
 	-S)
 		smoke_test=1
@@ -373,7 +373,7 @@ format()
 		echo "$name: starting job in $dir"
 	fi
 
-	cmd="$prefix_cmd $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
+	cmd="$pre_setting $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
 	verbose "$name: $cmd"
 
 	# Disassociate the command from the shell script so we can exit and let the command

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -26,10 +26,10 @@ usage() {
 	echo "    -h home      run directory (defaults to .)"
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
+	echo "    -p           prefix command to prepend before binary (defaults to empty)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"
-	echo "    -p           prefix command to prepend before executable (defaults to empty)"
 	echo "    --           separates $name arguments from format arguments"
 
 	exit 1
@@ -105,6 +105,9 @@ while :; do
 			exit 1
 		}
 		shift ; shift ;;
+	-p)
+		prefix_cmd="$2"
+		shift; shift;;
 	-S)
 		smoke_test=1
 		shift ;;
@@ -118,9 +121,6 @@ while :; do
 	-v)
 		verbose=1
 		shift ;;
-	-p)
-		prefix_cmd="$2"
-		shift; shift;;
 	--)
 		shift; break;;
 	-*)

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -75,7 +75,7 @@ parallel_jobs=8
 smoke_test=0
 total_jobs=0
 verbose=0
-format_binary_cmd="./t"
+format_binary="./t"
 
 while :; do
 	case "$1" in
@@ -83,7 +83,7 @@ while :; do
 		abort_test=1
 		shift ;;
 	-b)
-		format_binary_cmd="$2"
+		format_binary="$2"
 		shift ; shift ;;
 	-c)
 		config="$2"
@@ -160,18 +160,17 @@ cd $(dirname $0) || exit 1
 # local.
 [[ $config_found -eq 0 ]] && [[ -f "$config" ]] && config="$PWD/$config"
 
-# Find the last part of format_binary_cmd, which is format binary. Builds are normally in the
+# Find the last part of format_binary, which is format binary file. Builds are normally in the
 # WiredTiger source tree, in which case it's in the same directory as format.sh, else it's in
 # the build_posix tree. If the build is in the build_posix tree, move there, we have to run in
 # the directory where the format binary lives because the format binary "knows" the wt utility
 # is two directory levels above it.
-format_binary=${format_binary_cmd##* }
 
-[[ -x $format_binary ]] || {
+[[ -x ${format_binary##* } ]] || {
 	build_posix_directory="../../build_posix/test/format"
 	[[ ! -d $build_posix_directory ]] || cd $build_posix_directory || exit 1
-	[[ -x $format_binary ]] || {
-		echo "$name: format program \"$format_binary\" not found"
+	[[ -x ${format_binary##* } ]] || {
+		echo "$name: format program \"${format_binary##* }\" not found"
 		exit 1
 	}
 }
@@ -375,7 +374,7 @@ format()
 		echo "$name: starting job in $dir"
 	fi
 
-	cmd="$format_binary_cmd -c "$config" -h "$dir" -1 $args quiet=1"
+	cmd="$format_binary -c "$config" -h "$dir" -1 $args quiet=1"
 	verbose "$name: $cmd"
 
 	# Disassociate the command from the shell script so we can exit and let the command

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -18,7 +18,7 @@ trap 'onintr' 2
 
 usage() {
 	echo "usage: $0 [-aFSv] [-c config] "
-	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-p prefix-command] [-t minutes] [format-configuration]"
+	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-p pre-setting] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -c config    format configuration file (defaults to CONFIG.stress)"


### PR DESCRIPTION
Added a new argument(-b) to the format wrapper script to pass the fomat prefix with the binary 

For example : 
a. In some cases the format binary is run with nice command
    nice ./format.sh <other_arguments>
b. In some cases the format binary is run with nice & checksegv command
    nice checksegv ./format.sh <other_arguments>


So, with the new argument (-b) user can pass prefix with the binary.

For ex : 
format.sh -b "nice ./t"
format.sh -b "checksegv ./t"
format.sh -b "nice checksegv ./t"
format.sh 

NOTE - By default the format binary it is set to "./t" if -b is not specified