### PR TITLE
WT-5786 Detect if a file is too small to read a descriptor block

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -316,6 +316,16 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
     if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
         return (0);
 
+    /*
+     * If a data file is smaller than the allocation size, we're not going to be able to read the
+     * descriptor block. We should treat this as if the file has been deleted; that is, to log an
+     * error but continue on.
+     */
+    if (block->size < allocsize)
+        WT_RET_MSG(session, ENOENT,
+          "File %s is smaller than allocation size; file size=%" PRIu64 ", alloc size=%" PRIu32,
+          block->name, block->size, allocsize);
+
     /* Use a scratch buffer to get correct alignment for direct I/O. */
     WT_RET(__wt_scr_alloc(session, allocsize, &buf));
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -323,7 +323,7 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      */
     if (block->size < allocsize)
         WT_RET_MSG(session, ENOENT,
-          "File %s is smaller than allocation size; file size=%" PRIu64 ", alloc size=%" PRIu32,
+          "File %s is smaller than allocation size; file size=%" PRId64 ", alloc size=%" PRIu32,
           block->name, block->size, allocsize);
 
     /* Use a scratch buffer to get correct alignment for direct I/O. */


### PR DESCRIPTION
I've been thinking of a way to generalize this solution to detect changes to file size but I'm not sure how. When we checkpoint, we record the file size. However, if we evict dirty pages after a checkpoint, the data file should grow larger. And if we compact, I believe it may shrink. So I don't think I have any way of using the checkpoint size to check the file size.