### PR TITLE
WT-5891 Disable testing of checkpoint cursors in wt4333_handle_locks

### DIFF
--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -110,8 +110,8 @@ op(WT_SESSION *session, WT_RAND_STATE *rnd, WT_CURSOR **cpp)
          * Use a checkpoint handle for 50% of reads.
          *
          * FIXME: Checkpoint cursors are known to have issues in durable history so we've removing
-         * the use of checkpoint handles in this test. Depending on how we end up resolving this, we
-         * should either re-enable the testing of checkpoint cursors or remove this comment.
+         * the use of checkpoint handles in this test. As part of WT-5927, we should either
+         * re-enable the testing of checkpoint cursors or remove this comment.
          */
         ret = session->open_cursor(session, uri_list[i], NULL, NULL, &cursor);
         if (ret != EBUSY) {

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -106,9 +106,14 @@ op(WT_SESSION *session, WT_RAND_STATE *rnd, WT_CURSOR **cpp)
 
     /* Loop to open an object handle. */
     for (i = __wt_random(rnd) % uris; !done; __wt_yield()) {
-        /* Use a checkpoint handle for 50% of reads. */
-        ret = session->open_cursor(session, uri_list[i], NULL,
-          readonly && (i % 2 == 0) ? "checkpoint=WiredTigerCheckpoint" : NULL, &cursor);
+        /*
+         * Use a checkpoint handle for 50% of reads.
+         *
+         * FIXME: Checkpoint cursors are known to have issues in durable history so we've removing
+         * the use of checkpoint handles in this test. Depending on how we end up resolving this, we
+         * should either re-enable the testing of checkpoint cursors or remove this comment.
+         */
+        ret = session->open_cursor(session, uri_list[i], NULL, NULL, &cursor);
         if (ret != EBUSY) {
             testutil_check(ret);
             break;


### PR DESCRIPTION
Checkpoint cursors are known to be broken as of durable history. This particular visibility issue seems to only happen with checkpoint cursors so let's disable this part of the test temporarily.

If we see visibility issues crop up even with regular cursors, then we can investigate further.