### PR TITLE
WT-5914 Only configure log-incremental backup if archiving is off in test/format (V4.2 backport)

### DIFF
--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1082,14 +1082,16 @@ struct __wt_session {
 	 * this setting manages the granularity of how WiredTiger maintains modification maps
 	 * internally.  The larger the granularity\, the smaller amount of information WiredTiger
 	 * need to maintain., an integer between 1MB and 2GB; default \c 16MB.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;src_id, a string that identifies a previous checkpoint
-	 * backup source as the source of this incremental backup.  This identifier must have
-	 * already been created by use of the 'this_id' configuration in an earlier backup.  A
-	 * source id is required to begin an incremental backup., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a string that identifies the current system
-	 * state as a future backup source for an incremental backup via 'src_id'. This identifier
-	 * is required when opening an incremental backup cursor and an error will be returned if
-	 * one is not provided., a string; default empty.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;src_id, a string that identifies a previous checkpoint backup source as the
+	 * source of this incremental backup.  This identifier must have already been created by use
+	 * of the 'this_id' configuration in an earlier backup.  A source id is required to begin an
+	 * incremental backup., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a
+	 * string that identifies the current system state as a future backup source for an
+	 * incremental backup via 'src_id'. This identifier is required when opening an incremental
+	 * backup cursor and an error will be returned if one is not provided., a string; default
+	 * empty.}
 	 * @config{ ),,}
 	 * @config{next_random, configure the cursor to return a pseudo-random record from the
 	 * object when the WT_CURSOR::next method is called; valid only for row-store cursors.  See
@@ -1253,9 +1255,10 @@ struct __wt_session {
 	 * clear text\, and thus is available when the wiredtiger database is reopened.  On the
 	 * first use of a (name\, keyid) combination\, the WT_ENCRYPTOR::customize function is
 	 * called with the keyid as an argument., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, Permitted values are \c "none" or custom encryption
-	 * engine name created with WT_CONNECTION::add_encryptor.  See @ref encryption for more
-	 * information., a string; default \c none.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;name, Permitted values are \c "none" or custom encryption engine name created
+	 * with WT_CONNECTION::add_encryptor.  See @ref encryption for more information., a string;
+	 * default \c none.}
 	 * @config{ ),,}
 	 * @config{exclusive, fail if the object exists.  When false (the default)\, if the object
 	 * exists\, check that its settings match the specified configuration., a boolean flag;
@@ -1322,14 +1325,17 @@ struct __wt_session {
 	 * default \c true.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom, create bloom filters on LSM tree
 	 * chunks as they are merged., a boolean flag; default \c true.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_bit_count, the number of bits used per item for LSM
-	 * bloom filters., an integer between 2 and 1000; default \c 16.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_config, config string used when creating Bloom
-	 * filter files\, passed to WT_SESSION::create., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_hash_count, the number of hash values per item used
-	 * for LSM bloom filters., an integer between 2 and 100; default \c 8.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_oldest, create a bloom filter on the oldest LSM
-	 * tree chunk.  Only supported if bloom filters are enabled., a boolean flag; default \c
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;bloom_bit_count, the number of bits used per item for LSM bloom filters., an
+	 * integer between 2 and 1000; default \c 16.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_config,
+	 * config string used when creating Bloom filter files\, passed to WT_SESSION::create., a
+	 * string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_hash_count, the number of
+	 * hash values per item used for LSM bloom filters., an integer between 2 and 100; default
+	 * \c 8.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_oldest, create a bloom filter on the oldest
+	 * LSM tree chunk.  Only supported if bloom filters are enabled., a boolean flag; default \c
 	 * false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_count_limit, the maximum number of chunks
 	 * to allow in an LSM tree.  This option automatically times out old data.  As new chunks
@@ -1348,17 +1354,19 @@ struct __wt_session {
 	 * below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix, custom data
 	 * source prefix instead of \c "file"., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_generation, merge
-	 * generation at which the custom data source is used (zero indicates no custom data
-	 * source)., an integer between 0 and 10; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;suffix, custom data source suffix
-	 * instead of \c ".lsm"., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_generation, merge generation at which the custom data
+	 * source is used (zero indicates no custom data source)., an integer between 0 and 10;
+	 * default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;suffix, custom
+	 * data source suffix instead of \c ".lsm"., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge_max, the maximum number of chunks to include in a
 	 * merge operation., an integer between 2 and 100; default \c 15.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge_min, the minimum number of chunks to include in a
-	 * merge operation.  If set to 0 or 1 half the value of merge_max is used., an integer no
-	 * more than 100; default \c 0.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;merge_min, the minimum number of chunks to include in a merge operation.  If
+	 * set to 0 or 1 half the value of merge_max is used., an integer no more than 100; default
+	 * \c 0.}
 	 * @config{ ),,}
 	 * @config{memory_page_image_max, the maximum in-memory page image represented by a single
 	 * storage block.  Depending on compression efficiency\, compression can create storage
@@ -1974,8 +1982,9 @@ struct __wt_session {
 	 * including the specified name., a string; default empty.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
 	 * names, drop specific named snapshots., a list of strings; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;to, drop all snapshots up to and including the specified
-	 * name., a string; default empty.}
+	 * @config{&nbsp;
+	 * &nbsp;&nbsp;&nbsp;to, drop all snapshots up to and including the specified name., a
+	 * string; default empty.}
 	 * @config{ ),,}
 	 * @config{include_updates, make updates from the current transaction visible to users of
 	 * the named snapshot.  Transactions started with such a named snapshot are restricted to
@@ -2150,11 +2159,12 @@ struct __wt_connection {
 	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, enable
 	 * asynchronous operation., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;ops_max, maximum number of expected simultaneous
-	 * asynchronous operations., an integer between 1 and 4096; default \c 1024.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number of worker threads to service
-	 * asynchronous requests.  Each worker thread uses a session from the configured
-	 * session_max., an integer between 1 and 20; default \c 2.}
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;ops_max, maximum number of expected simultaneous asynchronous operations., an
+	 * integer between 1 and 4096; default \c 1024.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads,
+	 * the number of worker threads to service asynchronous requests.  Each worker thread uses a
+	 * session from the configured session_max., an integer between 1 and 20; default \c 2.}
 	 * @config{ ),,}
 	 * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will
 	 * wait for space to be available in cache before giving up.  Default will wait forever., an
