### PR TITLE
WT-6480 incremental backups can repeatedly copy entire objects on eac…

### DIFF
--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -31,6 +31,7 @@ __wt_backup_load_incr(
 static int
 __curbackup_incr_blkmod(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_CURSOR_BACKUP *cb)
 {
+    WT_CKPT ckpt;
     WT_CONFIG blkconf;
     WT_CONFIG_ITEM b, k, v;
     WT_DECL_RET;
@@ -41,7 +42,15 @@ __curbackup_incr_blkmod(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_CURSOR_BAC
     WT_ASSERT(session, cb->incr_src != NULL);
 
     WT_RET(__wt_metadata_search(session, btree->dhandle->name, &config));
+    /* Check if this is a file with no checkpointed content. */
+    ret = __wt_meta_checkpoint(session, btree->dhandle->name, 0, &ckpt);
+    if (ret == 0 && ckpt.addr.size == 0)
+        F_SET(cb, WT_CURBACKUP_CKPT_FAKE);
+    __wt_meta_checkpoint_free(session, &ckpt);
+
     WT_ERR(__wt_config_getones(session, config, "checkpoint_backup_info", &v));
+    if (v.len)
+        F_SET(cb, WT_CURBACKUP_HAS_CB_INFO);
     __wt_config_subinit(session, &blkconf, &v);
     while ((ret = __wt_config_next(&blkconf, &k, &v)) == 0) {
         /*
@@ -65,12 +74,13 @@ __curbackup_incr_blkmod(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_CURSOR_BAC
         /*
          * We found a match. Load the block information into the cursor.
          */
-        ret = __wt_config_subgets(session, &v, "blocks", &b);
-        if (ret != WT_NOTFOUND) {
+        if ((ret = __wt_config_subgets(session, &v, "blocks", &b)) == 0) {
             WT_ERR(__wt_backup_load_incr(session, &b, &cb->bitstring, cb->nbits));
             cb->bit_offset = 0;
-            cb->incr_init = true;
+            F_SET(cb, WT_CURBACKUP_INCR_INIT);
         }
+        WT_ERR_NOTFOUND_OK(ret);
+        break;
     }
     WT_ERR_NOTFOUND_OK(ret);
 
@@ -101,7 +111,8 @@ __curbackup_incr_next(WT_CURSOR *cursor)
     CURSOR_API_CALL(cursor, session, get_value, btree);
     F_CLR(cursor, WT_CURSTD_RAW);
 
-    if (!cb->incr_init && (btree == NULL || F_ISSET(cb, WT_CURBACKUP_FORCE_FULL))) {
+    if (!F_ISSET(cb, WT_CURBACKUP_INCR_INIT) &&
+      (btree == NULL || F_ISSET(cb, WT_CURBACKUP_FORCE_FULL))) {
         /*
          * We don't have this object's incremental information or it's a forced file copy. If this
          * is a log file, use the full pathname that may include the log path.
@@ -121,10 +132,10 @@ __curbackup_incr_next(WT_CURSOR *cursor)
          * By setting this to true, the next call will detect we're done in the code for the
          * incremental cursor below and return WT_NOTFOUND.
          */
-        cb->incr_init = true;
+        F_SET(cb, WT_CURBACKUP_INCR_INIT);
         __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
     } else {
-        if (cb->incr_init) {
+        if (F_ISSET(cb, WT_CURBACKUP_INCR_INIT)) {
             /* Look for the next chunk that had modifications.  */
             while (cb->bit_offset < cb->nbits)
                 if (__bit_test(cb->bitstring.mem, cb->bit_offset))
@@ -144,14 +155,24 @@ __curbackup_incr_next(WT_CURSOR *cursor)
              */
             WT_ERR(__curbackup_incr_blkmod(session, btree, cb));
             /*
-             * If there is no block modification information for this file, this is a newly created
-             * file without any checkpoint information. Return the whole file information.
+             * There are three cases where we do not have block modification information for
+             * the file. They are described and handled as follows:
+             *
+             * 1. Newly created file without checkpoint information. Return the whole file
+             *    information.
+             * 2. File created and checkpointed before incremental backups were configured.
+             *    Return no file information as it was copied in the initial full backup.
+             * 3. File that has not been modified since the previous incremental backup.
+             *    Return no file information as there is no new information.
              */
             if (cb->bitstring.mem == NULL) {
-                WT_ERR(__wt_fs_size(session, cb->incr_file, &size));
-                cb->incr_init = true;
-                __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
-                goto done;
+                F_SET(cb, WT_CURBACKUP_INCR_INIT);
+                if (F_ISSET(cb, WT_CURBACKUP_CKPT_FAKE) && F_ISSET(cb, WT_CURBACKUP_HAS_CB_INFO)) {
+                    WT_ERR(__wt_fs_size(session, cb->incr_file, &size));
+                    __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
+                    goto done;
+                }
+                WT_ERR(WT_NOTFOUND);
             }
         }
         __wt_cursor_set_key(cursor, cb->offset + cb->granularity * cb->bit_offset++,

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -51,7 +51,6 @@ struct __wt_cursor_backup {
 
     WT_CURSOR *incr_cursor; /* File cursor */
 
-    bool incr_init;       /* Cursor traversal initialized */
     WT_ITEM bitstring;    /* List of modified blocks */
     uint64_t nbits;       /* Number of bits in bitstring */
     uint64_t offset;      /* Zero bit offset in bitstring */
@@ -59,13 +58,16 @@ struct __wt_cursor_backup {
     uint64_t granularity; /* Length, transfer size */
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_CURBACKUP_DUP 0x01u        /* Duplicated backup cursor */
-#define WT_CURBACKUP_FORCE_FULL 0x02u /* Force full file copy for this cursor */
-#define WT_CURBACKUP_FORCE_STOP 0x04u /* Force stop incremental backup */
-#define WT_CURBACKUP_INCR 0x08u       /* Incremental backup cursor */
-#define WT_CURBACKUP_LOCKER 0x10u     /* Hot-backup started */
-                                      /* AUTOMATIC FLAG VALUE GENERATION STOP */
-    uint8_t flags;
+#define WT_CURBACKUP_CKPT_FAKE 0x01u   /* Object has fake checkpoint */
+#define WT_CURBACKUP_DUP 0x02u         /* Duplicated backup cursor */
+#define WT_CURBACKUP_FORCE_FULL 0x04u  /* Force full file copy for this cursor */
+#define WT_CURBACKUP_FORCE_STOP 0x08u  /* Force stop incremental backup */
+#define WT_CURBACKUP_HAS_CB_INFO 0x10u /* Object has checkpoint backup info */
+#define WT_CURBACKUP_INCR 0x20u        /* Incremental backup cursor */
+#define WT_CURBACKUP_INCR_INIT 0x40u   /* Cursor traversal initialized */
+#define WT_CURBACKUP_LOCKER 0x80u      /* Hot-backup started */
+                                       /* AUTOMATIC FLAG VALUE GENERATION STOP */
+    uint32_t flags;
 };
 
 struct __wt_cursor_btree {

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -409,8 +409,7 @@ __ckpt_valid_blk_mods(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
          * - Our entry's id string matches the current global information. We just want to add our
          *   information to the existing list.
          * - Our entry's id string does not match the current one. It is outdated. Free old
-         * resources
-         *   and then set up our entry.
+         * resources and then set up our entry.
          */
 
         /* Check if the global entry is valid at our index.  */

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -221,7 +221,7 @@ active_files_print(ACTIVE_FILES *active, const char *msg)
 {
     uint32_t i;
 
-    VERBOSE(6, "Active files: %s, %d entries\n", msg, (int)active->count);
+    VERBOSE(6, "Active files: %s, %" PRIu32 " entries\n", msg, active->count);
     for (i = 0; i < active->count; i++)
         VERBOSE(6, "  %s\n", active->names[i]);
 }
@@ -357,7 +357,7 @@ table_changes(WT_SESSION *session, TABLE *table)
         value = dcalloc(1, table->max_value_size);
         value2 = dcalloc(1, table->max_value_size);
         nrecords = __wt_random(&table->rand) % 1000;
-        VERBOSE(4, "changing %d records in %s\n", (int)nrecords, table->name);
+        VERBOSE(4, "changing %" PRIu32 " records in %s\n", nrecords, table->name);
         testutil_check(session->open_cursor(session, table->name, NULL, NULL, &cur));
         for (i = 0; i < nrecords; i++) {
             change_count = table->change_count++;
@@ -485,8 +485,8 @@ base_backup(WT_CONNECTION *conn, WT_RAND_STATE *rand, const char *home, const ch
         granularity += 1;
     }
     testutil_check(__wt_snprintf(buf, sizeof(buf),
-      "incremental=(granularity=%" PRIu32 "%c,enabled=true,this_id=ID%d)", granularity,
-      granularity_unit, (int)tinfo->full_backup_number));
+      "incremental=(granularity=%" PRIu32 "%c,enabled=true,this_id=ID%" PRIu32 ")", granularity,
+      granularity_unit, tinfo->full_backup_number));
     VERBOSE(3, "open_cursor(session, \"backup:\", NULL, \"%s\", &cursor)\n", buf);
     testutil_check(session->open_cursor(session, "backup:", NULL, buf, &cursor));
 
@@ -549,8 +549,9 @@ incr_backup(WT_CONNECTION *conn, const char *home, const char *backup_home, TABL
 
     active_files_init(&active);
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    testutil_check(__wt_snprintf(buf, sizeof(buf), "incremental=(src_id=ID%d,this_id=ID%d)",
-      (int)tinfo->full_backup_number, (int)tinfo->incr_backup_number++));
+    testutil_check(
+      __wt_snprintf(buf, sizeof(buf), "incremental=(src_id=ID%" PRIu32 ",this_id=ID%" PRIu32 ")",
+        tinfo->full_backup_number, tinfo->incr_backup_number++));
     VERBOSE(3, "open_cursor(session, \"backup:\", NULL, \"%s\", &cursor)\n", buf);
     testutil_check(session->open_cursor(session, "backup:", NULL, buf, &cursor));
 
@@ -770,7 +771,7 @@ main(int argc, char *argv[])
     testutil_work_dir_from_path(home, sizeof(home), working_dir);
     testutil_check(__wt_snprintf(backup_dir, sizeof(backup_dir), "%s.BACKUP", home));
     testutil_check(__wt_snprintf(backup_check, sizeof(backup_check), "%s.CHECK", home));
-    fprintf(stderr, "Seed: %" PRIu64 "\n", seed);
+    printf("Seed: %" PRIu64 "\n", seed);
 
     testutil_check(
       __wt_snprintf(command, sizeof(command), "rm -rf %s %s; mkdir %s", home, backup_dir, home));
@@ -821,7 +822,7 @@ main(int argc, char *argv[])
     next_checkpoint = __wt_random(&rnd) % tinfo.table_count;
 
     for (iter = 0; iter < ITERATIONS; iter++) {
-        VERBOSE(1, "**** iteration %d ****\n", (int)iter);
+        VERBOSE(1, "**** iteration %" PRIu32 " ****\n", iter);
 
         /*
          * We have schema changes during about half the iterations. The number of schema changes

--- a/test/suite/test_backup16.py
+++ b/test/suite/test_backup16.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+import os, shutil
+from helper import compare_files
+from suite_subprocess import suite_subprocess
+from wtdataset import simple_key
+from wtscenario import make_scenarios
+
+# test_backup16.py
+# Ensure incremental backup doesn't copy unnecessary files.
+class test_backup16(wttest.WiredTigerTestCase, suite_subprocess):
+
+    conn_config='cache_size=1G,log=(enabled,file_max=100K)'
+    counter=1
+    logmax='100K'
+    mult=1
+    nops=10
+    uri1='table:test1'
+    uri2='table:test2'
+    uri3='table:test3'
+    uri4='table:test4'
+    uri5='table:test5'
+
+    pfx = 'test_backup'
+    # Set the key and value big enough that we modify a few blocks.
+    bigkey = 'Key' * 10
+    bigval = 'Value' * 10
+
+    def add_data(self, uri):
+
+        c = self.session.open_cursor(uri)
+        for i in range(0, self.nops):
+            num = i + (self.mult * self.nops)
+            key = self.bigkey + str(num)
+            val = self.bigval + str(num)
+            c[key] = val
+        self.session.checkpoint()
+        c.close()
+        # Increase the multiplier so that later calls insert unique items.
+        self.mult += 1
+
+    def verify_incr_backup(self, expected_file_list):
+
+        bkup_config = ('incremental=(src_id="ID' +  str(self.counter-1) +
+                       '",this_id="ID' + str(self.counter) + '")')
+        bkup_cur = self.session.open_cursor('backup:', None, bkup_config)
+        self.counter += 1
+        num_files = 0
+
+        # Verify the files included in the incremental backup are the ones we expect.
+        while True:
+            ret = bkup_cur.next()
+            if ret != 0:
+                break
+
+            bkup_file = bkup_cur.get_key()
+            if bkup_file.startswith('WiredTiger'):
+                continue
+
+            incr_config = 'incremental=(file=' + bkup_file + ')'
+            incr_cur = self.session.open_cursor(None, bkup_cur, incr_config)
+
+            while True:
+                ret = incr_cur.next()
+                if ret != 0:
+                    break
+
+                # Check this file is one we are expecting.
+                self.assertTrue(bkup_file in expected_file_list)
+                num_files += 1
+
+                # Ensure that the file we changed has content to copy and the file we didn't
+                # change doesn't have any content to copy.
+                # Note:
+                # Pretty sure this is the file size and not the number of bytes to copy.
+                incr_list = incr_cur.get_keys()
+                self.assertNotEqual(incr_list[1], 0)
+
+            self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+            incr_cur.close()
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+        bkup_cur.close()
+
+        # Ensure that the backup saw all the expected files.
+        self.assertEqual(num_files, len(expected_file_list))
+
+    def test_backup16(self):
+
+        self.session.create(self.uri1, 'key_format=S,value_format=S')
+        self.session.create(self.uri2, 'key_format=S,value_format=S')
+        self.session.create(self.uri3, 'key_format=S,value_format=S')
+        self.add_data(self.uri1)
+        self.add_data(self.uri2)
+
+        # Checkpoint and simulate full backup.
+        self.session.checkpoint()
+        config = 'incremental=(enabled,granularity=1M,this_id="ID0")'
+        cursor = self.session.open_cursor('backup:', None, config)
+        cursor.close()
+
+        # Create new tables, add more data and checkpoint.
+        self.session.create(self.uri4, "key_format=S,value_format=S")
+        self.session.create(self.uri5, "key_format=S,value_format=S")
+        self.add_data(self.uri1)
+        self.add_data(self.uri5)
+        self.session.checkpoint()
+
+        # Validate these three files are included in the incremental.
+        files_to_backup = ['test1.wt', 'test4.wt', 'test5.wt']
+        self.verify_incr_backup(files_to_backup)
+
+        # Add more data and checkpoint.
+        self.add_data(self.uri3)
+        self.add_data(self.uri5)
+        self.session.checkpoint()
+
+        # Validate these three files are included in the incremental.
+        files_to_backup = ['test3.wt', 'test4.wt', 'test5.wt']
+        self.verify_incr_backup(files_to_backup)
+
+        # Perform one more incremental without changing anything. We should only
+        # see one file.
+        files_to_backup = ['test4.wt']
+        self.verify_incr_backup(files_to_backup)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
…h iteration (#5859)

Fix a bug where files without block modification information were repeatedly copied at each incremental backup.

Co-authored-by: Tammy Bailey <tammy.bailey@mongodb.com>
(cherry picked from commit 6142de1e7d863eed50b3c8449af29b0d361d77c5)