### PR TITLE
WT-6596 Increase cache for timestamp abort test.

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -68,6 +68,12 @@ static bool inmem;
 #define ENV_CONFIG_REC "log=(recover=on)"
 
 /*
+ * A minimum width of 10, along with zero filling, means that all the keys sort according to their
+ * integer value, making each thread's key space distinct.
+ */
+#define KEY_FORMAT ("%010" PRIu64)
+
+/*
  * Maximum number of modifications that are allowed to perform cursor modify operation.
  */
 #define MAX_MODIFY_ENTRIES 10
@@ -191,7 +197,7 @@ thread_run(void *arg)
         if (columnar_table)
             cursor->set_key(cursor, i);
         else {
-            testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, i));
+            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, i));
             cursor->set_key(cursor, kname);
         }
         /*
@@ -462,7 +468,7 @@ recover_and_verify(uint32_t nthreads)
                 if (columnar_table)
                     cursor->set_key(cursor, key);
                 else {
-                    testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, key));
+                    testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
                     cursor->set_key(cursor, kname);
                 }
 
@@ -493,7 +499,7 @@ recover_and_verify(uint32_t nthreads)
                 if (columnar_table)
                     cursor->set_key(cursor, key);
                 else {
-                    testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, key));
+                    testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
                     cursor->set_key(cursor, kname);
                 }
 
@@ -546,7 +552,7 @@ recover_and_verify(uint32_t nthreads)
                 if (columnar_table)
                     cursor->set_key(cursor, key);
                 else {
-                    testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, key));
+                    testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
                     cursor->set_key(cursor, kname);
                 }
 

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -94,6 +94,12 @@ static volatile THREAD_TS th_ts[MAX_TH];
     ",transaction_sync=(enabled,method=none)"
 #define ENV_CONFIG_REC "log=(archive=false,recover=on)"
 
+/*
+ * A minimum width of 10, along with zero filling, means that all the keys sort according to their
+ * integer value, making each thread's key space distinct.
+ */
+#define KEY_FORMAT ("%010" PRIu64)
+
 typedef struct {
     uint64_t absent_key; /* Last absent key */
     uint64_t exist_key;  /* First existing key after miss */
@@ -690,7 +696,7 @@ thread_run(void *arg)
             }
         if (use_ts)
             stable_ts = __wt_atomic_addv64(&global_ts, 1);
-        testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, i));
+        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, i));
 
         testutil_check(session->begin_transaction(session, NULL));
         if (use_prep)
@@ -1119,7 +1125,7 @@ main(int argc, char *argv[])
                   key, last_key);
                 break;
             }
-            testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, key));
+            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
             cur_coll->set_key(cur_coll, kname);
             cur_local->set_key(cur_local, kname);
             cur_oplog->set_key(cur_oplog, kname);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -85,20 +85,26 @@ static volatile uint64_t global_ts = 1;
  * See notes on eviction triggers and targets where these symbols are used.
  */
 #define ENV_CONFIG_ADD_COMPAT ",compatibility=(release=\"2.9\")"
-#define ENV_CONFIG_ADD_EVICT_DIRTY ",eviction_dirty_target=20,eviction_dirty_trigger=95"
+#define ENV_CONFIG_ADD_EVICT_DIRTY ",eviction_dirty_target=20,eviction_dirty_trigger=90"
 #define ENV_CONFIG_ADD_STRESS ",timing_stress_for_test=[prepare_checkpoint_delay]"
 
 #define ENV_CONFIG_DEF                                        \
     "cache_size=%" PRIu32                                     \
     "M,create,"                                               \
     "debug_mode=(table_logging=true,checkpoint_retention=5)," \
-    "eviction_updates_target=20,eviction_updates_trigger=95," \
+    "eviction_updates_target=20,eviction_updates_trigger=90," \
     "log=(archive=true,file_max=10M,enabled),session_max=%d," \
     "statistics=(fast),statistics_log=(wait=1,json=true)"
 #define ENV_CONFIG_TXNSYNC \
     ENV_CONFIG_DEF         \
     ",transaction_sync=(enabled,method=none)"
 #define ENV_CONFIG_REC "log=(archive=false,recover=on)"