@@ -2186,15 +2196,15 @@ struct __wt_connection {
 	 * value will use a minimum of the log file size.  A database can configure both log_size
 	 * and wait to set an upper bound for checkpoints; setting this value above 0 configures
 	 * periodic checkpoints., an integer between 0 and 2GB; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to wait between each checkpoint; setting
-	 * this value above 0 configures periodic checkpoints., an integer between 0 and 100000;
-	 * default \c 0.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;wait, seconds to wait between each checkpoint; setting this value above 0
+	 * configures periodic checkpoints., an integer between 0 and 100000; default \c 0.}
 	 * @config{ ),,}
 	 * @config{compatibility = (, set compatibility version of database.  Changing the
 	 * compatibility version requires that there are no active operations for the duration of
 	 * the call., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release version string., a string;
-	 * default empty.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;release, compatibility release version string., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{debug_mode = (, control the settings of various extended debugging features., a
 	 * set of related configuration options defined below.}
@@ -2211,19 +2221,21 @@ struct __wt_connection {
 	 * to change skew to force lookaside eviction to happen more aggressively.  This includes
 	 * but is not limited to not skewing newest\, not favoring leaf pages\, and modifying the
 	 * eviction score mechanism., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_exact, if true\, reallocation of memory will only
-	 * provide the exact amount requested.  This will help with spotting memory allocation
-	 * issues more easily., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;realloc_exact, if true\, reallocation of memory will only provide the exact amount
+	 * requested.  This will help with spotting memory allocation issues more easily., a boolean
+	 * flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a
+	 * WT_ROLLBACK error from a transaction operation about every Nth operation to simulate a
+	 * collision., an integer between 0 and 10M; default \c 0.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * rollback_error, return a WT_ROLLBACK error from a transaction operation about every Nth
-	 * operation to simulate a collision., an integer between 0 and 10M; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;slow_checkpoint, if true\, slow down checkpoint creation
-	 * by slowing down internal page processing., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write transaction related
-	 * information to the log for all operations\, even operations for tables with logging
-	 * turned off.  This setting introduces a log format change that may break older versions of
-	 * WiredTiger.  These operations are informational and skipped in recovery., a boolean flag;
-	 * default \c false.}
+	 * slow_checkpoint, if true\, slow down checkpoint creation by slowing down internal page
+	 * processing., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * table_logging, if true\, write transaction related information to the log for all
+	 * operations\, even operations for tables with logging turned off.  This setting introduces
+	 * a log format change that may break older versions of WiredTiger.  These operations are
+	 * informational and skipped in recovery., a boolean flag; default \c false.}
 	 * @config{ ),,}
 	 * @config{error_prefix, prefix string for error messages., a string; default empty.}
 	 * @config{eviction = (, eviction configuration options., a set of related configuration
@@ -2264,12 +2276,13 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
 	 * close_handle_minimum, number of handles open before the file manager will look for
 	 * handles to close., an integer greater than or equal to 0; default \c 250.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a file handle
-	 * needs to be idle before attempting to close it.  A setting of 0 means that idle handles
-	 * are not closed., an integer between 0 and 100000; default \c 30.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_scan_interval, interval in seconds at which to
-	 * check for files that are inactive and close them., an integer between 1 and 100000;
-	 * default \c 10.}
+	 * @config{&nbsp;
+	 * &nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a file handle needs to be
+	 * idle before attempting to close it.  A setting of 0 means that idle handles are not
+	 * closed., an integer between 0 and 100000; default \c 30.}
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;close_scan_interval, interval in seconds at which to check for files that are
+	 * inactive and close them., an integer between 1 and 100000; default \c 10.}
 	 * @config{ ),,}
 	 * @config{io_capacity = (, control how many bytes per second are written and read.
 	 * Exceeding the capacity results in throttling., a set of related configuration options
@@ -2288,10 +2301,10 @@ struct __wt_connection {
 	 * non-zero\, schedule writes for dirty blocks belonging to the log in the system buffer
 	 * cache after that percentage of the log has been written into the buffer cache without an
 	 * intervening file sync., an integer between 0 and 100; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag;
-	 * default \c true.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into
-	 * log files., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c true.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files., a
+	 * boolean flag; default \c false.}
 	 * @config{ ),,}
 	 * @config{lsm_manager = (, configure database wide options for LSM tree management.  The
 	 * LSM manager is started automatically the first time an LSM tree is opened.  The LSM
@@ -2327,17 +2340,19 @@ struct __wt_connection {
 	 * below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared cache is
 	 * redistributed., an integer between 1MB and 10TB; default \c 10MB.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is shared between
-	 * databases or \c "none" when no shared cache is configured., a string; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this database can be
-	 * allocated from the shared cache.  Defaults to the entire shared cache size., an integer;
-	 * default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is
-	 * guaranteed to have available from the shared cache.  This setting is per database.
-	 * Defaults to the chunk size., an integer; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * size, maximum memory to allocate for the shared cache.  Setting this will update the
-	 * value if one is already set., an integer between 1MB and 10TB; default \c 500MB.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;name, the name of a cache that is shared between databases or \c "none" when
+	 * no shared cache is configured., a string; default \c none.}
+	 * @config{&nbsp;&nbsp;&nbsp;
+	 * &nbsp;quota, maximum size of cache this database can be allocated from the shared cache.
+	 * Defaults to the entire shared cache size., an integer; default \c 0.}
+	 * @config{&nbsp;
+	 * &nbsp;&nbsp;&nbsp;reserve, amount of cache this database is guaranteed to have available
+	 * from the shared cache.  This setting is per database.  Defaults to the chunk size., an
+	 * integer; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate
+	 * for the shared cache.  Setting this will update the value if one is already set., an
+	 * integer between 1MB and 10TB; default \c 500MB.}
 	 * @config{ ),,}
 	 * @config{statistics, Maintain database statistics\, which may impact performance.
 	 * Choosing "all" maintains all statistics regardless of cost\, "fast" maintains a subset of
@@ -2358,18 +2373,19 @@ struct __wt_connection {
 	 * a boolean flag; default \c false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;on_close, log
 	 * statistics on database close., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;sources, if non-empty\, include statistics for the list
-	 * of data source URIs\, if they are open at the time of the statistics logging.  The list
-	 * may include URIs matching a single data source ("table:mytable")\, or a URI matching all
-	 * data sources of a particular type ("table:")., a list of strings; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;timestamp, a timestamp prepended to each log record\, may
-	 * contain strftime conversion specifications\, when \c json is configured\, defaults to \c
-	 * "%FT%Y.000Z"., a string; default \c "%b %d %H:%M:%S".}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * wait, seconds to wait between each write of the log records; setting this value above 0
-	 * configures statistics logging., an integer between 0 and 100000; default \c 0.}
-	 * @config{
-	 * ),,}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;sources, if non-empty\, include statistics for the list of data source URIs\,
+	 * if they are open at the time of the statistics logging.  The list may include URIs
+	 * matching a single data source ("table:mytable")\, or a URI matching all data sources of a
+	 * particular type ("table:")., a list of strings; default empty.}
+	 * @config{&nbsp;&nbsp;
+	 * &nbsp;&nbsp;timestamp, a timestamp prepended to each log record\, may contain strftime
+	 * conversion specifications\, when \c json is configured\, defaults to \c "%FT%Y.000Z"., a
+	 * string; default \c "%b %d %H:%M:%S".}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to
+	 * wait between each write of the log records; setting this value above 0 configures
+	 * statistics logging., an integer between 0 and 100000; default \c 0.}
+	 * @config{ ),,}
 	 * @config{verbose, enable messages for various events.  Options are given as a list\, such
 	 * as <code>"verbose=[evictserver\,read]"</code>., a list\, with values chosen from the
 	 * following options: \c "api"\, \c "backup"\, \c "block"\, \c "checkpoint"\, \c
@@ -2915,8 +2931,9 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a
  * file handle needs to be idle before attempting to close it.  A setting of 0 means that idle
  * handles are not closed., an integer between 0 and 100000; default \c 30.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_scan_interval, interval in seconds at which to check for
- * files that are inactive and close them., an integer between 1 and 100000; default \c 10.}
+ * @config{&nbsp;&nbsp;
+ * &nbsp;&nbsp;close_scan_interval, interval in seconds at which to check for files that are
+ * inactive and close them., an integer between 1 and 100000; default \c 10.}
  * @config{ ),,}
  * @config{in_memory, keep data in-memory only.  See @ref in_memory for more information., a boolean
  * flag; default \c false.}
