### PR TITLE
WT-6261 Turn off incremental backup rename testing until open ticket is fixed.

### DIFF
--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -59,7 +59,7 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 static bool slow_incremental = false;
 
 static bool do_drop = true;
-static bool do_rename = true;
+static bool do_rename = false;
 
 #define VERBOSE(level, fmt, ...)      \
     do {                              \


### PR DESCRIPTION
@ddanderson I'm turning off rename in general testing while WT-6215 is open. That ticket will turn it back on, but the fix is non-trivial so in order to allow testing to proceed in the meantime, I'm turning off rename.