### PR TITLE
WT-5801 Reduce runtime of Python unit tests by pruning test_compat02.py

### DIFF
--- a/test/suite/test_compat02.py
+++ b/test/suite/test_compat02.py
@@ -110,7 +110,9 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
         ('basecfg_true', dict(basecfg='true')),
         ('basecfg_false', dict(basecfg='false')),
     ]
-    scenarios = make_scenarios(compat_create, compat_release, compat_min, compat_max, base_config)
+
+    scenarios = make_scenarios(compat_create, compat_release, compat_min, compat_max, base_config,
+                               prune=100, prunelong=100000)
 
     def conn_config(self):
         # Set archive false on the home directory.


### PR DESCRIPTION
Add the `prune` & `prunelong` argument settings in test_compat02.py as suggested by @ddanderson. Created a patch build with some quick analysis (in jira). 