### PR TITLE
WT-6295 Aggregate time windows in salvage

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -403,6 +403,6 @@ void wts_rebalance(void);
 void wts_reopen(void);
 void wts_salvage(void);
 void wts_stats(void);
-void wts_verify(const char *);
+void wts_verify(WT_CONNECTION *, const char *);
 
 #include "format.i"

--- a/test/format/salvage.c
+++ b/test/format/salvage.c
@@ -139,16 +139,14 @@ wts_salvage(void)
     /* Salvage, then verify. */
     wts_open(g.home, &conn, &session, true);
     testutil_check(session->salvage(session, g.uri, "force=true"));
-
-#if 0
-    wts_verify("post-salvage verify");
-#endif
+    wts_verify(conn, "post-salvage verify");
     wts_close(&conn, &session);
 
     /* Corrupt the file randomly, salvage, then verify. */
     if (corrupt()) {
         wts_open(g.home, &conn, &session, false);
         testutil_check(session->salvage(session, g.uri, "force=true"));
+        wts_verify(conn, "post-corrupt-salvage verify");
         wts_close(&conn, &session);
     }
 }

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -274,7 +274,7 @@ main(int argc, char *argv[])
             trace_init();
 
             TIMED_MAJOR_OP(wts_load()); /* Load and verify initial records */
-            TIMED_MAJOR_OP(wts_verify("post-bulk verify"));
+            TIMED_MAJOR_OP(wts_verify(g.wts_conn, "post-bulk verify"));
         }
 
         TIMED_MAJOR_OP(wts_read_scan());
@@ -292,7 +292,7 @@ main(int argc, char *argv[])
          * Verify the objects. Verify closes the underlying handle and discards the statistics, read
          * them first.
          */
-        TIMED_MAJOR_OP(wts_verify("post-ops verify"));
+        TIMED_MAJOR_OP(wts_verify(g.wts_conn, "post-ops verify"));
 
         track("shutting down", 0ULL, NULL);
         wts_close(&g.wts_conn, NULL);

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -487,16 +487,14 @@ wts_close(WT_CONNECTION **connp, WT_SESSION **sessionp)
 }
 
 void
-wts_verify(const char *tag)
+wts_verify(WT_CONNECTION *conn, const char *tag)
 {
-    WT_CONNECTION *conn;
     WT_DECL_RET;
     WT_SESSION *session;
 
     if (g.c_verify == 0)
         return;
 
-    conn = g.wts_conn;
     track("verify", 0ULL, NULL);
 
     testutil_check(conn->open_session(conn, NULL, NULL, &session));


### PR DESCRIPTION
@quchenhao, this branch does timestamp aggregation during salvage, would you please do the review?

I have a few concerns:

* First, in WT-6260, you commented "The cause of the failure is we are not aggregating time window information to the internal pages when doing salvage. If we need to aggregate that information, we have to rebuild every page we try to salvage, which will make salvage take much longer." I'm not following that, my approach is to read the timestamps out of the leaf pages and then use that information to initialize the internal pages we create. It seems to me you're talking about rewriting leaf pages, which would be expensive -- can you please explain further what you were thinking, and if I'm missing something?

* Second, the failure in the initial WT-6260 ticket was that a prepare state in a leaf page wasn't being propagated to the parent. The code I added will, in fact fix that by propagating the prepare up the tree, but I think that's wrong. I would expect rollback-to-stable to clear ANY prepare information on startup, but if we're salvaging the file, I suspect we can't depend on that, the file was presumably corrupted. Shouldn't we clear any prepare flags that are set in the salvaged fiile? Prepared operations can't possible be resolved after a salvage, so I think we should clear them, not propagate them up the tree. Thoughts?

* Finally, please check me on my timestamp macro use, specifically, I think I should be using `WT_TIME_AGGREGATE_INIT_MAX`, not `WT_TIME_AGGREGATE_INIT`, but I'm not confident in that decision.