### PR TITLE
WT-5934 Stop validating timestamps read from disk in 4.2

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -738,7 +738,6 @@ __verify_ts_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num, c
       cell_num, __wt_page_addr_string(session, ref, vs->tmp1), ts1_name, ts1_bp,
       gt ? "less than" : "greater than", ts2_name, ts2_bp);
 }
-#endif
 
 /*
  * __verify_txn_addr_cmp --
@@ -762,6 +761,7 @@ __verify_txn_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num,
       cell_num, __wt_page_addr_string(session, ref, vs->tmp1), txn1_name, txn1,
       gt ? "less than" : "greater than", txn2_name, txn2);
 }
+#endif
 
 /*
  * __verify_page_cell --
@@ -776,7 +776,9 @@ __verify_page_cell(
     WT_DECL_RET;
     const WT_PAGE_HEADER *dsk;
     uint32_t cell_num;
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
     char ts_string[2][WT_TS_INT_STRING_SIZE];
+#endif
     bool found_ovfl;
 
     /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -302,6 +302,7 @@ __verify_checkpoint_reset(WT_VSTUFF *vs)
     vs->depth = 1;
 }
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
 /*
  * __verify_addr_ts --
  *     Check an address block's timestamps.
@@ -338,6 +339,7 @@ __verify_addr_ts(WT_SESSION_IMPL *session, WT_REF *ref, WT_CELL_UNPACK *unpack, 
           unpack->newest_stop_txn);
     return (0);
 }
+#endif
 
 /*
  * __verify_tree --
@@ -518,7 +520,9 @@ celltype_err:
 
             /* Unpack the address block and check timestamps */
             __wt_cell_unpack(session, child_ref->home, child_ref->addr, unpack);
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
+#endif
 
             /* Verify the subtree. */
             ++vs->depth;
@@ -548,7 +552,9 @@ celltype_err:
 
             /* Unpack the address block and check timestamps */
             __wt_cell_unpack(session, child_ref->home, child_ref->addr, unpack);
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
+#endif
 
             /* Verify the subtree. */
             ++vs->depth;
