### PR TITLE
WT-5423: Convert a history store modified value into a full update

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -159,12 +159,12 @@ __txn_abort_row_replace_with_hs_value(
     WT_ERR(__wt_row_leaf_key(session, page, rip, key, false));
 
     /* Get the full update value from the data store. */
-    unpack = &_unpack;
-    __wt_row_leaf_value_cell(session, page, rip, NULL, unpack);
     WT_CLEAR(ds_value);
-    if (!__wt_row_leaf_value(page, rip, &ds_value))
+    if (!__wt_row_leaf_value(page, rip, &ds_value)) {
+        unpack = &_unpack;
+        __wt_row_leaf_value_cell(session, page, rip, NULL, unpack);
         WT_ERR(__wt_page_cell_data_ref(session, page, unpack, &ds_value));
-
+    }
     WT_CLEAR(full_value);
     WT_ERR(__wt_buf_set(session, &full_value, ds_value.data, ds_value.size));
 
@@ -275,6 +275,7 @@ err:
     __wt_scr_free(session, &key);
     __wt_scr_free(session, &hs_key);
     __wt_scr_free(session, &hs_value);
+    __wt_buf_free(session, &ds_value);
     __wt_buf_free(session, &full_value);
     __wt_free(session, hs_upd);
     __wt_free(session, upd);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -202,9 +202,9 @@ __txn_abort_row_replace_with_hs_value(
 
         /* Get current value and convert to full update if it is a modify. */
         WT_ERR(hs_cursor->get_value(hs_cursor, &durable_ts, &prepare_state, &type, hs_value));
-        if (type == WT_UPDATE_MODIFY) {
+        if (type == WT_UPDATE_MODIFY)
             WT_ERR(__wt_modify_apply_item(session, &full_value, hs_value->data, false));
-        } else {
+        else {
             WT_ASSERT(session, type == WT_UPDATE_STANDARD);
             WT_ERR(__wt_buf_set(session, &full_value, hs_value->data, hs_value->size));
         }

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -134,7 +134,7 @@ __txn_abort_row_replace_with_hs_value(
     WT_DECL_ITEM(hs_value);
     WT_DECL_ITEM(key);
     WT_DECL_RET;
-    WT_ITEM ds_value, full_value;
+    WT_ITEM full_value;
     WT_TIME_PAIR hs_start, hs_stop;
     WT_UPDATE *hs_upd, *upd;
     wt_timestamp_t durable_ts;
@@ -159,14 +159,13 @@ __txn_abort_row_replace_with_hs_value(
     WT_ERR(__wt_row_leaf_key(session, page, rip, key, false));
 
     /* Get the full update value from the data store. */
-    WT_CLEAR(ds_value);
-    if (!__wt_row_leaf_value(page, rip, &ds_value)) {
+    WT_CLEAR(full_value);
+    if (!__wt_row_leaf_value(page, rip, &full_value)) {
         unpack = &_unpack;
         __wt_row_leaf_value_cell(session, page, rip, NULL, unpack);
-        WT_ERR(__wt_page_cell_data_ref(session, page, unpack, &ds_value));
+        WT_ERR(__wt_page_cell_data_ref(session, page, unpack, &full_value));
     }
-    WT_CLEAR(full_value);
-    WT_ERR(__wt_buf_set(session, &full_value, ds_value.data, ds_value.size));
+    WT_ERR(__wt_buf_set(session, &full_value, full_value.data, full_value.size));
 
     /* Open a history store table cursor. */
     WT_ERR(__wt_hs_cursor(session, &session_flags));
@@ -275,7 +274,6 @@ err:
     __wt_scr_free(session, &key);
     __wt_scr_free(session, &hs_key);
     __wt_scr_free(session, &hs_value);
-    __wt_buf_free(session, &ds_value);
     __wt_buf_free(session, &full_value);
     __wt_free(session, hs_upd);
     __wt_free(session, upd);

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -48,6 +48,18 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
             session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
         cursor.close()
 
+    def large_modifies(self, uri, value, ds, location, nbytes, nrows, commit_ts):
+        # Load a slight modification.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        session.begin_transaction()
+        for i in range(0, nrows):
+            cursor.set_key(i)
+            mods = [wiredtiger.Modify(value, location, nbytes)]
+            self.assertEqual(cursor.modify(mods), 0)
+        session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        cursor.close()
+
     def large_removes(self, uri, ds, nrows, commit_ts):
         # Remove a large number of records.
         session = self.session

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time, unittest, wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+def mod_val(value, char, location, nbytes=1):
+    return value[0:location] + char + value[location+nbytes:]
+
+# test_rollback_to_stable03.py
+# Test that rollback to stable always replaces the on-disk value with a full update
+# from the history store.
+class test_rollback_to_stable03(test_rollback_to_stable_base):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable03"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+
+        value_modQ = mod_val(value_a, 'Q', 0)
+        value_modR = mod_val(value_modQ, 'R', 1)
+        value_modS = mod_val(value_modR, 'S', 2)
+        value_modT = mod_val(value_c, 'T', 3)
+        value_modW = mod_val(value_d, 'W', 4)
+        value_modX = mod_val(value_a, 'X', 5)
+        value_modY = mod_val(value_modX, 'Y', 6)
+        value_modZ = mod_val(value_modY, 'Z', 7)
+
+        # Perform a combination of modifies and updates.
+        self.large_updates(uri, value_a, ds, nrows, 20)
+        self.large_modifies(uri, 'Q', ds, 0, 1, nrows, 30)
+        self.large_modifies(uri, 'R', ds, 1, 1, nrows, 40)
+        self.large_modifies(uri, 'S', ds, 2, 1, nrows, 50)
+        self.large_updates(uri, value_b, ds, nrows, 60)
+        self.large_updates(uri, value_c, ds, nrows, 70)
+        self.large_modifies(uri, 'T', ds, 3, 1, nrows, 80)
+        self.large_updates(uri, value_d, ds, nrows, 90)
+        self.large_modifies(uri, 'W', ds, 4, 1, nrows, 100)
+        self.large_updates(uri, value_a, ds, nrows, 110)
+        self.large_modifies(uri, 'X', ds, 5, 1, nrows, 120)
+        self.large_modifies(uri, 'Y', ds, 6, 1, nrows, 130)
+        self.large_modifies(uri, 'Z', ds, 7, 1, nrows, 140)
+
+        # Verify data is visible and correct.
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_modQ, uri, nrows, 30)
+        self.check(value_modR, uri, nrows, 40)
+        self.check(value_modS, uri, nrows, 50)
+        self.check(value_b, uri, nrows, 60)
+        self.check(value_c, uri, nrows, 70)
+        self.check(value_modT, uri, nrows, 80)
+        self.check(value_d, uri, nrows, 90)
+        self.check(value_modW, uri, nrows, 100)
+        self.check(value_a, uri, nrows, 110)
+        self.check(value_modX, uri, nrows, 120)
+        self.check(value_modY, uri, nrows, 130)
+        self.check(value_modZ, uri, nrows, 140)
+
+        # Set stable timestamp to 30.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+
+        # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
+        self.session.checkpoint()
+        self.conn.rollback_to_stable()
+
+        # Check that the correct data is seen at and after the stable timestamp.
+        self.check(value_modQ, uri, nrows, 30)
+        self.check(value_modQ, uri, nrows, 70)
+        self.check(value_modQ, uri, nrows, 150)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -26,9 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import time, unittest, wiredtiger, wttest
 from wtdataset import SimpleDataSet
-from wiredtiger import stat
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
 def timestamp_str(t):
@@ -37,10 +35,10 @@ def timestamp_str(t):
 def mod_val(value, char, location, nbytes=1):
     return value[0:location] + char + value[location+nbytes:]
 
-# test_rollback_to_stable03.py
+# test_rollback_to_stable04.py
 # Test that rollback to stable always replaces the on-disk value with a full update
 # from the history store.
-class test_rollback_to_stable03(test_rollback_to_stable_base):
+class test_rollback_to_stable04(test_rollback_to_stable_base):
     conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
 
@@ -48,7 +46,7 @@ class test_rollback_to_stable03(test_rollback_to_stable_base):
         nrows = 10000
 
         # Create a table without logging.
-        uri = "table:rollback_to_stable03"
+        uri = "table:rollback_to_stable04"
         ds = SimpleDataSet(
             self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
         ds.populate()


### PR DESCRIPTION
I added code to the `__txn_abort_row_replace_with_hs_value` function in `txn/txn_rollback_to_stable.c` so that if the stable timestamp corresponds to a modify value in the history store, the value is converted to a full update. This functionality is tested in `test_rollback_to_stable04.py`.