### PR TITLE
WT-6468 Discard a deleted page that is cleaned by a checkpoint

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -88,7 +88,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             /*
              * Discard the page regardless of whether it is dirty.
              *
-             * If the page has a page deleted structure, we are discarding the tree that is cleaned
+             * If the page has a page deleted structure, we are discarding the page that is cleaned
              * by a checkpoint.
              */
             WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_DEAD) ||

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -87,9 +87,13 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         case WT_SYNC_DISCARD:
             /*
              * Discard the page regardless of whether it is dirty.
+             *
+             * If the page has a page deleted structure, we are discarding the page that is cleaned
+             * by a checkpoint.
              */
             WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
-                F_ISSET(S2C(session), WT_CONN_CLOSING) || __wt_page_can_evict(session, ref, NULL));
+                F_ISSET(S2C(session), WT_CONN_CLOSING) || __wt_page_can_evict(session, ref, NULL) ||
+                (ref->page_del != NULL && __wt_page_evict_clean(ref->page)));
             __wt_ref_out(session, ref);
             break;
         case WT_SYNC_CHECKPOINT:

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -88,12 +88,12 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             /*
              * Discard the page regardless of whether it is dirty.
              *
-             * If the page has a page deleted structure, we are discarding the page that is cleaned
+             * If the page has a page deleted structure, we are discarding the tree that is cleaned
              * by a checkpoint.
              */
             WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
                 F_ISSET(S2C(session), WT_CONN_CLOSING) || __wt_page_can_evict(session, ref, NULL) ||
-                (ref->page_del != NULL && __wt_page_evict_clean(ref->page)));
+                (ref->page_del != NULL && page->modify->page_state == WT_PAGE_CLEAN));
             __wt_ref_out(session, ref);
             break;
         case WT_SYNC_CHECKPOINT:


### PR DESCRIPTION
The problem is that a single file checkpoint tries to close a clean tree. The tree has some pages that are truncated and loaded into memory again. These truncated pages are cleaned by a previous full checkpoint, thus triggering the assert as non-globally visible truncation are not evictable. The solution is to relax the assert as we should be able to discard these pages.

We don't see this before durable history because checkpoint cannot clean the page in this case as we can't write tombstones to disk.