### PR TITLE
WT-6561 Provide MongoDB configuration in the wt utility usage output

### DIFF
--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -154,12 +154,6 @@ main(int argc, char *argv[])
         fprintf(stderr, "-R and -S cannot be used with -r\n");
         goto err;
     }
-    /*
-     * If the user specifies log configuration with the -C flag, it will override the log
-     * configuration provided by the -R or -L flags. We should warn about this.
-     */
-    if ((logoff || recover) && cmd_config != NULL && strstr(cmd_config, "log") != NULL)
-        fprintf(stderr, "Custom \"log\" configuration detected. -R and -L will be overridden.\n");
     argc -= __wt_optind;
     argv += __wt_optind;
 

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -158,9 +158,8 @@ main(int argc, char *argv[])
      * If the user specifies log configuration with the -C flag, it will override the log
      * configuration provided by the -R or -L flags. We should warn about this.
      */
-    if ((logoff || recover) && cmd_config != NULL && strstr(cmd_config, "log") != NULL) {
+    if ((logoff || recover) && cmd_config != NULL && strstr(cmd_config, "log") != NULL)
         fprintf(stderr, "Custom \"log\" configuration detected. -R and -L will be overridden.\n");
-    }
     argc -= __wt_optind;
     argv += __wt_optind;
 

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -10,13 +10,13 @@
 
 const char *home = "."; /* Home directory */
 /* Give users a hint in the help output if they're trying to read MongoDB data files. */
-const char *mongodb_config = "log=(enabled=true,path=journal,compressor=snappy)";
 const char *progname; /* Program name */
                       /* Global arguments */
 const char *usage_prefix = "[-LmRrSVv] [-C config] [-E secretkey] [-h home]";
 bool verbose = false; /* Verbose flag */
 
 static const char *command; /* Command name */
+static const char *mongodb_config = "log=(enabled=true,path=journal,compressor=snappy)";
 
 #define READONLY "readonly=true"
 #define REC_ERROR "log=(recover=error)"

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -9,13 +9,14 @@
 #include "util.h"
 
 const char *home = "."; /* Home directory */
-/* Give users a hint in the help output if they're trying to read MongoDB data files. */
-const char *progname; /* Program name */
-                      /* Global arguments */
+const char *progname;   /* Program name */
+                        /* Global arguments */
 const char *usage_prefix = "[-LmRrSVv] [-C config] [-E secretkey] [-h home]";
 bool verbose = false; /* Verbose flag */
 
 static const char *command; /* Command name */
+
+/* Give users a hint in the help output if they're trying to read MongoDB data files. */
 static const char *mongodb_config = "log=(enabled=true,path=journal,compressor=snappy)";
 
 #define READONLY "readonly=true"

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -151,6 +151,13 @@ main(int argc, char *argv[])
         fprintf(stderr, "-R and -S cannot be used with -r\n");
         goto err;
     }
+    /*
+     * If the user specifies log configuration with the -C flag, it will override the log
+     * configuration provided by the -R or -L flags. We should warn about this.
+     */
+    if ((logoff || recover) && cmd_config != NULL && strstr(cmd_config, "log") != NULL) {
+        fprintf(stderr, "Custom \"log\" configuration detected. -R and -L will be overridden.\n");
+    }
     argc -= __wt_optind;
     argv += __wt_optind;
 

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -9,8 +9,10 @@
 #include "util.h"
 
 const char *home = "."; /* Home directory */
-const char *progname;   /* Program name */
-                        /* Global arguments */
+/* Give users a hint in the help output if they're trying to read MongoDB data files. */
+const char *mongodb_config = "log=(enabled=true,path=journal,compressor=snappy)";
+const char *progname; /* Program name */
+                      /* Global arguments */
 const char *usage_prefix = "[-LmRrSVv] [-C config] [-E secretkey] [-h home]";
 bool verbose = false; /* Verbose flag */
 
@@ -49,6 +51,7 @@ usage(void)
 
     fprintf(stderr, "WiredTiger Data Engine (version %d.%d)\n", WIREDTIGER_VERSION_MAJOR,
       WIREDTIGER_VERSION_MINOR);
+    fprintf(stderr, "MongoDB wiredtiger_open configuration: \"%s\"\n", mongodb_config);
     util_usage(NULL, "global_options:", options);
     util_usage(NULL, "commands:", commands);
 }

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -16,7 +16,7 @@ bool verbose = false; /* Verbose flag */
 
 static const char *command; /* Command name */
 
-/* Give users a hint in the help output if they're trying to read MongoDB data files. */
+/* Give users a hint in the help output for if they're trying to read MongoDB data files */
 static const char *mongodb_config = "log=(enabled=true,path=journal,compressor=snappy)";
 
 #define READONLY "readonly=true"


### PR DESCRIPTION
This PR is making a usability fix to the `wt` utility. A common use case is to use the utility on MongoDB data files which require a specific set of options in the `-C` argument.

I've added a line in the help output to provide the correct configuration to use for MongoDB data files.