### PR TITLE
WT-5590 Fix s_string failures.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -210,6 +210,7 @@ KVS
 Kanowski's
 Kounavis
 LANGID
+LAS
 LF
 LLLLLL
 LLLLLLL

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -92,7 +92,7 @@ __wt_value_return_buf(
     page = ref->page;
     cursor = &cbt->iface;
 
-    /* Initialise to globally visible. */
+    /* Initialize to globally visible. */
     if (start != NULL && stop != NULL) {
         start->txnid = WT_TXN_NONE;
         start->timestamp = WT_TS_NONE;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1156,7 +1156,7 @@ __verify_txn_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num,
 
 /*
  * __verify_timestamp_to_pretty_string --
- *     Convert a timestamp to a pretty string, utilises existing timestamp to string function.
+ *     Convert a timestamp to a pretty string, utilizes existing timestamp to string function.
  */
 static const char *
 __verify_timestamp_to_pretty_string(wt_timestamp_t ts)

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1016,7 +1016,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
             ret = hs_cursor->remove(hs_cursor);
             if (ret != 0)
                 WT_PANIC_ERR(session, ret,
-                  "initialised prepared update but was unable to remove the corresponding entry "
+                  "initialized prepared update but was unable to remove the corresponding entry "
                   "from hs");
 
             /* This is going in our update list so it should be accounted for in cache usage. */

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -931,7 +931,7 @@ __wt_cell_unpack_dsk(
      *
      * This is how the stop time pair should be interpreted for each type of delete:
      * -
-     *                  Timestamped delete  Non-timestamped delete  No delete
+     *                  Timestamp delete  Non-timestamp delete  No delete
      * Current startup  txnid=x, ts=y       txnid=x, ts=1           txnid=MAX, ts=MAX
      * Previous startup txnid=0, ts=y       txnid=0, ts=1           txnid=MAX, ts=MAX
      */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -862,7 +862,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     /*
      * If the start time pair is visible then we need to return the ondisk value.
      *
-     * FIXME-PM-1521: This should be probably be refactored to return a buffer of bytes rather than
+     * FIXME-PM-1521: This should be probably be re-factored to return a buffer of bytes rather than
      * an update. This allocation is expensive and doesn't serve a purpose other than to work within
      * the current system.
      */
@@ -888,7 +888,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
 
     /*
      * FIXME-PM-1521: We call transaction read in a lot of places so we can't do this yet. When we
-     * refactor this function to return a byte array, we should tackle this at the same time.
+     * re-factor this function to return a byte array, we should tackle this at the same time.
      */
     return (0);
 }

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -446,7 +446,7 @@ err:
 
 /*
  * __wt_modify_vector_init --
- *     Initialise a modify vector.
+ *     Initialize a modify vector.
  */
 void
 __wt_modify_vector_init(WT_SESSION_IMPL *session, WT_MODIFY_VECTOR *modifies)


### PR DESCRIPTION
@keithbostic This should be quick. I fixed the various complaints from s_string.
Notably however, I added `LAS` back to s_string.ok because it is used in `NEWS` in the check-in message for a release. 