### PR TITLE
WT-6514 Fix description of eviction_updates_trigger in the documentation

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -611,9 +611,9 @@ connection_runtime_config = [
         trigger application threads to perform eviction when the cache contains
         at least this many bytes of updates. It is a percentage of the cache size
         if the value is within the range of 1 to 100 or an absolute size when
-        greater than 100. Calculated as half of \c eviction_dirty_trigger by default.
+        greater than 100\. Calculated as half of \c eviction_dirty_trigger by default.
         The value is not allowed to exceed the \c cache_size. This setting only
-        alters behavior if it is lower than eviction_trigger''',
+        alters behavior if it is lower than \c eviction_trigger''',
         min=0, max='10TB'),
     Config('file_manager', '', r'''
         control how file handles are managed''',

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2259,9 +2259,9 @@ struct __wt_connection {
 	 * @config{eviction_updates_trigger, trigger application threads to perform eviction when
 	 * the cache contains at least this many bytes of updates.  It is a percentage of the cache
 	 * size if the value is within the range of 1 to 100 or an absolute size when greater than
-	 * 100. Calculated as half of \c eviction_dirty_trigger by default.  The value is not
+	 * 100\. Calculated as half of \c eviction_dirty_trigger by default.  The value is not
 	 * allowed to exceed the \c cache_size.  This setting only alters behavior if it is lower
-	 * than eviction_trigger., an integer between 0 and 10TB; default \c 0.}
+	 * than \c eviction_trigger., an integer between 0 and 10TB; default \c 0.}
 	 * @config{file_manager = (, control how file handles are managed., a set of related
 	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
@@ -2919,10 +2919,10 @@ struct __wt_connection {
  * integer between 0 and 10TB; default \c 0.}
  * @config{eviction_updates_trigger, trigger application threads to perform eviction when the cache
  * contains at least this many bytes of updates.  It is a percentage of the cache size if the value
- * is within the range of 1 to 100 or an absolute size when greater than 100. Calculated as half of
+ * is within the range of 1 to 100 or an absolute size when greater than 100\. Calculated as half of
  * \c eviction_dirty_trigger by default.  The value is not allowed to exceed the \c cache_size.
- * This setting only alters behavior if it is lower than eviction_trigger., an integer between 0 and
- * 10TB; default \c 0.}
+ * This setting only alters behavior if it is lower than \c eviction_trigger., an integer between 0
+ * and 10TB; default \c 0.}
  * @config{exclusive, fail if the database already exists\, generally used with the \c create
  * option., a boolean flag; default \c false.}
  * @config{extensions, list of shared library extensions to load (using dlopen). Any values


### PR DESCRIPTION
The formatting issue is seen externally [here](http://source.wiredtiger.com/develop/struct_w_t___c_o_n_n_e_c_t_i_o_n.html#a579141678af06217b22869cbc604c6d4), where an unintended ordered list item appears in the config parameter table for the value `eviction_updates_trigger`. The `struct_w_t___c_o_n_n_e_c_t_i_o_n.html` file is generated internally via our top-level `s_all` script. At a lower level, doxygen is used to (among other things) transform our auto-generated `wiredtiger.in` file to the html documentation. It appears that when generating `wiredtiger.in`, we created a text pattern that [doxygen interprets as an ordered list item](https://www.doxygen.nl/manual/lists.html).
```
      * size if the value is within the range of 1 to 100 or an absolute size when greater than
--->  * 100. Calculated as half of \c eviction_dirty_trigger by default.  The value is not
      * allowed to exceed the \c cache_size.  This setting only alters behavior if it is lower
```
Fortunately, [doxygen provides a solution](https://www.doxygen.nl/manual/commands.html#cmdchardot) to this: escape the dot following the number.