### PR TITLE
WT-6392 wt4156_metadata_salvage test doesn't clean up core files prop…

### DIFF
--- a/test/csuite/wt4156_metadata_salvage/main.c
+++ b/test/csuite/wt4156_metadata_salvage/main.c
@@ -351,7 +351,15 @@ wt_open_corrupt(const char *sfx)
         testutil_check(__wt_snprintf(buf, sizeof(buf), "%s.%s", home, sfx));
     else
         testutil_check(__wt_snprintf(buf, sizeof(buf), "%s", home));
-    ret = wiredtiger_open(buf, &event_handler, NULL, &conn);
+
+    /*
+     * Opening the database may cause a panic and core dump. Change dir to database directory so the
+     * core will be left someplace we will clean up.
+     */
+    if (chdir(buf) != 0)
+        testutil_die(errno, "Child chdir: %s", home);
+
+    ret = wiredtiger_open(NULL, &event_handler, NULL, &conn);
     /*
      * Not all out of sync combinations lead to corruption. We keep the previous checkpoint in the
      * file so some combinations of future or old turtle files and metadata files will succeed.
@@ -496,7 +504,7 @@ main(int argc, char *argv[])
     printf("corrupt metadata\n");
     corrupt_file(WT_METAFILE, CORRUPT);
     testutil_check(__wt_snprintf(
-      buf, sizeof(buf), "cp -p %s/WiredTiger.wt ./%s.SAVE/WiredTiger.wt.CORRUPT", home, home));
+      buf, sizeof(buf), "cp -p %s/WiredTiger.wt ./%s.%s/WiredTiger.wt.CORRUPT", home, home, SAVE));
     printf("copy: %s\n", buf);
     if ((ret = system(buf)) < 0)
         testutil_die(ret, "system: %s", buf);
@@ -508,7 +516,7 @@ main(int argc, char *argv[])
     printf("corrupt turtle\n");
     corrupt_file(WT_METADATA_TURTLE, WT_METAFILE_URI);
     testutil_check(__wt_snprintf(buf, sizeof(buf),
-      "cp -p %s/WiredTiger.turtle ./%s.SAVE/WiredTiger.turtle.CORRUPT", home, home));
+      "cp -p %s/WiredTiger.turtle ./%s.%s/WiredTiger.turtle.CORRUPT", home, home, SAVE));
     printf("copy: %s\n", buf);
     if ((ret = system(buf)) < 0)
         testutil_die(ret, "system: %s", buf);
@@ -518,13 +526,12 @@ main(int argc, char *argv[])
      * We need to set up the string before we clean up the structure. Then after the clean up we
      * will run this command.
      */
-    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf core* %s*", home));
+    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf %s.%s", home, SAVE));
+
+    /* Clean up database directory and any core files left there. */
     testutil_cleanup(opts);
 
-    /*
-     * We've created a lot of extra directories and possibly some core files from child process
-     * aborts. Manually clean them up.
-     */
+    /* Remove saved copy of original database directory. */
     printf("cleanup and remove: %s\n", buf);
     if ((ret = system(buf)) < 0)
         testutil_die(ret, "system: %s", buf);


### PR DESCRIPTION
Alex & Sue,

Second try for this PR.  I realized the metadata salvage test should be creating and deleting
cores in its current directory, since there's no way to be sure what other files might be that that match `core*`.  E.g., cores from other failed tests that we shouldn't blindly delete.

So now its child processes `chdir` into the database directory and any cores will be left there a deleted along with the directory during normal cleanup.