### PR TITLE
WT-5680 On evicting an empty page, mark it DELETED not DISK

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -373,19 +373,15 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
         /*
          * 1-for-1 page swap: Update the parent to reference the replacement page.
          *
-         * A page evicted with history store entries may not have an address, if no updates were
-         * visible to reconciliation.
-         *
          * Publish: a barrier to ensure the structure fields are set before the state change makes
          * the page available to readers.
          */
-        if (mod->mod_replace.addr != NULL) {
-            WT_RET(__wt_calloc_one(session, &addr));
-            *addr = mod->mod_replace;
-            mod->mod_replace.addr = NULL;
-            mod->mod_replace.size = 0;
-            ref->addr = addr;
-        }
+        WT_ASSERT(session, mod->mod_replace.addr != NULL);
+        WT_RET(__wt_calloc_one(session, &addr));
+        *addr = mod->mod_replace;
+        mod->mod_replace.addr = NULL;
+        mod->mod_replace.size = 0;
+        ref->addr = addr;
 
         /*
          * Eviction wants to keep this page if we have a disk image, re-instantiate the page in

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -246,9 +246,6 @@ typedef struct {
     uint64_t start_txn;
     wt_timestamp_t stop_ts;
     uint64_t stop_txn;
-
-    bool upd_saved; /* Updates saved to list */
-
 } WT_UPDATE_SELECT;
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -152,8 +152,8 @@ err:
  *     Return if we need to save the update chain
  */
 static bool
-__rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE *selected_upd, uint64_t max_txn,
-  wt_timestamp_t max_ts, bool has_newer_updates, uint64_t flags, WT_PAGE *page)
+__rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE_SELECT *upd_select, bool has_newer_updates,
+  uint64_t flags, WT_PAGE *page)
 {
     /*
      * Save updates for any reconciliation that doesn't involve history store (in-memory database
@@ -161,7 +161,7 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE *selected_upd, uint64_t 
      * visible.
      */
     if (LF_ISSET(WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX)
-        return (!__wt_txn_visible_all(session, max_txn, max_ts));
+        return (!__wt_txn_visible_all(session, upd_select->start_txn, upd_select->start_ts));
 
     if (!LF_ISSET(WT_REC_HS))
         return false;
@@ -170,11 +170,13 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WT_UPDATE *selected_upd, uint64_t 
         return true;
 
     /* When in checkpoint, no need to save update if no onpage value is selected. */
-    if (LF_ISSET(WT_REC_CHECKPOINT) && selected_upd == NULL)
+    if (LF_ISSET(WT_REC_CHECKPOINT) && upd_select->upd == NULL)
         return false;
 
-    /* No need to save updates if everything is globally visible. */
-    return (!__wt_txn_visible_all(session, max_txn, max_ts));
+    if (__wt_txn_visible_all(session, upd_select->stop_txn, upd_select->stop_ts))
+        return false;
+
+    return (!__wt_txn_visible_all(session, upd_select->start_txn, upd_select->start_ts));
 }
 
 /*
@@ -192,15 +194,13 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     wt_timestamp_t checkpoint_timestamp, max_ts, tombstone_durable_ts;
     size_t size, upd_memsize;
     uint64_t max_txn, txnid;
-    bool has_newer_updates;
-    bool is_hs_page;
+    bool has_newer_updates, is_hs_page, upd_saved;
 
     /*
      * The "saved updates" return value is used independently of returning an update we can write,
      * both must be initialized.
      */
     upd_select->upd = NULL;
-    upd_select->upd_saved = false;
 
     page = r->page;
     first_txn_upd = upd = last_upd = NULL;
@@ -209,7 +209,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     max_ts = WT_TS_NONE;
     tombstone_durable_ts = WT_TS_MAX;
     max_txn = WT_TXN_NONE;
-    has_newer_updates = false;
+    has_newer_updates = upd_saved = false;
     is_hs_page = F_ISSET(S2BT(session), WT_BTREE_HS);
 
     /*
@@ -465,10 +465,9 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      *
      * Additionally history store reconciliation is not set skip saving an update.
      */
-    if (__rec_need_save_upd(
-          session, upd_select->upd, max_txn, max_ts, has_newer_updates, r->flags, page)) {
+    if (__rec_need_save_upd(session, upd_select, has_newer_updates, r->flags, page)) {
         WT_ERR(__rec_update_save(session, r, ins, ripcip, upd_select->upd, upd_memsize));
-        upd_select->upd_saved = true;
+        upd_saved = true;
     }
 
     /*
@@ -483,8 +482,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      * be physically removed once it's no longer needed.
      */
     if (upd_select->upd != NULL &&
-      (upd_select->upd_saved || (vpack != NULL && F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) &&
-                                  vpack->raw != WT_CELL_VALUE_OVFL_RM)))
+      (upd_saved || (vpack != NULL && F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) &&
+                      vpack->raw != WT_CELL_VALUE_OVFL_RM)))
         WT_ERR(__rec_append_orig_value(session, page, upd_select->upd, vpack));
 
 err:


### PR DESCRIPTION
When a remove becomes stable, stop writing keys even if some history is saved.  Then when a page becomes empty, it won't have any content and will have a NULL address.  These pages should be evicted into the DELETED state.  There was left over code for LIMBO pages (where a page could be empty in a checkpoint but have relevant history): this commit removes that code.