### PR TITLE
WT-5112 Update regex to handle labels with underscores (#5062) BACKPORT-4.2

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -401,7 +401,7 @@ worker_async(void *arg)
                 break;
             goto op_err;
         default:
-        op_err:
+op_err:
             lprintf(wtperf, ret, 0, "%s failed for: %s, range: %" PRIu64, op_name(op), key_buf,
               wtperf_value_range(wtperf));
             goto err; /* can't happen */
@@ -831,7 +831,7 @@ worker(void *arg)
             if (ret == WT_NOTFOUND)
                 break;
 
-        op_err:
+op_err:
             if (ret == WT_ROLLBACK && (ops_per_txn != 0 || opts->log_like_table)) {
                 /*
                  * If we are running with explicit transactions configured and we hit a WT_ROLLBACK,

--- a/dist/s_goto.py
+++ b/dist/s_goto.py
@@ -6,7 +6,7 @@ import re, sys
 # 1. Zero or more whitespace characters.
 # 2. One or more lowercase ASCII characters.
 # 3. Colon character.
-p = re.compile('^\s*[a-z]+:$')
+p = re.compile('^\s*[a-z_]+:$')
 for line in sys.stdin:
     m = p.search(line)
     if m is not None:

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -57,7 +57,7 @@ __cursor_fix_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
         cbt->v = 0;
         cbt->iface.value.data = &cbt->v;
     } else {
-    restart_read:
+restart_read:
         WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
         if (upd == NULL) {
             cbt->v = 0;
@@ -111,7 +111,7 @@ new_page:
     if (cbt->ins != NULL && cbt->recno != WT_INSERT_RECNO(cbt->ins))
         cbt->ins = NULL;
     if (cbt->ins != NULL)
-    restart_read:
+restart_read:
     WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
     if (upd == NULL) {
         cbt->v = __bit_getv_recno(cbt->ref, cbt->recno, btree->bitcnt);
@@ -145,12 +145,12 @@ __cursor_var_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 
     for (;;) {
         cbt->ins = WT_SKIP_NEXT(cbt->ins);
-    new_page:
+new_page:
         if (cbt->ins == NULL)
             return (WT_NOTFOUND);
 
         __cursor_set_recno(cbt, WT_INSERT_RECNO(cbt->ins));
-    restart_read:
+restart_read:
         WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
         if (upd == NULL)
             continue;
@@ -209,8 +209,8 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
             return (WT_NOTFOUND);
         __cursor_set_recno(cbt, cbt->recno + 1);
 
-    new_page:
-    restart_read:
+new_page:
+restart_read:
         /* Find the matching WT_COL slot. */
         if ((cip = __col_var_search(cbt->ref, cbt->recno, &rle_start)) == NULL)
             return (WT_NOTFOUND);
@@ -337,9 +337,9 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
         if (cbt->ins != NULL)
             cbt->ins = WT_SKIP_NEXT(cbt->ins);
 
-    new_insert:
+new_insert:
         cbt->iter_retry = WT_CBT_RETRY_INSERT;
-    restart_read_insert:
+restart_read_insert:
         if ((ins = cbt->ins) != NULL) {
             WT_RET(__wt_txn_read(session, ins->upd, &upd));
             if (upd == NULL)
@@ -373,7 +373,7 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 
         cbt->iter_retry = WT_CBT_RETRY_PAGE;
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
-    restart_read_page:
+restart_read_page:
         rip = &page->pg_row[cbt->slot];
         WT_RET(__wt_txn_read(session, WT_ROW_UPDATE(page, rip), &upd));
         if (upd != NULL && upd->type == WT_UPDATE_TOMBSTONE) {

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -198,7 +198,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
         cbt->iface.value.data = &cbt->v;
     } else {
         upd = NULL;
-    restart_read:
+restart_read:
         WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
         if (upd == NULL) {
             cbt->v = 0;
@@ -252,7 +252,7 @@ new_page:
         cbt->ins = NULL;
     upd = NULL;
     if (cbt->ins != NULL)
-    restart_read:
+restart_read:
     WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
     if (upd == NULL) {
         cbt->v = __bit_getv_recno(cbt->ref, cbt->recno, btree->bitcnt);
@@ -286,12 +286,12 @@ __cursor_var_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 
     for (;;) {
         WT_RET(__cursor_skip_prev(cbt));
-    new_page:
+new_page:
         if (cbt->ins == NULL)
             return (WT_NOTFOUND);
 
         __cursor_set_recno(cbt, WT_INSERT_RECNO(cbt->ins));
-    restart_read:
+restart_read:
         WT_RET(__wt_txn_read(session, cbt->ins->upd, &upd));
         if (upd == NULL)
             continue;
@@ -348,11 +348,11 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     for (;;) {
         __cursor_set_recno(cbt, cbt->recno - 1);
 
-    new_page:
+new_page:
         if (cbt->recno < cbt->ref->ref_recno)
             return (WT_NOTFOUND);
 
-    restart_read:
+restart_read:
         /* Find the matching WT_COL slot. */
         if ((cip = __col_var_search(cbt->ref, cbt->recno, &rle_start)) == NULL)
             return (WT_NOTFOUND);
@@ -488,9 +488,9 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
         if (cbt->ins != NULL)
             WT_RET(__cursor_skip_prev(cbt));
 
-    new_insert:
+new_insert:
         cbt->iter_retry = WT_CBT_RETRY_INSERT;
-    restart_read_insert:
+restart_read_insert:
         if ((ins = cbt->ins) != NULL) {
             WT_RET(__wt_txn_read(session, ins->upd, &upd));
             if (upd == NULL)
@@ -526,7 +526,7 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 
         cbt->iter_retry = WT_CBT_RETRY_PAGE;
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
-    restart_read_page:
+restart_read_page:
         rip = &page->pg_row[cbt->slot];
         WT_RET(__wt_txn_read(session, WT_ROW_UPDATE(page, rip), &upd));
         if (upd != NULL && upd->type == WT_UPDATE_TOMBSTONE) {

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1142,7 +1142,7 @@ err:
          * subsequent iteration can succeed, we cannot return success.)
          */
         if (0) {
-        search_notfound:
+search_notfound:
             ret = WT_NOTFOUND;
             if (!iterating && !positioned && F_ISSET(cursor, WT_CURSTD_OVERWRITE))
                 ret = 0;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -754,7 +754,7 @@ read:
                 continue;
             }
 
-        skip_evict:
+skip_evict:
             /*
              * If we read the page and are configured to not trash the cache, and no other thread
              * has already used the page, set the read generation so the page is evicted soon.

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -917,7 +917,7 @@ __slvg_col_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
      * Case #5: a_trk is a superset of b_trk and a_trk is more desirable -- discard b_trk.
      */
     if (a_trk->trk_gen > b_trk->trk_gen) {
-    delete_b:
+delete_b:
         /*
          * After page and overflow reconciliation, one (and only one)
          * page can reference an overflow record.  But, if we split a
@@ -1512,7 +1512,7 @@ __slvg_row_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
      * Case #5: a_trk is a superset of b_trk and a_trk is more desirable -- discard b_trk.
      */
     if (a_trk->trk_gen > b_trk->trk_gen) {
-    delete_b:
+delete_b:
         /*
          * After page and overflow reconciliation, one (and only one)
          * page can reference an overflow record.  But, if we split a

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -423,7 +423,7 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
         goto recno_chk;
     case WT_PAGE_COL_VAR:
         recno = ref->ref_recno;
-    recno_chk:
+recno_chk:
         if (recno != vs->record_total + 1)
             WT_RET_MSG(session, WT_ERROR, "page at %s has a starting record of %" PRIu64
                                           " when the expected starting record is %" PRIu64,
@@ -473,7 +473,7 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
     case WT_PAGE_COL_INT:
     case WT_PAGE_ROW_INT:
         if (addr_unpack->raw != WT_CELL_ADDR_INT)
-        celltype_err:
+celltype_err:
         WT_RET_MSG(session, WT_ERROR,
           "page at %s, of type %s, is referenced in "
           "its parent by a cell of type %s",

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -557,7 +557,7 @@ __verify_dsk_row(
             current->size = prefix + unpack->size;
         }
 
-    key_compare:
+key_compare:
         /*
          * Compare the current key against the last key.
          *
@@ -770,7 +770,7 @@ __verify_dsk_col_var(
                 goto match_err;
         } else if (cell_type == WT_CELL_VALUE && last.data != NULL && last.size == unpack->size &&
           memcmp(last.data, unpack->data, last.size) == 0)
-        match_err:
+match_err:
         WT_RET_VRFY(session, "data entries %" PRIu32 " and %" PRIu32
                              " on page at %s are identical and should "
                              "have been run-length encoded",

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -168,7 +168,7 @@ __wt_row_leaf_key_work(
 #endif
     for (slot_offset = 0;;) {
         if (0) {
-        switch_and_jump:
+switch_and_jump:
             /* Switching to a forward roll. */
             WT_ASSERT(session, direction == BACKWARD);
             direction = FORWARD;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -533,7 +533,7 @@ leaf_only:
      * read-mostly workload. Check that case and get out fast.
      */
     if (0) {
-    leaf_match:
+leaf_match:
         cbt->compare = 0;
         cbt->slot = WT_ROW_SLOT(page, rip);
         return (0);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -716,7 +716,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
     WT_ERR(__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));
 
     if (0) {
-    config_err:
+config_err:
         WT_ERR_MSG(session, EINVAL,
           "cursor's statistics configuration doesn't match the "
           "database statistics configuration");

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -731,7 +731,7 @@ __wt_rec_col_var(
          */
         WT_ERR(__wt_dsk_cell_data_ref(session, WT_PAGE_COL_VAR, vpack, orig));
 
-    record_loop:
+record_loop:
         /*
          * Generate on-page entries: loop repeat records, looking for WT_INSERT entries matching the
          * record number. The WT_INSERT lists are in sorted order, so only need check the next one.

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -989,7 +989,7 @@ build:
         /* Update compression state. */
         __rec_key_state_update(r, ovfl_key);
 
-    leaf_insert:
+leaf_insert:
         /* Write any K/V pairs inserted into the page after this key. */
         if ((ins = WT_SKIP_FIRST(WT_ROW_INSERT(page, rip))) != NULL)
             WT_ERR(__rec_row_leaf_insert(session, r, ins));

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -486,7 +486,7 @@ thread_ts_run(void *arg)
                 printf("SET STABLE: %" PRIx64 " %" PRIu64 "\n", oldest_ts, oldest_ts);
             }
         } else
-        ts_wait:
+ts_wait:
         __wt_sleep(0, 1000);
     }
     /* NOTREACHED */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -842,7 +842,7 @@ ops(void *arg)
                 READ_OP_FAILED(true);
             break;
         case REMOVE:
-        remove_instead_of_truncate:
+remove_instead_of_truncate:
             switch (g.type) {
             case ROW:
                 ret = row_remove(tinfo, cursor, positioned);
@@ -930,7 +930,7 @@ ops(void *arg)
                 WRITE_OP_FAILED(false);
             break;
         case UPDATE:
-        update_instead_of_chosen_op:
+update_instead_of_chosen_op:
             ++tinfo->update;
             switch (g.type) {
             case ROW:
@@ -1250,7 +1250,7 @@ nextprev(TINFO *tinfo, WT_CURSOR *cursor, bool next)
             } else if (tinfo->keyno > keyno || (!record_gaps && keyno != tinfo->keyno + 1))
                 goto order_error_col;
             if (0) {
-            order_error_col:
+order_error_col:
                 testutil_die(
                   0, "%s returned %" PRIu64 " then %" PRIu64, which, tinfo->keyno, keyno);
             }
@@ -1284,7 +1284,7 @@ nextprev(TINFO *tinfo, WT_CURSOR *cursor, bool next)
                     goto order_error_row;
             }
             if (0) {
-            order_error_row:
+order_error_row:
                 testutil_die(0, "%s returned {%.*s} then {%.*s}", which, (int)tinfo->key->size,
                   (char *)tinfo->key->data, (int)key.size, (char *)key.data);
             }


### PR DESCRIPTION
(cherry picked from commit f1e0c0a784f0f86fa5fb6c1e914a9d0b7fac7448)