### PR TITLE
WT-6087 Add a C2S(cursor) macro to simplify translation from a cursor to a session.

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -18,7 +18,7 @@ __cursor_fix_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -97,7 +97,7 @@ __cursor_fix_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     btree = S2BT(session);
     page = cbt->ref->page;
     upd = NULL;
@@ -168,7 +168,7 @@ __cursor_var_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -219,7 +219,7 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     uint64_t rle, rle_start;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = cbt->ref->page;
 
     rle_start = 0; /* -Werror=maybe-uninitialized */
@@ -337,7 +337,7 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     bool kpack_used;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = cbt->ref->page;
     key = &cbt->iface.key;
 
@@ -536,7 +536,7 @@ __wt_cursor_key_order_init(WT_CURSOR_BTREE *cbt)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /*
      * Cursor searches set the position for cursor movements, set the last-key value for diagnostic
@@ -648,7 +648,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     bool newpage, restart;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_next);
     WT_STAT_DATA_INCR(session, cursor_next);

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -18,7 +18,7 @@ __cursor_fix_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -97,7 +97,7 @@ __cursor_fix_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     btree = S2BT(session);
     page = cbt->ref->page;
     upd = NULL;
@@ -168,7 +168,7 @@ __cursor_var_append_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -219,7 +219,7 @@ __cursor_var_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     uint64_t rle, rle_start;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = cbt->ref->page;
 
     rle_start = 0; /* -Werror=maybe-uninitialized */
@@ -337,7 +337,7 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     bool kpack_used;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = cbt->ref->page;
     key = &cbt->iface.key;
 
@@ -536,7 +536,7 @@ __wt_cursor_key_order_init(WT_CURSOR_BTREE *cbt)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /*
      * Cursor searches set the position for cursor movements, set the last-key value for diagnostic
@@ -648,7 +648,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     bool newpage, restart;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_next);
     WT_STAT_DATA_INCR(session, cursor_next);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -40,7 +40,7 @@ __cursor_skip_prev(WT_CURSOR_BTREE *cbt)
     uint64_t recno;
     int i;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
 restart:
     /*
@@ -125,7 +125,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -237,7 +237,7 @@ __cursor_fix_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = cbt->ref->page;
     btree = S2BT(session);
 
@@ -308,7 +308,7 @@ __cursor_var_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -358,7 +358,7 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     uint64_t rle_start;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = cbt->ref->page;
 
     rle_start = 0; /* -Werror=maybe-uninitialized */
@@ -477,7 +477,7 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     bool kpack_used;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = cbt->ref->page;
     key = &cbt->iface.key;
 
@@ -604,7 +604,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     bool newpage, restart;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_prev);
     WT_STAT_DATA_INCR(session, cursor_prev);

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -40,7 +40,7 @@ __cursor_skip_prev(WT_CURSOR_BTREE *cbt)
     uint64_t recno;
     int i;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
 restart:
     /*
@@ -125,7 +125,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -237,7 +237,7 @@ __cursor_fix_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = cbt->ref->page;
     btree = S2BT(session);
 
@@ -308,7 +308,7 @@ __cursor_var_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_SESSION_IMPL *session;
     WT_UPDATE *upd;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* If restarting after a prepare conflict, jump to the right spot. */
     if (restart)
@@ -358,7 +358,7 @@ __cursor_var_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     uint64_t rle_start;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = cbt->ref->page;
 
     rle_start = 0; /* -Werror=maybe-uninitialized */
@@ -477,7 +477,7 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
     WT_UPDATE *upd;
     bool kpack_used;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = cbt->ref->page;
     key = &cbt->iface.key;
 
@@ -604,7 +604,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     bool newpage, restart;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_prev);
     WT_STAT_DATA_INCR(session, cursor_prev);

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -60,7 +60,7 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
     WT_SESSION_IMPL *session;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /*
      * Check the page active flag, asserting the page reference with any external key.
@@ -185,7 +185,7 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, WT_UPDATE 
     *valid = false;
     btree = cbt->btree;
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /*
      * We may be pointing to an insert object, and we may have a page with
@@ -363,7 +363,7 @@ __cursor_col_search(WT_CURSOR_BTREE *cbt, WT_REF *leaf, bool *leaf_foundp)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_col_search(cbt, cbt->iface.recno, leaf, false, leaf_foundp));
     return (ret);
@@ -379,7 +379,7 @@ __cursor_row_search(WT_CURSOR_BTREE *cbt, bool insert, WT_REF *leaf, bool *leaf_
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_row_search(cbt, &cbt->iface.key, insert, leaf, false, leaf_foundp));
     return (ret);
@@ -429,7 +429,7 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
     WT_SESSION_IMPL *session;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_reset);
     WT_STAT_DATA_INCR(session, cursor_reset);
@@ -527,7 +527,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     upd = NULL; /* -Wuninitialized */
 
     WT_STAT_CONN_INCR(session, cursor_search);
@@ -625,7 +625,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     upd = NULL; /* -Wuninitialized */
     exact = 0;
 
@@ -781,7 +781,7 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
     btree = cbt->btree;
     cursor = &cbt->iface;
     insert_bytes = cursor->key.size + cursor->value.size;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_STAT_CONN_INCR(session, cursor_insert);
