### PR TITLE
WT-5587 Limit how many checkpoints are dropped by a subsequent checkpoint (v3.6 backport)

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1211,7 +1211,7 @@ __drop(WT_CKPT *ckptbase, const char *name, size_t len)
     /*
      * If we're dropping internal checkpoints, match to the '.' separating
 	 * the checkpoint name from the generational number, and take all that
-	 * we can find. Applications aren't allowed to use any variant of this
+	 * we can find.  Applications aren't allowed to use any variant of this
 	 * name, so the test is still pretty simple, if the leading bytes match,
      * it's one we want to drop.
      */

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1205,23 +1205,34 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
 static void
 __drop(WT_CKPT *ckptbase, const char *name, size_t len)
 {
-	WT_CKPT *ckpt;
+    WT_CKPT *ckpt;
+    u_int max_ckpt_drop;
 
-	/*
-	 * If we're dropping internal checkpoints, match to the '.' separating
-	 * the checkpoint name from the generational number, and take all that
-	 * we can find.  Applications aren't allowed to use any variant of this
-	 * name, so the test is still pretty simple, if the leading bytes match,
-	 * it's one we want to drop.
-	 */
-	if (strncmp(WT_CHECKPOINT, name, len) == 0) {
-		WT_CKPT_FOREACH(ckptbase, ckpt)
-			if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT))
-				F_SET(ckpt, WT_CKPT_DELETE);
-	} else
-		WT_CKPT_FOREACH(ckptbase, ckpt)
-			if (WT_STRING_MATCH(ckpt->name, name, len))
-				F_SET(ckpt, WT_CKPT_DELETE);
+    /*
+     * If we're dropping internal checkpoints, match to the '.' separating the checkpoint name from
+     * the generational number, and take all that we can find. Applications aren't allowed to use
+     * any variant of this name, so the test is still pretty simple, if the leading bytes match,
+     * it's one we want to drop.
+     */
+    if (strncmp(WT_CHECKPOINT, name, len) == 0) {
+        /*
+         * Currently, hot backup cursors block checkpoint drop, which means releasing a hot backup
+         * cursor can result in immediately attempting to drop lots of checkpoints, which involves a
+         * fair amount of work while holding locks. Limit the number of standard checkpoints dropped
+         * per checkpoint.
+         */
+        max_ckpt_drop = 0;
+        WT_CKPT_FOREACH (ckptbase, ckpt)
+            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+                F_SET(ckpt, WT_CKPT_DELETE);
+#define WT_MAX_CHECKPOINT_DROP 4
+                if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
+                    break;
+            }
+    } else
+        WT_CKPT_FOREACH (ckptbase, ckpt)
+            if (WT_STRING_MATCH(ckpt->name, name, len))
+                F_SET(ckpt, WT_CKPT_DELETE);
 }
 
 /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1209,30 +1209,32 @@ __drop(WT_CKPT *ckptbase, const char *name, size_t len)
     u_int max_ckpt_drop;
 
     /*
-     * If we're dropping internal checkpoints, match to the '.' separating the checkpoint name from
-     * the generational number, and take all that we can find. Applications aren't allowed to use
-     * any variant of this name, so the test is still pretty simple, if the leading bytes match,
+     * If we're dropping internal checkpoints, match to the '.' separating
+	 * the checkpoint name from the generational number, and take all that
+	 * we can find. Applications aren't allowed to use any variant of this
+	 * name, so the test is still pretty simple, if the leading bytes match,
      * it's one we want to drop.
      */
     if (strncmp(WT_CHECKPOINT, name, len) == 0) {
-        /*
-         * Currently, hot backup cursors block checkpoint drop, which means releasing a hot backup
-         * cursor can result in immediately attempting to drop lots of checkpoints, which involves a
-         * fair amount of work while holding locks. Limit the number of standard checkpoints dropped
-         * per checkpoint.
-         */
-        max_ckpt_drop = 0;
-        WT_CKPT_FOREACH (ckptbase, ckpt)
-            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
-                F_SET(ckpt, WT_CKPT_DELETE);
-#define WT_MAX_CHECKPOINT_DROP 4
-                if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
-                    break;
-            }
+	/*
+	 * Currently, hot backup cursors block checkpoint drop, which means
+	 * releasing a hot backup cursor can result in immediately attempting
+	 * to drop lots of checkpoints, which involves a fair amount of work
+	 * while holding locks. Limit the number of standard checkpoints dropped
+	 * per checkpoint.
+	 */
+	max_ckpt_drop = 0;
+	WT_CKPT_FOREACH (ckptbase, ckpt)
+	    if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+		F_SET(ckpt, WT_CKPT_DELETE);
+#define	WT_MAX_CHECKPOINT_DROP 4
+		if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
+		    break;
+	    }
     } else
-        WT_CKPT_FOREACH (ckptbase, ckpt)
-            if (WT_STRING_MATCH(ckpt->name, name, len))
-                F_SET(ckpt, WT_CKPT_DELETE);
+	WT_CKPT_FOREACH (ckptbase, ckpt)
+	    if (WT_STRING_MATCH(ckpt->name, name, len))
+		F_SET(ckpt, WT_CKPT_DELETE);
 }
 
 /*


### PR DESCRIPTION


(cherry picked from commit a19d2bff3d30fdd83086172b29161527aefc28e3)
(cherry picked from commit 58baf804dd6e5a72c4e122cfb696e2d06a9fc888)
(cherry picked from commit e58bd570c06955c5b85b75af4a58b6d1da7c5d90)