### PR TITLE
WT-6027 Fix docs spelling errors and warnings

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -97,7 +97,7 @@ spellchk()
 
 	(cd ../src/docs &&
 	cat *.dox |
-	aspell --encoding=iso-8859-1 --lang=en --personal=./spell.ok list) |
+	aspell --encoding=iso-8859-1 --lang=en_US --personal=./spell.ok list) |
 	sort -u > $t
 	test -s $t && {
 		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="

--- a/src/docs/Doxyfile
+++ b/src/docs/Doxyfile
@@ -175,9 +175,9 @@ QT_AUTOBRIEF           = YES
 
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make Doxygen 
 # treat a multi-line C++ special comment block (i.e. a block of //! or /// 
-# comments) as a brief description. This used to be the default behaviour. 
+# comments) as a brief description. This used to be the default behavior.
 # The new default is to treat a multi-line C++ comment block as a detailed 
-# description. Set this tag to YES if you prefer the old behaviour instead.
+# description. Set this tag to YES if you prefer the old behavior instead.
 
 MULTILINE_CPP_IS_BRIEF = NO
 

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -142,7 +142,7 @@ The \c downgrade command downgrades the database to the specified compatibility 
 The following are command-specific options for the \c downgrade command:
 
 @par <code>-V version</code>
-The \c -V option is required, and specfies the version to which the database is downgraded.
+The \c -V option is required, and specifies the version to which the database is downgraded.
 
 <hr>
 @section util_drop wt drop

--- a/src/docs/devdoc-optrack.dox
+++ b/src/docs/devdoc-optrack.dox
@@ -318,7 +318,7 @@ click on the white bar following the current, red-highlighted, bar.
 ![](interval_137_nav_bar.png)
 
 Next you see a legend that shows all functions that were called during this
-execution interval and their corresponding colours.
+execution interval and their corresponding colors.
 
 ![](interval_137_lgnd.png)
 

--- a/src/docs/devdoc-xray.dox
+++ b/src/docs/devdoc-xray.dox
@@ -41,7 +41,7 @@ In general the usage is:  
 wtperf_xray.sh <wtperf-config-file> [-h output-directory] [wtperf other arguments]
 @endcode
 
-The \c wtperf_xray.sh produces a few outputs to help analyse performance:
+The \c wtperf_xray.sh produces a few outputs to help analyze performance:
 
 - \c wtperf_account.txt: The top 10 functions where the workload is spending the
 most time with a count, min, max and some percentiles for each one.
@@ -50,15 +50,15 @@ most time with a count, min, max and some percentiles for each one.
 the most time. This calculation is done separately per thread.
 
 - \c wtperf_graph.svg: A function call graph showing what functions call each
-other. The edges are labelled and coloured proportionally to represent the ratio
+other. The edges are labeled and colored proportionally to represent the ratio
 of time spent in each function call.
 
-- \c wtperf_flame.svg: A graph visualising stack traces and the time spent
+- \c wtperf_flame.svg: A graph visualizing stack traces and the time spent
 within each stack frame. If \c FLAME_GRAPH_PATH is not specified, this graph
 won't be generated.
 
 The \c wtperf_xray.sh script uses a few optional environment variables to modify
-its behaviour:
+its behavior:
 
 - \c XRAY_BINARY: The binary to use to inspect the XRay log. The script defaults
 to using \c llvm-xray however, if you compiled with a particular \c clang
@@ -118,7 +118,7 @@ dependency to LLVM.
 $ ../configure --enable-llvm
 @endcode
 
-Take care NOT to customise \c CC or \c CXX. Customising either of these
+Take care NOT to customize \c CC or \c CXX. Customizing either of these
 variables will cause C++ programs such as \c workgen or \c xray_to_optrack to be
 skipped since we can't reliably link object files emitted by C and C++ compilers
 unless they are the system's default \c cc and \c c++.

--- a/src/docs/eviction.dox
+++ b/src/docs/eviction.dox
@@ -1,7 +1,7 @@
 /*! @m_page{{c,java},eviction, Eviction}
 
 All the operations performed in WiredTiger are on the data read into
-preconfigured amount of memory. WiredTiger uses memory as a cache for
+pre-configured amount of memory. WiredTiger uses memory as a cache for
 all the data on the disk and the data in memory forms the current
 working set.
 
@@ -17,7 +17,7 @@ The WiredTiger eviction runs in the background with one eviction server
 thread and several eviction worker threads.
 
 1) The eviction server thread walks the btrees and adds the least
-recently used pages to the eviction queues until the queus are full.
+recently used pages to the eviction queues until the queues are full.
 2) The eviction workers continuously remove pages from the eviction
 queue and try to evict them.
 
@@ -42,7 +42,7 @@ remains solely on the disk unchanged.
 For history store eviction, the page is modified but the changes are
 all committed. Therefore, the page should be clean and can be removed
 from memory after the dirty changes are written to the new disk image,
-which is the data fomat WiredTiger stores on disk. The process that
+which is the data format WiredTiger stores on disk. The process that
 builds the disk image is called reconciliation. In reconciliation,
 WiredTiger writes the newest committed value of each key to the disk
 image. All the older values of the key are moved to the history store

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -5,11 +5,13 @@ ActiveState
 Adler's
 Atomicity
 BLOBs
+BLRrVv
 CFLAGS
 CPPFLAGS
 CPUs
 CRC
 CSV
+CXX
 Cheng
 Christoph
 Collet's
@@ -72,6 +74,7 @@ MVCC's
 Makefiles
 Mewhort
 MongoDB
+MongoDB's
 Multithreaded
 NOTFOUND
 NSEC
@@ -278,6 +281,7 @@ hb
 hotbackup
 href
 hrow
+hs
 hsearch
 html
 htmlinclude
@@ -298,6 +302,7 @@ je
 jemalloc
 jitter
 jni
+jprx
 jrx
 json
 jxf
@@ -313,6 +318,7 @@ lastname
 latencies
 le
 len
+lgnd
 li
 libdir
 libhe
@@ -371,9 +377,11 @@ mutex
 mutexes
 mutexing
 mvcc
+mx
 mygcc
 mytable
 namespace
+nav
 ndary
 ndbm
 newsite
@@ -503,7 +511,6 @@ svg
 sys
 syscalls
 sz
-t2
 tRuE
 tablename
 tcl
@@ -551,12 +558,14 @@ valuefmt
 valuev
 vec
 versa
+viewable
 vm
 vpmsum
 warmup
 wget
 whitespace
 wiredtiger
+workgen
 workQ
 writelock
 writelocks

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -427,6 +427,7 @@ png
 posix
 pre
 prepends
+prev
 primary's
 printf
 printlog

--- a/src/docs/tune-capacity.dox
+++ b/src/docs/tune-capacity.dox
@@ -12,7 +12,7 @@ An example of setting a capacity limit to 40MB per second:
 
 @snippet ex_all.c Configure capacity
 
-When a total capacity is set the volume of system reads and writes totalled
+When a total capacity is set the volume of system reads and writes totaled
 will not exceed the given I/O capacity.
 If a read or write is scheduled and would overflow the capacity, the issuing
 thread will sleep to guarantee the capacity ceiling.  The policy used is

--- a/src/docs/tune-durability.dox
+++ b/src/docs/tune-durability.dox
@@ -100,7 +100,7 @@ logging subsystem to write any outstanding in-memory buffers to the
 file system before returning.
 
 If \c sync=background is configured then this flush operation will force
-the signalling of a background synchronization operation.
+the signaling of a background synchronization operation.
 The caller may then check the status of that background
 synchronization with the WT_SESSION::transaction_sync method.
  */


### PR DESCRIPTION
The issue in this ticket was initially reported as below spelling error about a digit character being included in a word. It turned out this error stopped the spell checking from running, and shadowed a list of warnings in the rest of unchecked `.dox` files.

> [2020/04/19 23:26:31.395] Error: ./spell.ok: The word "t2" is invalid. The character '2' (U+32) may not appear at the end of a word.

The 1st commit removes `t2` from `src/docs/spell.ok`, and fixes all [warnings](https://jira.mongodb.org/browse/WT-6027?focusedCommentId=3335816&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3335816) detected later on (as spell checking got unblocked for the rest of .dox files).

The 2nd commit updates aspell language setting to `--lang=en_US` in `dist/s_docs` script, to keep consistent with the `dist/s_string` script (see WT-5591 for details). Also fixed the additional [warnings](https://jira.mongodb.org/browse/WT-6027?focusedCommentId=3335821&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3335821) picked up by this new language setting.