### PR TITLE
WT-5400 Consistent wt verify debug output

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -885,7 +885,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
         WT_RET(ds->f(ds, ", page-state=%" PRIu32, mod->page_state));
     WT_RET(ds->f(ds, ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
     if (addr != NULL)
-        WT_RET(ds->f(ds, ", start stop time-pairs %s,%s",
+        WT_RET(ds->f(ds, ", start stop ts/txn %s,%s",
           __wt_time_pair_to_string(addr->oldest_start_ts, addr->oldest_start_txn, tp_string[0]),
           __wt_time_pair_to_string(addr->newest_stop_ts, addr->newest_stop_txn, tp_string[1])));
     WT_RET(ds->f(ds, "\n"));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -794,15 +794,18 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
 static int
 __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 {
+    WT_ADDR *addr;
     WT_PAGE *page;
     WT_PAGE_INDEX *pindex;
     WT_PAGE_MODIFY *mod;
     WT_SESSION_IMPL *session;
     uint64_t split_gen;
     uint32_t entries;
+    char tp_string[2][WT_TP_STRING_SIZE];
 
-    session = ds->session;
+    addr = ref->addr;
     page = ref->page;
+    session = ds->session;
     mod = page->modify;
     split_gen = 0;
 
@@ -881,6 +884,10 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
     if (mod != NULL)
         WT_RET(ds->f(ds, ", page-state=%" PRIu32, mod->page_state));
     WT_RET(ds->f(ds, ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
+    if (addr != NULL)
+        WT_RET(ds->f(ds, ", start stop time-pairs %s,%s",
+          __wt_time_pair_to_string(addr->oldest_start_ts, addr->oldest_start_txn, tp_string[0]),
+          __wt_time_pair_to_string(addr->newest_stop_ts, addr->newest_stop_txn, tp_string[1])));
     WT_RET(ds->f(ds, "\n"));
 
     return (0);
@@ -1256,7 +1263,8 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    char ts_string[3][WT_TS_INT_STRING_SIZE];
+    char tp_string[2][WT_TP_STRING_SIZE];
+    char ts_string[WT_TS_INT_STRING_SIZE];
 
     session = ds->session;
 
@@ -1298,10 +1306,10 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
     case WT_CELL_ADDR_INT:
     case WT_CELL_ADDR_LEAF:
     case WT_CELL_ADDR_LEAF_NO:
-        WT_RET(ds->f(ds, ", ts/txn %s,%s/%" PRIu64 ",%s/%" PRIu64,
-          __wt_timestamp_to_string(unpack->newest_durable_ts, ts_string[0]),
-          __wt_timestamp_to_string(unpack->oldest_start_ts, ts_string[1]), unpack->oldest_start_txn,
-          __wt_timestamp_to_string(unpack->newest_stop_ts, ts_string[2]), unpack->newest_stop_txn));
+        WT_RET(ds->f(ds, ", ts/txn %s,%s,%s",
+          __wt_timestamp_to_string(unpack->newest_durable_ts, ts_string),
+          __wt_time_pair_to_string(unpack->oldest_start_ts, unpack->oldest_start_txn, tp_string[0]),
+          __wt_time_pair_to_string(unpack->newest_stop_ts, unpack->newest_stop_txn, tp_string[1])));
         break;
     case WT_CELL_DEL:
     case WT_CELL_VALUE:
@@ -1309,9 +1317,9 @@ __debug_cell(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
     case WT_CELL_VALUE_OVFL:
     case WT_CELL_VALUE_OVFL_RM:
     case WT_CELL_VALUE_SHORT:
-        WT_RET(ds->f(ds, ", ts/txn %s/%" PRIu64 ",%s/%" PRIu64,
-          __wt_timestamp_to_string(unpack->start_ts, ts_string[0]), unpack->start_txn,
-          __wt_timestamp_to_string(unpack->stop_ts, ts_string[1]), unpack->stop_txn));
+        WT_RET(ds->f(ds, ", ts/txn %s,%s",
+          __wt_time_pair_to_string(unpack->start_ts, unpack->start_txn, tp_string[0]),
+          __wt_time_pair_to_string(unpack->stop_ts, unpack->stop_txn, tp_string[1])));
         break;
     }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -375,12 +375,16 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
     __wt_verbose(session, WT_VERB_VERIFY, "%s %s", __wt_page_addr_string(session, ref, vs->tmp1),
       __wt_page_type_string(page->type));
 
-    /* Optionally dump the address/timestamp information. */
-    if ((vs->dump_address || vs->dump_time_pairs) && !vs->dump_pages) {
+    /*
+     * Optionally dump the address/time pair information. dump_blocks prints time pairs and
+     * dump_pages dumps addresses and time pairs so here we try to avoid printing duplicate
+     * information when multiple -d options are provided.
+     */
+    if ((vs->dump_address || (vs->dump_time_pairs && !vs->dump_blocks)) && !vs->dump_pages) {
         WT_RET(__wt_msg(session, "%s", __wt_page_type_string(page->type)));
         if (vs->dump_address)
             WT_RET(__wt_msg(session, "\t%s", __wt_page_addr_string(session, ref, vs->tmp1)));
-        if (vs->dump_time_pairs) {
+        if (vs->dump_time_pairs && !vs->dump_blocks) {
             addr = ref->addr;
             if (addr != NULL)
                 WT_RET(__wt_msg(session, "\t%s,%s", __wt_time_pair_to_string(addr->oldest_start_ts,

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -364,7 +364,7 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
     WT_REF *child_ref;
     uint64_t recno;
     uint32_t entry, i;
-    char ts_string[WT_TS_INT_STRING_SIZE];
+    char tp_string[2][WT_TP_STRING_SIZE];
 
     addr = NULL;
     bm = S2BT(session)->bm;
@@ -376,17 +376,18 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
       __wt_page_type_string(page->type));
 
     /* Optionally dump the address/timestamp information. */
-    if (vs->dump_address || vs->dump_time_pairs) {
+    if ((vs->dump_address || vs->dump_time_pairs) && !vs->dump_pages) {
         WT_RET(__wt_msg(session, "%s", __wt_page_type_string(page->type)));
         if (vs->dump_address)
             WT_RET(__wt_msg(session, "\t%s", __wt_page_addr_string(session, ref, vs->tmp1)));
         if (vs->dump_time_pairs) {
             addr = ref->addr;
             if (addr != NULL)
-                WT_RET(__wt_msg(session, "\t%s/%" PRIu64 ",%s/%" PRIu64,
-                  __wt_timestamp_to_string(addr->oldest_start_ts, ts_string),
-                  addr->oldest_start_txn, __wt_timestamp_to_string(addr->newest_stop_ts, ts_string),
-                  addr->newest_stop_txn));
+                WT_RET(__wt_msg(session, "\t%s,%s",
+                  __wt_time_pair_to_string(addr->oldest_start_ts,
+                    addr->oldest_start_txn, tp_string[0]),
+                  __wt_time_pair_to_string(addr->newest_stop_ts,
+                    addr->newest_stop_txn, tp_string[1])));
         }
     }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -383,11 +383,10 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
         if (vs->dump_time_pairs) {
             addr = ref->addr;
             if (addr != NULL)
-                WT_RET(__wt_msg(session, "\t%s,%s",
-                  __wt_time_pair_to_string(addr->oldest_start_ts,
-                    addr->oldest_start_txn, tp_string[0]),
-                  __wt_time_pair_to_string(addr->newest_stop_ts,
-                    addr->newest_stop_txn, tp_string[1])));
+                WT_RET(__wt_msg(session, "\t%s,%s", __wt_time_pair_to_string(addr->oldest_start_ts,
+                                                      addr->oldest_start_txn, tp_string[0]),
+                  __wt_time_pair_to_string(
+                                  addr->newest_stop_ts, addr->newest_stop_txn, tp_string[1])));
         }
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -38,6 +38,8 @@ extern bool __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_rwlock_islocked(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern char *__wt_time_pair_to_string(wt_timestamp_t timestamp, uint64_t txn_id, char *tp_string)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern char *__wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const WT_CONFIG_ENTRY *__wt_conn_config_match(const char *method)

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -64,6 +64,14 @@ typedef enum {
 #define WT_TS_INT_STRING_SIZE (2 * 10 + 3 + 1)
 
 /*
+ * We need an appropriately sized buffer for formatted time pairs. This is for
+ * time pairs of the form time_stamp + slash + transaction_id, which gives
+ * the max digits of a timestamp + slash + the max digits of a 8 byte integer
+ * + a trailing nul byte.
+ */
+#define WT_TP_STRING_SIZE (WT_TS_INT_STRING_SIZE + 1 + 20 + 1)
+
+/*
  * Perform an operation at the specified isolation level.
  *
  * This is fiddly: we can't cope with operations that begin transactions

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -9,6 +9,19 @@
 #include "wt_internal.h"
 
 /*
+ * __wt_time_pair_to_string --
+ *     Converts a time pair to a standard string representation.
+ */
+char *
+__wt_time_pair_to_string(wt_timestamp_t timestamp, uint64_t txn_id, char *tp_string)
+{
+    char ts_string[WT_TS_INT_STRING_SIZE];
+    WT_IGNORE_RET(__wt_snprintf(tp_string, WT_TP_STRING_SIZE, "%s/%" PRIu64,
+      __wt_timestamp_to_string(timestamp, ts_string), txn_id));
+    return (tp_string);
+}
+
+/*
  * __wt_timestamp_to_string --
  *     Convert a timestamp to the MongoDB string representation.
  */


### PR DESCRIPTION
* Added a function which prints time pairs in a consistent format
