### PR TITLE
WT-6016 Fill source code comments where lines start with parentheticals.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -537,7 +537,7 @@ config_opt_file(WTPERF *wtperf, const char *filename)
             ;
 
         /*
-         * Find the end of the line; if there's no trailing newline, the
+         * Find the end of the line; if there's no trailing newline,
          * the line is too long for the buffer or the file was corrupted
          * (there's no terminating newline in the file).
          */

--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -537,9 +537,8 @@ config_opt_file(WTPERF *wtperf, const char *filename)
             ;
 
         /*
-         * Find the end of the line; if there's no trailing newline,
-         * the line is too long for the buffer or the file was corrupted
-         * (there's no terminating newline in the file).
+         * Find the end of the line; if there's no trailing newline, the line is too long for the
+         * buffer or the file was corrupted (there's no terminating newline in the file).
          */
         for (rtrim = line; *rtrim && *rtrim != '\n'; rtrim++)
             ;

--- a/dist/s_comment.py
+++ b/dist/s_comment.py
@@ -103,12 +103,13 @@ for line in sys.stdin:
         if (len(sline) >= 3 and sline.startswith('*') and sline[1] == ' ' and
             (sline[2].islower() or sline[2] == '_') and sline.endswith('--')):
             function_desc = True
-        # We're only reformatting block comments where each line begins with a
-        # space and an alphabetic character after the asterisk. The only
-        # exceptions are function descriptions.
+        # We're only reformatting block comments where each line begins with a space and an
+        # alphabetic character after the asterisk, or a parenthetical. The only exceptions
+        # are function descriptions.
         block = block and \
