### PR TITLE
WT-6427 Always set stable timestamp when setting oldest timestamp (2nd attempt)

### DIFF
--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -59,7 +59,7 @@ bulk_commit_transaction(WT_SESSION *session)
     testutil_check(session->commit_transaction(session, buf));
 
     /* Update the oldest timestamp, otherwise updates are pinned in memory. */
-    timestamp_once(session, false);
+    timestamp_once(session, false, false);
 }
 
 /*

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -930,12 +930,20 @@ config_transaction(void)
         if (g.c_txn_freq != 100 && config_is_perm("transaction.frequency"))
             testutil_die(EINVAL, "timestamps require transaction frequency set to 100");
     }
+
     /* FIXME-WT-6410: temporarily disable rebalance with timestamps. */
     if (g.c_txn_timestamps && g.c_rebalance) {
         if (config_is_perm("ops.rebalance"))
             testutil_die(EINVAL, "rebalance cannot run with timestamps");
         config_single("ops.rebalance=off", false);
     }
+    /* FIXME-WT-6431: temporarily disable salvage with timestamps. */
+    if (g.c_txn_timestamps && g.c_salvage) {
+        if (config_is_perm("ops.salvage"))
+            testutil_die(EINVAL, "salvage cannot run with timestamps");
+        config_single("ops.salvage=off", false);
+    }
+
     if (g.c_isolation_flag == ISOLATION_SNAPSHOT && config_is_perm("transaction.isolation")) {
         if (!g.c_txn_timestamps && config_is_perm("transaction.timestamps"))
             testutil_die(EINVAL, "snapshot isolation requires timestamps");

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -273,6 +273,8 @@ typedef struct {
 #define ISOLATION_SNAPSHOT 4
     u_int c_isolation_flag; /* Isolation flag value */
 
+/* The page must be a multiple of the allocation size, and 512 always works. */
+#define BLOCK_ALLOCATION_SIZE 512
     uint32_t intl_page_max; /* Maximum page sizes */
     uint32_t leaf_page_max;
 
@@ -410,8 +412,9 @@ void snap_repeat_single(WT_CURSOR *, TINFO *);
 int snap_repeat_txn(WT_CURSOR *, TINFO *);
 void snap_repeat_update(TINFO *, bool);
 void snap_track(TINFO *, thread_op);
-void timestamp_once(WT_SESSION *, bool);
+void timestamp_once(WT_SESSION *, bool, bool);
 void timestamp_parse(WT_SESSION *, const char *, uint64_t *);
+void timestamp_teardown(WT_SESSION *);
 int trace_config(const char *);
 void trace_init(void);
 void trace_ops_init(TINFO *);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -400,10 +400,13 @@ operations(u_int ops_seconds, bool lastrun)
     if (g.c_txn_rollback_to_stable)
         tinfo_rollback_to_stable_and_check(session);
 
-    testutil_check(session->close(session, NULL));
-
-    if (lastrun)
+    if (lastrun) {
         tinfo_teardown();
+
+        timestamp_teardown(session);
+    }
+
+    testutil_check(session->close(session, NULL));
 }
 
 /*

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -101,20 +101,13 @@ track(const char *tag, uint64_t cnt, TINFO *tinfo)
                 last_cur = cur_ts;
             }
 
-            if (g.c_txn_rollback_to_stable)
-                testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
-                  " old%s"
-                  "stb%s%s"
-                  "ts%s%s",
-                  track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, stable_ts),
-                  track_ts_dots(stable_dot_cnt), track_ts_diff(stable_ts, cur_ts),
-                  track_ts_dots(cur_dot_cnt)));
-            else
-                testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
-                  " old%s"
-                  "ts%s%s",
-                  track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, cur_ts),
-                  track_ts_dots(cur_dot_cnt)));
+            testutil_check(__wt_snprintf(ts_msg, sizeof(ts_msg),
+              " old%s"
+              "stb%s%s"
+              "ts%s%s",
+              track_ts_dots(old_dot_cnt), track_ts_diff(old_ts, stable_ts),
+              track_ts_dots(stable_dot_cnt), track_ts_diff(stable_ts, cur_ts),
+              track_ts_dots(cur_dot_cnt)));
         }
         testutil_check(__wt_snprintf_len_set(msg, sizeof(msg), &len, "%4" PRIu32 ": %s: "
                                                                      "S %" PRIu64 "%s, "
@@ -266,8 +259,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag)
         else
             g.oldest_timestamp = all_durable;
         g.stable_timestamp = all_durable;
-
-        testutil_check(__wt_snprintf(buf, sizeof(buf), "%s%" PRIx64 "%s%" PRIx64,
+        testutil_check(__wt_snprintf(buf, sizeof(buf), "%s%" PRIx64 ",%s%" PRIx64,
           oldest_timestamp_str, g.oldest_timestamp, stable_timestamp_str, g.stable_timestamp));
 
         testutil_check(conn->set_timestamp(conn, buf));

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -295,13 +295,11 @@ create_object(WT_CONNECTION *conn)
     p = config;
     max = sizeof(config);
 
-    CONFIG_APPEND(p,
-      "key_format=%s"
-      ",allocation_size=512"
-      ",%s"
-      ",internal_page_max=%" PRIu32 ",leaf_page_max=%" PRIu32 ",memory_page_max=%" PRIu32,
-      (g.type == ROW) ? "u" : "r", g.c_firstfit ? "block_allocation=first" : "", g.intl_page_max,
-      g.leaf_page_max, MEGABYTE(g.c_memory_page_max));
+    CONFIG_APPEND(p, "key_format=%s,allocation_size=%d,%s,internal_page_max=%" PRIu32
+                     ",leaf_page_max=%" PRIu32 ",memory_page_max=%" PRIu32,
+      (g.type == ROW) ? "u" : "r", BLOCK_ALLOCATION_SIZE,
+      g.c_firstfit ? "block_allocation=first" : "", g.intl_page_max, g.leaf_page_max,
+      MEGABYTE(g.c_memory_page_max));
 
     /*
      * Configure the maximum key/value sizes, but leave it as the default if we come up with


### PR DESCRIPTION
@ddanderson #5814 was reverted due to the testing fallout described [here](https://jira.mongodb.org/browse/WT-6427?focusedCommentId=3211591&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3211591). Please use this PR for further change. 