### PR TITLE
WT-6571 Lseek cannot use error_sys_check because it does not return an

### DIFF
--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -387,9 +387,11 @@ take_incr_backup(WT_SESSION *session, int i)
                     first = false;
                 }
 
-                error_sys_check(lseek(rfd, (wt_off_t)offset, SEEK_SET));
+                if (lseek(rfd, (wt_off_t)offset, SEEK_SET) == -1)
+                    testutil_die(errno, "lseek: read");
                 error_sys_check(rdsize = (size_t)read(rfd, tmp, (size_t)size));
-                error_sys_check(lseek(wfd, (wt_off_t)offset, SEEK_SET));
+                if (lseek(wfd, (wt_off_t)offset, SEEK_SET) == -1)
+                    testutil_die(errno, "lseek: write");
                 /* Use the read size since we may have read less than the granularity. */
                 error_sys_check(write(wfd, tmp, rdsize));
             } else {

--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -387,6 +387,11 @@ take_incr_backup(WT_SESSION *session, int i)
                     first = false;
                 }
 
+                /*
+                 * Don't use the system checker for lseek. The system check macro uses an int which
+                 * is often 4 bytes and checks for any negative value. The offset returned from
+                 * lseek is 8 bytes and we can have a false positive error check.
+                 */
                 if (lseek(rfd, (wt_off_t)offset, SEEK_SET) == -1)
                     testutil_die(errno, "lseek: read");
                 error_sys_check(rdsize = (size_t)read(rfd, tmp, (size_t)size));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -852,7 +852,7 @@ __wt_txn_read_upd_list(
          * If the cursor is configured to ignore tombstones, copy the timestamps from the tombstones
          * to the stop time window of the update value being returned to the caller. Caller can
          * process the stop time window to decide if there was a tombstone on the update chain. If
-         * the time window already has a stop time set then we must've seen a tombstone prior to
+         * the time window already has a stop time set then we must have seen a tombstone prior to
          * ours in the update list, and therefore don't need to do this again.
          */
         if (type == WT_UPDATE_TOMBSTONE && F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&


### PR DESCRIPTION
int.
(Also fix a contraction that is flagged on multiple machines in
s_string.)