### PR TITLE
WT-6252 Remove mutable read timestamp from transaction structure

### DIFF
--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -96,5 +96,5 @@ optypes = [
         [('uint64', 'time_sec'), ('uint64', 'time_nsec'),
             ('uint64', 'commit_ts'), ('uint64', 'durable_ts'),
             ('uint64', 'first_commit_ts'), ('uint64', 'prepare_ts'),
-            ('uint64', 'read_ts'), ('uint64', 'pinned_read_ts')]),
+            ('uint64', 'read_ts')]),
 ]

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -96,5 +96,5 @@ optypes = [
         [('uint64', 'time_sec'), ('uint64', 'time_nsec'),
             ('uint64', 'commit_ts'), ('uint64', 'durable_ts'),
             ('uint64', 'first_commit_ts'), ('uint64', 'prepare_ts'),
-            ('uint64', 'read_ts')]),
+            ('uint64', 'read_ts'), ('uint64', 'pinned_read_ts')]),
 ]

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -892,7 +892,6 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_ITEM hs_key, recno_key;
     WT_MODIFY_VECTOR modifies;
     WT_TXN *txn;
-    WT_TXN_SHARED *txn_shared;
     WT_UPDATE *mod_upd, *upd;
     wt_timestamp_t durable_timestamp, durable_timestamp_tmp, hs_start_ts, hs_start_ts_tmp;
     wt_timestamp_t hs_stop_durable_ts, hs_stop_durable_ts_tmp, read_timestamp;
@@ -908,7 +907,6 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_CLEAR(hs_key);
     __wt_modify_vector_init(session, &modifies);
     txn = session->txn;
-    txn_shared = WT_SESSION_TXN_SHARED(session);
     hs_btree_id = S2BT(session)->id;
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
     WT_NOT_READ(modify, false);
@@ -938,7 +936,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
      * timestamp is part of the key, our cursor needs to go from the newest record (further in the
      * las) to the oldest (earlier in the las) for a given key.
      */
-    read_timestamp = allow_prepare ? txn->prepare_timestamp : txn_shared->read_timestamp;
+    read_timestamp = allow_prepare ? txn->prepare_timestamp : txn->read_timestamp;
     WT_ERR_NOTFOUND_OK(
       __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, key, read_timestamp), true);
     if (ret == WT_NOTFOUND) {

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -908,13 +908,6 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_NOT_READ(modify, false);
     is_owner = false;
 
-    /*
-     * We temporarily move the read timestamp forwards to read modify records in the history store.
-     * Outside of that window, it should always be equal to the original read timestamp.
-     */
-    WT_ASSERT(
-      session, txn->read_timestamp == WT_SESSION_TXN_SHARED(session)->pinned_read_timestamp);
-
     /* Row-store key is as passed to us, create the column-store key as needed. */
     WT_ASSERT(
       session, (key == NULL && recno != WT_RECNO_OOB) || (key != NULL && recno == WT_RECNO_OOB));

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -892,6 +892,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_ITEM hs_key, recno_key;
     WT_MODIFY_VECTOR modifies;
     WT_TXN *txn;
+    WT_TXN_SHARED *txn_shared;
     WT_UPDATE *mod_upd, *upd;
     wt_timestamp_t durable_timestamp, durable_timestamp_tmp, hs_start_ts, hs_start_ts_tmp;
     wt_timestamp_t hs_stop_durable_ts, hs_stop_durable_ts_tmp, read_timestamp;
@@ -907,6 +908,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_CLEAR(hs_key);
     __wt_modify_vector_init(session, &modifies);
     txn = session->txn;
+    txn_shared = WT_SESSION_TXN_SHARED(session);
     hs_btree_id = S2BT(session)->id;
     session_flags = 0; /* [-Werror=maybe-uninitialized] */
     WT_NOT_READ(modify, false);
@@ -936,7 +938,7 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
      * timestamp is part of the key, our cursor needs to go from the newest record (further in the
      * las) to the oldest (earlier in the las) for a given key.
      */
-    read_timestamp = allow_prepare ? txn->prepare_timestamp : txn->read_timestamp;
+    read_timestamp = allow_prepare ? txn->prepare_timestamp : txn_shared->read_timestamp;
     WT_ERR_NOTFOUND_OK(
       __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, key, read_timestamp), true);
     if (ret == WT_NOTFOUND) {

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -871,6 +871,19 @@ err:
 }
 
 /*
+ * __hs_restore_read_timestamp --
+ *     Reset the currently running transaction's read timestamp with the original read timestamp.
+ */
+static void
+__hs_restore_read_timestamp(WT_SESSION_IMPL *session)
+{
+    WT_TXN_SHARED *txn_shared;
+
+    txn_shared = WT_SESSION_TXN_SHARED(session);
+    session->txn->read_timestamp = txn_shared->pinned_read_timestamp;
+}
+
+/*
  * __wt_find_hs_upd --
  *     Scan the history store for a record the btree cursor wants to position on. Create an update
  *     for the record and return to the caller. The caller may choose to optionally allow prepared
@@ -996,6 +1009,17 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
             mod_upd = NULL;
 
             /*
+             * Each entry in the lookaside is written with the actual start and stop time pair
+             * embedded in the key. In order to traverse a sequence of modifies, we're going to have
+             * to manipulate our read timestamp to see records we wouldn't otherwise be able to see.
+             *
+             * In this case, we want to read the next update in the chain meaning that its start
+             * timestamp should be equivalent to the stop timestamp of the record that we're
+             * currently on.
+             */
+            session->txn->read_timestamp = hs_stop_ts_tmp;
+
+            /*
              * Find the base update to apply the reverse deltas. If our cursor next fails to find an
              * update here we fall back to the datastore version. If its timestamp doesn't match our
              * timestamp then we return not found.
@@ -1040,6 +1064,8 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
             __wt_free_update_list(session, &mod_upd);
             mod_upd = NULL;
         }
+        /* After we're done looping over modifies, reset the read timestamp. */
+        __hs_restore_read_timestamp(session);
         WT_STAT_CONN_INCR(session, cache_hs_read_squash);
     }
 
