### PR TITLE
WT-5647 replace the WT_REF structure's WT_REF_READING state with a flag

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -256,7 +256,7 @@ __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, boo
      * Internal pages must be read to walk the tree; ask the block-manager if it's useful to rewrite
      * leaf pages, don't do the I/O if a rewrite won't help.
      */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (0);
 
     __wt_ref_info_lock(session, ref, addr, &addr_size);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -566,7 +566,7 @@ __debug_tree_shape_worker(WT_DBG *ds, WT_REF *ref, int level)
 
     session = ds->session;
 
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_RET(ds->f(ds,
           "%*s"
           "I"
@@ -1365,15 +1365,15 @@ __debug_ref(WT_DBG *ds, WT_REF *ref)
       "%p %s (",
       (void *)ref, __debug_ref_state(ref->state)));
     flagsep = "";
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_RET(ds->f(ds, "%s%s", flagsep, "internal"));
         flagsep = ", ";
     }
-    if (F_ISSET(ref, WT_REF_IS_LEAF)) {
+    if (F_ISSET(ref, WT_REF_FLAG_LEAF)) {
         WT_RET(ds->f(ds, "%s%s", flagsep, "leaf"));
         flagsep = ", ";
     }
-    if (F_ISSET(ref, WT_REF_READING))
+    if (F_ISSET(ref, WT_REF_FLAG_READING))
         WT_RET(ds->f(ds, "%s%s", flagsep, "reading"));
     __wt_ref_info(session, ref, &addr, &addr_size);
     return (ds->f(ds, ") %s\n", __wt_addr_string(session, addr, addr_size, ds->t1)));

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -172,7 +172,6 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
                 locked = true;
             break;
         case WT_REF_DISK:
-        case WT_REF_READING:
         default:
             return (__wt_illegal_value(session, current_state));
         }

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -247,7 +247,7 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
      * We create WT_REFs in many places, assert a WT_REF has been configured as either an internal
      * page or a leaf page, to catch any we've missed.
      */
-    WT_ASSERT(session, F_ISSET(ref, WT_REF_IS_INTERNAL) || F_ISSET(ref, WT_REF_IS_LEAF));
+    WT_ASSERT(session, F_ISSET(ref, WT_REF_FLAG_INTERNAL) || F_ISSET(ref, WT_REF_FLAG_LEAF));
 
     /*
      * Optionally free the referenced pages. (The path to free referenced page is used for error

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -545,7 +545,7 @@ __wt_root_ref_init(WT_SESSION_IMPL *session, WT_REF *root_ref, WT_PAGE *root, bo
     memset(root_ref, 0, sizeof(*root_ref));
 
     root_ref->page = root;
-    F_SET(root_ref, WT_REF_IS_INTERNAL);
+    F_SET(root_ref, WT_REF_FLAG_INTERNAL);
     WT_REF_SET_STATE(root_ref, WT_REF_MEM);
 
     root_ref->ref_recno = is_recno ? 1 : WT_RECNO_OOB;
@@ -675,7 +675,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
         ref->home = root;
         ref->page = NULL;
         ref->addr = NULL;
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         WT_REF_SET_STATE(ref, WT_REF_DELETED);
         ref->ref_recno = 1;
         break;
@@ -688,7 +688,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
         ref->home = root;
         ref->page = NULL;
         ref->addr = NULL;
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         WT_REF_SET_STATE(ref, WT_REF_DELETED);
         WT_ERR(__wt_row_ikey_incr(session, root, 0, "", 1, ref));
         break;
@@ -698,7 +698,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
     if (F_ISSET(btree, WT_BTREE_BULK)) {
         WT_ERR(__wt_btree_new_leaf_page(session, &leaf));
         ref->page = leaf;
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         WT_REF_SET_STATE(ref, WT_REF_MEM);
         WT_ERR(__wt_page_modify_init(session, leaf));
         __wt_page_only_modify_set(session, leaf);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -744,8 +744,8 @@ __wt_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
      * ever forced to re-instantiate that piece of the namespace, it comes back as a leaf page.
      * Reset the WT_REF type as it's possible that it has changed.
      */
