### PR TITLE
WT-5565 Clear WT_SESSION_LOCKED_PASS before eviction server starts to evict pages

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -700,11 +700,9 @@ __evict_pass(WT_SESSION_IMPL *session)
         if (!WT_EVICT_HAS_WORKERS(session) &&
           (cache->evict_empty_score < WT_EVICT_SCORE_CUTOFF ||
             !__evict_queue_empty(cache->evict_urgent_queue, false))) {
-            F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
             F_CLR(session, WT_SESSION_LOCKED_PASS);
             WT_RET(__evict_lru_pages(session, true));
             F_SET(session, WT_SESSION_LOCKED_PASS);
-            F_SET(cache->walk_session, WT_SESSION_LOCKED_PASS);
         }
 
         if (cache->pass_intr != 0)

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -700,8 +700,8 @@ __evict_pass(WT_SESSION_IMPL *session)
         if (!WT_EVICT_HAS_WORKERS(session) &&
           (cache->evict_empty_score < WT_EVICT_SCORE_CUTOFF ||
             !__evict_queue_empty(cache->evict_urgent_queue, false))) {
-            F_CLR(session, WT_SESSION_LOCKED_PASS);
             F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
+            F_CLR(session, WT_SESSION_LOCKED_PASS);
             WT_RET(__evict_lru_pages(session, true));
             F_SET(session, WT_SESSION_LOCKED_PASS);
             F_SET(cache->walk_session, WT_SESSION_LOCKED_PASS);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -699,8 +699,13 @@ __evict_pass(WT_SESSION_IMPL *session)
          */
         if (!WT_EVICT_HAS_WORKERS(session) &&
           (cache->evict_empty_score < WT_EVICT_SCORE_CUTOFF ||
-            !__evict_queue_empty(cache->evict_urgent_queue, false)))
+            !__evict_queue_empty(cache->evict_urgent_queue, false))) {
+            F_CLR(session, WT_SESSION_LOCKED_PASS);
+            F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
             WT_RET(__evict_lru_pages(session, true));
+            F_SET(session, WT_SESSION_LOCKED_PASS);
+            F_SET(cache->walk_session, WT_SESSION_LOCKED_PASS);
+        }
 
         if (cache->pass_intr != 0)
             break;

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -13,13 +13,11 @@ noinst_PROGRAMS=
 
 test_random_abort_SOURCES = random_abort/main.c
 noinst_PROGRAMS += test_random_abort
-# Temporarily disabled
-# all_TESTS += random_abort/smoke.sh
+all_TESTS += random_abort/smoke.sh
 
 test_random_directio_SOURCES = random_directio/main.c random_directio/util.c
 noinst_PROGRAMS += test_random_directio
-# Temporarily disabled
-# all_TESTS += random_directio/smoke.sh
+all_TESTS += random_directio/smoke.sh
 
 test_rwlock_SOURCES = rwlock/main.c
 noinst_PROGRAMS += test_rwlock

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -9,7 +9,7 @@ noinst_PROGRAMS=
 
 # The import test is only a shell script
 # Temporarily disabled
-all_TESTS += import/smoke.sh
+# all_TESTS += import/smoke.sh
 
 test_random_abort_SOURCES = random_abort/main.c
 noinst_PROGRAMS += test_random_abort
@@ -26,7 +26,7 @@ all_TESTS += test_rwlock
 test_schema_abort_SOURCES = schema_abort/main.c
 noinst_PROGRAMS += test_schema_abort
 # Temporarily disabled
-all_TESTS += schema_abort/smoke.sh
+# all_TESTS += schema_abort/smoke.sh
 
 test_scope_SOURCES = scope/main.c
 noinst_PROGRAMS += test_scope
@@ -34,7 +34,8 @@ all_TESTS += test_scope
 
 test_timestamp_abort_SOURCES = timestamp_abort/main.c
 noinst_PROGRAMS += test_timestamp_abort
