### PR TITLE
WT-6560 Fix usage of global salvage in WT utility

### DIFF
--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -282,8 +282,8 @@ open:
     }
     if ((ret = __wt_snprintf(p, len, "error_prefix=wt,%s,%s,%s,%s,%s%s%s%s",
            config == NULL ? "" : config, cmd_config == NULL ? "" : cmd_config,
-           readonly_config == NULL ? "" : readonly_config,
-           salvage_config == NULL ? "" : salvage_config, rec_config, p1, p2, p3)) != 0) {
+           readonly_config == NULL ? "" : readonly_config, rec_config,
+           salvage_config == NULL ? "" : salvage_config, p1, p2, p3)) != 0) {
         (void)util_err(NULL, ret, NULL);
         goto err;
     }

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -20,7 +20,7 @@ static const char *command; /* Command name */
 #define REC_ERROR "log=(recover=error)"
 #define REC_LOGOFF "log=(enabled=false)"
 #define REC_RECOVER "log=(recover=on)"
-#define REC_SALVAGE "log=(recover=salvage)"
+#define SALVAGE "salvage=true"
 
 static void
 usage(void)
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
     size_t len;
     int ch, major_v, minor_v, tret, (*func)(WT_SESSION *, int, char *[]);
     char *p, *secretkey;
-    const char *cmd_config, *config, *p1, *p2, *p3, *readonly_config, *rec_config;
+    const char *cmd_config, *config, *p1, *p2, *p3, *readonly_config, *rec_config, *salvage_config;
     bool backward_compatible, logoff, meta_verify, readonly, recover, salvage;
 
     conn = NULL;
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     }
 
-    cmd_config = config = readonly_config = secretkey = NULL;
+    cmd_config = config = readonly_config = salvage_config = secretkey = NULL;
     /*
      * We default to returning an error if recovery needs to be run. Generally we expect this to be
      * run after a clean shutdown. The printlog command disables logging entirely. If recovery is
@@ -130,7 +130,7 @@ main(int argc, char *argv[])
             readonly = true;
             break;
         case 'S': /* salvage */
-            rec_config = REC_SALVAGE;
+            salvage_config = SALVAGE;
             salvage = true;
             break;
         case 'V': /* version */
@@ -267,6 +267,8 @@ open:
         len += strlen(cmd_config);
     if (readonly_config != NULL)
         len += strlen(readonly_config);
+    if (salvage_config != NULL)
+        len += strlen(salvage_config);
     if (secretkey != NULL) {
         len += strlen(secretkey) + 30;
         p1 = ",encryption=(secretkey=";
@@ -278,9 +280,10 @@ open:
         (void)util_err(NULL, errno, NULL);
         goto err;
     }
-    if ((ret = __wt_snprintf(p, len, "error_prefix=wt,%s,%s,%s,%s%s%s%s",
+    if ((ret = __wt_snprintf(p, len, "error_prefix=wt,%s,%s,%s,%s,%s%s%s%s",
            config == NULL ? "" : config, cmd_config == NULL ? "" : cmd_config,
-           readonly_config == NULL ? "" : readonly_config, rec_config, p1, p2, p3)) != 0) {
+           readonly_config == NULL ? "" : readonly_config,
+           salvage_config == NULL ? "" : salvage_config, rec_config, p1, p2, p3)) != 0) {
         (void)util_err(NULL, ret, NULL);
         goto err;
     }


### PR DESCRIPTION
The global `-S` salvage option currently doesn't work with the `wt` utility. We moved this functionality from being an argument to `recover` to being its own option to `wiredtiger_open`.

This PR is changing the `wt` utility to use the new API correctly.