### PR TITLE
WT-5762 Make test_hs10 more robust

### DIFF
--- a/test/suite/test_hs10.py
+++ b/test/suite/test_hs10.py
@@ -83,10 +83,8 @@ class test_hs10(wttest.WiredTigerTestCase):
 
         # Insert a whole bunch of data into the other table to force wiredtiger to evict data
         # from the previous table.
-        session2.begin_transaction()
         for i in range(1, 10000):
             cursor2[i] = value2
-        session2.commit_transaction()
 
         # Validate that we see the correct value at each of the timestamps.
         self.session.begin_transaction('read_timestamp=' + timestamp_str(3))


### PR DESCRIPTION
Don't wrap the updates that are supposed to flush the cache into a
single transaction.