### PR TITLE
WT-6483 Add debugging for log file lists.

### DIFF
--- a/test/suite/test_bug019.py
+++ b/test/suite/test_bug019.py
@@ -86,6 +86,7 @@ class test_bug019(wttest.WiredTigerTestCase):
         self.assertTrue(self.max_prealloc > start_prealloc)
 
         # Loop, making sure pre-allocation is working and the range is moving.
+        self.pr("Check pre-allocation range is moving")
         older = self.prepfiles()
         for i in range(1, 10):
             self.populate(self.entries)
@@ -94,6 +95,12 @@ class test_bug019(wttest.WiredTigerTestCase):
             # Files can be returned in any order when reading a directory, older
             # pre-allocated files can persist longer than newer files when newer
             # files are returned first. Confirm files are being consumed.
+            if set(older) < set(newer):
+                self.pr("FAILURE on Iteration " + str(i))
+                self.pr("FAILURE: Older")
+                self.pr(str(older))
+                self.pr("FAILURE: Newer")
+                self.pr(str(newer))
             self.assertFalse(set(older) < set(newer))
 
             older = newer
@@ -107,6 +114,9 @@ class test_bug019(wttest.WiredTigerTestCase):
             if new_prealloc < self.max_prealloc:
                 break
             time.sleep(1.0)
+        if sleepcount >= max_wait_time:
+            self.pr("FAILURE: sleepcount " + str(sleepcount))
+            self.pr("FAILURE: max_wait_time " + str(max_wait_time))
         self.assertTrue(sleepcount < max_wait_time)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a test that has rarely failed when trying to reproduce. I'm adding more debugging to catch all the different assertions so that whenever it happens we get information.