### PR TITLE
WT-5544 Cache stuck during salvage

### DIFF
--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1761,10 +1761,8 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
     WT_REF *ref, **refp;
     WT_TRACK *trk;
     uint32_t i;
-    u_int decr_cnt;
 
     addr = NULL;
-    decr_cnt = 0;
 
     /* Allocate a row-store root (internal) page and fill it in. */
     WT_RET(__wt_page_alloc(session, WT_PAGE_ROW_INT, leaf_cnt, true, &page));
@@ -1828,21 +1826,14 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
          * the reconciliation of the root page. For now, make sure the eviction threads don't see us
          * as a threat.
          */
-        if (page->memory_footprint > WT_MEGABYTE) {
-            ++decr_cnt;
+        if (page->memory_footprint > WT_MEGABYTE * 2)
             __wt_cache_page_inmem_decr(session, page, WT_MEGABYTE);
-        }
     }
-    if (decr_cnt != 0)
-        __wt_cache_page_inmem_incr(session, page, decr_cnt * WT_MEGABYTE);
-
     __wt_root_ref_init(session, &ss->root_ref, page, false);
 
     if (0) {
 err:
         __wt_free(session, addr);
-        if (decr_cnt != 0)
-            __wt_cache_page_inmem_incr(session, page, decr_cnt * WT_MEGABYTE);
         __wt_page_out(session, &page);
     }
     return (ret);


### PR DESCRIPTION
@agorrod, our solution in WT-5437 isn't sufficient, the eviction of the constructed root page can itself be slow enough to trigger the cache stuck configuration.

You and I talked about decrementing the constructed root page's memory footprint and never restoring it when working on WT-5437, and we agreed we preferred restoring the memory footprint information. However, I don't see any alternative at this point, given we can't possibly wait and restore the memory footprint value after eviction completes.