@@ -1066,6 +1092,11 @@ err:
         __wt_scr_free(session, &hs_value);
     WT_ASSERT(session, hs_key.mem == NULL && hs_key.memsize == 0);
 
+    /*
+     * Restore the read timestamp if we encountered an error while processing a modify. There's no
+     * harm in doing this multiple times.
+     */
+    __hs_restore_read_timestamp(session);
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
 
     __wt_free_update_list(session, &mod_upd);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -871,19 +871,6 @@ err:
 }
 
 /*
- * __hs_restore_read_timestamp --
- *     Reset the currently running transaction's read timestamp with the original read timestamp.
- */
-static void
-__hs_restore_read_timestamp(WT_SESSION_IMPL *session)
-{
-    WT_TXN_SHARED *txn_shared;
-
-    txn_shared = WT_SESSION_TXN_SHARED(session);
-    session->txn->read_timestamp = txn_shared->pinned_read_timestamp;
-}
-
-/*
  * __wt_find_hs_upd --
  *     Scan the history store for a record the btree cursor wants to position on. Create an update
  *     for the record and return to the caller. The caller may choose to optionally allow prepared
@@ -1009,17 +996,6 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
             mod_upd = NULL;
 
             /*
-             * Each entry in the lookaside is written with the actual start and stop time pair
-             * embedded in the key. In order to traverse a sequence of modifies, we're going to have
-             * to manipulate our read timestamp to see records we wouldn't otherwise be able to see.
-             *
-             * In this case, we want to read the next update in the chain meaning that its start
-             * timestamp should be equivalent to the stop timestamp of the record that we're
-             * currently on.
-             */
-            session->txn->read_timestamp = hs_stop_ts_tmp;
-
-            /*
              * Find the base update to apply the reverse deltas. If our cursor next fails to find an
              * update here we fall back to the datastore version. If its timestamp doesn't match our
              * timestamp then we return not found.
@@ -1064,8 +1040,6 @@ __wt_find_hs_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
             __wt_free_update_list(session, &mod_upd);
             mod_upd = NULL;
         }
-        /* After we're done looping over modifies, reset the read timestamp. */
-        __hs_restore_read_timestamp(session);
         WT_STAT_CONN_INCR(session, cache_hs_read_squash);
     }
 
@@ -1092,11 +1066,6 @@ err:
         __wt_scr_free(session, &hs_value);
     WT_ASSERT(session, hs_key.mem == NULL && hs_key.memsize == 0);
 
