### PR TITLE
WT-6453 Pin transaction ids for history store cursor operations

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -667,7 +667,7 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
     __wt_cursor_dhandle_incr_use(session);
 
     if (session->dhandle->checkpoint != NULL)
-        F_SET(cbt, WT_CBT_NO_TXN | WT_CBT_NO_TRACKING);
+        F_SET(cbt, WT_CBT_NO_TXN);
 
     if (bulk) {
         F_SET(cursor, WT_CURSTD_BULK);

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -755,12 +755,9 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         /*
          * Trim any updates before writing to history store. This saves wasted work.
          */
-        if (WT_PAGE_TRYLOCK(session, page)) {
-            WT_WITH_BTREE(session, btree,
-              upd = __wt_update_obsolete_check(session, page, list->onpage_upd, true));
-            __wt_free_update_list(session, &upd);
-            WT_PAGE_UNLOCK(session, page);
-        }
+        WT_WITH_BTREE(
+          session, btree, upd = __wt_update_obsolete_check(session, page, list->onpage_upd, true));
+        __wt_free_update_list(session, &upd);
         upd = list->onpage_upd;
 
         first_non_ts_upd = NULL;

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -755,9 +755,12 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         /*
          * Trim any updates before writing to history store. This saves wasted work.
          */
-        WT_WITH_BTREE(
-          session, btree, upd = __wt_update_obsolete_check(session, page, list->onpage_upd, true));
-        __wt_free_update_list(session, &upd);
+        if (WT_PAGE_TRYLOCK(session, page)) {
+            WT_WITH_BTREE(session, btree,
+              upd = __wt_update_obsolete_check(session, page, list->onpage_upd, true));
+            __wt_free_update_list(session, &upd);
+            WT_PAGE_UNLOCK(session, page);
+        }
         upd = list->onpage_upd;
 
         first_non_ts_upd = NULL;

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -225,7 +225,7 @@ __wt_hs_cursor_open(WT_SESSION_IMPL *session)
     /*
      * Set the flag to stop creating snapshots for history store cursors
      */
-    F_SET((WT_CURSOR_BTREE *)cursor, WT_CBT_NO_TXN);
+    F_SET((WT_CURSOR_BTREE *)cursor, WT_CBT_HS);
     /* History store cursors should always ignore tombstones. */
     F_SET(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
 
@@ -1543,7 +1543,7 @@ __hs_fixup_out_of_order_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
               ret = __wt_open_cursor(session, WT_HS_URI, NULL, open_cursor_cfg, &insert_cursor));
             WT_ERR(ret);
             insert_cbt = (WT_CURSOR_BTREE *)insert_cursor;
-            F_SET(insert_cbt, WT_CBT_NO_TXN);
+            F_SET(insert_cbt, WT_CBT_HS);
         }
 
         start_time_point.ts = start_time_point.durable_ts = ts;

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -209,13 +209,13 @@ struct __wt_cursor_btree {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CBT_ACTIVE 0x001u             /* Active in the tree */
-#define WT_CBT_HS 0x002u                 /* Non-txn cursor (e.g. a checkpoint) */
+#define WT_CBT_HS 0x002u                 /* History store cursor */
 #define WT_CBT_ITERATE_APPEND 0x004u     /* Col-store: iterating append list */
 #define WT_CBT_ITERATE_NEXT 0x008u       /* Next iteration configuration */
 #define WT_CBT_ITERATE_PREV 0x010u       /* Prev iteration configuration */
 #define WT_CBT_ITERATE_RETRY_NEXT 0x020u /* Prepare conflict by next. */
 #define WT_CBT_ITERATE_RETRY_PREV 0x040u /* Prepare conflict by prev. */
-#define WT_CBT_NO_TXN 0x080u             /* Non tracking cursor. */
+#define WT_CBT_NO_TXN 0x080u             /* Non-txn cursor (e.g. a checkpoint) */
 #define WT_CBT_READ_ONCE 0x100u          /* Page in with WT_READ_WONT_NEED */
 #define WT_CBT_SEARCH_SMALLEST 0x200u    /* Row-store: small-key insert list */
 #define WT_CBT_VAR_ONPAGE_MATCH 0x400u   /* Var-store: on-page recno match */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -209,13 +209,13 @@ struct __wt_cursor_btree {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CBT_ACTIVE 0x001u             /* Active in the tree */
-#define WT_CBT_ITERATE_APPEND 0x002u     /* Col-store: iterating append list */
-#define WT_CBT_ITERATE_NEXT 0x004u       /* Next iteration configuration */
-#define WT_CBT_ITERATE_PREV 0x008u       /* Prev iteration configuration */
-#define WT_CBT_ITERATE_RETRY_NEXT 0x010u /* Prepare conflict by next. */
-#define WT_CBT_ITERATE_RETRY_PREV 0x020u /* Prepare conflict by prev. */
-#define WT_CBT_NO_TRACKING 0x040u        /* Non tracking cursor. */
-#define WT_CBT_NO_TXN 0x080u             /* Non-txn cursor (e.g. a checkpoint) */
+#define WT_CBT_HS 0x002u                 /* Non-txn cursor (e.g. a checkpoint) */
+#define WT_CBT_ITERATE_APPEND 0x004u     /* Col-store: iterating append list */
+#define WT_CBT_ITERATE_NEXT 0x008u       /* Next iteration configuration */
+#define WT_CBT_ITERATE_PREV 0x010u       /* Prev iteration configuration */
+#define WT_CBT_ITERATE_RETRY_NEXT 0x020u /* Prepare conflict by next. */
+#define WT_CBT_ITERATE_RETRY_PREV 0x040u /* Prepare conflict by prev. */
+#define WT_CBT_NO_TXN 0x080u             /* Non tracking cursor. */
 #define WT_CBT_READ_ONCE 0x100u          /* Page in with WT_READ_WONT_NEED */
 #define WT_CBT_SEARCH_SMALLEST 0x200u    /* Row-store: small-key insert list */
 #define WT_CBT_VAR_ONPAGE_MATCH 0x400u   /* Var-store: on-page recno match */

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -409,6 +409,9 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
 
     /*
      * If this is an ordinary transactional cursor, make sure we are set up to read.
+     *
+     * If we've opened a history store cursor, we want to pin ids in the same way that we would for
+     * a read-uncommitted transaction.
      */
     if (F_ISSET(cbt, WT_CBT_HS))
         __wt_txn_pin_ids(session);

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -199,7 +199,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
 
     /* If the cursor was active, deactivate it. */
     if (F_ISSET(cbt, WT_CBT_ACTIVE)) {
-        if (!F_ISSET(cbt, WT_CBT_NO_TRACKING))
+        if (!F_ISSET(cbt, WT_CBT_NO_TXN))
             __cursor_leave(session);
         F_CLR(cbt, WT_CBT_ACTIVE);
     }
@@ -402,7 +402,7 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
 
     /* Activate the file cursor. */
     if (!F_ISSET(cbt, WT_CBT_ACTIVE)) {
-        if (!F_ISSET(cbt, WT_CBT_NO_TRACKING))
+        if (!F_ISSET(cbt, WT_CBT_NO_TXN))
             WT_RET(__cursor_enter(session));
         F_SET(cbt, WT_CBT_ACTIVE);
     }
@@ -410,7 +410,9 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
     /*
      * If this is an ordinary transactional cursor, make sure we are set up to read.
      */
-    if (!F_ISSET(cbt, WT_CBT_NO_TXN))
+    if (F_ISSET(cbt, WT_CBT_HS))
+        __wt_txn_pin_ids(session);
+    else if (!F_ISSET(cbt, WT_CBT_NO_TXN))
         __wt_txn_cursor_op(session);
     return (0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2220,6 +2220,7 @@ static inline void __wt_txn_op_delete_commit_apply_timestamps(
   WT_SESSION_IMPL *session, WT_REF *ref);
 static inline void __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno);
 static inline void __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op);
+static inline void __wt_txn_pin_ids(WT_SESSION_IMPL *session);
 static inline void __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp);
 static inline void __wt_txn_read_last(WT_SESSION_IMPL *session);
 static inline void __wt_txn_timestamp_flags(WT_SESSION_IMPL *session);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -126,7 +126,8 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
 
     WT_ASSERT(session, txn_shared->pinned_id == WT_TXN_NONE ||
         session->txn->isolation == WT_ISO_READ_UNCOMMITTED ||
-        !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE));
+        !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE) ||
+        F_ISSET(session, WT_SESSION_HS_CURSOR));
 
     txn_shared->metadata_pinned = txn_shared->pinned_id = WT_TXN_NONE;
     F_CLR(txn, WT_TXN_HAS_SNAPSHOT);


### PR DESCRIPTION
This PR is to pin transaction ids when beginning history store cursor operations. The change in #5760 intended to stop us from acquiring snapshots but we still need to pin transaction ids as we would for a read-committed transaction.

If we don't, the `oldest_id` can potentially move past some records that we're reading and lead to an obsolete check freeing updates from underneath us.