### PR TITLE
WT-5169 WT_REF_LIMBO pages cannot support fast (leaf-page only) searches [Backport to 4.0]

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -16,6 +16,7 @@ __wt_config_getone
 __wt_cursor_get_raw_value
 __wt_debug_addr
 __wt_debug_addr_print
+__wt_debug_cursor_las
 __wt_debug_cursor_page
 __wt_debug_offset
 __wt_debug_set_verbose

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -87,17 +87,16 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt)
         return (false);
 
     /*
-     * If we are doing an update, we need a page with history, release the page so we get it again
-     * with history if required. Eviction may be locking the page, wait until we see a "normal"
-     * state and then test against that state (eviction may have already locked the page again).
+     * We need a page with history: updates need complete update lists and a read might be based on
+     * a different timestamp than the one that brought the page into memory. Release the page and
+     * read it again with history if required. Eviction may be locking the page, wait until we see a
+     * "normal" state and then test against that state (eviction may have already locked the page
+     * again).
      */
-    if (F_ISSET(&session->txn, WT_TXN_UPDATE)) {
-        while ((current_state = cbt->ref->state) == WT_REF_LOCKED)
-            __wt_yield();
-        return (current_state == WT_REF_MEM);
-    }
-
-    return (true);
+    while ((current_state = cbt->ref->state) == WT_REF_LOCKED)
+        __wt_yield();
+    WT_ASSERT(session, current_state == WT_REF_LIMBO || current_state == WT_REF_MEM);
+    return (current_state == WT_REF_MEM);
 }
 
 /*

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -700,6 +700,28 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
 }
 
 /*
+ * __wt_debug_cursor_las --
+ *     Dump the LAS tree given a user cursor.
+ */
+int
+__wt_debug_cursor_las(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_SESSION_IMPL *las_session;
+
+    cursor = cursor_arg;
+    conn = S2C((WT_SESSION_IMPL *)cursor->session);
+    las_session = conn->cache->las_session[0];
+    if (las_session == NULL)
+        return (0);
+    cbt = (WT_CURSOR_BTREE *)las_session->las_cursor;
+    return (__wt_debug_tree_all(las_session, cbt->btree, NULL, ofile));
+}
+
+/*
  * __debug_tree --
  *     Dump the in-memory information for a tree.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -251,6 +251,8 @@ extern int __wt_debug_page(void *session_arg, WT_BTREE *btree, WT_REF *ref, cons
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_cursor_las(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
+  (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)


### PR DESCRIPTION
* Add a function to dump the LAS table based on a random cursor.

* If a thread does a timestamp-based read which doesn't require page history (that is, the page
is left in WT_REF_LIMBO state), and then does a subsequent read based on a different timestamp
which does require page history, we can't treat the page as "pinned", we have to take the full
read path in order to load the page history.

* Assert a pinned page is either in a WT_REF_LIMBO or WT_REF_MEM state.

(cherry picked from commit 9dde82b6f01edc02562535291b02b52a01e6f05d)