-                (len(sline) >= 3 and sline.startswith('*') and
-                 sline[1] == ' ' and sline[2].isalpha()) or function_desc
+            len(sline) >= 3 and sline.startswith('*') and sline[1] == ' ' and \
+            (sline[2].isalpha() or (len(sline) >= 5 and \
+            (sline[2] == '(' and sline[3].isalpha() and sline[4] != ')'))) or function_desc
         # Trim asterisks at the beginning of each line in a multiline comment.
         if sline.startswith('*'):
             sline = sline[1:]

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -567,8 +567,8 @@ session_ops_create(WT_SESSION *session)
 
     /*! [Create a table with columns] */
     /*
-     * Create a table with columns: keys are record numbers, values are
-     * (string, signed 32-bit integer, unsigned 16-bit integer).
+     * Create a table with columns: keys are record numbers, values are (string, signed 32-bit
+     * integer, unsigned 16-bit integer).
      */
     error_check(session->create(session, "table:mytable",
       "key_format=r,value_format=SiH,"

--- a/examples/c/ex_extractor.c
+++ b/examples/c/ex_extractor.c
@@ -73,11 +73,9 @@ my_extract(WT_EXTRACTOR *extractor, WT_SESSION *session, const WT_ITEM *key, con
      */
     for (year = term_start; year <= term_end; ++year) {
         /*
-         * Note that the extract callback is called for all operations
-         * that update the table, not just inserts.  The user sets the
-         * key and uses the cursor->insert() method to return the index
-         * key(s).  WiredTiger will perform the required operation
-         * (such as a remove()).
+         * Note that the extract callback is called for all operations that update the table, not
+         * just inserts. The user sets the key and uses the cursor->insert() method to return the
+         * index key(s). WiredTiger will perform the required operation (such as a remove()).
          */
         fprintf(
           stderr, "EXTRACTOR: index op for year %" PRIu16 ": %s %s\n", year, first_name, last_name);

--- a/ext/compressors/lz4/lz4_compress.c
+++ b/ext/compressors/lz4/lz4_compress.c
@@ -52,23 +52,21 @@ typedef struct {
 } LZ4_COMPRESSOR;
 
 /*
- * LZ4 decompression requires the exact compressed byte count returned by the
- * LZ4_compress_default and LZ4_compress_destSize functions. WiredTiger doesn't
- * track that value, store it in the destination buffer.
+ * LZ4 decompression requires the exact compressed byte count returned by the LZ4_compress_default
+ * and LZ4_compress_destSize functions. WiredTiger doesn't track that value, store it in the
+ * destination buffer.
  *
- * Additionally, LZ4_compress_destSize may compress into the middle of a record,
- * and after decompression we return the length to the last record successfully
- * decompressed, not the number of bytes decompressed; store that value in the
- * destination buffer as well.
+ * Additionally, LZ4_compress_destSize may compress into the middle of a record, and after
+ * decompression we return the length to the last record successfully decompressed, not the number
+ * of bytes decompressed; store that value in the destination buffer as well.
  *
- * (Since raw compression has been removed from WiredTiger, the lz4 compression
- * code no longer calls LZ4_compress_destSize. Some support remains to support
- * existing compressed objects.)
+ * (Since raw compression has been removed from WiredTiger, the lz4 compression code no longer calls
+ * LZ4_compress_destSize. Some support remains to support existing compressed objects.)
  *
  * Use fixed-size, 4B values (WiredTiger never writes buffers larger than 4GB).
  *
- * The unused field is available for a mode flag if one is needed in the future,
- * we guarantee it's 0.
+ * The unused field is available for a mode flag if one is needed in the future, we guarantee it's
+ * 0.
  */
 typedef struct {
     uint32_t compressed_len;   /* True compressed length */

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -273,11 +273,9 @@ restart_read:
         }
 
         /*
-         * If we're at the same slot as the last reference and there's
-         * no matching insert list item, re-use the return information
-         * (so encoded items with large repeat counts aren't repeatedly
-         * decoded).  Otherwise, unpack the cell and build the return
-         * information.
+         * If we're at the same slot as the last reference and there's no matching insert list item,
+         * re-use the return information (so encoded items with large repeat counts aren't
+         * repeatedly decoded). Otherwise, unpack the cell and build the return information.
          */
         if (cbt->cip_saved != cip) {
             cell = WT_COL_PTR(page, cip);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -413,11 +413,9 @@ restart_read:
         }
 
         /*
-         * If we're at the same slot as the last reference and there's
-         * no matching insert list item, re-use the return information
-         * (so encoded items with large repeat counts aren't repeatedly
-         * decoded).  Otherwise, unpack the cell and build the return
-         * information.
+         * If we're at the same slot as the last reference and there's no matching insert list item,
+         * re-use the return information (so encoded items with large repeat counts aren't
+         * repeatedly decoded). Otherwise, unpack the cell and build the return information.
          */
         if (cbt->cip_saved != cip) {
             cell = WT_COL_PTR(page, cip);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -306,9 +306,8 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     /*
      * Give the page a modify structure.
      *
-     * Mark tree dirty, unless the handle is read-only.
-     * (We'd like to free the deleted pages, but if the handle is read-only,
-     * we're not able to do so.)
+     * Mark tree dirty, unless the handle is read-only. (We'd like to free the deleted pages, but if
+     * the handle is read-only, we're not able to do so.)
      */
     WT_RET(__wt_page_modify_init(session, page));
     if (!F_ISSET(btree, WT_BTREE_READONLY))

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -190,9 +190,8 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
         /*
          * Free the insert array.
          *
-         * Row-store tables have one additional slot in the insert array
-         * (the insert array has an extra slot to hold keys that sort
-         * before keys found on the original page).
+         * Row-store tables have one additional slot in the insert array (the insert array has an
+         * extra slot to hold keys that sort before keys found on the original page).
          */
         if (mod->mod_row_insert != NULL)
             __free_skip_array(session, mod->mod_row_insert, page->entries + 1, update_ignore);
@@ -261,12 +260,11 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
     }
 
     /*
-     * Optionally free row-store WT_REF key allocation. Historic versions of
-     * this code looked in a passed-in page argument, but that is dangerous,
-     * some of our error-path callers create WT_REF structures without ever
-     * setting WT_REF.home or having a parent page to which the WT_REF will
-     * be linked. Those WT_REF structures invariably have instantiated keys,
-     * (they obviously cannot be on-page keys), and we must free the memory.
+     * Optionally free row-store WT_REF key allocation. Historic versions of this code looked in a
+     * passed-in page argument, but that is dangerous, some of our error-path callers create WT_REF
+     * structures without ever setting WT_REF.home or having a parent page to which the WT_REF will
+     * be linked. Those WT_REF structures invariably have instantiated keys, (they obviously cannot
+     * be on-page keys), and we must free the memory.
      */
     switch (page_type) {
     case WT_PAGE_ROW_INT:

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -336,9 +336,9 @@ __inmem_col_var(WT_SESSION_IMPL *session, WT_PAGE *page, uint64_t recno, size_t 
     repeat_off = 0;
 
     /*
-     * Walk the page, building references: the page contains unsorted value
-     * items.  The value items are on-page (WT_CELL_VALUE), overflow items
-     * (WT_CELL_VALUE_OVFL) or deleted items (WT_CELL_DEL).
+     * Walk the page, building references: the page contains unsorted value items. The value items
+     * are on-page (WT_CELL_VALUE), overflow items (WT_CELL_VALUE_OVFL) or deleted items
+     * (WT_CELL_DEL).
      */
     indx = 0;
     cip = page->pg_var;

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -79,23 +79,18 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     mod = page->modify;
 
     /*
-     * If modifying a record not previously modified, but which is in the
-     * same update slot as a previously modified record, cursor.ins will
-     * not be set because there's no list of update records for this recno,
-     * but cursor.ins_head will be set to point to the correct update slot.
-     * Acquire the necessary insert information, then create a new update
-     * entry and link it into the existing list. We get here if a page has
-     * a single cell representing multiple records (the records have the
-     * same value), and then a record in the cell is updated or removed,
-     * creating the update list for the cell, and then a cursor iterates
-     * into that same cell to update/remove a different record. We find the
-     * correct slot in the update array, but we don't find an update list
-     * (because it doesn't exist), and don't have the information we need
-     * to do the insert. Normally, we wouldn't care (we could fail and do
-     * a search for the record which would configure everything for the
-     * insert), but range truncation does this pattern for every record in
-     * the cell, and the performance is terrible. For that reason, catch it
-     * here.
+     * If modifying a record not previously modified, but which is in the same update slot as a
+     * previously modified record, cursor.ins will not be set because there's no list of update
+     * records for this recno, but cursor.ins_head will be set to point to the correct update slot.
+     * Acquire the necessary insert information, then create a new update entry and link it into the
+     * existing list. We get here if a page has a single cell representing multiple records (the
+     * records have the same value), and then a record in the cell is updated or removed, creating
+     * the update list for the cell, and then a cursor iterates into that same cell to update/remove
+     * a different record. We find the correct slot in the update array, but we don't find an update
+     * list (because it doesn't exist), and don't have the information we need to do the insert.
+     * Normally, we wouldn't care (we could fail and do a search for the record which would
+     * configure everything for the insert), but range truncation does this pattern for every record
+     * in the cell, and the performance is terrible. For that reason, catch it here.
      */
     if (cbt->ins == NULL && cbt->ins_head != NULL) {
         cbt->ins = __col_insert_search(cbt->ins_head, cbt->ins_stack, cbt->next_stack, recno);

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -156,9 +156,8 @@ descend:
         /*
          * Reference the slot used for next step down the tree.
          *
-         * Base is the smallest index greater than recno and may be the
-         * (last + 1) index.  The slot for descent is the one before
-         * base.
+         * Base is the smallest index greater than recno and may be the (last + 1) index. The slot
+         * for descent is the one before base.
          */
         if (recno != descent->ref_recno) {
             /*

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -315,14 +315,12 @@ restart:
         }
 
         /*
-         * Binary search of an internal page. There are three versions
-         * (keys with no application-specified collation order, in long
-         * and short versions, and keys with an application-specified
-         * collation order), because doing the tests and error handling
-         * inside the loop costs about 5%.
+         * Binary search of an internal page. There are three versions (keys with no
+         * application-specified collation order, in long and short versions, and keys with an
+         * application-specified collation order), because doing the tests and error handling inside
+         * the loop costs about 5%.
          *
-         * Reference the comment above about the 0th key: we continue to
-         * special-case it.
+         * Reference the comment above about the 0th key: we continue to special-case it.
          */
         base = 1;
         limit = pindex->entries - 1;
@@ -542,20 +540,17 @@ leaf_match:
     /*
      * We didn't find an exact match in the WT_ROW array.
      *
-     * Base is the smallest index greater than key and may be the 0th index
-     * or the (last + 1) index.  Set the slot to be the largest index less
-     * than the key if that's possible (if base is the 0th index it means
-     * the application is inserting a key before any key found on the page).
+     * Base is the smallest index greater than key and may be the 0th index or the (last + 1) index.
+     * Set the slot to be the largest index less than the key if that's possible (if base is the 0th
+     * index it means the application is inserting a key before any key found on the page).
      *
-     * It's still possible there is an exact match, but it's on an insert
-     * list.  Figure out which insert chain to search and then set up the
-     * return information assuming we'll find nothing in the insert list
-     * (we'll correct as needed inside the search routine, depending on
-     * what we find).
+     * It's still possible there is an exact match, but it's on an insert list. Figure out which
+     * insert chain to search and then set up the return information assuming we'll find nothing in
+     * the insert list (we'll correct as needed inside the search routine, depending on what we
+     * find).
      *
-     * If inserting a key smaller than any key found in the WT_ROW array,
-     * use the extra slot of the insert array, otherwise the insert array
-     * maps one-to-one to the WT_ROW array.
+     * If inserting a key smaller than any key found in the WT_ROW array, use the extra slot of the
+     * insert array, otherwise the insert array maps one-to-one to the WT_ROW array.
      */
     if (base == 0) {
         cbt->compare = 1;

--- a/src/conn/api_calc_modify.c
+++ b/src/conn/api_calc_modify.c
@@ -146,12 +146,11 @@ __wt_calc_modify(WT_SESSION_IMPL *wt_session, const WT_ITEM *oldv, const WT_ITEM
         goto end;
 
     /*
-     * Walk through the post-image, maintaining start / end markers
-     * separated by a gap in the pre-image.  If the current point in the
-     * post-image matches either marker, try to extend the match to find a
-     * (large) range of matching bytes.  If the end of the range is reached
-     * in the post-image without finding a good match, double the size of
-     * the gap, update the markers and keep trying.
+     * Walk through the post-image, maintaining start / end markers separated by a gap in the
+     * pre-image. If the current point in the post-image matches either marker, try to extend the
+     * match to find a (large) range of matching bytes. If the end of the range is reached in the
+     * post-image without finding a good match, double the size of the gap, update the markers and
+     * keep trying.
      */
     hstart = hend = 0;
     i = gap = 0;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2645,13 +2645,12 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_ERR(__conn_write_base_config(session, cfg));
 
     /*
-     * Check on the turtle and metadata files, creating them if necessary
-     * (which avoids application threads racing to create the metadata file
-     * later).  Once the metadata file exists, get a reference to it in
-     * the connection's session.
+     * Check on the turtle and metadata files, creating them if necessary (which avoids application
+     * threads racing to create the metadata file later). Once the metadata file exists, get a
+     * reference to it in the connection's session.
      *
-     * THE TURTLE FILE MUST BE THE LAST FILE CREATED WHEN INITIALIZING THE
-     * DATABASE HOME, IT'S WHAT WE USE TO DECIDE IF WE'RE CREATING OR NOT.
+     * THE TURTLE FILE MUST BE THE LAST FILE CREATED WHEN INITIALIZING THE DATABASE HOME, IT'S WHAT
+     * WE USE TO DECIDE IF WE'RE CREATING OR NOT.
      */
     WT_ERR(__wt_turtle_init(session));
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -367,13 +367,12 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead)
     }
 
     /*
-     * If marking the handle dead, do so after closing the underlying btree.
-     * (Don't do it before that, the block manager asserts there are never
-     * two references to a block manager object, and re-opening the handle
-     * can succeed once we mark this handle dead.)
+     * If marking the handle dead, do so after closing the underlying btree. (Don't do it before
+     * that, the block manager asserts there are never two references to a block manager object, and
+     * re-opening the handle can succeed once we mark this handle dead.)
      *
-     * Check discard too, code we call to clear the cache expects the data
-     * handle dead flag to be set when discarding modified pages.
+     * Check discard too, code we call to clear the cache expects the data handle dead flag to be
+     * set when discarding modified pages.
      */
     if (marked_dead || discard)
         F_SET(dhandle, WT_DHANDLE_DEAD);
@@ -527,9 +526,8 @@ __conn_btree_apply_internal(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle,
         return (0);
 
     /*
-     * We need to pull the handle into the session handle cache and make
-     * sure it's referenced to stop other internal code dropping the handle
-     * (e.g in LSM when cleaning up obsolete chunks).
+     * We need to pull the handle into the session handle cache and make sure it's referenced to
+     * stop other internal code dropping the handle (e.g in LSM when cleaning up obsolete chunks).
      */
     if ((ret = __wt_session_get_dhandle(session, dhandle->name, dhandle->checkpoint, NULL, 0)) != 0)
         return (ret == EBUSY ? 0 : ret);

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -202,11 +202,9 @@ __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_logmgr_create(session, cfg));
 
     /*
-     * Run recovery.
-     * NOTE: This call will start (and stop) eviction if recovery is
-     * required.  Recovery must run before the history store table is created
-     * (because recovery will update the metadata), and before eviction is
-     * started for real.
+     * Run recovery. NOTE: This call will start (and stop) eviction if recovery is required.
+     * Recovery must run before the history store table is created (because recovery will update the
+     * metadata), and before eviction is started for real.
      */
     WT_RET(__wt_txn_recover(session));
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -135,15 +135,13 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
         FLD_SET(conn->stat_flags, WT_STAT_ON_CLOSE);
 
     /*
-     * We don't allow the log path to be reconfigured for security reasons.
-     * (Applications passing input strings directly to reconfigure would
-     * expose themselves to a potential security problem, the utility of
-     * reconfiguring a statistics log path isn't worth the security risk.)
+     * We don't allow the log path to be reconfigured for security reasons. (Applications passing
+     * input strings directly to reconfigure would expose themselves to a potential security
+     * problem, the utility of reconfiguring a statistics log path isn't worth the security risk.)
      *
-     * See above for the details, but during reconfiguration we're loading
-     * the path value from the saved configuration information, and it's
-     * required during reconfiguration because we potentially stopped and
-     * are restarting, the server.
+     * See above for the details, but during reconfiguration we're loading the path value from the
+     * saved configuration information, and it's required during reconfiguration because we
+     * potentially stopped and are restarting, the server.
      */
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.path", &cval));
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -66,17 +66,14 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
     /*
      * Acquire an exclusive lock on the handle and mark it dead.
      *
-     * The close would require I/O if an update cannot be written
-     * (updates in a no-longer-referenced file might not yet be
-     * globally visible if sessions have disjoint sets of files
-     * open).  In that case, skip it: we'll retry the close the
-     * next time, after the transaction state has progressed.
+     * The close would require I/O if an update cannot be written (updates in a no-longer-referenced
+     * file might not yet be globally visible if sessions have disjoint sets of files open). In that
+     * case, skip it: we'll retry the close the next time, after the transaction state has
+     * progressed.
      *
-     * We don't set WT_DHANDLE_EXCLUSIVE deliberately, we want
-     * opens to block on us and then retry rather than returning an
-     * EBUSY error to the application.  This is done holding the
-     * handle list lock so that connection-level handle searches
-     * never need to retry.
+     * We don't set WT_DHANDLE_EXCLUSIVE deliberately, we want opens to block on us and then retry
+     * rather than returning an EBUSY error to the application. This is done holding the handle list
+     * lock so that connection-level handle searches never need to retry.
      */
     WT_RET(__wt_try_writelock(session, &dhandle->rwlock));
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -678,20 +678,15 @@ __backup_start(
     }
     if (!target_list) {
         /*
-         * It's important to first gather the log files to be copied
-         * (which internally starts a new log file), followed by
-         * choosing a checkpoint to reference in the WiredTiger.backup
-         * file.
+         * It's important to first gather the log files to be copied (which internally starts a new
+         * log file), followed by choosing a checkpoint to reference in the WiredTiger.backup file.
          *
-         * Applications may have logic that takes a checkpoint, followed
-         * by performing a write that should only appear in the new
-         * checkpoint. This ordering prevents choosing the prior
-         * checkpoint, but including the write in the log files
-         * returned.
+         * Applications may have logic that takes a checkpoint, followed by performing a write that
+         * should only appear in the new checkpoint. This ordering prevents choosing the prior
+         * checkpoint, but including the write in the log files returned.
          *
-         * It is also possible, and considered legal, to choose the new
-         * checkpoint, but not include the log file that contains the
-         * log entry for taking the new checkpoint.
+         * It is also possible, and considered legal, to choose the new checkpoint, but not include
+         * the log file that contains the log entry for taking the new checkpoint.
          */
         WT_ERR(__backup_log_append(session, cb, true));
         WT_ERR(__backup_all(session));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -457,12 +457,11 @@ err:
     CURSOR_UPDATE_API_END(session, ret);
 
     /*
-     * The application might do a WT_CURSOR.get_value call when we return,
-     * so we need a value and the underlying functions didn't set one up.
-     * For various reasons, those functions may not have done a search and
-     * any previous value in the cursor might race with WT_CURSOR.reserve
-     * (and in cases like LSM, the reserve never encountered the original
-     * key). For simplicity, repeat the search here.
+     * The application might do a WT_CURSOR.get_value call when we return, so we need a value and
+     * the underlying functions didn't set one up. For various reasons, those functions may not have
+     * done a search and any previous value in the cursor might race with WT_CURSOR.reserve (and in
+     * cases like LSM, the reserve never encountered the original key). For simplicity, repeat the
+     * search here.
      */
     return (ret == 0 ? cursor->search(cursor) : ret);
 }

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -226,11 +226,9 @@ __curindex_search(WT_CURSOR *cursor)
     JOINABLE_CURSOR_API_CALL(cursor, session, search, NULL);
 
     /*
-     * We are searching using the application-specified key, which
-     * (usually) doesn't contain the primary key, so it is just a prefix of
-     * any matching index key.  Do a search_near, step to the next entry if
-     * we land on one that is too small, then check that the prefix
-     * matches.
+     * We are searching using the application-specified key, which (usually) doesn't contain the
+     * primary key, so it is just a prefix of any matching index key. Do a search_near, step to the
+     * next entry if we land on one that is too small, then check that the prefix matches.
      */
     __wt_cursor_set_raw_key(child, &cursor->key);
     WT_ERR(child->search_near(child, &cmp));
@@ -297,15 +295,12 @@ __curindex_search_near(WT_CURSOR *cursor, int *exact)
     JOINABLE_CURSOR_API_CALL(cursor, session, search, NULL);
 
     /*
-     * We are searching using the application-specified key, which
-     * (usually) doesn't contain the primary key, so it is just a prefix of
-     * any matching index key.  That said, if there is an exact match, we
-     * want to find the first matching index entry and set exact equal to
-     * zero.
+     * We are searching using the application-specified key, which (usually) doesn't contain the
+     * primary key, so it is just a prefix of any matching index key. That said, if there is an
+     * exact match, we want to find the first matching index entry and set exact equal to zero.
      *
-     * Do a search_near, and if we find an entry that is too small, step to
-     * the next one.  In the unlikely event of a search past the end of the
-     * tree, go back to the last key.
+     * Do a search_near, and if we find an entry that is too small, step to the next one. In the
+     * unlikely event of a search past the end of the tree, go back to the last key.
      */
     __wt_cursor_set_raw_key(child, &cursor->key);
     WT_ERR(child->search_near(child, &cmp));

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -128,8 +128,7 @@ __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
         WT_RET(__wt_schema_project_merge(
           session, ctable->cg_cursors, idx->key_plan, idx->key_format, &cur->key));
         /*
-         * The index key is now set and the value is empty
-         * (it starts clear and is never set).
+         * The index key is now set and the value is empty (it starts clear and is never set).
          */
         F_SET(cur, WT_CURSTD_KEY_EXT | WT_CURSTD_VALUE_EXT);
         WT_RET(f(cur));
@@ -704,12 +703,11 @@ err:
     CURSOR_UPDATE_API_END(session, ret);
 
     /*
-     * The application might do a WT_CURSOR.get_value call when we return,
-     * so we need a value and the underlying functions didn't set one up.
-     * For various reasons, those functions may not have done a search and
-     * any previous value in the cursor might race with WT_CURSOR.reserve
-     * (and in cases like LSM, the reserve never encountered the original
-     * key). For simplicity, repeat the search here.
+     * The application might do a WT_CURSOR.get_value call when we return, so we need a value and
+     * the underlying functions didn't set one up. For various reasons, those functions may not have
+     * done a search and any previous value in the cursor might race with WT_CURSOR.reserve (and in
+     * cases like LSM, the reserve never encountered the original key). For simplicity, repeat the
+     * search here.
      */
     return (ret == 0 ? cursor->search(cursor) : ret);
 }
@@ -1039,20 +1037,18 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     WT_ERR(__curtable_open_colgroups(ctable, cfg));
 
     /*
-     * We'll need to squirrel away a copy of the cursor configuration for
-     * if/when we open indices.
+     * We'll need to squirrel away a copy of the cursor configuration for if/when we open indices.
      *
-     * cfg[0] is the baseline configuration for the cursor open and we can
-     * acquire another copy from the configuration structures, so it would
-     * be reasonable not to copy it here: but I'd rather be safe than sorry.
+     * cfg[0] is the baseline configuration for the cursor open and we can acquire another copy from
+     * the configuration structures, so it would be reasonable not to copy it here: but I'd rather
+     * be safe than sorry.
      *
      * cfg[1] is the application configuration.
      *
-     * Underlying indices are always opened without dump or readonly; that
-     * information is appended to cfg[1] so later "fast" configuration calls
-     * (checking only cfg[0] and cfg[1]) work. I don't expect to see more
-     * than two configuration strings here, but it's written to compact into
-     * two configuration strings, a copy of cfg[0] and the rest in cfg[1].
+     * Underlying indices are always opened without dump or readonly; that information is appended
+     * to cfg[1] so later "fast" configuration calls (checking only cfg[0] and cfg[1]) work. I don't
+     * expect to see more than two configuration strings here, but it's written to compact into two
+     * configuration strings, a copy of cfg[0] and the rest in cfg[1].
      */
     WT_ERR(__wt_calloc_def(session, 3, &ctable->cfg));
     WT_ERR(__wt_strdup(session, cfg[0], &ctable->cfg[0]));

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -608,8 +608,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      *
      * Don't set any other flags for internal pages: there are no update lists to be saved and
      * restored, changes can't be written into the history store table, nor can we re-create
-     * internal
-     * pages in memory.
+     * internal pages in memory.
      *
      * For leaf pages:
      *

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -170,9 +170,9 @@ struct __wt_cache {
     uint32_t evict_aggressive_score;
 
     /*
-     * Score of how often LRU queues are empty on refill. This score varies
-     * between 0 (if the queue hasn't been empty for a long time) and 100
-     * (if the queue has been empty the last 10 times we filled up.
+     * Score of how often LRU queues are empty on refill. This score varies between 0 (if the queue
+     * hasn't been empty for a long time) and 100 (if the queue has been empty the last 10 times we
+     * filled up.
      */
     uint32_t evict_empty_score;
 

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -219,9 +219,8 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
     cbt->page_deleted_count = 0;
 
     /*
-     * Release any page references we're holding. This can trigger eviction
-     * (e.g., forced eviction of big pages), so it's important to do after
-     * releasing our snapshot above.
+     * Release any page references we're holding. This can trigger eviction (e.g., forced eviction
+     * of big pages), so it's important to do after releasing our snapshot above.
      *
      * Clear the reference regardless, so we don't try the release twice.
      */

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -145,11 +145,10 @@ struct __wt_session_impl {
     /*
      * Operations acting on handles.
      *
-     * The preferred pattern is to gather all of the required handles at
-     * the beginning of an operation, then drop any other locks, perform
-     * the operation, then release the handles.  This cannot be easily
-     * merged with the list of checkpoint handles because some operations
-     * (such as compact) do checkpoints internally.
+     * The preferred pattern is to gather all of the required handles at the beginning of an
+     * operation, then drop any other locks, perform the operation, then release the handles. This
+     * cannot be easily merged with the list of checkpoint handles because some operations (such as
+     * compact) do checkpoints internally.
      */
     WT_DATA_HANDLE **op_handle; /* Handle list */
     u_int op_handle_next;       /* Next empty slot */

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -72,10 +72,10 @@ typedef enum {
 /*
  * Perform an operation at the specified isolation level.
  *
- * This is fiddly: we can't cope with operations that begin transactions
- * (leaving an ID allocated), and operations must not move our published
- * snap_min forwards (or updates we need could be freed while this operation is
- * in progress).  Check for those cases: the bugs they cause are hard to debug.
+ * This is fiddly: we can't cope with operations that begin transactions (leaving an ID allocated),
+ * and operations must not move our published snap_min forwards (or updates we need could be freed
+ * while this operation is in progress). Check for those cases: the bugs they cause are hard to
+ * debug.
  */
 #define WT_WITH_TXN_ISOLATION(s, iso, op)                                       \
     do {                                                                        \

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1191,10 +1191,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      */
     if (create_log) {
         /*
-         * Increment the missed pre-allocated file counter only
-         * if a hot backup is not in progress. We are deliberately
-         * not using pre-allocated log files during backup
-         * (see comment above).
+         * Increment the missed pre-allocated file counter only if a hot backup is not in progress.
+         * We are deliberately not using pre-allocated log files during backup (see comment above).
          */
         if (!conn->hot_backup)
             log->prep_missed++;
@@ -1430,10 +1428,9 @@ __log_truncate(WT_SESSION_IMPL *session, WT_LSN *lsn, bool this_log, bool salvag
     /*
      * Truncate the log file to the given LSN.
      *
-     * It's possible the underlying file system doesn't support truncate
-     * (there are existing examples), which is fine, but we don't want to
-     * repeatedly do the setup work just to find that out every time. Check
-     * before doing work, and if there's a not-supported error, turn off
+     * It's possible the underlying file system doesn't support truncate (there are existing
+     * examples), which is fine, but we don't want to repeatedly do the setup work just to find that
+     * out every time. Check before doing work, and if there's a not-supported error, turn off
      * future truncates.
      */
     WT_ERR(__log_openfile(session, lsn->l.file, 0, &log_fh));

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1618,12 +1618,11 @@ err:
     CURSOR_UPDATE_API_END(session, ret);
 
     /*
-     * The application might do a WT_CURSOR.get_value call when we return,
-     * so we need a value and the underlying functions didn't set one up.
-     * For various reasons, those functions may not have done a search and
-     * any previous value in the cursor might race with WT_CURSOR.reserve
-     * (and in cases like LSM, the reserve never encountered the original
-     * key). For simplicity, repeat the search here.
+     * The application might do a WT_CURSOR.get_value call when we return, so we need a value and
+     * the underlying functions didn't set one up. For various reasons, those functions may not have
+     * done a search and any previous value in the cursor might race with WT_CURSOR.reserve (and in
+     * cases like LSM, the reserve never encountered the original key). For simplicity, repeat the
+     * search here.
      */
     return (ret == 0 ? cursor->search(cursor) : ret);
 }

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -328,11 +328,10 @@ __wt_meta_block_metadata(WT_SESSION_IMPL *session, const char *config, WT_CKPT *
     filecfg[1] = config;
 
     /*
-     * Find out if this file is encrypted. If encrypting, encrypt and encode.
-     * The metadata has to be encrypted because it contains private data
-     * (for example, column names). We pass the block manager text that
-     * describes the metadata (the encryption information), and the
-     * possibly encrypted metadata encoded as a hexadecimal string.
+     * Find out if this file is encrypted. If encrypting, encrypt and encode. The metadata has to be
+     * encrypted because it contains private data (for example, column names). We pass the block
+     * manager text that describes the metadata (the encryption information), and the possibly
+     * encrypted metadata encoded as a hexadecimal string.
      */
     WT_ERR(__wt_btree_config_encryptor(session, filecfg, &kencryptor));
     if (kencryptor == NULL) {

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -109,13 +109,11 @@ __win_fs_rename(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char 
     WT_ERR(__wt_to_utf16_string(session, to, &to_wide));
 
     /*
-     * We want an atomic rename, but that's not guaranteed by MoveFileExW
-     * (or by any MSDN API). Don't set the MOVEFILE_COPY_ALLOWED flag to
-     * prevent the system from falling back to a copy and delete process.
-     * Do set the MOVEFILE_WRITE_THROUGH flag so the window is as small
-     * as possible, just in case. WiredTiger renames are done in a single
-     * directory and we expect that to be an atomic metadata update on any
-     * modern filesystem.
+     * We want an atomic rename, but that's not guaranteed by MoveFileExW (or by any MSDN API).
+     * Don't set the MOVEFILE_COPY_ALLOWED flag to prevent the system from falling back to a copy
+     * and delete process. Do set the MOVEFILE_WRITE_THROUGH flag so the window is as small as
+     * possible, just in case. WiredTiger renames are done in a single directory and we expect that
+     * to be an atomic metadata update on any modern filesystem.
      */
     WT_WINCALL_RETRY(MoveFileExW(from_wide->data, to_wide->data,
                        MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH),

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -42,9 +42,9 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     /*
      * Sanity check flags.
      *
-     * If we try to do eviction using transaction visibility, we had better
-     * have a snapshot.  This doesn't apply to checkpoints: there are
-     * (rare) cases where we write data at read-uncommitted isolation.
+     * If we try to do eviction using transaction visibility, we had better have a snapshot. This
+     * doesn't apply to checkpoints: there are (rare) cases where we write data at read-uncommitted
+     * isolation.
      */
     WT_ASSERT(session, !LF_ISSET(WT_REC_EVICT) || LF_ISSET(WT_REC_VISIBLE_ALL) ||
         F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
@@ -225,11 +225,10 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     __rec_cleanup(session, r);
 
     /*
-     * When threads perform eviction, don't cache block manager structures
-     * (even across calls), we can have a significant number of threads
-     * doing eviction at the same time with large items. Ignore checkpoints,
-     * once the checkpoint completes, all unnecessary session resources will
-     * be discarded.
+     * When threads perform eviction, don't cache block manager structures (even across calls), we
+     * can have a significant number of threads doing eviction at the same time with large items.
+     * Ignore checkpoints, once the checkpoint completes, all unnecessary session resources will be
+     * discarded.
      */
     if (!WT_SESSION_IS_CHECKPOINT(session)) {
         /*
@@ -551,19 +550,16 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_HS) || !LF_ISSET(WT_REC_HS));
 
     /*
-     * History store table eviction is configured when eviction gets aggressive,
-     * adjust the flags for cases we don't support.
+     * History store table eviction is configured when eviction gets aggressive, adjust the flags
+     * for cases we don't support.
      *
-     * We don't yet support fixed-length column-store combined with the
-     * history store table. It's not hard to do, but the underlying function
-     * that reviews which updates can be written to the evicted page and
-     * which updates need to be written to the history store table needs access
-     * to the original value from the page being evicted, and there's no
-     * code path for that in the case of fixed-length column-store objects.
-     * (Row-store and variable-width column-store objects provide a
-     * reference to the unpacked on-page cell for this purpose, but there
-     * isn't an on-page cell for fixed-length column-store objects.) For
-     * now, turn it off.
+     * We don't yet support fixed-length column-store combined with the history store table. It's
+     * not hard to do, but the underlying function that reviews which updates can be written to the
+     * evicted page and which updates need to be written to the history store table needs access to
+     * the original value from the page being evicted, and there's no code path for that in the case
+     * of fixed-length column-store objects. (Row-store and variable-width column-store objects
+     * provide a reference to the unpacked on-page cell for this purpose, but there isn't an on-page
+     * cell for fixed-length column-store objects.) For now, turn it off.
      */
     if (page->type == WT_PAGE_COL_FIX)
         LF_CLR(WT_REC_HS);
@@ -755,23 +751,20 @@ __rec_leaf_page_max(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     switch (page->type) {
     case WT_PAGE_COL_FIX:
         /*
-         * Column-store pages can grow if there are missing records
-         * (that is, we lost a chunk of the range, and have to write
-         * deleted records).  Fixed-length objects are a problem, if
-         * there's a big missing range, we could theoretically have to
-         * write large numbers of missing objects.
+         * Column-store pages can grow if there are missing records (that is, we lost a chunk of the
+         * range, and have to write deleted records). Fixed-length objects are a problem, if there's
+         * a big missing range, we could theoretically have to write large numbers of missing
+         * objects.
          */
         page_size = (uint32_t)WT_ALIGN(
           WT_FIX_ENTRIES_TO_BYTES(btree, r->salvage->take + r->salvage->missing), btree->allocsize);
         break;
     case WT_PAGE_COL_VAR:
         /*
-         * Column-store pages can grow if there are missing records
-         * (that is, we lost a chunk of the range, and have to write
-         * deleted records).  Variable-length objects aren't usually a
-         * problem because we can write any number of deleted records
-         * in a single page entry because of the RLE, we just need to
-         * ensure that additional entry fits.
+         * Column-store pages can grow if there are missing records (that is, we lost a chunk of the
+         * range, and have to write deleted records). Variable-length objects aren't usually a
+         * problem because we can write any number of deleted records in a single page entry because
+         * of the RLE, we just need to ensure that additional entry fits.
          */
         break;
     case WT_PAGE_ROW_LEAF:
@@ -946,15 +939,14 @@ __wt_rec_split_init(
     }
 
     /*
-     * Ensure the disk image buffer is large enough for the max object, as
-     * corrected by the underlying block manager.
+     * Ensure the disk image buffer is large enough for the max object, as corrected by the
+     * underlying block manager.
      *
-     * Since we want to support split_size values larger than the page size
-     * (to allow for adjustments based on the compression), this buffer
-     * should be the greater of split_size and page_size, then aligned to
-     * the next allocation size boundary. The latter shouldn't be an issue,
-     * but it's a possible scenario if, for example, the compression engine
-     * is expected to give us 5x compression and gives us nothing at all.
+     * Since we want to support split_size values larger than the page size (to allow for
+     * adjustments based on the compression), this buffer should be the greater of split_size and
+     * page_size, then aligned to the next allocation size boundary. The latter shouldn't be an
+     * issue, but it's a possible scenario if, for example, the compression engine is expected to
+     * give us 5x compression and gives us nothing at all.
      */
     corrected_page_size = r->page_size;
     WT_RET(bm->write_size(bm, session, &corrected_page_size));
@@ -1626,12 +1618,11 @@ __rec_split_write_reuse(
         return (false);
 
     /*
-     * Quit if evicting with no previously written block to compare against.
-     * (In other words, if there's eviction pressure and the page was never
-     * written by a checkpoint, calculating a checksum is worthless.)
+     * Quit if evicting with no previously written block to compare against. (In other words, if
+     * there's eviction pressure and the page was never written by a checkpoint, calculating a
+     * checksum is worthless.)
      *
-     * Quit if evicting and a previous check failed, once there's a miss no
-     * future block will match.
+     * Quit if evicting and a previous check failed, once there's a miss no future block will match.
      */
     if (F_ISSET(r, WT_REC_EVICT)) {
         if (mod->rec_result != WT_PM_REC_MULTIBLOCK || mod->mod_multi_entries < r->multi_next)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -184,14 +184,12 @@ static void
 __session_clear(WT_SESSION_IMPL *session)
 {
     /*
-     * There's no serialization support around the review of the hazard
-     * array, which means threads checking for hazard pointers first check
-     * the active field (which may be 0) and then use the hazard pointer
-     * (which cannot be NULL).
+     * There's no serialization support around the review of the hazard array, which means threads
+     * checking for hazard pointers first check the active field (which may be 0) and then use the
+     * hazard pointer (which cannot be NULL).
      *
-     * Additionally, the session structure can include information that
-     * persists past the session's end-of-life, stored as part of page
-     * splits.
+     * Additionally, the session structure can include information that persists past the session's
+     * end-of-life, stored as part of page splits.
      *
      * For these reasons, be careful when clearing the session structure.
      */

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -156,14 +156,13 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
     }
 
     /*
-     * The page isn't available, it's being considered for eviction
-     * (or being evicted, for all we know).  If the eviction server
-     * sees our hazard pointer before evicting the page, it will
-     * return the page to use, no harm done, if it doesn't, it will
-     * go ahead and complete the eviction.
+     * The page isn't available, it's being considered for eviction (or being evicted, for all we
+     * know). If the eviction server sees our hazard pointer before evicting the page, it will
+     * return the page to use, no harm done, if it doesn't, it will go ahead and complete the
+     * eviction.
      *
-     * We don't bother publishing this update: the worst case is we
-     * prevent some random page from being evicted.
+     * We don't bother publishing this update: the worst case is we prevent some random page from
+     * being evicted.
      */
     hp->ref = NULL;
     *busyp = true;
@@ -244,15 +243,13 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
 #endif
 
     /*
-     * Clear any hazard pointers because it's not a correctness problem
-     * (any hazard pointer we find can't be real because the session is
-     * being closed when we're called). We do this work because session
-     * close isn't that common that it's an expensive check, and we don't
-     * want to let a hazard pointer lie around, keeping a page from being
-     * evicted.
+     * Clear any hazard pointers because it's not a correctness problem (any hazard pointer we find
+     * can't be real because the session is being closed when we're called). We do this work because
+     * session close isn't that common that it's an expensive check, and we don't want to let a
+     * hazard pointer lie around, keeping a page from being evicted.
      *
-     * We don't panic: this shouldn't be a correctness issue (at least, I
-     * can't think of a reason it would be).
+     * We don't panic: this shouldn't be a correctness issue (at least, I can't think of a reason it
+     * would be).
      */
     for (hp = session->hazard; hp < session->hazard + session->hazard_inuse; ++hp)
         if (hp->ref != NULL) {

--- a/src/support/huffman.c
+++ b/src/support/huffman.c
@@ -310,10 +310,9 @@ __wt_huffman_open(
     WT_RET(__wt_calloc_one(session, &huffman));
 
     /*
-     * The frequency table is 4B pairs of symbol and frequency.  The symbol
-     * is either 1 or 2 bytes and the frequency ranges from 1 to UINT32_MAX
-     * (a frequency of 0 means the value is never expected to appear in the
-     * input).  Validate the symbols are within range.
+     * The frequency table is 4B pairs of symbol and frequency. The symbol is either 1 or 2 bytes
+     * and the frequency ranges from 1 to UINT32_MAX (a frequency of 0 means the value is never
+     * expected to appear in the input). Validate the symbols are within range.
      */
     if (numbytes != 1 && numbytes != 2)
         WT_ERR_MSG(session, EINVAL,

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -101,11 +101,10 @@ bool
 __wt_ispo2(uint32_t v)
 {
     /*
-     * Only numbers that are powers of two will satisfy the relationship
-     * (v & (v - 1) == 0).
+     * Only numbers that are powers of two will satisfy the relationship (v & (v - 1) == 0).
      *
-     * However n must be positive, this returns 0 as a power of 2; to fix
-     * that, use: (! (v & (v - 1)) && v)
+     * However n must be positive, this returns 0 as a power of 2; to fix that, use: (! (v & (v -
+     * 1)) && v)
      */
     return ((v & (v - 1)) == 0);
 }

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -176,8 +176,7 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
     for (i = group->max; i < new_max; i++) {
         WT_ERR(__wt_calloc_one(session, &thread));
         /*
-         * Threads get their own session and hs table cursor
-         * (if the hs table is open).
+         * Threads get their own session and hs table cursor (if the hs table is open).
          */
         session_flags = LF_ISSET(WT_THREAD_CAN_WAIT) ? WT_SESSION_CAN_WAIT : 0;
         WT_ERR(

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -269,13 +269,11 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
         return (0);
 
     /*
-     * We may have raced between starting the checkpoint transaction and
-     * some operation completing on the handle that updated the metadata
-     * (e.g., closing a bulk load cursor).  All such operations either have
-     * exclusive access to the handle or hold the schema lock.  We are now
-     * holding the schema lock and have an open btree handle, so if we
-     * can't update the metadata, then there has been some state change
-     * invisible to the checkpoint transaction.
+     * We may have raced between starting the checkpoint transaction and some operation completing
+     * on the handle that updated the metadata (e.g., closing a bulk load cursor). All such
+     * operations either have exclusive access to the handle or hold the schema lock. We are now
+     * holding the schema lock and have an open btree handle, so if we can't update the metadata,
+     * then there has been some state change invisible to the checkpoint transaction.
      */
     if (!WT_IS_METADATA(session->dhandle)) {
         WT_CURSOR *meta_cursor;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -141,9 +141,8 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
             WT_ERR_NOTFOUND_OK(ret, false);
         else {
             /*
-             * Build/insert a complete value during recovery rather
-             * than using cursor modify to create a partial update
-             * (for no particular reason than simplicity).
+             * Build/insert a complete value during recovery rather than using cursor modify to
+             * create a partial update (for no particular reason than simplicity).
              */
             WT_ERR(__wt_modify_apply(cursor, value.data));
             WT_ERR(cursor->insert(cursor));
@@ -203,9 +202,8 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
             WT_ERR_NOTFOUND_OK(ret, false);
         else {
             /*
-             * Build/insert a complete value during recovery rather
-             * than using cursor modify to create a partial update
-             * (for no particular reason than simplicity).
+             * Build/insert a complete value during recovery rather than using cursor modify to
+             * create a partial update (for no particular reason than simplicity).
              */
             WT_ERR(__wt_modify_apply(cursor, value.data));
             WT_ERR(cursor->insert(cursor));

--- a/test/packing/intpack-test3.c
+++ b/test/packing/intpack-test3.c
@@ -110,8 +110,8 @@ main(void)
     int64_t i;
 
     /*
-     * Test all values in a range, to ensure pack/unpack of small numbers
-     * (which most actively use different numbers of bits) works.
+     * Test all values in a range, to ensure pack/unpack of small numbers (which most actively use
+     * different numbers of bits) works.
      */
     test_spread(0, 100000, 100000);
     test_spread(INT16_MAX, 1025, 1025);


### PR DESCRIPTION
@tetsuo-cpp, if you don't want to go in this direction, feel free to discard without further discussion.

9da351b and 8bd537a are the real changes, then e869d09 is the re-format run.