### PR TITLE
WT-5221 Bypass test_wt2853_perf in Evergreen make-check-msan-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -283,7 +283,7 @@ tasks:
           posix_configure_flags: --enable-silent-rules --enable-strict --enable-diagnostic --disable-static
       - func: "make check all"
         vars:
-          test_env_vars: MSAN_OPTIONS=abort_on_error=1:disable_coredump=0 MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+          test_env_vars: MSAN_OPTIONS=abort_on_error=1:disable_coredump=0 MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer TESTUTIL_SLOW_MACHINE=1
 
   - name: make-check-asan-test
     depends_on:


### PR DESCRIPTION
I added `TESTUTIL_SLOW_MACHINE=1` to the environment variable list for `make-check-msan-test` to bypass the `test_wt2853_perf` test. The existing code already checks for this environment variable, so the only change required was to the Evergreen configuration.