### PR TITLE
WT-5774 Move stress test tasks into a separate build variant

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2237,15 +2237,6 @@ buildvariants:
     - name: wtperf-test
     - name: ftruncate-test
     - name: long-test
-    - name: recovery-stress-test
-    - name: format-stress-sanitizer-test
-    - name: format-stress-sanitizer-smoke-test
-    - name: format-stress-sanitizer-lsm-test
-    - name: split-stress-test
-    - name: format-stress-test
-    - name: format-stress-smoke-test
-    - name: race-condition-stress-sanitizer-test
-    - name: checkpoint-stress-test
     - name: static-wt-build-test
 
 - name: ubuntu1804-compilers
@@ -2274,6 +2265,26 @@ buildvariants:
     - name: compile
     - name: ".unit_test"
     - name: conf-dump-test
+
+- name: ubuntu1804-stress-tests
+  display_name: Ubuntu 18.04 Stress tests
+  run_on:
+  - ubuntu1804-test
+  expansions:
+    test_env_vars: LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
+    make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
+  tasks:
+    - name: recovery-stress-test
+    - name: format-stress-sanitizer-test
+    - name: format-stress-sanitizer-smoke-test
+    - name: format-stress-sanitizer-lsm-test
+    - name: split-stress-test
+    - name: format-stress-test
+    - name: format-stress-smoke-test
+    - name: race-condition-stress-sanitizer-test
+    - name: checkpoint-stress-test
 
 - name: package
   display_name: Package
@@ -2338,8 +2349,8 @@ buildvariants:
     # Temporarily disabled
     # - name: coverage-report
 
-- name: large-scale-test
-  display_name: Large scale testing
+- name: large-scale-tests
+  display_name: Large scale tests
   batchtime: 1440 # 1 day
   run_on:
   - rhel80-build


### PR DESCRIPTION
Hopefully, this change could make finding stress tasks and triaging test failures easier. 