-all_TESTS += timestamp_abort/smoke.sh
+# Temporarily disabled
+# all_TESTS += timestamp_abort/smoke.sh
 
 test_truncated_log_SOURCES = truncated_log/main.c
 noinst_PROGRAMS += test_truncated_log
@@ -55,7 +56,7 @@ all_TESTS += test_wt2246_col_append
 test_wt2323_join_visibility_SOURCES = wt2323_join_visibility/main.c
 noinst_PROGRAMS += test_wt2323_join_visibility
 # Temporarily disabled
-all_TESTS += test_wt2323_join_visibility
+# all_TESTS += test_wt2323_join_visibility
 
 test_wt2535_insert_race_SOURCES = wt2535_insert_race/main.c
 noinst_PROGRAMS += test_wt2535_insert_race
@@ -133,7 +134,7 @@ all_TESTS += test_wt4156_metadata_salvage
 test_wt4333_handle_locks_SOURCES = wt4333_handle_locks/main.c
 noinst_PROGRAMS += test_wt4333_handle_locks
 # Temporarily disabled
-all_TESTS += test_wt4333_handle_locks
+# all_TESTS += test_wt4333_handle_locks
 
 test_wt4699_json_SOURCES = wt4699_json/main.c
 noinst_PROGRAMS += test_wt4699_json

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -13,11 +13,13 @@ noinst_PROGRAMS=
 
 test_random_abort_SOURCES = random_abort/main.c
 noinst_PROGRAMS += test_random_abort
-all_TESTS += random_abort/smoke.sh
+# Temporarily disabled
+# all_TESTS += random_abort/smoke.sh
 
 test_random_directio_SOURCES = random_directio/main.c random_directio/util.c
 noinst_PROGRAMS += test_random_directio
-all_TESTS += random_directio/smoke.sh
+# Temporarily disabled
+# all_TESTS += random_directio/smoke.sh
 
 test_rwlock_SOURCES = rwlock/main.c
 noinst_PROGRAMS += test_rwlock

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -9,7 +9,7 @@ noinst_PROGRAMS=
 
 # The import test is only a shell script
 # Temporarily disabled
-# all_TESTS += import/smoke.sh
+all_TESTS += import/smoke.sh
 
 test_random_abort_SOURCES = random_abort/main.c
 noinst_PROGRAMS += test_random_abort
@@ -26,7 +26,7 @@ all_TESTS += test_rwlock
 test_schema_abort_SOURCES = schema_abort/main.c
 noinst_PROGRAMS += test_schema_abort
 # Temporarily disabled
-# all_TESTS += schema_abort/smoke.sh
+all_TESTS += schema_abort/smoke.sh
 
 test_scope_SOURCES = scope/main.c
 noinst_PROGRAMS += test_scope
@@ -34,8 +34,7 @@ all_TESTS += test_scope
 
 test_timestamp_abort_SOURCES = timestamp_abort/main.c
 noinst_PROGRAMS += test_timestamp_abort
-# Temporarily disabled
-# all_TESTS += timestamp_abort/smoke.sh
+all_TESTS += timestamp_abort/smoke.sh
 
 test_truncated_log_SOURCES = truncated_log/main.c
 noinst_PROGRAMS += test_truncated_log
@@ -56,7 +55,7 @@ all_TESTS += test_wt2246_col_append
 test_wt2323_join_visibility_SOURCES = wt2323_join_visibility/main.c
 noinst_PROGRAMS += test_wt2323_join_visibility
 # Temporarily disabled
-# all_TESTS += test_wt2323_join_visibility
+all_TESTS += test_wt2323_join_visibility
 
 test_wt2535_insert_race_SOURCES = wt2535_insert_race/main.c
 noinst_PROGRAMS += test_wt2535_insert_race
@@ -84,8 +83,7 @@ all_TESTS += test_wt2834_join_bloom_fix
 
 test_wt2853_perf_SOURCES = wt2853_perf/main.c
 noinst_PROGRAMS += test_wt2853_perf
