### PR TITLE
WT 5357 WT_SESSION.truncate of a log cursor isn't documented

### DIFF
--- a/examples/c/ex_backup.c
+++ b/examples/c/ex_backup.c
@@ -217,7 +217,9 @@ take_incr_backup(WT_SESSION *session, int i)
      * With an incremental cursor, we want to truncate on the backup cursor to archive the logs.
      * Only do this if the copy process was entirely successful.
      */
+    /*! [Truncate a backup cursor] */
     error_check(session->truncate(session, "log:", cursor, NULL, NULL));
+    /*! [Truncate a backup cursor] */
     error_check(cursor->close(cursor));
 }
 

--- a/src/docs/durability.dox
+++ b/src/docs/durability.dox
@@ -76,10 +76,13 @@ instead must disable log file removal using the \c log=(archive=false)
 configuration to ::wiredtiger_open.
 
 Log files may be removed or archived after a checkpoint has completed,
-as long as there's not a backup in progress.  Immediately after the checkpoint
-has completed, only the most recent log file is needed for recovery, and all
-other log files can be removed or archived.  Note that there must always
-be at least one log file for the database.
+as long as there's not a backup in progress.  When performing @ref
+backup_incremental, WT_SESSION::truncate can be used to remove log files
+after completing each incremental backup.
+
+Immediately after the checkpoint has completed, only the most recent log file
+is needed for recovery, and all other log files can be removed or archived.
+Note that there must always be at least one log file for the database.
 
 Open log cursors prevents WiredTiger from automatically removing log files.
 Therefore, we recommend proactively closing log cursors when done with them.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1627,7 +1627,7 @@ struct __wt_session {
 	    const char *name, const char *config);
 
 	/*!
-	 * Truncate a file, table or cursor range.
+	 * Truncate a file, table, cursor range, or backup cursor
 	 *
 	 * Truncate a table or file.
 	 * @snippet ex_all.c Truncate a table
@@ -1649,14 +1649,20 @@ struct __wt_session {
 	 * they do commit, and if there is a crash and recovery runs, the result
 	 * may be different than what was in cache before the crash.
 	 *
+	 * Truncate a backup cursor.  This operation removes all log files that
+	 * have been returned by the backup cursor.  It can be used to remove log
+	 * files after copying them during @ref backup_incremental.
+	 * @snippet ex_backup.c Truncate a backup cursor
+	 *
 	 * @param session the session handle
-	 * @param name the URI of the table or file to truncate
+	 * @param name the URI of the table or file to truncate, or \c "log:"
+	 * for a backup cursor
 	 * @param start optional cursor marking the first record discarded;
 	 * if <code>NULL</code>, the truncate starts from the beginning of
-	 * the object
+	 * the object; must be provided when truncating a backup cursor
 	 * @param stop optional cursor marking the last record discarded;
 	 * if <code>NULL</code>, the truncate continues to the end of the
-	 * object
+	 * object; ignored when truncating a backup cursor
 	 * @configempty{WT_SESSION.truncate, see dist/api_data.py}
 	 * @errors
 	 */


### PR DESCRIPTION
Add documentation of WT_SESSION::truncate behavior when called on a backup_cursor.
In addition to WT_SESSION::truncate, updated description in the "Log file archival" section
of the "Commit-level durability" page. 

Possible issue:  Is the description of the `start` parameter confusing? It's generally optional, but mandatory for the backup cursor use case.