### PR TITLE
WT-6092 Use durable timestamp to find out global visibility

### DIFF
--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -65,7 +65,7 @@ __wt_ovfl_read(
      */
     __wt_readlock(session, &S2BT(session)->ovfl_lock);
     if (__wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM) {
-        WT_ASSERT(session, __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.stop_ts));
+        WT_ASSERT(session, __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.durable_stop_ts));
         ret = __wt_buf_setstr(session, store, "WT_CELL_VALUE_OVFL_RM");
         *decoded = true;
     } else

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -65,7 +65,8 @@ __wt_ovfl_read(
      */
     __wt_readlock(session, &S2BT(session)->ovfl_lock);
     if (__wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM) {
-        WT_ASSERT(session, __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.durable_stop_ts));
+        WT_ASSERT(
+          session, __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.durable_stop_ts));
         ret = __wt_buf_setstr(session, store, "WT_CELL_VALUE_OVFL_RM");
         *decoded = true;
     } else

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -587,7 +587,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
              */
             if (!btree->huffman_value && unpack.tw.stop_txn == WT_TXN_MAX &&
               unpack.tw.stop_ts == WT_TS_MAX && !F_ISSET(&unpack, WT_CELL_UNPACK_PREPARE) &&
-              __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.start_ts))
+              __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts))
                 __wt_row_leaf_value_set(page, rip - 1, &unpack);
             break;
         case WT_CELL_VALUE_OVFL:

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1070,7 +1070,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
      */
     WT_ERR(__wt_buf_set(session, &upd_value->buf, hs_value->data, hs_value->size));
 skip_buf:
-    upd_value->start_ts = hs_start_ts;
+    upd_value->durable_ts = durable_timestamp;
     upd_value->txnid = WT_TXN_NONE;
     upd_value->type = upd_type;
     upd_value->prepare_state =

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1111,7 +1111,7 @@ struct __wt_update {
  */
 struct __wt_update_value {
     WT_ITEM buf;
-    wt_timestamp_t start_ts;
+    wt_timestamp_t durable_ts;
     uint64_t txnid;
     uint8_t type;
     uint8_t prepare_state;

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -31,7 +31,6 @@ struct __wt_reconcile {
     /* Track the page's min/maximum transactions. */
     uint64_t max_txn;
     wt_timestamp_t max_ts;
-    wt_timestamp_t max_ondisk_ts;
     wt_timestamp_t min_skipped_ts;
 
     u_int updates_seen;     /* Count of updates seen. */

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -580,7 +580,11 @@ __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     if (upd->prepare_state == WT_PREPARE_LOCKED || upd->prepare_state == WT_PREPARE_INPROGRESS)
         return (false);
 
-    return (__wt_txn_visible_all(session, upd->txnid, upd->start_ts));
+    /*
+     * This function is used to determine when an update is obsolete: that should take into account
+     * the durable timestamp which is greater than or equal to the start timestamp.
+     */
+    return (__wt_txn_visible_all(session, upd->txnid, upd->durable_ts));
 }
 
 /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -598,7 +598,7 @@ __wt_txn_upd_value_visible_all(WT_SESSION_IMPL *session, WT_UPDATE_VALUE *upd_va
       upd_value->prepare_state == WT_PREPARE_INPROGRESS)
         return (false);
 
-    return (__wt_txn_visible_all(session, upd_value->txnid, upd_value->start_ts));
+    return (__wt_txn_visible_all(session, upd_value->txnid, upd_value->durable_ts));
 }
 
 /*
@@ -877,10 +877,10 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
       __wt_txn_visible(session, tw.stop_txn, tw.stop_ts) &&
       ((!F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
          (!WT_IS_HS(S2BT(session)) || !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))) ||
-          __wt_txn_visible_all(session, tw.stop_txn, tw.stop_ts))) {
+          __wt_txn_visible_all(session, tw.stop_txn, tw.durable_stop_ts))) {
         cbt->upd_value->buf.data = NULL;
         cbt->upd_value->buf.size = 0;
-        cbt->upd_value->start_ts = tw.stop_ts;
+        cbt->upd_value->durable_ts = tw.durable_stop_ts;
         cbt->upd_value->txnid = tw.stop_txn;
         cbt->upd_value->type = WT_UPDATE_TOMBSTONE;
         cbt->upd_value->prepare_state = WT_PREPARE_INIT;
@@ -904,7 +904,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
             cbt->upd_value->buf.data = NULL;
             cbt->upd_value->buf.size = 0;
         }
-        cbt->upd_value->start_ts = tw.start_ts;
+        cbt->upd_value->durable_ts = tw.durable_start_ts;
         cbt->upd_value->txnid = tw.start_txn;
         cbt->upd_value->type = WT_UPDATE_STANDARD;
         cbt->upd_value->prepare_state = WT_PREPARE_INIT;
@@ -1280,7 +1280,7 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         upd_value->buf.data = upd->data;
         upd_value->buf.size = upd->size;
     }
-    upd_value->start_ts = upd->start_ts;
+    upd_value->durable_ts = upd->durable_ts;
     upd_value->txnid = upd->txnid;
     upd_value->type = upd->type;
     upd_value->prepare_state = upd->prepare_state;
@@ -1299,7 +1299,7 @@ __wt_upd_value_clear(WT_UPDATE_VALUE *upd_value)
      */
     upd_value->buf.data = NULL;
     upd_value->buf.size = 0;
-    upd_value->start_ts = WT_TS_NONE;
+    upd_value->durable_ts = WT_TS_NONE;
     upd_value->txnid = WT_TXN_NONE;
     upd_value->type = WT_UPDATE_INVALID;
     upd_value->prepare_state = WT_PREPARE_INIT;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -535,7 +535,7 @@ __rec_row_zero_len(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
      */
     return ((tw->stop_ts == WT_TS_MAX && tw->stop_txn == WT_TXN_MAX) &&
       ((tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE) ||
-              __wt_txn_visible_all(session, tw->start_txn, tw->start_ts)));
+              __wt_txn_visible_all(session, tw->start_txn, tw->durable_start_ts)));
 }
 
 /*
@@ -767,7 +767,7 @@ __wt_rec_row_leaf(
          * new updates for that key, skip writing that key.
          */
         if (upd == NULL && (tw.stop_txn != WT_TXN_MAX || tw.stop_ts != WT_TS_MAX) &&
-          __wt_txn_visible_all(session, tw.stop_txn, tw.stop_ts))
+          __wt_txn_visible_all(session, tw.stop_txn, tw.durable_stop_ts))
             upd = &upd_tombstone;
 
         /* Build value cell. */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -18,7 +18,7 @@ __rec_update_stable(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *upd)
     return (F_ISSET(r, WT_REC_VISIBLE_ALL) ?
         __wt_txn_upd_visible_all(session, upd) :
         __wt_txn_upd_visible_type(session, upd) == WT_VISIBLE_TRUE &&
-          __wt_txn_visible(session, upd->txnid, upd->start_ts));
+          __wt_txn_visible(session, upd->txnid, upd->durable_ts));
 }
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -112,7 +112,7 @@ __rec_append_orig_value(
 
     /* Done if the stop time pair of the onpage cell is globally visible. */
     if ((unpack->tw.stop_ts != WT_TS_MAX || unpack->tw.stop_txn != WT_TXN_MAX) &&
-      __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.stop_ts))
+      __wt_txn_visible_all(session, unpack->tw.stop_txn, unpack->tw.durable_stop_ts))
         return (0);
 
     /* We need the original on-page value for some reader: get a copy. */
