### PR TITLE
WT-5192 Dont allow checkpoints to evict without a snapshot (#5104) [BACKPORT-v4.0]

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -299,9 +299,12 @@ __sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * cache clean but with history that cannot be
              * discarded), that is not wasted effort because
              * checkpoint doesn't need to write the page again.
+             *
+             * Once the transaction has given up it's snapshot it is no longer safe to reconcile
+             * pages. That happens prior to the final metadata checkpoint.
              */
             if (!WT_PAGE_IS_INTERNAL(page) && page->read_gen == WT_READGEN_WONT_NEED &&
-              !tried_eviction) {
+              !tried_eviction && F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT)) {
                 WT_ERR_BUSY_OK(__wt_page_release_evict(session, walk, 0));
                 walk = prev;
                 prev = NULL;


### PR DESCRIPTION
(cherry picked from commit 5bd9fdfc0bb7f8fcf791e234b6e436c79dfe1fee)