### PR TITLE
WT-5607 Verify history store fix

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -687,6 +687,7 @@ __wt_verify_history_store_tree(WT_SESSION_IMPL *session)
 
         WT_ERR(ret);
     }
+    WT_ERR_NOTFOUND_OK(ret);
 err:
     if (data_cursor != NULL)
         data_cursor->close(data_cursor);


### PR DESCRIPTION
When the while loop finishes, ret is going to be WT_ERR_NOTFOUND, which is expected behaviour and totally cool! 

I removed this code after a comment from @tetsuo-cpp and managed to overlook this. Sorry about that!