@@ -2929,10 +2946,10 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;archive, automatically archive unneeded log files., a boolean
- * flag; default \c true.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for
- * log records.  Permitted values are \c "none" or custom compression engine name created with
+ * @config{&nbsp;&nbsp;&nbsp;
+ * &nbsp;archive, automatically archive unneeded log files., a boolean flag; default \c true.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for log records.  Permitted
+ * values are \c "none" or custom compression engine name created with
  * WT_CONNECTION::add_compressor.  If WiredTiger has builtin support for \c "lz4"\, \c "snappy"\, \c
  * "zlib" or \c "zstd" compression\, these names are also available.  See @ref compression for more
  * information., a string; default \c none.}
@@ -2940,20 +2957,22 @@ struct __wt_connection {
  * subsystem., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;file_max, the
  * maximum size of log files., an integer between 100KB and 2GB; default \c 100MB.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\, as
- * a percentage of the log's \c file_max.  If non-zero\, schedule writes for dirty blocks belonging
- * to the log in the system buffer cache after that percentage of the log has been written into the
- * buffer cache without an intervening file sync., an integer between 0 and 100; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the name of a directory into which log files are written.
- * The directory must already exist.  If the value is not an absolute path\, the path is relative to
- * the database home (see @ref absolute_path for more information)., a string; default \c ".".}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c
- * true.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if recovery needs to run
- * after an unclean shutdown., a string\, chosen from the following options: \c "error"\, \c "on";
- * default \c on.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files.,
- * a boolean flag; default \c false.}
+ * @config{&nbsp;
+ * &nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\, as a percentage
+ * of the log's \c file_max.  If non-zero\, schedule writes for dirty blocks belonging to the log in
+ * the system buffer cache after that percentage of the log has been written into the buffer cache
+ * without an intervening file sync., an integer between 0 and 100; default \c 0.}
+ * @config{&nbsp;
+ * &nbsp;&nbsp;&nbsp;path, the name of a directory into which log files are written.  The directory
+ * must already exist.  If the value is not an absolute path\, the path is relative to the database
+ * home (see @ref absolute_path for more information)., a string; default \c ".".}
+ * @config{&nbsp;
+ * &nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c true.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if recovery needs to run after an
+ * unclean shutdown., a string\, chosen from the following options: \c "error"\, \c "on"; default \c
+ * on.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files., a boolean
+ * flag; default \c false.}
  * @config{ ),,}
  * @config{lsm_manager = (, configure database wide options for LSM tree management.  The LSM
  * manager is started automatically the first time an LSM tree is opened.  The LSM manager uses a
@@ -2998,19 +3017,20 @@ struct __wt_connection {
  * a cache_size or a shared_cache not both.  Enabling a shared cache uses a session from the
  * configured session_max.  A shared cache can not have absolute values configured for cache
  * eviction settings., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared cache is redistributed., an
- * integer between 1MB and 10TB; default \c 10MB.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of
- * a cache that is shared between databases or \c "none" when no shared cache is configured., a
- * string; default \c none.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this
- * database can be allocated from the shared cache.  Defaults to the entire shared cache size., an
- * integer; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is
- * guaranteed to have available from the shared cache.  This setting is per database.  Defaults to
- * the chunk size., an integer; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
- * to allocate for the shared cache.  Setting this will update the value if one is already set., an
+ * @config{&nbsp;&nbsp;
+ * &nbsp;&nbsp;chunk, the granularity that a shared cache is redistributed., an integer between 1MB
+ * and 10TB; default \c 10MB.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is
+ * shared between databases or \c "none" when no shared cache is configured., a string; default \c
+ * none.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this database can be
+ * allocated from the shared cache.  Defaults to the entire shared cache size., an integer; default
+ * \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is guaranteed to
+ * have available from the shared cache.  This setting is per database.  Defaults to the chunk
+ * size., an integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to
+ * allocate for the shared cache.  Setting this will update the value if one is already set., an
  * integer between 1MB and 10TB; default \c 500MB.}
  * @config{ ),,}
  * @config{statistics, Maintain database statistics\, which may impact performance.  Choosing "all"
@@ -3050,9 +3070,10 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether to
  * sync the log on every commit by default\, can be overridden by the \c sync setting to
  * WT_SESSION::commit_transaction., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;method, the method used to ensure log records are stable on
- * disk\, see @ref tune_durability for more information., a string\, chosen from the following
- * options: \c "dsync"\, \c "fsync"\, \c "none"; default \c fsync.}
+ * @config{&nbsp;&nbsp;&nbsp;
+ * &nbsp;method, the method used to ensure log records are stable on disk\, see @ref tune_durability
+ * for more information., a string\, chosen from the following options: \c "dsync"\, \c "fsync"\, \c
+ * "none"; default \c fsync.}
  * @config{ ),,}
  * @config{use_environment, use the \c WIREDTIGER_CONFIG and \c WIREDTIGER_HOME environment
  * variables if the process is not running with special privileges.  See @ref home for more

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1082,16 +1082,14 @@ struct __wt_session {
 	 * this setting manages the granularity of how WiredTiger maintains modification maps
 	 * internally.  The larger the granularity\, the smaller amount of information WiredTiger
 	 * need to maintain., an integer between 1MB and 2GB; default \c 16MB.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;src_id, a string that identifies a previous checkpoint backup source as the
-	 * source of this incremental backup.  This identifier must have already been created by use
-	 * of the 'this_id' configuration in an earlier backup.  A source id is required to begin an
-	 * incremental backup., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a
-	 * string that identifies the current system state as a future backup source for an
-	 * incremental backup via 'src_id'. This identifier is required when opening an incremental
-	 * backup cursor and an error will be returned if one is not provided., a string; default
-	 * empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;src_id, a string that identifies a previous checkpoint
+	 * backup source as the source of this incremental backup.  This identifier must have
+	 * already been created by use of the 'this_id' configuration in an earlier backup.  A
+	 * source id is required to begin an incremental backup., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a string that identifies the current system
+	 * state as a future backup source for an incremental backup via 'src_id'. This identifier
+	 * is required when opening an incremental backup cursor and an error will be returned if
+	 * one is not provided., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{next_random, configure the cursor to return a pseudo-random record from the
 	 * object when the WT_CURSOR::next method is called; valid only for row-store cursors.  See
@@ -1255,10 +1253,9 @@ struct __wt_session {
 	 * clear text\, and thus is available when the wiredtiger database is reopened.  On the
 	 * first use of a (name\, keyid) combination\, the WT_ENCRYPTOR::customize function is
 	 * called with the keyid as an argument., a string; default empty.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;name, Permitted values are \c "none" or custom encryption engine name created
-	 * with WT_CONNECTION::add_encryptor.  See @ref encryption for more information., a string;
-	 * default \c none.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, Permitted values are \c "none" or custom encryption
+	 * engine name created with WT_CONNECTION::add_encryptor.  See @ref encryption for more
+	 * information., a string; default \c none.}
 	 * @config{ ),,}
 	 * @config{exclusive, fail if the object exists.  When false (the default)\, if the object
 	 * exists\, check that its settings match the specified configuration., a boolean flag;
@@ -1325,17 +1322,14 @@ struct __wt_session {
 	 * default \c true.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom, create bloom filters on LSM tree
 	 * chunks as they are merged., a boolean flag; default \c true.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;bloom_bit_count, the number of bits used per item for LSM bloom filters., an
-	 * integer between 2 and 1000; default \c 16.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_config,
-	 * config string used when creating Bloom filter files\, passed to WT_SESSION::create., a
-	 * string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_hash_count, the number of
-	 * hash values per item used for LSM bloom filters., an integer between 2 and 100; default
-	 * \c 8.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_oldest, create a bloom filter on the oldest
-	 * LSM tree chunk.  Only supported if bloom filters are enabled., a boolean flag; default \c
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_bit_count, the number of bits used per item for LSM
+	 * bloom filters., an integer between 2 and 1000; default \c 16.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_config, config string used when creating Bloom
+	 * filter files\, passed to WT_SESSION::create., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_hash_count, the number of hash values per item used
+	 * for LSM bloom filters., an integer between 2 and 100; default \c 8.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;bloom_oldest, create a bloom filter on the oldest LSM
+	 * tree chunk.  Only supported if bloom filters are enabled., a boolean flag; default \c
 	 * false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_count_limit, the maximum number of chunks
 	 * to allow in an LSM tree.  This option automatically times out old data.  As new chunks
@@ -1354,19 +1348,17 @@ struct __wt_session {
 	 * below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix, custom data
 	 * source prefix instead of \c "file"., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_generation, merge generation at which the custom data
-	 * source is used (zero indicates no custom data source)., an integer between 0 and 10;
-	 * default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;suffix, custom
-	 * data source suffix instead of \c ".lsm"., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_generation, merge
+	 * generation at which the custom data source is used (zero indicates no custom data
+	 * source)., an integer between 0 and 10; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;suffix, custom data source suffix
+	 * instead of \c ".lsm"., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge_max, the maximum number of chunks to include in a
 	 * merge operation., an integer between 2 and 100; default \c 15.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;merge_min, the minimum number of chunks to include in a merge operation.  If
-	 * set to 0 or 1 half the value of merge_max is used., an integer no more than 100; default
-	 * \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;merge_min, the minimum number of chunks to include in a
+	 * merge operation.  If set to 0 or 1 half the value of merge_max is used., an integer no
+	 * more than 100; default \c 0.}
 	 * @config{ ),,}
 	 * @config{memory_page_image_max, the maximum in-memory page image represented by a single
 	 * storage block.  Depending on compression efficiency\, compression can create storage
@@ -1982,9 +1974,8 @@ struct __wt_session {
 	 * including the specified name., a string; default empty.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
 	 * names, drop specific named snapshots., a list of strings; default empty.}
-	 * @config{&nbsp;
-	 * &nbsp;&nbsp;&nbsp;to, drop all snapshots up to and including the specified name., a
-	 * string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;to, drop all snapshots up to and including the specified
+	 * name., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{include_updates, make updates from the current transaction visible to users of
 	 * the named snapshot.  Transactions started with such a named snapshot are restricted to
@@ -2159,12 +2150,11 @@ struct __wt_connection {
 	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, enable
 	 * asynchronous operation., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;ops_max, maximum number of expected simultaneous asynchronous operations., an
-	 * integer between 1 and 4096; default \c 1024.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads,
-	 * the number of worker threads to service asynchronous requests.  Each worker thread uses a
-	 * session from the configured session_max., an integer between 1 and 20; default \c 2.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;ops_max, maximum number of expected simultaneous
+	 * asynchronous operations., an integer between 1 and 4096; default \c 1024.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads, the number of worker threads to service
+	 * asynchronous requests.  Each worker thread uses a session from the configured
+	 * session_max., an integer between 1 and 20; default \c 2.}
 	 * @config{ ),,}
 	 * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will
 	 * wait for space to be available in cache before giving up.  Default will wait forever., an
@@ -2196,15 +2186,15 @@ struct __wt_connection {
 	 * value will use a minimum of the log file size.  A database can configure both log_size
 	 * and wait to set an upper bound for checkpoints; setting this value above 0 configures
 	 * periodic checkpoints., an integer between 0 and 2GB; default \c 0.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;wait, seconds to wait between each checkpoint; setting this value above 0
-	 * configures periodic checkpoints., an integer between 0 and 100000; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to wait between each checkpoint; setting
+	 * this value above 0 configures periodic checkpoints., an integer between 0 and 100000;
+	 * default \c 0.}
 	 * @config{ ),,}
 	 * @config{compatibility = (, set compatibility version of database.  Changing the
 	 * compatibility version requires that there are no active operations for the duration of
 	 * the call., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;release, compatibility release version string., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;release, compatibility release version string., a string;
+	 * default empty.}
 	 * @config{ ),,}
 	 * @config{debug_mode = (, control the settings of various extended debugging features., a
 	 * set of related configuration options defined below.}
@@ -2221,21 +2211,19 @@ struct __wt_connection {
 	 * to change skew to force lookaside eviction to happen more aggressively.  This includes
 	 * but is not limited to not skewing newest\, not favoring leaf pages\, and modifying the
 	 * eviction score mechanism., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;realloc_exact, if true\, reallocation of memory will only provide the exact amount
-	 * requested.  This will help with spotting memory allocation issues more easily., a boolean
-	 * flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a
-	 * WT_ROLLBACK error from a transaction operation about every Nth operation to simulate a
-	 * collision., an integer between 0 and 10M; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_exact, if true\, reallocation of memory will only
+	 * provide the exact amount requested.  This will help with spotting memory allocation
+	 * issues more easily., a boolean flag; default \c false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * slow_checkpoint, if true\, slow down checkpoint creation by slowing down internal page
-	 * processing., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * table_logging, if true\, write transaction related information to the log for all
-	 * operations\, even operations for tables with logging turned off.  This setting introduces
-	 * a log format change that may break older versions of WiredTiger.  These operations are
-	 * informational and skipped in recovery., a boolean flag; default \c false.}
+	 * rollback_error, return a WT_ROLLBACK error from a transaction operation about every Nth
+	 * operation to simulate a collision., an integer between 0 and 10M; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;slow_checkpoint, if true\, slow down checkpoint creation
+	 * by slowing down internal page processing., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;table_logging, if true\, write transaction related
+	 * information to the log for all operations\, even operations for tables with logging
+	 * turned off.  This setting introduces a log format change that may break older versions of
+	 * WiredTiger.  These operations are informational and skipped in recovery., a boolean flag;
+	 * default \c false.}
 	 * @config{ ),,}
 	 * @config{error_prefix, prefix string for error messages., a string; default empty.}
 	 * @config{eviction = (, eviction configuration options., a set of related configuration
@@ -2276,13 +2264,12 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
 	 * close_handle_minimum, number of handles open before the file manager will look for
 	 * handles to close., an integer greater than or equal to 0; default \c 250.}
-	 * @config{&nbsp;
-	 * &nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a file handle needs to be
-	 * idle before attempting to close it.  A setting of 0 means that idle handles are not
-	 * closed., an integer between 0 and 100000; default \c 30.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;close_scan_interval, interval in seconds at which to check for files that are
-	 * inactive and close them., an integer between 1 and 100000; default \c 10.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a file handle
+	 * needs to be idle before attempting to close it.  A setting of 0 means that idle handles
+	 * are not closed., an integer between 0 and 100000; default \c 30.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_scan_interval, interval in seconds at which to
+	 * check for files that are inactive and close them., an integer between 1 and 100000;
+	 * default \c 10.}
 	 * @config{ ),,}
 	 * @config{io_capacity = (, control how many bytes per second are written and read.
 	 * Exceeding the capacity results in throttling., a set of related configuration options
@@ -2301,10 +2288,10 @@ struct __wt_connection {
 	 * non-zero\, schedule writes for dirty blocks belonging to the log in the system buffer
 	 * cache after that percentage of the log has been written into the buffer cache without an
 	 * intervening file sync., an integer between 0 and 100; default \c 0.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c true.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files., a
-	 * boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag;
+	 * default \c true.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into
+	 * log files., a boolean flag; default \c false.}
 	 * @config{ ),,}
 	 * @config{lsm_manager = (, configure database wide options for LSM tree management.  The
 	 * LSM manager is started automatically the first time an LSM tree is opened.  The LSM
@@ -2340,19 +2327,17 @@ struct __wt_connection {
 	 * below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared cache is
 	 * redistributed., an integer between 1MB and 10TB; default \c 10MB.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;name, the name of a cache that is shared between databases or \c "none" when
-	 * no shared cache is configured., a string; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;
-	 * &nbsp;quota, maximum size of cache this database can be allocated from the shared cache.
-	 * Defaults to the entire shared cache size., an integer; default \c 0.}
-	 * @config{&nbsp;
-	 * &nbsp;&nbsp;&nbsp;reserve, amount of cache this database is guaranteed to have available
-	 * from the shared cache.  This setting is per database.  Defaults to the chunk size., an
-	 * integer; default \c 0.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate
-	 * for the shared cache.  Setting this will update the value if one is already set., an
-	 * integer between 1MB and 10TB; default \c 500MB.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is shared between
+	 * databases or \c "none" when no shared cache is configured., a string; default \c none.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this database can be
+	 * allocated from the shared cache.  Defaults to the entire shared cache size., an integer;
+	 * default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is
+	 * guaranteed to have available from the shared cache.  This setting is per database.
+	 * Defaults to the chunk size., an integer; default \c 0.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * size, maximum memory to allocate for the shared cache.  Setting this will update the
+	 * value if one is already set., an integer between 1MB and 10TB; default \c 500MB.}
 	 * @config{ ),,}
 	 * @config{statistics, Maintain database statistics\, which may impact performance.
 	 * Choosing "all" maintains all statistics regardless of cost\, "fast" maintains a subset of
@@ -2373,19 +2358,18 @@ struct __wt_connection {
 	 * a boolean flag; default \c false.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;on_close, log
 	 * statistics on database close., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;sources, if non-empty\, include statistics for the list of data source URIs\,
-	 * if they are open at the time of the statistics logging.  The list may include URIs
-	 * matching a single data source ("table:mytable")\, or a URI matching all data sources of a
-	 * particular type ("table:")., a list of strings; default empty.}
-	 * @config{&nbsp;&nbsp;
-	 * &nbsp;&nbsp;timestamp, a timestamp prepended to each log record\, may contain strftime
-	 * conversion specifications\, when \c json is configured\, defaults to \c "%FT%Y.000Z"., a
-	 * string; default \c "%b %d %H:%M:%S".}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to
-	 * wait between each write of the log records; setting this value above 0 configures
-	 * statistics logging., an integer between 0 and 100000; default \c 0.}
-	 * @config{ ),,}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;sources, if non-empty\, include statistics for the list
+	 * of data source URIs\, if they are open at the time of the statistics logging.  The list
+	 * may include URIs matching a single data source ("table:mytable")\, or a URI matching all
+	 * data sources of a particular type ("table:")., a list of strings; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;timestamp, a timestamp prepended to each log record\, may
+	 * contain strftime conversion specifications\, when \c json is configured\, defaults to \c
+	 * "%FT%Y.000Z"., a string; default \c "%b %d %H:%M:%S".}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * wait, seconds to wait between each write of the log records; setting this value above 0
+	 * configures statistics logging., an integer between 0 and 100000; default \c 0.}
+	 * @config{
+	 * ),,}
 	 * @config{verbose, enable messages for various events.  Options are given as a list\, such
 	 * as <code>"verbose=[evictserver\,read]"</code>., a list\, with values chosen from the
 	 * following options: \c "api"\, \c "backup"\, \c "block"\, \c "checkpoint"\, \c
@@ -2931,9 +2915,8 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_idle_time, amount of time in seconds a
  * file handle needs to be idle before attempting to close it.  A setting of 0 means that idle
  * handles are not closed., an integer between 0 and 100000; default \c 30.}
- * @config{&nbsp;&nbsp;
- * &nbsp;&nbsp;close_scan_interval, interval in seconds at which to check for files that are
- * inactive and close them., an integer between 1 and 100000; default \c 10.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;close_scan_interval, interval in seconds at which to check for
+ * files that are inactive and close them., an integer between 1 and 100000; default \c 10.}
  * @config{ ),,}
  * @config{in_memory, keep data in-memory only.  See @ref in_memory for more information., a boolean
  * flag; default \c false.}
@@ -2946,10 +2929,10 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;&nbsp;
- * &nbsp;archive, automatically archive unneeded log files., a boolean flag; default \c true.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for log records.  Permitted
- * values are \c "none" or custom compression engine name created with
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;archive, automatically archive unneeded log files., a boolean
+ * flag; default \c true.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for
+ * log records.  Permitted values are \c "none" or custom compression engine name created with
  * WT_CONNECTION::add_compressor.  If WiredTiger has builtin support for \c "lz4"\, \c "snappy"\, \c
  * "zlib" or \c "zstd" compression\, these names are also available.  See @ref compression for more
  * information., a string; default \c none.}
