### PR TITLE
WT-5615 Coverity-Read of uninitialised value

### DIFF
--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -90,6 +90,7 @@ __wt_key_string(
      * If the format is 'S', it's a string and our version of it may not yet be nul-terminated.
      */
     if (WT_STREQ(key_format, "S") && ((char *)data_arg)[size - 1] != '\0') {
+        WT_CLEAR(tmp);
         if (__wt_buf_fmt(session, &tmp, "%.*s", (int)size, (char *)data_arg) == 0) {
             data_arg = tmp.data;
             size = tmp.size + 1;


### PR DESCRIPTION
Memset the `tmp` variable to 0 with `WT_CLEAR`.