### PR TITLE
WT-6323 Increase cache size in test_prepare10 to avoid rollback errors

### DIFF
--- a/test/suite/test_prepare08.py
+++ b/test/suite/test_prepare08.py
@@ -37,9 +37,9 @@ def timestamp_str(t):
 # test_prepare07.py
 # Test to ensure prepared tombstones are properly aborted even when they are written
 # to the data store.
-class test_prepare07(wttest.WiredTigerTestCase):
+class test_prepare08(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=1MB'
+    conn_config = 'cache_size=2MB'
 
     def updates(self, ds, uri, nrows, value, ts):
         cursor = self.session.open_cursor(uri)

--- a/test/suite/test_prepare10.py
+++ b/test/suite/test_prepare10.py
@@ -39,7 +39,7 @@ def timestamp_str(t):
 # to the data store.
 class test_prepare10(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=1MB'
+    conn_config = 'cache_size=2MB'
     session_config = 'isolation=snapshot'
 
     def updates(self, ds, uri, nrows, value, ts):

--- a/test/suite/test_prepare10.py
+++ b/test/suite/test_prepare10.py
@@ -34,10 +34,10 @@ from wtdataset import SimpleDataSet
 def timestamp_str(t):
     return '%x' % t
 
-# test_prepare07.py
+# test_prepare10.py
 # Test to ensure prepared tombstones are properly aborted even when they are written
 # to the data store.
-class test_prepare07(wttest.WiredTigerTestCase):
+class test_prepare10(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = 'cache_size=1MB'
     session_config = 'isolation=snapshot'


### PR DESCRIPTION
@kommiharibabu - I have increased the cache size to 2MB and so far I haven't seen the test failing again with WT_ROLLBACK error. 