### PR TITLE
WT-5636 prefix compression is slow in the history-store access pattern

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -216,7 +216,7 @@ struct __wt_ovfl_reuse {
     "key_format=" WT_UNCHECKED_STRING(IuQQQQ) ",value_format=" WT_UNCHECKED_STRING( \
       QBBu) ",block_compressor=" WT_HS_COMPRESSOR                                   \
             ",leaf_value_max=64MB"                                                  \
-            ",prefix_compression=true"
+            ",prefix_compression=false"
 
 /*
  * WT_PAGE_MODIFY --


### PR DESCRIPTION
Given the access pattern for the history-store file, I think we might want to turn off prefix compression.