### PR TITLE
WT-6093 __wt_rec_upd_select may not append the onpage value if the global txn structure is updated

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -416,8 +416,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 upd_select->upd = last_upd->next;
                 __wt_time_window_set_start(select_tw, last_upd->next);
             } else {
-                WT_ASSERT(session,
-                  __wt_txn_upd_visible_all(session, tombstone) && upd_select->upd == NULL);
+                WT_ASSERT(
+                  session, __wt_txn_upd_visible_all(session, tombstone) && upd_select->upd == NULL);
                 upd_select->upd = tombstone;
             }
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -378,7 +378,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             tombstone = upd;
 
             /* Find the update this tombstone applies to. */
-            if (!__wt_txn_visible_all(session, upd->txnid, upd->start_ts)) {
+            if (!__wt_txn_upd_visible_all(session, upd)) {
                 while (upd->next != NULL && upd->next->txnid == WT_TXN_ABORTED)
                     upd = upd->next;
                 WT_ASSERT(session, upd->next == NULL || upd->next->txnid != WT_TXN_ABORTED);
@@ -387,10 +387,10 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                 upd_select->upd = upd = upd->next;
             }
         }
-        if (upd != NULL) {
+        if (upd != NULL)
             /* The beginning of the validity window is the selected update's time pair. */
             __wt_time_window_set_start(select_tw, upd);
-        } else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
+        else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
             /* If we only have a tombstone in the update list, we must have an ondisk value. */
             WT_ASSERT(session, vpack != NULL && tombstone != NULL);
             /*
@@ -404,12 +404,22 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
              * window ends when this tombstone started.
              */
             WT_ERR(__rec_append_orig_value(session, page, tombstone, vpack));
-            WT_ASSERT(session, last_upd->next != NULL &&
-                last_upd->next->txnid == vpack->tw.start_txn &&
-                last_upd->next->start_ts == vpack->tw.start_ts &&
-                last_upd->next->type == WT_UPDATE_STANDARD && last_upd->next->next == NULL);
-            upd_select->upd = last_upd->next;
-            __wt_time_window_set_start(select_tw, last_upd->next);
+
+            /*
+             * We may have updated the global transaction concurrently and the tombstone is now
+             * globally visible. In this case, the on page value is not appended. Check that.
+             */
+            if (last_upd->next != NULL) {
+                WT_ASSERT(session, last_upd->next->txnid == vpack->tw.start_txn &&
+                    last_upd->next->start_ts == vpack->tw.start_ts &&
+                    last_upd->next->type == WT_UPDATE_STANDARD && last_upd->next->next == NULL);
+                upd_select->upd = last_upd->next;
+                __wt_time_window_set_start(select_tw, last_upd->next);
+            } else {
+                WT_ASSERT(session,
+                  __wt_txn_upd_visible_all(session, tombstone) && upd_select->upd == NULL);
+                upd_select->upd = tombstone;
+            }
         }
     }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -392,7 +392,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             __wt_time_window_set_start(select_tw, upd);
         else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
             /* If we only have a tombstone in the update list, we must have an ondisk value. */
-            WT_ASSERT(session, vpack != NULL && tombstone != NULL);
+            WT_ASSERT(session, vpack != NULL && tombstone != NULL && last_upd->next == NULL);
             /*
              * It's possible to have a tombstone as the only update in the update list. If we
              * reconciled before with only a single update and then read the page back into cache,

--- a/test/csuite/random_abort/smoke.sh
+++ b/test/csuite/random_abort/smoke.sh
@@ -9,10 +9,6 @@ set -e
 top_builddir=${top_builddir:-../../build_posix}
 top_srcdir=${top_srcdir:-../..}
 
-#FIXME-WT-6093: reenable calls to test_random_abort
-echo "Warning: test_random_abort temporarily disabled"
-exit 0
-
 $TEST_WRAPPER $top_builddir/test/csuite/test_random_abort -t 10 -T 5
 $TEST_WRAPPER $top_builddir/test/csuite/test_random_abort -m -t 10 -T 5
 $TEST_WRAPPER $top_builddir/test/csuite/test_random_abort -C -t 10 -T 5

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -198,9 +198,7 @@ functions:
       script: |
         set -o errexit
         set -o verbose
-        #FIXME-WT-6093: reenable all calls to test_random_abort
-        echo "Warning: test_random_abort temporarily disabled"
-        ##${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
+        ${test_env_vars|} ./test_random_abort ${random_abort_args|} 2>&1
   "timestamp abort test":
     command: shell.exec
     params:
@@ -228,20 +226,19 @@ functions:
         for i in $(seq ${times|1}); do
           # Run the various combinations of args.  Let time and threads be random.
           # Run current version with write-no-sync txns.
-          echo "Warning: test_random_abort temporarily disabled"
-          ##${test_env_vars|} ./test_random_abort 2>&1
+          ${test_env_vars|} ./test_random_abort 2>&1
           ${test_env_vars|} ./test_timestamp_abort 2>&1
 
           # Current version with memory-based txns (MongoDB usage).
-          ##${test_env_vars|} ./test_random_abort -m 2>&1
+          ${test_env_vars|} ./test_random_abort -m 2>&1
           ${test_env_vars|} ./test_timestamp_abort -m 2>&1
 
           # V1 log compatibility mode with write-no-sync txns.
-          ##${test_env_vars|} ./test_random_abort -C 2>&1
+          ${test_env_vars|} ./test_random_abort -C 2>&1
           ${test_env_vars|} ./test_timestamp_abort -C 2>&1
 
           # V1 log compatibility mode with memory-based txns.
-          ##${test_env_vars|} ./test_random_abort -C -m 2>&1
+          ${test_env_vars|} ./test_random_abort -C -m 2>&1
           ${test_env_vars|} ./test_timestamp_abort -C -m 2>&1
 
           ${test_env_vars|} ./test_truncated_log ${truncated_log_args|} 2>&1


### PR DESCRIPTION
The problem is the globally txn structure is updated concurrently and the tombstone becomes globally visible so the onpage value is not appended to the update chain.