### PR TITLE
WT-5281 Assert that we're no longer writing tombstones to the history store

### DIFF
--- a/src/cache/cache_las.c
+++ b/src/cache/cache_las.c
@@ -402,6 +402,12 @@ __las_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, const uint32_t 
   const WT_ITEM *key, const WT_UPDATE *upd, const uint8_t type, const WT_ITEM *las_value,
   WT_TIME_PAIR stop_ts_pair)
 {
+    /*
+     * Only deltas or full updates should be written to the lookaside. More specifically, we should
+     * NOT be writing tombstone records in the lookaside table.
+     */
+    WT_ASSERT(session, type == WT_UPDATE_STANDARD || type == WT_UPDATE_MODIFY);
+
     cursor->set_key(
       cursor, btree_id, key, upd->start_ts, upd->txnid, stop_ts_pair.timestamp, stop_ts_pair.txnid);
 


### PR DESCRIPTION
As it stands, we're clearly not writing any tombstones to the history store as the `type` parameter to this function can only ever be `WT_UPDATE_STANDARD` and `WT_UPDATE_MODIFY`.

I've just added an assertion to prevent regressions and will consider this ticket done.