### PR TITLE
WT-5366 read-committed and read-uncommitted transactions can stall eviction

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2266,7 +2266,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
     WT_TXN_STATE *txn_state;
     uint64_t elapsed, time_start, time_stop;
     uint64_t initial_progress, max_progress;
-    bool timer;
+    bool app_thread;
 
     WT_TRACK_OP_INIT(session);
 
@@ -2286,8 +2286,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
     __wt_evict_server_wake(session);
 
     /* Track how long application threads spend doing eviction. */
-    timer = !F_ISSET(session, WT_SESSION_INTERNAL);
-    if (timer)
+    app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
+    if (app_thread)
         time_start = __wt_clock(session);
 
     for (initial_progress = cache->eviction_progress;; ret = 0) {
@@ -2300,10 +2300,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
             if (ret == WT_ROLLBACK) {
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
-                if (timer)
-                    WT_IGNORE_RET(__wt_msg(session,
-                      "Application thread returned a rollback error because "
-                      "it was forced to evict and eviction is stuck"));
+                if (app_thread)
+                    WT_TRET(__wt_msg(session, "%s", session->txn.rollback_reason));
             }
             WT_ERR(ret);
         }
@@ -2343,7 +2341,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
             goto err;
         }
         /* Stop if we've exceeded the time out. */
-        if (timer && cache->cache_max_wait_us != 0) {
+        if (app_thread && cache->cache_max_wait_us != 0) {
             time_stop = __wt_clock(session);
             if (session->cache_wait_us + WT_CLOCKDIFF_US(time_stop, time_start) >
               cache->cache_max_wait_us)
@@ -2352,7 +2350,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
     }
 
 err:
-    if (timer) {
+    if (app_thread) {
         time_stop = __wt_clock(session);
         elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
         WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1589,15 +1589,16 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const cha
 
 /*
  * __wt_txn_is_blocking --
- *     Return if this transaction is likely blocking eviction because of a pinned transaction ID,
- *     called by eviction to determine if a worker thread should be released from eviction.
+ *     Return an error if this transaction is likely blocking eviction because of a pinned
+ *     transaction ID, called by eviction to determine if a worker thread should be released from
+ *     eviction.
  */
 int
 __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
     WT_TXN_STATE *txn_state;
-    uint64_t global_oldest, txn_oldest;
+    uint64_t global_oldest;
 
     txn = &session->txn;
     txn_state = WT_SESSION_TXN_STATE(session);
@@ -1605,7 +1606,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 
     /* We can't roll back prepared transactions. */
     if (F_ISSET(txn, WT_TXN_PREPARE))
-        return (false);
+        return (0);
 
     /*
      * MongoDB can't (yet) handle rolling back read only transactions. For this reason, don't check
@@ -1613,21 +1614,12 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
      * to confirm our caller is prepared for rollback).
      */
     if (txn->mod_count == 0 && !__wt_op_timer_fired(session))
-        return (false);
+        return (0);
 
     /*
-     * Check the oldest transaction ID of either the current transaction ID or the snapshot.
-     *
-     * Read-committed and read-uncommitted transactions enter transaction IDs into the global table
-     * to stop updates they're reading from being freed, and that can prevent the oldest ID from
-     * moving forward.
+     * Check if either the transaction's ID or its pinned ID is equal to the oldest transaction ID.
      */
-    txn_oldest = txn->id;
-    if (F_ISSET(txn, WT_TXN_HAS_SNAPSHOT) && txn->snap_min != WT_TXN_NONE &&
-      (txn_oldest == WT_TXN_NONE || WT_TXNID_LT(txn->snap_min, txn_oldest)))
-        txn_oldest = txn->snap_min;
-    return (txn_oldest == global_oldest || txn_state->pinned_id == global_oldest ||
-          txn_state->metadata_pinned == global_oldest ?
+    return (txn_state->id == global_oldest || txn_state->pinned_id == global_oldest ?
         __wt_txn_rollback_required(
           session, "oldest pinned transaction ID rolled back for eviction") :
         0);


### PR DESCRIPTION
This change works, but I'm unsure if it's correct. Specific questions:

* Should the check be wrapped in `!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT)` or `txn->isolation == WT_ISO_READ_UNCOMMITTED || txn->isolation == WT_ISO_READ_COMMITTED` or something else?

* I don't understand why `txn_state->metadata_pinned` needs to be checked; my reading of the code indicates it shouldn't be blocking the oldest ID from moving forward permanently, but it does (and it does not move in lockstep with `txn_state->pinned_id`, they can have different values).

EDIT:
In commit a7e0242, I made the checks of `WT_TXN_STATE.pinned_id` and `WT_TXN_STATE.metadata_pinned` independent. As far as I can tell, they have no consistent relationship and either one can independently stall the system. Again, I need some guidance here to get to the correct fix.