### PR TITLE
WT-5811 For evergreen runs, mark ASAN tests as running on a slow machine.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -458,7 +458,7 @@ tasks:
           posix_configure_flags: --enable-silent-rules --enable-strict --enable-diagnostic --disable-static
       - func: "make check all"
         vars:
-          test_env_vars: ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:disable_coredump=0 ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+          test_env_vars: ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:disable_coredump=0 ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer TESTUTIL_SLOW_MACHINE=1
 
   - name: make-check-linux-no-ftruncate-test
     depends_on:


### PR DESCRIPTION
Setting the env flag `TESTUTIL_SLOW_MACHINE=1` keeps certain time sensitive tests from running.