### PR TITLE
WT-4701 Switch test/format to use WiredTiger locking primitives

### DIFF
--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -379,9 +379,9 @@ backup(void *arg)
          * with named checkpoints. Wait for the checkpoint to complete, otherwise backups might be
          * starved out.
          */
-	lock_writelock(session, &g.backup_lock);
+        lock_writelock(session, &g.backup_lock);
         if (g.workers_finished) {
-	    lock_writeunlock(session, &g.backup_lock);
+            lock_writeunlock(session, &g.backup_lock);
             break;
         }
 
@@ -471,7 +471,7 @@ backup(void *arg)
             testutil_check(session->truncate(session, "log:", backup_cursor, NULL, NULL));
 
         testutil_check(backup_cursor->close(backup_cursor));
-	lock_writeunlock(session, &g.backup_lock);
+        lock_writeunlock(session, &g.backup_lock);
         active_files_sort(active_now);
         active_files_remove_missing(active_prev, active_now);
         active_prev = active_now;

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -379,9 +379,9 @@ backup(void *arg)
          * with named checkpoints. Wait for the checkpoint to complete, otherwise backups might be
          * starved out.
          */
-        testutil_check(pthread_rwlock_wrlock(&g.backup_lock));
+	lock_writelock(session, &g.backup_lock);
         if (g.workers_finished) {
-            testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+	    lock_writeunlock(session, &g.backup_lock);
             break;
         }
 
@@ -471,7 +471,7 @@ backup(void *arg)
             testutil_check(session->truncate(session, "log:", backup_cursor, NULL, NULL));
 
         testutil_check(backup_cursor->close(backup_cursor));
-        testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+	lock_writeunlock(session, &g.backup_lock);
         active_files_sort(active_now);
         active_files_remove_missing(active_prev, active_now);
         active_prev = active_now;

--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -59,7 +59,7 @@ bulk_commit_transaction(WT_SESSION *session)
     testutil_check(session->commit_transaction(session, buf));
 
     /* Update the oldest timestamp, otherwise updates are pinned in memory. */
-    timestamp_once();
+    timestamp_once(session);
 }
 
 /*

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -85,7 +85,7 @@ checkpoint(void *arg)
                  * few names to test multiple named snapshots in
                  * the system.
                  */
