### PR TITLE
WT-6152 Fix accessing checkpoint durable timestamp including older ve…

### DIFF
--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -598,6 +598,16 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
     WT_RET_NOTFOUND_OK(ret);
     if (ret != WT_NOTFOUND && a.len != 0)
         ckpt->ta.newest_start_durable_ts = (uint64_t)a.val;
+    else {
+        /*
+         * Backward compatibility changes, as the parameter name is different in older versions of
+         * WT, make sure that we read older format in case if we didn't find the newer format name.
+         */
+        ret = __wt_config_subgets(session, v, "start_durable_ts", &a);
+        WT_RET_NOTFOUND_OK(ret);
+        if (ret != WT_NOTFOUND && a.len != 0)
+            ckpt->ta.newest_start_durable_ts = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "newest_stop_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
@@ -613,6 +623,16 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
     WT_RET_NOTFOUND_OK(ret);
     if (ret != WT_NOTFOUND && a.len != 0)
         ckpt->ta.newest_stop_durable_ts = (uint64_t)a.val;
+    else {
+        /*
+         * Backward compatibility changes, as the parameter name is different in older versions of
+         * WT, make sure that we read older format in case if we didn't find the newer format name.
+         */
+        ret = __wt_config_subgets(session, v, "stop_durable_ts", &a);
+        WT_RET_NOTFOUND_OK(ret);
+        if (ret != WT_NOTFOUND && a.len != 0)
+            ckpt->ta.newest_stop_durable_ts = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "prepare", &a);
     WT_RET_NOTFOUND_OK(ret);


### PR DESCRIPTION
…rsion

The durable timestamps that are stored for checkpoint as part of the WT
metadata file are changed to unify the name across all the code base led
to missed in handling the reading older format name also, as the older
format is used in older database files that are generated fails to load
with newer format name binary.