### PR TITLE
WT-5669 Prepare support with durable history: backport data format changes to 4.2

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -320,6 +320,15 @@ static inline bool
 __unstable_skip(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK *unpack)
 {
     /*
+     * We should never see a prepared cell, it implies an unclean shutdown followed by a downgrade
+     * (clean shutdown rolls back any prepared cells). Complain and ignore the row.
+     */
+    if (F_ISSET(unpack, WT_CELL_UNPACK_PREPARE)) {
+        __wt_err(session, EINVAL, "unexpected prepared cell found, ignored");
+        return (true);
+    }
+
+    /*
      * Skip unstable entries after downgrade to releases without validity windows and from previous
      * wiredtiger_open connections.
      */

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -154,17 +154,20 @@ struct __wt_cell_unpack {
     uint64_t v; /* RLE count or recno */
 
     /* Value validity window */
-    wt_timestamp_t start_ts; /* default value: WT_TS_NONE */
-    uint64_t start_txn;      /* default value: WT_TXN_NONE */
-    wt_timestamp_t stop_ts;  /* default value: WT_TS_MAX */
-    uint64_t stop_txn;       /* default value: WT_TXN_MAX */
+    wt_timestamp_t start_ts;         /* default value: WT_TS_NONE */
+    uint64_t start_txn;              /* default value: WT_TXN_NONE */
+    wt_timestamp_t durable_start_ts; /* default value: WT_TS_NONE */
+    wt_timestamp_t stop_ts;          /* default value: WT_TS_MAX */
+    uint64_t stop_txn;               /* default value: WT_TXN_MAX */
+    wt_timestamp_t durable_stop_ts;  /* default value: WT_TS_NONE */
 
     /* Address validity window */
-    wt_timestamp_t oldest_start_ts;   /* default value: WT_TS_NONE */
-    uint64_t oldest_start_txn;        /* default value: WT_TXN_NONE */
-    wt_timestamp_t newest_durable_ts; /* default value: WT_TS_NONE */
-    wt_timestamp_t newest_stop_ts;    /* default value: WT_TS_MAX */
-    uint64_t newest_stop_txn;         /* default value: WT_TXN_MAX */
+    wt_timestamp_t oldest_start_ts;         /* default value: WT_TS_NONE */
+    uint64_t oldest_start_txn;              /* default value: WT_TXN_NONE */
+    wt_timestamp_t newest_start_durable_ts; /* default value: WT_TS_NONE */
+    wt_timestamp_t newest_stop_ts;          /* default value: WT_TS_MAX */
+    uint64_t newest_stop_txn;               /* default value: WT_TXN_MAX */
+    wt_timestamp_t newest_stop_durable_ts;  /* default value: WT_TS_NONE */
 
     /*
      * !!!
@@ -187,5 +190,7 @@ struct __wt_cell_unpack {
 #define WT_CELL_UNPACK_TIME_PAIRS_CLEARED 0x4u /* time pairs are cleared because of restart */
                                                /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint8_t flags;
+
+    wt_timestamp_t newest_durable_ts; /* 4.2, 4.4 compatibility */
     uint8_t ovfl;
 };

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -61,8 +61,9 @@
  *
  * Bit 4 marks a value with an additional descriptor byte. If this flag is set,
  * the next byte after the initial cell byte is an additional description byte.
- * The bottom 4 bits describe a validity window of timestamp/transaction IDs.
- * The top 4 bits are currently unused.
+ * The bottom bit in this additional byte indicates that the cell is part of a
+ * prepared, and not yet committed transaction. The next 6 bits describe a validity
+ * and durability window of timestamp/transaction IDs.  The top bit is currently unused.
  *
  * Bits 5-8 are cell "types".
  */
@@ -77,11 +78,13 @@
 #define WT_CELL_64V 0x04         /* Associated value */
 #define WT_CELL_SECOND_DESC 0x08 /* Second descriptor byte */
 
-#define WT_CELL_TS_DURABLE 0x01 /* Newest-durable timestamp */
-#define WT_CELL_TS_START 0x02   /* Oldest-start timestamp */
-#define WT_CELL_TS_STOP 0x04    /* Newest-stop timestamp */
-#define WT_CELL_TXN_START 0x08  /* Oldest-start txn ID */
-#define WT_CELL_TXN_STOP 0x10   /* Newest-stop txn ID */
+#define WT_CELL_PREPARE 0x01          /* Part of prepared transaction */
+#define WT_CELL_TS_DURABLE_START 0x02 /* Start durable timestamp */
+#define WT_CELL_TS_DURABLE_STOP 0x04  /* Stop durable timestamp */
+#define WT_CELL_TS_START 0x08         /* Oldest-start timestamp */
+#define WT_CELL_TS_STOP 0x10          /* Newest-stop timestamp */
+#define WT_CELL_TXN_START 0x20        /* Oldest-start txn ID */
+#define WT_CELL_TXN_STOP 0x40         /* Newest-stop txn ID */
 
 /*
  * WT_CELL_ADDR_INT is an internal block location, WT_CELL_ADDR_LEAF is a leaf block location, and
@@ -125,11 +128,11 @@
  */
 struct __wt_cell {
     /*
-     * Maximum of 62 bytes:
+     * Maximum of 71 bytes:
      *  1: cell descriptor byte
      *  1: prefix compression count
      *  1: secondary descriptor byte
-     * 27: 3 timestamps		(uint64_t encoding, max 9 bytes)
+     * 36: 4 timestamps		(uint64_t encoding, max 9 bytes)
      * 18: 2 transaction IDs	(uint64_t encoding, max 9 bytes)
      *  9: associated 64-bit value	(uint64_t encoding, max 9 bytes)
      *  5: data length		(uint32_t encoding, max 5 bytes)
@@ -138,7 +141,7 @@ struct __wt_cell {
      * count and 64V value overlap, and the validity window, 64V value
      * and data length are all optional in some cases.
      */
-    uint8_t __chunk[1 + 1 + 1 + 6 * WT_INTPACK64_MAXSIZE + WT_INTPACK32_MAXSIZE];
+    uint8_t __chunk[1 + 1 + 1 + 7 * WT_INTPACK64_MAXSIZE + WT_INTPACK32_MAXSIZE];
 };
 
 /*
@@ -150,17 +153,18 @@ struct __wt_cell_unpack {
 
     uint64_t v; /* RLE count or recno */
 
-    wt_timestamp_t start_ts; /* Value validity window */
-    uint64_t start_txn;
-    wt_timestamp_t stop_ts;
-    uint64_t stop_txn;
+    /* Value validity window */
+    wt_timestamp_t start_ts; /* default value: WT_TS_NONE */
+    uint64_t start_txn;      /* default value: WT_TXN_NONE */
+    wt_timestamp_t stop_ts;  /* default value: WT_TS_MAX */
+    uint64_t stop_txn;       /* default value: WT_TXN_MAX */
 
     /* Address validity window */
-    wt_timestamp_t newest_durable_ts;
-    wt_timestamp_t oldest_start_ts;
-    uint64_t oldest_start_txn;
-    wt_timestamp_t newest_stop_ts;
-    uint64_t newest_stop_txn;
+    wt_timestamp_t oldest_start_ts;   /* default value: WT_TS_NONE */
+    uint64_t oldest_start_txn;        /* default value: WT_TXN_NONE */
+    wt_timestamp_t newest_durable_ts; /* default value: WT_TS_NONE */
+    wt_timestamp_t newest_stop_ts;    /* default value: WT_TS_MAX */
+    uint64_t newest_stop_txn;         /* default value: WT_TXN_MAX */
 
     /*
      * !!!
@@ -177,5 +181,11 @@ struct __wt_cell_unpack {
     uint8_t raw;  /* Raw cell type (include "shorts") */
     uint8_t type; /* Cell type */
 
-    uint8_t ovfl; /* boolean: cell is an overflow */
+/* AUTOMATIC FLAG VALUE GENERATION START */
+#define WT_CELL_UNPACK_OVERFLOW 0x1u           /* cell is an overflow */
+#define WT_CELL_UNPACK_PREPARE 0x2u            /* cell is part of a prepared transaction */
+#define WT_CELL_UNPACK_TIME_PAIRS_CLEARED 0x4u /* time pairs are cleared because of restart */
+                                               /* AUTOMATIC FLAG VALUE GENERATION STOP */
+    uint8_t flags;
+    uint8_t ovfl;
 };

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -786,6 +786,7 @@ restart:
     unpack->raw = (uint8_t)__wt_cell_type_raw(cell);
     unpack->type = (uint8_t)__wt_cell_type(cell);
     unpack->flags = 0;