-    F_CLR(ref, WT_REF_IS_INTERNAL);
-    F_SET(ref, WT_REF_IS_LEAF);
+    F_CLR(ref, WT_REF_FLAG_INTERNAL);
+    F_SET(ref, WT_REF_FLAG_LEAF);
 
     return (0);
 }

--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -130,29 +130,3 @@ __wt_page_type_string(u_int type) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
     }
     /* NOTREACHED */
 }
-
-/*
- * __wt_ref_state_string --
- *     Return a string representing the WT_REF state.
- */
-const char *
-__wt_ref_state_string(u_int state)
-{
-    switch (state) {
-    case WT_REF_DISK:
-        return ("disk");
-    case WT_REF_DELETED:
-        return ("deleted");
-    case WT_REF_LOCKED:
-        return ("locked");
-    case WT_REF_MEM:
-        return ("memory");
-    case WT_REF_READING:
-        return ("reading");
-    case WT_REF_SPLIT:
-        return ("split");
-    default:
-        return ("INVALID");
-    }
-    /* NOTREACHED */
-}

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -287,7 +287,7 @@ __inmem_col_int(WT_SESSION_IMPL *session, WT_PAGE *page)
         ref->addr = unpack.cell;
         ref->ref_recno = unpack.v;
 
-        F_SET(ref, unpack.type == WT_CELL_ADDR_INT ? WT_REF_IS_INTERNAL : WT_REF_IS_LEAF);
+        F_SET(ref, unpack.type == WT_CELL_ADDR_INT ? WT_REF_FLAG_INTERNAL : WT_REF_FLAG_LEAF);
     }
     WT_CELL_FOREACH_END;
 }
