### PR TITLE
WT-5789 Check that the history store file exists before performing rollback to stable

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -631,8 +631,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
 
     /*
      * While we have the metadata cursor open, we should check whether the history store file exists
-     * or not. If it does not, then we should not apply rollback to stable to each table and we
-     * should not perform a checkpoint. This might happen if we're upgrading from an older version.
+     * or not. If it does not, then we should not apply rollback to stable to each table. This might
+     * happen if we're upgrading from an older version.
      */
     metac->set_key(metac, WT_HS_URI);
     ret = metac->search(metac);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -529,8 +529,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     WT_CLEAR(r);
     WT_INIT_LSN(&r.ckpt_lsn);
     config = NULL;
-    do_checkpoint = true;
-    eviction_started = hs_exists = true;
+    do_checkpoint = hs_exists = true;
+    eviction_started = false;
     was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
 
     /* We need a real session for recovery. */

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -522,17 +522,15 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_RECOVERY r;
     WT_RECOVERY_FILE *metafile;
-    uint32_t session_flags;
     char *config;
-    bool do_checkpoint, eviction_started, hs_does_not_exist, is_owner, needs_rec, was_backup;
+    bool do_checkpoint, eviction_started, hs_does_not_exist, needs_rec, was_backup;
 
     conn = S2C(session);
     WT_CLEAR(r);
     WT_INIT_LSN(&r.ckpt_lsn);
     config = NULL;
-    session_flags = 0;
     do_checkpoint = true;
-    eviction_started = hs_does_not_exist = is_owner = false;
+    eviction_started = hs_does_not_exist = false;
     was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
 
     /* We need a real session for recovery. */
@@ -632,6 +630,17 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     WT_NOT_READ(metafile, NULL);
 
     /*
+     * While we have the metadata cursor open, we should check whether the history store file exists
+     * or not. If it does not, then we should not apply rollback to stable to each table and we
+     * should not perform a checkpoint. This might happen if we're upgrading from an older version.
+     */
+    metac->set_key(metac, WT_HS_URI);
+    ret = metac->search(metac);
+    if (ret == WT_NOTFOUND)
+        hs_does_not_exist = true;
+    WT_ERR_NOTFOUND_OK(ret);
+
+    /*
      * We no longer need the metadata cursor: close it to avoid pinning any resources that could
      * block eviction during recovery.
      */
@@ -691,24 +700,13 @@ done:
     WT_ERR(__recovery_set_checkpoint_timestamp(&r));
 
     /*
-     * Check whether the history store file exists or not. If it does not, then we should not apply
-     * rollback to stable to each table and we should not perform a checkpoint. This might happen if
-     * we're upgrading from an older version.
-     */
-    ret = __wt_hs_cursor(session, &session_flags, &is_owner);
-    if (ret == ENOENT) {
-        ret = 0;
-        hs_does_not_exist = true;
-    }
-    WT_ERR(ret);
-
-    /*
      * Perform rollback to stable only when the following conditions met.
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
      *    any changes that need to be done on the database other than reading.
      * 2. A valid recovery timestamp. The recovery timestamp is the stable timestamp retrieved
      *    from the metadata checkpoint information to indicate the stable timestamp when the
      *    checkpoint happened. Anything updates newer than this timestamp must rollback.
+     * 3. The history store file was found in the metadata.
      */
     if (hs_does_not_exist)
         ;
@@ -772,7 +770,6 @@ done:
     FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 
 err:
-    WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
     WT_TRET(__recovery_free(&r));
     __wt_free(session, config);
     FLD_CLR(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -711,8 +711,7 @@ done:
      *    checkpoint happened. Anything updates newer than this timestamp must rollback.
      */
     if (hs_does_not_exist)
-        WT_ERR(__wt_msg(session,
-          "Could not find history store during recovery phase. Skipping rollback to stable."));
+        ;
     else if (!F_ISSET(conn, WT_CONN_READONLY) &&
       conn->txn_global.recovery_timestamp != WT_TS_NONE) {
         /* Start the eviction threads for rollback to stable if not already started. */


### PR DESCRIPTION
If there is no history store file, we should skip performing rollback to stable and the recovery checkpoint. This situation gets triggered when we're upgrading from 4.2 so we can't do anything sensible in recovery.