+    unpack->newest_durable_ts = WT_TS_NONE;
     unpack->ovfl = 0;
 
     /*

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -12,39 +12,47 @@
  */
 static inline void
 __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_start_ts,
-  wt_timestamp_t durable_stop_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t durable_stop_ts,
   wt_timestamp_t stop_ts, uint64_t stop_txn)
 {
 #ifdef HAVE_DIAGNOSTIC
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
-    if (start_ts != WT_TS_NONE && stop_ts == WT_TS_NONE) {
-        __wt_errx(session, "stop timestamp of 0");
-        WT_ASSERT(session, stop_ts != WT_TS_NONE);
-    }
-    if (start_ts > stop_ts) {
-        __wt_errx(session, "a start timestamp %s newer than its stop timestamp %s",
+    if (start_ts > durable_start_ts)
+        WT_ERR_ASSERT(session, start_ts <= durable_start_ts, WT_PANIC,
+          "a start timestamp %s newer than its durable start timestamp %s",
+          __wt_timestamp_to_string(start_ts, ts_string[0]),
+          __wt_timestamp_to_string(durable_start_ts, ts_string[1]));
+
+    if (start_ts != WT_TS_NONE && stop_ts == WT_TS_NONE)
+        WT_ERR_ASSERT(session, stop_ts != WT_TS_NONE, WT_PANIC, "stop timestamp of 0");
+
+    if (start_ts > stop_ts)
+        WT_ERR_ASSERT(session, start_ts <= stop_ts, WT_PANIC,
+          "a start timestamp %s newer than its stop timestamp %s",
           __wt_timestamp_to_string(start_ts, ts_string[0]),
           __wt_timestamp_to_string(stop_ts, ts_string[1]));
-        WT_ASSERT(session, start_ts <= stop_ts);
-    }
 
-    if (start_txn > stop_txn) {
-        __wt_errx(session, "a start transaction ID %" PRIu64
-                           " newer than its stop "
-                           "transaction ID %" PRIu64,
+    if (start_txn > stop_txn)
+        WT_ERR_ASSERT(session, start_txn <= stop_txn, WT_PANIC,
+          "a start transaction ID %" PRIu64 " newer than its stop transaction ID %" PRIu64,
           start_txn, stop_txn);
-        WT_ASSERT(session, start_txn <= stop_txn);
-    }
+
+    if (stop_ts != WT_TS_MAX && stop_ts > durable_stop_ts)
+        WT_ERR_ASSERT(session, stop_ts <= durable_stop_ts, WT_PANIC,
+          "a stop timestamp %s newer than its durable stop timestamp %s",
+          __wt_timestamp_to_string(stop_ts, ts_string[0]),
+          __wt_timestamp_to_string(durable_stop_ts, ts_string[1]));
+
 #else
     WT_UNUSED(session);
+    WT_UNUSED(durable_start_ts);
+    WT_UNUSED(durable_stop_ts);
     WT_UNUSED(start_ts);
     WT_UNUSED(start_txn);
     WT_UNUSED(stop_ts);
     WT_UNUSED(stop_txn);
 #endif
-    WT_UNUSED(durable_start_ts);
-    WT_UNUSED(durable_stop_ts);
 }
 
 /*
@@ -53,17 +61,17 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_sta
  */
 static inline void
 __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t durable_start_ts,
-  wt_timestamp_t durable_stop_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t durable_stop_ts,
   wt_timestamp_t stop_ts, uint64_t stop_txn, bool prepare)
 {
     uint8_t flags, *flagsp;
 
     __cell_check_value_validity(
-      session, durable_start_ts, durable_stop_ts, start_ts, start_txn, stop_ts, stop_txn);
+      session, durable_start_ts, start_ts, start_txn, durable_stop_ts, stop_ts, stop_txn);
 
     /* Globally visible values have no associated validity window, set a flag bit and store them. */
-    if (start_ts == WT_TS_NONE && start_txn == WT_TXN_NONE && stop_ts == WT_TS_MAX &&
-      stop_txn == WT_TXN_MAX)
+    if (durable_start_ts == WT_TS_NONE && start_ts == WT_TS_NONE && start_txn == WT_TXN_NONE &&
+      durable_stop_ts == WT_TS_NONE && stop_ts == WT_TS_MAX && stop_txn == WT_TXN_MAX)
         ++*pp;
     else {
         **pp |= WT_CELL_SECOND_DESC;
@@ -113,36 +121,45 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_
  *     Check the address' validity window for sanity.
  */
 static inline void
-__wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t oldest_start_ts,
-  uint64_t oldest_start_txn, wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn)
+__wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t start_durable_ts,
+  wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn, wt_timestamp_t stop_durable_ts,
+  wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn)
 {
-/* FIXME-prepare-support: accept durable timestamps as args, and do checks on them. */
 #ifdef HAVE_DIAGNOSTIC
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
-    if (oldest_start_ts != WT_TS_NONE && newest_stop_ts == WT_TS_NONE) {
-        __wt_errx(session, "newest stop timestamp of 0");
-        WT_ASSERT(session, newest_stop_ts != WT_TS_NONE);
-    }
-    if (oldest_start_ts > newest_stop_ts) {
-        __wt_errx(session,
-          "an oldest start timestamp %s newer than its newest "
-          "stop timestamp %s",
+    if (oldest_start_ts != WT_TS_NONE && newest_stop_ts == WT_TS_NONE)
+        WT_ERR_ASSERT(
+          session, newest_stop_ts != WT_TS_NONE, WT_PANIC, "newest stop timestamp of 0");
+
+    if (oldest_start_ts > newest_stop_ts)
+        WT_ERR_ASSERT(session, oldest_start_ts <= newest_stop_ts, WT_PANIC,
+          "an oldest start timestamp %s newer than its newest stop timestamp %s",
           __wt_timestamp_to_string(oldest_start_ts, ts_string[0]),
           __wt_timestamp_to_string(newest_stop_ts, ts_string[1]));
-        WT_ASSERT(session, oldest_start_ts <= newest_stop_ts);
-    }
-    if (oldest_start_txn > newest_stop_txn) {
-        __wt_errx(session, "an oldest start transaction %" PRIu64
-                           " newer than its "
-                           "newest stop transaction %" PRIu64,
+
+    if (oldest_start_txn > newest_stop_txn)
+        WT_ERR_ASSERT(session, oldest_start_txn <= newest_stop_txn, WT_PANIC,
+          "an oldest start transaction %" PRIu64 " newer than its newest stop transaction %" PRIu64,
           oldest_start_txn, newest_stop_txn);
-        WT_ASSERT(session, oldest_start_txn <= newest_stop_txn);
-    }
+
+    if (oldest_start_ts > start_durable_ts)
+        WT_ERR_ASSERT(session, oldest_start_ts <= start_durable_ts, WT_PANIC,
+          "an oldest start timestamp %s newer than its durable start timestamp %s",
+          __wt_timestamp_to_string(oldest_start_ts, ts_string[0]),
+          __wt_timestamp_to_string(start_durable_ts, ts_string[1]));
+
+    if (newest_stop_ts != WT_TS_MAX && newest_stop_ts > stop_durable_ts)
+        WT_ERR_ASSERT(session, newest_stop_ts <= stop_durable_ts, WT_PANIC,
+          "a newest stop timestamp %s newer than its durable stop timestamp %s",
+          __wt_timestamp_to_string(newest_stop_ts, ts_string[0]),
+          __wt_timestamp_to_string(stop_durable_ts, ts_string[1]));
 #else
     WT_UNUSED(session);
+    WT_UNUSED(start_durable_ts);
     WT_UNUSED(oldest_start_ts);
     WT_UNUSED(oldest_start_txn);
+    WT_UNUSED(stop_durable_ts);
     WT_UNUSED(newest_stop_ts);
     WT_UNUSED(newest_stop_txn);
 #endif
@@ -154,14 +171,13 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t oldest_start_t
  */
 static inline void
 __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t start_durable_ts,
-  wt_timestamp_t stop_durable_ts, wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn,
+  wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn, wt_timestamp_t stop_durable_ts,
   wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn)
 {
     uint8_t flags, *flagsp;
 
-    /* FIXME-prepare-support: Check validity of durable timestamps. */
-    __wt_check_addr_validity(
-      session, oldest_start_ts, oldest_start_txn, newest_stop_ts, newest_stop_txn);
+    __wt_check_addr_validity(session, start_durable_ts, oldest_start_ts, oldest_start_txn,
+      stop_durable_ts, newest_stop_ts, newest_stop_txn);
 
     /* Globally visible values have no associated validity window, set a flag bit and store them. */
     if (start_durable_ts == WT_TS_NONE && stop_durable_ts == WT_TS_NONE &&
@@ -185,8 +201,11 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
         }
         if (start_durable_ts != WT_TS_NONE) {
             /* Store differences, not absolutes. */
-            WT_ASSERT(
-              session, oldest_start_ts != WT_TS_NONE && oldest_start_ts <= start_durable_ts);
+            /*
+             * FIXME-prepare-support:
+             * WT_ASSERT(
+             *  session, oldest_start_ts != WT_TS_NONE && oldest_start_ts <= start_durable_ts);
+             */
             WT_IGNORE_RET(__wt_vpack_uint(pp, 0, start_durable_ts - oldest_start_ts));
             LF_SET(WT_CELL_TS_DURABLE_START);
         }
@@ -220,24 +239,18 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
  */
 static inline size_t
 __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, uint64_t recno,
-  wt_timestamp_t stop_durable_ts, wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn,
-  wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn, size_t size)
+  wt_timestamp_t start_durable_ts, wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn,
+  wt_timestamp_t stop_durable_ts, wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn,
+  size_t size)
 {
-    wt_timestamp_t start_durable_ts;
     uint8_t *p;
-
-    /*
-     * FIXME-prepare-support: This value should be passed in when support for prepared transactions
-     * with durable history is fully implemented.
-     */
-    start_durable_ts = WT_TS_NONE;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_addr_validity(session, &p, start_durable_ts, stop_durable_ts, oldest_start_ts,
-      oldest_start_txn, newest_stop_ts, newest_stop_txn);
+    __cell_pack_addr_validity(session, &p, start_durable_ts, oldest_start_ts, oldest_start_txn,
+      stop_durable_ts, newest_stop_ts, newest_stop_txn);
 
     if (recno == WT_RECNO_OOB)
         cell->__chunk[0] |= (uint8_t)cell_type; /* Type */
@@ -256,26 +269,21 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
  *     Set a value item's WT_CELL contents.
  */
 static inline size_t
-__wt_cell_pack_value(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start_ts,
-  uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle, size_t size)
+__wt_cell_pack_value(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t durable_start_ts,
+  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t durable_stop_ts,
+  wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle, size_t size)
 {
-    wt_timestamp_t durable_start_ts, durable_stop_ts;
     uint8_t byte, *p;
     bool prepare, validity;
 
-    /*
-     * FIXME-prepare-support: These values should be passed in when support for prepared
-     * transactions with durable history is fully implemented.
-     */
-    durable_start_ts = WT_TS_NONE;
-    durable_stop_ts = WT_TS_NONE;
+    /* FIXME-prepare-support: The prepare flag should be passed in. */
     prepare = false;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_value_validity(session, &p, durable_start_ts, durable_stop_ts, start_ts, start_txn,
+    __cell_pack_value_validity(session, &p, durable_start_ts, start_ts, start_txn, durable_stop_ts,
       stop_ts, stop_txn, prepare);
 
     /*
@@ -398,10 +406,10 @@ __wt_cell_pack_value_match(
  *     Write a copy value cell.
  */
 static inline size_t
-__wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start_ts,
-  uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle, uint64_t v)
+__wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start_durable_ts,
+  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_durable_ts,
+  wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle, uint64_t v)
 {
-    wt_timestamp_t durable_start_ts, durable_stop_ts;
     uint8_t *p;
     bool prepare;
 
@@ -409,15 +417,13 @@ __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t star
      * FIXME-prepare-support: These values should be passed in when support for prepared
      * transactions with durable history is fully implemented.
      */
-    durable_start_ts = WT_TS_NONE;
-    durable_stop_ts = WT_TS_NONE;
     prepare = false;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_value_validity(session, &p, durable_start_ts, durable_stop_ts, start_ts, start_txn,
+    __cell_pack_value_validity(session, &p, start_durable_ts, start_ts, start_txn, stop_durable_ts,
       stop_ts, stop_txn, prepare);
 
     if (rle < 2)
@@ -438,8 +444,9 @@ __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t star
  *     Write a deleted value cell.
  */
 static inline size_t
-__wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start_ts,
-  uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle)
+__wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start_durable_ts,
+  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_durable_ts,
+  wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle)
 {
     uint8_t *p;
 
@@ -447,9 +454,9 @@ __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell, wt_timestamp_t start
     p = cell->__chunk;
     *p = '\0';
 
-    /* FIXME-prepare-support: we should pass durable start and stop values. */
-    __cell_pack_value_validity(
-      session, &p, WT_TS_NONE, WT_TS_NONE, start_ts, start_txn, stop_ts, stop_txn, false);
+    /* FIXME-prepare-support: we should pass prepare value. */
+    __cell_pack_value_validity(session, &p, start_durable_ts, start_ts, start_txn, stop_durable_ts,
+      stop_ts, stop_txn, false);
 
     if (rle < 2)
         cell->__chunk[0] |= WT_CELL_DEL; /* Type */
@@ -535,16 +542,15 @@ __wt_cell_pack_leaf_key(WT_CELL *cell, uint8_t prefix, size_t size)
  *     Pack an overflow cell.
  */
 static inline size_t
-__wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type, wt_timestamp_t start_ts,
-  uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle, size_t size)
+__wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type,
+  wt_timestamp_t durable_start_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t durable_stop_ts, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle,
+  size_t size)
 {
-    wt_timestamp_t durable_start_ts, durable_stop_ts;
     uint8_t *p;
     bool prepare;
 
-    /* FIXME-prepare-support: The durable timestamps should be passed in. */
-    durable_start_ts = WT_TS_NONE;
-    durable_stop_ts = WT_TS_NONE;
+    /* FIXME-prepare-support: The prepare flag should be passed in. */
     prepare = false;
 
     /* Start building a cell: the descriptor byte starts zero. */
@@ -558,8 +564,8 @@ __wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type, wt_ti
         break;
     case WT_CELL_VALUE_OVFL:
     case WT_CELL_VALUE_OVFL_RM:
-        __cell_pack_value_validity(session, &p, durable_start_ts, durable_stop_ts, start_ts,
-          start_txn, stop_ts, stop_txn, prepare);
+        __cell_pack_value_validity(session, &p, durable_start_ts, start_ts, start_txn,
+          durable_stop_ts, stop_ts, stop_txn, prepare);
         break;
     }
 
@@ -716,24 +722,30 @@ __wt_cell_unpack_safe(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CE
     struct {
         uint64_t v;
         wt_timestamp_t start_ts;
+        wt_timestamp_t durable_start_ts;
         uint64_t start_txn;
         wt_timestamp_t stop_ts;
+        wt_timestamp_t durable_stop_ts;
         uint64_t stop_txn;
         uint32_t len;
     } copy;
-    wt_timestamp_t durable_ts_compat;
+    wt_timestamp_t durable_start_ts, durable_stop_ts;
+    wt_timestamp_t newest_start_durable_ts, newest_stop_durable_ts;
     uint64_t v;
     const uint8_t *p;
     uint8_t flags;
 
+    durable_start_ts = durable_stop_ts = newest_start_durable_ts = newest_stop_durable_ts =
+      WT_TS_NONE;
+
     copy.v = 0; /* -Werror=maybe-uninitialized */
     copy.start_ts = WT_TS_NONE;
+    copy.durable_start_ts = WT_TS_NONE;
     copy.start_txn = WT_TXN_NONE;
     copy.stop_ts = WT_TS_MAX;
+    copy.durable_stop_ts = WT_TS_NONE;
     copy.stop_txn = WT_TXN_MAX;
     copy.len = 0;
-
-    durable_ts_compat = WT_TS_NONE;
 
 /*
  * The verification code specifies an end argument, a pointer to 1B past the end-of-page. In which
@@ -834,9 +846,11 @@ restart:
             WT_RET(__wt_vunpack_uint(
               &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->oldest_start_txn));
         if (LF_ISSET(WT_CELL_TS_DURABLE_START)) {
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &durable_ts_compat));
-            durable_ts_compat += unpack->oldest_start_txn;
+            WT_RET(__wt_vunpack_uint(
+              &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &newest_start_durable_ts));
+            newest_start_durable_ts += unpack->oldest_start_ts;
         }
+
         if (LF_ISSET(WT_CELL_TS_STOP)) {
             WT_RET(
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->newest_stop_ts));
@@ -848,14 +862,15 @@ restart:
             unpack->newest_stop_txn += unpack->oldest_start_txn;
         }
         if (LF_ISSET(WT_CELL_TS_DURABLE_STOP)) {
-            WT_RET(__wt_vunpack_uint(
-              &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->newest_durable_ts));
-            unpack->newest_durable_ts += unpack->newest_stop_ts;
+            WT_RET(
+              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &newest_stop_durable_ts));
+            newest_stop_durable_ts += unpack->newest_stop_ts;
+            unpack->newest_durable_ts = newest_stop_durable_ts;
         }
 
-        /* FIXME-prepare-support: Check validity of durable timestamps. */
-        __wt_check_addr_validity(session, unpack->oldest_start_ts, unpack->oldest_start_txn,
-          unpack->newest_stop_ts, unpack->newest_stop_txn);
+        __wt_check_addr_validity(session, newest_start_durable_ts, unpack->oldest_start_ts,
+          unpack->oldest_start_txn, newest_stop_durable_ts, unpack->newest_stop_ts,
+          unpack->newest_stop_txn);
         break;
     case WT_CELL_DEL:
     case WT_CELL_VALUE:
@@ -873,8 +888,8 @@ restart:
         if (LF_ISSET(WT_CELL_TXN_START))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->start_txn));
         if (LF_ISSET(WT_CELL_TS_DURABLE_START)) {
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &durable_ts_compat));
-            durable_ts_compat += unpack->start_ts;
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &durable_start_ts));
+            durable_start_ts += unpack->start_ts;
         }
         if (LF_ISSET(WT_CELL_TS_STOP)) {
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->stop_ts));
@@ -884,10 +899,12 @@ restart:
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->stop_txn));
             unpack->stop_txn += unpack->start_txn;
         }
