### PR TITLE
WT-5710 Review WT_PANIC usage.

### DIFF
--- a/src/async/async_op.c
+++ b/src/async/async_op.c
@@ -291,7 +291,7 @@ __wt_async_op_enqueue(WT_SESSION_IMPL *session, WT_ASYNC_OP_IMPL *op)
 #ifdef HAVE_DIAGNOSTIC
     WT_ORDERED_READ(my_op, async->async_queue[my_slot]);
     if (my_op != NULL)
-        return (__wt_panic(session));
+        return (__wt_panic(session, WT_PANIC, "async failure"));
 #endif
     WT_PUBLISH(async->async_queue[my_slot], op);
     op->state = WT_ASYNCOP_ENQUEUED;

--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -309,7 +309,7 @@ __wt_async_worker(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "async worker error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "async worker error"));
     }
     /*
      * Worker thread cleanup, close our cached cursors and free all the WT_ASYNC_CURSOR structures.

--- a/src/async/async_worker.c
+++ b/src/async/async_worker.c
@@ -309,7 +309,7 @@ __wt_async_worker(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "async worker error");
+        ret = __wt_panic(session, ret, "async worker error");
     }
     /*
      * Worker thread cleanup, close our cached cursors and free all the WT_ASYNC_CURSOR structures.

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -200,7 +200,7 @@ __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
           "%s: an unexpected checkpoint start: the checkpoint "
           "has already started or was configured for salvage",
           block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
         break;
     case WT_CKPT_NONE:
         block->ckpt_state = WT_CKPT_INPROGRESS;
@@ -393,7 +393,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
           "%s: an unexpected checkpoint attempt: the checkpoint "
           "was never started or has already completed",
           block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
         break;
     case WT_CKPT_SALVAGE:
         /* Salvage doesn't use the standard checkpoint APIs. */
