### PR TITLE
WT-6444 Abort a transaction if it is force evicting and oldest

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -350,6 +350,11 @@ read:
                 else if (ret == EBUSY) {
                     WT_NOT_READ(ret, 0);
                     WT_STAT_CONN_INCR(session, page_forcible_evict_blocked);
+                    /*
+                     * Forced eviction failed: check if this transaction is keeping content pinned
+                     * in cache.
+                     */
+                    WT_RET(__wt_txn_is_blocking(session));
                     stalled = true;
                     break;
                 }


### PR DESCRIPTION
It could be blocking itself from making progress.
Also try to run eviction as of a snapshot, rather than at a visible
all setting. That should let us write more content out to disk, and
unblock the cache faster.

I'm mostly creating the PR as a discussion point - it isn't ready to merge