-# Temporarily disabled
-# all_TESTS += test_wt2853_perf
+all_TESTS += test_wt2853_perf
 
 test_wt2909_checkpoint_integrity_SOURCES = wt2909_checkpoint_integrity/main.c
 noinst_PROGRAMS += test_wt2909_checkpoint_integrity
@@ -135,7 +133,7 @@ all_TESTS += test_wt4156_metadata_salvage
 test_wt4333_handle_locks_SOURCES = wt4333_handle_locks/main.c
 noinst_PROGRAMS += test_wt4333_handle_locks
 # Temporarily disabled
-# all_TESTS += test_wt4333_handle_locks
+all_TESTS += test_wt4333_handle_locks
 
 test_wt4699_json_SOURCES = wt4699_json/main.c
 noinst_PROGRAMS += test_wt4699_json

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -761,21 +761,20 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
 
-  # Temporarily disabled
-  # - name: csuite-timestamp-abort-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-timestamp-abort-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/../test/csuite/timestamp_abort/smoke.sh 2>&1
+            ${test_env_vars|} $(pwd)/../test/csuite/timestamp_abort/smoke.sh 2>&1
 
   - name: csuite-scope-test
     tags: ["pull_request"]
@@ -890,20 +889,20 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2719_reconfig 2>&1
 
-  # - name: csuite-wt2999-join-extractor-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-wt2999-join-extractor-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/test/csuite/test_wt2999_join_extractor 2>&1
+            ${test_env_vars|} $(pwd)/test/csuite/test_wt2999_join_extractor 2>&1
 
   - name: csuite-wt3120-filesys-test
     tags: ["pull_request"]
@@ -1146,21 +1145,20 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/csuite/test_wt2834_join_bloom_fix 2>&1
 
-  # Temporarily disabled
-  # - name: csuite-wt2853-perf-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-wt2853-perf-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
+            ${test_env_vars|} $(pwd)/test/csuite/test_wt2853_perf 2>&1
 
   # - name: csuite-wt2909-checkpoint-integrity-test
   #   tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -191,6 +191,7 @@ functions:
         set -o errexit
         set -o verbose
         ${test_env_vars|} ./t ${thread_test_args|} 2>&1
+  # Temporarily disabled
   # "random abort test":
   #   command: shell.exec
   #   params:
@@ -762,6 +763,7 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
 
+  # Temporarily disabled
   # - name: csuite-timestamp-abort-test
   #   tags: ["pull_request"]
   #   depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -191,14 +191,14 @@ functions:
         set -o errexit
         set -o verbose
         ${test_env_vars|} ./t ${thread_test_args|} 2>&1