@@ -639,7 +639,7 @@ live_update:
 err:
     if (ret != 0 && fatal) {
         ret = __wt_panic(session, ret, "%s: fatal checkpoint failure", block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
     }
 
     if (locked)
@@ -864,14 +864,14 @@ __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool fa
           "%s: an unexpected checkpoint resolution: the checkpoint "
           "was never started or completed, or configured for salvage",
           block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
         break;
     case WT_CKPT_PANIC_ON_FAILURE:
         if (!failed)
             break;
         ret = __wt_panic(
           session, EINVAL, "%s: the checkpoint failed, the system must restart", block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
         break;
     }
     WT_ERR(ret);
@@ -879,7 +879,7 @@ __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool fa
     if ((ret = __wt_block_extlist_merge(session, block, &ci->ckpt_avail, &ci->avail)) != 0) {
         ret = __wt_panic(
           session, ret, "%s: fatal checkpoint failure during extent list merge", block->name);
-        __wt_block_panic(session);
+        __wt_block_set_readonly(session);
     }
     __wt_spin_unlock(session, &block->live_lock);
 

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -196,11 +196,11 @@ __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     case WT_CKPT_INPROGRESS:
     case WT_CKPT_PANIC_ON_FAILURE:
     case WT_CKPT_SALVAGE:
-        __wt_err(session, EINVAL,
+        ret = __wt_panic(session, EINVAL,
           "%s: an unexpected checkpoint start: the checkpoint "
           "has already started or was configured for salvage",
           block->name);
-        ret = __wt_block_panic(session);
+        __wt_block_panic(session);
         break;
     case WT_CKPT_NONE:
         block->ckpt_state = WT_CKPT_INPROGRESS;
@@ -389,11 +389,11 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
         break;
     case WT_CKPT_NONE:
     case WT_CKPT_PANIC_ON_FAILURE:
-        __wt_err(session, EINVAL,
+        ret = __wt_panic(session, EINVAL,
           "%s: an unexpected checkpoint attempt: the checkpoint "
           "was never started or has already completed",
           block->name);
-        ret = __wt_block_panic(session);
+        __wt_block_panic(session);
         break;
     case WT_CKPT_SALVAGE:
         /* Salvage doesn't use the standard checkpoint APIs. */
@@ -638,8 +638,8 @@ live_update:
 
 err:
     if (ret != 0 && fatal) {
-        __wt_err(session, ret, "%s: fatal checkpoint failure", block->name);
-        ret = __wt_block_panic(session);
+        ret = __wt_panic(session, ret, "%s: fatal checkpoint failure", block->name);
+        __wt_block_panic(session);
     }
 
     if (locked)
@@ -860,26 +860,26 @@ __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool fa
         goto done;
     case WT_CKPT_NONE:
     case WT_CKPT_SALVAGE:
-        __wt_err(session, EINVAL,
+        ret = __wt_panic(session, EINVAL,
           "%s: an unexpected checkpoint resolution: the checkpoint "
           "was never started or completed, or configured for salvage",
           block->name);
-        ret = __wt_block_panic(session);
+        __wt_block_panic(session);
         break;
     case WT_CKPT_PANIC_ON_FAILURE:
         if (!failed)
             break;
-        __wt_err(
+        ret = __wt_panic(
           session, EINVAL, "%s: the checkpoint failed, the system must restart", block->name);
-        ret = __wt_block_panic(session);
+        __wt_block_panic(session);
         break;
     }
     WT_ERR(ret);
 
     if ((ret = __wt_block_extlist_merge(session, block, &ci->ckpt_avail, &ci->avail)) != 0) {
-        __wt_err(
+        ret = __wt_panic(
           session, ret, "%s: fatal checkpoint failure during extent list merge", block->name);
-        ret = __wt_block_panic(session);
+        __wt_block_panic(session);
     }
     __wt_spin_unlock(session, &block->live_lock);
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -334,7 +334,7 @@ __block_off_remove(
         __block_size_srch(el->sz, ext->size, sstack);
         szp = *sstack[0];
         if (szp == NULL || szp->size != ext->size)
-            WT_PANIC_RET(session, EINVAL, "extent not found in by-size list during remove");
+            WT_RET_PANIC(session, EINVAL, "extent not found in by-size list during remove");
         __block_off_srch(szp->off, off, astack, true);
         ext = *astack[0];
         if (ext == NULL || ext->off != off)
@@ -641,7 +641,7 @@ __wt_block_extlist_check(WT_SESSION_IMPL *session, WT_EXTLIST *al, WT_EXTLIST *b
             b = b->next[0];
             continue;
         }
-        WT_PANIC_RET(session, EINVAL, "checkpoint merge check: %s list overlaps the %s list",
+        WT_RET_PANIC(session, EINVAL, "checkpoint merge check: %s list overlaps the %s list",
           al->name, bl->name);
     }
     return (0);

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -631,13 +631,11 @@ err:
 
 /*
  * __wt_block_panic --
- *     Report an error, then panic the handle and the system.
+ *     Set the block API to read-only.
  */
-int
+void
 __wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     /* Switch the handle into read-only mode. */
     __bm_method_set(S2BT(session)->bm, true);
-
-    return (__wt_panic(session));
 }

--- a/src/block/block_mgr.c
+++ b/src/block/block_mgr.c
@@ -630,11 +630,11 @@ err:
 }
 
 /*
- * __wt_block_panic --
+ * __wt_block_set_readonly --
  *     Set the block API to read-only.
  */
 void
-__wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((cold))
+__wt_block_set_readonly(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     /* Switch the handle into read-only mode. */
     __bm_method_set(S2BT(session)->bm, true);

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -289,5 +289,5 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_
     F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
     if (block->verify || F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
         return (WT_ERROR);
-    WT_PANIC_RET(session, WT_ERROR, "%s: fatal read error", block->name);
+    WT_RET_PANIC(session, WT_ERROR, "%s: fatal read error", block->name);
 }

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -461,7 +461,7 @@ __cursor_key_order_check_col(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
         return (0);
     }
 
-    WT_PANIC_RET(session, EINVAL, "WT_CURSOR.%s out-of-order returns: returned key %" PRIu64
+    WT_RET_PANIC(session, EINVAL, "WT_CURSOR.%s out-of-order returns: returned key %" PRIu64
                                   " then "
                                   "key %" PRIu64,
       next ? "next" : "prev", cbt->lastrecno, cbt->recno);
@@ -494,7 +494,7 @@ __cursor_key_order_check_row(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
     WT_ERR(__wt_scr_alloc(session, 512, &a));
     WT_ERR(__wt_scr_alloc(session, 512, &b));
 
-    WT_PANIC_ERR(session, EINVAL,
+    WT_ERR_PANIC(session, EINVAL,
       "WT_CURSOR.%s out-of-order returns: returned key %.1024s then "
       "key %.1024s",
       next ? "next" : "prev", __wt_buf_set_printable_format(session, cbt->lastkey->data,

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -784,6 +784,9 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
     session = (WT_SESSION_IMPL *)cursor->session;
     yield_count = sleep_usecs = 0;
 
+    WT_RET_PANIC_ASSERT(
+      session, S2BT(session) == btree, WT_PANIC, "btree differs unexpectedly from session's btree");
+
     WT_STAT_CONN_INCR(session, cursor_insert);
     WT_STAT_DATA_INCR(session, cursor_insert);
     WT_STAT_CONN_INCRV(session, cursor_insert_bytes, insert_bytes);
@@ -792,9 +795,6 @@ __wt_btcur_insert(WT_CURSOR_BTREE *cbt)
     if (btree->type == BTREE_ROW)
         WT_RET(__cursor_size_chk(session, &cursor->key));
     WT_RET(__cursor_size_chk(session, &cursor->value));
-
-    WT_RET_ASSERT(
-      session, S2BT(session) == btree, WT_PANIC, "btree differs unexpectedly from session's btree");
 
     /* It's no longer possible to bulk-load into the tree. */
     __wt_cursor_disable_bulk(session);
@@ -1206,7 +1206,7 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     session = (WT_SESSION_IMPL *)cursor->session;
     yield_count = sleep_usecs = 0;
 
-    WT_RET_ASSERT(
+    WT_RET_PANIC_ASSERT(
       session, S2BT(session) == btree, WT_PANIC, "btree differs unexpectedly from session's btree");
 
     /* It's no longer possible to bulk-load into the tree. */

--- a/src/btree/bt_io.c
+++ b/src/btree/bt_io.c
@@ -140,7 +140,7 @@ corrupt:
         F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
         if (!F_ISSET(btree, WT_BTREE_VERIFY) && !F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE)) {
             WT_TRET(bm->corrupt(bm, session, addr, addr_size));
-            WT_PANIC_ERR(session, ret, "%s: fatal read error: %s", btree->dhandle->name, fail_msg);
+            WT_ERR_PANIC(session, ret, "%s: fatal read error: %s", btree->dhandle->name, fail_msg);
         }
     }
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -917,7 +917,7 @@ __slvg_col_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
      */
     /* Case #2/8, #10, #11 */
     if (a_trk->col_start > b_trk->col_start)
-        WT_PANIC_RET(session, EINVAL, "unexpected merge array sort order");
+        WT_RET_PANIC(session, EINVAL, "unexpected merge array sort order");
 
     if (a_trk->col_start == b_trk->col_start) { /* Case #1, #4 and #9 */
                                                 /*
@@ -1323,7 +1323,7 @@ __slvg_col_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL_UNPACK *
             return (__slvg_ovfl_ref(session, ovfl, false));
     }
 
-    WT_PANIC_RET(session, EINVAL, "overflow record at column-store page merge not found");
+    WT_RET_PANIC(session, EINVAL, "overflow record at column-store page merge not found");
 }
 
 /*
@@ -1512,7 +1512,7 @@ __slvg_row_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
     WT_RET(__wt_compare(session, btree->collator, A_TRK_STOP, B_TRK_STOP, &stop_cmp));
 
     if (start_cmp > 0) /* Case #2/8, #10, #11 */
-        WT_PANIC_RET(session, EINVAL, "unexpected merge array sort order");
+        WT_RET_PANIC(session, EINVAL, "unexpected merge array sort order");
 
     if (start_cmp == 0) { /* Case #1, #4, #9 */
                           /*
@@ -1992,7 +1992,7 @@ __slvg_row_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL_UNPACK *
             return (__slvg_ovfl_ref(session, ovfl, true));
     }
 
-    WT_PANIC_RET(session, EINVAL, "overflow record at row-store page merge not found");
+    WT_RET_PANIC(session, EINVAL, "overflow record at row-store page merge not found");
 }
 
 /*
@@ -2270,7 +2270,7 @@ __slvg_ovfl_ref(WT_SESSION_IMPL *session, WT_TRACK *trk, bool multi_panic)
     if (F_ISSET(trk, WT_TRACK_OVFL_REFD)) {
         if (!multi_panic)
             return (__wt_set_return(session, EBUSY));
-        WT_PANIC_RET(session, EINVAL,
+        WT_RET_PANIC(session, EINVAL,
           "overflow record unexpectedly referenced multiple times "
           "during leaf page merge");
     }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -147,7 +147,7 @@ __split_verify_root(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 err:
     /* Something really bad just happened. */
-    WT_PANIC_RET(session, ret, "fatal error during page split");
+    WT_RET_PANIC(session, ret, "fatal error during page split");
 }
 #endif
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -574,17 +574,18 @@ err:
     case WT_ERR_RETURN:
         __wt_free_ref_index(session, root, alloc_index, true);
         break;
-    case WT_ERR_PANIC:
-        __wt_err(session, ret, "fatal error during root page split to deepen the tree");
-        ret = WT_PANIC;
-        break;
     case WT_ERR_IGNORE:
-        if (ret != 0 && ret != WT_PANIC) {
-            __wt_err(session, ret,
-              "ignoring not-fatal error during root page split "
-              "to deepen the tree");
+        if (ret == 0)
+            break;
+        if (ret != WT_PANIC) {
+            __wt_err(
+              session, ret, "ignoring not-fatal error during root page split to deepen the tree");
             ret = 0;
+            break;
         }
+    /* FALLTHROUGH */
+    case WT_ERR_PANIC:
+        ret = __wt_panic(session, ret, "fatal error during root page split to deepen the tree");
         break;
     }
     return (ret);
@@ -877,17 +878,17 @@ err:
         if (empty_parent)
             ret = __wt_set_return(session, EBUSY);
         break;
-    case WT_ERR_PANIC:
-        __wt_err(session, ret, "fatal error during parent page split");
-        ret = WT_PANIC;
-        break;
     case WT_ERR_IGNORE:
-        if (ret != 0 && ret != WT_PANIC) {
-            __wt_err(session, ret,
-              "ignoring not-fatal error during parent page "
-              "split");
+        if (ret == 0)
+            break;
+        if (ret != WT_PANIC) {
+            __wt_err(session, ret, "ignoring not-fatal error during parent page split");
             ret = 0;
+            break;
         }
+    /* FALLTHROUGH */
+    case WT_ERR_PANIC:
+        ret = __wt_panic(session, ret, "fatal error during parent page split");
         break;
     }
     __wt_scr_free(session, &scr);
@@ -1154,17 +1155,17 @@ err:
         }
         __wt_free_ref_index(session, page, alloc_index, true);
         break;
-    case WT_ERR_PANIC:
-        __wt_err(session, ret, "fatal error during internal page split");
-        ret = WT_PANIC;
-        break;
     case WT_ERR_IGNORE:
-        if (ret != 0 && ret != WT_PANIC) {
-            __wt_err(session, ret,
-              "ignoring not-fatal error during internal page "
-              "split");
+        if (ret == 0)
+            break;
+        if (ret != WT_PANIC) {
+            __wt_err(session, ret, "ignoring not-fatal error during internal page split");
             ret = 0;
+            break;
         }
+    /* FALLTHROUGH */
+    case WT_ERR_PANIC:
+        ret = __wt_panic(session, ret, "fatal error during internal page split");
         break;
     }
     return (ret);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -575,11 +575,10 @@ err:
         __wt_free_ref_index(session, root, alloc_index, true);
         break;
     case WT_ERR_IGNORE:
-        if (ret == 0)
-            break;
         if (ret != WT_PANIC) {
-            __wt_err(
-              session, ret, "ignoring not-fatal error during root page split to deepen the tree");
+            if (ret != 0)
+                __wt_err(session, ret,
+                  "ignoring not-fatal error during root page split to deepen the tree");
             ret = 0;
             break;
         }
@@ -879,10 +878,9 @@ err:
             ret = __wt_set_return(session, EBUSY);
         break;
     case WT_ERR_IGNORE:
-        if (ret == 0)
-            break;
         if (ret != WT_PANIC) {
-            __wt_err(session, ret, "ignoring not-fatal error during parent page split");
+            if (ret != 0)
+                __wt_err(session, ret, "ignoring not-fatal error during parent page split");
             ret = 0;
             break;
         }
@@ -1156,10 +1154,9 @@ err:
         __wt_free_ref_index(session, page, alloc_index, true);
         break;
     case WT_ERR_IGNORE:
-        if (ret == 0)
-            break;
         if (ret != WT_PANIC) {
-            __wt_err(session, ret, "ignoring not-fatal error during internal page split");
+            if (ret != 0)
+                __wt_err(session, ret, "ignoring not-fatal error during internal page split");
             ret = 0;
             break;
         }

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -115,7 +115,7 @@ __capacity_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "capacity server error");
+        ret = __wt_panic(session, ret, "capacity server error");
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -115,7 +115,7 @@ __capacity_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "capacity server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "capacity server error"));
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -116,7 +116,7 @@ __ckpt_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "checkpoint server error");
+        ret = __wt_panic(session, ret, "checkpoint server error");
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -116,7 +116,7 @@ __ckpt_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "checkpoint server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "checkpoint server error"));
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -166,7 +166,7 @@ __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri, const char *c
         dhandle = (WT_DATA_HANDLE *)table;
         dhandle->type = WT_DHANDLE_TYPE_TABLE;
     } else
-        WT_PANIC_RET(session, EINVAL, "illegal handle allocation URI %s", uri);
+        WT_RET_PANIC(session, EINVAL, "illegal handle allocation URI %s", uri);
 
     /* Btree handles keep their data separate from the interface. */
     if (dhandle->type == WT_DHANDLE_TYPE_BTREE) {

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -661,7 +661,7 @@ __log_file_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "log close server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "log close server error"));
     }
     WT_STAT_CONN_INCRV(session, log_server_sync_blocked, yield_count);
     if (locked)
@@ -856,7 +856,7 @@ __log_wrlsn_server(void *arg)
     __wt_log_wrlsn(session, NULL);
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "log wrlsn server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "log wrlsn server error"));
     }
     return (WT_THREAD_RET_VALUE);
 }
@@ -947,7 +947,7 @@ __log_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "log server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "log server error"));
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -661,7 +661,7 @@ __log_file_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "log close server error");
+        ret = __wt_panic(session, ret, "log close server error");
     }
     WT_STAT_CONN_INCRV(session, log_server_sync_blocked, yield_count);
     if (locked)
@@ -856,7 +856,7 @@ __log_wrlsn_server(void *arg)
     __wt_log_wrlsn(session, NULL);
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "log wrlsn server error");
+        ret = __wt_panic(session, ret, "log wrlsn server error");
     }
     return (WT_THREAD_RET_VALUE);
 }
