### PR TITLE
WT-5376 WT_UPDATE.type field can race with visibility checks when returning key/value pairs

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -770,8 +770,10 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
             skipped_birthmark = true;
     }
 
-    if (upd == NULL && skipped_birthmark)
+    if (upd == NULL && skipped_birthmark) {
         upd = &tombstone;
+        type = upd->type;
+    }
 
     *updp = upd == NULL || type == WT_UPDATE_BIRTHMARK ? NULL : upd;
     return (0);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -754,6 +754,8 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
     bool skipped_birthmark;
 
     *updp = NULL;
+
+    type = 0; /* [-Wconditional-uninitialized] */
     for (skipped_birthmark = false; upd != NULL; upd = upd->next) {
         WT_ORDERED_READ(type, upd->type);
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -750,12 +750,15 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
 {
     static WT_UPDATE tombstone = {.txnid = WT_TXN_NONE, .type = WT_UPDATE_TOMBSTONE};
     WT_VISIBLE_TYPE upd_visible;
+    uint8_t type;
     bool skipped_birthmark;
 
     *updp = NULL;
     for (skipped_birthmark = false; upd != NULL; upd = upd->next) {
+        WT_ORDERED_READ(type, upd->type);
+
         /* Skip reserved place-holders, they're never visible. */
-        if (upd->type != WT_UPDATE_RESERVE) {
+        if (type != WT_UPDATE_RESERVE) {
             upd_visible = __wt_txn_upd_visible_type(session, upd);
             if (upd_visible == WT_VISIBLE_TRUE)
                 break;
@@ -763,14 +766,14 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
                 return (WT_PREPARE_CONFLICT);
         }
         /* An invisible birthmark is equivalent to a tombstone. */
-        if (upd->type == WT_UPDATE_BIRTHMARK)
+        if (type == WT_UPDATE_BIRTHMARK)
             skipped_birthmark = true;
     }
 
     if (upd == NULL && skipped_birthmark)
         upd = &tombstone;
 
-    *updp = upd == NULL || upd->type == WT_UPDATE_BIRTHMARK ? NULL : upd;
+    *updp = upd == NULL || type == WT_UPDATE_BIRTHMARK ? NULL : upd;
     return (0);
 }
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -755,7 +755,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
 
     *updp = NULL;
 
-    type = 0; /* [-Wconditional-uninitialized] */
+    type = WT_UPDATE_INVALID; /* [-Wconditional-uninitialized] */
     for (skipped_birthmark = false; upd != NULL; upd = upd->next) {
         WT_ORDERED_READ(type, upd->type);
 


### PR DESCRIPTION
@agorrod, @bvpvamsikrishna, should we reconsider having `__ rec_append_orig_value()` change the underlying type of the `WT_UPDATE`?

I'm not familiar enough with the birthmark code to argue the point, but one of the rules we try to follow is that `WT_UPDATE` structures aren't modified once they're inserted into an update chain, and this chunk of code has been remarkably difficult to debug.