### PR TITLE
WT-5120 checkpoint hangs when reconciliation doesn't release the evic…

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -163,7 +163,7 @@ restart_read:
                 ++cbt->page_deleted_count;
             continue;
         }
-        return (__wt_value_return(session, cbt, upd));
+        return (__wt_value_return(cbt, upd));
     }
     /* NOTREACHED */
 }
@@ -232,7 +232,7 @@ restart_read:
                     ++cbt->page_deleted_count;
                 continue;
             }
-            return (__wt_value_return(session, cbt, upd));
+            return (__wt_value_return(cbt, upd));
         }
 
         /*
@@ -360,7 +360,7 @@ restart_read_insert:
             }
             key->data = WT_INSERT_KEY(ins);
             key->size = WT_INSERT_KEY_SIZE(ins);
-            return (__wt_value_return(session, cbt, upd));
+            return (__wt_value_return(cbt, upd));
         }
 
         /* Check for the end of the page. */
@@ -489,8 +489,12 @@ __wt_cursor_key_order_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, bool
  *     Initialize key ordering checks for cursor movements after a successful search.
  */
 int
-__wt_cursor_key_order_init(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+__wt_cursor_key_order_init(WT_CURSOR_BTREE *cbt)
 {
+    WT_SESSION_IMPL *session;
+
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
+
     /*
      * Cursor searches set the position for cursor movements, set the last-key value for diagnostic
      * checking.

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -303,7 +303,7 @@ restart_read:
                 ++cbt->page_deleted_count;
             continue;
         }
-        return (__wt_value_return(session, cbt, upd));
+        return (__wt_value_return(cbt, upd));
     }
     /* NOTREACHED */
 }
@@ -373,7 +373,7 @@ restart_read:
                     ++cbt->page_deleted_count;
                 continue;
             }
-            return (__wt_value_return(session, cbt, upd));
+            return (__wt_value_return(cbt, upd));
         }
 
         /*
@@ -510,7 +510,7 @@ restart_read_insert:
             }
             key->data = WT_INSERT_KEY(ins);
             key->size = WT_INSERT_KEY_SIZE(ins);
-            return (__wt_value_return(session, cbt, upd));
+            return (__wt_value_return(cbt, upd));
         }
 
         /* Check for the beginning of the page. */

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -355,11 +355,14 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *valid)
  *     Column-store search from a cursor.
  */
 static inline int
-__cursor_col_search(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_REF *leaf)
+__cursor_col_search(WT_CURSOR_BTREE *cbt, WT_REF *leaf, bool *leaf_foundp)
 {
     WT_DECL_RET;
+    WT_SESSION_IMPL *session;
 
-    WT_WITH_PAGE_INDEX(session, ret = __wt_col_search(session, cbt->iface.recno, leaf, cbt, false));
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    WT_WITH_PAGE_INDEX(
+      session, ret = __wt_col_search(cbt, cbt->iface.recno, leaf, false, leaf_foundp));
     return (ret);
 }
 
@@ -368,12 +371,14 @@ __cursor_col_search(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_REF *leaf
  *     Row-store search from a cursor.
  */
 static inline int
-__cursor_row_search(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_REF *leaf, bool insert)
+__cursor_row_search(WT_CURSOR_BTREE *cbt, bool insert, WT_REF *leaf, bool *leaf_foundp)
 {
     WT_DECL_RET;
+    WT_SESSION_IMPL *session;
 
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     WT_WITH_PAGE_INDEX(
-      session, ret = __wt_row_search(session, &cbt->iface.key, leaf, cbt, insert, false));
+      session, ret = __wt_row_search(cbt, &cbt->iface.key, insert, leaf, false, leaf_foundp));
     return (ret);
 }
 
