### PR TITLE
WT-5553 Return error if primary cursor is not an incremental source.

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -578,6 +578,9 @@ __backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[
         if (is_dup && !F_ISSET(othercb, WT_CURBACKUP_INCR))
             WT_ERR_MSG(session, EINVAL,
               "Incremental duplicate cursor must have an incremental primary backup cursor");
+        if (is_dup && othercb->incr_src == NULL)
+            WT_ERR_MSG(
+              session, EINVAL, "Incremental primary cursor must have a known source identifier");
         F_SET(cb, WT_CURBACKUP_INCR);
     }
 err:

--- a/test/suite/test_backup11.py
+++ b/test/suite/test_backup11.py
@@ -154,6 +154,7 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         # - We cannot duplicate the duplicate backup cursor.
         # - We cannot mix block incremental with a log target on the same duplicate.
         # - Incremental ids must be on primary, not duplicate.
+        # - Incremental must be opened on a primary with a source identifier.
         # - Force stop must be on primary, not duplicate.
 
         # - Incremental filename must be on duplicate, not primary.
@@ -236,6 +237,21 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         #    lambda:self.assertEquals(self.session.open_cursor(None,
         #    bkup_c, config), 0), msg)
 
+        bkup_c.close()
+
+        # - Incremental must be opened on a primary with a source identifier.
+        # Open a top level backup cursor without a source id.
+        # Try to open an incremental cursor off this backup cursor.
+        self.pr("Test incremental without source identifier on primary")
+        self.pr("=========")
+        config = 'incremental=(enabled,this_id="ID3")'
+        bkup_c = self.session.open_cursor('backup:', None, config)
+        ret = bkup_c.next()
+        newfile = bkup_c.get_key()
+        config = 'incremental=(file=' + newfile + ')'
+        msg = '/known source identifier/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(None, bkup_c, config), msg)
         bkup_c.close()
 
         # After the full backup, open and recover the backup database.

--- a/test/suite/test_backup11.py
+++ b/test/suite/test_backup11.py
@@ -247,6 +247,7 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         config = 'incremental=(enabled,this_id="ID3")'
         bkup_c = self.session.open_cursor('backup:', None, config)
         ret = bkup_c.next()
+        self.assertTrue(ret == 0)
         newfile = bkup_c.get_key()
         config = 'incremental=(file=' + newfile + ')'
         msg = '/known source identifier/'


### PR DESCRIPTION
@ddanderson This is the identical code change, but adds the error test code to an existing Python test instead of creating a new file. Please review.