### PR TITLE
WT-5678 Fix infinite looping behaviour in history store cursor positioning

### DIFF
--- a/test/suite/test_inmem01.py
+++ b/test/suite/test_inmem01.py
@@ -88,6 +88,7 @@ class test_inmem01(wttest.WiredTigerTestCase):
 
     # Run queries after adding, removing and re-inserting data.
     # Try out keeping a cursor open while adding new data.
+    @unittest.skip("Temporarily disabled")
     def test_insert_over_delete_replace(self):
         msg = '/WT_CACHE_FULL.*/'
         ds = SimpleDataSet(self, self.uri, 10000000, key_format=self.keyfmt,

--- a/test/suite/test_inmem01.py
+++ b/test/suite/test_inmem01.py
@@ -88,7 +88,6 @@ class test_inmem01(wttest.WiredTigerTestCase):
 
     # Run queries after adding, removing and re-inserting data.
     # Try out keeping a cursor open while adding new data.
-    @unittest.skip("Temporarily disabled")
     def test_insert_over_delete_replace(self):
         msg = '/WT_CACHE_FULL.*/'
         ds = SimpleDataSet(self, self.uri, 10000000, key_format=self.keyfmt,


### PR DESCRIPTION
As part of #5295, I noticed infrequent infinite looping behavior in the positioning of the history store cursor. This is because we're comparing the embedded data store key and using this to infer something about our position in the history store which we know is not allowed.

Consider a case where we have string keys 9, 10 and 11 in the history store. Since strings are encoded with a length prefix, the history store order will be 9, 10, 11. Whereas the data store order will be 10, 11, 9 as it will be sorted alphabetically. So you can imagine a case where we search for the key 10 (which doesn't exist) and position ourselves at the beginning of the entries for 11. When we realize that we have overshot and try to go back to the previous entry, we'll land on 9 (which is lexicographically greater than our target 10). So we would assume that this record was inserted in between our `search_near` and our `prev` and then attempt another `search_near` which gets us into an infinite loop.

What we're really trying to do is figure out whether we're before or after the key that we've used with our `search_near` call so there is no need to compare each component of the key separately like we're doing now.