### PR TITLE
WT-5650 A race is possible between reading the WT_PAGE.modify field and the page being dirtied.

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -495,8 +495,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * any page modify structure. (It needs to be ordered else a page could be dirtied after
              * taking the local reference.)
              */
-            dirty = __wt_page_is_modified(page);
-            WT_READ_BARRIER();
+            WT_ORDERED_READ(dirty, __wt_page_is_modified(page));
 
             /* Skip clean pages, but always update the maximum transaction ID. */
             if (!dirty) {


### PR DESCRIPTION
@agorrod, see a more detailed discussion in the JIRA ticket.

I have no opinion on whether or not it's actually a problem if the page is dirtied after taking a reference to the (presumably NULL) page modify structure during a checkpoint, but the commit in WT-2204 makes me think it was believed to be a problem at that time (November, 2015).