### PR TITLE
 WT-6331 Set oldest timestamp on startup of WiredTiger

### DIFF
--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -33,8 +33,11 @@
 #define WT_HS_FILE "WiredTigerHS.wt"     /* History store table */
 #define WT_HS_URI "file:WiredTigerHS.wt" /* History store table URI */
 
-#define WT_SYSTEM_PREFIX "system:"             /* System URI prefix */
-#define WT_SYSTEM_CKPT_URI "system:checkpoint" /* Checkpoint URI */
+#define WT_SYSTEM_PREFIX "system:"               /* System URI prefix */
+#define WT_SYSTEM_CKPT_TS "checkpoint_timestamp" /* Checkpoint timestamp name */
+#define WT_SYSTEM_CKPT_URI "system:checkpoint"   /* Checkpoint timestamp URI */
+#define WT_SYSTEM_OLDEST_TS "oldest_timestamp"   /* Oldest timestamp name */
+#define WT_SYSTEM_OLDEST_URI "system:oldest"     /* Oldest timestamp URI */
 
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference the metadata file.

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -166,10 +166,11 @@ struct __wt_txn_global {
      * We rely on the fact that (a) the only table a checkpoint updates is the metadata; and (b)
      * once checkpoint has finished reading a table, it won't revisit it.
      */
-    volatile bool checkpoint_running;    /* Checkpoint running */
-    volatile uint32_t checkpoint_id;     /* Checkpoint's session ID */
-    WT_TXN_SHARED checkpoint_txn_shared; /* Checkpoint's txn shared state */
-    wt_timestamp_t checkpoint_timestamp; /* Checkpoint's timestamp */
+    volatile bool checkpoint_running;           /* Checkpoint running */
+    volatile uint32_t checkpoint_id;            /* Checkpoint's session ID */
+    WT_TXN_SHARED checkpoint_txn_shared;        /* Checkpoint's txn shared state */
+    wt_timestamp_t checkpoint_timestamp;        /* Checkpoint's timestamp */
+    wt_timestamp_t checkpoint_oldest_timestamp; /* The oldest timestamp at the time of checkpoint */
 
     volatile uint64_t debug_ops;       /* Debug mode op counter */
     uint64_t debug_rollback;           /* Debug mode rollback */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -917,12 +917,9 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
 {
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    char hex_timestamp[2 * sizeof(wt_timestamp_t) + 2];
+    char hex_timestamp[WT_TS_HEX_STRING_SIZE];
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
-    hex_timestamp[0] = '0';
-    hex_timestamp[1] = '\0';
-
     /*
      * We need to record the timestamp of the checkpoint in the metadata. The timestamp value is set
      * at a higher level, either in checkpoint or in recovery.
@@ -937,8 +934,18 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session)
     if (strcmp(hex_timestamp, "0") == 0)
         WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, WT_SYSTEM_CKPT_URI), false);
     else {
-        WT_ERR(__wt_buf_catfmt(session, buf, "checkpoint_timestamp=\"%s\"", hex_timestamp));
+        WT_ERR(__wt_buf_fmt(session, buf, WT_SYSTEM_CKPT_TS "=\"%s\"", hex_timestamp));
         WT_ERR(__wt_metadata_update(session, WT_SYSTEM_CKPT_URI, buf->data));
+    }
+
+    /* We also need to record the oldest timestamp in the metadata so we can set it on startup. */
+    __wt_timestamp_to_hex_string(
+      S2C(session)->txn_global.checkpoint_oldest_timestamp, hex_timestamp);
+    if (strcmp(hex_timestamp, "0") == 0)
+        WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, WT_SYSTEM_OLDEST_URI), false);
+    else {
+        WT_ERR(__wt_buf_fmt(session, buf, WT_SYSTEM_OLDEST_TS "=\"%s\"", hex_timestamp));
+        WT_ERR(__wt_metadata_update(session, WT_SYSTEM_OLDEST_URI, buf->data));
     }
 
 err:

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -616,6 +616,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
                 txn_global->meta_ckpt_timestamp = txn_global->checkpoint_timestamp;
         } else if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = txn_global->recovery_timestamp;
