### PR TITLE
WT-5003 Migrate wiredtiger-test-race-condition-stress-sanitizer from Jenkins to Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1954,6 +1954,21 @@ tasks:
           format_test_script_args: -S
           times: 16
 
+  - name: race-condition-stress-sanitizer-test
+    # set an evergreen timeout of 25 hours
+    exec_timeout_secs: 90000
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars: CC="/opt/mongodbtoolchain/v3/bin/clang -fsanitize=address" PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fno-omit-frame-pointer"
+          posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
+      - func: "format test script"
+        vars:
+          # set a format.sh timeout of 24 hours
+          format_test_script_args: -R -t 1440
+          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+
   - name: recovery-stress-test
     #set a 25 hours timeout
     exec_timeout_secs: 90000
@@ -2102,6 +2117,7 @@ buildvariants:
     - name: split-stress-test
     - name: format-stress-test
     - name: format-stress-smoke-test
+    - name: race-condition-stress-sanitizer-test
     - name: checkpoint-stress-test
 
 - name: ubuntu1804-compilers

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -372,6 +372,7 @@ format()
 		for k in {1..7}; do
 			args+=" timing_stress_split_$k=$(($RANDOM%2))"
 		done
+		echo "$name: starting timing-stress-split job in $dir ($(date))"
 	else
 		args=$format_args
 

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -27,6 +27,7 @@ usage() {
 	echo "    -h home      run directory (defaults to .)"
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
+	echo "    -R           run timing stress split test configurations (defaults to off)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"
@@ -70,6 +71,7 @@ home="."
 minutes=0
 parallel_jobs=8
 smoke_test=0
+timing_stress_split_test=0
 total_jobs=0
 verbose=0
 format_binary="./t"
@@ -105,6 +107,9 @@ while :; do
 			exit 1
 		}
 		shift ; shift ;;
+	-R)
+		timing_stress_split_test=1
+		shift ;;
 	-S)
 		smoke_test=1
 		shift ;;
@@ -362,6 +367,11 @@ format()
 		args=${smoke_list[$smoke_next]}
 		smoke_next=$(($smoke_next + 1))
 		echo "$name: starting smoke-test job in $dir"
+	elif [[ $timing_stress_split_test -ne 0 ]]; then
+		args=$format_args
+		for k in {1..7}; do
+			args+=" timing_stress_split_$k=$(($RANDOM%2))"
+		done
 	else
 		args=$format_args
 


### PR DESCRIPTION
I updated the `format.sh` script to add a command line argument to run the timing stress split testing.

* The Jenkins test is [here](http://build.wiredtiger.com:8080/job/wiredtiger-test-race-condition-stress-sanitizer/)
* A successful patch build run over one hour is [here](https://evergreen.mongodb.com/version/5e12cb15a4cf47798eb0f30a)
* The 24-hour patch build is [here](https://evergreen.mongodb.com/build/wiredtiger_ubuntu1804_patch_d6ab08870356f990972e588c7be39fd9f396df8c_5e12ca6d0305b91a4325fe41_20_01_06_05_53_17)

