### PR TITLE
WT-5948 Search shouldn't ignore globally visible tombstones

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -753,10 +753,8 @@ __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **upd
         upd_visible = __wt_txn_upd_visible_type(session, upd);
         if (upd_visible == WT_VISIBLE_TRUE) {
             /*
-             * Don't consider tombstone updates for the history store when the session is requested
-             * unless if it is globally visible tombstone. A globally visible tombstone that is
-             * added by rollback to stable operation should contains all the timestamps and
-             * transaction id's to zero.
+             * A tombstone representing a stop time pair will have either a valid txn id or a valid
+             * timestamp. Ignore such tombstones in history store based on session settings.
              */
             if (type == WT_UPDATE_TOMBSTONE && WT_IS_HS(S2BT(session)) &&
               F_ISSET(session, WT_SESSION_IGNORE_HS_TOMBSTONE) &&

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -758,9 +758,9 @@ __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **upd
              * added by rollback to stable operation should contains all the timestamps and
              * transaction id's to zero.
              */
-            if (type == WT_UPDATE_TOMBSTONE && upd->durable_ts != WT_TS_NONE &&
-              upd->txnid != WT_TXN_NONE && WT_IS_HS(S2BT(session)) &&
-              F_ISSET(session, WT_SESSION_IGNORE_HS_TOMBSTONE))
+            if (type == WT_UPDATE_TOMBSTONE && WT_IS_HS(S2BT(session)) &&
+              F_ISSET(session, WT_SESSION_IGNORE_HS_TOMBSTONE) &&
+              (upd->start_ts != WT_TS_NONE || upd->txnid != WT_TXN_NONE))
                 continue;
             *updp = upd;
             return (0);

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -752,8 +752,14 @@ __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **upd
             continue;
         upd_visible = __wt_txn_upd_visible_type(session, upd);
         if (upd_visible == WT_VISIBLE_TRUE) {
-            /* Don't consider tombstone updates for the history store during rollback to stable. */
-            if (type == WT_UPDATE_TOMBSTONE && WT_IS_HS(S2BT(session)) &&
+            /*
+             * Don't consider tombstone updates for the history store when the session is requested
+             * unless if it is globally visible tombstone. A globally visible tombstone that is
+             * added by rollback to stable operation should contains all the timestamps and
+             * transaction id's to zero.
+             */
+            if (type == WT_UPDATE_TOMBSTONE && upd->durable_ts != WT_TS_NONE &&
+              upd->txnid != WT_TXN_NONE && WT_IS_HS(S2BT(session)) &&
               F_ISSET(session, WT_SESSION_IGNORE_HS_TOMBSTONE))
                 continue;
             *updp = upd;


### PR DESCRIPTION
As part of rollback to stable operations, any updates that are needs
to be removed, rollback to stable adds globally visible updates to
both data and history store. Search is not ignoring these updates
for the data store, but whereas these are getting ignored for history
store when session is requested to ignore the tombstones of the
history store, but globally visible tombstone updates shouldn't be
ignored for hs irrespective of the session flags.