### PR TITLE
WT-5688 Memory leak during page overflow read

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -789,6 +789,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
   WT_UPDATE **updp)
 {
     WT_ITEM buf;
+    WT_DECL_RET;
     WT_TIME_PAIR start, stop;
     size_t size;
 
@@ -808,8 +809,13 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     buf.flags = 0;
 
     /* Check the ondisk value. */
-    if (vpack == NULL)
-        WT_RET(__wt_value_return_buf(cbt, cbt->ref, &buf, &start, &stop));
+    if (vpack == NULL) {
+        ret = __wt_value_return_buf(cbt, cbt->ref, &buf, &start, &stop);
+        if(ret != 0) {
+            __wt_buf_free(session, &buf);
+            WT_RET(ret);
+        }
+    }
     else {
         start.timestamp = vpack->start_ts;
         start.txnid = vpack->start_txn;
@@ -827,6 +833,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     if (stop.txnid != WT_TXN_MAX && stop.timestamp != WT_TS_MAX &&
       (!WT_IS_HS(S2BT(session)) || !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE)) &&
       __wt_txn_visible(session, stop.txnid, stop.timestamp)) {
+        __wt_buf_free(session, &buf);
         WT_RET(__wt_upd_alloc_tombstone(session, updp));
         (*updp)->txnid = stop.txnid;
         /* FIXME: Reevaluate this as part of PM-1524. */
@@ -843,7 +850,9 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
      * the current system.
      */
     if (__wt_txn_visible(session, start.txnid, start.timestamp)) {
-        WT_RET(__wt_update_alloc(session, &buf, updp, &size, WT_UPDATE_STANDARD));
+        ret = __wt_update_alloc(session, &buf, updp, &size, WT_UPDATE_STANDARD);
+        __wt_buf_free(session, &buf);
+        WT_RET(ret);
         (*updp)->txnid = start.txnid;
         (*updp)->start_ts = start.timestamp;
         F_SET((*updp), WT_UPDATE_RESTORED_FROM_DISK);
@@ -851,9 +860,13 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     }
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
-    if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(S2BT(session), WT_BTREE_HS))
-        WT_RET_NOTFOUND_OK(__wt_find_hs_upd(session, cbt, updp, false, &buf));
+    if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(S2BT(session), WT_BTREE_HS)) {
+        ret = __wt_find_hs_upd(session, cbt, updp, false, &buf);
+        __wt_buf_free(session, &buf);
+        WT_RET_NOTFOUND_OK(ret);
+    }
 
+    __wt_buf_free(session, &buf);
     /*
      * Return null not tombstone if nothing is found in history store.
      */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -788,8 +788,8 @@ static inline int
 __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT_CELL_UNPACK *vpack,
   WT_UPDATE **updp)
 {
-    WT_ITEM buf;
     WT_DECL_RET;
+    WT_ITEM buf;
     WT_TIME_PAIR start, stop;
     size_t size;
 
@@ -811,12 +811,11 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     /* Check the ondisk value. */
     if (vpack == NULL) {
         ret = __wt_value_return_buf(cbt, cbt->ref, &buf, &start, &stop);
-        if(ret != 0) {
+        if (ret != 0) {
             __wt_buf_free(session, &buf);
             WT_RET(ret);
         }
-    }
-    else {
+    } else {
         start.timestamp = vpack->start_ts;
         start.txnid = vpack->start_txn;
         stop.timestamp = vpack->stop_ts;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -811,10 +811,8 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     /* Check the ondisk value. */
     if (vpack == NULL) {
         ret = __wt_value_return_buf(cbt, cbt->ref, &buf, &start, &stop);
-        if (ret != 0) {
-            __wt_buf_free(session, &buf);
-            WT_RET(ret);
-        }
+        __wt_buf_free(session, &buf);
+        WT_RET(ret);
     } else {
         start.timestamp = vpack->start_ts;
         start.txnid = vpack->start_txn;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -811,8 +811,10 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, WT
     /* Check the ondisk value. */
     if (vpack == NULL) {
         ret = __wt_value_return_buf(cbt, cbt->ref, &buf, &start, &stop);
-        __wt_buf_free(session, &buf);
-        WT_RET(ret);
+        if (ret != 0) {
+            __wt_buf_free(session, &buf);
+            return (ret);
+        }
     } else {
         start.timestamp = vpack->start_ts;
         start.txnid = vpack->start_txn;


### PR DESCRIPTION
These changes would fix memory leak during the overflow page read (pasted the call stack below). 

Evergreen link [[here](https://evergreen.mongodb.com/task/wiredtiger_ubuntu1804_format_stress_sanitizer_smoke_test_patch_fa51dc8d84fb621ef6a3f92c0117a55fa16cbb34_5e5d96d661837d088fad3f45_20_03_02_23_29_48)]

`#1 0x7f3ebab6881d in __realloc_func /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/os_common/os_alloc.c:141:14
#2 0x7f3ebab689a0 in __wt_realloc_noclear /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/os_common/os_alloc.c:180:13
#3 0x7f3ebad0bc5e in __wt_buf_grow_worker /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/support/scratch.c:54:19
#4 0x7f3eba73b51f in __wt_buf_grow /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/buf.i:17:54
#5 0x7f3eba73b35c in __wt_buf_init /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/buf.i:49:13
#6 0x7f3eba736ffb in __wt_buf_initsize /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/buf.i:61:11
#7 0x7f3eba73541e in __wt_bt_read /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_io.c:86:15
#8 0x7f3eba73cd2c in __ovfl_read /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_ovfl.c:31:11
#9 0x7f3eba73cbdc in __wt_ovfl_read /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_ovfl.c:87:15
#10 0x7f3eba783022 in __cell_data_ref /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/cell.i:1011:15
#11 0x7f3eba780365 in __wt_page_cell_data_ref /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/cell.i:1055:13
#12 0x7f3eba77f69e in __wt_value_return_buf /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_ret.c:125:17
#13 0x7f3eba69dce8 in __wt_txn_read /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/include/txn.i:814:15
#14 0x7f3eba697f88 in __cursor_row_next /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_curnext.c:400:9
#15 0x7f3eba692014 in __wt_btcur_next /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/btree/bt_curnext.c:679:23
#16 0x7f3eba957726 in __curfile_next /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/cursor/cur_file.c:93:5
#17 0x7f3ebaada6d5 in __clsm_next /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/lsm/lsm_cursor.c:904:9
#18 0x7f3ebab060e8 in __wt_lsm_merge /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/lsm/lsm_merge.c:436:35
#19 0x7f3ebab3c191 in __lsm_worker /data/mci/eec7f4b32cfd8eff50bd6eb953fb8a61/wiredtiger/build_posix/../src/lsm/lsm_worker.c:140:19`