### PR TITLE
WT-5510 Enable more tests in durable history branch

### DIFF
--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -87,7 +87,7 @@ all_TESTS += test_wt2834_join_bloom_fix
 test_wt2853_perf_SOURCES = wt2853_perf/main.c
 noinst_PROGRAMS += test_wt2853_perf
 # Temporarily disabled
-# all_TESTS += test_wt2853_perf
+all_TESTS += test_wt2853_perf
 
 test_wt2909_checkpoint_integrity_SOURCES = wt2909_checkpoint_integrity/main.c
 noinst_PROGRAMS += test_wt2909_checkpoint_integrity
@@ -145,7 +145,7 @@ all_TESTS += test_wt4699_json
 test_wt4803_history_store_abort_SOURCES = wt4803_history_store_abort/main.c
 noinst_PROGRAMS += test_wt4803_history_store_abort
 # Temporarily disabled
-# all_TESTS += test_wt4803_history_store_abort
+all_TESTS += test_wt4803_history_store_abort
 
 test_wt4891_meta_ckptlist_get_alloc_SOURCES=wt4891_meta_ckptlist_get_alloc/main.c
 noinst_PROGRAMS += test_wt4891_meta_ckptlist_get_alloc

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -86,7 +86,8 @@ all_TESTS += test_wt2834_join_bloom_fix
 
 test_wt2853_perf_SOURCES = wt2853_perf/main.c
 noinst_PROGRAMS += test_wt2853_perf
-all_TESTS += test_wt2853_perf
+# Temporarily disabled
+# all_TESTS += test_wt2853_perf
 
 test_wt2909_checkpoint_integrity_SOURCES = wt2909_checkpoint_integrity/main.c
 noinst_PROGRAMS += test_wt2909_checkpoint_integrity

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -86,7 +86,6 @@ all_TESTS += test_wt2834_join_bloom_fix
 
 test_wt2853_perf_SOURCES = wt2853_perf/main.c
 noinst_PROGRAMS += test_wt2853_perf
-# Temporarily disabled
 all_TESTS += test_wt2853_perf
 
 test_wt2909_checkpoint_integrity_SOURCES = wt2909_checkpoint_integrity/main.c
@@ -144,7 +143,6 @@ all_TESTS += test_wt4699_json
 
 test_wt4803_history_store_abort_SOURCES = wt4803_history_store_abort/main.c
 noinst_PROGRAMS += test_wt4803_history_store_abort
-# Temporarily disabled
 all_TESTS += test_wt4803_history_store_abort
 
 test_wt4891_meta_ckptlist_get_alloc_SOURCES=wt4891_meta_ckptlist_get_alloc/main.c

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1148,20 +1148,21 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2834_join_bloom_fix 2>&1
 
-  - name: csuite-wt2853-perf-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
+  # Temporarily disabled
+  # - name: csuite-wt2853-perf-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger/build_posix"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
 
-            ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
+  #           ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
 
   # - name: csuite-wt2909-checkpoint-integrity-test
   #   tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -578,16 +578,17 @@ tasks:
         vars:
           directory: test/cursor_order
 
-  - name: fops-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          directory: test/fops
+  # Temporarily disabled
+  # - name: fops-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - func: "compile wiredtiger"
+  #     - func: "make check directory"
+  #       vars:
+  #         directory: test/fops
 
   # Temporarily disabled
   # - name: format-test
@@ -1433,23 +1434,24 @@ tasks:
             pip install scons==3.1.1
             scons-3.1.1.bat ${smp_command|} check
 
-  - name: fops
-    tags: ["pull_request"]
-    depends_on:
-    - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger"
-          script: |
-            set -o errexit
-            set -o verbose
-            if [ "Windows_NT" = "$OS" ]; then
-              cmd.exe /c t_fops.exe
-            else
-              build_posix/test/fops/t
-            fi
+  # Temporarily disabled
+  # - name: fops
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #   - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
+  #           if [ "Windows_NT" = "$OS" ]; then
+  #             cmd.exe /c t_fops.exe
+  #           else
+  #             build_posix/test/fops/t
+  #           fi
 
   # Temporarily disabled
   # - name: format
@@ -2264,7 +2266,8 @@ buildvariants:
     - name: compile
     - name: make-check-test
     - name: unit-test
-    - name: fops
+    # Temporarily disabled
+    # - name: fops
     - name: time-shift-sensitivity-test
     - name: compile-msan
     - name: make-check-msan-test
@@ -2312,7 +2315,8 @@ buildvariants:
     - name: compile
     - name: ".windows_only"
     - name: ".unit_test"
-    - name: fops
+    # Temporarily disabled
+    # - name: fops
 
 - name: macos-1012
   display_name: OS X 10.12
@@ -2328,7 +2332,8 @@ buildvariants:
     - name: compile
     - name: make-check-test
     - name: unit-test
