### PR TITLE
WT-5376 WT_UPDATE.type field can race with visibility checks when returning key/value pairs (v3.6 backport)

### DIFF
--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -784,32 +784,39 @@ __wt_txn_upd_visible(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 static inline int
 __wt_txn_read(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_UPDATE **updp)
 {
-	static WT_UPDATE tombstone = {
+    static WT_UPDATE tombstone = {
 		.txnid = WT_TXN_NONE, .type = WT_UPDATE_TOMBSTONE
 	};
-	WT_VISIBLE_TYPE upd_visible;
-	bool skipped_birthmark;
+    WT_VISIBLE_TYPE upd_visible;
+    uint8_t type;
+    bool skipped_birthmark;
 
-	*updp = NULL;
-	for (skipped_birthmark = false; upd != NULL; upd = upd->next) {
-		/* Skip reserved place-holders, they're never visible. */
-		if (upd->type != WT_UPDATE_RESERVE) {
-			upd_visible = __wt_txn_upd_visible_type(session, upd);
-			if (upd_visible == WT_VISIBLE_TRUE)
-				break;
-			if (upd_visible == WT_VISIBLE_PREPARE)
-				return (WT_PREPARE_CONFLICT);
-		}
-		/* An invisible birthmark is equivalent to a tombstone. */
-		if (upd->type == WT_UPDATE_BIRTHMARK)
-			skipped_birthmark = true;
+    *updp = NULL;
+
+    type = WT_UPDATE_INVALID; /* [-Wconditional-uninitialized] */
+    for (skipped_birthmark = false; upd != NULL; upd = upd->next) {
+	WT_ORDERED_READ(type, upd->type);
+
+	/* Skip reserved place-holders, they're never visible. */
+	if (type != WT_UPDATE_RESERVE) {
+	    upd_visible = __wt_txn_upd_visible_type(session, upd);
+	    if (upd_visible == WT_VISIBLE_TRUE)
+		break;
+	    if (upd_visible == WT_VISIBLE_PREPARE)
+		return (WT_PREPARE_CONFLICT);
 	}
+	/* An invisible birthmark is equivalent to a tombstone. */
+	if (type == WT_UPDATE_BIRTHMARK)
+	    skipped_birthmark = true;
+    }
 
-	if (upd == NULL && skipped_birthmark)
-		upd = &tombstone;
+    if (upd == NULL && skipped_birthmark) {
+	upd = &tombstone;
+	type = upd->type;
+    }
 
-	*updp = upd == NULL || upd->type == WT_UPDATE_BIRTHMARK ? NULL : upd;
-	return (0);
+    *updp = upd == NULL || type == WT_UPDATE_BIRTHMARK ? NULL : upd;
+    return (0);
 }
 
 /*


### PR DESCRIPTION
* Cache the WT_UPDATE.type field so that it can't change underneath us after the visibility checks.

(cherry picked from commit 168c7f1b3859516115721868f312544abb0caf5b)