### PR TITLE
WT-5144 Improve runtime in perf programs.

### DIFF
--- a/bench/workgen/workgen_func.c
+++ b/bench/workgen/workgen_func.c
@@ -50,6 +50,12 @@ workgen_atomic_add64(uint64_t *vp, uint64_t v)
 }
 
 void
+workgen_clock(uint64_t *clockp)
+{
+    *clockp = __wt_clock(NULL);
+}
+
+void
 workgen_epoch(struct timespec *tsp)
 {
     __wt_epoch(NULL, tsp);

--- a/bench/workgen/workgen_func.h
+++ b/bench/workgen/workgen_func.h
@@ -29,6 +29,7 @@ struct workgen_random_state;
 
 extern uint32_t workgen_atomic_add32(uint32_t *vp, uint32_t v);
 extern uint64_t workgen_atomic_add64(uint64_t *vp, uint64_t v);
+extern void workgen_clock(uint64_t *tsp);
 extern void workgen_epoch(struct timespec *tsp);
 extern uint32_t workgen_random(struct workgen_random_state volatile *rnd_state);
 extern int workgen_random_alloc(WT_SESSION *session, struct workgen_random_state **rnd_state);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -51,10 +51,10 @@ struct WorkgenTimeStamp {
     WorkgenTimeStamp() {}
 
     static uint64_t get_timestamp_lag(double seconds) {
-        timespec start_time;
-        workgen_epoch(&start_time);
+        uint64_t start_time;
+        workgen_clock(&start_time);
 
-        return (ts_us(start_time) - secs_us(seconds));
+        return (ns_to_us(start_time) - secs_us(seconds));
     }
 
     static void sleep(double seconds) {
@@ -62,10 +62,9 @@ struct WorkgenTimeStamp {
     }
 
     static uint64_t get_timestamp() {
-        timespec start_time;
-        workgen_epoch(&start_time);
-
-        return (ts_us(start_time));
+        uint64_t start_time;
+        workgen_clock(&start_time);
+        return (ns_to_us(start_time));
     }
 };
 


### PR DESCRIPTION
@ddanderson please carefully check the changes to `workgen`. I left some of the `workgen_epoch` calls in there where it was not an obvious `stop-start` timing situation.