### PR TITLE
WT-6148 Add new update to the history store with valid stop timestamp

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -693,6 +693,12 @@ __txn_fixup_prepared_update(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR *
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd, NULL));
         hs_upd->durable_ts = hs_upd->start_ts = txn->durable_timestamp;
         hs_upd->txnid = txn->id;
+
+        hs_cursor->set_value(hs_cursor, txn->durable_timestamp, durable_ts, type_full, hs_value);
+        WT_ERR(__wt_upd_alloc(session, &hs_cursor->value, WT_UPDATE_STANDARD, &hs_upd->next, NULL));
+        hs_upd->next->durable_ts = durable_ts;
+        hs_upd->next->start_ts = hs_start_ts;
+        hs_upd->next->txnid = hs_cbt->upd_value->txnid;
     } else {
         WT_ERR(__wt_upd_alloc(session, hs_value, WT_UPDATE_STANDARD, &upd, NULL));
 
@@ -746,7 +752,7 @@ __txn_fixup_prepared_update(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR *
 err:
     __wt_scr_free(session, &hs_key);
     __wt_scr_free(session, &hs_value);
-    __wt_free(session, hs_upd);
+    __wt_free_update_list(session, &hs_upd);
     __wt_free(session, upd);
     __wt_free(session, tombstone);
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -52,7 +52,7 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
     scenarios = make_scenarios(prepare_values)
 
     def conn_config(self):
-        config = 'cache_size=50MB,statistics=(all),log=(enabled=true)'
+        config = 'cache_size=5MB,statistics=(all),log=(enabled=true)'
         return config
 
     def simulate_crash_restart(self, uri, olddir, newdir):


### PR DESCRIPTION
When a uncommitted prepaed update is written to the data store, the
history store update must have a value with stop timestamp as WT_TS_MAX.
Need to update that value with proper stop timestamp by inserting a
new update to the history store folllowed by a tombstone with valid
stop timestamp.