-        if (LF_ISSET(WT_CELL_TS_DURABLE_STOP))
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &durable_ts_compat));
-        __cell_check_value_validity(session, durable_ts_compat, durable_ts_compat, unpack->start_ts,
-          unpack->start_txn, unpack->stop_ts, unpack->stop_txn);
+        if (LF_ISSET(WT_CELL_TS_DURABLE_STOP)) {
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &durable_stop_ts));
+            durable_stop_ts += unpack->stop_ts;
+        }
+        __cell_check_value_validity(session, durable_start_ts, unpack->start_ts, unpack->start_txn,
+          durable_stop_ts, unpack->stop_ts, unpack->stop_txn);
         break;
     }
 
@@ -912,8 +929,10 @@ restart:
         WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &v));
         copy.v = unpack->v;
         copy.start_ts = unpack->start_ts;
+        copy.durable_start_ts = durable_start_ts;
         copy.start_txn = unpack->start_txn;
         copy.stop_ts = unpack->stop_ts;
+        copy.durable_stop_ts = durable_stop_ts;
         copy.stop_txn = unpack->stop_txn;
         copy.len = WT_PTRDIFF32(p, cell);
         cell = (WT_CELL *)((uint8_t *)cell - v);
@@ -973,8 +992,10 @@ done:
         unpack->raw = WT_CELL_VALUE_COPY;
         unpack->v = copy.v;
         unpack->start_ts = copy.start_ts;
