### PR TITLE
WT-5801 DO NOT MERGE: this removes disk flushing for Windows.

### DIFF
--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -344,6 +344,8 @@ __win_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
     if (win_fh->filehandle == INVALID_HANDLE_VALUE)
         return (0);
 
+/* XXX - disable windows FlushFileBuffers to see the effect on test run times. */
+#define FlushFileBuffers(x)	(TRUE)
     if (FlushFileBuffers(win_fh->filehandle) == FALSE) {
         windows_error = __wt_getlasterror();
         ret = __wt_map_windows_error(windows_error);


### PR DESCRIPTION
I'm just running this to see now long the pull request test runs on Windows.  If it is hugely less, we might investigate a way to inject disabling of FlushFileBuffers during testing, like we disable fflush on Linux via eatmydata.