### PR TITLE
WT-6556 Fix internal sessions to use internal session close function than public API to avoid memory leak 

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1080,7 +1080,7 @@ err:
     WT_TRET(__wt_checkpoint_server_destroy(session));
 
     /* Perform a final checkpoint and shut down the global transaction state. */
-    WT_TRET(__wt_txn_global_shutdown(session, config, cfg));
+    WT_TRET(__wt_txn_global_shutdown(session, cfg));
 
     if (ret != 0) {
         __wt_err(session, ret, "failure during close, disabling further writes");

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1043,7 +1043,7 @@ err:
              */
             if (s->event_handler->handle_close != NULL)
                 WT_TRET(s->event_handler->handle_close(s->event_handler, wt_session, NULL));
-            WT_TRET(wt_session->close(wt_session, config));
+            WT_TRET(__wt_session_close_internal(s));
         }
 
     /* Wait for in-flight operations to complete. */
@@ -2811,8 +2811,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     if (verify_meta) {
         WT_ERR(__wt_open_internal_session(conn, "verify hs", false, 0, &verify_session));
         ret = __wt_history_store_verify(verify_session);
-        wt_session = &verify_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(verify_session));
         WT_ERR(ret);
     }
 #endif

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -349,7 +349,6 @@ __wt_cache_destroy(WT_SESSION_IMPL *session)
     WT_CACHE *cache;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     int i;
 
     conn = S2C(session);
@@ -380,9 +379,8 @@ __wt_cache_destroy(WT_SESSION_IMPL *session)
     __wt_spin_destroy(session, &cache->evict_pass_lock);
     __wt_spin_destroy(session, &cache->evict_queue_lock);
     __wt_spin_destroy(session, &cache->evict_walk_lock);
-    wt_session = &cache->walk_session->iface;
-    if (wt_session != NULL)
-        WT_TRET(wt_session->close(wt_session, NULL));
+    if (cache->walk_session != NULL)
+        WT_TRET(__wt_session_close_internal(cache->walk_session));
 
     for (i = 0; i < WT_EVICT_QUEUE_MAX; ++i) {
         __wt_spin_destroy(session, &cache->evict_queues[i].evict_lock);

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -281,7 +281,6 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
     WT_CACHE_POOL *cp;
     WT_CONNECTION_IMPL *conn, *entry;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     bool cp_locked, found;
 
     conn = S2C(session);
@@ -325,8 +324,7 @@ __wt_conn_cache_pool_destroy(WT_SESSION_IMPL *session)
         __wt_cond_signal(session, cp->cache_pool_cond);
         WT_TRET(__wt_thread_join(session, &cache->cp_tid));
 
-        wt_session = &cache->cp_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(cache->cp_session));
 
         /*
          * Grab the lock again now to stop other threads joining the pool while we are figuring out

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -193,7 +193,6 @@ __wt_capacity_server_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
@@ -206,10 +205,8 @@ __wt_capacity_server_destroy(WT_SESSION_IMPL *session)
     __wt_cond_destroy(session, &conn->capacity_cond);
 
     /* Close the server thread's session. */
-    if (conn->capacity_session != NULL) {
-        wt_session = &conn->capacity_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
-    }
+    if (conn->capacity_session != NULL)
+        WT_TRET(__wt_session_close_internal(conn->capacity_session));
 
     /*
      * Ensure capacity settings are cleared - so that reconfigure doesn't get confused.

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -198,7 +198,6 @@ __wt_checkpoint_server_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
@@ -211,10 +210,8 @@ __wt_checkpoint_server_destroy(WT_SESSION_IMPL *session)
     __wt_cond_destroy(session, &conn->ckpt_cond);
 
     /* Close the server thread's session. */
