### PR TITLE
WT-5557 The wrong page type is returned when checking the on-page cell.

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1085,7 +1085,7 @@ __wt_ref_info(
         *sizep = unpack->size;
 
         if (is_leafp != NULL)
-            *is_leafp = unpack->type != WT_ADDR_INT;
+            *is_leafp = unpack->type != WT_CELL_ADDR_INT;
     }
 }
 


### PR DESCRIPTION
Use proper enum macro to find out page type