### PR TITLE
WT-6301 Add short running stress jobs

### DIFF
--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -16,6 +16,9 @@ args="$args runs.threads=4 "
 # $TEST_WRAPPER ./t $args runs.type=row runs.source=lsm
 # $TEST_WRAPPER ./t $args runs.type=var
 
-$TEST_WRAPPER ./t $args runs.type=row
-# Force a rebalance to occur with statistics logging to test the utility
-$TEST_WRAPPER ./t $args runs.type=row statistics.server=1 ops.rebalance=1
+# Run this loop for 10 times, short running stress jobs.
+for i in $(seq 10); do
+    $TEST_WRAPPER ./t $args runs.type=row
+    # Force a rebalance to occur with statistics logging to test the utility
+    $TEST_WRAPPER ./t $args runs.type=row statistics.server=1 ops.rebalance=1
+done

--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -3,7 +3,6 @@
 set -e
 
 # Smoke-test format as part of running "make check".
-args="-1 -c . "
 args="$args btree.compression=none "
 args="$args logging_compression=none"
 args="$args runs.ops=50000 "
@@ -11,14 +10,18 @@ args="$args runs.rows=10000 "
 args="$args runs.source=table "
 args="$args runs.threads=4 "
 
-# Temporarily disabled
-# $TEST_WRAPPER ./t $args runs.type=fix
-# $TEST_WRAPPER ./t $args runs.type=row runs.source=lsm
-# $TEST_WRAPPER ./t $args runs.type=var
+# Locate format.sh from home directory.
+FORMAT_SCRIPT=$(git rev-parse --show-toplevel)/test/format/format.sh
 
-# Run this loop for 10 times, short running stress jobs.
-for i in $(seq 10); do
-    $TEST_WRAPPER ./t $args runs.type=row
-    # Force a rebalance to occur with statistics logging to test the utility
-    $TEST_WRAPPER ./t $args runs.type=row statistics.server=1 ops.rebalance=1
-done
+# Temporarily disabled
+# $FORMAT_SCRIPT -t 2 $args runs.type=fix
+# $FORMAT_SCRIPT -t 2 $args runs.type=row runs.source=lsm
+# $FORMAT_SCRIPT -t 2 $args runs.type=var
+
+# Run the format script for 10 minutues, distribute it across the number
+# of different test arguments.
+
+# This will run the test/format binary for 5 minutes each.
+$FORMAT_SCRIPT -t 5 $args runs.type=row
+
+$FORMAT_SCRIPT -t 5 $args runs.type=row statistics.server=1 ops.rebalance=1


### PR DESCRIPTION
This is the suggested change in the existing `smoke.sh` to run test/format binary for 10 times, which takes ~ 11 minutes. 

Evergreen patch build with the changes
https://evergreen.mongodb.com/build/wiredtiger_ubuntu1804_patch_b9e8146ae5bc2f131cd7d9c19a2870746573cb38_5ed31853d6d80a49850ef5ba_20_05_31_02_37_56

Another approach would be to call `format.sh` with `-t` option and specify the time in minutes to run the test/format binary.
