### PR TITLE
WT-6722 Review History Store API naming conventions

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -286,7 +286,7 @@ __debug_wrapup(WT_DBG *ds)
     msg = ds->msg;
 
     if (session->hs_cursor != NULL)
-        WT_TRET(__wt_hs_cursor_close(session));
+        WT_TRET(__wt_history_cursor_close(session));
 
     __wt_scr_free(session, &ds->key);
     __wt_scr_free(session, &ds->hs_key);
@@ -977,10 +977,10 @@ __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
 
     session = CUR2S(cursor_arg);
 
-    WT_RET(__wt_hs_cursor_open(session));
+    WT_RET(__wt_history_cursor_open(session));
     cbt = (WT_CURSOR_BTREE *)session->hs_cursor;
     WT_WITH_BTREE(session, CUR2BT(cbt), ret = __wt_debug_tree_all(session, NULL, NULL, ofile));
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
 
     return (ret);
 }
@@ -1026,7 +1026,7 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
      * doesn't work, we may be running in-memory.
      */
     if (!WT_IS_HS(S2BT(session))) {
-        if (session->hs_cursor != NULL || __wt_hs_cursor_open(session) == 0) {
+        if (session->hs_cursor != NULL || __wt_history_cursor_open(session) == 0) {
             WT_RET(__wt_scr_alloc(session, 0, &ds->hs_key));
             WT_RET(__wt_scr_alloc(session, 0, &ds->hs_value));
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -282,9 +282,9 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              */
             if (ret == 0 && (ckpt + 1)->name == NULL && !skip_hs) {
                 /* Open a history store cursor. */
-                WT_ERR(__wt_hs_cursor_open(session));
+                WT_ERR(__wt_history_cursor_open(session));
                 WT_TRET(__wt_history_store_verify_one(session));
-                WT_TRET(__wt_hs_cursor_close(session));
+                WT_TRET(__wt_history_cursor_close(session));
                 /*
                  * We cannot error out here. If we got an error verifying the history store, we need
                  * to follow through with reacquiring the exclusive call below. We'll error out

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -283,7 +283,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
             if (ret == 0 && (ckpt + 1)->name == NULL && !skip_hs) {
                 /* Open a history store cursor. */
                 WT_ERR(__wt_history_cursor_open(session));
-                WT_TRET(__wt_history_store_verify_one(session));
+                WT_TRET(__wt_history_verify_one(session));
                 WT_TRET(__wt_history_cursor_close(session));
                 /*
                  * We cannot error out here. If we got an error verifying the history store, we need

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2762,7 +2762,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      */
     if (verify_meta) {
         WT_ERR(__wt_open_internal_session(conn, "verify hs", false, 0, &verify_session));
-        ret = __wt_history_store_verify(verify_session);
+        ret = __wt_history_verify(verify_session);
         WT_TRET(__wt_session_close_internal(verify_session));
         WT_ERR(ret);
     }

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -819,7 +819,7 @@ restart:
     }
 
     /* Shut down the history store table after all eviction is complete. */
-    __wt_hs_close(session);
+    __wt_history_close(session);
 
     /*
      * Closing the files may have resulted in entries on our default session's list of open data

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -220,7 +220,7 @@ __wt_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
      * Create the history store file. This will only actually create it on a clean upgrade or when
      * creating a new database.
      */
-    WT_RET(__wt_hs_open(session, cfg));
+    WT_RET(__wt_history_open(session, cfg));
 
     /*
      * Start the optional logging/archive threads. NOTE: The log manager must be started before

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -422,7 +422,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     WT_ERR(__wt_capacity_server_create(session, cfg));
     WT_ERR(__wt_checkpoint_server_create(session, cfg));
     WT_ERR(__wt_debug_mode_config(session, cfg));
-    WT_ERR(__wt_hs_config(session, cfg));
+    WT_ERR(__wt_history_config(session, cfg));
     WT_ERR(__wt_logmgr_reconfig(session, cfg));
     WT_ERR(__wt_lsm_manager_reconfig(session, cfg));
     WT_ERR(__wt_statlog_create(session, cfg));

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -10,11 +10,11 @@
 #include "wt_internal.h"
 
 /*
- * __wt_hs_cursor_open --
+ * __wt_history_cursor_open --
  *     Open a new history store table cursor.
  */
 int
-__wt_hs_cursor_open(WT_SESSION_IMPL *session)
+__wt_history_cursor_open(WT_SESSION_IMPL *session)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -35,11 +35,11 @@ __wt_hs_cursor_open(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_hs_cursor_close --
+ * __wt_history_cursor_close --
  *     Discard a history store cursor.
  */
 int
-__wt_hs_cursor_close(WT_SESSION_IMPL *session)
+__wt_history_cursor_close(WT_SESSION_IMPL *session)
 {
     /* Should only be called when session has an open history store cursor */
     WT_ASSERT(session, session->hs_cursor != NULL);
@@ -50,11 +50,11 @@ __wt_hs_cursor_close(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_hs_cursor_next --
+ * __wt_history_cursor_next --
  *     Execute a next operation on a history store cursor with the appropriate isolation level.
  */
 int
-__wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+__wt_history_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 {
     WT_DECL_RET;
 
@@ -63,11 +63,11 @@ __wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 }
 
 /*
- * __wt_hs_cursor_prev --
+ * __wt_history_cursor_prev --
  *     Execute a prev operation on a history store cursor with the appropriate isolation level.
  */
 int
-__wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+__wt_history_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 {
     WT_DECL_RET;
 
@@ -76,12 +76,12 @@ __wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 }
 
 /*
- * __wt_hs_cursor_search_near --
+ * __wt_history_cursor_search_near --
  *     Execute a search near operation on a history store cursor with the appropriate isolation
  *     level.
  */
 int
-__wt_hs_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
+__wt_history_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
 {
     WT_DECL_RET;
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -283,8 +283,8 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
      * thread waiting for the first file to drain from the eviction queue. See WT-5946 for details.
      */
     if (session->hs_cursor == NULL && !F_ISSET(conn, WT_CONN_IN_MEMORY)) {
-        WT_RET(__wt_hs_cursor_open(session));
-        WT_RET(__wt_hs_cursor_close(session));
+        WT_RET(__wt_history_cursor_open(session));
+        WT_RET(__wt_history_cursor_close(session));
     }
 
     if (conn->evict_server_running && __wt_spin_trylock(session, &cache->evict_pass_lock) == 0) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -582,7 +582,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     if (!__evict_queue_empty(cache->evict_urgent_queue, false))
         LF_SET(WT_CACHE_EVICT_URGENT);
 
-    if (F_ISSET(conn, WT_CONN_HS_OPEN) && __wt_hs_get_btree(session, &hs_tree) == 0)
+    if (F_ISSET(conn, WT_CONN_HS_OPEN) && __wt_history_get_btree(session, &hs_tree) == 0)
         cache->bytes_hs = hs_tree->bytes_inmem;
 
     /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -142,8 +142,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     if (!WT_IS_METADATA(S2BT(session)->dhandle) && !F_ISSET(conn, WT_CONN_IN_MEMORY) &&
       session->hs_cursor == NULL && !F_ISSET(session, WT_SESSION_NO_RECONCILE) &&
       session != conn->default_session) {
-        WT_RET(__wt_hs_cursor_open(session));
-        WT_RET(__wt_hs_cursor_close(session));
+        WT_RET(__wt_history_cursor_open(session));
+        WT_RET(__wt_history_cursor_close(session));
     }
 
     /*

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -64,12 +64,12 @@ __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 
     *hs_btreep = NULL;
 
-    WT_RET(__wt_hs_cursor_open(session));
+    WT_RET(__wt_history_cursor_open(session));
 
     *hs_btreep = CUR2BT(session->hs_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
 
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
 
     return (ret);
 }

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -54,11 +54,11 @@ __hs_cleanup_las(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_hs_get_btree --
+ * __wt_history_get_btree --
  *     Get the history store btree. Open a history store cursor if needed to get the btree.
  */
 int
-__wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
+__wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 {
     WT_DECL_RET;
 
@@ -75,11 +75,11 @@ __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 }
 
 /*
- * __wt_hs_config --
+ * __wt_history_config --
  *     Configure the history store table.
  */
 int
-__wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
+__wt_history_config(WT_SESSION_IMPL *session, const char **cfg)
 {
     WT_BTREE *btree;
     WT_CONFIG_ITEM cval;
@@ -104,7 +104,7 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
     /*
      * Retrieve the btree from the history store cursor.
      */
-    WT_ERR(__wt_hs_get_btree(tmp_setup_session, &btree));
+    WT_ERR(__wt_history_get_btree(tmp_setup_session, &btree));
 
     /* Track the history store file ID. */
     if (conn->cache->hs_fileid == 0)
@@ -135,11 +135,11 @@ err:
 }
 
 /*
- * __wt_hs_open --
+ * __wt_history_open --
  *     Initialize the database's history store.
  */
 int
-__wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
+__wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
 {
     WT_CONNECTION_IMPL *conn;
 
@@ -155,7 +155,7 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
     /* Create the table. */
     WT_RET(__wt_session_create(session, WT_HS_URI, WT_HS_CONFIG));
 
-    WT_RET(__wt_hs_config(session, cfg));
+    WT_RET(__wt_history_config(session, cfg));
 
     /* The statistics server is already running, make sure we don't race. */
     WT_WRITE_BARRIER();
@@ -165,11 +165,11 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
 }
 
 /*
- * __wt_hs_close --
+ * __wt_history_close --
  *     Destroy the database's history store.
  */
 void
-__wt_hs_close(WT_SESSION_IMPL *session)
+__wt_history_close(WT_SESSION_IMPL *session)
 {
     F_CLR(S2C(session), WT_CONN_HS_OPEN);
 }

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -55,7 +55,7 @@ __wt_hs_row_search(WT_CURSOR_BTREE *hs_cbt, WT_ITEM *srch_key, bool insert)
 }
 
 /*
- * __wt_hs_modify --
+ * __wt_history_modify --
  *     Make an update to the history store.
  *
  * History store updates don't use transactions as those updates should be immediately visible and
@@ -63,7 +63,7 @@ __wt_hs_row_search(WT_CURSOR_BTREE *hs_cbt, WT_ITEM *srch_key, bool insert)
  *     directly modified using the low level api instead of the ordinary cursor api.
  */
 int
-__wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
+__wt_history_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
 {
     WT_DECL_RET;
 
@@ -139,7 +139,7 @@ err:
 }
 
 /*
- * __wt_hs_cursor_position --
+ * __wt_history_cursor_position --
  *     Position a history store cursor at the end of a set of updates for a given btree id, record
  *     key and timestamp. There may be no history store entries for the given btree id and record
  *     key if they have been removed by WT_CONNECTION::rollback_to_stable. There is an optional
@@ -148,7 +148,7 @@ err:
  *     WT_ISO_READ_UNCOMMITTED.
  */
 int
-__wt_hs_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id,
+__wt_history_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id,
   const WT_ITEM *key, wt_timestamp_t timestamp, WT_ITEM *user_srch_key)
 {
     WT_DECL_RET;
@@ -158,15 +158,16 @@ __wt_hs_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t bt
 }
 
 /*
- * __wt_hs_find_upd --
+ * __wt_history_find_upd --
  *     Scan the history store for a record the btree cursor wants to position on. Create an update
  *     for the record and return to the caller. The caller may choose to optionally allow prepared
  *     updates to be returned regardless of whether prepare is being ignored globally. Otherwise, a
  *     prepare conflict will be returned upon reading a prepared update.
  */
 int
-__wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format, uint64_t recno,
-  WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf, WT_TIME_WINDOW *on_disk_tw)
+__wt_history_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
+  uint64_t recno, WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf,
+  WT_TIME_WINDOW *on_disk_tw)
 {
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *hs_cbt;
@@ -226,7 +227,8 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
      */
     read_timestamp = allow_prepare ? txn->prepare_timestamp : txn_shared->read_timestamp;
     WT_ERR_NOTFOUND_OK(
-      __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, key, read_timestamp, NULL), true);
+      __wt_history_cursor_position(session, hs_cursor, hs_btree_id, key, read_timestamp, NULL),
+      true);
     if (ret == WT_NOTFOUND) {
         ret = 0;
         goto done;

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -215,7 +215,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
     WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
 
     /* Open a history store table cursor. */
-    WT_ERR(__wt_hs_cursor_open(session));
+    WT_ERR(__wt_history_cursor_open(session));
     hs_cursor = session->hs_cursor;
     hs_cbt = (WT_CURSOR_BTREE *)hs_cursor;
 
@@ -231,7 +231,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
         ret = 0;
         goto done;
     }
-    for (;; ret = __wt_hs_cursor_prev(session, hs_cursor)) {
+    for (;; ret = __wt_history_cursor_prev(session, hs_cursor)) {
         WT_ERR_NOTFOUND_OK(ret, true);
         /* If we hit the end of the table, let's get out of here. */
         if (ret == WT_NOTFOUND) {
@@ -310,7 +310,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
              * update here we fall back to the datastore version. If its timestamp doesn't match our
              * timestamp then we return not found.
              */
-            WT_ERR_NOTFOUND_OK(__wt_hs_cursor_next(session, hs_cursor), true);
+            WT_ERR_NOTFOUND_OK(__wt_history_cursor_next(session, hs_cursor), true);
             if (ret == WT_NOTFOUND) {
                 /* Fallback to the onpage value as the base value. */
                 orig_hs_value_buf = hs_value;
@@ -395,7 +395,7 @@ err:
         __wt_scr_free(session, &hs_value);
     WT_ASSERT(session, hs_key.mem == NULL && hs_key.memsize == 0);
 
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
 
     __wt_free_update_list(session, &mod_upd);
     while (modifies.size > 0) {

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -332,11 +332,11 @@ __hs_next_upd_full_value(WT_SESSION_IMPL *session, WT_MODIFY_VECTOR *modifies,
 }
 
 /*
- * __wt_hs_insert_updates --
+ * __wt_history_insert_updates --
  *     Copy one set of saved updates into the database's history store table.
  */
 int
-__wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
+__wt_history_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
 {
     WT_BTREE *btree;
     WT_CURSOR *cursor;
@@ -557,7 +557,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
         if (oldest_upd->type == WT_UPDATE_TOMBSTONE && oldest_upd == first_non_ts_upd &&
           !F_ISSET(first_non_ts_upd, WT_UPDATE_CLEARED_HS)) {
             /* We can only delete history store entries that have timestamps. */
-            WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, key, 1));
+            WT_ERR(__wt_history_delete_key_from_ts(session, btree->id, key, 1));
             WT_STAT_CONN_INCR(session, cache_hs_key_truncate_mix_ts);
             clear_hs = false;
             F_SET(first_non_ts_upd, WT_UPDATE_CLEARED_HS);
@@ -663,7 +663,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
              */
             if (clear_hs && upd->start_ts != WT_TS_NONE) {
                 /* We can only delete history store entries that have timestamps. */
-                WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, key, 1));
+                WT_ERR(__wt_history_delete_key_from_ts(session, btree->id, key, 1));
                 WT_STAT_CONN_INCR(session, cache_hs_key_truncate_mix_ts);
                 clear_hs = false;
                 F_SET(first_non_ts_upd, WT_UPDATE_CLEARED_HS);
@@ -723,7 +723,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
           (first_non_ts_upd->txnid != list->onpage_upd->txnid ||
             first_non_ts_upd->start_ts != list->onpage_upd->start_ts)) {
             /* We can only delete history store entries that have timestamps. */
-            WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, key, 1));
+            WT_ERR(__wt_history_delete_key_from_ts(session, btree->id, key, 1));
             WT_STAT_CONN_INCR(session, cache_hs_key_truncate_mix_ts);
             F_SET(first_non_ts_upd, WT_UPDATE_CLEARED_HS);
         }
@@ -814,11 +814,11 @@ err:
 }
 
 /*
- * __wt_hs_delete_key_from_ts --
+ * __wt_history_delete_key_from_ts --
  *     Delete history store content of a given key from a timestamp.
  */
 int
-__wt_hs_delete_key_from_ts(
+__wt_history_delete_key_from_ts(
   WT_SESSION_IMPL *session, uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts)
 {
     WT_DECL_RET;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -223,7 +223,7 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
      * updates, we should remove them and reinsert them at the current timestamp.
      */
     if (upd->start_ts != WT_TS_NONE) {
-        WT_ERR_NOTFOUND_OK(__wt_hs_cursor_next(session, cursor), true);
+        WT_ERR_NOTFOUND_OK(__wt_history_cursor_next(session, cursor), true);
         if (ret == 0)
             WT_ERR(__hs_fixup_out_of_order_from_pos(
               session, cursor, btree, key, upd->start_ts, &counter, srch_key));
@@ -255,7 +255,7 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
      * timestamped tables that are occasionally getting a non-timestamped update, that means that
      * all timestamped updates should get removed.
      */
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_next(session, cursor), true);
+    WT_ERR_NOTFOUND_OK(__wt_history_cursor_next(session, cursor), true);
 
     /* No records to delete. */
     if (ret == WT_NOTFOUND) {
@@ -773,7 +773,7 @@ __hs_delete_key_from_ts_int(
 
     hs_cursor->set_key(hs_cursor, btree_id, key, ts, 0);
     WT_ERR(__wt_buf_set(session, srch_key, hs_cursor->key.data, hs_cursor->key.size));
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near(session, hs_cursor, &exact), true);
+    WT_ERR_NOTFOUND_OK(__wt_history_cursor_search_near(session, hs_cursor, &exact), true);
     /* Empty history store is fine. */
     if (ret == WT_NOTFOUND)
         goto done;
@@ -786,7 +786,7 @@ __hs_delete_key_from_ts_int(
      * beginning.
      */
     if (exact < 0) {
-        while ((ret = __wt_hs_cursor_next(session, hs_cursor)) == 0) {
+        while ((ret = __wt_history_cursor_next(session, hs_cursor)) == 0) {
             WT_ERR(__wt_compare(session, NULL, &hs_cursor->key, srch_key, &cmp));
             if (cmp >= 0)
                 break;
@@ -870,7 +870,7 @@ __hs_fixup_out_of_order_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
      * to keep doing "next" until we've got a key greater than the one we attempted to position
      * ourselves with.
      */
-    for (; ret == 0; ret = __wt_hs_cursor_next(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_next(session, hs_cursor)) {
         /*
          * Prior to getting here, we've done a "search near" on our key for the timestamp we're
          * inserting and then a "next". In the regular case, our cursor will be positioned on the
@@ -905,7 +905,7 @@ __hs_fixup_out_of_order_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
      * 2     foo 3  2       ccc
      * 2     foo 3  3       ddd
      */
-    for (; ret == 0; ret = __wt_hs_cursor_next(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_next(session, hs_cursor)) {
         /*
          * Prior to getting here, we've done a "search near" on our key for the timestamp we're
          * inserting and then a "next". In the regular case, our cursor will be positioned on the
@@ -1023,7 +1023,7 @@ __hs_delete_key_from_pos(
     upd = NULL;
 
     /* If there is nothing else in history store, we're done here. */
-    for (; ret == 0; ret = __wt_hs_cursor_next(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_next(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, &hs_key, &hs_start_ts, &hs_counter));
         /*
          * If the btree id or key isn't ours, that means that we've hit the end of the key range and

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -125,7 +125,7 @@ __hs_insert_record_with_btree_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor, W
     /* Search the page and insert the updates. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_hs_row_search(cbt, &cursor->key, true));
     WT_ERR(ret);
-    WT_ERR(__wt_hs_modify(cbt, hs_upd));
+    WT_ERR(__wt_history_modify(cbt, hs_upd));
 
     /*
      * Since the two updates (tombstone and the standard) will reconcile into a single entry, we are
@@ -201,7 +201,7 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
      * one can lead to wrong order.
      */
     WT_ERR_NOTFOUND_OK(
-      __wt_hs_cursor_position(session, cursor, btree->id, key, upd->start_ts, srch_key), true);
+      __wt_history_cursor_position(session, cursor, btree->id, key, upd->start_ts, srch_key), true);
     if (ret == 0) {
         WT_ERR(cursor->get_key(cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
@@ -986,7 +986,7 @@ __hs_fixup_out_of_order_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
         WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
         tombstone->txnid = WT_TXN_NONE;
         tombstone->start_ts = tombstone->durable_ts = WT_TS_NONE;
-        while ((ret = __wt_hs_modify(hs_cbt, tombstone)) == WT_RESTART)
+        while ((ret = __wt_history_modify(hs_cbt, tombstone)) == WT_RESTART)
             ;
         WT_ERR(ret);
         tombstone = NULL;
@@ -1055,7 +1055,7 @@ __hs_delete_key_from_pos(
         WT_ERR(__wt_upd_alloc_tombstone(session, &upd, NULL));
         upd->txnid = WT_TXN_NONE;
         upd->start_ts = upd->durable_ts = WT_TS_NONE;
-        WT_ERR(__wt_hs_modify(hs_cbt, upd));
+        WT_ERR(__wt_history_modify(hs_cbt, upd));
         upd = NULL;
         WT_STAT_CONN_INCR(session, cache_hs_key_truncate);
     }

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -9,13 +9,13 @@
 #include "wt_internal.h"
 
 /*
- * __verify_history_store_id --
+ * __hs_verify_btree_id --
  *     Verify the history store for a single btree. Given a cursor to the tree, walk all history
  *     store keys. This function assumes any caller has already opened a cursor to the history
  *     store.
  */
 static int
-__verify_history_store_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *ds_cbt, uint32_t this_btree_id)
+__hs_verify_btree_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *ds_cbt, uint32_t this_btree_id)
 {
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *hs_cbt;
@@ -104,12 +104,12 @@ err:
 }
 
 /*
- * __wt_history_store_verify_one --
+ * __wt_history_verify_one --
  *     Verify the history store for the btree that is set up in this session. This must be called
  *     when we are known to have exclusive access to the btree.
  */
 int
-__wt_history_store_verify_one(WT_SESSION_IMPL *session)
+__wt_history_verify_one(WT_SESSION_IMPL *session)
 {
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE ds_cbt;
@@ -141,19 +141,19 @@ __wt_history_store_verify_one(WT_SESSION_IMPL *session)
     if (ret == 0) {
         __wt_btcur_init(session, &ds_cbt);
         __wt_btcur_open(&ds_cbt);
-        ret = __verify_history_store_id(session, &ds_cbt, btree_id);
+        ret = __hs_verify_btree_id(session, &ds_cbt, btree_id);
         WT_TRET(__wt_btcur_close(&ds_cbt, false));
     }
     return (ret == WT_NOTFOUND ? 0 : ret);
 }
 
 /*
- * __wt_history_store_verify --
+ * __wt_history_verify --
  *     Verify the history store. There can't be an entry in the history store without having the
  *     latest value for the respective key in the data store.
  */
 int
-__wt_history_store_verify(WT_SESSION_IMPL *session)
+__wt_history_verify(WT_SESSION_IMPL *session)
 {
     WT_CURSOR *ds_cursor, *hs_cursor;
     WT_DECL_ITEM(buf);
@@ -198,7 +198,7 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
         }
         WT_ERR(__wt_open_cursor(session, uri_data, NULL, NULL, &ds_cursor));
         F_SET(ds_cursor, WT_CURSOR_RAW_OK);
-        ret = __verify_history_store_id(session, (WT_CURSOR_BTREE *)ds_cursor, btree_id);
+        ret = __hs_verify_btree_id(session, (WT_CURSOR_BTREE *)ds_cursor, btree_id);
         if (ret == WT_NOTFOUND)
             stop = true;
         WT_TRET(ds_cursor->close(ds_cursor));

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -46,7 +46,7 @@ __verify_history_store_id(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *ds_cbt, uin
      * verify. When we return after moving to a new key the caller is responsible for keeping the
      * cursor there or deciding they're done.
      */
-    for (; ret == 0; ret = __wt_hs_cursor_next(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_next(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &btree_id, &key, &hs_start_ts, &hs_counter));
 
         /*
@@ -127,9 +127,9 @@ __wt_history_store_verify_one(WT_SESSION_IMPL *session)
      */
     memset(&hs_key, 0, sizeof(hs_key));
     hs_cursor->set_key(hs_cursor, btree_id, &hs_key, 0, 0);
-    ret = __wt_hs_cursor_search_near(session, hs_cursor, &exact);
+    ret = __wt_history_cursor_search_near(session, hs_cursor, &exact);
     if (ret == 0 && exact < 0)
-        ret = __wt_hs_cursor_next(session, hs_cursor);
+        ret = __wt_history_cursor_next(session, hs_cursor);
 
     /*
      * If we positioned the cursor there is something to verify.
@@ -174,9 +174,9 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
     uri_data = NULL;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
-    WT_ERR(__wt_hs_cursor_open(session));
+    WT_ERR(__wt_history_cursor_open(session));
     hs_cursor = session->hs_cursor;
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_next(session, hs_cursor), true);
+    WT_ERR_NOTFOUND_OK(__wt_history_cursor_next(session, hs_cursor), true);
     stop = ret == WT_NOTFOUND ? true : false;
     ret = 0;
 
@@ -205,7 +205,7 @@ __wt_history_store_verify(WT_SESSION_IMPL *session)
         WT_ERR_NOTFOUND_OK(ret, false);
     }
 err:
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
 
     __wt_scr_free(session, &buf);
     WT_ASSERT(session, key.mem == NULL && key.memsize == 0);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -743,10 +743,14 @@ extern int __wt_history_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_delete_key_from_ts(WT_SESSION_IMPL *session, uint32_t btree_id,
+  const WT_ITEM *key, wt_timestamp_t ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
   uint64_t recno, WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf,
   WT_TIME_WINDOW *on_disk_tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -755,10 +759,6 @@ extern int __wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
 extern int __wt_history_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_verify_one(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, uint32_t btree_id,
-  const WT_ITEM *key, wt_timestamp_t ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_row_search(WT_CURSOR_BTREE *hs_cbt, WT_ITEM *srch_key, bool insert)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -744,9 +744,9 @@ extern int __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_history_store_verify(WT_SESSION_IMPL *session)
+extern int __wt_history_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_history_store_verify_one(WT_SESSION_IMPL *session)
+extern int __wt_history_verify_one(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id,
   const WT_ITEM *key, wt_timestamp_t timestamp, WT_ITEM *user_srch_key)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -728,11 +728,15 @@ extern int __wt_hex2byte(const u_char *from, u_char *to)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *to)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_config(WT_SESSION_IMPL *session, const char **cfg)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_store_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_store_verify_one(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_close(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -752,13 +756,9 @@ extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, uint32_t btree_i
 extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
   uint64_t recno, WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf,
   WT_TIME_WINDOW *on_disk_tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_row_search(WT_CURSOR_BTREE *hs_cbt, WT_ITEM *srch_key, bool insert)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1667,7 +1667,7 @@ extern void __wt_gen_drain(WT_SESSION_IMPL *session, int which, uint64_t generat
 extern void __wt_gen_init(WT_SESSION_IMPL *session);
 extern void __wt_gen_next_drain(WT_SESSION_IMPL *session, int which);
 extern void __wt_hazard_close(WT_SESSION_IMPL *session);
-extern void __wt_hs_close(WT_SESSION_IMPL *session);
+extern void __wt_history_close(WT_SESSION_IMPL *session);
 extern void __wt_huffman_close(WT_SESSION_IMPL *session, void *huffman_arg);
 extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
 extern void __wt_log_background(WT_SESSION_IMPL *session, WT_LSN *lsn);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -730,6 +730,16 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_close(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_open(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
@@ -738,18 +748,8 @@ extern int __wt_history_store_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_store_verify_one(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_close(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_open(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id,
   const WT_ITEM *key, wt_timestamp_t timestamp, WT_ITEM *user_srch_key)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, uint32_t btree_id,
   const WT_ITEM *key, wt_timestamp_t ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -736,11 +736,19 @@ extern int __wt_history_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_cursor_open(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
+  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t timestamp, WT_ITEM *user_srch_key)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
+  uint64_t recno, WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf,
+  WT_TIME_WINDOW *on_disk_tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_history_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_open(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -748,17 +756,9 @@ extern int __wt_history_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_history_verify_one(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_position(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id,
-  const WT_ITEM *key, wt_timestamp_t timestamp, WT_ITEM *user_srch_key)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, uint32_t btree_id,
   const WT_ITEM *key, wt_timestamp_t ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
-  uint64_t recno, WT_UPDATE_VALUE *upd_value, bool allow_prepare, WT_ITEM *on_disk_buf,
-  WT_TIME_WINDOW *on_disk_tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_row_search(WT_CURSOR_BTREE *hs_cbt, WT_ITEM *srch_key, bool insert)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn.i
+++ b/src/include/txn.i
@@ -993,7 +993,7 @@ retry:
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(S2BT(session), WT_BTREE_HS))
-        WT_RET_NOTFOUND_OK(__wt_hs_find_upd(session, key, cbt->iface.value_format, recno,
+        WT_RET_NOTFOUND_OK(__wt_history_find_upd(session, key, cbt->iface.value_format, recno,
           cbt->upd_value, false, &cbt->upd_value->buf, &tw));
 
     /*

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -919,7 +919,8 @@ __wt_rec_row_leaf(
                      */
                     if (!F_ISSET(session, WT_SESSION_NO_DATA_HANDLES)) {
                         WT_ERR(__wt_history_cursor_open(session));
-                        WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, tmpkey, WT_TS_NONE));
+                        WT_ERR(
+                          __wt_history_delete_key_from_ts(session, btree->id, tmpkey, WT_TS_NONE));
                         WT_ERR(__wt_history_cursor_close(session));
                         WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
                     }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -918,9 +918,9 @@ __wt_rec_row_leaf(
                      * ever need to blow away history store content, so we can skip this.
                      */
                     if (!F_ISSET(session, WT_SESSION_NO_DATA_HANDLES)) {
-                        WT_ERR(__wt_hs_cursor_open(session));
+                        WT_ERR(__wt_history_cursor_open(session));
                         WT_ERR(__wt_hs_delete_key_from_ts(session, btree->id, tmpkey, WT_TS_NONE));
-                        WT_ERR(__wt_hs_cursor_close(session));
+                        WT_ERR(__wt_history_cursor_close(session));
                         WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
                     }
                 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2276,7 +2276,7 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     if (i == r->multi_next)
         return (0);
 
-    WT_RET(__wt_hs_cursor_open(session));
+    WT_RET(__wt_history_cursor_open(session));
 
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
         if (multi->supd != NULL) {
@@ -2289,7 +2289,7 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         }
 
 err:
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
     return (ret);
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2280,7 +2280,7 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
         if (multi->supd != NULL) {
-            WT_ERR(__wt_hs_insert_updates(session, r->page, multi));
+            WT_ERR(__wt_history_insert_updates(session, r->page, multi));
             r->cache_write_hs = true;
             if (!multi->supd_restore) {
                 __wt_free(session, multi->supd);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -687,7 +687,7 @@ __txn_append_hs_record(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, WT_ITEM *
     WT_ERR(__wt_scr_alloc(session, 0, &hs_key));
     WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
 
-    for (; ret == 0; ret = __wt_hs_cursor_prev(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_prev(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
         /* Stop before crossing over to the next btree */
@@ -995,7 +995,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
         cbt = (WT_CURSOR_BTREE *)(*cursorp);
         hs_btree_id = S2BT(session)->id;
         /* Open a history store table cursor. */
-        WT_ERR(__wt_hs_cursor_open(session));
+        WT_ERR(__wt_history_cursor_open(session));
         hs_cursor = session->hs_cursor;
 
         /*
@@ -1087,7 +1087,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
 
 err:
     if (hs_cursor != NULL)
-        WT_TRET(__wt_hs_cursor_close(session));
+        WT_TRET(__wt_history_cursor_close(session));
     if (!upd_appended)
         __wt_free(session, fix_upd);
     __wt_free(session, tombstone);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -871,7 +871,7 @@ __txn_fixup_prepared_update(
         hs_upd->next->txnid = fix_upd->txnid;
     }
 
-    WT_ERR(__wt_hs_modify(hs_cbt, hs_upd));
+    WT_ERR(__wt_history_modify(hs_cbt, hs_upd));
 
     if (0) {
 err:
@@ -1002,7 +1002,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * Scan the history store for the given btree and key with maximum start timestamp to let
          * the search point to the last version of the key.
          */
-        WT_ERR_NOTFOUND_OK(__wt_hs_cursor_position(
+        WT_ERR_NOTFOUND_OK(__wt_history_cursor_position(
                              session, hs_cursor, hs_btree_id, &op->u.op_row.key, WT_TS_MAX, NULL),
           true);
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -605,7 +605,7 @@ __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool 
             /*
              * Attempt to configure the history store, this will detect corruption if it fails.
              */
-            ret = __wt_hs_config(session, cfg);
+            ret = __wt_history_config(session, cfg);
             if (ret != 0) {
                 if (F_ISSET(conn, WT_CONN_SALVAGE)) {
                     wt_session = &session->iface;
@@ -795,7 +795,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
         /*
          * Create the history store as we might need it while applying log records in recovery.
          */
-        WT_ERR(__wt_hs_open(session, cfg));
+        WT_ERR(__wt_history_open(session, cfg));
     }
 
     /*

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -211,7 +211,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
      * into data store and removed from history store. If none of the history store records satisfy
      * the given timestamp, the key is removed from data store.
      */
-    ret = __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, key, WT_TS_MAX, NULL);
+    ret = __wt_history_cursor_position(session, hs_cursor, hs_btree_id, key, WT_TS_MAX, NULL);
     for (; ret == 0; ret = __wt_history_cursor_prev(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
@@ -316,7 +316,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
 #endif
 
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd, NULL));
-        WT_ERR(__wt_hs_modify(cbt, hs_upd));
+        WT_ERR(__wt_history_modify(cbt, hs_upd));
         WT_STAT_CONN_INCR(session, txn_rts_hs_removed);
         WT_STAT_CONN_INCR(session, cache_hs_key_truncate_rts_unstable);
     }
@@ -382,7 +382,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     /* Finally remove that update from history store. */
     if (valid_update_found) {
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd, NULL));
-        WT_ERR(__wt_hs_modify(cbt, hs_upd));
+        WT_ERR(__wt_history_modify(cbt, hs_upd));
         WT_STAT_CONN_INCR(session, txn_rts_hs_removed);
         WT_STAT_CONN_INCR(session, cache_hs_key_truncate_rts);
     }
@@ -1060,7 +1060,7 @@ __rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_
           __wt_timestamp_to_string(hs_start_ts, ts_string));
 
         WT_ERR(__wt_upd_alloc_tombstone(session, &hs_upd, NULL));
-        WT_ERR(__wt_hs_modify(cbt, hs_upd));
+        WT_ERR(__wt_history_modify(cbt, hs_upd));
         WT_STAT_CONN_INCR(session, txn_rts_hs_removed);
         WT_STAT_CONN_INCR(session, cache_hs_key_truncate_rts);
         hs_upd = NULL;

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -200,7 +200,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
     newer_hs_durable_ts = unpack->tw.durable_start_ts;
 
     /* Open a history store table cursor. */
-    WT_ERR(__wt_hs_cursor_open(session));
+    WT_ERR(__wt_history_cursor_open(session));
     hs_cursor = session->hs_cursor;
     cbt = (WT_CURSOR_BTREE *)hs_cursor;
 
@@ -212,7 +212,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
      * the given timestamp, the key is removed from data store.
      */
     ret = __wt_hs_cursor_position(session, hs_cursor, hs_btree_id, key, WT_TS_MAX, NULL);
-    for (; ret == 0; ret = __wt_hs_cursor_prev(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_prev(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
         /* Stop before crossing over to the next btree */
@@ -397,7 +397,7 @@ err:
     __wt_scr_free(session, &hs_value);
     __wt_scr_free(session, &key);
     __wt_buf_free(session, &full_value);
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
     return (ret);
 }
 
@@ -1021,13 +1021,13 @@ __rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_
     WT_RET(__wt_scr_alloc(session, 0, &hs_key));
 
     /* Open a history store table cursor. */
-    WT_ERR(__wt_hs_cursor_open(session));
+    WT_ERR(__wt_history_cursor_open(session));
     hs_cursor = session->hs_cursor;
     cbt = (WT_CURSOR_BTREE *)hs_cursor;
 
     /* Walk the history store for the given btree. */
     hs_cursor->set_key(hs_cursor, btree_id, &key, WT_TS_NONE, 0);
-    ret = __wt_hs_cursor_search_near(session, hs_cursor, &exact);
+    ret = __wt_history_cursor_search_near(session, hs_cursor, &exact);
 
     /*
      * The search should always end up pointing to the start of the required btree or end of the
@@ -1035,9 +1035,9 @@ __rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_
      */
     WT_ASSERT(session, (ret != 0 || exact != 0));
     if (ret == 0 && exact < 0)
-        ret = __wt_hs_cursor_next(session, hs_cursor);
+        ret = __wt_history_cursor_next(session, hs_cursor);
 
-    for (; ret == 0; ret = __wt_hs_cursor_next(session, hs_cursor)) {
+    for (; ret == 0; ret = __wt_history_cursor_next(session, hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
         /* Stop crossing into the next btree boundary. */
@@ -1070,7 +1070,7 @@ __rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_
 err:
     __wt_scr_free(session, &hs_key);
     __wt_free(session, hs_upd);
-    WT_TRET(__wt_hs_cursor_close(session));
+    WT_TRET(__wt_history_cursor_close(session));
 
     return (ret);
 }


### PR DESCRIPTION
This aim of this change is name the History Store module API according to their usage. I have adapted following naming convention:

- Static file local function -> Prefix with `__hs_XXX`
- Functions/APIs that are only called from other WT modules -> Prefix with `__wt_history_XX`
- Functions/APIs that are only called between files in HS module -> Prefix with `__wt_hs_XX`
- Functions/APIs that are called both from within HS module and by other WT modules -> Prefix with `__wt_history_XX`