### PR TITLE
WT-6379 Split Evergreen stress test job into multiple shorter running jobs

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -308,6 +308,88 @@ functions:
           done
         done
 
+#########################################################################################
+# VARIABLES
+#
+# The following stress tests are configured to run for six hours via the "-t 360"
+# argument to format.sh: format-stress-test, format-stress-sanitizer-test, and
+# race-condition-stress-sanitizer-test. The smoke and recovery tests run in a loop,
+# with the number of runs adjusted to provide aproximately six hours of testing.
+#########################################################################################
+variables:
+
+  - &format-stress-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger with builtins"
+      - func: "format test script"
+        vars:
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
+
+  - &format-stress-sanitizer-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger address sanitizer"
+      - func: "format test script"
+        vars:
+          format_test_script_args: -t 360
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+
+  - &format-stress-smoke-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger with builtins"
+      - func: "format test script"
+        vars:
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -S
+          times: 30
+
+  - &format-stress-sanitizer-smoke-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger address sanitizer"
+      - func: "format test script"
+        vars:
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+          format_test_script_args: -S
+          times: 20
+
+  - &race-condition-stress-sanitizer-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars:
+            CC="/opt/mongodbtoolchain/v3/bin/clang -fsanitize=address"
+            PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fno-omit-frame-pointer"
+          posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
+      - func: "format test script"
+        vars:
+          format_test_script_args: -R -t 360
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+
+  - &recovery-stress-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          posix_configure_flags: --enable-strict --enable-diagnostic --with-builtins=lz4,snappy,zlib
+      - func: "recovery stress test script"
+        vars:
+          times: 40
+
 pre:
   - func: "cleanup"
 post:
@@ -1981,8 +2063,6 @@ tasks:
   - name: time-shift-sensitivity-test
     depends_on:
     - name: compile
-      vars:
-        posix_configure_flags: --enable-strict
     commands:
       - func: "fetch artifacts"
         vars:
@@ -1995,140 +2075,6 @@ tasks:
             set -o verbose
 
             ./time_shift_test.sh /usr/local/lib/faketime/libfaketimeMT.so.1 0-1 2>&1
-
-  - name: format-stress-sanitizer-test
-    #set a 25 hours (25*60*60 = 90000 seconds) timeout
-    exec_timeout_secs: 90000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger address sanitizer"
-      - func: "format test script"
-        vars:
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
-          # run for 24 hours ( 24 * 60 = 1440 minutes), skip known errors, don't stop at failed tests, use default config
-          format_test_script_args: -E -t 1440
-
-  - name: format-stress-sanitizer-lsm-test
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger address sanitizer"
-      - func: "format test script"
-        vars:
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
-          # Run for 30 mins, and explicitly set data_source to LSM with a large cache
-          format_test_script_args: -t 30 data_source=lsm cache_minimum=5000
-
-  - name: format-stress-sanitizer-smoke-test
-    #set a 7 hours timeout
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger address sanitizer"
-      - func: "format test script"
-        # to emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
-        # run smoke tests, skip known errors, don't stop at failed tests, use default config
-        vars:
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
-          format_test_script_args: -E -S
-          times: 16
-
-  - name: race-condition-stress-sanitizer-test
-    # set an evergreen timeout of 25 hours
-    exec_timeout_secs: 90000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          configure_env_vars: CC="/opt/mongodbtoolchain/v3/bin/clang -fsanitize=address" PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fno-omit-frame-pointer"
-          posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
-      - func: "format test script"
-        vars:
-          # set a format.sh timeout of 24 hours, skip known errors, don't stop at failed tests, use default config
-          format_test_script_args: -E -R -t 1440
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
-
-  - name: recovery-stress-test
-    #set a 25 hours timeout
-    exec_timeout_secs: 90000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          posix_configure_flags: --enable-strict --enable-diagnostic --with-builtins=lz4,snappy,zlib
-      - func: "recovery stress test script"
-        vars:
-          # Repeat this script enough times to make this task run for 24 hours
-          # At the time of writing this script, one call to underlying scripts takes about ~15 mins to finish in worst case.
-          # We are giving an extra ~20% room for vairance in execution time.
-          times: 80
-
-  - name: split-stress-test
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          configure_env_vars: CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/bench/workgen/runner"
-          script: |
-            set -o errexit
-            set -o verbose
-            for i in {1..10}; do ${python_binary|python} split_stress.py; done
-
-  - name: format-stress-test
-    # Set 25 hours timeout
-    exec_timeout_secs: 90000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger with builtins"
-      - func: "format test script"
-        vars:
-          #run for 24 hours ( 24 * 60 = 1440 minutes), use default config
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 1440
-
-  - name: format-stress-smoke-test
-    # Set 7 hours timeout
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger with builtins"
-      - func: "format test script"
-        vars:
-          # to emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
-          # run smoke tests, use default config (-S)
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -S
-          times: 16
-
-  - name: checkpoint-stress-test
-    commands:
-      - command: timeout.update
-        params:
-          # set 24 hour timeout for the task and command
-          exec_timeout_secs: 86400
-          timeout_secs: 86400
-      - func: "get project"
-      - func: "compile wiredtiger with builtins"
-      - func: "checkpoint stress test"
-        vars:
-          # No of times to run the loop
-          times: 1
-          # No of processes to run in the background
-          no_of_procs: 8
-
-  # The task name is ppc-zseries because this task will be used in both buildVariants
-  - name: format-stress-ppc-zseries-test
-    # Set 2.5 hours timeout (60 * 60 * 2.5)
-    exec_timeout_secs: 9000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger with builtins"
-      - func: "format test script"
-        vars:
-          # Make sure we dump core on failure
-          format_test_setting: ulimit -c unlimited
-          #run for 2 hours ( 2 * 60 = 120 minutes), use default config
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
 
   - name: format-wtperf-test
     commands:
