### PR TITLE
WT-6017 WT_SESSION_IGNORE_HS_TOMBSTONE flag has multiple meanings

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -334,12 +334,7 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      * to be returning across the API boundary.
      */
     if (block->size < allocsize) {
-        /*
-         * We use the "ignore history store tombstone" flag as of verify so we need to check that
-         * we're not performing a verify.
-         */
-        if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE_FLAGS) &&
-          !F_ISSET(S2BT(session), WT_BTREE_VERIFY))
+        if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
             ret = ENOENT;
         else {
             ret = WT_ERROR;

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -190,8 +190,9 @@ struct __wt_session_impl {
 #define WT_SESSION_QUIET_CORRUPT_FILE 0x02000000u
 #define WT_SESSION_READ_WONT_NEED 0x04000000u
 #define WT_SESSION_RESOLVING_TXN 0x08000000u
-#define WT_SESSION_SCHEMA_TXN 0x10000000u
-#define WT_SESSION_SERVER_ASYNC 0x20000000u
+#define WT_SESSION_ROLLBACK_TO_STABLE 0x10000000u
+#define WT_SESSION_SCHEMA_TXN 0x20000000u
+#define WT_SESSION_SERVER_ASYNC 0x40000000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 
@@ -271,9 +272,3 @@ struct __wt_session_impl {
 
     WT_SESSION_STATS stats;
 };
-
-/*
- * Rollback to stable should ignore tombstones in the history store since it needs to scan the
- * entire table sequentially.
- */
-#define WT_SESSION_ROLLBACK_TO_STABLE_FLAGS (WT_SESSION_IGNORE_HS_TOMBSTONE)

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1138,6 +1138,7 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
     F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
     ret = __rollback_to_stable(session, cfg);
     F_CLR(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
+    WT_RET(ret);
 
     /*
      * If the configuration is not in-memory, forcibly log a checkpoint after rollback to stable to

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1131,9 +1131,13 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
     WT_RET(__wt_open_internal_session(S2C(session), "txn rollback_to_stable", true,
       F_MASK(session, WT_SESSION_NO_LOGGING), &session));
 
-    F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE_FLAGS);
+    /*
+     * Rollback to stable should ignore tombstones in the history store since it needs to scan the
+     * entire table sequentially.
+     */
+    F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
     ret = __rollback_to_stable(session, cfg);
-    F_CLR(session, WT_SESSION_ROLLBACK_TO_STABLE_FLAGS);
+    F_CLR(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
 
     /*
      * If the configuration is not in-memory, forcibly log a checkpoint after rollback to stable to


### PR DESCRIPTION
Alex, I removed the next-to-last use of the WT_SESSION_ROLLBACK_TO_STABLE macro in WT-5946, so I thought I'd try and clean up the final use.

My concern is that the macro is fragile because any operation that's changed to set the WT_SESSION_IGNORE_HS_TOMBSTONE flag would lead to the block manager treating the operation
as if it were rollback-to-stable.