### PR TITLE
WT-5968 Allocate the WT_TXN structure when activating the WT_SESSION 

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -89,7 +89,7 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
      * functions, but in the case of a search, we will see different results based on the cursor's
      * initial location. See WT-5134 for the details.
      */
-    if (search_operation && session->txn.isolation == WT_ISO_READ_COMMITTED)
+    if (search_operation && session->txn->isolation == WT_ISO_READ_COMMITTED)
         return (false);
 
     /*
@@ -1471,11 +1471,11 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
      * time and the failure is unlikely to be detected. Require explicit transactions for modify
      * operations.
      */
-    if (session->txn.isolation != WT_ISO_SNAPSHOT)
+    if (session->txn->isolation != WT_ISO_SNAPSHOT)
         WT_ERR_MSG(session, ENOTSUP,
           "not supported in read-committed or read-uncommitted "
           "transactions");
-    if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
+    if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
         WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
 
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT))

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -257,7 +257,7 @@ read:
              */
             if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE))
                 WT_RET(__wt_cache_eviction_check(
-                  session, true, !F_ISSET(&session->txn, WT_TXN_HAS_ID), NULL));
+                  session, true, !F_ISSET(session->txn, WT_TXN_HAS_ID), NULL));
             WT_RET(__page_read(session, ref, flags));
 
             /* We just read a page, don't evict it before we have a chance to use it. */

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -30,7 +30,7 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
     u_int i;
 
     mod = ref->page->modify;
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * We can skip some dirty pages during a checkpoint. The requirements:
@@ -362,7 +362,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     conn = S2C(session);
     btree = S2BT(session);
     prev = walk = NULL;
-    txn = &session->txn;
+    txn = session->txn;
     tried_eviction = false;
     time_start = time_stop = 0;
     is_hs = false;
