### PR TITLE
WT-6392 wt4156_meta_salvage test doesn't clean up core files when running in Evergreen

### DIFF
--- a/test/csuite/wt4156_metadata_salvage/main.c
+++ b/test/csuite/wt4156_metadata_salvage/main.c
@@ -518,7 +518,7 @@ main(int argc, char *argv[])
      * We need to set up the string before we clean up the structure. Then after the clean up we
      * will run this command.
      */
-    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf core* %s*", home));
+    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf core* *.core %s*", home));
     testutil_cleanup(opts);
 
     /*


### PR DESCRIPTION
Alex & Sue,

Tapping you for this trivial PR since your names are on previous modifications to this test.

I suppose it would be more comprehensive to read and parse `/proc/sys/kernel/core_pattern` to determine the core file name(s) to remove, but I wasn't that ambitious (and it wouldn't help on non-Linux platforms).