-    /*
-     * Restore the read timestamp if we encountered an error while processing a modify. There's no
-     * harm in doing this multiple times.
-     */
-    __hs_restore_read_timestamp(session);
     WT_TRET(__wt_hs_cursor_close(session, session_flags, is_owner));
 
     __wt_free_update_list(session, &mod_upd);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -936,14 +936,14 @@ extern int __wt_logop_row_truncate_unpack(WT_SESSION_IMPL *session, const uint8_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec,
   uint64_t time_sec, uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts,
-  uint64_t first_commit_ts, uint64_t prepare_ts, uint64_t read_ts, uint64_t pinned_read_ts)
+  uint64_t first_commit_ts, uint64_t prepare_ts, uint64_t read_ts)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_print(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp,
-  uint64_t *durable_tsp, uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp,
-  uint64_t *pinned_read_tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint64_t *durable_tsp, uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logrec_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -936,14 +936,14 @@ extern int __wt_logop_row_truncate_unpack(WT_SESSION_IMPL *session, const uint8_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec,
   uint64_t time_sec, uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts,
-  uint64_t first_commit_ts, uint64_t prepare_ts, uint64_t read_ts)
+  uint64_t first_commit_ts, uint64_t prepare_ts, uint64_t read_ts, uint64_t pinned_read_ts)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_print(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp,
-  uint64_t *durable_tsp, uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint64_t *durable_tsp, uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp,
+  uint64_t *pinned_read_tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logrec_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -98,11 +98,10 @@ struct __wt_txn_shared {
     wt_timestamp_t pinned_durable_timestamp;
 
     /*
-     * Set to the first read timestamp used in the transaction. As part of our history store
-     * mechanism, we can move the read timestamp forward so we need to keep track of the original
-     * read timestamp to know what history should be pinned in front of oldest.
+     * The read timestamp used for this transaction. Determines what updates can be read and
+     * prevents the oldest timestamp moving past this point.
      */
-    wt_timestamp_t pinned_read_timestamp;
+    wt_timestamp_t read_timestamp;
 
     TAILQ_ENTRY(__wt_txn_shared) read_timestampq;
     TAILQ_ENTRY(__wt_txn_shared) durable_timestampq;
@@ -290,9 +289,6 @@ struct __wt_txn {
      * Timestamp copied into updates created by this transaction, when this transaction is prepared.
      */
     wt_timestamp_t prepare_timestamp;
-
-    /* Read updates committed as of this timestamp. */
-    wt_timestamp_t read_timestamp;
 
     /* Array of modifications by this transaction. */
     WT_TXN_OP *mod;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -98,10 +98,11 @@ struct __wt_txn_shared {
     wt_timestamp_t pinned_durable_timestamp;
 
     /*
-     * The read timestamp used for this transaction. Determines what updates can be read and
-     * prevents the oldest timestamp moving past this point.
+     * Set to the first read timestamp used in the transaction. As part of our history store
+     * mechanism, we can move the read timestamp forward so we need to keep track of the original
+     * read timestamp to know what history should be pinned in front of oldest.
      */
-    wt_timestamp_t read_timestamp;
+    wt_timestamp_t pinned_read_timestamp;
 
     TAILQ_ENTRY(__wt_txn_shared) read_timestampq;
     TAILQ_ENTRY(__wt_txn_shared) durable_timestampq;
@@ -289,6 +290,9 @@ struct __wt_txn {
      * Timestamp copied into updates created by this transaction, when this transaction is prepared.
      */
     wt_timestamp_t prepare_timestamp;
+
+    /* Read updates committed as of this timestamp. */
+    wt_timestamp_t read_timestamp;
 
     /* Array of modifications by this transaction. */
     WT_TXN_OP *mod;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -938,7 +938,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
     }
 
     /* If the start time pair is visible then we need to return the ondisk value. */
-    if (__wt_txn_tw_start_visible(session, &tw) || F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
+    if (F_ISSET(session, WT_SESSION_RESOLVING_MODIFY) || __wt_txn_tw_start_visible(session, &tw)) {
         /* If we are resolving a modify then the btree must be the history store. */
         WT_ASSERT(
           session, (F_ISSET(session, WT_SESSION_RESOLVING_MODIFY) && WT_IS_HS(S2BT(session))) ||

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -703,8 +703,10 @@ static inline bool
 __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp)
 {
     WT_TXN *txn;
+    WT_TXN_SHARED *txn_shared;
 
     txn = session->txn;
+    txn_shared = WT_SESSION_TXN_SHARED(session);
 
     if (!__txn_visible_id(session, id))
         return (false);
@@ -717,7 +719,7 @@ __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp
     if (!F_ISSET(txn, WT_TXN_HAS_TS_READ) || timestamp == WT_TS_NONE)
         return (true);
 
-    return (timestamp <= txn->read_timestamp);
+    return (timestamp <= txn_shared->read_timestamp);
 }
 
 /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -736,11 +736,6 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (prepare_state == WT_PREPARE_LOCKED)
             continue;
 
-        if (upd->type == WT_UPDATE_STANDARD && F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
-            WT_ASSERT(session, WT_IS_HS(S2BT(session)));
-            return (WT_VISIBLE_TRUE);
-        }
-
         upd_visible = __wt_txn_visible(session, upd->txnid, upd->start_ts);
 
         /*
@@ -917,10 +912,10 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
     }
 
     /*
-     * If the stop time point is set, that means that there is a tombstone at that time. If it is
-     * not prepared and the it is visible to our txn then that means we've just spotted a tombstone
-     * and should return "not found", except for history store scan during rollback to stable and
-     * when we are told to ignore non-globally visible tombstones.
+     * If the stop pair is set, that means that there is a tombstone at that time. If it is not
+     * prepared and the stop time pair is visible to our txn then that means we've just spotted a
+     * tombstone and should return "not found", except for history store scan during rollback to
+     * stable and when we are told to ignore non-globally visible tombstones.
      */
     if (__wt_txn_tw_stop_visible(session, &tw) &&
       ((!F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
@@ -935,7 +930,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
         return (0);
     }
 
-    /* If the start time point is visible then we need to return the ondisk value. */
+    /* If the start time pair is visible then we need to return the ondisk value. */
     if (__wt_txn_tw_start_visible(session, &tw) || F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
         /* If we are resolving a modify then the btree must be the history store. */
         WT_ASSERT(

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -703,10 +703,8 @@ static inline bool
 __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp)
 {
     WT_TXN *txn;
-    WT_TXN_SHARED *txn_shared;
 
     txn = session->txn;
-    txn_shared = WT_SESSION_TXN_SHARED(session);
 
     if (!__txn_visible_id(session, id))
         return (false);
@@ -719,7 +717,7 @@ __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp
     if (!F_ISSET(txn, WT_TXN_HAS_TS_READ) || timestamp == WT_TS_NONE)
         return (true);
 
-    return (timestamp <= txn_shared->read_timestamp);
+    return (timestamp <= txn->read_timestamp);
 }
 
 /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -736,6 +736,11 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (prepare_state == WT_PREPARE_LOCKED)
             continue;
 
+        if (upd->type == WT_UPDATE_STANDARD && F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
+            WT_ASSERT(session, WT_IS_HS(S2BT(session)));
+            return (WT_VISIBLE_TRUE);
+        }
+
         upd_visible = __wt_txn_visible(session, upd->txnid, upd->start_ts);
 
         /*

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -736,7 +736,9 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (prepare_state == WT_PREPARE_LOCKED)
             continue;
 
-        if (upd->type == WT_UPDATE_STANDARD && F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
+        if (F_ISSET(session, WT_SESSION_RESOLVING_MODIFY) && upd->txnid != WT_TXN_ABORTED &&
+          upd->type == WT_UPDATE_STANDARD) {
+            /* If we are resolving a modify then the btree must be the history store. */
             WT_ASSERT(session, WT_IS_HS(S2BT(session)));
             return (WT_VISIBLE_TRUE);
         }

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -937,7 +937,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
         return (0);
     }
 
-    /* If the start time pair is visible then we need to return the ondisk value. */
+    /* If the start time point is visible then we need to return the ondisk value. */
     if (F_ISSET(session, WT_SESSION_RESOLVING_MODIFY) || __wt_txn_tw_start_visible(session, &tw)) {
         /* If we are resolving a modify then the btree must be the history store. */
         WT_ASSERT(

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -736,6 +736,11 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (prepare_state == WT_PREPARE_LOCKED)
             continue;
 
+        if (upd->type == WT_UPDATE_STANDARD && F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
+            WT_ASSERT(session, WT_IS_HS(S2BT(session)));
+            return (WT_VISIBLE_TRUE);
+        }
+
         upd_visible = __wt_txn_visible(session, upd->txnid, upd->start_ts);
 
         /*
@@ -912,10 +917,10 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
     }
 
     /*
-     * If the stop pair is set, that means that there is a tombstone at that time. If it is not
-     * prepared and the stop time pair is visible to our txn then that means we've just spotted a
-     * tombstone and should return "not found", except for history store scan during rollback to
-     * stable and when we are told to ignore non-globally visible tombstones.
+     * If the stop time point is set, that means that there is a tombstone at that time. If it is
+     * not prepared and the it is visible to our txn then that means we've just spotted a tombstone
+     * and should return "not found", except for history store scan during rollback to stable and
+     * when we are told to ignore non-globally visible tombstones.
      */
     if (__wt_txn_tw_stop_visible(session, &tw) &&
       ((!F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
@@ -930,7 +935,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
         return (0);
     }
 
-    /* If the start time pair is visible then we need to return the ondisk value. */
+    /* If the start time point is visible then we need to return the ondisk value. */
     if (__wt_txn_tw_start_visible(session, &tw) || F_ISSET(session, WT_SESSION_RESOLVING_MODIFY)) {
         /* If we are resolving a modify then the btree must be the history store. */
         WT_ASSERT(

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -712,22 +712,21 @@ __wt_logop_prev_lsn_print(
 int
 __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_t time_sec,
   uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts, uint64_t first_commit_ts,
-  uint64_t prepare_ts, uint64_t read_ts, uint64_t pinned_read_ts)
+  uint64_t prepare_ts, uint64_t read_ts)
 {
-    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQQ);
+    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQ);
     size_t size;
     uint32_t optype, recsize;
 
     optype = WT_LOGOP_TXN_TIMESTAMP;
     WT_RET(__wt_struct_size(session, &size, fmt, optype, 0, time_sec, time_nsec, commit_ts,
-      durable_ts, first_commit_ts, prepare_ts, read_ts, pinned_read_ts));
+      durable_ts, first_commit_ts, prepare_ts, read_ts));
 
     __wt_struct_size_adjust(session, &size);
     WT_RET(__wt_buf_extend(session, logrec, logrec->size + size));
     recsize = (uint32_t)size;
     WT_RET(__wt_struct_pack(session, (uint8_t *)logrec->data + logrec->size, size, fmt, optype,
-      recsize, time_sec, time_nsec, commit_ts, durable_ts, first_commit_ts, prepare_ts, read_ts,
-      pinned_read_ts));
+      recsize, time_sec, time_nsec, commit_ts, durable_ts, first_commit_ts, prepare_ts, read_ts));
 
     logrec->size += (uint32_t)size;
     return (0);
@@ -736,15 +735,15 @@ __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_
 int
 __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp, uint64_t *durable_tsp,
-  uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp, uint64_t *pinned_read_tsp)
+  uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp)
 {
     WT_DECL_RET;
-    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQQ);
+    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQ);
     uint32_t optype, size;
 
-    if ((ret = __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt, &optype, &size,
-           time_secp, time_nsecp, commit_tsp, durable_tsp, first_commit_tsp, prepare_tsp, read_tsp,
-           pinned_read_tsp)) != 0)
+    if ((ret =
+            __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt, &optype, &size, time_secp,
+              time_nsecp, commit_tsp, durable_tsp, first_commit_tsp, prepare_tsp, read_tsp)) != 0)
         WT_RET_MSG(session, ret, "logop_txn_timestamp: unpack failure");
     WT_ASSERT(session, optype == WT_LOGOP_TXN_TIMESTAMP);
 
@@ -763,10 +762,9 @@ __wt_logop_txn_timestamp_print(
     uint64_t first_commit_ts;
     uint64_t prepare_ts;
     uint64_t read_ts;
-    uint64_t pinned_read_ts;
 
     WT_RET(__wt_logop_txn_timestamp_unpack(session, pp, end, &time_sec, &time_nsec, &commit_ts,
-      &durable_ts, &first_commit_ts, &prepare_ts, &read_ts, &pinned_read_ts));
+      &durable_ts, &first_commit_ts, &prepare_ts, &read_ts));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"txn_timestamp\",\n"));
     WT_RET(__wt_fprintf(session, args->fs, "        \"time_sec\": %" PRIu64 ",\n", time_sec));
