### PR TITLE
WT-6015 Check log and turtle versions early before modifying database.

### DIFF
--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -108,9 +108,9 @@ __wt_import(WT_SESSION_IMPL *session, const char *uri)
     __wt_verbose(session, WT_VERB_CHECKPOINT, "import configuration: %s/%s", uri, fileconf);
 
     /*
-     * The just inserted metadata was correct as of immediately before the before the final
-     * checkpoint, but it's not quite right. The block manager returned the corrected final
-     * checkpoint, put it all together.
+     * The just inserted metadata was correct as of immediately before the final checkpoint, but
+     * it's not quite right. The block manager returned the corrected final checkpoint, put it all
+     * together.
      *
      * Get the checkpoint information from the file's metadata as an array of WT_CKPT structures.
      *

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1403,7 +1403,7 @@ __conn_config_file(
         /*
          * Replace any newline characters with commas (and strings of commas are safe).
          *
-         * After any newline, skip toy a non-white-space character; if the next character is a hash
+         * After any newline, skip to a non-white-space character; if the next character is a hash
          * mark, skip to the next newline.
          */
         for (;;) {
@@ -2591,11 +2591,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_ERR(__wt_config_gets(session, cfg, "operation_timeout_ms", &cval));
     conn->operation_timeout_us = (uint64_t)(cval.val * WT_THOUSAND);
 
-    /*
-     * Set compatibility versions early so that any subsystem sees it. Call after we own the
-     * database so that we can know if the database is new or not. Compatibility testing needs to
-     * know if salvage has been set, so parse that early.
-     */
     WT_ERR(__wt_config_gets(session, cfg, "salvage", &cval));
     if (cval.val) {
         if (F_ISSET(conn, WT_CONN_READONLY))
@@ -2662,7 +2657,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     __wt_logmgr_compat_version(session);
     WT_ERR(__wt_logmgr_config(session, cfg, false));
     if (!F_ISSET(conn, WT_CONN_SALVAGE) && FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED))
-        WT_RET(__wt_log_compat_verify(session));
+        WT_ERR(__wt_log_compat_verify(session));
 
     /*
      * Configuration completed; optionally write a base configuration file.

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -190,11 +190,11 @@ __logmgr_version(WT_SESSION_IMPL *session, bool reconfig)
 }
 
 /*
- * __logmgr_config --
+ * __wt_logmgr_config --
  *     Parse and setup the logging server options.
  */
-static int
-__logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp, bool reconfig)
+int
+__wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
 {
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
@@ -245,7 +245,10 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp, bool rec
               "log=(enabled=true)");
     }
 
-    *runp = enabled;
+    if (enabled)
+        FLD_SET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED);
+    else
+        FLD_CLR(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED);
 
     /*
      * Setup a log path and compression even if logging is disabled in case we are going to print a
@@ -258,12 +261,13 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp, bool rec
         WT_RET(__wt_config_gets_none(session, cfg, "log.compressor", &cval));
         WT_RET(__wt_compressor_config(session, &cval, &conn->log_compressor));
 
+        conn->log_path = NULL;
         WT_RET(__wt_config_gets(session, cfg, "log.path", &cval));
         WT_RET(__wt_strndup(session, cval.str, cval.len, &conn->log_path));
     }
 
     /* We are done if logging isn't enabled. */
-    if (!*runp)
+    if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED))
         return (0);
 
     WT_RET(__wt_config_gets(session, cfg, "log.archive", &cval));
@@ -336,9 +340,7 @@ __logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp, bool rec
 int
 __wt_logmgr_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 {
-    bool dummy;
-
-    WT_RET(__logmgr_config(session, cfg, &dummy, true));
+    WT_RET(__wt_logmgr_config(session, cfg, true));
     return (__logmgr_version(session, true));
 }
 
@@ -967,19 +969,18 @@ err:
  *     Initialize the log subsystem (before running recovery).
  */
 int
-__wt_logmgr_create(WT_SESSION_IMPL *session, const char *cfg[])
+__wt_logmgr_create(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_LOG *log;
-    bool run;
 
     conn = S2C(session);
 
-    /* Handle configuration. */
-    WT_RET(__logmgr_config(session, cfg, &run, false));
-
-    /* If logging is not configured, we're done. */
-    if (!run)
+    /*
+     * Logging configuration is parsed early on for compatibility checking. It is separated from
+     * turning on the subsystem. We only need to proceed here if logging is enabled.
+     */
+    if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED))
         return (0);
 
     FLD_SET(conn->log_flags, WT_CONN_LOG_ENABLED);

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -205,7 +205,7 @@ __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
      * can know if statistics are enabled or not.
      */
     WT_RET(__wt_statlog_create(session, cfg));
