### PR TITLE
WT-6521 Distinguish the difference between dirty and cleanup dirty

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -195,7 +195,7 @@ __wt_compact(WT_SESSION_IMPL *session)
 
         /* Rewrite the page: mark the page and tree dirty. */
         WT_ERR(__wt_page_modify_init(session, ref->page));
-        __wt_page_modify_set(session, ref->page);
+        __wt_page_modify_set(session, ref->page, false);
 
         session->compact_state = WT_COMPACT_SUCCESS;
         WT_STAT_DATA_INCR(session, btree_compact_rewrite);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -311,7 +311,7 @@ __wt_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_RET(__wt_page_modify_init(session, page));
     if (!F_ISSET(btree, WT_BTREE_READONLY))
-        __wt_page_modify_set(session, page);
+        __wt_page_modify_set(session, page, false);
 
     if (ref->page_del != NULL && ref->page_del->prepare_state != WT_PREPARE_INIT) {
         WT_STAT_CONN_INCR(session, cache_read_deleted_prepared);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -523,7 +523,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
     WT_RET(__wt_rwlock_init(session, &btree->ovfl_lock));
     WT_RET(__wt_spin_init(session, &btree->flush_lock, "btree flush"));
 
-    btree->modified = false; /* Clean */
+    btree->modified = WT_BTREE_MODIFY_NONE; /* Clean */
 
     btree->syncing = WT_BTREE_SYNC_OFF; /* Not syncing */
                                         /* Checkpoint generation */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -455,9 +455,9 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
              * free the deleted pages, but if the handle is read-only or if the application never
              * modifies the tree, we're not able to do so.)
              */
-            if (btree->modified) {
+            if (btree->modified != WT_BTREE_MODIFY_NONE) {
                 WT_ERR(__wt_page_modify_init(session, page));
-                __wt_page_modify_set(session, page);
+                __wt_page_modify_set(session, page, false);
             }
             break;
         case WT_CELL_ADDR_INT:
@@ -596,7 +596,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (prepare && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
         WT_RET(__wt_page_modify_init(session, page));
         if (!F_ISSET(btree, WT_BTREE_READONLY))
-            __wt_page_modify_set(session, page);
+            __wt_page_modify_set(session, page, false);
 
         /* Allocate the per-page update array if one doesn't already exist. */
         if (page->entries != 0 && page->modify->mod_row_update == NULL)

--- a/src/btree/bt_rebalance.c
+++ b/src/btree/bt_rebalance.c
@@ -140,7 +140,7 @@ __rebalance_internal(WT_SESSION_IMPL *session, WT_REBALANCE_STUFF *rs)
     WT_RET(__wt_page_alloc(session, rs->type, leaf_next, false, &page));
     page->pg_intl_parent_ref = &btree->root;
     WT_ERR(__wt_page_modify_init(session, page));
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     pindex = WT_INTL_INDEX_GET_SAFE(page);
     for (refp = pindex->index, i = 0; i < leaf_next; ++i) {
@@ -376,7 +376,7 @@ __wt_bt_rebalance(WT_SESSION_IMPL *session, const char *cfg[])
      */
     if (ref->page->dsk == NULL)
         return (0);
-    if (btree->modified)
+    if (btree->modified == WT_BTREE_MODIFY_NORMAL)
         WT_RET_MSG(session, EINVAL, "tree is modified, only clean trees may be rebalanced");
 
     WT_CLEAR(_rstuff);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1134,7 +1134,7 @@ static int
 __slvg_modify_init(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
     WT_RET(__wt_page_modify_init(session, page));
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     return (0);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -403,7 +403,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
 
     /* Mark the root page dirty. */
     WT_RET(__wt_page_modify_init(session, root));
-    __wt_page_modify_set(session, root);
+    __wt_page_modify_set(session, root, false);
 
     /*
      * Our caller is holding the root page locked to single-thread splits, which means we can safely
@@ -481,7 +481,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
         child->pg_intl_parent_ref = ref;
         child->pg_intl_split_gen = split_gen;
         WT_ERR(__wt_page_modify_init(session, child));
-        __wt_page_modify_set(session, child);
+        __wt_page_modify_set(session, child, false);
 
         /*
          * The newly allocated child's page index references the same structures as the root. (We
@@ -671,7 +671,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
 
     /* Mark the page dirty. */
     WT_RET(__wt_page_modify_init(session, parent));
-    __wt_page_modify_set(session, parent);
+    __wt_page_modify_set(session, parent, false);
 
     /*
      * We've locked the parent, which means it cannot split (which is the only reason to worry about
@@ -911,7 +911,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
     /* Mark the page dirty. */
     WT_RET(__wt_page_modify_init(session, page));
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     btree = S2BT(session);
     alloc_index = replace_index = NULL;
@@ -1017,7 +1017,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
         child->pg_intl_parent_ref = ref;
         child->pg_intl_split_gen = split_gen;
         WT_ERR(__wt_page_modify_init(session, child));
-        __wt_page_modify_set(session, child);
+        __wt_page_modify_set(session, child, false);
 
         /*
          * The newly allocated child's page index references the same structures as the parent. (We
@@ -1827,7 +1827,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      * structure, so create it now.
      */
     WT_ERR(__wt_page_modify_init(session, right));
-    __wt_page_modify_set(session, right);
+    __wt_page_modify_set(session, right, false);
 
     if (type == WT_PAGE_ROW_LEAF) {
         WT_ERR(__wt_calloc_one(session, &right->modify->mod_row_insert));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -553,8 +553,11 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             if (walk == NULL)
                 break;
 
-            /* Traverse through the internal page for obsolete child pages. */
-            if (F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
+            /*
+             * Perform checkpoint cleanup when not in recovery phase by traverse through the
+             * internal page for obsolete child pages.
+             */
+            if (!F_ISSET(conn, WT_CONN_RECOVERING) && F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
                 WT_WITH_PAGE_INDEX(
                   session, ret = __sync_ref_int_obsolete_cleanup(session, walk, &ref_list));
                 WT_ERR(ret);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -79,7 +79,7 @@ __sweep_expire_one(WT_SESSION_IMPL *session)
 
     /* Only sweep clean trees where all updates are visible. */
     if (btree != NULL &&
-      (btree->modified ||
+      (btree->modified == WT_BTREE_MODIFY_NORMAL ||
           !__wt_txn_visible_all(session, btree->rec_max_txn, btree->rec_max_timestamp)))
         goto err;
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -155,8 +155,13 @@ struct __wt_btree {
 
     uint64_t last_recno; /* Column-store last record number */
 
-    WT_REF root;      /* Root page reference */
-    bool modified;    /* If the tree ever modified */
+    WT_REF root; /* Root page reference */
+    volatile enum {
+        WT_BTREE_MODIFY_NONE,
+        WT_BTREE_MODIFY_NORMAL,
+        WT_BTREE_MODIFY_CLEANUP
+    } modified; /* Tree modified status */
+
     uint8_t original; /* Newly created: bulk-load possible
                          (want a bool but needs atomic cas) */
 

--- a/src/include/cache.i
+++ b/src/include/cache.i
@@ -108,7 +108,7 @@ static inline int
 __wt_page_dirty_and_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_RET(__wt_page_modify_init(session, ref->page));
-    __wt_page_modify_set(session, ref->page);
+    __wt_page_modify_set(session, ref->page, false);
     __wt_page_evict_soon(session, ref);
 
     return (0);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2190,7 +2190,7 @@ static inline void __wt_op_timer_start(WT_SESSION_IMPL *session);
 static inline void __wt_op_timer_stop(WT_SESSION_IMPL *session);
 static inline void __wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref);
 static inline void __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page);
-static inline void __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page);
+static inline void __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page, bool cleanup);
 static inline void __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page);
 static inline void __wt_rec_addr_ts_init(WT_RECONCILE *r, WT_TIME_AGGREGATE *ta);
 static inline void __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCILE *r,
@@ -2218,7 +2218,7 @@ static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *siz
 static inline void __wt_time_window_clear_obsolete(
   WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, uint64_t oldest_id, wt_timestamp_t oldest_ts);
 static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag);
-static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);
+static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session, bool cleanup);
 static inline void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static inline void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);
 static inline void __wt_txn_op_apply_prepare_state(

--- a/src/include/serial.i
+++ b/src/include/serial.i
@@ -155,7 +155,7 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *
     __wt_cache_page_inmem_incr(session, page, new_ins_size);
 
     /* Mark the page dirty after updating the footprint. */
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     return (0);
 }
@@ -207,7 +207,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *ins_
     __wt_cache_page_inmem_incr(session, page, new_ins_size);
 
     /* Mark the page dirty after updating the footprint. */
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     return (0);
 }
