### PR TITLE
WT-5697 Fix incremental backup with schema operations. (#5565) (v4.2 backport)

### DIFF
--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -58,9 +58,8 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
  */
 static bool slow_incremental = false;
 
-/* TODO: rename and drop are not currently working, they give resource busy. */
-static bool do_rename = false;
-static bool do_drop = false;
+static bool do_drop = true;
+static bool do_rename = true;
 
 #define VERBOSE(level, fmt, ...)      \
     do {                              \


### PR DESCRIPTION
* WT-5697 Fix incremental backup with schema operations.

* Whitespace

* Only need to clear cursor caching around open call.

* Remove old comment. Alphabetize.

(cherry picked from commit 4a3bbfa97835c6dba98ae03aa1566a708a552bde)