### PR TITLE
WT-6589 Fix disabled cursor cache python tests

### DIFF
--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -42,12 +42,35 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
     stat_cursor_reopen = 0
 
     # Returns a list: [cursor_cached, cursor_reopened]
+    #
+    # We want the statistics for operations triggered from our program. The challenge is that
+    # eviction threads may cache history store cursors in the background. We address this by
+    # subtracting out operations from the history store file. This is tricky because we can't
+    # atomically check the connections stats and the history store stats.  So we look at the
+    # history store stats before and after the connection stats and only accept a result where
+    # the history store stats haven't changed.
     def caching_stats(self):
-        stat_cursor = self.session.open_cursor('statistics:', None, None)
-        cache = stat_cursor[stat.conn.cursor_cache][2]
-        reopen = stat_cursor[stat.conn.cursor_reopen][2]
-        stat_cursor.close()
-        return [cache, reopen]
+        hs_stats_uri = 'statistics:file:WiredTigerHS.wt'
+        while 1:
+            hs_stats_before = self.session.open_cursor(hs_stats_uri, None, None)
+            conn_stats = self.session.open_cursor('statistics:', None, None)
+            hs_stats_after = self.session.open_cursor(hs_stats_uri, None, None)
+
+            totals = [ conn_stats [stat.conn.cursor_cache][2],
+                         conn_stats [stat.conn.cursor_reopen][2] ]
+            hs_before = [ hs_stats_before[stat.dsrc.cursor_cache][2],
+                          hs_stats_before[stat.dsrc.cursor_reopen][2] ]
+            hs_after = [ hs_stats_after[stat.dsrc.cursor_cache][2],
+                         hs_stats_after[stat.dsrc.cursor_reopen][2] ]
+
+            hs_stats_before.close()
+            hs_stats_after.close()
+            conn_stats.close()
+
+            if hs_before[0] == hs_after[0] and hs_before[1] == hs_after[1]:
+                break
+
+        return [totals[0] - hs_after[0], totals[1] - hs_after[1]]
 
     # Returns a list: [cursor_sweep, cursor_sweep_buckets,
     #                  cursor_sweep_examined, cursor_sweep_closed]
@@ -65,18 +88,16 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
         if expect_change:
             self.assertGreater(stats[0], self.stat_cursor_cache)
             self.stat_cursor_cache = stats[0]
-        # Stats may change due to background operations in history store cursor
-        #else:
-        #    self.assertEqual(stats[0], self.stat_cursor_cache)
+        else:
+            self.assertEqual(stats[0], self.stat_cursor_cache)
 
     def assert_cursor_reopened(self, expect_change):
         stats = self.caching_stats()
         if expect_change:
             self.assertGreater(stats[1], self.stat_cursor_reopen)
             self.stat_cursor_reopen = stats[1]
-        # Stats may change due to background operations in history store cursor
-        #else:
-        #    self.assertEqual(stats[1], self.stat_cursor_reopen)
+        else:
+            self.assertEqual(stats[1], self.stat_cursor_reopen)
 
     def cursor_stats_init(self):
         stats = self.caching_stats()
@@ -450,10 +471,8 @@ class test_cursor13_big(test_cursor13_big_base):
         #         ', closes = ' + str(self.closecount))
         #self.tty('stats after = ' + str(end_stats))
 
-        # Stats won't be exact because they may include operations triggered by other
-        # threads (e.g., eviction) opening and closing history store cursors.
-        self.assertGreaterEqual(end_stats[0] - begin_stats[0], self.closecount)
-        self.assertGreaterEqual(end_stats[1] - begin_stats[1], self.opencount)
+        self.assertEquals(end_stats[0] - begin_stats[0], self.closecount)
+        self.assertEquals(end_stats[1] - begin_stats[1], self.opencount)
 
 class test_cursor13_sweep(test_cursor13_big_base):
     # Set dhandle sweep configuration so that dhandles should be closed within
@@ -512,7 +531,7 @@ class test_cursor13_sweep(test_cursor13_big_base):
         #         ', closes = ' + str(self.closecount))
         #self.tty('stats after = ' + str(end_stats))
         #self.tty('sweep stats after = ' + str(end_sweep_stats))
-        self.assertGreaterEqual(end_stats[0] - begin_stats[0], self.closecount)
+        self.assertEquals(end_stats[0] - begin_stats[0], self.closecount)
         swept = end_sweep_stats[3] - begin_sweep_stats[3]
 
         # Although this is subject to tuning parameters, we know that

--- a/test/suite/test_cursor16.py
+++ b/test/suite/test_cursor16.py
@@ -39,7 +39,7 @@ class test_cursor16(wttest.WiredTigerTestCase):
     uri_count = 100
     session_count = 100
 
-    conn_config = 'cache_cursors=true,statistics=(fast)'
+    conn_config = 'cache_cursors=true,statistics=(fast),in_memory=true'
 
     # Returns the number of cursors cached
     def cached_stats(self):
@@ -64,8 +64,7 @@ class test_cursor16(wttest.WiredTigerTestCase):
             for j in range(0, 10):
                 cursor[str(j)] = str(j)
 
-        # Skewed by internal history store operations
-        #self.assertEqual(0, self.cached_stats())
+        self.assertEqual(0, self.cached_stats())
 
         sessions = []
         for i in range(0, self.session_count):
@@ -90,8 +89,7 @@ class test_cursor16(wttest.WiredTigerTestCase):
             session.close()
 
         #self.tty('end cursors cached=' + str(self.cached_stats()))
-        # Skewed by internal history store operations
-        #self.assertEqual(0, self.cached_stats())
+        self.assertEqual(0, self.cached_stats())
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@ddanderson & @sueloverso.  I think the [JIRA Ticket](https://jira.mongodb.org/browse/WT-6589) sufficiently explains what's going on here.  But feel free to ping me with questions—here or on Slack.

This basically goes back to the version of these tests before WT-6274, and then fixes the tests to work with the changes from WT-6274 and WT-6478.