### PR TITLE
WT-5986 Create scripts for running multiversion testing.

### DIFF
--- a/bench/workgen/runner/runner/__init__.py
+++ b/bench/workgen/runner/runner/__init__.py
@@ -30,7 +30,7 @@
 #   Used as a first import by runners, does any common initialization.
 from __future__ import print_function
 
-import os, shutil, sys
+import os, sys
 thisdir = os.path.dirname(os.path.abspath(__file__))
 workgen_src = os.path.dirname(os.path.dirname(thisdir))
 wt_dir = os.path.dirname(os.path.dirname(workgen_src))
@@ -83,10 +83,6 @@ except:
     sys.path.insert(0, os.path.join(workgen_src, 'workgen'))
     sys.path.insert(0, os.path.join(wt_builddir, 'bench', 'workgen'))
     import workgen
-
-# Clear out the WT_TEST directory.
-shutil.rmtree('WT_TEST', True)
-os.mkdir('WT_TEST')
 
 from .core import txn, extensions_config, op_append, op_group_transaction, op_log_like, op_multi_table, op_populate_with_range, sleep, timed
 from .latency import workload_latency

--- a/bench/workgen/workgen.swig
+++ b/bench/workgen/workgen.swig
@@ -51,7 +51,7 @@
 %}
 
 %pythoncode %{
-import numbers
+    import argparse,numbers,os,shutil,wiredtiger
 %}
 
 %exception {
@@ -116,6 +116,9 @@ import numbers
 InterruptableFunction(workgen::execute)
 InterruptableFunction(workgen::Workload::run)
 
+/* We'll define a different constructor below. */
+%ignore workgen::Context::Context();
+
 %module workgen
 /* Parse the header to generate wrappers. */
 %include "workgen.h"
@@ -141,6 +144,67 @@ WorkgenClass(Context)
 WorkgenFrozenClass(TableOptions)
 WorkgenFrozenClass(ThreadOptions)
 WorkgenFrozenClass(WorkloadOptions)
+
+/*
+ * It's a bit tricky to redefine a constructor, but it can be done.
+ * This question had the needed clues to make it work:
+ *   https://stackoverflow.com/questions/33564645/how-to-add-an-alternative-constructor-to-the-target-language-specifically-pytho
+ * It does unfortunately rely on some SWIG implementation details.
+ */
+%inline %{
+    workgen::Context* _new_Context() {
+        return new workgen::Context();
+    }
+%}
+
+%extend workgen::Context {
+%pythoncode %{
+    def __init__(self, parser = None):
+        this = _new_Context()
+        try:
+             self.this.append(this)
+        except:
+            self.this = this
+        self.__internal_init(parser)
+
+    def __internal_init(self, parser):
+        self.default_home = "WT_TEST"
+        self.default_config = "create"
+        if not parser:
+            parser = argparse.ArgumentParser("Execute workgen.")
+        parser.add_argument("--home", dest="home", type=str,
+          help="home directory for the run (default=%s)" % self.default_home)
+        parser.add_argument("--keep", dest="keep", action="store_true",
+          help="Run the workload on an existing home directory")
+        parser.add_argument("--verbose", dest="verbose", action="store_true",
+          help="Run the workload verbosely")
+        self.parser = parser
+        self._initialized = False
+
+    def parse_arguments(self, parser):
+        self.args = parser.parse_args()
+
+    def wiredtiger_open_config(self, config):
+        return config
+
+    def wiredtiger_open(self, config = None):
+        if config == None:
+            config = self.default_config
+        self.initialize()
+        return wiredtiger.wiredtiger_open(self.args.home, self.wiredtiger_open_config(config))
+
+    def initialize(self):
+        if not self._initialized:
+            self.parse_arguments(self.parser)
+            if self.args.home == None:
+               self.args.home = self.default_home
+            self._initialized = True
+            if not self.args.keep:
+                shutil.rmtree(self.args.home, True)
+                os.mkdir(self.args.home)
+        return self
+%}
+};
 
 %extend workgen::Operation {
 %pythoncode %{

--- a/test/multiversion/wt_multiversion.sh
+++ b/test/multiversion/wt_multiversion.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+last_stable=4.2
+last_stable_dir=wiredtiger_${last_stable}/
+last_stable_branch=mongodb-${last_stable}
+
+# Exporting to satisfy ShellCheck.
+export last_stable_branch
+
+# FIXME-WT-5986: Temporarily point this at a local branch for testing.
+# Remove this once workgen args are backported to v4.2.
+tmp_branch=wt-5989-workgen-args-4_2
+
+function setup_last_stable {
+    #git clone git@github.com:wiredtiger/wiredtiger.git ${last_stable_dir}
+    git clone https://github.com/wiredtiger/wiredtiger ${last_stable_dir}
+    cd ${last_stable_dir}/build_posix/ || exit
+    git checkout $tmp_branch || exit 1
+    bash reconf
+    ../configure --enable-python --enable-diagnostic
+    make -j 10
+    # Back to multiversion/ in "latest" repo.
+    cd ../../ || exit
+}
+
+function run_check {
+    echo + "$@"
+    "$@" || exit 1
+}
+
+# Clone and build v4.2 if it doesn't already exist.
+if [ ! -d $last_stable_dir ]; then
+    setup_last_stable
+fi
+
+latest_workgen=../../bench/workgen/runner/multiversion.py
+last_stable_workgen=${last_stable_dir}/bench/workgen/runner/multiversion.py
+
+# Copy the workload into the v4.2 tree.
+cp $latest_workgen $last_stable_workgen
+
+run_check $latest_workgen --release 4.4
+run_check $latest_workgen --keep --release 4.4
+run_check $last_stable_workgen --keep --release 4.2
+run_check $latest_workgen --keep --release 4.4
+
+echo Success.
+exit 0


### PR DESCRIPTION
Includes changes to workgen to allow command line arguments, with --home, --keep, --verbose.