@@ -947,7 +947,7 @@ __log_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "log server error");
+        ret = __wt_panic(session, ret, "log server error");
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -596,7 +596,7 @@ __statlog_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "statistics log server error");
+        ret = __wt_panic(session, ret, "statistics log server error");
     }
     __wt_buf_free(session, &path);
     __wt_buf_free(session, &tmp);

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -596,7 +596,7 @@ __statlog_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "statistics log server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "statistics log server error"));
     }
     __wt_buf_free(session, &path);
     __wt_buf_free(session, &tmp);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -325,7 +325,7 @@ __sweep_server(void *arg)
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "handle sweep server error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "handle sweep server error"));
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -325,7 +325,7 @@ __sweep_server(void *arg)
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "handle sweep server error");
+        ret = __wt_panic(session, ret, "handle sweep server error");
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -319,7 +319,7 @@ __backup_add_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval)
      * We didn't find an entry. This should not happen.
      */
     if (i == WT_BLKINCR_MAX)
-        WT_PANIC_RET(session, WT_NOTFOUND, "Could not find an incremental backup slot to use");
+        WT_RET_PANIC(session, WT_NOTFOUND, "Could not find an incremental backup slot to use");
 
     /* Use the slot.  */
     if (blk->id_str != NULL)

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -770,7 +770,7 @@ __curjoin_init_bloom(
                 goto done;
             WT_ERR(ret);
         } else
-            WT_PANIC_ERR(session, EINVAL, "fatal error in join cursor position state");
+            WT_ERR_PANIC(session, EINVAL, "fatal error in join cursor position state");
     }
     collator = (entry->index == NULL) ? NULL : entry->index->collator;
     while (ret == 0) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -325,7 +325,7 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
     if (0) {
 err:
-        WT_PANIC_RET(session, ret, "cache eviction thread error");
+        WT_RET_PANIC(session, ret, "cache eviction thread error");
     }
     return (ret);
 }
@@ -362,7 +362,7 @@ __wt_evict_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
     if (0) {
 err:
-        WT_PANIC_RET(session, ret, "cache eviction thread error");
+        WT_RET_PANIC(session, ret, "cache eviction thread error");
     }
     return (ret);
 }

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -764,10 +764,9 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
     WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
     max_hs_size = ((WT_CURSOR_BTREE *)cursor)->btree->file_max;
     if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
-        WT_PANIC_ERR(session, WT_PANIC, "WiredTigerHS: file size of %" PRIu64
-                                        " exceeds maximum "
-                                        "size %" PRIu64,
-          (uint64_t)hs_size, max_hs_size);
+        WT_PANIC_ERR(session, WT_PANIC,
+          "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
+          max_hs_size);
 
 err:
     if (ret == 0 && insert_cnt > 0)