+        durable_start_ts = copy.durable_start_ts;
         unpack->start_txn = copy.start_txn;
         unpack->stop_ts = copy.stop_ts;
+        durable_stop_ts = copy.durable_stop_ts;
         unpack->stop_txn = copy.stop_txn;
         unpack->__len = copy.len;
     }
@@ -1004,7 +1025,6 @@ __wt_cell_unpack_dsk(
         unpack->start_txn = WT_TXN_NONE;
         unpack->stop_ts = WT_TS_MAX;
         unpack->stop_txn = WT_TXN_MAX;
-        unpack->newest_durable_ts = WT_TS_NONE;
         unpack->oldest_start_ts = WT_TS_NONE;
         unpack->oldest_start_txn = WT_TXN_NONE;
         unpack->newest_stop_ts = WT_TS_MAX;

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -48,16 +48,6 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_sta
 }
 
 /*
- * __cell_unexpected_prepare --
- *     Issue a standard error message when an item marked as prepared is found in a cell.
- */
-static inline int
-__cell_unexpected_prepare(WT_SESSION_IMPL *session)
-{
-    WT_RET_MSG(session, EINVAL, "prepared item in data file");
-}
-
-/*
  * __cell_pack_value_validity --
  *     Pack the validity window for a value.
  */
@@ -900,8 +890,6 @@ restart:
           unpack->start_txn, unpack->stop_ts, unpack->stop_txn);
         break;
     }