@@ -2957,22 +2940,20 @@ struct __wt_connection {
  * subsystem., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;file_max, the
  * maximum size of log files., an integer between 100KB and 2GB; default \c 100MB.}
- * @config{&nbsp;
- * &nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\, as a percentage
- * of the log's \c file_max.  If non-zero\, schedule writes for dirty blocks belonging to the log in
- * the system buffer cache after that percentage of the log has been written into the buffer cache
- * without an intervening file sync., an integer between 0 and 100; default \c 0.}
- * @config{&nbsp;
- * &nbsp;&nbsp;&nbsp;path, the name of a directory into which log files are written.  The directory
- * must already exist.  If the value is not an absolute path\, the path is relative to the database
- * home (see @ref absolute_path for more information)., a string; default \c ".".}
- * @config{&nbsp;
- * &nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c true.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if recovery needs to run after an
- * unclean shutdown., a string\, chosen from the following options: \c "error"\, \c "on"; default \c
- * on.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files., a boolean
- * flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\, as
+ * a percentage of the log's \c file_max.  If non-zero\, schedule writes for dirty blocks belonging
+ * to the log in the system buffer cache after that percentage of the log has been written into the
+ * buffer cache without an intervening file sync., an integer between 0 and 100; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the name of a directory into which log files are written.
+ * The directory must already exist.  If the value is not an absolute path\, the path is relative to
+ * the database home (see @ref absolute_path for more information)., a string; default \c ".".}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c
+ * true.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if recovery needs to run
+ * after an unclean shutdown., a string\, chosen from the following options: \c "error"\, \c "on";
+ * default \c on.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files.,
+ * a boolean flag; default \c false.}
  * @config{ ),,}
  * @config{lsm_manager = (, configure database wide options for LSM tree management.  The LSM
  * manager is started automatically the first time an LSM tree is opened.  The LSM manager uses a
@@ -3017,20 +2998,19 @@ struct __wt_connection {
  * a cache_size or a shared_cache not both.  Enabling a shared cache uses a session from the
  * configured session_max.  A shared cache can not have absolute values configured for cache
  * eviction settings., a set of related configuration options defined below.}
- * @config{&nbsp;&nbsp;
- * &nbsp;&nbsp;chunk, the granularity that a shared cache is redistributed., an integer between 1MB
- * and 10TB; default \c 10MB.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of a cache that is
- * shared between databases or \c "none" when no shared cache is configured., a string; default \c
- * none.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this database can be
- * allocated from the shared cache.  Defaults to the entire shared cache size., an integer; default
- * \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is guaranteed to
- * have available from the shared cache.  This setting is per database.  Defaults to the chunk
- * size., an integer; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to
- * allocate for the shared cache.  Setting this will update the value if one is already set., an
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk, the granularity that a shared cache is redistributed., an
+ * integer between 1MB and 10TB; default \c 10MB.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, the name of
+ * a cache that is shared between databases or \c "none" when no shared cache is configured., a
+ * string; default \c none.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;quota, maximum size of cache this
+ * database can be allocated from the shared cache.  Defaults to the entire shared cache size., an
+ * integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;reserve, amount of cache this database is
+ * guaranteed to have available from the shared cache.  This setting is per database.  Defaults to
+ * the chunk size., an integer; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory
+ * to allocate for the shared cache.  Setting this will update the value if one is already set., an
  * integer between 1MB and 10TB; default \c 500MB.}
  * @config{ ),,}
  * @config{statistics, Maintain database statistics\, which may impact performance.  Choosing "all"
@@ -3070,10 +3050,9 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether to
  * sync the log on every commit by default\, can be overridden by the \c sync setting to
  * WT_SESSION::commit_transaction., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;
- * &nbsp;method, the method used to ensure log records are stable on disk\, see @ref tune_durability
- * for more information., a string\, chosen from the following options: \c "dsync"\, \c "fsync"\, \c
- * "none"; default \c fsync.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;method, the method used to ensure log records are stable on
+ * disk\, see @ref tune_durability for more information., a string\, chosen from the following
+ * options: \c "dsync"\, \c "fsync"\, \c "none"; default \c fsync.}
  * @config{ ),,}
  * @config{use_environment, use the \c WIREDTIGER_CONFIG and \c WIREDTIGER_HOME environment
  * variables if the process is not running with special privileges.  See @ref home for more

--- a/test/format/CONFIG.stress
+++ b/test/format/CONFIG.stress
@@ -5,4 +5,5 @@ cache.minimum=20
 runs.rows=1000000:5000000
 runs.threads=4:32
 runs.timer=6:30
+runs.type=row-store
 runs=100

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -379,9 +379,9 @@ backup(void *arg)
          * with named checkpoints. Wait for the checkpoint to complete, otherwise backups might be
          * starved out.
          */
-        testutil_check(pthread_rwlock_wrlock(&g.backup_lock));
+        lock_writelock(session, &g.backup_lock);
         if (g.workers_finished) {
-            testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+            lock_writeunlock(session, &g.backup_lock);
             break;
         }
 
@@ -471,7 +471,7 @@ backup(void *arg)
             testutil_check(session->truncate(session, "log:", backup_cursor, NULL, NULL));
 
         testutil_check(backup_cursor->close(backup_cursor));
-        testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+        lock_writeunlock(session, &g.backup_lock);
         active_files_sort(active_now);
         active_files_remove_missing(active_prev, active_now);
         active_prev = active_now;

--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -59,7 +59,7 @@ bulk_commit_transaction(WT_SESSION *session)
     testutil_check(session->commit_transaction(session, buf));
 
     /* Update the oldest timestamp, otherwise updates are pinned in memory. */
-    timestamp_once();
+    timestamp_once(session);
 }
 
 /*
@@ -133,20 +133,20 @@ wts_load(void)
             if (!is_bulk)
                 cursor->set_key(cursor, keyno);
             cursor->set_value(cursor, *(uint8_t *)value.data);
-            logop(session, "%-10s %" PRIu64 " {0x%02" PRIx8 "}", "bulk", keyno,
+            logop(session, "%-10s %" PRIu32 " {0x%02" PRIx8 "}", "bulk", keyno,
               ((uint8_t *)value.data)[0]);
             break;
         case VAR:
             if (!is_bulk)
                 cursor->set_key(cursor, keyno);
             cursor->set_value(cursor, &value);
-            logop(session, "%-10s %" PRIu64 " {%.*s}", "bulk", keyno, (int)value.size,
+            logop(session, "%-10s %" PRIu32 " {%.*s}", "bulk", keyno, (int)value.size,
               (char *)value.data);
             break;
         case ROW:
             cursor->set_key(cursor, &key);
             cursor->set_value(cursor, &value);
-            logop(session, "%-10s %" PRIu64 " {%.*s}, {%.*s}", "bulk", keyno, (int)key.size,
+            logop(session, "%-10s %" PRIu32 " {%.*s}, {%.*s}", "bulk", keyno, (int)key.size,
               (char *)key.data, (int)value.size, (char *)value.data);
             break;
         }
@@ -175,15 +175,8 @@ wts_load(void)
                 g.c_delete_pct += g.c_insert_pct - 5;
                 g.c_insert_pct = 5;
             }
-            if (g.c_delete_pct < 20) {
-                g.c_delete_pct += g.c_write_pct / 2;
-                g.c_write_pct = g.c_write_pct / 2;
-            }
-            if (g.c_delete_pct < 20) {
-                g.c_delete_pct += g.c_modify_pct / 2;
-                g.c_write_pct = g.c_modify_pct / 2;
-            }
-            break;
+            g.c_delete_pct += g.c_write_pct / 2;
+            g.c_write_pct = g.c_write_pct / 2;
         }
     }
 

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -85,7 +85,7 @@ checkpoint(void *arg)
                  * few names to test multiple named snapshots in
                  * the system.
                  */
