### PR TITLE
WT-5988 Do not write log records as part of recovery rollback to stable operation

### DIFF
--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -534,12 +534,21 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
     unbuffered = yielded = false;
     closed = raced = slept = false;
     wait_cnt = 0;
+    diag_yield = false;
+
+/*
+ * Figure out whether this write should be buffered. If a record is bigger than the buffer size it
+ * needs to be non-buffered. If the record is being written during recovery it needs to be
+ * unbuffered - since the log server thread isn't present to flush in the background. Also
+ * occasionally write unbuffered records periodically in diagnostic mode - we've had bugs in the
+ * past related to coordinating buffered and unbuffered log writes.
+ */
 #ifdef HAVE_DIAGNOSTIC
     diag_yield = (++log->write_calls % 7) == 0;
-    if ((log->write_calls % WT_THOUSAND) == 0 || mysize > WT_LOG_SLOT_BUF_MAX) {
+    if (mysize > WT_LOG_SLOT_BUF_MAX || F_ISSET(conn, WT_CONN_RECOVERING) ||
+      (log->write_calls % WT_THOUSAND) == 0) {
 #else
-    diag_yield = false;
-    if (mysize > WT_LOG_SLOT_BUF_MAX) {
+    if (mysize > WT_LOG_SLOT_BUF_MAX || F_ISSET(conn, WT_CONN_RECOVERING)) {
 #endif
         unbuffered = true;
         F_SET(myslot, WT_MYSLOT_UNBUFFERED);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1119,9 +1119,11 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
     /*
      * Don't use the connection's default session: we are working on data handles and (a) don't want
      * to cache all of them forever, plus (b) can't guarantee that no other method will be called
-     * concurrently.
+     * concurrently. Copy parent session no logging option to the internal session to make sure that
+     * rollback to stable doesn't generate log records.
      */
-    WT_RET(__wt_open_internal_session(S2C(session), "txn rollback_to_stable", true, 0, &session));
+    WT_RET(__wt_open_internal_session(S2C(session), "txn rollback_to_stable", true,
+      F_MASK(session, WT_SESSION_NO_LOGGING), &session));
 
     F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE_FLAGS);
     ret = __rollback_to_stable(session, cfg);


### PR DESCRIPTION
As the log server didn't get started until end of recovery, any log
records that are written during recovery can block. To avoid it, ensure
that all log records written during recovery are unbuffered to let them
write directly.