### PR TITLE
WT-6482 Cleanup and bug fixes in __rec_append_orig_value

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -69,6 +69,14 @@ __rec_append_orig_value(
 
     /* Review the current update list, checking conditions that mean no work is needed. */
     for (;; upd = upd->next) {
+        if (upd->txnid != WT_TXN_ABORTED)
+            oldest_upd = upd;
+        /* Leave reference pointing to the last item in the update list. */
+        else if (upd->next == NULL)
+            break;
+        else
+            continue;
+
         /* Done if the update was restored from the history store. */
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS))
             return (0);
@@ -99,9 +107,6 @@ __rec_append_orig_value(
          */
         if (WT_UPDATE_DATA_VALUE(upd) && __wt_txn_upd_visible_all(session, upd))
             return (0);
-
-        if (upd->txnid != WT_TXN_ABORTED)
-            oldest_upd = upd;
 
         /* Leave reference pointing to the last item in the update list. */
         if (upd->next == NULL)

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -92,7 +92,7 @@ __rec_append_orig_value(
          * Done if the on page value already appears on the update list. We can't do the same check
          * for stop time point because we may still need to append the onpage value if only the
          * tombstone is on the update chain. We only need to check the in memory case as in other
-         * cases, the update must have been flagged by WT_UPDATE_RESTORED_FROM_DS.
+         * cases, the update must have been restored from data store.
          */
         if (unpack->tw.start_ts == upd->start_ts && unpack->tw.start_txn == upd->txnid &&
           upd->type != WT_UPDATE_TOMBSTONE) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -49,7 +49,9 @@ __rec_update_save(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, voi
 
 /*
  * __rec_append_orig_value --
- *     Append the key's original value to its update list.
+ *     Append the key's original value to its update list. It assumes that we have an onpage value,
+ *     the onpage value is not a prepared update, and we don't overwrite transaction id to
+ *     WT_TXN_NONE and timestamps to WT_TS_NONE in time window for in-memory databases.
  */
 static int
 __rec_append_orig_value(
@@ -61,7 +63,8 @@ __rec_append_orig_value(
     size_t size, total_size;
     bool tombstone_globally_visible;
 
-    WT_ASSERT(session, upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL);
+    WT_ASSERT(
+      session, upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL && !unpack->tw.prepare);
 
     append = oldest_upd = tombstone = NULL;
     total_size = 0;
@@ -69,36 +72,21 @@ __rec_append_orig_value(
 
     /* Review the current update list, checking conditions that mean no work is needed. */
     for (;; upd = upd->next) {
-        if (upd->txnid != WT_TXN_ABORTED)
-            oldest_upd = upd;
-        /* Leave reference pointing to the last item in the update list. */
-        else if (upd->next == NULL)
-            break;
-        else
-            continue;
-
-        /* Done if the update was restored from the data store or history store. */
+        /* Done if the update was restored from the data store or the history store. */
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS))
-            return (0);
-
-        /*
-         * Prepared updates should already be in the update list, add the original update to the
-         * list only when the prepared update is a tombstone.
-         */
-        if (unpack->tw.prepare && upd->type != WT_UPDATE_TOMBSTONE)
             return (0);
 
         /*
          * Done if the on page value already appears on the update list. We can't do the same check
          * for stop time point because we may still need to append the onpage value if only the
-         * tombstone is on the update chain. We only need to check the in memory case as in other
-         * cases, the update must have been restored from data store.
+         * tombstone is on the update chain. We only need to check it in the in memory case as in
+         * other cases, the update must have been restored from the data store and we may overwrite
+         * its transaction id to WT_TXN_NONE and its timestamps to WT_TS_NONE when we write the
+         * update to the time window.
          */
-        if (unpack->tw.start_ts == upd->start_ts && unpack->tw.start_txn == upd->txnid &&
-          upd->type != WT_UPDATE_TOMBSTONE) {
-            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_IN_MEMORY));
+        if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && unpack->tw.start_ts == upd->start_ts &&
+          unpack->tw.start_txn == upd->txnid && upd->type != WT_UPDATE_TOMBSTONE)
             return (0);
-        }
 
         /*
          * Done if at least one self-contained update is globally visible. It's tempting to pull
@@ -110,6 +98,9 @@ __rec_append_orig_value(
          */
         if (WT_UPDATE_DATA_VALUE(upd) && __wt_txn_upd_visible_all(session, upd))
             return (0);
+
+        if (upd->txnid != WT_TXN_ABORTED)
+            oldest_upd = upd;
 
         /* Leave reference pointing to the last item in the update list. */
         if (upd->next == NULL)
@@ -135,13 +126,8 @@ __rec_append_orig_value(
     if (WT_TIME_WINDOW_HAS_STOP(&unpack->tw)) {
         tombstone_globally_visible = __wt_txn_tw_stop_visible_all(session, &unpack->tw);
 
-        /*
-         * No need to append the tombstone if it is already in the update chain.
-         *
-         * Don't append the onpage tombstone if it is a prepared update as it is either on the
-         * update chain or has been aborted. If it is aborted, discard it silently.
-         */
-        if (oldest_upd->type != WT_UPDATE_TOMBSTONE && !unpack->tw.prepare) {
+        /* No need to append the tombstone if it is already in the update chain. */
+        if (oldest_upd->type != WT_UPDATE_TOMBSTONE) {
             /*
              * We still need to append the globally visible tombstone if its timestamp is WT_TS_NONE
              * as we may need it to clear the history store content of the key. We don't append a
@@ -160,28 +146,17 @@ __rec_append_orig_value(
             F_SET(tombstone, WT_UPDATE_RESTORED_FROM_DS);
         } else {
             /*
-             * Once the prepared update is resolved, the in-memory update and on-disk written copy
-             * doesn't have same timestamp due to replacing of prepare timestamp with commit and
-             * durable timestamps. Don't compare them when the on-disk version is a prepare.
-             *
-             * We may have written WT_TXN_NONE to the transaction id and WT_TS_NONE to the timestamp
-             * in the time window if the transaction id is behind the oldest transaction id and the
-             * timestamp is behind the pinned timestamp.
+             * We may have overwritten its transaction id to WT_TXN_NONE and its timestamps to
+             * WT_TS_NONE in the time window.
              */
-            WT_ASSERT(session, unpack->tw.prepare ||
-                ((unpack->tw.stop_ts == oldest_upd->start_ts || unpack->tw.stop_ts == WT_TS_NONE) &&
-                                 (unpack->tw.stop_txn == oldest_upd->txnid ||
-                                   unpack->tw.stop_txn == WT_TXN_NONE)));
+            WT_ASSERT(session,
+              (unpack->tw.stop_ts == oldest_upd->start_ts || unpack->tw.stop_ts == WT_TS_NONE) &&
+                (unpack->tw.stop_txn == oldest_upd->txnid || unpack->tw.stop_txn == WT_TXN_NONE));
 
             if (tombstone_globally_visible)
                 return (0);
         }
-    } else if (unpack->tw.prepare)
-        /*
-         * Don't append the onpage value if it is a prepared update as it is either on the update
-         * chain or has been aborted. If it is aborted, discard it silently.
-         */
-        return (0);
+    }
 
     /* We need the original on-page value for some reader: get a copy. */
     if (!tombstone_globally_visible) {
@@ -559,9 +534,13 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
      * part of the page, and they are physically removed by checkpoint writing this page, that is,
      * the checkpoint doesn't include the overflow blocks so they're removed and future readers of
      * this page won't be able to find them.
+     *
+     * We never append prepared updates back to the onpage value. If it is a prepared full update,
+     * it is already on the update chain. If it is a prepared tombstone, the onpage value is already
+     * appended to the update chain when the page is read into memory.
      */
     if (upd_select->upd != NULL && vpack != NULL && vpack->type != WT_CELL_DEL &&
-      (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
+      !vpack->tw.prepare && (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
         WT_ERR(__rec_append_orig_value(session, page, upd_select->upd, vpack));
 
     __wt_time_window_clear_obsolete(

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -160,9 +160,16 @@ __rec_append_orig_value(
              * Once the prepared update is resolved, the in-memory update and on-disk written copy
              * doesn't have same timestamp due to replacing of prepare timestamp with commit and
              * durable timestamps. Don't compare them when the on-disk version is a prepare.
+             *
+             * We may have written WT_TXN_NONE to the transaction id and WT_TS_NONE to the timestamp
+             * in the time window if the transaction id is behind the oldest transaction id and the
+             * timestamp is behind the pinned timestamp.
              */
-            WT_ASSERT(session, unpack->tw.prepare || (unpack->tw.stop_ts == oldest_upd->start_ts &&
-                                                       unpack->tw.stop_txn == oldest_upd->txnid));
+            WT_ASSERT(session, unpack->tw.prepare ||
+                ((unpack->tw.stop_ts == oldest_upd->start_ts || unpack->tw.stop_ts == WT_TS_NONE) &&
+                                 (unpack->tw.stop_txn == oldest_upd->txnid ||
+                                   unpack->tw.stop_txn == WT_TXN_NONE)));
+
             if (tombstone_globally_visible)
                 return (0);
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -77,8 +77,8 @@ __rec_append_orig_value(
         else
             continue;
 
-        /* Done if the update was restored from the history store. */
-        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS))
+        /* Done if the update was restored from the data store or history store. */
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS | WT_UPDATE_RESTORED_FROM_HS))
             return (0);
 
         /*
@@ -86,15 +86,6 @@ __rec_append_orig_value(
          * list only when the prepared update is a tombstone.
          */
         if (unpack->tw.prepare && upd->type != WT_UPDATE_TOMBSTONE)
-            return (0);
-
-        /*
-         * Done if the on page value already appears on the update list. We can't do the same check
-         * for stop time point because we may still need to append the onpage value if only the
-         * tombstone is on the update chain.
-         */
-        if (unpack->tw.start_ts == upd->start_ts && unpack->tw.start_txn == upd->txnid &&
-          upd->type != WT_UPDATE_TOMBSTONE)
             return (0);
 
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -91,7 +91,8 @@ __rec_append_orig_value(
         /*
          * Done if the on page value already appears on the update list. We can't do the same check
          * for stop time point because we may still need to append the onpage value if only the
-         * tombstone is on the update chain.
+         * tombstone is on the update chain. We only need to check the in memory case as in other
+         * cases, the update must have been flagged by WT_UPDATE_RESTORED_FROM_DS.
          */
         if (unpack->tw.start_ts == upd->start_ts && unpack->tw.start_txn == upd->txnid &&
           upd->type != WT_UPDATE_TOMBSTONE) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -78,7 +78,7 @@ __rec_append_orig_value(
             continue;
 
         /* Done if the update was restored from the data store or history store. */
-        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS | WT_UPDATE_RESTORED_FROM_HS))
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS))
             return (0);
 
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -89,6 +89,17 @@ __rec_append_orig_value(
             return (0);
 
         /*
+         * Done if the on page value already appears on the update list. We can't do the same check
+         * for stop time point because we may still need to append the onpage value if only the
+         * tombstone is on the update chain.
+         */
+        if (unpack->tw.start_ts == upd->start_ts && unpack->tw.start_txn == upd->txnid &&
+          upd->type != WT_UPDATE_TOMBSTONE) {
+            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_IN_MEMORY));
+            return (0);
+        }
+
+        /*
          * Done if at least one self-contained update is globally visible. It's tempting to pull
          * this test out of the loop and only test the oldest self-contained update for global
          * visibility (as visibility tests are expensive). However, when running at lower isolation

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -466,6 +466,7 @@ __rollback_abort_row_ondisk_kv(
         upd->txnid = vpack->tw.start_txn;
         upd->durable_ts = vpack->tw.durable_start_ts;
         upd->start_ts = vpack->tw.start_ts;
+        F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
         WT_STAT_CONN_INCR(session, txn_rts_keys_restored);
         __wt_verbose(session, WT_VERB_RTS,
           "key restored with commit timestamp: %s, durable timestamp: %s txnid: %" PRIu64


### PR DESCRIPTION
Fix an assert may trigger if transaction id or timstamps are overwritten in time window.
No need to append onpage value if a prepared update is written to disk.
Fix we may append the onpage value already on the update chain if transaction id or timstamps are overwritten in time window.