### PR TITLE
WT-5841 Set the data corruption flag if we find history store issues.

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1308,11 +1308,13 @@ __verify_history_store_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, uint32
         found = cbt->compare == 0;
         WT_ERR(__cursor_reset(cbt));
 
-        if (!found)
+        if (!found) {
+            F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
             WT_ERR_PANIC(session, WT_PANIC,
               "the associated history store key %s was not found in the data store %s",
               __wt_buf_set_printable(session, hs_key->data, hs_key->size, prev_hs_key),
               session->dhandle->name);
+        }
 
         /* Swap current/previous buffers. */
         tmp = hs_key;
@@ -1412,11 +1414,13 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
          * first key of a new btree id.
          */
         WT_ERR(cursor->get_key(cursor, &btree_id, hs_key, &hs_start_ts, &hs_counter));
-        if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0)
+        if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0) {
+            F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
             WT_ERR_PANIC(session, WT_PANIC,
               "Unable to find btree id %" PRIu32
               " in the metadata file for the associated history store key %s",
               btree_id, __wt_buf_set_printable(session, hs_key->data, hs_key->size, buf));
+        }
         WT_ERR(__wt_open_cursor(session, uri_data, NULL, NULL, &data_cursor));
         F_SET(data_cursor, WT_CURSOR_RAW_OK);
         ret = __verify_history_store_id(session, (WT_CURSOR_BTREE *)data_cursor, btree_id);


### PR DESCRIPTION
This will allow wiredtiger_open to return WT_TRY_SALVAGE.