### PR TITLE
WT-6643 Add barrier to make sure we read the latest value in the log slot.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -802,6 +802,7 @@ restart:
                  */
                 if (slot->slot_start_lsn.l.offset != slot->slot_last_offset)
                     slot->slot_start_lsn.l.offset = (uint32_t)slot->slot_last_offset;
+                WT_READ_BARRIER();
                 log->write_start_lsn = slot->slot_start_lsn;
                 log->write_lsn = slot->slot_end_lsn;
                 __wt_cond_signal(session, log->log_write_cond);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1930,6 +1930,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
     WT_STAT_CONN_INCR(session, log_release_write_lsn);
     __log_wait_for_earlier_slot(session, slot);
 
+    WT_READ_BARRIER();
     log->write_start_lsn = slot->slot_start_lsn;
     log->write_lsn = slot->slot_end_lsn;
 


### PR DESCRIPTION
Debugging the one reproduced case, the evidence said "this shouldn't happen" because the value in the `slot_end_lsn` in the slot was the correct value, but the value in the system field was its original value. That suggests a barrier issue to me. I have not been able to reproduce otherwise.