### PR TITLE
WT-5979 Add Evergreen release compatibility test for forward compatibility

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -43,6 +43,7 @@ Barack
 BerkeleyDB
 Bitfield
 Bitwise
+Blqr
 Brueckner
 Bsearch
 Btree
@@ -958,7 +959,6 @@ lookaside
 lookup
 lookups
 lossy
-lqr
 lqrt
 lr
 lrt

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -61,7 +61,7 @@ run_format()
         for am in $2; do
             dir="RUNDIR.$am"
             echo "./t running $am access method..."
-            ./t -1q $arg3 -h $dir "file_type=$am" $args
+            ./t -1q $3 -h $dir "file_type=$am" $args
 
             # Remove the version string from the base configuration file. (MongoDB does not
             # create a base configuration file, but format does, so we need to clean it up

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -30,6 +30,7 @@ build_release()
 # run_format:
 #       arg1: release
 #       arg2: access methods list
+#       arg3: -B for compatibility testing
 #############################################################
 run_format()
 {
@@ -46,6 +47,10 @@ run_format()
         args+="data_source=table "
         args+="in_memory=0 "                    # Interested in the on-disk format
         args+="leak_memory=1 "                  # Faster runs
+        # XXX
+        # We're currently not testing logging compatability, format is not yet creating
+        # log file formats that previous releases can read.
+        args+="logging=0 "                      # Test log compatibility
         args+="logging_compression=snappy "     # We only built with snappy, force the choice
         args+="rebalance=0 "                    # Faster runs
         args+="rows=1000000 "
@@ -56,7 +61,13 @@ run_format()
         for am in $2; do
             dir="RUNDIR.$am"
             echo "./t running $am access method..."
-            ./t -1q -h $dir "file_type=$am" $args
+            ./t -1q $arg3 -h $dir "file_type=$am" $args
+
+            # Remove the version string from the base configuration file. (MongoDB does not
+            # create a base configuration file, but format does, so we need to clean it up
+            # to support backward compatibility testing.)
+            (echo '/^version=/d'
+             echo w) | ed -s $dir/WiredTiger.basecfg > /dev/null
         done
 }
 
@@ -67,12 +78,12 @@ EXT+="ext/encryptors/rotn/.libs/libwiredtiger_rotn.so, "
 EXT+="]"
 
 #############################################################
-# verify_backward:
+# verify_release:
 #       arg1: release #1
 #       arg2: release #2
 #       arg3: access methods list
 #############################################################
