### PR TITLE
WT-5319 Avoid clearing the saved last-key when no instantiated key

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -838,10 +838,6 @@ __wt_row_leaf_key_info(
             *ikeyp = NULL;
         if (cellp != NULL)
             *cellp = WT_PAGE_REF_OFFSET(page, WT_CELL_DECODE_OFFSET(v));
-        if (datap != NULL) {
-            *(void **)datap = NULL;
-            *sizep = 0;
-        }
         return (false);
     case WT_K_FLAG:
         /* Encoded key: no instantiated key, no cell. */


### PR DESCRIPTION
Reconciliation has some fast-path code to work on prefix-compressed
to avoid figuring out each key from scratch which would require
going back some number of K/V pairs to key that's not
prefix-compressed and then rolling forward), we use the complete
key we just built for the last K/V pair's reconciliation, and
apply the current key's prefix-compression change to it, saving
us quite a bit of work. The change in WT-4642 clears that saved,
last-key information, and it leads to a performance drop compared
to 4.0 version. More details are available in SERVER-44991.