### PR TITLE
WT-6172 Fix silent failures of Evergreen test/format tasks

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2070,7 +2070,7 @@ tasks:
       - func: "format test script"
         vars:
           #run for 24 hours ( 24 * 60 = 1440 minutes), use default config
-          format_test_script_args: -b "SEGFAULT_SIGNALS=all catchsegv ./t" -t 1440
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -t 1440
 
   - name: format-stress-smoke-test
     # Set 7 hours timeout
@@ -2082,7 +2082,7 @@ tasks:
         vars:
           # to emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
           # run smoke tests, use default config (-S)
-          format_test_script_args: -b "SEGFAULT_SIGNALS=all catchsegv ./t" -S
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -S
           times: 16
 
   - name: checkpoint-stress-test
@@ -2113,7 +2113,7 @@ tasks:
           # Make sure we dump core on failure
           format_test_setting: ulimit -c unlimited
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
-          format_test_script_args: -b "SEGFAULT_SIGNALS=all catchsegv ./t" -t 120
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -t 120
 
   - name: format-wtperf-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2070,7 +2070,7 @@ tasks:
       - func: "format test script"
         vars:
           #run for 24 hours ( 24 * 60 = 1440 minutes), use default config
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -t 1440
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 1440
 
   - name: format-stress-smoke-test
     # Set 7 hours timeout
@@ -2082,7 +2082,7 @@ tasks:
         vars:
           # to emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
           # run smoke tests, use default config (-S)
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -S
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -S
           times: 16
 
   - name: checkpoint-stress-test
@@ -2113,7 +2113,7 @@ tasks:
           # Make sure we dump core on failure
           format_test_setting: ulimit -c unlimited
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all catchsegv" -b "./t" -t 120
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
 
   - name: format-wtperf-test
     commands:

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -17,12 +17,13 @@ onintr()
 trap 'onintr' 2
 
 usage() {
-	echo "usage: $0 [-aEFSv] [-b format-binary] [-c config] "
+	echo "usage: $0 [-aEFSv] [-b format-binary] [-c config] [-e env-var]"
 	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -b binary    format binary (defaults to "./t")"
 	echo "    -c config    format configuration file (defaults to CONFIG.stress)"
+	echo "    -e envvar    Environment variable setting (default to none)"
 	echo "    -E           skip known errors (defaults to off)"
 	echo "    -F           quit on first failure (defaults to off)"
 	echo "    -h home      run directory (defaults to .)"
@@ -77,6 +78,7 @@ timing_stress_split_test=0
 total_jobs=0
 verbose=0
 format_binary="./t"
+env_var=""
 
 while :; do
 	case "$1" in
@@ -88,6 +90,9 @@ while :; do
 		shift ; shift ;;
 	-c)
 		config="$2"
+		shift ; shift ;;
+	-e)
+		env_var="$2"
 		shift ; shift ;;
 	-E)
 		skip_errors=1
@@ -443,7 +448,16 @@ format()
 	# continue to run.
 	# Run format in its own session so child processes are in their own process gorups
 	# and we can individually terminate (and clean up) running jobs and their children.
-	nohup setsid $cmd > $log 2>&1 &
+	$env_var setsid $cmd > $log 2>&1 &
+
+	# Check for setsid command failed execution, and forcibly quit.
+	# The RUNDIR is not successfully created in this failure type.
+	sleep 1
+	grep -E -i 'setsid: failed to execute' $log > /dev/null && {
+		failure=$(($failure + 1))
+		force_quit=1
+		echo "$name: job in $dir failed to execute"
+	}
 }
 
 seconds=$((minutes * 60))
@@ -504,4 +518,5 @@ echo "$name: $success successful jobs, $failure failed jobs"
 
 verbose "$name: run ending at $(date)"
 [[ $failure -ne 0 ]] && exit 1
+[[ $success -eq 0 ]] && exit 1
 exit 0

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -442,13 +442,13 @@ format()
 	fi
 
 	cmd="$format_binary -c "$config" -h "$dir" -1 $args quiet=1"
-	verbose "$name: $cmd"
+	echo "$name: $cmd"
 
 	# Disassociate the command from the shell script so we can exit and let the command
 	# continue to run.
 	# Run format in its own session so child processes are in their own process gorups
 	# and we can individually terminate (and clean up) running jobs and their children.
-	$env_var setsid $cmd > $log 2>&1 &
+	eval $env_var setsid $cmd > $log 2>&1 &
 
 	# Check for setsid command failed execution, and forcibly quit.
 	# The RUNDIR is not successfully created in this failure type.


### PR DESCRIPTION
Introduce a new "-e" argument to the `format.sh` wrapper for environment variable setting, so that the setting could be put in front of the `setsid` command to avoid execution failures. 

Also add the checking of the RUNDIR log file for the execution failure right after the `setsid` command, mark failure counter and force quit. 