### PR TITLE
WT-5196 data mismatch with las sweep (#4967) [Backport to 4.0]

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -1030,7 +1030,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_ITEM las_key, las_value;
     WT_ITEM *sweep_key;
-    WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t las_timestamp;
     uint64_t cnt, remove_cnt, las_pageid, saved_pageid, visit_cnt;
     uint64_t las_counter, las_txnid;
@@ -1061,7 +1060,6 @@ __wt_las_sweep(WT_SESSION_IMPL *session)
      */
     __wt_las_cursor(session, &cursor, &session_flags);
     WT_ASSERT(session, cursor->session == &session->iface);
-    __las_set_isolation(session, &saved_isolation);
     WT_ERR(__wt_txn_begin(session, NULL));
     local_txn = true;
 
@@ -1232,7 +1230,6 @@ err:
             (void)__wt_atomic_add64(&cache->las_remove_count, remove_cnt);
     }
 
-    __las_restore_isolation(session, saved_isolation);
     WT_TRET(__wt_las_cursor_close(session, &cursor, session_flags));
 
     if (locked)


### PR DESCRIPTION
* WT-5196 Let the LAS sweep works under read committed isolation

LAS sweep working under read uncommitted isolation can find the
LAS records that are even not committed. The LAS sweep does the
cleanup based on the first record that is present for the key.
As the LAS sweep operates in read uncommitted mode, sometimes
even when the entire record chain for the key is not finished
insertion, the LAS sweep may clean the part of the update chain
as it finds them as obsolete. This leads to missing update chain
records and that leads to record miss.

To solve this problem, let the LAS sweep to work under read
committed isolation level, that leads to non visibility of records
from a running transaction.

* The isolation level is set to default in LAS sweep, there is no need
of save and restore functions to update the isolation level.

(cherry picked from commit 8fbc0ac864e410ddb877dad9c180f50ffeba06e3)