### PR TITLE
WT-5247 Resizing modify operation log full values. (#4977) [BACKPORT-v3.6]

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -731,6 +731,7 @@ extern void __wt_huffman_close(WT_SESSION_IMPL *session, void *huffman_arg);
 extern void __wt_print_huffman_code(void *huffman_arg, uint16_t symbol);
 extern int __wt_huffman_encode(WT_SESSION_IMPL *session, void *huffman_arg, const uint8_t *from_arg, size_t from_len, WT_ITEM *to_buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_huffman_decode(WT_SESSION_IMPL *session, void *huffman_arg, const uint8_t *from_arg, size_t from_len, WT_ITEM *to_buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_modify_idempotent(const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_pack(WT_SESSION_IMPL *session, WT_ITEM **modifyp, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply_api(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_MODIFY *entries, int nentries) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply(WT_SESSION_IMPL *session, WT_CURSOR *cursor, const void *modify) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -8,6 +8,25 @@
 
 #include "wt_internal.h"
 
+#define	WT_MODIFY_FOREACH_BEGIN(mod, p, nentries, napplied)                \
+    do {                                                                   \
+	const size_t *__p = p;                                                 \
+	const uint8_t *__data = (const uint8_t *)(__p + (size_t)(nentries)*3); \
+	int __i;                                                               \
+	for (__i = 0; __i < (nentries); ++__i) {                               \
+	    memcpy(&(mod).data.size, __p++, sizeof(size_t));                   \
+	    memcpy(&(mod).offset, __p++, sizeof(size_t));                      \
+	    memcpy(&(mod).size, __p++, sizeof(size_t));                        \
+	    (mod).data.data = __data;                                          \
+	    __data += (mod).data.size;                                         \
+	    if (__i < (napplied))                                              \
+		continue;
+
+#define	WT_MODIFY_FOREACH_END \
+    }                         \
+    }                         \
+    while (0)
+
 /*
  * __wt_modify_idempotent --
  *     Check if a modify operation is idempotent.


### PR DESCRIPTION
* WT-5247 Resizing modify operation log full values.

When modify operations resize part of a value, subsequent bytes are shuffled around and the operation is no longer idempotent.  Since WiredTiger's recovery can reapply operations that overlap with a checkpoint, it is not safe to log resizing modify operations.  Instead, log full update operations for that case.

(cherry picked from commit 9badd6c26c9b5f9e008913a271355cf99ba17952)