### PR TITLE
WT-6195 Ensure that we don't perform rollback to stable without a history store

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -539,6 +539,7 @@ __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool 
     WT_ERR_NOTFOUND_OK(metac->search(metac), true);
     if (ret == WT_NOTFOUND) {
         *hs_exists = false;
+        ret = 0;
     } else {
         /* Given the history store exists in the metadata validate whether it exists on disk. */
         WT_ERR(__wt_fs_exist(session, WT_HS_FILE, hs_exists));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -542,7 +542,7 @@ __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool 
     } else {
         /* Given the history store exists in the metadata validate whether it exists on disk. */
         WT_ERR(__wt_fs_exist(session, WT_HS_FILE, hs_exists));
-        if (hs_exists) {
+        if (*hs_exists) {
             /*
              * Attempt to configure the history store, this will detect corruption if it fails.
              */

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -512,6 +512,69 @@ __recovery_file_scan(WT_RECOVERY *r)
 }
 
 /*
+ * __hs_exists --
+ *     Check whether the history store exists. This function looks for both the history store URI in
+ *     the metadata file and for the history store data file itself.
+ */
+static int
+__hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool *hs_exists)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_SESSION *wt_session;
+
+    conn = S2C(session);
+
+    /*
+     * We should check whether the history store file exists in the metadata or not. If it does not,
+     * then we should skip rollback to stable for each table. This might happen if we're upgrading
+     * from an older version. If it does exist in the metadata we should check that it exists on
+     * disk to confirm that it wasn't deleted between runs.
+     *
+     * This needs to happen after we apply the logs as they may contain the metadata changes which
+     * include the history store creation. As such the on disk metadata file won't contain the
+     * history store but will after log application.
+     */
+    metac->set_key(metac, WT_HS_URI);
+    WT_ERR_NOTFOUND_OK(metac->search(metac), true);
+    if (ret == WT_NOTFOUND) {
+        *hs_exists = false;
+    } else {
+        /* Given the history store exists in the metadata validate whether it exists on disk. */
+        WT_ERR(__wt_fs_exist(session, WT_HS_FILE, hs_exists));
+        if (hs_exists) {
+            /*
+             * Attempt to configure the history store, this will detect corruption if it fails.
+             */
+            ret = __wt_hs_config(session, cfg);
+            if (ret != 0) {
+                if (F_ISSET(conn, WT_CONN_SALVAGE)) {
+                    wt_session = &session->iface;
+                    WT_ERR(wt_session->salvage(wt_session, WT_HS_URI, NULL));
+                } else
+                    WT_ERR(ret);
+            }
+        } else {
+            /*
+             * We're attempting to salvage the database with a missing history store, remove it from
+             * the metadata and pretend it never existed. As such we won't run rollback to stable
+             * later.
+             */
+            if (F_ISSET(conn, WT_CONN_SALVAGE)) {
+                *hs_exists = false;
+                metac->remove(metac);
+            } else
+                /* The history store file has likely been deleted, we cannot recover from this. */
+                WT_ERR_MSG(session, WT_TRY_SALVAGE, "%s file is corrupted or missing", WT_HS_FILE);
+        }
+    }
+err:
+    /* Unpin the page from cache. */
+    WT_TRET(metac->reset(metac));
+    return (ret);
+}
+
+/*
  * __wt_txn_recover --
  *     Run recovery.
  */
@@ -576,6 +639,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
             WT_ERR(__wt_log_reset(session, r.max_ckpt_lsn.l.file));
         else
             do_checkpoint = false;
+        WT_ERR(__hs_exists(session, metac, cfg, &hs_exists));
         goto done;
     }
 
@@ -624,52 +688,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
         WT_ERR(ret);
     }
 
-    /*
-     * We should check whether the history store file exists in the metadata or not. If it does not,
-     * then we should skip rollback to stable for each table. This might happen if we're upgrading
-     * from an older version. If it does exist in the metadata we should check that it exists on
-     * disk to confirm that it wasn't deleted between runs.
-     *
-     * This needs to happen after we apply the logs as they may contain the metadata changes which
-     * include the history store creation. As such the on disk metadata file won't contain the
-     * history store but will after log application.
-     */
-    metac->set_key(metac, WT_HS_URI);
-    WT_ERR_NOTFOUND_OK(metac->search(metac), true);
-    if (ret == WT_NOTFOUND) {
-        hs_exists = false;
-    } else {
-        /* Given the history store exists in the metadata validate whether it exists on disk. */
-        WT_ERR(__wt_fs_exist(session, WT_HS_FILE, &hs_exists));
-        if (hs_exists) {
-            /*
-             * Attempt to configure the history store, this will detect corruption if it fails.
-             */
-            ret = __wt_hs_config(session, cfg);
-            if (ret != 0) {
-                if (F_ISSET(conn, WT_CONN_SALVAGE)) {
-                    wt_session = &session->iface;
-                    WT_ERR(wt_session->salvage(wt_session, WT_HS_URI, NULL));
-                } else
-                    WT_ERR(ret);
-            }
-        } else {
-            /*
-             * We're attempting to salvage the database with a missing history store, remove it from
-             * the metadata and pretend it never existed. As such we won't run rollback to stable
-             * later.
-             */
-            if (F_ISSET(conn, WT_CONN_SALVAGE)) {
-                hs_exists = false;
-                metac->remove(metac);
-            } else
-                /* The history store file has likely been deleted, we cannot recover from this. */
-                WT_ERR_MSG(session, WT_TRY_SALVAGE, "%s file is corrupted or missing", WT_HS_FILE);
-        }
-    }
-
-    /* Unpin the page from cache. */
-    WT_ERR(metac->reset(metac));
+    /* Check whether the history store exists. */
+    WT_ERR(__hs_exists(session, metac, cfg, &hs_exists));
 
     /* Scan the metadata to find the live files and their IDs. */
     WT_ERR(__recovery_file_scan(&r));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -514,7 +514,8 @@ __recovery_file_scan(WT_RECOVERY *r)
 /*
  * __hs_exists --
  *     Check whether the history store exists. This function looks for both the history store URI in
- *     the metadata file and for the history store data file itself.
+ *     the metadata file and for the history store data file itself. If we're running salvage, we'll
+ *     attempt to salvage the history store here.
  */
 static int
 __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool *hs_exists)

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -587,7 +587,6 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     WT_DECL_RET;
     WT_RECOVERY r;
     WT_RECOVERY_FILE *metafile;
-    WT_SESSION *wt_session;
     char *config;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool do_checkpoint, eviction_started, hs_exists, needs_rec, was_backup;


### PR DESCRIPTION
This change is to avoid performing rollback to stable when we have no history store file. Previously, if we skip log recovery we `goto done` which will skip the logic where we determine whether or not a history store exists and `hs_exists` won't be assigned to properly.