### PR TITLE
WT-5534 Handle the absence of checkpoint_backup_info in metadata.

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -86,10 +86,10 @@ __wt_backup_open(WT_SESSION_IMPL *session)
     }
 
 err:
-    if (ret != 0)
+    if (ret != 0 && ret != WT_NOTFOUND)
         __wt_backup_destroy(session);
     __wt_free(session, config);
-    return (ret);
+    return (ret == WT_NOTFOUND ? 0 : ret);
 }
 
 /*

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -76,7 +76,7 @@ __curbackup_incr_blkmod(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_CURSOR_BAC
 
 err:
     __wt_free(session, config);
-    return (ret);
+    return (ret == WT_NOTFOUND ? 0 : ret);
 }
 
 /*

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -34,7 +34,12 @@ __ckpt_load_blk_mods(WT_SESSION_IMPL *session, const char *config, WT_CKPT *ckpt
     conn = S2C(session);
     if (config == NULL)
         return (0);
-    WT_RET(__wt_config_getones(session, config, "checkpoint_backup_info", &v));
+    /*
+     * We could be reading in a configuration from an earlier release. If the string doesn't exist
+     * then we're done.
+     */
+    if ((ret = __wt_config_getones(session, config, "checkpoint_backup_info", &v)) != 0)
+        return (ret == WT_NOTFOUND ? 0 : ret);
     __wt_config_subinit(session, &blkconf, &v);
     /*
      * Load block lists. Ignore any that have an id string that is not known.


### PR DESCRIPTION
@keithbostic the incremental code was not handling older metadata configs. This change allows us to handle configurations that don't contain `checkpoint_backup_info` at all. I have checked out and confirmed `wt` can now run successfully on a database created in 3.2.1. (And fails with WT_NOTFOUND without this change.)