### PR TITLE
WT-5894 Don't persist durable timestamp if it is same as commit

### DIFF
--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -906,8 +906,10 @@ restart:
             WT_RET(__wt_vunpack_uint(
               &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->durable_stop_ts));
             unpack->durable_stop_ts += unpack->stop_ts;
-        } else
+        } else if (unpack->stop_ts != WT_TS_MAX)
             unpack->durable_stop_ts = unpack->stop_ts;
+        else
+            unpack->durable_stop_ts = WT_TS_NONE;
 
         __cell_check_value_validity(session, unpack->durable_start_ts, unpack->start_ts,
           unpack->start_txn, unpack->durable_stop_ts, unpack->stop_ts, unpack->stop_txn);

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -213,6 +213,13 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
          * WT_ASSERT(
          *  session, oldest_start_ts != WT_TS_NONE && oldest_start_ts <= start_durable_ts);
          */
+        /*
+         * Unlike value cell, we store the durable start timestamp even the difference is zero
+         * compared to oldest commit timestamp. The difference can only be zero when the page
+         * contains all the key/value pairs with the same timestamp. But this scenario is rare and
+         * having that check to find out whether it is zero or not will unnecessarily add overhead
+         * than benefit.
+         */
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, start_durable_ts - oldest_start_ts));
         LF_SET(WT_CELL_TS_DURABLE_START);
     }
@@ -232,7 +239,14 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
          * FIXME-prepare-support:
          * WT_ASSERT(session,
          *   newest_stop_ts != WT_TS_MAX && newest_stop_ts <= stop_durable__ts);
-        */
+         */
+        /*
+         * Unlike value cell, we store the durable stop timestamp even the difference is zero
+         * compared to newest commit timestamp. The difference can only be zero when the page
+         * contains all the key/value pairs with the same timestamp. But this scenario is rare and
+         * having that check to find out whether it is zero or not will unnecessarily add overhead
+         * than benefit.
+         */
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, stop_durable_ts - newest_stop_ts));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }


### PR DESCRIPTION
As we are storing the differences in the value cell from durable
timestamp to commit timestamp, there is no need to save when there
is no difference. When unpacking the cell, assign commit timestamp
to durable timestamp when there is no durable timestamp in the cell.