### PR TITLE
WT-5597 Fix the history store file access during recovery

### DIFF
--- a/test/suite/test_prepare07.py
+++ b/test/suite/test_prepare07.py
@@ -139,7 +139,6 @@ class test_prepare07(wttest.WiredTigerTestCase):
         cursor_b.close()
         session_b.close()
 
-    @unittest.skip("Temporarily disabled")
     def test_older_prepare_updates(self):
         # Create a small table.
         uri = "table:test"

--- a/test/suite/test_schema08.py
+++ b/test/suite/test_schema08.py
@@ -147,7 +147,6 @@ class test_schema08(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Test that creating and dropping tables does not write individual
     # log records.
-    @unittest.skip("Temporarily disabled")
     def test_schema08_create(self):
         self.count = 0
         self.lsns = []

--- a/test/suite/test_txn04.py
+++ b/test/suite/test_txn04.py
@@ -183,7 +183,6 @@ class test_txn04(wttest.WiredTigerTestCase, suite_subprocess):
         # Backup the target we modified and verify the data.
         # print 'Call hot_backup with ' + self.uri
         self.hot_backup(self.uri, committed)
-    @unittest.skip("Temporarily disabled")
     def test_ops(self):
         self.backup_dir = os.path.join(self.home, "WT_BACKUP")
         self.session2 = self.conn.open_session()


### PR DESCRIPTION
Fix the scenarios where the history store file doesn't
exist in metadata during recovery.