### PR TITLE
WT-5989 Support arguments in workgen (v4.2 backport)

### DIFF
--- a/bench/workgen/runner/compress_ratio.py
+++ b/bench/workgen/runner/compress_ratio.py
@@ -97,7 +97,7 @@ compression_opts = {
 #
 #conn_config += extensions_config(['compressors/snappy'])
 
-conn = wiredtiger_open("WT_TEST", conn_config)
+conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
 tables = []

--- a/bench/workgen/runner/evict-btree-lookaside.py
+++ b/bench/workgen/runner/evict-btree-lookaside.py
@@ -79,11 +79,10 @@ from wiredtiger import *
 from workgen import *
 
 context = Context()
-homedir = "WT_TEST"
 conn_config =   "cache_size=1G,checkpoint=(wait=60,log_size=2GB),\
                 eviction=(threads_min=12,threads_max=12),log=(enabled=true),session_max=800,\
                 eviction_target=60,statistics=(fast),statistics_log=(wait=1,json)"# explicitly added
-conn = wiredtiger_open(homedir, "create," + conn_config)
+conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 
 wtperf_table_config = "key_format=S,value_format=S," +\

--- a/bench/workgen/runner/example_txn.py
+++ b/bench/workgen/runner/example_txn.py
@@ -31,7 +31,8 @@ from runner import *
 from wiredtiger import *
 from workgen import *
 
-conn = wiredtiger_open("WT_TEST", "create,cache_size=500MB")
+context = Context()
+conn = context.wiredtiger_open("create,cache_size=500MB")
 s = conn.open_session()
 tname = "table:test"
 s.create(tname, 'key_format=S,value_format=S')
@@ -39,7 +40,6 @@ table = Table(tname)
 table.options.key_size = 20
 table.options.value_size = 100
 
-context = Context()
 op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 500000)
 pop_workload = Workload(context, thread)

--- a/bench/workgen/runner/insert_stress.py
+++ b/bench/workgen/runner/insert_stress.py
@@ -34,7 +34,7 @@ from workgen import *
 context = Context()
 conn_config="create,cache_size=4GB,session_max=1000,eviction=(threads_min=4,threads_max=8),log=(enabled=false),transaction_sync=(enabled=false),checkpoint_sync=true,checkpoint=(wait=10),statistics=(fast),statistics_log=(json,wait=1)"
 table_config="allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,internal_page_max=16k,type=file,block_compressor=snappy"
-conn = wiredtiger_open("WT_TEST", conn_config)
+conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 tname = "file:test.wt"
 table_config="key_format=S,value_format=S,allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,leaf_value_max=64MB,internal_page_max=16k,type=file,block_compressor=snappy"

--- a/bench/workgen/runner/insert_test.py
+++ b/bench/workgen/runner/insert_test.py
@@ -55,7 +55,7 @@ def expectException(expr):
         raise Exception("missing expected exception")
 
 context = Context()
-conn = wiredtiger_open("WT_TEST", "create,cache_size=1G")
+conn = context.wiredtiger_open("create,cache_size=1G")
 s = conn.open_session()
 tname0 = tablename(0)
 tname1 = tablename(1)

--- a/bench/workgen/runner/maintain_low_dirty_cache.py
+++ b/bench/workgen/runner/maintain_low_dirty_cache.py
@@ -81,7 +81,7 @@ context = Context()
 conn_config="create,cache_size=2GB,session_max=1000,eviction=(threads_min=4,threads_max=8),log=(enabled=false),transaction_sync=(enabled=false),checkpoint_sync=true,checkpoint=(wait=8),statistics=(fast),statistics_log=(json,wait=1)"
 table_config="allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,internal_page_max=16k,type=file,block_compressor=snappy"
 conn_config += extensions_config(['compressors/snappy'])
-conn = wiredtiger_open("WT_TEST", conn_config)
+conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
 tables = []

--- a/bench/workgen/runner/multi_btree_heavy_stress.py
+++ b/bench/workgen/runner/multi_btree_heavy_stress.py
@@ -80,7 +80,7 @@ context = Context()
 conn_config="create,cache_size=1GB,session_max=1000,eviction=(threads_min=4,threads_max=8),log=(enabled=false),transaction_sync=(enabled=false),checkpoint_sync=true,checkpoint=(wait=60),statistics=(fast),statistics_log=(json,wait=1)"
 table_config="allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,internal_page_max=16k,type=file,block_compressor=snappy"
 conn_config += extensions_config(['compressors/snappy'])
-conn = wiredtiger_open("WT_TEST", conn_config)
+conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
 tables = []

