### PR TITLE
WT-5722 Add standard name checks to incremental backup identifiers. (#5351) (v4.2 backport)

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -368,6 +368,7 @@ __backup_find_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_BLKINCR **in
     u_int i;
 
     conn = S2C(session);
+    WT_RET(__wt_name_check(session, cval->str, cval->len, false));
     for (i = 0; i < WT_BLKINCR_MAX; ++i) {
         blk = &conn->incr_backups[i];
         /* If it isn't valid, skip it. */
@@ -495,8 +496,10 @@ __backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[
             WT_ERR_MSG(session, EINVAL,
               "Incremental identifier can only be specified on a primary backup cursor");
         ret = __backup_find_id(session, &cval, NULL);
-        if (ret != WT_NOTFOUND)
+        if (ret == 0)
             WT_ERR_MSG(session, EINVAL, "Incremental identifier already exists");
+        if (ret != WT_NOTFOUND)
+            WT_ERR(ret);
 
         WT_ERR(__backup_add_id(session, &cval));
         incremental_config = true;

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -134,7 +134,9 @@ this cursor will return the filename as the key.  There is no associated
 value.  The information returned will be based on blocks tracked since the time of
 the previous backup designated with "ID1".  New block tracking will be started as
 "ID2" as well.  WiredTiger will maintain modifications from two IDs, the current
-and the most recent completed one.
+and the most recent completed one. Note that all backup identifiers are subject to
+the same naming restrictions as other configuration naming. See @ref config_intro
+for details.
 
 3. For each file returned by \c backup_cursor->next(), open a duplicate
 backup cursor to do the incremental backup on that file.  The list

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1082,7 +1082,7 @@ extern int __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...)
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi,
   WT_REF **refp, size_t *incrp, bool closing) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_name_check(WT_SESSION_IMPL *session, const char *str, size_t len)
+extern int __wt_name_check(WT_SESSION_IMPL *session, const char *str, size_t len, bool check_uri)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_nfilename(WT_SESSION_IMPL *session, const char *name, size_t namelen, char **path)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -22,7 +22,7 @@ static int
 __checkpoint_name_ok(WT_SESSION_IMPL *session, const char *name, size_t len)
 {
     /* Check for characters we don't want to see in a metadata file. */
-    WT_RET(__wt_name_check(session, name, len));
+    WT_RET(__wt_name_check(session, name, len, true));
 
     /*
      * The internal checkpoint name is special, applications aren't allowed to use it. Be aggressive

--- a/src/txn/txn_nsnap.c
+++ b/src/txn/txn_nsnap.c
@@ -344,7 +344,7 @@ __wt_txn_named_snapshot_config(
         if (WT_STRING_MATCH("all", cval.str, cval.len))
             WT_RET_MSG(session, EINVAL, "Can't create snapshot with reserved \"all\" name");
 
-        WT_RET(__wt_name_check(session, cval.str, cval.len));
+        WT_RET(__wt_name_check(session, cval.str, cval.len, true));
 
         if (F_ISSET(txn, WT_TXN_RUNNING) && txn->isolation != WT_ISO_SNAPSHOT)
             WT_RET_MSG(session, EINVAL,

--- a/src/txn/txn_nsnap.c
+++ b/src/txn/txn_nsnap.c
@@ -344,7 +344,7 @@ __wt_txn_named_snapshot_config(
         if (WT_STRING_MATCH("all", cval.str, cval.len))
             WT_RET_MSG(session, EINVAL, "Can't create snapshot with reserved \"all\" name");
 
-        WT_RET(__wt_name_check(session, cval.str, cval.len, true));
+        WT_RET(__wt_name_check(session, cval.str, cval.len, false));
 
         if (F_ISSET(txn, WT_TXN_RUNNING) && txn->isolation != WT_ISO_SNAPSHOT)
             WT_RET_MSG(session, EINVAL,

--- a/test/suite/test_backup11.py
+++ b/test/suite/test_backup11.py
@@ -109,15 +109,7 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         # Add more data
         self.add_data()
 
-        # Test a few error cases now.
-        # - Incremental filename must be on duplicate, not primary.
-        # - An incremental duplicate must have an incremental primary.
-        # - We cannot make multiple incremental duplcate backup cursors.
-        # - We cannot duplicate the duplicate backup cursor.
-        # - We cannot mix block incremental with a log target on the same duplicate.
-        # - Incremental ids must be on primary, not duplicate.
-        # - Incremental must be opened on a primary with a source identifier.
-        # - Force stop must be on primary, not duplicate.
+        # Test error cases now.
 
         # - Incremental filename must be on duplicate, not primary.
         # Test this first because we currently do not have a primary open.
@@ -224,6 +216,36 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         config = 'incremental=(enabled,src_id="ID_BAD",this_id="ID4")'
         self.assertRaises(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor('backup:', None, config))
+
+        # - Test opening a primary backup with an id in WiredTiger namespace.
+        self.pr("Test incremental with illegal src identifier using WiredTiger namespace")
+        self.pr("=========")
+        msg = '/name space may not/'
+        config = 'incremental=(enabled,src_id="WiredTiger.0")'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor('backup:', None, config), msg)
+
+        # - Test opening a primary backup with an id in WiredTiger namespace.
+        self.pr("Test incremental with illegal this identifier using WiredTiger namespace")
+        self.pr("=========")
+        config = 'incremental=(enabled,this_id="WiredTiger.ID")'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor('backup:', None, config), msg)
+
+        # - Test opening a primary backup with an id using illegal characters.
+        self.pr("Test incremental with illegal source identifier using illegal colon character")
+        self.pr("=========")
+        msg = '/grouping characters/'
+        config = 'incremental=(enabled,src_id="ID4:4.0")'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor('backup:', None, config), msg)
+
+        # - Test opening a primary backup with an id using illegal characters.
+        self.pr("Test incremental with illegal this identifier using illegal colon character")
+        self.pr("=========")
+        config = 'incremental=(enabled,this_id="ID4:4.0")'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor('backup:', None, config), msg)
 
         # - Test opening a primary backup with the same source id and this id (new id).
         self.pr("Test incremental with the same new source and this identifiers")

--- a/test/suite/test_backup12.py
+++ b/test/suite/test_backup12.py
@@ -79,7 +79,7 @@ class test_backup12(wttest.WiredTigerTestCase, suite_subprocess):
         #
         # Note, this first backup is actually done before a checkpoint is taken.
         #
-        config = 'incremental=(enabled,granularity=1M,this_id="ID1:1.1")'
+        config = 'incremental=(enabled,granularity=1M,this_id="ID1")'
         bkup_c = self.session.open_cursor('backup:', None, config)
 
         # Add more data while the backup cursor is open.
@@ -130,7 +130,7 @@ class test_backup12(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.drop(self.uri_rem)
 
         # Now do an incremental backup.
-        config = 'incremental=(src_id="ID1:1.1",this_id="ID2:2.2")'
+        config = 'incremental=(src_id="ID1",this_id="ID2")'
         bkup_c = self.session.open_cursor('backup:', None, config)
         self.pr('Open backup cursor ID1')
         bkup_files = []


### PR DESCRIPTION
Cherry-picked from c61fcdc6656d048339b797290514a604f6007f55