### PR TITLE
WT-6350 Do not perform clean page validation as part of rollback to s…

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -695,7 +695,7 @@ __rollback_page_needs_abort(
     return (result);
 }
 
-#ifdef HAVE_DIAGNOSTIC
+#if 0
 /*
  * __rollback_verify_ondisk_page --
  *     Verify the on-disk page that it doesn't have updates newer than the timestamp.
@@ -749,7 +749,11 @@ __rollback_abort_newer_updates(
     if ((page = ref->page) == NULL || !__wt_page_is_modified(page)) {
         if (!__rollback_page_needs_abort(session, ref, rollback_timestamp)) {
             __wt_verbose(session, WT_VERB_RTS, "%p: page skipped", (void *)ref);
-#ifdef HAVE_DIAGNOSTIC
+#if 0
+            /*
+             * FIXME: Enable the clean page verification once the eviction is able to evict the
+             * newly loaded clean pages of this tree to avoid cache full.
+             */
             if (ref->page == NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
                 WT_RET(__wt_page_in(session, ref, 0));
                 if (ref->page->type == WT_PAGE_ROW_LEAF)


### PR DESCRIPTION
…table

Validating a clean page to verify whether all the updates on the page
are less than the stable timestamp or not led to increase the cache usage
due to eviction unable to evict these pages.