### PR TITLE
WT-6229 Fix memory growth bug during MDB shutdown

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1911,14 +1911,8 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
             continue;
         }
 
-        /*
-         * Pages that are empty or from dead trees are fast-tracked.
-         *
-         * Also evict the history store table pages without further filtering: the cache is under
-         * pressure by definition and we want to free space.
-         */
-        if (__wt_page_is_empty(page) || F_ISSET(session->dhandle, WT_DHANDLE_DEAD) ||
-          WT_IS_HS(btree))
+        /* Pages that are empty or from dead trees are fast-tracked. */
+        if (__wt_page_is_empty(page) || F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
             goto fast;
 
         /*


### PR DESCRIPTION
Don't fast track the eviction of HS pages, as this can lead
to thrashing when there are a lot of deletes to apply to the
HS file during checkpoint reconciliation.