@@ -687,6 +693,7 @@ __verify_overflow(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_siz
     return (0);
 }
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
 /*
  * __verify_ts_addr_cmp --
  *     Do a cell timestamp check against the parent.
@@ -731,6 +738,7 @@ __verify_ts_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num, c
       cell_num, __wt_page_addr_string(session, ref, vs->tmp1), ts1_name, ts1_bp,
       gt ? "less than" : "greater than", ts2_name, ts2_bp);
 }
+#endif
 
 /*
  * __verify_txn_addr_cmp --
@@ -808,6 +816,7 @@ __verify_page_cell(
         case WT_CELL_ADDR_INT:
         case WT_CELL_ADDR_LEAF:
         case WT_CELL_ADDR_LEAF_NO:
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
             if (unpack.newest_stop_ts == WT_TS_NONE)
                 WT_RET_MSG(session, WT_ERROR, "cell %" PRIu32
                                               " on page at %s has a "
@@ -837,11 +846,9 @@ __verify_page_cell(
                   unpack.oldest_start_txn, unpack.newest_stop_txn);
             }
 
-#ifdef MONGODB42_DONT_SKIP_ADDR_DURABLE_VERIFICATION
             WT_RET(__verify_ts_addr_cmp(session, ref, cell_num - 1, "newest durable",
               unpack.newest_durable_ts, "newest durable", addr_unpack->newest_durable_ts, false,
               vs));
-#endif
             WT_RET(__verify_ts_addr_cmp(session, ref, cell_num - 1, "oldest start",
               unpack.oldest_start_ts, "oldest start", addr_unpack->oldest_start_ts, true, vs));
             WT_RET(__verify_txn_addr_cmp(session, ref, cell_num - 1, "oldest start",
@@ -850,12 +857,14 @@ __verify_page_cell(
               unpack.newest_stop_ts, "newest stop", addr_unpack->newest_stop_ts, false, vs));
             WT_RET(__verify_txn_addr_cmp(session, ref, cell_num - 1, "newest stop",
               unpack.newest_stop_txn, "newest stop", addr_unpack->newest_stop_txn, false, vs));
+#endif
             break;
         case WT_CELL_DEL:
         case WT_CELL_VALUE:
         case WT_CELL_VALUE_COPY:
         case WT_CELL_VALUE_OVFL:
         case WT_CELL_VALUE_SHORT:
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
             if (unpack.stop_ts == WT_TS_NONE)
                 WT_RET_MSG(session, WT_ERROR, "cell %" PRIu32
                                               " on page at %s has a stop "
@@ -891,6 +900,7 @@ __verify_page_cell(
               "newest stop", addr_unpack->newest_stop_ts, false, vs));
             WT_RET(__verify_txn_addr_cmp(session, ref, cell_num - 1, "stop", unpack.stop_txn,
               "newest stop", addr_unpack->newest_stop_txn, false, vs));
+#endif
             break;
         }
     }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -837,9 +837,11 @@ __verify_page_cell(
                   unpack.oldest_start_txn, unpack.newest_stop_txn);
             }
 
+#ifdef MONGODB42_DONT_SKIP_ADDR_DURABLE_VERIFICATION
             WT_RET(__verify_ts_addr_cmp(session, ref, cell_num - 1, "newest durable",
               unpack.newest_durable_ts, "newest durable", addr_unpack->newest_durable_ts, false,
               vs));
+#endif
             WT_RET(__verify_ts_addr_cmp(session, ref, cell_num - 1, "oldest start",
               unpack.oldest_start_ts, "oldest start", addr_unpack->oldest_start_ts, true, vs));
             WT_RET(__verify_txn_addr_cmp(session, ref, cell_num - 1, "oldest start",

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -188,6 +188,7 @@ __wt_verify_dsk(WT_SESSION_IMPL *session, const char *tag, WT_ITEM *buf)
     return (__wt_verify_dsk_image(session, tag, buf->data, buf->size, NULL, false));
 }
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
 /*
  * __verify_dsk_ts_addr_cmp --
  *     Do a cell timestamp check against the parent.
@@ -362,6 +363,7 @@ __verify_dsk_validity(WT_SESSION_IMPL *session, WT_CELL_UNPACK *unpack, uint32_t
 
     return (0);
 }
+#endif
 
 /*
  * __verify_dsk_row --
@@ -470,8 +472,10 @@ __verify_dsk_row(
             break;
         }
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_ERR(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#endif
 
         /* Check if any referenced item has an invalid address. */
         switch (cell_type) {
@@ -665,8 +669,10 @@ __verify_dsk_col_int(
         WT_RET(__err_cell_type(session, cell_num, tag, unpack->raw, dsk->type));
         WT_RET(__err_cell_type(session, cell_num, tag, unpack->type, dsk->type));
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_RET(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#endif
 
         /* Check if any referenced item is entirely in the file. */
         ret = bm->addr_invalid(bm, session, unpack->data, unpack->size);
@@ -747,8 +753,10 @@ __verify_dsk_col_var(
         WT_RET(__err_cell_type(session, cell_num, tag, unpack->type, dsk->type));
         cell_type = unpack->type;
 
+#ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_RET(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#endif
 
         /* Check if any referenced item is entirely in the file. */
         if (cell_type == WT_CELL_VALUE_OVFL) {

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -475,6 +475,8 @@ __verify_dsk_row(
 #ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_ERR(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#else
+        WT_UNUSED(addr);
 #endif
 
         /* Check if any referenced item has an invalid address. */
@@ -672,6 +674,8 @@ __verify_dsk_col_int(
 #ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_RET(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#else
+        WT_UNUSED(addr);
 #endif
 
         /* Check if any referenced item is entirely in the file. */
@@ -756,6 +760,8 @@ __verify_dsk_col_var(
 #ifdef MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE
         /* Check the validity window. */
         WT_RET(__verify_dsk_validity(session, unpack, cell_num, addr, tag));
+#else
+        WT_UNUSED(addr);
 #endif
 
         /* Check if any referenced item is entirely in the file. */

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -92,10 +92,12 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_
         LF_SET(WT_CELL_TXN_START);
     }
     if (durable_start_ts != WT_TS_NONE) {
-        /* Store differences, not absolutes. */
         WT_ASSERT(session, start_ts != WT_TS_NONE && start_ts <= durable_start_ts);
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, durable_start_ts - start_ts));
-        LF_SET(WT_CELL_TS_DURABLE_START);
+        /* Store differences if any, not absolutes. */
+        if (durable_start_ts - start_ts > 0) {
+            WT_IGNORE_RET(__wt_vpack_uint(pp, 0, durable_start_ts - start_ts));
+            LF_SET(WT_CELL_TS_DURABLE_START);
+        }
     }
     if (stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
@@ -108,10 +110,12 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_
         LF_SET(WT_CELL_TXN_STOP);
     }
     if (durable_stop_ts != WT_TS_NONE) {
-        /* Store differences, not absolutes. */
         WT_ASSERT(session, stop_ts != WT_TS_MAX && stop_ts <= durable_stop_ts);
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, durable_stop_ts - stop_ts));
-        LF_SET(WT_CELL_TS_DURABLE_STOP);
+        /* Store differences if any, not absolutes. */
+        if (durable_stop_ts - stop_ts > 0) {
+            WT_IGNORE_RET(__wt_vpack_uint(pp, 0, durable_stop_ts - stop_ts));
+            LF_SET(WT_CELL_TS_DURABLE_STOP);
+        }
     }
     if (prepare)
         LF_SET(WT_CELL_PREPARE);
@@ -211,6 +215,13 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
          * WT_ASSERT(
          *  session, oldest_start_ts != WT_TS_NONE && oldest_start_ts <= start_durable_ts);
          */
+        /*
+         * Unlike value cell, we store the durable start timestamp even the difference is zero
+         * compared to oldest commit timestamp. The difference can only be zero when the page
+         * contains all the key/value pairs with the same timestamp. But this scenario is rare and
+         * having that check to find out whether it is zero or not will unnecessarily add overhead
+         * than benefit.
+         */
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, start_durable_ts - oldest_start_ts));
         LF_SET(WT_CELL_TS_DURABLE_START);
     }
