### PR TITLE
WT-6434 Configure tests to avoid rollback due to cache pressure.

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -82,15 +82,15 @@ static bool compat, inmem, use_ts;
 static volatile uint64_t global_ts = 1;
 
 #define ENV_CONFIG_COMPAT ",compatibility=(release=\"2.9\")"
-#define ENV_CONFIG_DEF                                               \
-    "cache_size=20M,create,log=(archive=true,file_max=10M,enabled)," \
-    "debug_mode=(table_logging=true,checkpoint_retention=5),"        \
-    "statistics=(fast),statistics_log=(wait=1,json=true),session_max=%d"
-#define ENV_CONFIG_TXNSYNC                                           \
-    "cache_size=20M,create,log=(archive=true,file_max=10M,enabled)," \
-    "debug_mode=(table_logging=true,checkpoint_retention=5),"        \
-    "statistics=(fast),statistics_log=(wait=1,json=true),"           \
-    "transaction_sync=(enabled,method=none),session_max=%d"
+#define ENV_CONFIG_DEF                                        \
+    "cache_size=20M,create,"                                  \
+    "debug_mode=(table_logging=true,checkpoint_retention=5)," \
+    "eviction_dirty_trigger=100,"                             \
+    "log=(archive=true,file_max=10M,enabled),session_max=%d," \
+    "statistics=(fast),statistics_log=(wait=1,json=true),"
+#define ENV_CONFIG_TXNSYNC \
+    ENV_CONFIG_DEF         \
+    "transaction_sync=(enabled,method=none)"
 #define ENV_CONFIG_REC "log=(archive=false,recover=on)"
 
 typedef struct {

--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -52,7 +52,7 @@ class test_txn13(wttest.WiredTigerTestCase, suite_subprocess):
     # Turn on logging for this test.
     def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%s)' % self.logmax + \
-            ',cache_size=20G'
+            ',cache_size=20G,eviction_dirty_trigger=100'
 
     @wttest.longtest('txn tests with huge values')
     def test_large_values(self):


### PR DESCRIPTION
Ideally tests would be written to retry on rollback errors rather than treat them as fatal, but for now configure to make rollbacks unlikely.