### PR TITLE
WT-6583 Flag history store cursor as WT_CBT_NO_TXN

### DIFF
--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -1609,6 +1609,12 @@ __hs_fixup_out_of_order_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
             WT_WITHOUT_DHANDLE(session,
               ret = __wt_open_cursor(session, WT_HS_URI, NULL, open_cursor_cfg, &insert_cursor));
             WT_ERR(ret);
+
+            /* History store cursors should always ignore tombstones. */
+            F_SET(insert_cursor, WT_CURSTD_IGNORE_TOMBSTONE);
+
+            /* Set the flag to stop creating snapshots for history store cursors. */
+            F_SET((WT_CURSOR_BTREE *)insert_cursor, WT_CBT_NO_TXN);
         }
 
         /*

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -219,6 +219,11 @@ __wt_hs_cursor_open(WT_SESSION_IMPL *session)
     /* History store cursors should always ignore tombstones. */
     F_SET(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
 
+    /*
+     * Set the flag to stop creating snapshots for history store cursors
+     */
+    F_SET((WT_CURSOR_BTREE *)cursor, WT_CBT_NO_TXN);
+
     session->hs_cursor = cursor;
     return (0);
 }

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -219,9 +219,7 @@ __wt_hs_cursor_open(WT_SESSION_IMPL *session)
     /* History store cursors should always ignore tombstones. */
     F_SET(cursor, WT_CURSTD_IGNORE_TOMBSTONE);
 
-    /*
-     * Set the flag to stop creating snapshots for history store cursors
-     */
+    /* Set the flag to stop creating snapshots for history store cursors. */
     F_SET((WT_CURSOR_BTREE *)cursor, WT_CBT_NO_TXN);
 
     session->hs_cursor = cursor;

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -209,7 +209,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * and we can release any snapshot we're holding for read committed isolation.
      */
     if (session->ncursors == 0 && !F_ISSET(cbt, WT_CBT_NO_TXN) &&
-      session->txn->isolation == WT_TXN_ISO_READ_COMMITTED)
+      session->txn->isolation == WT_ISO_READ_COMMITTED)
         __wt_txn_read_last(session);
 
     /* If we're not holding a cursor reference, we're done. */

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -208,8 +208,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * When the count of active cursors in the session goes to zero, there are no active cursors,
      * and we can release any snapshot we're holding for read committed isolation.
      */
-    if (session->ncursors == 0 && !F_ISSET(cbt, WT_CBT_NO_TXN) &&
-      session->txn->isolation == WT_ISO_READ_COMMITTED)
+    if (session->ncursors == 0 && !F_ISSET(cbt, WT_CBT_NO_TXN))
         __wt_txn_read_last(session);
 
     /* If we're not holding a cursor reference, we're done. */

--- a/src/include/cursor.i
+++ b/src/include/cursor.i
@@ -208,7 +208,8 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * When the count of active cursors in the session goes to zero, there are no active cursors,
      * and we can release any snapshot we're holding for read committed isolation.
      */
-    if (session->ncursors == 0 && !F_ISSET(cbt, WT_CBT_NO_TXN))
+    if (session->ncursors == 0 && !F_ISSET(cbt, WT_CBT_NO_TXN) &&
+      session->txn->isolation == WT_TXN_ISO_READ_COMMITTED)
         __wt_txn_read_last(session);
 
     /* If we're not holding a cursor reference, we're done. */

--- a/test/suite/test_txn22.py
+++ b/test/suite/test_txn22.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_txn22.py
+#   Transactions: ensure read timestamp is not cleared under cache pressure
+#
+
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_txn22(wttest.WiredTigerTestCase):
+    session_config = 'isolation=snapshot'
+
+    def conn_config(self):
+        config = 'cache_size=5MB'
+        return config
+
+    def large_updates(self, uri, value, ds, nrows, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(0, nrows):
+            session.begin_transaction()
+            cursor[ds.key(i)] = value
+            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, ds, nrows, read_ts):
+        session = self.session
+        for i in range(0, nrows):
+            session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            cursor = session.open_cursor(uri)
+            self.assertEqual(cursor[ds.key(i)], check_value)
+            cursor.close()
+            session.commit_transaction()
+
+    def test_txn(self):
+        nrows = 2000
+
+        # Create a table.
+        uri_1 = "table:txn22_1"
+        ds_1 = SimpleDataSet(
+            self, uri_1, 0, key_format="i", value_format="S")
+        ds_1.populate()
+
+        # Create another table.
+        uri_2 = "table:txn22_2"
+        ds_2 = SimpleDataSet(
+            self, uri_2, 0, key_format="i", value_format="S")
+        ds_2.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+        value_e = "eeeee" * 100
+        value_f = "fffff" * 100
+
+        # Perform several updates.
+        self.large_updates(uri_1, value_d, ds_1, nrows, 20)
+        self.large_updates(uri_1, value_c, ds_1, nrows, 30)
+        self.large_updates(uri_1, value_b, ds_1, nrows, 40)
+        self.large_updates(uri_1, value_a, ds_1, nrows, 50)
+
+        self.large_updates(uri_2, value_d, ds_2, nrows, 20)
+        self.large_updates(uri_2, value_c, ds_2, nrows, 30)
+        self.large_updates(uri_2, value_b, ds_2, nrows, 40)
+        self.large_updates(uri_2, value_a, ds_2, nrows, 50)
+
+        # Verify data is visible and correct.
+        self.check(value_d, uri_1, ds_1, nrows, 20)
+        self.check(value_c, uri_1, ds_1, nrows, 30)
+        self.check(value_b, uri_1, ds_1, nrows, 40)
+        self.check(value_a, uri_1, ds_1, nrows, 50)
+
+        self.check(value_d, uri_2, ds_2, nrows, 20)
+        self.check(value_c, uri_2, ds_2, nrows, 30)
+        self.check(value_b, uri_2, ds_2, nrows, 40)
+        self.check(value_a, uri_2, ds_2, nrows, 50)


### PR DESCRIPTION
In WT-6339, we added the code to flag the history store cursor as WT_CBT_NO_TXN.

```
/*
* Set the flag to stop creating snapshots for history store cursors
*/
F_SET((WT_CURSOR_BTREE *)cursor, WT_CBT_NO_TXN);

```

That part of the code then is removed in WT-6453, causing this issue.