### PR TITLE
WT-6277 Compatibility tests verify failure in timestamp validation

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -323,7 +323,11 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
      * Fast check that we're seeing what we expect to see: some number of checkpoints to add, delete
      * or ignore, terminated by a new checkpoint.
      */
-    WT_CKPT_FOREACH (ckptbase, ckpt)
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (F_ISSET(ckpt, WT_CKPT_TIME_AGGREGATE)) {
+            /* Maybe do something with the aggregate here? */
+            F_CLR(ckpt, WT_CKPT_TIME_AGGREGATE);
+        }
         switch (ckpt->flags) {
         case 0:
         case WT_CKPT_DELETE:
@@ -338,6 +342,7 @@ __ckpt_verify(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
         default:
             return (__wt_illegal_value(session, ckpt->flags));
         }
+    }
     return (0);
 }
 #endif

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -427,6 +427,7 @@ __verify_tree(
     bm = S2BT(session)->bm;
     unpack = &_unpack;
     page = ref->page;
+    child_ta = false; /* [-Wconditional-uninitialized] */
 
     __wt_verbose(session, WT_VERB_VERIFY, "%s %s", __verify_addr_string(session, ref, vs->tmp1),
       __wt_page_type_string(page->type));

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -147,6 +147,7 @@ struct __wt_cell {
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CELL_UNPACK_OVERFLOW 0x1u            /* cell is an overflow */
 #define WT_CELL_UNPACK_TIME_WINDOW_CLEARED 0x2u /* time window cleared because of restart */
+#define WT_CELL_UNPACK_TIME_WINDOW_SET 0x4u     /* time window was found in the cell  */
                                                 /* AUTOMATIC FLAG VALUE GENERATION STOP */
 
 /*

--- a/src/include/cell.i
+++ b/src/include/cell.i
@@ -766,6 +766,7 @@ copy_cell_restart:
         if ((cell->__chunk[0] & WT_CELL_SECOND_DESC) == 0)
             break;
         flags = *p++; /* skip second descriptor byte */
+        F_SET(unpack_addr, WT_CELL_UNPACK_TIME_WINDOW_SET);
 
         if (LF_ISSET(WT_CELL_PREPARE))
             ta->prepare = 1;
@@ -810,6 +811,7 @@ copy_cell_restart:
         if ((cell->__chunk[0] & WT_CELL_SECOND_DESC) == 0)
             break;
         flags = *p++; /* skip second descriptor byte */
+        F_SET(unpack_value, WT_CELL_UNPACK_TIME_WINDOW_SET);
 
         if (LF_ISSET(WT_CELL_PREPARE))
             tw->prepare = 1;

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -141,11 +141,12 @@ struct __wt_ckpt {
     void *bpriv; /* Block manager private */
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_CKPT_ADD 0x01u        /* Checkpoint to be added */
-#define WT_CKPT_BLOCK_MODS 0x02u /* Return list of modified blocks */
-#define WT_CKPT_DELETE 0x04u     /* Checkpoint to be deleted */
-#define WT_CKPT_FAKE 0x08u       /* Checkpoint is a fake */
-#define WT_CKPT_UPDATE 0x10u     /* Checkpoint requires update */
-                                 /* AUTOMATIC FLAG VALUE GENERATION STOP */
+#define WT_CKPT_ADD 0x01u            /* Checkpoint to be added */
+#define WT_CKPT_BLOCK_MODS 0x02u     /* Return list of modified blocks */
+#define WT_CKPT_DELETE 0x04u         /* Checkpoint to be deleted */
+#define WT_CKPT_FAKE 0x08u           /* Checkpoint is a fake */
+#define WT_CKPT_TIME_AGGREGATE 0x10u /* Checkpoint contained time aggregate information */
+#define WT_CKPT_UPDATE 0x20u         /* Checkpoint requires update */
+                                     /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -600,52 +600,66 @@ __ckpt_load(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v, WT_C
 
     ret = __wt_config_subgets(session, v, "oldest_start_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.oldest_start_ts = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "oldest_start_txn", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.oldest_start_txn = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "newest_start_durable_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.newest_start_durable_ts = (uint64_t)a.val;
-    else {
+    } else {
         /*
          * Backward compatibility changes, as the parameter name is different in older versions of
          * WT, make sure that we read older format in case if we didn't find the newer format name.
          */
         ret = __wt_config_subgets(session, v, "start_durable_ts", &a);
         WT_RET_NOTFOUND_OK(ret);
-        if (ret != WT_NOTFOUND && a.len != 0)
+        if (ret != WT_NOTFOUND && a.len != 0) {
+            F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
             ckpt->ta.newest_start_durable_ts = (uint64_t)a.val;
+        }
     }
 
     ret = __wt_config_subgets(session, v, "newest_stop_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.newest_stop_ts = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "newest_stop_txn", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.newest_stop_txn = (uint64_t)a.val;
+    }
 
     ret = __wt_config_subgets(session, v, "newest_stop_durable_ts", &a);
     WT_RET_NOTFOUND_OK(ret);
-    if (ret != WT_NOTFOUND && a.len != 0)
+    if (ret != WT_NOTFOUND && a.len != 0) {
+        F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
         ckpt->ta.newest_stop_durable_ts = (uint64_t)a.val;
-    else {
+    } else {
         /*
          * Backward compatibility changes, as the parameter name is different in older versions of
          * WT, make sure that we read older format in case if we didn't find the newer format name.
          */
         ret = __wt_config_subgets(session, v, "stop_durable_ts", &a);
         WT_RET_NOTFOUND_OK(ret);
-        if (ret != WT_NOTFOUND && a.len != 0)
+        if (ret != WT_NOTFOUND && a.len != 0) {
+            F_SET(ckpt, WT_CKPT_TIME_AGGREGATE);
             ckpt->ta.newest_stop_durable_ts = (uint64_t)a.val;
+        }
     }
 
     ret = __wt_config_subgets(session, v, "prepare", &a);


### PR DESCRIPTION
@luke-pearson, I was talking this one over with @agorrod, and he had a good idea: if we don't see aggregated timestamp information anywhere in an internal page or as part of the checkpoint, then don't validate the aggregated timestamp information against the root page (checkpoint lacks aggregated timestamp information), or any of the internal page's children in the case where the internal page has no aggregated timestamp information.

I don't have the test case, so I can't test it, but the change is pretty straight-forward. Can you test it (or hand off the test case to me?), and do the review if you agree this is a sufficient change?