-verify_backward()
+verify_release()
 {
         echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
         echo "Release \"$1\" verifying \"$2\""
@@ -106,14 +117,17 @@ cd "$top"
 (run_format mongodb-4.0 "fix row var")
 (run_format mongodb-4.2 "fix row var")
 #(run_format mongodb-4.4 "row")
-(run_format "develop" "row")
+(run_format "develop" "row" "-B")
 
 # Verify backward compatibility for supported access methods.
-(verify_backward mongodb-3.6 mongodb-3.4 "fix row var")
-(verify_backward mongodb-4.0 mongodb-3.6 "fix row var")
-(verify_backward mongodb-4.2 mongodb-4.0 "fix row var")
-#(verify_backward mongodb-4.4 mongodb-4.2 "fix row var")
-#(verify_backward develop mongodb-4.4 "row")
- (verify_backward develop mongodb-4.2 "fix row var")
+(verify_release mongodb-3.6 mongodb-3.4 "fix row var")
+(verify_release mongodb-4.0 mongodb-3.6 "fix row var")
+(verify_release mongodb-4.2 mongodb-4.0 "fix row var")
+#(verify_release mongodb-4.4 mongodb-4.2 "fix row var")
+#(verify_release develop mongodb-4.4 "row")
+(verify_release develop mongodb-4.2 "fix row var")
+
+# Verify forward compatibility for supported access methods.
+(verify_release mongodb-4.2 develop "row")
 
 exit 0

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -48,7 +48,7 @@ run_format()
         args+="in_memory=0 "                    # Interested in the on-disk format
         args+="leak_memory=1 "                  # Faster runs
         # XXX
-        # We're currently not testing logging compatability, format is not yet creating
+        # We're currently not testing logging compatibility, format is not yet creating
         # log file formats that previous releases can read.
         args+="logging=0 "                      # Test log compatibility
         args+="logging_compression=snappy "     # We only built with snappy, force the choice

--- a/test/evergreen/compatibility_test_for_mongodb_releases.sh
+++ b/test/evergreen/compatibility_test_for_mongodb_releases.sh
@@ -47,10 +47,7 @@ run_format()
         args+="data_source=table "
         args+="in_memory=0 "                    # Interested in the on-disk format
         args+="leak_memory=1 "                  # Faster runs
-        # XXX
-        # We're currently not testing logging compatibility, format is not yet creating
-        # log file formats that previous releases can read.
-        args+="logging=0 "                      # Test log compatibility
+        args+="logging=1 "                      # Test log compatibility
         args+="logging_compression=snappy "     # We only built with snappy, force the choice
         args+="rebalance=0 "                    # Faster runs
         args+="rows=1000000 "
@@ -63,9 +60,9 @@ run_format()
             echo "./t running $am access method..."
             ./t -1q $3 -h $dir "file_type=$am" $args
 
-            # Remove the version string from the base configuration file. (MongoDB does not
-            # create a base configuration file, but format does, so we need to clean it up
-            # to support backward compatibility testing.)
+            # Remove the version string from the base configuration file. (MongoDB does not create
+            # a base configuration file, but format does, so we need to remove its version string
+            # to allow backward compatibility testing.)
             (echo '/^version=/d'
              echo w) | ed -s $dir/WiredTiger.basecfg > /dev/null
         done
@@ -123,8 +120,8 @@ cd "$top"
 (verify_release mongodb-3.6 mongodb-3.4 "fix row var")
 (verify_release mongodb-4.0 mongodb-3.6 "fix row var")
 (verify_release mongodb-4.2 mongodb-4.0 "fix row var")
-#(verify_release mongodb-4.4 mongodb-4.2 "fix row var")
-#(verify_release develop mongodb-4.4 "row")
+(verify_release mongodb-4.4 mongodb-4.2 "fix row var")
+(verify_release develop mongodb-4.4 "row")
 (verify_release develop mongodb-4.2 "fix row var")
 
 # Verify forward compatibility for supported access methods.

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -280,8 +280,8 @@ config_backup(void)
 }
 
 /*
- * config_backup --
- *     Backup configuration.
+ * config_backward_compatible --
+ *     Backward compatibility configuration.
  */
 static void
 config_backward_compatible(void)

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -287,10 +287,10 @@ static void
 config_backward_compatible(void)
 {
     if (!g.backward_compatible)
-	return;
+        return;
 
     if (config_is_perm("disk.mmap_all"))
-	testutil_die(EINVAL, "-B option incompatible with mmap_all configuration");
+        testutil_die(EINVAL, "-B option incompatible with mmap_all configuration");
     config_single("disk.mmap_all=off", false);
 }
 

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -30,6 +30,7 @@
 #include "config.h"
 
 static void config_backup(void);
+static void config_backward_compatible(void);
 static void config_cache(void);
 static void config_checkpoint(void);
 static void config_checksum(void);
@@ -190,11 +191,13 @@ config_setup(void)
     config_pct();
     config_cache();
 
-    /* Give in-memory and LSM configurations a final review. */
+    /* Give in-memory, LSM and backward compatible configurations a final review. */
     if (g.c_in_memory != 0)
         config_in_memory_reset();
     if (DATASOURCE("lsm"))
         config_lsm_reset();
+    if (g.backward_compatible != 0)
+        config_backward_compatible();
 
     /*
      * Key/value minimum/maximum are related, correct unless specified by the configuration.
@@ -275,6 +278,22 @@ config_backup(void)
         config_single(cstr, false);
     }
 }
+
+/*
+ * config_backup --
+ *     Backup configuration.
+ */
+static void
+config_backward_compatible(void)
+{
+    if (!g.backward_compatible)
+	return;
+
+    if (config_is_perm("disk.mmap_all"))
+	testutil_die(EINVAL, "-B option incompatible with mmap_all configuration");
+    config_single("disk.mmap_all=off", false);
+}
+
 /*
  * config_cache --
  *     Cache configuration.

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -86,8 +86,9 @@ typedef struct {
     bool logging; /* log operations  */
     FILE *logfp;  /* log file */
 