-  "random abort test":
-    command: shell.exec
-    params:
-      working_dir: "wiredtiger/build_posix/test/csuite"
-      script: |
-        set -o errexit
-        set -o verbose
-        ${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
+  # "random abort test":
+  #   command: shell.exec
+  #   params:
+  #     working_dir: "wiredtiger/build_posix/test/csuite"
+  #     script: |
+  #       set -o errexit
+  #       set -o verbose
+  #       ${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
   "timestamp abort test":
     command: shell.exec
     params:
@@ -731,7 +731,6 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
 
-  # Temporarily disabled
   # - name: csuite-random-directio-test
   #   tags: ["pull_request"]
   #   depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -761,20 +761,20 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/schema_abort/smoke.sh 2>&1
 
-  - name: csuite-timestamp-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
+  # - name: csuite-timestamp-abort-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger/build_posix"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
 
-            ${test_env_vars|} $(pwd)/../test/csuite/timestamp_abort/smoke.sh 2>&1
+  #           ${test_env_vars|} $(pwd)/../test/csuite/timestamp_abort/smoke.sh 2>&1
 
   - name: csuite-scope-test
     tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -715,35 +715,37 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/import/smoke.sh 2>&1
 
-  - name: csuite-random-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
+  # Temporarily disabled
+  # - name: csuite-random-abort-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger/build_posix"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
 
-            ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
+  #           ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
 
-  - name: csuite-random-directio-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
+  # Temporarily disabled
+  # - name: csuite-random-directio-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - command: shell.exec
+  #       params:
+  #         working_dir: "wiredtiger/build_posix"
+  #         script: |
+  #           set -o errexit
+  #           set -o verbose
 
-            ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
+  #           ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
 
   # Temporarily disabled
   # - name: csuite-schema-abort-test
@@ -1922,16 +1924,17 @@ tasks:
         vars:
           thread_test_args: -S -F -n 100000 -t v
 
-      # random-abort - default (random time and number of threads)
-      - func: "random abort test"
-      # random-abort - minimum time, random number of threads
-      - func: "random abort test"
-        vars:
-          random_abort_args: -t 10
-      # random-abort - maximum time, random number of threads
-      - func: "random abort test"
-        vars:
-          random_abort_args: -t 40
+      # Temporarily disabled
+      # # random-abort - default (random time and number of threads)
+      # - func: "random abort test"
+      # # random-abort - minimum time, random number of threads
+      # - func: "random abort test"
+      #   vars:
+      #     random_abort_args: -t 10
+      # # random-abort - maximum time, random number of threads
+      # - func: "random abort test"
+      #   vars:
+      #     random_abort_args: -t 40
 
       # truncated-log
       - func: "truncated log test"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -191,15 +191,14 @@ functions:
         set -o errexit
         set -o verbose
         ${test_env_vars|} ./t ${thread_test_args|} 2>&1
-  # Temporarily disabled
-  # "random abort test":
-  #   command: shell.exec
-  #   params:
-  #     working_dir: "wiredtiger/build_posix/test/csuite"
-  #     script: |
-  #       set -o errexit
-  #       set -o verbose
-  #       ${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
+  "random abort test":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/build_posix/test/csuite"
+      script: |
+        set -o errexit
+        set -o verbose
+        ${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
   "timestamp abort test":
     command: shell.exec
     params:
@@ -716,36 +715,35 @@ tasks:
 
   #           ${test_env_vars|} $(pwd)/../test/csuite/import/smoke.sh 2>&1
 
-  # Temporarily disabled
-  # - name: csuite-random-abort-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-random-abort-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
+            ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
 
-  # - name: csuite-random-directio-test
-  #   tags: ["pull_request"]
-  #   depends_on:
-  #     - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - command: shell.exec
-  #       params:
-  #         working_dir: "wiredtiger/build_posix"
-  #         script: |
-  #           set -o errexit
-  #           set -o verbose
+  - name: csuite-random-directio-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix"
+          script: |
+            set -o errexit
+            set -o verbose
 
-  #           ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
+            ${test_env_vars|} $(pwd)/../test/csuite/random_directio/smoke.sh 2>&1
 
   # Temporarily disabled
   # - name: csuite-schema-abort-test
@@ -1926,17 +1924,16 @@ tasks:
         vars:
           thread_test_args: -S -F -n 100000 -t v
 
-      # Temporarily disabled
-      # # random-abort - default (random time and number of threads)
-      # - func: "random abort test"
-      # # random-abort - minimum time, random number of threads
-      # - func: "random abort test"
-      #   vars:
-      #     random_abort_args: -t 10
-      # # random-abort - maximum time, random number of threads
-      # - func: "random abort test"
-      #   vars:
-      #     random_abort_args: -t 40
+      # random-abort - default (random time and number of threads)
+      - func: "random abort test"
+      # random-abort - minimum time, random number of threads
+      - func: "random abort test"
+        vars:
+          random_abort_args: -t 10
+      # random-abort - maximum time, random number of threads
+      - func: "random abort test"
+        vars:
+          random_abort_args: -t 40
 
       # truncated-log
       - func: "truncated log test"


### PR DESCRIPTION
In case there is only one eviction thread, eviction server will also evicit
pages. Clear the WT_SESSION_LOCKED_PASS flag before it starts to do that.