### PR TITLE
WT-6421 Avoid parsing metadata checkpoint for clean files. (#5924)

### DIFF
--- a/dist/s_stat
+++ b/dist/s_stat
@@ -22,6 +22,7 @@ search=`sed \
 
 # There are some fields that are used, but we can't detect it.
 cat << UNUSED_STAT_FIELDS
+btree_clean_checkpoint_timer
 lock_checkpoint_count
 lock_checkpoint_wait_application
 lock_checkpoint_wait_internal

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -652,6 +652,7 @@ dsrc_stats = [
     # Btree statistics
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
+    BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_fix', 'column-store fixed-size leaf pages', 'no_scale,tree_walk'),
     BtreeStat('btree_column_internal', 'column-store internal pages', 'no_scale,tree_walk'),

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -196,6 +196,21 @@ struct __wt_btree {
      */
     uint64_t file_max;
 
+/*
+ * We maintain a timer for a clean file to avoid excessive checking of checkpoint information that
+ * incurs a large processing penalty. We avoid that but will periodically incur the cost to clean up
+ * checkpoints that can be deleted.
+ */
+#define WT_BTREE_CLEAN_CKPT(session, btree, val)                          \
+    do {                                                                  \
+        (btree)->clean_ckpt_timer = (val);                                \
+        WT_STAT_DATA_SET((session), btree_clean_checkpoint_timer, (val)); \
+    } while (0)
+/* Statistics don't like UINT64_MAX, use INT64_MAX. It's still forever. */
+#define WT_BTREE_CLEAN_CKPT_FOREVER INT64_MAX
+#define WT_BTREE_CLEAN_MINUTES 10
+    uint64_t clean_ckpt_timer;
+
     /*
      * We flush pages from the tree (in order to make checkpoint faster), without a high-level lock.
      * To avoid multiple threads flushing at the same time, lock the tree.

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -734,6 +734,7 @@ struct __wt_dsrc_stats {
     int64_t block_size;
     int64_t block_minor;
     int64_t btree_checkpoint_generation;
+    int64_t btree_clean_checkpoint_timer;
     int64_t btree_column_fix;
     int64_t btree_column_internal;
     int64_t btree_column_rle;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5859,364 +5859,366 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BLOCK_MINOR			2021
 /*! btree: btree checkpoint generation */
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2022
+/*! btree: btree clean tree checkpoint expiration time */
+#define	WT_STAT_DSRC_BTREE_CLEAN_CHECKPOINT_TIMER	2023
 /*!
  * btree: column-store fixed-size leaf pages, only reported if tree_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2023
+#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2024
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2024
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2025
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2025
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2026
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2026
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2027
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2027
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2028
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2028
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2029
 /*! btree: maximum internal page key size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLKEY			2029
+#define	WT_STAT_DSRC_BTREE_MAXINTLKEY			2030
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2030
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2031
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2031
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2032
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2032
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2033
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2033
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2034
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2034
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2035
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2035
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2036
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2036
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2037
 /*! btree: pages rewritten by compaction */
-#define	WT_STAT_DSRC_BTREE_COMPACT_REWRITE		2037
+#define	WT_STAT_DSRC_BTREE_COMPACT_REWRITE		2038
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2038
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2039
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2039
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2040
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2040
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2041
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2041
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2042
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2042
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2043
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2043
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2044
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2044
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2045
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2045
+#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2046
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2046
+#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2047
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2047
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2048
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2048
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2049
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2049
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2050
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2051
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2052
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2053
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2054
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2054
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2055
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2055
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2056
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2056
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2057
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2057
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2058
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2059
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2060
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2061
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2061
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2062
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2062
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2063
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2064
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2065
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2066
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2067
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2067
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2068
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2069
 /*! cache: page written requiring cache overflow records */
-#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2069
+#define	WT_STAT_DSRC_CACHE_WRITE_LOOKASIDE		2070
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2070
+#define	WT_STAT_DSRC_CACHE_READ				2071
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2071
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2072
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2072
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2073
 /*! cache: pages read into cache requiring cache overflow entries */
-#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2073
+#define	WT_STAT_DSRC_CACHE_READ_LOOKASIDE		2074
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2074
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2075
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2076
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2076
+#define	WT_STAT_DSRC_CACHE_WRITE			2077
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2077
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2078
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2078
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2079
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2080
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2080
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2081
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2081
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2082
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2082
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2083
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2083
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2084
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2084
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2085
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2085
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2086
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2086
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2087
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2087
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2088
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2088
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2089
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2089
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2090
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2090
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2091
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2091
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2092
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2092
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2093
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2093
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2094
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2094
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2095
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2095
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2096
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2096
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2097
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2097
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2098
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2098
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2099
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2099
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2100
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2100
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2101
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2101
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2102
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2102
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2103
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2103
+#define	WT_STAT_DSRC_COMPRESS_READ			2104
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2104
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2105
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2105
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2106
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2106
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2107
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2107
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2108
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2108
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2109
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2109
+#define	WT_STAT_DSRC_CURSOR_CACHE			2110
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2110
+#define	WT_STAT_DSRC_CURSOR_CREATE			2111
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2111
+#define	WT_STAT_DSRC_CURSOR_INSERT			2112
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2112
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2113
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2113
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2114
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2114
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2115
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2115
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2116
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2116
+#define	WT_STAT_DSRC_CURSOR_NEXT			2117
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2117
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2118
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2118
+#define	WT_STAT_DSRC_CURSOR_RESTART			2119
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2119
+#define	WT_STAT_DSRC_CURSOR_PREV			2120
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2120
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2121
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2121
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2122
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2122
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2123
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2123
+#define	WT_STAT_DSRC_CURSOR_RESET			2124
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2124
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2125
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2125
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2126
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2126
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2127
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2127
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2128
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2128
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2129
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2129
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2130
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2130
+#define	WT_STAT_DSRC_REC_DICTIONARY			2131
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2131
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2132
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2132
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2133
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2133
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2134
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2134
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2135
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2135
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2136
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2136
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2137
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2137
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2138
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2138
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2139
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2139
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2140
 /*! reconciliation: page checksum matches */
-#define	WT_STAT_DSRC_REC_PAGE_MATCH			2140
+#define	WT_STAT_DSRC_REC_PAGE_MATCH			2141
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2141
+#define	WT_STAT_DSRC_REC_PAGES				2142
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2142
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2143
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2143
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2144
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2144
+#define	WT_STAT_DSRC_SESSION_COMPACT			2145
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2145
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2146
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -15,8 +15,8 @@ static const char *const __stats_dsrc_desc[] = {
   "block-manager: file bytes available for reuse", "block-manager: file magic number",
   "block-manager: file major version number", "block-manager: file size in bytes",
   "block-manager: minor version number", "btree: btree checkpoint generation",
-  "btree: column-store fixed-size leaf pages", "btree: column-store internal pages",
-  "btree: column-store variable-size RLE encoded values",
+  "btree: btree clean tree checkpoint expiration time", "btree: column-store fixed-size leaf pages",
+  "btree: column-store internal pages", "btree: column-store variable-size RLE encoded values",
   "btree: column-store variable-size deleted values",
   "btree: column-store variable-size leaf pages", "btree: fixed-record size",
   "btree: maximum internal page key size", "btree: maximum internal page size",
@@ -154,6 +154,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->block_size = 0;
     stats->block_minor = 0;
     /* not clearing btree_checkpoint_generation */
+    /* not clearing btree_clean_checkpoint_timer */
     stats->btree_column_fix = 0;
     stats->btree_column_internal = 0;
     stats->btree_column_rle = 0;
@@ -319,6 +320,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     if (from->block_minor > to->block_minor)
         to->block_minor = from->block_minor;
     to->btree_checkpoint_generation += from->btree_checkpoint_generation;
+    to->btree_clean_checkpoint_timer += from->btree_clean_checkpoint_timer;
     to->btree_column_fix += from->btree_column_fix;
     to->btree_column_internal += from->btree_column_internal;
     to->btree_column_rle += from->btree_column_rle;
@@ -485,6 +487,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     if ((v = WT_STAT_READ(from, block_minor)) > to->block_minor)
         to->block_minor = v;
     to->btree_checkpoint_generation += WT_STAT_READ(from, btree_checkpoint_generation);
+    to->btree_clean_checkpoint_timer += WT_STAT_READ(from, btree_clean_checkpoint_timer);
     to->btree_column_fix += WT_STAT_READ(from, btree_column_fix);
     to->btree_column_internal += WT_STAT_READ(from, btree_column_internal);
     to->btree_column_rle += WT_STAT_READ(from, btree_column_rle);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1301,16 +1301,15 @@ __checkpoint_lock_dirty_tree(
     WT_CONFIG_ITEM cval, k, v;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
+    uint64_t now;
     char *name_alloc;
     const char *name;
+    bool is_drop, is_wt_ckpt, skip_ckpt;
 
     btree = S2BT(session);
     ckpt = ckptbase = NULL;
     dhandle = session->dhandle;
     name_alloc = NULL;
-
-    /* Only referenced in diagnostic builds. */
-    WT_UNUSED(is_checkpoint);
 
     /*
      * Only referenced in diagnostic builds and gcc 5.1 isn't satisfied with wrapping the entire
@@ -1327,20 +1326,56 @@ __checkpoint_lock_dirty_tree(
      */
     WT_ASSERT(session, !need_tracking || WT_IS_METADATA(dhandle) || WT_META_TRACKING(session));
 
-    /* Get the list of checkpoints for this file. */
-    WT_RET(__wt_meta_ckptlist_get(session, dhandle->name, true, &ckptbase));
-
     /* This may be a named checkpoint, check the configuration. */
     cval.len = 0;
+    is_drop = is_wt_ckpt = false;
     if (cfg != NULL)
         WT_ERR(__wt_config_gets(session, cfg, "name", &cval));
-    if (cval.len == 0)
+    if (cval.len == 0) {
         name = WT_CHECKPOINT;
-    else {
+        is_wt_ckpt = true;
+    } else {
         WT_ERR(__checkpoint_name_ok(session, cval.str, cval.len));
         WT_ERR(__wt_strndup(session, cval.str, cval.len, &name_alloc));
         name = name_alloc;
     }
+
+    /*
+     * Determine if a drop is part of the configuration. It usually isn't, so delay processing more
+     * until we know if we need to process this tree.
+     */
+    if (cfg != NULL) {
+        cval.len = 0;
+        WT_ERR(__wt_config_gets(session, cfg, "drop", &cval));
+        if (cval.len != 0)
+            is_drop = true;
+    }
+
+    /*
+     * This is a complicated test to determine if we can avoid the expensive call of getting the
+     * list of checkpoints for this file. We want to avoid that for clean files. But on clean files
+     * we want to periodically check if we need to delete old checkpoints that may have been in use
+     * by an open cursor.
+     */
+    if (!btree->modified && !force && is_checkpoint && is_wt_ckpt && !is_drop) {
+        /* In the common case of the timer set forever, don't even check the time. */
+        skip_ckpt = true;
+        if (btree->clean_ckpt_timer != WT_BTREE_CLEAN_CKPT_FOREVER) {
+            __wt_seconds(session, &now);
+            if (now > btree->clean_ckpt_timer)
+                skip_ckpt = false;
+        }
+        if (skip_ckpt) {
+            F_SET(btree, WT_BTREE_SKIP_CKPT);
+            goto skip;
+        }
+    }
+
+    /* If we have to process this btree for any reason, reset the timer. */
+    WT_BTREE_CLEAN_CKPT(session, btree, 0);
+
+    /* Get the list of checkpoints for this file. */
+    WT_ERR(__wt_meta_ckptlist_get(session, dhandle->name, true, &ckptbase));
 
     /* We may be dropping specific checkpoints, check the configuration. */
     if (cfg != NULL) {
@@ -1396,6 +1431,7 @@ __checkpoint_lock_dirty_tree(
 err:
         __wt_meta_ckptlist_free(session, &ckptbase);
     }
+skip:
     __wt_free(session, name_alloc);
 
     return (ret);
@@ -1410,6 +1446,7 @@ __checkpoint_mark_skip(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, bool force)
 {
     WT_BTREE *btree;
     WT_CKPT *ckpt;
+    uint64_t timer;
     int deleted;
     const char *name;
 
@@ -1454,6 +1491,19 @@ __checkpoint_mark_skip(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, bool force)
               (WT_PREFIX_MATCH(name, WT_CHECKPOINT) &&
                 WT_PREFIX_MATCH((ckpt - 2)->name, WT_CHECKPOINT)))) {
             F_SET(btree, WT_BTREE_SKIP_CKPT);
+            /*
+             * If there are potentially extra checkpoints to delete, we set the timer to recheck
+             * later. If there are at most two checkpoints, the current one and possibly a previous
+             * one, then we know there are no additional ones to delete. In that case, set the timer
+             * to forever. If the table gets dirtied or a checkpoint is forced that will clear the
+             * timer.
+             */
+            if (ckpt - ckptbase > 2) {
+                __wt_seconds(session, &timer);
+                timer += WT_MINUTE * WT_BTREE_CLEAN_MINUTES;
+                WT_BTREE_CLEAN_CKPT(session, btree, timer);
+            } else
+                WT_BTREE_CLEAN_CKPT(session, btree, WT_BTREE_CLEAN_CKPT_FOREVER);
             return (0);
         }
     }

--- a/test/suite/test_checkpoint05.py
+++ b/test/suite/test_checkpoint05.py
@@ -44,7 +44,7 @@ class test_checkpoint05(wttest.WiredTigerTestCase):
         while metadata_cursor.next() == 0:
             key = metadata_cursor.get_key()
             value = metadata_cursor[key]
-            nckpt = nckpt + value.count("WiredTigerCheckpoint")
+            nckpt += value.count("WiredTigerCheckpoint")
         metadata_cursor.close()
         return nckpt
 

--- a/test/suite/test_checkpoint07.py
+++ b/test/suite/test_checkpoint07.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_checkpoint07.py
+# Test that the checkpoints timing statistics are populated as expected.
+
+import wiredtiger, wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+
+def timestamp_str(t):
+    return '%x' % t
+
+class test_checkpoint07(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    def get_stat(self, uri):
+        stat_uri = 'statistics:' + uri
+        stat_cursor = self.session.open_cursor(stat_uri)
+        val = stat_cursor[stat.dsrc.btree_clean_checkpoint_timer][2]
+        stat_cursor.close()
+        return val
+
+    def test_checkpoint07(self):
+        self.uri1 = 'table:ckpt05.1'
+        self.file1 = 'file:ckpt05.1.wt'
+        self.uri2 = 'table:ckpt05.2'
+        self.file2 = 'file:ckpt05.2.wt'
+        self.uri3 = 'table:ckpt05.3'
+        self.file3 = 'file:ckpt05.3.wt'
+        self.session.create(self.uri1, 'key_format=i,value_format=i')
+        self.session.create(self.uri2, 'key_format=i,value_format=i')
+        self.session.create(self.uri3, 'key_format=i,value_format=i')
+
+        # Setup: Insert some data and checkpoint it. Then modify only
+        # the data in the first table and checkpoint. Verify the clean skip
+        # timer is not set for the modified table and is set for the clean one.
+        c1 = self.session.open_cursor(self.uri1, None)
+        c2 = self.session.open_cursor(self.uri2, None)
+        c3 = self.session.open_cursor(self.uri3, None)
+        c1[1] = 1
+        c2[1] = 1
+        c3[1] = 1
+        self.session.checkpoint(None)
+        c1[2] = 2
+        self.session.checkpoint(None)
+        val1 = self.get_stat(self.file1)
+        self.assertEqual(val1, 0)
+        val2 = self.get_stat(self.file2)
+        self.assertNotEqual(val2, 0)
+        val3 = self.get_stat(self.file3)
+        self.assertNotEqual(val3, 0)
+        # It is possible that we could span the second timer when processing table
+        # two and table three during the checkpoint. If they're different check
+        # they are within 1 second of each other.
+        if val2 != val3:
+            self.assertTrue(val2 == val3 - 1 or val3 == val2 - 1)
+
+        # Now force a checkpoint on clean tables. No clean timer should be set.
+        self.session.checkpoint('force=true')
+        val = self.get_stat(self.uri1)
+        self.assertEqual(val, 0)
+        val = self.get_stat(self.uri2)
+        self.assertEqual(val, 0)
+        val = self.get_stat(self.uri3)
+        self.assertEqual(val, 0)
+
+        # Modify the first two tables and reverify all three.
+        c1[3] = 3
+        c2[3] = 3
+        self.session.checkpoint(None)
+        val = self.get_stat(self.uri1)
+        self.assertEqual(val, 0)
+        val = self.get_stat(self.uri2)
+        self.assertEqual(val, 0)
+        val = self.get_stat(self.uri3)
+        self.assertNotEqual(val, 0)
+
+        # Open a backup cursor. This will pin the most recent checkpoint.
+        # Modify table 1 and checkpoint, then modify table 2 and checkpoint.
+        # The open backup cursor will cause table 1 to get the smaller timer.
+        backup_cursor = self.session.open_cursor('backup:', None, None)
+        c1[4] = 4
+        self.session.checkpoint(None)
+        val = self.get_stat(self.uri1)
+        self.assertEqual(val, 0)
+
+        c2[4] = 4
+        self.session.checkpoint(None)
+        val2 = self.get_stat(self.uri2)
+        self.assertEqual(val2, 0)
+
+        val1 = self.get_stat(self.uri1)
+        val3 = self.get_stat(self.uri3)
+        # Assert table 1 does not have the forever timer value, but it is set.
+        # This assumes table 3 has the forever value.
+        self.assertNotEqual(val1, 0)
+        self.assertNotEqual(val3, 0)
+        self.assertLess(val1, val3)
+        # Save the old forever value from table 3.
+        oldval3 = val3
+
+        # Force a checkpoint while the backup cursor is open. Then write again
+        # to table 2. Since table 1 and table 3 are clean again, this should
+        # force both table 1 and table 3 to have the smaller timer.
+        self.session.checkpoint('force=true')
+        val1 = self.get_stat(self.uri1)
+        val3 = self.get_stat(self.uri3)
+        self.assertEqual(val1, 0)
+        self.assertEqual(val3, 0)
+        c2[5] = 5
+        self.session.checkpoint(None)
+        val2 = self.get_stat(self.uri2)
+        self.assertEqual(val2, 0)
+
+        val1 = self.get_stat(self.uri1)
+        val3 = self.get_stat(self.uri3)
+        self.assertNotEqual(val1, 0)
+        self.assertNotEqual(val3, 0)
+        self.assertLess(val3, oldval3)
+        # It is possible that we could span the second timer when processing table
+        # two and table three during the checkpoint. If they're different check
+        # they are within 1 second of each other.
+        if val1 != val3:
+            self.assertTrue(val1 == val3 - 1 or val3 == val1 - 1)
+
+        backup_cursor.close()
+
+        # Repeat the sequence of forcing a checkpoint and then modifying after
+        # closing the backup cursor to check that both tables are now marked
+        # with the forever value.
+        self.session.checkpoint('force=true')
+        val1 = self.get_stat(self.uri1)
+        val3 = self.get_stat(self.uri3)
+        self.assertEqual(val1, 0)
+        self.assertEqual(val3, 0)
+        c2[6] = 6
+        self.session.checkpoint(None)
+        val2 = self.get_stat(self.uri2)
+        self.assertEqual(val2, 0)
+
+        val1 = self.get_stat(self.uri1)
+        val3 = self.get_stat(self.uri3)
+        self.assertNotEqual(val1, 0)
+        self.assertNotEqual(val3, 0)
+        # It is possible that we could span the second timer when processing table
+        # two and table three during the checkpoint. If they're different check
+        # they are within 1 second of each other.
+        if val1 != val3:
+            self.assertTrue(val1 == val3 - 1 or val3 == val1 - 1)
+        self.assertEqual(val3, oldval3)
+
+        self.session.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
* WT-6421 Avoid parsing metadata checkpoint for clean files.

* Set timer to forever if we know we'll never have to delete older
checkpoints.

* Fix WT_RET to WT_ERR.

* Remove unneeded WT_UNUSED. And formatting.

* Add per-btree stat for clean checkpoint timer

* Add new stat to list we cannot detect.

* Add test and fixes for it.

* Alphabetize.

* Clean up and simplify test

* Fix test to check values are within 1 second of each other.

* Style fixes. Remove unneeded code/comment.

(cherry picked from commit 8d8e71d683e08794cfd6946e56bdd81042fb2fd8)