### PR TITLE
WT-6245 Instantiate both update and tombstone for prepared tombstone

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -618,7 +618,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
                 upd->txnid = unpack.tw.start_txn;
 
                 /*
-                 * Instantiating both update and tombstone if the prepared update is of tombstone.
+                 * Instantiating both update and tombstone if the prepared update is a tombstone.
                  * This is required to ensure that written prepared delete operation must be removed
                  * from the data store, when the prepared transaction gets rollback.
                  */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -532,14 +532,16 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
     WT_BTREE *btree;
     WT_CELL_UNPACK_KV unpack;
+    WT_DECL_RET;
     WT_ITEM buf;
     WT_ROW *rip;
-    WT_UPDATE **upd_array, *upd;
+    WT_UPDATE *tombstone, **upd_array, *upd;
     size_t size, total_size;
     uint32_t i;
     bool instantiate_prepared, prepare;
 
     btree = S2BT(session);
+    tombstone = upd = NULL;
     prepare = false;
     WT_CLEAR(buf);
 
@@ -607,23 +609,35 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
             /* Unpack the on-page value cell. */
             __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
             if (unpack.tw.prepare) {
-                if (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw)) {
-                    /* Take the value from the original page cell. */
-                    WT_RET(__wt_page_cell_data_ref(session, page, &unpack, &buf));
+                /* Take the value from the original page cell. */
+                WT_RET(__wt_page_cell_data_ref(session, page, &unpack, &buf));
 
-                    WT_RET(__wt_upd_alloc(session, &buf, WT_UPDATE_STANDARD, &upd, &size));
-                    upd->durable_ts = WT_TS_NONE;
-                    upd->start_ts = unpack.tw.start_ts;
-                    upd->txnid = unpack.tw.start_txn;
+                WT_RET(__wt_upd_alloc(session, &buf, WT_UPDATE_STANDARD, &upd, &size));
+                upd->durable_ts = unpack.tw.durable_start_ts;
+                upd->start_ts = unpack.tw.start_ts;
+                upd->txnid = unpack.tw.start_txn;
+
+                /*
+                 * If the prepared update is of tombstone, instantiating both update and tombstone
+                 * are required. As both update and tombstone are present in the update list, there
+                 * is no need to set the flag that is used to indicate restoring the history store
+                 * in case of a prepared transaction abort.
+                 */
+                if (WT_TIME_WINDOW_HAS_STOP(&unpack.tw)) {
+                    WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
+                    tombstone->durable_ts = WT_TS_NONE;
+                    tombstone->start_ts = unpack.tw.stop_ts;
+                    tombstone->txnid = unpack.tw.stop_txn;
+                    tombstone->prepare_state = WT_PREPARE_INPROGRESS;
+                    tombstone->next = upd;
                 } else {
-                    WT_RET(__wt_upd_alloc_tombstone(session, &upd, &size));
                     upd->durable_ts = WT_TS_NONE;
-                    upd->start_ts = unpack.tw.stop_ts;
-                    upd->txnid = unpack.tw.stop_txn;
+                    upd->prepare_state = WT_PREPARE_INPROGRESS;
+                    F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DISK);
+                    tombstone = upd;
                 }
-                F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DISK);
-                upd->prepare_state = WT_PREPARE_INPROGRESS;
-                upd_array[WT_ROW_SLOT(page, rip)] = upd;
+
+                upd_array[WT_ROW_SLOT(page, rip)] = tombstone;
                 total_size += size;
             }
         }
@@ -631,5 +645,10 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
         __wt_cache_page_inmem_incr(session, page, total_size);
     }
 
-    return (0);
+    if (0) {
+err:
+        __wt_free(session, upd);
+    }
+
+    return (ret);
 }

--- a/test/suite/test_prepare08.py
+++ b/test/suite/test_prepare08.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import fnmatch, os, shutil, time
+from helper import copy_wiredtiger_home
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_prepare07.py
+# Test to ensure prepared tombstones are properly aborted even when they are written
+# to the data store.
+class test_prepare07(wttest.WiredTigerTestCase):
+    # Force a small cache.
+    conn_config = 'cache_size=1MB'
+
+    def updates(self, ds, uri, nrows, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction('isolation=snapshot')
+        for i in range(1, nrows):
+            cursor.set_key(ds.key(i))
+            cursor.set_value(value)
+            self.assertEquals(cursor.insert(), 0)
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+        cursor.close()
+
+    def check(self, ds, uri, nrows, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + timestamp_str(ts))
+        for i in range(1, nrows):
+            cursor.set_key(ds.key(i))
+            self.assertEquals(cursor.search(), 0)
+            self.assertEquals(cursor.get_value(),value)
+        self.session.commit_transaction()
+        cursor.close()
+
+    def test_prepare(self):
+        # Create a small table.
+        uri = "table:test"
+        nrows = 1000
+        ds = SimpleDataSet(self, uri, 0, key_format="S", value_format='u')
+        ds.populate()
+
+        value_a = b"aaaaa" * 100
+        value_b = b"bbbbb" * 100
+
+        # Commit some updates along with a prepared update, which is not resolved.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+
+        # Initially load huge data
+        self.updates(ds, uri, nrows, value_a, 20)
+        # Add some more updates
+        self.updates(ds, uri, nrows, value_b, 30)
+
+        # Checkpoint
+        self.session.checkpoint()
+
+        # Remove the updates from a prepare session and and keep it open.
+        session_p = self.conn.open_session()
+        cursor_p = session_p.open_cursor(uri)
+        session_p.begin_transaction('isolation=snapshot')
+        for i in range(1, nrows):
+            cursor_p.set_key(ds.key(i))
+            self.assertEquals(cursor_p.remove(), 0)
+        session_p.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+
+        self.check(ds, uri, nrows, value_a, 20)
+        self.check(ds, uri, nrows, value_b, 50)
+
+        #rollback the prepared session
+        session_p.rollback_transaction()
+
+        self.check(ds, uri, nrows, value_a, 20)
+        self.check(ds, uri, nrows, value_b, 50)
+
+        # close sessions.
+        cursor_p.close()
+        session_p.close()
+        self.session.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
When the prepared update is a tomnbstone that is written to the datastore,
while instantiating the data store, make sure that instantiate both
update and tombstone to avoid replacing the on-disk value.