### PR TITLE
WT-6070 Coverity: Copy paste error

### DIFF
--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -175,15 +175,8 @@ wts_load(void)
                 g.c_delete_pct += g.c_insert_pct - 5;
                 g.c_insert_pct = 5;
             }
-            if (g.c_delete_pct < 20) {
-                g.c_delete_pct += g.c_write_pct / 2;
-                g.c_write_pct = g.c_write_pct / 2;
-            }
-            if (g.c_delete_pct < 20) {
-                g.c_delete_pct += g.c_modify_pct / 2;
-                g.c_write_pct = g.c_modify_pct / 2;
-            }
-            break;
+            g.c_delete_pct += g.c_write_pct / 2;
+            g.c_write_pct = g.c_write_pct / 2;
         }
     }
 


### PR DESCRIPTION
@keithbostic 
This is the diff that was pasted in the ticket description. I don't understand the intention behind that original snippet or the fix associated with it. If you could explain, that'd be helpful.