### PR TITLE
WT-5780 Avoid inserting updates into history store with same start/st…

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -475,7 +475,7 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
      * out-of-order timestamps), so this value can never be seen, don't bother inserting it.
      */
     if (stop_ts_pair.timestamp < upd->start_ts ||
-      (stop_ts_pair.timestamp == upd->start_ts && stop_ts_pair.txnid <= upd->txnid)) {
+      (stop_ts_pair.timestamp != WT_TS_NONE && stop_ts_pair.timestamp == upd->start_ts)) {
         char ts_string[2][WT_TS_INT_STRING_SIZE];
         __wt_verbose(session, WT_VERB_TIMESTAMP,
           "Warning: fixing out-of-order timestamps %s earlier than previous update %s",
@@ -685,7 +685,12 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
             WT_ASSERT(session, upd->type == WT_UPDATE_STANDARD || upd->type == WT_UPDATE_MODIFY);
 
             __wt_modify_vector_pop(&modifies, &prev_upd);
-            stop_ts_pair.timestamp = prev_upd->start_ts;
+
+            /* Set the stop timestamp from durable or commit timestamp. */
+            if (prev_upd->durable_ts != WT_TS_NONE)
+                stop_ts_pair.timestamp = prev_upd->durable_ts;
+            else
+                stop_ts_pair.timestamp = prev_upd->start_ts;
             stop_ts_pair.txnid = prev_upd->txnid;
 
             if (prev_upd->type == WT_UPDATE_TOMBSTONE) {

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -686,11 +686,13 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
 
             __wt_modify_vector_pop(&modifies, &prev_upd);
 
-            /* Set the stop timestamp from durable or commit timestamp. */
-            if (prev_upd->durable_ts != WT_TS_NONE)
-                stop_ts_pair.timestamp = prev_upd->durable_ts;
-            else
-                stop_ts_pair.timestamp = prev_upd->start_ts;
+            /*
+             * Set the stop timestamp from durable timestamp instead of commit timestamp. The
+             * Garbage collection of history store removes the history values once the stop
+             * timestamp is globally visible. i.e. durable timestamp of data store version.
+             */
+            WT_ASSERT(session, prev_upd->start_ts <= prev_upd->durable_ts)
+            stop_ts_pair.timestamp = prev_upd->durable_ts;
             stop_ts_pair.txnid = prev_upd->txnid;
 
             if (prev_upd->type == WT_UPDATE_TOMBSTONE) {

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -691,7 +691,7 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
              * Garbage collection of history store removes the history values once the stop
              * timestamp is globally visible. i.e. durable timestamp of data store version.
              */
-            WT_ASSERT(session, prev_upd->start_ts <= prev_upd->durable_ts)
+            WT_ASSERT(session, prev_upd->start_ts <= prev_upd->durable_ts);
             stop_ts_pair.timestamp = prev_upd->durable_ts;
             stop_ts_pair.txnid = prev_upd->txnid;
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -429,8 +429,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      * a record. We don't want to generate a warning in that case.
      */
     if (upd_select->stop_ts < upd_select->start_ts ||
-      (upd_select->stop_ts == upd_select->start_ts &&
-          upd_select->stop_txn < upd_select->start_txn)) {
+      (upd_select->stop_ts != WT_TS_NONE && upd_select->stop_ts == upd_select->start_ts)) {
         char ts_string[2][WT_TS_INT_STRING_SIZE];
         __wt_verbose(session, WT_VERB_TIMESTAMP,
           "Warning: fixing out-of-order timestamps remove at %s earlier than value at %s",


### PR DESCRIPTION
…op timestamp

In case of out-of-order timestamp inserts from the application, it is possible
that newer update may have lesser timestamp than the current update. In such
scenarios don't insert them into the history store.

Make sure that history store stop timestamp is from the durable timestamp of a
newer update of the key insead of commit timestamp.