-    if (conn->ckpt_session != NULL) {
-        wt_session = &conn->ckpt_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
-    }
+    if (conn->ckpt_session != NULL)
+        WT_TRET(__wt_session_close_internal(conn->ckpt_session));
 
     /*
      * Ensure checkpoint settings are cleared - so that reconfigure doesn't get confused.

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -74,7 +74,7 @@ __logmgr_force_archive(WT_SESSION_IMPL *session, uint32_t lognum)
         WT_RET(WT_SESSION_CHECK_PANIC(tmp_session));
         WT_RET(__wt_log_truncate_files(tmp_session, NULL, true));
     }
-    WT_RET(tmp_session->iface.close(&tmp_session->iface, NULL));
+    WT_RET(__wt_session_close_internal(tmp_session));
     return (0);
 }
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -1101,7 +1101,6 @@ __wt_logmgr_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
@@ -1126,8 +1125,7 @@ __wt_logmgr_destroy(WT_SESSION_IMPL *session)
         conn->log_file_tid_set = false;
     }
     if (conn->log_file_session != NULL) {
-        wt_session = &conn->log_file_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->log_file_session));
         conn->log_file_session = NULL;
     }
     if (conn->log_wrlsn_tid_set) {
@@ -1136,8 +1134,7 @@ __wt_logmgr_destroy(WT_SESSION_IMPL *session)
         conn->log_wrlsn_tid_set = false;
     }
     if (conn->log_wrlsn_session != NULL) {
-        wt_session = &conn->log_wrlsn_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->log_wrlsn_session));
         conn->log_wrlsn_session = NULL;
     }
 
@@ -1146,8 +1143,7 @@ __wt_logmgr_destroy(WT_SESSION_IMPL *session)
 
     /* Close the server thread's session. */
     if (conn->log_session != NULL) {
-        wt_session = &conn->log_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->log_session));
         conn->log_session = NULL;
     }
 

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -157,7 +157,7 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
      * error messages from the remaining operations while destroying the connection handle.
      */
     if (session != &conn->dummy_session) {
-        WT_TRET(session->iface.close(&session->iface, NULL));
+        WT_TRET(__wt_session_close_internal(session));
         session = conn->default_session = &conn->dummy_session;
     }
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -682,7 +682,6 @@ __wt_statlog_destroy(WT_SESSION_IMPL *session, bool is_close)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
@@ -704,8 +703,7 @@ __wt_statlog_destroy(WT_SESSION_IMPL *session, bool is_close)
 
     /* Close the server thread's session. */
     if (conn->stat_session != NULL) {
-        wt_session = &conn->stat_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->stat_session));
         conn->stat_session = NULL;
     }
 

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -403,7 +403,6 @@ __wt_sweep_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
@@ -416,8 +415,7 @@ __wt_sweep_destroy(WT_SESSION_IMPL *session)
     __wt_cond_destroy(session, &conn->sweep_cond);
 
     if (conn->sweep_session != NULL) {
-        wt_session = &conn->sweep_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->sweep_session));
 
         conn->sweep_session = NULL;
     }

