### PR TITLE
WT-6068 Disable format test in make check

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -587,16 +587,17 @@ tasks:
         vars:
           directory: test/fops
 
-  - name: format-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          directory: test/format
+  # Temporarily disabled
+  # - name: format-test
+  #   tags: ["pull_request"]
+  #   depends_on:
+  #     - name: compile
+  #   commands:
+  #     - func: "fetch artifacts"
+  #     - func: "compile wiredtiger"
+  #     - func: "make check directory"
+  #       vars:
+  #         directory: test/format
 
   - name: huge-test
     tags: ["pull_request"]

--- a/test/format/Makefile.am
+++ b/test/format/Makefile.am
@@ -25,7 +25,8 @@ backup:
 refresh:
 	rm -rf RUNDIR && cp -p -r BACKUP RUNDIR
 
-TESTS = smoke.sh
+# Temporarily disabled
+# TESTS = smoke.sh
 
 clean-local:
 	rm -rf RUNDIR s_dumpcmp core.* *.core


### PR DESCRIPTION
The previous change of enabling make check format test caused some fallout - the failure pattern is different this time (not WT-5839). Will re-disable this test to address the fallout, and create another ticket to re-enable it later (as part of PM-1852).