-    bool replay;           /* Replaying a run. */
-    bool workers_finished; /* Operations completed */
+    bool backward_compatible; /* Backward compatibility testing */
+    bool replay;              /* Replaying a run. */
+    bool workers_finished;    /* Operations completed */
 
     pthread_rwlock_t backup_lock; /* Backup running */
     uint32_t backup_id;           /* Block incremental id */

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -152,11 +152,14 @@ main(int argc, char *argv[])
     /* Set values from the command line. */
     home = NULL;
     one_flag = quiet_flag = false;
-    while ((ch = __wt_getopt(progname, argc, argv, "1C:c:h:lqrt:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "1BC:c:h:lqrt:")) != EOF)
         switch (ch) {
         case '1': /* One run */
             one_flag = true;
             break;
+	case 'B': /* Backward compatibility */
+	    g.backward_compatible = true;
+	    break;
         case 'C': /* wiredtiger_open config */
             g.config_open = __wt_optarg;
             break;
@@ -394,11 +397,12 @@ static void
 usage(void)
 {
     fprintf(stderr,
-      "usage: %s [-1lqr] [-C wiredtiger-config]\n    "
+      "usage: %s [-1Blqr] [-C wiredtiger-config]\n    "
       "[-c config-file] [-h home] [name=value ...]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-1 run once\n"
+      "\t-B create backward compatible configurations\n"
       "\t-C specify wiredtiger_open configuration arguments\n"
       "\t-c read test program configuration from a file\n"
       "\t-h home (default 'RUNDIR')\n"

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -157,9 +157,9 @@ main(int argc, char *argv[])
         case '1': /* One run */
             one_flag = true;
             break;
-	case 'B': /* Backward compatibility */
-	    g.backward_compatible = true;
-	    break;
+        case 'B': /* Backward compatibility */
+            g.backward_compatible = true;
+            break;
         case 'C': /* wiredtiger_open config */
             g.config_open = __wt_optarg;
             break;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -453,6 +453,10 @@ wts_close(void)
     WT_CONNECTION *conn;
 
     conn = g.wts_conn;
+
+    if (g.backward_compatible)
+        testutil_check(conn->reconfigure(conn, "compatibility=(release=3.3)"));
+
     testutil_check(conn->close(conn, g.c_leak_memory ? "leak_memory" : NULL));
 
     g.wts_conn = NULL;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -199,9 +199,9 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
 #endif
 
     if (g.c_mmap)
-	CONFIG_APPEND(p, ",mmap=1");
+        CONFIG_APPEND(p, ",mmap=1");
     if (g.c_mmap_all)
-	CONFIG_APPEND(p, ",mmap_all=1");
+        CONFIG_APPEND(p, ",mmap_all=1");
 
     if (g.c_direct_io)
         CONFIG_APPEND(p, ",direct_io=(data)");

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -198,7 +198,10 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
     CONFIG_APPEND(p, ",buffer_alignment=512");
 #endif
 
-    CONFIG_APPEND(p, ",mmap=%d,mmap_all=%d", g.c_mmap ? 1 : 0, g.c_mmap_all ? 1 : 0);
+    if (g.c_mmap)
+	CONFIG_APPEND(p, ",mmap=1");
+    if (g.c_mmap_all)
+	CONFIG_APPEND(p, ",mmap_all=1");
 
     if (g.c_direct_io)
         CONFIG_APPEND(p, ",direct_io=(data)");
@@ -448,13 +451,10 @@ void
 wts_close(void)
 {
     WT_CONNECTION *conn;
-    const char *config;
 
     conn = g.wts_conn;
+    testutil_check(conn->close(conn, g.c_leak_memory ? "leak_memory" : NULL));
 
-    config = g.c_leak_memory ? "leak_memory" : NULL;
-
-    testutil_check(conn->close(conn, config));
     g.wts_conn = NULL;
     g.wt_api = NULL;
 }


### PR DESCRIPTION
@tetsuo-cpp, @agorrod, here are a set of changes that allow you to run format to create a database and then you can run the 4.2 wt command to verify it, so it's easier to do local testing.

I've updated the evergreen test, but if you want to run this locally, use "./t -B" to create the database in the develop branch, so it's backward compatible with 4.2, and of course you need a 4.2 branch with at  least WT-5894 applied to verify that 4.2 can read the develop database cell format.