### PR TITLE
WT-6065 Enable spin lock gcc test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2220,7 +2220,7 @@ buildvariants:
     # - name: checkpoint-filetypes-test
     # - name: coverage-report
     - name: unit-test-long
-    # - name: spinlock-gcc-test
+    - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf
     - name: wtperf-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2323,7 +2323,7 @@ buildvariants:
     - name: make-check-asan-test
     # - name: checkpoint-filetypes-test
     - name: unit-test-long
-    # - name: spinlock-gcc-test
+    - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf
     - name: wtperf-test


### PR DESCRIPTION
The test is now passing:

https://evergreen.mongodb.com/build/wiredtiger_ubuntu1804_patch_5b7d6ff3503cfa2e7c6ca858bb9955dc6f28936d_5eb8df407742ae0e1643829a_20_05_11_05_15_38