-    - name: fops
+    # Temporarily disabled
+    # - name: fops
 
 # Temporarily disabled
 # - name: little-endian

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -183,15 +183,15 @@ functions:
         set -o errexit
         set -o verbose
         ${test_env_vars|} ./t ${many_db_args|} 2>&1
+  "thread test":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/build_posix/test/thread"
+      script: |
+        set -o errexit
+        set -o verbose
+        ${test_env_vars|} ./t ${thread_test_args|} 2>&1
   # Temporarily disabled
-  # "thread test":
-  #   command: shell.exec
-  #   params:
-  #     working_dir: "wiredtiger/build_posix/test/thread"
-  #     script: |
-  #       set -o errexit
-  #       set -o verbose
-  #       ${test_env_vars|} ./t ${thread_test_args|} 2>&1
   # "random abort test":
   #   command: shell.exec
   #   params:
@@ -578,17 +578,16 @@ tasks:
         vars:
           directory: test/cursor_order
 
-  # Temporarily disabled
-  # - name: fops-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - func: "compile wiredtiger"
-  #     - func: "make check directory"
-  #       vars:
-  #         directory: test/fops
+  - name: fops-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "compile wiredtiger"
+      - func: "make check directory"
+        vars:
+          directory: test/fops
 
   # Temporarily disabled
   # - name: format-test
@@ -657,17 +656,16 @@ tasks:
         vars:
           directory: test/salvage
 
-  # Temporarily disabled
-  # - name: thread-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - func: "compile wiredtiger"
-  #     - func: "make check directory"
-  #       vars:
-  #         directory: test/thread
+  - name: thread-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "compile wiredtiger"
+      - func: "make check directory"
+        vars:
+          directory: test/thread
 
   - name: bench-wtperf-test
     tags: ["pull_request"]
@@ -1043,21 +1041,20 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/csuite/test_wt4699_json 2>&1
 
-  # Temporarily disabled
-  # - name: csuite-wt4803-history-store-abort-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-wt4803-history-store-abort-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/test/csuite/test_wt4803_history_store_abort 2>&1
+            ${test_env_vars|} $(pwd)/test/csuite/test_wt4803_history_store_abort 2>&1
 
   - name: csuite-wt4891-meta-ckptlist-get-alloc-test
     tags: ["pull_request"]
@@ -1150,21 +1147,20 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2834_join_bloom_fix 2>&1
 
-  # Temporarily disabled
-  # - name: csuite-wt2853-perf-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-wt2853-perf-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
+            ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
 
   # - name: csuite-wt2909-checkpoint-integrity-test
   #   tags: ["pull_request"]
@@ -1437,24 +1433,23 @@ tasks:
             pip install scons==3.1.1
             scons-3.1.1.bat ${smp_command|} check
 
-  # Temporarily disabled
-  # - name: fops
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #   - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
-  #           if [ "Windows_NT" = "$OS" ]; then
-  #             cmd.exe /c t_fops.exe
-  #           else
-  #             build_posix/test/fops/t
-  #           fi
+  - name: fops
+    tags: ["pull_request"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          script: |
+            set -o errexit
+            set -o verbose
+            if [ "Windows_NT" = "$OS" ]; then
+              cmd.exe /c t_fops.exe
+            else
+              build_posix/test/fops/t
+            fi
 
   # Temporarily disabled
   # - name: format
@@ -1908,26 +1903,25 @@ tasks:
         vars:
           many_db_args: -I -D 40
 
-      # Temporarily disabled
-      # # extended test/thread runs
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -t f
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -S -F -n 100000 -t f
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -t r
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -S -F -n 100000 -t r
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -t v
-      # - func: "thread test"
-      #   vars:
-      #     thread_test_args: -S -F -n 100000 -t v
+      # extended test/thread runs
+      - func: "thread test"
+        vars:
+          thread_test_args: -t f
+      - func: "thread test"
+        vars:
+          thread_test_args: -S -F -n 100000 -t f
+      - func: "thread test"
+        vars:
+          thread_test_args: -t r
+      - func: "thread test"
+        vars:
+          thread_test_args: -S -F -n 100000 -t r
+      - func: "thread test"
+        vars:
+          thread_test_args: -t v
+      - func: "thread test"
+        vars:
+          thread_test_args: -S -F -n 100000 -t v
 
       # Temporarily disabled
       # # random-abort - default (random time and number of threads)
@@ -2270,8 +2264,7 @@ buildvariants:
     - name: compile
     - name: make-check-test
     - name: unit-test
-    # Temporarily disabled
-    # - name: fops
+    - name: fops
     - name: time-shift-sensitivity-test
     - name: compile-msan
     - name: make-check-msan-test
@@ -2319,8 +2312,7 @@ buildvariants:
     - name: compile
     - name: ".windows_only"
     - name: ".unit_test"
-    # Temporarily disabled
-    # - name: fops
+    - name: fops
 
 - name: macos-1012
   display_name: OS X 10.12
@@ -2336,8 +2328,7 @@ buildvariants:
     - name: compile
     - name: make-check-test
     - name: unit-test
-    # Temporarily disabled
-    # - name: fops
+    - name: fops
 
 # Temporarily disabled
 # - name: little-endian

--- a/test/fops/Makefile.am
+++ b/test/fops/Makefile.am
@@ -11,7 +11,8 @@ t_LDADD +=$(top_builddir)/libwiredtiger.la
 t_LDFLAGS = -static
 
 # Run this during a "make check" smoke test.
-TESTS = $(noinst_PROGRAMS)
+# Temporarily disabled
+# TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)
 
 clean-local:

--- a/test/fops/Makefile.am
+++ b/test/fops/Makefile.am
@@ -12,7 +12,7 @@ t_LDFLAGS = -static
 
 # Run this during a "make check" smoke test.
 # Temporarily disabled
-# TESTS = $(noinst_PROGRAMS)
+TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)
 
 clean-local:

