### PR TITLE
WT-5448 Fix column reconciliation overwrites cells with default time pairs

### DIFF
--- a/dist/s_clang-scan.diff
+++ b/dist/s_clang-scan.diff
@@ -14,22 +14,10 @@ src/conn/conn_capacity.c:291:5: warning: Value stored to 'capacity' is never rea
     capacity = steal_capacity = 0;
     ^          ~~~~~~~~~~~~~~~~~~
 1 warning generated.
-src/reconcile/rec_col.c:658:5: warning: Value stored to 'start_ts' is never read
-    start_ts = WT_TS_MAX;
-    ^          ~~~~~~~~~
-src/reconcile/rec_col.c:659:5: warning: Value stored to 'start_txn' is never read
-    start_txn = WT_TXN_MAX;
-    ^           ~~~~~~~~~~
-src/reconcile/rec_col.c:660:5: warning: Value stored to 'stop_ts' is never read
-    stop_ts = WT_TS_NONE;
-    ^         ~~~~~~~~~~
-src/reconcile/rec_col.c:661:5: warning: Value stored to 'stop_txn' is never read
-    stop_txn = WT_TS_NONE;
-    ^          ~~~~~~~~~~
-src/reconcile/rec_col.c:1062:53: warning: Null pointer passed as an argument to a 'nonnull' parameter
-                        last.value->size == size && memcmp(last.value->data, data, size) == 0))) {
-                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-5 warnings generated.
+src/reconcile/rec_col.c:1050:23: warning: Null pointer passed as an argument to a 'nonnull' parameter
+                      memcmp(last.value->data, data, size) == 0)) {
+                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 warnings generated.
 In file included from src/reconcile/rec_write.c:9:
 In file included from ./src/include/wt_internal.h:421:
 ./src/include/mutex.i:184:16: warning: Null pointer passed as an argument to a 'nonnull' parameter

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -868,19 +868,20 @@ compare:
              * record number, we've been doing that all along.
              */
             if (rle != 0) {
-                if ((deleted && last.deleted) ||
-                  (!deleted && !last.deleted && last.value->size == size &&
-                      memcmp(last.value->data, data, size) == 0)) {
+                if ((last.start_ts == start_ts && last.start_txn == start_txn &&
+                      last.stop_ts == stop_ts && last.stop_txn == stop_txn) &&
+                  ((deleted && last.deleted) ||
+                      (!deleted && !last.deleted && last.value->size == size &&
+                        memcmp(last.value->data, data, size) == 0))) {
                     /*
                      * The start time pair for deleted keys must be (WT_TS_NONE, WT_TXN_NONE) and
                      * stop time pair must be (WT_TS_MAX, WT_TXN_MAX) since we no longer select
                      * tombstone to write to disk and the deletion of the keys must be globally
                      * visible.
                      */
-                    WT_ASSERT(session,
-                      (!deleted && !last.deleted) ||
+                    WT_ASSERT(session, (!deleted && !last.deleted) ||
                         (last.start_ts == WT_TS_NONE && last.start_txn == WT_TXN_NONE &&
-                          last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
+                                         last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
                     rle += repeat_count;
                     continue;
                 }
@@ -1045,18 +1046,20 @@ compare:
                 /*
                  * FIXME-PM-1521: Follow up issue with clang in WT-5341.
                  */
-                if ((deleted && last.deleted) ||
-                  (!deleted && !last.deleted && last.value->size == size &&
-                      memcmp(last.value->data, data, size) == 0)) {
+                if ((last.start_ts == start_ts && last.start_txn == start_txn &&
+                      last.stop_ts == stop_ts && last.stop_txn == stop_txn) &&
+                  ((deleted && last.deleted) ||
+                      (!deleted && !last.deleted && last.value->size == size &&
+                        memcmp(last.value->data, data, size) == 0))) {
                     /*
                      * The start time pair for deleted keys must be (WT_TS_NONE, WT_TXN_NONE) and
                      * stop time pair must be (WT_TS_MAX, WT_TXN_MAX) since we no longer select
                      * tombstone to write to disk and the deletion of the keys must be globally
                      * visible.
                      */
-                    WT_ASSERT(session,
-                      (!deleted && !last.deleted) || (last.start_ts == WT_TS_NONE && last.start_txn == WT_TXN_NONE &&
-                        last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
+                    WT_ASSERT(session, (!deleted && !last.deleted) ||
+                        (last.start_ts == WT_TS_NONE && last.start_txn == WT_TXN_NONE &&
+                                         last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
                     ++rle;
                     goto next;
                 }

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -871,6 +871,16 @@ compare:
                 if ((deleted && last.deleted) ||
                   (!deleted && !last.deleted && last.value->size == size &&
                       memcmp(last.value->data, data, size) == 0)) {
+                    /*
+                     * The start time pair for deleted keys must be (WT_TS_NONE, WT_TXN_NONE) and
+                     * stop time pair must be (WT_TS_MAX, WT_TXN_MAX) since we no longer select
+                     * tombstone to write to disk and the deletion of the keys must be globally
+                     * visible.
+                     */
+                    WT_ASSERT(session,
+                      (!deleted && !last.deleted) ||
+                        (last.start_ts == WT_TS_NONE && last.start_txn == WT_TXN_NONE &&
+                          last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
                     rle += repeat_count;
                     continue;
                 }
@@ -983,7 +993,7 @@ compare:
                     rle += skip;
                     src_recno += skip;
                 } else {
-                    /* Set time pairs for the first deleted keys in a deleted range. */
+                    /* Set time pairs for the first deleted key in a deleted range. */
                     durable_ts = WT_TS_NONE;
                     start_ts = WT_TS_NONE;
                     start_txn = WT_TXN_NONE;
@@ -1038,6 +1048,15 @@ compare:
                 if ((deleted && last.deleted) ||
                   (!deleted && !last.deleted && last.value->size == size &&
                       memcmp(last.value->data, data, size) == 0)) {
+                    /*
+                     * The start time pair for deleted keys must be (WT_TS_NONE, WT_TXN_NONE) and
+                     * stop time pair must be (WT_TS_MAX, WT_TXN_MAX) since we no longer select
+                     * tombstone to write to disk and the deletion of the keys must be globally
+                     * visible.
+                     */
+                    WT_ASSERT(session,
+                      (!deleted && !last.deleted) || (last.start_ts == WT_TS_NONE && last.start_txn == WT_TXN_NONE &&
+                        last.stop_ts == WT_TS_MAX && last.stop_txn == WT_TXN_MAX));
                     ++rle;
                     goto next;
                 }

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -989,12 +989,6 @@ compare:
             } else if (upd == NULL)
                 deleted = true;
             else {
-                durable_ts = upd_select.durable_ts;
-                start_ts = upd_select.start_ts;
-                start_txn = upd_select.start_txn;
-                stop_ts = upd_select.stop_ts;
-                stop_txn = upd_select.stop_txn;
-
                 switch (upd->type) {
                 case WT_UPDATE_MODIFY:
                     /*

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -809,7 +809,12 @@ record_loop:
                     goto compare;
                 }
 
-                /* The key on the old disk image is unchanged. Use time pairs from the cell. */
+                /*
+                 * The key on the old disk image is unchanged. Use time pairs from the cell.
+                 *
+                 * FIXME-PM-1524: Currently, we don't store durable_ts in cell, which is a problem
+                 * we need to solve for prepared transactions. Revisit this in PM-1524.
+                 */
                 durable_ts = newest_durable_ts;
                 start_ts = vpack->start_ts;
                 start_txn = vpack->start_txn;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -798,8 +798,8 @@ record_loop:
                     repeat_count = WT_INSERT_RECNO(ins) - src_recno;
 
                 deleted = orig_deleted;
-                /* Set time pairs for the deleted key. */
                 if (deleted) {
+                    /* Set time pairs for the deleted key. */
                     durable_ts = WT_TS_NONE;
                     start_ts = WT_TS_NONE;
                     start_txn = WT_TXN_NONE;
@@ -809,7 +809,7 @@ record_loop:
                     goto compare;
                 }
 
-                /* Set time pairs for unchanged key on the old disk image. */
+                /* The key on the old disk image is unchanged. Use time pairs from the cell. */
                 durable_ts = newest_durable_ts;
                 start_ts = vpack->start_ts;
                 start_txn = vpack->start_txn;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -612,8 +612,6 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
               F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DISK), start_ts, start_txn, stop_ts, stop_txn,
               0));
             break;
-        case WT_UPDATE_TOMBSTONE:
-            continue;
         default:
             ret = __wt_illegal_value(session, upd->type);
             WT_ERR(ret);
@@ -839,34 +837,6 @@ __wt_rec_row_leaf(
                   stop_txn, 0));
                 dictionary = true;
                 break;
-            case WT_UPDATE_TOMBSTONE:
-                /*
-                 * If this key/value pair was deleted, we're done.
-                 *
-                 * Overflow keys referencing discarded values are no longer useful, discard the
-                 * backing blocks. Don't worry about reuse, reusing keys from a row-store page
-                 * reconciliation seems unlikely enough to ignore.
-                 */
-                if (kpack != NULL && kpack->ovfl && kpack->raw != WT_CELL_KEY_OVFL_RM) {
-                    /*
-                     * Keys are part of the name-space, we can't remove them from the in-memory
-                     * tree; if an overflow key was deleted without being instantiated (for example,
-                     * cursor-based truncation), do it now.
-                     */
-                    if (ikey == NULL)
-                        WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
-
-                    WT_ERR(__wt_ovfl_discard_add(session, page, kpack->cell));
-                }
-
-                /*
-                 * We aren't actually creating the key so we can't use bytes from this key to
-                 * provide prefix information for a subsequent key.
-                 */
-                tmpkey->size = 0;
-
-                /* Proceed with appended key/value pairs. */
-                goto leaf_insert;
             default:
                 WT_ERR(__wt_illegal_value(session, upd->type));
             }
@@ -971,7 +941,6 @@ build:
         /* Update compression state. */
         __rec_key_state_update(r, ovfl_key);
 
-leaf_insert:
         /* Write any K/V pairs inserted into the page after this key. */
         if ((ins = WT_SKIP_FIRST(WT_ROW_INSERT(page, rip))) != NULL)
             WT_ERR(__rec_row_leaf_insert(session, r, ins));

--- a/test/suite/test_hs09.py
+++ b/test/suite/test_hs09.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import unittest, wiredtiger, wttest
+import wiredtiger, wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
@@ -76,7 +76,6 @@ class test_hs09(wttest.WiredTigerTestCase):
         cursor.close()
         session.close()
 
-    @unittest.skip("Temporarily disabled until WT-5448 is fixed")
     def test_uncommitted_updates_not_written_to_hs(self):
         # Create a small table.
         create_params = 'key_format={},value_format=S'.format(self.key_format)
@@ -107,7 +106,6 @@ class test_hs09(wttest.WiredTigerTestCase):
 
         self.chech_ckpt_hs(value2, value1, 2, 3)
 
-    @unittest.skip("Temporarily disabled until WT-5448 is fixed")
     def test_prepared_updates_not_written_to_hs(self):
         # Create a small table.
         create_params = 'key_format={},value_format=S'.format(self.key_format)
@@ -139,7 +137,6 @@ class test_hs09(wttest.WiredTigerTestCase):
 
         self.chech_ckpt_hs(value2, value1, 2, 3)
 
-    @unittest.skip("Temporarily disabled until WT-5448 is fixed")
     def test_write_newest_version_to_data_store(self):
         # Create a small table.
         create_params = 'key_format={},value_format=S'.format(self.key_format)
@@ -164,7 +161,6 @@ class test_hs09(wttest.WiredTigerTestCase):
 
         self.chech_ckpt_hs(value2, value1, 2, 3)
 
-    @unittest.skip("Temporarily disabled until WT-5448 is fixed")
     def test_write_deleted_version_to_data_store(self):
         # Create a small table.
         create_params = 'key_format={},value_format=S'.format(self.key_format)

--- a/test/suite/test_inmem01.py
+++ b/test/suite/test_inmem01.py
@@ -41,8 +41,8 @@ class test_inmem01(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios([
         ('col', dict(keyfmt='r', valuefmt='S')),
-        ('fix', dict(keyfmt='r', valuefmt='8t')),
-        ('row', dict(keyfmt='S', valuefmt='S')),
+        #('fix', dict(keyfmt='r', valuefmt='8t')),
+        #('row', dict(keyfmt='S', valuefmt='S')),
     ])
 
     # Smoke-test in-memory configurations, add a small amount of data and

--- a/test/suite/test_inmem01.py
+++ b/test/suite/test_inmem01.py
@@ -41,8 +41,8 @@ class test_inmem01(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios([
         ('col', dict(keyfmt='r', valuefmt='S')),
-        #('fix', dict(keyfmt='r', valuefmt='8t')),
-        #('row', dict(keyfmt='S', valuefmt='S')),
+        ('fix', dict(keyfmt='r', valuefmt='8t')),
+        ('row', dict(keyfmt='S', valuefmt='S')),
     ])
 
     # Smoke-test in-memory configurations, add a small amount of data and


### PR DESCRIPTION
The code is complex and I don't understand all of it. So please have a careful look.