@@ -1305,7 +1304,7 @@ __verify_history_store_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint32
         WT_ERR(__cursor_reset(cbt));
 
         if (!found)
-            WT_ERR_MSG(session, WT_PANIC,
+            WT_PANIC_ERR(session, WT_PANIC,
               "the associated history store key %s was not found in the data store %s",
               __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key),
               session->dhandle->name);
@@ -1407,7 +1406,7 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
          */
         WT_ERR(cursor->get_key(cursor, &btree_id, hs_key, &hs_start_ts, &hs_counter));
         if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0)
-            WT_ERR_MSG(session, WT_PANIC,
+            WT_PANIC_ERR(session, WT_PANIC,
               "Unable to find btree id %" PRIu32
               " in the metadata file for the associated history store key %s",
               btree_id, __wt_buf_set_printable(session, hs_key->data, hs_key->size, buf));

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -764,7 +764,7 @@ __wt_hs_insert_updates(WT_CURSOR *cursor, WT_BTREE *btree, WT_PAGE *page, WT_MUL
     WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
     max_hs_size = ((WT_CURSOR_BTREE *)cursor)->btree->file_max;
     if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
-        WT_PANIC_ERR(session, WT_PANIC,
+        WT_ERR_PANIC(session, WT_PANIC,
           "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
           max_hs_size);
 
@@ -1304,7 +1304,7 @@ __verify_history_store_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint32
         WT_ERR(__cursor_reset(cbt));
 
         if (!found)
-            WT_PANIC_ERR(session, WT_PANIC,
+            WT_ERR_PANIC(session, WT_PANIC,
               "the associated history store key %s was not found in the data store %s",
               __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key),
               session->dhandle->name);
@@ -1406,7 +1406,7 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
          */
         WT_ERR(cursor->get_key(cursor, &btree_id, hs_key, &hs_start_ts, &hs_counter));
         if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0)
-            WT_PANIC_ERR(session, WT_PANIC,
+            WT_ERR_PANIC(session, WT_PANIC,
               "Unable to find btree id %" PRIu32
               " in the metadata file for the associated history store key %s",
               btree_id, __wt_buf_set_printable(session, hs_key->data, hs_key->size, buf));

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -17,6 +17,7 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_sta
 {
 #ifdef HAVE_DIAGNOSTIC
     /*
+     * We're using WT_ERR_ASSERT rather than WT_ASSERT because we want to push out a message string.
      * This usage of WT_ERR_ASSERT isn't "correct", because it jumps to a non-existent error label
      * in non-diagnostic builds and returns WT_PANIC without calling the underlying panic routine.
      * That's OK, we have to be in a diagnostic build to get here, and fixing it would require new
@@ -143,6 +144,7 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t start_durable_
 {
 #ifdef HAVE_DIAGNOSTIC
     /*
+     * We're using WT_ERR_ASSERT rather than WT_ASSERT because we want to push out a message string.
      * This usage of WT_ERR_ASSERT isn't "correct", because it jumps to a non-existent error label
      * in non-diagnostic builds and returns WT_PANIC without calling the underlying panic routine.
      * That's OK, we have to be in a diagnostic build to get here, and fixing it would require new

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -16,6 +16,12 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, wt_timestamp_t durable_sta
   wt_timestamp_t stop_ts, uint64_t stop_txn)
 {
 #ifdef HAVE_DIAGNOSTIC
+    /*
+     * This usage of WT_ERR_ASSERT isn't "correct", because it jumps to a non-existent error label
+     * in non-diagnostic builds and returns WT_PANIC without calling the underlying panic routine.
+     * That's OK, we have to be in a diagnostic build to get here, and fixing it would require new
+     * macros that aren't needed anywhere else, so we're leaving it alone.
+     */
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     if (start_ts > durable_start_ts)
@@ -136,6 +142,12 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, wt_timestamp_t start_durable_
   wt_timestamp_t newest_stop_ts, uint64_t newest_stop_txn)
 {
 #ifdef HAVE_DIAGNOSTIC
+    /*
+     * This usage of WT_ERR_ASSERT isn't "correct", because it jumps to a non-existent error label
+     * in non-diagnostic builds and returns WT_PANIC without calling the underlying panic routine.
+     * That's OK, we have to be in a diagnostic build to get here, and fixing it would require new
+     * macros that aren't needed anywhere else, so we're leaving it alone.
+     */
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     if (oldest_start_ts != WT_TS_NONE && newest_stop_ts == WT_TS_NONE)

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -162,7 +162,7 @@
 #define WT_RET_PANIC_ASSERT(session, exp, v, ...)  \
     do {                                           \
         if (!(exp))                                \
-            WT_PANIC_RET(session, v, __VA_ARGS__); \
+            WT_RET_PANIC(session, v, __VA_ARGS__); \
     } while (0)
 #endif
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -22,6 +22,8 @@
 
 #define __wt_err(session, error, ...) __wt_err_func(session, error, __func__, __LINE__, __VA_ARGS__)
 #define __wt_errx(session, ...) __wt_errx_func(session, __func__, __LINE__, __VA_ARGS__)
+#define __wt_panic(session, error, ...) \
+    __wt_panic_func(session, error, __func__, __LINE__, __VA_ARGS__)
 #define __wt_set_return(session, error) __wt_set_return_func(session, __func__, __LINE__, error)
 
 /* Set "ret" and branch-to-err-label tests. */
@@ -46,6 +48,9 @@
     } while (0)
 #define WT_ERR_ERROR_OK(a, e, keep) WT_ERR_TEST((ret = (a)) != 0 && ret != (e), ret, keep)
 #define WT_ERR_NOTFOUND_OK(a, keep) WT_ERR_ERROR_OK(a, WT_NOTFOUND, keep)
+
+/* Return WT_PANIC regardless of earlier return codes. */
+#define WT_PANIC_ERR(session, v, ...) WT_ERR(__wt_panic(session, v, __VA_ARGS__))
 
 /* Return tests. */
 #define WT_RET(a)               \
@@ -99,27 +104,13 @@
 #define WT_TRET_BUSY_OK(a) WT_TRET_ERROR_OK(a, EBUSY)
 #define WT_TRET_NOTFOUND_OK(a) WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
-/* Called on unexpected code path: locate the failure. */
-#define __wt_illegal_value(session, v) \
-    __wt_illegal_value_func(session, (uintmax_t)(v), __func__, __LINE__)
+/* Return WT_PANIC regardless of earlier return codes. */
+#define WT_PANIC_RET(session, v, ...) return (__wt_panic(session, v, __VA_ARGS__))
 
-#define WT_PANIC_MSG(session, v, ...)       \
-    do {                                    \
-        __wt_err(session, v, __VA_ARGS__);  \
-        WT_IGNORE_RET(__wt_panic(session)); \
-    } while (0)
-#define WT_PANIC_ERR(session, v, ...)                             \
-    do {                                                          \
-        WT_PANIC_MSG(session, v, __VA_ARGS__);                    \
-        /* Return WT_PANIC regardless of earlier return codes. */ \
-        WT_ERR(WT_PANIC);                                         \
-    } while (0)
-#define WT_PANIC_RET(session, v, ...)                             \
-    do {                                                          \
-        WT_PANIC_MSG(session, v, __VA_ARGS__);                    \
-        /* Return WT_PANIC regardless of earlier return codes. */ \
-        return (WT_PANIC);                                        \
-    } while (0)
+/* Called on unexpected code path: locate the failure. */
+#define __wt_illegal_value(session, v)             \
+    __wt_panic(session, EINVAL, "%s: 0x%" PRIxMAX, \
+      "encountered an illegal file format or internal value", (uintmax_t)(v))
 
 /*
  * WT_ERR_ASSERT, WT_RET_ASSERT, WT_ASSERT
@@ -149,6 +140,13 @@
             __wt_abort(session);               \
         }                                      \
     } while (0)
+#define WT_RET_PANIC_ASSERT(session, exp, v, ...) \
+    do {                                          \
+        if (!(exp)) {                             \
+            __wt_err(session, v, __VA_ARGS__);    \
+            __wt_abort(session);                  \
+        }                                         \
+    } while (0)
 #else
 #define WT_ASSERT(session, exp) WT_UNUSED(session)
 #define WT_ERR_ASSERT(session, exp, v, ...)      \
@@ -160,6 +158,11 @@
     do {                                         \
         if (!(exp))                              \
             WT_RET_MSG(session, v, __VA_ARGS__); \
+    } while (0)
+#define WT_RET_PANIC_ASSERT(session, exp, v, ...)  \
+    do {                                           \
+        if (!(exp))                                \
+            WT_PANIC_RET(session, v, __VA_ARGS__); \
     } while (0)
 #endif
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -50,7 +50,7 @@
 #define WT_ERR_NOTFOUND_OK(a, keep) WT_ERR_ERROR_OK(a, WT_NOTFOUND, keep)
 
 /* Return WT_PANIC regardless of earlier return codes. */
-#define WT_PANIC_ERR(session, v, ...) WT_ERR(__wt_panic(session, v, __VA_ARGS__))
+#define WT_ERR_PANIC(session, v, ...) WT_ERR(__wt_panic(session, v, __VA_ARGS__))
 
 /* Return tests. */
 #define WT_RET(a)               \
@@ -105,7 +105,7 @@
 #define WT_TRET_NOTFOUND_OK(a) WT_TRET_ERROR_OK(a, WT_NOTFOUND)
 
 /* Return WT_PANIC regardless of earlier return codes. */
-#define WT_PANIC_RET(session, v, ...) return (__wt_panic(session, v, __VA_ARGS__))
+#define WT_RET_PANIC(session, v, ...) return (__wt_panic(session, v, __VA_ARGS__))
 
 /* Called on unexpected code path: locate the failure. */
 #define __wt_illegal_value(session, v)             \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1588,7 +1588,7 @@ extern void __wt_block_ckpt_destroy(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci)
 extern void __wt_block_configure_first_fit(WT_BLOCK *block, bool on);
 extern void __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
 extern void __wt_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);
-extern void __wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
+extern void __wt_block_set_readonly(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
 extern void __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz);
 extern void __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats);
 extern void __wt_bloom_hash(WT_BLOOM *bloom, WT_ITEM *key, WT_BLOOM_HASH *bhash);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -184,8 +184,6 @@ extern int __wt_block_off_remove_overlap(WT_SESSION_IMPL *session, WT_BLOCK *blo
 extern int __wt_block_open(WT_SESSION_IMPL *session, const char *filename, const char *cfg[],
   bool forced_salvage, bool readonly, uint32_t allocsize, WT_BLOCK **blockp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf,
   wt_off_t offset, uint32_t size, uint32_t checksum)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -772,9 +770,6 @@ extern int __wt_huffman_encode(WT_SESSION_IMPL *session, void *huffman_arg, cons
   size_t from_len, WT_ITEM *to_buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_huffman_open(WT_SESSION_IMPL *session, void *symbol_frequency_array, u_int symcnt,
   u_int numbytes, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_illegal_value_func(WT_SESSION_IMPL *session, uintmax_t v, const char *func,
-  int line) WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_import(WT_SESSION_IMPL *session, const char *uri)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_inmem_unsupported_op(WT_SESSION_IMPL *session, const char *tag)
@@ -1157,9 +1152,11 @@ extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
-  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
-    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_panic_func(
+  WT_SESSION_IMPL *session, int error, const char *func, int line, const char *fmt, ...)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 5, 6)))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+      WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags)
@@ -1591,6 +1588,7 @@ extern void __wt_block_ckpt_destroy(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci)
 extern void __wt_block_configure_first_fit(WT_BLOCK *block, bool on);
 extern void __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
 extern void __wt_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);
