### PR TITLE
WT-6359 Coverity Explicit NULL dereference

### DIFF
--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -311,7 +311,7 @@ real_worker(void)
     }
 
 err:
-    if ((t_ret = session->close(session, NULL)) != 0 && ret == 0) {
+    if (session != NULL && (t_ret = session->close(session, NULL)) != 0 && ret == 0) {
         ret = t_ret;
         (void)log_print_err("session.close", ret, 1);
     }


### PR DESCRIPTION
Coverity link
https://coverity.corp.mongodb.com/reports.htm#v15509/p10049/fileInstanceId=30123292&defectInstanceId=19812275&mergedDefectId=114181&fileStart=1&fileEnd=125