### PR TITLE
WT-5756 Don't copy data from cursor for reserve update

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -266,7 +266,7 @@ __wt_update_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, WT_UPDATE **up
      */
     WT_ASSERT(session, modify_type != WT_UPDATE_INVALID);
 
-    if (modify_type == WT_UPDATE_TOMBSTONE)
+    if (modify_type == WT_UPDATE_TOMBSTONE || modify_type == WT_UPDATE_RESERVE)
         value = NULL;
 
     /* Allocate the WT_UPDATE structure and room for the value, then copy any value into place. */


### PR DESCRIPTION
We copy some garbage data from cursor when we allocate update for reserve. Similar problem to WT-5745. I don't know why this is not failing before durable history. @michaelcahill 