### PR TITLE
WT-5119 Birthmark records can be read as normal updates if reads race with checkpoints. (#5082) [Backport to 4.0]

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -16,6 +16,13 @@
         (v) = (val);        \
     } while (0)
 
+/* Write after all previous stores are completed. */
+#define WT_ORDERED_WRITE(v, val) \
+    do {                         \
+        WT_WRITE_BARRIER();      \
+        (v) = (val);             \
+    } while (0)
+
 /*
  * Read a shared location and guarantee that subsequent reads do not see any earlier state.
  */


### PR DESCRIPTION
* We need to make sure the WT_UPDATE txnid is set to WT_TXN_ABORTED before the type is switched to
WT_UPDATE_STANDARD, otherwise a read can race with the update and read the birthmark record as a
normal update.

* The most conservative version of this fix, committed for discussion.

Add/Use a WT_ORDERED_WRITE macro, currently synonymous with WT_PUBLISH.

(cherry picked from commit e3cbe6dc8dfb3e39fc014ac32e6192d7fe469677)