### PR TITLE
WT-5690 Skip removing update from hs when its newer version is stable

### DIFF
--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -60,7 +60,7 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         if self.prepare:
             config += 'cache_size=250MB,statistics=(all)'
         else:
-            config += 'cache_size=50MB,statistics=(all)'
+            config += 'cache_size=100MB,statistics=(all)'
         if self.in_memory:
             config += ',in_memory=true'
         else:
@@ -113,9 +113,7 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         # Check that the new updates are only seen after the update timestamp.
         self.check(valueb, uri, nrows, 40)
         self.check(valueb, uri, nrows, 20)
-        # @unittest.skip("Temporarily disabled")
-        # Temporarily disabled until the fix is found as part of WT-5690
-        # self.check(valuea, uri, nrows, 10)
+        self.check(valuea, uri, nrows, 10)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]


### PR DESCRIPTION
As part of rollback to stable process, it aborts the updates in the
order of update list, on page and reconciled page. As part of one page
value correction once the history updates are removed, don't remove
the visible updates again as part of processing reconciled page if the
newer version of the key is stable.