### PR TITLE
WT-5042 Reduce configuration parsing overhead from checkpoints (#4936) #5009 [BACKPORT-v3.6]

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -25,6 +25,7 @@ __conn_dhandle_config_clear(WT_SESSION_IMPL *session)
 	for (a = dhandle->cfg; *a != NULL; ++a)
 		__wt_free(session, *a);
 	__wt_free(session, dhandle->cfg);
+	__wt_free(session, dhandle->meta_base);
 }
 
 /*
@@ -36,9 +37,12 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
 {
 	WT_DATA_HANDLE *dhandle;
 	WT_DECL_RET;
-	char *metaconf;
+	const char *base, *cfg[3];
+	char *metaconf, *tmp;
 
 	dhandle = session->dhandle;
+	base = NULL;
+	tmp = NULL;
 
 	/*
 	 * Read the object's entry from the metadata file, we're done if we
@@ -68,8 +72,40 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
 	WT_ERR(__wt_calloc_def(session, 3, &dhandle->cfg));
 	switch (dhandle->type) {
 	case WT_DHANDLE_TYPE_BTREE:
+		/*
+		 * We are stripping out the checkpoint and checkpoint_lsn
+		 * information from the config string. We save the rest of
+		 * the metadata string, that is essentially static and
+		 * unchanging and then concatenate the new checkpoint and
+		 * LSN information on each checkpoint. The reason is
+		 * performance and avoiding a lot of calls to the config
+		 * parsing functions during a checkpoint for information
+		 * that changes in a very well known way.
+		 */
+		cfg[0] = metaconf;
+		cfg[1] = "checkpoint=()";
+		cfg[2] = NULL;
 		WT_ERR(__wt_strdup(session,
 		    WT_CONFIG_BASE(session, file_meta), &dhandle->cfg[0]));
+		WT_ASSERT(session, dhandle->meta_base == NULL);
+		/*
+		 * First collapse and overwrite any checkpoint information
+		 * because we do not know the name or how many checkpoints
+		 * may be in this metadata. So first we have to set the string
+		 * to the empty checkpoint string and call collapse to
+		 * overwrite anything existing.
+		 */
+		WT_ERR(__wt_config_collapse(session, cfg, &tmp));
+		/*
+		 * Now strip out the checkpoint and checkpoint LSN items
+		 * from the configuration string and that is now our
+		 * base metadata string.
+		 */
+		cfg[0] = tmp;
+		cfg[1] = NULL;
+		WT_ERR(__wt_config_merge(session,
+		    cfg, "checkpoint=,checkpoint_lsn=", &base));
+		__wt_free(session, tmp);
 		break;
 	case WT_DHANDLE_TYPE_TABLE:
 		WT_ERR(__wt_strdup(session,
@@ -77,9 +113,12 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
 		break;
 	}
 	dhandle->cfg[1] = metaconf;
+	dhandle->meta_base = base;
 	return (0);
 
-err:	__wt_free(session, metaconf);
+err:	__wt_free(session, base);
+	__wt_free(session, metaconf);
+	__wt_free(session, tmp);
 	return (ret);
 }
 

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -74,6 +74,7 @@ struct __wt_data_handle {
 	uint64_t name_hash;		/* Hash of name */
 	const char *checkpoint;		/* Checkpoint name (or NULL) */
 	const char **cfg;		/* Configuration information */
+	const char *meta_base;		/* Base metadata configuration */
 
 	/*
 	 * Sessions holding a connection's data handle will have a non-zero

--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -131,9 +131,6 @@ pwrite64(wt, ""..., 0x1000, 0x3000);
 #ifdef __linux__
 fdatasync(wt);
 #endif /* __linux__ */
-fd = OPEN_EXISTING("./WiredTiger.turtle", O_RDWR|O_CLOEXEC);
-
-close(fd);
 fd = open("./WiredTiger.turtle.set", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0666);
 pwrite64(fd, "WiredTiger version string\nWiredTiger"..., ...);
 #ifdef __linux__


### PR DESCRIPTION
Backports both WT-5042 and WT-5239.

The syscall test mentioned in #5009 still fails in 3.6 version.
JIRA: https://jira.mongodb.org/browse/BACKPORT-5645