### PR TITLE
WT-6159 tag verbose messages to make them easier to distinguish

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -166,6 +166,9 @@
     } while (0)
 #endif
 
+/* Verbose messages. */
+#define WT_VERBOSE_ISSET(session, flag) (FLD_ISSET(S2C(session)->verbose, flag))
+
 /*
  * __wt_verbose --
  *     Display a verbose message. Not an inlined function because you can't inline functions taking
@@ -174,8 +177,8 @@
  *     additional argument, there's no portable way to remove the comma before an empty __VA_ARGS__
  *     value.
  */
-#define __wt_verbose(session, flag, fmt, ...)               \
-    do {                                                    \
-        if (WT_VERBOSE_ISSET(session, flag))                \
-            __wt_verbose_worker(session, fmt, __VA_ARGS__); \
+#define __wt_verbose(session, flag, fmt, ...)                              \
+    do {                                                                   \
+        if (WT_VERBOSE_ISSET(session, flag))                               \
+            __wt_verbose_worker(session, "[" #flag "] " fmt, __VA_ARGS__); \
     } while (0)

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -235,9 +235,6 @@
         }                                                              \
     } while (0)
 
-/* Verbose messages. */
-#define WT_VERBOSE_ISSET(session, f) (FLD_ISSET(S2C(session)->verbose, f))
-
 #define WT_CLEAR(s) memset(&(s), 0, sizeof(s))
 
 /* Check if a string matches a prefix. */


### PR DESCRIPTION
@agorrod, @sueloverso, I add this in every so often so I can figure out what verbose messages came from where. Maybe it's generally useful?

Verbose messages get the flag added, so they look like this:
```
file:wt.wt, WT_CURSOR.insert: [WT_VERB_BLOCK] file extend 512B @ 145408
file:wt.wt, WT_CURSOR.insert: [WT_VERB_BLOCK] file extend 512B @ 145920
file:wt.wt, WT_CURSOR.insert: [WT_VERB_BLOCK] file extend 9216B @ 146432
```
