### PR TITLE
WT-5896 Recovery sometimes attempts rollback to stable with an absent history store file

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -549,6 +549,17 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     metafile->c = metac;
 
     /*
+     * We should check whether the history store file exists or not. or not. If it does not, then we
+     * should not apply rollback to stable to each table. This might happen if we're upgrading from
+     * an older version.
+     */
+    metac->set_key(metac, WT_HS_URI);
+    ret = metac->search(metac);
+    if (ret == WT_NOTFOUND)
+        hs_exists = false;
+    WT_ERR_NOTFOUND_OK(ret);
+
+    /*
      * If no log was found (including if logging is disabled), or if the last checkpoint was done
      * with logging disabled, recovery should not run. Scan the metadata to figure out the largest
      * file ID.
@@ -629,17 +640,6 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
      * files.
      */
     WT_NOT_READ(metafile, NULL);
-
-    /*
-     * While we have the metadata cursor open, we should check whether the history store file exists
-     * or not. If it does not, then we should not apply rollback to stable to each table. This might
-     * happen if we're upgrading from an older version.
-     */
-    metac->set_key(metac, WT_HS_URI);
-    ret = metac->search(metac);
-    if (ret == WT_NOTFOUND)
-        hs_exists = false;
-    WT_ERR_NOTFOUND_OK(ret);
 
     /*
      * We no longer need the metadata cursor: close it to avoid pinning any resources that could

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -558,6 +558,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
     if (ret == WT_NOTFOUND)
         hs_exists = false;
     WT_ERR_NOTFOUND_OK(ret);
+    /* Unpin the page from cache. */
+    WT_ERR(metac->reset(metac));
 
     /*
      * If no log was found (including if logging is disabled), or if the last checkpoint was done


### PR DESCRIPTION
This PR is fixing an issue seen in `logkeeper` where there is a code path where we still attempt rollback to stable even without a history store file (i.e. when upgrading from `v4.2`).

This was caused by a bit of a boneheaded error on my part. There's a `goto` above my initial fix that jumps straight to the rollback to stable code if there were no log files found and `hs_exists` is left as `true`. I've moved this check right after the opening of the cursor so we should be safe.

I've verified that `unionWith_fcv.js` still passes with this iteration of the fix.