### PR TITLE
WT-6344 Trim the update vector until there is a full update

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -753,15 +753,16 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         prev_upd = upd = NULL;
 
         /*
-         * Trim from the end until there is a full update. We need this if we are dealing with mixed
-         * mode operation and there are modify updates at the end of update chain that are not
-         * relevant due to newer full updates without timestamps.
+         * Trim from the end until there is a full update. We need this if we are dealing with
+         * updates without timestamps, and there are timestamped modify updates at the end of update
+         * chain that are not relevant due to newer full updates without timestamps.
          */
         for (; modifies.size > 0;) {
             __wt_modify_vector_peek(&modifies, &upd);
-            if (upd->type == WT_UPDATE_MODIFY && F_ISSET(upd, WT_UPDATE_MASKED_BY_NON_TS_UPDATE))
+            if (upd->type == WT_UPDATE_MODIFY) {
+                WT_ASSERT(session, F_ISSET(upd, WT_UPDATE_MASKED_BY_NON_TS_UPDATE));
                 __wt_modify_vector_pop(&modifies, &upd);
-            else
+            } else
                 break;
         }
         upd = NULL;

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -689,7 +689,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
          * newer than a TOMBSTONE must be a full update.
          *
          * The algorithm walks from the oldest update, or the most recently inserted into history
-         * store update. To the newest update and build full updates along the way. It sets the stop
+         * store update, to the newest update and build full updates along the way. It sets the stop
          * time point of the update to the start time point of the next update, squashes the updates
          * that are from the same transaction and of the same start timestamp, calculates reverse
          * modification if prev_upd is a MODIFY, and inserts the update to the history store.
@@ -751,6 +751,20 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         }
 
         prev_upd = upd = NULL;
+
+        /*
+         * Trim from the end until there is a full update. We need this if we are dealing with mixed
+         * mode operation and there are modify updates at the end of update chain that are not
+         * relevant due to newer full updates without timestamps.
+         */
+        for (; modifies.size > 0;) {
+            __wt_modify_vector_peek(&modifies, &upd);
+            if (upd->type == WT_UPDATE_MODIFY && F_ISSET(upd, WT_UPDATE_MASKED_BY_NON_TS_UPDATE))
+                __wt_modify_vector_pop(&modifies, &upd);
+            else
+                break;
+        }
+        upd = NULL;
 
         /* Construct the oldest full update. */
         WT_ASSERT(session, modifies.size > 0);


### PR DESCRIPTION
This is handling a corner case where we end up with an update chain with `WT_UPDATE_MODIFY` type update as the oldest update when handling mixed mode operation (timestamped and non-timestamped updates).