-    WT_RET(__wt_logmgr_create(session, cfg));
+    WT_RET(__wt_logmgr_create(session));
 
     /*
      * Run recovery. NOTE: This call will start (and stop) eviction if recovery is required.

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -200,15 +200,6 @@ done:
     conn->req_max_minor = max_minor;
     conn->req_min_major = min_major;
     conn->req_min_minor = min_minor;
-    /*
-     * Set up the log manager versions in the connection and verify any logs. We do this at the end
-     * here, but very early in the startup process so that if we're starting from a backup and there
-     * are compatibility errors, we inform the user but leave the directory unchanged.
-     */
-    __wt_logmgr_compat_version(session);
-    if (!reconfig && !F_ISSET(conn, WT_CONN_SALVAGE))
-        WT_ERR(__wt_log_compat_verify(session));
-
 err:
     __wt_free(session, value);
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -354,16 +354,17 @@ struct __wt_connection_impl {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CONN_LOG_ARCHIVE 0x001u         /* Archive is enabled */
-#define WT_CONN_LOG_DEBUG_MODE 0x002u      /* Debug-mode logging enabled */
-#define WT_CONN_LOG_DOWNGRADED 0x004u      /* Running older version */
-#define WT_CONN_LOG_ENABLED 0x008u         /* Logging is enabled */
-#define WT_CONN_LOG_EXISTED 0x010u         /* Log files found */
-#define WT_CONN_LOG_FORCE_DOWNGRADE 0x020u /* Force downgrade */
-#define WT_CONN_LOG_RECOVER_DIRTY 0x040u   /* Recovering unclean */
-#define WT_CONN_LOG_RECOVER_DONE 0x080u    /* Recovery completed */
-#define WT_CONN_LOG_RECOVER_ERR 0x100u     /* Error if recovery required */
-#define WT_CONN_LOG_RECOVER_FAILED 0x200u  /* Recovery failed */
-#define WT_CONN_LOG_ZERO_FILL 0x400u       /* Manually zero files */
+#define WT_CONN_LOG_CONFIG_ENABLED 0x002u  /* Logging is configured */
+#define WT_CONN_LOG_DEBUG_MODE 0x004u      /* Debug-mode logging enabled */
+#define WT_CONN_LOG_DOWNGRADED 0x008u      /* Running older version */
+#define WT_CONN_LOG_ENABLED 0x010u         /* Logging is enabled */
+#define WT_CONN_LOG_EXISTED 0x020u         /* Log files found */
+#define WT_CONN_LOG_FORCE_DOWNGRADE 0x040u /* Force downgrade */
+#define WT_CONN_LOG_RECOVER_DIRTY 0x080u   /* Recovering unclean */
+#define WT_CONN_LOG_RECOVER_DONE 0x100u    /* Recovery completed */
+#define WT_CONN_LOG_RECOVER_ERR 0x200u     /* Error if recovery required */
+#define WT_CONN_LOG_RECOVER_FAILED 0x400u  /* Recovery failed */
+#define WT_CONN_LOG_ZERO_FILL 0x800u       /* Manually zero files */
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t log_flags;                    /* Global logging configuration */
     WT_CONDVAR *log_cond;                  /* Log server wait mutex */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -854,7 +854,9 @@ extern int __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list a
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_logmgr_create(WT_SESSION_IMPL *session, const char *cfg[])
+extern int __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_logmgr_create(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1445,6 +1447,8 @@ extern int __wt_turtle_init(WT_SESSION_IMPL *session)
 extern int __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_turtle_validate_version(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_activity_drain(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -149,8 +149,8 @@ err:
  *     Retrieve version numbers from the turtle file and validate them against our WiredTiger
  *     version.
  */
-static int
-__turtle_validate_version(WT_SESSION_IMPL *session)
+int
+__wt_turtle_validate_version(WT_SESSION_IMPL *session)
 {
     WT_DECL_RET;
     uint32_t major, minor;
@@ -293,7 +293,7 @@ __wt_turtle_init(WT_SESSION_IMPL *session)
             WT_RET(__wt_remove_if_exists(session, WT_METADATA_TURTLE, false));
             load = true;
         } else if (validate_turtle)
-            WT_RET(__turtle_validate_version(session));
+            WT_RET(__wt_turtle_validate_version(session));
     } else
         load = true;
     if (load) {

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -145,7 +145,7 @@ err:
 }
 
 /*
- * __turtle_validate_version --
+ * __wt_turtle_validate_version --
  *     Retrieve version numbers from the turtle file and validate them against our WiredTiger
  *     version.
  */


### PR DESCRIPTION
@agorrod and @luke-pearson here is a redo of the compatibility changes and adding in the turtle validation. I found in `conn_single` we were already doing some turtle work and added it there. That felt better than adding another case where we interact with the turtle. It happens to come before the log checking so it should fix the skip version test.

@luke-pearson can you check or test with this branch and that failure? I am still not thrilled with the fragility of certain things being in order in the server code, but this works around that for the moment.

Also @luke-pearson do we still need/want the second call to `wt_turtle_validate_version` in `wt_turtle_init`? Or, is the one I added in `conn_single` going to break or crash in the case of corruption and/or salvage? 