@@ -776,9 +774,7 @@ __wt_logop_txn_timestamp_print(
     WT_RET(__wt_fprintf(
       session, args->fs, "        \"first_commit_ts\": %" PRIu64 ",\n", first_commit_ts));
     WT_RET(__wt_fprintf(session, args->fs, "        \"prepare_ts\": %" PRIu64 ",\n", prepare_ts));
-    WT_RET(__wt_fprintf(session, args->fs, "        \"read_ts\": %" PRIu64 ",\n", read_ts));
-    WT_RET(
-      __wt_fprintf(session, args->fs, "        \"pinned_read_ts\": %" PRIu64 "", pinned_read_ts));
+    WT_RET(__wt_fprintf(session, args->fs, "        \"read_ts\": %" PRIu64 "", read_ts));
     return (0);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -712,21 +712,22 @@ __wt_logop_prev_lsn_print(
 int
 __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_t time_sec,
   uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts, uint64_t first_commit_ts,
-  uint64_t prepare_ts, uint64_t read_ts)
+  uint64_t prepare_ts, uint64_t read_ts, uint64_t pinned_read_ts)
 {
-    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQ);
+    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQQ);
     size_t size;
     uint32_t optype, recsize;
 
     optype = WT_LOGOP_TXN_TIMESTAMP;
     WT_RET(__wt_struct_size(session, &size, fmt, optype, 0, time_sec, time_nsec, commit_ts,
-      durable_ts, first_commit_ts, prepare_ts, read_ts));
+      durable_ts, first_commit_ts, prepare_ts, read_ts, pinned_read_ts));
 
     __wt_struct_size_adjust(session, &size);
     WT_RET(__wt_buf_extend(session, logrec, logrec->size + size));
     recsize = (uint32_t)size;
     WT_RET(__wt_struct_pack(session, (uint8_t *)logrec->data + logrec->size, size, fmt, optype,
-      recsize, time_sec, time_nsec, commit_ts, durable_ts, first_commit_ts, prepare_ts, read_ts));
+      recsize, time_sec, time_nsec, commit_ts, durable_ts, first_commit_ts, prepare_ts, read_ts,
+      pinned_read_ts));
 
     logrec->size += (uint32_t)size;
     return (0);
