### PR TITLE
WT-5242 Minimize checkpoints pinned during backup (v4.0 backport)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1380,8 +1380,9 @@ methods = {
         including the named checkpoint, or
         \c "to=<checkpoint>" to drop all checkpoints before and
         including the named checkpoint.  Checkpoints cannot be
-        dropped while a hot backup is in progress or if open in
-        a cursor''', type='list'),
+        dropped if open in a cursor.  While a hot backup is in
+        progress, checkpoints created prior to the start of the
+        backup cannot be dropped''', type='list'),
     Config('force', 'false', r'''
         if false (the default), checkpoints may be skipped if the underlying object has not been
         modified, if true, this option forces the checkpoint''',

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -41,9 +41,9 @@ __wt_block_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t len)
      * backups, stops all block truncation unnecessarily). We may want a
      * more targeted solution at some point.
      */
-    if (!conn->hot_backup) {
+    if (conn->hot_backup_start == 0) {
         __wt_readlock(session, &conn->hot_backup_lock);
-        if (!conn->hot_backup)
+        if (conn->hot_backup_start == 0)
             ret = __wt_ftruncate(session, block->fh, len);
         __wt_readunlock(session, &conn->hot_backup_lock);
     }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -171,7 +171,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         goto done;
 
     /* Get a list of the checkpoints for this file. */
-    WT_ERR(__wt_meta_ckptlist_get(session, btree->dhandle->name, &ckptbase));
+    WT_ERR(__wt_meta_ckptlist_get(session, btree->dhandle->name, false, &ckptbase));
 
     /* Inform the underlying block manager we're verifying. */
     WT_ERR(bm->verify_start(bm, session, ckptbase, cfg));

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -377,7 +377,7 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
      */
     __wt_readlock(session, &conn->hot_backup_lock);
     locked = true;
-    if (!conn->hot_backup || backup_file != 0) {
+    if (conn->hot_backup_start == 0 || backup_file != 0) {
         for (i = 0; i < logcount; i++) {
             WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
             if (lognum < min_lognum)
@@ -560,9 +560,9 @@ __log_file_server(void *arg)
                  * file system may not support truncate: both are OK, it's just more work during
                  * cursor traversal.
                  */
-                if (!conn->hot_backup) {
+                if (conn->hot_backup_start == 0) {
                     __wt_readlock(session, &conn->hot_backup_lock);
-                    if (!conn->hot_backup && conn->log_cursors == 0)
+                    if (conn->hot_backup_start == 0 && conn->log_cursors == 0)
                         WT_ERR_ERROR_OK(
                           __wt_ftruncate(session, close_fh, close_end_lsn.l.offset), ENOTSUP);
                     __wt_readunlock(session, &conn->hot_backup_lock);
@@ -894,7 +894,7 @@ __log_server(void *arg)
                  * have agreed not to rename or remove any files in the database directory.
                  */
                 __wt_readlock(session, &conn->hot_backup_lock);
-                if (!conn->hot_backup)
+                if (conn->hot_backup_start == 0)
                     ret = __log_prealloc_once(session);
                 __wt_readunlock(session, &conn->hot_backup_lock);
                 WT_ERR(ret);

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -16,7 +16,7 @@ int
 __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
 {
     WT_SESSION_IMPL *session;
-    time_t finish_secs;
+    time_t most_recent;
 
     /* Default session. */
     session = conn->default_session;
@@ -40,8 +40,8 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
      */
     conn->default_session = session;
 
-    __wt_seconds(session, &finish_secs);
-    conn->ckpt_finish_secs = finish_secs;
+    __wt_seconds(session, &most_recent);
+    conn->ckpt_most_recent = most_recent;
 
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -16,6 +16,7 @@ int
 __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
 {
     WT_SESSION_IMPL *session;
+    time_t finish_secs;
 
     /* Default session. */
     session = conn->default_session;
@@ -38,6 +39,9 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
      * allocate into a stack variable and then assign it on success.
      */
     conn->default_session = session;
+
+    __wt_seconds(session, &finish_secs);
+    conn->ckpt_finish_secs = finish_secs;
 
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -41,7 +41,7 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
     conn->default_session = session;
 
     __wt_seconds(session, &most_recent);
-    conn->ckpt_most_recent = most_recent;
+    conn->ckpt_most_recent = (uint64_t)most_recent;
 
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -234,7 +234,7 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
      * Single thread hot backups: we're holding the schema lock, so we know we'll serialize with
      * other attempts to start a hot backup.
      */
-    if (conn->hot_backup && !is_dup)
+    if (conn->hot_backup_start != 0 && !is_dup)
         WT_RET_MSG(session, EINVAL, "there is already a backup cursor open");
 
     if (F_ISSET(session, WT_SESSION_BACKUP_DUP) && is_dup)
@@ -258,7 +258,7 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
          * complete and valid.
          */
         __wt_writelock(session, &conn->hot_backup_lock);
-        conn->hot_backup = true;
+        conn->hot_backup_start = conn->ckpt_finish_secs;
         conn->hot_backup_list = NULL;
         __wt_writeunlock(session, &conn->hot_backup_lock);
 
@@ -392,7 +392,7 @@ __backup_stop(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
 
     /* Checkpoint deletion and next hot backup can proceed. */
     __wt_writelock(session, &conn->hot_backup_lock);
-    conn->hot_backup = false;
+    conn->hot_backup_start = 0;
     __wt_writeunlock(session, &conn->hot_backup_lock);
     F_CLR(session, WT_SESSION_BACKUP_CURSOR);
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -258,7 +258,7 @@ __backup_start(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, bool is_dup, cons
          * complete and valid.
          */
         __wt_writelock(session, &conn->hot_backup_lock);
-        conn->hot_backup_start = conn->ckpt_finish_secs;
+        conn->hot_backup_start = conn->ckpt_most_recent;
         conn->hot_backup_list = NULL;
         __wt_writeunlock(session, &conn->hot_backup_lock);
 

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -56,10 +56,9 @@ aggregate the file names from the cursor and then list the file names as
 arguments to a file archiver such as the system tar utility.
 
 During the period the backup cursor is open, database checkpoints can
-be created, but no checkpoints can be deleted.  This may result in
-significant file growth.  Additionally while the backup cursor is open
-automatic log file archiving, even if enabled, will not reclaim any
-log files.
+be created, but checkpoints created prior to the backup cursor cannot
+be deleted. Additionally while the backup cursor is open automatic log
+file archiving, even if enabled, will not reclaim any log files.
 
 Additionally, if a crash occurs during the period the backup cursor is
 open and logging is disabled (in other words, when depending on

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -260,7 +260,7 @@ struct __wt_connection_impl {
     wt_thread_t ckpt_tid;          /* Checkpoint thread */
     bool ckpt_tid_set;             /* Checkpoint thread set */
     WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
-    uint64_t ckpt_finish_secs;     /* Clock value of last completed checkpoint */
+    uint64_t ckpt_most_recent;     /* Clock value of most recent checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -253,13 +253,14 @@ struct __wt_connection_impl {
     WT_TXN_GLOBAL txn_global; /* Global transaction state */
 
     WT_RWLOCK hot_backup_lock; /* Hot backup serialization */
-    bool hot_backup;           /* Hot backup in progress */
+    uint64_t hot_backup_start; /* Clock value of most recent checkpoint needed by hot backup */
     char **hot_backup_list;    /* Hot backup file list */
 
     WT_SESSION_IMPL *ckpt_session; /* Checkpoint thread session */
     wt_thread_t ckpt_tid;          /* Checkpoint thread */
     bool ckpt_tid_set;             /* Checkpoint thread set */
     WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
+    uint64_t ckpt_finish_secs;     /* Clock value of last completed checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -997,8 +997,8 @@ extern int __wt_meta_checkpoint_last_name(WT_SESSION_IMPL *session, const char *
   const char **namep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_checkpoint_clear(WT_SESSION_IMPL *session, const char *fname)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, WT_CKPT **ckptbasep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, bool update,
+  WT_CKPT **ckptbasep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_ckptlist_set(WT_SESSION_IMPL *session, const char *fname, WT_CKPT *ckptbase,
   WT_LSN *ckptlsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __wt_meta_ckptlist_free(WT_SESSION_IMPL *session, WT_CKPT **ckptbasep);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1853,8 +1853,9 @@ struct __wt_session {
 	 * one of the following keys: \c "from=all" to drop all checkpoints\, \c "from=<checkpoint>"
 	 * to drop all checkpoints after and including the named checkpoint\, or \c
 	 * "to=<checkpoint>" to drop all checkpoints before and including the named checkpoint.
-	 * Checkpoints cannot be dropped while a hot backup is in progress or if open in a cursor.,
-	 * a list of strings; default empty.}
+	 * Checkpoints cannot be dropped if open in a cursor.  While a hot backup is in progress\,
+	 * checkpoints created prior to the start of the backup cannot be dropped., a list of
+	 * strings; default empty.}
 	 * @config{force, if false (the default)\, checkpoints may be skipped if the underlying
 	 * object has not been modified\, if true\, this option forces the checkpoint., a boolean
 	 * flag; default \c false.}

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -698,7 +698,7 @@ __wt_lsm_free_chunks(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
          * prevents us from removing a file that hot backup already
          * knows about.
          */
-        if (S2C(session)->hot_backup)
+        if (S2C(session)->hot_backup_start != 0)
             break;
 
         /*

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -264,6 +264,7 @@ __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, WT_CKPT **ck
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
     size_t allocated, slot;
+    uint64_t most_recent;
     char *config;
 
     *ckptbasep = NULL;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -256,20 +256,24 @@ __ckpt_compare_order(const void *a, const void *b)
  *     Load all available checkpoint information for a file.
  */
 int
-__wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, WT_CKPT **ckptbasep)
+__wt_meta_ckptlist_get(
+  WT_SESSION_IMPL *session, const char *fname, bool update, WT_CKPT **ckptbasep)
 {
     WT_CKPT *ckpt, *ckptbase;
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM k, v;
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
     size_t allocated, slot;
+    time_t secs;
     uint64_t most_recent;
     char *config;
 
     *ckptbasep = NULL;
 
     ckptbase = NULL;
+    conn = S2C(session);
     allocated = slot = 0;
     config = NULL;
 
@@ -302,6 +306,27 @@ __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, WT_CKPT **ck
 
     /* Sort in creation-order. */
     __wt_qsort(ckptbase, slot, sizeof(WT_CKPT), __ckpt_compare_order);
+
+    if (update) {
+        /*
+         * We're updating the time value here instead of in the "set" helper because this needs to
+         * happen first in order to figure out what checkpoints we can safely remove.
+         */
+        ckpt = &ckptbase[slot];
+        __wt_seconds(session, &secs);
+        ckpt->sec = (uint64_t)secs;
+        /*
+         * Update time value for most recent checkpoint, not letting it move backwards. It is
+         * possible to race here, so use atomic CAS. This code relies on the fact that anyone we
+         * race with will only increase (never decrease) the most recent checkpoint time value.
+         */
+        for (;;) {
+            WT_ORDERED_READ(most_recent, conn->ckpt_most_recent);
+            if (ckpt->sec <= most_recent ||
+              __wt_atomic_cas64(&conn->ckpt_most_recent, most_recent, ckpt->sec))
+                break;
+        }
+    }
 
     /* Return the array to our caller. */
     *ckptbasep = ckptbase;
@@ -381,7 +406,6 @@ __wt_meta_ckptlist_set(
     WT_CKPT *ckpt;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    time_t secs;
     int64_t maxorder;
     const char *sep;
     bool has_lsn;
@@ -420,13 +444,6 @@ __wt_meta_ckptlist_set(
             /* Set the order and timestamp. */
             if (F_ISSET(ckpt, WT_CKPT_ADD))
                 ckpt->order = ++maxorder;
-
-            /*
-             * XXX Assumes a time_t fits into a uintmax_t, which isn't guaranteed, a time_t has to
-             * be an arithmetic type, but not an integral type.
-             */
-            __wt_seconds(session, &secs);
-            ckpt->sec = (uintmax_t)secs;
         }
         if (strcmp(ckpt->name, WT_CHECKPOINT) == 0)
             WT_ERR(__wt_buf_catfmt(session, buf,

--- a/src/meta/meta_ext.c
+++ b/src/meta/meta_ext.c
@@ -88,7 +88,7 @@ int
 __wt_metadata_get_ckptlist(WT_SESSION *session, const char *name, WT_CKPT **ckptbasep)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    return (__wt_meta_ckptlist_get((WT_SESSION_IMPL *)session, name, ckptbasep));
+    return (__wt_meta_ckptlist_get((WT_SESSION_IMPL *)session, name, false, ckptbasep));
 }
 
 /*

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -23,14 +23,14 @@ __wt_schema_backup_check(WT_SESSION_IMPL *session, const char *name)
     char **backup_list;
 
     conn = S2C(session);
-    if (!conn->hot_backup)
+    if (conn->hot_backup_start == 0)
         return (0);
     __wt_readlock(session, &conn->hot_backup_lock);
     /*
      * There is a window at the end of a backup where the list has been cleared from the connection
      * but the flag is still set. It is safe to drop at that point.
      */
-    if (!conn->hot_backup || (backup_list = conn->hot_backup_list) == NULL) {
+    if (conn->hot_backup_start == 0 || (backup_list = conn->hot_backup_list) == NULL) {
         __wt_readunlock(session, &conn->hot_backup_lock);
         return (0);
     }

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1253,7 +1253,7 @@ __checkpoint_lock_dirty_tree(
     WT_ASSERT(session, !need_tracking || WT_IS_METADATA(dhandle) || WT_META_TRACKING(session));
 
     /* Get the list of checkpoints for this file. */
-    WT_RET(__wt_meta_ckptlist_get(session, dhandle->name, &ckptbase));
+    WT_RET(__wt_meta_ckptlist_get(session, dhandle->name, true, &ckptbase));
 
     /* This may be a named checkpoint, check the configuration. */
     cval.len = 0;
@@ -1319,19 +1319,12 @@ __checkpoint_lock_dirty_tree(
             continue;
         is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
 
-/*
- * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have been
- * created before the backup started. Fail if trying to delete any other named checkpoint.
- */
-#ifdef DISABLED_CODE
-        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
-#else
         /*
-         * N.B. Despite the comment above, dropping checkpoints during backup can corrupt the
-         * backup. For now we retain all WiredTiger checkpoints.
+         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
+         * been created before the backup started. Fail if trying to delete any other named
+         * checkpoint.
          */
-        if (conn->hot_backup_start != 0) {
-#endif
+        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
             if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -740,6 +740,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_ISOLATION saved_isolation;
     wt_timestamp_t ckpt_tmp_ts;
+    time_t finish_secs;
     uint64_t fsync_duration_usecs, generation, time_start, time_stop;
     u_int i;
     bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
@@ -961,6 +962,16 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
                 conn->txn_global.last_ckpt_timestamp = conn->txn_global.recovery_timestamp;
         } else
             conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
+
+        /*
+         * Save clock value marking end of checkpoint processing. If a hot backup starts before the
+         * next checkpoint, we will need to keep all checkpoints up to this clock value until the
+         * backup completes.
+         */
+        __wt_seconds(session, &finish_secs);
+        /* Be defensive: time is only monotonic per session */
+        if (finish_secs > conn->ckpt_finish_secs)
+            conn->ckpt_finish_secs = finish_secs;
     }
 
 err:
@@ -1127,7 +1138,6 @@ static void
 __drop(WT_CKPT *ckptbase, const char *name, size_t len)
 {
     WT_CKPT *ckpt;
-    u_int max_ckpt_drop;
 
     /*
      * If we're dropping internal checkpoints, match to the '.' separating the checkpoint name from
@@ -1136,20 +1146,9 @@ __drop(WT_CKPT *ckptbase, const char *name, size_t len)
      * it's one we want to drop.
      */
     if (strncmp(WT_CHECKPOINT, name, len) == 0) {
-        /*
-         * Currently, hot backup cursors block checkpoint drop, which means releasing a hot backup
-         * cursor can result in immediately attempting to drop lots of checkpoints, which involves a
-         * fair amount of work while holding locks. Limit the number of standard checkpoints dropped
-         * per checkpoint.
-         */
-        max_ckpt_drop = 0;
         WT_CKPT_FOREACH (ckptbase, ckpt)
-            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT))
                 F_SET(ckpt, WT_CKPT_DELETE);
-#define WT_MAX_CHECKPOINT_DROP 4
-                if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
-                    break;
-            }
     } else
         WT_CKPT_FOREACH (ckptbase, ckpt)
             if (WT_STRING_MATCH(ckpt->name, name, len))
@@ -1234,9 +1233,10 @@ __checkpoint_lock_dirty_tree(
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
+    u_int max_ckpt_drop;
     char *name_alloc;
     const char *name;
-    bool hot_backup_locked;
+    bool hot_backup_locked, is_wt_ckpt;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -1320,19 +1320,23 @@ __checkpoint_lock_dirty_tree(
     __wt_free(session, name_alloc);
     F_SET(ckpt, WT_CKPT_ADD);
 
-    /*
-     * We can't delete checkpoints if a backup cursor is open. WiredTiger checkpoints are uniquely
-     * named and it's OK to have multiple of them in the system: clear the delete flag for them, and
-     * otherwise fail. Hold the lock until we're done (blocking hot backups from starting), we don't
-     * want to race with a future hot backup.
-     */
     __wt_readlock(session, &conn->hot_backup_lock);
     hot_backup_locked = true;
-    if (conn->hot_backup)
-        WT_CKPT_FOREACH (ckptbase, ckpt) {
-            if (!F_ISSET(ckpt, WT_CKPT_DELETE))
-                continue;
-            if (WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT)) {
+
+    /* Check that it is OK to remove all the checkpoints marked for deletion. */
+    max_ckpt_drop = 0;
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (!F_ISSET(ckpt, WT_CKPT_DELETE))
+            continue;
+        is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
+
+        /*
+         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
+         * been created before the backup started. Fail if trying to delete any other named
+         * checkpoint.
+         */
+        if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
+            if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;
             }
@@ -1342,6 +1346,15 @@ __checkpoint_lock_dirty_tree(
               "cannot be deleted during a hot backup",
               ckpt->name);
         }
+        /*
+         * Dropping checkpoints involves a fair amount of work while holding locks. Limit the number
+         * of WiredTiger checkpoints dropped per checkpoint.
+         */
+        if (is_wt_ckpt)
+#define WT_MAX_CHECKPOINT_DROP 4
+            if (++max_ckpt_drop >= WT_MAX_CHECKPOINT_DROP)
+                F_CLR(ckpt, WT_CKPT_DELETE);
+    }
 
     /*
      * Mark old checkpoints that are being deleted and figure out which trees we can skip in this
@@ -1364,7 +1377,8 @@ __checkpoint_lock_dirty_tree(
         WT_CKPT_FOREACH (ckptbase, ckpt) {
             if (!F_ISSET(ckpt, WT_CKPT_DELETE))
                 continue;
-
+            WT_ASSERT(session, !WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT) ||
+                conn->hot_backup_start == 0 || ckpt->sec > conn->hot_backup_start);
             /*
              * We can't delete checkpoints referenced by a cursor. WiredTiger checkpoints are
              * uniquely named and it's OK to have multiple in the system: clear the delete flag for

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1319,12 +1319,19 @@ __checkpoint_lock_dirty_tree(
             continue;
         is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
 
-        /*
-         * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
-         * been created before the backup started. Fail if trying to delete any other named
-         * checkpoint.
-         */
+/*
+ * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have been
+ * created before the backup started. Fail if trying to delete any other named checkpoint.
+ */
+#ifdef DISABLED_CODE
         if (conn->hot_backup_start != 0 && ckpt->sec <= conn->hot_backup_start) {
+#else
+        /*
+         * N.B. Despite the comment above, dropping checkpoints during backup can corrupt the
+         * backup. For now we retain all WiredTiger checkpoints.
+         */
+        if (conn->hot_backup_start != 0) {
+#endif
             if (is_wt_ckpt) {
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -537,8 +537,9 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
          * connection close, only during a full checkpoint. A clean close may not update any
          * metadata LSN and we do not want to archive in that case.
          */
-        if (!conn->hot_backup && (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) ||
-                                   FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE)) &&
+        if (conn->hot_backup_start == 0 &&
+          (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) ||
+              FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE)) &&
           txn->full_ckpt)
             __wt_log_ckpt(session, ckpt_lsn);
 

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -30,6 +30,7 @@ import glob
 import os
 import shutil
 import string
+import time
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet, ComplexDataSet, ComplexLSMDataSet
@@ -163,8 +164,7 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
         self.assertEqual(i, total)
 
-    # Test that named checkpoints can't be deleted while backup cursors are
-    # open, but that normal checkpoints continue to work.
+    # Test interaction between checkpoints and a backup cursor.
     def test_checkpoint_delete(self):
         # You cannot name checkpoints including LSM tables, skip those.
         self.populate(1)
@@ -177,7 +177,8 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
             self.objs[0][0], None, "checkpoint=one"))
 
         # Confirm opening a backup cursor causes checkpoint to fail if dropping
-        # a named checkpoint, but does not stop a default checkpoint.
+        # a named checkpoint created before the backup cursor, but does not stop a
+        # default checkpoint.
         cursor = self.session.open_cursor('backup:', None, None)
         self.session.checkpoint()
         msg = '/checkpoints cannot be deleted during a hot backup/'
@@ -187,7 +188,24 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("name=three,drop=(two)"), msg)
         self.session.checkpoint()
+
+        # Confirm that a named checkpoint created after a backup cursor can be dropped.
+        # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
+        # the backup will be pinned, even if they occur after the backup starts.
+        time.sleep(2)
+        self.session.checkpoint("name=four")
+        self.session.checkpoint("drop=(four)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=four"))
+
+        # Confirm that after closing the backup cursor the original named checkpoint can
+        # be deleted.
         cursor.close()
+        self.session.checkpoint("drop=(two)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=two"))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -189,10 +189,11 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
             lambda: self.session.checkpoint("name=three,drop=(two)"), msg)
         self.session.checkpoint()
 
-        # Confirm that a named checkpoint created after a backup cursor can be dropped.
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
         time.sleep(2)
+
+        # Confirm that a named checkpoint created after a backup cursor can be dropped.
         self.session.checkpoint("name=four")
         self.session.checkpoint("drop=(four)")
         self.assertRaises(wiredtiger.WiredTigerError,

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -191,14 +191,15 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
-        time.sleep(2)
 
-        # Confirm that a named checkpoint created after a backup cursor can be dropped.
-        self.session.checkpoint("name=four")
-        self.session.checkpoint("drop=(four)")
-        self.assertRaises(wiredtiger.WiredTigerError,
-            lambda: self.session.open_cursor(
-            self.objs[0][0], None, "checkpoint=four"))
+        time.sleep(2)
+        # N.B. This test is temporarily disabled because deleting checkpoints during backup
+        # can corrupt the backup.
+        #self.session.checkpoint("name=four")
+        #self.session.checkpoint("drop=(four)")
+        #self.assertRaises(wiredtiger.WiredTigerError,
+        #    lambda: self.session.open_cursor(
+        #    self.objs[0][0], None, "checkpoint=four"))
 
         # Confirm that after closing the backup cursor the original named checkpoint can
         # be deleted.

--- a/test/suite/test_backup01.py
+++ b/test/suite/test_backup01.py
@@ -191,15 +191,12 @@ class test_backup(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Need to pause a couple seconds; checkpoints that are assigned the same timestamp as
         # the backup will be pinned, even if they occur after the backup starts.
-
         time.sleep(2)
-        # N.B. This test is temporarily disabled because deleting checkpoints during backup
-        # can corrupt the backup.
-        #self.session.checkpoint("name=four")
-        #self.session.checkpoint("drop=(four)")
-        #self.assertRaises(wiredtiger.WiredTigerError,
-        #    lambda: self.session.open_cursor(
-        #    self.objs[0][0], None, "checkpoint=four"))
+        self.session.checkpoint("name=four")
+        self.session.checkpoint("drop=(four)")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(
+            self.objs[0][0], None, "checkpoint=four"))
 
         # Confirm that after closing the backup cursor the original named checkpoint can
         # be deleted.

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_checkpoint05.py
+# Verify that we don't accumulate a lot of checkpoints while a backup
+# cursor is open. WiredTiger checkpoints created after the backup cursor
+# should get deleted as usual.
+
+import time
+import wiredtiger, wttest
+
+class test_checkpoint05(wttest.WiredTigerTestCase):
+    conn_config = 'create,cache_size=100MB,log=(archive=false,enabled=true,file_max=100K)'
+
+    def count_checkpoints(self):
+        metadata_cursor = self.session.open_cursor('metadata:', None, None)
+
+        nckpt = 0
+        while metadata_cursor.next() == 0:
+            key = metadata_cursor.get_key()
+            value = metadata_cursor[key]
+            nckpt = nckpt + value.count("WiredTigerCheckpoint")
+        metadata_cursor.close()
+        return nckpt
+
+    def test_checkpoints_during_backup(self):
+        self.uri = 'table:ckpt05'
+        self.session.create(self.uri, 'key_format=i,value_format=i')
+
+        # Setup: Insert some data and checkpoint it
+        cursor = self.session.open_cursor(self.uri, None)
+        for i in range(16):
+            cursor[i] = i
+        self.session.checkpoint(None)
+
+        # Create backup and check how many checkpoints we have.
+        backup_cursor = self.session.open_cursor('backup:', None, None)
+        initial_count = self.count_checkpoints()
+
+        # Checkpoints created immediately after a backup cursor may get pinned.
+        # Pause to avoid this.
+        time.sleep(2)
+
+        # Take a bunch of checkpoints.
+        for i in range (50):
+            self.session.checkpoint('force=true')
+        cursor.close()
+
+        # There may be a few more checkpoints than when we opened the
+        # backup cursor, but not too many more.  The factor of three
+        # is generous.  But if WT isn't deleting checkpoints there would
+        # be about 30x more checkpoints here.
+        final_count = self.count_checkpoints()
+        self.assertTrue (final_count < initial_count * 3)
+
+        self.session.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -76,10 +76,7 @@ class test_checkpoint05(wttest.WiredTigerTestCase):
         # is generous.  But if WT isn't deleting checkpoints there would
         # be about 30x more checkpoints here.
         final_count = self.count_checkpoints()
-
-        # N.B. This test is temporarily disabled because deleting checkpoints during backup
-        # can corrupt the backup.
-        # self.assertTrue (final_count < initial_count * 3)
+        self.assertTrue (final_count < initial_count * 3)
 
         self.session.close()
 

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -76,7 +76,10 @@ class test_checkpoint05(wttest.WiredTigerTestCase):
         # is generous.  But if WT isn't deleting checkpoints there would
         # be about 30x more checkpoints here.
         final_count = self.count_checkpoints()
-        self.assertTrue (final_count < initial_count * 3)
+
+        # N.B. This test is temporarily disabled because deleting checkpoints during backup
+        # can corrupt the backup.
+        # self.assertTrue (final_count < initial_count * 3)
 
         self.session.close()
 


### PR DESCRIPTION
This PR is a series of cherry-picks from #5684. These cherry-picks were very unclean mainly because 4.0 doesn't have #4520. I was briefly considering backporting that change too but it happened BEFORE Clang Format so it's a bit complicated.

Before merging this PR, I'll squash any changes I make into @tammybailey's "PR changes" commit.