### PR TITLE
WT-5440 __wt_txn_clear_read_timestamp() has an unnecessary serialization point

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1222,16 +1222,11 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
         txn->read_timestamp = WT_TS_NONE;
         return;
     }
-#ifdef HAVE_DIAGNOSTIC
-    {
-        WT_TXN_GLOBAL *txn_global;
-        wt_timestamp_t pinned_ts;
 
-        txn_global = &S2C(session)->txn_global;
-        pinned_ts = txn_global->pinned_timestamp;
-        WT_ASSERT(session, txn->read_timestamp >= pinned_ts);
-    }
-#endif
+    /* Assert the read timestamp is greater than or equal to the pinned timestamp. */
+    WT_RET_ASSERT(session, txn->read_timestamp >= S2C(session)->txn_global.pinned_timestamp, EINVAL,
+      "transaction's read timestamp less than the global pinned timestamp");
+
     flags = txn->flags;
     LF_CLR(WT_TXN_PUBLIC_TS_READ);
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1114,15 +1114,16 @@ __wt_txn_clear_durable_timestamp(WT_SESSION_IMPL *session)
 
     if (!F_ISSET(txn, WT_TXN_TS_PUBLISHED))
         return;
-    flags = txn->flags;
-    LF_CLR(WT_TXN_TS_PUBLISHED);
 
     /*
      * Notify other threads that our transaction is inactive and can be cleaned up safely from the
      * durable timestamp queue whenever the next thread walks the queue. We do not need to remove it
      * now.
      */
-    WT_PUBLISH(txn->clear_durable_q, true);
+    txn->clear_durable_q = true;
+
+    flags = txn->flags;
+    LF_CLR(WT_TXN_TS_PUBLISHED);
     WT_PUBLISH(txn->flags, flags);
 }
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1123,8 +1123,8 @@ __wt_txn_clear_durable_timestamp(WT_SESSION_IMPL *session)
     txn->clear_durable_q = true;
 
     /*
-     * Serialize clearing the flag with setting the queue state. The serialization has been here
-     * for awhile, but nobody remembers if or why it's necessary.
+     * Serialize clearing the flag with setting the queue state. The serialization has been here for
+     * awhile, but nobody remembers if or why it's necessary.
      */
     flags = txn->flags;
     LF_CLR(WT_TXN_TS_PUBLISHED);
@@ -1239,8 +1239,8 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
     txn->clear_read_q = true;
 
     /*
-     * Serialize clearing the flag with setting the queue state. The serialization has been here
-     * for awhile, but nobody remembers if or why it's necessary.
+     * Serialize clearing the flag with setting the queue state. The serialization has been here for
+     * awhile, but nobody remembers if or why it's necessary.
      */
     flags = txn->flags;
     LF_CLR(WT_TXN_PUBLIC_TS_READ);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1122,6 +1122,10 @@ __wt_txn_clear_durable_timestamp(WT_SESSION_IMPL *session)
      */
     txn->clear_durable_q = true;
 
+    /*
+     * Serialize clearing the flag with setting the queue state. The serialization has been here
+     * for awhile, but nobody remembers if or why it's necessary.
+     */
     flags = txn->flags;
     LF_CLR(WT_TXN_TS_PUBLISHED);
     WT_PUBLISH(txn->flags, flags);
@@ -1234,6 +1238,10 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
      */
     txn->clear_read_q = true;
 
+    /*
+     * Serialize clearing the flag with setting the queue state. The serialization has been here
+     * for awhile, but nobody remembers if or why it's necessary.
+     */
     flags = txn->flags;
     LF_CLR(WT_TXN_PUBLIC_TS_READ);
     WT_PUBLISH(txn->flags, flags);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1224,8 +1224,7 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
     }
 
     /* Assert the read timestamp is greater than or equal to the pinned timestamp. */
-    WT_RET_ASSERT(session, txn->read_timestamp >= S2C(session)->txn_global.pinned_timestamp, EINVAL,
-      "transaction's read timestamp less than the global pinned timestamp");
+    WT_ASSERT(session, txn->read_timestamp >= S2C(session)->txn_global.pinned_timestamp);
 
     /*
      * Notify other threads that our transaction is inactive and can be cleaned up safely from the

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1227,16 +1227,17 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
     WT_RET_ASSERT(session, txn->read_timestamp >= S2C(session)->txn_global.pinned_timestamp, EINVAL,
       "transaction's read timestamp less than the global pinned timestamp");
 
-    flags = txn->flags;
-    LF_CLR(WT_TXN_PUBLIC_TS_READ);
-
     /*
      * Notify other threads that our transaction is inactive and can be cleaned up safely from the
      * read timestamp queue whenever the next thread walks the queue. We do not need to remove it
      * now.
      */
-    WT_PUBLISH(txn->clear_read_q, true);
+    txn->clear_read_q = true;
+
+    flags = txn->flags;
+    LF_CLR(WT_TXN_PUBLIC_TS_READ);
     WT_PUBLISH(txn->flags, flags);
+
     txn->read_timestamp = WT_TS_NONE;
 }
 


### PR DESCRIPTION
Alex, I think this is a trivial cleanup, I can't see a reason the first `WT_PUBLISH` line in `__wt_txn_clear_read_timestamp()` is necessary, and having it there could be confusing.

However, I couldn't spot the reason the second `WT_PUBLISH` is necessary either: do you remember why it's necessary for `WT_TXN.clear_read_q` to be set before the `WT_TXN_PUBLIC_TS_READ` flag is cleared?