### PR TITLE
WT-6026 Fix s_all breakage on format.h

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -61,8 +61,8 @@
 #define MAX_MODIFY_ENTRIES 5 /* maximum change vectors */
 
 /*
- * Abstract lock that lets us use either pthread reader-writer locks or WiredTiger's own
- * (likely faster) implementation.
+ * Abstract lock that lets us use either pthread reader-writer locks or WiredTiger's own (likely
+ * faster) implementation.
  */
 typedef struct {
     union {


### PR DESCRIPTION
We got unlucky with the timing of WT-4701 and WT-6016. A comment beginning with a parenthesis was added in WT-4701 and was missed in the mass formatting introduced by WT-6016.

Need to fix this now as it's going to break everyone's builds.