### PR TITLE
WT-6353 Print out failing values and value history of prealloc.

### DIFF
--- a/test/suite/test_bug019.py
+++ b/test/suite/test_bug019.py
@@ -57,6 +57,8 @@ class test_bug019(wttest.WiredTigerTestCase):
             if i % 500 == 0:
                 prealloc = self.get_prealloc_stat()
                 if prealloc > self.max_prealloc:
+                    self.pr("Updating max_prealloc from " + str(self.max_prealloc))
+                    self.pr("    to new prealloc " + str(prealloc))
                     self.max_prealloc = prealloc
         c.close()
 
@@ -78,6 +80,9 @@ class test_bug019(wttest.WiredTigerTestCase):
         start_prealloc = self.get_prealloc_stat()
         self.populate(self.entries)
         self.session.checkpoint()
+        if self.max_prealloc <= start_prealloc:
+            self.pr("FAILURE: max_prealloc " + str(self.max_prealloc))
+            self.pr("FAILURE: start_prealloc " + str(start_prealloc))
         self.assertTrue(self.max_prealloc > start_prealloc)
 
         # Loop, making sure pre-allocation is working and the range is moving.


### PR DESCRIPTION
@keitharnoldsmith I want to merge this into the tree so that there are breadcrumbs of what the values are in any artifacts. I've run several hundred iterations on two machines without a failure so this will capture information for whenever it next hits on evergreen or for anyone.