### PR TITLE
WT-5427 Rollback to stable tests

### DIFF
--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -47,14 +47,24 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         ('inmem', dict(in_memory=True))
     ]
 
-    scenarios = make_scenarios(in_memory_values)
+    prepare_values = [
+        ('no_prepare', dict(prepare=False)),
+        ('prepare', dict(prepare=True))
+    ]
+
+    scenarios = make_scenarios(in_memory_values, prepare_values)
 
     def conn_config(self):
         config = ''
-        if self.in_memory:
-            config += 'cache_size=250MB,statistics=(all),in_memory=true'
+        # Temporarily solution to have good cache size until prepare updates are written to disk.
+        if self.prepare:
+            config += 'cache_size=250MB,statistics=(all)'
         else:
-            config += 'cache_size=50MB,statistics=(all),log=(enabled),in_memory=false'
+            config += 'cache_size=50MB,statistics=(all)'
+        if self.in_memory:
+            config += ',in_memory=true'
+        else:
+            config += ',log=(enabled),in_memory=false'
         return config
 
     def test_rollback_to_stable(self):
@@ -90,15 +100,20 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         # Check that the new updates are only seen after the update timestamp.
         self.check(valued, uri, nrows, 40)
 
-        # Pin stable to timestamp 10.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        # Pin stable to timestamp 30 if prepare otherwise 20.
+        if self.prepare:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+        else:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
         # Checkpoint to ensure that all the data is flushed.
         if not self.in_memory:
             self.session.checkpoint()
 
         self.conn.rollback_to_stable()
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valuea, uri, nrows, 40)
+        self.check(valueb, uri, nrows, 40)
+        self.check(valueb, uri, nrows, 20)
+        self.check(valuea, uri, nrows, 10)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]
@@ -113,7 +128,7 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         self.assertEqual(keys_removed, 0)
         self.assertEqual(keys_restored, 0)
         self.assertGreater(pages_visited, 0)
-        self.assertGreaterEqual(upd_aborted, nrows * 3)
+        self.assertGreaterEqual(upd_aborted, nrows * 2)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_rollback_to_stable05.py
+++ b/test/suite/test_rollback_to_stable05.py
@@ -47,14 +47,24 @@ class test_rollback_to_stable05(test_rollback_to_stable_base):
         ('inmem', dict(in_memory=True))
     ]
 
-    scenarios = make_scenarios(in_memory_values)
+    prepare_values = [
+        ('no_prepare', dict(prepare=False)),
+        ('prepare', dict(prepare=True))
+    ]
+
+    scenarios = make_scenarios(in_memory_values, prepare_values)
 
     def conn_config(self):
         config = ''
-        if self.in_memory:
-            config += 'cache_size=100MB,statistics=(all),in_memory=true'
+        # Temporarily solution to have good cache size until prepare updates are written to disk.
+        if self.prepare:
+            config += 'cache_size=250MB,statistics=(all)'
         else:
-            config += 'cache_size=50MB,statistics=(all),log=(enabled),in_memory=false'
+            config += 'cache_size=50MB,statistics=(all)'
+        if self.in_memory:
+            config += ',in_memory=true'
+        else:
+            config += ',log=(enabled),in_memory=false'
         return config
 
     def test_rollback_to_stable(self):
@@ -108,8 +118,11 @@ class test_rollback_to_stable05(test_rollback_to_stable_base):
         self.large_updates(uri_2, valued, ds_2, nrows, 0)
         self.check(valued, uri_2, nrows, 0)
 