--- a/bench/workgen/runner/read_write_storms.py
+++ b/bench/workgen/runner/read_write_storms.py
@@ -37,7 +37,7 @@ from workgen import *
 context = Context()
 conn_config = ""
 conn_config += ",cache_size=2GB,eviction=(threads_max=8),log=(enabled=true),session_max=250,statistics=(fast),statistics_log=(wait=1,json),io_capacity=(total=30M)"   # explicitly added
-conn = wiredtiger_open("WT_TEST", "create," + conn_config)
+conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 
 wtperf_table_config = "key_format=S,value_format=S," +\
@@ -140,5 +140,5 @@ workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
 workload.run(conn)
 
-latency_filename = "WT_TEST/latency.out"
+latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/read_write_sync_long.py
+++ b/bench/workgen/runner/read_write_sync_long.py
@@ -38,7 +38,7 @@ from workgen import *
 context = Context()
 conn_config = ""
 conn_config += ",cache_size=2GB,eviction=(threads_max=8),log=(enabled=true),session_max=250,statistics=(fast),statistics_log=(wait=1,json)"   # explicitly added
-conn = wiredtiger_open("WT_TEST", "create," + conn_config)
+conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 
 wtperf_table_config = "key_format=S,value_format=S," +\
@@ -132,5 +132,5 @@ workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
 workload.run(conn)
 
-latency_filename = "WT_TEST/latency.out"
+latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/read_write_sync_short.py
+++ b/bench/workgen/runner/read_write_sync_short.py
@@ -38,7 +38,7 @@ from workgen import *
 context = Context()
 conn_config = ""
 conn_config += ",cache_size=2GB,eviction=(threads_max=8),log=(enabled=true),session_max=250,statistics=(fast),statistics_log=(wait=1,json)"   # explicitly added
-conn = wiredtiger_open("WT_TEST", "create," + conn_config)
+conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 
 wtperf_table_config = "key_format=S,value_format=S," +\
@@ -147,5 +147,5 @@ workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
 workload.run(conn)
 
-latency_filename = "WT_TEST/latency.out"
+latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/runner/__init__.py
+++ b/bench/workgen/runner/runner/__init__.py
@@ -30,7 +30,7 @@
 #   Used as a first import by runners, does any common initialization.
 from __future__ import print_function
 
-import os, shutil, sys
+import os, sys
 thisdir = os.path.dirname(os.path.abspath(__file__))
 workgen_src = os.path.dirname(os.path.dirname(thisdir))
 wt_dir = os.path.dirname(os.path.dirname(workgen_src))
@@ -83,10 +83,6 @@ except:
     sys.path.insert(0, os.path.join(workgen_src, 'workgen'))
     sys.path.insert(0, os.path.join(wt_builddir, 'bench', 'workgen'))
     import workgen
-
-# Clear out the WT_TEST directory.
-shutil.rmtree('WT_TEST', True)
-os.mkdir('WT_TEST')
 
 from .core import txn, extensions_config, op_append, op_group_transaction, op_log_like, op_multi_table, op_populate_with_range, sleep, timed
 from .latency import workload_latency

--- a/bench/workgen/runner/small_btree.py
+++ b/bench/workgen/runner/small_btree.py
@@ -32,7 +32,7 @@ from wiredtiger import *
 from workgen import *
 
 context = Context()
-conn = wiredtiger_open("WT_TEST", "create,cache_size=500MB")
+conn = context.wiredtiger_open("create,cache_size=500MB")
 s = conn.open_session()
 tname = "file:test.wt"
 s.create(tname, 'key_format=S,value_format=S')

--- a/bench/workgen/runner/small_btree_reopen.py
+++ b/bench/workgen/runner/small_btree_reopen.py
@@ -32,7 +32,7 @@ from wiredtiger import *
 from workgen import *
 
 context = Context()
-conn = wiredtiger_open("WT_TEST", "create,cache_size=500MB")
+conn = context.wiredtiger_open("create,cache_size=500MB")
 s = conn.open_session()
 tname = "file:test.wt"
 s.create(tname, 'key_format=S,value_format=S')

--- a/bench/workgen/runner/split_stress.py
+++ b/bench/workgen/runner/split_stress.py
@@ -38,7 +38,7 @@ from workgen import *
 context = Context()
 # Connection configuration.
 conn_config = "cache_size=100MB,log=(enabled=false),statistics=[fast],statistics_log=(wait=1,json=false)"
-conn = wiredtiger_open("WT_TEST", "create," + conn_config)
+conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 
 # Table configuration.
