### PR TITLE
WT-5862 Add conditional around macro definition

### DIFF
--- a/src/os_posix/os_fallocate.c
+++ b/src/os_posix/os_fallocate.c
@@ -18,6 +18,8 @@
  *	Call the underlying fallocate function, wrapped in a macro so there's only a single copy of
  * the mmap support code.
  */
+#if defined(HAVE_FALLOCATE) || (defined(__linux__) && defined(SYS_fallocate)) || \
+  defined(HAVE_POSIX_FALLOCATE)
 #define WT_CALL_FUNCTION(op)                                                   \
     do {                                                                       \
         WT_DECL_RET;                                                           \
@@ -43,6 +45,7 @@
         }                                                                      \
         return (0);                                                            \
     } while (0)
+#endif
 
 /*
  * __posix_std_fallocate --


### PR DESCRIPTION
The MacOS build has been complaining about an unused macro since #5155 went in. I've just added a preprocessor conditional to define the macro only when we end up actually using it.

I came across this in my triage baroning but figured I'd make a fix since I already know what it is. I've run a patch build on Ubuntu, RHEL, Windows and MacOS to confirm that this compiles everywhere.