### PR TITLE
WT-5769 Remove remaining usage of ignore visibility flag

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -920,11 +920,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
 
         /*
          * Scan the history store for the given btree and key with maximum start timestamp to let
-         * the search point to the last version of the key. We must ignore tombstone in the history
-         * store while retrieving the update from the history store to replace the update in the
-         * data store. We also need to ignore visibility of the updates as we have already released
-         * our snapshot in prepare. Otherwise, we can't see updates with non-globally visible
-         * transaction ids.
+         * the search point to the last version of the key.
          */
         WT_ERR_NOTFOUND_OK(
           __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, &op->u.op_row.key, WT_TS_MAX),

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -926,8 +926,6 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * our snapshot in prepare. Otherwise, we can't see updates with non-globally visible
          * transaction ids.
          */
-        F_SET(hs_cursor, WT_CURSTD_IGNORE_TOMBSTONE);
-        F_SET(session, WT_SESSION_HS_IGNORE_VISIBILITY);
         WT_ERR_NOTFOUND_OK(
           __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, &op->u.op_row.key, WT_TS_MAX),
           true);
@@ -1011,11 +1009,8 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
         WT_ERR(__txn_fixup_prepared_update(session, hs_cursor, fix_upd, commit));
 
 err:
-    if (hs_cursor != NULL) {
-        F_CLR(session, WT_SESSION_HS_IGNORE_VISIBILITY);
-        F_CLR(hs_cursor, WT_CURSTD_IGNORE_TOMBSTONE);
+    if (hs_cursor != NULL)
         ret = __wt_hs_cursor_close(session, session_flags, is_owner);
-    }
     if (!upd_appended)
         __wt_free(session, fix_upd);
     return (ret);


### PR DESCRIPTION
Sorry, I forgot to merge in `develop`. Same deal here, I think it's fine to remove this usage because we're always ignoring visibility for history store now.