@@ -567,7 +567,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * pages. That happens prior to the final metadata checkpoint.
              */
             if (F_ISSET(walk, WT_REF_FLAG_LEAF) && page->read_gen == WT_READGEN_WONT_NEED &&
-              !tried_eviction && F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT)) {
+              !tried_eviction && F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT)) {
                 ret = __wt_page_release_evict(session, walk, 0);
                 walk = NULL;
                 WT_ERR_ERROR_OK(ret, EBUSY, false);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1033,7 +1033,7 @@ err:
      * never referenced that file.
      */
     for (s = conn->sessions, i = 0; i < conn->session_cnt; ++s, ++i)
-        if (s->active && !F_ISSET(s, WT_SESSION_INTERNAL) && F_ISSET(&s->txn, WT_TXN_RUNNING)) {
+        if (s->active && !F_ISSET(s, WT_SESSION_INTERNAL) && F_ISSET(s->txn, WT_TXN_RUNNING)) {
             wt_session = &s->iface;
             WT_TRET(wt_session->rollback_transaction(wt_session, NULL));
         }

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -926,7 +926,7 @@ __curjoin_init_next(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin, bool iterab
          * doing any needed check during the iteration.
          */
         if (!iterable && F_ISSET(je, WT_CURJOIN_ENTRY_BLOOM)) {
-            if (session->txn.isolation == WT_ISO_READ_UNCOMMITTED)
+            if (session->txn->isolation == WT_ISO_READ_UNCOMMITTED)
                 WT_ERR_MSG(session, EINVAL,
                   "join cursors with Bloom filters cannot be "
                   "used with read-uncommitted isolation");

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -949,11 +949,11 @@ __cursor_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
      * read-uncommitted transaction, or outside of an explicit transaction. Disallow here as well,
      * for consistency.
      */
-    if (session->txn.isolation != WT_ISO_SNAPSHOT)
+    if (session->txn->isolation != WT_ISO_SNAPSHOT)
         WT_ERR_MSG(session, ENOTSUP,
           "not supported in read-committed or read-uncommitted "
           "transactions");
-    if (F_ISSET(&session->txn, WT_TXN_AUTOCOMMIT))
+    if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
         WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
 
     WT_ERR(__cursor_checkkey(cursor));

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2303,7 +2303,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
                 if (app_thread)
-                    WT_TRET(__wt_msg(session, "%s", session->txn.rollback_reason));
+                    WT_TRET(__wt_msg(session, "%s", session->txn->rollback_reason));
             }
             WT_ERR(ret);
         }

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -855,7 +855,7 @@ __hs_restore_read_timestamp(WT_SESSION_IMPL *session)
     WT_TXN_SHARED *txn_shared;
 
     txn_shared = WT_SESSION_TXN_SHARED(session);
-    session->txn.read_timestamp = txn_shared->pinned_read_timestamp;
+    session->txn->read_timestamp = txn_shared->pinned_read_timestamp;
 }
 
 /*
@@ -893,7 +893,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, uint64_t recno, WT_UPDA
     mod_upd = upd = NULL;
     orig_hs_value_buf = NULL;
     __wt_modify_vector_init(session, &modifies);
-    txn = &session->txn;
+    txn = session->txn;
     notused = size = 0;
     hs_btree_id = S2BT(session)->id;
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
@@ -982,7 +982,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, uint64_t recno, WT_UPDA
              * timestamp should be equivalent to the stop timestamp of the record that we're
              * currently on.
              */
-            session->txn.read_timestamp = hs_stop_ts_tmp;
+            session->txn->read_timestamp = hs_stop_ts_tmp;
 
             /*
              * Find the base update to apply the reverse deltas. If our cursor next fails to find an

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -86,39 +86,39 @@
     while (0)
 
 /* An API call wrapped in a transaction if necessary. */
-#define TXN_API_CALL(s, h, n, bt, config, cfg)                               \
-    do {                                                                     \
-        bool __autotxn = false, __update = false;                            \
-        API_CALL(s, h, n, bt, config, cfg);                                  \
-        __wt_txn_timestamp_flags(s);                                         \
-        __autotxn = !F_ISSET(&(s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
-        if (__autotxn)                                                       \
-            F_SET(&(s)->txn, WT_TXN_AUTOCOMMIT);                             \
-        __update = !F_ISSET(&(s)->txn, WT_TXN_UPDATE);                       \
-        if (__update)                                                        \
-            F_SET(&(s)->txn, WT_TXN_UPDATE);
+#define TXN_API_CALL(s, h, n, bt, config, cfg)                              \
+    do {                                                                    \
+        bool __autotxn = false, __update = false;                           \
+        API_CALL(s, h, n, bt, config, cfg);                                 \
+        __wt_txn_timestamp_flags(s);                                        \
+        __autotxn = !F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
+        if (__autotxn)                                                      \
+            F_SET((s)->txn, WT_TXN_AUTOCOMMIT);                             \
+        __update = !F_ISSET((s)->txn, WT_TXN_UPDATE);                       \
+        if (__update)                                                       \
+            F_SET((s)->txn, WT_TXN_UPDATE);
 
 /* An API call wrapped in a transaction if necessary. */
-#define TXN_API_CALL_NOCONF(s, h, n, dh)                                     \
-    do {                                                                     \
-        bool __autotxn = false, __update = false;                            \
-        API_CALL_NOCONF(s, h, n, dh);                                        \
-        __wt_txn_timestamp_flags(s);                                         \
-        __autotxn = !F_ISSET(&(s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
-        if (__autotxn)                                                       \
-            F_SET(&(s)->txn, WT_TXN_AUTOCOMMIT);                             \
-        __update = !F_ISSET(&(s)->txn, WT_TXN_UPDATE);                       \
-        if (__update)                                                        \
-            F_SET(&(s)->txn, WT_TXN_UPDATE);
+#define TXN_API_CALL_NOCONF(s, h, n, dh)                                    \
+    do {                                                                    \
+        bool __autotxn = false, __update = false;                           \
+        API_CALL_NOCONF(s, h, n, dh);                                       \
+        __wt_txn_timestamp_flags(s);                                        \
+        __autotxn = !F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
+        if (__autotxn)                                                      \
+            F_SET((s)->txn, WT_TXN_AUTOCOMMIT);                             \
+        __update = !F_ISSET((s)->txn, WT_TXN_UPDATE);                       \
+        if (__update)                                                       \
+            F_SET((s)->txn, WT_TXN_UPDATE);
 
 /* End a transactional API call, optional retry on deadlock. */
 #define TXN_API_END_RETRY(s, ret, retry)                           \
     API_END(s, ret);                                               \
     if (__update)                                                  \
-        F_CLR(&(s)->txn, WT_TXN_UPDATE);                           \
+        F_CLR((s)->txn, WT_TXN_UPDATE);                            \
     if (__autotxn) {                                               \
-        if (F_ISSET(&(s)->txn, WT_TXN_AUTOCOMMIT))                 \
-            F_CLR(&(s)->txn, WT_TXN_AUTOCOMMIT);                   \
+        if (F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT))                  \
+            F_CLR((s)->txn, WT_TXN_AUTOCOMMIT);                    \
         else if ((ret) == 0)                                       \
             (ret) = __wt_txn_commit((s), NULL);                    \
         else {                                                     \

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -555,8 +555,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /* Check if this is the largest transaction ID to update the page. */
-    if (WT_TXNID_LT(page->modify->update_txn, session->txn.id))
-        page->modify->update_txn = session->txn.id;
+    if (WT_TXNID_LT(page->modify->update_txn, session->txn->id))
+        page->modify->update_txn = session->txn->id;
 }
 
 /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -129,7 +129,7 @@ struct __wt_session_impl {
     WT_ITEM err; /* Error buffer */
 
     WT_TXN_ISOLATION isolation;
-    WT_TXN txn; /* Transaction state */
+    WT_TXN *txn; /* Transaction state */
 
 #define WT_SESSION_BG_SYNC_MSEC 1200000
     WT_LSN bg_sync_lsn; /* Background sync operation LSN. */

--- a/src/include/time.i
+++ b/src/include/time.i
@@ -163,7 +163,7 @@ __wt_op_timer_start(WT_SESSION_IMPL *session)
     uint64_t timeout_us;
 
     /* Timer can be configured per-transaction, and defaults to per-connection. */
-    if ((timeout_us = session->txn->operation_timeout_us) == 0)
+    if (session->txn == NULL || (timeout_us = session->txn->operation_timeout_us) == 0)
         timeout_us = S2C(session)->operation_timeout_us;
     if (timeout_us == 0)
         session->operation_start_us = session->operation_timeout_us = 0;

--- a/src/include/time.i
+++ b/src/include/time.i
@@ -163,7 +163,7 @@ __wt_op_timer_start(WT_SESSION_IMPL *session)
     uint64_t timeout_us;
 
     /* Timer can be configured per-transaction, and defaults to per-connection. */
-    if ((timeout_us = session->txn.operation_timeout_us) == 0)
+    if ((timeout_us = session->txn->operation_timeout_us) == 0)
         timeout_us = S2C(session)->operation_timeout_us;
     if (timeout_us == 0)
         session->operation_start_us = session->operation_timeout_us = 0;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -80,16 +80,16 @@ typedef enum {
 #define WT_WITH_TXN_ISOLATION(s, iso, op)                                       \
     do {                                                                        \
         WT_TXN_ISOLATION saved_iso = (s)->isolation;                            \
-        WT_TXN_ISOLATION saved_txn_iso = (s)->txn.isolation;                    \
+        WT_TXN_ISOLATION saved_txn_iso = (s)->txn->isolation;                   \
         WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(s);                   \
         WT_TXN_SHARED saved_txn_shared = *txn_shared;                           \
-        (s)->txn.forced_iso++;                                                  \
-        (s)->isolation = (s)->txn.isolation = (iso);                            \
+        (s)->txn->forced_iso++;                                                 \
+        (s)->isolation = (s)->txn->isolation = (iso);                           \
         op;                                                                     \
         (s)->isolation = saved_iso;                                             \
-        (s)->txn.isolation = saved_txn_iso;                                     \
-        WT_ASSERT((s), (s)->txn.forced_iso > 0);                                \
-        (s)->txn.forced_iso--;                                                  \
+        (s)->txn->isolation = saved_txn_iso;                                    \
+        WT_ASSERT((s), (s)->txn->forced_iso > 0);                               \
+        (s)->txn->forced_iso--;                                                 \
         WT_ASSERT((s), txn_shared->id == saved_txn_shared.id &&                 \
             (txn_shared->metadata_pinned == saved_txn_shared.metadata_pinned || \
                          saved_txn_shared.metadata_pinned == WT_TXN_NONE) &&    \
@@ -369,4 +369,10 @@ struct __wt_txn {
 #define WT_TXN_UPDATE 0x800000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
+
+    /*
+     * Zero or more bytes of value (the payload) immediately follows the WT_UPDATE structure. We use
+     * a C99 flexible array member which has the semantics we want.
+     */
+    uint64_t __snapshot[];
 };

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -13,7 +13,7 @@
 static inline int
 __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)
 {
-    if (F_ISSET(&session->txn, WT_TXN_PREPARE))
+    if (F_ISSET(session->txn, WT_TXN_PREPARE))
         WT_RET_MSG(session, EINVAL, "not permitted in a prepared transaction");
     return (0);
 }
@@ -25,9 +25,9 @@ __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)
 static inline int
 __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
 {
-    if (requires_txn && !F_ISSET(&session->txn, WT_TXN_RUNNING))
+    if (requires_txn && !F_ISSET(session->txn, WT_TXN_RUNNING))
         WT_RET_MSG(session, EINVAL, "only permitted in a running transaction");
-    if (!requires_txn && F_ISSET(&session->txn, WT_TXN_RUNNING))
+    if (!requires_txn && F_ISSET(session->txn, WT_TXN_RUNNING))
         WT_RET_MSG(session, EINVAL, "not permitted in a running transaction");
     return (0);
 }
@@ -41,7 +41,7 @@ __wt_txn_err_set(WT_SESSION_IMPL *session, int ret)
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*  Ignore standard errors that don't fail the transaction. */
     if (ret == WT_NOTFOUND || ret == WT_DUPLICATE_KEY || ret == WT_PREPARE_CONFLICT)
@@ -78,17 +78,17 @@ __wt_txn_timestamp_flags(WT_SESSION_IMPL *session)
     if (btree == NULL)
         return;
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_COMMIT_TS_ALWAYS))
-        F_SET(&session->txn, WT_TXN_TS_COMMIT_ALWAYS);
+        F_SET(session->txn, WT_TXN_TS_COMMIT_ALWAYS);
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_COMMIT_TS_KEYS))
-        F_SET(&session->txn, WT_TXN_TS_COMMIT_KEYS);
+        F_SET(session->txn, WT_TXN_TS_COMMIT_KEYS);
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_COMMIT_TS_NEVER))
-        F_SET(&session->txn, WT_TXN_TS_COMMIT_NEVER);
+        F_SET(session->txn, WT_TXN_TS_COMMIT_NEVER);
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_DURABLE_TS_ALWAYS))
-        F_SET(&session->txn, WT_TXN_TS_DURABLE_ALWAYS);
+        F_SET(session->txn, WT_TXN_TS_DURABLE_ALWAYS);
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_DURABLE_TS_KEYS))
-        F_SET(&session->txn, WT_TXN_TS_DURABLE_KEYS);
+        F_SET(session->txn, WT_TXN_TS_DURABLE_KEYS);
     if (FLD_ISSET(btree->assert_flags, WT_ASSERT_DURABLE_TS_NEVER))
-        F_SET(&session->txn, WT_TXN_TS_DURABLE_NEVER);
+        F_SET(session->txn, WT_TXN_TS_DURABLE_NEVER);
 }
 
 /*
@@ -101,7 +101,7 @@ __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno)
     WT_TXN *txn;
     WT_TXN_OP *op;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     WT_ASSERT(session, txn->mod_count > 0 && recno != WT_RECNO_OOB);
     op = txn->mod + txn->mod_count - 1;
@@ -132,7 +132,7 @@ __wt_txn_op_set_key(WT_SESSION_IMPL *session, const WT_ITEM *key)
     WT_TXN *txn;
     WT_TXN_OP *op;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     WT_ASSERT(session, txn->mod_count > 0 && key->data != NULL);
 
@@ -163,7 +163,7 @@ __txn_resolve_prepared_update(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
     /*
      * In case of a prepared transaction, the order of modification of the prepare timestamp to
      * commit timestamp in the update chain will not affect the data visibility, a reader will
@@ -190,7 +190,7 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
 
     *opp = NULL;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * We're about to perform an update. Make sure we have allocated a transaction ID.
@@ -219,7 +219,7 @@ __wt_txn_unmodify(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_OP *op;
 
-    txn = &session->txn;
+    txn = session->txn;
     if (F_ISSET(txn, WT_TXN_HAS_ID)) {
         WT_ASSERT(session, txn->mod_count > 0);
         --txn->mod_count;
@@ -241,7 +241,7 @@ __wt_txn_op_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bool comm
     wt_timestamp_t ts;
     uint8_t prepare_state, previous_state;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * Lock the ref to ensure we don't race with eviction freeing the page deleted update list or
@@ -285,7 +285,7 @@ __wt_txn_op_delete_commit_apply_timestamps(WT_SESSION_IMPL *session, WT_REF *ref
     WT_UPDATE **updp;
     uint8_t previous_state;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * Lock the ref to ensure we don't race with eviction freeing the page deleted update list or
@@ -314,7 +314,7 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     WT_UPDATE *upd;
     wt_timestamp_t *timestamp;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * Updates in the metadata never get timestamps (either now or at commit): metadata cannot be
@@ -366,7 +366,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     WT_TXN *txn;
     WT_TXN_OP *op;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     if (F_ISSET(txn, WT_TXN_READONLY)) {
         if (F_ISSET(txn, WT_TXN_IGNORE_PREPARE))
@@ -393,7 +393,7 @@ __wt_txn_modify(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     /* History store bypasses transactions, transaction modify should never be called on it. */
     WT_ASSERT(session, !WT_IS_HS(S2BT(session)));
 