+
+/*
+ * A minimum width of 10, along with zero filling, means that all the keys sort according to their
+ * integer value, making each thread's key space distinct.
+ */
+#define KEY_FORMAT ("%010" PRIu64)
 
 typedef struct {
     uint64_t absent_key; /* Last absent key */
@@ -316,7 +322,7 @@ thread_run(void *arg)
     printf("Thread %" PRIu32 " starts at %" PRIu64 "\n", td->info, td->start);
     active_ts = 0;
     for (i = td->start;; ++i) {
-        testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, i));
+        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, i));
 
         testutil_check(session->begin_transaction(session, NULL));
         if (use_prep)
@@ -438,18 +444,18 @@ run_workload(uint32_t nth)
     td = dcalloc(nth + 2, sizeof(THREAD_DATA));
 
     /*
-     * Size the cache appropriately for the number of threads. Each thread generally adds keys
-     * sequentially to its own portion of the key space, so each thread will be dirtying one page at
-     * a time. By default, a leaf page grows to 32K in size before it splits and the thread begins
-     * to fill another page. We'll budget for 5 full size leaf pages per thread in the cache plus a
-     * little extra in the total for overhead.
+     * Size the cache appropriately for the number of threads. Each thread adds keys sequentially to
+     * its own portion of the key space, so each thread will be dirtying one page at a time. By
+     * default, a leaf page grows to 32K in size before it splits and the thread begins to fill
+     * another page. We'll budget for 10 full size leaf pages per thread in the cache plus a little
+     * extra in the total for overhead.
      *
      * The configuration sets the eviction update and dirty targets at 20% so that on average, each
-     * thread can have a dirty page before eviction threads kick in. On the other side, the eviction
-     * update and dirty triggers are 95%, so application threads aren't involved in eviction until
-     * we're close to running out of cache.
+     * thread can have a couple of dirty pages before eviction threads kick in. On the other side,
+     * the eviction update and dirty triggers are 90%, so application threads aren't involved in
+     * eviction until we're close to running out of cache.
      */
-    cache_mb = ((32 * WT_KILOBYTE * nth) * 5) / WT_MEGABYTE + 5;
+    cache_mb = ((32 * WT_KILOBYTE * 10) * nth) / WT_MEGABYTE + 20;
 
     if (chdir(home) != 0)
         testutil_die(errno, "Child chdir: %s", home);
@@ -471,6 +477,7 @@ run_workload(uint32_t nth)
     if (!compat && !inmem)
         strcat(envconf, ENV_CONFIG_ADD_EVICT_DIRTY);
 
+    printf("wiredtiger_open configuration: %s\n", envconf);
     testutil_check(wiredtiger_open(NULL, NULL, envconf, &conn));
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     /*
@@ -811,7 +818,7 @@ main(int argc, char *argv[])
                   key, last_key);
                 break;
             }
-            testutil_check(__wt_snprintf(kname, sizeof(kname), "%" PRIu64, key));
+            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
             cur_coll->set_key(cur_coll, kname);
             cur_local->set_key(cur_local, kname);
             cur_oplog->set_key(cur_oplog, kname);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -82,7 +82,11 @@ static bool compat, inmem, stress, use_ts;
 static volatile uint64_t global_ts = 1;
 
 /*
- * See notes on eviction triggers and targets where these symbols are used.
+ * The configuration sets the eviction update and dirty targets at 20% so that on average, each
+ * thread can have a couple of dirty pages before eviction threads kick in. See below where these
+ * symbols are used for cache sizing - we'll have about 10 pages allocated per thread. On the other
+ * side, the eviction update and dirty triggers are 90%, so application threads aren't involved in
+ * eviction until we're close to running out of cache.
  */
 #define ENV_CONFIG_ADD_COMPAT ",compatibility=(release=\"2.9\")"
 #define ENV_CONFIG_ADD_EVICT_DIRTY ",eviction_dirty_target=20,eviction_dirty_trigger=90"
@@ -449,11 +453,6 @@ run_workload(uint32_t nth)
      * default, a leaf page grows to 32K in size before it splits and the thread begins to fill
      * another page. We'll budget for 10 full size leaf pages per thread in the cache plus a little
      * extra in the total for overhead.
-     *
-     * The configuration sets the eviction update and dirty targets at 20% so that on average, each
-     * thread can have a couple of dirty pages before eviction threads kick in. On the other side,
-     * the eviction update and dirty triggers are 90%, so application threads aren't involved in
-     * eviction until we're close to running out of cache.
      */
     cache_mb = ((32 * WT_KILOBYTE * 10) * nth) / WT_MEGABYTE + 20;
 


### PR DESCRIPTION
Ensure threads' key spaces are truly separate.
Show the wiredtiger_open configuration on output.