+extern void __wt_block_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
 extern void __wt_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz);
 extern void __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats);
 extern void __wt_bloom_hash(WT_BLOOM *bloom, WT_ITEM *key, WT_BLOOM_HASH *bhash);

--- a/src/include/mutex.i
+++ b/src/include/mutex.i
@@ -168,7 +168,7 @@ __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
     WT_DECL_RET;
 
     if ((ret = pthread_mutex_lock(&t->lock)) != 0)
-        WT_PANIC_MSG(session, ret, "pthread_mutex_lock: %s", t->name);
+        WT_IGNORE_RET(__wt_panic(session, ret, "pthread_mutex_lock: %s", t->name));
 }
 #endif
 
@@ -182,7 +182,7 @@ __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
     WT_DECL_RET;
 
     if ((ret = pthread_mutex_unlock(&t->lock)) != 0)
-        WT_PANIC_MSG(session, ret, "pthread_mutex_unlock: %s", t->name);
+        WT_IGNORE_RET(__wt_panic(session, ret, "pthread_mutex_unlock: %s", t->name));
 }
 
 #elif SPINLOCK_TYPE == SPINLOCK_MSVC

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -59,8 +59,8 @@ __wt_txn_err_set(WT_SESSION_IMPL *session, int ret)
      * a prepared transaction.
      */
     if (F_ISSET(txn, WT_TXN_PREPARE))
-        WT_PANIC_MSG(session, ret,
-          "transactional error logged after transaction was prepared, failing the system");
+        WT_IGNORE_RET(__wt_panic(session, ret,
+          "transactional error logged after transaction was prepared, failing the system"));
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -215,7 +215,7 @@ __log_fs_write(
     }
     __wt_capacity_throttle(session, len, WT_THROTTLE_LOG);
     if ((ret = __wt_write(session, slot->slot_fh, offset, len, buf)) != 0)
