### PR TITLE
WT-6471 Avoid the error message for non-existent clang-format binary

### DIFF
--- a/dist/s_clang-format
+++ b/dist/s_clang-format
@@ -6,6 +6,7 @@ t=__wt.$$
 trap 'rm -rf $t' 0 1 2 3 13 15
 
 download_clang_format() {
+	echo "Downloading the clang-format tarball ..."
 	if [ `uname` = "Linux" ]; then
 		curl https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-3.8-rhel55.tar.gz -o dist/clang-format.tar.gz
 		tar --strip=2 -C dist/ -xf dist/clang-format.tar.gz build/bin/clang-format && rm dist/clang-format.tar.gz
@@ -23,6 +24,9 @@ cd `git rev-parse --show-toplevel` || exit 1
 
 # Override existing Clang Format versions in the PATH.
 export PATH="${PWD}/dist":$PATH
+
+# Download the clang-format binary if it's not in place.
+[ ! -x "$(command -v clang-format)" ] && download_clang_format
 
 # Ensure that we have the correct version of clang-format.
 clang_format_version="3.8.0"

--- a/dist/s_clang-format
+++ b/dist/s_clang-format
@@ -6,7 +6,6 @@ t=__wt.$$
 trap 'rm -rf $t' 0 1 2 3 13 15
 
 download_clang_format() {
-	echo "Downloading the clang-format tarball ..."
 	if [ `uname` = "Linux" ]; then
 		curl https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-3.8-rhel55.tar.gz -o dist/clang-format.tar.gz
 		tar --strip=2 -C dist/ -xf dist/clang-format.tar.gz build/bin/clang-format && rm dist/clang-format.tar.gz


### PR DESCRIPTION
Below log message was dumped out when the `clang-format` binary does not exist in the git tree when running `s_all` or `s_clang_format` (which is the case in Evergreen testing). The message may confuse users and make them think the `s_clang-format` script did not get to run, though in reality the script will try to download the clang-format tarball, unzip it and continue running. 

> [2020/06/23 07:17:55.123] ./s_clang-format: line 29: clang-format: command not found


This PR is to avoid the "command not found" error message, ~~and add another log line by indicating the tarball downloading is happening~~.