### PR TITLE
WT-6798 Utilize Arm LSE atomics and the correct strength barriers

### DIFF
--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -102,6 +102,12 @@ if test "$GCC" = "yes"; then
 	# instructions.
 	if test "$wt_cv_arm64" = "yes"; then
 		AM_CFLAGS="$AM_CFLAGS -march=armv8-a+crc"
+		# moutline-atomics preserves backwards compatibility with Arm v8.0
+		# systems but also supports using Arm v8.1 atomics. The latter can
+		# massively improve performance on larger Arm systems. The flag was
+		# back ported to gcc8, 9 and is the default in gcc10+. See if  the
+		# compiler supports the flag.
+		AX_CHECK_COMPILE_FLAG([-moutline-atomics], [AM_CFLAGS="$AM_CFLAGS -moutline-atomics"])
 	fi
 else
 	# The Solaris native compiler gets the additional -mt flag.

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -698,12 +698,14 @@ dll
 dlopen
 dlsym
 dmalloc
+dmb
 dmsg
 doxgen
 doxygen
 drealloc
 ds
 dsb
+dsbs
 dsk
 dsrc
 dst
@@ -894,6 +896,9 @@ isalpha
 iscntrl
 isdigit
 isgraph
+ish
+ishld
+ishst
 islocked
 islower
 ispo
@@ -1224,6 +1229,7 @@ setstr
 setv
 setvbuf
 sfence
+shareability
 signalled
 sii
 sizeof
@@ -1305,6 +1311,7 @@ timestamp
 timestamped
 timestamps
 tinfo
+tlb
 tmp
 todo
 tokenizer


### PR DESCRIPTION
Armv8 originally had load-exclusive/store-exclusive atomics. In Arm v8.1 these were extended with the Large Scale Extensions (LSE) which provided native atomic primitives such as compare-and-swap, load-and-add, etc which have been shown to scale much better on larger core-count systems. These are the default for -march=armv8.1-a, but to retain compatibility with older Arm systems the -moutline-atomics option is available which includes both new and old-style atomics and chooses dynamically. moutline-atomics is the default in gcc10 and has been backported to some distro gcc7 compilers as well as the official gcc 8 and 9 branches. Detect if the flag is available and if it is use it. 

bench/wtperf/runners/medium-btree.wtperf ops/s increases by 5x with  the flag applied.

Additionally, the barriers used for Arm are stronger than required. The existing dsb barriers guarantee completion, not ordering and synchronize other system activities such as tlb and cache maintenance instructions. Additionally, the sharability domain of them is system. Both of these are stronger than required. A dmb enforces ordering described in the header and the stronger dsb isn't needed. Furthermore, given that all the entities in the system which are depending on the ordering are CPUs the shareability doesn't need to order accesses with respect to device or non-cacheable memory, so it can be reduced to the inner-sharable domain.

This improve performance on the above test by about 4%. 

Both changes passed make check. 

