### PR TITLE
WT-5319 Avoid clearing the saved last-key when no instantiated key

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -838,10 +838,6 @@ __wt_row_leaf_key_info(
             *ikeyp = NULL;
         if (cellp != NULL)
             *cellp = WT_PAGE_REF_OFFSET(page, WT_CELL_DECODE_OFFSET(v));
-        if (datap != NULL) {
-            *(void **)datap = NULL;
-            *sizep = 0;
-        }
         return (false);
     case WT_K_FLAG:
         /* Encoded key: no instantiated key, no cell. */
@@ -998,6 +994,9 @@ __wt_row_leaf_value_cell(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
     WT_CELL_UNPACK unpack;
     size_t size;
     void *copy, *key;
+
+    size = 0;   /* -Werror=maybe-uninitialized */
+    key = NULL; /* -Werror=maybe-uninitialized */
 
     /* If we already have an unpacked key cell, use it. */
     if (kpack != NULL)

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -397,6 +397,12 @@ snap_repeat_txn(WT_CURSOR *cursor, TINFO *tinfo)
         if (current->opid != tinfo->opid)
             break;
 
+        /*
+         * The transaction is not yet resolved, so the rules are as if the transaction has
+         * committed. Note we are NOT checking if reads are repeatable based on the chosen
+         * timestamp. This is because we expect snapshot isolation to work even in the presence of
+         * other threads of control committing in our past, until the transaction resolves.
+         */
         if (snap_repeat_ok_commit(tinfo, current))
             WT_RET(snap_verify(cursor, tinfo, current));
     }


### PR DESCRIPTION
Reconciliation has some fast-path code to work on prefix-compressed
to avoid figuring out each key from scratch which would require
going back some number of K/V pairs to key that's not
prefix-compressed and then rolling forward), we use the complete
key we just built for the last K/V pair's reconciliation, and
apply the current key's prefix-compression change to it, saving
us quite a bit of work. Clearing the last-key information can
leads to a performance drop.