### PR TITLE
WT-4458 Only sweep btree handles that have been evicted from cache

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -381,8 +381,8 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
         dhandle = dhandle_cache->dhandle;
         if (dhandle != session->dhandle && dhandle->session_inuse == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) ||
-              (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time)
-              || __wt_btree_bytes_evictable(session) == 0)) {
+              (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time) ||
+              (dhandle->type == WT_DHANDLE_TYPE_BTREE && __wt_btree_bytes_evictable(session) == 0))) {
             WT_STAT_CONN_INCR(session, dh_session_handles);
             WT_ASSERT(session, !WT_IS_METADATA(dhandle));
             __session_discard_dhandle(session, dhandle_cache);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -366,7 +366,6 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
     bool empty_btree;
 
     conn = S2C(session);
-    empty_btree = false;
 
     /*
      * Periodically sweep for dead handles; if we've swept recently, don't do it again.

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -383,8 +383,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
           (WT_DHANDLE_INACTIVE(dhandle) ||
               (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time) ||
               (dhandle->type == WT_DHANDLE_TYPE_BTREE &&
-                __wt_btree_bytes_evictable(session) == 0)
-              )) {
+                __wt_btree_bytes_evictable(session) == 0))) {
             WT_STAT_CONN_INCR(session, dh_session_handles);
             WT_ASSERT(session, !WT_IS_METADATA(dhandle));
             __session_discard_dhandle(session, dhandle_cache);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -383,8 +383,9 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
         dhandle = dhandle_cache->dhandle;
         empty_btree = false;
         if (dhandle->type == WT_DHANDLE_TYPE_BTREE)
-            WT_WITH_DHANDLE(session, dhandle, empty_btree = (__wt_btree_bytes_evictable(session) == 0));
-        
+            WT_WITH_DHANDLE(
+              session, dhandle, empty_btree = (__wt_btree_bytes_evictable(session) == 0));
+
         if (dhandle != session->dhandle && dhandle->session_inuse == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) ||
               (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time) ||

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -382,7 +382,9 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
         if (dhandle != session->dhandle && dhandle->session_inuse == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) ||
               (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time) ||
-              (dhandle->type == WT_DHANDLE_TYPE_BTREE && __wt_btree_bytes_evictable(session) == 0))) {
+              (dhandle->type == WT_DHANDLE_TYPE_BTREE &&
+                __wt_btree_bytes_evictable(session) == 0)
+              )) {
             WT_STAT_CONN_INCR(session, dh_session_handles);
             WT_ASSERT(session, !WT_IS_METADATA(dhandle));
             __session_discard_dhandle(session, dhandle_cache);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -381,7 +381,8 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
         dhandle = dhandle_cache->dhandle;
         if (dhandle != session->dhandle && dhandle->session_inuse == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) ||
-              (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time))) {
+              (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time)
+              || __wt_btree_bytes_evictable(session) == 0)) {
             WT_STAT_CONN_INCR(session, dh_session_handles);
             WT_ASSERT(session, !WT_IS_METADATA(dhandle));
             __session_discard_dhandle(session, dhandle_cache);


### PR DESCRIPTION
When choosing which dhandles should be swept, we should also sweep the dhandle's that are already evicted. This PR aims to add that functionality when sweeping dhandles.