### PR TITLE
WT-5795 Disable assertion that inserts to the history store are unique

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -390,7 +390,6 @@ __hs_insert_record_with_btree_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor, W
      * we don't find a matching key.
      */
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, &cursor->key, true, NULL, false, NULL));
-    WT_ASSERT(session, cbt->compare != 0);
     WT_ERR(ret);
     WT_ERR(__wt_hs_modify(cbt, hs_upd));
 


### PR DESCRIPTION
@michaelcahill you were right - the assertion fired. Let's revert for now - I expect we can encounter the situation after an aborted reconciliation in the least.