### PR TITLE
WT-5948 Fix assert to check history store ordering

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -234,8 +234,8 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
          * Verify the history store timestamps are in order. The start timestamp may be equal to the
          * stop timestamp if the original update's commit timestamp is out of order.
          */
-        WT_ASSERT(session,
-          (newer_hs_ts == WT_TS_NONE || hs_stop_ts <= newer_hs_ts || hs_start_ts == hs_stop_ts));
+        WT_ASSERT(session, (newer_hs_ts == WT_TS_NONE || hs_stop_ts <= newer_hs_ts ||
+                             hs_start_ts == newer_hs_ts || hs_start_ts == hs_stop_ts));
 
         /*
          * Stop processing when we find the newer version value of this key is stable according to


### PR DESCRIPTION
The out of order inserts into the main table can lead to out of order
records in history store with start/stop timestamps. Update the assert
to include those scenarios also.