### PR TITLE
WT-5923 Avoid performing history store cleanup for modified trees

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -146,7 +146,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     WT_DECL_RET;
     WT_ITEM full_value;
     WT_UPDATE *hs_upd, *upd;
-    wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts;
+    wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts, newer_hs_ts;
     size_t size;
     uint64_t hs_counter, type_full;
     uint32_t hs_btree_id, session_flags;
@@ -157,7 +157,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
 
     hs_cursor = NULL;
     hs_upd = upd = NULL;
-    durable_ts = hs_start_ts = WT_TS_NONE;
+    durable_ts = hs_start_ts = newer_hs_ts = WT_TS_NONE;
     hs_btree_id = S2BT(session)->id;
     session_flags = 0;
     is_owner = valid_update_found = false;
@@ -226,6 +226,13 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
         }
 
         /*
+         * Verify the history store timestamps are in order. The start timestamp may be equal to the
+         * stop timestamp if the original update's commit timestamp is out of order.
+         */
+        WT_ASSERT(session,
+          (newer_hs_ts == WT_TS_NONE || hs_stop_ts <= newer_hs_ts || hs_start_ts == hs_stop_ts));
+
+        /*
          * Stop processing when we find the newer version value of this key is stable according to
          * the current version stop timestamp. Also it confirms that history store doesn't contains
          * any newer version than the current version for the key.
@@ -253,6 +260,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
           S2BT(session)->dhandle->name, __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(rollback_timestamp, ts_string[1]));
 
+        newer_hs_ts = hs_start_ts;
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd));
         WT_ERR(__wt_hs_modify(cbt, hs_upd));
         WT_STAT_CONN_INCR(session, txn_rts_hs_removed);
@@ -866,24 +874,23 @@ __rollback_to_stable_check(WT_SESSION_IMPL *session)
 }
 
 /*
- * __rollback_to_stable_btree_hs_cleanup --
+ * __rollback_to_stable_btree_hs_truncate --
  *     Wipe all history store updates for the btree (non-timestamped tables)
  */
 static int
-__rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_id)
+__rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_ITEM(hs_key);
-    WT_DECL_ITEM(hs_value);
     WT_DECL_RET;
     WT_ITEM key;
     WT_UPDATE *hs_upd;
-    wt_timestamp_t durable_ts, hs_start_ts, hs_stop_ts;
-    uint64_t hs_counter, type_full;
+    wt_timestamp_t hs_start_ts;
+    uint64_t hs_counter;
     uint32_t hs_btree_id, session_flags;
     int exact;
-    char ts_string[3][WT_TS_INT_STRING_SIZE];
+    char ts_string[WT_TS_INT_STRING_SIZE];
     bool is_owner;
 
     hs_cursor = NULL;
@@ -893,7 +900,6 @@ __rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_i
     is_owner = false;
 
     WT_RET(__wt_scr_alloc(session, 0, &hs_key));
-    WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
 
     /* Open a history store table cursor. */
     WT_ERR(__wt_hs_cursor(session, &session_flags, &is_owner));
@@ -921,14 +927,9 @@ __rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_i
 
         /* Set this comparison as exact match of the search for later use. */
         cbt->compare = 0;
-        WT_ERR(hs_cursor->get_value(hs_cursor, &hs_stop_ts, &durable_ts, &type_full, hs_value));
-
         __wt_verbose(session, WT_VERB_RTS,
-          "%s: Rollback to stable history cleanup update with start timestamp: %s, stop timestamp: "
-          "%s and durable timestamp: %s",
-          S2BT(session)->dhandle->name, __wt_timestamp_to_string(hs_start_ts, ts_string[0]),
-          __wt_timestamp_to_string(hs_stop_ts, ts_string[1]),
-          __wt_timestamp_to_string(durable_ts, ts_string[2]));
+          "%s: Rollback to stable history cleanup update with start timestamp: %s",
+          S2BT(session)->dhandle->name, __wt_timestamp_to_string(hs_start_ts, ts_string));
 
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd));
         WT_ERR(__wt_hs_modify(cbt, hs_upd));
@@ -939,7 +940,6 @@ __rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_i
 
 err:
     __wt_scr_free(session, &hs_key);
-    __wt_scr_free(session, &hs_value);
     __wt_free(session, hs_upd);
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
 
@@ -1036,12 +1036,20 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
             __wt_verbose(session, WT_VERB_RTS, "%s: file skipped with durable timestamp: %s", uri,
               __wt_timestamp_to_string(max_durable_ts, ts_string));
 
-        /* Cleanup any history store entries for this non-timestamped table. */
+        /*
+         * Truncate history store entries for the non-timestamped table.
+         * Exceptions:
+         * 1. Modified tree - Scenarios where the tree is never checkpointed lead to zero
+         * durable timestamp even they are timestamped tables. Until we have a special indication
+         * of letting to know the table type other than checking checkpointed durable timestamp
+         * to WT_TS_NONE, We need this exception.
+         * 2. In-memory database - In this scenario, there is no history store to truncate.
+         */
         if (!S2BT(session)->modified && max_durable_ts == WT_TS_NONE &&
           !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
             __wt_verbose(
               session, WT_VERB_RTS, "%s: non-timestamped file history store cleanup", uri);
-            WT_TRET(__rollback_to_stable_btree_hs_cleanup(session, S2BT(session)->id));
+            WT_TRET(__rollback_to_stable_btree_hs_truncate(session, S2BT(session)->id));
         }
 
         WT_TRET(__wt_session_release_dhandle(session));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -900,7 +900,8 @@ __rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_i
     session_flags = 0;
     is_owner = false;
 
-    WT_ERR(__wt_scr_alloc(session, 0, &hs_key));
+    WT_RET(__wt_scr_alloc(session, 0, &hs_key));
+    WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
 
     /* Open a history store table cursor. */
     WT_ERR(__wt_hs_cursor(session, &session_flags, &is_owner));
@@ -946,6 +947,7 @@ __rollback_to_stable_btree_hs_cleanup(WT_SESSION_IMPL *session, uint32_t btree_i
 
 err:
     __wt_scr_free(session, &hs_key);
+    __wt_scr_free(session, &hs_value);
     __wt_free(session, hs_upd);
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
 


### PR DESCRIPTION
Scenarios when the trees are not checkpointed at once, it is possible
that durable timestamp of that tree can be zero, because of this reason
the trees are treated as non-timestamped tables and lead them to clean
their history store. To avoid this problem, ignore history store cleanup
when the trees are modified.

The side affect of this change is that it doesn't perform the history store
cleanup for the non-timestamped tables also that are modified, but anyway
these tables gets cleaned during recovery rollback to stable phase.