### PR TITLE
WT-6521 Don't perform checkpoint cleanup during recovery

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -553,8 +553,11 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             if (walk == NULL)
                 break;
 
-            /* Traverse through the internal page for obsolete child pages. */
-            if (F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
+            /*
+             * Perform checkpoint cleanup when not in recovery phase by traverse through the
+             * internal page for obsolete child pages.
+             */
+            if (!F_ISSET(conn, WT_CONN_RECOVERING) && F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {
                 WT_WITH_PAGE_INDEX(
                   session, ret = __sync_ref_int_obsolete_cleanup(session, walk, &ref_list));
                 WT_ERR(ret);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -560,8 +560,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 break;
 
             /*
-             * Perform checkpoint cleanup when not in startup or shutdown phase by traverse through
-             * the internal page for obsolete child pages.
+             * Perform checkpoint cleanup when not in startup or shutdown phase by traversing
+             * through internal pages looking for obsolete child pages.
              */
             if (!F_ISSET(conn, WT_CONN_RECOVERING | WT_CONN_CLOSING_TIMESTAMP) &&
               F_ISSET(walk, WT_REF_FLAG_INTERNAL)) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -394,7 +394,10 @@ __sync_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *ski
         return (0);
     }
 
-    /* Check whether this ref has any possible updates to be aborted. */
+    /*
+     * Ignore the pages with no on-disk address. It is possible that a page with deleted state may
+     * not have an on-disk address.
+     */
     if (!__wt_ref_addr_copy(session, ref, &addr))
         return (0);
 


### PR DESCRIPTION
Avoiding the checkpoint cleanup during recovery let the trees to be
in clean state to change the logging of the table during startup.