### PR TITLE
WT-5242 Minimize checkpoints pinned during backup (v4.2 backport)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1495,8 +1495,9 @@ methods = {
         including the named checkpoint, or
         \c "to=<checkpoint>" to drop all checkpoints before and
         including the named checkpoint.  Checkpoints cannot be
-        dropped while a hot backup is in progress or if open in
-        a cursor''', type='list'),
+        dropped if open in a cursor.  While a hot backup is in
+        progress, checkpoints created prior to the start of the
+        backup cannot be dropped''', type='list'),
     Config('force', 'false', r'''
         if false (the default), checkpoints may be skipped if the underlying object has not been
         modified, if true, this option forces the checkpoint''',

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -39,7 +39,7 @@ __wt_block_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t len)
      * backups, which only copies log files, or targeted backups, stops all block truncation
      * unnecessarily). We may want a more targeted solution at some point.
      */
-    if (!conn->hot_backup) {
+    if (conn->hot_backup_start == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(session, ret = __wt_ftruncate(session, block->fh, len), NULL);
     }
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -567,7 +567,7 @@ __log_file_server(void *arg)
                  * file system may not support truncate: both are OK, it's just more work during
                  * cursor traversal.
                  */
-                if (!conn->hot_backup && conn->log_cursors == 0) {
+                if (conn->hot_backup_start == 0 && conn->log_cursors == 0) {
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
                       WT_ERR_ERROR_OK(__wt_ftruncate(session, close_fh, close_end_lsn.l.offset),
                                                   ENOTSUP),

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -39,7 +39,7 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
      */
     conn->default_session = session;
 
-    __wt_seconds(session, &conn->ckpt_finish_secs);
+    __wt_seconds(session, &conn->ckpt_most_recent);
 
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -39,6 +39,8 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
      */
     conn->default_session = session;
 
+    __wt_seconds(session, &conn->ckpt_finish_secs);
+
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before
      * other threads read from the pointer.

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -614,7 +614,7 @@ __backup_start(
      * Single thread hot backups: we're holding the schema lock, so we know we'll serialize with
      * other attempts to start a hot backup.
      */
-    if (conn->hot_backup && !is_dup)
+    if (conn->hot_backup_start != 0 && !is_dup)
         WT_RET_MSG(session, EINVAL, "there is already a backup cursor open");
 
     if (F_ISSET(session, WT_SESSION_BACKUP_DUP) && is_dup)
@@ -775,7 +775,7 @@ __backup_stop(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
     WT_TRET(__wt_backup_file_remove(session));
 
     /* Checkpoint deletion and next hot backup can proceed. */
-    WT_WITH_HOTBACKUP_WRITE_LOCK(session, conn->hot_backup = false);
+    WT_WITH_HOTBACKUP_WRITE_LOCK(session, conn->hot_backup_start = 0);
     F_CLR(session, WT_SESSION_BACKUP_CURSOR);
 
     return (ret);

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -56,10 +56,9 @@ aggregate the file names from the cursor and then list the file names as
 arguments to a file archiver such as the system tar utility.
 
 During the period the backup cursor is open, database checkpoints can
-be created, but no checkpoints can be deleted.  This may result in
-significant file growth. Additionally while the backup cursor is open
-automatic log file archiving, even if enabled, will not reclaim any
-log files.
+be created, but checkpoints created prior to the backup cursor cannot
+be deleted. Additionally while the backup cursor is open automatic log
+file archiving, even if enabled, will not reclaim any log files.
 
 Additionally, if a crash occurs during the period the backup cursor is
 open and logging is disabled (in other words, when depending on

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -151,10 +151,10 @@ struct __wt_named_extractor {
  *	Macro to set connection data appropriately for when we commence hot
  *	backup.
  */
-#define WT_CONN_HOTBACKUP_START(conn)   \
-    do {                                \
-        (conn)->hot_backup = true;      \
-        (conn)->hot_backup_list = NULL; \
+#define WT_CONN_HOTBACKUP_START(conn)                        \
+    do {                                                     \
+        (conn)->hot_backup_start = (conn)->ckpt_finish_secs; \
+        (conn)->hot_backup_list = NULL;                      \
     } while (0)
 
 /*
@@ -270,13 +270,14 @@ struct __wt_connection_impl {
     WT_TXN_GLOBAL txn_global; /* Global transaction state */
 
     WT_RWLOCK hot_backup_lock; /* Hot backup serialization */
-    bool hot_backup;           /* Hot backup in progress */
+    uint64_t hot_backup_start; /* Clock value of most recent checkpoint needed by hot backup */
     char **hot_backup_list;    /* Hot backup file list */
 
     WT_SESSION_IMPL *ckpt_session; /* Checkpoint thread session */
     wt_thread_t ckpt_tid;          /* Checkpoint thread */
     bool ckpt_tid_set;             /* Checkpoint thread set */
     WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
+    uint64_t ckpt_finish_secs;     /* Clock value of last completed checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -153,7 +153,7 @@ struct __wt_named_extractor {
  */
 #define WT_CONN_HOTBACKUP_START(conn)                        \
     do {                                                     \
-        (conn)->hot_backup_start = (conn)->ckpt_finish_secs; \
+        (conn)->hot_backup_start = (conn)->ckpt_most_recent; \
         (conn)->hot_backup_list = NULL;                      \
     } while (0)
 
@@ -277,7 +277,7 @@ struct __wt_connection_impl {
     wt_thread_t ckpt_tid;          /* Checkpoint thread */
     bool ckpt_tid_set;             /* Checkpoint thread set */
     WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
-    uint64_t ckpt_finish_secs;     /* Clock value of last completed checkpoint */
+    uint64_t ckpt_most_recent;     /* Clock value of most recent checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -264,7 +264,7 @@ struct __wt_table {
         if ((skipp) != (bool *)NULL)                            \
             *(bool *)(skipp) = true;                            \
         if (F_ISSET(session, WT_SESSION_LOCKED_HOTBACKUP)) {    \
-            if (!__conn->hot_backup) {                          \
+            if (__conn->hot_backup_start == 0) {                \
                 if ((skipp) != (bool *)NULL)                    \
                     *(bool *)(skipp) = false;                   \
                 op;                                             \
@@ -272,7 +272,7 @@ struct __wt_table {
         } else {                                                \
             __wt_readlock(session, &__conn->hot_backup_lock);   \
             F_SET(session, WT_SESSION_LOCKED_HOTBACKUP_READ);   \
-            if (!__conn->hot_backup) {                          \
+            if (__conn->hot_backup_start == 0) {                \
                 if ((skipp) != (bool *)NULL)                    \
                     *(bool *)(skipp) = false;                   \
                 op;                                             \

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1938,8 +1938,9 @@ struct __wt_session {
 	 * one of the following keys: \c "from=all" to drop all checkpoints\, \c "from=<checkpoint>"
 	 * to drop all checkpoints after and including the named checkpoint\, or \c
 	 * "to=<checkpoint>" to drop all checkpoints before and including the named checkpoint.
-	 * Checkpoints cannot be dropped while a hot backup is in progress or if open in a cursor.,
-	 * a list of strings; default empty.}
+	 * Checkpoints cannot be dropped if open in a cursor.  While a hot backup is in progress\,
+	 * checkpoints created prior to the start of the backup cannot be dropped., a list of
+	 * strings; default empty.}
 	 * @config{force, if false (the default)\, checkpoints may be skipped if the underlying
 	 * object has not been modified\, if true\, this option forces the checkpoint., a boolean
 	 * flag; default \c false.}

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1166,7 +1166,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (conn->log_prealloc > 0 && !conn->hot_backup) {
+    if (conn->log_prealloc > 0 && conn->hot_backup_start == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 
@@ -1196,7 +1196,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
          * not using pre-allocated log files during backup
          * (see comment above).
          */
-        if (!conn->hot_backup)
+        if (conn->hot_backup_start == 0)
             log->prep_missed++;
         WT_RET(__wt_log_allocfile(session, log->fileid, WT_LOG_FILENAME));
     }
@@ -1385,7 +1385,7 @@ __log_truncate_file(WT_SESSION_IMPL *session, WT_FH *log_fh, wt_off_t offset)
     conn = S2C(session);
     log = conn->log;
 
-    if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP) && !conn->hot_backup) {
+    if (!F_ISSET(log, WT_LOG_TRUNCATE_NOTSUP) && conn->hot_backup_start == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(session, ret = __wt_ftruncate(session, log_fh, offset), &skipp);
         if (!skipp) {
             if (ret != ENOTSUP)

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -462,8 +462,10 @@ __wt_meta_ckptlist_get(
     WT_CKPT *ckpt, *ckptbase;
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM k, v;
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     size_t allocated, slot;
+    uint64_t most_recent;
     char *config;
 
     *ckptbasep = NULL;
@@ -471,6 +473,7 @@ __wt_meta_ckptlist_get(
     ckptbase = NULL;
     allocated = slot = 0;
     config = NULL;
+    conn = S2C(session);
 
     /* Retrieve the metadata information for the file. */
     WT_RET(__wt_metadata_search(session, fname, &config));
@@ -512,6 +515,17 @@ __wt_meta_ckptlist_get(
         ckpt->order = (slot == 0) ? 1 : ckptbase[slot - 1].order + 1;
         __wt_seconds(session, &ckpt->sec);
         /*
+         * Update time value for most recent checkpoint, not letting it move backwards. It is
+         * possible to race here, so use atomic CAS. This code relies on the fact that anyone we
+         * race with will only increase (never decrease) the most recent checkpoint time value.
+         */
+        for (;;) {
+            WT_ORDERED_READ(most_recent, conn->ckpt_most_recent);
+            if (ckpt->sec <= most_recent ||
+              __wt_atomic_cas64(&conn->ckpt_most_recent, most_recent, ckpt->sec))
+                break;
+        }
+        /*
          * Load most recent checkpoint backup blocks to this checkpoint.
          */
         WT_ERR(__ckpt_load_blk_mods(session, config, ckpt));
@@ -523,7 +537,7 @@ __wt_meta_ckptlist_get(
          * the checkpoint's modified blocks from the block manager.
          */
         F_SET(ckpt, WT_CKPT_ADD);
-        if (F_ISSET(S2C(session), WT_CONN_INCR_BACKUP)) {
+        if (F_ISSET(conn, WT_CONN_INCR_BACKUP)) {
             F_SET(ckpt, WT_CKPT_BLOCK_MODS);
             WT_ERR(__ckpt_valid_blk_mods(session, ckpt));
         }

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -464,7 +464,6 @@ __wt_meta_ckptlist_get(
     WT_CONFIG_ITEM k, v;
     WT_DECL_RET;
     size_t allocated, slot;
-    int64_t maxorder;
     char *config;
 
     *ckptbasep = NULL;
@@ -509,11 +508,8 @@ __wt_meta_ckptlist_get(
         WT_ERR(__wt_realloc_def(session, &allocated, slot + 2, &ckptbase));
 
         /* The caller may be adding a value, initialize it. */
-        maxorder = 0;
-        WT_CKPT_FOREACH (ckptbase, ckpt)
-            if (ckpt->order > maxorder)
-                maxorder = ckpt->order;
-        ckpt->order = maxorder + 1;
+        ckpt = &ckptbase[slot];
+        ckpt->order = (slot == 0) ? 1 : ckptbase[slot - 1].order + 1;
         __wt_seconds(session, &ckpt->sec);
         /*
          * Load most recent checkpoint backup blocks to this checkpoint.

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -26,7 +26,7 @@ __schema_backup_check_int(WT_SESSION_IMPL *session, const char *name)
      * There is a window at the end of a backup where the list has been cleared from the connection
      * but the flag is still set. It is safe to drop at that point.
      */
-    if (!conn->hot_backup || (backup_list = conn->hot_backup_list) == NULL) {
+    if (conn->hot_backup_start == 0 || (backup_list = conn->hot_backup_list) == NULL) {
         return (0);
     }
     for (i = 0; backup_list[i] != NULL; ++i) {
@@ -50,7 +50,7 @@ __wt_schema_backup_check(WT_SESSION_IMPL *session, const char *name)
     WT_DECL_RET;
 
     conn = S2C(session);
-    if (!conn->hot_backup)
+    if (conn->hot_backup_start == 0)
         return (0);
     WT_WITH_HOTBACKUP_READ_LOCK_UNCOND(session, ret = __schema_backup_check_int(session, name));
     return (ret);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1215,19 +1215,12 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
             continue;
         is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
 
-/*
- * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have been
- * created before the backup started. Fail if trying to delete any other named checkpoint.
- */
-#ifdef DISABLED_CODE
-        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
-#else
         /*
-         * N.B. Despite the comment above, dropping checkpoints during backup can corrupt the
-         * backup. For now we retain all WiredTiger checkpoints.
+         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
+         * been created before the backup started. Fail if trying to delete any other named
+         * checkpoint.
          */
-        if (conn->hot_backup_start != 0) {
-#endif
+        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
             if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1215,12 +1215,19 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
             continue;
         is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
 
-        /*
-         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
-         * been created before the backup started. Fail if trying to delete any other named
-         * checkpoint.
-         */
+/*
+ * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have been
+ * created before the backup started. Fail if trying to delete any other named checkpoint.
+ */
+#ifdef DISABLED_CODE
         if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
+#else
+        /*
+         * N.B. Despite the comment above, dropping checkpoints during backup can corrupt the
+         * backup. For now we retain all WiredTiger checkpoints.
+         */
+        if (conn->hot_backup_start != 0) {
+#endif
             if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -738,7 +738,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t ckpt_tmp_ts;
-    uint64_t finish_secs, fsync_duration_usecs, generation, time_start, time_stop;
+    uint64_t fsync_duration_usecs, generation, time_start, time_stop;
     u_int i;
     bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
     void *saved_meta_next;
@@ -952,16 +952,6 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
                 conn->txn_global.last_ckpt_timestamp = conn->txn_global.recovery_timestamp;
         } else
             conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
-
-        /*
-         * Save clock value marking end of checkpoint processing. If a hot backup starts before the
-         * next checkpoint, we will need to keep all checkpoints up to this clock value until the
-         * backup completes.
-         */
-        __wt_seconds(session, &finish_secs);
-        /* Be defensive: time is only monotonic per session */
-        if (finish_secs > conn->ckpt_finish_secs)
-            conn->ckpt_finish_secs = finish_secs;
     }
 
 err:
@@ -1237,8 +1227,8 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
             }
             WT_RET_MSG(session, EBUSY,
               "checkpoint %s blocked by hot backup: it would "
-              "delete an existing checkpoint, and checkpoints "
-              "cannot be deleted during a hot backup",
+              "delete an existing named checkpoint, and such "
+              "checkpoints cannot be deleted during a hot backup",
               ckpt->name);
         }
         /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -738,7 +738,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t ckpt_tmp_ts;
-    uint64_t fsync_duration_usecs, generation, time_start, time_stop;
+    uint64_t finish_secs, fsync_duration_usecs, generation, time_start, time_stop;
     u_int i;
     bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
     void *saved_meta_next;
@@ -952,6 +952,16 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
                 conn->txn_global.last_ckpt_timestamp = conn->txn_global.recovery_timestamp;
         } else
             conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
+
+        /*
+         * Save clock value marking end of checkpoint processing. If a hot backup starts before the
+         * next checkpoint, we will need to keep all checkpoints up to this clock value until the
+         * backup completes.
+         */
+        __wt_seconds(session, &finish_secs);
+        /* Be defensive: time is only monotonic per session */
+        if (finish_secs > conn->ckpt_finish_secs)
+            conn->ckpt_finish_secs = finish_secs;
     }
 
 err:
@@ -1112,7 +1122,6 @@ static void
 __drop(WT_CKPT *ckptbase, const char *name, size_t len)
 {
     WT_CKPT *ckpt;
-    u_int max_ckpt_drop;
 
     /*
      * If we're dropping internal checkpoints, match to the '.' separating the checkpoint name from
@@ -1121,20 +1130,9 @@ __drop(WT_CKPT *ckptbase, const char *name, size_t len)
      * it's one we want to drop.
      */
     if (strncmp(WT_CHECKPOINT, name, len) == 0) {
-        /*
-         * Currently, hot backup cursors block checkpoint drop, which means releasing a hot backup
-         * cursor can result in immediately attempting to drop lots of checkpoints, which involves a
-         * fair amount of work while holding locks. Limit the number of standard checkpoints dropped
-         * per checkpoint.
-         */
-        max_ckpt_drop = 0;
         WT_CKPT_FOREACH (ckptbase, ckpt)
-            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT))
                 F_SET(ckpt, WT_CKPT_DELETE);
-#define WT_MAX_CHECKPOINT_DROP 4
-                if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
-                    break;
-            }
     } else
         WT_CKPT_FOREACH (ckptbase, ckpt)
             if (WT_STRING_MATCH(ckpt->name, name, len))
@@ -1214,30 +1212,44 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
+    u_int max_ckpt_drop;
+    bool is_wt_ckpt;
 
     WT_UNUSED(is_checkpoint);
     conn = S2C(session);
 
-    /*
-     * We can't delete checkpoints if a backup cursor is open. WiredTiger checkpoints are uniquely
-     * named and it's OK to have multiple of them in the system: clear the delete flag for them, and
-     * otherwise fail. Hold the lock until we're done (blocking hot backups from starting), we don't
-     * want to race with a future hot backup.
-     */
-    if (conn->hot_backup)
-        WT_CKPT_FOREACH (ckptbase, ckpt) {
-            if (!F_ISSET(ckpt, WT_CKPT_DELETE))
-                continue;
-            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+    /* Check that it is OK to remove all the checkpoints marked for deletion. */
+    max_ckpt_drop = 0;
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (!F_ISSET(ckpt, WT_CKPT_DELETE))
+            continue;
+        is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
+
+        /*
+         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
+         * been created before the backup started. Fail if trying to delete any other named
+         * checkpoint.
+         */
+        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
+            if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;
             }
             WT_RET_MSG(session, EBUSY,
-              "checkpoint %s blocked by hot backup: it would"
+              "checkpoint %s blocked by hot backup: it would "
               "delete an existing checkpoint, and checkpoints "
               "cannot be deleted during a hot backup",
               ckpt->name);
         }
+        /*
+         * Dropping checkpoints involves a fair amount of work while holding locks. Limit the number
+         * of WiredTiger checkpoints dropped per checkpoint.
+         */
+        if (is_wt_ckpt)
+#define WT_MAX_CHECKPOINT_DROP 4
+            if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
+                F_CLR(ckpt, WT_CKPT_DELETE);
+    }
 
     /*
      * Mark old checkpoints that are being deleted and figure out which trees we can skip in this
@@ -1257,6 +1269,8 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
         WT_CKPT_FOREACH (ckptbase, ckpt) {
             if (!F_ISSET(ckpt, WT_CKPT_DELETE))
                 continue;
+            WT_ASSERT(session, !WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT) ||
+                conn->hot_backup_start == 0 || ckpt->sec > conn->hot_backup_start);
             /*
              * We can't delete checkpoints referenced by a cursor. WiredTiger checkpoints are
              * uniquely named and it's OK to have multiple in the system: clear the delete flag for

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -550,8 +550,9 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
          * connection close, only during a full checkpoint. A clean close may not update any
          * metadata LSN and we do not want to archive in that case.
          */
-        if (!conn->hot_backup && (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) ||
-                                   FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE)) &&
+        if (conn->hot_backup_start == 0 &&
+          (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) ||
+              FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE)) &&
           txn->full_ckpt)
             __wt_log_ckpt(session, ckpt_lsn);
 

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -30,6 +30,7 @@ import glob
 import os
 import shutil
 import string
+import time
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet, ComplexDataSet, ComplexLSMDataSet
@@ -163,8 +164,7 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
         self.assertEqual(i, total)
 
-    # Test that named checkpoints can't be deleted while backup cursors are
-    # open, but that normal checkpoints continue to work.
+    # Test interaction between checkpoints and a backup cursor.
     def test_checkpoint_delete(self):
         # You cannot name checkpoints including LSM tables, skip those.
         self.populate(1)
@@ -177,7 +177,8 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
             self.objs[0][0], None, "checkpoint=one"))
 
         # Confirm opening a backup cursor causes checkpoint to fail if dropping
-        # a named checkpoint, but does not stop a default checkpoint.
+        # a named checkpoint created before the backup cursor, but does not stop a
+        # default checkpoint.
         cursor = self.session.open_cursor('backup:', None, None)
         self.session.checkpoint()
         msg = '/checkpoints cannot be deleted during a hot backup/'
@@ -187,7 +188,24 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("name=three,drop=(two)"), msg)
         self.session.checkpoint()
+
+        # Confirm that a named checkpoint created after a backup cursor can be dropped.
+        # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
+        # the backup will be pinned, even if they occur after the backup starts.
+        time.sleep(2)
+        self.session.checkpoint("name=four")
+        self.session.checkpoint("drop=(four)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=four"))
+
+        # Confirm that after closing the backup cursor the original named checkpoint can
+        # be deleted.
         cursor.close()
+        self.session.checkpoint("drop=(two)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=two"))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -189,10 +189,11 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
             lambda: self.session.checkpoint("name=three,drop=(two)"), msg)
         self.session.checkpoint()
 
-        # Confirm that a named checkpoint created after a backup cursor can be dropped.
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
         time.sleep(2)
+
+        # Confirm that a named checkpoint created after a backup cursor can be dropped.
         self.session.checkpoint("name=four")
         self.session.checkpoint("drop=(four)")
         self.assertRaises(wiredtiger.WiredTigerError,

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -191,14 +191,15 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
-        time.sleep(2)
 
-        # Confirm that a named checkpoint created after a backup cursor can be dropped.
-        self.session.checkpoint("name=four")
-        self.session.checkpoint("drop=(four)")
-        self.assertRaises(wiredtiger.WiredTigerError,
-            lambda: self.session.open_cursor(
-            self.objs[0][0], None, "checkpoint=four"))
+        time.sleep(2)
+        # N.B. This test is temporarily disabled because deleting checkpoints during backup
+        # can corrupt the backup.
+        #self.session.checkpoint("name=four")
+        #self.session.checkpoint("drop=(four)")
+        #self.assertRaises(wiredtiger.WiredTigerError,
+        #    lambda: self.session.open_cursor(
+        #    self.objs[0][0], None, "checkpoint=four"))
 
         # Confirm that after closing the backup cursor the original named checkpoint can
         # be deleted.

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -191,15 +191,12 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
-
         time.sleep(2)
-        # N.B. This test is temporarily disabled because deleting checkpoints during backup
-        # can corrupt the backup.
-        #self.session.checkpoint("name=four")
-        #self.session.checkpoint("drop=(four)")
-        #self.assertRaises(wiredtiger.WiredTigerError,
-        #    lambda: self.session.open_cursor(
-        #    self.objs[0][0], None, "checkpoint=four"))
+        self.session.checkpoint("name=four")
+        self.session.checkpoint("drop=(four)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=four"))
 
         # Confirm that after closing the backup cursor the original named checkpoint can
         # be deleted.

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_checkpoint05.py
+# Verify that we don't accumulate a lot of checkpoints while a backup
+# cursor is open. WiredTiger checkpoints created after the backup cursor
+# should get deleted as usual.
+
+import time
+import wiredtiger, wttest
+
+class test_checkpoint05(wttest.WiredTigerTestCase):
+    conn_config = 'create,cache_size=100MB,log=(archive=false,enabled=true,file_max=100K)'
+
+    def count_checkpoints(self):
+        metadata_cursor = self.session.open_cursor('metadata:', None, None)
+
+        nckpt = 0
+        while metadata_cursor.next() == 0:
+            key = metadata_cursor.get_key()
+            value = metadata_cursor[key]
+            nckpt = nckpt + value.count("WiredTigerCheckpoint")
+        metadata_cursor.close()
+        return nckpt
+
+    def test_checkpoints_during_backup(self):
+        self.uri = 'table:ckpt05'
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+
+        # Setup: Insert some data and checkpoint it
+        cursor = self.session.open_cursor(self.uri, None)
+        for i in range(16):
+            cursor[i] = i
+        self.session.checkpoint(None)
+
+        # Create backup and check how many checkpoints we have.
+        backup_cursor = self.session.open_cursor('backup:', None, None)
+        initial_count = self.count_checkpoints()
+
+        # Checkpoints created immediately after a backup cursor may get pinned.
+        # Pause to avoid this.
+        time.sleep(2)
+
+        # Take a bunch of checkpoints.
+        for i in range (50):
+            self.session.checkpoint('force=true')
+        cursor.close()
+
+        # There may be a few more checkpoints than when we opened the
+        # backup cursor, but not too many more.  The factor of three
+        # is generous.  But if WT isn't deleting checkpoints there would
+        # be about 30x more checkpoints here.
+        final_count = self.count_checkpoints()
+        self.assertTrue (final_count < initial_count * 3)
+
+        self.session.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -76,10 +76,7 @@ class test_checkpoint05(wttest.WiredTigerTestCase):
         # is generous.  But if WT isn't deleting checkpoints there would
         # be about 30x more checkpoints here.
         final_count = self.count_checkpoints()
-
-        # N.B. This test is temporarily disabled because deleting checkpoints during backup
-        # can corrupt the backup.
-        # self.assertTrue (final_count < initial_count * 3)
+        self.assertTrue (final_count < initial_count * 3)
 
         self.session.close()
 

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -76,7 +76,10 @@ class test_checkpoint05(wttest.WiredTigerTestCase):
         # is generous.  But if WT isn't deleting checkpoints there would
         # be about 30x more checkpoints here.
         final_count = self.count_checkpoints()
-        self.assertTrue (final_count < initial_count * 3)
+
+        # N.B. This test is temporarily disabled because deleting checkpoints during backup
+        # can corrupt the backup.
+        # self.assertTrue (final_count < initial_count * 3)
 
         self.session.close()
 


### PR DESCRIPTION
WT-5242 Minimize checkpoints pinned during backup (#5590)
- Checkpoints have time values generated from a per-session monotonic clock.  Use these values to preserve only the checkpoints that may be needed by backup.  At the end of each checkpoint, we save a time value from the same clock.  When we open a backup cursor we use this save value as a limit on checkpoint preservation.  All checkpoints with times values less than or equal to that are kept until the backup cursor is closed.
- Add python tests for new behavior and update docs to reflect new way checkpoints and backup cursors interact.
- Eliminate unnecessary iteration searching for highest value in sorted array.

Co-authored-by: Keith A. Smith <keith.smith@mongodb>
(cherry picked from commit 19f3761b35482c91f5d50d643ebfb7d0e6316584)

WT-6118 Missing checkpoint in backup (#5643)
- Change how we track the time of the most recent checkpoint.  Instead of saving it after a checkpoint completes, use the time value we assign when initializing a new checkpoint structure. 
- Rename the variable where we store this to better reflect new usage.
- Re-enable deletion of checkpoints during backup and the tests of that functionality.

Co-authored-by: Keith A. Smith <keith.smith@mongodb>
(cherry picked from commit 3e87b896d1d07c2ec5979ea0951847e51dbfcc57)

WT-6141 Disable checkpoint deletion during backup (#5616)
- Keep all WiredTiger checkpoints while a hot backup is active.
- Also disables a pair of tests that checked for the old behavior.

Co-authored-by: Keith A. Smith <keith.smith@mongodb>
(cherry picked from commit 2fd82090f1cccf52f9aed342b54e3006839dc1e3)