-        WT_PANIC_RET(session, ret, "%s: fatal log failure", slot->slot_fh->name);
+        WT_RET_PANIC(session, ret, "%s: fatal log failure", slot->slot_fh->name);
     return (ret);
 }
 

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -442,7 +442,7 @@ __lsm_worker_manager(void *arg)
 
     if (ret != 0) {
 err:
-        WT_PANIC_MSG(session, ret, "LSM worker manager thread error");
+        ret = __wt_panic(session, ret, "LSM worker manager thread error");
     }
 
     /* Connection close waits on us to shutdown, let it know we're done. */

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -442,7 +442,7 @@ __lsm_worker_manager(void *arg)
 
     if (ret != 0) {
 err:
-        ret = __wt_panic(session, ret, "LSM worker manager thread error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "LSM worker manager thread error"));
     }
 
     /* Connection close waits on us to shutdown, let it know we're done. */

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -544,7 +544,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
      * of the tree.
      */
     if ((ret = __wt_lsm_meta_write(session, lsm_tree, NULL)) != 0)
-        WT_PANIC_ERR(session, ret, "Failed finalizing LSM merge");
+        WT_ERR_PANIC(session, ret, "Failed finalizing LSM merge");
 
     lsm_tree->dsk_gen++;
 

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -781,7 +781,7 @@ err:
      * progress. Error out of WiredTiger.
      */
     if (ret != 0)
-        WT_PANIC_RET(session, ret, "Failed doing LSM switch");
+        WT_RET_PANIC(session, ret, "Failed doing LSM switch");
     else if (!first_switch)
         WT_RET(__wt_lsm_manager_push_entry(session, WT_LSM_WORK_FLUSH, 0, lsm_tree));
     return (ret);

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -164,7 +164,7 @@ __lsm_worker(void *arg)
     if (ret != 0) {
 err:
         __wt_lsm_manager_free_work_unit(session, entry);
-        ret = __wt_panic(session, ret, "Error in LSM worker thread %u", cookie->id);
+        WT_IGNORE_RET(__wt_panic(session, ret, "Error in LSM worker thread %u", cookie->id));
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -164,7 +164,7 @@ __lsm_worker(void *arg)
     if (ret != 0) {
 err:
         __wt_lsm_manager_free_work_unit(session, entry);
-        WT_PANIC_MSG(session, ret, "Error in LSM worker thread %u", cookie->id);
+        ret = __wt_panic(session, ret, "Error in LSM worker thread %u", cookie->id);
     }
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -331,7 +331,7 @@ err:
         __wt_cond_signal(session, S2C(session)->sweep_cond);
 
     if (ret != 0)
-        WT_PANIC_RET(session, ret, "failed to apply or unroll all tracked operations");
+        WT_RET_PANIC(session, ret, "failed to apply or unroll all tracked operations");
     return (saved_ret == 0 ? 0 : saved_ret);
 }
 

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -80,7 +80,7 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session)
             break;
         WT_ERR(__wt_getline(session, fs, value));
         if (value->size == 0)
-            WT_PANIC_ERR(session, EINVAL, "%s: zero-length value", WT_METADATA_BACKUP);
+            WT_ERR_PANIC(session, EINVAL, "%s: zero-length value", WT_METADATA_BACKUP);
         WT_ERR(__wt_metadata_update(session, key->data, value->data));
     }
 
@@ -381,7 +381,7 @@ err:
      */
     if (ret == 0 || strcmp(key, WT_METADATA_COMPAT) == 0 || F_ISSET(S2C(session), WT_CONN_SALVAGE))
         return (ret);
-    WT_PANIC_RET(session, WT_TRY_SALVAGE, "%s: fatal turtle file read error", WT_METADATA_TURTLE);
+    WT_RET_PANIC(session, WT_TRY_SALVAGE, "%s: fatal turtle file read error", WT_METADATA_TURTLE);
 }
 
 /*
@@ -437,5 +437,5 @@ err:
      */
     if (ret == 0)
         return (ret);