@@ -382,10 +387,9 @@ __cursor_row_search(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_REF *leaf
  *     Column-store modify from a cursor, with a separate value.
  */
 static inline int
-__cursor_col_modify_v(
-  WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
+__cursor_col_modify_v(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
 {
-    return (__wt_col_modify(session, cbt, cbt->iface.recno, value, NULL, modify_type, false));
+    return (__wt_col_modify(cbt, cbt->iface.recno, value, NULL, modify_type, false));
 }
 
 /*
@@ -393,10 +397,9 @@ __cursor_col_modify_v(
  *     Row-store modify from a cursor, with a separate value.
  */
 static inline int
-__cursor_row_modify_v(
-  WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
+__cursor_row_modify_v(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
 {
-    return (__wt_row_modify(session, cbt, &cbt->iface.key, value, NULL, modify_type, false));
+    return (__wt_row_modify(cbt, &cbt->iface.key, value, NULL, modify_type, false));
 }
 
 /*
@@ -404,10 +407,9 @@ __cursor_row_modify_v(
  *     Column-store modify from a cursor.
  */
 static inline int
-__cursor_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, u_int modify_type)
+__cursor_col_modify(WT_CURSOR_BTREE *cbt, u_int modify_type)
 {
-    return (
-      __wt_col_modify(session, cbt, cbt->iface.recno, &cbt->iface.value, NULL, modify_type, false));
+    return (__wt_col_modify(cbt, cbt->iface.recno, &cbt->iface.value, NULL, modify_type, false));
 }
 
 /*
@@ -415,10 +417,9 @@ __cursor_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, u_int modify
  *     Row-store modify from a cursor.
  */
 static inline int
-__cursor_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, u_int modify_type)
+__cursor_row_modify(WT_CURSOR_BTREE *cbt, u_int modify_type)
 {
-    return (
-      __wt_row_modify(session, cbt, &cbt->iface.key, &cbt->iface.value, NULL, modify_type, false));
+    return (__wt_row_modify(cbt, &cbt->iface.key, &cbt->iface.value, NULL, modify_type, false));
 }
 
 /*
@@ -472,8 +473,8 @@ __wt_btcur_search_uncommitted(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp)
     session = (WT_SESSION_IMPL *)cursor->session;
     *updp = upd = NULL; /* -Wuninitialized */
 
-    WT_RET(btree->type == BTREE_ROW ? __cursor_row_search(session, cbt, NULL, false) :
-                                      __cursor_col_search(session, cbt, NULL));
+    WT_RET(btree->type == BTREE_ROW ? __cursor_row_search(cbt, false, NULL, NULL) :
+                                      __cursor_col_search(cbt, NULL, NULL));
 
     /*
      * Ideally exact match should be found, as this transaction has searched for updates done by
@@ -512,7 +513,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
-    bool valid;
+    bool leaf_found, valid;
 
     btree = cbt->btree;
     cursor = &cbt->iface;
@@ -543,18 +544,18 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
     if (__cursor_page_pinned(cbt)) {
         __wt_txn_cursor_op(session);
 
-        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(session, cbt, cbt->ref, false) :
-                                          __cursor_col_search(session, cbt, cbt->ref));
+        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, false, cbt->ref, &leaf_found) :
+                                          __cursor_col_search(cbt, cbt->ref, &leaf_found));
 
         /* Return, if prepare conflict encountered. */
-        if (cbt->compare == 0)
+        if (leaf_found && cbt->compare == 0)
             WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
     }
     if (!valid) {
         WT_ERR(__cursor_func_init(cbt, true));
 
-        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(session, cbt, NULL, false) :
-                                          __cursor_col_search(session, cbt, NULL));
+        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, false, NULL, NULL) :
+                                          __cursor_col_search(cbt, NULL, NULL));
 
         /* Return, if prepare conflict encountered. */
         if (cbt->compare == 0)
@@ -562,7 +563,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
     }
 
     if (valid)
-        ret = __cursor_kv_return(session, cbt, upd);
+        ret = __cursor_kv_return(cbt, upd);
     else if (__cursor_fix_implicit(btree, cbt)) {
         /*
          * Creating a record past the end of the tree in a fixed-length column-store implicitly
@@ -579,7 +580,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 
 #ifdef HAVE_DIAGNOSTIC
     if (ret == 0)
-        WT_ERR(__wt_cursor_key_order_init(session, cbt));
+        WT_ERR(__wt_cursor_key_order_init(cbt));
 #endif
 
 err:
@@ -604,7 +605,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
     int exact;
-    bool valid;
+    bool leaf_found, valid;
 
     btree = cbt->btree;
     cursor = &cbt->iface;
@@ -644,7 +645,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
     if (btree->type == BTREE_ROW && __cursor_page_pinned(cbt)) {
         __wt_txn_cursor_op(session);
 
-        WT_ERR(__cursor_row_search(session, cbt, cbt->ref, true));
+        WT_ERR(__cursor_row_search(cbt, true, cbt->ref, &leaf_found));
 
         /*
          * Search-near is trickier than search when searching an already pinned page. If search
@@ -653,13 +654,13 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
          * append lists (there may be no page slots or we might be legitimately positioned after the
          * last page slot). Ignore those cases, it makes things too complicated.
          */
-        if (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)
+        if (leaf_found && cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)
             WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
     }
     if (!valid) {
         WT_ERR(__cursor_func_init(cbt, true));
-        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(session, cbt, NULL, true) :
-                                          __cursor_col_search(session, cbt, NULL));
+        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, NULL, NULL) :
+                                          __cursor_col_search(cbt, NULL, NULL));
         WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
     }
 