+        txn_global->checkpoint_oldest_timestamp =
+          txn_global->has_oldest_timestamp ? txn_global->oldest_timestamp : WT_TS_NONE;
     } else {
         if (!F_ISSET(conn, WT_CONN_RECOVERING))
             txn_global->meta_ckpt_timestamp = WT_TS_NONE;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -350,20 +350,50 @@ __txn_log_recover(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *lsnp, WT_LS
 }
 
 /*
+ * __recovery_retrieve_timestamp --
+ *     Retrieve a timestamp from the metadata.
+ */
+static int
+__recovery_retrieve_timestamp(
+  WT_RECOVERY *r, const char *system_uri, const char *timestamp_name, wt_timestamp_t *timestampp)
+{
+    WT_CONFIG_ITEM cval;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    char *sys_config;
+
+    sys_config = NULL;
+
+    session = r->session;
+
+    /* Search the metadata for the system information. */
+    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, system_uri, &sys_config), false);
+    if (sys_config != NULL) {
+        WT_CLEAR(cval);
+        WT_ERR_NOTFOUND_OK(__wt_config_getones(session, sys_config, timestamp_name, &cval), false);
+        if (cval.len != 0) {
+            __wt_verbose(session, WT_VERB_RECOVERY, "Recovery %s %.*s", timestamp_name,
+              (int)cval.len, cval.str);
+            WT_ERR(__wt_txn_parse_timestamp_raw(session, timestamp_name, timestampp, &cval));
+        }
+    }
+
+err:
+    __wt_free(session, sys_config);
+    return (ret);
+}
+
+/*
  * __recovery_set_checkpoint_timestamp --
  *     Set the checkpoint timestamp as retrieved from the metadata file.
  */
 static int
 __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
 {
-    WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
     WT_SESSION_IMPL *session;
     wt_timestamp_t ckpt_timestamp;
-    char ts_string[WT_TS_INT_STRING_SIZE], *sys_config;
-
-    sys_config = NULL;
+    char ts_string[WT_TS_INT_STRING_SIZE];
 
     session = r->session;
     conn = S2C(session);
@@ -373,18 +403,8 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
      */
     ckpt_timestamp = 0;
 
-    /* Search in the metadata for the system information. */
-    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, WT_SYSTEM_CKPT_URI, &sys_config), false);
-    if (sys_config != NULL) {
-        WT_CLEAR(cval);
-        WT_ERR_NOTFOUND_OK(
-          __wt_config_getones(session, sys_config, "checkpoint_timestamp", &cval), false);
-        if (cval.len != 0) {
-            __wt_verbose(
-              session, WT_VERB_RECOVERY, "Recovery timestamp %.*s", (int)cval.len, cval.str);
-            WT_ERR(__wt_txn_parse_timestamp_raw(session, "recovery", &ckpt_timestamp, &cval));
-        }
-    }
+    WT_RET(
+      __recovery_retrieve_timestamp(r, WT_SYSTEM_CKPT_URI, WT_SYSTEM_CKPT_TS, &ckpt_timestamp));
 
     /*
      * Set the recovery checkpoint timestamp and the metadata checkpoint timestamp so that the
@@ -396,9 +416,39 @@ __recovery_set_checkpoint_timestamp(WT_RECOVERY *r)
       "Set global recovery timestamp: %s",
       __wt_timestamp_to_string(conn->txn_global.recovery_timestamp, ts_string));
 
-err:
-    __wt_free(session, sys_config);
-    return (ret);
+    return (0);
+}
+
+/*
+ * __recovery_set_oldest_timestamp --
+ *     Set the oldest timestamp as retrieved from the metadata file.
+ */
+static int
+__recovery_set_oldest_timestamp(WT_RECOVERY *r)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_SESSION_IMPL *session;
+    wt_timestamp_t oldest_timestamp;
+    char ts_string[WT_TS_INT_STRING_SIZE];
+
+    session = r->session;
+    conn = S2C(session);
+    /*
+     * Read the system checkpoint information from the metadata file and save the oldest timestamp
+     * of the last checkpoint for later query. This gets saved in the connection.
+     */
+    oldest_timestamp = 0;
+
+    WT_RET(__recovery_retrieve_timestamp(
+      r, WT_SYSTEM_OLDEST_URI, WT_SYSTEM_OLDEST_TS, &oldest_timestamp));
+    conn->txn_global.oldest_timestamp = oldest_timestamp;
+    conn->txn_global.has_oldest_timestamp = oldest_timestamp != WT_TS_NONE;
+
+    __wt_verbose(session, WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS,
+      "Set global oldest timestamp: %s",
+      __wt_timestamp_to_string(conn->txn_global.oldest_timestamp, ts_string));
+
+    return (0);
 }
 
 /*
@@ -768,7 +818,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
 
 done:
     WT_ERR(__recovery_set_checkpoint_timestamp(&r));
-
+    WT_ERR(__recovery_set_oldest_timestamp(&r));
     /*
      * Perform rollback to stable only when the following conditions met.
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
@@ -797,11 +847,8 @@ done:
          * written. The rollback to stable operation should only rollback the latest page changes
          * solely based on the write generation numbers.
          */