-        # Pin stable to timestamp 10.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        # Pin stable to timestamp 20 if prepare otherwise 10.
+        if self.prepare:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+        else:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
 
         # Checkpoint to ensure that all the data is flushed.
         if not self.in_memory:

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable06.py
+# Test that rollback to stable removes all keys when the stable timestamp is earlier than
+# all commit timestamps.
+class test_rollback_to_stable06(test_rollback_to_stable_base):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable06"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+
+        # Perform several updates.
+        self.large_updates(uri, value_a, ds, nrows, 20)
+        self.large_updates(uri, value_b, ds, nrows, 30)
+        self.large_updates(uri, value_c, ds, nrows, 40)
+        self.large_updates(uri, value_d, ds, nrows, 50)
+
+        # Verify data is visible and correct.
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_d, uri, nrows, 50)
+
+        # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
+        self.session.checkpoint()
+        self.conn.rollback_to_stable()
+
+        # Check that all keys are removed.
+        self.check(value_a, uri, 0, 20)
+        self.check(value_b, uri, 0, 30)
+        self.check(value_c, uri, 0, 40)
+        self.check(value_d, uri, 0, 50)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rts][2]
+        hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
+        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
+        keys_restored = stat_cursor[stat.conn.txn_rts_keys_restored][2]
+        pages_visited = stat_cursor[stat.conn.txn_rts_pages_visited][2]
+        upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
+        stat_cursor.close()
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(keys_restored, 0)
+        self.assertEqual(keys_removed, nrows)
+        self.assertGreater(pages_visited, 0)
+        self.assertGreaterEqual(upd_aborted, 0)
+        self.assertGreaterEqual(hs_removed, nrows * 3)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from helper import copy_wiredtiger_home
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable07.py
+# Test the rollback to stable operation performs as expected following a server crash and
+# recovery. Verify that
+#   (a) the on-disk value is replaced by the correct value from the history store, and
+#   (b) newer updates are removed.
+class test_rollback_to_stable07(test_rollback_to_stable_base):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def simulate_crash_restart(self, uri, olddir, newdir):
+        ''' Simulate a crash from olddir and restart in newdir. '''
+        # With the connection still open, copy files to new directory.
+        copy_wiredtiger_home(olddir, newdir)
+
+        # Open the new directory
+        conn = self.setUpConnectionOpen(newdir)
+        session = self.setUpSessionOpen(conn)
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable07"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+
+        # Perform several updates.
+        self.large_updates(uri, value_d, ds, nrows, 20)
+        self.large_updates(uri, value_c, ds, nrows, 30)
+        self.large_updates(uri, value_b, ds, nrows, 40)
+        self.large_updates(uri, value_a, ds, nrows, 50)
+
+        # Verify data is visible and correct.
+        self.check(value_d, uri, nrows, 20)
+        self.check(value_c, uri, nrows, 30)
+        self.check(value_b, uri, nrows, 40)
+        self.check(value_a, uri, nrows, 50)
+
+        # Set the stable timestamp to 40.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+
+        # Perform additional updates.
+        self.large_updates(uri, value_b, ds, nrows, 60)
+        self.large_updates(uri, value_c, ds, nrows, 70)
+        self.large_updates(uri, value_d, ds, nrows, 80)
+
+        # Checkpoint to ensure the data is flushed to disk.
+        self.session.checkpoint()
+
+        # Verify additional update data is visible and correct.
+        self.check(value_b, uri, nrows, 60)
+        self.check(value_c, uri, nrows, 70)
+        self.check(value_d, uri, nrows, 80)
+
+        # Simulate a server crash and restart.
+        self.simulate_crash_restart(uri, ".", "RESTART")
+
+        # Rollback to the stable timestamp.
+        self.conn.rollback_to_stable()
+
+        # Check that the correct data is seen at and after the stable timestamp.
+        self.check(value_b, uri, nrows, 40)
+        self.check(value_b, uri, nrows, 80)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rts][2]
+        hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
+        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
+        keys_restored = stat_cursor[stat.conn.txn_rts_keys_restored][2]
+        pages_visited = stat_cursor[stat.conn.txn_rts_pages_visited][2]
+        upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
+        stat_cursor.close()
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(keys_removed, 0)
+        self.assertEqual(keys_restored, 0)
+        self.assertGreater(pages_visited, 0)
+        self.assertGreaterEqual(upd_aborted, 0)
+        self.assertGreaterEqual(hs_removed, nrows * 4)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable08.py
+# Test that rollback to stable does not abort updates when the stable timestamp is
+# set to the latest commit.
+class test_rollback_to_stable08(test_rollback_to_stable_base):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable08"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+
+        # Perform several updates.
+        self.large_updates(uri, value_a, ds, nrows, 20)
+        self.large_updates(uri, value_b, ds, nrows, 30)
+        self.large_updates(uri, value_c, ds, nrows, 40)
+        self.large_updates(uri, value_d, ds, nrows, 50)
+
+        # Verify data is visible and correct.
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_d, uri, nrows, 50)
+
+        # Set stable timestamp to the latest commit.
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+
+        # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
+        self.session.checkpoint()
+        self.conn.rollback_to_stable()
+
+        # Check that the correct data is seen.
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_d, uri, nrows, 50)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rts][2]
+        hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
+        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
+        keys_restored = stat_cursor[stat.conn.txn_rts_keys_restored][2]
+        pages_visited = stat_cursor[stat.conn.txn_rts_pages_visited][2]
+        upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
+        stat_cursor.close()
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(hs_removed, 0)
+        self.assertEqual(upd_aborted, 0)
+        self.assertEqual(keys_removed, 0)
+        self.assertEqual(keys_restored, 0)
+        self.assertEqual(pages_visited, 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import wiredtiger
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable09.py
+# Test that rollback to stable does not abort schema operations that are done
+# as they don't have transaction support
+class test_rollback_to_stable09(test_rollback_to_stable_base):
+    session_config = 'isolation=snapshot'
+
+    in_memory_values = [
+        ('no_inmem', dict(in_memory=False)),
+        ('inmem', dict(in_memory=True))
+    ]
+
+    prepare_values = [
+        ('no_prepare', dict(prepare=False)),
+        ('prepare', dict(prepare=True))
+    ]
+
+    tablename = "test_rollback_stable09"
+    uri = "table:" + tablename
+    index_uri = "index:test_rollback_stable09:country"
+
+    scenarios = make_scenarios(in_memory_values, prepare_values)
+
+    def conn_config(self):
+        config = 'cache_size=250MB,statistics=(all)'
+        if self.in_memory:
+            config += ',in_memory=true'
+        else:
+            config += ',log=(enabled),in_memory=false'
+        return config
+
+    def create_table(self, commit_ts):
+        self.pr('create table')
+        session = self.session
+        session.begin_transaction()
+        session.create(self.uri, 'key_format=5s,value_format=HQ,' +
+                            'columns=(country,year,population),' )
+        if commit_ts == 0:
+                session.commit_transaction()
+        elif self.prepare:
+            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.commit_transaction()
+        else:
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+
+    def drop_table(self, commit_ts):
+        self.pr('drop table')
+        session = self.session
+        session.begin_transaction()
+        session.drop(self.uri)
+        if commit_ts == 0:
+                session.commit_transaction()
+        elif self.prepare:
+            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.commit_transaction()
+        else:
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+
+    def create_index(self, commit_ts):
+        session = self.session
+        session.begin_transaction()
+        self.session.create(self.index_uri, "key_format=s,columns=(country)")
+        if commit_ts == 0:
+                session.commit_transaction()
+        elif self.prepare:
+            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.commit_transaction()
+        else:
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+
+    def test_rollback_to_stable(self):
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        # Create table and index at a later timestamp
+        self.create_table(20)
+        self.create_index(30)
+
+        #perform rollback to stable, still the table and index must exist
+        self.conn.rollback_to_stable()
+
+        if not self.in_memory:
+            self.assertTrue(os.path.exists(self.tablename + ".wt"))
+            self.assertTrue(os.path.exists(self.tablename + "_country.wti"))
+
+        # Check that we are able to open cursor successfully on the table and index
+        c = self.session.open_cursor(self.uri, None, None)
+        self.assertTrue(c.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(c.close(), 0)
+
+        c = self.session.open_cursor(self.index_uri, None, None)
+        self.assertTrue(c.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(c.close(), 0)
+
+        # Drop the table
+        self.drop_table(40)
+
+        #perform rollback to stable, the table and index must not exist
+        self.conn.rollback_to_stable()
+
+        if not self.in_memory:
+            self.assertFalse(os.path.exists(self.tablename + ".wt"))
+            self.assertFalse(os.path.exists(self.tablename + "_country.wti"))
+
+        # Check that we are unable to open cursor on the table and index
+        self.assertRaises(wiredtiger.WiredTigerError, lambda:
+            self.session.open_cursor(self.uri, None, None))
+        self.assertRaises(wiredtiger.WiredTigerError, lambda:
+            self.session.open_cursor(self.index_uri, None, None))
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Along with test, a fix to perform history store cleanup from a reconciled page only when the reconciled page has updates greater than the stable timestamp.