### PR TITLE
WT-6265 Coverity: Integer overflow in test/format/ops.c

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -524,7 +524,7 @@ prepare_transaction(TINFO *tinfo)
         longwait = mmrand(&tinfo->rnd, 0, 999);
         if (longwait < 10) {
             pause_ms = mmrand(&tinfo->rnd, 1, 10) << longwait;
-            __wt_sleep(0, pause_ms * WT_THOUSAND);
+            __wt_sleep(0, (uint64_t)pause_ms * WT_THOUSAND);
         }
     }
     return (ret);


### PR DESCRIPTION
This expression (`pause_ms *  WT_THOUSAND`) can overflow since it is using 32-bit integer arithmetic. We can avoid this by casting one of the operands to `uint64_t`.