### PR TITLE
WT-5563 Transactions ID are getting wiped which causes errors in WT Verify

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -266,6 +266,10 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *unpack, 
     hs_btree_id = btree->id;
     /* Set the data store timestamp and transactions to initiate timestamp range verification */
     prev_start.timestamp = unpack->start_ts;
+    /*
+     * FIXME-PM-1694: Currently transaction IDs in Data store are wiped upon start up, thus we can't
+     * check data continuity from data store to history store.
+     */
     prev_start.txnid = WT_TXN_MAX;
     session_flags = 0;
     stop.timestamp = 0;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -266,7 +266,7 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *unpack, 
     hs_btree_id = btree->id;
     /* Set the data store timestamp and transactions to initiate timestamp range verification */
     prev_start.timestamp = unpack->start_ts;
-    prev_start.txnid = unpack->start_txn;
+    prev_start.txnid = WT_TXN_MAX;
     session_flags = 0;
     stop.timestamp = 0;
     stop.txnid = 0;
@@ -325,7 +325,7 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *unpack, 
               ", Key %s has a overlap of "
               "timestamp ranges between history store stop transaction (%" PRIu64
               ") being "
-              "newer than a more recent timestamp range having start transaction (%" PRIu64 ")",
+              "newer than a more recent transaction range having start transaction (%" PRIu64 ")",
               hs_btree_id, __wt_buf_set_printable(session, hs_key->data, hs_key->size, vs->tmp1),
               stop.txnid, prev_start.txnid);
         }

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -886,8 +886,8 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
      *
      * Return null not tombstone if nothing is found in history store.
      */
-    WT_ASSERT(session,
-      (*updp) == NULL || ((*updp)->type != WT_UPDATE_BIRTHMARK && (*updp)->type != WT_UPDATE_TOMBSTONE));
+    WT_ASSERT(session, (*updp) == NULL ||
+        ((*updp)->type != WT_UPDATE_BIRTHMARK && (*updp)->type != WT_UPDATE_TOMBSTONE));
 
     /*
      * FIXME-PM-1521: We call transaction read in a lot of places so we can't do this yet. When we

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -887,7 +887,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
      * Return null not tombstone if nothing is found in history store.
      */
     WT_ASSERT(session,
-      upd == NULL || (upd->type != WT_UPDATE_BIRTHMARK && upd->type != WT_UPDATE_TOMBSTONE));
+      (*updp) == NULL || ((*updp)->type != WT_UPDATE_BIRTHMARK && (*updp)->type != WT_UPDATE_TOMBSTONE));
 
     /*
      * FIXME-PM-1521: We call transaction read in a lot of places so we can't do this yet. When we

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -887,7 +887,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
      * Return null not tombstone if nothing is found in history store.
      */
     WT_ASSERT(
-      session, upd == NULL || upd->type != WT_UPDATE_BIRTHMARK || upd->type != WT_UPDATE_TOMBSTONE);
+      session, upd == NULL || (upd->type != WT_UPDATE_BIRTHMARK && upd->type != WT_UPDATE_TOMBSTONE));
 
     /*
      * FIXME-PM-1521: We call transaction read in a lot of places so we can't do this yet. When we

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -886,8 +886,8 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
      *
      * Return null not tombstone if nothing is found in history store.
      */
-    WT_ASSERT(
-      session, upd == NULL || (upd->type != WT_UPDATE_BIRTHMARK && upd->type != WT_UPDATE_TOMBSTONE));
+    WT_ASSERT(session,
+      upd == NULL || (upd->type != WT_UPDATE_BIRTHMARK && upd->type != WT_UPDATE_TOMBSTONE));
 
     /*
      * FIXME-PM-1521: We call transaction read in a lot of places so we can't do this yet. When we


### PR DESCRIPTION
This PR aims to fix the current verify bug that happens upon startup of database. Talked with @tetsuo-cpp and @sulabhM, and reached a consensus that we will stop verifying the start transaction ID from the data store for now.