### PR TITLE
WT-6284 History store isn't visible to wt dump

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -502,4 +502,7 @@ struct __wt_cursor_table {
 
 #define WT_CURSOR_RECNO(cursor) WT_STREQ((cursor)->key_format, "r")
 
+#define WT_CURSOR_IS_DUMP(cursor) \
+    F_ISSET(cursor, (WT_CURSTD_DUMP_HEX | WT_CURSTD_DUMP_PRINT | WT_CURSTD_DUMP_JSON))
+
 #define WT_CURSOR_RAW_OK (WT_CURSTD_DUMP_HEX | WT_CURSTD_DUMP_PRINT | WT_CURSTD_RAW)

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -955,7 +955,7 @@ __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint
     if (__wt_txn_tw_stop_visible(session, &tw) &&
       ((!F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
          (!WT_IS_HS(S2BT(session)) || !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))) ||
-          __wt_txn_tw_stop_visible_all(session, &tw))) {
+          (__wt_txn_tw_stop_visible_all(session, &tw) && !WT_CURSOR_IS_DUMP(&cbt->iface)))) {
         cbt->upd_value->buf.data = NULL;
         cbt->upd_value->buf.size = 0;
         cbt->upd_value->tw.durable_stop_ts = tw.durable_stop_ts;

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -51,7 +51,7 @@ int
 util_dump(WT_SESSION *session, int argc, char *argv[])
 {
     WT_CURSOR *cursor;
-    WT_CURSOR_DUMP *dump_cursor;
+    WT_CURSOR_DUMP *hs_dump_cursor;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     WT_SESSION_IMPL *session_impl;
@@ -62,6 +62,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
     session_impl = (WT_SESSION_IMPL *)session;
 
     cursor = NULL;
+    hs_dump_cursor = NULL;
     checkpoint = ofile = simpleuri = uri = timestamp = NULL;
     hex = json = reverse = false;
     while ((ch = __wt_getopt(progname, argc, argv, "c:f:t:jrx")) != EOF)
@@ -156,9 +157,9 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
          * case, we're specifically interested in what is visible at a given read timestamp.
          */
         if (WT_STREQ(simpleuri, WT_HS_URI) && timestamp == NULL) {
-            dump_cursor = (WT_CURSOR_DUMP *)cursor;
+            hs_dump_cursor = (WT_CURSOR_DUMP *)cursor;
             /* Set the "ignore tombstone" flag on the underlying cursor. */
-            F_SET(dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
+            F_SET(hs_dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
         }
         if (dump_config(session, simpleuri, cursor, hex, json) != 0)
             goto err;
@@ -168,9 +169,10 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
         if (json && dump_json_table_end(session) != 0)
             goto err;
 
-        F_CLR(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
+        if (hs_dump_cursor != NULL)
+            F_CLR(hs_dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
         ret = cursor->close(cursor);
-        cursor = NULL;
+        cursor = hs_dump_cursor = NULL;
         if (ret != 0) {
             (void)util_err(session, ret, NULL);
             goto err;
@@ -185,7 +187,8 @@ err:
     }
 
     if (cursor != NULL) {
-        F_CLR(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
+        if (hs_dump_cursor != NULL)
+            F_CLR(hs_dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
         if ((ret = cursor->close(cursor)) != 0)
             ret = util_err(session, ret, NULL);
     }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -51,6 +51,7 @@ int
 util_dump(WT_SESSION *session, int argc, char *argv[])
 {
     WT_CURSOR *cursor;
+    WT_CURSOR_DUMP *dump_cursor;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     WT_SESSION_IMPL *session_impl;
@@ -154,8 +155,11 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
          * nothing will be visible. The only exception is if we've supplied a timestamp in which
          * case, we're specifically interested in what is visible at a given read timestamp.
          */
-        if (WT_STREQ(simpleuri, WT_HS_URI) && timestamp == NULL)
-            F_SET(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
+        if (WT_STREQ(simpleuri, WT_HS_URI) && timestamp == NULL) {
+            dump_cursor = (WT_CURSOR_DUMP *)cursor;
+            /* Set the "ignore tombstone" flag on the underlying cursor. */
+            F_SET(dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
+        }
         if (dump_config(session, simpleuri, cursor, hex, json) != 0)
             goto err;
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -172,7 +172,8 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
         if (hs_dump_cursor != NULL)
             F_CLR(hs_dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
         ret = cursor->close(cursor);
-        cursor = hs_dump_cursor = NULL;
+        cursor = NULL;
+        hs_dump_cursor = NULL;
         if (ret != 0) {
             (void)util_err(session, ret, NULL);
             goto err;


### PR DESCRIPTION
When we moved `WT_CURSTD_IGNORE_TOMBSTONE` from being a session flag to a cursor flag, we broke wt dump. `wt dump` uses a dump cursor which delegates calls to the cursor API to a "child" cursor. We need to set the flag on the child cursor for this to work.

We also modified the check in `__wt_txn_read` such that we will read the on-disk value's stop time pair even with `WT_CURSTD_IGNORE_TOMBSTONE` enabled if it is globally visible. This makes `wt dump` less useful so let's make an exception here.