-    upd->txnid = session->txn.id;
+    upd->txnid = session->txn->id;
     __wt_txn_op_set_timestamp(session, op);
 
     return (0);
@@ -410,7 +410,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_TXN *txn;
     WT_TXN_OP *op;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     WT_RET(__txn_next_op(session, &op));
     op->type = WT_TXN_OP_REF_DELETE;
@@ -593,7 +593,7 @@ __txn_visible_id(WT_SESSION_IMPL *session, uint64_t id)
     WT_TXN *txn;
     bool found;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /* Changes with no associated transaction are always visible. */
     if (id == WT_TXN_NONE)
@@ -642,13 +642,13 @@ __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     if (!__txn_visible_id(session, id))
         return (false);
 
     /* Transactions read their writes, regardless of timestamps. */
-    if (F_ISSET(&session->txn, WT_TXN_HAS_ID) && id == session->txn.id)
+    if (F_ISSET(session->txn, WT_TXN_HAS_ID) && id == session->txn->id)
         return (true);
 
     /* Timestamp check. */
@@ -694,7 +694,7 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     /* Ignore the prepared update, if transaction configuration says so. */
     if (prepare_state == WT_PREPARE_INPROGRESS)
         return (
-          F_ISSET(&session->txn, WT_TXN_IGNORE_PREPARE) ? WT_VISIBLE_FALSE : WT_VISIBLE_PREPARE);
+          F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE) ? WT_VISIBLE_FALSE : WT_VISIBLE_PREPARE);
 
     return (WT_VISIBLE_TRUE);
 }
