### PR TITLE
WT-6063 Enable checkpoint-filetypes-test in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2217,7 +2217,7 @@ buildvariants:
     - name: syscall-linux
     - name: make-check-asan-test
     - name: configure-combinations
-    # - name: checkpoint-filetypes-test
+    - name: checkpoint-filetypes-test
     # - name: coverage-report
     - name: unit-test-long
     # - name: spinlock-gcc-test
@@ -2321,7 +2321,7 @@ buildvariants:
     - name: syscall-linux
     - name: compile-asan
     - name: make-check-asan-test
-    # - name: checkpoint-filetypes-test
+    - name: checkpoint-filetypes-test
     - name: unit-test-long
     # - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test


### PR DESCRIPTION
This test appears to now be passing in Evergreen. Patch build is [here](https://evergreen.mongodb.com/version/5eb8c63c2a60ed36b28a3696).