### PR TITLE
WT-6142 Fix the assert with no more than one aborted update in chain

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -718,8 +718,7 @@ __txn_fixup_prepared_update(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR *
             upd->next = cbt->ins->upd;
         else if (cbt->ref->page->modify != NULL && cbt->ref->page->modify->mod_row_update != NULL)
             upd->next = cbt->ref->page->modify->mod_row_update[cbt->slot];
-        WT_ASSERT(session,
-          upd->next != NULL && upd->next->next == NULL && upd->next->txnid == WT_TXN_ABORTED);
+        WT_ASSERT(session, upd->next != NULL && upd->next->txnid == WT_TXN_ABORTED);
 
         /* Append a tombstone if the stop timestamp exists. */
         if (hs_stop_ts != WT_TS_MAX) {


### PR DESCRIPTION
It is possible that there can be multiple aborted updates in the update
chain when the prepared update is rolling back. So fix the assert to
not to expect an update that is aborted.