### PR TITLE
WT-5464 Open reading history cursors on the user session

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -853,6 +853,7 @@ __wt_find_hs_upd(
     uint8_t prepare_state, prepare_state_tmp, *p, recno_key[WT_INTPACK64_MAXSIZE], upd_type;
     const uint8_t *recnop;
     int cmp;
+    const char *hs_cursor_cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), NULL};
     bool modify;
 
     *updp = NULL;
@@ -887,7 +888,7 @@ __wt_find_hs_upd(
     WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
 
     /* Open a history store table cursor. */
-    __wt_hs_cursor(session, &hs_cursor, &session_flags);
+    WT_ERR(__wt_open_cursor(session, WT_HS_URI, NULL, hs_cursor_cfg, &hs_cursor));
 
     /*
      * After positioning our cursor, we're stepping backwards to find the correct update. Since the
@@ -1042,7 +1043,8 @@ err:
     __wt_scr_free(session, &hs_key);
     __wt_scr_free(session, &hs_value);
 
-    WT_TRET(__wt_hs_cursor_close(session, &hs_cursor, session_flags));
+    if (hs_cursor != NULL)
+        hs_cursor->close(hs_cursor);
     __wt_free_update_list(session, &mod_upd);
     while (modifies.size > 0) {
         __wt_modify_vector_pop(&modifies, &upd);

--- a/test/suite/test_hs06.py
+++ b/test/suite/test_hs06.py
@@ -125,7 +125,6 @@ class test_hs06(wttest.WiredTigerTestCase):
         # self.assertLessEqual(end_usage, (start_usage * 2))
 
     # WT-5336 causing the read at timestamp 4 returning the value committed at timestamp 5 or 3
-    @unittest.skip("Temporarily disabled until WT-5336 is fixed")
     def test_hs_modify_reads(self):
         # Create a small table.
         uri = "table:test_hs06"
@@ -255,7 +254,6 @@ class test_hs06(wttest.WiredTigerTestCase):
             self.assertEquals(value2, cursor[self.create_key(i)])
         self.session.rollback_transaction()
 
-    @unittest.skip("Temporarily disabled")
     def test_hs_multiple_updates(self):
         # Create a small table.
         uri = "table:test_hs06"
@@ -295,7 +293,6 @@ class test_hs06(wttest.WiredTigerTestCase):
             self.assertEquals(cursor[self.create_key(i)], value3)
         self.session.rollback_transaction()
 
-    @unittest.skip("Temporarily disabled")
     def test_hs_multiple_modifies(self):
         # Create a small table.
         uri = "table:test_hs06"
@@ -465,7 +462,6 @@ class test_hs06(wttest.WiredTigerTestCase):
             self.assertEqual(cursor[self.create_key(i)], expected)
         self.session.rollback_transaction()
 
-    @unittest.skip("Temporarily disabled")
     def test_hs_rec_modify(self):
         # Create a small table.
         uri = "table:test_hs06"


### PR DESCRIPTION
As part of WT-5441, I noticed that we're unable to find keys in the history store due to a visibility issue.

To aid garbage collection, we're inserting tombstones after each lookaside insert to represent the stop timestamp of the value. When reading with a history store cursor, we use "read uncommitted" isolation which means that we will only see tombstones. In general, we're unable to even position the cursor since not even a single key in the history store table is visible to us.

The proposed solution is to open history store cursors from the user session (and therefore inherit their transaction id, timestamp and isolation level). When it comes to modifies, we'll have to do something interesting and repeatedly reset the read timestamp to be able to see subsequent keys.