### PR TITLE
WT-5952 Fix freeing updates racing with application threads

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1529,7 +1529,7 @@ __split_multi_inmem_final(
     /*
      * We successfully created new in-memory pages. For error-handling reasons, we've left the
      * update chains referenced by both the original and new pages. We're ready to discard the
-     * original page, terminate the original page's reference to any update list.
+     * original page, terminate the original page's reference to any update list we moved.
      */
     for (i = 0, supd = multi->supd; i < multi->supd_entries; ++i, ++supd) {
         /* We have finished restoration. Discard the update chains that aren't restored. */

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1467,7 +1467,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
              */
             WT_ASSERT(session, upd != supd->onpage_upd);
             /*
-             * Move the pointer to the position before the onpage value and free all the updates
+             * Move the pointer to the position before the onpage value and truncate all the updates
              * starting from the onpage value.
              */
             for (prev_onpage = upd;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1517,10 +1517,10 @@ err:
  *     Discard moved update lists from the original page.
  */
 static void
-__split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
+__split_multi_inmem_final(
+  WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE *upd;
     uint32_t i, slot;
 
     /* If we have saved updates, we must have decided to restore them to the new page. */
@@ -1529,8 +1529,7 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
     /*
      * We successfully created new in-memory pages. For error-handling reasons, we've left the
      * update chains referenced by both the original and new pages. We're ready to discard the
-     * original page, terminate the original page's reference to any update list we moved and free
-     * the values have been moved to the data store and the history store.
+     * original page, terminate the original page's reference to any update list.
      */
     for (i = 0, supd = multi->supd; i < multi->supd_entries; ++i, ++supd) {
         /* We have finished restoration. Discard the update chains that aren't restored. */
@@ -1539,35 +1538,9 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
 
         if (supd->ins == NULL) {
             slot = WT_ROW_SLOT(orig, supd->ripcip);
-            upd = orig->modify->mod_row_update[slot];
             orig->modify->mod_row_update[slot] = NULL;
-        } else {
-            upd = supd->ins->upd;
+        } else
             supd->ins->upd = NULL;
-        }
-
-        /*
-         * Free the onpage value and the older versions moved to the history store. We can't free
-         * the updates for in memory database and fixed length column store as they don't support
-         * the history sore.
-         */
-        if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          orig->type != WT_PAGE_COL_FIX) {
-            /*
-             * We have decided to restore this update chain so it must have newer updates than the
-             * onpage value on it.
-             */
-            WT_ASSERT(session, upd != NULL && upd != supd->onpage_upd && supd->onpage_upd != NULL);
-            /*
-             * Move the pointer to the position before the onpage value and free all the updates
-             * starting from the onpage value.
-             */
-            for (; upd->next != NULL && upd->next != supd->onpage_upd; upd = upd->next)
-                ;
-            WT_ASSERT(session, upd->next == supd->onpage_upd);
-            upd->next = NULL;
-            __wt_free_update_list(session, &supd->onpage_upd);
-        }
     }
 }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1517,8 +1517,7 @@ err:
  *     Discard moved update lists from the original page.
  */
 static void
-__split_multi_inmem_final(
-  WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
+__split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
     uint32_t i, slot;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1579,8 +1579,8 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
 
 /*
  * __split_multi_inmem_fail --
- *     Discard allocated pages after failure and append the onpage value back to the original update
- *     chains.
+ *     Discard allocated pages after failure and append the onpage values back to the original
+ *     update chains.
  */
 static void
 __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT_REF *ref)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1603,9 +1603,10 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
 
         if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
           orig->type != WT_PAGE_COL_FIX) {
-            for (; upd->next != NULL; upd = upd->next)
+            for (; upd->next != NULL && upd->next != supd->onpage_upd; upd = upd->next)
                 ;
-            upd->next = supd->onpage_upd;
+            if (upd->next == NULL)
+                upd->next = supd->onpage_upd;
         }
     }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1550,11 +1550,8 @@ static void
 __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE *upd;
-    size_t size;
     uint32_t i, slot;
 
-    size = 0;
     /* If we have saved updates, we must have decided to restore them to the new page. */
     WT_ASSERT(session, multi->supd_entries == 0 || multi->supd_restore);
 
@@ -1577,16 +1574,9 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
 
         /* Free the updates written to the data store and the history store. */
         if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          orig->type != WT_PAGE_COL_FIX) {
-            /* Track the freed size. */
-            for (upd = supd->onpage_upd; upd != NULL; upd = upd->next)
-                size += WT_UPDATE_MEMSIZE(upd);
+          orig->type != WT_PAGE_COL_FIX)
             __wt_free_update_list(session, &supd->onpage_upd);
-        }
     }
-
-    if (size != 0)
-        __wt_cache_page_inmem_decr(session, orig, size);
 }
 
 /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1541,8 +1541,8 @@ err:
 
 /*
  * __split_multi_inmem_final --
- *     Discard moved update lists from the original page and the updates written to the data store
- *     and the history store.
+ *     Discard moved update lists from the original page and free the updates written to the data
+ *     store and the history store.
  */
 static void
 __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
@@ -1579,7 +1579,8 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
 
 /*
  * __split_multi_inmem_fail --
- *     Discard allocated pages after failure.
+ *     Discard allocated pages after failure and append the onpage value back to the original update
+ *     chains.
  */
 static void
 __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT_REF *ref)


### PR DESCRIPTION
In __split_multi_inmem_final, I suspect we no longer have exclusive access to the page. In that case, we
cannot free the updates moved to data store and history store as we may race
with the application threads. @keithbostic Can you confirm that we don't have exclusive access to the page in __split_multi_inmem_final?