### PR TITLE
WT-5488 Evergreen test/format jobs need to report the failing CONFIG

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -162,7 +162,7 @@ functions:
         set -o errexit
         set -o verbose
         for i in $(seq ${times|1}); do
-          ./t -1 -c ${config|../../../test/format/CONFIG.stress} ${extra_args|} 2>&1
+          ./t -1 -c ${config|../../../test/format/CONFIG.stress} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
         done
   "format test script":
     command: shell.exec

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -215,6 +215,8 @@ report_failure()
 	echo "$name: job in $dir failed"
 	echo "$name: $dir log:"
 	sed 's/^/    > /' < $log
+	echo "$name: $dir/CONFIG:"
+	sed 's/^/    > /' < $dir/CONFIG
 }
 
 # Resolve/cleanup completed jobs.

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -214,9 +214,9 @@ report_failure()
 
 	echo "$name: job in $dir failed"
 	echo "$name: $dir log:"
-	sed 's/^/    > /' < $log
+	sed 's/^/    /' < $log
 	echo "$name: $dir/CONFIG:"
-	sed 's/^/    > /' < $dir/CONFIG
+	sed 's/^/    /' < $dir/CONFIG
 }
 
 # Resolve/cleanup completed jobs.


### PR DESCRIPTION
Please see the output for the failed tests in the following patch builds:

- [Patch 1](https://evergreen.mongodb.com/version/5e3113043627e064c2aa21b6)
- [Patch 2](https://evergreen.mongodb.com/version/5e31131132f417502f3ebad3)
