### PR TITLE
WT-6694 Verify hs file exists or not before recovery

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1508,7 +1508,7 @@ extern int __wt_txn_query_timestamp(WT_SESSION_IMPL *session, char *hex_timestam
   const char *cfg[], bool global_txn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
+extern int __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[], bool hs_exists)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
Verifying history store file exists or not before recovery avoids a
PANIC error thus it frees the allocated memory