### PR TITLE
WT-6460 Consider checkpoint timestamp also as part of pinned timestamp for HS

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -504,8 +504,8 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
      * If there is no active checkpoint or this handle is up to date with the active checkpoint then
      * it's safe to ignore the checkpoint ID in the visibility check.
      */
-    include_checkpoint_txn = btree == NULL ||
-      (btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT));
+    include_checkpoint_txn =
+      btree == NULL || (btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT));
     if (!include_checkpoint_txn)
         return;
 

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -505,7 +505,7 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
      * it's safe to ignore the checkpoint ID in the visibility check.
      */
     include_checkpoint_txn = btree == NULL ||
-      (!WT_IS_HS(btree) && btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT));
+      (btree->checkpoint_gen != __wt_gen(session, WT_GEN_CHECKPOINT));
     if (!include_checkpoint_txn)
         return;
 


### PR DESCRIPTION
Checkpoint timestamp is not included while calculating the pinned timestamp
for history store, this can lead to the removal of history store updates that
are may be required later as per the checkpoint timestamp.