### PR TITLE
WT-6427 Always set stable timestamp when setting oldest timestamp.

### DIFF
--- a/test/format/util.c
+++ b/test/format/util.c
@@ -101,20 +101,13 @@ track(const char *tag, uint64_t cnt, TINFO *tinfo)
                 last_cur = cur_ts;
             }
 
-            if (g.c_txn_rollback_to_stable)
-                testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
-                  " old%s"
-                  "stb%s%s"
-                  "ts%s%s",
-                  track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, stable_ts),
-                  track_ts_dots(stable_dot_cnt), track_ts_diff(stable_ts, cur_ts),
-                  track_ts_dots(cur_dot_cnt)));
-            else
-                testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
-                  " old%s"
-                  "ts%s%s",
-                  track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, cur_ts),
-                  track_ts_dots(cur_dot_cnt)));
+            testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
+              " old%s"
+              "stb%s%s"
+              "ts%s%s",
+              track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, stable_ts),
+              track_ts_dots(stable_dot_cnt), track_ts_diff(stable_ts, cur_ts),
+              track_ts_dots(cur_dot_cnt)));
         }
         testutil_check(__wt_snprintf_len_set(msg, sizeof(msg), &len, "%4" PRIu32 ": %s: "
                                                                      "S %" PRIu64 "%s, "
@@ -266,8 +259,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag)
         else
             g.oldest_timestamp = all_durable;
         g.stable_timestamp = all_durable;
-
-        testutil_check(__wt_snprintf(buf, sizeof(buf), "%s%" PRIx64 "%s%" PRIx64,
+        testutil_check(__wt_snprintf(buf, sizeof(buf), "%s%" PRIx64 ",%s%" PRIx64,
           oldest_timestamp_str, g.oldest_timestamp, stable_timestamp_str, g.stable_timestamp));
 
         testutil_check(conn->set_timestamp(conn, buf));


### PR DESCRIPTION
Set stable ts to the "all_durable" value, and let oldest ts lag that.