### PR TITLE
WT-6018 WiredTiger shouldn't checkpoint if rollback-to-stable fails.

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1138,6 +1138,7 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
     F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
     ret = __rollback_to_stable(session, cfg);
     F_CLR(session, WT_SESSION_ROLLBACK_TO_STABLE | WT_SESSION_IGNORE_HS_TOMBSTONE);
+    WT_RET(ret);
 
     /*
      * If the configuration is not in-memory, forcibly log a checkpoint after rollback to stable to


### PR DESCRIPTION
Hari, staring at the rollback-to-stable code, it seems to me like we could lose data if rollback-to-stable fails and then we checkpoint. In other words, it seems like:
```
rollback-to-stable -- fails
rollback-to-stable -- fails
rollback-to-stable -- succeeds
checkpoint
```
should be safe and work correctly, but I don't think that:
```
rollback-to-stable -- fails
checkpoint
rollback-to-stable -- fails
checkpoint
rollback-to-stable -- succeeds
checkpoint
```
will work, I think we can lose stuff from the pages because of the checkpoint that would mean a subsequent rollback-to-stable wouldn't work correctly.

I don't understand this stuff very well, so please just discard this PR if I'm misunderstanding how rollback-to-stable is supposed to behave.