### PR TITLE
WT-5901 Evergreen release compatibility testing isn't working as intended.

### DIFF
--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -5,14 +5,6 @@
 
 set -e
 
-###########################################################################
-# Return the most recent version of a tagged release.
-###########################################################################
-get_tagged_release()
-{
-        echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -V | sed -e '$p' -e d)"
-}
-
 #############################################################
 # build_release:
 #       arg1: release
@@ -100,35 +92,27 @@ top="test-compatibility-run"
 rm -rf "$top" && mkdir "$top"
 cd "$top"
 
-# Build a release with a known name, then use it to figure out tagged release names.
+# Build the releases.
+(build_release mongodb-3.4)
+(build_release mongodb-3.6)
+(build_release mongodb-4.0)
+(build_release mongodb-4.2)
+(build_release mongodb-4.4)
 (build_release "develop")
 
-# Figure out the names of the releases we'll compare.
-cd develop
-rel34="$(get_tagged_release "3.4")"
-rel36="$(get_tagged_release "3.6")"
-rel40="$(get_tagged_release "4.0")"
-#rel42="$(get_tagged_release "4.2")"    XXX cannot handle 4.4 formats yet.
-rel42="mongodb-4.2"
-cd ..
-
-# Build the rest of the releases.
-(build_release "$rel34")
-(build_release "$rel36")
-(build_release "$rel40")
-(build_release "$rel42")
-
 # Run format in each release for supported access methods.
-(run_format "$rel34" "fix row var")
-(run_format "$rel36" "fix row var")
-(run_format "$rel40" "fix row var")
-(run_format "$rel42" "fix row var")
+(run_format mongodb-3.4 "fix row var")
+(run_format mongodb-3.6 "fix row var")
+(run_format mongodb-4.0 "fix row var")
+(run_format mongodb-4.2 "fix row var")
+(run_format mongodb-4.4 "row")
 (run_format "develop" "row")
 
 # Verify backward compatibility for supported access methods.
-(verify_backward $rel36 "$rel34" "fix row var")
-(verify_backward $rel40 "$rel36" "fix row var")
-(verify_backward $rel42 "$rel40" "fix row var")
-(verify_backward "develop" "$rel42" "row")
+(verify_backward mongodb-3.6 mongodb-3.4 "fix row var")
+(verify_backward mongodb-4.0 mongodb-3.6 "fix row var")
+(verify_backward mongodb-4.2 mongodb-4.0 "fix row var")
+(verify_backward mongodb-4.4 mongodb-4.2 "fix row var")
+(verify_backward develop mongodb-4.4 "row")
 
 exit 0

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -37,6 +37,7 @@ build_release()
 #############################################################
 # run_format:
 #       arg1: release
+#       arg2: access methods list
 #############################################################
 run_format()
 {
@@ -60,8 +61,9 @@ run_format()
         args+="timer=4 "
         args+="verify=0 "                       # Faster runs
 
-        for am in fix row var; do
+        for am in $2; do
             dir="RUNDIR.$am"
+            echo "./t running $am access method..."
             ./t -1q -h $dir "file_type=$am" $args
         done
 }
@@ -76,6 +78,7 @@ EXT+="]"
 # verify_backward:
 #       arg1: release #1
 #       arg2: release #2
