### PR TITLE
Add the ability to dump a given btree as of a timestamp

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -962,6 +962,7 @@ lsnappy
 lt
 lu
 lwsync
+lx
 lz
 lzo
 mT


### PR DESCRIPTION
This tickets enhances the wt utility tool, specifically the **wt dump** to also allow to read from specific timestamps. I have also updated and created test cases for the new functionality.'

For some reason, the wt utility doesn't filter the read specific timestamps properly.