### PR TITLE
WT-5879 Fix a bug reconciling metadata.

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -518,7 +518,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
      * checkpoints into account.
      */
     if (WT_IS_METADATA(session->dhandle)) {
-        WT_ORDERED_READ(ckpt_txn, txn_global->checkpoint_id);
+        WT_ORDERED_READ(ckpt_txn, txn_global->checkpoint_state.id);
         if (ckpt_txn != WT_TXN_NONE && WT_TXNID_LT(ckpt_txn, r->last_running))
             r->last_running = ckpt_txn;
     }


### PR DESCRIPTION
A previous attempt to fix this mixed up WT_TXN_GLOBAL.checkpoint_id (an increasing integer that represents the checkpoint generation) with WT_TXN_GLOBAL.checkpoint_state.id (the checkpoint transaction ID).