### PR TITLE
WT-5970 test_wt2853_perf failure

### DIFF
--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -259,7 +259,7 @@ runone(bool config_cache)
     testutil_check(__wt_snprintf(buf, sizeof(buf),
       "create"
       ", cache_cursors=%s"
-      ", cache_size=5GB"
+      ", cache_size=2GB"
       ", checkpoint_sync=true"
       ", eviction=(threads_max=5)"
       ", file_manager=("
@@ -306,10 +306,8 @@ run(int argc, char *argv[])
         bool cache_cursors;
     } runs[] = {
       {1, 1, false}, {1, 1, true}, {8, 1, false}, {8, 1, true}, {16, 1, false}, {16, 1, true},
-      {16, WT_ELEMENTS(uri_list), false}, {16, WT_ELEMENTS(uri_list), true}, {200, 100, false},
-      {200, 100, true}, {200, WT_ELEMENTS(uri_list), false}, {200, WT_ELEMENTS(uri_list), true},
-      {300, 100, false}, {300, 100, true}, {600, WT_ELEMENTS(uri_list), false},
-      {600, WT_ELEMENTS(uri_list), true},
+      {16, WT_ELEMENTS(uri_list), false}, {16, WT_ELEMENTS(uri_list), true}, {64, 100, false},
+      {64, 100, true}, {64, WT_ELEMENTS(uri_list), false}, {64, WT_ELEMENTS(uri_list), true},
     };
     WT_RAND_STATE rnd;
     u_int i, n;

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -259,7 +259,7 @@ runone(bool config_cache)
     testutil_check(__wt_snprintf(buf, sizeof(buf),
       "create"
       ", cache_cursors=%s"
-      ", cache_size=2GB"
+      ", cache_size=1GB"
       ", checkpoint_sync=true"
       ", eviction=(threads_max=5)"
       ", file_manager=("


### PR DESCRIPTION
The test test_wt2853_perf fails because of memory contention by other csuite binaries, ex: `test_wt4333_handle_locks`
uses 5 GB of cache and runs a maximum of 600 threads.

I updated the binary `test_wt4333_handle_locks` to use a maximum of 64 threads, cache_size of 1 GB, ran the test overnight and none of the csuite binaries failed.