### PR TITLE
WT-6397 Reduce restrictions on reading tombstone info from history store update list

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -851,6 +851,11 @@ __wt_txn_read_upd_list(
         if (type == WT_UPDATE_RESERVE)
             continue;
 
+        /*
+         * If the cursor is configured to ignore tombstones, copy the timestamps from the tombstones
+         * to the stop time window of the update value being returned to the caller. Caller can
+         * process the stop time window to decide if there was a tombstone on the update chain.
+         */
         if (type == WT_UPDATE_TOMBSTONE && F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
           !__wt_txn_upd_visible_all(session, upd)) {
             cbt->upd_value->tw.durable_stop_ts = upd->durable_ts;

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -851,24 +851,20 @@ __wt_txn_read_upd_list(
         if (type == WT_UPDATE_RESERVE)
             continue;
 
+        if (type == WT_UPDATE_TOMBSTONE && F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
+          !__wt_txn_upd_visible_all(session, upd)) {
+            cbt->upd_value->tw.durable_stop_ts = upd->durable_ts;
+            cbt->upd_value->tw.stop_ts = upd->start_ts;
+            cbt->upd_value->tw.stop_txn = upd->txnid;
+            cbt->upd_value->tw.prepare = upd->prepare_state == WT_PREPARE_INPROGRESS ||
+              upd->prepare_state == WT_PREPARE_LOCKED;
+            continue;
+        }
+
         upd_visible = __wt_txn_upd_visible_type(session, upd);
 
-        if (upd_visible == WT_VISIBLE_TRUE) {
-            /*
-             * Ignore non-globally visible tombstones when we are doing history store scans in
-             * rollback to stable or when we are told to.
-             */
-            if (type == WT_UPDATE_TOMBSTONE && F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
-              !__wt_txn_upd_visible_all(session, upd)) {
-                cbt->upd_value->tw.durable_stop_ts = upd->durable_ts;
-                cbt->upd_value->tw.stop_ts = upd->start_ts;
-                cbt->upd_value->tw.stop_txn = upd->txnid;
-                cbt->upd_value->tw.prepare = upd->prepare_state == WT_PREPARE_INPROGRESS ||
-                  upd->prepare_state == WT_PREPARE_LOCKED;
-                continue;
-            }
+        if (upd_visible == WT_VISIBLE_TRUE)
             break;
-        }
 
         if (upd_visible == WT_VISIBLE_PREPARE) {
             /* Ignore the prepared update, if transaction configuration says so. */

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -711,6 +711,7 @@ __txn_append_hs_record(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, WT_ITEM *
 
     /* If the history store record has a valid stop time point, append it. */
     if (hs_stop_durable_ts != WT_TS_MAX) {
+        WT_ASSERT(session, hs_cbt->upd_value->tw.stop_ts != WT_TS_MAX);
         WT_ERR(__wt_upd_alloc(session, NULL, WT_UPDATE_TOMBSTONE, &tombstone, &size));
         tombstone->durable_ts = hs_cbt->upd_value->tw.durable_stop_ts;
         tombstone->start_ts = hs_cbt->upd_value->tw.stop_ts;


### PR DESCRIPTION
When we read values from history store's update list as part of prepared transaction rollback, the tombstones on the update list are not visible and we end up in restoring deleted values. This change will skip tombstone visibility checks and brings it line with how we deal with tombstones when reading on-disk values.