@@ -682,7 +683,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
      */
     if (valid) {
         exact = cbt->compare;
-        ret = __cursor_kv_return(session, cbt, upd);
+        ret = __cursor_kv_return(cbt, upd);
     } else if (__cursor_fix_implicit(btree, cbt)) {
         cbt->recno = cursor->recno;
         cbt->v = 0;
@@ -728,7 +729,7 @@ err:
 
 #ifdef HAVE_DIAGNOSTIC
     if (ret == 0)
-        WT_TRET(__wt_cursor_key_order_init(session, cbt));
+        WT_TRET(__wt_cursor_key_order_init(cbt));
 #endif
 
     if (ret != 0) {
@@ -797,8 +798,8 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
          * Correct to an exact match so we can update whatever we're pointing at.
          */
         cbt->compare = 0;
-        ret = btree->type == BTREE_ROW ? __cursor_row_modify(session, cbt, WT_UPDATE_STANDARD) :
-                                         __cursor_col_modify(session, cbt, WT_UPDATE_STANDARD);
+        ret = btree->type == BTREE_ROW ? __cursor_row_modify(cbt, WT_UPDATE_STANDARD) :
+                                         __cursor_col_modify(cbt, WT_UPDATE_STANDARD);
         if (ret == 0)
             goto done;
 
@@ -825,7 +826,7 @@ retry:
     WT_ERR(__cursor_func_init(cbt, true));
 
     if (btree->type == BTREE_ROW) {
-        WT_ERR(__cursor_row_search(session, cbt, NULL, true));
+        WT_ERR(__cursor_row_search(cbt, true, NULL, NULL));
         /*
          * If not overwriting, fail if the key exists, else insert the key/value pair.
          */
@@ -835,7 +836,7 @@ retry:
                 WT_ERR(WT_DUPLICATE_KEY);
         }
 
-        ret = __cursor_row_modify(session, cbt, WT_UPDATE_STANDARD);
+        ret = __cursor_row_modify(cbt, WT_UPDATE_STANDARD);
     } else if (append_key) {
         /*
          * Optionally insert a new record (ignoring the application's record number). The real
@@ -843,11 +844,11 @@ retry:
          */
         cbt->iface.recno = WT_RECNO_OOB;
         cbt->compare = 1;
-        WT_ERR(__cursor_col_search(session, cbt, NULL));
-        WT_ERR(__cursor_col_modify(session, cbt, WT_UPDATE_STANDARD));
+        WT_ERR(__cursor_col_search(cbt, NULL, NULL));
+        WT_ERR(__cursor_col_modify(cbt, WT_UPDATE_STANDARD));
         cursor->recno = cbt->recno;
     } else {
-        WT_ERR(__cursor_col_search(session, cbt, NULL));
+        WT_ERR(__cursor_col_search(cbt, NULL, NULL));
 
         /*
          * If not overwriting, fail if the key exists. Creating a record past the end of the tree in
@@ -863,7 +864,7 @@ retry:
                 WT_ERR(WT_DUPLICATE_KEY);
         }
 
-        WT_ERR(__cursor_col_modify(session, cbt, WT_UPDATE_STANDARD));
+        WT_ERR(__cursor_col_modify(cbt, WT_UPDATE_STANDARD));
     }
 
 err:
@@ -943,7 +944,7 @@ __wt_btcur_insert_check(WT_CURSOR_BTREE *cbt)
 
 retry:
     WT_ERR(__cursor_func_init(cbt, true));
-    WT_ERR(__cursor_row_search(session, cbt, NULL, true));
+    WT_ERR(__cursor_row_search(cbt, true, NULL, NULL));
 
     /* Just check for conflicts. */
     ret = __curfile_update_check(cbt);
@@ -1022,8 +1023,8 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned)
          * Correct to an exact match so we can remove whatever we're pointing at.
          */
         cbt->compare = 0;
-        ret = btree->type == BTREE_ROW ? __cursor_row_modify(session, cbt, WT_UPDATE_TOMBSTONE) :
-                                         __cursor_col_modify(session, cbt, WT_UPDATE_TOMBSTONE);
+        ret = btree->type == BTREE_ROW ? __cursor_row_modify(cbt, WT_UPDATE_TOMBSTONE) :
+                                         __cursor_col_modify(cbt, WT_UPDATE_TOMBSTONE);
         if (ret == 0)
             goto done;
         goto err;
@@ -1045,7 +1046,7 @@ retry:
     WT_ERR(__cursor_func_init(cbt, true));
 
     if (btree->type == BTREE_ROW) {
-        ret = __cursor_row_search(session, cbt, NULL, false);
+        ret = __cursor_row_search(cbt, false, NULL, NULL);
         if (ret == WT_NOTFOUND)
             goto search_notfound;
         WT_ERR(ret);
@@ -1059,9 +1060,9 @@ retry:
         if (!valid)
             goto search_notfound;
 
-        ret = __cursor_row_modify(session, cbt, WT_UPDATE_TOMBSTONE);
+        ret = __cursor_row_modify(cbt, WT_UPDATE_TOMBSTONE);
     } else {
-        ret = __cursor_col_search(session, cbt, NULL);
+        ret = __cursor_col_search(cbt, NULL, NULL);
         if (ret == WT_NOTFOUND)
             goto search_notfound;
         WT_ERR(ret);
@@ -1091,7 +1092,7 @@ retry:
              */
             cbt->recno = cursor->recno;
         } else
-            ret = __cursor_col_modify(session, cbt, WT_UPDATE_TOMBSTONE);
+            ret = __cursor_col_modify(cbt, WT_UPDATE_TOMBSTONE);
     }
 
 err:
