### PR TITLE
WT-6334 Coverity: Use return value when closing incremental backup cursor

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -169,7 +169,7 @@ err:
  * __backup_free --
  *     Free list resources for a backup cursor.
  */
-static void
+static int
 __backup_free(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
 {
     int i;
@@ -181,7 +181,8 @@ __backup_free(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
     }
     if (cb->incr_file != NULL)
         __wt_free(session, cb->incr_file);
-    __wt_curbackup_free_incr(session, cb);
+
+    return (__wt_curbackup_free_incr(session, cb));
 }
 
 /*
@@ -213,7 +214,7 @@ err:
      * cursor is closed), because that cursor will never not be responsible for cleanup.
      */
     if (F_ISSET(cb, WT_CURBACKUP_DUP)) {
-        __backup_free(session, cb);
+        WT_TRET(__backup_free(session, cb));
         /* Make sure the original backup cursor is still open. */
         WT_ASSERT(session, F_ISSET(session, WT_SESSION_BACKUP_CURSOR));
         F_CLR(session, WT_SESSION_BACKUP_DUP);
@@ -760,7 +761,7 @@ __backup_stop(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
     WT_WITH_HOTBACKUP_WRITE_LOCK(session, conn->hot_backup_list = NULL);
     if (cb->incr_src != NULL)
         F_CLR(cb->incr_src, WT_BLKINCR_INUSE);
-    __backup_free(session, cb);
+    WT_TRET(__backup_free(session, cb));
 
     /* Remove any backup specific file. */
     WT_TRET(__wt_backup_file_remove(session));

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -169,13 +169,17 @@ err:
  * __wt_curbackup_free_incr --
  *     Free the duplicate backup cursor for a file-based incremental backup.
  */
-void
+int
 __wt_curbackup_free_incr(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
 {
+    WT_DECL_RET;
+
     __wt_free(session, cb->incr_file);
     if (cb->incr_cursor != NULL)
-        cb->incr_cursor->close(cb->incr_cursor);
+        ret = cb->incr_cursor->close(cb->incr_cursor);
     __wt_buf_free(session, &cb->bitstring);
+
+    return (ret);
 }
 
 /*
@@ -233,7 +237,7 @@ __wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *o
 
 err:
     if (ret != 0)
-        __wt_curbackup_free_incr(session, cb);
+        WT_TRET(__wt_curbackup_free_incr(session, cb));
     __wt_scr_free(session, &open_uri);
     return (ret);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -473,6 +473,8 @@ extern int __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
 extern int __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curbackup_free_incr(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
@@ -1624,7 +1626,6 @@ extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);
 extern void __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
-extern void __wt_curbackup_free_incr(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb);
 extern void __wt_cursor_close(WT_CURSOR *cursor);
 extern void __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt);
 extern void __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);


### PR DESCRIPTION
This was picked up by Coverity so I figured we may as well propagate the return value upwards to callers.