### PR TITLE
WT-6468 With durable history, we can evict truncated page that is not globally visible

### DIFF
--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1455,7 +1455,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     mod = page->modify;
 
     /* A truncated page can't be evicted until the truncate completes. */
-    if (__wt_page_del_active(session, ref, true))
+    if (__wt_page_del_active(session, ref, false))
         return (false);
 
     /* Otherwise, never modified pages can always be evicted. */

--- a/src/include/btree.i
+++ b/src/include/btree.i
@@ -1454,10 +1454,6 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     page = ref->page;
     mod = page->modify;
 
-    /* A truncated page can't be evicted until the truncate completes. */
-    if (__wt_page_del_active(session, ref, false))
-        return (false);
-
     /* Otherwise, never modified pages can always be evicted. */
     if (mod == NULL)
         return (true);


### PR DESCRIPTION
I haven't reproduced the problem but I don't see why we can't evict deleted pages that are not globally visible with durable history. We will simply reconcile the tombstone appended when we read the truncated page into memory to the stop time point in the cell and it should work. The only concern I can think of is that it may cause WT-6494 happen more frequently.