### PR TITLE
WT-6501 Don't fix out of order timestamps for updates without timestamps

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -761,6 +761,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         ts_updates_in_hs = false;
         enable_reverse_modify = true;
 
+        __wt_modify_vector_clear(&modifies);
+
         /*
          * The algorithm assumes the oldest update on the update chain in memory is either a full
          * update or a tombstone.
@@ -814,7 +816,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
                   __wt_timestamp_to_string(min_insert_ts, ts_string[2]));
                 upd->start_ts = upd->durable_ts = min_insert_ts;
                 WT_STAT_CONN_INCR(session, cache_hs_order_fixup_insert);
-            } else
+            } else if (upd->start_ts != WT_TS_NONE)
                 min_insert_ts = upd->start_ts;
             WT_ERR(__wt_modify_vector_push(&modifies, upd));
 

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -817,6 +817,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
                 upd->start_ts = upd->durable_ts = min_insert_ts;
                 WT_STAT_CONN_INCR(session, cache_hs_order_fixup_insert);
             } else if (upd->start_ts != WT_TS_NONE)
+                /* Don't fix out of order timestamps for updates without timestamps. */
                 min_insert_ts = upd->start_ts;
             WT_ERR(__wt_modify_vector_push(&modifies, upd));
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1709,6 +1709,7 @@ extern void __wt_meta_track_discard(WT_SESSION_IMPL *session);
 extern void __wt_meta_track_sub_on(WT_SESSION_IMPL *session);
 extern void __wt_metadata_free_ckptlist(WT_SESSION *session, WT_CKPT *ckptbase)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_modify_vector_clear(WT_MODIFY_VECTOR *modifies);
 extern void __wt_modify_vector_free(WT_MODIFY_VECTOR *modifies);
 extern void __wt_modify_vector_init(WT_SESSION_IMPL *session, WT_MODIFY_VECTOR *modifies);
 extern void __wt_modify_vector_peek(WT_MODIFY_VECTOR *modifies, WT_UPDATE **updp);

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -517,6 +517,16 @@ __wt_modify_vector_peek(WT_MODIFY_VECTOR *modifies, WT_UPDATE **updp)
 }
 
 /*
+ * __wt_modify_vector_clear --
+ *     Clear a modify vector.
+ */
+void
+__wt_modify_vector_clear(WT_MODIFY_VECTOR *modifies)
+{
+    modifies->size = 0;
+}
+
+/*
  * __wt_modify_vector_free --
  *     Free any resources associated with a modify vector. If we exceeded the allowed stack space on
  *     the vector and had to fallback to dynamic allocations, we'll be doing a free here.


### PR DESCRIPTION
This PR brings it closer to the proper fix for WT-6479 and should address the BF we see in mongodb. But it is still not 100% correct.