### PR TITLE
WT-5692 Revert a test change hoping to fix a Python hang

### DIFF
--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -202,6 +202,13 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             # Check the state after each commit/rollback.
             self.check_all(current, committed)
 
+        #
+        # Run printlog and make sure it exits with zero status. This should be
+        # run as soon as we can after the crash to try and conflict with the
+        # journal file read.
+        #
+        self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
+
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         clen = stat_cursor[stat.conn.log_compress_len][2]
         cmem = stat_cursor[stat.conn.log_compress_mem][2]
@@ -209,14 +216,6 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
         cfails = stat_cursor[stat.conn.log_compress_write_fails][2]
         csmall = stat_cursor[stat.conn.log_compress_small][2]
         stat_cursor.close()
-
-        #
-        # Run printlog and make sure it exits with zero status. This should be
-        # run as soon as we can after the crash to try and conflict with the
-        # journal file read.
-        #
-
-        self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
 
         if self.compress == '':
             self.assertEqual(clen, cmem)

--- a/test/suite/test_txn07.py
+++ b/test/suite/test_txn07.py
@@ -202,13 +202,8 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             # Check the state after each commit/rollback.
             self.check_all(current, committed)
 
-        #
-        # Run printlog and make sure it exits with zero status. This should be
-        # run as soon as we can after the crash to try and conflict with the
-        # journal file read.
-        #
-        self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
-
+        # Gather statistics - this needs to be done before the connection is
+        # closed or statistics would be reset.
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         clen = stat_cursor[stat.conn.log_compress_len][2]
         cmem = stat_cursor[stat.conn.log_compress_mem][2]
@@ -229,6 +224,13 @@ class test_txn07(wttest.WiredTigerTestCase, suite_subprocess):
             self.assertEqual(clen < cmem, True)
             self.assertEqual(cwrites > 0, True)
             self.assertEqual((cfails > 0 or csmall > 0), True)
+
+        #
+        # Run printlog and make sure it exits with zero status. This should be
+        # run as soon as we can after the crash to try and conflict with the
+        # journal file read.
+        #
+        self.runWt(['-h', self.backup_dir, 'printlog'], outfilename='printlog.out')
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
A test case was checking statistics after runWt, which closes
the connection, which led to using the wrong stats. That check
was re-ordered (along with other changes), after which some automate
testing started hanging. Revert that bit of the change to see if is
the cause.