### PR TITLE
WT-5633 Fix another assertion for reconciling fixed length column store

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -137,15 +137,18 @@ err:
  */
 static bool
 __rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE *selected_upd, uint64_t max_txn,
-  wt_timestamp_t max_ts, bool has_newer_updates, uint64_t flags)
+  wt_timestamp_t max_ts, bool has_newer_updates, uint64_t flags, WT_PAGE *page)
 {
     /*
      * Save updates for any reconciliation that doesn't involve history store (in-memory database
      * and fixed length column store), except when the maximum timestamp and txnid are globally
      * visible.
      */
-    if (!LF_ISSET(WT_REC_HS))
+    if (LF_ISSET(WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX)
         return (!__wt_txn_visible_all(session, max_txn, max_ts));
+
+    if (!LF_ISSET(WT_REC_HS))
+        return false;
 
     if (LF_ISSET(WT_REC_EVICT) && has_newer_updates)
         return true;
@@ -444,7 +447,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      * Additionally history store reconciliation is not set skip saving an update.
      */
     if (__rec_need_save_upd(
-          session, upd_select->upd, max_txn, max_ts, has_newer_updates, r->flags)) {
+          session, upd_select->upd, max_txn, max_ts, has_newer_updates, r->flags, page)) {
         WT_ERR(__rec_update_save(session, r, ins, ripcip, upd_select->upd, upd_memsize));
         upd_select->upd_saved = true;
     }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -140,19 +140,12 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE *selected_upd, uint64_t 
   wt_timestamp_t max_ts, bool has_newer_updates, uint64_t flags)
 {
     /*
-     * Save updates for in-memory database, except when the maximum timestamp and txnid are globally
+     * Save updates for any reconciliation that doesn't involve history store (in-memory database
+     * and fixed length column store), except when the maximum timestamp and txnid are globally
      * visible.
      */
-    if (LF_ISSET(WT_REC_IN_MEMORY))
-        return (!__wt_txn_visible_all(session, max_txn, max_ts));
-
-    /*
-     * FIXME-PM-1523: The current implementation doesn't work with fixed-length column store.
-     * Currently, we don't write history versions to history store for fixed-length column store. I
-     * don't know how that is going to work in durable history.
-     */
     if (!LF_ISSET(WT_REC_HS))
-        return false;
+        return (!__wt_txn_visible_all(session, max_txn, max_ts));
 
     if (LF_ISSET(WT_REC_EVICT) && has_newer_updates)
         return true;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2177,8 +2177,15 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
              * update lists and splits can.
              */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->cache_write_restore) {
+            /*
+             * If we're restoring the update list, we should be leaving the page dirty due to
+             * updates that can't be written to the history store because they are uncommitted OR
+             * because the page is from a fixed length column store which doesn't support writing
+             * updates to the history store.
+             */
             WT_ASSERT(session, F_ISSET(r, WT_REC_IN_MEMORY) ||
-                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0));
+                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty &&
+                                 (r->multi->supd_entries != 0 || page->type == WT_PAGE_COL_FIX)));
             goto split;
         }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2178,7 +2178,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
              */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->cache_write_restore) {
             WT_ASSERT(session, F_ISSET(r, WT_REC_IN_MEMORY) ||
-                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && (r->multi->supd_entries != 0)));
+                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0));
             goto split;
         }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2177,15 +2177,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
              * update lists and splits can.
              */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->cache_write_restore) {
-            /*
-             * If we're restoring the update list, we should be leaving the page dirty due to
-             * updates that can't be written to the history store because they are uncommitted OR
-             * because the page is from a fixed length column store which doesn't support writing
-             * updates to the history store.
-             */
             WT_ASSERT(session, F_ISSET(r, WT_REC_IN_MEMORY) ||
-                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty &&
-                                 (r->multi->supd_entries != 0 || page->type == WT_PAGE_COL_FIX)));
+                (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && (r->multi->supd_entries != 0)));
             goto split;
         }
 


### PR DESCRIPTION
I kept hitting this when running `test/format` for a fixed-length column store configuration. The change is along the same lines as #5278.