### PR TITLE
WT-5119 Birthmark records can be read as normal updates if reads race with checkpoints.

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -16,6 +16,13 @@
         (v) = (val);        \
     } while (0)
 
+/* Write after all previous stores are completed. */
+#define WT_ORDERED_WRITE(v, val) \
+    do {                         \
+        WT_WRITE_BARRIER();      \
+        (v) = (val);             \
+    } while (0)
+
 /*
  * Read a shared location and guarantee that subsequent reads do not see any earlier state.
  */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -102,8 +102,8 @@ __rec_append_orig_value(
 
     /* Replace the birthmark with an aborted transaction. */
     if (upd->type == WT_UPDATE_BIRTHMARK) {
-        upd->txnid = WT_TXN_ABORTED;
-        WT_PUBLISH(upd->type, WT_UPDATE_STANDARD);
+        WT_ORDERED_WRITE(upd->txnid, WT_TXN_ABORTED);
+        WT_ORDERED_WRITE(upd->type, WT_UPDATE_STANDARD);
     }
 
     __wt_cache_page_inmem_incr(session, page, size);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -86,10 +86,9 @@ __rec_append_orig_value(
 
     /*
      * If we're saving the original value for a birthmark, transfer over the transaction ID and
-     * clear out the birthmark update.
-     *
-     * Else, set the entry's transaction information to the lowest possible value. Cleared memory
-     * matches the lowest possible transaction ID and timestamp, do nothing.
+     * clear out the birthmark update. Else, set the entry's transaction information to the lowest
+     * possible value (as cleared memory matches the lowest possible transaction ID and timestamp,
+     * do nothing).
      */
     if (upd->type == WT_UPDATE_BIRTHMARK) {
         append->txnid = upd->txnid;
@@ -100,12 +99,14 @@ __rec_append_orig_value(
 
     /* Append the new entry into the update list. */
     WT_PUBLISH(upd->next, append);
-    __wt_cache_page_inmem_incr(session, page, size);
 
+    /* Replace the birthmark with an aborted transaction. */
     if (upd->type == WT_UPDATE_BIRTHMARK) {
-        upd->type = WT_UPDATE_STANDARD;
         upd->txnid = WT_TXN_ABORTED;
+        WT_PUBLISH(upd->type, WT_UPDATE_STANDARD);
     }
+
+    __wt_cache_page_inmem_incr(session, page, size);
 
 err:
     __wt_scr_free(session, &tmp);


### PR DESCRIPTION
Sue, Alex, Vamsi:

The problem in the original code is here:

```
    105     if (upd->type == WT_UPDATE_BIRTHMARK) {
    106         upd->type = WT_UPDATE_STANDARD;
    107         upd->txnid = WT_TXN_ABORTED;
    108     }
```
If the updates are written to memory in the above order, and a reader gets in between lines 106 and 107, a birthmark record can be read as a normal update because its type is `WT_UPDATE_STANDARD` and `upd.txnid` has yet to be set to `WT_TXN_ABORTED`.

I think it might be safe to merge the two `WT_PUBLISH` commands into something like this:
```
    if (upd->type == WT_UPDATE_BIRTHMARK) {
        append->txnid = upd->txnid;
        append->start_ts = upd->start_ts;
        append->durable_ts = upd->durable_ts;
        append->next = upd->next;

        upd->txnid = WT_TXN_ABORTED;
    }

    /* Append the new entry into the update list. */
    WT_PUBLISH(upd->next, append);

    if (upd->type == WT_UPDATE_BIRTHMARK)  
        upd->type = WT_UPDATE_STANDARD;

    __wt_cache_page_inmem_incr(session, page, size);
```
That potentially sets `upd.txnid = WT_TXN_ABORTED` before `upd.next = append`, and my reading of the code makes me think that's safe because if we skip the birthmark record, we'll instead read the original value from that page, and I think that's correct behavior.

However, I'm not confident that's true in all cases, so this diff is the slower, more cautious change of updating `upd.next = append`, then ensuring we've aborted the update before setting the update's type to `WT_UPDATE_STANDARD`.

EDIT:
It is also worth considering if this solution isn't conservative enough. The current diff allows `WT_UPDATE.txnid = WT_TXN_ABORTED` to be written before `WT_UPDATE.next = append` is written. As above, I think that's safe, but I'm not confident.

EDIT:
Here's the most conservative diff:
```
diff --git a/src/reconcile/rec_visibility.c b/src/reconcile/rec_visibility.c
index 9a78ffe07..744d2a4bd 100644
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -102,7 +102,7 @@ __rec_append_orig_value(
 
     /* Replace the birthmark with an aborted transaction. */
     if (upd->type == WT_UPDATE_BIRTHMARK) {
-        upd->txnid = WT_TXN_ABORTED;
+        WT_PUBLISH(upd->txnid, WT_TXN_ABORTED);
         WT_PUBLISH(upd->type, WT_UPDATE_STANDARD);
     }
```