### PR TITLE
WT-5422 remove history store updates

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1247,7 +1247,7 @@ __conn_rollback_to_stable(WT_CONNECTION *wt_conn, const char *config)
 
     CONNECTION_API_CALL(conn, session, rollback_to_stable, config, cfg);
     WT_STAT_CONN_INCR(session, txn_rollback_to_stable);
-    WT_TRET(__wt_txn_rollback_to_stable(session, cfg));
+    WT_TRET(__wt_rollback_to_stable(session, cfg));
 err:
     API_END_RET(session, ret);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1201,6 +1201,8 @@ extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOK
   uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name, bool durable)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[])
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_ikey_alloc(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
@@ -1483,8 +1485,6 @@ extern int __wt_txn_recover(WT_SESSION_IMPL *session)
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -732,7 +732,7 @@ done:
         conn->txn_global.oldest_timestamp = WT_TS_NONE;
         conn->txn_global.has_oldest_timestamp = true;
 
-        WT_ERR(__wt_txn_rollback_to_stable(session, NULL));
+        WT_ERR(__wt_rollback_to_stable(session, NULL));
 
         /* Reset the stable and oldest timestamp. */
         conn->txn_global.stable_timestamp = WT_TS_NONE;

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -381,6 +381,7 @@ __rollback_abort_row_reconciled_page_internal(WT_SESSION_IMPL *session, const vo
      */
     WT_CLEAR(tmp);
 
+    mod_page = NULL;
     image_local = image;
 
     if (image_local == NULL) {
@@ -394,15 +395,11 @@ __rollback_abort_row_reconciled_page_internal(WT_SESSION_IMPL *session, const vo
     WT_ROW_FOREACH (mod_page, rip, i)
         WT_ERR_NOTFOUND_OK(
           __rollback_row_ondisk_fixup_key(session, mod_page, rip, rollback_timestamp, false));
-    __wt_page_out(session, &mod_page);
 
-    if (0) {
 err:
-        if (mod_page != NULL)
-            __wt_page_out(session, &mod_page);
-
-        __wt_buf_free(session, &tmp);
-    }
+    if (mod_page != NULL)
+        __wt_page_out(session, &mod_page);
+    __wt_buf_free(session, &tmp);
 
     return (ret);
 }

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -108,5 +108,13 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         # Check that the new updates are only seen after the update timestamp
         self.check(valuea, uri, nrows, 20)
 
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rollback_to_stable][2]
+        upd_aborted = (stat_cursor[stat.conn.txn_rollback_upd_aborted][2] +
+            stat_cursor[stat.conn.txn_rollback_hs_removed][2])
+        stat_cursor.close()
+        self.assertEqual(calls, 1)
+        self.assertTrue(upd_aborted >= nrows)
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -43,7 +43,6 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
     conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
 
-    @unittest.skip("Temporarily disabled")
     def test_rollback_to_stable(self):
         nrows = 10000
 
@@ -85,6 +84,14 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         self.conn.rollback_to_stable()
         # Check that the new updates are only seen after the update timestamp
         self.check(valuea, uri, nrows, 40)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rollback_to_stable][2]
+        upd_aborted = (stat_cursor[stat.conn.txn_rollback_upd_aborted][2] +
+            stat_cursor[stat.conn.txn_rollback_hs_removed][2])
+        stat_cursor.close()
+        self.assertEqual(calls, 1)
+        self.assertTrue(upd_aborted >= nrows * 3)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+from helper import copy_wiredtiger_home
+import unittest, wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable03.py
+# Test that rollback to stable clears the history store updates from reconciled pages.
+class test_rollback_to_stable01(test_rollback_to_stable_base):
+    conn_config = 'cache_size=4GB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def test_rollback_to_stable(self):
+        nrows = 1000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable03"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
+            ',stable_timestamp=' + timestamp_str(1))
+
+        valuea = "aaaaa" * 100
+        valueb = "bbbbb" * 100
+        self.large_updates(uri, valuea, ds, nrows, 10)
+        # Check that all updates are seen
+        self.check(valuea, uri, nrows, 10)
+
+        # Remove all keys with newer timestamp
+        self.large_updates(uri, valueb, ds, nrows, 20)
+        # Check that all updates are seen
+        self.check(valueb, uri, nrows, 20)
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        # Checkpoint to ensure that all the updates are flushed to disk.
+        self.session.checkpoint()
+
+        self.conn.rollback_to_stable()
+        # Check that the old updates are only seen even with the update timestamp
+        self.check(valuea, uri, nrows, 20)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -75,5 +75,13 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         # Check that the old updates are only seen even with the update timestamp
         self.check(valuea, uri, nrows, 20)
 
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rollback_to_stable][2]
+        upd_aborted = (stat_cursor[stat.conn.txn_rollback_upd_aborted][2] +
+            stat_cursor[stat.conn.txn_rollback_hs_removed][2])
+        stat_cursor.close()
+        self.assertEqual(calls, 1)
+        self.assertTrue(upd_aborted == nrows * 2)
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
When a page gets reconciled, its updates in the update list may have
been inserted into the history store, whenever we are aborting those
updates, the updates in the history store also needs to be removed.