### PR TITLE
BACKPORT-5611 Data mismatch failures with test/checkpoint after enabling LAS sweep

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1030,7 +1030,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_ITEM las_key, las_value;
     WT_ITEM *sweep_key;
-    WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t las_timestamp;
     uint64_t cnt, remove_cnt, las_pageid, saved_pageid, visit_cnt;
     uint64_t las_counter, las_txnid;
@@ -1061,7 +1060,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
      */
     __wt_las_cursor(session, &cursor, &session_flags);
     WT_ASSERT(session, cursor->session == &session->iface);
-    __las_set_isolation(session, &saved_isolation);
     WT_ERR(__wt_txn_begin(session, NULL));
     local_txn = true;
 
@@ -1232,7 +1230,6 @@ err:
             (void)__wt_atomic_add64(&cache->las_remove_count, remove_cnt);
     }
 
-    __las_restore_isolation(session, saved_isolation);
     WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
 
     if (locked)


### PR DESCRIPTION
Backporting the changes in WT-5196 to branch `mongodb-4.0` 