### PR TITLE
WT-5460 Buffer alignment failure captured by linux-directio test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1648,7 +1648,7 @@ tasks:
         vars:
           times: 3
           config: ../../../test/format/CONFIG.stress
-          extra_args: -C "direct_io=[data]"
+          extra_args: direct_io=1
 
   - name: format-linux-no-ftruncate
     depends_on:


### PR DESCRIPTION
Patch builds for Ubuntu 18.04 and RHEL 8.0:

- [Patch](https://evergreen.mongodb.com/version/5e27976ce3c33179485a1af4)
- [Another patch](https://evergreen.mongodb.com/version/5e27977532f41731210c0488)
- [And a third patch](https://evergreen.mongodb.com/version/5e27977f0ae6061d48939468)