### PR TITLE
WT-5654 Reserve extra space in history store format for future schema changes

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -744,8 +744,9 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
     WT_UPDATE *upd;
     wt_timestamp_t hs_durable_ts;
     size_t notused;
+    uint64_t hs_extra;
     uint32_t hs_btree_id;
-    uint8_t hs_prep_state, hs_upd_type;
+    uint8_t hs_flags, hs_prep_state, hs_upd_type;
 
     ds = &_ds;
     notused = 0;
@@ -759,7 +760,10 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
 
     WT_ERR(__debug_time_pairs(ds, "T", start.timestamp, start.txnid, stop.timestamp, stop.txnid));
 
-    WT_ERR(hs_cursor->get_value(hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type, hs_value));
+    WT_ERR(hs_cursor->get_value(
+      hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type, hs_value, &hs_flags, &hs_extra));
+    WT_ASSERT(session, hs_flags == 0);
+    WT_ASSERT(session, hs_extra == 0);
     switch (hs_upd_type) {
     case WT_UPDATE_MODIFY:
         WT_ERR(__wt_update_alloc(session, hs_value, &upd, &notused, hs_upd_type));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -744,6 +744,7 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
     WT_UPDATE *upd;
     wt_timestamp_t hs_durable_ts;
     size_t notused;
+    uint64_t hs_upd_type_full;
     uint32_t hs_btree_id;
     uint8_t hs_prep_state, hs_upd_type;
 
@@ -759,7 +760,9 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
 
     WT_ERR(__debug_time_pairs(ds, "T", start.timestamp, start.txnid, stop.timestamp, stop.txnid));
 
-    WT_ERR(hs_cursor->get_value(hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type, hs_value));
+    WT_ERR(
+      hs_cursor->get_value(hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type_full, hs_value));
+    hs_upd_type = (uint8_t)hs_upd_type_full;
     switch (hs_upd_type) {
     case WT_UPDATE_MODIFY:
         WT_ERR(__wt_update_alloc(session, hs_value, &upd, &notused, hs_upd_type));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -744,9 +744,8 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
     WT_UPDATE *upd;
     wt_timestamp_t hs_durable_ts;
     size_t notused;
-    uint64_t hs_extra;
     uint32_t hs_btree_id;
-    uint8_t hs_flags, hs_prep_state, hs_upd_type;
+    uint8_t hs_prep_state, hs_upd_type;
 
     ds = &_ds;
     notused = 0;
@@ -760,10 +759,7 @@ __wt_debug_cursor_hs(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor)
 
     WT_ERR(__debug_time_pairs(ds, "T", start.timestamp, start.txnid, stop.timestamp, stop.txnid));
 
-    WT_ERR(hs_cursor->get_value(
-      hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type, hs_value, &hs_flags, &hs_extra));
-    WT_ASSERT(session, hs_flags == 0);
-    WT_ASSERT(session, hs_extra == 0);
+    WT_ERR(hs_cursor->get_value(hs_cursor, &hs_durable_ts, &hs_prep_state, &hs_upd_type, hs_value));
     switch (hs_upd_type) {
     case WT_UPDATE_MODIFY:
         WT_ERR(__wt_update_alloc(session, hs_value, &upd, &notused, hs_upd_type));

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -355,7 +355,7 @@ retry:
      */
     cursor->set_key(
       cursor, btree->id, key, upd->start_ts, __wt_atomic_add64(&btree->hs_counter, 1));
-    cursor->set_value(cursor, stop_ts_pair.timestamp, upd->durable_ts, type, hs_value);
+    cursor->set_value(cursor, stop_ts_pair.timestamp, upd->durable_ts, (uint64_t)type, hs_value);
 
     /* Only create the update chain the first time we try inserting into the history store. */
     if (hs_upd == NULL) {
@@ -786,7 +786,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
     wt_timestamp_t durable_timestamp, durable_timestamp_tmp, hs_start_ts, hs_start_ts_tmp;
     wt_timestamp_t hs_stop_ts, hs_stop_ts_tmp, read_timestamp, saved_timestamp;
     size_t notused, size;
-    uint64_t hs_counter, hs_counter_tmp;
+    uint64_t hs_counter, hs_counter_tmp, upd_type_full;
     uint32_t hs_btree_id, session_flags;
     uint8_t *p, recno_key[WT_INTPACK64_MAXSIZE], upd_type;
     int cmp;
@@ -854,7 +854,9 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
     if (cmp != 0)
         goto done;
 
-    WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_timestamp, &upd_type, hs_value));
+    WT_ERR(
+      hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_timestamp, &upd_type_full, hs_value));
+    upd_type = (uint8_t)upd_type_full;
 
     /* We do not have tombstones in the history store anymore. */
     WT_ASSERT(session, upd_type != WT_UPDATE_TOMBSTONE);
@@ -917,7 +919,8 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
             }
 
             WT_ERR(hs_cursor->get_value(
-              hs_cursor, &hs_stop_ts_tmp, &durable_timestamp_tmp, &upd_type, hs_value));
+              hs_cursor, &hs_stop_ts_tmp, &durable_timestamp_tmp, &upd_type_full, hs_value));
+            upd_type = (uint8_t)upd_type_full;
         }
 
         WT_ASSERT(session, upd_type == WT_UPDATE_STANDARD);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -355,8 +355,7 @@ retry:
      */
     cursor->set_key(
       cursor, btree->id, key, upd->start_ts, __wt_atomic_add64(&btree->hs_counter, 1));
