### PR TITLE
WT-5371 Skip usec time check on Windows.

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -42,6 +42,7 @@ This provides an API similar to the C API, with the following modifications:
   - Statistics cursors behave a little differently and are best handled using the C-like functions
   - C Constants starting with WT_STAT_DSRC are instead exposed under wiredtiger.stat.dsrc
   - C Constants starting with WT_STAT_CONN are instead exposed under wiredtiger.stat.conn
+  - C Constants starting with WT_STAT_SESSION are instead exposed under wiredtiger.stat.session
 "
 %enddef
 
@@ -1472,12 +1473,17 @@ class stat:
 		'''keys for cursors on data source statistics'''
 		pass
 
+	class session:
+		'''keys for cursors on session statistics'''
+		pass
+
 ## @}
 
 import sys
 # All names starting with 'WT_STAT_DSRC_' are renamed to
 # the wiredtiger.stat.dsrc class, those starting with 'WT_STAT_CONN' are
-# renamed to wiredtiger.stat.conn class.
+# renamed to the wiredtiger.stat.conn class. All names starting with 'WT_STAT_SESSION'
+# are renamed to the wiredtiger.stat.session class.
 def _rename_with_prefix(prefix, toclass):
 	curmodule = sys.modules[__name__]
 	for name in dir(curmodule):
@@ -1488,5 +1494,6 @@ def _rename_with_prefix(prefix, toclass):
 
 _rename_with_prefix('WT_STAT_CONN_', stat.conn)
 _rename_with_prefix('WT_STAT_DSRC_', stat.dsrc)
+_rename_with_prefix('WT_STAT_SESSION_', stat.session)
 del _rename_with_prefix
 %}

--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import os
 import wiredtiger, wttest
 
 # test_stat08.py
@@ -41,6 +42,13 @@ class test_stat08(wttest.WiredTigerTestCase):
         READ_TIME : "session: page read from disk to cache time (usecs)"}
 
     def check_stats(self, cur, k):
+        #
+        # Some Windows machines lack the time granularity to detect microseconds.
+        # Skip the time check on Windows.
+        #
+        if os.name == "nt" and k is self.READ_TIME:
+            return
+
         exp_desc = self.session_stats[k]
         cur.set_key(k)
         cur.search()

--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -36,8 +36,8 @@ class test_stat08(wttest.WiredTigerTestCase):
     nentries = 350000
     conn_config = 'cache_size=10MB,statistics=(all)'
     entry_value = "abcde" * 40
-    BYTES_READ = 4000
-    READ_TIME = 4003
+    BYTES_READ = wiredtiger.stat.session.bytes_read
+    READ_TIME = wiredtiger.stat.session.read_time
     session_stats = { BYTES_READ : "session: bytes read into cache",           \
         READ_TIME : "session: page read from disk to cache time (usecs)"}
 


### PR DESCRIPTION
@ddanderson Please review this small test change. In particular, do you know if my supposition that some Windows systems lack usec granularity? I recall that from a while ago but, well, it was a while ago and I'm far from expert on anything Windows.