### PR TITLE
WT-5712 Treat history store file as internal file like metadata

### DIFF
--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -31,7 +31,7 @@
 #define WT_METAFILE_URI "file:WiredTiger.wt"  /* Metadata table URI */
 
 #define WT_HS_FILE "WiredTigerHS.wt"     /* History store table */
-#define WT_HS_URI "file:WiredTigerHS.wt" /* History store table URI*/
+#define WT_HS_URI "file:WiredTigerHS.wt" /* History store table URI */
 
 #define WT_SYSTEM_PREFIX "system:"             /* System URI prefix */
 #define WT_SYSTEM_CKPT_URI "system:checkpoint" /* Checkpoint URI */

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -135,15 +135,14 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 
         /*
          * !!!
-         * We don't normally say anything about the WiredTiger metadata
-         * since it's not an application/user "object" in the database.
-         * I'm making an exception for the checkpoint and verbose
-         * options. However, skip over the metadata system information
+         * We don't normally say anything about the WiredTiger metadata and history store since
+         * they are not an application/user "objects" in the database. I'm making an exception for
+         * the checkpoint and verbose options. However, skip over the metadata system information
          * for anything except the verbose option.
          */
         if (!vflag && WT_PREFIX_MATCH(key, WT_SYSTEM_PREFIX))
             continue;
-        if (cflag || vflag || strcmp(key, WT_METADATA_URI) != 0)
+        if (cflag || vflag || (strcmp(key, WT_METADATA_URI) != 0 && strcmp(key, WT_HS_URI) != 0))
             printf("%s\n", key);
 
         if (!cflag && !vflag)

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -124,9 +124,7 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
         if ((ret = cursor->get_key(cursor, &key)) != 0)
             return (util_cerr(cursor, "get_key", ret));
 
-        /*
-         * If a name is specified, only show objects that match.
-         */
+        /* If a name is specified, only show objects that match. */
         if (uri != NULL) {
             if (!WT_PREFIX_MATCH(key, uri))
                 continue;
@@ -135,10 +133,9 @@ list_print(WT_SESSION *session, const char *uri, bool cflag, bool vflag)
 
         /*
          * !!!
-         * We don't normally say anything about the WiredTiger metadata and history store since
-         * they are not an application/user "objects" in the database. I'm making an exception for
-         * the checkpoint and verbose options. However, skip over the metadata system information
-         * for anything except the verbose option.
+         * Don't report anything about the WiredTiger metadata and history store since they are not
+         * user created objects unless the verbose or checkpoint options are passed in. However,
+         * skip over the metadata system information for anything except the verbose option.
          */
         if (!vflag && WT_PREFIX_MATCH(key, WT_SYSTEM_PREFIX))
             continue;

--- a/test/suite/test_util11.py
+++ b/test/suite/test_util11.py
@@ -32,7 +32,6 @@ import wiredtiger, wttest
 
 # test_util11.py
 #    Utilities: wt list
-@unittest.skip("Temporarily disabled")
 class test_util11(wttest.WiredTigerTestCase, suite_subprocess):
     tablenamepfx = 'test_util11.'
     session_params = 'key_format=S,value_format=S'


### PR DESCRIPTION
Both metadata and history store files are created as part of Wiredtiger
connection open and they are not an application/user objects in the
database. Currently metadata is not listed as part of the WT utility
list, apply the same for the history store file also.