### PR TITLE
WT-5628 Don't perform rollback to stable on files that don't exist

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -776,7 +776,16 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
             WT_ERR_NOTFOUND_OK(ret);
         }
 
-        WT_ERR(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
+        ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
+        /* Ignore performing rollback to stable on files that don't exist. */
+        if (ret == ENOENT) {
+            __wt_verbose(
+              session, WT_VERB_RTS, "%s: rollback to stable ignored on non existing file", uri);
+            ret = 0;
+            continue;
+        }
+        WT_ERR(ret);
+
         /*
          * The rollback operation should be performed on this file based on the following:
          * 1. The tree is modified.

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -781,7 +781,6 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
         if (ret == ENOENT) {
             __wt_verbose(
               session, WT_VERB_RTS, "%s: rollback to stable ignored on non existing file", uri);
-            ret = 0;
             continue;
         }
         WT_ERR(ret);

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -31,6 +31,7 @@ from helper import copy_wiredtiger_home
 import unittest, wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wiredtiger import stat
+from wtscenario import make_scenarios
 
 def timestamp_str(t):
     return '%x' % t
@@ -84,9 +85,22 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
 
 # Test that rollback to stable clears the remove operation.
 class test_rollback_to_stable01(test_rollback_to_stable_base):
-    # Force a small cache.
-    conn_config = 'cache_size=20MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
+
+    in_memory_values = [
+        ('no_inmem', dict(in_memory=False)),
+        ('inmem', dict(in_memory=True))
+    ]
+
+    scenarios = make_scenarios(in_memory_values)
+
+    def conn_config(self):
+        config = ''
+        if self.in_memory:
+            config += 'cache_size=50MB,statistics=(all),in_memory=true'
+        else:
+            config += 'cache_size=20MB,statistics=(all),log=(enabled),in_memory=false'
+        return config
 
     def test_rollback_to_stable(self):
         nrows = 10000
@@ -114,7 +128,8 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         # Pin stable to timestamp 10.
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
         # Checkpoint to ensure that all the updates are flushed to disk.
-        self.session.checkpoint()
+        if not self.in_memory:
+            self.session.checkpoint()
 
         self.conn.rollback_to_stable()
         # Check that the new updates are only seen after the update timestamp.
@@ -132,7 +147,10 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         self.assertEqual(calls, 1)
         self.assertEqual(hs_removed, 0)
         self.assertEqual(keys_removed, 0)
-        self.assertEqual(upd_aborted, nrows)
+        if self.in_memory:
+            self.assertEqual(upd_aborted, nrows)
+        else:
+            self.assertEqual(upd_aborted + keys_restored, nrows)
         self.assertGreaterEqual(keys_restored, 0)
         self.assertGreater(pages_visited, 0)
 

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -55,7 +55,7 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         if self.in_memory:
             config += 'cache_size=250MB,statistics=(all),in_memory=true'
         else:
-            config += 'cache_size=20MB,statistics=(all),log=(enabled),in_memory=false'
+            config += 'cache_size=50MB,statistics=(all),log=(enabled),in_memory=false'
         return config
 
     def test_rollback_to_stable(self):

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -28,6 +28,7 @@
 
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
 def timestamp_str(t):
@@ -40,11 +41,25 @@ def mod_val(value, char, location, nbytes=1):
 # Test that rollback to stable always replaces the on-disk value with a full update
 # from the history store.
 class test_rollback_to_stable04(test_rollback_to_stable_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
 
+    in_memory_values = [
+        ('no_inmem', dict(in_memory=False)),
+        ('inmem', dict(in_memory=True))
+    ]
+
+    scenarios = make_scenarios(in_memory_values)
+
+    def conn_config(self):
+        config = ''
+        if self.in_memory:
+            config += 'cache_size=250MB,statistics=(all),in_memory=true'
+        else:
+            config += 'cache_size=20MB,statistics=(all),log=(enabled),in_memory=false'
+        return config
+
     def test_rollback_to_stable(self):
-        nrows = 10000
+        nrows = 1000
 
         # Create a table without logging.
         uri = "table:rollback_to_stable04"
@@ -104,7 +119,8 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
 
         # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
-        self.session.checkpoint()
+        if not self.in_memory:
+            self.session.checkpoint()
         self.conn.rollback_to_stable()
 
         # Check that the correct data is seen at and after the stable timestamp.
@@ -125,8 +141,12 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.assertEqual(keys_removed, 0)
         self.assertEqual(keys_restored, 0)
         self.assertGreater(pages_visited, 0)
-        self.assertGreaterEqual(upd_aborted, 0)
-        self.assertGreaterEqual(hs_removed, nrows * 11)
+        if self.in_memory:
+            self.assertGreaterEqual(upd_aborted, nrows * 11)
+            self.assertGreaterEqual(hs_removed, 0)
+        else:
+            self.assertGreaterEqual(upd_aborted, 0)
+            self.assertGreaterEqual(hs_removed, nrows * 11)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -53,13 +53,13 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
     def conn_config(self):
         config = ''
         if self.in_memory:
-            config += 'cache_size=250MB,statistics=(all),in_memory=true'
+            config += 'cache_size=2GB,statistics=(all),in_memory=true'
         else:
-            config += 'cache_size=50MB,statistics=(all),log=(enabled),in_memory=false'
+            config += 'cache_size=500MB,statistics=(all),log=(enabled),in_memory=false'
         return config
 
     def test_rollback_to_stable(self):
-        nrows = 1000
+        nrows = 10000
 
         # Create a table without logging.
         uri = "table:rollback_to_stable04"


### PR DESCRIPTION
As part of rollback to stable ignore performing rollback to stable operation on files that don't exist and also avoid performing the checkpoint and history store search when in in_memory configuration mode