### PR TITLE
WT-5537 Use correct WT_ITEM fields per memory sanitizer.

### DIFF
--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -305,7 +305,7 @@ take_incr_backup(WT_SESSION *session, int i)
     FILELIST *flist;
     WT_CURSOR *backup_cur, *incr_cur;
     uint64_t offset, size, type;
-    size_t alloc, count, tmp_sz;
+    size_t alloc, count, rdsize, tmp_sz;
     int j, ret, rfd, wfd;
     char buf[1024], h[256], *tmp;
     const char *filename;
@@ -367,9 +367,10 @@ take_incr_backup(WT_SESSION *session, int i)
                 }
 
                 error_sys_check(lseek(rfd, (wt_off_t)offset, SEEK_SET));
-                error_sys_check(read(rfd, tmp, (size_t)size));
+                error_sys_check(rdsize = (size_t)read(rfd, tmp, (size_t)size));
                 error_sys_check(lseek(wfd, (wt_off_t)offset, SEEK_SET));
-                error_sys_check(write(wfd, tmp, (size_t)size));
+                /* Use the read size since we may have read less than the granularity. */
+                error_sys_check(write(wfd, tmp, rdsize));
             } else {
                 /* Whole file, so close both files and just copy the whole thing. */
                 testutil_assert(first == true);

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -669,10 +669,14 @@ __ckpt_add_blkmod_entry(
     end = (uint64_t)(offset + len) / blk_mod->granularity;
     WT_ASSERT(session, end < UINT32_MAX);
     end_rdup = WT_MAX(__wt_rduppo2((uint32_t)end, 8), WT_BLOCK_MODS_LIST_MIN);
-    if (end_rdup > blk_mod->nbits) {
+    if ((end_rdup << 3) > blk_mod->nbits) {
         /* If we don't have enough, extend the buffer. */
-        WT_RET(__wt_buf_extend(session, &blk_mod->bitstring, end_rdup));
-        blk_mod->nbits = end_rdup;
+        if (blk_mod->nbits == 0) {
+            WT_RET(__wt_buf_initsize(session, &blk_mod->bitstring, end_rdup));
+            memset(blk_mod->bitstring.mem, 0, end_rdup);
+        } else
+            WT_RET(__wt_buf_extend(session, &blk_mod->bitstring, end_rdup));
+        blk_mod->nbits = end_rdup << 3;
     }
 
     /* Set all the bits needed to record this offset/length pair. */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -759,11 +759,11 @@ __ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
     for (i = 0, blk = &ckpt->backup_blocks[0]; i < WT_BLKINCR_MAX; ++i, ++blk) {
         if (!F_ISSET(blk, WT_BLOCK_MODS_VALID))
             continue;
-        WT_RET(__wt_raw_to_hex(session, blk->bitstring.mem, blk->nbits >> 3, &bitstring));
+        WT_RET(__wt_raw_to_hex(session, blk->bitstring.data, blk->bitstring.size, &bitstring));
         WT_RET(__wt_buf_catfmt(session, buf, "%s%s=(id=%" PRIu32 ",granularity=%" PRIu64
                                              ",nbits=%" PRIu64 ",offset=%" PRIu64 ",blocks=%.*s)",
           i == 0 ? "" : ",", blk->id_str, i, blk->granularity, blk->nbits, blk->offset,
-          (int)bitstring.size, (char *)bitstring.mem));
+          (int)bitstring.size, (char *)bitstring.data));
         __wt_buf_free(session, &bitstring);
     }
     WT_RET(__wt_buf_catfmt(session, buf, ")"));


### PR DESCRIPTION
Also, in the example, if we have a short read, then only write what we
read.