### PR TITLE
WT-5725 Remove the WT_CURSOR_BTREE.btree field.

### DIFF
--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -48,7 +48,7 @@ restart:
      */
     recno = WT_INSERT_RECNO(cbt->ins);
     while ((current = cbt->ins) != PREV_INS(cbt, 0)) {
-        if (cbt->btree->type == BTREE_ROW) {
+        if (CUR2BT(cbt)->type == BTREE_ROW) {
             key.data = WT_INSERT_KEY(current);
             key.size = WT_INSERT_KEY_SIZE(current);
             WT_RET(__wt_search_insert(session, cbt, cbt->ins_head, &key));

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1543,18 +1543,20 @@ __wt_btcur_update(WT_CURSOR_BTREE *cbt)
 int
 __wt_btcur_compare(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *cmpp)
 {
+    WT_BTREE *btree;
     WT_CURSOR *a, *b;
     WT_SESSION_IMPL *session;
 
+    btree = CUR2BT(a_arg);
     a = (WT_CURSOR *)a_arg;
     b = (WT_CURSOR *)b_arg;
     session = CUR2S(a_arg);
 
     /* Confirm both cursors reference the same object. */
-    if (a_arg->dhandle->handle != b_arg->dhandle->handle)
-        WT_RET_MSG(session, EINVAL, "Cursors must reference the same object");
+    if (CUR2BT(a_arg) != CUR2BT(b_arg))
+        WT_RET_MSG(session, EINVAL, "cursors must reference the same object");
 
-    switch (CUR2BT(a_arg)->type) {
+    switch (btree->type) {
     case BTREE_COL_FIX:
     case BTREE_COL_VAR:
         /*
@@ -1569,7 +1571,7 @@ __wt_btcur_compare(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *cmpp)
             *cmpp = 1;
         break;
     case BTREE_ROW:
-        WT_RET(__wt_compare(session, CUR2BT(a_arg)->collator, &a->key, &b->key, cmpp));
+        WT_RET(__wt_compare(session, btree->collator, &a->key, &b->key, cmpp));
         break;
     }
     return (0);
@@ -1624,8 +1626,8 @@ __wt_btcur_equals(WT_CURSOR_BTREE *a_arg, WT_CURSOR_BTREE *b_arg, int *equalp)
     cmp = 0;
 
     /* Confirm both cursors reference the same object. */
-    if (a_arg->dhandle->handle != b_arg->dhandle->handle)
-        WT_RET_MSG(session, EINVAL, "Cursors must reference the same object");
+    if (CUR2BT(a_arg) != CUR2BT(b_arg))
+        WT_RET_MSG(session, EINVAL, "cursors must reference the same object");
 
     /*
      * The reason for an equals method is because we can avoid doing a full key comparison in some

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -878,12 +878,15 @@ int
 __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
 
-    cursor = cursor_arg;
     cbt = cursor_arg;
-    return (__wt_debug_page(cursor->session, cbt->btree, cbt->ref, ofile));
+    session = CUR2S(cursor_arg);
+
+    WT_WITH_BTREE(session, CUR2BT(cbt), ret = __wt_debug_page(session, NULL, cbt->ref, ofile));
+    return (ret);
 }
 
 /*
@@ -905,7 +908,7 @@ __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
 
     WT_RET(__wt_hs_cursor(session, &session_flags, &is_owner));
     cbt = (WT_CURSOR_BTREE *)session->hs_cursor;
-    ret = __wt_debug_tree_all(session, cbt->btree, NULL, ofile);
+    WT_WITH_BTREE(session, CUR2BT(cbt), ret = __wt_debug_tree_all(session, NULL, NULL, ofile));
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
 
     return (ret);

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -474,7 +474,7 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
     uint64_t n, skip;
     uint32_t read_flags;
 
-    btree = cbt->btree;
+    btree = CUR2BT(cbt);
     cursor = &cbt->iface;
     session = CUR2S(cbt);
 

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -249,7 +249,7 @@ __wt_value_return(WT_CURSOR_BTREE *cbt, WT_UPDATE_VALUE *upd_value)
          * still required for fixed length column store as we have issues with this table type in
          * durable history which we're planning to address in PM-1814.
          */
-        WT_ASSERT(session, cbt->btree->type == BTREE_COL_FIX);
+        WT_ASSERT(session, CUR2BT(cbt)->type == BTREE_COL_FIX);
         WT_RET(__value_return(cbt));
     } else {
         /*

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -31,7 +31,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     u_int i, skipdepth;
     bool append, logged;
 
-    btree = cbt->btree;
+    btree = CUR2BT(cbt);
     ins = NULL;
     page = cbt->ref->page;
     session = CUR2S(cbt);

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -96,7 +96,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
     const char *file;
 
     cb = (WT_CURSOR_BACKUP *)cursor;
-    btree = cb->incr_cursor == NULL ? NULL : ((WT_CURSOR_BTREE *)cb->incr_cursor)->btree;
+    btree = cb->incr_cursor == NULL ? NULL : CUR2BT(cb->incr_cursor);
     raw = F_MASK(cursor, WT_CURSTD_RAW);
     CURSOR_API_CALL(cursor, session, get_value, btree);
     F_CLR(cursor, WT_CURSTD_RAW);

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -341,6 +341,10 @@ __wt_curbulk_init(
 int
 __wt_curbulk_close(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 {
+    WT_DECL_RET;
+
+    ret = __wt_bulk_wrapup(session, cbulk);
+
     __wt_buf_free(session, &cbulk->last);
-    return (__wt_bulk_wrapup(session, cbulk));
+    return (ret);
 }

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -41,7 +41,7 @@ __curbulk_insert_fix(WT_CURSOR *cursor)
     uint64_t recno;
 
     cbulk = (WT_CURSOR_BULK *)cursor;
-    btree = cbulk->cbt.btree;
+    btree = CUR2BT(&cbulk->cbt);
 
     /*
      * Bulk cursor inserts are updates, but don't need auto-commit transactions because they are
@@ -91,7 +91,7 @@ __curbulk_insert_fix_bitmap(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbulk = (WT_CURSOR_BULK *)cursor;
-    btree = cbulk->cbt.btree;
+    btree = CUR2BT(&cbulk->cbt);
 
     /*
      * Bulk cursor inserts are updates, but don't need auto-commit transactions because they are
@@ -124,7 +124,7 @@ __curbulk_insert_var(WT_CURSOR *cursor)
     uint64_t recno;
 
     cbulk = (WT_CURSOR_BULK *)cursor;
-    btree = cbulk->cbt.btree;
+    btree = CUR2BT(&cbulk->cbt);
 
     /*
      * Bulk cursor inserts are updates, but don't need auto-commit transactions because they are
@@ -228,7 +228,7 @@ __curbulk_insert_row(WT_CURSOR *cursor)
     int cmp;
 
     cbulk = (WT_CURSOR_BULK *)cursor;
-    btree = cbulk->cbt.btree;
+    btree = CUR2BT(&cbulk->cbt);
 
     /*
      * Bulk cursor inserts are updates, but don't need auto-commit transactions because they are
@@ -274,7 +274,7 @@ __curbulk_insert_row_skip_check(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbulk = (WT_CURSOR_BULK *)cursor;
-    btree = cbulk->cbt.btree;
+    btree = CUR2BT(&cbulk->cbt);
 
     /*
      * Bulk cursor inserts are updates, but don't need auto-commit transactions because they are
@@ -301,27 +301,27 @@ int
 __wt_curbulk_init(
   WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool bitmap, bool skip_sort_check)
 {
-    WT_CURSOR *c;
+    WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
 
-    c = &cbulk->cbt.iface;
+    cursor = &cbulk->cbt.iface;
     cbt = &cbulk->cbt;
 
     /* Bulk cursors only support insert and close (reset is a no-op). */
-    __wt_cursor_set_notsup(c);
-    switch (cbt->btree->type) {
+    __wt_cursor_set_notsup(cursor);
+    switch (CUR2BT(cbt)->type) {
     case BTREE_COL_FIX:
-        c->insert = bitmap ? __curbulk_insert_fix_bitmap : __curbulk_insert_fix;
+        cursor->insert = bitmap ? __curbulk_insert_fix_bitmap : __curbulk_insert_fix;
         break;
     case BTREE_COL_VAR:
-        c->insert = __curbulk_insert_var;
+        cursor->insert = __curbulk_insert_var;
         break;
     case BTREE_ROW:
         /*
          * Row-store order comparisons are expensive, so we optionally skip them when we know the
          * input is correct.
          */
-        c->insert = skip_sort_check ? __curbulk_insert_row_skip_check : __curbulk_insert_row;
+        cursor->insert = skip_sort_check ? __curbulk_insert_row_skip_check : __curbulk_insert_row;
         break;
     }
 
@@ -329,7 +329,18 @@ __wt_curbulk_init(
     cbulk->recno = 0;
     cbulk->bitmap = bitmap;
     if (bitmap)
-        F_SET(c, WT_CURSTD_RAW);
+        F_SET(cursor, WT_CURSTD_RAW);
 
     return (__wt_bulk_init(session, cbulk));
+}
+
+/*
+ * __wt_curbulk_close --
+ *     Close a bulk cursor.
+ */
+int
+__wt_curbulk_close(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+{
+    __wt_buf_free(session, &cbulk->last);
+    return (__wt_bulk_wrapup(session, cbulk));
 }

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -27,7 +27,7 @@ __curfile_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)a;
-    CURSOR_API_CALL(a, session, compare, cbt->btree);
+    CURSOR_API_CALL(a, session, compare, CUR2BT(cbt));
 
     /*
      * Check both cursors are a "file:" type then call the underlying function, it can handle
@@ -57,7 +57,7 @@ __curfile_equals(WT_CURSOR *a, WT_CURSOR *b, int *equalp)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)a;
-    CURSOR_API_CALL(a, session, equals, cbt->btree);
+    CURSOR_API_CALL(a, session, equals, CUR2BT(cbt));
 
     /*
      * Check both cursors are a "file:" type then call the underlying function, it can handle
@@ -87,7 +87,7 @@ __curfile_next(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL(cursor, session, next, cbt->btree);
+    CURSOR_API_CALL(cursor, session, next, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
 
     WT_ERR(__wt_btcur_next(cbt, false));
@@ -114,7 +114,7 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL(cursor, session, next, cbt->btree);
+    CURSOR_API_CALL(cursor, session, next, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
 
     WT_ERR(__wt_btcur_next_random(cbt));
@@ -140,7 +140,7 @@ __curfile_prev(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL(cursor, session, prev, cbt->btree);
+    CURSOR_API_CALL(cursor, session, prev, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
 
     WT_ERR(__wt_btcur_prev(cbt, false));
@@ -166,7 +166,7 @@ __curfile_reset(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, reset, cbt->btree);
+    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, reset, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
 
     ret = __wt_btcur_reset(cbt);
@@ -192,7 +192,7 @@ __curfile_search(WT_CURSOR *cursor)
     uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL(cursor, session, search, cbt->btree);
+    CURSOR_API_CALL(cursor, session, search, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -223,7 +223,7 @@ __curfile_search_near(WT_CURSOR *cursor, int *exact)
     uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL(cursor, session, search_near, cbt->btree);
+    CURSOR_API_CALL(cursor, session, search_near, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -254,7 +254,7 @@ __curfile_insert(WT_CURSOR *cursor)
     uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, insert, cbt->btree);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, insert);
     WT_ERR(__cursor_copy_release(cursor));
 
     if (!F_ISSET(cursor, WT_CURSTD_APPEND))
@@ -295,7 +295,7 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     tret = 0;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update);
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -322,7 +322,7 @@ __curfile_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, modify, cbt->btree);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, modify);
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -357,7 +357,7 @@ __curfile_update(WT_CURSOR *cursor)
     uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update, cbt->btree);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update);
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
     WT_ERR(__cursor_checkvalue(cursor));
@@ -400,7 +400,7 @@ __curfile_remove(WT_CURSOR *cursor)
     positioned = F_ISSET(cursor, WT_CURSTD_KEY_INT);
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_REMOVE_API_CALL(cursor, session, cbt->btree);
+    CURSOR_REMOVE_API_CALL(cursor, session, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -437,7 +437,7 @@ __curfile_reserve(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, reserve, cbt->btree);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, reserve);
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 
@@ -474,13 +474,12 @@ static int
 __curfile_close(WT_CURSOR *cursor)
 {
     WT_CURSOR_BTREE *cbt;
-    WT_CURSOR_BULK *cbulk;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     bool dead, released;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, cbt->btree);
+    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, CUR2BT(cbt));
     WT_ERR(__cursor_copy_release(cursor));
 err:
 
@@ -496,12 +495,10 @@ err:
     }
 
     dead = F_ISSET(cursor, WT_CURSTD_DEAD);
-    if (F_ISSET(cursor, WT_CURSTD_BULK)) {
-        /* Free the bulk-specific resources. */
-        cbulk = (WT_CURSOR_BULK *)cbt;
-        WT_TRET(__wt_bulk_wrapup(session, cbulk));
-        __wt_buf_free(session, &cbulk->last);
-    }
+
+    /* Free the bulk-specific resources. */
+    if (F_ISSET(cursor, WT_CURSTD_BULK))
+        WT_TRET(__wt_curbulk_close(session, (WT_CURSOR_BULK *)cursor));
 
     WT_TRET(__wt_btcur_close(cbt, false));
     /* The URI is owned by the btree handle. */
@@ -543,7 +540,6 @@ __curfile_cache(WT_CURSOR *cursor)
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     session = CUR2S(cursor);
-    cbt->dhandle = cbt->btree->dhandle;
 
     WT_TRET(__wt_cursor_cache(cursor, cbt->dhandle));
     WT_TRET(__wt_session_release_dhandle(session));
@@ -557,6 +553,7 @@ __curfile_cache(WT_CURSOR *cursor)
 static int
 __curfile_reopen(WT_CURSOR *cursor, bool check_only)
 {
+    WT_BTREE *btree;
     WT_CURSOR_BTREE *cbt;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
@@ -601,10 +598,10 @@ __curfile_reopen(WT_CURSOR *cursor, bool check_only)
         WT_ASSERT(session, dhandle->type == WT_DHANDLE_TYPE_BTREE);
         WT_ASSERT(session, ((WT_BTREE *)dhandle->handle)->root.page != NULL);
 
-        cbt->btree = dhandle->handle;
-        cursor->internal_uri = cbt->btree->dhandle->name;
-        cursor->key_format = cbt->btree->key_format;
-        cursor->value_format = cbt->btree->value_format;
+        btree = CUR2BT(cbt);
+        cursor->internal_uri = btree->dhandle->name;
+        cursor->key_format = btree->key_format;
+        cursor->value_format = btree->value_format;
     }
     return (ret);
 }
@@ -661,7 +658,7 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
     cursor->internal_uri = btree->dhandle->name;
     cursor->key_format = btree->key_format;
     cursor->value_format = btree->value_format;
-    cbt->btree = btree;
+    cbt->dhandle = session->dhandle;
 
     /*
      * Increment the data-source's in-use counter; done now because closing the cursor will
@@ -728,12 +725,14 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
 
     if (0) {
 err:
+        __wt_cursor_dhandle_decr_use(session);
+
         /*
          * Our caller expects to release the data handle if we fail. Disconnect it from the cursor
          * before closing.
          */
-        __wt_cursor_dhandle_decr_use(session);
-        cbt->btree = NULL;
+        cbt->dhandle = NULL;
+
         WT_TRET(__curfile_close(cursor));
         *cursorp = NULL;
     }

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -222,7 +222,7 @@ __curmetadata_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     a_file_cursor = a_mdc->file_cursor;
     b_file_cursor = b_mdc->file_cursor;
 
-    CURSOR_API_CALL(a, session, compare, ((WT_CURSOR_BTREE *)a_file_cursor)->btree);
+    CURSOR_API_CALL(a, session, compare, CUR2BT(a_file_cursor));
 
     if (b->compare != __curmetadata_compare)
         WT_ERR_MSG(session, EINVAL, "Can only compare cursors of the same type");
@@ -258,7 +258,7 @@ __curmetadata_next(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, next, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, next, CUR2BT(file_cursor));
 
     if (!F_ISSET(mdc, WT_MDC_POSITIONED))
         WT_ERR(__curmetadata_metadata_search(session, cursor));
@@ -304,7 +304,7 @@ __curmetadata_prev(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, prev, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, prev, CUR2BT(file_cursor));
 
     if (F_ISSET(mdc, WT_MDC_ONMETADATA)) {
         ret = WT_NOTFOUND;
@@ -351,8 +351,7 @@ __curmetadata_reset(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL_PREPARE_ALLOWED(
-      cursor, session, reset, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, reset, CUR2BT(file_cursor));
 
     if (F_ISSET(mdc, WT_MDC_POSITIONED) && !F_ISSET(mdc, WT_MDC_ONMETADATA))
         ret = file_cursor->reset(file_cursor);
@@ -377,7 +376,7 @@ __curmetadata_search(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, search, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, search, CUR2BT(file_cursor));
 
     WT_MD_CURSOR_NEEDKEY(cursor);
 
@@ -414,7 +413,7 @@ __curmetadata_search_near(WT_CURSOR *cursor, int *exact)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, search_near, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, search_near, CUR2BT(file_cursor));
 
     WT_MD_CURSOR_NEEDKEY(cursor);
 
@@ -452,7 +451,7 @@ __curmetadata_insert(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, insert, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, insert, CUR2BT(file_cursor));
 
     WT_MD_CURSOR_NEEDKEY(cursor);
     WT_MD_CURSOR_NEEDVALUE(cursor);
@@ -480,7 +479,7 @@ __curmetadata_update(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, update, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, update, CUR2BT(file_cursor));
 
     WT_MD_CURSOR_NEEDKEY(cursor);
     WT_MD_CURSOR_NEEDVALUE(cursor);
@@ -508,7 +507,7 @@ __curmetadata_remove(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     file_cursor = mdc->file_cursor;
-    CURSOR_API_CALL(cursor, session, remove, ((WT_CURSOR_BTREE *)file_cursor)->btree);
+    CURSOR_API_CALL(cursor, session, remove, CUR2BT(file_cursor));
 
     WT_MD_CURSOR_NEEDKEY(cursor);
 
@@ -535,8 +534,7 @@ __curmetadata_close(WT_CURSOR *cursor)
 
     mdc = (WT_CURSOR_METADATA *)cursor;
     c = mdc->file_cursor;
-    CURSOR_API_CALL_PREPARE_ALLOWED(
-      cursor, session, close, c == NULL ? NULL : ((WT_CURSOR_BTREE *)c)->btree);
+    CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, c == NULL ? NULL : CUR2BT(c));
 err:
 
     if (c != NULL)

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -66,7 +66,7 @@ __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 
     WT_RET(__wt_hs_cursor(session, &session_flags, &is_owner));
 
-    *hs_btreep = ((WT_CURSOR_BTREE *)session->hs_cursor)->btree;
+    *hs_btreep = CUR2BT(session->hs_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
 
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
@@ -303,7 +303,7 @@ __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
             last_upd->next = mod->mod_row_update[hs_cbt->slot];
     }
 
-    WT_WITH_BTREE(session, hs_cbt->btree,
+    WT_WITH_BTREE(session, CUR2BT(hs_cbt),
       ret = __wt_row_modify(hs_cbt, &hs_cbt->iface.key, NULL, hs_upd, WT_UPDATE_INVALID, true));
     return (ret);
 }
@@ -526,8 +526,8 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
     WT_DECL_RET;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    WT_WITH_BTREE(session, cbt->btree, ret = __hs_insert_record_with_btree(session, cursor, btree,
-                                         key, upd, type, hs_value, stop_ts_pair));
+    WT_WITH_BTREE(session, CUR2BT(cbt), ret = __hs_insert_record_with_btree(session, cursor, btree,
+                                          key, upd, type, hs_value, stop_ts_pair));
     return (ret);
 }
 
@@ -788,7 +788,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
 
     WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
     WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
-    max_hs_size = ((WT_CURSOR_BTREE *)cursor)->btree->file_max;
+    max_hs_size = CUR2BT(cursor)->file_max;
     if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
         WT_ERR_PANIC(session, WT_PANIC,
           "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -86,10 +86,10 @@
     while (0)
 
 /* An API call wrapped in a transaction if necessary. */
-#define TXN_API_CALL(s, h, n, bt, config, cfg)                              \
+#define TXN_API_CALL(s, h, n, dh, config, cfg)                              \
     do {                                                                    \
         bool __autotxn = false, __update = false;                           \
-        API_CALL(s, h, n, bt, config, cfg);                                 \
+        API_CALL(s, h, n, dh, config, cfg);                                 \
         __wt_txn_timestamp_flags(s);                                        \
         __autotxn = !F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
         if (__autotxn)                                                      \
@@ -233,12 +233,12 @@
     CURSOR_REMOVE_API_CALL(cur, s, bt);             \
     JOINABLE_CURSOR_CALL_CHECK(cur)
 
-#define CURSOR_UPDATE_API_CALL_BTREE(cur, s, n, bt)                                                \
-    (s) = (WT_SESSION_IMPL *)(cur)->session;                                                       \
-    SESSION_API_PREPARE_CHECK(s, WT_CURSOR, n);                                                    \
-    TXN_API_CALL_NOCONF(s, WT_CURSOR, n, ((WT_BTREE *)(bt))->dhandle);                             \
-    if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET((WT_BTREE *)(bt), WT_BTREE_IGNORE_CACHE) && \
-      __wt_cache_full(s))                                                                          \
+#define CURSOR_UPDATE_API_CALL_BTREE(cur, s, n)                                               \
+    (s) = (WT_SESSION_IMPL *)(cur)->session;                                                  \
+    SESSION_API_PREPARE_CHECK(s, WT_CURSOR, n);                                               \
+    TXN_API_CALL_NOCONF(s, WT_CURSOR, n, ((WT_CURSOR_BTREE *)(cur))->dhandle);                \
+    if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) && \
+      __wt_cache_full(s))                                                                     \
         WT_ERR(WT_CACHE_FULL);
 
 #define CURSOR_UPDATE_API_CALL(cur, s, n)       \

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -71,14 +71,12 @@ struct __wt_cursor_backup {
     uint8_t flags;
 };
 
+/* Get the WT_BTREE from any WT_CURSOR/WT_CURSOR_BTREE. */
+#define CUR2BT(c) ((WT_BTREE *)((WT_CURSOR_BTREE *)(c))->dhandle->handle)
+
 struct __wt_cursor_btree {
     WT_CURSOR iface;
 
-    /*
-     * The btree field is safe to use when the cursor is open. When the cursor is cached, the btree
-     * may be closed, so it is only safe initially to look at the underlying data handle.
-     */
-    WT_BTREE *btree;         /* Enclosing btree */
     WT_DATA_HANDLE *dhandle; /* Data handle for the btree */
 
     /*

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -72,7 +72,10 @@ struct __wt_cursor_backup {
 };
 
 /* Get the WT_BTREE from any WT_CURSOR/WT_CURSOR_BTREE. */
-#define CUR2BT(c) ((WT_BTREE *)((WT_CURSOR_BTREE *)(c))->dhandle->handle)
+#define CUR2BT(c)                                \
+    (((WT_CURSOR_BTREE *)(c))->dhandle == NULL ? \
+        NULL :                                   \
+        (WT_BTREE *)((WT_CURSOR_BTREE *)(c))->dhandle->handle)
 
 struct __wt_cursor_btree {
     WT_CURSOR iface;

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -37,7 +37,7 @@
       !F_ISSET(dhandle, WT_DHANDLE_DROPPED))
 
 /* The metadata cursor's data handle. */
-#define WT_SESSION_META_DHANDLE(s) (((WT_CURSOR_BTREE *)((s)->meta_cursor))->btree->dhandle)
+#define WT_SESSION_META_DHANDLE(s) (((WT_CURSOR_BTREE *)((s)->meta_cursor))->dhandle)
 
 #define WT_DHANDLE_ACQUIRE(dhandle) (void)__wt_atomic_add32(&(dhandle)->session_ref, 1)
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -478,6 +478,8 @@ extern int __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CUR
 extern int __wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
   WT_CURSOR *cursor, const char *cfg[], WT_CURSOR **cursorp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curbulk_close(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curbulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool bitmap,
   bool skip_sort_check) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curconfig_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -1156,7 +1156,7 @@ __wt_txn_update_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
      * aborted updates. Otherwise, we would have either already detected a conflict if we saw an
      * uncommitted update or determined that it would be safe to write if we saw a committed update.
      */
-    if (!rollback && upd == NULL && cbt != NULL && cbt->btree->type != BTREE_COL_FIX &&
+    if (!rollback && upd == NULL && cbt != NULL && CUR2BT(cbt)->type != BTREE_COL_FIX &&
       cbt->ins == NULL) {
         __wt_read_cell_time_window(cbt, cbt->ref, &tw);
         if (tw.stop_txn != WT_TXN_MAX && tw.stop_ts != WT_TS_MAX)

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -123,7 +123,7 @@ __clsm_enter_update(WT_CURSOR_LSM *clsm)
 
     if (have_primary) {
         WT_ENTER_PAGE_INDEX(session);
-        WT_WITH_BTREE(session, ((WT_CURSOR_BTREE *)primary)->btree,
+        WT_WITH_BTREE(session, CUR2BT(primary),
           ovfl = __wt_btree_lsm_over_size(
             session, hard_limit ? 2 * lsm_tree->chunk_size : lsm_tree->chunk_size));
         WT_LEAVE_PAGE_INDEX(session);
@@ -530,7 +530,7 @@ retry:
              */
             if (lsm_tree->custom_generation == 0 ||
               chunk->generation < lsm_tree->custom_generation) {
-                checkpoint = ((WT_CURSOR_BTREE *)cursor)->btree->dhandle->checkpoint;
+                checkpoint = ((WT_CURSOR_BTREE *)cursor)->dhandle->checkpoint;
                 if (checkpoint == NULL && F_ISSET(chunk, WT_LSM_CHUNK_ONDISK) && !chunk->empty)
                     break;
             }
@@ -639,7 +639,7 @@ retry:
     /* The last chunk is our new primary. */
     if (chunk != NULL && !F_ISSET(chunk, WT_LSM_CHUNK_ONDISK) && chunk->switch_txn == WT_TXN_NONE) {
         primary = clsm->chunks[clsm->nchunks - 1]->cursor;
-        btree = ((WT_CURSOR_BTREE *)primary)->btree;
+        btree = CUR2BT(primary);
 
         /*
          * If the primary is not yet set as the primary, do that now. Note that eviction was
@@ -681,7 +681,7 @@ err:
              */
             if (lsm_tree->custom_generation == 0 ||
               chunk->generation < lsm_tree->custom_generation) {
-                checkpoint = ((WT_CURSOR_BTREE *)cursor)->btree->dhandle->checkpoint;
+                checkpoint = ((WT_CURSOR_BTREE *)cursor)->dhandle->checkpoint;
                 WT_ASSERT(session, (F_ISSET(chunk, WT_LSM_CHUNK_ONDISK) && !chunk->empty) ?
                     checkpoint != NULL :
                     checkpoint == NULL);

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -71,7 +71,7 @@ __wt_metadata_cursor_open(WT_SESSION_IMPL *session, const char *config, WT_CURSO
      * Retrieve the btree from the cursor, rather than the session because we don't always switch
      * the metadata handle in to the session before entering this function.
      */
-    btree = ((WT_CURSOR_BTREE *)(*cursorp))->btree;
+    btree = CUR2BT(*cursorp);
 
 /*
  * Special settings for metadata: skew eviction so metadata almost always stays in cache and make

--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -138,7 +138,7 @@ __wt_schema_range_truncate(WT_SESSION_IMPL *session, WT_CURSOR *start, WT_CURSOR
         WT_ERR(__cursor_needkey(start));
         if (stop != NULL)
             WT_ERR(__cursor_needkey(stop));
-        WT_WITH_BTREE(session, ((WT_CURSOR_BTREE *)start)->btree,
+        WT_WITH_BTREE(session, CUR2BT(start),
           ret = __wt_btcur_range_truncate((WT_CURSOR_BTREE *)start, (WT_CURSOR_BTREE *)stop));
     } else if (WT_PREFIX_MATCH(uri, "table:"))
         ret = __wt_table_range_truncate((WT_CURSOR_TABLE *)start, (WT_CURSOR_TABLE *)stop);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -730,7 +730,7 @@ __txn_fixup_prepared_update(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR *
         } else
             tombstone = upd;
 
-        WT_WITH_BTREE(session, cbt->btree,
+        WT_WITH_BTREE(session, CUR2BT(cbt),
           ret = __wt_row_modify(cbt, &cbt->iface.key, NULL, tombstone, WT_UPDATE_INVALID, true));
         WT_ERR(ret);
         tombstone = NULL;
@@ -774,7 +774,7 @@ __txn_search_prepared_op(
     txn = session->txn;
 
     cursor = *cursorp;
-    if (cursor == NULL || ((WT_CURSOR_BTREE *)cursor)->btree->id != op->btree->id) {
+    if (cursor == NULL || CUR2BT(cursor)->id != op->btree->id) {
         *cursorp = NULL;
         if (cursor != NULL)
             WT_RET(cursor->close(cursor));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1039,8 +1039,7 @@ err:
      * database was idle.
      */
     if (full && logging) {
-        if (ret == 0 &&
-          F_ISSET(((WT_CURSOR_BTREE *)session->meta_cursor)->btree, WT_BTREE_SKIP_CKPT))
+        if (ret == 0 && F_ISSET(CUR2BT(session->meta_cursor), WT_BTREE_SKIP_CKPT))
             idle = true;
         WT_TRET(__wt_txn_checkpoint_log(session, full,
           (ret == 0 && !idle) ? WT_TXN_LOG_CKPT_STOP : WT_TXN_LOG_CKPT_CLEANUP, NULL));

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -45,7 +45,7 @@ __txn_op_log_row_key_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
         key.size = WT_INSERT_KEY_SIZE(cbt->ins);
     }
 
-    WT_ASSERT(session, __wt_compare(session, cbt->btree->collator, &key, &cursor->key, &cmp) == 0);
+    WT_ASSERT(session, __wt_compare(session, CUR2BT(cbt)->collator, &key, &cursor->key, &cmp) == 0);
     WT_ASSERT(session, cmp == 0);
 
     __wt_buf_free(session, &key);
@@ -74,7 +74,7 @@ __txn_op_log(
      * Log the row- or column-store insert, modify, remove or update. Our caller doesn't log reserve
      * operations, we shouldn't see them here.
      */
-    if (cbt->btree->type == BTREE_ROW) {
+    if (CUR2BT(cbt)->type == BTREE_ROW) {
 #ifdef HAVE_DIAGNOSTIC
         __txn_op_log_row_key_check(session, cbt);
 #endif


### PR DESCRIPTION
@agorrod, would you please approve the overall change, and @ddanderson, would you please do the detailed review?

The potentially interesting changes:

- `btree/bt_debug.c`, use `WT_WITH_BTREE`  in two more places
- `cursor/cur_bulk.c`, create a per-bulk cursor close routine
- `cursor/cur_file.c`, setting/clearing `WT_CURSOR_BTREE.dhandle` in different places`
- `include/api.h`, don't pass a `WT_BTREE` handle to `CURSOR_UPDATE_API_CALL_BTREE`, which makes that macro different but clarifies the `WT_BTREE` handle isn't optional as it is in other places
- `include/cursor.h`, remove `WT_CURSOR_BTREE.btree`, add the `CUR2BT` macro

I also fixed up a few places in LSM and `dhandle.h` where we were using the `WT_CURSOR_BTREE.WT_BTREE.dhandle`, and it was simpler to just use `WT_CURSOR_BTREE.dhandle`.

I think this is better, but we're still doing some fairly dirty stuff on handles. We should probably get rid of `WT_BTREE.dhandle` entirely, but that's for another day.
