### PR TITLE
WT-5458 Fix Evergreen timeout failures in linux-directio test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1637,18 +1637,20 @@ tasks:
         vars:
           make_command: make all
       - func: "make check all"
-  
+
+  # Use format.sh to run tests in parallel (x4) for just under two hours (the
+  # default Evergreen timeout) on the higher spec build distros. This allows
+  # us to perform multiple test runs while ensuring a long-running config does
+  # not result in an Evergreen test timeout failure.
   - name: linux-directio
     depends_on:
     - name: compile
     commands:
       - func: "fetch artifacts"
       - func: "compile wiredtiger"
-      - func: "format test"
+      - func: "format test script"
         vars:
-          times: 3
-          config: ../../../test/format/CONFIG.stress
-          extra_args: -C "direct_io=[data]"
+          format_test_script_args: -t 110 -j 4 direct_io=1
 
   - name: format-linux-no-ftruncate
     depends_on:
@@ -2140,6 +2142,7 @@ buildvariants:
     - name: compile-ubsan
     - name: ubsan-test
     - name: linux-directio
+      distros: ubuntu1804-build
     - name: syscall-linux
     - name: make-check-asan-test
     - name: configure-combinations
@@ -2231,6 +2234,7 @@ buildvariants:
     - name: compile-ubsan
     - name: ubsan-test
     - name: linux-directio
+      distros: rhel80-build
     - name: syscall-linux
     - name: compile-asan
     - name: make-check-asan-test


### PR DESCRIPTION
Here we update the `linux-directio` Evergreen test to use the `format.sh` script rather than calling `t` in a loop. This allows us to run tests in parallel, virtually ensuring that we will accumulate completed test results even if we generate long-running configs. We set the `format.sh` timeout to just under the two hour default Evergreen timeout. We also set the build distros to higher spec machines for this task. Successful patch builds below.

- [Patch One](https://evergreen.mongodb.com/version/5e28e34be3c3314abdf82885)
- [Patch Two](https://evergreen.mongodb.com/version/5e28e35857e85a429c58768e)
- [Patch Three](https://evergreen.mongodb.com/version/5e28e3631e2d176633e47276)