@@ -192,8 +192,8 @@ __rec_need_save_upd(
     if (F_ISSET(r, WT_REC_CHECKPOINT) && upd_select->upd == NULL)
         return (false);
 
-    return (!__wt_txn_visible_all(session, upd_select->tw.stop_txn, upd_select->tw.stop_ts) &&
-      !__wt_txn_visible_all(session, upd_select->tw.start_txn, upd_select->tw.start_ts));
+    return (!__wt_txn_visible_all(session, upd_select->tw.stop_txn, upd_select->tw.durable_stop_ts) &&
+      !__wt_txn_visible_all(session, upd_select->tw.start_txn, upd_select->tw.durable_start_ts));
 }
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -343,9 +343,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         return (__wt_set_return(session, EBUSY));
     }
 
-    if (upd != NULL && upd->start_ts > r->max_ondisk_ts)
-        r->max_ondisk_ts = upd->start_ts;
-
     /*
      * The start timestamp is determined by the commit timestamp when the key is first inserted (or
      * last updated). The end timestamp is set when a key/value pair becomes invalid, either because

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -192,7 +192,8 @@ __rec_need_save_upd(
     if (F_ISSET(r, WT_REC_CHECKPOINT) && upd_select->upd == NULL)
         return (false);
 
-    return (!__wt_txn_visible_all(session, upd_select->tw.stop_txn, upd_select->tw.durable_stop_ts) &&
+    return (
+      !__wt_txn_visible_all(session, upd_select->tw.stop_txn, upd_select->tw.durable_stop_ts) &&
       !__wt_txn_visible_all(session, upd_select->tw.start_txn, upd_select->tw.durable_start_ts));
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -519,7 +519,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
 
     /* Track the page's min/maximum transaction */
     r->max_txn = WT_TXN_NONE;
-    r->max_ondisk_ts = r->max_ts = WT_TS_NONE;
+    r->max_ts = WT_TS_NONE;
     r->min_skipped_ts = WT_TS_MAX;
 
     /* Track if updates were used and/or uncommitted. */

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -535,7 +535,7 @@ __wt_modify_reconstruct_from_upd_list(
     cursor = &cbt->iface;
 
     /* While we have a pointer to our original modify, grab this information. */
-    upd_value->start_ts = upd->start_ts;
+    upd_value->durable_ts = upd->durable_ts;
     upd_value->txnid = upd->txnid;
     upd_value->prepare_state = upd->prepare_state;
 


### PR DESCRIPTION
The durable timestamp represents whether the update is stable or not.
Use the durable timestamp only to decide whether the update is globally visible
instead of commit timestamp. This change reverts part of the changes
done by ticket 5414.