### PR TITLE
WT-6591 Stop checkpoint thread before closing connection in Python tests

### DIFF
--- a/test/suite/test_backup02.py
+++ b/test/suite/test_backup02.py
@@ -58,35 +58,42 @@ class test_backup02(wttest.WiredTigerTestCase):
 #        ckpt = checkpoint_thread(self.conn, done)
 #        ckpt.start()
         bkp = backup_thread(self.conn, 'backup.dir', done)
-        bkp.start()
-
         work_queue = queue.Queue()
-        my_data = 'a' * self.dsize
-        for i in range(self.nops):
-            work_queue.put_nowait(('gi', i, my_data))
-
         opthreads = []
-        for i in range(self.nthreads):
-            t = op_thread(self.conn, uris, self.fmt, work_queue, done)
-            opthreads.append(t)
-            t.start()
+        try:
+            bkp.start()
 
-        # Add 200 update entries into the queue every .1 seconds.
-        more_time = self.time
-        while more_time > 0:
-            time.sleep(0.1)
-            my_data = str(more_time) + 'a' * (self.dsize - len(str(more_time)))
-            more_time = more_time - 0.1
+            my_data = 'a' * self.dsize
             for i in range(self.nops):
-                work_queue.put_nowait(('gu', i, my_data))
+                work_queue.put_nowait(('gi', i, my_data))
 
-        work_queue.join()
-        done.set()
-#        # Wait for checkpoint thread to notice status change.
-#        ckpt.join()
-        for t in opthreads:
-            t.join()
-        bkp.join()
+            for i in range(self.nthreads):
+                t = op_thread(self.conn, uris, self.fmt, work_queue, done)
+                opthreads.append(t)
+                t.start()
+
+            # Add 200 update entries into the queue every .1 seconds.
+            more_time = self.time
+            while more_time > 0:
+                time.sleep(0.1)
+                my_data = str(more_time) + 'a' * (self.dsize - len(str(more_time)))
+                more_time = more_time - 0.1
+                for i in range(self.nops):
+                    work_queue.put_nowait(('gu', i, my_data))
+        except:
+            # Deplete the work queue if there's an error.
+            while not work_queue.empty():
+                work_queue.get()
+                work_queue.task_done()
+            raise
+        finally:
+            work_queue.join()
+            done.set()
+            # Wait for checkpoint thread to notice status change.
+            # ckpt.join()
+            for t in opthreads:
+                t.join()
+            bkp.join()
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint02.py
+++ b/test/suite/test_checkpoint02.py
@@ -52,28 +52,35 @@ class test_checkpoint02(wttest.WiredTigerTestCase):
         self.session.create(self.uri,
             "key_format=" + self.fmt + ",value_format=S")
         ckpt = checkpoint_thread(self.conn, done)
-        ckpt.start()
-
-        uris = list()
-        uris.append(self.uri)
         work_queue = queue.Queue()
-        my_data = 'a' * self.dsize
-        for i in xrange(self.nops):
-            if i % 191 == 0 and i != 0:
-                work_queue.put_nowait(('b', i, my_data))
-            work_queue.put_nowait(('i', i, my_data))
-
         opthreads = []
-        for i in range(self.nthreads):
-            t = op_thread(self.conn, uris, self.fmt, work_queue, done)
-            opthreads.append(t)
-            t.start()
+        try:
+            ckpt.start()
 
-        work_queue.join()
-        done.set()
-        for t in opthreads:
-            t.join()
-        ckpt.join()
+            uris = list()
+            uris.append(self.uri)
+            my_data = 'a' * self.dsize
+            for i in xrange(self.nops):
+                if i % 191 == 0 and i != 0:
+                    work_queue.put_nowait(('b', i, my_data))
+                work_queue.put_nowait(('i', i, my_data))
+
+            for i in range(self.nthreads):
+                t = op_thread(self.conn, uris, self.fmt, work_queue, done)
+                opthreads.append(t)
+                t.start()
+        except:
+            # Deplete the work queue if there's an error.
+            while not work_queue.empty():
+                work_queue.get()
+                work_queue.task_done()
+            raise
+        finally:
+            work_queue.join()
+            done.set()
+            for t in opthreads:
+                t.join()
+            ckpt.join()
 
         # Create a cursor - ensure all items have been put.
         cursor = self.session.open_cursor(self.uri, None, None)

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -133,16 +133,17 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         # Create a checkpoint thread
         done = threading.Event()
         ckpt = checkpoint_thread(self.conn, done)