@@ -1110,7 +1111,7 @@ err:
          */
         if (positioned) {
             if (searched)
-                WT_TRET(__wt_key_return(session, cbt));
+                WT_TRET(__wt_key_return(cbt));
         } else {
             F_CLR(cursor, WT_CURSTD_KEY_SET);
             WT_TRET(__cursor_reset(cbt));
@@ -1173,7 +1174,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     uint64_t yield_count, sleep_usecs;
-    bool valid;
+    bool leaf_found, valid;
 
     btree = cbt->btree;
     cursor = &cbt->iface;
@@ -1204,8 +1205,8 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
          * Correct to an exact match so we can update whatever we're pointing at.
          */
         cbt->compare = 0;
-        ret = btree->type == BTREE_ROW ? __cursor_row_modify_v(session, cbt, value, modify_type) :
-                                         __cursor_col_modify_v(session, cbt, value, modify_type);
+        ret = btree->type == BTREE_ROW ? __cursor_row_modify_v(cbt, value, modify_type) :
+                                         __cursor_col_modify_v(cbt, value, modify_type);
         if (ret == 0)
             goto done;
 
@@ -1228,12 +1229,22 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     WT_ERR(__cursor_localvalue(cursor));
     __cursor_state_save(cursor, &state);
 
+    /* If our caller configures for a local search and we have a page pinned, do that search. */
+    if (F_ISSET(cursor, WT_CURSTD_UPDATE_LOCAL) && __cursor_page_pinned(cbt)) {
+        __wt_txn_cursor_op(session);
+
+        WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, cbt->ref, &leaf_found) :
+                                          __cursor_col_search(cbt, cbt->ref, &leaf_found));
+        if (leaf_found)
+            goto update_local;
+    }
+
 retry:
     WT_ERR(__cursor_func_init(cbt, true));
-
+    WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, NULL, NULL) :
+                                      __cursor_col_search(cbt, NULL, NULL));
+update_local:
     if (btree->type == BTREE_ROW) {
-        WT_ERR(__cursor_row_search(session, cbt, NULL, true));
-
         /*
          * If not overwriting, check for conflicts and fail if the key does not exist.
          */
@@ -1245,10 +1256,8 @@ retry:
             if (!valid)
                 WT_ERR(WT_NOTFOUND);
         }
