### PR TITLE
WT-6561 Add wt utility options for logging configuration

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -232,7 +232,7 @@ LZO
 LeafGreen
 LevelDB
 Levyx
-LmRrSVv
+LlmRrSVv
 LmsT
 LoadLoad
 LockFile
@@ -983,6 +983,7 @@ lwsync
 lx
 lz
 lzo
+mRrSVv
 mT
 madvise
 majmin

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -287,10 +287,6 @@ open:
     }
     len += strlen("log=(");
     len += strlen(rec_config);
-    if ((p = malloc(len)) == NULL) {
-        (void)util_err(NULL, errno, NULL);
-        goto err;
-    }
     if (compressor != NULL) {
         len += strlen(COMPRESSOR_PREFIX);
         len += strlen(compressor);
@@ -300,6 +296,10 @@ open:
         len += strlen(log_path);
     }
     len += strlen(")");
+    if ((p = malloc(len)) == NULL) {
+        (void)util_err(NULL, errno, NULL);
+        goto err;
+    }
     if ((ret = __wt_snprintf(p, len, "error_prefix=wt,%s,%s,%s,log=(%s,%s%s,%s%s),%s%s%s%s",
            config == NULL ? "" : config, cmd_config == NULL ? "" : cmd_config,
            readonly_config == NULL ? "" : readonly_config, rec_config,

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -16,13 +16,13 @@ bool verbose = false; /* Verbose flag */
 
 static const char *command; /* Command name */
 
+#define COMPRESSOR_PREFIX "compressor="
+#define PATH_PREFIX "path="
 #define READONLY "readonly=true"
 #define REC_ERROR "enabled=true,recover=error"
 #define REC_LOGOFF "enabled=false"
 #define REC_RECOVER "enabled=true,recover=on"
 #define SALVAGE "salvage=true"
-#define COMPRESSOR_PREFIX "compressor="
-#define PATH_PREFIX "path="
 
 static void
 usage(void)


### PR DESCRIPTION
This PR is adding some options to the `wt` utility to allow us to specify the log compressor and path relative to the data files. This is important for MongoDB data files because they're usually running with the `snappy` compressor and the logs are in `<dbpath>journal`.

The data files that @kommiharibabu was looking at can be salvaged like so:
```
LD_LIBRARY_PATH=.libs .libs/wt -h ~/work/data/db/job0/resmoke/shard0/node1 -R -c snappy -l journal salvage file:_mdb_catalog.wt
```