### PR TITLE
WT-3726 Add documentation specifying build pre-requisites

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,11 @@
+WiredTiger 10.0.0: (April 20, 2020)
+
+This is version 10.0.0 of WiredTiger.
+
+Instructions for configuring, building, and installing WiredTiger are available online.
+
+    For Linux, MacOS, and other POSIX systems:
+    http://source.wiredtiger.com/develop/build-posix.html
+
+    For Windows:
+    http://source.wiredtiger.com/develop/build-windows.html

--- a/dist/s_all
+++ b/dist/s_all
@@ -72,6 +72,7 @@ run()
 # Non parallelizable scripts The following scripts either modify files or
 # already parallelize internally.
 run "sh ./s_readme $force"
+run "sh ./s_install $force"
 run "python api_config.py"
 run "python api_err.py"
 run "python flags.py"

--- a/dist/s_install
+++ b/dist/s_install
@@ -1,0 +1,46 @@
+#! /bin/sh
+
+t=__wt.$$
+trap 'rm -f $t' 0 1 2 3 13 15
+f=../INSTALL
+
+. ../RELEASE_INFO
+
+force=no
+while :
+	do case "$1" in
+	-f)	# Force versions to be updated
+		force=yes
+		shift;;
+	*)
+		break;;
+	esac
+done
+
+# If the version hasn't changed and we aren't forcing the issue, we're done.
+# Don't generate a new INSTALL file just because the date changed unless forced:
+# that happens all the time.
+if test "$force" = no ; then
+	cnt=`(sed -e q < $f; echo "$WIREDTIGER_VERSION_STRING") |
+	    sed -e 's/:.*//' | sort -u | wc -l`
+	test $cnt -eq 1 && exit 0
+fi
+
+cat << END_TEXT > $t
+$WIREDTIGER_VERSION_STRING
+
+This is version $WIREDTIGER_VERSION of WiredTiger.
+
+Instructions for configuring, building, and installing WiredTiger are available online.
+
+    For Linux, MacOS, and other POSIX systems:
+    http://source.wiredtiger.com/develop/build-posix.html
+
+    For Windows:
+    http://source.wiredtiger.com/develop/build-windows.html
+END_TEXT
+
+cmp $t $f > /dev/null 2>&1 ||
+    (echo "Building $f" && rm -f $f && cp $t $f)
+
+exit 0

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -121,14 +121,16 @@ Configure WiredTiger to perform various run-time diagnostic tests.
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c --enable-java
-Build the WiredTiger Java API.
+Build the WiredTiger Java API; requires <a href="http://swig.org">SWIG</a>
+and Java JDK.
 
 @par \c --enable-lz4
 Configure WiredTiger for <a href="https://github.com/Cyan4973/lz4">LZ4</a>
 compression; see @ref compression for more information.
 
 @par \c --enable-python
-Build the WiredTiger <a href="http://www.python.org">Python</a> API.
+Build the WiredTiger <a href="http://www.python.org">Python</a> API;
+requires <a href="http://swig.org">SWIG</a>.
 
 @par \c --enable-snappy
 Configure WiredTiger for <a href="http://code.google.com/p/snappy/">snappy</a>


### PR DESCRIPTION
Added INSTALL file (and script to update/generate it) describing pre-requisites, as well as
configure, build, and installation instructions.  These instructions are simply pointers to the
appropriate pages in the existing WT reference guide.

The reference guide had almost all of the required information already.  The only change there is an update to the "Building... on POSIX" page to include SWIG requirement for building python and/or Java support.  The corresponding "Building... on Windows" page already had this information.

