### PR TITLE
WT-5090 Log message to event handler when rollback due to cache full

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2300,6 +2300,10 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
             if (ret == WT_ROLLBACK) {
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
+                if (timer)
+                    WT_ERR(__wt_msg(session, "%s", 
+                        "Application thread returned a rollback error because "
+                        "it was forced to evict and eviction is stuck"));
             }
             WT_ERR(ret);
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2301,9 +2301,9 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
                 if (timer)
-                    WT_ERR(__wt_msg(session, "%s", 
-                        "Application thread returned a rollback error because "
-                        "it was forced to evict and eviction is stuck"));
+                    WT_ERR(__wt_msg(session, "%s",
+                      "Application thread returned a rollback error because "
+                      "it was forced to evict and eviction is stuck"));
             }
             WT_ERR(ret);
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2301,7 +2301,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
                 if (timer)
-                    WT_IGNORE_RET(__wt_msg(session, "%s",
+                    WT_IGNORE_RET(__wt_msg(session,
                       "Application thread returned a rollback error because "
                       "it was forced to evict and eviction is stuck"));
             }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2301,7 +2301,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
                 if (timer)
-                    WT_ERR(__wt_msg(session, "%s",
+                    WT_IGNORE_RET(__wt_msg(session, "%s",
                       "Application thread returned a rollback error because "
                       "it was forced to evict and eviction is stuck"));
             }


### PR DESCRIPTION
Added log message to the event handler when rollback due to cache full. Tested through randomly factors which forcibly initiates the workflow of producing the message.  

JIRA: https://jira.mongodb.org/browse/WT-5090