-    WT_PANIC_RET(session, ret, "%s: fatal turtle file update error", WT_METADATA_TURTLE);
+    WT_RET_PANIC(session, ret, "%s: fatal turtle file update error", WT_METADATA_TURTLE);
 }

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -39,7 +39,7 @@ __wt_optrack_record_funcid(WT_SESSION_IMPL *session, const char *func, uint16_t 
 
     if (0) {
 err:
-        ret = __wt_panic(session, ret, "operation tracking initialization failure");
+        WT_IGNORE_RET(__wt_panic(session, ret, "operation tracking initialization failure"));
     }
 
     if (locked)

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -39,7 +39,7 @@ __wt_optrack_record_funcid(WT_SESSION_IMPL *session, const char *func, uint16_t 
 
     if (0) {
 err:
-        WT_PANIC_MSG(session, ret, "operation tracking initialization failure");
+        ret = __wt_panic(session, ret, "operation tracking initialization failure");
     }
 
     if (locked)

--- a/src/os_common/os_errno.c
+++ b/src/os_common/os_errno.c
@@ -78,7 +78,7 @@ __wt_ext_map_windows_error(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, uin
     return (__wt_map_windows_error(windows_error));
 #else
     WT_UNUSED(windows_error);
-    WT_PANIC_RET(
+    WT_RET_PANIC(
       (WT_SESSION_IMPL *)wt_session, WT_PANIC, "unexpected attempt to map Windows error");
 #endif
 }

--- a/src/os_common/os_errno.c
+++ b/src/os_common/os_errno.c
@@ -78,6 +78,7 @@ __wt_ext_map_windows_error(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, uin
     return (__wt_map_windows_error(windows_error));
 #else
     WT_UNUSED(windows_error);
-    return (WT_PANIC);
+    WT_PANIC_RET(
+      (WT_SESSION_IMPL *)wt_session, WT_PANIC, "unexpected attempt to map Windows error");
 #endif
 }

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -88,7 +88,7 @@ __posix_sync(WT_SESSION_IMPL *session, int fd, const char *name, const char *fun
         WT_SYSCALL(fcntl(fd, F_FULLFSYNC, 0) == -1 ? -1 : 0, ret);
         if (ret == 0)
             return (0);
-        WT_PANIC_RET(session, ret, "%s: %s: fcntl(F_FULLFSYNC)", name, func);
+        WT_RET_PANIC(session, ret, "%s: %s: fcntl(F_FULLFSYNC)", name, func);
     }
 #endif
 #if defined(HAVE_FDATASYNC)
@@ -96,13 +96,13 @@ __posix_sync(WT_SESSION_IMPL *session, int fd, const char *name, const char *fun
     WT_SYSCALL(fdatasync(fd), ret);
     if (ret == 0)
         return (0);
-    WT_PANIC_RET(session, ret, "%s: %s: fdatasync", name, func);
+    WT_RET_PANIC(session, ret, "%s: %s: fdatasync", name, func);
 #else
     /* See comment in __posix_sync(): sync cannot be retried or fail. */
     WT_SYSCALL(fsync(fd), ret);
     if (ret == 0)
         return (0);
-    WT_PANIC_RET(session, ret, "%s: %s: fsync", name, func);
+    WT_RET_PANIC(session, ret, "%s: %s: fsync", name, func);
 #endif
 }
 
@@ -148,7 +148,7 @@ err:
         return (ret);
 
     /* See comment in __posix_sync(): sync cannot be retried or fail. */
-    WT_PANIC_RET(session, ret, "%s: directory-sync", path);
+    WT_RET_PANIC(session, ret, "%s: directory-sync", path);
 }
 #endif
 
@@ -541,7 +541,7 @@ __posix_file_sync_nowait(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
     if (ret == 0)
         return (0);
 
-    WT_PANIC_RET(session, ret, "%s: handle-sync-nowait: sync_file_range", file_handle->name);
+    WT_RET_PANIC(session, ret, "%s: handle-sync-nowait: sync_file_range", file_handle->name);
 }
 #endif
 

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -106,7 +106,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
 #ifdef HAVE_PTHREAD_COND_MONOTONIC
         WT_SYSCALL_RETRY(clock_gettime(CLOCK_MONOTONIC, &ts), ret);
         if (ret != 0)
-            WT_PANIC_MSG(session, ret, "clock_gettime");
+            WT_IGNORE_RET(__wt_panic(session, ret, "clock_gettime"));
 #else
         __wt_epoch_raw(session, &ts);
 #endif
@@ -140,7 +140,7 @@ err:
     if (ret == 0)
         return;
 
-    WT_PANIC_MSG(session, ret, "pthread_cond_wait: %s", cond->name);
+    WT_IGNORE_RET(__wt_panic(session, ret, "pthread_cond_wait: %s", cond->name));
 }
 
 /*
@@ -175,7 +175,7 @@ __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond)
         return;
 
 err:
-    WT_PANIC_MSG(session, ret, "pthread_cond_broadcast: %s", cond->name);
+    WT_IGNORE_RET(__wt_panic(session, ret, "pthread_cond_broadcast: %s", cond->name));
 }
 
 /*
@@ -193,10 +193,10 @@ __wt_cond_destroy(WT_SESSION_IMPL *session, WT_CONDVAR **condp)
         return;
 
     if ((ret = pthread_cond_destroy(&cond->cond)) != 0)
-        WT_PANIC_MSG(session, ret, "pthread_cond_destroy: %s", cond->name);
+        WT_IGNORE_RET(__wt_panic(session, ret, "pthread_cond_destroy: %s", cond->name));
 
     if ((ret = pthread_mutex_destroy(&cond->mtx)) != 0)
-        WT_PANIC_MSG(session, ret, "pthread_mutex_destroy: %s", cond->name);
+        WT_IGNORE_RET(__wt_panic(session, ret, "pthread_mutex_destroy: %s", cond->name));
 
     __wt_free(session, *condp);
 }

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -30,7 +30,7 @@ __wt_epoch_raw(WT_SESSION_IMPL *session, struct timespec *tsp)
     WT_SYSCALL_RETRY(clock_gettime(CLOCK_REALTIME, tsp), ret);
     if (ret == 0)
         return;
-    WT_PANIC_MSG(session, ret, "clock_gettime");
+    WT_IGNORE_RET(__wt_panic(session, ret, "clock_gettime"));
 #elif defined(HAVE_GETTIMEOFDAY)
     {
         struct timeval v;
@@ -41,7 +41,7 @@ __wt_epoch_raw(WT_SESSION_IMPL *session, struct timespec *tsp)
             tsp->tv_nsec = v.tv_usec * WT_THOUSAND;
             return;
         }
-        WT_PANIC_MSG(session, ret, "gettimeofday");
+        WT_IGNORE_RET(__wt_panic(session, ret, "gettimeofday"));
     }
 #else
     NO TIME - OF - DAY IMPLEMENTATION : see src / os_posix / os_time.c

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -116,8 +116,8 @@ skipping:
 
     __wt_err(session, __wt_map_windows_error(windows_error), "SleepConditionVariableCS: %s: %s",
       cond->name, __wt_formatmessage(session, windows_error));
-    WT_PANIC_MSG(
-      session, __wt_map_windows_error(windows_error), "SleepConditionVariableCS: %s", cond->name);
+    WT_IGNORE_RET(__wt_panic(
+      session, __wt_map_windows_error(windows_error), "SleepConditionVariableCS: %s", cond->name));
 }
 
 /*

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -56,11 +56,10 @@ __wt_thread_join(WT_SESSION_IMPL *session, wt_thread_t *tid)
     if ((windows_error = WaitForSingleObject(tid->id, INFINITE)) != WAIT_OBJECT_0) {
         if (windows_error == WAIT_FAILED)
             windows_error = __wt_getlasterror();
-        __wt_err(session, __wt_map_windows_error(windows_error),
-          "thread join: WaitForSingleObject: %s", __wt_formatmessage(session, windows_error));
 
         /* If we fail to wait, we will leak handles, do not continue. */
-        return (WT_PANIC);
+        return (__wt_panic(session, __wt_map_windows_error(windows_error),
+          "thread join: WaitForSingleObject: %s", __wt_formatmessage(session, windows_error)));
     }
 
     if (CloseHandle(tid->id) == 0) {

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -36,7 +36,7 @@ __rec_child_deleted(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *ref, WT_C
     if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_VISIBILITY_ERR) && page_del != NULL &&
       __wt_page_del_active(session, ref, false)) {
         if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
-            WT_PANIC_RET(session, EINVAL, "reconciliation illegally skipped an update");
+            WT_RET_PANIC(session, EINVAL, "reconciliation illegally skipped an update");
         return (__wt_set_return(session, EBUSY));
     }
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -504,7 +504,7 @@ __wt_rec_col_fix_slvg(
      * We can't split during salvage -- if everything didn't fit, it's all gone wrong.
      */
     if (salvage->missing != 0 || page_take != 0)
-        WT_PANIC_RET(session, WT_PANIC, "%s page too large, attempted split during salvage",
+        WT_RET_PANIC(session, WT_PANIC, "%s page too large, attempted split during salvage",
           __wt_page_type_string(page->type));
 
     /* Write the page. */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -322,7 +322,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      */
     if (has_newer_updates && F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_VISIBILITY_ERR)) {
         if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
-            WT_PANIC_RET(session, EINVAL, "reconciliation error, update not visible");
+            WT_RET_PANIC(session, EINVAL, "reconciliation error, update not visible");
         return (__wt_set_return(session, EBUSY));
     }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1111,7 +1111,7 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool 
      * page.
      */
     if (r->salvage != NULL)
-        WT_PANIC_RET(session, WT_PANIC, "%s page too large, attempted split during salvage",
+        WT_RET_PANIC(session, WT_PANIC, "%s page too large, attempted split during salvage",
           __wt_page_type_string(r->page->type));
 
     /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1658,7 +1658,7 @@ err:
         F_CLR(session, WT_SESSION_RESOLVING_TXN);
     } else if (F_ISSET(txn, WT_TXN_RUNNING)) {
         if (F_ISSET(txn, WT_TXN_PREPARE))
-            WT_PANIC_RET(session, ret, "failed to commit prepared transaction, failing the system");
+            WT_RET_PANIC(session, ret, "failed to commit prepared transaction, failing the system");
 
         WT_TRET(__wt_session_reset_cursors(session, false));
         F_SET(session, WT_SESSION_RESOLVING_TXN);

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -332,6 +332,73 @@ __wt_errx_func(WT_SESSION_IMPL *session, const char *func, int line, const char 
 }
 
 /*
+ * __wt_panic_func --
+ *     A standard error message when we panic.
+ */
+int
+__wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line, const char *fmt,
+  ...) WT_GCC_FUNC_ATTRIBUTE((cold)) WT_GCC_FUNC_ATTRIBUTE((format(printf, 5, 6)))
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    va_list ap;
+
+    /*
+     * Ignore error returns from underlying event handlers, we already have an error value to
+     * return.
+     */
+    va_start(ap, fmt);
+    WT_IGNORE_RET(__eventv(session, false, error, func, line, fmt, ap));
+    va_end(ap);
+
+    /*
+     * !!!
+     * This function MUST handle a NULL WT_SESSION_IMPL handle.
+     *
+     * If the connection has already panicked, just return the error.
+     */
+    if (session != NULL && F_ISSET(S2C(session), WT_CONN_PANIC))
+        return (WT_PANIC);
+
+    /*
+     * Call the error callback function before setting the connection's panic flag, so applications
+     * can trace the failing thread before being flooded with panic returns from API calls. Using
+     * the variable-arguments list from the current call even thought the format doesn't need it as
+     * I'm not confident of underlying support for a NULL.
+     */
+    va_start(ap, fmt);
+    WT_IGNORE_RET(
+      __eventv(session, false, WT_PANIC, func, line, "the process must exit and restart", ap));
+    va_end(ap);
+
+/*
+ * Confusing #ifdef structure because gcc/clang knows the abort call won't return, and Visual Studio
+ * doesn't.
+ */
+#if defined(HAVE_DIAGNOSTIC)
+    __wt_abort(session); /* Drop core if testing. */
+                         /* NOTREACHED */
+#endif
+#if !defined(HAVE_DIAGNOSTIC) || defined(_WIN32)
+    /*
+     * !!!
+     * This function MUST handle a NULL WT_SESSION_IMPL handle.
+     *
+     * Panic the connection;
+     */
+    if (session != NULL)
+        F_SET(S2C(session), WT_CONN_PANIC);
+
+    /*
+     * !!!
+     * Chaos reigns within.
+     * Reflect, repent, and reboot.
+     * Order shall return.
+     */
+    return (WT_PANIC);
+#endif
+}
+
+/*
  * __wt_set_return_func --
  *     Conditionally log the source of an error code and return the error.
  */