@@ -932,7 +932,7 @@ __curfile_update_check(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     upd = NULL;
 
     if (cbt->compare != 0)
@@ -964,7 +964,7 @@ __wt_btcur_insert_check(WT_CURSOR_BTREE *cbt)
     uint64_t yield_count, sleep_usecs;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_ASSERT(session, cbt->btree->type == BTREE_ROW);
@@ -1015,7 +1015,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     yield_count = sleep_usecs = 0;
     iterating = F_ISSET(cbt, WT_CBT_ITERATE_NEXT | WT_CBT_ITERATE_PREV);
     searched = false;
@@ -1203,7 +1203,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_RET_ASSERT(
@@ -1375,7 +1375,7 @@ __cursor_chain_exceeded(WT_CURSOR_BTREE *cbt)
 
     cursor = &cbt->iface;
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     upd = NULL;
     if (cbt->ins != NULL)
@@ -1429,7 +1429,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     bool overwrite;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* Save the cursor state. */
     __cursor_state_save(cursor, &state);
@@ -1515,7 +1515,7 @@ __wt_btcur_reserve(WT_CURSOR_BTREE *cbt)
     bool overwrite;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_reserve);
     WT_STAT_DATA_INCR(session, cursor_reserve);
@@ -1542,7 +1542,7 @@ __wt_btcur_update(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_update);
     WT_STAT_DATA_INCR(session, cursor_update);
@@ -1568,7 +1568,7 @@ __wt_btcur_compare(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *cmpp)
 
     a = (WT_CURSOR *)a_arg;
     b = (WT_CURSOR *)b_arg;
-    session = C2S(a_arg);
+    session = CUR2S(a_arg);
 
     /* Confirm both cursors reference the same object. */
     if (a_arg->btree != b_arg->btree)
@@ -1640,7 +1640,7 @@ __wt_btcur_equals(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *equalp)
 
     a = (WT_CURSOR *)a_arg;
     b = (WT_CURSOR *)b_arg;
-    session = C2S(a_arg);
+    session = CUR2S(a_arg);
     cmp = 0;
 
     /* Confirm both cursors reference the same object. */
@@ -1673,7 +1673,7 @@ __cursor_truncate(
     WT_SESSION_IMPL *session;
     uint64_t yield_count, sleep_usecs;
 
-    session = C2S(start);
+    session = CUR2S(start);
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1729,7 +1729,7 @@ __cursor_truncate_fix(
     uint64_t yield_count, sleep_usecs;
     const uint8_t *value;
 
-    session = C2S(start);
+    session = CUR2S(start);
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1787,7 +1787,7 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
     WT_SESSION_IMPL *session;
 
     btree = start->btree;
-    session = C2S(start);
+    session = CUR2S(start);
     WT_STAT_DATA_INCR(session, cursor_truncate);
 
     WT_RET(__wt_txn_autocommit_check(session));
@@ -1869,7 +1869,7 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt, bool lowlevel)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /*
      * The in-memory split and history store table code creates low-level btree cursors to

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -60,7 +60,7 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
     WT_SESSION_IMPL *session;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
 
     /*
      * Check the page active flag, asserting the page reference with any external key.
@@ -185,7 +185,7 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, WT_UPDATE 
     *valid = false;
     btree = cbt->btree;
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /*
      * We may be pointing to an insert object, and we may have a page with
@@ -363,7 +363,7 @@ __cursor_col_search(WT_CURSOR_BTREE *cbt, WT_REF *leaf, bool *leaf_foundp)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_col_search(cbt, cbt->iface.recno, leaf, false, leaf_foundp));
     return (ret);
@@ -379,7 +379,7 @@ __cursor_row_search(WT_CURSOR_BTREE *cbt, bool insert, WT_REF *leaf, bool *leaf_
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_row_search(cbt, &cbt->iface.key, insert, leaf, false, leaf_foundp));
     return (ret);
@@ -429,7 +429,7 @@ __wt_btcur_reset(WT_CURSOR_BTREE *cbt)
     WT_SESSION_IMPL *session;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_reset);
     WT_STAT_DATA_INCR(session, cursor_reset);
@@ -527,7 +527,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     upd = NULL; /* -Wuninitialized */
 
     WT_STAT_CONN_INCR(session, cursor_search);
@@ -625,7 +625,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     upd = NULL; /* -Wuninitialized */
     exact = 0;
 
@@ -781,7 +781,7 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
     btree = cbt->btree;
     cursor = &cbt->iface;
     insert_bytes = cursor->key.size + cursor->value.size;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_STAT_CONN_INCR(session, cursor_insert);
@@ -932,7 +932,7 @@ __curfile_update_check(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     upd = NULL;
 
     if (cbt->compare != 0)
@@ -964,7 +964,7 @@ __wt_btcur_insert_check(WT_CURSOR_BTREE *cbt)
     uint64_t yield_count, sleep_usecs;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_ASSERT(session, cbt->btree->type == BTREE_ROW);
@@ -1015,7 +1015,7 @@ __wt_btcur_remove(WT_CURSOR_BTREE *cbt, bool positioned)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     yield_count = sleep_usecs = 0;
     iterating = F_ISSET(cbt, WT_CBT_ITERATE_NEXT | WT_CBT_ITERATE_PREV);
     searched = false;
@@ -1203,7 +1203,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
     yield_count = sleep_usecs = 0;
 
     WT_RET_ASSERT(
@@ -1375,7 +1375,7 @@ __cursor_chain_exceeded(WT_CURSOR_BTREE *cbt)
 
     cursor = &cbt->iface;
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
 
     upd = NULL;
     if (cbt->ins != NULL)
@@ -1429,7 +1429,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     bool overwrite;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
 
     /* Save the cursor state. */
     __cursor_state_save(cursor, &state);
@@ -1515,7 +1515,7 @@ __wt_btcur_reserve(WT_CURSOR_BTREE *cbt)
     bool overwrite;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_reserve);
     WT_STAT_DATA_INCR(session, cursor_reserve);
@@ -1542,7 +1542,7 @@ __wt_btcur_update(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cbt);
 
     WT_STAT_CONN_INCR(session, cursor_update);
     WT_STAT_DATA_INCR(session, cursor_update);
@@ -1568,7 +1568,7 @@ __wt_btcur_compare(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *cmpp)
 
     a = (WT_CURSOR *)a_arg;
     b = (WT_CURSOR *)b_arg;
-    session = (WT_SESSION_IMPL *)a->session;
+    session = C2S(a_arg);
 
     /* Confirm both cursors reference the same object. */
     if (a_arg->btree != b_arg->btree)
@@ -1640,8 +1640,8 @@ __wt_btcur_equals(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *equalp)
 
     a = (WT_CURSOR *)a_arg;
     b = (WT_CURSOR *)b_arg;
+    session = C2S(a_arg);
     cmp = 0;
-    session = (WT_SESSION_IMPL *)a->session;
 
     /* Confirm both cursors reference the same object. */
     if (a_arg->btree != b_arg->btree)
@@ -1673,7 +1673,7 @@ __cursor_truncate(
     WT_SESSION_IMPL *session;
     uint64_t yield_count, sleep_usecs;
 
-    session = (WT_SESSION_IMPL *)start->iface.session;
+    session = C2S(start);
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1729,7 +1729,7 @@ __cursor_truncate_fix(
     uint64_t yield_count, sleep_usecs;
     const uint8_t *value;
 
-    session = (WT_SESSION_IMPL *)start->iface.session;
+    session = C2S(start);
     yield_count = sleep_usecs = 0;
 
 /*
@@ -1786,8 +1786,8 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)start->iface.session;
     btree = start->btree;
+    session = C2S(start);
     WT_STAT_DATA_INCR(session, cursor_truncate);
 
     WT_RET(__wt_txn_autocommit_check(session));
@@ -1869,7 +1869,7 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt, bool lowlevel)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /*
      * The in-memory split and history store table code creates low-level btree cursors to

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -711,15 +711,13 @@ int
 __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     uint32_t session_flags;
     bool is_owner;
 
-    cursor = cursor_arg;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor_arg);
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
 
     WT_RET(__wt_hs_cursor(session, &session_flags, &is_owner));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -717,7 +717,7 @@ __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
     uint32_t session_flags;
     bool is_owner;
 
-    session = C2S(cursor_arg);
+    session = CUR2S(cursor_arg);
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
 
     WT_RET(__wt_hs_cursor(session, &session_flags, &is_owner));

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -64,7 +64,7 @@ __random_skip_entries(WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head)
     uint32_t entries;
     int level;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     entries = 0; /* [-Wconditional-uninitialized] */
 
     if (ins_head == NULL)
@@ -117,7 +117,7 @@ __random_leaf_skip(
     *updp = NULL;
     *validp = false;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* This is a relatively expensive test, try a few times then quit. */
     for (retry = 0; retry < WT_RANDOM_SKIP_RETRY; ++retry) {
@@ -177,7 +177,7 @@ __random_leaf_insert(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *validp)
     *validp = false;
 
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /* Check for a large insert list with no items, that's common when tables are newly created. */
     ins_head = WT_ROW_INSERT_SMALLEST(page);
@@ -245,7 +245,7 @@ __random_leaf_disk(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *validp)
     *validp = false;
 
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     entries = cbt->ref->page->entries;
 
     /* This is a relatively cheap test, so try several times. */
@@ -279,7 +279,7 @@ __random_leaf(WT_CURSOR_BTREE *cbt)
     bool next, valid;
 
     cursor = (WT_CURSOR *)cbt;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     /*
      * If the page has a sufficiently large number of disk-based entries, randomly select from them.
@@ -484,7 +484,7 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     read_flags = WT_READ_RESTART_OK;
     if (F_ISSET(cbt, WT_CBT_READ_ONCE))

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -64,7 +64,7 @@ __random_skip_entries(WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head)
     uint32_t entries;
     int level;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     entries = 0; /* [-Wconditional-uninitialized] */
 
     if (ins_head == NULL)
@@ -117,7 +117,7 @@ __random_leaf_skip(
     *updp = NULL;
     *validp = false;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* This is a relatively expensive test, try a few times then quit. */
     for (retry = 0; retry < WT_RANDOM_SKIP_RETRY; ++retry) {
@@ -177,7 +177,7 @@ __random_leaf_insert(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *validp)
     *validp = false;
 
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /* Check for a large insert list with no items, that's common when tables are newly created. */
     ins_head = WT_ROW_INSERT_SMALLEST(page);
@@ -245,7 +245,7 @@ __random_leaf_disk(WT_CURSOR_BTREE *cbt, WT_UPDATE **updp, bool *validp)
     *validp = false;
 
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     entries = cbt->ref->page->entries;
 
     /* This is a relatively cheap test, so try several times. */
@@ -279,7 +279,7 @@ __random_leaf(WT_CURSOR_BTREE *cbt)
     bool next, valid;
 
     cursor = (WT_CURSOR *)cbt;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     /*
      * If the page has a sufficiently large number of disk-based entries, randomly select from them.
@@ -484,7 +484,7 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
 
     btree = cbt->btree;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     read_flags = WT_READ_RESTART_OK;
     if (F_ISSET(cbt, WT_CBT_READ_ONCE))

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -23,7 +23,7 @@ __key_return(WT_CURSOR_BTREE *cbt)
 
     page = cbt->ref->page;
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     if (page->type == WT_PAGE_ROW_LEAF) {
         rip = &page->pg_row[cbt->slot];
@@ -106,7 +106,7 @@ __wt_read_cell_time_pairs(
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     page = ref->page;
 
     WT_ASSERT(session, start != NULL && stop != NULL);
@@ -176,7 +176,7 @@ __wt_value_return_buf(
     WT_SESSION_IMPL *session;
     uint8_t v;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     btree = S2BT(session);
 
     page = ref->page;
@@ -249,7 +249,7 @@ __wt_value_return_upd(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
     WT_TIME_PAIR start, stop;
 
     cursor = &cbt->iface;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     __wt_modify_vector_init(session, &modifies);
 
     /*

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -23,7 +23,7 @@ __key_return(WT_CURSOR_BTREE *cbt)
 
     page = cbt->ref->page;
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     if (page->type == WT_PAGE_ROW_LEAF) {
         rip = &page->pg_row[cbt->slot];
@@ -106,7 +106,7 @@ __wt_read_cell_time_pairs(
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     page = ref->page;
 
     WT_ASSERT(session, start != NULL && stop != NULL);
@@ -176,7 +176,7 @@ __wt_value_return_buf(
     WT_SESSION_IMPL *session;
     uint8_t v;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     btree = S2BT(session);
 
     page = ref->page;
@@ -249,7 +249,7 @@ __wt_value_return_upd(WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
     WT_TIME_PAIR start, stop;
 
     cursor = &cbt->iface;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     __wt_modify_vector_init(session, &modifies);
 
     /*

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -34,7 +34,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     btree = cbt->btree;
     ins = NULL;
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     upd = upd_arg;
     append = logged = false;
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -34,7 +34,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     btree = cbt->btree;
     ins = NULL;
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     upd = upd_arg;
     append = logged = false;
 

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -74,7 +74,7 @@ __wt_col_search(
     uint32_t base, indx, limit, read_flags;
     int depth;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     btree = S2BT(session);
     current = NULL;
 

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -74,7 +74,7 @@ __wt_col_search(
     uint32_t base, indx, limit, read_flags;
     int depth;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     btree = S2BT(session);
     current = NULL;
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -58,7 +58,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
 
     ins = NULL;
     page = cbt->ref->page;
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     upd = upd_arg;
     logged = false;
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -58,7 +58,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
 
     ins = NULL;
     page = cbt->ref->page;
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     upd = upd_arg;
     logged = false;
 

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -224,7 +224,7 @@ __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *le
     int cmp, depth;
     bool append_check, descend_right, done;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     btree = S2BT(session);
     collator = btree->collator;
     item = cbt->tmp;

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -224,7 +224,7 @@ __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *le
     int cmp, depth;
     bool append_check, descend_right, done;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     btree = S2BT(session);
     collator = btree->collator;
     item = cbt->tmp;

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -19,7 +19,7 @@ __bulk_col_keycmp_err(WT_CURSOR_BULK *cbulk)
     WT_SESSION_IMPL *session;
 
     cursor = &cbulk->cbt.iface;
-    session = C2S(cbulk);
+    session = CUR2S(cbulk);
 
     WT_RET_MSG(session, EINVAL, "bulk-load presented with out-of-order keys: %" PRIu64
                                 " is less "
@@ -197,7 +197,7 @@ __bulk_row_keycmp_err(WT_CURSOR_BULK *cbulk)
     WT_SESSION_IMPL *session;
 
     cursor = &cbulk->cbt.iface;
-    session = C2S(cbulk);
+    session = CUR2S(cbulk);
 
     WT_ERR(__wt_scr_alloc(session, 512, &a));
     WT_ERR(__wt_scr_alloc(session, 512, &b));

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -18,8 +18,8 @@ __bulk_col_keycmp_err(WT_CURSOR_BULK *cbulk)
     WT_CURSOR *cursor;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbulk->cbt.iface.session;
     cursor = &cbulk->cbt.iface;
+    session = C2S(cbulk);
 
     WT_RET_MSG(session, EINVAL, "bulk-load presented with out-of-order keys: %" PRIu64
                                 " is less "
@@ -196,8 +196,8 @@ __bulk_row_keycmp_err(WT_CURSOR_BULK *cbulk)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbulk->cbt.iface.session;
     cursor = &cbulk->cbt.iface;
+    session = C2S(cbulk);
 
     WT_ERR(__wt_scr_alloc(session, 512, &a));
     WT_ERR(__wt_scr_alloc(session, 512, &b));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -542,7 +542,7 @@ __curfile_cache(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     cbt->dhandle = cbt->btree->dhandle;
 
     WT_TRET(__wt_cursor_cache(cursor, cbt->dhandle));
@@ -565,7 +565,7 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     dhandle = cbt->dhandle;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     if (check_only)
         return (WT_DHANDLE_CAN_REOPEN(dhandle) ? 0 : WT_NOTFOUND);

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -542,7 +542,7 @@ __curfile_cache(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     cbt->dhandle = cbt->btree->dhandle;
 
     WT_TRET(__wt_cursor_cache(cursor, cbt->dhandle));
@@ -565,7 +565,7 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     dhandle = cbt->dhandle;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     if (check_only)
         return (WT_DHANDLE_CAN_REOPEN(dhandle) ? 0 : WT_NOTFOUND);

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -103,7 +103,7 @@ __curindex_move(WT_CURSOR_INDEX *cindex)
     WT_SESSION_IMPL *session;
     u_int i;
 
-    session = (WT_SESSION_IMPL *)cindex->iface.session;
+    session = CUR2S(cindex);
     first = NULL;
 
     /* Point the public cursor to the key in the child. */

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -35,7 +35,7 @@ __wt_curjoin_joined(WT_CURSOR *cursor) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     WT_RET_MSG(session, ENOTSUP, "cursor is being used in a join");
 }

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -35,7 +35,7 @@ __wt_curjoin_joined(WT_CURSOR *cursor) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     WT_RET_MSG(session, ENOTSUP, "cursor is being used in a join");
 }

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -373,7 +373,7 @@ __wt_json_column_init(WT_CURSOR *cursor, const char *uri, const char *keyformat,
     const char *beginkey, *end, *lparen, *p;
 
     json = (WT_CURSOR_JSON *)cursor->json_private;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     beginkey = colconf->str;
     end = beginkey + colconf->len;
 

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -373,7 +373,7 @@ __wt_json_column_init(WT_CURSOR *cursor, const char *uri, const char *keyformat,
     const char *beginkey, *end, *lparen, *p;
 
     json = (WT_CURSOR_JSON *)cursor->json_private;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     beginkey = colconf->str;
     end = beginkey + colconf->len;
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -487,7 +487,7 @@ __curstat_join_desc(WT_CURSOR_STAT *cst, int slot, const char **resultp)
     const char *static_desc;
 
     sgrp = &cst->u.join_stats_group;
-    session = (WT_SESSION_IMPL *)sgrp->join_cursor->iface.session;
+    session = C2S(sgrp->join_cursor);
     WT_RET(__wt_stat_join_desc(cst, slot, &static_desc));
     len = strlen("join: ") + strlen(sgrp->desc_prefix) + strlen(static_desc) + 1;
     WT_RET(__wt_realloc(session, NULL, len, &cst->desc_buf));

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -487,7 +487,7 @@ __curstat_join_desc(WT_CURSOR_STAT *cst, int slot, const char **resultp)
     const char *static_desc;
 
     sgrp = &cst->u.join_stats_group;
-    session = C2S(sgrp->join_cursor);
+    session = CUR2S(sgrp->join_cursor);
     WT_RET(__wt_stat_join_desc(cst, slot, &static_desc));
     len = strlen("join: ") + strlen(sgrp->desc_prefix) + strlen(static_desc) + 1;
     WT_RET(__wt_realloc(session, NULL, len, &cst->desc_buf));

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -29,7 +29,7 @@ __wt_cursor_cached(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     WT_RET_MSG(session, ENOTSUP, "Cursor has been closed");
 }
 
@@ -42,7 +42,7 @@ __wt_cursor_notsup(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     WT_RET_MSG(session, ENOTSUP, "Unsupported cursor operation");
 }
 
@@ -142,7 +142,7 @@ __wt_cursor_modify_value_format_notsup(WT_CURSOR *cursor, WT_MODIFY *entries, in
     WT_UNUSED(nentries);
 
     if (cursor->value_format != NULL && strlen(cursor->value_format) != 0) {
-        session = (WT_SESSION_IMPL *)cursor->session;
+        session = C2S(cursor);
         WT_RET_MSG(session, ENOTSUP,
           "WT_CURSOR.modify only supported for 'S' and 'u' value "
           "formats");
@@ -221,7 +221,7 @@ __wt_cursor_kv_not_set(WT_CURSOR *cursor, bool key) WT_GCC_FUNC_ATTRIBUTE((cold)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     WT_RET_MSG(session, cursor->saved_err == 0 ? EINVAL : cursor->saved_err, "requires %s be set",
       key ? "key" : "value");
@@ -238,7 +238,7 @@ __wt_cursor_copy_release_item(WT_CURSOR *cursor, WT_ITEM *item) WT_GCC_FUNC_ATTR
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     /* Bail out if the item has been cleared. */
     if (item->data == NULL)
@@ -646,7 +646,7 @@ __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     WT_SESSION_IMPL *session;
     uint64_t bucket;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     WT_ASSERT(session, !F_ISSET(cursor, WT_CURSTD_CACHED) && dhandle != NULL);
 
     WT_TRET(cursor->reset(cursor));
@@ -687,7 +687,7 @@ __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     WT_SESSION_IMPL *session;
     uint64_t bucket;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_CACHED));
 
     if (dhandle != NULL) {
@@ -892,7 +892,7 @@ __wt_cursor_close(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     if (F_ISSET(cursor, WT_CURSTD_OPEN)) {
         TAILQ_REMOVE(&session->cursors, cursor, q);
@@ -1066,7 +1066,7 @@ __wt_cursor_init(
     WT_SESSION_IMPL *session;
     bool readonly;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     if (cursor->internal_uri == NULL)
         WT_RET(__wt_strdup(session, uri, &cursor->internal_uri));

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -29,7 +29,7 @@ __wt_cursor_cached(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     WT_RET_MSG(session, ENOTSUP, "Cursor has been closed");
 }
 
@@ -42,7 +42,7 @@ __wt_cursor_notsup(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     WT_RET_MSG(session, ENOTSUP, "Unsupported cursor operation");
 }
 
@@ -142,7 +142,7 @@ __wt_cursor_modify_value_format_notsup(WT_CURSOR *cursor, WT_MODIFY *entries, in
     WT_UNUSED(nentries);
 
     if (cursor->value_format != NULL && strlen(cursor->value_format) != 0) {
-        session = C2S(cursor);
+        session = CUR2S(cursor);
         WT_RET_MSG(session, ENOTSUP,
           "WT_CURSOR.modify only supported for 'S' and 'u' value "
           "formats");
@@ -221,7 +221,7 @@ __wt_cursor_kv_not_set(WT_CURSOR *cursor, bool key) WT_GCC_FUNC_ATTRIBUTE((cold)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     WT_RET_MSG(session, cursor->saved_err == 0 ? EINVAL : cursor->saved_err, "requires %s be set",
       key ? "key" : "value");
@@ -238,7 +238,7 @@ __wt_cursor_copy_release_item(WT_CURSOR *cursor, WT_ITEM *item) WT_GCC_FUNC_ATTR
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     /* Bail out if the item has been cleared. */
     if (item->data == NULL)
@@ -646,7 +646,7 @@ __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     WT_SESSION_IMPL *session;
     uint64_t bucket;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     WT_ASSERT(session, !F_ISSET(cursor, WT_CURSTD_CACHED) && dhandle != NULL);
 
     WT_TRET(cursor->reset(cursor));
@@ -687,7 +687,7 @@ __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     WT_SESSION_IMPL *session;
     uint64_t bucket;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_CACHED));
 
     if (dhandle != NULL) {
@@ -892,7 +892,7 @@ __wt_cursor_close(WT_CURSOR *cursor)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     if (F_ISSET(cursor, WT_CURSTD_OPEN)) {
         TAILQ_REMOVE(&session->cursors, cursor, q);
@@ -1066,7 +1066,7 @@ __wt_cursor_init(
     WT_SESSION_IMPL *session;
     bool readonly;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     if (cursor->internal_uri == NULL)
         WT_RET(__wt_strdup(session, uri, &cursor->internal_uri));

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -150,7 +150,7 @@ __apply_idx(WT_CURSOR_TABLE *ctable, size_t func_off, bool skip_immutable)
     int (*f)(WT_CURSOR *);
 
     cp = ctable->idx_cursors;
-    session = (WT_SESSION_IMPL *)ctable->iface.session;
+    session = CUR2S(ctable);
 
     for (i = 0; i < ctable->table->nindices; i++, cp++) {
         idx = ctable->table->indices[i];
@@ -729,7 +729,7 @@ __wt_table_range_truncate(WT_CURSOR_TABLE *start, WT_CURSOR_TABLE *stop)
     int cmp;
 
     ctable = (start != NULL) ? start : stop;
-    session = (WT_SESSION_IMPL *)ctable->iface.session;
+    session = CUR2S(ctable);
     wt_start = &start->iface;
     wt_stop = &stop->iface;
 
@@ -877,7 +877,7 @@ __curtable_open_colgroups(WT_CURSOR_TABLE *ctable, const char *cfg_arg[])
     const char *cfg[] = {cfg_arg[0], cfg_arg[1], "dump=\"\",readonly=0", NULL, NULL};
     u_int i;
 
-    session = (WT_SESSION_IMPL *)ctable->iface.session;
+    session = CUR2S(ctable);
     table = ctable->table;
 
     WT_RET(__curtable_complete(session, table)); /* completeness check */
@@ -904,7 +904,7 @@ __curtable_open_indices(WT_CURSOR_TABLE *ctable)
     WT_TABLE *table;
     u_int i;
 
-    session = (WT_SESSION_IMPL *)ctable->iface.session;
+    session = CUR2S(ctable);
     table = ctable->table;
 
     WT_RET(__wt_schema_open_indices(session, table));

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -282,7 +282,7 @@ __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
     WT_SESSION_IMPL *session;
     WT_UPDATE *last_upd;
 
-    session = C2S(hs_cbt);
+    session = CUR2S(hs_cbt);
 
     /* If there are existing updates, append them after the new updates. */
     if (hs_cbt->compare == 0) {
@@ -564,7 +564,7 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
     int nentries;
     bool squashed;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     prev_upd = NULL;
     insert_cnt = 0;
     __wt_modify_vector_init(session, &modifies);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -282,7 +282,7 @@ __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
     WT_SESSION_IMPL *session;
     WT_UPDATE *last_upd;
 
-    session = (WT_SESSION_IMPL *)hs_cbt->iface.session;
+    session = C2S(hs_cbt);
 
     /* If there are existing updates, append them after the new updates. */
     if (hs_cbt->compare == 0) {
@@ -564,8 +564,8 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
     int nentries;
     bool squashed;
 
+    session = C2S(cursor);
     prev_upd = NULL;
-    session = (WT_SESSION_IMPL *)cursor->session;
     insert_cnt = 0;
     __wt_modify_vector_init(session, &modifies);
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -7,7 +7,7 @@
  */
 
 /* Get the session from any cursor. */
-#define C2S(c) ((WT_SESSION_IMPL *)((WT_CURSOR *)c)->session)
+#define CUR2S(c) ((WT_SESSION_IMPL *)((WT_CURSOR *)c)->session)
 
 /*
  * Initialize a static WT_CURSOR structure.

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -6,6 +6,9 @@
  * See the file LICENSE for redistribution information.
  */
 
+/* Get the session from any cursor. */
+#define C2S(c) ((WT_SESSION_IMPL *)((WT_CURSOR *)c)->session)
+
 /*
  * Initialize a static WT_CURSOR structure.
  */

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -193,7 +193,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     __cursor_pos_clear(cbt);
 
@@ -242,7 +242,7 @@ __wt_curindex_get_valuev(WT_CURSOR *cursor, va_list ap)
     WT_SESSION_IMPL *session;
 
     cindex = (WT_CURSOR_INDEX *)cursor;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     WT_RET(__cursor_checkvalue(cursor));
 
     if (F_ISSET(cursor, WT_CURSOR_RAW_OK)) {
@@ -269,7 +269,7 @@ __wt_curtable_get_valuev(WT_CURSOR *cursor, va_list ap)
     WT_SESSION_IMPL *session;
 
     ctable = (WT_CURSOR_TABLE *)cursor;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     primary = *ctable->cg_cursors;
     WT_RET(__cursor_checkvalue(primary));
 
@@ -371,7 +371,7 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
 
     if (reenter) {
 #ifdef HAVE_DIAGNOSTIC
@@ -421,7 +421,7 @@ __cursor_row_slot_key_return(
 
     *kpack_used = false;
 
-    session = C2S(cbt);
+    session = CUR2S(cbt);
     btree = S2BT(session);
     page = cbt->ref->page;
 

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -193,7 +193,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     __cursor_pos_clear(cbt);
 
@@ -242,7 +242,7 @@ __wt_curindex_get_valuev(WT_CURSOR *cursor, va_list ap)
     WT_SESSION_IMPL *session;
 
     cindex = (WT_CURSOR_INDEX *)cursor;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     WT_RET(__cursor_checkvalue(cursor));
 
     if (F_ISSET(cursor, WT_CURSOR_RAW_OK)) {
@@ -269,7 +269,7 @@ __wt_curtable_get_valuev(WT_CURSOR *cursor, va_list ap)
     WT_SESSION_IMPL *session;
 
     ctable = (WT_CURSOR_TABLE *)cursor;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     primary = *ctable->cg_cursors;
     WT_RET(__cursor_checkvalue(primary));
 
@@ -371,7 +371,7 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
 
     if (reenter) {
 #ifdef HAVE_DIAGNOSTIC
@@ -421,7 +421,7 @@ __cursor_row_slot_key_return(
 
     *kpack_used = false;
 
-    session = (WT_SESSION_IMPL *)cbt->iface.session;
+    session = C2S(cbt);
     btree = S2BT(session);
     page = cbt->ref->page;
 

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -32,7 +32,7 @@ __wt_clsm_request_switch(WT_CURSOR_LSM *clsm)
     WT_SESSION_IMPL *session;
 
     lsm_tree = clsm->lsm_tree;
-    session = C2S(clsm);
+    session = CUR2S(clsm);
 
     if (!lsm_tree->need_switch) {
         /*
@@ -64,7 +64,7 @@ __wt_clsm_await_switch(WT_CURSOR_LSM *clsm)
     int waited;
 
     lsm_tree = clsm->lsm_tree;
-    session = C2S(clsm);
+    session = CUR2S(clsm);
 
     /*
      * If there is no primary chunk, or a chunk has overflowed the hard limit, which either means a
@@ -96,7 +96,7 @@ __clsm_enter_update(WT_CURSOR_LSM *clsm)
     bool hard_limit, have_primary, ovfl;
 
     lsm_tree = clsm->lsm_tree;
-    session = C2S(clsm);
+    session = CUR2S(clsm);
 
     if (clsm->nchunks == 0) {
         primary = NULL;
@@ -159,7 +159,7 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
     uint64_t i, pinned_id, switch_txn;
 
     lsm_tree = clsm->lsm_tree;
-    session = C2S(clsm);
+    session = CUR2S(clsm);
     txn = session->txn;
 
     /* Merge cursors never update. */
@@ -259,7 +259,7 @@ __clsm_leave(WT_CURSOR_LSM *clsm)
 {
     WT_SESSION_IMPL *session;
 
-    session = C2S(clsm);
+    session = CUR2S(clsm);
 
     if (F_ISSET(clsm, WT_CLSM_ACTIVE)) {
         --session->ncursors;
@@ -428,7 +428,7 @@ __clsm_open_cursors(WT_CURSOR_LSM *clsm, bool update, u_int start_chunk, uint32_
 
     c = &clsm->iface;
     cursor = NULL;
-    session = C2S(clsm);
+    session = CUR2S(clsm);
     txn = session->txn;
     chunk = NULL;
     locked = false;
@@ -712,7 +712,7 @@ __wt_clsm_init_merge(WT_CURSOR *cursor, u_int start_chunk, uint32_t start_id, u_
     WT_SESSION_IMPL *session;
 
     clsm = (WT_CURSOR_LSM *)cursor;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     F_SET(clsm, WT_CLSM_MERGE);
     if (start_chunk != 0)
@@ -816,7 +816,7 @@ __clsm_position_chunk(WT_CURSOR_LSM *clsm, WT_CURSOR *c, bool forward, int *cmpp
     WT_SESSION_IMPL *session;
 
     cursor = &clsm->iface;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     c->set_key(c, &cursor->key);
     WT_RET(c->search_near(c, cmpp));
@@ -1149,7 +1149,7 @@ __clsm_lookup(WT_CURSOR_LSM *clsm, WT_ITEM *value)
     c = NULL;
     cursor = &clsm->iface;
     have_hash = false;
-    session = C2S(cursor);
+    session = CUR2S(cursor);
 
     WT_FORALL_CURSORS(clsm, c, i)
     {

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -32,7 +32,7 @@ __wt_clsm_request_switch(WT_CURSOR_LSM *clsm)
     WT_SESSION_IMPL *session;
 
     lsm_tree = clsm->lsm_tree;
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = C2S(clsm);
 
     if (!lsm_tree->need_switch) {
         /*
@@ -64,7 +64,7 @@ __wt_clsm_await_switch(WT_CURSOR_LSM *clsm)
     int waited;
 
     lsm_tree = clsm->lsm_tree;
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = C2S(clsm);
 
     /*
      * If there is no primary chunk, or a chunk has overflowed the hard limit, which either means a
@@ -96,7 +96,7 @@ __clsm_enter_update(WT_CURSOR_LSM *clsm)
     bool hard_limit, have_primary, ovfl;
 
     lsm_tree = clsm->lsm_tree;
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = C2S(clsm);
 
     if (clsm->nchunks == 0) {
         primary = NULL;
@@ -159,7 +159,7 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
     uint64_t i, pinned_id, switch_txn;
 
     lsm_tree = clsm->lsm_tree;
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = C2S(clsm);
     txn = session->txn;
 
     /* Merge cursors never update. */
@@ -259,7 +259,7 @@ __clsm_leave(WT_CURSOR_LSM *clsm)
 {
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = C2S(clsm);
 
     if (F_ISSET(clsm, WT_CLSM_ACTIVE)) {
         --session->ncursors;
@@ -428,7 +428,7 @@ __clsm_open_cursors(WT_CURSOR_LSM *clsm, bool update, u_int start_chunk, uint32_
 
     c = &clsm->iface;
     cursor = NULL;
-    session = (WT_SESSION_IMPL *)c->session;
+    session = C2S(clsm);
     txn = session->txn;
     chunk = NULL;
     locked = false;
@@ -712,7 +712,7 @@ __wt_clsm_init_merge(WT_CURSOR *cursor, u_int start_chunk, uint32_t start_id, u_
     WT_SESSION_IMPL *session;
 
     clsm = (WT_CURSOR_LSM *)cursor;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     F_SET(clsm, WT_CLSM_MERGE);
     if (start_chunk != 0)
@@ -816,7 +816,7 @@ __clsm_position_chunk(WT_CURSOR_LSM *clsm, WT_CURSOR *c, bool forward, int *cmpp
     WT_SESSION_IMPL *session;
 
     cursor = &clsm->iface;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     c->set_key(c, &cursor->key);
     WT_RET(c->search_near(c, cmpp));
@@ -1149,7 +1149,7 @@ __clsm_lookup(WT_CURSOR_LSM *clsm, WT_ITEM *value)
     c = NULL;
     cursor = &clsm->iface;
     have_hash = false;
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
 
     WT_FORALL_CURSORS(clsm, c, i)
     {

--- a/src/lsm/lsm_cursor_bulk.c
+++ b/src/lsm/lsm_cursor_bulk.c
@@ -25,7 +25,7 @@ __clsm_close_bulk(WT_CURSOR *cursor)
     clsm = (WT_CURSOR_LSM *)cursor;
     lsm_tree = clsm->lsm_tree;
     chunk = lsm_tree->chunk[0];
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = CUR2S(clsm);
 
     /* Close the bulk cursor to ensure the chunk is written to disk. */
     bulk_cursor = clsm->chunks[0]->cursor;
@@ -67,7 +67,7 @@ __clsm_insert_bulk(WT_CURSOR *cursor)
     clsm = (WT_CURSOR_LSM *)cursor;
     lsm_tree = clsm->lsm_tree;
     chunk = lsm_tree->chunk[0];
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = CUR2S(clsm);
 
     WT_ASSERT(session, lsm_tree->nchunks == 1 && clsm->nchunks == 1);
     ++chunk->count;
@@ -95,7 +95,7 @@ __wt_clsm_open_bulk(WT_CURSOR_LSM *clsm, const char *cfg[])
     bulk_cursor = NULL;
     cursor = &clsm->iface;
     lsm_tree = clsm->lsm_tree;
-    session = (WT_SESSION_IMPL *)clsm->iface.session;
+    session = CUR2S(clsm);
 
     F_SET(clsm, WT_CLSM_BULK);
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -19,7 +19,7 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
     WT_RECONCILE *r;
     WT_SESSION_IMPL *session;
 
-    session = (WT_SESSION_IMPL *)cbulk->cbt.iface.session;
+    session = C2S(cbulk);
     r = cbulk->reconcile;
     btree = S2BT(session);
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -19,7 +19,7 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
     WT_RECONCILE *r;
     WT_SESSION_IMPL *session;
 
-    session = C2S(cbulk);
+    session = CUR2S(cbulk);
     r = cbulk->reconcile;
     btree = S2BT(session);
 

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -81,7 +81,7 @@ __wt_modify_pack(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries, WT_ITEM **
     uint8_t *data;
     int i;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     *modifyp = NULL;
 
     /*
@@ -355,7 +355,7 @@ __wt_modify_apply(WT_CURSOR *cursor, const void *modify)
     WT_SESSION_IMPL *session;
     bool sformat;
 
-    session = C2S(cursor);
+    session = CUR2S(cursor);
     sformat = cursor->value_format[0] == 'S';
 
     return (__wt_modify_apply_item(session, &cursor->value, modify, sformat));

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -81,7 +81,7 @@ __wt_modify_pack(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries, WT_ITEM **
     uint8_t *data;
     int i;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     *modifyp = NULL;
 
     /*
@@ -355,7 +355,7 @@ __wt_modify_apply(WT_CURSOR *cursor, const void *modify)
     WT_SESSION_IMPL *session;
     bool sformat;
 
-    session = (WT_SESSION_IMPL *)cursor->session;
+    session = C2S(cursor);
     sformat = cursor->value_format[0] == 'S';
 
     return (__wt_modify_apply_item(session, &cursor->value, modify, sformat));

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -35,7 +35,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
      * the original page.
      */
     if (cbt->ins == NULL) {
-        session = C2S(cbt);
+        session = CUR2S(cbt);
         page = cbt->ref->page;
         WT_ASSERT(session, cbt->slot < page->entries);
         rip = &page->pg_row[cbt->slot];

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -35,7 +35,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
      * the original page.
      */
     if (cbt->ins == NULL) {
-        session = (WT_SESSION_IMPL *)cbt->iface.session;
+        session = C2S(cbt);
         page = cbt->ref->page;
         WT_ASSERT(session, cbt->slot < page->entries);
         rip = &page->pg_row[cbt->slot];


### PR DESCRIPTION
Alex, Michael: I almost added this once before, so this time I made the change for your consideration.

It steps on name-space we don't control, but we pass cursors around more now than we used to, and I think this might simplify that process.

If you disagree, feel free to discard this change without further discussion.