### PR TITLE
WT-6517 Update test_txn13 to avoid getting a rollback error

### DIFF
--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -40,13 +40,13 @@ class test_txn13(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = "100K"
     tablename = 'test_txn13'
     uri = 'table:' + tablename
-    nops = 1024
+    nops = 8
     create_params = 'key_format=i,value_format=S'
 
     scenarios = make_scenarios([
-        ('1gb', dict(expect_err=False, valuesize=1048576)),
-        ('2gb', dict(expect_err=False, valuesize=2097152)),
-        ('4gb', dict(expect_err=True, valuesize=4194304))
+        ('1gb', dict(expect_err=False, valuesize=134217728)),
+        ('2gb', dict(expect_err=False, valuesize=268435456)),
+        ('4gb', dict(expect_err=True, valuesize=536870912))
     ])
 
     # Turn on logging for this test.

--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -40,9 +40,12 @@ class test_txn13(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = "100K"
     tablename = 'test_txn13'
     uri = 'table:' + tablename
+    # We use 8 ops here to get around the 10 operation check done by WiredTiger to determine if
+    # a transaction is blocking or not.
     nops = 8
     create_params = 'key_format=i,value_format=S'
 
+    # The 1gb, 2gb and 4gb scenario names refer to the valuesize * nops.
     scenarios = make_scenarios([
         ('1gb', dict(expect_err=False, valuesize=134217728)),
         ('2gb', dict(expect_err=False, valuesize=268435456)),


### PR DESCRIPTION
So essentially if we avoid doing > 10 modifications we can prevent the rollback logic from triggering while also ensuring we keep the intention behind the test and write large log records. All I've done is taken the mod count to 8 and multiplied the value size by the same factor.