### PR TITLE
WT-5263 prepared updates written to the lookaside file are not always read as needed

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -189,6 +189,13 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 list_prepared = true;
                 if (upd->start_ts > max_ts)
                     max_ts = upd->start_ts;
+
+                /*
+                 * Track the oldest update not on the page, used to decide whether reads can use the
+                 * page image, hence using the start rather than the durable timestamp.
+                 */
+                if (upd->start_ts < r->min_skipped_ts)
+                    r->min_skipped_ts = upd->start_ts;
                 continue;
             }
         }
@@ -231,10 +238,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 skipped_birthmark = true;
 
             /*
-             * Track the oldest update not on the page.
-             *
-             * This is used to decide whether reads can use the page image, hence using the start
-             * rather than the durable timestamp.
+             * Track the oldest update not on the page, used to decide whether reads can use the
+             * page image, hence using the start rather than the durable timestamp.
              */
             if (upd_select->upd == NULL && upd->start_ts < r->min_skipped_ts)
                 r->min_skipped_ts = upd->start_ts;


### PR DESCRIPTION
@bvpvamsikrishna, this change fixes the failure, but I'm not familiar enough with the lookaside visibility rules to be confident it's the correct fix.

Additionally, I would suggest reviewing the update walk loop in the `__wt_rec_upd_select()` function for any other information not being collected because prepared updates are detected and ignored too early in the loop. I reviewed it and don't see anything, but I think it's worth further review.