### PR TITLE
WT-5993 restore disk page header version

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1185,6 +1185,7 @@ __wt_block_extlist_write(
     dsk = tmp->mem;
     memset(dsk, 0, WT_BLOCK_HEADER_BYTE_SIZE);
     dsk->type = WT_PAGE_BLOCK_MANAGER;
+    dsk->version = WT_PAGE_VERSION_TS;
 
     /* Fill the page's data. */
     p = WT_BLOCK_HEADER_BYTE(dsk);

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -119,6 +119,15 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
     if (dsk->unused != 0)
         WT_RET_VRFY(session, "page at %s has non-zero unused page header bytes", tag);
 
+    /* Check the page version. */
+    switch (dsk->version) {
+    case WT_PAGE_VERSION_ORIG:
+    case WT_PAGE_VERSION_TS:
+        break;
+    default:
+        WT_RET_VRFY(session, "page at %s has an invalid version of %" PRIu8, tag, dsk->version);
+    }
+
     /*
      * Any bytes after the data chunk should be nul bytes; ignore if the size is 0, that allows easy
      * checking of disk images where we don't have the size.

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -79,6 +79,10 @@ struct __wt_page_header {
 
     /* A byte of padding, positioned to be added to the flags. */
     uint8_t unused; /* 26: unused padding */
+
+#define WT_PAGE_VERSION_ORIG 0 /* Original version */
+#define WT_PAGE_VERSION_TS 1   /* Timestamps added */
+    uint8_t version;           /* 27: version */
 };
 /*
  * WT_PAGE_HEADER_SIZE is the number of bytes we allocate for the structure: if the compiler inserts

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -19,8 +19,6 @@ struct __wt_process {
     /* Locked: connection queue */
     TAILQ_HEAD(__wt_connection_impl_qh, __wt_connection_impl) connqh;
 
-    bool page_version_ts; /* timestamp version page formats */
-
 /* Checksum functions */
 #define __wt_checksum(chunk, len) __wt_process.checksum(chunk, len)
     uint32_t (*checksum)(const void *, size_t);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1579,6 +1579,7 @@ __rec_split_write_header(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK
     }
 
     dsk->unused = 0;
+    dsk->version = WT_PAGE_VERSION_TS;
 
     /* Clear the memory owned by the block manager. */
     memset(WT_BLOCK_HEADER_REF(dsk), 0, btree->block_header);


### PR DESCRIPTION
@agorrod, as you know, we updated the on-disk page header to include a version number in the 4.2 release. The version number was removed in the 4.4 release, and I'm not sure if that change was deliberate or not?

We don't strictly need this change because (as far as I know), we never wrote non-zero versions into customer databases, and we do not yet use the page header version in the 4.4 release (the cell code uses the fact that the "interesting" timestamps are never set to detect 4.4 created tombstones).

However, this change was never backported into 4.2, so it's writing a "version" that happens to be 0 and so matches the zero'd out bytes on the disk the 4.4 release expects.

If the change to remove the page-header version was deliberate, this PR can be almost entirely discarded (we should still remove the `page_version_ts` field from the `WT_CONNECTION_IMPL` structure), and we might want to consider backporting the removal into 4.2 for clarity.