@@ -410,12 +410,12 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
 
         switch (unpack.type) {
         case WT_CELL_ADDR_INT:
-            F_SET(ref, WT_REF_IS_INTERNAL);
+            F_SET(ref, WT_REF_FLAG_INTERNAL);
             break;
         case WT_CELL_ADDR_DEL:
         case WT_CELL_ADDR_LEAF:
         case WT_CELL_ADDR_LEAF_NO:
-            F_SET(ref, WT_REF_IS_LEAF);
+            F_SET(ref, WT_REF_FLAG_LEAF);
             break;
         }
 

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -395,7 +395,7 @@ restart:
     /* Search the internal pages of the tree. */
     current = &btree->root;
     for (;;) {
-        if (F_ISSET(current, WT_REF_IS_LEAF))
+        if (F_ISSET(current, WT_REF_FLAG_LEAF))
             break;
 
         page = current->page;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -130,7 +130,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
      */
     __wt_ref_info(session, ref, &addr, &addr_size);
     if (addr == NULL) {
-        WT_ASSERT(session, previous_state != WT_REF_DISK);
+        WT_ASSERT(session, previous_state == WT_REF_DELETED);
 
         WT_ERR(__wt_btree_new_leaf_page(session, ref));
         goto skip_read;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -23,7 +23,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
     page = ref->page;
 
     /* Leaf pages only. */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (false);
 
     /*
@@ -117,12 +117,12 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     }
 
     /*
-     * Set the WT_REF_READING flag for normal reads. Checkpoints can skip over clean pages being
-     * read into cache, but need to wait for deletes to be resolved (in order for checkpoint to
-     * write the correct version of the page).
+     * Set the WT_REF_FLAG_READING flag for normal reads. Checkpoints can skip over clean pages
+     * being read into cache, but need to wait for deletes to be resolved (in order for checkpoint
+     * to write the correct version of the page).
      */
     if (previous_state == WT_REF_DISK)
-        F_SET(ref, WT_REF_READING);
+        F_SET(ref, WT_REF_FLAG_READING);
 
     /*
      * Get the address: if there is no address, the page was deleted and a subsequent search or
@@ -175,7 +175,7 @@ skip_read:
         break;
     }
 
-    F_CLR(ref, WT_REF_READING);
+    F_CLR(ref, WT_REF_FLAG_READING);
     WT_REF_SET_STATE(ref, WT_REF_MEM);
 
     WT_ASSERT(session, ret == 0);
@@ -189,7 +189,7 @@ err:
     if (ref->page != NULL)
         __wt_ref_out(session, ref);
 
-    F_CLR(ref, WT_REF_READING);
+    F_CLR(ref, WT_REF_FLAG_READING);
     WT_REF_SET_STATE(ref, previous_state);
 
     __wt_buf_free(session, &tmp);
@@ -252,7 +252,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
                 return (WT_NOTFOUND);
 
             /* Optionally limit reads to internal pages only. */
-            if (LF_ISSET(WT_READ_CACHE_LEAF) && F_ISSET(ref, WT_REF_IS_LEAF))
+            if (LF_ISSET(WT_READ_CACHE_LEAF) && F_ISSET(ref, WT_REF_FLAG_LEAF))
                 return (WT_NOTFOUND);
 
 read:
@@ -282,7 +282,7 @@ read:
             if (LF_ISSET(WT_READ_NO_WAIT))
                 return (WT_NOTFOUND);
 
-            if (F_ISSET(ref, WT_REF_READING)) {
+            if (F_ISSET(ref, WT_REF_FLAG_READING)) {
                 if (LF_ISSET(WT_READ_CACHE))
                     return (WT_NOTFOUND);
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -93,7 +93,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     size_t addr_size;
     uint64_t time_diff, time_start, time_stop;
     uint32_t page_flags;
-    uint8_t final_state, new_state, previous_state;
+    uint8_t previous_state;
     const uint8_t *addr;
     bool timer;
 
@@ -105,28 +105,24 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
      */
     WT_CLEAR(tmp);
 
-    /*
-     * Attempt to set the state to WT_REF_READING for normal reads, or WT_REF_LOCKED, for deleted
-     * pages. The difference is that checkpoints can skip over clean pages that are being read into
-     * cache, but need to wait for deletes to be resolved (in order for checkpoint to write the
-     * correct version of the page).
-     *
-     * If successful, we've won the race, read the page.
-     */
+    /* Lock the WT_REF. */
     switch (previous_state = ref->state) {
     case WT_REF_DISK:
-        new_state = WT_REF_READING;
-        break;
     case WT_REF_DELETED:
-        new_state = WT_REF_LOCKED;
-        break;
+        if (WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
+            break;
+        return (0);
     default:
         return (0);
     }
-    if (!WT_REF_CAS_STATE(session, ref, previous_state, new_state))
-        return (0);
 
-    final_state = WT_REF_MEM;
+    /*
+     * Set the WT_REF_READING flag for normal reads. Checkpoints can skip over clean pages being
+     * read into cache, but need to wait for deletes to be resolved (in order for checkpoint to
+     * write the correct version of the page).
+     */
+    if (previous_state == WT_REF_DISK)
+        F_SET(ref, WT_REF_READING);
 
     /*
      * Get the address: if there is no address, the page was deleted and a subsequent search or
@@ -179,7 +175,8 @@ skip_read:
         break;
     }
 
-    WT_REF_SET_STATE(ref, final_state);
+    F_CLR(ref, WT_REF_READING);
+    WT_REF_SET_STATE(ref, WT_REF_MEM);
 
     WT_ASSERT(session, ret == 0);
     return (0);
@@ -191,6 +188,8 @@ err:
      */
     if (ref->page != NULL)
         __wt_ref_out(session, ref);
+
+    F_CLR(ref, WT_REF_READING);
     WT_REF_SET_STATE(ref, previous_state);
 
     __wt_buf_free(session, &tmp);
@@ -279,22 +278,20 @@ read:
               F_ISSET(session, WT_SESSION_READ_WONT_NEED) ||
               F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_NOKEEP);
             continue;
-        case WT_REF_READING:
-            if (LF_ISSET(WT_READ_CACHE))
-                return (WT_NOTFOUND);
-            if (LF_ISSET(WT_READ_NO_WAIT))
-                return (WT_NOTFOUND);
-
-            /* Waiting on another thread's read, stall. */
-            WT_STAT_CONN_INCR(session, page_read_blocked);
-            stalled = true;
-            break;
         case WT_REF_LOCKED:
             if (LF_ISSET(WT_READ_NO_WAIT))
                 return (WT_NOTFOUND);
 
-            /* Waiting on eviction, stall. */
-            WT_STAT_CONN_INCR(session, page_locked_blocked);
+            if (F_ISSET(ref, WT_REF_READING)) {
+                if (LF_ISSET(WT_READ_CACHE))
+                    return (WT_NOTFOUND);
+
+                /* Waiting on another thread's read, stall. */
+                WT_STAT_CONN_INCR(session, page_read_blocked);
+            } else
+                /* Waiting on eviction, stall. */
+                WT_STAT_CONN_INCR(session, page_locked_blocked);
+
             stalled = true;
             break;
         case WT_REF_SPLIT:

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -71,7 +71,7 @@ __rebalance_leaf_append(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts, con
     WT_RET(__wt_calloc_one(session, &copy));
     rs->leaf[rs->leaf_next++] = copy;
 
-    F_SET(copy, WT_REF_IS_LEAF);
+    F_SET(copy, WT_REF_FLAG_LEAF);
     copy->state = WT_REF_DISK;
 
     WT_RET(__wt_calloc_one(session, &copy_addr));

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1176,7 +1176,7 @@ __slvg_col_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
         addr = NULL;
 
         ref->ref_recno = trk->col_start;
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         WT_REF_SET_STATE(ref, WT_REF_DISK);
 
         /*
@@ -1784,7 +1784,7 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
         addr = NULL;
 
         __wt_ref_key_clear(ref);
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         WT_REF_SET_STATE(ref, WT_REF_DISK);
 
         /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -476,7 +476,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
             root_incr += sizeof(WT_IKEY) + size;
         } else
             ref->ref_recno = (*root_refp)->ref_recno;
-        F_SET(ref, WT_REF_IS_INTERNAL);
+        F_SET(ref, WT_REF_FLAG_INTERNAL);
         WT_REF_SET_STATE(ref, WT_REF_MEM);
 
         /*
@@ -1019,7 +1019,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
             parent_incr += sizeof(WT_IKEY) + size;
         } else
             ref->ref_recno = (*page_refp)->ref_recno;
-        F_SET(ref, WT_REF_IS_INTERNAL);
+        F_SET(ref, WT_REF_FLAG_INTERNAL);
         WT_REF_SET_STATE(ref, WT_REF_MEM);
 
         /*
@@ -1615,10 +1615,10 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_R
     switch (page->type) {
     case WT_PAGE_COL_INT:
     case WT_PAGE_ROW_INT:
-        F_SET(ref, WT_REF_IS_INTERNAL);
+        F_SET(ref, WT_REF_FLAG_INTERNAL);
         break;
     default:
-        F_SET(ref, WT_REF_IS_LEAF);
+        F_SET(ref, WT_REF_FLAG_LEAF);
         break;
     }
 
@@ -1719,7 +1719,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     child->home = ref->home;
     child->pindex_hint = ref->pindex_hint;
     child->addr = ref->addr;
-    F_SET(child, WT_REF_IS_LEAF);
+    F_SET(child, WT_REF_FLAG_LEAF);
     child->state = WT_REF_MEM;
 
     WT_ERR_ASSERT(session, ref->page_del == NULL, WT_PANIC,
@@ -1782,7 +1782,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     parent_incr += sizeof(WT_REF);
     child = split_ref[1];
     child->page = right;
-    F_SET(child, WT_REF_IS_LEAF);
+    F_SET(child, WT_REF_FLAG_LEAF);
     child->state = WT_REF_MEM;
 
     if (type == WT_PAGE_ROW_LEAF) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -199,7 +199,7 @@ __sync_ref_obsolete_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_LIST *rl
     /* Lock the ref to avoid any change during the obsolete checks.*/
     for (;; __wt_yield()) {
         previous_state = ref->state;
-        if (previous_state != WT_REF_LOCKED && previous_state != WT_REF_READING &&
+        if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;
     }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -49,7 +49,7 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     if (WT_IS_HS(S2BT(session)))
         return (false);
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (false);
     if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
         return (false);
@@ -212,7 +212,7 @@ __sync_ref_obsolete_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_LIST *rl
     }
 
     /* Ignore internal pages, these are taken care of during reconciliation. */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_REF_SET_STATE(ref, previous_state);
         __wt_verbose(session, WT_VERB_CHECKPOINT_GC, "%p: skipping internal page with parent: %p",
           (void *)ref, (void *)ref->home);
@@ -480,7 +480,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             }
 
             /* Traverse through the internal page for obsolete child pages. */
-            if (is_hs && F_ISSET(walk, WT_REF_IS_INTERNAL)) {
+            if (is_hs && F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
                 WT_WITH_PAGE_INDEX(
                   session, ret = __sync_ref_int_obsolete_cleanup(session, walk, &ref_list));
                 WT_ERR(ret);
@@ -516,7 +516,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 continue;
             }
 
-            if (F_ISSET(walk, WT_REF_IS_INTERNAL)) {
+            if (F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
                 internal_bytes += page->memory_footprint;
                 ++internal_pages;
                 /* Slow down checkpoints. */
@@ -543,7 +543,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * Once the transaction has given up it's snapshot it is no longer safe to reconcile
              * pages. That happens prior to the final metadata checkpoint.
              */
-            if (F_ISSET(walk, WT_REF_IS_LEAF) && page->read_gen == WT_READGEN_WONT_NEED &&
+            if (F_ISSET(walk, WT_REF_FLAG_LEAF) && page->read_gen == WT_READGEN_WONT_NEED &&
               !tried_eviction && F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT)) {
                 ret = __wt_page_release_evict(session, walk, 0);
                 walk = NULL;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -738,7 +738,7 @@ __verify_tree(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *addr_unpack
           __wt_page_type_string(page->type)));
 
     /* Track the shape of the tree. */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         ++vs->depth_internal[WT_MIN(vs->depth, WT_ELEMENTS(vs->depth_internal) - 1)];
     else
         ++vs->depth_leaf[WT_MIN(vs->depth, WT_ELEMENTS(vs->depth_internal) - 1)];

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -465,7 +465,7 @@ descend:
                 couple = NULL;
 
                 /* Return leaf pages to our caller. */
-                if (F_ISSET(ref, WT_REF_IS_LEAF)) {
+                if (F_ISSET(ref, WT_REF_FLAG_LEAF)) {
                     *refp = ref;
                     goto done;
                 }
@@ -572,7 +572,7 @@ __tree_walk_skip_count_callback(WT_SESSION_IMPL *session, WT_REF *ref, void *con
      */
     if (ref->state == WT_REF_DELETED && __wt_delete_page_skip(session, ref, false))
         *skipp = true;
-    else if (*skipleafcntp > 0 && F_ISSET(ref, WT_REF_IS_LEAF)) {
+    else if (*skipleafcntp > 0 && F_ISSET(ref, WT_REF_FLAG_LEAF)) {
         --*skipleafcntp;
         *skipp = true;
     } else

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -96,7 +96,7 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
     read_gen += btree->evict_priority;
 
 #define WT_EVICT_INTL_SKEW 1000
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         read_gen += WT_EVICT_INTL_SKEW;
 
     return (read_gen);
@@ -1841,13 +1841,13 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
         page->evict_pass_gen = cache->evict_pass_gen;
 
         /* Count internal pages seen. */
-        if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
             internal_pages_seen++;
 
         /* Use the EVICT_LRU flag to avoid putting pages onto the list multiple times. */
         if (F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU)) {
             pages_already_queued++;
-            if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+            if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
                 internal_pages_already_queued++;
             continue;
         }
@@ -1890,7 +1890,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
          * assertion that we don't discard dirty pages from a clean tree.
          */
         if (F_ISSET(cache, WT_CACHE_EVICT_CLEAN_HARD) && !F_ISSET(conn, WT_CONN_EVICTION_NO_HS) &&
-          F_ISSET(ref, WT_REF_IS_LEAF) && !modified && page->modify != NULL &&
+          F_ISSET(ref, WT_REF_FLAG_LEAF) && !modified && page->modify != NULL &&
           !__wt_txn_visible_all(
               session, page->modify->rec_max_txn, page->modify->rec_max_timestamp)) {
             __wt_page_modify_set(session, page);
@@ -1913,7 +1913,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
          * being skipped for walks), or we are in eviction debug mode. The goal here is that if
          * trees become completely idle, we eventually push them out of cache completely.
          */
-        if (!F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE) && F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+        if (!F_ISSET(cache, WT_CACHE_EVICT_DEBUG_MODE) && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
             if (page == last_parent)
                 continue;
             if (btree->evict_walk_period == 0 && !__wt_cache_aggressive(session))
@@ -1947,7 +1947,7 @@ fast:
         ++btree->evict_walk_progress;
 
         /* Count internal pages queued. */
-        if (F_ISSET(ref, WT_REF_IS_INTERNAL))
+        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
             internal_pages_queued++;
 
         __wt_verbose(session, WT_VERB_EVICTSERVER, "select: %p, size %" WT_SIZET_FMT, (void *)page,
@@ -2483,7 +2483,7 @@ __verbose_dump_cache_single(
         page = next_walk->page;
         size = page->memory_footprint;
 
-        if (F_ISSET(next_walk, WT_REF_IS_INTERNAL)) {
+        if (F_ISSET(next_walk, WT_REF_FLAG_INTERNAL)) {
             ++intl_pages;
             intl_bytes += size;
             intl_bytes_max = WT_MAX(intl_bytes_max, size);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -157,7 +157,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         goto done;
 
     /* Count evictions of internal pages during normal operation. */
-    if (!closing && F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+    if (!closing && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_STAT_CONN_INCR(session, cache_eviction_internal);
         WT_STAT_DATA_INCR(session, cache_eviction_internal);
     }
@@ -519,7 +519,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * necessary but shouldn't fire much: the eviction code is biased for leaf pages, an internal
      * page shouldn't be selected for eviction until all children have been evicted.
      */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_WITH_PAGE_INDEX(session, ret = __evict_child_check(session, ref));
         if (ret != 0)
             WT_STAT_CONN_INCR(session, cache_eviction_fail_active_children_on_an_internal_page);
@@ -610,7 +610,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
 
     if (closing)
         LF_SET(WT_REC_VISIBILITY_ERR);
-    else if (F_ISSET(ref, WT_REF_IS_INTERNAL) || WT_IS_HS(S2BT(session)))
+    else if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || WT_IS_HS(S2BT(session)))
         ;
     else if (WT_SESSION_BTREE_SYNC(session))
         LF_SET(WT_REC_HS);

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -69,7 +69,7 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
         } else
             ++num_memory;
 
-        if (F_ISSET(next_walk, WT_REF_IS_INTERNAL))
+        if (F_ISSET(next_walk, WT_REF_FLAG_INTERNAL))
             ++pages_internal;
         else
             ++pages_leaf;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -748,11 +748,6 @@ struct __wt_page {
  *	Set by a reading thread once the page has been read from disk; the page
  *	is in the cache and the page reference is OK.
  *
- * WT_REF_READING:
- *	Set by a reading thread before reading an ordinary page from disk;
- *	other readers of the page wait until the read completes.  Sync can
- *	safely skip over such pages: they are clean by definition.
- *
  * WT_REF_SPLIT:
  *	Set when the page is split; the WT_REF is dead and can no longer be
  *	used.
@@ -830,14 +825,14 @@ struct __wt_ref {
  */
 #define WT_REF_IS_INTERNAL 0x01 /* Page is an internal page */
 #define WT_REF_IS_LEAF 0x02     /* Page is a leaf page */
+#define WT_REF_READING 0x04     /* Page is being read in */
     uint8_t flags;
 
 #define WT_REF_DISK 0       /* Page is on disk */
 #define WT_REF_DELETED 1    /* Page is on disk, but deleted */
 #define WT_REF_LOCKED 2     /* Page locked for exclusive access */
 #define WT_REF_MEM 3        /* Page is in cache and valid */
-#define WT_REF_READING 4    /* Page being read */
-#define WT_REF_SPLIT 5      /* Parent page split (WT_REF dead) */
+#define WT_REF_SPLIT 4      /* Parent page split (WT_REF dead) */
     volatile uint8_t state; /* Page state */
 
     /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -823,9 +823,11 @@ struct __wt_ref {
  * miss one). If we run out of bits in the flags field, remove the internal flag and rewrite tests
  * depending on it to be "!leaf" instead.
  */
-#define WT_REF_IS_INTERNAL 0x01 /* Page is an internal page */
-#define WT_REF_IS_LEAF 0x02     /* Page is a leaf page */
-#define WT_REF_READING 0x04     /* Page is being read in */
+/* AUTOMATIC FLAG VALUE GENERATION START */
+#define WT_REF_FLAG_INTERNAL 0x1u /* Page is an internal page */
+#define WT_REF_FLAG_LEAF 0x2u     /* Page is a leaf page */
+#define WT_REF_FLAG_READING 0x4u  /* Page is being read in */
+                                  /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint8_t flags;
 
 #define WT_REF_DISK 0       /* Page is on disk */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1138,7 +1138,7 @@ __wt_ref_info_lock(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t *addr_buf, siz
      */
     for (;; __wt_yield()) {
         previous_state = ref->state;
-        if (previous_state != WT_REF_LOCKED && previous_state != WT_REF_READING &&
+        if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;
     }

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1432,7 +1432,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * One special case where we know this is safe is if the handle is locked exclusive (e.g., when
      * the whole tree is being evicted). In that case, no readers can be looking at an old index.
      */
-    if (F_ISSET(ref, WT_REF_IS_INTERNAL) && !F_ISSET(session->dhandle, WT_DHANDLE_EXCLUSIVE) &&
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) && !F_ISSET(session->dhandle, WT_DHANDLE_EXCLUSIVE) &&
       __wt_gen_active(session, WT_GEN_SPLIT, page->pg_intl_split_gen))
         return (false);
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -58,8 +58,6 @@ extern const char *__wt_key_string(WT_SESSION_IMPL *session, const void *data_ar
   const char *key_format, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_page_type_string(u_int type) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern const char *__wt_ref_state_string(u_int state)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_session_strerror(WT_SESSION *wt_session, int error)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -249,7 +249,6 @@ __wt_txn_op_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bool comm
      */
     for (;; __wt_yield()) {
         previous_state = ref->state;
-        WT_ASSERT(session, previous_state != WT_REF_READING);
         if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;
@@ -300,7 +299,6 @@ __wt_txn_op_delete_commit_apply_timestamps(WT_SESSION_IMPL *session, WT_REF *ref
      */
     for (;; __wt_yield()) {
         previous_state = ref->state;
-        WT_ASSERT(session, previous_state != WT_REF_READING);
         if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -160,7 +160,7 @@ __wt_rec_child_modify(
              * We should never be here during eviction, active child pages in an evicted page's
              * subtree fails the eviction attempt.
              */
-            WT_ERR_ASSERT(session, !F_ISSET(r, WT_REC_EVICT), EBUSY,
+            WT_RET_ASSERT(session, !F_ISSET(r, WT_REC_EVICT), EBUSY,
               "unexpected WT_REF_LOCKED child state during eviction reconciliation");
 
             /* If the page is being read from disk, it's not modified by definition. */
@@ -183,7 +183,7 @@ __wt_rec_child_modify(
              * We should never be here during eviction, active child pages in an evicted page's
              * subtree fails the eviction attempt.
              */
-            WT_ERR_ASSERT(session, !F_ISSET(r, WT_REC_EVICT), EBUSY,
+            WT_RET_ASSERT(session, !F_ISSET(r, WT_REC_EVICT), EBUSY,
               "unexpected WT_REF_MEM child state during eviction reconciliation");
 
             /*
@@ -218,7 +218,7 @@ __wt_rec_child_modify(
              * checkpoint, all splits in process will have completed before we walk any pages for
              * checkpoint.
              */
-            WT_ERR_ASSERT(
+            WT_RET_ASSERT(
               session, false, EBUSY, "unexpected WT_REF_SPLIT child state during reconciliation");
 
         default:

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -164,7 +164,7 @@ __wt_rec_child_modify(
               "unexpected WT_REF_LOCKED child state during eviction reconciliation");
 
             /* If the page is being read from disk, it's not modified by definition. */
-            if (F_ISSET(ref, WT_REF_READING))
+            if (F_ISSET(ref, WT_REF_FLAG_READING))
                 goto done;
 
             /*

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -220,6 +220,8 @@ __wt_rec_child_modify(
              */
             WT_RET_ASSERT(
               session, false, EBUSY, "unexpected WT_REF_SPLIT child state during reconciliation");
+	    /* NOTREACHED */
+	    return (EBUSY);
 
         default:
             return (__wt_illegal_value(session, r->tested_ref_state));

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -220,8 +220,8 @@ __wt_rec_child_modify(
              */
             WT_RET_ASSERT(
               session, false, EBUSY, "unexpected WT_REF_SPLIT child state during reconciliation");
-	    /* NOTREACHED */
-	    return (EBUSY);
+            /* NOTREACHED */
+            return (EBUSY);
 
         default:
             return (__wt_illegal_value(session, r->tested_ref_state));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -645,7 +645,7 @@ __rollback_to_stable_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollbac
     while ((ret = __wt_tree_walk(
               session, &ref, WT_READ_CACHE_LEAF | WT_READ_NO_EVICT | WT_READ_WONT_NEED)) == 0 &&
       ref != NULL)
-        if (F_ISSET(ref, WT_REF_IS_INTERNAL)) {
+        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
             WT_INTL_FOREACH_BEGIN (session, ref->page, child_ref) {
                 WT_RET(__rollback_abort_newer_updates(session, child_ref, rollback_timestamp));
             }


### PR DESCRIPTION
@agorrod, this is the change that removes the `WT_REF.WT_REF_READiNG` state.

As you know, I like this change because it simplifies the `WT_REF` locking protocol a bit, because we only ever care about the `WT_REF_LOCKED` state for the purposes of thread serialization.

I know you see this work a bit differently than I do, so wanted to give you a chance to see the actual change and kill it if you want to go a different direction.

If you're OK with this change, let me know and I'll find a reviewer.