### PR TITLE
WT-5006 Migrate wiredtiger-test-split-stress test to Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1784,6 +1784,20 @@ tasks:
 
             ./time_shift_test.sh /usr/local/lib/faketime/libfaketimeMT.so.1 0-1 2>&1
 
+  - name: split-stress-test
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars: CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/bench/workgen/runner"
+          script: |
+            set -o errexit
+            set -o verbose
+            for i in {1..10}; do ${python_binary|python} split_stress.py; done
+
 buildvariants:
 - name: ubuntu1804
   display_name: Ubuntu 18.04
@@ -1813,6 +1827,7 @@ buildvariants:
     - name: wtperf-test
     - name: ftruncate-test
     - name: long-test
+    - name: split-stress-test
 
 - name: ubuntu1804-python3
   display_name: Ubuntu 18.04 (Python3)
@@ -1965,3 +1980,4 @@ buildvariants:
   tasks:
   - name: compile
   - name: unit-test
+  - name: split-stress-test


### PR DESCRIPTION
The default behaviour of the `compile wiredtiger` function is to set the `CC` environment variable to `gcc`. However, the `bench/workgen` compilation requires `CC` to be set to `cc`, otherwise the directory is bypassed by the recursive make. I overrode the value of `configure_env_vars` so that the `CC` environment variable was not set prior to calling `configure` (thus using the system `/usr/bin/cc`).

The Jenkins test is here: `http://build.wiredtiger.com:8080/job/wiredtiger-test-split-stress/`