### PR TITLE
WT-5257 Coverity dereference after null check

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1568,6 +1568,7 @@ __rec_split_write_supd(
                 key->data = WT_INSERT_KEY(supd->ins);
                 key->size = WT_INSERT_KEY_SIZE(supd->ins);
             }
+            WT_ASSERT(session, next != NULL);
             WT_ERR(__wt_compare(session, btree->collator, key, &next->key, &cmp));
             if (cmp >= 0)
                 break;


### PR DESCRIPTION
I've added an assert to check that the previous reconciliation buffer (r->prev_ptr) is not null. This is because this value should always be initialized when a write is triggered either because it was 'forced' or part of a 'bulk-load'. 

The hope is that this silences Coverity, otherwise I will manually mark the report as a false positive. The assertion remains valid in order to find any actual exceptions.