### PR TITLE
WT-5713 Don't clear the stable timestamp after recovery

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -736,9 +736,7 @@ done:
 
         WT_ERR(__wt_rollback_to_stable(session, NULL));
 
-        /* Reset the stable and oldest timestamp. */
-        conn->txn_global.stable_timestamp = WT_TS_NONE;
-        conn->txn_global.has_stable_timestamp = false;
+        /* Reset the oldest timestamp. */
         conn->txn_global.oldest_timestamp = WT_TS_NONE;
         conn->txn_global.has_oldest_timestamp = false;
     } else if (do_checkpoint)

--- a/test/suite/test_durable_rollback_to_stable.py
+++ b/test/suite/test_durable_rollback_to_stable.py
@@ -65,7 +65,6 @@ class test_durable_rollback_to_stable(wttest.WiredTigerTestCase, suite_subproces
             (self.ds.is_lsm() or self.uri == 'lsm')
 
     # Test durable timestamp.
-    @unittest.skip("Temporarily disabled")
     def test_durable_rollback_to_stable(self):
         if self.skip():
             return
@@ -170,8 +169,8 @@ class test_durable_rollback_to_stable(wttest.WiredTigerTestCase, suite_subproces
 
         # Use util to verify that second updates values have been flushed.
         errfilename = "verifyrollbackerr.out"
-        self.runWt(["verify", "-S", uri],
-            errfilename=errfilename, failure=True)
+        self.runWt(["verify", "-s", uri],
+            errfilename=errfilename, failure=False)
         self.check_empty_file(errfilename)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since we were clearing the stable timestamp after recovery, `wt` would complain when using the `-s` option since there would be no stable timestamp to compare against. There doesn't seem to be a compelling reason to clear it so the easiest fix is just to remove this logic.