### PR TITLE
WT-5495 Disable hs06:test_hs_modify_reads

### DIFF
--- a/test/suite/test_hs06.py
+++ b/test/suite/test_hs06.py
@@ -125,6 +125,7 @@ class test_hs06(wttest.WiredTigerTestCase):
         # self.assertLessEqual(end_usage, (start_usage * 2))
 
     # WT-5336 causing the read at timestamp 4 returning the value committed at timestamp 5 or 3
+    @unittest.skip("Temporarily disabled")
     def test_hs_modify_reads(self):
         # Create a small table.
         uri = "table:test_hs06"


### PR DESCRIPTION
This test was passing in WT-5464 so I reenabled it, but an interaction with something that got merged in that day must have caused it to begin failing.

I will be working on a fix but it's best to keep other branches green in the interim.