@@ -252,7 +252,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
     __wt_cache_page_inmem_incr(session, page, upd_size);
 
     /* Mark the page dirty after updating the footprint. */
-    __wt_page_modify_set(session, page);
+    __wt_page_modify_set(session, page, false);
 
     /* If there are no subsequent WT_UPDATE structures we are done here. */
     if (upd->next == NULL || exclusive)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -308,7 +308,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
          * the flag be set before a subsequent checkpoint reads it, and as the current checkpoint is
          * waiting on this reconciliation to complete, there's no risk of that happening).
          */
-        btree->modified = true;
+        btree->modified = WT_BTREE_MODIFY_NORMAL;
         WT_FULL_BARRIER();
         if (!S2C(session)->modified)
             S2C(session)->modified = true;
@@ -1940,7 +1940,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     /* Mark the page's parent and the tree dirty. */
     parent = r->ref->home;
     WT_ERR(__wt_page_modify_init(session, parent));
-    __wt_page_modify_set(session, parent);
+    __wt_page_modify_set(session, parent, false);
 
 err:
     __rec_cleanup(session, r);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1996,7 +1996,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const cha
             /*
              * Mark the metadata dirty so we flush it on close, allowing recovery to be skipped.
              */
-            WT_WITH_DHANDLE(s, WT_SESSION_META_DHANDLE(s), __wt_tree_modify_set(s));
+            WT_WITH_DHANDLE(s, WT_SESSION_META_DHANDLE(s), __wt_tree_modify_set(s, false));
 
             WT_TRET(wt_session->close(wt_session, config));
         }

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -616,7 +616,7 @@ __rollback_abort_row_reconciled_page(
          * let the reconciliation happens again on the page. Otherwise, the eviction may pick the
          * already reconciled page to write to disk with newer updates.
          */
-        __wt_page_modify_set(session, page);
+        __wt_page_modify_set(session, page, false);
     } else if (mod->rec_result == WT_PM_REC_MULTIBLOCK) {
         for (multi = mod->mod_multi, multi_entry = 0; multi_entry < mod->mod_multi_entries;
              ++multi, ++multi_entry)
@@ -642,7 +642,7 @@ __rollback_abort_row_reconciled_page(
                  * eviction may pick the already reconciled page to write to disk with newer
                  * updates.
                  */
-                __wt_page_modify_set(session, page);
+                __wt_page_modify_set(session, page, false);
             }
     }
 
