### PR TITLE
WT-5833 overflow key/value item caching is not working

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -203,10 +203,9 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
         break;
     }
 
-    /* Free the overflow on-page, reuse and transaction-cache skiplists. */
+    /* Free the overflow on-page and reuse skiplists. */
     __wt_ovfl_reuse_free(session, page);
     __wt_ovfl_discard_free(session, page);
-    __wt_ovfl_discard_remove(session, page);
 
     __wt_free(session, page->modify->ovfl_track);
     __wt_spin_destroy(session, &page->modify->page_lock);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -447,15 +447,6 @@ struct __wt_page_modify {
         WT_CELL **discard;
         size_t discard_entries;
         size_t discard_allocated;
-
-        /* Cached overflow value cell/update address pairs. */
-        struct {
-            WT_CELL *cell;
-            uint8_t *data;
-            size_t size;
-        } * remove;
-        size_t remove_allocated;
-        uint32_t remove_next;
     } * ovfl_track;
 
 #define WT_PAGE_LOCK(s, p) __wt_spin_lock((s), &(p)->modify->page_lock)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1127,8 +1127,8 @@ extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CEL
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK *unpack,
   WT_ITEM *store, bool *decoded) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_ovfl_remove(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK *unpack,
-  bool evicting) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ovfl_remove(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK *unpack)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_reuse_add(WT_SESSION_IMPL *session, WT_PAGE *page, const uint8_t *addr,
   size_t addr_size, const void *value, size_t value_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1702,7 +1702,6 @@ extern void __wt_optrack_record_funcid(
   WT_SESSION_IMPL *session, const char *func, uint16_t *func_idp);
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);
 extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);
-extern void __wt_ovfl_discard_remove(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern void __wt_ovfl_reuse_free(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
 extern void __wt_print_huffman_code(void *huffman_arg, uint16_t symbol);

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -968,7 +968,7 @@ compare:
          * they're no longer useful.
          */
         if (ovfl_state == OVFL_UNUSED && vpack->raw != WT_CELL_VALUE_OVFL_RM)
-            WT_ERR(__wt_ovfl_remove(session, page, vpack, F_ISSET(r, WT_REC_EVICT)));
+            WT_ERR(__wt_ovfl_remove(session, page, vpack));
     }
 
     /* Walk any append list. */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -879,7 +879,7 @@ __wt_rec_row_leaf(
         } else {
             /* The first time we find an overflow record, discard the underlying blocks. */
             if (F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) && vpack->raw != WT_CELL_VALUE_OVFL_RM)
-                WT_ERR(__wt_ovfl_remove(session, page, vpack, F_ISSET(r, WT_REC_EVICT)));
+                WT_ERR(__wt_ovfl_remove(session, page, vpack));
 
             switch (upd->type) {
             case WT_UPDATE_MODIFY:

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -463,7 +463,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     /*
      * Returning an update means the original on-page value might be lost, and that's a problem if
      * there's a reader that needs it, make a copy of the on-page value. We do that any time there
-     * are saved updates (we may need to original on-page value to terminate a the update chain, for
+     * are saved updates (we may need to original on-page value to terminate the update chain, for
      * example, in the case of an update that modifies the original value). Additionally, make a
      * copy of the on-page value if the value is an overflow item and anything other than the
      * on-page cell is being written. This is because the value's backing overflow blocks aren't

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -462,11 +462,17 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
 
     /*
      * Returning an update means the original on-page value might be lost, and that's a problem if
-     * there's a reader that needs it. This call makes a copy of the on-page value. We do that any
-     * time there are saved updates and during reconciliation of a backing overflow record that will
-     * be physically removed once it's no longer needed.
+     * there's a reader that needs it, make a copy of the on-page value. We do that any time there
+     * are saved updates (we may need to original on-page value to terminate a the update chain, for
+     * example, in the case of an update that modifies the original value). Additionally, make a
+     * copy of the on-page value if the value is an overflow item and anything other than the
+     * on-page cell is being written. This is because the value's backing overflow blocks aren't
+     * part of the page, and they are physically removed by checkpoint writing this page, that is,
+     * the checkpoint doesn't include the overflow blocks so they're removed and future readers of
+     * this page won't be able to find them.
      */
-    if (vpack != NULL && vpack->type != WT_CELL_DEL && upd_select->upd != NULL && upd_saved)
+    if (upd_select->upd != NULL && vpack != NULL && vpack->type != WT_CELL_DEL &&
+      (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
         WT_ERR(__rec_append_orig_value(session, page, upd_select->upd, vpack));
 
 err:

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -153,8 +153,8 @@ __rec_need_save_upd(
 
     /*
      * Save updates for any reconciliation that doesn't involve history store (in-memory database
-     * and fixed length column store), except when the maximum timestamp and txnid are globally
-     * visible.
+     * and fixed length column store), except when the selected stop time pair or the selected start
+     * time pair is globally visible.
      */
     if (!F_ISSET(r, WT_REC_HS) && !F_ISSET(r, WT_REC_IN_MEMORY) && r->page->type != WT_PAGE_COL_FIX)
         return (false);
@@ -463,7 +463,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     /*
      * Returning an update means the original on-page value might be lost, and that's a problem if
      * there's a reader that needs it, make a copy of the on-page value. We do that any time there
-     * are saved updates (we may need to original on-page value to terminate the update chain, for
+     * are saved updates (we may need the original on-page value to terminate the update chain, for
      * example, in the case of an update that modifies the original value). Additionally, make a
      * copy of the on-page value if the value is an overflow item and anything other than the
      * on-page cell is being written. This is because the value's backing overflow blocks aren't

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -242,14 +242,6 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
 
         WT_TRET(__rec_destroy_session(session));
     }
-
-    /*
-     * We track removed overflow objects in case there's a reader in transit when they're removed.
-     * Any form of eviction locks out readers, we can discard them all.
-     */
-    if (LF_ISSET(WT_REC_EVICT))
-        __wt_ovfl_discard_remove(session, page);
-
     WT_RET(ret);
 
     /*


### PR DESCRIPTION
I think this is close, but I'm concerned there is something about HS caching of overflow items I still don't understand, specifically, other paths in `__wt_rec_upd_select()` where we won't cache a deleted overflow item, or if there is any additional work that's needed for overflow keys.

@bvpvamsikrishna, @agorrod, I need a reviewer for overflow changes, can you please assign someone?