### PR TITLE
WT-5503 free the updates after a full update inserted into history st…

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -755,9 +755,8 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_RECONCILE *r, WT_M
                           WT_UPDATE_STANDARD, full_value, stop_ts_pair));
                         /*
                          * If we are evicting, we can now free older updates which have already been
-                         * written to the history store. However, we can only free the updates after
-                         * an original full update on the chain being inserted into the history
-                         * store also as a full update.
+                         * written to the history store. However we can only free updates after an
+                         * original full update is inserted as a full update.
                          */
                         if (F_ISSET(r, WT_REC_EVICT) && upd->type == WT_UPDATE_STANDARD)
                             __wt_free_update_list(session, &upd->next);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -756,8 +756,8 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_RECONCILE *r, WT_M
                         /*
                          * If we are evicting, we can now free older updates which have already been
                          * written to the history store. However, we can only free the updates after
-                         * an original full update on the chain bing inserted into the history store
-                         * also as a full update.
+                         * an original full update on the chain being inserted into the history
+                         * store also as a full update.
                          */
                         if (F_ISSET(r, WT_REC_EVICT) && upd->type == WT_UPDATE_STANDARD)
                             __wt_free_update_list(session, &upd->next);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -754,9 +754,10 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_RECONCILE *r, WT_M
                         WT_ERR(__hs_insert_record(session, cursor, btree_id, key, upd,
                           WT_UPDATE_STANDARD, full_value, stop_ts_pair));
                         /*
-                         * If we are evicting, we can now free some older updates which has already
-                         * been written to the history store. However, we can only free the updates
-                         * after a full update inserted into the history store as a full update.
+                         * If we are evicting, we can now free older updates which have already been
+                         * written to the history store. However, we can only free the updates after
+                         * an original full update on the chain bing inserted into the history store
+                         * also as a full update.
                          */
                         if (F_ISSET(r, WT_REC_EVICT) && upd->type == WT_UPDATE_STANDARD)
                             __wt_free_update_list(session, &upd->next);


### PR DESCRIPTION
…ore in eviction

It is only safe to free the updates after a full update which is inserted into history store as a full update in __wt_hs_insert_updates.

If we free everything inserted into history store and we have modifies still on the chain, we may not be able to reconstruct the full values of the modifies on the chain currently. In the future, we will try to reconstruct modifies base on the onpage value (WT-5507). However, even if we can do that, it is still not safe to free the onpage value here as reconciliation may fail and in that case we will lose everything from the onpage value.

Also we have made the decision to not always insert a full update to the history store if it is the newest update in the history store for that key. In that case, we may need to reconstruct the value of a reverse modify base on the full value on page. Again we cannot guarantee we can successfully write the onpage value to disk at this point.