@@ -735,15 +736,15 @@ __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_
 int
 __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp, uint64_t *durable_tsp,
-  uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp)
+  uint64_t *first_commit_tsp, uint64_t *prepare_tsp, uint64_t *read_tsp, uint64_t *pinned_read_tsp)
 {
     WT_DECL_RET;
-    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQ);
+    const char *fmt = WT_UNCHECKED_STRING(IIQQQQQQQQ);
     uint32_t optype, size;
 
-    if ((ret =
-            __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt, &optype, &size, time_secp,
-              time_nsecp, commit_tsp, durable_tsp, first_commit_tsp, prepare_tsp, read_tsp)) != 0)
+    if ((ret = __wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), fmt, &optype, &size,
+           time_secp, time_nsecp, commit_tsp, durable_tsp, first_commit_tsp, prepare_tsp, read_tsp,
+           pinned_read_tsp)) != 0)
         WT_RET_MSG(session, ret, "logop_txn_timestamp: unpack failure");
     WT_ASSERT(session, optype == WT_LOGOP_TXN_TIMESTAMP);
 
@@ -762,9 +763,10 @@ __wt_logop_txn_timestamp_print(
     uint64_t first_commit_ts;
     uint64_t prepare_ts;
     uint64_t read_ts;
+    uint64_t pinned_read_ts;
 
     WT_RET(__wt_logop_txn_timestamp_unpack(session, pp, end, &time_sec, &time_nsec, &commit_ts,
-      &durable_ts, &first_commit_ts, &prepare_ts, &read_ts));
+      &durable_ts, &first_commit_ts, &prepare_ts, &read_ts, &pinned_read_ts));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"txn_timestamp\",\n"));
     WT_RET(__wt_fprintf(session, args->fs, "        \"time_sec\": %" PRIu64 ",\n", time_sec));