@@ -78,6 +78,6 @@ workload.options.run_time=300
 print('Split stress workload running...')
 workload.run(conn)
 
-latency_filename = "WT_TEST/latency.out"
+latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)
 conn.close()

--- a/bench/workgen/workgen.swig
+++ b/bench/workgen/workgen.swig
@@ -51,7 +51,7 @@
 %}
 
 %pythoncode %{
-import numbers
+    import argparse,numbers,os,shutil,wiredtiger
 %}
 
 %exception {
@@ -141,6 +141,60 @@ WorkgenClass(Context)
 WorkgenFrozenClass(TableOptions)
 WorkgenFrozenClass(ThreadOptions)
 WorkgenFrozenClass(WorkloadOptions)
+
+%extend workgen::Context {
+%pythoncode %{
+    # This will be the actual __init__ function after we shuffle names below!
+    def Xinit(self, parser = None):
+        self.__original_init__()
+        self._internal_init(parser)
+
+    def _internal_init(self, parser):
+        self.default_home = "WT_TEST"
+        self.default_config = "create"
+        if not parser:
+            parser = argparse.ArgumentParser("Execute workgen.")
+        parser.add_argument("--home", dest="home", type=str,
+          help="home directory for the run (default=%s)" % self.default_home)
+        parser.add_argument("--keep", dest="keep", action="store_true",
+          help="Run the workload on an existing home directory")
+        parser.add_argument("--verbose", dest="verbose", action="store_true",
+          help="Run the workload verbosely")
+        self.parser = parser
+        self._initialized = False
+
+    def parse_arguments(self, parser):
+        self.args = parser.parse_args()
+
+    def wiredtiger_open_config(self, config):
+        return config
+
+    def wiredtiger_open(self, config = None):
+        if config == None:
+            config = self.default_config
+        self.initialize()
+        return wiredtiger.wiredtiger_open(self.args.home, self.wiredtiger_open_config(config))
+
+    def initialize(self):
+        if not self._initialized:
+            self.parse_arguments(self.parser)
+            if self.args.home == None:
+               self.args.home = self.default_home
+            self._initialized = True
+            if not self.args.keep:
+                shutil.rmtree(self.args.home, True)
+                os.mkdir(self.args.home)
+        return self
+%}
+};
+
+%pythoncode %{
+# Shuffle the names of the __init__ function, we want ours (Xinit above), called first.
+# This seems to be the most natural way to intercept a C++ constructor, and do
+# Python-specific actions as part of the regular constructor.
+Context.__original_init__ = Context.__init__
+Context.__init__ = Context.Xinit
+%}
 
 %extend workgen::Operation {
 %pythoncode %{

--- a/bench/workgen/wtperf.py
+++ b/bench/workgen/wtperf.py
@@ -601,7 +601,6 @@ class Translator:
             s += '        return op_ret\n'
             s += '\n'
         s += 'context = Context()\n'
-        s += 'homedir = "' + self.homedir + '"\n'
         extra_config = ''
         s += 'conn_config = ""\n'
 
@@ -616,7 +615,7 @@ class Translator:
                 s += 'conn_config += extensions_config(["compressors/' + \
                     compression + '"])\n'
             compression = 'block_compressor=' + compression + ','
-        s += 'conn = wiredtiger_open(homedir, "create," + conn_config)\n'
+        s += 'conn = context.wiredtiger_open("create," + conn_config)\n'
         s += 's = conn.open_session("' + sess_config + '")\n'
         s += '\n'
         s += self.translate_table_create()
@@ -634,8 +633,7 @@ class Translator:
                 s += 'conn.close()\n'
                 if readonly:
                     'conn_config += ",readonly=true"\n'
-                s += 'conn = wiredtiger_open(homedir, ' + \
-                    '"create," + conn_config)\n'
+                s += 'conn = context.wiredtiger_open("create," + conn_config)\n'
                 s += '\n'
             s += 'workload = Workload(context, ' + t_var + ')\n'
             s += workloadopts
@@ -643,7 +641,7 @@ class Translator:
             if self.verbose > 0:
                 s += 'print("workload:")\n'
             s += 'workload.run(conn)\n\n'
-            s += 'latency_filename = homedir + "/latency.out"\n'
+            s += 'latency_filename = context.args.home + "/latency.out"\n'
             s += 'latency.workload_latency(workload, latency_filename)\n'
 
         if close_conn:


### PR DESCRIPTION
Relatively clean cherry-pick of c8116016de0f93931f5275ec65de3c9418d3c0a8. One of the workgen runners didn't exist in `mongodb-4.2` so I discarded those changes.