### PR TITLE
WT-6056 Set DATA_CORRUPTION flag so we return TRY_SALVAGE on open.

### DIFF
--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -381,6 +381,7 @@ err:
      */
     if (ret == 0 || strcmp(key, WT_METADATA_COMPAT) == 0 || F_ISSET(S2C(session), WT_CONN_SALVAGE))
         return (ret);
+    F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
     WT_RET_PANIC(session, WT_TRY_SALVAGE, "%s: fatal turtle file read error", WT_METADATA_TURTLE);
 }
 
@@ -437,5 +438,6 @@ err:
      */
     if (ret == 0)
         return (ret);
+    F_SET(conn, WT_CONN_DATA_CORRUPTION);
     WT_RET_PANIC(session, ret, "%s: fatal turtle file update error", WT_METADATA_TURTLE);
 }

--- a/test/csuite/wt4156_metadata_salvage/main.c
+++ b/test/csuite/wt4156_metadata_salvage/main.c
@@ -345,6 +345,8 @@ wt_open_corrupt(const char *sfx)
     WT_DECL_RET;
     char buf[1024];
 
+    /* The child should not abort the test in the message handler. Set it here, don't inherit. */
+    test_abort = false;
     if (sfx != NULL)
         testutil_check(__wt_snprintf(buf, sizeof(buf), "%s.%s", home, sfx));
     else


### PR DESCRIPTION
Also set test_abort to false in child process instead of inheriting.