-    if (F_ISSET(unpack, WT_CELL_UNPACK_PREPARE))
-        WT_RET(__cell_unexpected_prepare(session));
 
     /*
      * Check for an RLE count or record number that optionally follows the cell descriptor byte on

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -1040,6 +1040,7 @@ __wt_cell_unpack_dsk(
         unpack->prefix = 0;
         unpack->raw = unpack->type = WT_CELL_VALUE;
         unpack->flags = 0;
+        unpack->newest_durable_ts = WT_TS_NONE;
         unpack->ovfl = 0;
         return;
     }

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -939,7 +939,7 @@ restart:
          * Set overflow flag.
          */
         F_SET(unpack, WT_CELL_UNPACK_OVERFLOW);
-        unpack->ovfl = 0;
+        unpack->ovfl = 1;
     /* FALLTHROUGH */
 
     case WT_CELL_ADDR_DEL:

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2015,25 +2015,29 @@ static inline int __wt_vunpack_uint(const uint8_t **pp, size_t maxlen, uint64_t 
 static inline int __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len,
   const void *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type,
-  uint64_t recno, wt_timestamp_t stop_durable_ts, wt_timestamp_t oldest_start_ts,
-  uint64_t oldest_start_txn, wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn, size_t size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint64_t recno, wt_timestamp_t start_durable_ts, wt_timestamp_t oldest_start_ts,
+  uint64_t oldest_start_txn, wt_timestamp_t stop_durable_ts, wt_timestamp_t newest_stop_ts,
+  uint64_t newest_stop_txn, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell,
-  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn,
-  uint64_t rle, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t start_durable_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t stop_durable_ts, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle,
+  uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell,
-  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn,
-  uint64_t rle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t start_durable_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t stop_durable_ts, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_int_key(WT_CELL *cell, size_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_leaf_key(WT_CELL *cell, uint8_t prefix, size_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type,
-  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn,
-  uint64_t rle, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t durable_start_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t durable_stop_ts, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle,
+  size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_value(WT_SESSION_IMPL *session, WT_CELL *cell,
-  wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_ts, uint64_t stop_txn,
-  uint64_t rle, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t durable_start_ts, wt_timestamp_t start_ts, uint64_t start_txn,
+  wt_timestamp_t durable_stop_ts, wt_timestamp_t stop_ts, uint64_t stop_txn, uint64_t rle,
+  size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_total_len(WT_CELL_UNPACK *unpack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_strnlen(const char *s, size_t maxlen)
@@ -2114,8 +2118,8 @@ static inline void __wt_cell_unpack(
 static inline void __wt_cell_unpack_dsk(
   WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL *cell, WT_CELL_UNPACK *unpack);
 static inline void __wt_check_addr_validity(WT_SESSION_IMPL *session,
-  wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn, wt_timestamp_t newest_stop_ts,
-  uint64_t newest_stop_txn);
+  wt_timestamp_t start_durable_ts, wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn,
+  wt_timestamp_t stop_durable_ts, wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn);
 static inline void __wt_cond_wait(
   WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, bool (*run_func)(WT_SESSION_IMPL *));
 static inline void __wt_cursor_dhandle_decr_use(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2015,7 +2015,7 @@ static inline int __wt_vunpack_uint(const uint8_t **pp, size_t maxlen, uint64_t 
 static inline int __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len,
   const void *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type,
-  uint64_t recno, wt_timestamp_t newest_durable_ts, wt_timestamp_t oldest_start_ts,
+  uint64_t recno, wt_timestamp_t stop_durable_ts, wt_timestamp_t oldest_start_ts,
   uint64_t oldest_start_txn, wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn, size_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell,

--- a/src/include/reconcile.i
+++ b/src/include/reconcile.i
@@ -190,8 +190,8 @@ __wt_rec_cell_build_addr(
      */
     val->buf.data = addr->addr;
     val->buf.size = addr->size;
-    val->cell_len = __wt_cell_pack_addr(session, &val->cell, cell_type, recno,
-      addr->newest_durable_ts, addr->oldest_start_ts, addr->oldest_start_txn, addr->newest_stop_ts,
+    val->cell_len = __wt_cell_pack_addr(session, &val->cell, cell_type, recno, WT_TS_NONE,
+      addr->oldest_start_ts, addr->oldest_start_txn, addr->newest_durable_ts, addr->newest_stop_ts,
       addr->newest_stop_txn, val->buf.size);
     val->len = val->cell_len + val->buf.size;
 }
@@ -234,8 +234,8 @@ __wt_rec_cell_build_val(WT_SESSION_IMPL *session, WT_RECONCILE *r, const void *d
               session, r, val, WT_CELL_VALUE_OVFL, start_ts, start_txn, stop_ts, stop_txn, rle));
         }
     }
-    val->cell_len = __wt_cell_pack_value(
-      session, &val->cell, start_ts, start_txn, stop_ts, stop_txn, rle, val->buf.size);
+    val->cell_len = __wt_cell_pack_value(session, &val->cell, WT_TS_NONE, start_ts, start_txn,
+      WT_TS_NONE, stop_ts, stop_txn, rle, val->buf.size);
     val->len = val->cell_len + val->buf.size;
 
     return (0);
@@ -283,8 +283,8 @@ __wt_rec_dict_replace(WT_SESSION_IMPL *session, WT_RECONCILE *r, wt_timestamp_t 
          * offset from the beginning of the page.
          */
         offset = (uint64_t)WT_PTRDIFF(r->first_free, (uint8_t *)r->cur_ptr->image.mem + dp->offset);
-        val->len = val->cell_len = __wt_cell_pack_copy(
-          session, &val->cell, start_ts, start_txn, stop_ts, stop_txn, rle, offset);
+        val->len = val->cell_len = __wt_cell_pack_copy(session, &val->cell, WT_TS_NONE, start_ts,
+          start_txn, WT_TS_NONE, stop_ts, stop_txn, rle, offset);
         val->buf.data = NULL;
         val->buf.size = 0;
     }

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -605,8 +605,8 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
     ret = __wt_config_subgets(session, v, "newest_stop_txn", &a);
     WT_RET_NOTFOUND_OK(ret);
     ckpt->newest_stop_txn = ret == WT_NOTFOUND || a.len == 0 ? WT_TXN_MAX : (uint64_t)a.val;
-    __wt_check_addr_validity(session, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
-      ckpt->newest_stop_ts, ckpt->newest_stop_txn);
+    __wt_check_addr_validity(session, WT_TS_NONE, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
+      WT_TS_NONE, ckpt->newest_stop_ts, ckpt->newest_stop_txn);
 
     WT_RET(__wt_config_subgets(session, v, "write_gen", &a));
     if (a.len == 0)
@@ -703,8 +703,8 @@ __wt_meta_ckptlist_to_meta(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, WT_ITEM 
                 WT_RET(__wt_raw_to_hex(session, ckpt->raw.data, ckpt->raw.size, &ckpt->addr));
         }
 
-        __wt_check_addr_validity(session, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
-          ckpt->newest_stop_ts, ckpt->newest_stop_txn);
+        __wt_check_addr_validity(session, WT_TS_NONE, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
+          WT_TS_NONE, ckpt->newest_stop_ts, ckpt->newest_stop_txn);
 
         WT_RET(__wt_buf_catfmt(session, buf, "%s%s", sep, ckpt->name));
         sep = ",";

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -588,6 +588,9 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
 
     /* Default to durability. */
     ret = __wt_config_subgets(session, v, "newest_durable_ts", &a);
+    if (ret == WT_NOTFOUND)
+        /* Check the parameter as it known in 4.4.  We may see this when a system is downgraded. */
+        ret = __wt_config_subgets(session, v, "stop_durable_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
     ckpt->newest_durable_ts = ret == WT_NOTFOUND || a.len == 0 ? WT_TS_NONE : (uint64_t)a.val;
     ret = __wt_config_subgets(session, v, "oldest_start_ts", &a);

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -116,8 +116,8 @@ __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
 
     val = &r->v;
     if (deleted) {
-        val->cell_len = __wt_cell_pack_del(
-          session, &val->cell, WT_TS_NONE, WT_TXN_NONE, WT_TS_MAX, WT_TXN_MAX, cbulk->rle);
+        val->cell_len = __wt_cell_pack_del(session, &val->cell, WT_TS_NONE, WT_TS_NONE, WT_TXN_NONE,
+          WT_TS_NONE, WT_TS_MAX, WT_TXN_MAX, cbulk->rle);
         val->buf.data = NULL;
         val->buf.size = 0;
         val->len = val->cell_len;
@@ -537,14 +537,14 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_SALVAGE_COOKI
     }
 
     if (deleted) {
-        val->cell_len =
-          __wt_cell_pack_del(session, &val->cell, start_ts, start_txn, stop_ts, stop_txn, rle);
+        val->cell_len = __wt_cell_pack_del(
+          session, &val->cell, WT_TS_NONE, start_ts, start_txn, WT_TS_NONE, stop_ts, stop_txn, rle);
         val->buf.data = NULL;
         val->buf.size = 0;
         val->len = val->cell_len;
     } else if (overflow_type) {
-        val->cell_len = __wt_cell_pack_ovfl(session, &val->cell, WT_CELL_VALUE_OVFL, start_ts,
-          start_txn, stop_ts, stop_txn, rle, value->size);
+        val->cell_len = __wt_cell_pack_ovfl(session, &val->cell, WT_CELL_VALUE_OVFL, WT_TS_NONE,
+          start_ts, start_txn, WT_TS_NONE, stop_ts, stop_txn, rle, value->size);
         val->buf.data = value->data;
         val->buf.size = value->size;
         val->len = val->cell_len + value->size;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2511,8 +2511,8 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
     WT_ERR(__wt_buf_set(session, &kv->buf, addr, size));
 
     /* Build the cell and return. */
-    kv->cell_len = __wt_cell_pack_ovfl(
-      session, &kv->cell, type, start_ts, start_txn, stop_ts, stop_txn, rle, kv->buf.size);
+    kv->cell_len = __wt_cell_pack_ovfl(session, &kv->cell, type, WT_TS_NONE, start_ts, start_txn,
+      WT_TS_NONE, stop_ts, stop_txn, rle, kv->buf.size);
     kv->len = kv->cell_len + kv->buf.size;
 
 err:


### PR DESCRIPTION
@ddanderson, I was looking at WT-5669 with @agorrod today, and was wondering if it might make sense to only port the `cell.h` and `cell.i` code from 4.4, that is, don't try and backport the timestamp work, just make 4.2 use the current 4.4 cell code.

I've pushed a branch to show what I'm thinking. Can you take a look and then we can talk about which you prefer? Or if I'm totally missing something?