### PR TITLE
WT-5263 Prepared updates written to the lookaside file are not always read as needed (#5039) [BACKPORT-v4.0]

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -182,6 +182,13 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
                 list_prepared = true;
                 if (upd->timestamp > max_ts)
                     max_ts = upd->timestamp;
+
+                /*
+                 * Track the oldest update not on the page, used to decide whether reads can use the
+                 * page image, hence using the start rather than the durable timestamp.
+                 */
+                if (upd->timestamp < r->min_skipped_ts)
+                    r->min_skipped_ts = upd->timestamp;
                 continue;
             }
         }
@@ -229,11 +236,8 @@ __wt_rec_txn_read(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
                 skipped_birthmark = true;
 
             /*
-             * Track the oldest update not on the page.
-             *
-             * This is used to decide whether reads can use the
-             * page image, hence using the start rather than the
-             * durable timestamp.
+             * Track the oldest update not on the page, used to decide whether reads can use the
+             * page image, hence using the start rather than the durable timestamp.
              */
             if (*updp == NULL && upd->timestamp < r->min_skipped_ts)
                 r->min_skipped_ts = upd->timestamp;


### PR DESCRIPTION
this backports wt-5263

(cherry picked from commit 33204938da7bb1c0722536f9f74854ab59237e89)