### PR TITLE
WT-5333 Simplify txn read and remove invisible birthmark optimisation

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -728,7 +728,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
             return (WT_PREPARE_CONFLICT);
     }
 
-    /* If there's no visible update in memory, check the history file. */
+    /* If there's no visible update in the update chain, check the lookaside file. */
     if (__wt_page_las_active(session, cbt->ref))
         WT_RET_NOTFOUND_OK(__wt_find_lookaside_upd(session, cbt, &upd, false));
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -732,6 +732,8 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     if (__wt_page_las_active(session, cbt->ref))
         WT_RET_NOTFOUND_OK(__wt_find_lookaside_upd(session, cbt, &upd, false));
 
+    /* There is no BIRTHMARK in history file. */
+    WT_ASSERT(session, upd->type != WT_UPDATE_BIRTHMARK);
     *updp = upd;
     return (0);
 }

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -733,7 +733,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
         WT_RET_NOTFOUND_OK(__wt_find_lookaside_upd(session, cbt, &upd, false));
 
     /* There is no BIRTHMARK in history file. */
-    WT_ASSERT(session, upd->type != WT_UPDATE_BIRTHMARK);
+    WT_ASSERT(session, upd == NULL || upd->type != WT_UPDATE_BIRTHMARK);
     *updp = upd;
     return (0);
 }

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -732,7 +732,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     if (__wt_page_las_active(session, cbt->ref))
         WT_RET_NOTFOUND_OK(__wt_find_lookaside_upd(session, cbt, &upd, false));
 
-    /* There is no BIRTHMARK in history file. */
+    /* There is no BIRTHMARK in lookaside file. */
     WT_ASSERT(session, upd == NULL || upd->type != WT_UPDATE_BIRTHMARK);
     *updp = upd;
     return (0);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -711,13 +711,9 @@ __wt_txn_upd_visible(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 static inline int
 __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT_UPDATE **updp)
 {
-    /* FIXME-PM1521: To be Removed by WT-5282 */
-    // static WT_UPDATE tombstone = {.txnid = WT_TXN_NONE, .type = WT_UPDATE_TOMBSTONE};
     WT_VISIBLE_TYPE upd_visible;
-    // bool skipped_birthmark;
 
     *updp = NULL;
-    // skipped_birthmark = false;
     for (; upd != NULL; upd = upd->next) {
         /* Skip reserved place-holders, they're never visible. */
         if (upd->type != WT_UPDATE_RESERVE) {
@@ -727,21 +723,11 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
             if (upd_visible == WT_VISIBLE_PREPARE)
                 return (WT_PREPARE_CONFLICT);
         }
-
-        /*
-         * FIXME-PM1521: To be Removed by WT-5282 An invisible birthmark is equivalent to a
-         * tombstone.
-         */
-        // if (upd->type == WT_UPDATE_BIRTHMARK)
-        //     skipped_birthmark = true;
     }
 
     /* Cannot find the update in memory. Try lookaside. */
     if (upd == NULL && __wt_page_las_active(session, cbt->ref))
         WT_RET_NOTFOUND_OK(__wt_find_lookaside_upd(session, cbt, &upd, false));
-
-    // if (upd == NULL && skipped_birthmark)
-    //     upd = &tombstone;
 
     *updp = upd == NULL || upd->type == WT_UPDATE_BIRTHMARK ? NULL : upd;
     return (0);


### PR DESCRIPTION
Now the algorithm can be simplified to first walk the update chain,
then the history store, and return the first visibile update.