--- a/test/fops/Makefile.am
+++ b/test/fops/Makefile.am
@@ -11,7 +11,6 @@ t_LDADD +=$(top_builddir)/libwiredtiger.la
 t_LDFLAGS = -static
 
 # Run this during a "make check" smoke test.
-# Temporarily disabled
 TESTS = $(noinst_PROGRAMS)
 LOG_COMPILER = $(TEST_WRAPPER)
 

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -61,7 +61,6 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
         'eviction_dirty_target=80,eviction_dirty_trigger=95,statistics=(all)'
 
     # Test compaction.
-    @unittest.skip("Temporarily disabled")
     def test_compact(self):
         # Populate an object
         uri = self.type + self.name

--- a/test/suite/test_gc02.py
+++ b/test/suite/test_gc02.py
@@ -29,6 +29,7 @@
 from test_gc01 import test_gc_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
+import unittest
 
 def timestamp_str(t):
     return '%x' % t
@@ -39,6 +40,7 @@ class test_gc02(test_gc_base):
     conn_config = 'cache_size=1GB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
 
+    @unittest.skip("Temporarily disabled")
     def test_gc(self):
         nrows = 100000
 

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -92,7 +92,6 @@ class test_hs01(wttest.WiredTigerTestCase):
         session.close()
         conn.close()
 
-    @unittest.skip("Temporarily disabled")
     def test_hs(self):
         # Create a small table.
         uri = "table:test_hs01"

--- a/test/suite/test_stat04.py
+++ b/test/suite/test_stat04.py
@@ -73,7 +73,6 @@ class test_stat04(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(statcursor[stat.dsrc.btree_entries][2], expectpairs)
         statcursor.close()
 
-    @unittest.skip("Temporarily disabled")
     def test_stat_nentries(self):
         """
         Test to make sure the number of key/value pairs is accurate.

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -204,7 +204,6 @@ class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
         pr_logs = fnmatch.filter(os.listdir(self.backup_dir), "*gerLog*")
         self.assertEqual(cur_logs, pr_logs)
 
-    @unittest.skip("Temporarily disabled")
     def test_ops(self):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         self.session2 = self.conn.open_session()

--- a/test/suite/test_txn05.py
+++ b/test/suite/test_txn05.py
@@ -166,7 +166,6 @@ class test_txn05(wttest.WiredTigerTestCase, suite_subprocess):
         #
         self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
 
-    @unittest.skip("Temporarily disabled")
     def test_ops(self):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         self.session2 = self.conn.open_session()

--- a/test/suite/test_txn09.py
+++ b/test/suite/test_txn09.py
@@ -110,7 +110,6 @@ class test_txn09(wttest.WiredTigerTestCase, suite_subprocess):
         self.check(self.session2, "isolation=read-committed", committed)
         self.check(self.session2, "isolation=read-uncommitted", current)
 
-    @unittest.skip("Temporarily disabled")
     def test_ops(self):
         # print "Creating %s with config '%s'" % (self.uri, self.create_params)
         self.session.create(self.uri, self.create_params)

--- a/test/thread/Makefile.am
+++ b/test/thread/Makefile.am
@@ -10,7 +10,7 @@ t_LDADD +=$(top_builddir)/libwiredtiger.la
 t_LDFLAGS = -static
 
 # Temporarily disabled
-# TESTS = smoke.sh
+TESTS = smoke.sh
 
 clean-local:
 	rm -rf WT_TEST __stats core.* *.core

--- a/test/thread/Makefile.am
+++ b/test/thread/Makefile.am
@@ -9,7 +9,6 @@ t_LDADD = $(top_builddir)/test/utility/libtest_util.la
 t_LDADD +=$(top_builddir)/libwiredtiger.la
 t_LDFLAGS = -static
 
-# Temporarily disabled
 TESTS = smoke.sh
 
 clean-local:


### PR DESCRIPTION
I was going to enable `test_hs01` as per @luke-pearson's ticket but I realized that quite a few tests are now passing.