### PR TITLE
WT-5717 Reenable history store salvage test

### DIFF
--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -423,7 +423,6 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
     not_salvageable = [
         "removal:WiredTiger.turtle",
         "removal:WiredTiger.wt",
-        "removal:WiredTigerHS.wt",
         "truncate:WiredTiger.wt",
         "truncate:WiredTigerHS.wt",
         "zero:WiredTiger.wt",
@@ -546,13 +545,10 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
                 # an error during the wiredtiger_open.  But the nature of the
                 # messages produced during the error is variable by which case
                 # it is, and even variable from system to system.
-                if self.filename == "WiredTigerHS.wt":
-                    self.run_wt_and_check(salvagedir, salvagedir + '_' + errfile, salvagedir + '_' + outfile, True)
-                else:
-                    with self.expectedStdoutPattern('.'):
-                        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                            lambda: self.reopen_conn(salvagedir, salvage_config),
-                            '/.*/')
+                with self.expectedStdoutPattern('.'):
+                    self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                        lambda: self.reopen_conn(salvagedir, salvage_config),
+                        '/.*/')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -423,6 +423,7 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
     not_salvageable = [
         "removal:WiredTiger.turtle",
         "removal:WiredTiger.wt",
+        "removal:WiredTigerHS.wt",
         "truncate:WiredTiger.wt",
         "truncate:WiredTigerHS.wt",
         "zero:WiredTiger.wt",
@@ -481,7 +482,13 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
             closeconn=False)
 
         if expect_fail:
-            self.check_file_contains_one_of(errfile, ['WT_TRY_SALVAGE: database corruption detected'])
+            errmsg = 'WT_TRY_SALVAGE: database corruption detected'
+            if self.filename == 'WiredTigerHS.wt':
+                if self.kind == 'removal':
+                    errmsg = 'hs_exists'
+                elif self.kind == 'truncate':
+                    errmsg = 'file size=0, alloc size=4096'
+            self.check_file_contains_one_of(errfile, [errmsg])
 
     def test_corrupt_meta(self):
         errfile = 'list.err'
@@ -539,10 +546,13 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
                 # an error during the wiredtiger_open.  But the nature of the
                 # messages produced during the error is variable by which case
                 # it is, and even variable from system to system.
-                with self.expectedStdoutPattern('.'):
-                    self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                        lambda: self.reopen_conn(salvagedir, salvage_config),
-                        '/.*/')
+                if self.filename == "WiredTigerHS.wt":
+                    self.run_wt_and_check(salvagedir, salvagedir + '_' + errfile, salvagedir + '_' + outfile, True)
+                else:
+                    with self.expectedStdoutPattern('.'):
+                        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                            lambda: self.reopen_conn(salvagedir, salvage_config),
+                            '/.*/')
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Not sure what the intention of the test change in #5541 was but I believe that we were already testing that the history store can be salvaged. The removal of the history store from the `non_salvageable` list just means that we expect that it can be salvaged (not that it isn't tested anymore). I added back the extra checks of the history store error pattern but I believe this does the job.