@@ -774,7 +776,9 @@ __wt_logop_txn_timestamp_print(
     WT_RET(__wt_fprintf(
       session, args->fs, "        \"first_commit_ts\": %" PRIu64 ",\n", first_commit_ts));
     WT_RET(__wt_fprintf(session, args->fs, "        \"prepare_ts\": %" PRIu64 ",\n", prepare_ts));
-    WT_RET(__wt_fprintf(session, args->fs, "        \"read_ts\": %" PRIu64 "", read_ts));
+    WT_RET(__wt_fprintf(session, args->fs, "        \"read_ts\": %" PRIu64 ",\n", read_ts));
+    WT_RET(
+      __wt_fprintf(session, args->fs, "        \"pinned_read_ts\": %" PRIu64 "", pinned_read_ts));
     return (0);
 }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1897,7 +1897,7 @@ __wt_verbose_dump_txn_one(
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     char buf[512];
-    char ts_string[6][WT_TS_INT_STRING_SIZE];
+    char ts_string[7][WT_TS_INT_STRING_SIZE];
     const char *iso_tag;
 
     txn = txn_session->txn;
@@ -1927,8 +1927,9 @@ __wt_verbose_dump_txn_one(
                    ", durable_timestamp: %s"
                    ", first_commit_timestamp: %s"
                    ", prepare_timestamp: %s"
-                   ", pinned_durable_timestamp: %s"
                    ", read_timestamp: %s"
+                   ", pinned_durable_timestamp: %s"
+                   ", pinned_read_timestamp: %s"
                    ", checkpoint LSN: [%" PRIu32 "][%" PRIu32 "]"
                    ", full checkpoint: %s"
                    ", rollback reason: %s"
@@ -1938,9 +1939,10 @@ __wt_verbose_dump_txn_one(
       __wt_timestamp_to_string(txn->durable_timestamp, ts_string[1]),
       __wt_timestamp_to_string(txn->first_commit_timestamp, ts_string[2]),
       __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[3]),
-      __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[4]),
-      __wt_timestamp_to_string(txn_shared->read_timestamp, ts_string[5]), txn->ckpt_lsn.l.file,
-      txn->ckpt_lsn.l.offset, txn->full_ckpt ? "true" : "false",
+      __wt_timestamp_to_string(txn->read_timestamp, ts_string[4]),
+      __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[5]),
+      __wt_timestamp_to_string(txn_shared->pinned_read_timestamp, ts_string[6]),
+      txn->ckpt_lsn.l.file, txn->ckpt_lsn.l.offset, txn->full_ckpt ? "true" : "false",
       txn->rollback_reason == NULL ? "" : txn->rollback_reason, txn->flags, iso_tag));
 
     /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1897,7 +1897,7 @@ __wt_verbose_dump_txn_one(
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     char buf[512];
-    char ts_string[7][WT_TS_INT_STRING_SIZE];
+    char ts_string[6][WT_TS_INT_STRING_SIZE];
     const char *iso_tag;
 
     txn = txn_session->txn;
@@ -1927,9 +1927,8 @@ __wt_verbose_dump_txn_one(
                    ", durable_timestamp: %s"
                    ", first_commit_timestamp: %s"
                    ", prepare_timestamp: %s"
-                   ", read_timestamp: %s"
                    ", pinned_durable_timestamp: %s"
-                   ", pinned_read_timestamp: %s"
+                   ", read_timestamp: %s"
                    ", checkpoint LSN: [%" PRIu32 "][%" PRIu32 "]"
                    ", full checkpoint: %s"
                    ", rollback reason: %s"
@@ -1939,10 +1938,9 @@ __wt_verbose_dump_txn_one(
       __wt_timestamp_to_string(txn->durable_timestamp, ts_string[1]),
       __wt_timestamp_to_string(txn->first_commit_timestamp, ts_string[2]),
       __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[3]),
-      __wt_timestamp_to_string(txn->read_timestamp, ts_string[4]),
-      __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[5]),
-      __wt_timestamp_to_string(txn_shared->pinned_read_timestamp, ts_string[6]),
-      txn->ckpt_lsn.l.file, txn->ckpt_lsn.l.offset, txn->full_ckpt ? "true" : "false",
+      __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[4]),
+      __wt_timestamp_to_string(txn_shared->read_timestamp, ts_string[5]), txn->ckpt_lsn.l.file,
+      txn->ckpt_lsn.l.offset, txn->full_ckpt ? "true" : "false",
       txn->rollback_reason == NULL ? "" : txn->rollback_reason, txn->flags, iso_tag));
 
     /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -623,7 +623,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
     } else {
         if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = WT_TS_NONE;
-        txn->read_timestamp = txn_shared->pinned_read_timestamp = WT_TS_NONE;
+        txn_shared->read_timestamp = WT_TS_NONE;
     }
 
     __wt_writeunlock(session, &txn_global->rwlock);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -623,7 +623,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
     } else {
         if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = WT_TS_NONE;
-        txn_shared->read_timestamp = WT_TS_NONE;
+        txn->read_timestamp = txn_shared->pinned_read_timestamp = WT_TS_NONE;
     }
 
     __wt_writeunlock(session, &txn_global->rwlock);

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -395,7 +395,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
     WT_ITEM *logrec;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
