### PR TITLE
WT-5649 Refactor WT_REF locking, review all WT_REF.addr reads for locking issues

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -15,6 +15,7 @@
 static int
 __compact_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 {
+    WT_ADDR_COPY addr;
     WT_BM *bm;
     WT_MULTI *multi;
     WT_PAGE_MODIFY *mod;
@@ -24,13 +25,15 @@ __compact_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
     bm = S2BT(session)->bm;
 
+    /* If the page is clean, test the original addresses. */
+    if (__wt_page_evict_clean(ref->page))
+        return (__wt_ref_addr_copy(session, ref, &addr) ?
+            bm->compact_page_skip(bm, session, addr.addr, addr.size, skipp) :
+            0);
+
     /*
      * If the page is a replacement, test the replacement addresses. Ignore empty pages, they get
      * merged into the parent.
-     *
-     * Page-modify variable initialization done here because the page could be modified while we're
-     * looking at it, so the page modified structure may appear at any time (but cannot disappear).
-     * We've confirmed there is a page modify structure, it's OK to look at it.
      */
     mod = ref->page->modify;
     if (mod->rec_result == WT_PM_REC_REPLACE)
@@ -56,38 +59,19 @@ __compact_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 static int
 __compact_rewrite_lock(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 {
-    WT_BM *bm;
     WT_BTREE *btree;
     WT_DECL_RET;
-    size_t addr_size;
-    const uint8_t *addr;
-
-    *skipp = true; /* Default skip. */
 
     btree = S2BT(session);
-    bm = btree->bm;
-
-    /*
-     * If the page is clean, test the original addresses. We're holding a hazard pointer on the
-     * page, so we're safe from eviction, no additional locking is required.
-     */
-    if (__wt_page_evict_clean(ref->page)) {
-        __wt_ref_info(session, ref, &addr, &addr_size);
-        if (addr == NULL)
-            return (0);
-        return (bm->compact_page_skip(bm, session, addr, addr_size, skipp));
-    }
 
     /*
      * Reviewing in-memory pages requires looking at page reconciliation results, because we care
      * about where the page is stored now, not where the page was stored when we first read it into
      * the cache. We need to ensure we don't race with page reconciliation as it's writing the page
-     * modify information.
-     *
-     * There are two ways we call reconciliation: checkpoints and eviction. Get the tree's flush
-     * lock which blocks threads writing pages for checkpoints. If checkpoint is holding the lock,
-     * quit working this file, we'll visit it again in our next pass. As noted above, we're holding
-     * a hazard pointer on the page, we're safe from eviction.
+     * modify information. There are two ways we call reconciliation: checkpoints and eviction. We
+     * are holding a hazard pointer that blocks eviction, but there's nothing blocking a checkpoint.
+     * Get the tree's flush lock which blocks threads writing pages for checkpoints. If checkpoint
+     * is holding the lock, quit working this file, we'll visit it again in our next pass.
      */
     WT_RET(__wt_spin_trylock(session, &btree->flush_lock));
 
@@ -194,7 +178,11 @@ __wt_compact(WT_SESSION_IMPL *session)
          * Ignore the root: it may not have a replacement address, and besides, if anything else
          * gets written, so will it.
          *
-         * Ignore dirty pages, checkpoint writes them regardless.
+         * Ignore dirty pages, checkpoint will likely write them. There are cases where checkpoint
+         * can skip dirty pages: to avoid that, we could alter the transactional information of the
+         * page, which is what checkpoint reviews to decide if a page can be skipped. Not doing that
+         * for now, the repeated checkpoints that compaction requires are more than likely to pick
+         * up all dirty pages at some point.
          */
         if (__wt_ref_is_root(ref))
             continue;
@@ -227,13 +215,18 @@ err:
 int
 __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *skipp)
 {
+    WT_ADDR_COPY addr;
     WT_BM *bm;
-    size_t addr_size;
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t previous_state;
+    bool diskaddr;
 
     WT_UNUSED(context);
 
     *skipp = false; /* Default to reading */
+
+    /* Internal pages must be read to walk the tree. */
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+        return (0);
 
     /*
      * Skip deleted pages, rewriting them doesn't seem useful; in a better world we'd write the
@@ -246,20 +239,28 @@ __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, boo
 
     /*
      * If the page is in-memory, we want to look at it (it may have been modified and written, and
-     * the current location is the interesting one in terms of compaction, not the original
-     * location).
+     * the current location is the interesting one in terms of compaction, not the original).
      */
     if (ref->state != WT_REF_DISK)
         return (0);
 
     /*
-     * Internal pages must be read to walk the tree; ask the block-manager if it's useful to rewrite
-     * leaf pages, don't do the I/O if a rewrite won't help.
+     * Lock the WT_REF and if it's still on-disk, get a copy of the address. This is safe because
+     * it's an on-disk page and we're holding the WT_REF locked, so nobody can read the page giving
+     * either checkpoint or eviction a chance to modify the address.
      */
-    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+    for (;; __wt_yield()) {
+        previous_state = ref->state;
+        if (previous_state != WT_REF_LOCKED &&
+          WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
+            break;
+    }
+    diskaddr = previous_state == WT_REF_DISK && __wt_ref_addr_copy(session, ref, &addr);
+    WT_REF_SET_STATE(ref, previous_state);
+    if (!diskaddr)
         return (0);
 
-    __wt_ref_info_lock(session, ref, addr, &addr_size);
+    /* Ask the block-manager if it's useful to rewrite the page. */
     bm = S2BT(session)->bm;
-    return (bm->compact_page_skip(bm, session, addr, addr_size, skipp));
+    return (bm->compact_page_skip(bm, session, addr.addr, addr.size, skipp));
 }

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -249,14 +249,9 @@ __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, boo
      * it's an on-disk page and we're holding the WT_REF locked, so nobody can read the page giving
      * either checkpoint or eviction a chance to modify the address.
      */
-    for (;; __wt_yield()) {
-        previous_state = ref->state;
-        if (previous_state != WT_REF_LOCKED &&
-          WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
-            break;
-    }
+    WT_REF_LOCK(session, ref, &previous_state);
     diskaddr = previous_state == WT_REF_DISK && __wt_ref_addr_copy(session, ref, &addr);
-    WT_REF_SET_STATE(ref, previous_state);
+    WT_REF_UNLOCK(ref, previous_state);
     if (!diskaddr)
         return (0);
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -887,16 +887,13 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
 static int
 __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
 {
-    WT_ADDR *addr;
     WT_PAGE *page;
     WT_PAGE_INDEX *pindex;
     WT_PAGE_MODIFY *mod;
     WT_SESSION_IMPL *session;
     uint64_t split_gen;
     uint32_t entries;
-    char tp_string[2][WT_TP_STRING_SIZE];
 
-    addr = ref->addr;
     page = ref->page;
     session = ds->session;
     mod = page->modify;
@@ -932,6 +929,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
     }
 
     WT_RET(ds->f(ds, ": %s\n", __wt_page_type_string(page->type)));
+    WT_RET(__debug_ref(ds, ref));
+
     WT_RET(ds->f(ds,
       "\t"
       "disk %p",
@@ -976,14 +975,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
         WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));
     if (mod != NULL)
         WT_RET(ds->f(ds, ", page-state=%" PRIu32, mod->page_state));
-    if (addr != NULL)
-        WT_RET(ds->f(ds, ", start stop ts/txn %s,%s",
-          __wt_time_pair_to_string(addr->oldest_start_ts, addr->oldest_start_txn, tp_string[0]),
-          __wt_time_pair_to_string(addr->newest_stop_ts, addr->newest_stop_txn, tp_string[1])));
     WT_RET(ds->f(ds, ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
-    WT_RET(ds->f(ds, "\n"));
-
-    return (0);
+    return (ds->f(ds, "\n"));
 }
 
 /*
@@ -1353,30 +1346,29 @@ __debug_ref_state(u_int state)
 static int
 __debug_ref(WT_DBG *ds, WT_REF *ref)
 {
+    WT_ADDR_COPY addr;
     WT_SESSION_IMPL *session;
-    size_t addr_size;
-    const uint8_t *addr;
-    const char *flagsep;
+    char tp_string[2][WT_TP_STRING_SIZE];
+    char ts_string[WT_TS_INT_STRING_SIZE];
 
     session = ds->session;
 
-    WT_RET(ds->f(ds,
-      "\t"
-      "%p %s (",
-      (void *)ref, __debug_ref_state(ref->state)));
-    flagsep = "";
-    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
-        WT_RET(ds->f(ds, "%s%s", flagsep, "internal"));
-        flagsep = ", ";
-    }
-    if (F_ISSET(ref, WT_REF_FLAG_LEAF)) {
-        WT_RET(ds->f(ds, "%s%s", flagsep, "leaf"));
-        flagsep = ", ";
-    }
+    WT_RET(ds->f(ds, "\t%p, ", (void *)ref));
+    WT_RET(ds->f(ds, "%s", __debug_ref_state(ref->state)));
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+        WT_RET(ds->f(ds, ", %s", "internal"));
+    if (F_ISSET(ref, WT_REF_FLAG_LEAF))
+        WT_RET(ds->f(ds, ", %s", "leaf"));
     if (F_ISSET(ref, WT_REF_FLAG_READING))
-        WT_RET(ds->f(ds, "%s%s", flagsep, "reading"));
-    __wt_ref_info(session, ref, &addr, &addr_size);
-    return (ds->f(ds, ") %s\n", __wt_addr_string(session, addr, addr_size, ds->t1)));
+        WT_RET(ds->f(ds, ", %s", "reading"));
+
+    if (__wt_ref_addr_copy(session, ref, &addr))
+        WT_RET(ds->f(ds, ", newest-durable ts %s, start/stop ts/txn %s,%s, %s",
+          __wt_timestamp_to_string(addr.newest_durable_ts, ts_string),
+          __wt_time_pair_to_string(addr.oldest_start_ts, addr.oldest_start_txn, tp_string[0]),
+          __wt_time_pair_to_string(addr.newest_stop_ts, addr.newest_stop_txn, tp_string[1]),
+          __wt_addr_string(session, addr.addr, addr.size, ds->t1)));
+    return (ds->f(ds, "\n"));
 }
 
 /*

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -757,21 +757,18 @@ __wt_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
 static int
 __btree_preload(WT_SESSION_IMPL *session)
 {
+    WT_ADDR_COPY addr;
     WT_BM *bm;
     WT_BTREE *btree;
     WT_REF *ref;
-    size_t addr_size;
-    const uint8_t *addr;
 
     btree = S2BT(session);
     bm = btree->bm;
 
     /* Pre-load the second-level internal pages. */
-    WT_INTL_FOREACH_BEGIN (session, btree->root.page, ref) {
-        __wt_ref_info(session, ref, &addr, &addr_size);
-        if (addr != NULL)
-            WT_RET(bm->preload(bm, session, addr, addr_size));
-    }
+    WT_INTL_FOREACH_BEGIN (session, btree->root.page, ref)
+        if (__wt_ref_addr_copy(session, ref, &addr))
+            WT_RET(bm->preload(bm, session, addr.addr, addr.size));
     WT_INTL_FOREACH_END;
     return (0);
 }

--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -20,7 +20,7 @@ __wt_addr_string(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size
 
     btree = S2BT_SAFE(session);
 
-    if (addr == NULL) {
+    if (addr == NULL || addr_size == 0) {
         buf->data = WT_NO_ADDR_STRING;
         buf->size = strlen(WT_NO_ADDR_STRING);
     } else if (btree == NULL || (bm = btree->bm) == NULL ||

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -290,7 +290,8 @@ __sync_ref_obsolete_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_LIST *rl
         newest_stop_txn = addr.newest_stop_txn;
         newest_stop_ts = addr.newest_stop_ts;
         obsolete = __wt_txn_visible_all(session, newest_stop_txn, newest_stop_ts);
-    }
+    } else
+        tag = "unexpected page state";
 
     /* If the page is obsolete, add it to the list of pages to be evicted. */
     if (obsolete) {

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -537,24 +537,19 @@ __verify_checkpoint_reset(WT_VSTUFF *vs)
 static const char *
 __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
 {
+    WT_ADDR_COPY addr;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
-    wt_timestamp_t start_ts, stop_ts;
-    size_t addr_size;
-    uint64_t start_txn, stop_txn;
-    const uint8_t *addr;
     char tp_string[2][WT_TP_STRING_SIZE];
 
-    if (__wt_ref_is_root(ref)) {
-        buf->data = "[Root]";
-        buf->size = strlen("[Root]");
-        return (buf->data);
-    }
-    __wt_ref_info_all(session, ref, &addr, &addr_size, &start_ts, &stop_ts, &start_txn, &stop_txn);
-    WT_ERR(__wt_scr_alloc(session, 0, &tmp));
-    WT_ERR(__wt_buf_fmt(session, buf, "%s %s,%s", __wt_addr_string(session, addr, addr_size, tmp),
-      addr != NULL ? __wt_time_pair_to_string(start_ts, start_txn, tp_string[0]) : "-/-",
-      addr != NULL ? __wt_time_pair_to_string(stop_ts, stop_txn, tp_string[1]) : "-/-"));
+    if (__wt_ref_addr_copy(session, ref, &addr)) {
+        WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+        WT_ERR(__wt_buf_fmt(session, buf, "%s %s,%s",
+          __wt_addr_string(session, addr.addr, addr.size, tmp),
+          __wt_time_pair_to_string(addr.oldest_start_ts, addr.oldest_start_txn, tp_string[0]),
+          __wt_time_pair_to_string(addr.newest_stop_ts, addr.newest_stop_txn, tp_string[1])));
+    } else
+        WT_ERR(__wt_buf_fmt(session, buf, "%s -/-,-/-", __wt_addr_string(session, NULL, 0, tmp)));
 
 err:
     __wt_scr_free(session, &tmp);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -146,6 +146,25 @@ struct __wt_addr {
 };
 
 /*
+ * WT_ADDR_COPY --
+ *	We have to lock the WT_REF to look at a WT_ADDR: a structure we can use to quickly get a
+ * copy of the WT_REF address information.
+ */
+struct __wt_addr_copy {
+    /* Validity window */
+    wt_timestamp_t newest_durable_ts;
+    wt_timestamp_t oldest_start_ts;
+    uint64_t oldest_start_txn;
+    wt_timestamp_t newest_stop_ts;
+    uint64_t newest_stop_txn;
+
+    uint8_t type;
+
+    uint8_t addr[255 /* WT_BTREE_MAX_ADDR_COOKIE */];
+    uint8_t size;
+};
+
+/*
  * Overflow tracking for reuse: When a page is reconciled, we write new K/V overflow items. If pages
  * are reconciled multiple times, we need to know if we've already written a particular overflow
  * record (so we don't write it again), as well as if we've modified an overflow record previously

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -51,6 +51,11 @@ __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t old_state,
 static inline bool
 __wt_page_is_empty(WT_PAGE *page)
 {
+    /*
+     * Be cautious modifying this function: it's reading fields set by checkpoint reconciliation,
+     * and we're not blocking checkpoints (although we must block eviction as it might clear and
+     * free these structures).
+     */
     return (page->modify != NULL && page->modify->rec_result == WT_PM_REC_EMPTY);
 }
 
@@ -61,6 +66,11 @@ __wt_page_is_empty(WT_PAGE *page)
 static inline bool
 __wt_page_evict_clean(WT_PAGE *page)
 {
+    /*
+     * Be cautious modifying this function: it's reading fields set by checkpoint reconciliation,
+     * and we're not blocking checkpoints (although we must block eviction as it might clear and
+     * free these structures).
+     */
     return (page->modify == NULL ||
       (page->modify->page_state == WT_PAGE_CLEAN && page->modify->rec_result == 0));
 }
@@ -72,6 +82,11 @@ __wt_page_evict_clean(WT_PAGE *page)
 static inline bool
 __wt_page_is_modified(WT_PAGE *page)
 {
+    /*
+     * Be cautious modifying this function: it's reading fields set by checkpoint reconciliation,
+     * and we're not blocking checkpoints (although we must block eviction as it might clear and
+     * free these structures).
+     */
     return (page->modify != NULL && page->modify->page_state != WT_PAGE_CLEAN);
 }
 
@@ -1060,12 +1075,11 @@ __wt_row_leaf_value(WT_PAGE *page, WT_ROW *rip, WT_ITEM *value)
 }
 
 /*
- * __wt_ref_info_all --
- *     Return the addr/size, type and start/stop time pairs for a reference.
+ * __wt_ref_addr_copy --
+ *     Return a copy of the WT_REF address information.
  */
-static inline void
-__wt_ref_info_all(WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp, size_t *sizep,
-  wt_timestamp_t *start_ts, wt_timestamp_t *stop_ts, uint64_t *start_txn, uint64_t *stop_txn)
+static inline bool
+__wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
 {
     WT_ADDR *addr;
     WT_CELL_UNPACK *unpack, _unpack;
@@ -1075,93 +1089,30 @@ __wt_ref_info_all(WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp, 
     unpack = &_unpack;
     page = ref->home;
 
-    /*
-     * If NULL, there is no location. If off-page, the pointer references a WT_ADDR structure. If
-     * on-page, the pointer references a cell.
-     *
-     * The type is of a limited set: internal, leaf or no-overflow leaf.
-     */
-    if (addr == NULL) {
-        *addrp = NULL;
-        *sizep = 0;
-        if (start_ts != NULL)
-            *start_ts = 0;
-        if (stop_ts != NULL)
-            *stop_ts = 0;
-        if (start_txn != NULL)
-            *start_txn = 0;
-        if (stop_txn != NULL)
-            *stop_txn = 0;
-    } else if (__wt_off_page(page, addr)) {
-        *addrp = addr->addr;
-        *sizep = addr->size;
-        if (start_ts != NULL)
-            *start_ts = addr->oldest_start_ts;
-        if (start_txn != NULL)
-            *start_txn = addr->oldest_start_txn;
-        if (stop_ts != NULL)
-            *stop_ts = addr->oldest_start_ts;
-        if (stop_txn != NULL)
-            *stop_txn = addr->oldest_start_txn;
-    } else {
-        __wt_cell_unpack(session, page, (WT_CELL *)addr, unpack);
-        *addrp = unpack->data;
-        *sizep = unpack->size;
-        if (start_ts != NULL)
-            *start_ts = unpack->oldest_start_ts;
-        if (start_txn != NULL)
-            *start_txn = unpack->oldest_start_txn;
-        if (stop_ts != NULL)
-            *stop_ts = unpack->newest_stop_ts;
-        if (stop_txn != NULL)
-            *stop_txn = unpack->newest_stop_txn;
-    }
-}
+    /* If NULL, there is no information. */
+    if (addr == NULL)
+        return (false);
 
-/*
- * __wt_ref_info_lock --
- *     Lock the WT_REF and return the addr/size and type triplet for a reference.
- */
-static inline void
-__wt_ref_info_lock(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t *addr_buf, size_t *sizep)
-{
-    size_t size;
-    uint8_t previous_state;
-    const uint8_t *addr;
-
-    /*
-     * The WT_REF address references either an on-page cell or in-memory structure, and eviction
-     * frees both. If our caller is already blocking eviction (either because the WT_REF is locked
-     * or there's a hazard pointer on the page), no locking is required, and the caller should call
-     * the underlying function directly. Otherwise, our caller is not blocking eviction and we lock
-     * here, and copy out the address instead of returning a reference.
-     */
-    for (;; __wt_yield()) {
-        previous_state = ref->state;
-        if (previous_state != WT_REF_LOCKED &&
-          WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
-            break;
+    /* If off-page, the pointer references a WT_ADDR structure. */
+    if (__wt_off_page(page, addr)) {
+        copy->newest_durable_ts = addr->newest_durable_ts;
+        copy->oldest_start_ts = addr->oldest_start_ts;
+        copy->oldest_start_txn = addr->oldest_start_txn;
+        copy->newest_stop_ts = addr->newest_stop_ts;
+        copy->newest_stop_txn = addr->newest_stop_txn;
+        memcpy(copy->addr, addr->addr, copy->size = addr->size);
+        return (true);
     }
 
-    __wt_ref_info(session, ref, &addr, &size);
-
-    if (addr_buf != NULL) {
-        if (addr != NULL)
-            memcpy(addr_buf, addr, size);
-        *sizep = size;
-    }
-
-    WT_REF_SET_STATE(ref, previous_state);
-}
-
-/*
- * __wt_ref_info --
- *     Return the address, size and type triplet for a reference.
- */
-static inline void
-__wt_ref_info(WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp, size_t *sizep)
-{
-    __wt_ref_info_all(session, ref, addrp, sizep, NULL, NULL, NULL, NULL);
+    /* If on-page, the pointer references a cell. */
+    __wt_cell_unpack(session, page, (WT_CELL *)addr, unpack);
+    copy->newest_durable_ts = unpack->newest_durable_ts;
+    copy->oldest_start_ts = unpack->oldest_start_ts;
+    copy->oldest_start_txn = unpack->oldest_start_txn;
+    copy->newest_stop_ts = unpack->newest_stop_ts;
+    copy->newest_stop_txn = unpack->newest_stop_txn;
+    memcpy(copy->addr, unpack->data, copy->size = (uint8_t)unpack->size);
+    return (true);
 }
 
 /*
@@ -1171,14 +1122,12 @@ __wt_ref_info(WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp, size
 static inline int
 __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
 {
-    size_t addr_size;
-    const uint8_t *addr;
+    WT_ADDR_COPY addr;
 
-    if (ref->addr == NULL)
+    if (!__wt_ref_addr_copy(session, ref, &addr))
         return (0);
 
-    __wt_ref_info(session, ref, &addr, &addr_size);
-    WT_RET(__wt_btree_block_free(session, addr, addr_size));
+    WT_RET(__wt_btree_block_free(session, addr.addr, addr.size));
 
     /* Clear the address (so we don't free it twice). */
     __wt_ref_addr_free(session, ref);

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1130,6 +1130,7 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
     copy->oldest_start_txn = unpack->oldest_start_txn;
     copy->newest_stop_ts = unpack->newest_stop_ts;
     copy->newest_stop_txn = unpack->newest_stop_txn;
+    copy->type = 0; /* Avoid static analyzer uninitialized value complaints. */
     switch (unpack->raw) {
     case WT_CELL_ADDR_INT:
         copy->type = WT_ADDR_INT;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -731,7 +731,7 @@ extern int __wt_getopt(const char *progname, int nargc, char *const *nargv, cons
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
+extern int __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
 #ifdef HAVE_DIAGNOSTIC
   ,
   const char *func, int line
@@ -1805,6 +1805,8 @@ static inline bool __wt_page_is_modified(WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_rec_need_split(WT_RECONCILE *r, size_t len)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t old_state,
   uint8_t new_state, const char *func, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_ref_is_root(WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2151,13 +2153,6 @@ static inline void __wt_rec_cell_build_addr(
 static inline void __wt_rec_image_copy(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv);
 static inline void __wt_rec_incr(
   WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, size_t size);
-static inline void __wt_ref_info(
-  WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp, size_t *sizep);
-static inline void __wt_ref_info_all(WT_SESSION_IMPL *session, WT_REF *ref, const uint8_t **addrp,
-  size_t *sizep, wt_timestamp_t *start_ts, wt_timestamp_t *stop_ts, uint64_t *start_txn,
-  uint64_t *stop_txn);
-static inline void __wt_ref_info_lock(
-  WT_SESSION_IMPL *session, WT_REF *ref, uint8_t *addr_buf, size_t *sizep);
 static inline void __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep);
 static inline void __wt_ref_key_clear(WT_REF *ref);
 static inline void __wt_ref_key_onpage_set(WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK *unpack);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -294,12 +294,15 @@
  * acquired.
  */
 #ifdef HAVE_DIAGNOSTIC
+#define __wt_hazard_set(session, walk, busyp) \
+    __wt_hazard_set_func(session, walk, busyp, __func__, __LINE__)
 #define __wt_scr_alloc(session, size, scratchp) \
     __wt_scr_alloc_func(session, size, scratchp, __func__, __LINE__)
 #define __wt_page_in(session, ref, flags) __wt_page_in_func(session, ref, flags, __func__, __LINE__)
 #define __wt_page_swap(session, held, want, flags) \
     __wt_page_swap_func(session, held, want, flags, __func__, __LINE__)
 #else
+#define __wt_hazard_set(session, walk, busyp) __wt_hazard_set_func(session, walk, busyp)
 #define __wt_scr_alloc(session, size, scratchp) __wt_scr_alloc_func(session, size, scratchp)
 #define __wt_page_in(session, ref, flags) __wt_page_in_func(session, ref, flags)
 #define __wt_page_swap(session, held, want, flags) __wt_page_swap_func(session, held, want, flags)

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -67,6 +67,8 @@ extern "C" {
  */
 struct __wt_addr;
 typedef struct __wt_addr WT_ADDR;
+struct __wt_addr_copy;
+typedef struct __wt_addr_copy WT_ADDR_COPY;
 struct __wt_async;
 typedef struct __wt_async WT_ASYNC;
 struct __wt_async_cursor;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2058,12 +2058,10 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 {
     WT_BM *bm;
     WT_BTREE *btree;
-    WT_DECL_RET;
     WT_MULTI *multi;
     WT_PAGE_MODIFY *mod;
     WT_REF *ref;
     uint32_t i;
-    uint8_t previous_state;
 
     btree = S2BT(session);
     bm = btree->bm;
@@ -2088,23 +2086,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
         if (__wt_ref_is_root(ref))
             break;
 
-        /*
-         * We're about to discard the WT_REF.addr field, and that can race with the cursor walk code
-         * examining tree WT_REFs for leaf pages. Lock the WT_REF unless we know we have exclusive
-         * access.
-         */
-        previous_state = WT_REF_LOCKED; /* -Wuninitialized */
-        if (!F_ISSET(r, WT_REC_EVICT))
-            for (;; __wt_yield()) {
-                previous_state = ref->state;
-                if (previous_state != WT_REF_LOCKED &&
-                  WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
-                    break;
-            }
-        ret = __wt_ref_block_free(session, ref);
-        if (!F_ISSET(r, WT_REC_EVICT))
-            WT_REF_SET_STATE(ref, previous_state);
-        WT_RET(ret);
+        WT_RET(__wt_ref_block_free(session, ref));
         break;
     case WT_PM_REC_EMPTY: /* Page deleted */
         break;

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -57,11 +57,11 @@ hazard_grow(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_hazard_set --
+ * __wt_hazard_set_func --
  *     Set a hazard pointer.
  */
 int
-__wt_hazard_set(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
+__wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
 #ifdef HAVE_DIAGNOSTIC
   ,
   const char *func, int line


### PR DESCRIPTION
@kommiharibabu, @tetsuo-cpp: here are some changes to fix problems with looking at the `WT_REF.addr` fields.

In summary, it's not safe look at `WT_REF.addr` (including the associated timestamps), unless we know they won't change underfoot, and that means we either lock them somehow or ensure that checkpoint & eviction are both ignoring the `WT_REF` when we're looking at them.

I tried to come up with some kind of locking scheme, but failed -- we just touch those fields all over the place, and most of the time it's fine, I believe it's just compaction and checkpoint-sync we have to worry about. I'm a little worried about fast-truncate, too, but I didn't spot any problems.

Let me know if you see an approach that leads to a locking solution, I'm happy to back off from this change if there's a better one!

@kommiharibabu, I ended up reworking `bt_sync.c:__sync_ref_obsolete_check()` in major ways, please look at it carefully.

What I did to find everywhere a `WT_REF.addr` was touched was to change the field name and work my way through all the compiler complaints, convincing myself the usage was safe.

If there are any questions about what I'm doing and why I think it's safe, maybe it's worth the three of us meeting and talking through the change, just let me know.