### PR TITLE
WT-5844 Adjust error codes for when we detect files that are too small to contain a descriptor block

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -318,13 +318,34 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
 
     /*
      * If a data file is smaller than the allocation size, we're not going to be able to read the
-     * descriptor block. We should treat this as if the file has been deleted; that is, to log an
-     * error but continue on.
+     * descriptor block.
+     *
+     * If this has happened to the metadata file, we need to signal to callers that they need to
+     * attempt to repair the database with salvage.
+     *
+     * Otherwise, if we're performing rollback to stable as part of recovery, we should treat this
+     * as if the file has been deleted; that is, to log an error but continue on.
+     *
+     * In the general case, we should return a generic error.
+     *
+     * FIXME: MongoDB relies heavily on the error codes reported when opening cursors (which hits
+     * this logic if the relevant data handle isn't already open). However this code gets run in
+     * rollback to stable as part of recovery where we want to skip any corrupted data files
+     * temporarily to allow MongoDB to initiate salvage. This is why we've been forced into this
+     * situation. We should address this as part of WT-5832 and clarify what error codes we expect
+     * to be returning across the API boundary.
      */
-    if (block->size < allocsize)
-        WT_RET_MSG(session, ENOENT,
+    if (block->size < allocsize) {
+        if (WT_STREQ(block->name, WT_METAFILE))
+            ret = WT_TRY_SALVAGE;
+        else if (F_ISSET(session, WT_SESSION_IGNORE_HS_TOMBSTONE))
+            ret = ENOENT;
+        else
+            ret = WT_ERROR;
+        WT_RET_MSG(session, ret,
           "File %s is smaller than allocation size; file size=%" PRId64 ", alloc size=%" PRIu32,
           block->name, block->size, allocsize);
+    }
 
     /* Use a scratch buffer to get correct alignment for direct I/O. */
     WT_RET(__wt_scr_alloc(session, allocsize, &buf));

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -334,8 +334,10 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      * to be returning across the API boundary.
      */
     if (block->size < allocsize) {
-        /* We use the "ignore history store tombstone" flag as of verify so we need to check that
-         * we're not performing a verify.*/
+        /*
+         * We use the "ignore history store tombstone" flag as of verify so we need to check that
+         * we're not performing a verify.
+         */
         if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE_FLAGS) &&
           !F_ISSET(S2BT(session), WT_BTREE_VERIFY))
             ret = ENOENT;


### PR DESCRIPTION
We recently made a change in WT-5786 to return `ENOENT` if we found files that are too small to contain a descriptor block in order for WiredTiger to get past rollback to stable and start properly so that MongoDB can run verify/salvage on a database.

There's been some fallout in `wt_corrupt_file_errors.js` since MongoDB is quite specific about what error codes it gets back from WiredTiger and reacts differently on each one. We should maybe negotiate with server to agree on what each value means, but for the time being we should mimic what we were returning before to get the patch closer to green.