-
         WT_ASSERT(session, conn->txn_global.has_stable_timestamp == false &&
             conn->txn_global.stable_timestamp == WT_TS_NONE);
-        WT_ASSERT(session, conn->txn_global.has_oldest_timestamp == false &&
-            conn->txn_global.oldest_timestamp == WT_TS_NONE);
 
         /*
          * Set the stable timestamp from recovery timestamp and process the trees for rollback to
@@ -810,12 +857,6 @@ done:
         conn->txn_global.stable_timestamp = conn->txn_global.recovery_timestamp;
         conn->txn_global.has_stable_timestamp = true;
 
-        /*
-         * Set the oldest timestamp to WT_TS_NONE to make sure that we didn't remove any history
-         * window as part of rollback to stable operation.
-         */
-        conn->txn_global.oldest_timestamp = WT_TS_NONE;
-        conn->txn_global.has_oldest_timestamp = true;
         __wt_verbose(session, WT_VERB_RTS,
           "Performing recovery rollback_to_stable with stable timestamp: %s and oldest timestamp: "
           "%s",
@@ -823,10 +864,6 @@ done:
           __wt_timestamp_to_string(conn->txn_global.oldest_timestamp, ts_string[1]));
 
         WT_ERR(__wt_rollback_to_stable(session, NULL, false));
-
-        /* Reset the oldest timestamp. */
-        conn->txn_global.oldest_timestamp = WT_TS_NONE;
-        conn->txn_global.has_oldest_timestamp = false;
     } else if (do_checkpoint)
         /*
          * Forcibly log a checkpoint so the next open is fast and keep the metadata up to date with

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -402,6 +402,7 @@ void operations(u_int, bool);
 void path_setup(const char *);
 void set_alarm(u_int);
 void set_core_off(void);
+void set_oldest_timestamp(void);
 void snap_init(TINFO *);
 void snap_teardown(TINFO *);
 void snap_op_init(TINFO *, uint64_t, bool);

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -269,6 +269,7 @@ main(int argc, char *argv[])
         if (g.reopen) {
             config_final();
             wts_open(g.home, &g.wts_conn, &g.wts_session, true);
+            set_oldest_timestamp();
         } else {
             wts_create(g.home);
             config_final();

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -376,7 +376,7 @@ set_oldest_timestamp(void)
 
     if ((ret = conn->query_timestamp(conn, tsbuf, "get=oldest")) == 0) {
         timestamp_parse(NULL, tsbuf, &oldest_ts);
-        g.oldest_timestamp = oldest_ts;
+        g.timestamp = oldest_ts;
         testutil_check(
           __wt_snprintf(buf, sizeof(buf), "%s%" PRIx64, oldest_timestamp_str, g.oldest_timestamp));
     } else

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -378,7 +378,14 @@ set_oldest_timestamp(void)
         g.timestamp = oldest_ts;
         testutil_check(
           __wt_snprintf(buf, sizeof(buf), "%s%" PRIx64, oldest_timestamp_str, g.oldest_timestamp));
-    } else
+    } else if (ret != WT_NOTFOUND)
+        /*
+         * Its possible there may not be an oldest timestamp as such we could get not found. This
+         * should be okay assuming timestamps are not configured if they are, it's still okay as we
+         * could have configured timestamps after not running with timestamps. As such only error if
+         * we get a non not found error. If we were supposed to fail with not found we'll see an
+         * error later on anyway.
+         */
         testutil_die(ret, "unable to query oldest timestamp");
 }
 

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -303,7 +303,8 @@ timestamp_parse(WT_SESSION *session, const char *str, uint64_t *tsp)
     char *p;
 
     *tsp = strtoull(str, &p, 16);