+#       arg3: access methods list
 #############################################################
 verify_backward()
 {
@@ -84,9 +87,9 @@ verify_backward()
         echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
         
         cd "$1"
-        for am in fix row var; do
+        for am in $3; do
             dir="$2/test/format/RUNDIR.$am"
-            echo "$1/wt verifying $2..."
+            echo "$1/wt verifying $2 access method $am..."
 
             WIREDTIGER_CONFIG="$EXT" ./wt -h "../$dir" verify table:wt
         done
@@ -115,17 +118,17 @@ cd ..
 (build_release "$rel40")
 (build_release "$rel42")
 
-# Run format in each release for each access method type.
-(run_format "$rel34")
-(run_format "$rel36")
-(run_format "$rel40")
-(run_format "$rel42")
-(run_format "develop")
+# Run format in each release for supported access methods.
+(run_format "$rel34" "fix row var")
+(run_format "$rel36" "fix row var")
+(run_format "$rel40" "fix row var")
+(run_format "$rel42" "fix row var")
+(run_format "develop" "row")
 
-# Verify backward compatibility.
-(verify_backward $rel36 "$rel34")
-(verify_backward $rel40 "$rel36")
-(verify_backward $rel42 "$rel40")
-(verify_backward "develop" "$rel42")
+# Verify backward compatibility for supported access methods.
+(verify_backward $rel36 "$rel34" "fix row var")
+(verify_backward $rel40 "$rel36" "fix row var")
+(verify_backward $rel42 "$rel40" "fix row var")
+(verify_backward "develop" "$rel42" "row")
 
 exit 0

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -97,7 +97,7 @@ cd "$top"
 (build_release mongodb-3.6)
 (build_release mongodb-4.0)
 (build_release mongodb-4.2)
-(build_release mongodb-4.4)
+#(build_release mongodb-4.4)
 (build_release "develop")
 
 # Run format in each release for supported access methods.
@@ -105,14 +105,15 @@ cd "$top"
 (run_format mongodb-3.6 "fix row var")
 (run_format mongodb-4.0 "fix row var")
 (run_format mongodb-4.2 "fix row var")
-(run_format mongodb-4.4 "row")
+#(run_format mongodb-4.4 "row")
 (run_format "develop" "row")
 
 # Verify backward compatibility for supported access methods.
 (verify_backward mongodb-3.6 mongodb-3.4 "fix row var")
 (verify_backward mongodb-4.0 mongodb-3.6 "fix row var")
 (verify_backward mongodb-4.2 mongodb-4.0 "fix row var")
-(verify_backward mongodb-4.4 mongodb-4.2 "fix row var")
-(verify_backward develop mongodb-4.4 "row")
+#(verify_backward mongodb-4.4 mongodb-4.2 "fix row var")
+#(verify_backward develop mongodb-4.4 "row")
+ (verify_backward develop mongodb-4.2 "fix row var")
 
 exit 0

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -1,131 +1,131 @@
 #!/usr/bin/env bash
 ##############################################################################################
-# Check releases to ensure forward and backward compatibility.
+# Check releases to ensure backward compatibility.
 ##############################################################################################
 
+set -e
+
 ###########################################################################
-# Return the most recent version of the tagged release.
+# Return the most recent version of a tagged release.
 ###########################################################################
-get_release()
+get_tagged_release()
 {
-	echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -V | sed -e '$p' -e d)"
+        echo "$(git tag | grep "^mongodb-$1.[0-9]" | sort -V | sed -e '$p' -e d)"
 }
 
 #############################################################
-# This function will
-#	- checkout git tree of the desired release and build it,
-#	- generate test objects.
-#
-# arg1: MongoDB tagged release number or develop branch identifier.
+# build_release:
+#       arg1: release
 #############################################################
