### PR TITLE
WT-5314 For python tests, if the name of an extension is blank, don't try to load it

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -160,7 +160,7 @@ class TestSuiteConnection(object):
 class ExtensionList(list):
     skipIfMissing = False
     def extension(self, dirname, name, extarg=None):
-        if name != None and name != 'none':
+        if name and name != 'none':
             ext = '' if extarg == None else '=' + extarg
             self.append(dirname + '/' + name + ext)
 


### PR DESCRIPTION
Extensions that have a name of None, or "" or "none" are treated the same, they are not loaded.