### PR TITLE
WT-5682 Ensure that we can't apply modifies on top of tombstones

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -606,7 +606,6 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
             if (prev_upd->type == WT_UPDATE_TOMBSTONE) {
                 WT_ASSERT(session, modifies.size > 0);
                 __wt_modify_vector_pop(&modifies, &prev_upd);
-                /* The base value of a modify newer than a tombstone is the empty value. */
                 WT_ASSERT(session, prev_upd->type == WT_UPDATE_STANDARD);
                 prev_full_value->data = prev_upd->data;
                 prev_full_value->size = prev_upd->size;

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -585,7 +585,9 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
                 continue;
         }
 
-        WT_ERR(__hs_calculate_full_value(session, full_value, upd, "", 0));
+        WT_ASSERT(session, upd->type == WT_UPDATE_STANDARD);
+        full_value->data = upd->data;
+        full_value->size = upd->size;
 
         squashed = false;
 
@@ -608,7 +610,9 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
                 WT_ASSERT(session, modifies.size > 0);
                 __wt_modify_vector_pop(&modifies, &prev_upd);
                 /* The base value of a modify newer than a tombstone is the empty value. */
-                WT_ERR(__hs_calculate_full_value(session, prev_full_value, prev_upd, "", 0));
+                WT_ASSERT(session, prev_upd->type == WT_UPDATE_STANDARD);
+                prev_full_value->data = prev_upd->data;
+                prev_full_value->size = prev_upd->size;
             } else
                 WT_ERR(__hs_calculate_full_value(
                   session, prev_full_value, prev_upd, full_value->data, full_value->size));

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -553,9 +553,6 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
          * U (selected onpage value) -> U -> T -> M -> U.
          * We write the stop time pair of M with the start time pair of the tombstone and skip the
          * tombstone.
-         * 4) We have modifies newer than a tombstone, e.g., U (selected onpage value) -> M -> T ->
-         * M -> U. In this case, the base update for the modify newer than the tombstone is the
-         * empty value.
          * 4) We have a single tombstone on the chain, it is simply ignored.
          */
         for (; upd != NULL; upd = upd->next) {

--- a/test/suite/test_bug022.py
+++ b/test/suite/test_bug022.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_bug022.py
+#       Testing whether we check the visibility of the onpage value when applying modifies.
+
+import wiredtiger, wttest
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_bug022(wttest.WiredTigerTestCase):
+    uri = 'file:test_bug022'
+    conn_config = 'cache_size=50MB'
+    session_config = 'isolation=snapshot'
+
+    def test_apply_modifies_on_onpage_tombstone(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(self.uri)
+
+        value = 'a' * 500
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[str(i)] = value
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            cursor.remove()
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        self.session.checkpoint()
+
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.modify([wiredtiger.Modify('B', 0, 100)]), wiredtiger.WT_NOTFOUND)
+            self.session.rollback_transaction()
+
+        for i in range(1, 10000):
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)


### PR DESCRIPTION
I wasn't able to hit the condition where we apply modifies on top of an on-page value with a set time pair (I get `WT_NOTFOUND` when trying to modify). After chatting with @michaelcahill, we think that this case shouldn't be possible and may have existed from when the rules around modifies were laxer.