### PR TITLE
WT-5696 Reconciliation use commit timestamp of cell as durable timestamp

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -578,6 +578,31 @@ __rollback_page_needs_abort(
     return (false);
 }
 
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __rollback_verify_ondisk_page --
+ *     Verify the on-disk page that it doesn't have updates newer than the timestamp.
+ */
+static void
+__rollback_verify_ondisk_page(
+  WT_SESSION_IMPL *session, WT_PAGE *page, wt_timestamp_t rollback_timestamp)
+{
+    WT_CELL_UNPACK *vpack, _vpack;
+    WT_ROW *rip;
+    uint32_t i;
+
+    vpack = &_vpack;
+
+    /* Review updates that belong to keys that are on the disk image. */
+    WT_ROW_FOREACH (page, rip, i) {
+        __wt_row_leaf_value_cell(session, page, rip, NULL, vpack);
+        WT_ASSERT(session, vpack->start_ts <= rollback_timestamp);
+        if (vpack->stop_ts != WT_TS_MAX)
+            WT_ASSERT(session, vpack->stop_ts <= rollback_timestamp);
+    }
+}
+#endif
+
 /*
  * __rollback_abort_newer_updates --
  *     Abort updates on this page newer than the timestamp.
@@ -607,6 +632,13 @@ __rollback_abort_newer_updates(
     if ((page = ref->page) == NULL || !__wt_page_is_modified(page)) {
         if (!__rollback_page_needs_abort(session, ref, rollback_timestamp)) {
             __wt_verbose(session, WT_VERB_RTS, "%p: page skipped", (void *)ref);
+#ifdef HAVE_DIAGNOSTIC
+            if (ref->page == NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+                WT_RET(__wt_page_in(session, ref, 0));
+                __rollback_verify_ondisk_page(session, ref->page, rollback_timestamp);
+                WT_TRET(__wt_page_release(session, ref, 0));
+            }
+#endif
             return (0);
         }
 


### PR DESCRIPTION
Currently, the value cell doesn't store the durable timestamp and when a page
is getting reconciled again with no newer updates on the page to be considered,
the aggregated durable timestamp is calculated as zero. This gets fixed when
the value cell has durable timestamp, till then consider the commit timestamp
instead of zero.