@@ -876,7 +876,7 @@ __wt_txn_begin(WT_SESSION_IMPL *session, const char *cfg[])
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn->isolation = session->isolation;
     txn->txn_logsync = S2C(session)->txn_logsync;
 
@@ -916,7 +916,7 @@ __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
     if (F_ISSET(txn, WT_TXN_AUTOCOMMIT)) {
         F_CLR(txn, WT_TXN_AUTOCOMMIT);
         return (__wt_txn_begin(session, NULL));
@@ -935,7 +935,7 @@ __wt_txn_idle_cache_check(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     /*
@@ -988,7 +988,7 @@ __wt_txn_id_alloc(WT_SESSION_IMPL *session, bool publish)
         WT_PUBLISH(txn_shared->is_allocating, true);
         WT_PUBLISH(txn_shared->id, txn_global->current);
         id = __wt_atomic_addv64(&txn_global->current, 1) - 1;
-        session->txn.id = id;
+        session->txn->id = id;
         WT_PUBLISH(txn_shared->id, id);
         WT_PUBLISH(txn_shared->is_allocating, false);
     } else
@@ -1006,7 +1006,7 @@ __wt_txn_id_check(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 
@@ -1039,7 +1039,7 @@ __wt_txn_search_check(WT_SESSION_IMPL *session)
     WT_TXN *txn;
 
     btree = S2BT(session);
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * If the user says a table should always use a read timestamp, verify this transaction has one.
@@ -1073,7 +1073,7 @@ __wt_txn_update_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
     bool ignore_prepare_set, rollback;
 
     rollback = false;
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &S2C(session)->txn_global;
 
     if (txn->isolation != WT_ISO_SNAPSHOT)
@@ -1131,7 +1131,7 @@ __wt_txn_read_last(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
 
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * Release the snap_min ID we put in the global table.
@@ -1155,7 +1155,7 @@ __wt_txn_cursor_op(WT_SESSION_IMPL *session)
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *txn_shared;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -104,10 +104,10 @@ __clsm_enter_update(WT_CURSOR_LSM *clsm)
     } else {
         primary = clsm->chunks[clsm->nchunks - 1]->cursor;
         primary_chunk = clsm->primary_chunk;
-        WT_ASSERT(session, F_ISSET(&session->txn, WT_TXN_HAS_ID));
+        WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_ID));
         have_primary = (primary != NULL && primary_chunk != NULL &&
           (primary_chunk->switch_txn == WT_TXN_NONE ||
-                          WT_TXNID_LT(session->txn.id, primary_chunk->switch_txn)));
+                          WT_TXNID_LT(session->txn->id, primary_chunk->switch_txn)));
     }
 
     /*
@@ -160,7 +160,7 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
 
     lsm_tree = clsm->lsm_tree;
     session = (WT_SESSION_IMPL *)clsm->iface.session;
-    txn = &session->txn;
+    txn = session->txn;
 
     /* Merge cursors never update. */
     if (F_ISSET(clsm, WT_CLSM_MERGE))
@@ -429,7 +429,7 @@ __clsm_open_cursors(WT_CURSOR_LSM *clsm, bool update, u_int start_chunk, uint32_
     c = &clsm->iface;
     cursor = NULL;
     session = (WT_SESSION_IMPL *)c->session;
-    txn = &session->txn;
+    txn = session->txn;
     chunk = NULL;
     locked = false;
     lsm_tree = clsm->lsm_tree;
@@ -832,7 +832,7 @@ __clsm_position_chunk(WT_CURSOR_LSM *clsm, WT_CURSOR *c, bool forward, int *cmpp
          * and stepping forward / back. In that case, keep going until we see a key in the expected
          * range.
          */
-        if (session->txn.isolation != WT_ISO_READ_UNCOMMITTED)
+        if (session->txn->isolation != WT_ISO_READ_UNCOMMITTED)
             return (0);
 
         WT_RET(WT_LSM_CURCMP(session, clsm->lsm_tree, c, cursor, *cmpp));
@@ -1386,9 +1386,9 @@ __clsm_put(WT_SESSION_IMPL *session, WT_CURSOR_LSM *clsm, const WT_ITEM *key, co
 
     lsm_tree = clsm->lsm_tree;
 
-    WT_ASSERT(session, F_ISSET(&session->txn, WT_TXN_HAS_ID) && clsm->primary_chunk != NULL &&
+    WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_ID) && clsm->primary_chunk != NULL &&
         (clsm->primary_chunk->switch_txn == WT_TXN_NONE ||
-                         WT_TXNID_LE(session->txn.id, clsm->primary_chunk->switch_txn)));
+                         WT_TXNID_LE(session->txn->id, clsm->primary_chunk->switch_txn)));
 
     /*
      * Clear the existing cursor position. Don't clear the primary cursor: we're about to use it

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -403,10 +403,10 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
      * Set read-uncommitted: we have already checked that all of the updates in this chunk are
      * globally visible, use the cheapest possible check in reconciliation.
      */
-    saved_isolation = session->txn.isolation;
-    session->txn.isolation = WT_ISO_READ_UNCOMMITTED;
+    saved_isolation = session->txn->isolation;
+    session->txn->isolation = WT_ISO_READ_UNCOMMITTED;
     ret = __wt_sync_file(session, WT_SYNC_WRITE_LEAVES);
-    session->txn.isolation = saved_isolation;
+    session->txn->isolation = saved_isolation;
     WT_ERR(ret);
 
     __wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s", chunk->uri);

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -111,7 +111,7 @@ int
 __wt_meta_track_on(WT_SESSION_IMPL *session)
 {
     if (session->meta_track_nest++ == 0) {
-        if (!F_ISSET(&session->txn, WT_TXN_RUNNING)) {
+        if (!F_ISSET(session->txn, WT_TXN_RUNNING)) {
 #ifdef WT_ENABLE_SCHEMA_TXN
             WT_RET(__wt_txn_begin(session, NULL));
             __wt_errx(session, "TRACK: Using internal schema txn");
@@ -282,11 +282,11 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
          * If this operation is part of a running transaction, that should be included in the
          * checkpoint.
          */
-        ckpt_session->txn.id = session->txn.id;
+        ckpt_session->txn->id = session->txn->id;
         WT_ASSERT(session, !F_ISSET(session, WT_SESSION_LOCKED_METADATA));
         WT_WITH_DHANDLE(ckpt_session, WT_SESSION_META_DHANDLE(session),
           WT_WITH_METADATA_LOCK(ckpt_session, ret = __wt_checkpoint(ckpt_session, NULL)));
-        ckpt_session->txn.id = WT_TXN_NONE;
+        ckpt_session->txn->id = WT_TXN_NONE;
         if (ret == 0)
             WT_WITH_DHANDLE(
               session, WT_SESSION_META_DHANDLE(session), ret = __wt_checkpoint_sync(session, NULL));
@@ -316,7 +316,7 @@ err:
          * We should have committed above unless we're unrolling, there was an error or the
          * operation was a noop.
          */
-        WT_ASSERT(session, unroll || saved_ret != 0 || session->txn.mod_count == 0);
+        WT_ASSERT(session, unroll || saved_ret != 0 || session->txn->mod_count == 0);
 #ifdef WT_ENABLE_SCHEMA_TXN
         __wt_err(session, saved_ret, "TRACK: Abort internal schema txn");
         WT_TRET(__wt_txn_rollback(session, NULL));
@@ -521,7 +521,7 @@ __wt_meta_track_init(WT_SESSION_IMPL *session)
          * Sessions default to read-committed isolation, we rely on that for the correctness of
          * metadata checkpoints.
          */
-        WT_ASSERT(session, conn->meta_ckpt_session->txn.isolation == WT_ISO_READ_COMMITTED);
+        WT_ASSERT(session, conn->meta_ckpt_session->txn->isolation == WT_ISO_READ_COMMITTED);
     }
 
     return (0);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -47,7 +47,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * (rare) cases where we write data at read-uncommitted isolation.
      */
     WT_ASSERT(session, !LF_ISSET(WT_REC_EVICT) || LF_ISSET(WT_REC_VISIBLE_ALL) ||
-        F_ISSET(&session->txn, WT_TXN_HAS_SNAPSHOT));
+        F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
     /* It's an error to be called with a clean page. */
     WT_ASSERT(session, __wt_page_is_modified(page));

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -84,7 +84,7 @@ __wt_schema_internal_session(WT_SESSION_IMPL *session, WT_SESSION_IMPL **int_ses
      * flags from the original.
      */
     *int_sessionp = session;
-    if (F_ISSET(&session->txn, WT_TXN_RUNNING)) {
+    if (F_ISSET(session->txn, WT_TXN_RUNNING)) {
         /* We should not have a schema txn running now. */
         WT_ASSERT(session, !F_ISSET(session, WT_SESSION_SCHEMA_TXN));
         WT_RET(

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -274,7 +274,7 @@ __session_close(WT_SESSION *wt_session, const char *config)
     F_CLR(session, WT_SESSION_CACHE_CURSORS);
 
     /* Rollback any active transaction. */
-    if (F_ISSET(&session->txn, WT_TXN_RUNNING))
+    if (F_ISSET(session->txn, WT_TXN_RUNNING))
         WT_TRET(__session_rollback_transaction(wt_session, NULL));
 
     /*
@@ -1644,7 +1644,7 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
     WT_TXN *txn;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    txn = &session->txn;
+    txn = session->txn;
     SESSION_API_CALL_PREPARE_ALLOWED(session, commit_transaction, config, cfg);
     WT_STAT_CONN_INCR(session, txn_commit);
 
@@ -1748,7 +1748,7 @@ __session_rollback_transaction(WT_SESSION *wt_session, const char *config)
     SESSION_API_CALL_PREPARE_ALLOWED(session, rollback_transaction, config, cfg);
     WT_STAT_CONN_INCR(session, txn_rollback);
 
-    txn = &session->txn;
+    txn = session->txn;
     if (F_ISSET(txn, WT_TXN_PREPARE)) {
         WT_STAT_CONN_INCR(session, txn_prepare_rollback);
         WT_STAT_CONN_DECR(session, txn_prepare_active);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1489,7 +1489,7 @@ __wt_txn_release_resources(WT_SESSION_IMPL *session)
     WT_TXN *txn;
 
     if ((txn = session->txn) == NULL)
-	return;
+        return;
 
     WT_ASSERT(session, txn->mod_count == 0);
     __wt_free(session, txn->mod);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -280,7 +280,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
     if (!WT_IS_METADATA(session->dhandle)) {
         WT_CURSOR *meta_cursor;
 
-        WT_ASSERT(session, !F_ISSET(&session->txn, WT_TXN_ERROR));
+        WT_ASSERT(session, !F_ISSET(session->txn, WT_TXN_ERROR));
         WT_RET(__wt_metadata_cursor(session, &meta_cursor));
         meta_cursor->set_key(meta_cursor, session->dhandle->name);
         ret = __wt_curfile_insert_check(meta_cursor);
@@ -537,7 +537,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
     bool use_timestamp;
 
     conn = S2C(session);
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &conn->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
@@ -756,7 +756,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     cache = conn->cache;
     hs_dhandle = NULL;
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &conn->txn_global;
     saved_isolation = session->isolation;
     full = idle = logging = tracking = use_timestamp = false;
@@ -1632,7 +1632,7 @@ fake:
      * that case, we need to sync the file here or we could roll forward the metadata in recovery
      * and open a checkpoint that isn't yet durable.
      */
-    if (WT_IS_METADATA(dhandle) || !F_ISSET(&session->txn, WT_TXN_RUNNING))
+    if (WT_IS_METADATA(dhandle) || !F_ISSET(session->txn, WT_TXN_RUNNING))
         WT_ERR(__wt_checkpoint_sync(session, NULL));
 
     WT_ERR(__wt_meta_ckptlist_set(session, dhandle->name, btree->ckpt, &ckptlsn));
@@ -1704,7 +1704,7 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
     bool with_timestamp;
 
     btree = S2BT(session);
-    txn = &session->txn;
+    txn = session->txn;
 
     /* Are we using a read timestamp for this checkpoint transaction? */
     with_timestamp = F_ISSET(txn, WT_TXN_HAS_TS_READ);

--- a/src/txn/txn_ext.c
+++ b/src/txn/txn_ext.c
@@ -21,7 +21,7 @@ __wt_ext_transaction_id(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session)
     session = (WT_SESSION_IMPL *)wt_session;
     /* Ignore failures: the only case is running out of transaction IDs. */
     WT_IGNORE_RET(__wt_txn_id_check(session));
-    return (session->txn.id);
+    return (session->txn->id);
 }
 
 /*
@@ -37,7 +37,7 @@ __wt_ext_transaction_isolation_level(WT_EXTENSION_API *wt_api, WT_SESSION *wt_se
     (void)wt_api; /* Unused parameters */
 
     session = (WT_SESSION_IMPL *)wt_session;
-    txn = &session->txn;
+    txn = session->txn;
 
     if (txn->isolation == WT_ISO_READ_COMMITTED)
         return (WT_TXN_ISO_READ_COMMITTED);
@@ -59,7 +59,7 @@ __wt_ext_transaction_notify(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, WT
     (void)wt_api; /* Unused parameters */
 
     session = (WT_SESSION_IMPL *)wt_session;
-    txn = &session->txn;
+    txn = session->txn;
 
     /*
      * XXX For now, a single slot for notifications: I'm not bothering with more than one because

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -206,7 +206,7 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
     uint32_t rectype;
     const char *fmt;
 
-    txn = &session->txn;
+    txn = session->txn;
     rectype = WT_LOGREC_COMMIT;
     fmt = WT_UNCHECKED_STRING(Iq);
 
@@ -255,7 +255,7 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
     uint32_t fileid;
 
     conn = S2C(session);
-    txn = &session->txn;
+    txn = session->txn;
 
     if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ||
       F_ISSET(session, WT_SESSION_NO_LOGGING) ||
@@ -314,7 +314,7 @@ __wt_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN *txn;
 
     WT_UNUSED(cfg);
-    txn = &session->txn;
+    txn = session->txn;
     /*
      * If there are no log records there is nothing to do.
      */
@@ -398,7 +398,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
     wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
 
     conn = S2C(session);
-    txn = &session->txn;
+    txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ||
@@ -459,7 +459,7 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
 
     conn = S2C(session);
     txn_global = &conn->txn_global;
-    txn = &session->txn;
+    txn = session->txn;
     ckpt_lsn = &txn->ckpt_lsn;
 
     /*

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -312,7 +312,7 @@ __txn_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, const char 
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     WT_STAT_CONN_INCR(session, session_query_ts);
@@ -585,10 +585,13 @@ __txn_assert_after_reads(
   WT_SESSION_IMPL *session, const char *op, wt_timestamp_t ts, WT_TXN_SHARED **prev_sharedp)
 {
 #ifdef HAVE_DIAGNOSTIC
-    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
-    WT_TXN_SHARED *prev_shared, *txn_shared = WT_SESSION_TXN_SHARED(session);
+    WT_TXN_GLOBAL *txn_global;
+    WT_TXN_SHARED *prev_shared, *txn_shared;
     wt_timestamp_t tmp_timestamp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
+
+    txn_global = &S2C(session)->txn_global;
+    txn_shared = WT_SESSION_TXN_SHARED(session);
 
     __wt_readlock(session, &txn_global->read_timestamp_rwlock);
     prev_shared = TAILQ_LAST(&txn_global->read_timestamph, __wt_txn_rts_qh);
@@ -637,11 +640,14 @@ __txn_assert_after_reads(
 int
 __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts)
 {
-    WT_TXN *txn = &session->txn;
-    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+    WT_TXN *txn;
+    WT_TXN_GLOBAL *txn_global;
     wt_timestamp_t oldest_ts, stable_ts;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool has_oldest_ts, has_stable_ts;
+
+    txn = session->txn;
+    txn_global = &S2C(session)->txn_global;
 
     /* Added this redundant initialization to circumvent build failure. */
     oldest_ts = stable_ts = WT_TS_NONE;
@@ -743,11 +749,14 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts
 int
 __wt_txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts)
 {
-    WT_TXN *txn = &session->txn;
-    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+    WT_TXN *txn;
+    WT_TXN_GLOBAL *txn_global;
     wt_timestamp_t oldest_ts, stable_ts;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool has_oldest_ts, has_stable_ts;
+
+    txn = session->txn;
+    txn_global = &S2C(session)->txn_global;
 
     /* Added this redundant initialization to circumvent build failure. */
     oldest_ts = stable_ts = 0;
@@ -806,12 +815,14 @@ __wt_txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_
 int
 __wt_txn_set_prepare_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t prepare_ts)
 {
-    WT_TXN *txn = &session->txn;
-    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+    WT_TXN *txn;
+    WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *prev_shared, *txn_shared;
     wt_timestamp_t oldest_ts;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
+    txn = session->txn;
+    txn_global = &S2C(session)->txn_global;
     prev_shared = txn_shared = WT_SESSION_TXN_SHARED(session);
 
     WT_RET(__wt_txn_context_prepare_check(session));
@@ -868,13 +879,15 @@ __wt_txn_set_prepare_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t prepare_
 int
 __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
 {
-    WT_TXN *txn = &session->txn;
-    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+    WT_TXN *txn;
+    WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *txn_shared;
     wt_timestamp_t ts_oldest;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool did_roundup_to_oldest;
 
+    txn = session->txn;
+    txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     WT_RET(__wt_txn_context_prepare_check(session));
@@ -1022,7 +1035,7 @@ __wt_txn_publish_durable_timestamp(WT_SESSION_IMPL *session)
     wt_timestamp_t tmpts, ts;
     uint64_t walked;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
@@ -1115,7 +1128,7 @@ __wt_txn_clear_durable_timestamp(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     if (!F_ISSET(txn, WT_TXN_SHARED_TS_DURABLE))
@@ -1144,7 +1157,7 @@ __wt_txn_publish_read_timestamp(WT_SESSION_IMPL *session)
     wt_timestamp_t tmp_timestamp;
     uint64_t walked;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
@@ -1225,7 +1238,7 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
 
-    txn = &session->txn;
+    txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     if (F_ISSET(txn, WT_TXN_SHARED_TS_READ)) {


### PR DESCRIPTION
@tetsuo-cpp, as anticipated, your changes in WT-5766 make this a much simpler change. (It was easier to re-create the branch than to bring the old branch forward, so it's a new PR.)