### PR TITLE
WT-6082 Alternative that clears values when writing

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -766,11 +766,11 @@ __verify_ts_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num, c
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     /*
-     * On page timestamps are aggressively cleared when older than oldest to save space, so we
-     * can't rely on them in checks against the aggregated timestamp.
+     * On page timestamps are aggressively cleared when older than oldest to save space, so we can't
+     * rely on them in checks against the aggregated timestamp.
      */
     if (ts1 == WT_TS_NONE)
-            return (0);
+        return (0);
 
     if (gt && ts1 >= ts2)
         return (0);
@@ -847,7 +847,7 @@ __verify_txn_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num,
      * include them in checks against the aggregated ID.
      */
     if (txn1 == WT_TXN_NONE)
-            return (0);
+        return (0);
     if (gt && txn1 >= txn2)
         return (0);
     if (!gt && txn1 <= txn2)

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -765,6 +765,13 @@ __verify_ts_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num, c
 {
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
+    /*
+     * On page timestamps are aggressively cleared when older than oldest to save space, so we
+     * can't rely on them in checks against the aggregated timestamp.
+     */
+    if (ts1 == WT_TS_NONE)
+            return (0);
+
     if (gt && ts1 >= ts2)
         return (0);
     if (!gt && ts1 <= ts2)
@@ -835,6 +842,12 @@ __verify_txn_addr_cmp(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t cell_num,
   const char *txn1_name, uint64_t txn1, const char *txn2_name, uint64_t txn2, bool gt,
   const WT_PAGE_HEADER *dsk, WT_VSTUFF *vs)
 {
+    /*
+     * On page IDs are aggressively cleared when older than oldest to save space, so we can't
+     * include them in checks against the aggregated ID.
+     */
+    if (txn1 == WT_TXN_NONE)
+            return (0);
     if (gt && txn1 >= txn2)
         return (0);
     if (!gt && txn1 <= txn2)

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -200,11 +200,11 @@ __verify_dsk_ts_addr_cmp(WT_SESSION_IMPL *session, uint32_t cell_num, const char
     const char *ts1_bp, *ts2_bp;
 
     /*
-     * On page timestamps are aggressively cleared when older than oldest to save space, so we
-     * can't rely on them in checks against the aggregated timestamp.
+     * On page timestamps are aggressively cleared when older than oldest to save space, so we can't
+     * rely on them in checks against the aggregated timestamp.
      */
     if (ts1 == WT_TS_NONE)
-       return (0);
+        return (0);
 
     if (gt && ts1 >= ts2)
         return (0);

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -199,6 +199,13 @@ __verify_dsk_ts_addr_cmp(WT_SESSION_IMPL *session, uint32_t cell_num, const char
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     const char *ts1_bp, *ts2_bp;
 
+    /*
+     * On page timestamps are aggressively cleared when older than oldest to save space, so we
+     * can't rely on them in checks against the aggregated timestamp.
+     */
+    if (ts1 == WT_TS_NONE)
+       return (0);
+
     if (gt && ts1 >= ts2)
         return (0);
     if (!gt && ts1 <= ts2)
@@ -241,6 +248,12 @@ __verify_dsk_txn_addr_cmp(WT_SESSION_IMPL *session, uint32_t cell_num, const cha
   uint64_t txn1, const char *txn2_name, uint64_t txn2, bool gt, const char *tag,
   const WT_PAGE_HEADER *dsk)
 {
+    /*
+     * On page IDs are aggressively cleared when older than oldest to save space, so we can't
+     * include them in checks against the aggregated ID.
+     */
+    if (txn1 == WT_TXN_NONE)
+        return (0);
     if (gt && txn1 >= txn2)
         return (0);
     if (!gt && txn1 <= txn2)

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -93,8 +93,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         WT_ASSERT(session, trimmed_tw.start_ts <= trimmed_tw.durable_start_ts);
         /* Store differences if any, not absolutes. */
         if (trimmed_tw.durable_start_ts - trimmed_tw.start_ts > 0) {
-            WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-                trimmed_tw.durable_start_ts - trimmed_tw.start_ts));
+            WT_IGNORE_RET(
+              __wt_vpack_uint(pp, 0, trimmed_tw.durable_start_ts - trimmed_tw.start_ts));
             LF_SET(WT_CELL_TS_DURABLE_START);
         }
     }
@@ -112,8 +112,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         WT_ASSERT(session, trimmed_tw.stop_ts <= trimmed_tw.durable_stop_ts);
         /* Store differences if any, not absolutes. */
         if (trimmed_tw.durable_stop_ts - trimmed_tw.stop_ts > 0) {
-            WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-                trimmed_tw.durable_stop_ts - trimmed_tw.stop_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(pp, 0, trimmed_tw.durable_stop_ts - trimmed_tw.stop_ts));
             LF_SET(WT_CELL_TS_DURABLE_STOP);
         }
     }
@@ -217,20 +216,20 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREG
          * having that check to find out whether it is zero or not will unnecessarily add overhead
          * than benefit.
          */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-            trimmed_ta.newest_start_durable_ts - trimmed_ta.oldest_start_ts));
+        WT_IGNORE_RET(
+          __wt_vpack_uint(pp, 0, trimmed_ta.newest_start_durable_ts - trimmed_ta.oldest_start_ts));
         LF_SET(WT_CELL_TS_DURABLE_START);
     }
     if (trimmed_ta.newest_stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-            trimmed_ta.newest_stop_ts - trimmed_ta.oldest_start_ts));
