### PR TITLE
WT-5482 Increment cache usage when appending on-disk value to update list

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -397,6 +397,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             upd->start_ts = upd->durable_ts = vpack->start_ts;
             upd->txnid = vpack->start_txn;
             WT_PUBLISH(last_upd->next, upd);
+            /* This is going in our update list so it should be accounted for in cache usage. */
+            __wt_cache_page_inmem_incr(session, page, size);
             upd_select->upd = upd;
         }
         WT_ASSERT(session, upd == NULL || upd->type != WT_UPDATE_TOMBSTONE);


### PR DESCRIPTION
When we select a tombstone in reconciliation, we append an update to the update list representing the on-disk value. Since it is in the in-memory update list, it needs to be taken into account as part of our cache usage calculation.

We're not suffering any ill effects from this. I just noticed it when scanning through the reconciliation code.