### PR TITLE
WT-4954 Document the duplicate log backup cursor. (#5322) (v4.2 backport)

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1102,6 +1102,7 @@ backup(WT_SESSION *session)
 {
     char buf[1024];
 
+    WT_CURSOR *dup_cursor;
     /*! [backup]*/
     WT_CURSOR *cursor;
     const char *filename;
@@ -1124,6 +1125,13 @@ backup(WT_SESSION *session)
 
     error_check(cursor->close(cursor));
     /*! [backup]*/
+
+    /*! [backup log duplicate]*/
+    /* Open the backup data source. */
+    error_check(session->open_cursor(session, "backup:", NULL, NULL, &cursor));
+    /* Open a duplicate cursor for additional log files. */
+    error_check(session->open_cursor(session, NULL, cursor, "target=(\"log:\")", &dup_cursor));
+    /*! [backup log duplicate]*/
 
     /*! [incremental backup]*/
     /* Open the backup data source for log-based incremental backup. */

--- a/examples/java/com/wiredtiger/examples/ex_all.java
+++ b/examples/java/com/wiredtiger/examples/ex_all.java
@@ -845,6 +845,7 @@ backup(Session session)
 {
     char buf[] = new char[1024];
 
+    Cursor dup_cursor;
     /*! [backup]*/
     Cursor cursor;
     String filename;
@@ -889,6 +890,21 @@ backup(Session session)
                 ": backup failed: " + ex.toString());
         }
     /*! [backup]*/
+        try {
+	    /*! [backup log duplicate]*/
+            /* Open the backup data source. */
+            cursor = session.open_cursor("backup:", null, null);
+            /* Open a duplicate cursor for additional log files. */
+            dup_cursor = session.open_cursor(null, cursor, "target=(\"log:\")");
+	    /*! [backup log duplicate]*/
+
+            ret = dup_cursor.close();
+            ret = cursor.close();
+        }
+        catch (Exception ex) {
+            System.err.println(progname +
+                ": duplicate log backup failed: " + ex.toString());
+        }
         try {
 	    /*! [incremental backup]*/
             /* Open the backup data source for incremental backup. */

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -72,6 +72,24 @@ The following is a programmatic example of creating a backup:
 
 @snippet ex_all.c backup
 
+When logging is enabled, opening the backup cursor forces a log file switch.
+The reason is so that only data that was committed and visible at the time of
+the backup is available in the backup when that log file is included in the
+list of files. WiredTiger offers a mechanism to gather additional log files that
+may be created during the backup.
+
+Since backups can take a long time, it may be desirable to catch up at the
+end of a backup with the log files so that operations that occurred during
+backup can be recovered. WiredTiger provides the ability to open a duplicate
+backup cursor with the configuration \c target=log:. This secondary backup
+cursor will return the file names of all log files via \c dup_cursor->get_key().
+There will be overlap with log file names returned in the original cursor. The user
+only needs to copy file names that are new but there is no error copying all
+log file names returned. This secondary cursor must be closed explicitly prior
+to closing the parent backup cursor.
+
+@snippet ex_all.c backup log duplicate
+
 In cases where the backup is desired for a checkpoint other than the
 most recent, applications can discard all checkpoints subsequent to the
 checkpoint they want using the WT_SESSION::checkpoint method.  For


### PR DESCRIPTION
* WT-4954 Document the duplicate log backup cursor.

* Clarify cursor name.

* Add more information about log files returned.

(cherry picked from commit f3db4f868600a9a46a183f4b4362ef53d767012b)