### PR TITLE
WT-5610 Fix assertion for reconciling fixed length column store

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -311,8 +311,9 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
             S2C(session)->modified = true;
 
         /*
-         * Eviction should only be here if following the history store or in-memory eviction path.
-         * Otherwise, we must be reconciling a fixed length column store page.
+         * Eviction should only be here if allowing writes to history store or in the in-memory
+         * eviction case. Otherwise, we must be reconciling a fixed length column store page (which
+         * does not allow history store content).
          */
         WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT) ||
             (F_ISSET(r, WT_REC_HS | WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -312,10 +312,10 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
         /*
          * Eviction should only be here if following the history store or in-memory eviction path.
-         *
-         * PM-1521-FIXME: What will we do for in memory database?
+         * Otherwise, we must be reconciling a fixed length column store page.
          */
-        WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT) || F_ISSET(r, WT_REC_HS | WT_REC_IN_MEMORY));
+        WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT) ||
+            (F_ISSET(r, WT_REC_HS | WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX));
 
         /*
          * We have written the page, but something prevents it from being evicted. If we wrote the


### PR DESCRIPTION
For the fixed-length column store, we unset `WT_REC_HS`. Therefore, this condition needs to be part of the assertion.