### PR TITLE
WT-6328 Update test_compact02 to handle being halted by eviction pressure.

### DIFF
--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -149,11 +149,11 @@ class test_compact02(wttest.WiredTigerTestCase):
         # Compact can collide with eviction, if that happens we retry. Wait for
         # a long time, the check for EBUSY means we're not retrying on any real
         # errors.
-        for i in range(1, 60):
+        for i in range(1, 80):
             if not self.raisesBusy(
               lambda: self.session.compact(self.uri, None)):
                 break
-            time.sleep(5)
+            time.sleep(6)
 
         # 6. Get stats on compacted table.
         sz = self.getSize()


### PR DESCRIPTION
Looks like this error was reported earlier as well and the maximum timer was increased to 5 minutes since it is not failing because of any bug, it is just that eviction taking a very long time to finish in the small cache case. The maximum wait time was increased to 5 minutes with the ticket [WT-3942](https://jira.mongodb.org/browse/WT-3942). 

I have increased the maximum timer to 8 minutes and give enough time for eviction with a small cache.