-                ret = pthread_rwlock_trywrlock(&g.backup_lock);
+		ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     testutil_check(__wt_snprintf(
@@ -98,7 +98,7 @@ checkpoint(void *arg)
                 /*
                  * 5% drop all named snapshots.
                  */
-                ret = pthread_rwlock_trywrlock(&g.backup_lock);
+		ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     ckpt_config = "drop=(all)";
@@ -110,7 +110,7 @@ checkpoint(void *arg)
         testutil_check(session->checkpoint(session, ckpt_config));
 
         if (backup_locked)
-            testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+	    lock_writeunlock(session, &g.backup_lock);
 
         secs = mmrand(NULL, 5, 40);
     }

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -85,7 +85,7 @@ checkpoint(void *arg)
                  * few names to test multiple named snapshots in
                  * the system.
                  */
-		ret = lock_try_writelock(session, &g.backup_lock);
+                ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     testutil_check(__wt_snprintf(
@@ -98,7 +98,7 @@ checkpoint(void *arg)
                 /*
                  * 5% drop all named snapshots.
                  */
-		ret = lock_try_writelock(session, &g.backup_lock);
+                ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     ckpt_config = "drop=(all)";
@@ -110,7 +110,7 @@ checkpoint(void *arg)
         testutil_check(session->checkpoint(session, ckpt_config));
 
         if (backup_locked)
-	    lock_writeunlock(session, &g.backup_lock);
+            lock_writeunlock(session, &g.backup_lock);
 
         secs = mmrand(NULL, 5, 40);
     }

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -336,6 +336,10 @@ static CONFIG c[] = {
   {"wiredtiger.config", "configuration string used to wiredtiger_open", C_IGNORE | C_STRING, 0, 0,
     0, NULL, &g.c_config_open},
 
+  /* 80% */
+  {"wiredtiger.fast_mutex", "if wiredtiger's fast mutexes should be used", C_BOOL, 80, 0, 0,
+    &g.c_wt_mutex, NULL},
+
   {"wiredtiger.leak_memory", "if memory should be leaked on close", C_BOOL, 0, 0, 0,
     &g.c_leak_memory, NULL},
 

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -337,7 +337,7 @@ static CONFIG c[] = {
     0, NULL, &g.c_config_open},
 
   /* 80% */
-  {"wiredtiger.fast_mutex", "if wiredtiger fast mutexes should be used", C_BOOL, 80, 0, 0,
+  {"wiredtiger.rwlock", "if wiredtiger read/write mutexes should be used", C_BOOL, 80, 0, 0,
     &g.c_wt_mutex, NULL},
 
   {"wiredtiger.leak_memory", "if memory should be leaked on close", C_BOOL, 0, 0, 0,

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -337,7 +337,7 @@ static CONFIG c[] = {
     0, NULL, &g.c_config_open},
 
   /* 80% */
-  {"wiredtiger.fast_mutex", "if wiredtiger's fast mutexes should be used", C_BOOL, 80, 0, 0,
+  {"wiredtiger.fast_mutex", "if wiredtiger fast mutexes should be used", C_BOOL, 80, 0, 0,
     &g.c_wt_mutex, NULL},
 
   {"wiredtiger.leak_memory", "if memory should be leaked on close", C_BOOL, 0, 0, 0,

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -60,18 +60,18 @@
 
 #define MAX_MODIFY_ENTRIES 5 /* maximum change vectors */
 
-/* 
+/*
  * Abstract lock that lets us use either pthread reader-writer locks or WiredTiger's own
  * (likely faster) implementation.
  */
 typedef struct {
     union {
-	WT_RWLOCK	 wt;
-	pthread_rwlock_t pthread;
+        WT_RWLOCK wt;
+        pthread_rwlock_t pthread;
     } l;
-#define LOCK_NONE	0
-#define LOCK_WT    	1
-#define LOCK_PTHREAD	2
+#define LOCK_NONE 0
+#define LOCK_WT 1
+#define LOCK_PTHREAD 2
     uint32_t lock_type;
 } RWLOCK;
 
@@ -111,7 +111,7 @@ typedef struct {
     FILE *logfp;  /* log file */
 
     RWLOCK backup_lock; /* Backup running */
-    uint64_t backup_id;           /* Block incremental id */
+    uint64_t backup_id; /* Block incremental id */
 
     WT_RAND_STATE rnd; /* Global RNG state */
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -158,13 +158,11 @@ operations(u_int ops_seconds, bool lastrun)
     if (!SINGLETHREADED)
         g.rand_log_stop = true;
 
-    /* Logging and locking require a session. */
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     logop(session, "%s", "=============== thread ops start");
 
     /* Initialize locks to single-thread backups, failures, and timestamp updates. */
     lock_init(session, &g.backup_lock);
-    lock_init(session, &g.death_lock);
     lock_init(session, &g.ts_lock);
 
     /*
@@ -300,7 +298,6 @@ operations(u_int ops_seconds, bool lastrun)
     g.workers_finished = false;
 
     lock_destroy(session, &g.backup_lock);
-    lock_destroy(session, &g.death_lock);
     lock_destroy(session, &g.ts_lock);
 
     logop(session, "%s", "=============== thread ops stop");

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -158,10 +158,14 @@ operations(u_int ops_seconds, bool lastrun)
     if (!SINGLETHREADED)
         g.rand_log_stop = true;
 
-    /* Logging requires a session. */
-    if (g.logging)
-        testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    /* Logging and locking require a session. */
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
     logop(session, "%s", "=============== thread ops start");
+
+    /* Initialize locks to single-thread backups, failures, and timestamp updates. */
+    lock_init(session, &g.backup_lock);
+    lock_init(session, &g.death_lock);
+    lock_init(session, &g.ts_lock);
 
     /*
      * Create the per-thread structures and start the worker threads. Allocate the thread structures
@@ -295,9 +299,12 @@ operations(u_int ops_seconds, bool lastrun)
         testutil_check(__wt_thread_join(NULL, &timestamp_tid));
     g.workers_finished = false;
 
+    lock_destroy(session, &g.backup_lock);
+    lock_destroy(session, &g.death_lock);
+    lock_destroy(session, &g.ts_lock);
+
     logop(session, "%s", "=============== thread ops stop");
-    if (g.logging)
-        testutil_check(session->close(session, NULL));
+    testutil_check(session->close(session, NULL));
 
     for (i = 0; i < g.c_threads; ++i) {
         tinfo = tinfo_list[i];
@@ -372,13 +379,13 @@ begin_transaction_ts(TINFO *tinfo, u_int *iso_configp)
      *
      * Lock out the oldest timestamp update.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    lock_writelock(session, &g.ts_lock);
 
     ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(__wt_snprintf(buf, sizeof(buf), "read_timestamp=%" PRIx64, ts));
     testutil_check(session->timestamp_transaction(session, buf));
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    lock_writeunlock(session, &g.ts_lock);
 
     snap_init(tinfo, ts, false);
     logop(session, "begin snapshot read-ts=%" PRIu64 " (not repeatable)", ts);
@@ -443,7 +450,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
     ts = 0; /* -Wconditional-uninitialized */
     if (g.c_txn_timestamps) {
         /* Lock out the oldest timestamp update. */
-        testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+	lock_writelock(session, &g.ts_lock);
 
         ts = __wt_atomic_addv64(&g.timestamp, 1);
         testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
@@ -454,7 +461,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
             testutil_check(session->timestamp_transaction(session, buf));
         }
 
-        testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+	lock_writeunlock(session, &g.ts_lock);
     }
     testutil_check(session->commit_transaction(session, NULL));
 
@@ -509,7 +516,7 @@ prepare_transaction(TINFO *tinfo)
      *
      * Lock out the oldest timestamp update.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    lock_writelock(session, &g.ts_lock);
 
     ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(__wt_snprintf(buf, sizeof(buf), "prepare_timestamp=%" PRIx64, ts));
@@ -517,7 +524,7 @@ prepare_transaction(TINFO *tinfo)
 
     logop(session, "prepare ts=%" PRIu64, ts);
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    lock_writeunlock(session, &g.ts_lock);
 
     return (ret);
 }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -450,7 +450,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
     ts = 0; /* -Wconditional-uninitialized */
     if (g.c_txn_timestamps) {
         /* Lock out the oldest timestamp update. */
-	lock_writelock(session, &g.ts_lock);
+        lock_writelock(session, &g.ts_lock);
 
         ts = __wt_atomic_addv64(&g.timestamp, 1);
         testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
@@ -461,7 +461,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
             testutil_check(session->timestamp_transaction(session, buf));
         }
 
-	lock_writeunlock(session, &g.ts_lock);
+        lock_writeunlock(session, &g.ts_lock);
     }
     testutil_check(session->commit_transaction(session, NULL));
 

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -354,7 +354,6 @@ void
 lock_init(WT_SESSION *session, RWLOCK *lock)
 {
     testutil_assert(lock->lock_type == LOCK_NONE);
-    testutil_assert(session != NULL);
 
     if (g.c_wt_mutex) {
         testutil_check(__wt_rwlock_init((WT_SESSION_IMPL *)session, &lock->l.wt));
@@ -372,60 +371,12 @@ lock_init(WT_SESSION *session, RWLOCK *lock)
 void
 lock_destroy(WT_SESSION *session, RWLOCK *lock)
 {
-    if (g.c_wt_mutex) {
-        testutil_assert(lock->lock_type == LOCK_WT);
+    testutil_assert(LOCK_INITIALIZED(lock));
+
+    if (lock->lock_type == LOCK_WT) {
         __wt_rwlock_destroy((WT_SESSION_IMPL *)session, &lock->l.wt);
     } else {
-        testutil_assert(lock->lock_type == LOCK_PTHREAD);
         testutil_check(pthread_rwlock_destroy(&lock->l.pthread));
     }
     lock->lock_type = LOCK_NONE;
-}
-
-/*
- * lock_try_writelock
- *     Try to get exclusive lock.  Fail immediately if not available.
- */
-int
-lock_try_writelock(WT_SESSION *session, RWLOCK *lock)
-{
-    if (g.c_wt_mutex) {
-        testutil_assert(lock->lock_type == LOCK_WT);
-        return (__wt_try_writelock((WT_SESSION_IMPL *)session, &lock->l.wt));
-    } else {
-        testutil_assert(lock->lock_type == LOCK_PTHREAD);
-        return (pthread_rwlock_trywrlock(&lock->l.pthread));
-    }
-}
-
-/*
- * lock_writelock --
- *     Wait to get exclusive lock.
- */
-void
-lock_writelock(WT_SESSION *session, RWLOCK *lock)
-{
-    if (g.c_wt_mutex) {
-        testutil_assert(lock->lock_type == LOCK_WT);
-        __wt_writelock((WT_SESSION_IMPL *)session, &lock->l.wt);
-    } else {
-        testutil_assert(lock->lock_type == LOCK_PTHREAD);
-        testutil_check(pthread_rwlock_wrlock(&lock->l.pthread));
-    }
-}
-
-/*
- * lock_writeunlock --
- *     Release an exclusive lock.
- */
-void
-lock_writeunlock(WT_SESSION *session, RWLOCK *lock)
-{
-    if (g.c_wt_mutex) {
-        testutil_assert(lock->lock_type == LOCK_WT);
-        __wt_writeunlock((WT_SESSION_IMPL *)session, &lock->l.wt);
-    } else {
-        testutil_assert(lock->lock_type == LOCK_PTHREAD);
-        testutil_check(pthread_rwlock_unlock(&lock->l.pthread));
-    }
 }

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -246,12 +246,12 @@ timestamp_once(WT_SESSION *session)
 
     /*
      * Lock out transaction timestamp operations. The lock acts as a barrier ensuring we've checked
-     * if the workers have finished, we don't want that line reordered.  We can also be called
-     * from places, such as bulk load, where we are single-threaded and the locks haven't been
+     * if the workers have finished, we don't want that line reordered. We can also be called from
+     * places, such as bulk load, where we are single-threaded and the locks haven't been
      * initialized.
      */
     if (LOCK_INITIALIZED(&g.ts_lock))
-	lock_writelock(session, &g.ts_lock);
+        lock_writelock(session, &g.ts_lock);
 
     ret = conn->query_timestamp(conn, buf + strlen(oldest_timestamp_str), "get=all_durable");
     testutil_assert(ret == 0 || ret == WT_NOTFOUND);
@@ -259,7 +259,7 @@ timestamp_once(WT_SESSION *session)
         testutil_check(conn->set_timestamp(conn, buf));
 
     if (LOCK_INITIALIZED(&g.ts_lock))
-	lock_writeunlock(session, &g.ts_lock);
+        lock_writeunlock(session, &g.ts_lock);
 }
 
 /*
@@ -353,15 +353,15 @@ alter(void *arg)
 void
 lock_init(WT_SESSION *session, RWLOCK *lock)
 {
-    testutil_assert (lock->lock_type == LOCK_NONE);
-    testutil_assert (session != NULL);
+    testutil_assert(lock->lock_type == LOCK_NONE);
+    testutil_assert(session != NULL);
 
     if (g.c_wt_mutex) {
-	testutil_check(__wt_rwlock_init((WT_SESSION_IMPL *)session, &lock->l.wt));
-	lock->lock_type = LOCK_WT;
+        testutil_check(__wt_rwlock_init((WT_SESSION_IMPL *)session, &lock->l.wt));
+        lock->lock_type = LOCK_WT;
     } else {
-	testutil_check(pthread_rwlock_init(&lock->l.pthread, NULL));
-	lock->lock_type = LOCK_PTHREAD;
+        testutil_check(pthread_rwlock_init(&lock->l.pthread, NULL));
+        lock->lock_type = LOCK_PTHREAD;
     }
 }
 
@@ -373,11 +373,11 @@ void
 lock_destroy(WT_SESSION *session, RWLOCK *lock)
 {
     if (g.c_wt_mutex) {
-	testutil_assert(lock->lock_type == LOCK_WT);
-	__wt_rwlock_destroy((WT_SESSION_IMPL *)session, &lock->l.wt);
+        testutil_assert(lock->lock_type == LOCK_WT);
+        __wt_rwlock_destroy((WT_SESSION_IMPL *)session, &lock->l.wt);
     } else {
-	testutil_assert(lock->lock_type == LOCK_PTHREAD);
-	testutil_check(pthread_rwlock_destroy(&lock->l.pthread));
+        testutil_assert(lock->lock_type == LOCK_PTHREAD);
+        testutil_check(pthread_rwlock_destroy(&lock->l.pthread));
     }
     lock->lock_type = LOCK_NONE;
 }
@@ -390,11 +390,11 @@ int
 lock_try_writelock(WT_SESSION *session, RWLOCK *lock)
 {
     if (g.c_wt_mutex) {
-	testutil_assert(lock->lock_type == LOCK_WT);
-	return(__wt_try_writelock((WT_SESSION_IMPL *)session, &lock->l.wt));
+        testutil_assert(lock->lock_type == LOCK_WT);
+        return (__wt_try_writelock((WT_SESSION_IMPL *)session, &lock->l.wt));
     } else {
-	testutil_assert(lock->lock_type == LOCK_PTHREAD);
-	return(pthread_rwlock_trywrlock(&lock->l.pthread));
+        testutil_assert(lock->lock_type == LOCK_PTHREAD);
+        return (pthread_rwlock_trywrlock(&lock->l.pthread));
     }
 }
 
@@ -406,11 +406,11 @@ void
 lock_writelock(WT_SESSION *session, RWLOCK *lock)
 {
     if (g.c_wt_mutex) {
-	testutil_assert(lock->lock_type == LOCK_WT);
-	__wt_writelock((WT_SESSION_IMPL *)session, &lock->l.wt);
+        testutil_assert(lock->lock_type == LOCK_WT);
+        __wt_writelock((WT_SESSION_IMPL *)session, &lock->l.wt);
     } else {
-	testutil_assert(lock->lock_type == LOCK_PTHREAD);
-	testutil_check(pthread_rwlock_wrlock(&lock->l.pthread));
+        testutil_assert(lock->lock_type == LOCK_PTHREAD);
+        testutil_check(pthread_rwlock_wrlock(&lock->l.pthread));
     }
 }
 
@@ -422,10 +422,10 @@ void
 lock_writeunlock(WT_SESSION *session, RWLOCK *lock)
 {
     if (g.c_wt_mutex) {
-	testutil_assert(lock->lock_type == LOCK_WT);
-	__wt_writeunlock((WT_SESSION_IMPL *)session, &lock->l.wt);
+        testutil_assert(lock->lock_type == LOCK_WT);
+        __wt_writeunlock((WT_SESSION_IMPL *)session, &lock->l.wt);
     } else {
-	testutil_assert(lock->lock_type == LOCK_PTHREAD);
-	testutil_check(pthread_rwlock_unlock(&lock->l.pthread));
+        testutil_assert(lock->lock_type == LOCK_PTHREAD);
+        testutil_check(pthread_rwlock_unlock(&lock->l.pthread));
     }
 }

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -233,7 +233,7 @@ fclose_and_clear(FILE **fpp)
  *     Update the timestamp once.
  */
 void
-timestamp_once(void)
+timestamp_once(WT_SESSION *session)
 {
     static const char *oldest_timestamp_str = "oldest_timestamp=";
     WT_CONNECTION *conn;
@@ -246,16 +246,20 @@ timestamp_once(void)
 
     /*
      * Lock out transaction timestamp operations. The lock acts as a barrier ensuring we've checked
-     * if the workers have finished, we don't want that line reordered.
+     * if the workers have finished, we don't want that line reordered.  We can also be called
+     * from places, such as bulk load, where we are single-threaded and the locks haven't been
+     * initialized.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    if (LOCK_INITIALIZED(&g.ts_lock))
+	lock_writelock(session, &g.ts_lock);
 
     ret = conn->query_timestamp(conn, buf + strlen(oldest_timestamp_str), "get=all_durable");
     testutil_assert(ret == 0 || ret == WT_NOTFOUND);
     if (ret == 0)
         testutil_check(conn->set_timestamp(conn, buf));
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    if (LOCK_INITIALIZED(&g.ts_lock))
+	lock_writeunlock(session, &g.ts_lock);
 }
 
 /*
@@ -265,9 +269,15 @@ timestamp_once(void)
 WT_THREAD_RET
 timestamp(void *arg)
 {
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
     bool done;
 
     (void)(arg);
+    conn = g.wts_conn;
+
+    /* Locks need session */
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /* Update the oldest timestamp at least once every 15 seconds. */
     done = false;
@@ -281,10 +291,11 @@ timestamp(void *arg)
         else
             random_sleep(&g.rnd, 15);
 
-        timestamp_once();
+        timestamp_once(session);
 
     } while (!done);
 
+    testutil_check(session->close(session, NULL));
     return (WT_THREAD_RET_VALUE);
 }
 
@@ -333,4 +344,88 @@ alter(void *arg)
 
     testutil_check(session->close(session, NULL));
     return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * lock_init --
+ *     Initialize abstract lock that can use either pthread of wt reader-writer locks.
+ */
+void
+lock_init(WT_SESSION *session, RWLOCK *lock)
+{
+    testutil_assert (lock->lock_type == LOCK_NONE);
+    testutil_assert (session != NULL);
+
+    if (g.c_wt_mutex) {
+	testutil_check(__wt_rwlock_init((WT_SESSION_IMPL *)session, &lock->l.wt));
+	lock->lock_type = LOCK_WT;
+    } else {
+	testutil_check(pthread_rwlock_init(&lock->l.pthread, NULL));
+	lock->lock_type = LOCK_PTHREAD;
+    }
+}
+
+/*
+ * lock_destroy --
+ *     Destroy abstract lock.
+ */
+void
+lock_destroy(WT_SESSION *session, RWLOCK *lock)
+{
+    if (g.c_wt_mutex) {
+	testutil_assert(lock->lock_type == LOCK_WT);
+	__wt_rwlock_destroy((WT_SESSION_IMPL *)session, &lock->l.wt);
+    } else {
+	testutil_assert(lock->lock_type == LOCK_PTHREAD);
+	testutil_check(pthread_rwlock_destroy(&lock->l.pthread));
+    }
+    lock->lock_type = LOCK_NONE;
+}
+
+/*
+ * lock_try_writelock
+ *     Try to get exclusive lock.  Fail immediately if not available.
+ */
+int
+lock_try_writelock(WT_SESSION *session, RWLOCK *lock)
+{
+    if (g.c_wt_mutex) {
+	testutil_assert(lock->lock_type == LOCK_WT);
+	return(__wt_try_writelock((WT_SESSION_IMPL *)session, &lock->l.wt));
+    } else {
+	testutil_assert(lock->lock_type == LOCK_PTHREAD);
+	return(pthread_rwlock_trywrlock(&lock->l.pthread));
+    }
+}
+
+/*
+ * lock_writelock --
+ *     Wait to get exclusive lock.
+ */
+void
+lock_writelock(WT_SESSION *session, RWLOCK *lock)
+{
+    if (g.c_wt_mutex) {
+	testutil_assert(lock->lock_type == LOCK_WT);
+	__wt_writelock((WT_SESSION_IMPL *)session, &lock->l.wt);
+    } else {
+	testutil_assert(lock->lock_type == LOCK_PTHREAD);
+	testutil_check(pthread_rwlock_wrlock(&lock->l.pthread));
+    }
+}
+
+/*
+ * lock_writeunlock --
+ *     Release an exclusive lock.
+ */
+void
+lock_writeunlock(WT_SESSION *session, RWLOCK *lock)
+{
+    if (g.c_wt_mutex) {
+	testutil_assert(lock->lock_type == LOCK_WT);
+	__wt_writeunlock((WT_SESSION_IMPL *)session, &lock->l.wt);
+    } else {
+	testutil_assert(lock->lock_type == LOCK_PTHREAD);
+	testutil_check(pthread_rwlock_unlock(&lock->l.pthread));
+    }
 }


### PR DESCRIPTION
This change replaces calls to pthread reader-write locks with an abstract lock that can be
implemented with either the pthread locks or with WT's faster locks.  The lock type can be
specified (or selected at random) via a new config parameter (`wiredtiger.fast_mutex`).

WT's locks require a `WT_SESSION`.  There are a few changes that were required to ensure that we (mostly) have a one when we use a lock:

- Locks are initialized and torn down each time we call `operations()` instead of just once in `main()`. 
- The timestamp thread opens its own session just to have a one when it uses the timestamp lock.
- There are two cases where we might access a lock outside of `operations()` --- during failure handling and during bulk load. In those cases we now check whether the locks are initialized and if they aren't we don't use them.  This is safe because if the locks aren't initialized we are single-threaded.

I've run a number of format tests with the new code and both locking options. It seems to work fine. I've seen a few failures, but they seem to be covered by existing tickets (mostly [WT-5839](https://jira.mongodb.org/browse/WT-5839))

Questions for reviewers (essentially about our "house style"):

1. I considered a couple ways of building the lock abstraction.  Let me know if something else would be a better fit for WT coding practices.
2. Would it be better to move the lock abstraction to separate source files?