### PR TITLE
WT-6010 Workgen changes - Add session config at Thread level.

### DIFF
--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -69,7 +69,7 @@ update_txn = txn(opupdate * 5, 'isolation=snapshot')
 # use_commit_timestamp - Commit the transaction with commit_timestamp.
 update_txn.transaction.use_commit_timestamp = True
 tupdate = Thread(update_txn)
-# Thread.options.session_config - Session configuration. 
+# Thread.options.session_config - Session configuration.
 tupdate.options.session_config="isolation=snapshot"
 
 workload = Workload(context, 30 * twriter + 30 * tupdate + 30 * treader)

--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -89,6 +89,6 @@ run_time = end_time - start_time
 
 print('Workload took %d minutes' %(run_time//60))
 
-latency_filename = "WT_TEST" + "/latency.out"
+latency_filename = os.path.join(context.args.home, "latency.out")
 latency.workload_latency(workload, latency_filename)
 conn.close()

--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -32,9 +32,11 @@ from wiredtiger import *
 from workgen import *
 import time
 
+homedir = "WT_TEST"
 context = Context()
 conn = context.wiredtiger_open("create,cache_size=500MB")
 s = conn.open_session()
+#s = conn.open_session("isolation=snapshot")
 tname = "table:test"
 config = "key_format=S,value_format=S,"
 s.create(tname, config)
@@ -45,15 +47,16 @@ table.options.value_size = 10
 start_time = time.time()
 
 op = Operation(Operation.OP_INSERT, table)
-thread = Thread(op * 5000)
+pop_txn = txn(op, 'isolation=snapshot')
+thread = Thread(pop_txn * 5000)
 pop_workload = Workload(context, thread)
 print('populate:')
 pop_workload.run(conn)
 
 opread = Operation(Operation.OP_SEARCH, table)
-read_txn = txn(opread, 'read_timestamp')
+read_txn = txn(opread * 10, 'read_timestamp')
 # read_timestamp_lag is the lag to the read_timestamp from current time
-read_txn.transaction.read_timestamp_lag = 2
+read_txn.transaction.read_timestamp_lag = 5
 treader = Thread(read_txn)
 
 opwrite = Operation(Operation.OP_INSERT, table)
@@ -63,12 +66,12 @@ write_txn.transaction.use_prepare_timestamp = True
 twriter = Thread(write_txn)
 
 opupdate = Operation(Operation.OP_UPDATE, table)
-update_txn = txn(opupdate, 'isolation=snapshot')
+update_txn = txn(opupdate * 10, 'isolation=snapshot')
 # use_commit_timestamp - Commit the transaction with commit_timestamp.
 update_txn.transaction.use_commit_timestamp = True
 tupdate = Thread(update_txn)
 
-workload = Workload(context, 30 * twriter + 20 * tupdate + 10 * treader)
+workload = Workload(context, 20 * twriter + 20 * tupdate + 20 * treader)
 workload.options.run_time = 50
 workload.options.report_interval=500
 # read_timestamp_lag - Number of seconds lag to the oldest_timestamp from current time.

--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -61,12 +61,16 @@ write_txn = txn(opwrite * 5, 'isolation=snapshot')
 # use_prepare_timestamp - Commit the transaction with stable_timestamp.
 write_txn.transaction.use_prepare_timestamp = True
 twriter = Thread(write_txn)
+# Thread.options.session_config - Session configuration.
+twriter.options.session_config="isolation=snapshot"
 
 opupdate = Operation(Operation.OP_UPDATE, table)
 update_txn = txn(opupdate * 5, 'isolation=snapshot')
 # use_commit_timestamp - Commit the transaction with commit_timestamp.
 update_txn.transaction.use_commit_timestamp = True
 tupdate = Thread(update_txn)
+# Thread.options.session_config - Session configuration. 
+tupdate.options.session_config="isolation=snapshot"
 
 workload = Workload(context, 30 * twriter + 30 * tupdate + 30 * treader)
 workload.options.run_time = 50

--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -36,7 +36,6 @@ homedir = "WT_TEST"
 context = Context()
 conn = context.wiredtiger_open("create,cache_size=500MB")
 s = conn.open_session()
-#s = conn.open_session("isolation=snapshot")
 tname = "table:test"
 config = "key_format=S,value_format=S,"
 s.create(tname, config)

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -890,7 +890,7 @@ int ThreadRunner::op_run(Operation *op) {
             _in_transaction = true;
         }
         // Call cursor operations only when transaction != NULL or _in_transaction is true.
-        if (op->is_table_op() && _in_transaction) {
+        if (op->is_table_op()) {
             switch (op->_optype) {
             case Operation::OP_INSERT:
                 ret = cursor->insert(cursor);

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -882,6 +882,7 @@ int ThreadRunner::op_run(Operation *op) {
 
             _in_transaction = true;
         }
+        // Call cursor operations only when transaction != NULL or _in_transaction is true.
         if (op->is_table_op() && _in_transaction) {
             switch (op->_optype) {
             case Operation::OP_INSERT:
@@ -975,7 +976,7 @@ err:
             else if (op->transaction->use_commit_timestamp) {
                 uint64_t commit_time_us = WorkgenTimeStamp::get_timestamp();
                 sprintf(buf, "commit_timestamp=%" PRIu64, commit_time_us);
-                ret = _session->commit_transaction(_session, buf);
+                ret = _session->commit_transaction(_session, buf);     
             }
             else {
                 ret = _session->commit_transaction(_session,

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -513,9 +513,7 @@ int ThreadRunner::create_all(WT_CONNECTION *conn) {
     ASSERT(_session == NULL);
     if (_thread->options.synchronized)
         _thread->_op.synchronized_check();
-
     WT_RET(conn->open_session(conn, NULL, _thread->options.session_config.c_str(), &_session));
-
     _table_usage.clear();
     _stats.track_latency(_workload->options.sample_interval_ms > 0);
     WT_RET(workgen_random_alloc(_session, &_rand_state));

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -889,7 +889,6 @@ int ThreadRunner::op_run(Operation *op) {
 
             _in_transaction = true;
         }
-        // Call cursor operations only when transaction != NULL or _in_transaction is true.
         if (op->is_table_op()) {
             switch (op->_optype) {
             case Operation::OP_INSERT:

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -882,7 +882,7 @@ int ThreadRunner::op_run(Operation *op) {
 
             _in_transaction = true;
         }
-        if (op->is_table_op()) {
+        if (op->is_table_op() && _in_transaction) {
             switch (op->_optype) {
             case Operation::OP_INSERT:
                 ret = cursor->insert(cursor);
@@ -975,7 +975,7 @@ err:
             else if (op->transaction->use_commit_timestamp) {
                 uint64_t commit_time_us = WorkgenTimeStamp::get_timestamp();
                 sprintf(buf, "commit_timestamp=%" PRIu64, commit_time_us);
-                ret = _session->commit_transaction(_session, buf);     
+                ret = _session->commit_transaction(_session, buf);
             }
             else {
                 ret = _session->commit_transaction(_session,

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -330,6 +330,7 @@ struct Operation {
 //
 struct ThreadOptions {
     std::string name;
+    std::string session_config;
     double throttle;
     double throttle_burst;
     bool synchronized;
@@ -342,6 +343,7 @@ struct ThreadOptions {
 	os << "throttle " << throttle;
 	os << ", throttle_burst " << throttle_burst;
 	os << ", synchronized " << synchronized;
+    os << ", session_config " << session_config;
     }
 
     std::string help() const { return _options.help(); }

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -343,7 +343,7 @@ struct ThreadOptions {
 	os << "throttle " << throttle;
 	os << ", throttle_burst " << throttle_burst;
 	os << ", synchronized " << synchronized;
-    os << ", session_config " << session_config;
+	os << ", session_config " << session_config;
     }
 
     std::string help() const { return _options.help(); }


### PR DESCRIPTION
Looks like some Operation flow in workgen.cxx calls cursor operations without calling begin_transaction().

Updated workgen.cxx to call any cursor operation only after begin_transaction() (_in_transaction = true).