### PR TITLE
WT-6351 Fix race between threads to update condition variable's previous wait value.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -302,9 +302,7 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
         F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
         F_CLR(session, WT_SESSION_LOCKED_PASS);
         was_intr = cache->pass_intr != 0;
-        if (ret != 0) {
-            __wt_spin_unlock(session, &cache->evict_pass_lock);
-        }
+        __wt_spin_unlock(session, &cache->evict_pass_lock);
         WT_ERR(ret);
 
         /*
@@ -322,7 +320,6 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
             __wt_cond_auto_wait(session, cache->evict_cond, did_work, NULL);
             __wt_verbose(session, WT_VERB_EVICTSERVER, "%s", "waking");
         }
-        __wt_spin_unlock(session, &cache->evict_pass_lock);
     } else
         WT_ERR(__evict_lru_pages(session, false));
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -302,7 +302,9 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
         F_CLR(cache->walk_session, WT_SESSION_LOCKED_PASS);
         F_CLR(session, WT_SESSION_LOCKED_PASS);
         was_intr = cache->pass_intr != 0;
-        __wt_spin_unlock(session, &cache->evict_pass_lock);
+        if (ret != 0) {
+            __wt_spin_unlock(session, &cache->evict_pass_lock);
+        }
         WT_ERR(ret);
 
         /*
@@ -320,6 +322,7 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
             __wt_cond_auto_wait(session, cache->evict_cond, did_work, NULL);
             __wt_verbose(session, WT_VERB_EVICTSERVER, "%s", "waking");
         }
+        __wt_spin_unlock(session, &cache->evict_pass_lock);
     } else
         WT_ERR(__evict_lru_pages(session, false));
 

--- a/src/support/cond_auto.c
+++ b/src/support/cond_auto.c
@@ -42,7 +42,7 @@ void
 __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool progress,
   bool (*run_func)(WT_SESSION_IMPL *), bool *signalled)
 {
-    uint64_t delta;
+    uint64_t delta, saved_prev_wait;
 
     /*
      * Catch cases where this function is called with a condition variable that wasn't initialized
@@ -55,7 +55,17 @@ __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool prog
         cond->prev_wait = cond->min_wait;
     else {
         delta = WT_MAX(1, (cond->max_wait - cond->min_wait) / 10);
+        /*
+         * Try to update the previous wait value for the condition variable. There can be
+         * multiple threads doing this concurrently, so use atomic operations to make sure the
+         * value remains within the bounds of the maximum configured. Don't retry if our update
+         * didn't make it in - it's not necessary for the previous wait time to be updated every
+         * time.
+         */
+        WT_ORDERED_READ(saved_prev_wait, cond->prev_wait);
         cond->prev_wait = WT_MIN(cond->max_wait, cond->prev_wait + delta);
+        __wt_atomic_cas64(&cond->prev_wait, saved_prev_wait,
+                WT_MIN(cond->max_wait, saved_prev_wait + delta));
     }
 
     __wt_cond_wait_signal(session, cond, cond->prev_wait, run_func, signalled);

--- a/src/support/cond_auto.c
+++ b/src/support/cond_auto.c
@@ -62,7 +62,6 @@ __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool prog
          * - it's not necessary for the previous wait time to be updated every time.
          */
         WT_ORDERED_READ(saved_prev_wait, cond->prev_wait);
-        cond->prev_wait = WT_MIN(cond->max_wait, cond->prev_wait + delta);
         __wt_atomic_cas64(
           &cond->prev_wait, saved_prev_wait, WT_MIN(cond->max_wait, saved_prev_wait + delta));
     }

--- a/src/support/cond_auto.c
+++ b/src/support/cond_auto.c
@@ -56,16 +56,15 @@ __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool prog
     else {
         delta = WT_MAX(1, (cond->max_wait - cond->min_wait) / 10);
         /*
-         * Try to update the previous wait value for the condition variable. There can be
-         * multiple threads doing this concurrently, so use atomic operations to make sure the
-         * value remains within the bounds of the maximum configured. Don't retry if our update
-         * didn't make it in - it's not necessary for the previous wait time to be updated every
-         * time.
+         * Try to update the previous wait value for the condition variable. There can be multiple
+         * threads doing this concurrently, so use atomic operations to make sure the value remains
+         * within the bounds of the maximum configured. Don't retry if our update didn't make it in
+         * - it's not necessary for the previous wait time to be updated every time.
          */
         WT_ORDERED_READ(saved_prev_wait, cond->prev_wait);
         cond->prev_wait = WT_MIN(cond->max_wait, cond->prev_wait + delta);
-        __wt_atomic_cas64(&cond->prev_wait, saved_prev_wait,
-                WT_MIN(cond->max_wait, saved_prev_wait + delta));
+        __wt_atomic_cas64(
+          &cond->prev_wait, saved_prev_wait, WT_MIN(cond->max_wait, saved_prev_wait + delta));
     }
 
     __wt_cond_wait_signal(session, cond, cond->prev_wait, run_func, signalled);


### PR DESCRIPTION
Here we are trying to read the `prev_wait` of condition variables's value using atomic operations because there can be multiple threads accessing this block of code simultaneously. 

The `cond->prev_wait` value was going above WT_MILLION due to race between threads and causing it to assert. 