### PR TITLE
WT-6349 Don't truncate hs updates for timestamped deletes

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -860,8 +860,8 @@ __wt_rec_row_leaf(
                 }
 
                 /*
-                 * If we're removing a key with durable timestamp of tombstone is NONE, also remove
-                 * the history store contents associated with that key. Even if we fail
+                 * If we're removing a key due to a tombstone with a durable timestamp of "none",
+                 * also remove the history store contents associated with that key. Even if we fail
                  * reconciliation after this point, we're safe to do this. The history store content
                  * must be obsolete in order for us to consider removing the key.
                  */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -860,12 +860,13 @@ __wt_rec_row_leaf(
                 }
 
                 /*
-                 * If we're removing a key, also remove the history store contents associated with
-                 * that key. Even if we fail reconciliation after this point, we're safe to do this.
-                 * The history store content must be obsolete in order for us to consider removing
-                 * the key.
+                 * If we're removing a key with durable timestamp of tombstone is NONE, also remove
+                 * the history store contents associated with that key. Even if we fail
+                 * reconciliation after this point, we're safe to do this. The history store content
+                 * must be obsolete in order for us to consider removing the key.
                  */
-                if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !WT_IS_HS(btree)) {
+                if (tw.durable_stop_ts == WT_TS_NONE && F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
+                  !WT_IS_HS(btree)) {
                     WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
                     /* Start from WT_TS_NONE to delete all the history store content of the key. */
                     WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, tmpkey, WT_TS_NONE));

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -28,6 +28,7 @@
 
 import wiredtiger, wttest
 from wtscenario import make_scenarios
+from wiredtiger import stat
 
 def timestamp_str(t):
     return '%x' % t
@@ -35,12 +36,18 @@ def timestamp_str(t):
 # test_hs11.py
 # Ensure that updates without timestamps clear the history store records.
 class test_hs11(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB'
+    conn_config = 'cache_size=50MB,statistics=(all)'
     session_config = 'isolation=snapshot'
     scenarios = make_scenarios([
         ('deletion', dict(update_type='deletion')),
         ('update', dict(update_type='update')),
     ])
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
 
     def test_non_ts_updates_clears_hs(self):
         uri = 'table:test_hs11'
@@ -71,6 +78,9 @@ class test_hs11(wttest.WiredTigerTestCase):
                 else:
                     cursor[str(i)] = value2
 
+        # Reconcile and remove the obsolete entries.
+        self.session.checkpoint()
+
         # Now apply an update at timestamp 10.
         for i in range(1, 10000):
             self.session.begin_transaction()
@@ -90,3 +100,58 @@ class test_hs11(wttest.WiredTigerTestCase):
                 else:
                     self.assertEqual(cursor[str(i)], value1)
             self.session.rollback_transaction()
+
+        if self.update_type == 'deletion':
+            hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
+            self.assertGreater(hs_truncate, 0)
+
+    def test_ts_updates_donot_clears_hs(self):
+        uri = 'table:test_hs11'
+        create_params = 'key_format=S,value_format=S'
+        self.session.create(uri, create_params)
+
+        value1 = 'a' * 500
+        value2 = 'b' * 500
+
+        # Apply a series of updates from timestamps 1-4.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        for ts in range(1, 5):
+            for i in range(1, 10000):
+                self.session.begin_transaction()
+                cursor[str(i)] = value1
+                self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+
+        # Reconcile and flush versions 1-3 to the history store.
+        self.session.checkpoint()
+
+        # Remove the key with timestamp 10.
+        for i in range(1, 10000):
+            if i % 2 == 0:
+                self.session.begin_transaction()
+                cursor.set_key(str(i))
+                cursor.remove()
+                self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+
+        # Reconcile and remove the obsolete entries.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
+        self.session.checkpoint()
+
+        # Now apply an update at timestamp 20.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[str(i)] = value2
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+
+        # Ensure that we didn't select old history store content even if it is not blew away.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(10))
+        for i in range(1, 10000):
+            if i % 2 == 0:
+                cursor.set_key(str(i))
+                self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+            else:
+                self.assertEqual(cursor[str(i)], value1)
+        self.session.rollback_transaction()
+
+        hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
+        self.assertEqual(hs_truncate, 0)


### PR DESCRIPTION
When a timestamped delete is globally visible led to removal
of data store key doesn't need to truncate all the previous
history store updates until the tombstone from a mixed mode
delete operation.