### PR TITLE
WT-6425 Turn off log archiving to avoid file copy race.

### DIFF
--- a/test/suite/test_rollback_to_stable11.py
+++ b/test/suite/test_rollback_to_stable11.py
@@ -49,7 +49,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
     scenarios = make_scenarios(prepare_values)
 
     def conn_config(self):
-        config = 'cache_size=1MB,statistics=(all),log=(enabled=true)'
+        config = 'cache_size=1MB,statistics=(all),log=(archive=false,enabled=true)'
         return config
 
     def simulate_crash_restart(self, olddir, newdir):


### PR DESCRIPTION
@ddanderson I put an explanation in the ticket if you want/need more context.