@@ -2177,41 +2123,175 @@ tasks:
               exit 1
             fi
 
+  - name: format-stress-sanitizer-lsm-test
+    # Temporarily disabled (WT-6255)
+    # tags: ["stress-test-1"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger address sanitizer"
+      - func: "format test script"
+        vars:
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v3/bin/llvm-symbolizer
+          # Run for 30 mins, and explicitly set data_source to LSM with a large cache
+          format_test_script_args: -t 30 data_source=lsm cache_minimum=5000
+
+  - name: checkpoint-stress-test
+    tags: ["stress-test-1"]
+    exec_timeout_secs: 86400
+    commands:
+      - command: timeout.update
+        params:
+          timeout_secs: 86400
+      - func: "get project"
+      - func: "compile wiredtiger with builtins"
+      - func: "checkpoint stress test"
+        vars:
+          times: 1       # No of times to run the loop
+          no_of_procs: 8 # No of processes to run in the background
+
+  - name: split-stress-test
+    tags: ["stress-test-1", "stress-test-zseries-1"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars:
+            CXX=/opt/mongodbtoolchain/v3/bin/g++
+            PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/bench/workgen/runner"
+          script: |
+            set -o errexit
+            set -o verbose
+            for i in {1..10}; do ${python_binary|python} split_stress.py; done
+
+  # The task name is ppc-zseries because this task will be used in both buildVariants
+  - name: format-stress-ppc-zseries-test
+    tags: ["stress-test-ppc-1", "stress-test-zseries-1"]
+    # Set 2.5 hours timeout (60 * 60 * 2.5)
+    exec_timeout_secs: 9000
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger with builtins"
+      - func: "format test script"
+        vars:
+          # Make sure we dump core on failure
+          format_test_setting: ulimit -c unlimited
+          #run for 2 hours ( 2 * 60 = 120 minutes), use default config
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
+
+  # Replace this test with format-stress-sanitizer-test after BUILD-10248 fix.
   - name: format-stress-sanitizer-ppc-test
+    tags: ["stress-test-ppc-1"]
     # Set 2.5 hours timeout (60 * 60 * 2.5)
     exec_timeout_secs: 9000
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          # CC is set to the system default "clang" binary here as a workaround. Change it back to mongodbtoolchain "clang" binary after BUILD-10248 fix.
-          configure_env_vars: CCAS=/opt/mongodbtoolchain/v3/bin/gcc CC=/usr/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fsanitize=address -fno-omit-frame-pointer -I/opt/mongodbtoolchain/v3/lib/gcc/ppc64le-mongodb-linux/8.2.0/include"
+          # CC is set to the system default "clang" binary here as a workaround. Change it back
+          # to mongodbtoolchain "clang" binary after BUILD-10248 fix.
+          configure_env_vars:
+            CCAS=/opt/mongodbtoolchain/v3/bin/gcc CC=/usr/bin/clang
+            CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+            CFLAGS="-ggdb -fPIC -fsanitize=address -fno-omit-frame-pointer
+            -I/opt/mongodbtoolchain/v3/lib/gcc/ppc64le-mongodb-linux/8.2.0/include"
           posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
       - func: "format test script"
         vars:
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          # run for 2 hours ( 2 * 60 = 120 minutes), don't stop at failed tests, use default config
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
+          # Run for 2 hours (2 * 60 = 120 minutes), don't stop at failed tests, use default config
           format_test_script_args: -t 120
 
+  # Replace this test with format-stress-sanitizer-smoke-test after BUILD-10248 fix.
   - name: format-stress-sanitizer-smoke-ppc-test
+    tags: ["stress-test-ppc-1"]
     # Set 7 hours timeout (60 * 60 * 7)
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          # CC is set to the system default "clang" binary here as a workaround. Change it back to mongodbtoolchain "clang" binary after BUILD-10248 fix.
-          configure_env_vars: CCAS=/opt/mongodbtoolchain/v3/bin/gcc CC=/usr/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fsanitize=address -fno-omit-frame-pointer -I/opt/mongodbtoolchain/v3/lib/gcc/ppc64le-mongodb-linux/8.2.0/include"
+          # CC is set to the system default "clang" binary here as a workaround. Change it back
+          # to mongodbtoolchain "clang" binary after BUILD-10248 fix.
+          configure_env_vars:
+            CCAS=/opt/mongodbtoolchain/v3/bin/gcc CC=/usr/bin/clang
+            CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+            CFLAGS="-ggdb -fPIC -fsanitize=address -fno-omit-frame-pointer
+            -I/opt/mongodbtoolchain/v3/lib/gcc/ppc64le-mongodb-linux/8.2.0/include"
           posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
       - func: "format test script"
-        # to emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
-        # run smoke tests, don't stop at failed tests, use default config
+        # To emulate the original Jenkins job's test coverage, we are running the smoke test 16 times
+        # Run smoke tests, don't stop at failed tests, use default config
         vars:
-          test_env_vars: ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0" ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
+            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
           format_test_script_args: -S
           times: 16
 
+  - <<: *format-stress-test
+    name: format-stress-test-1
+    tags: ["stress-test-1"]
+  - <<: *format-stress-test
+    name: format-stress-test-2
+    tags: ["stress-test-2"]
+  - <<: *format-stress-test
+    name: format-stress-test-3
+    tags: ["stress-test-3"]
+  - <<: *format-stress-test
+    name: format-stress-test-4
+    tags: ["stress-test-4"]
+  - <<: *format-stress-sanitizer-test
+    name: format-stress-sanitizer-test-1
+    tags: ["stress-test-1"]
+  - <<: *format-stress-sanitizer-test
+    name: format-stress-sanitizer-test-2
+    tags: ["stress-test-2"]
+  - <<: *format-stress-sanitizer-test
+    name: format-stress-sanitizer-test-3
+    tags: ["stress-test-3"]
+  - <<: *format-stress-sanitizer-test
+    name: format-stress-sanitizer-test-4
+    tags: ["stress-test-4"]
+  - <<: *format-stress-smoke-test
+    name: format-stress-smoke-test-1
+    tags: ["stress-test-1", "stress-test-ppc-1", "stress-test-zseries-1"]
+  - <<: *format-stress-smoke-test
+    name: format-stress-smoke-test-2
+    tags: ["stress-test-2", "stress-test-ppc-2", "stress-test-zseries-2"]
+  - <<: *format-stress-sanitizer-smoke-test
+    name: format-stress-sanitizer-smoke-test-1
+    tags: ["stress-test-1"]
+  - <<: *format-stress-sanitizer-smoke-test
+    name: format-stress-sanitizer-smoke-test-2
+    tags: ["stress-test-2"]
+  - <<: *race-condition-stress-sanitizer-test
+    name: race-condition-stress-sanitizer-test-1
+    tags: ["stress-test-1"]
+  - <<: *race-condition-stress-sanitizer-test
+    name: race-condition-stress-sanitizer-test-2
+    tags: ["stress-test-2"]
+  - <<: *race-condition-stress-sanitizer-test
+    name: race-condition-stress-sanitizer-test-3
+    tags: ["stress-test-3"]
+  - <<: *race-condition-stress-sanitizer-test
+    name: race-condition-stress-sanitizer-test-4
+    tags: ["stress-test-4"]
+  - <<: *recovery-stress-test
+    name: recovery-stress-test-1
+    tags: ["stress-test-1", "stress-test-zseries-1"]
+  - <<: *recovery-stress-test
+    name: recovery-stress-test-2
+    tags: ["stress-test-2", "stress-test-zseries-2"]
+
 buildvariants:
+
 - name: ubuntu1804
   display_name: "! Ubuntu 18.04"
   run_on:
@@ -2275,21 +2355,19 @@ buildvariants:
   run_on:
   - ubuntu1804-test
   expansions:
-    test_env_vars: LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
-    posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
+    test_env_vars:
+      LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so LD_LIBRARY_PATH=$(pwd)/.libs
+      PATH=/opt/mongodbtoolchain/v3/bin:$PATH top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    posix_configure_flags:
+      --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy
+      --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
   tasks:
-    - name: recovery-stress-test
-    - name: format-stress-sanitizer-test
-    - name: format-stress-sanitizer-smoke-test
-    # Temporarily disabled (WT-6255)
-    # - name: format-stress-sanitizer-lsm-test
-    - name: split-stress-test
-    - name: format-stress-test
-    - name: format-stress-smoke-test
-    - name: race-condition-stress-sanitizer-test
-    - name: checkpoint-stress-test
+    - name: ".stress-test-1"
+    - name: ".stress-test-2"
+    - name: ".stress-test-3"
+    - name: ".stress-test-4"
 
 - name: package
   display_name: "~ Package"
@@ -2433,18 +2511,19 @@ buildvariants:
   - ubuntu1804-power8-test
   expansions:
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
-    posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
-    test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    test_env_vars:
+      PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs
+      top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    posix_configure_flags:
+      --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy
+      --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
   tasks:
   - name: compile
   - name: unit-test
-  - name: format-stress-ppc-zseries-test
-  - name: format-stress-smoke-test
   - name: format-wtperf-test
-  # Replace the below two tests with format-stress-sanitizer-ppc-test and format-stress-sanitizer-smoke-test after BUILD-10248 fix.
-  - name: format-stress-sanitizer-ppc-test
-  - name: format-stress-sanitizer-smoke-ppc-test
+  - name: ".stress-test-ppc-1"
+  - name: ".stress-test-ppc-2"
 
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"
@@ -2452,13 +2531,15 @@ buildvariants:
   - ubuntu1804-zseries-test
   expansions:
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
-    posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
-    test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs:$(pwd)/lang/python top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    test_env_vars:
+      PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs:$(pwd)/lang/python
+      top_srcdir=$(pwd)/.. top_builddir=$(pwd)
+    posix_configure_flags:
+      --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-snappy
+      --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL
   tasks:
   - name: compile
   - name: unit-test
-  - name: recovery-stress-test
-  - name: split-stress-test
-  - name: format-stress-ppc-zseries-test
-  - name: format-stress-smoke-test
+  - name: ".stress-test-zseries-1"
+  - name: ".stress-test-zseries-2"


### PR DESCRIPTION
- Moved the long running stress test jobs into variables so that we could run multiple parallel instances in the same build variant without creating duplicate code in the `evergreen.yml` file.
- Added task tags to identify and group the stress tests and simply the build variant configurations.
- Removed a few lines of code in an unrelated test that caused `evergreen validate` to error.
- Removed redundant comments in the task definitions.
- Further discussion/work is needed to split the `checkpoint-stress-test` into shorter running instances. With the column-store and lsm testing disabled, it currently takes approximately six hours to complete.