+        WT_IGNORE_RET(
+          __wt_vpack_uint(pp, 0, trimmed_ta.newest_stop_ts - trimmed_ta.oldest_start_ts));
         LF_SET(WT_CELL_TS_STOP);
     }
     if (trimmed_ta.newest_stop_txn != WT_TXN_MAX) {
         /* Store differences, not absolutes. */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-            trimmed_ta.newest_stop_txn - trimmed_ta.oldest_start_txn));
+        WT_IGNORE_RET(
+          __wt_vpack_uint(pp, 0, trimmed_ta.newest_stop_txn - trimmed_ta.oldest_start_txn));
         LF_SET(WT_CELL_TXN_STOP);
     }
     if (trimmed_ta.newest_stop_durable_ts != WT_TS_NONE) {
@@ -246,8 +245,8 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREG
          * having that check to find out whether it is zero or not will unnecessarily add overhead
          * than benefit.
          */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0,
-            trimmed_ta.newest_stop_durable_ts - trimmed_ta.newest_stop_ts));
+        WT_IGNORE_RET(
+          __wt_vpack_uint(pp, 0, trimmed_ta.newest_stop_durable_ts - trimmed_ta.newest_stop_ts));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
     if (trimmed_ta.prepare)

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -158,11 +158,10 @@ struct __wt_session_impl {
     int (*reconcile_cleanup)(WT_SESSION_IMPL *);
 
     /*
-     * Save the time pair used to choose a visibility point for the most recent reconciliation
-     * done by this session. It's a bit of a hack, but saves us passing a time pair through
-     * a lot of code.
-     * These values are used to remember what oldest time is for a reconciliation, so we can avoid
-     * saving transaction IDs and timestamps to disk where possible.
+     * Save the time pair used to choose a visibility point for the most recent reconciliation done
+     * by this session. It's a bit of a hack, but saves us passing a time pair through a lot of
+     * code. These values are used to remember what oldest time is for a reconciliation, so we can
+     * avoid saving transaction IDs and timestamps to disk where possible.
      */
     wt_timestamp_t rec_pinned_ts;
     uint64_t rec_oldest_txnid;

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -157,6 +157,16 @@ struct __wt_session_impl {
     void *reconcile; /* Reconciliation support */
     int (*reconcile_cleanup)(WT_SESSION_IMPL *);
 
+    /*
+     * Save the time pair used to choose a visibility point for the most recent reconciliation
+     * done by this session. It's a bit of a hack, but saves us passing a time pair through
+     * a lot of code.
+     * These values are used to remember what oldest time is for a reconciliation, so we can avoid
+     * saving transaction IDs and timestamps to disk where possible.
+     */
+    wt_timestamp_t rec_pinned_ts;
+    uint64_t rec_oldest_txnid;
+
     /* Sessions have an associated statistics bucket based on its ID. */
     u_int stat_bucket; /* Statistics bucket offset */
 

--- a/src/include/timestamp.i
+++ b/src/include/timestamp.i
@@ -76,13 +76,12 @@ __wt_time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
     /* Avoid retrieving the pinned timestamp unless we need it. */
     if (tw->stop_ts == WT_TS_MAX) {
         /*
-         * The durable stop timestamp should be it's default value whenever the stop timestamp
-         * is.
+         * The durable stop timestamp should be it's default value whenever the stop timestamp is.
          */
         WT_ASSERT(session, tw->durable_stop_ts == WT_TS_NONE);
         /*
-         * The durable start timestamp is always greater than or equal to the start timestamp,
-         * as such we must check it against the pinned timestamp and not the start timestamp.
+         * The durable start timestamp is always greater than or equal to the start timestamp, as
+         * such we must check it against the pinned timestamp and not the start timestamp.
          */
         WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
         if (tw->durable_start_ts < session->rec_pinned_ts)

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -771,8 +771,6 @@ __wt_rec_row_leaf(
           __wt_txn_visible_all(session, tw.stop_txn, tw.stop_ts))
             upd = &upd_tombstone;
 
-        __wt_time_window_clear_obsolete(session, &tw);
-
         /* Build value cell. */
         if (upd == NULL) {
             /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -85,7 +85,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * that information.
      */
     ret = __reconcile(session, ref, salvage, flags, &page_locked);
-    /* TODO: should we clear the session reconciliation times here, or leave them set? */
+/* TODO: should we clear the session reconciliation times here, or leave them set? */
 
 err:
     if (page_locked)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -85,6 +85,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * that information.
      */
     ret = __reconcile(session, ref, salvage, flags, &page_locked);
+    /* TODO: should we clear the session reconciliation times here, or leave them set? */
 
 err:
     if (page_locked)
@@ -152,6 +153,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     /* Initialize the reconciliation structure for each new run. */
     WT_RET(__rec_init(session, ref, flags, salvage, &session->reconcile));
     r = session->reconcile;
+
+    __wt_txn_pinned_timestamp(session, &session->rec_pinned_ts);
+    session->rec_oldest_txnid = __wt_txn_oldest_id(session);
 
     /* Reconcile the page. */
     switch (page->type) {


### PR DESCRIPTION
This might be less efficient than clearing them earlier in reconciliation, but I think it captures all the cases in a better way.

It is failing testing similarly to the base branch. I wonder if the verify check is happening before a pair of aggregated time windows are being merged?