-    cursor->set_value(
-      cursor, stop_ts_pair.timestamp, upd->durable_ts, type, hs_value, (uint8_t)0, (uint64_t)0);
+    cursor->set_value(cursor, stop_ts_pair.timestamp, upd->durable_ts, type, hs_value);
 
     /* Only create the update chain the first time we try inserting into the history store. */
     if (hs_upd == NULL) {
@@ -787,9 +786,9 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
     wt_timestamp_t durable_timestamp, durable_timestamp_tmp, hs_start_ts, hs_start_ts_tmp;
     wt_timestamp_t hs_stop_ts, hs_stop_ts_tmp, read_timestamp, saved_timestamp;
     size_t notused, size;
-    uint64_t hs_counter, hs_counter_tmp, hs_extra;
+    uint64_t hs_counter, hs_counter_tmp;
     uint32_t hs_btree_id, session_flags;
-    uint8_t hs_flags, *p, recno_key[WT_INTPACK64_MAXSIZE], upd_type;
+    uint8_t *p, recno_key[WT_INTPACK64_MAXSIZE], upd_type;
     int cmp;
     bool modify;
 
@@ -855,14 +854,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
     if (cmp != 0)
         goto done;
 
-    WT_ERR(hs_cursor->get_value(
-      hs_cursor, &hs_stop_ts, &durable_timestamp, &upd_type, hs_value, &hs_flags, &hs_extra));
-    /*
-     * We're storing a flags byte and 8 bytes of extra data to cope with future requirements. At the
-     * moment we're not using them for anything so they should both be set to zero.
-     */
-    WT_ASSERT(session, hs_flags == 0);
-    WT_ASSERT(session, hs_extra == 0);
+    WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_timestamp, &upd_type, hs_value));
 
     /* We do not have tombstones in the history store anymore. */
     WT_ASSERT(session, upd_type != WT_UPDATE_TOMBSTONE);
@@ -924,10 +916,8 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE **upd
                 break;
             }
 
