### PR TITLE
WT-5961 Respect write generations when constructing the root addr

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -433,12 +433,16 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              */
             memset(&addr_unpack, 0, sizeof(addr_unpack));
             addr_unpack.newest_start_durable_ts = ckpt->start_durable_ts;
-            addr_unpack.oldest_start_ts = ckpt->oldest_start_ts;
-            addr_unpack.oldest_start_txn =
-              ckpt->write_gen > S2C(session)->base_write_gen ? ckpt->oldest_start_txn : 0;
             addr_unpack.newest_stop_durable_ts = ckpt->stop_durable_ts;
+            addr_unpack.oldest_start_ts = ckpt->oldest_start_ts;
             addr_unpack.newest_stop_ts = ckpt->newest_stop_ts;
-            addr_unpack.newest_stop_txn = ckpt->newest_stop_txn;
+            if (ckpt->write_gen > S2C(session)->base_write_gen) {
+                addr_unpack.oldest_start_txn = ckpt->oldest_start_txn;
+                addr_unpack.newest_stop_txn = ckpt->newest_stop_txn;
+            } else {
+                addr_unpack.oldest_start_txn = WT_TXN_NONE;
+                addr_unpack.newest_stop_txn = WT_TXN_MAX;
+            }
             addr_unpack.raw = WT_CELL_ADDR_INT;
 
             /* Verify the tree. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -434,7 +434,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
             memset(&addr_unpack, 0, sizeof(addr_unpack));
             addr_unpack.newest_start_durable_ts = ckpt->start_durable_ts;
             addr_unpack.oldest_start_ts = ckpt->oldest_start_ts;
-            addr_unpack.oldest_start_txn = ckpt->oldest_start_txn;
+            addr_unpack.oldest_start_txn =
+              ckpt->write_gen > S2C(session)->base_write_gen ? ckpt->oldest_start_txn : 0;
             addr_unpack.newest_stop_durable_ts = ckpt->stop_durable_ts;
             addr_unpack.newest_stop_ts = ckpt->newest_stop_ts;
             addr_unpack.newest_stop_txn = ckpt->newest_stop_txn;


### PR DESCRIPTION
In `__wt_verify`, if the write generation on the checkpoint is less than or equal to the `base_write_gen` on the connection, we should set the parent cell `addr_unpack.oldest_start_txn` to 0.