### PR TITLE
WT-5236 Coverity issues in cur_backup

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -351,8 +351,7 @@ __backup_add_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval)
     return (0);
 
 err:
-    if (blk != NULL)
-        __wt_free(session, blk->id_str);
+    __wt_free(session, blk->id_str);
     return (ret);
 }
 


### PR DESCRIPTION
Removed the condition to check if `blk != NULL` as `blk` has already been dereferenced before NULL-checking.