### PR TITLE
WT-6650 Don't raise error until session is closed properly

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -267,7 +267,7 @@ __session_close(WT_SESSION *wt_session, const char *config)
     SESSION_API_CALL_PREPARE_ALLOWED(session, close, config, cfg);
     WT_UNUSED(cfg);
 
-    WT_ERR(__wt_session_close_internal(session));
+    WT_TRET(__wt_session_close_internal(session));
     session = NULL;
 
 err:


### PR DESCRIPTION
Once the session->close API enters the code to close the session,
don't raise intermmediate errors until the session is closed properly.