### PR TITLE
WT-5666 Deleting a chunk of the namespace changes the WT_REF type

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -136,7 +136,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     if (addr == NULL) {
         WT_ASSERT(session, previous_state != WT_REF_DISK);
 
-        WT_ERR(__wt_btree_new_leaf_page(session, &ref->page));
+        WT_ERR(__wt_btree_new_leaf_page(session, ref));
         goto skip_read;
     }
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -281,14 +281,6 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         }
     }
 
-    /*
-     * When deleting a chunk of the name-space, we can delete internal pages. However, if we are
-     * ever forced to re-instantiate that piece of the namespace, it comes back as a leaf page. Set
-     * the WT_REF type now so scanning cursors treat this chunk of the name space correctly.
-     */
-    F_CLR(ref, WT_REF_IS_INTERNAL);
-    F_SET(ref, WT_REF_IS_LEAF);
-
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
     return (0);
 }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -281,6 +281,14 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         }
     }
 
+    /*
+     * When deleting a chunk of the name-space, we can delete internal pages. However, if we are
+     * ever forced to re-instantiate that piece of the namespace, it comes back as a leaf page. Set
+     * the WT_REF type now so scanning cursors treat this chunk of the name space correctly.
+     */
+    F_CLR(ref, WT_REF_IS_INTERNAL);
+    F_SET(ref, WT_REF_IS_LEAF);
+
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
     return (0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -293,7 +293,7 @@ extern int __wt_btree_discard(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btree_huffman_open(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_PAGE **pagep)
+extern int __wt_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
If we delete a chunk of the name space and evict the page, we can migrate that change up the tree, eventually deleting and evicting internal nodes, setting and internal node's `WT_REF.state` to `WT_REF_DELETED`.

If we're ever forced to re-instantiate that chunk of the name space, it's re-instantiated as a leaf page, not a subtree with both internal and leaf pages.

I see two places to flip the `WT_REF` type from an internal page to a leaf page: when we delete the internal node, or when we re-instantiate the page. I did it in the first one in commit 9020de7, when we delete the internal node because it was a simpler change, but I changed my mind and did it in the second one in commit cafee99, because that matches current practice and so I think it's less likely to cause more breakage.