-    wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
+    wt_timestamp_t commit, durable, first_commit, prepare, read;
 
     conn = S2C(session);
     txn = session->txn;
@@ -419,7 +419,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
 
     WT_RET(__txn_logrec_init(session));
     logrec = txn->logrec;
-    commit = durable = first_commit = pinned_read = prepare = read = WT_TS_NONE;
+    commit = durable = first_commit = prepare = read = WT_TS_NONE;
     if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT)) {
         commit = txn->commit_timestamp;
         first_commit = txn->first_commit_timestamp;
@@ -428,14 +428,12 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
         durable = txn->durable_timestamp;
     if (F_ISSET(txn, WT_TXN_HAS_TS_PREPARE))
         prepare = txn->prepare_timestamp;
-    if (F_ISSET(txn, WT_TXN_HAS_TS_READ)) {
-        read = txn->read_timestamp;
-        pinned_read = txn_shared->pinned_read_timestamp;
-    }
+    if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
+        read = txn_shared->read_timestamp;
 
     __wt_epoch(session, &t);
     return (__wt_logop_txn_timestamp_pack(session, logrec, (uint64_t)t.tv_sec, (uint64_t)t.tv_nsec,
-      commit, durable, first_commit, prepare, read, pinned_read));
+      commit, durable, first_commit, prepare, read));
 }
 
 /*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -395,7 +395,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
     WT_ITEM *logrec;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
-    wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
+    wt_timestamp_t commit, durable, first_commit, prepare, read;
 
     conn = S2C(session);
     txn = session->txn;
@@ -419,7 +419,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
 
     WT_RET(__txn_logrec_init(session));
     logrec = txn->logrec;
-    commit = durable = first_commit = pinned_read = prepare = read = WT_TS_NONE;
+    commit = durable = first_commit = prepare = read = WT_TS_NONE;
     if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT)) {
         commit = txn->commit_timestamp;
         first_commit = txn->first_commit_timestamp;
@@ -428,14 +428,13 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
         durable = txn->durable_timestamp;
     if (F_ISSET(txn, WT_TXN_HAS_TS_PREPARE))
         prepare = txn->prepare_timestamp;
-    if (F_ISSET(txn, WT_TXN_HAS_TS_READ)) {
-        read = txn->read_timestamp;
-        pinned_read = txn_shared->pinned_read_timestamp;
-    }
+    if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
+        read = txn_shared->read_timestamp;
 
     __wt_epoch(session, &t);
+
     return (__wt_logop_txn_timestamp_pack(session, logrec, (uint64_t)t.tv_sec, (uint64_t)t.tv_nsec,
-      commit, durable, first_commit, prepare, read, pinned_read));
+      commit, durable, first_commit, prepare, read));
 }
 
 /*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -395,7 +395,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
     WT_ITEM *logrec;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
-    wt_timestamp_t commit, durable, first_commit, prepare, read;
+    wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
 
     conn = S2C(session);
     txn = session->txn;
@@ -419,7 +419,7 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
 
     WT_RET(__txn_logrec_init(session));
     logrec = txn->logrec;
-    commit = durable = first_commit = prepare = read = WT_TS_NONE;
+    commit = durable = first_commit = pinned_read = prepare = read = WT_TS_NONE;
     if (F_ISSET(txn, WT_TXN_HAS_TS_COMMIT)) {
         commit = txn->commit_timestamp;
         first_commit = txn->first_commit_timestamp;
@@ -428,13 +428,14 @@ __wt_txn_ts_log(WT_SESSION_IMPL *session)
         durable = txn->durable_timestamp;
     if (F_ISSET(txn, WT_TXN_HAS_TS_PREPARE))
         prepare = txn->prepare_timestamp;
-    if (F_ISSET(txn, WT_TXN_HAS_TS_READ))
-        read = txn_shared->read_timestamp;
+    if (F_ISSET(txn, WT_TXN_HAS_TS_READ)) {
+        read = txn->read_timestamp;
+        pinned_read = txn_shared->pinned_read_timestamp;
+    }
 
     __wt_epoch(session, &t);
-
     return (__wt_logop_txn_timestamp_pack(session, logrec, (uint64_t)t.tv_sec, (uint64_t)t.tv_nsec,
-      commit, durable, first_commit, prepare, read));
+      commit, durable, first_commit, prepare, read, pinned_read));
 }
 
 /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -112,7 +112,7 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
     WT_DECL_RET;
     WT_ITEM key, start_key, stop_key, value;
     WT_SESSION_IMPL *session;
-    wt_timestamp_t commit, durable, first_commit, prepare, read;
+    wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
     uint64_t recno, start_recno, stop_recno, t_nsec, t_sec;
     uint32_t fileid, mode, optype, opsize;
 
@@ -268,8 +268,8 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
          * Timestamp records are informational only. We have to unpack it to properly move forward
          * in the log record to the next operation, but otherwise ignore.
          */
