### PR TITLE
WT-5796 Speed up verification of file's associated history store information.

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -794,7 +794,8 @@ err:
  *     Dump information about a key and/or value.
  */
 int
-__wt_debug_key_value(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *value)
+__wt_debug_key_value(
+  WT_SESSION_IMPL *session, WT_ITEM *key, uint64_t recno, uint64_t rle, WT_CELL_UNPACK *value)
 {
     WT_DBG *ds, _ds;
     WT_DECL_RET;
@@ -803,17 +804,16 @@ __wt_debug_key_value(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *val
 
     WT_ERR(__debug_config(session, ds, NULL));
 
-    if (key != NULL)
+    if (key == NULL)
+        WT_ERR(ds->f(ds, "\tK {%" PRIu64 " %" PRIu64 "}", recno, rle));
+    else
         WT_ERR(__debug_item_key(ds, "K", key->data, key->size));
-    if (value != NULL) {
-        WT_ERR(__debug_time_pairs(
-          ds, "T", value->start_ts, value->start_txn, value->stop_ts, value->stop_txn));
-        WT_ERR(__debug_cell_data(ds, NULL, value != NULL ? value->type : 0, "V", value));
-    }
+    WT_ERR(__debug_time_pairs(
+      ds, "T", value->start_ts, value->start_txn, value->stop_ts, value->stop_txn));
+    WT_ERR(__debug_cell_data(ds, NULL, value != NULL ? value->type : 0, "V", value));
 
 err:
-    WT_RET(__debug_wrapup(ds));
-    return (ret);
+    return (__debug_wrapup(ds));
 }
 
 /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -928,7 +928,6 @@ __verify_page_content(
 {
     WT_BTREE *btree;
     WT_CELL_UNPACK unpack;
-    WT_COL *cip;
     WT_DECL_RET;
     WT_PAGE *page;
     const WT_PAGE_HEADER *dsk;
@@ -941,7 +940,6 @@ __verify_page_content(
 
     btree = S2BT(session);
     page = ref->page;
-    cip = page->pg_var;
     rip = page->pg_row;
     recno = ref->ref_recno;
     found_ovfl = false;
@@ -1093,15 +1091,13 @@ __verify_page_content(
             if (unpack.type != WT_CELL_KEY && unpack.type != WT_CELL_KEY_OVFL)
                 continue;
 
-            WT_RET(__wt_row_leaf_key(session, page, rip, vs->tmp1, false));
+            WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
+            WT_RET(__verify_key_hs(session, vs->tmp1, unpack.start_ts, vs));
 
 #ifdef HAVE_DIAGNOSTIC
             if (vs->dump_history)
                 WT_RET(__wt_debug_key_value(session, vs->tmp1, WT_RECNO_OOB, 0, &unpack));
 #endif
-            WT_RET(__verify_key_hs(session, vs->tmp1, unpack.start_ts, vs));
-
-            ++rip;
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
             p = vs->tmp1->mem;
@@ -1114,7 +1110,6 @@ __verify_page_content(
                 WT_RET(__wt_debug_key_value(session, NULL, recno, rle, &unpack));
 #endif
             recno += rle;
-            ++cip;
         }
     }
     WT_CELL_FOREACH_END;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1094,7 +1094,7 @@ __verify_page_content(
                 WT_RET(__wt_debug_key_value(session, NULL, recno, rle, &unpack));
 #endif
             recno += rle;
-	    vs->records_so_far += rle;
+            vs->records_so_far += rle;
         }
     }
     WT_CELL_FOREACH_END;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -13,7 +13,7 @@
  * prettier.
  */
 typedef struct {
-    uint64_t records_so_far; /* Total record count seen so far */
+    uint64_t records_so_far; /* Records seen so far */
 
     WT_ITEM *max_key;  /* Largest key */
     WT_ITEM *max_addr; /* Largest key page */
@@ -858,7 +858,7 @@ __verify_key_hs(
      * and iterate backwards until we reach a different key or btree.
      */
     hs_cursor = session->hs_cursor;
-    hs_cursor->set_key(hs_cursor, hs_btree_id, tmp1, WT_TS_MAX, UINT64_MAX);
+    hs_cursor->set_key(hs_cursor, hs_btree_id, tmp1, WT_TS_MAX, WT_TXN_MAX);
     ret = hs_cursor->search_near(hs_cursor, &exact);
 
     /* If we jumped to the next key, go back to the previous key. */

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1239,3 +1239,123 @@ err:
     __wt_free(session, upd);
     return (ret);
 }
+
+/*
+ * __wt_verify_history_store_tree --
+ *     Verify the history store. There can't be an entry in the history store without having the
+ *     latest value for the respective key in the data store. If given a uri, limit the verification
+ *     to the corresponding btree.
+ */
+int
+__wt_verify_history_store_tree(WT_SESSION_IMPL *session, const char *uri)
+{
+    WT_CURSOR *cursor, *data_cursor;
+    WT_DECL_ITEM(hs_key);
+    WT_DECL_ITEM(prev_hs_key);
+    WT_DECL_RET;
+    wt_timestamp_t hs_start_ts;
+    uint64_t hs_counter;
+    uint32_t btree_id, btree_id_given_uri, session_flags, prev_btree_id;
+    int exact, cmp;
+    char *uri_itr;
+    bool is_owner;
+
+    cursor = data_cursor = NULL;
+    btree_id_given_uri = 0; /* [-Wconditional-uninitialized] */
+    session_flags = 0;      /* [-Wconditional-uninitialized] */
+    prev_btree_id = 0;      /* [-Wconditional-uninitialized] */
+    uri_itr = NULL;
+    is_owner = false; /* [-Wconditional-uninitialized] */
+
+    WT_ERR(__wt_scr_alloc(session, 0, &hs_key));
+    WT_ERR(__wt_scr_alloc(session, 0, &prev_hs_key));
+
+    WT_ERR(__wt_hs_cursor(session, &session_flags, &is_owner));
+    cursor = session->hs_cursor;
+
+    /*
+     * If a uri has been provided, limit verification to the corresponding btree by jumping to the
+     * first record for that btree in the history store. Otherwise scan the whole history store.
+     */
+    if (uri != NULL) {
+        ret = __wt_metadata_uri_to_btree_id(session, uri, &btree_id_given_uri);
+        if (ret != 0)
+            WT_ERR_MSG(session, ret, "Unable to locate the URI %s in the metadata file", uri);
+
+        /*
+         * Position the cursor at the first record of the specified btree, or one after. It is
+         * possible there are no records in the history store for this btree.
+         */
+        cursor->set_key(cursor, btree_id_given_uri, hs_key, 0, 0, 0, 0);
+        ret = cursor->search_near(cursor, &exact);
+        if (ret == 0 && exact < 0)
+            ret = cursor->next(cursor);
+    } else
+        ret = cursor->next(cursor);
+
+    /* We have the history store cursor positioned at the first record that we want to verify. */
+    for (; ret == 0; ret = cursor->next(cursor)) {
+        WT_ERR(cursor->get_key(cursor, &btree_id, hs_key, &hs_start_ts, &hs_counter));
+
+        /* When limiting our verification to a uri, bail out if the btree-id doesn't match. */
+        if (uri != NULL && btree_id != btree_id_given_uri)
+            break;
+
+        /*
+         *  Keep track of the previous comparison. The history store is stored in order, so we can
+         *  avoid redundant comparisons. Previous btree ID isn't set, until data cursor is open.
+         */
+        if (data_cursor == NULL || (prev_btree_id != btree_id)) {
+            /*
+             * Check whether this btree-id exists in the metadata. We do that by finding what uri
+             * this btree belongs to. Using this URI, verify the history store key with the data
+             * store.
+             */
+            if (data_cursor != NULL) {
+                WT_ERR(data_cursor->close(data_cursor));
+                /* Setting data_cursor to null, to avoid double free */
+                data_cursor = NULL;
+            }
+            /*
+             * Using the btree-id find the metadata entry and extract the URI for this btree. Don't
+             * forget to free the copy of the URI returned.
+             *
+             * Re-purpose the previous-key buffer on error, safe because we're about to error out.
+             */
+            __wt_free(session, uri_itr);
+            if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_itr)) != 0)
+                WT_ERR_MSG(session, ret,
+                  "Unable to find btree-id %" PRIu32
+                  " in the metadata file for the associated history store key %s",
+                  btree_id,
+                  __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key));
+
+            WT_ERR(__wt_open_cursor(session, uri_itr, NULL, NULL, &data_cursor));
+            F_SET(data_cursor, WT_CURSOR_RAW_OK);
+        } else {
+            WT_ERR(__wt_compare(session, NULL, hs_key, prev_hs_key, &cmp));
+            if (cmp == 0)
+                continue;
+        }
+        WT_ERR(__wt_buf_set(session, prev_hs_key, hs_key->data, hs_key->size));
+        prev_btree_id = btree_id;
+
+        /* Re-purpose the previous-key buffer on error, safe because we're about to error out. */
+        data_cursor->set_key(data_cursor, hs_key);
+        if ((ret = data_cursor->search(data_cursor)) == WT_NOTFOUND)
+            WT_ERR_MSG(session, ret,
+              "In %s, the associated history store key %s not found in the data store", uri_itr,
+              __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key));
+        WT_ERR(ret);
+    }
+    WT_ERR_NOTFOUND_OK(ret);
+err:
+    if (data_cursor != NULL)
+        WT_TRET(data_cursor->close(data_cursor));
+    WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
+
+    __wt_scr_free(session, &hs_key);
+    __wt_scr_free(session, &prev_hs_key);
+    __wt_free(session, uri_itr);
+    return (ret);
+}

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1344,7 +1344,7 @@ __wt_verify_history_store_tree(WT_SESSION_IMPL *session, const char *uri)
         data_cursor->set_key(data_cursor, hs_key);
         if ((ret = data_cursor->search(data_cursor)) == WT_NOTFOUND)
             WT_ERR_MSG(session, ret,
-              "In %s, the associated history store key %s not found in the data store", uri_itr,
+              "In %s, the associated history store key %s was not found in the data store", uri_itr,
               __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key));
         WT_ERR(ret);
     }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -592,8 +592,8 @@ extern int __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_disk(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, const char *ofile)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_debug_key_value(WT_SESSION_IMPL *session, WT_ITEM *key, WT_CELL_UNPACK *value)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_key_value(WT_SESSION_IMPL *session, WT_ITEM *key, uint64_t recno,
+  uint64_t rle, WT_CELL_UNPACK *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size,


### PR DESCRIPTION
@luke-pearson, @sulabhM, Jeremy Tay did the original work and you were the reviewers; of course, please turf the review elsewhere if that's appropriate.

I haven't tested if this change fixes the timeouts in Evergreen tests, but the speedup is more than 100x, and is roughly the speed of verify in previous releases.

The 903469b commit is the interesting one, and 1c4b3cc adds some minor additional changes (the other commits are code shuffling).