@@ -230,7 +241,14 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, wt_timestamp_t
          * FIXME-prepare-support:
          * WT_ASSERT(session,
          *   newest_stop_ts != WT_TS_MAX && newest_stop_ts <= stop_durable__ts);
-        */
+         */
+        /*
+         * Unlike value cell, we store the durable stop timestamp even the difference is zero
+         * compared to newest commit timestamp. The difference can only be zero when the page
+         * contains all the key/value pairs with the same timestamp. But this scenario is rare and
+         * having that check to find out whether it is zero or not will unnecessarily add overhead
+         * than benefit.
+         */
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, stop_durable_ts - newest_stop_ts));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
@@ -894,7 +912,9 @@ restart:
             WT_RET(__wt_vunpack_uint(
               &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->durable_start_ts));
             unpack->durable_start_ts += unpack->start_ts;
-        }
+        } else
+            unpack->durable_start_ts = unpack->start_ts;
+
         if (LF_ISSET(WT_CELL_TS_STOP)) {
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->stop_ts));
             unpack->stop_ts += unpack->start_ts;
@@ -907,7 +927,11 @@ restart:
             WT_RET(__wt_vunpack_uint(
               &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &unpack->durable_stop_ts));
             unpack->durable_stop_ts += unpack->stop_ts;
-        }
+        } else if (unpack->stop_ts != WT_TS_MAX)
+            unpack->durable_stop_ts = unpack->stop_ts;
+        else
+            unpack->durable_stop_ts = WT_TS_NONE;
+
         __cell_check_value_validity(session, unpack->durable_start_ts, unpack->start_ts,
           unpack->start_txn, unpack->durable_stop_ts, unpack->stop_ts, unpack->stop_txn);
         break;

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -15,7 +15,7 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_sta
   wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t durable_stop_ts,
   wt_timestamp_t stop_ts, uint64_t stop_txn)
 {
-#ifdef HAVE_DIAGNOSTIC
+#if defined(MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE) && defined(HAVE_DIAGNOSTIC)
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     if (start_ts > durable_start_ts)
@@ -131,7 +131,7 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t start_durable_
   wt_timestamp_t oldest_start_ts, uint64_t oldest_start_txn, wt_timestamp_t stop_durable_ts,
   wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn)
 {
-#ifdef HAVE_DIAGNOSTIC
+#if defined(MONGODB42_WITH_TIMESTAMP_AND_TXN_VALIDATE) && defined(HAVE_DIAGNOSTIC)
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     if (oldest_start_ts != WT_TS_NONE && newest_stop_ts == WT_TS_NONE)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -605,8 +605,10 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
     ret = __wt_config_subgets(session, v, "newest_stop_txn", &a);
     WT_RET_NOTFOUND_OK(ret);
     ckpt->newest_stop_txn = ret == WT_NOTFOUND || a.len == 0 ? WT_TXN_MAX : (uint64_t)a.val;
+#ifdef MONGODB42_DONT_SKIP_CHECKPOINT_DURABLE_VERIFICATION
     __wt_check_addr_validity(session, WT_TS_NONE, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
       WT_TS_NONE, ckpt->newest_stop_ts, ckpt->newest_stop_txn);
+#endif
 
     WT_RET(__wt_config_subgets(session, v, "write_gen", &a));
     if (a.len == 0)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -605,10 +605,8 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
     ret = __wt_config_subgets(session, v, "newest_stop_txn", &a);
     WT_RET_NOTFOUND_OK(ret);
     ckpt->newest_stop_txn = ret == WT_NOTFOUND || a.len == 0 ? WT_TXN_MAX : (uint64_t)a.val;
-#ifdef MONGODB42_DONT_SKIP_CHECKPOINT_DURABLE_VERIFICATION
     __wt_check_addr_validity(session, WT_TS_NONE, ckpt->oldest_start_ts, ckpt->oldest_start_txn,
       WT_TS_NONE, ckpt->newest_stop_ts, ckpt->newest_stop_txn);
-#endif
 
     WT_RET(__wt_config_subgets(session, v, "write_gen", &a));
     if (a.len == 0)


### PR DESCRIPTION
@agorrod, @tetsuo-cpp, this is the set of changes that I needed to get current develop branch row-store databases to read in a mongodb-4.2 branch. Basically,  it's a cherry-pick of WT-5894's changes to the cell code, and then removing validation of address and checkpoint durable timestamps. (I was able to get those tests to pass, but it required sufficient changes that I thought it was more destructive than helpful.)

I haven't run this against the failing Evergreen tests.

Anyway, it's an alternative approach to #5478. 