-        ret = __cursor_row_modify_v(session, cbt, value, modify_type);
+        ret = __cursor_row_modify_v(cbt, value, modify_type);
     } else {
-        WT_ERR(__cursor_col_search(session, cbt, NULL));
-
         /*
          * If not overwriting, fail if the key doesn't exist. If we find an update for the key,
          * check for conflicts. Update the record if it exists. Creating a record past the end of
@@ -1263,7 +1272,7 @@ retry:
             if ((cbt->compare != 0 || !valid) && !__cursor_fix_implicit(btree, cbt))
                 WT_ERR(WT_NOTFOUND);
         }
-        ret = __cursor_col_modify_v(session, cbt, value, modify_type);
+        ret = __cursor_col_modify_v(cbt, value, modify_type);
     }
 
 err:
@@ -1286,7 +1295,7 @@ done:
             /*
              * WT_CURSOR.update returns a key and a value.
              */
-            ret = __cursor_kv_return(session, cbt, cbt->modify_update);
+            ret = __cursor_kv_return(cbt, cbt->modify_update);
             break;
         case WT_UPDATE_RESERVE:
             /*
@@ -1299,7 +1308,7 @@ done:
              * WT_CURSOR.modify has already created the return value and our job is to leave it
              * untouched.
              */
-            ret = __wt_key_return(session, cbt);
+            ret = __wt_key_return(cbt);
             break;
         case WT_UPDATE_BIRTHMARK:
         case WT_UPDATE_TOMBSTONE:
@@ -1631,12 +1640,14 @@ __wt_btcur_equals(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *equalp)
  *     Discard a cursor range from row-store or variable-width column-store tree.
  */
 static int
-__cursor_truncate(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop,
-  int (*rmfunc)(WT_SESSION_IMPL *, WT_CURSOR_BTREE *, u_int))
+__cursor_truncate(
+  WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop, int (*rmfunc)(WT_CURSOR_BTREE *, u_int))
 {
     WT_DECL_RET;
+    WT_SESSION_IMPL *session;
     uint64_t yield_count, sleep_usecs;
 
+    session = (WT_SESSION_IMPL *)start->iface.session;
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1663,7 +1674,7 @@ retry:
     WT_ASSERT(session, F_MASK((WT_CURSOR *)start, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
 
     for (;;) {
-        WT_ERR(rmfunc(session, start, WT_UPDATE_TOMBSTONE));
+        WT_ERR(rmfunc(start, WT_UPDATE_TOMBSTONE));
 
         if (stop != NULL && __cursor_equals(start, stop))
             return (0);
@@ -1688,13 +1699,15 @@ err:
  *     Discard a cursor range from fixed-width column-store tree.
  */
 static int
-__cursor_truncate_fix(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop,
-  int (*rmfunc)(WT_SESSION_IMPL *, WT_CURSOR_BTREE *, u_int))
+__cursor_truncate_fix(
+  WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop, int (*rmfunc)(WT_CURSOR_BTREE *, u_int))
 {
     WT_DECL_RET;
+    WT_SESSION_IMPL *session;
     uint64_t yield_count, sleep_usecs;
     const uint8_t *value;
 
+    session = (WT_SESSION_IMPL *)start->iface.session;
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1723,7 +1736,7 @@ retry:
     for (;;) {
         value = (const uint8_t *)start->iface.value.data;
         if (*value != 0)
-            WT_ERR(rmfunc(session, start, WT_UPDATE_TOMBSTONE));
+            WT_ERR(rmfunc(start, WT_UPDATE_TOMBSTONE));
 
         if (stop != NULL && __cursor_equals(start, stop))
             return (0);
@@ -1772,10 +1785,10 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
 
     switch (btree->type) {
     case BTREE_COL_FIX:
-        WT_ERR(__cursor_truncate_fix(session, start, stop, __cursor_col_modify));
+        WT_ERR(__cursor_truncate_fix(start, stop, __cursor_col_modify));
         break;
     case BTREE_COL_VAR:
-        WT_ERR(__cursor_truncate(session, start, stop, __cursor_col_modify));
+        WT_ERR(__cursor_truncate(start, stop, __cursor_col_modify));
         break;
     case BTREE_ROW:
         /*
@@ -1787,7 +1800,7 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
          * setting up the truncate so we're good to go: if that ever changes, we'd need to do
          * something here to ensure a fully instantiated cursor.
          */
-        WT_ERR(__cursor_truncate(session, start, stop, __cursor_row_modify));
+        WT_ERR(__cursor_truncate(start, stop, __cursor_row_modify));
         break;
     }
 

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -402,7 +402,7 @@ random_page_entry:
     WT_ERR(__wt_row_random_leaf(session, cbt));
     WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
     if (valid)
-        WT_ERR(__cursor_kv_return(session, cbt, upd));
+        WT_ERR(__cursor_kv_return(cbt, upd));
     else {
         if ((ret = __wt_btcur_next(cbt, false)) == WT_NOTFOUND)
             ret = __wt_btcur_prev(cbt, false);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -31,8 +31,8 @@ __col_instantiate(
         __wt_free_update_list(session, upd);
 
     /* Search the page and add updates. */
-    WT_RET(__wt_col_search(session, recno, ref, cbt, true));
-    WT_RET(__wt_col_modify(session, cbt, recno, NULL, updlist, WT_UPDATE_INVALID, false));
+    WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
+    WT_RET(__wt_col_modify(cbt, recno, NULL, updlist, WT_UPDATE_INVALID, false));
     return (0);
 }
 
@@ -59,8 +59,8 @@ __row_instantiate(
         __wt_free_update_list(session, upd);
 
     /* Search the page and add updates. */
-    WT_RET(__wt_row_search(session, key, ref, cbt, true, true));
-    WT_RET(__wt_row_modify(session, cbt, key, NULL, updlist, WT_UPDATE_INVALID, false));
+    WT_RET(__wt_row_search(cbt, key, true, ref, true, NULL));
+    WT_RET(__wt_row_modify(cbt, key, NULL, updlist, WT_UPDATE_INVALID, false));
     return (0);
 }
 

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -13,15 +13,17 @@
  *     Change the cursor to reference an internal return key.
  */
 static inline int
-__key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+__key_return(WT_CURSOR_BTREE *cbt)
 {
     WT_CURSOR *cursor;
     WT_ITEM *tmp;
     WT_PAGE *page;
     WT_ROW *rip;
+    WT_SESSION_IMPL *session;
 
     page = cbt->ref->page;
     cursor = &cbt->iface;
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
 
     if (page->type == WT_PAGE_ROW_LEAF) {
         rip = &page->pg_row[cbt->slot];
@@ -72,7 +74,7 @@ __key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
  *     Change the cursor to reference an internal original-page return value.
  */
 static inline int
-__value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+__value_return(WT_CURSOR_BTREE *cbt)
 {
     WT_BTREE *btree;
     WT_CELL *cell;
@@ -80,8 +82,10 @@ __value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
     WT_CURSOR *cursor;
     WT_PAGE *page;
     WT_ROW *rip;
+    WT_SESSION_IMPL *session;
     uint8_t v;
 
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     btree = S2BT(session);
 
     page = cbt->ref->page;
@@ -123,17 +127,18 @@ __value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
  *     Change the cursor to reference an internal update structure return value.
  */
 int
-__wt_value_return_upd(
-  WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, bool ignore_visibility)
+__wt_value_return_upd(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, bool ignore_visibility)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
+    WT_SESSION_IMPL *session;
     WT_UPDATE **listp, *list[WT_MODIFY_ARRAY_SIZE];
     size_t allocated_bytes;
     u_int i;
     bool skipped_birthmark;
 
     cursor = &cbt->iface;
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     allocated_bytes = 0;
 
     /*
@@ -213,7 +218,7 @@ __wt_value_return_upd(
              */
             WT_ASSERT(session, cbt->slot != UINT32_MAX);
 
-            WT_ERR(__value_return(session, cbt));
+            WT_ERR(__value_return(cbt));
         }
     } else if (upd->type == WT_UPDATE_TOMBSTONE)
         WT_ERR(__wt_buf_set(session, &cursor->value, "", 0));
@@ -237,7 +242,7 @@ err:
  *     Change the cursor to reference an internal return key.
  */
 int
-__wt_key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+__wt_key_return(WT_CURSOR_BTREE *cbt)
 {
     WT_CURSOR *cursor;
 
@@ -253,7 +258,7 @@ __wt_key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
      */
     F_CLR(cursor, WT_CURSTD_KEY_EXT);
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT)) {
-        WT_RET(__key_return(session, cbt));
+        WT_RET(__key_return(cbt));
         F_SET(cursor, WT_CURSTD_KEY_INT);
     }
     return (0);
@@ -264,7 +269,7 @@ __wt_key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
  *     Change the cursor to reference an internal return value.
  */
 int
-__wt_value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+__wt_value_return(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 {
     WT_CURSOR *cursor;
 
@@ -272,9 +277,9 @@ __wt_value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd
 
     F_CLR(cursor, WT_CURSTD_VALUE_EXT);
     if (upd == NULL)
-        WT_RET(__value_return(session, cbt));
+        WT_RET(__value_return(cbt));
     else
-        WT_RET(__wt_value_return_upd(session, cbt, upd, false));
+        WT_RET(__wt_value_return_upd(cbt, upd, false));
     F_SET(cursor, WT_CURSTD_VALUE_INT);
     return (0);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1425,10 +1425,10 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             recno = WT_INSERT_RECNO(supd->ins);
 
             /* Search the page. */
-            WT_ERR(__wt_col_search(session, recno, ref, &cbt, true));
+            WT_ERR(__wt_col_search(&cbt, recno, ref, true, NULL));
 
             /* Apply the modification. */
-            WT_ERR(__wt_col_modify(session, &cbt, recno, NULL, upd, WT_UPDATE_INVALID, true));
+            WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true));
             break;
         case WT_PAGE_ROW_LEAF:
             /* Build a key. */
@@ -1447,15 +1447,13 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             WT_ASSERT(session, __wt_count_birthmarks(upd) <= 1);
 
             /* Search the page. */
-            WT_ERR(__wt_row_search(session, key, ref, &cbt, true, true));
+            WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
 
-            /*
-             * Birthmarks should only be applied to on-page values.
-             */
+            /* Birthmarks should only be applied to on-page values. */
             WT_ASSERT(session, cbt.compare == 0 || upd->type != WT_UPDATE_BIRTHMARK);
 
             /* Apply the modification. */
-            WT_ERR(__wt_row_modify(session, &cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
+            WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
             break;
         default:
             WT_ERR(__wt_illegal_value(session, orig->type));

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -15,8 +15,8 @@ static int __col_insert_alloc(WT_SESSION_IMPL *, uint64_t, u_int, WT_INSERT **, 
  *     Column-store delete, insert, and update.
  */
 int
-__wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint64_t recno,
-  const WT_ITEM *value, WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
+__wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_UPDATE *upd_arg,
+  u_int modify_type, bool exclusive)
 {
     static const WT_ITEM col_fix_remove = {"", 1, NULL, 0, 0};
     WT_BTREE *btree;
@@ -25,6 +25,7 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint64_t recno,
     WT_INSERT_HEAD *ins_head, **ins_headp;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
+    WT_SESSION_IMPL *session;
     WT_UPDATE *old_upd, *upd;
     size_t ins_size, upd_size;
     u_int i, skipdepth;
@@ -33,6 +34,7 @@ __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint64_t recno,
     btree = cbt->btree;
     ins = NULL;
     page = cbt->ref->page;
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     upd = upd_arg;
     append = logged = false;
 

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -59,7 +59,7 @@ __check_leaf_key_range(WT_SESSION_IMPL *session, uint64_t recno, WT_REF *leaf, W
  */
 int
 __wt_col_search(
-  WT_SESSION_IMPL *session, uint64_t search_recno, WT_REF *leaf, WT_CURSOR_BTREE *cbt, bool restore)
+  WT_CURSOR_BTREE *cbt, uint64_t search_recno, WT_REF *leaf, bool leaf_safe, bool *leaf_foundp)
 {
     WT_BTREE *btree;
     WT_COL *cip;
@@ -69,10 +69,12 @@ __wt_col_search(
     WT_PAGE *page;
     WT_PAGE_INDEX *pindex, *parent_pindex;
     WT_REF *current, *descent;
+    WT_SESSION_IMPL *session;
     uint64_t recno;
     uint32_t base, indx, limit, read_flags;
     int depth;
 
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     btree = S2BT(session);
     current = NULL;
 
@@ -88,23 +90,18 @@ __wt_col_search(
     /*
      * We may be searching only a single leaf page, not the full tree. In the normal case where we
      * are searching a tree, check the page's parent keys before doing the full search, it's faster
-     * when the cursor is being re-positioned. Skip this if the page is being re-instantiated in
-     * memory.
+     * when the cursor is being re-positioned. Skip that check if we know the page is the right one
+     * (for example, when re-instantiating a page in memory, in that case we know the target must be
+     * on the current page).
      */
     if (leaf != NULL) {
         WT_ASSERT(session, search_recno != WT_RECNO_OOB);
 
-        if (!restore) {
+        if (!leaf_safe) {
             WT_RET(__check_leaf_key_range(session, recno, leaf, cbt));
-            if (cbt->compare != 0) {
-                /*
-                 * !!!
-                 * WT_CURSOR.search_near uses the slot value to
-                 * decide if there was an on-page match.
-                 */
-                cbt->slot = 0;
+            *leaf_foundp = cbt->compare == 0;
+            if (!*leaf_foundp)
                 return (0);
-            }
         }
 
         current = leaf;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -41,14 +41,15 @@ err:
  *     Row-store insert, update and delete.
  */
 int
-__wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, const WT_ITEM *key,
-  const WT_ITEM *value, WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
+__wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, WT_UPDATE *upd_arg,
+  u_int modify_type, bool exclusive)
 {
     WT_DECL_RET;
     WT_INSERT *ins;
     WT_INSERT_HEAD *ins_head, **ins_headp;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
+    WT_SESSION_IMPL *session;
     WT_UPDATE *old_upd, *upd, **upd_entry;
     size_t ins_size, upd_size;
     uint32_t ins_slot;
@@ -57,6 +58,7 @@ __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, const WT_ITEM *k
 
     ins = NULL;
     page = cbt->ref->page;
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     upd = upd_arg;
     logged = false;
 

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -199,8 +199,8 @@ __check_leaf_key_range(
  *     Search a row-store tree for a specific key.
  */
 int
-__wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CURSOR_BTREE *cbt,
-  bool insert, bool restore)
+__wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *leaf, bool leaf_safe,
+  bool *leaf_foundp)
 {
     WT_BTREE *btree;
     WT_COLLATOR *collator;
@@ -211,11 +211,13 @@ __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CU
     WT_PAGE_INDEX *pindex, *parent_pindex;
     WT_REF *current, *descent;
     WT_ROW *rip;
+    WT_SESSION_IMPL *session;
     size_t match, skiphigh, skiplow;
     uint32_t base, indx, limit, read_flags;
     int cmp, depth;
     bool append_check, descend_right, done;
 
+    session = (WT_SESSION_IMPL *)cbt->iface.session;
     btree = S2BT(session);
     collator = btree->collator;
     item = cbt->tmp;
@@ -245,21 +247,16 @@ __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf, WT_CU
     /*
      * We may be searching only a single leaf page, not the full tree. In the normal case where we
      * are searching a tree, check the page's parent keys before doing the full search, it's faster
-     * when the cursor is being re-positioned. Skip this if the page is being re-instantiated in
-     * memory.
+     * when the cursor is being re-positioned. Skip that check if we know the page is the right one
+     * (for example, when re-instantiating a page in memory, in that case we know the target must be
+     * on the current page).
      */
     if (leaf != NULL) {
-        if (!restore) {
+        if (!leaf_safe) {
             WT_RET(__check_leaf_key_range(session, srch_key, leaf, cbt));
-            if (cbt->compare != 0) {
-                /*
-                 * !!!
-                 * WT_CURSOR.search_near uses the slot value to
-                 * decide if there was an on-page match.
-                 */
-                cbt->slot = 0;
+            *leaf_foundp = cbt->compare == 0;
+            if (!*leaf_foundp)
                 return (0);
-            }
         }
 
         current = leaf;

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -303,10 +303,10 @@ __wt_cursor_dhandle_decr_use(WT_SESSION_IMPL *session)
  *     Return a page referenced key/value pair to the application.
  */
 static inline int
-__cursor_kv_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+__cursor_kv_return(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 {
-    WT_RET(__wt_key_return(session, cbt));
-    WT_RET(__wt_value_return(session, cbt, upd));
+    WT_RET(__wt_key_return(cbt));
+    WT_RET(__wt_value_return(cbt, upd));
 
     return (0);
 }
@@ -445,7 +445,7 @@ value:
      * (if any) is visible.
      */
     if (upd != NULL)
-        return (__wt_value_return(session, cbt, upd));
+        return (__wt_value_return(cbt, upd));
 
     /* Else, simple values have their location encoded in the WT_ROW. */
     if (__wt_row_leaf_value(page, rip, vb))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -193,7 +193,7 @@ extern int __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *c
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_key_order_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, bool next)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_cursor_key_order_init(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+extern int __wt_cursor_key_order_init(WT_CURSOR_BTREE *cbt)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt);
 extern void __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt);
@@ -320,11 +320,10 @@ extern int __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
   );
 extern int __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_value_return_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd,
-  bool ignore_visibility) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_key_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+extern int __wt_value_return_upd(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, bool ignore_visibility)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_value_return(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
+extern int __wt_key_return(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_value_return(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bt_salvage(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -361,11 +360,11 @@ extern int __wt_tree_walk_custom_skip(WT_SESSION_IMPL *session, WT_REF **refp,
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tree_walk_skip(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *skipleafcntp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_col_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint64_t recno,
-  const WT_ITEM *value, WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
+extern int __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value,
+  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_col_search(WT_SESSION_IMPL *session, uint64_t search_recno, WT_REF *leaf,
-  WT_CURSOR_BTREE *cbt, bool restore) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_col_search(WT_CURSOR_BTREE *cbt, uint64_t search_recno, WT_REF *leaf,
+  bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_leaf_key_copy(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
@@ -380,8 +379,8 @@ extern int __wt_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const v
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_row_modify(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, const WT_ITEM *key,
-  const WT_ITEM *value, WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
+extern int __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
+  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_insert_alloc(WT_SESSION_IMPL *session, const WT_ITEM *key, u_int skipdepth,
   WT_INSERT **insp, size_t *ins_sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -391,8 +390,8 @@ extern WT_UPDATE *__wt_update_obsolete_check(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd, bool update_accounting);
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_row_search(WT_SESSION_IMPL *session, WT_ITEM *srch_key, WT_REF *leaf,
-  WT_CURSOR_BTREE *cbt, bool insert, bool restore) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *leaf,
+  bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_las_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_las_empty(WT_SESSION_IMPL *session)

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -711,8 +711,9 @@ struct __wt_cursor {
 #define	WT_CURSTD_OVERWRITE	0x02000u
 #define	WT_CURSTD_RAW		0x04000u
 #define	WT_CURSTD_RAW_SEARCH	0x08000u
-#define	WT_CURSTD_VALUE_EXT	0x10000u	/* Value points out of tree. */
-#define	WT_CURSTD_VALUE_INT	0x20000u	/* Value points into tree. */
+#define	WT_CURSTD_UPDATE_LOCAL	0x10000u
+#define	WT_CURSTD_VALUE_EXT	0x20000u	/* Value points out of tree. */
+#define	WT_CURSTD_VALUE_INT	0x40000u	/* Value points into tree. */
 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 #define	WT_CURSTD_KEY_SET	(WT_CURSTD_KEY_EXT | WT_CURSTD_KEY_INT)
 #define	WT_CURSTD_VALUE_SET	(WT_CURSTD_VALUE_EXT | WT_CURSTD_VALUE_INT)

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -576,6 +576,7 @@ __wt_rec_col_var(
     last = r->last;
     vpack = &_vpack;
     cbt = &r->update_modify_cbt;
+    cbt->iface.session = (WT_SESSION *)session;
 
     WT_RET(__wt_rec_split_init(session, r, page, pageref->ref_recno, btree->maxleafpage_precomp));
 
@@ -691,8 +692,7 @@ record_loop:
                 switch (upd->type) {
                 case WT_UPDATE_MODIFY:
                     cbt->slot = WT_COL_SLOT(page, cip);
-                    WT_ERR(
-                      __wt_value_return_upd(session, cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
+                    WT_ERR(__wt_value_return_upd(cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
                     data = cbt->iface.value.data;
                     size = (uint32_t)cbt->iface.value.size;
                     update_no_copy = false;
@@ -906,8 +906,7 @@ compare:
                      * Impossible slot, there's no backing on-page item.
                      */
                     cbt->slot = UINT32_MAX;
-                    WT_ERR(
-                      __wt_value_return_upd(session, cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
+                    WT_ERR(__wt_value_return_upd(cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
                     data = cbt->iface.value.data;
                     size = (uint32_t)cbt->iface.value.size;
                     update_no_copy = false;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -505,7 +505,9 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
     bool ovfl_key, upd_saved;
 
     btree = S2BT(session);
+
     cbt = &r->update_modify_cbt;
+    cbt->iface.session = (WT_SESSION *)session;
 
     key = &r->k;
     val = &r->v;
@@ -539,7 +541,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
              * Impossible slot, there's no backing on-page item.
              */
             cbt->slot = UINT32_MAX;
-            WT_RET(__wt_value_return_upd(session, cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
+            WT_RET(__wt_value_return_upd(cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
             WT_RET(__wt_rec_cell_build_val(
               session, r, cbt->iface.value.data, cbt->iface.value.size, (uint64_t)0));
             break;
@@ -620,8 +622,10 @@ __wt_rec_row_leaf(
     const void *p;
 
     btree = S2BT(session);
-    cbt = &r->update_modify_cbt;
     slvg_skip = salvage == NULL ? 0 : salvage->skip;
+
+    cbt = &r->update_modify_cbt;
+    cbt->iface.session = (WT_SESSION *)session;
 
     key = &r->k;
     val = &r->v;
@@ -759,7 +763,7 @@ __wt_rec_row_leaf(
             switch (upd->type) {
             case WT_UPDATE_MODIFY:
                 cbt->slot = WT_ROW_SLOT(page, rip);
-                WT_ERR(__wt_value_return_upd(session, cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
+                WT_ERR(__wt_value_return_upd(cbt, upd, F_ISSET(r, WT_REC_VISIBLE_ALL)));
                 WT_ERR(__wt_rec_cell_build_val(
                   session, r, cbt->iface.value.data, cbt->iface.value.size, (uint64_t)0));
                 dictionary = true;


### PR DESCRIPTION
…tion generation

* I'm about to add a new argument to the row-search routine: restructure some cursor routines so the WT_CURSOR_BTREE argument is primary, and quit passing around the WT_SESSION_IMPL, we can derive it from the WT_CURSOR_BTREE.

* Add a new cursor flag that modifies WT_CURSOR.updates to search any pinned page before doing a full tree search. Currently internal only, used for LAS inserts.

Historically, we used either (WT_CURSOR_BTREE.slot != 0) or (WT_CURSOR_BTREE.compare == 0) to determine when a leaf-only search wasn't possible because the key was outside the pinned cursor page's name space (in other words, the search was only successful if the searched-for key was within the leaf page's name space). I know how we got here, but it's getting messy and there are already too many different tests of search "success": change __wt_row_search/__wt_col_search to take an additional argument that returns if the leaf-page search wasn't possible. Reorder the __wt_row_search/__wt_col_search arguments so all 3 of the leaf-page-search oriented arguments are in order at the end of the argument list, triggered by a non-NULL leaf page.

(cherry picked from commit 0f5c32a35d06bb175fbe7fe351e7c4ba4f47cab5)