@@ -1201,8 +1201,8 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
          * 2. The checkpoint durable start/stop timestamp is greater than the rollback timestamp.
          * 3. There is no durable timestamp in any checkpoint.
          */
-        if (S2BT(session)->modified || max_durable_ts > rollback_timestamp || prepared_updates ||
-          !durable_ts_found) {
+        if (S2BT(session)->modified == WT_BTREE_MODIFY_NORMAL ||
+          max_durable_ts > rollback_timestamp || prepared_updates || !durable_ts_found) {
             __wt_verbose(session, WT_VERB_RTS,
               "tree rolled back with durable timestamp: %s, or when tree is modified: %s or "
               "prepared updates: %s or when durable time is not found: %s",
@@ -1225,7 +1225,7 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
          * to WT_TS_NONE, We need this exception.
          * 2. In-memory database - In this scenario, there is no history store to truncate.
          */
-        if (!S2BT(session)->modified && max_durable_ts == WT_TS_NONE &&
+        if (S2BT(session)->modified == WT_BTREE_MODIFY_NORMAL && max_durable_ts == WT_TS_NONE &&
           !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
             WT_TRET(__rollback_to_stable_btree_hs_truncate(session, S2BT(session)->id));
 


### PR DESCRIPTION
As part of checkpoint cleanup, the pages that cannot be fast deleted are marked them dirty and let them be reconciled in the next checkpoint but this leads to problems for the operations that are expecting clean trees. To avoid the problem, split the dirty flags into normal and cleanup. Only raise errors when the tree is dirtied normally and not for cleanup.