### PR TITLE
WT-5159 Fixes to allow SWIG4 to generate code compatible with Python3 or Python2.

### DIFF
--- a/bench/workgen/runner/runner/__init__.py
+++ b/bench/workgen/runner/runner/__init__.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # runner/__init__.py
-#	Used as a first import by runners, does any common initialization.
+#   Used as a first import by runners, does any common initialization.
 from __future__ import print_function
 
 import os, shutil, sys

--- a/dist/s_python
+++ b/dist/s_python
@@ -7,9 +7,10 @@ trap 'rm -f $t' 0 1 2 3 13 15
 cd ..
 
 # Check Python coding standards: check for tab characters.
+# Ignore generated files.
 egrep '	' `find . -name '*.py'` |
     sed -e 's/:.*//' \
-	-e '/__init__.py/d' \
+	-e '/swig_wiredtiger.py/d' \
 	-e '/\/wiredtiger.py/d' \
 	-e '/src\/docs\/tools\/doxypy.py/d' |
     sort -u |

--- a/lang/python/Makefile.am
+++ b/lang/python/Makefile.am
@@ -2,7 +2,7 @@ PYSRC = $(top_srcdir)/lang/python
 PYDIRS = -t $(abs_builddir) -I $(abs_top_srcdir):$(abs_top_builddir) -L $(abs_top_builddir)/.libs
 PYDST = $(abs_builddir)/wiredtiger
 PYFILES = $(PYDST)/fpacking.py $(PYDST)/intpacking.py $(PYDST)/packing.py \
-	$(PYDST)/packutil.py $(PYDST)/__init__.py
+	$(PYDST)/packutil.py $(PYDST)/swig_wiredtiger.py $(PYDST)/__init__.py
 PY_MAJOR_VERSION := $$($(PYTHON) -c \
 	'import sys; print(int(sys.version_info.major))')
 
@@ -25,7 +25,12 @@ pyfiles: $(PYFILES)
 $(PYDST)/%: $(PYSRC)/wiredtiger/%
 	mkdir -p $(PYDST) && cp -f $< $@
 
-$(PYDST)/__init__.py: $(PYSRC)/wiredtiger.py
+$(PYDST)/__init__.py: $(PYSRC)/wiredtiger/init.py
+	mkdir -p $(PYDST) && cp -f $< $@
+
+# Note: this cannot be named wiredtiger.py in the target directory,
+# we won't be able to import it.
+$(PYDST)/swig_wiredtiger.py: $(PYSRC)/wiredtiger.py
 	mkdir -p $(PYDST) && cp -f $< $@
 
 install-exec-local:

--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -188,8 +188,10 @@ def get_library_dirs():
     return dirs
 
 # source_filter
-#   Make any needed changes to the sources list.  Any entry that
-# needs to be moved is returned in a dictionary.
+#   Make any needed changes to the original sources list and return a manifest,
+# a list of source file names relative to the new staging root.  Any entry
+# that needs to be renamed returned in a dictionary where the entry's key
+# is the new name and the value is the old source name.
 def source_filter(sources):
     result = []
     movers = dict()
@@ -205,15 +207,16 @@ def source_filter(sources):
         # move all lang/python files to the top level.
         if dest.startswith(pywt_prefix):
             dest = os.path.basename(dest)
-            if dest == 'pip_init.py':
+            if dest == 'init.py':
                 dest = '__init__.py'
         if dest != src:
             movers[dest] = src
         result.append(dest)
     # Add SWIG generated files
-    result.append('wiredtiger.py')
-    movers['wiredtiger.py'] = os.path.join(pywt_build_dir, '__init__.py')
     result.append(os.path.join(py_dir, 'wiredtiger_wrap.c'))
+    wiredtiger_py = 'swig_wiredtiger.py'
+    result.append('swig_wiredtiger.py')
+    movers['swig_wiredtiger.py'] = os.path.join(py_dir, 'wiredtiger.py')
     return result, movers
 
 ################################################################

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -32,6 +32,8 @@
  */
 %include <pybuffer.i>
 
+ /*TODO: if SWIG_VERSION < 0x040000  version must be >= 4.0 */
+
 %define DOCSTRING
 "Python wrappers around the WiredTiger C API
 
@@ -50,7 +52,7 @@ This provides an API similar to the C API, with the following modifications:
 %feature("autodoc", "0");
 
 %pythoncode %{
-from .packing import pack, unpack
+from packing import pack, unpack
 ## @endcond
 %}
 

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -32,8 +32,6 @@
  */
 %include <pybuffer.i>
 
- /*TODO: if SWIG_VERSION < 0x040000  version must be >= 4.0 */
-
 %define DOCSTRING
 "Python wrappers around the WiredTiger C API
 

--- a/lang/python/wiredtiger/init.py
+++ b/lang/python/wiredtiger/init.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# pip_init.py
+# init.py
 #      This is installed as __init__.py, and imports the file created by SWIG.
 # This is needed because SWIG's import helper code created by certain SWIG
 # versions may be broken, see: https://github.com/swig/swig/issues/769 .
@@ -42,11 +42,11 @@ if fname != '__init__.py' and fname != '__init__.pyc':
 # to this module so they will appear in the wiredtiger namespace.
 me = sys.modules[__name__]
 sys.path.append(os.path.dirname(__file__))
-try:
-    import wiredtiger.wiredtiger as swig_wiredtiger
-except ImportError:
-    # for Python2
-    import wiredtiger as swig_wiredtiger
+
+# explicitly importing _wiredtiger in advance of SWIG allows us to not
+# use relative importing, as SWIG does.  It doesn't work for us with Python2.
+import _wiredtiger
+import swig_wiredtiger
 for name in dir(swig_wiredtiger):
     value = getattr(swig_wiredtiger, name)
     setattr(me, name, value)


### PR DESCRIPTION
Tested with SWIG4 running with Python3 'in the tree'.  That is `cd build_posix; python3 ../test/suite/run.py ...` . Also tested it running with python2 'in the tree'.  Also did pip_setup.py (using python3, in case it matters), and was able to pip install/test the result in a python3 virtual env, as well as a python2 virtual env.

I made some of these tests with SWIG3.  That is, I can run python3 or python2 'in the tree'.  (These will be confirmed by the PR testing).  I did not check running pip_setup.py and pip install with SWIG3 .  The test matrix is getting too big.

If this works and passes review, I think we should merge, then upgrade all machines to SWIG4, and then deprecate SWIG3 and finally deprecate Python2.  We can deprecate in either order, but I think the SWIG3 deprecate will be easier (a single line in `build_posix/configure.ac.in`).