### PR TITLE
WT-6543 Adding task execution number to name of Artifacts uploaded to S3 (2nd attempt)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1950,7 +1950,7 @@ tasks:
           permissions: public-read
           content_type: text/html
           display_name: Coverage report
-          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report/coverage_report_${build_id}_${execution}.html
+          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report/coverage_report_${build_id}-${execution}.html
 
   - name: spinlock-gcc-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -13,7 +13,7 @@ functions:
     params:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
-      remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${dependent_task|compile}_${build_id}_${execution}.tgz
+      remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${dependent_task|compile}_${build_id}.tgz
       bucket: build_external
       extract_to: wiredtiger
   "fetch artifacts from little-endian" :
@@ -262,7 +262,7 @@ functions:
         permissions: public-read
         content_type: application/tar
         display_name: Artifacts
-        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}_${execution}.tgz
+        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}${postfix|}.tgz
   "cleanup":
     command: shell.exec
     params:
@@ -394,6 +394,8 @@ pre:
   - func: "cleanup"
 post:
   - func: "upload artifact"
+    vars:
+      postfix: -${execution}
   - func: "cleanup"
 
 tasks:
@@ -403,6 +405,8 @@ tasks:
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-asan
     tags: ["pull_request"]
@@ -412,6 +416,8 @@ tasks:
         vars:
           configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-fsanitize=address -fno-omit-frame-pointer -ggdb"
           posix_configure_flags: --enable-silent-rules --enable-strict --enable-diagnostic --disable-static
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-msan
     commands:
@@ -420,6 +426,8 @@ tasks:
         vars:
           configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-fsanitize=memory -ggdb"
           posix_configure_flags: --enable-silent-rules --enable-strict --enable-diagnostic --disable-static
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-ubsan
     commands:
@@ -428,6 +436,8 @@ tasks:
         vars:
           configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-fsanitize=undefined -ggdb"
           posix_configure_flags: --enable-silent-rules --enable-strict --enable-diagnostic
+      - func: "upload artifact"
+      - func: "cleanup"
 
   # production build with --disable-shared
   - name: compile-production-disable-shared
@@ -437,6 +447,8 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           posix_configure_flags: --enable-silent-rules --enable-strict --disable-shared
+      - func: "upload artifact"
+      - func: "cleanup"
 
   # production build with --disable-static
   - name: compile-production-disable-static
@@ -446,6 +458,8 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           posix_configure_flags: --enable-silent-rules --enable-strict --disable-static --enable-lz4 --enable-snappy --enable-zlib --enable-zstd --enable-python
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-linux-no-ftruncate
     commands:
@@ -453,6 +467,8 @@ tasks:
       - func: "compile wiredtiger no linux ftruncate"
         vars:
           posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-strict --enable-python
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-wtperf
     commands:
@@ -460,6 +476,8 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           posix_configure_flags: --enable-strict --enable-diagnostic
+      - func: "upload artifact"
+      - func: "cleanup"
 
   - name: compile-gcc
     tags: ["pull_request", "pull_request_compilers"]
@@ -770,6 +788,8 @@ tasks:
       - name: compile-ubsan
     commands:
       - func: "fetch artifacts"
+        vars:
+          dependent_task: compile-ubsan
       - func: "compile wiredtiger"
         vars:
           configure_env_vars: CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-fsanitize=undefined -ggdb"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -13,7 +13,7 @@ functions:
     params:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
-      remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${dependent_task|compile}_${build_id}.tgz
+      remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${dependent_task|compile}_${build_id}_${execution}.tgz
       bucket: build_external
       extract_to: wiredtiger
   "fetch artifacts from little-endian" :
@@ -262,7 +262,7 @@ functions:
         permissions: public-read
         content_type: application/tar
         display_name: Artifacts
-        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}.tgz
+        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}_${execution}.tgz
   "cleanup":
     command: shell.exec
     params:
@@ -1930,7 +1930,7 @@ tasks:
           permissions: public-read
           content_type: text/html
           display_name: Coverage report
-          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report/coverage_report_${build_id}.html
+          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report/coverage_report_${build_id}_${execution}.html
 
   - name: spinlock-gcc-test
     commands:
@@ -2337,7 +2337,7 @@ buildvariants:
     - name: make-check-asan-test
     - name: configure-combinations
     - name: checkpoint-filetypes-test
-    # - name: coverage-report
+    - name: coverage-report
     - name: unit-test-long
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2337,7 +2337,7 @@ buildvariants:
     - name: make-check-asan-test
     - name: configure-combinations
     - name: checkpoint-filetypes-test
-    - name: coverage-report
+    # - name: coverage-report
     - name: unit-test-long
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test


### PR DESCRIPTION
#5914 was reverted due to fallout on the Evergreen waterfall page. Will use this PR for further changes/fixes.

The fallout was because some testing tasks restarted, and in those newer executions the tests tried to retrieve artifacts of the dependant compile task, using their own execution number 1, however, the compile task was never restarted and only had the artifacts with execution number 0 uploaded. That caused artifacts retrieval (and task) failures.

To resolve this issue, the new design is to avoid distinguishing artifacts using task execution number for compile tasks, and let all testing tasks to retrieve compile artifacts without the execution number. For testing tasks, the artifacts will still be distinguished across task restarts, to provide users the flexibility to check into them when needed.

Below testing were covered in a patch build:
- Verify multiple executions of compile tasks generate the same S3 URL for artifacts
- Verify multiple executions of testing tasks generate different S3 URLs for artifacts (distinguished by execution number)
- Verify the 1st executions of testing tasks are able to retrieve artifacts from the 1st execution of relevant compile tasks
- Verify the 2nd executions of testing tasks are able to retrieve artifacts from the 1st execution of relevant compile tasks
- Verify the 2nd executions of testing tasks are able to retrieve artifacts from the 2nd execution of relevant compile tasks