### PR TITLE
WT-5405 Make format LSM test a separate Evergreen task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1947,8 +1947,8 @@ tasks:
       - func: "format test script"
         vars:
           test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
-          # Run for 1 hour (60 mins), and explicitly set data_source to LSM
-          format_test_script_args: -t 60 data_source=lsm
+          # Run for 30 mins, and explicitly set data_source to LSM with a large cache
+          format_test_script_args: -t 30 data_source=lsm cache_minimum=5000
 
   - name: format-stress-sanitizer-smoke-test
     #set a 7 hours timeout

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1940,6 +1940,16 @@ tasks:
           # run for 24 hours ( 24 * 60 = 1440 minutes), don't stop at failed tests, use default config
           format_test_script_args: -t 1440
   
+  - name: format-stress-sanitizer-lsm-test
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger address sanitizer"
+      - func: "format test script"
+        vars:
+          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+          # Run for 1 hour (60 mins), and explicitly set data_source to LSM
+          format_test_script_args: -t 60 data_source=lsm
+
   - name: format-stress-sanitizer-smoke-test
     #set a 7 hours timeout
     exec_timeout_secs: 25200
@@ -2155,6 +2165,7 @@ buildvariants:
     - name: recovery-stress-test
     - name: format-stress-sanitizer-test
     - name: format-stress-sanitizer-smoke-test
+    - name: format-stress-sanitizer-lsm-test
     - name: split-stress-test
     - name: format-stress-test
     - name: format-stress-smoke-test

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -106,6 +106,7 @@ config_setup(void)
             config_single("data_source=file", false);
             break;
         case 2: /* 20% */
+#if 0
                 /*
                  * LSM requires a row-store and backing disk.
                  *
@@ -121,6 +122,7 @@ config_setup(void)
             if (config_is_perm("truncate") && g.c_truncate)
                 break;
             config_single("data_source=lsm", false);
+#endif
             break;
         case 3:
         case 4:

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -52,6 +52,12 @@ static void config_reset(void);
 static void config_transaction(void);
 
 /*
+ * We currently disable random LSM testing, that is, it can be specified explicitly but we won't
+ * randomly choose LSM as a data_source configuration.
+ */
+#define DISABLE_RANDOM_LSM_TESTING 1
+
+/*
  * config_setup --
  *     Initialize configuration for a run.
  */
@@ -106,15 +112,15 @@ config_setup(void)
             config_single("data_source=file", false);
             break;
         case 2: /* 20% */
-#if 0
-                /*
-                 * LSM requires a row-store and backing disk.
-                 *
-                 * Configuring truncation or timestamps results in LSM cache problems, don't
-                 * configure LSM if those set.
-                 *
-                 * XXX Remove the timestamp test when WT-4162 resolved.
-                 */
+#if !defined(DISABLE_RANDOM_LSM_TESTING)
+            /*
+             * LSM requires a row-store and backing disk.
+             *
+             * Configuring truncation or timestamps results in LSM cache problems, don't configure
+             * LSM if those set.
+             *
+             * XXX Remove the timestamp test when WT-4162 resolved.
+             */
             if (g.type != ROW || g.c_in_memory)
                 break;
             if (config_is_perm("transaction_timestamps") && g.c_txn_timestamps)


### PR DESCRIPTION
Disable `data_source=lsm` setting in test/format configuration generation, and explicitly set & test LSM in a separate format stress sanitizer Evergreen task (run for 1 hour). 