### PR TITLE
WT-6592 Avoid marking errors for skipped Python tests due to not-built extension

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -254,6 +254,10 @@ class WiredTigerTestCase(unittest.TestCase):
     def buildDirectory(self):
         return self._builddir
 
+    def skipTest(self, reason):
+        self.skipped = True
+        super(WiredTigerTestCase, self).skipTest(reason)
+
     # Return the wiredtiger_open extension argument for
     # any needed shared library.
     def extensionsConfig(self):
@@ -284,7 +288,6 @@ class WiredTigerTestCase(unittest.TestCase):
             filenames = glob.glob(pat)
             if len(filenames) == 0:
                 if skipIfMissing:
-                    self.skipped = True
                     self.skipTest('extension "' + ext + '" not built')
                     continue
                 else:
@@ -462,7 +465,7 @@ class WiredTigerTestCase(unittest.TestCase):
         self.pr('skipped=' + str(self.skipped))
 
         # Clean up unless there's a failure
-        if passed and not WiredTigerTestCase._preserveFiles or self.skipped:
+        if (passed and (not WiredTigerTestCase._preserveFiles)) or self.skipped:
             shutil.rmtree(self.testdir, ignore_errors=True)
         else:
             self.pr('preserving directory ' + self.testdir)
@@ -470,7 +473,7 @@ class WiredTigerTestCase(unittest.TestCase):
         elapsed = time.time() - self.starttime
         if elapsed > 0.001 and WiredTigerTestCase._verbose >= 2:
             print("%s: %.2f seconds" % (str(self), elapsed))
-        if not passed and not self.skipped:
+        if (not passed) and (not self.skipped):
             print("ERROR in " + str(self))
             self.pr('FAIL')
             self.pr('preserving directory ' + self.testdir)


### PR DESCRIPTION
Introducing a new `skipped` instance variable in `WiredTigerTestCase` Python class. Setting the variable while detecting not-built extension and calling skipTest(), and at the tearDown phase avoid treating the skipped test as an error.

Please note normally when a test is marked as skipped in unittest framework, no setUp() or tearDown() would be called. The case we are trying to address here is a bit special, that the test is not skipped at the beginning (as a whole), instead, the skip decision is made at a later stage of the test when detecting missing extension. 