### PR TITLE
WT-5685 Set aspell dictionary to en_US

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2460,7 +2460,7 @@ below:
   now it will be used if the shared_cache configuration option is included.
 
 * Add the ability to specify a per-connection reserved size for cache
-  pools.  Ensure cache pool reconfiguration is honoured quickly.
+  pools.  Ensure cache pool reconfiguration is honored quickly.
 
 * Rework hazard pointer coupling during cursor walks to be more efficient.
 

--- a/dist/s_string
+++ b/dist/s_string
@@ -22,7 +22,7 @@ type aspell > /dev/null 2>&1 || {
 # catalogs and generating a shorter list on any single system will break other
 # systems.
 replace() {
-	aspell --mode=ccpp --lang=en list < ../$1 |
+	aspell --mode=ccpp --lang=en_US list < ../$1 |
 	sort -u |
 	comm -12 /dev/stdin s_string.ok
 }
@@ -33,7 +33,7 @@ check() {
 	# Strip out git hashes, which are seven character hex strings.
 	# Strip out double quote char literals ('"'), they confuse aspell.
 	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" ../$2 |
-	aspell --lang=en $1 list |
+	aspell --lang=en_US $1 list |
 	sort -u |
 	comm -23 /dev/stdin s_string.ok > $t
 	test -s $t && {

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -314,6 +314,7 @@ PowerPC
 Pre
 Preload
 Prepend
+Prev
 Qsort
 RCS
 RDNOLOCK
@@ -1118,6 +1119,7 @@ prepended
 prepending
 presize
 presync
+prev
 prevlsn
 primary's
 printf
@@ -1210,6 +1212,7 @@ setstr
 setv
 setvbuf
 sfence
+signalled
 sii
 sizeof
 sizep

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -1178,7 +1178,7 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
 
     /*
      * Default to true - callers shouldn't rely on this if an error is returned, but let's give them
-     * deterministic behaviour if they do.
+     * deterministic behavior if they do.
      */
     *txn_active = true;
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1894,7 +1894,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
          * After this point the worker thread owns the slot. There is nothing more to do but return.
          */
         /*
-         * !!! Signalling the wrlsn_cond condition here results in
+         * !!! Signaling the wrlsn_cond condition here results in
          * worse performance because it causes more scheduling churn
          * and more walking of the slot pool for a very small number
          * of slots to process.  Don't signal here.


### PR DESCRIPTION
Switch the dictionary `aspell` uses to check and replace spelling from `en` (English) to `en_US` (American English), and address spelling issues detected by the dictionary switch.

I put `signalled` into the ok list as it's already been widely used in the source code (both comments and variable names). 