@@ -464,67 +531,6 @@ __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
                handler, wt_session, s == NULL ? session->name : s, v)) != 0)
             __handler_failure(session, ret, "progress", false);
     return (0);
-}
-
-/*
- * __wt_panic --
- *     A standard error message when we panic.
- */
-int
-__wt_panic(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((cold))
-  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
-{
-    /*
-     * !!!
-     * This function MUST handle a NULL WT_SESSION_IMPL handle.
-     *
-     * If the connection has already panicked, just return the error.
-     */
-    if (session != NULL && F_ISSET(S2C(session), WT_CONN_PANIC))
-        return (WT_PANIC);
-
-    /*
-     * Call the error callback function before setting the connection's panic flag, so applications
-     * can trace the failing thread before being flooded with panic returns from API calls.
-     */
-    __wt_err(session, WT_PANIC, "the process must exit and restart");
-
-/*
- * Confusing #ifdef structure because gcc/clang knows the abort call won't return, and Visual Studio
- * doesn't.
- */
-#if defined(HAVE_DIAGNOSTIC)
-    __wt_abort(session); /* Drop core if testing. */
-                         /* NOTREACHED */
-#endif
-#if !defined(HAVE_DIAGNOSTIC) || defined(_WIN32)
-    /*
-     * !!!
-     * This function MUST handle a NULL WT_SESSION_IMPL handle.
-     *
-     * Panic the connection;
-     */
-    if (session != NULL)
-        F_SET(S2C(session), WT_CONN_PANIC);
-
-    /*
-     * Chaos reigns within. Reflect, repent, and reboot. Order shall return.
-     */
-    return (WT_PANIC);
-#endif
-}
-
-/*
- * __wt_illegal_value_func --
- *     A standard error message when we detect an illegal value.
- */
-int
-__wt_illegal_value_func(WT_SESSION_IMPL *session, uintmax_t v, const char *func, int line)
-  WT_GCC_FUNC_ATTRIBUTE((cold)) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
-{
-    __wt_err_func(session, EINVAL, func, line, "%s: 0x%" PRIxMAX,
-      "encountered an illegal file format or internal value", v);
-    return (__wt_panic(session));
 }
 
 /*

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -136,8 +136,8 @@ __wt_gen_drain(WT_SESSION_IMPL *session, int which, uint64_t generation)
 
             /* If we're waiting on ourselves, we're deadlocked. */
             if (session == s) {
-                WT_ASSERT(session, session != s);
-                WT_IGNORE_RET(__wt_panic(session));
+                WT_IGNORE_RET(__wt_panic(session, WT_PANIC, "self-deadlock"));
+                return;
             }
 
             /*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -210,7 +210,7 @@ __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
      * A serious error, we should always find the hazard pointer. Panic, because using a page we
      * didn't have pinned down implies corruption.
      */
-    WT_PANIC_RET(session, EINVAL, "session %p: clear hazard pointer: %p: not found",
+    WT_RET_PANIC(session, EINVAL, "session %p: clear hazard pointer: %p: not found",
       (void *)session, (void *)ref);
 }
 

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -232,7 +232,7 @@ err:
     group->min = new_min;
     WT_TRET(__wt_thread_group_destroy(session, group));
 
-    WT_PANIC_RET(session, ret, "Error while resizing thread group");
+    WT_RET_PANIC(session, ret, "Error while resizing thread group");
 }
 
 /*

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -39,7 +39,7 @@ err:
         ret = thread->stop_func(session, thread);
 
     if (ret != 0 && F_ISSET(thread, WT_THREAD_PANIC_FAIL))
-        WT_PANIC_MSG(session, ret, "Unrecoverable utility thread error");
+        WT_IGNORE_RET(__wt_panic(session, ret, "Unrecoverable utility thread error"));
 
     /*
      * The three cases when threads are expected to stop are:

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1144,7 +1144,7 @@ err:
      * a prepared transaction.
      */
     if (prepare)
-        WT_PANIC_RET(session, ret, "failed to commit prepared transaction, failing the system");
+        WT_RET_PANIC(session, ret, "failed to commit prepared transaction, failing the system");
 
     WT_TRET(__wt_txn_rollback(session, cfg));
     return (ret);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -645,7 +645,7 @@ __txn_search_prepared_op(
     case WT_TXN_OP_REF_DELETE:
     case WT_TXN_OP_TRUNCATE_COL:
     case WT_TXN_OP_TRUNCATE_ROW:
-        WT_RET_ASSERT(session, false, WT_PANIC, "invalid prepared operation update type");
+        WT_RET_PANIC_ASSERT(session, false, WT_PANIC, "invalid prepared operation update type");
         break;
     }
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -424,7 +424,7 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
     }
 
     if (r->files[fileid].uri != NULL)
-        WT_PANIC_RET(r->session, WT_PANIC,
+        WT_RET_PANIC(r->session, WT_PANIC,
           "metadata corruption: files %s and %s have the same "
           "file ID %u",
           uri, r->files[fileid].uri, fileid);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -846,7 +846,7 @@ __rollback_to_stable_btree(WT_SESSION_IMPL *session, wt_timestamp_t rollback_tim
      */
     if (__wt_btree_immediately_durable(session)) {
         if (btree->id >= conn->stable_rollback_maxfile)
-            WT_PANIC_RET(session, EINVAL, "btree file ID %" PRIu32 " larger than max %" PRIu32,
+            WT_RET_PANIC(session, EINVAL, "btree file ID %" PRIu32 " larger than max %" PRIu32,
               btree->id, conn->stable_rollback_maxfile);
         return (0);
     }


### PR DESCRIPTION
Sue, Keith, Alex: since you folks have all thought hard about `WT_ERR/WT_RET` and friends recently, I've asked you to review this one.

The bug fix is that we need to ensure that when we panic the system, the underlying panic routines are called, that is, it's not sufficient to just return `WT_PANIC` out of a random function.

I tried to clean things up and get the naming in sync. It's not great, but I think it's better.

I didn't find a way to make it less likely the same problems will come back in the future, I couldn't come up with any ideas that didn't require hiding the `WT_PANIC` error return, and that got ugly fast. Let me know if you've got something better!