### PR TITLE
WT-5825 Timeout failure in checkpoint-stress-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2146,7 +2146,7 @@ tasks:
           # No of times to run the loop
           times: 1
           # No of processes to run in the background
-          no_of_procs: 10
+          no_of_procs: 8
 
   # The task name is ppc-zseries because this task will be used in both buildVariants
   - name: format-stress-ppc-zseries-test


### PR DESCRIPTION
This test fails with TEST TIMED OUT error because of the performance degradation after 'pm-1521-durable-history' branch merge to develop. 

So, closing this ticket by reducing the number of test runs and wait for the resolution of performance degradation ticket [WT-5929](https://jira.mongodb.org/browse/WT-5929).

Successful evergreen patch builds with 8 binaries. 
https://evergreen.mongodb.com/task/wiredtiger_ubuntu1804_stress_tests_checkpoint_stress_test_patch_ddc71be625083937af2e6858f25e6bcc16f9885d_5e927384850e615c287a474c_20_04_12_01_49_17
