### PR TITLE
WT-5277 Cursor key out-of-order detected in the lookaside file (#5018) [BACKPORT-v4.0]

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -630,35 +630,40 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
     __cursor_state_save(cursor, &state);
 
     /*
-     * If we have a row-store page pinned, search it; if we don't have a
-     * page pinned, or the search of the pinned page doesn't find an exact
-     * match, search from the root. Unlike WT_CURSOR.search, ignore pinned
-     * pages in the case of column-store, search-near isn't an interesting
-     * enough case for column-store to add the complexity needed to avoid
-     * the tree search.
-     *
-     * Set the "insert" flag for the btree row-store search; we may intend
-     * to position the cursor at the end of the tree, rather than match an
-     * existing record.
+     * If we have a row-store page pinned, search it; if we don't have a page pinned, or the search
+     * of the pinned page doesn't find an exact match, search from the root. Unlike
+     * WT_CURSOR.search, ignore pinned pages in the case of column-store, search-near isn't an
+     * interesting enough case for column-store to add the complexity needed to avoid the tree
+     * search.
      */
     valid = false;
     if (btree->type == BTREE_ROW && __cursor_page_pinned(cbt)) {
         __wt_txn_cursor_op(session);
 
+        /*
+         * Set the "insert" flag for row-store search; we may intend to position the cursor at the
+         * the end of the tree, rather than match an existing record. (LSM requires this semantic.)
+         */
         WT_ERR(__cursor_row_search(cbt, true, cbt->ref, &leaf_found));
 
         /*
-         * Search-near is trickier than search when searching an already pinned page. If search
-         * returns the first or last page slots, discard the results and search the full tree as the
-         * neighbor pages might offer better matches. This test is simplistic as we're ignoring
-         * append lists (there may be no page slots or we might be legitimately positioned after the
-         * last page slot). Ignore those cases, it makes things too complicated.
+         * Only use the pinned page search results if search returns an exact match or a slot other
+         * than the page's boundary slots, if that's not the case, a neighbor page might offer a
+         * better match. This test is simplistic as we're ignoring append lists (there may be no
+         * page slots or we might be legitimately positioned after the last page slot). Ignore those
+         * cases, it makes things too complicated.
          */
-        if (leaf_found && cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)
+        if (leaf_found &&
+          (cbt->compare == 0 || (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)))
             WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
     }
     if (!valid) {
         WT_ERR(__cursor_func_init(cbt, true));
+
+        /*
+         * Set the "insert" flag for row-store search; we may intend to position the cursor at the
+         * the end of the tree, rather than match an existing record. (LSM requires this semantic.)
+         */
         WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, NULL, NULL) :
                                           __cursor_col_search(cbt, NULL, NULL));
         WT_ERR(__wt_cursor_valid(cbt, &upd, &valid));
@@ -1232,10 +1237,19 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     /* If our caller configures for a local search and we have a page pinned, do that search. */
     if (F_ISSET(cursor, WT_CURSTD_UPDATE_LOCAL) && __cursor_page_pinned(cbt)) {
         __wt_txn_cursor_op(session);
+        WT_ERR(__wt_txn_autocommit_check(session));
 
         WT_ERR(btree->type == BTREE_ROW ? __cursor_row_search(cbt, true, cbt->ref, &leaf_found) :
                                           __cursor_col_search(cbt, cbt->ref, &leaf_found));
-        if (leaf_found)
+        /*
+         * Only use the pinned page search results if search returns an exact match or a slot other
+         * than the page's boundary slots, if that's not the case, the record might belong on an
+         * entirely different page. This test is simplistic as we're ignoring append lists (there
+         * may be no page slots or we might be legitimately positioned after the last page slot).
+         * Ignore those cases, it makes things too complicated.
+         */
+        if (leaf_found &&
+          (cbt->compare == 0 || (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)))
             goto update_local;
     }
 
@@ -1770,6 +1784,8 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
     session = (WT_SESSION_IMPL *)start->iface.session;
     btree = start->btree;
     WT_STAT_DATA_INCR(session, cursor_truncate);
+
+    WT_RET(__wt_txn_autocommit_check(session));
 
     /*
      * For recovery, log the start and stop keys for a truncate operation,


### PR DESCRIPTION
* If the WT_SESSION.update leaf-page search returns either the first or last slot of the page,
discard the search results and search the entire tree, an inserted item might belong on an
entirely different page.

* If a search-near or update based leaf-page search returns an exact match, then we
should be able to use it, no matter what page slots are involved.

* Fix two cases where successful pinned page searches can result in attempting to modify
an object before starting the necessary implicit transaction: WT_SESSION.truncate and
WT_SESSION.update (with the WT_CURSTD_UPDATE_LOCAL flag set).

We haven't seen the failure in truncate before because a "read" of any page normally
results in starting the transaction, it's only pinned pages that avoid that operation,
and it's relatively unlikely both the start/stop cursors involved in a range truncate
operation are the result of successful pinned page searches.

We haven't seen the failure in update because it's currently only possible when updating
the lookaside table, which uses explicit transactions.

* clang format & typo in error handling.

* Rework the comments to match the code.

* Fix a comment.

(cherry picked from commit 47fdb87459c726873d6af326e38771504f8a91d8)