-        WT_ERR(__wt_logop_txn_timestamp_unpack(
-          session, pp, end, &t_sec, &t_nsec, &commit, &durable, &first_commit, &prepare, &read));
+        WT_ERR(__wt_logop_txn_timestamp_unpack(session, pp, end, &t_sec, &t_nsec, &commit, &durable,
+          &first_commit, &prepare, &read, &pinned_read));
         break;
     default:
         WT_ERR(__wt_illegal_value(session, optype));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -112,7 +112,7 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
     WT_DECL_RET;
     WT_ITEM key, start_key, stop_key, value;
     WT_SESSION_IMPL *session;
-    wt_timestamp_t commit, durable, first_commit, pinned_read, prepare, read;
+    wt_timestamp_t commit, durable, first_commit, prepare, read;
     uint64_t recno, start_recno, stop_recno, t_nsec, t_sec;
     uint32_t fileid, mode, optype, opsize;
 
@@ -268,8 +268,8 @@ __txn_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8_t *
          * Timestamp records are informational only. We have to unpack it to properly move forward
          * in the log record to the next operation, but otherwise ignore.
          */
-        WT_ERR(__wt_logop_txn_timestamp_unpack(session, pp, end, &t_sec, &t_nsec, &commit, &durable,
-          &first_commit, &prepare, &read, &pinned_read));
+        WT_ERR(__wt_logop_txn_timestamp_unpack(
+          session, pp, end, &t_sec, &t_nsec, &commit, &durable, &first_commit, &prepare, &read));
         break;
     default:
         WT_ERR(__wt_illegal_value(session, optype));

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -75,7 +75,7 @@ __wt_txn_parse_timestamp(
 static bool
 __txn_get_read_timestamp(WT_TXN_SHARED *txn_shared, wt_timestamp_t *read_timestampp)
 {
-    WT_ORDERED_READ(*read_timestampp, txn_shared->read_timestamp);
+    WT_ORDERED_READ(*read_timestampp, txn_shared->pinned_read_timestamp);
     return (!txn_shared->clear_read_q);
 }
 
@@ -256,7 +256,7 @@ __txn_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, const char 
     else if (WT_STRING_MATCH("prepare", cval.str, cval.len))
         *tsp = txn->prepare_timestamp;
     else if (WT_STRING_MATCH("read", cval.str, cval.len))
-        *tsp = txn_shared->read_timestamp;
+        *tsp = txn_shared->pinned_read_timestamp;
     else
         WT_RET_MSG(session, EINVAL, "unknown timestamp query %.*s", (int)cval.len, cval.str);
 
@@ -848,7 +848,7 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
          * oldest timestamp.
          */
         if (F_ISSET(txn, WT_TXN_TS_ROUND_READ)) {
-            txn_shared->read_timestamp = ts_oldest;
+            txn->read_timestamp = txn_shared->pinned_read_timestamp = ts_oldest;
             did_roundup_to_oldest = true;
         } else {
             __wt_readunlock(session, &txn_global->rwlock);
@@ -868,7 +868,7 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
             return (EINVAL);
         }
     } else
-        txn_shared->read_timestamp = read_ts;
+        txn->read_timestamp = txn_shared->pinned_read_timestamp = read_ts;
 
     __wt_txn_publish_read_timestamp(session);
     __wt_readunlock(session, &txn_global->rwlock);
@@ -1131,7 +1131,7 @@ __wt_txn_publish_read_timestamp(WT_SESSION_IMPL *session)
         qtxn_shared = TAILQ_LAST(&txn_global->read_timestamph, __wt_txn_rts_qh);
         while (qtxn_shared != NULL) {
             if (!__txn_get_read_timestamp(qtxn_shared, &tmp_timestamp) ||
-              tmp_timestamp > txn_shared->read_timestamp) {
+              tmp_timestamp > txn_shared->pinned_read_timestamp) {
                 ++walked;
                 qtxn_shared = TAILQ_PREV(qtxn_shared, __wt_txn_rts_qh, read_timestampq);
             } else
@@ -1171,7 +1171,8 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
 
     if (F_ISSET(txn, WT_TXN_SHARED_TS_READ)) {
         /* Assert the read timestamp is greater than or equal to the pinned timestamp. */
-        WT_ASSERT(session, txn_shared->read_timestamp >= S2C(session)->txn_global.pinned_timestamp);
+        WT_ASSERT(session, txn->read_timestamp == txn_shared->pinned_read_timestamp &&
+            txn->read_timestamp >= S2C(session)->txn_global.pinned_timestamp);
 
         /*
          * Notify other threads that our transaction is inactive and can be cleaned up safely from
@@ -1183,7 +1184,7 @@ __wt_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
 
         F_CLR(txn, WT_TXN_SHARED_TS_READ);
     }
-    txn_shared->read_timestamp = WT_TS_NONE;
+    txn->read_timestamp = txn_shared->pinned_read_timestamp = WT_TS_NONE;
 }
 
 /*


### PR DESCRIPTION
As part of #5677, @quchenhao  noted that we can simplify our transaction structures since we're no longer moving our read timestamp back and forth for resolving modifies since the introduction of the `WT_SESSION_RESOLVING_MODIFY` flag.