-    WT_ASSERT((WT_SESSION_IMPL *)session, p - str <= 16);
+    if (session != NULL)
+        WT_ASSERT((WT_SESSION_IMPL *)session, p - str <= 16);
 }
 
 /*
@@ -353,6 +354,33 @@ timestamp(void *arg)
 
     testutil_check(session->close(session, NULL));
     return (WT_THREAD_RET_VALUE);
+}
+
+
+/*
+ * set_oldest_timestamp --
+ *     Query the oldest timestamp from wiredtiger and set it as our global oldest timestamp. This should
+ *     only be called on runs for pre existing databases.
+ */
+void
+set_oldest_timestamp(void)
+{
+    static const char *oldest_timestamp_str = "oldest_timestamp=";
+
+    WT_CONNECTION *conn;
+    WT_DECL_RET;
+    uint64_t oldest_ts;
+    char buf[WT_TS_HEX_STRING_SIZE * 2 + 64], tsbuf[WT_TS_HEX_STRING_SIZE];
+
+    conn = g.wts_conn;
+
+    if ((ret = conn->query_timestamp(conn, tsbuf, "get=oldest")) == 0) {
+        timestamp_parse(NULL, tsbuf, &oldest_ts);
+        g.oldest_timestamp = oldest_ts;
+        testutil_check(
+          __wt_snprintf(buf, sizeof(buf), "%s%" PRIx64, oldest_timestamp_str, g.oldest_timestamp));
+    } else
+        testutil_die(ret, "unable to query oldest timestamp");
 }
 
 /*

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -356,11 +356,10 @@ timestamp(void *arg)
     return (WT_THREAD_RET_VALUE);
 }
 
-
 /*
  * set_oldest_timestamp --
- *     Query the oldest timestamp from wiredtiger and set it as our global oldest timestamp. This should
- *     only be called on runs for pre existing databases.
+ *     Query the oldest timestamp from wiredtiger and set it as our global oldest timestamp. This
+ *     should only be called on runs for pre existing databases.
  */
 void
 set_oldest_timestamp(void)

--- a/test/suite/test_timestamp19.py
+++ b/test/suite/test_timestamp19.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_timestamp19.py
+# Use the oldest timestamp in the metadata as the oldest timestamp on restart.
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_timestamp19(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def updates(self, uri, value, ds, nrows, commit_ts):
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor[ds.key(i)] = value
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        cursor.close()
+
+    def test_timestamp(self):
+        uri = "table:test_timestamp19"
+        create_params = 'value_format=S,key_format=i'
+        self.session.create(uri, create_params)
+
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        nrows = 1000
+        value_x = 'x' * 1000
+        value_y = 'y' * 1000
+        value_z = 'z' * 1000
+
+        # Set the oldest and stable timestamps to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+          ', stable_timestamp=' + timestamp_str(10))
+
+        # Insert values with varying timestamps.
+        self.updates(uri, value_x, ds, nrows, 20)
+        self.updates(uri, value_y, ds, nrows, 30)
+        self.updates(uri, value_z, ds, nrows, 40)
+
+        # Perform a checkpoint.
+        self.session.checkpoint('use_timestamp=true')
+
+        # Move the oldest and stable timestamps to 40.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(40) +
+          ', stable_timestamp=' + timestamp_str(40))
+
+        # Update values.
+        self.updates(uri, value_z, ds, nrows, 50)
+        self.updates(uri, value_x, ds, nrows, 60)
+        self.updates(uri, value_y, ds, nrows, 70)
+
+        # Perform a checkpoint.
+        self.session.checkpoint('use_timestamp=true')
+
+        # Close and reopen the connection.
+        self.close_conn()
+        self.conn = self.setUpConnectionOpen('.')
+        self.session = self.setUpSessionOpen(self.conn)
+
+        # The oldest timestamp on recovery is 40. Trying to set it earlier is a no-op.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), timestamp_str(40))
+
+        # Trying to set an earlier stable timestamp is an error.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10)),
+            '/oldest timestamp \(0, 40\) must not be later than stable timestamp \(0, 10\)/')
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), timestamp_str(40))
+
+        # Move the oldest and stable timestamps to 70.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(70) +
+          ', stable_timestamp=' + timestamp_str(70))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), timestamp_str(70))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), timestamp_str(70))
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Fixed the issue that test format had when it reopened a previously existing database.

New changes are in:
t.c, util.c and format.h