### PR TITLE
WT-6507 Exit cache eviction worker after our operation has timed out

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2327,7 +2327,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
          * previous txn is blocking call, however it won't pickup transactions that have been
          * committed or rolled back as their mod count is 0, and that txn needs to be the oldest.
          *
-         * Additionally we don't return rollback which would could confuse the caller.
+         * Additionally we don't return rollback which could confuse the caller.
          */
         if (__wt_op_timer_fired(session))
             break;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2323,6 +2323,16 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
         }
 
         /*
+         * Check if we've exceeded our operation timeout, this would also get called from the
+         * previous txn is blocking call, however it won't pickup transactions that have been
+         * committed or rolled back as their mod count is 0, and that txn needs to be the oldest.
+         *
+         * Additionally we don't return rollback which would could confuse the caller.
+         */
+        if (__wt_op_timer_fired(session))
+            break;
+
+        /*
          * Check if we have become busy.
          *
          * If we're busy (because of the transaction check we just did or because our caller is


### PR DESCRIPTION
This ended up looking a bit different to how I anticipated as while we do clear `operation_timeout_ms` on our transaction we actually check against the sessions timeout parameter.