### PR TITLE
WT-5419 Add a TOMBSTONE to update on-disk KV pairs

### DIFF
--- a/dist/s_clang-scan.diff
+++ b/dist/s_clang-scan.diff
@@ -14,14 +14,20 @@ src/conn/conn_capacity.c:291:5: warning: Value stored to 'capacity' is never rea
     capacity = steal_capacity = 0;
     ^          ~~~~~~~~~~~~~~~~~~
 1 warning generated.
-src/reconcile/rec_col.c:1050:23: warning: Null pointer passed as an argument to a 'nonnull' parameter
-                      memcmp(last.value->data, data, size) == 0)) {
-                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warnings generated.
+src/reconcile/rec_col.c:1063:25: warning: Null pointer passed as an argument to a 'nonnull' parameter
+                        memcmp(last.value->data, data, size) == 0))) {
+                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 warning generated.
 In file included from src/reconcile/rec_write.c:9:
 In file included from ./src/include/wt_internal.h:421:
 ./src/include/mutex.i:184:16: warning: Null pointer passed as an argument to a 'nonnull' parameter
     if ((ret = pthread_mutex_unlock(&t->lock)) != 0)
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 warning generated.
+In file included from src/txn/txn_rollback_to_stable.c:9:
+In file included from ./src/include/wt_internal.h:421:
+./src/include/mutex.i:158:13: warning: Null pointer passed as an argument to a 'nonnull' parameter
+    return (pthread_mutex_trylock(&t->lock));
+            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1 warning generated.
 ar: `u' modifier ignored since `D' is the default (see `U')

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -388,6 +388,11 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
               vpack->start_ts <= upd_select->stop_ts && vpack->start_txn <= upd_select->stop_txn);
             upd_select->durable_ts = upd_select->start_ts = vpack->start_ts;
             upd_select->start_txn = vpack->start_txn;
