### PR TITLE
WT-5719 Add quotes to the metadata string. Modify example to use special characters. (#5347) (v4.2 backport) 

### DIFF
--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -269,7 +269,7 @@ take_full_backup(WT_SESSION *session, int i)
         hdir = home_incr;
     if (i == 0) {
         (void)snprintf(
-          buf, sizeof(buf), "incremental=(granularity=1M,enabled=true,this_id=ID%d)", i);
+          buf, sizeof(buf), "incremental=(granularity=1M,enabled=true,this_id=\"ID%d\")", i);
         error_check(session->open_cursor(session, "backup:", NULL, buf, &cursor));
     } else
         error_check(session->open_cursor(session, "backup:", NULL, NULL, &cursor));
@@ -333,7 +333,7 @@ take_incr_backup(WT_SESSION *session, int i)
     tmp = NULL;
     tmp_sz = 0;
     /* Open the backup data source for incremental backup. */
-    (void)snprintf(buf, sizeof(buf), "incremental=(src_id=ID%d,this_id=ID%d)", i - 1, i);
+    (void)snprintf(buf, sizeof(buf), "incremental=(src_id=\"ID%d\",this_id=\"ID%d\")", i - 1, i);
     error_check(session->open_cursor(session, "backup:", NULL, buf, &backup_cur));
     rfd = wfd = -1;
     count = 0;
@@ -503,7 +503,8 @@ main(int argc, char *argv[])
     /*
      * We should have an entry for i-1 and i-2. Use the older one.
      */
-    (void)snprintf(cmd_buf, sizeof(cmd_buf), "incremental=(src_id=ID%d,this_id=ID%d)", i - 2, i);
+    (void)snprintf(
+      cmd_buf, sizeof(cmd_buf), "incremental=(src_id=\"ID%d\",this_id=\"ID%d\")", i - 2, i);
     error_check(session->open_cursor(session, "backup:", NULL, cmd_buf, &backup_cur));
     error_check(backup_cur->close(backup_cur));
 
@@ -537,7 +538,8 @@ main(int argc, char *argv[])
     /*
      * We should not have any information.
      */
-    (void)snprintf(cmd_buf, sizeof(cmd_buf), "incremental=(src_id=ID%d,this_id=ID%d)", i - 2, i);
+    (void)snprintf(
+      cmd_buf, sizeof(cmd_buf), "incremental=(src_id=\"ID%d\",this_id=\"ID%d\")", i - 2, i);
     testutil_assert(session->open_cursor(session, "backup:", NULL, cmd_buf, &backup_cur) == ENOENT);
     error_check(wt_conn->close(wt_conn, NULL));
 

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -763,7 +763,7 @@ __ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
         if (!F_ISSET(blk, WT_BLOCK_MODS_VALID))
             continue;
         WT_RET(__wt_raw_to_hex(session, blk->bitstring.data, blk->bitstring.size, &bitstring));
-        WT_RET(__wt_buf_catfmt(session, buf, "%s%s=(id=%" PRIu32 ",granularity=%" PRIu64
+        WT_RET(__wt_buf_catfmt(session, buf, "%s\"%s\"=(id=%" PRIu32 ",granularity=%" PRIu64
                                              ",nbits=%" PRIu64 ",offset=%" PRIu64 ",blocks=%.*s)",
           i == 0 ? "" : ",", blk->id_str, i, blk->granularity, blk->nbits, blk->offset,
           (int)bitstring.size, (char *)bitstring.data));

--- a/test/suite/test_backup12.py
+++ b/test/suite/test_backup12.py
@@ -79,7 +79,7 @@ class test_backup12(wttest.WiredTigerTestCase, suite_subprocess):
         #
         # Note, this first backup is actually done before a checkpoint is taken.
         #
-        config = 'incremental=(enabled,granularity=1M,this_id="ID1")'
+        config = 'incremental=(enabled,granularity=1M,this_id="ID1:1.1")'
         bkup_c = self.session.open_cursor('backup:', None, config)
 
         # Add more data while the backup cursor is open.
@@ -130,7 +130,7 @@ class test_backup12(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.drop(self.uri_rem)
 
         # Now do an incremental backup.
-        config = 'incremental=(src_id="ID1",this_id="ID2")'
+        config = 'incremental=(src_id="ID1:1.1",this_id="ID2:2.2")'
         bkup_c = self.session.open_cursor('backup:', None, config)
         self.pr('Open backup cursor ID1')
         bkup_files = []


### PR DESCRIPTION
* WT-5719 Add quotes to the metadata string. Modify example to use special
characters.

* Use quotes in example. Use special characters in python test.

* Fix typo.

(cherry picked from commit 9bf859e311aa75bc2cba4bad041c6e3f6df27ce5)