-        ckpt.start()
+        try:
+            ckpt.start()
 
-        # Perform several updates in parallel with checkpoint.
-        self.large_updates(uri_1, value_e, ds_1, nrows, 70)
-        self.large_updates(uri_2, value_e, ds_2, nrows, 70)
-        self.large_updates(uri_1, value_f, ds_1, nrows, 80)
-        self.large_updates(uri_2, value_f, ds_2, nrows, 80)
-
-        done.set()
-        ckpt.join()
+            # Perform several updates in parallel with checkpoint.
+            self.large_updates(uri_1, value_e, ds_1, nrows, 70)
+            self.large_updates(uri_2, value_e, ds_2, nrows, 70)
+            self.large_updates(uri_1, value_f, ds_1, nrows, 80)
+            self.large_updates(uri_2, value_f, ds_2, nrows, 80)
+        finally:
+            done.set()
+            ckpt.join()
 
         # Simulate a server crash and restart.
         self.simulate_crash_restart(".", "RESTART")

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -239,30 +239,31 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         # Create a checkpoint thread
         done = threading.Event()
         ckpt = checkpoint_thread(self.conn, done)
-        ckpt.start()
+        try:
+            ckpt.start()
 
-        # Perform several updates in parallel with checkpoint.
-        session_p1 = self.conn.open_session()
-        cursor_p1 = session_p1.open_cursor(uri_1)
-        session_p1.begin_transaction('isolation=snapshot')
-        for i in range(1, nrows):
-            cursor_p1.set_key(ds_1.key(i))
-            cursor_p1.set_value(value_e)
-            self.assertEquals(cursor_p1.update(), 0)
-        session_p1.prepare_transaction('prepare_timestamp=' + timestamp_str(69))
+            # Perform several updates in parallel with checkpoint.
+            session_p1 = self.conn.open_session()
+            cursor_p1 = session_p1.open_cursor(uri_1)
+            session_p1.begin_transaction('isolation=snapshot')
+            for i in range(1, nrows):
+                cursor_p1.set_key(ds_1.key(i))
+                cursor_p1.set_value(value_e)
+                self.assertEquals(cursor_p1.update(), 0)
+            session_p1.prepare_transaction('prepare_timestamp=' + timestamp_str(69))
 
-        # Perform several updates in parallel with checkpoint.
-        session_p2 = self.conn.open_session()
-        cursor_p2 = session_p2.open_cursor(uri_2)
-        session_p2.begin_transaction('isolation=snapshot')
-        for i in range(1, nrows):
-            cursor_p2.set_key(ds_2.key(i))
-            cursor_p2.set_value(value_e)
-            self.assertEquals(cursor_p2.update(), 0)
-        session_p2.prepare_transaction('prepare_timestamp=' + timestamp_str(69))
-
-        done.set()
-        ckpt.join()
+            # Perform several updates in parallel with checkpoint.
+            session_p2 = self.conn.open_session()
+            cursor_p2 = session_p2.open_cursor(uri_2)
+            session_p2.begin_transaction('isolation=snapshot')
+            for i in range(1, nrows):
+                cursor_p2.set_key(ds_2.key(i))
+                cursor_p2.set_value(value_e)
+                self.assertEquals(cursor_p2.update(), 0)
+            session_p2.prepare_transaction('prepare_timestamp=' + timestamp_str(69))
+        finally:
+            done.set()
+            ckpt.join()
 
         # Simulate a crash by copying to a new directory(RESTART).
         copy_wiredtiger_home(".", "RESTART")


### PR DESCRIPTION
While trying to repro a separate issue, I noticed that tests that use `checkpoint_thread` occasionally hit a C assertion if they're failing in Python.

The issue is that we spin up a separate checkpoint thread but if we fail in Python before reaching the `ckpt.join()`, we'll close the connection mid-checkpoint which is not allowed. Our API doesn't allow users to be doing things with the engine from other threads if they're closing the connection.