### PR TITLE
WT-6381 RTS to remove hs record that is appended to the update chain

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -247,10 +247,11 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
 
         /*
          * Stop processing when we find the newer version value of this key is stable according to
-         * the current version stop timestamp. Also it confirms that history store doesn't contains
-         * any newer version than the current version for the key.
+         * the current version stop timestamp when it is not appending the selected update to the
+         * update chain. Also it confirms that history store doesn't contains any newer version than
+         * the current version for the key.
          */
-        if (hs_stop_ts <= rollback_timestamp) {
+        if (!replace && hs_stop_ts <= rollback_timestamp) {
             __wt_verbose(session, WT_VERB_RTS,
               "history store update valid with stop timestamp: %s and stable timestamp: %s",
               __wt_timestamp_to_string(hs_stop_ts, ts_string[0]),


### PR DESCRIPTION
During aborting of on-disk update on a data store while replacing it
with the history store update that have both equal start and stop
timestamps led to not removing the history store record can led to
the update present in both data store and history store. To hanlde
this problem, RTS must remove the history store update that is getting
appended to the data store.