-                ret = pthread_rwlock_trywrlock(&g.backup_lock);
+                ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     testutil_check(__wt_snprintf(
@@ -98,7 +98,7 @@ checkpoint(void *arg)
                 /*
                  * 5% drop all named snapshots.
                  */
-                ret = pthread_rwlock_trywrlock(&g.backup_lock);
+                ret = lock_try_writelock(session, &g.backup_lock);
                 if (ret == 0) {
                     backup_locked = true;
                     ckpt_config = "drop=(all)";
@@ -110,7 +110,7 @@ checkpoint(void *arg)
         testutil_check(session->checkpoint(session, ckpt_config));
 
         if (backup_locked)
-            testutil_check(pthread_rwlock_unlock(&g.backup_lock));
+            lock_writeunlock(session, &g.backup_lock);
 
         secs = mmrand(NULL, 5, 40);
     }

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -336,6 +336,10 @@ static CONFIG c[] = {
   {"wiredtiger.config", "configuration string used to wiredtiger_open", C_IGNORE | C_STRING, 0, 0,
     0, NULL, &g.c_config_open},
 
+  /* 80% */
+  {"wiredtiger.rwlock", "if wiredtiger read/write mutexes should be used", C_BOOL, 80, 0, 0,
+    &g.c_wt_mutex, NULL},
+
   {"wiredtiger.leak_memory", "if memory should be leaked on close", C_BOOL, 0, 0, 0,
     &g.c_leak_memory, NULL},
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -158,10 +158,12 @@ operations(u_int ops_seconds, bool lastrun)
     if (!SINGLETHREADED)
         g.rand_log_stop = true;
 
-    /* Logging requires a session. */
-    if (g.logging)
-        testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
     logop(session, "%s", "=============== thread ops start");
+
+    /* Initialize locks to single-thread backups, failures, and timestamp updates. */
+    lock_init(session, &g.backup_lock);
+    lock_init(session, &g.ts_lock);
 
     /*
      * Create the per-thread structures and start the worker threads. Allocate the thread structures
@@ -295,9 +297,11 @@ operations(u_int ops_seconds, bool lastrun)
         testutil_check(__wt_thread_join(NULL, &timestamp_tid));
     g.workers_finished = false;
 
+    lock_destroy(session, &g.backup_lock);
+    lock_destroy(session, &g.ts_lock);
+
     logop(session, "%s", "=============== thread ops stop");
-    if (g.logging)
-        testutil_check(session->close(session, NULL));
+    testutil_check(session->close(session, NULL));
 
     for (i = 0; i < g.c_threads; ++i) {
         tinfo = tinfo_list[i];
@@ -372,13 +376,13 @@ begin_transaction_ts(TINFO *tinfo, u_int *iso_configp)
      *
      * Lock out the oldest timestamp update.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    lock_writelock(session, &g.ts_lock);
 
     ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(__wt_snprintf(buf, sizeof(buf), "read_timestamp=%" PRIx64, ts));
     testutil_check(session->timestamp_transaction(session, buf));
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    lock_writeunlock(session, &g.ts_lock);
 
     snap_init(tinfo, ts, false);
     logop(session, "begin snapshot read-ts=%" PRIu64 " (not repeatable)", ts);
@@ -443,7 +447,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
     ts = 0; /* -Wconditional-uninitialized */
     if (g.c_txn_timestamps) {
         /* Lock out the oldest timestamp update. */
-        testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+        lock_writelock(session, &g.ts_lock);
 
         ts = __wt_atomic_addv64(&g.timestamp, 1);
         testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
@@ -454,7 +458,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
             testutil_check(session->timestamp_transaction(session, buf));
         }
 
-        testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+        lock_writeunlock(session, &g.ts_lock);
     }
     testutil_check(session->commit_transaction(session, NULL));
 
@@ -492,7 +496,7 @@ prepare_transaction(TINFO *tinfo)
 {
     WT_DECL_RET;
     WT_SESSION *session;
-    uint64_t ts;
+    uint64_t longwait, pause_ms, ts;
     char buf[64];
 
     session = tinfo->session;
@@ -509,7 +513,7 @@ prepare_transaction(TINFO *tinfo)
      *
      * Lock out the oldest timestamp update.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    lock_writelock(session, &g.ts_lock);
 
     ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(__wt_snprintf(buf, sizeof(buf), "prepare_timestamp=%" PRIx64, ts));
@@ -517,8 +521,21 @@ prepare_transaction(TINFO *tinfo)
 
     logop(session, "prepare ts=%" PRIu64, ts);
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    lock_writeunlock(session, &g.ts_lock);
 
+    /*
+     * Sometimes add a delay after prepare to induce extra memory stress. For 80% of the threads,
+     * there is never a delay, so there is always a dedicated set of threads trying to do work. For
+     * the other 20%, we'll sometimes delay. For these threads, 99% of the time, proceed without
+     * delay. The rest of the time, pause up to 5 seconds, weighted toward the smaller delays.
+     */
+    if (tinfo->id % 5 == 0) {
+        longwait = mmrand(&tinfo->rnd, 0, 999);
+        if (longwait < 10) {
+            pause_ms = mmrand(&tinfo->rnd, 1, 10) << longwait;
+            __wt_sleep(0, pause_ms * WT_THOUSAND);
+        }
+    }
     return (ret);
 }
 

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -118,10 +118,8 @@ format_process_env(void)
     (void)signal(SIGTERM, signal_handler);
 #endif
 
-    /* Initialize locks to single-thread backups, failures, and timestamp updates. */
-    testutil_check(pthread_rwlock_init(&g.backup_lock, NULL));
+    /* Initialize lock to ensure single threading during failure handling */
     testutil_check(pthread_rwlock_init(&g.death_lock, NULL));
-    testutil_check(pthread_rwlock_init(&g.ts_lock, NULL));
 
 #if 0
     /* Configure the GNU malloc for debugging. */
@@ -328,10 +326,6 @@ main(int argc, char *argv[])
 
     config_print(false);
 
-    testutil_check(pthread_rwlock_destroy(&g.backup_lock));
-    testutil_check(pthread_rwlock_destroy(&g.death_lock));
-    testutil_check(pthread_rwlock_destroy(&g.ts_lock));
-
     config_clear();
 
     printf("%s: successful run completed\n", progname);
@@ -384,7 +378,7 @@ usage(void)
       progname);
     fprintf(stderr, "%s",
       "\t-1 run once then quit\n"
-      "\t-B create backward compatible configurations\n"
+      "\t-B maintain 3.3 release log and configuration option compatibility\n"
       "\t-C specify wiredtiger_open configuration arguments\n"
       "\t-c read test program configuration from a file (default 'CONFIG')\n"
       "\t-h home directory (default 'RUNDIR')\n"

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -233,7 +233,7 @@ fclose_and_clear(FILE **fpp)
  *     Update the timestamp once.
  */
 void
-timestamp_once(void)
+timestamp_once(WT_SESSION *session)
 {
     static const char *oldest_timestamp_str = "oldest_timestamp=";
     WT_CONNECTION *conn;
@@ -246,16 +246,20 @@ timestamp_once(void)
 
     /*
      * Lock out transaction timestamp operations. The lock acts as a barrier ensuring we've checked
-     * if the workers have finished, we don't want that line reordered.
+     * if the workers have finished, we don't want that line reordered. We can also be called from
+     * places, such as bulk load, where we are single-threaded and the locks haven't been
+     * initialized.
      */
-    testutil_check(pthread_rwlock_wrlock(&g.ts_lock));
+    if (LOCK_INITIALIZED(&g.ts_lock))
+        lock_writelock(session, &g.ts_lock);
 
     ret = conn->query_timestamp(conn, buf + strlen(oldest_timestamp_str), "get=all_durable");
     testutil_assert(ret == 0 || ret == WT_NOTFOUND);
     if (ret == 0)
         testutil_check(conn->set_timestamp(conn, buf));
 
-    testutil_check(pthread_rwlock_unlock(&g.ts_lock));
+    if (LOCK_INITIALIZED(&g.ts_lock))
+        lock_writeunlock(session, &g.ts_lock);
 }
 
 /*
@@ -265,9 +269,15 @@ timestamp_once(void)
 WT_THREAD_RET
 timestamp(void *arg)
 {
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
     bool done;
 
     (void)(arg);
+    conn = g.wts_conn;
+
+    /* Locks need session */
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /* Update the oldest timestamp at least once every 15 seconds. */
     done = false;
@@ -281,10 +291,11 @@ timestamp(void *arg)
         else
             random_sleep(&g.rnd, 15);
 
-        timestamp_once();
+        timestamp_once(session);
 
     } while (!done);
 
+    testutil_check(session->close(session, NULL));
     return (WT_THREAD_RET_VALUE);
 }
 