-            WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts_tmp, &durable_timestamp_tmp,
-              &upd_type, hs_value, &hs_flags, &hs_extra));
-            WT_ASSERT(session, hs_flags == 0);
-            WT_ASSERT(session, hs_extra == 0);
+            WT_ERR(hs_cursor->get_value(
+              hs_cursor, &hs_stop_ts_tmp, &durable_timestamp_tmp, &upd_type, hs_value));
         }
 
         WT_ASSERT(session, upd_type == WT_UPDATE_STANDARD);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -201,8 +201,8 @@ struct __wt_ovfl_reuse {
  *	- value
  * In order to cope with future requirements whilst avoiding a data format change, we've added a
  * flags byte and 8 bytes of data at the end of the value. If we decide to use this flags byte, it's
- *important that we DO NOT use auto generated flags since the values need to remain consistent
- *across versions.
+ * important that we DO NOT use auto generated flags since the values need to remain consistent
+ * across versions.
  *
  * As the key for the history store table is different for row- and column-store, we store both key
  * types in a WT_ITEM, building/parsing them in the code, because otherwise we'd need two

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -201,8 +201,8 @@ struct __wt_ovfl_reuse {
  *	- value
  * In order to cope with future requirements whilst avoiding a data format change, we've added a
  * flags byte and 8 bytes of data at the end of the value. If we decide to use this flags byte, it's
- * important that we DO NOT use auto generated flags since the values need to remain consistent
- * across versions.
+ *important that we DO NOT use auto generated flags since the values need to remain consistent
+ *across versions.
  *
  * As the key for the history store table is different for row- and column-store, we store both key
  * types in a WT_ITEM, building/parsing them in the code, because otherwise we'd need two

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -206,6 +206,12 @@ struct __wt_ovfl_reuse {
  * standard by moving the source key into the history store table value, but that doesn't make the
  * coding any simpler, and it makes the history store table's value more likely to overflow the page
  * size when the row-store key is relatively large.
+ *
+ * Note that we deliberately store the update type as larger than necessary (8 bytes vs 1 byte).
+ * We've done this to leave room in case we need to store extra bit flags in this value at a later
+ * point. If we need to store more information, we can potentially tack extra information at the end
+ * of the "value" buffer and then use bit flags within the update type to determine how to interpret
+ * it.
  */
 #ifdef HAVE_BUILTIN_EXTENSION_SNAPPY
 #define WT_HS_COMPRESSOR "snappy"
@@ -214,7 +220,7 @@ struct __wt_ovfl_reuse {
 #endif
 #define WT_HS_CONFIG                                                              \
     "key_format=" WT_UNCHECKED_STRING(IuQQ) ",value_format=" WT_UNCHECKED_STRING( \
-      QQBu) ",block_compressor=" WT_HS_COMPRESSOR                                 \
+      QQQu) ",block_compressor=" WT_HS_COMPRESSOR                                 \
             ",leaf_value_max=64MB"                                                \
             ",prefix_compression=false"
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -198,7 +198,11 @@ struct __wt_ovfl_reuse {
  * 	- stop timestamp
  * 	- durable timestamp
  *	- update type
- *	- value.
+ *	- value
+ * In order to cope with future requirements whilst avoiding a data format change, we've added a
+ * flags byte and 8 bytes of data at the end of the value. If we decide to use this flags byte, it's
+ *important that we DO NOT use auto generated flags since the values need to remain consistent
+ *across versions.
  *
  * As the key for the history store table is different for row- and column-store, we store both key
  * types in a WT_ITEM, building/parsing them in the code, because otherwise we'd need two
@@ -214,9 +218,9 @@ struct __wt_ovfl_reuse {
 #endif
 #define WT_HS_CONFIG                                                              \
     "key_format=" WT_UNCHECKED_STRING(IuQQ) ",value_format=" WT_UNCHECKED_STRING( \
-      QQBu) ",block_compressor=" WT_HS_COMPRESSOR                                 \
-            ",leaf_value_max=64MB"                                                \
-            ",prefix_compression=false"
+      QQBuBQ) ",block_compressor=" WT_HS_COMPRESSOR                               \
+              ",leaf_value_max=64MB"                                              \
+              ",prefix_compression=false"
 
 /*
  * WT_PAGE_MODIFY --

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -198,11 +198,7 @@ struct __wt_ovfl_reuse {
  * 	- stop timestamp
  * 	- durable timestamp
  *	- update type
- *	- value
- * In order to cope with future requirements whilst avoiding a data format change, we've added a
- * flags byte and 8 bytes of data at the end of the value. If we decide to use this flags byte, it's
- *important that we DO NOT use auto generated flags since the values need to remain consistent
- *across versions.
+ *	- value.
  *
  * As the key for the history store table is different for row- and column-store, we store both key
  * types in a WT_ITEM, building/parsing them in the code, because otherwise we'd need two
@@ -218,9 +214,9 @@ struct __wt_ovfl_reuse {
 #endif
 #define WT_HS_CONFIG                                                              \
     "key_format=" WT_UNCHECKED_STRING(IuQQ) ",value_format=" WT_UNCHECKED_STRING( \
-      QQBuBQ) ",block_compressor=" WT_HS_COMPRESSOR                               \
-              ",leaf_value_max=64MB"                                              \
-              ",prefix_compression=false"
+      QQBu) ",block_compressor=" WT_HS_COMPRESSOR                                 \
+            ",leaf_value_max=64MB"                                                \
+            ",prefix_compression=false"
 
 /*
  * WT_PAGE_MODIFY --

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -141,9 +141,9 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     WT_UPDATE *hs_upd, *upd;
     wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts, newer_hs_ts;
     size_t size;
-    uint64_t hs_counter, hs_extra;
+    uint64_t hs_counter;
     uint32_t hs_btree_id, session_flags;
-    uint8_t hs_flags, type;
+    uint8_t type;
     int cmp;
     bool valid_update_found;
 
@@ -208,14 +208,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
         cbt->compare = 0;
 
         /* Get current value and convert to full update if it is a modify. */
-        WT_ERR(hs_cursor->get_value(
-          hs_cursor, &hs_stop_ts, &durable_ts, &type, hs_value, &hs_flags, &hs_extra));
-        /*
-         * We're storing a flags byte and 8 bytes of extra data to cope with future requirements. At
-         * the moment we're not using them for anything so they should both be set to zero.
-         */
-        WT_ASSERT(session, hs_flags == 0);
-        WT_ASSERT(session, hs_extra == 0);
+        WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_ts, &type, hs_value));
         if (type == WT_UPDATE_MODIFY)
             WT_ERR(__wt_modify_apply_item(session, &full_value, hs_value->data, false));
         else {

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -141,9 +141,9 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     WT_UPDATE *hs_upd, *upd;
     wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts, newer_hs_ts;
     size_t size;
-    uint64_t hs_counter;
+    uint64_t hs_counter, hs_extra;
     uint32_t hs_btree_id, session_flags;
-    uint8_t type;
+    uint8_t hs_flags, type;
     int cmp;
     bool valid_update_found;
 
@@ -208,7 +208,14 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
         cbt->compare = 0;
 
         /* Get current value and convert to full update if it is a modify. */
-        WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_ts, &type, hs_value));
+        WT_ERR(hs_cursor->get_value(
+          hs_cursor, &hs_stop_ts, &durable_ts, &type, hs_value, &hs_flags, &hs_extra));
+        /*
+         * We're storing a flags byte and 8 bytes of extra data to cope with future requirements. At
+         * the moment we're not using them for anything so they should both be set to zero.
+         */
+        WT_ASSERT(session, hs_flags == 0);
+        WT_ASSERT(session, hs_extra == 0);
         if (type == WT_UPDATE_MODIFY)
             WT_ERR(__wt_modify_apply_item(session, &full_value, hs_value->data, false));
         else {

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -141,7 +141,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     WT_UPDATE *hs_upd, *upd;
     wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts, newer_hs_ts;
     size_t size;
-    uint64_t hs_counter;
+    uint64_t hs_counter, type_full;
     uint32_t hs_btree_id, session_flags;
     uint8_t type;
     int cmp;
@@ -208,7 +208,8 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
         cbt->compare = 0;
 
         /* Get current value and convert to full update if it is a modify. */
-        WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_ts, &type, hs_value));
+        WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_ts, &type_full, hs_value));
+        type = (uint8_t)type_full;
         if (type == WT_UPDATE_MODIFY)
             WT_ERR(__wt_modify_apply_item(session, &full_value, hs_value->data, false));
         else {


### PR DESCRIPTION
This PR is reserving some extra space in the history store schema to future proof our decision and allow us to add more things if need be. We've decided on extending the `update_type` to 8 bytes. We can then tack on extra data to the `value` buffer and set bit flags on the `update_type` to determine how to interpret it.