+
+            /* Use stop timestamp as durable timestamp if exist. */
+            if (upd_select->stop_ts != WT_TS_MAX)
+                upd_select->durable_ts = upd_select->stop_ts;
+
             /*
              * Leaving the update unset means that we can skip reconciling. If we've set the stop
              * time pair because of a tombstone after the on-disk value, we still have work to do so

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -371,7 +371,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 upd_select->start_txn = upd->txnid;
             }
 
-            /* Use tombstone durable timestamp as overall durable timestamp if exist. */
+            /* Use the tombstone durable timestamp as the overall durable timestamp if it exists. */
             if (tombstone_durable_ts != WT_TS_MAX)
                 upd_select->durable_ts = tombstone_durable_ts;
         } else {
@@ -392,7 +392,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             upd_select->durable_ts = upd_select->start_ts = vpack->start_ts;
             upd_select->start_txn = vpack->start_txn;
 
-            /* Use tombstone durable timestamp as overall durable timestamp if exist. */
+            /* Use the tombstone durable timestamp as the overall durable timestamp if it exists. */
             if (tombstone_durable_ts != WT_TS_MAX)
                 upd_select->durable_ts = tombstone_durable_ts;
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -131,11 +131,11 @@ __txn_abort_newer_insert(
 }
 
 /*
- * __txn_abort_fix_row_on_disk_kv --
+ * __txn_abort_row_ondisk_kv --
  *     Fix the on-disk row K/V version according to the given timestamp.
  */
 static int
-__txn_abort_fix_row_on_disk_kv(
+__txn_abort_row_ondisk_kv(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, wt_timestamp_t rollback_timestamp)
 {
     WT_CELL_UNPACK *vpack, _vpack;
@@ -258,7 +258,7 @@ __txn_abort_newer_row_leaf(
 
         /* Check for updates in the update list that satisfy the given timestamp. */
         if (WT_ROW_UPDATE(page, rip) == NULL && WT_ROW_INSERT(page, rip) == NULL)
-            WT_RET(__txn_abort_fix_row_on_disk_kv(session, page, rip, rollback_timestamp));
+            WT_RET(__txn_abort_row_ondisk_kv(session, page, rip, rollback_timestamp));
 
         if ((insert = WT_ROW_INSERT(page, rip)) != NULL)
             __txn_abort_newer_insert(session, insert, rollback_timestamp);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -113,7 +113,7 @@ __txn_abort_newer_update(
 
     /* Reset the history store flag for the stable update. */
     if (first_upd)
-        first_upd->flags |= WT_UPDATE_HS;
+        F_CLR(first_upd, WT_UPDATE_HS);
 }
 
 /*

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -154,7 +154,6 @@ __txn_abort_fix_row_on_disk_kv(
         upd->txnid = WT_TXN_NONE;
         upd->durable_ts = WT_TS_NONE;
         upd->start_ts = WT_TS_NONE;
-
     } else if (vpack->stop_ts != WT_TS_MAX && vpack->stop_ts > rollback_timestamp) {
         /*
          * Clear the remove operation from the key by inserting a TOMBSTONE with infinite
@@ -179,6 +178,7 @@ __txn_abort_fix_row_on_disk_kv(
     upd_entry = &mod->mod_row_update[WT_ROW_SLOT(page, rip)];
     upd->next = NULL;
     WT_ERR(__wt_update_serial(session, page, upd_entry, &upd, size, false));
+    WT_STAT_CONN_INCR(session, txn_rollback_upd_aborted);
     return (0);
 
 err:

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -169,7 +169,7 @@ __txn_abort_fix_row_on_disk_kv(
         return (0);
 
     /* If we don't yet have a modify structure, we'll need one. */
-    WT_RET(__wt_page_modify_init(session, page));
+    WT_ERR(__wt_page_modify_init(session, page));
     mod = page->modify;
 
     /* Allocate an update array as necessary. */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -112,7 +112,7 @@ __txn_abort_newer_update(
     }
 
     /* Reset the history store flag for the stable update. */
-    if (first_upd)
+    if (first_upd != NULL)
         F_CLR(first_upd, WT_UPDATE_HS);
 }
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -127,7 +127,8 @@ __txn_abort_newer_insert(
     WT_INSERT *ins;
 
     WT_SKIP_FOREACH (ins, head)
-        __txn_abort_newer_update(session, ins->upd, rollback_timestamp);
+        if (ins->upd != NULL)
+            __txn_abort_newer_update(session, ins->upd, rollback_timestamp);
 }
 
 /*

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -67,7 +67,7 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
         for k, v in cursor:
             self.assertEqual(v, check_value)
             count += 1
-        session.rollback_transaction()
+        session.commit_transaction()
         self.assertEqual(count, nrows)
 
 # Test that rollback to stable clears the remove operation.

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+from helper import copy_wiredtiger_home
+import unittest, wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable01.py
+# Shared base class used by gc tests.
+class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
+    def large_updates(self, uri, value, ds, nrows, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor[ds.key(i)] = value
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        cursor.close()
+
+    def large_removes(self, uri, ds, nrows, commit_ts):
+        # Remove a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor.set_key(i)
+            cursor.remove()
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, nrows, read_ts):
+        session = self.session
+        session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, check_value)
+            count += 1
+        session.rollback_transaction()
+        self.assertEqual(count, nrows)
+
+# Test that rollback to stable clears the remove operation.
+class test_rollback_to_stable01(test_rollback_to_stable_base):
+    # Force a small cache.
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable01"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
+            ',stable_timestamp=' + timestamp_str(1))
+
+        valuea = "aaaaa" * 100
+        self.large_updates(uri, valuea, ds, nrows, 10)
+
+        # Check that all updates are seen
+        self.check(valuea, uri, nrows, 10)
+
+        # Remove all keys with newer timestamp
+        self.large_removes(uri, ds, nrows, 20)
+
+        # Check that the no keys should be visible
+        self.check(valuea, uri, 0, 20)
+
+        # Pin oldest and stable to timestamp 100.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+
+        # Checkpoint to ensure that all the updates are flushed to disk.
+        self.session.checkpoint()
+
+        self.conn.rollback_to_stable()
+
+        # Check that the new updates are only seen after the update timestamp
+        self.check(valuea, uri, nrows, 20)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -91,24 +91,20 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         valuea = "aaaaa" * 100
         self.large_updates(uri, valuea, ds, nrows, 10)
-
         # Check that all updates are seen
         self.check(valuea, uri, nrows, 10)
 
         # Remove all keys with newer timestamp
         self.large_removes(uri, ds, nrows, 20)
-
         # Check that the no keys should be visible
         self.check(valuea, uri, 0, 20)
 
         # Pin oldest and stable to timestamp 100.
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
-
         # Checkpoint to ensure that all the updates are flushed to disk.
         self.session.checkpoint()
 
         self.conn.rollback_to_stable()
-
         # Check that the new updates are only seen after the update timestamp
         self.check(valuea, uri, nrows, 20)
 


### PR DESCRIPTION
TOMBSTONE with WT_TS_NONE and WT_TXN_NONE to remove an on-disk key
and to remove an on-disk key remove operation, the TOMBSTONE update
with WT_TS_MAX and WT_TXN_MAX is added.