### PR TITLE
WT-5695 Fixed incremental backup example to use O_CREAT in the backup range case. (#5330) (v4.2 backport)

### DIFF
--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -383,7 +383,7 @@ take_incr_backup(WT_SESSION *session, int i)
                     error_sys_check(rfd = open(buf, O_RDONLY, 0));
                     (void)snprintf(h, sizeof(h), "%s.%d", home_incr, i);
                     (void)snprintf(buf, sizeof(buf), "%s/%s", h, filename);
-                    error_sys_check(wfd = open(buf, O_WRONLY, 0));
+                    error_sys_check(wfd = open(buf, O_WRONLY | O_CREAT, 0));
                     first = false;
                 }
 


### PR DESCRIPTION
… range case. (#5330)

(cherry picked from commit 9849337bf9e206cc6e50fa84c6805f13f91bc59b)