### PR TITLE
WT-5943 Consider all non aborted updates as valid

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -47,6 +47,10 @@ __rollback_abort_newer_update(WT_SESSION_IMPL *session, WT_UPDATE *first_upd,
             upd->txnid = WT_TXN_ABORTED;
             WT_STAT_CONN_INCR(session, txn_rts_upd_aborted);
             upd->durable_ts = upd->start_ts = WT_TS_NONE;
+        } else {
+            /* Valid update is found. */
+            WT_ASSERT(session, first_upd == upd);
+            break;
         }
     }
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -22,20 +22,10 @@ __rollback_abort_newer_update(WT_SESSION_IMPL *session, WT_UPDATE *first_upd,
 
     *stable_update_found = false;
     for (upd = first_upd; upd != NULL; upd = upd->next) {
-        /*
-         * Updates with no timestamp will have a timestamp of zero and will never be rolled back. If
-         * the table is configured for strict timestamp checking, assert that all more recent
-         * updates were also rolled back.
-         */
-        if (upd->txnid == WT_TXN_ABORTED || upd->start_ts == WT_TS_NONE) {
+        /* Skip the updates that are aborted. */
+        if (upd->txnid == WT_TXN_ABORTED) {
             if (upd == first_upd)
                 first_upd = upd->next;
-
-            /*
-             * Consider WT_TS_NONE timestamped update as a valid stable update if it is not aborted.
-             */
-            if (upd->txnid != WT_TXN_ABORTED)
-                *stable_update_found = true;
         } else if (rollback_timestamp < upd->durable_ts) {
             /*
              * If any updates are aborted, all newer updates better be aborted as well.

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -30,6 +30,12 @@ __rollback_abort_newer_update(WT_SESSION_IMPL *session, WT_UPDATE *first_upd,
         if (upd->txnid == WT_TXN_ABORTED || upd->start_ts == WT_TS_NONE) {
             if (upd == first_upd)
                 first_upd = upd->next;
+
+            /*
+             * Consider WT_TS_NONE timestamped update as a valid stable update if it is not aborted.
+             */
+            if (upd->txnid != WT_TXN_ABORTED)
+                *stable_update_found = true;
         } else if (rollback_timestamp < upd->durable_ts) {
             /*
              * If any updates are aborted, all newer updates better be aborted as well.


### PR DESCRIPTION
While aborting the updates that are more than the stable timestamp,
if it found any update that is not aborted even with the timestamp
of WT_TS_NONE, consider it as a vaid update.