-build_rel()
+build_release()
 {
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-	echo "Building release: \"$1\""
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+        echo "Building release: \"$1\""
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 
-	git clone --quiet https://github.com/wiredtiger/wiredtiger.git "wt.$1" > /dev/null || return 1
-	cd "wt.$1" || return 1
+        git clone --quiet https://github.com/wiredtiger/wiredtiger.git "$1"
+        cd "$1"
+        git checkout --quiet "$1"
 
-	config=""
-	config+="--enable-snappy "
-
-	if [ $1 == "develop" ]; then
-		branch="develop"
-	else
-		branch=$(get_release "$1")
-	fi
-
-	git checkout --quiet -b $branch || return 1
-
-	(sh build_posix/reconf && ./configure $config && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null || return 1
-
-	cd test/format || return 1
-
-	# Run a configuration and generate some on-disk files.
-	args=""
-	args+="cache=80 "				# Medium cache so there's eviction
-	args+="checkpoints=1 "				# Force periodic writes
-	args+="compression=snappy "			# We only built with snappy, force the choice
-	args+="data_source=table "
-	args+="in_memory=0 "				# Interested in the on-disk format
-	args+="leak_memory=1 "				# Faster runs
-	args+="logging_compression=snappy "		# We only built with snappy, force the choice
-	args+="quiet=1 "
-	args+="rebalance=0 "				# Faster runs
-	args+="rows=1000000 "
-	args+="salvage=0 "				# Faster runs
-	args+="timer=4 "
-	args+="verify=0 "				# Faster runs
-	for am in fix row var; do
-		./t -h "RUNDIR.$am" -1 "file_type=$am" $args || return 1
-	done
-
-	return 0
+        config=""
+        config+="--enable-diagnostic "
+        config+="--enable-snappy "
+        (sh build_posix/reconf &&
+            ./configure $config && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null
 }
 
 #############################################################
-# This function will
-#	- verify a pair of releases can verify each other's objects.
-#
-# arg1: release #1
-# arg2: release #2
+# run_format:
+#       arg1: release
 #############################################################
-verify()
+run_format()
 {
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-	echo "Verifying release \"$1\" and \"$2\""
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-	a="wt.$1"
-	b="wt.$2"
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+        echo "Running format in release: \"$1\""
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 
-	EXT="extensions=["
-	EXT+="ext/compressors/snappy/.libs/libwiredtiger_snappy.so,"
-	EXT+="ext/collators/reverse/.libs/libwiredtiger_reverse_collator.so, "
-	EXT+="ext/encryptors/rotn/.libs/libwiredtiger_rotn.so, "
-	EXT+="]"
-	
-	cd $a || return 1
-	for am in fix row var; do
-		echo "$a/wt verifying $b/test/format/RUNDIR.$am..."
-		WIREDTIGER_CONFIG="$EXT" \
-		    ./wt -h ../$b/test/format/RUNDIR.$am verify table:wt || return 1
-	done
+        cd "$1/test/format"
 
-	cd ../$b || return 1
-	for am in fix row var; do
-		echo "$b/wt verifying $a/test/format/RUNDIR.$am..."
-		WIREDTIGER_CONFIG="$EXT" \
-		    ./wt -h ../$a/test/format/RUNDIR.$am verify table:wt || return 1
-	done
+        args=""
+        args+="cache=80 "                       # Medium cache so there's eviction
+        args+="checkpoints=1 "                  # Force periodic writes
+        args+="compression=snappy "             # We only built with snappy, force the choice
+        args+="data_source=table "
+        args+="in_memory=0 "                    # Interested in the on-disk format
+        args+="leak_memory=1 "                  # Faster runs
+        args+="logging_compression=snappy "     # We only built with snappy, force the choice
+        args+="rebalance=0 "                    # Faster runs
+        args+="rows=1000000 "
+        args+="salvage=0 "                      # Faster runs
+        args+="timer=4 "
+        args+="verify=0 "                       # Faster runs
 
-	return 0
+        for am in fix row var; do
+            dir="RUNDIR.$am"
+            ./t -1q -h $dir "file_type=$am" $args
+        done
 }
 
-run()
+EXT="extensions=["
+EXT+="ext/compressors/snappy/.libs/libwiredtiger_snappy.so,"
+EXT+="ext/collators/reverse/.libs/libwiredtiger_reverse_collator.so, "
+EXT+="ext/encryptors/rotn/.libs/libwiredtiger_rotn.so, "
+EXT+="]"
+
+#############################################################
+# verify_backward:
+#       arg1: release #1
+#       arg2: release #2
+#############################################################
+verify_backward()
 {
-	# Build test files from each release.
-	(build_rel 3.4) || return 1
-	(build_rel 3.6) || return 1
-	(build_rel 4.0) || return 1
-	(build_rel 4.2) || return 1
-	(build_rel develop) || return 1
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+        echo "Release \"$1\" verifying \"$2\""
+        echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+        
+        cd "$1"
+        for am in fix row var; do
+            dir="$2/test/format/RUNDIR.$am"
+            echo "$1/wt verifying $2..."
 
-	# Verify forward/backward compatibility.
-	(verify 3.4 3.6) || return 1
-	(verify 3.6 4.0) || return 1
-	(verify 4.0 4.2) || return 1
-	(verify 4.2 develop) || return 1
-
-	return 0
+            WIREDTIGER_CONFIG="$EXT" ./wt -h "../$dir" verify table:wt
+        done
 }
 
 # Create a directory in which to do the work.
 top="test-compatibility-run"
-rm -rf $top && mkdir $top && cd $top || {
-	echo "$0: unable to create $top working directory"
-	exit 1
-}
+rm -rf "$top" && mkdir "$top"
+cd "$top"
 
-run
-exit $?
+# Build a release with a known name, then use it to figure out tagged release names.
+(build_release "develop")
+
+# Figure out the names of the releases we'll compare.
+cd develop
+rel34="$(get_tagged_release "3.4")"
+rel36="$(get_tagged_release "3.6")"
+rel40="$(get_tagged_release "4.0")"
+#rel42="$(get_tagged_release "4.2")"    XXX cannot handle 4.4 formats yet.
+rel42="mongodb-4.2"
+cd ..
+
+# Build the rest of the releases.
+(build_release "$rel34")
+(build_release "$rel36")
+(build_release "$rel40")
+(build_release "$rel42")
+
+# Run format in each release for each access method type.
+(run_format "$rel34")
+(run_format "$rel36")
+(run_format "$rel40")
+(run_format "$rel42")
+(run_format "develop")
+
+# Verify backward compatibility.
+(verify_backward $rel36 "$rel34")
+(verify_backward $rel40 "$rel36")
+(verify_backward $rel42 "$rel40")
+(verify_backward "develop" "$rel42")
+
+exit 0


### PR DESCRIPTION
@lukech, a new version of the release compatibility test script for your consideration.

Note: that this script needs to be updated once there's a 4.2 tagged release that can handle the current 4.4 disk format.

Also note: because the test runs `format` to create variable- and fixed-length column store tables, running this version of the test in Evergreen is going to make the test go red. (cc: @agorrod)