### PR TITLE
WT-6390 Extend compact02 timeout from 8 => 10 minutes

### DIFF
--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -149,7 +149,7 @@ class test_compact02(wttest.WiredTigerTestCase):
         # Compact can collide with eviction, if that happens we retry. Wait for
         # a long time, the check for EBUSY means we're not retrying on any real
         # errors.
-        for i in range(1, 80):
+        for i in range(1, 100):
             if not self.raisesBusy(
               lambda: self.session.compact(self.uri, None)):
                 break


### PR DESCRIPTION
I haven't had a great deal of luck reproducing this on either my MacBook or even on one of the MacStadium hosts (1000+ runs). I'm not surprised as it's very rare given how frequently we run this test in Evergreen.

It seems to be reproducing much less often than when @raviprakashgiri29 extended the timeout so I think we're on the right track. I'm hoping that after bumping this to 10 min, the last x% of failures will disappear.