@@ -333,4 +344,39 @@ alter(void *arg)
 
     testutil_check(session->close(session, NULL));
     return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * lock_init --
+ *     Initialize abstract lock that can use either pthread of wt reader-writer locks.
+ */
+void
+lock_init(WT_SESSION *session, RWLOCK *lock)
+{
+    testutil_assert(lock->lock_type == LOCK_NONE);
+
+    if (g.c_wt_mutex) {
+        testutil_check(__wt_rwlock_init((WT_SESSION_IMPL *)session, &lock->l.wt));
+        lock->lock_type = LOCK_WT;
+    } else {
+        testutil_check(pthread_rwlock_init(&lock->l.pthread, NULL));
+        lock->lock_type = LOCK_PTHREAD;
+    }
+}
+
+/*
+ * lock_destroy --
+ *     Destroy abstract lock.
+ */
+void
+lock_destroy(WT_SESSION *session, RWLOCK *lock)
+{
+    testutil_assert(LOCK_INITIALIZED(lock));
+
+    if (lock->lock_type == LOCK_WT) {
+        __wt_rwlock_destroy((WT_SESSION_IMPL *)session, &lock->l.wt);
+    } else {
+        testutil_check(pthread_rwlock_destroy(&lock->l.pthread));
+    }
+    lock->lock_type = LOCK_NONE;
 }

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -281,8 +281,10 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
         CONFIG_APPEND(p, ",split_8");
     CONFIG_APPEND(p, "]");
 
+#if WIREDTIGER_VERSION_MAJOR >= 10
     if (g.c_verify)
         CONFIG_APPEND(p, ",verify_metadata=true");
+#endif
 
     /* Extensions. */
     CONFIG_APPEND(p,

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -281,6 +281,9 @@ wts_open(const char *home, bool set_api, WT_CONNECTION **connp)
         CONFIG_APPEND(p, ",split_8");
     CONFIG_APPEND(p, "]");
 
+    if (g.c_verify)
+        CONFIG_APPEND(p, ",verify_metadata=true");
+
     /* Extensions. */
     CONFIG_APPEND(p,
       ",extensions=["


### PR DESCRIPTION
Copying the entire format/config.c file from 4.4 to 4.2 instead of backporting parts of the format code.