--- a/src/history/hs.c
+++ b/src/history/hs.c
@@ -42,10 +42,7 @@ __hs_start_internal_session(WT_SESSION_IMPL *session, WT_SESSION_IMPL **int_sess
 static int
 __hs_release_internal_session(WT_SESSION_IMPL *int_session)
 {
-    WT_SESSION *wt_session;
-
-    wt_session = &int_session->iface;
-    return (wt_session->close(wt_session, NULL));
+    return (__wt_session_close_internal(int_session));
 }
 
 /*

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -49,8 +49,7 @@
      * No code before this line, otherwise error handling won't be \
      * correct.                                                    \
      */                                                            \
-    if (!F_ISSET(s, WT_SESSION_INTERNAL))                          \
-        WT_ERR(WT_SESSION_CHECK_PANIC(s));                         \
+    WT_ERR(WT_SESSION_CHECK_PANIC(s));                             \
     WT_SINGLE_THREAD_CHECK_START(s);                               \
     WT_TRACK_OP_INIT(s);                                           \
     __wt_op_timer_start(s);                                        \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -49,7 +49,8 @@
      * No code before this line, otherwise error handling won't be \
      * correct.                                                    \
      */                                                            \
-    WT_ERR(WT_SESSION_CHECK_PANIC(s));                             \
+    if (!F_ISSET(s, WT_SESSION_INTERNAL))                          \
+        WT_ERR(WT_SESSION_CHECK_PANIC(s));                         \
     WT_SINGLE_THREAD_CHECK_START(s);                               \
     WT_TRACK_OP_INIT(s);                                           \
     __wt_op_timer_start(s);                                        \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1325,7 +1325,7 @@ extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_breakpoint(WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_session_close_internal(WT_SESSION_IMPL *wt_session)
+extern int __wt_session_close_internal(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1479,7 +1479,7 @@ extern int __wt_txn_global_init(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const char **cfg)
+extern int __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_init(WT_SESSION_IMPL *session, WT_SESSION_IMPL *session_ret)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1325,6 +1325,8 @@ extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_breakpoint(WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_session_close_internal(WT_SESSION_IMPL *wt_session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -261,7 +261,6 @@ __wt_lsm_manager_destroy(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_LSM_MANAGER *manager;
     WT_LSM_WORK_UNIT *current;
-    WT_SESSION *wt_session;
     uint64_t removed;
     uint32_t i;
 
@@ -303,10 +302,8 @@ __wt_lsm_manager_destroy(WT_SESSION_IMPL *session)
         }
 
         /* Close all LSM worker sessions. */
-        for (i = 0; i < WT_LSM_MAX_WORKERS; i++) {
-            wt_session = &manager->lsm_worker_cookies[i].session->iface;
-            WT_TRET(wt_session->close(wt_session, NULL));
-        }
+        for (i = 0; i < WT_LSM_MAX_WORKERS; i++)
+            WT_TRET(__wt_session_close_internal(manager->lsm_worker_cookies[i].session));
     }
     WT_STAT_CONN_INCRV(session, lsm_work_units_discarded, removed);
 

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -536,14 +536,12 @@ __wt_meta_track_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
 
     conn = S2C(session);
 
     /* Close the session used for metadata checkpoints. */
     if (conn->meta_ckpt_session != NULL) {
-        wt_session = &conn->meta_ckpt_session->iface;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(conn->meta_ckpt_session));
         conn->meta_ckpt_session = NULL;
     }
 

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -100,12 +100,8 @@ __wt_schema_internal_session(WT_SESSION_IMPL *session, WT_SESSION_IMPL **int_ses
 int
 __wt_schema_session_release(WT_SESSION_IMPL *session, WT_SESSION_IMPL *int_session)
 {
-    WT_SESSION *wt_session;
-
-    if (session != int_session) {
-        wt_session = &int_session->iface;
-        WT_RET(wt_session->close(wt_session, NULL));
-    }
+    if (session != int_session)
+        WT_RET(__wt_session_close_internal(int_session));
 
     return (0);
 }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2188,7 +2188,6 @@ __wt_open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, con
   bool open_metadata, WT_SESSION_IMPL **sessionp)
 {
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     WT_SESSION_IMPL *session;
 
     *sessionp = NULL;
@@ -2206,8 +2205,7 @@ __wt_open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, con
     if (open_metadata) {
         WT_ASSERT(session, !F_ISSET(session, WT_SESSION_LOCKED_SCHEMA));
         if ((ret = __wt_metadata_cursor(session, NULL)) != 0) {
-            wt_session = &session->iface;
-            WT_TRET(wt_session->close(wt_session, NULL));
+            WT_TRET(__wt_session_close_internal(session));
             return (ret);
         }
     }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1991,12 +1991,11 @@ __wt_txn_activity_drain(WT_SESSION_IMPL *session)
  *     Shut down the global transaction state.
  */
 int
-__wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const char **cfg)
+__wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 {
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     WT_SESSION_IMPL *s;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *ckpt_cfg;
@@ -2033,7 +2032,6 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const cha
         if (s != NULL) {
             const char *checkpoint_cfg[] = {
               WT_CONFIG_BASE(session, WT_SESSION_checkpoint), ckpt_cfg, NULL};
-            wt_session = &s->iface;
             WT_TRET(__wt_txn_checkpoint(s, checkpoint_cfg, true));
 
             /*
@@ -2041,7 +2039,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const cha
              */
             WT_WITH_DHANDLE(s, WT_SESSION_META_DHANDLE(s), __wt_tree_modify_set(s));
 
-            WT_TRET(wt_session->close(wt_session, config));
+            WT_TRET(__wt_session_close_internal(s));
         }
     }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2016,7 +2016,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char *config, const cha
         if (conn->txn_global.has_stable_timestamp)
             F_SET(conn, WT_CONN_CLOSING_TIMESTAMP);
     }
-    if (!F_ISSET(conn, WT_CONN_IN_MEMORY | WT_CONN_READONLY)) {
+    if (!F_ISSET(conn, WT_CONN_IN_MEMORY | WT_CONN_READONLY | WT_CONN_PANIC)) {
         /*
          * Perform rollback to stable to ensure that the stable version is written to disk on a
          * clean shutdown.

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -897,7 +897,7 @@ err:
     if (eviction_started)
         WT_TRET(__wt_evict_destroy(session));
 
-    WT_TRET(session->iface.close(&session->iface, NULL));
+    WT_TRET(__wt_session_close_internal(session));
     F_CLR(conn, WT_CONN_RECOVERING);
 
     return (ret);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1326,7 +1326,7 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
      */
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !no_ckpt)
         WT_TRET(session->iface.checkpoint(&session->iface, "force=1"));
-    WT_TRET(session->iface.close(&session->iface, NULL));
+    WT_TRET(__wt_session_close_internal(session));
 
     return (ret);
 }

--- a/test/suite/test_txn22.py
+++ b/test/suite/test_txn22.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_txn22.py
+#   Transactions: test salvage with removed
+
+import fnmatch, os, shutil, time
+from wtscenario import make_scenarios
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+
+def copy_for_crash_restart(olddir, newdir):
+    ''' Simulate a crash from olddir and restart in newdir. '''
+    # with the connection still open, copy files to new directory
+    shutil.rmtree(newdir, ignore_errors=True)
+    os.mkdir(newdir)
+    for fname in os.listdir(olddir):
+        fullname = os.path.join(olddir, fname)
+        # Skip lock file on Windows since it is locked
+        if os.path.isfile(fullname) and \
+            "WiredTiger.lock" not in fullname and \
+            "Tmplog" not in fullname and \
+            "Preplog" not in fullname:
+            shutil.copy(fullname, newdir)
+
+class test_txn22(wttest.WiredTigerTestCase, suite_subprocess):
+    base_config = 'cache_size=1GB'
+    conn_config = base_config
+
+    # File to be corrupted
+    filename_scenarios = [
+        ('WiredTiger', dict(filename='WiredTiger')),
+        ('WiredTiger.basecfg', dict(filename='WiredTiger.basecfg')),
+        ('WiredTiger.turtle', dict(filename='WiredTiger.turtle')),
+        ('WiredTiger.wt', dict(filename='WiredTiger.wt')),
+        ('WiredTigerHS.wt', dict(filename='WiredTigerHS.wt')),
+        ('test_txn22.wt', dict(filename='test_txn22.wt')),
+    ]
+
+    # In many cases, wiredtiger_open without any salvage options will
+    # just work.  We list those cases here.
+    openable = [
+        "removal:WiredTiger.basecfg",
+        "removal:WiredTiger.turtle",
+    ]
+
+    # The cases for which salvage will not work
+    not_salvageable = [
+        "removal:WiredTiger.turtle",
+        "removal:WiredTiger.wt",
+    ]
+
+    scenarios = make_scenarios(filename_scenarios)
+    uri = 'table:test_txn22'
+    create_params = 'key_format=i,value_format=S'
+    nrecords = 1000                                  # records per table.
+
+    def valuegen(self, i):
+        return str(i) + 'A' * 1024
+
+    # Insert a list of keys
+    def inserts(self, keylist):
+        c = self.session.open_cursor(self.uri)
+        for i in keylist:
+            c[i] = self.valuegen(i)
+        c.close()
+
+    def checks(self):
+        c = self.session.open_cursor(self.uri)
+        gotlist = []
+        for key, value in c:
+            gotlist.append(key)
+            self.assertEqual(self.valuegen(key), value)
+        c.close()
+
+    def corrupt_meta(self, homedir):
+        # Mark this test has having corrupted files
+        self.databaseCorrupted()
+        filename = os.path.join(homedir, self.filename)
+        os.remove(filename)
+
+    def is_openable(self):
+        key = 'removal:' + self.filename
+        return key in self.openable
+
+    def is_salvageable(self):
+        key = 'removal:' + self.filename
+        return key not in self.not_salvageable
+
+    def test_corrupt_meta(self):
+        newdir = "RESTART"
+        newdir2 = "RESTART2"
+        expect = list(range(0, self.nrecords))
+        salvage_config = self.base_config + ',salvage=true'
+
+        self.session.create(self.uri, self.create_params)
+        self.inserts(expect)
+
+        # Simulate a crash by copying the contents of the directory
+        # before closing.  After we corrupt the copy, make another
+        # copy of the corrupted directory.
+        #
+        # The first corrupted copy will be used to run:
+        #    wiredtiger_open without salvage flag, followed by:
+        #    wiredtiger_open with salvage flag.
+        # The second directory will be used to run:
+        #    wiredtiger_open with salvage flag first.
+
+        copy_for_crash_restart(self.home, newdir)
+        self.close_conn()
+        self.corrupt_meta(newdir)
+        copy_for_crash_restart(newdir, newdir2)
+
+        for salvagedir in [ newdir, newdir2 ]:
+            # Removing the 'WiredTiger.turtle' file has weird behavior:
+            #  Immediately doing wiredtiger_open (without salvage) succeeds.
+            #  Following that, wiredtiger_open w/ salvage also succeeds.
+            #
+            #  But, immediately after the corruption, if we run
+            #  wiredtiger_open with salvage, it will fail.
+            # This anomoly should be fixed or explained.
+            if self.filename == 'WiredTiger.turtle':
+                continue
+
+            if self.is_salvageable():
+                if self.filename == 'WiredTigerHS.wt':
+                    # Without salvage, they result in an error during the wiredtiger_open.
+                    # But the nature of the messages produced during the error is variable
+                    # by which case it is, and even variable from system to system.
+                    with self.expectedStdoutPattern('.'):
+                        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                            lambda: self.reopen_conn(salvagedir, self.base_config),
+                            '/.*/')
+
+                self.reopen_conn(salvagedir, salvage_config)
+                if self.filename == 'test_txn22':
+                    self.checks()
+            else:
+                # Certain cases are not currently salvageable, they result in
+                # an error during the wiredtiger_open.  But the nature of the
+                # messages produced during the error is variable by which case
+                # it is, and even variable from system to system.
+                with self.expectedStdoutPattern('.'):
+                    self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                        lambda: self.reopen_conn(salvagedir, salvage_config),
+                        '/.*/')
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Due to PANIC error set by the recovery failure stops processing
any session operations led to memory leak. Avoid stopping of processing
session operations for the internal sessions can fix the memory leak
and also avoid performing the final checkpoint when the connection
is PANIC state