### PR TITLE
WT-6643 Explicitly set the 64-bit uint part of the LSN for atomic assignment.

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -406,7 +406,7 @@ __log_archive_once(WT_SESSION_IMPL *session, uint32_t backup_file)
          */
         if ((dbg_val + 1) >= log->fileid)
             return (0);
-        if (log->ckpt_lsn.l.file == 1 && log->ckpt_lsn.l.offset == 0)
+        if (WT_IS_INIT_LSN(&log->ckpt_lsn))
             min_lognum = log->fileid - (dbg_val + 1);
         else
             min_lognum = WT_MIN(log->fileid - (dbg_val + 1), min_lognum);
@@ -584,7 +584,7 @@ __log_file_server(void *arg)
                  * to be set again. Copy the LSN before clearing the file handle. Use a barrier to
                  * make sure the compiler does not reorder the following two statements.
                  */
-                close_end_lsn = log->log_close_lsn;
+                WT_ASSIGN_LSN(&close_end_lsn, &log->log_close_lsn);
                 WT_FULL_BARRIER();
                 log->log_close_fh = NULL;
                 /*
@@ -612,7 +612,7 @@ __log_file_server(void *arg)
                 locked = true;
                 WT_ERR(__wt_close(session, &close_fh));
                 WT_ASSERT(session, __wt_log_cmp(&close_end_lsn, &log->sync_lsn) >= 0);
-                log->sync_lsn = close_end_lsn;
+                WT_ASSIGN_LSN(&log->sync_lsn, &close_end_lsn);
                 __wt_cond_signal(session, log->log_sync_cond);
                 locked = false;
                 __wt_spin_unlock(session, &log->log_sync_lock);
@@ -650,7 +650,7 @@ __log_file_server(void *arg)
                  */
                 if (__wt_log_cmp(&log->sync_lsn, &min_lsn) <= 0) {
                     WT_ASSERT(session, min_lsn.l.file == log->sync_lsn.l.file);
-                    log->sync_lsn = min_lsn;
+                    WT_ASSIGN_LSN(&log->sync_lsn, &min_lsn);
                     __wt_cond_signal(session, log->log_sync_cond);
                 }
                 locked = false;
@@ -733,7 +733,7 @@ restart:
         if (slot->slot_state != WT_LOG_SLOT_WRITTEN)
             continue;
         written[written_i].slot_index = save_i;
-        written[written_i++].lsn = slot->slot_release_lsn;
+        WT_ASSIGN_LSN(&written[written_i++].lsn, &slot->slot_release_lsn);
     }
     /*
      * If we found any written slots process them. We sort them based on the release LSN, and then
@@ -773,7 +773,7 @@ restart:
                  * If we get here we have a slot to coalesce and free.
                  */
                 coalescing->slot_last_offset = slot->slot_last_offset;
-                coalescing->slot_end_lsn = slot->slot_end_lsn;
+                WT_ASSIGN_LSN(&coalescing->slot_end_lsn, &slot->slot_end_lsn);
                 WT_STAT_CONN_INCR(session, log_slot_coalesced);
                 /*
                  * Copy the flag for later closing.
@@ -802,8 +802,8 @@ restart:
                  */
                 if (slot->slot_start_lsn.l.offset != slot->slot_last_offset)
                     slot->slot_start_lsn.l.offset = (uint32_t)slot->slot_last_offset;
-                log->write_start_lsn = slot->slot_start_lsn;
-                log->write_lsn = slot->slot_end_lsn;
+                WT_ASSIGN_LSN(&log->write_start_lsn, &slot->slot_start_lsn);
+                WT_ASSIGN_LSN(&log->write_lsn, &slot->slot_end_lsn);
                 __wt_cond_signal(session, log->log_write_cond);
                 WT_STAT_CONN_INCR(session, log_write_lsn);
                 /*

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -50,8 +50,11 @@ union __wt_lsn {
 #define WT_LOG_ALIGN 128
 
 /*
- * Atomically set the two components of the LSN.
+ * Atomically set the LSN. There are two forms. We need WT_ASSIGN_LSN because some compilers (at
+ * least clang address sanitizer) does not do atomic 64-bit structure assignment so we need to
+ * explicitly assign the 64-bit field. And WT_SET_LSN atomically sets the LSN given a file/offset.
  */
+#define WT_ASSIGN_LSN(dstl, srcl) (dstl)->file_offset = (srcl)->file_offset
 #define WT_SET_LSN(l, f, o) (l)->file_offset = (((uint64_t)(f) << 32) + (o))
 
 #define WT_INIT_LSN(l) WT_SET_LSN((l), 1, 0)

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -232,7 +232,7 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
 
     conn = S2C(session);
     log = conn->log;
-    log->ckpt_lsn = *ckpt_lsn;
+    WT_ASSIGN_LSN(&log->ckpt_lsn, ckpt_lsn);
     if (conn->log_cond != NULL)
         __wt_cond_signal(session, conn->log_cond);
     /*
@@ -262,9 +262,9 @@ __wt_log_flush_lsn(WT_SESSION_IMPL *session, WT_LSN *lsn, bool start)
     WT_RET(__wt_log_force_write(session, 1, NULL));
     __wt_log_wrlsn(session, NULL);
     if (start)
-        *lsn = log->write_start_lsn;
+        WT_ASSIGN_LSN(lsn, &log->write_start_lsn);
     else
-        *lsn = log->write_lsn;
+        WT_ASSIGN_LSN(lsn, &log->write_lsn);
     return (0);
 }
 
@@ -285,14 +285,14 @@ __wt_log_background(WT_SESSION_IMPL *session, WT_LSN *lsn)
      */
     if (__wt_log_cmp(&session->bg_sync_lsn, lsn) > 0)
         return;
-    session->bg_sync_lsn = *lsn;
+    WT_ASSIGN_LSN(&session->bg_sync_lsn, lsn);
 
     /*
      * Advance the logging subsystem background sync LSN if needed.
      */
     __wt_spin_lock(session, &log->log_sync_lock);
     if (__wt_log_cmp(lsn, &log->bg_sync_lsn) > 0)
-        log->bg_sync_lsn = *lsn;
+        WT_ASSIGN_LSN(&log->bg_sync_lsn, lsn);
     __wt_spin_unlock(session, &log->log_sync_lock);
     __wt_cond_signal(session, conn->log_file_cond);
 }
@@ -334,7 +334,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
         WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
         time_stop = __wt_clock(session);
         fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
-        log->sync_dir_lsn = *min_lsn;
+        WT_ASSIGN_LSN(&log->sync_dir_lsn, min_lsn);
         WT_STAT_CONN_INCR(session, log_sync_dir);
         WT_STAT_CONN_INCRV(session, log_sync_dir_duration, fsync_duration_usecs);
     }
@@ -354,7 +354,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
         WT_ERR(__wt_fsync(session, log_fh, true));
         time_stop = __wt_clock(session);
         fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
-        log->sync_lsn = *min_lsn;
+        WT_ASSIGN_LSN(&log->sync_lsn, min_lsn);
         WT_STAT_CONN_INCR(session, log_sync);
         WT_STAT_CONN_INCRV(session, log_sync_duration, fsync_duration_usecs);
         __wt_cond_signal(session, log->log_sync_cond);
@@ -816,7 +816,7 @@ __log_file_header(WT_SESSION_IMPL *session, WT_FH *fh, WT_LSN *end_lsn, bool pre
      */
     WT_ERR(__wt_fsync(session, tmp.slot_fh, true));
     if (end_lsn != NULL)
-        *end_lsn = tmp.slot_end_lsn;
+        WT_ASSIGN_LSN(end_lsn, &tmp.slot_end_lsn);
 
 err:
     __wt_scr_free(session, &buf);
@@ -1153,7 +1153,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
     if (log->log_fh == NULL)
         log->log_close_fh = NULL;
     else {
-        log->log_close_lsn = log->alloc_lsn;
+        WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);
         WT_PUBLISH(log->log_close_fh, log->log_fh);
     }
     log->fileid++;
@@ -1209,7 +1209,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
     if (log->fileid == 1)
         WT_INIT_LSN(&logrec_lsn);
     else
-        logrec_lsn = log->alloc_lsn;
+        WT_ASSIGN_LSN(&logrec_lsn, &log->alloc_lsn);
     /*
      * We need to setup the LSNs. Set the end LSN and alloc LSN to the end of the header.
      */
@@ -1222,7 +1222,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
         WT_RET(__wt_log_system_record(session, log_fh, &logrec_lsn));
         WT_SET_LSN(&log->alloc_lsn, log->fileid, log->first_record);
     }
-    end_lsn = log->alloc_lsn;
+    WT_ASSIGN_LSN(&end_lsn, &log->alloc_lsn);
     WT_PUBLISH(log->log_fh, log_fh);
 
     /*
@@ -1231,11 +1231,11 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      */
     if (conn_open) {
         WT_RET(__wt_fsync(session, log->log_fh, true));
-        log->sync_lsn = end_lsn;
-        log->write_lsn = end_lsn;
-        log->write_start_lsn = end_lsn;
+        WT_ASSIGN_LSN(&log->sync_lsn, &end_lsn);
+        WT_ASSIGN_LSN(&log->write_lsn, &end_lsn);
+        WT_ASSIGN_LSN(&log->write_start_lsn, &end_lsn);
     }
-    log->dirty_lsn = log->alloc_lsn;
+    WT_ASSIGN_LSN(&log->dirty_lsn, &log->alloc_lsn);
     if (created != NULL)
         *created = create_log;
     return (0);
@@ -1338,7 +1338,7 @@ __wt_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WT_LOGSLOT *slot)
     /*
      * We need to set the release LSN earlier, before a log file change.
      */
-    slot->slot_release_lsn = log->alloc_lsn;
+    WT_ASSIGN_LSN(&slot->slot_release_lsn, &log->alloc_lsn);
     /*
      * Make sure that the size can fit in the file. Proactively switch if it cannot. This reduces,
      * but does not eliminate, log files that exceed the maximum file size. We want to minimize the
@@ -1703,7 +1703,7 @@ again:
                 }
             }
         }
-        log->trunc_lsn = log->alloc_lsn;
+        WT_ASSIGN_LSN(&log->trunc_lsn, &log->alloc_lsn);
         FLD_SET(conn->log_flags, WT_CONN_LOG_EXISTED);
     }
 
@@ -1930,8 +1930,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
     WT_STAT_CONN_INCR(session, log_release_write_lsn);
     __log_wait_for_earlier_slot(session, slot);
 
-    log->write_start_lsn = slot->slot_start_lsn;
-    log->write_lsn = slot->slot_end_lsn;
+    WT_ASSIGN_LSN(&log->write_start_lsn, &slot->slot_start_lsn);
+    WT_ASSIGN_LSN(&log->write_lsn, &slot->slot_end_lsn);
 
     WT_ASSERT(session, slot != log->active_slot);
     __wt_cond_signal(session, log->log_write_cond);
@@ -1973,7 +1973,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
          * Record the current end of our update after the lock. That is how far our calls can
          * guarantee.
          */
-        sync_lsn = slot->slot_end_lsn;
+        WT_ASSIGN_LSN(&sync_lsn, &slot->slot_end_lsn);
         /*
          * Check if we have to sync the parent directory. Some combinations of sync flags may result
          * in the log file not yet stable in its parent directory. Do that now if needed.
@@ -1987,7 +1987,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
             WT_ERR(__wt_fsync(session, log->log_dir_fh, true));
             time_stop = __wt_clock(session);
             fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
-            log->sync_dir_lsn = sync_lsn;
+            WT_ASSIGN_LSN(&log->sync_dir_lsn, &sync_lsn);
             WT_STAT_CONN_INCR(session, log_sync_dir);
             WT_STAT_CONN_INCRV(session, log_sync_dir_duration, fsync_duration_usecs);
         }
@@ -2005,7 +2005,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
             time_stop = __wt_clock(session);
             fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
             WT_STAT_CONN_INCRV(session, log_sync_duration, fsync_duration_usecs);
-            log->sync_lsn = sync_lsn;
+            WT_ASSIGN_LSN(&log->sync_lsn, &sync_lsn);
             __wt_cond_signal(session, log->log_sync_cond);
         }
         /*
@@ -2307,7 +2307,7 @@ advance:
              * remember any error returns, but don't skip to the error handler.
              */
             if (log != NULL)
-                log->trunc_lsn = rd_lsn;
+                WT_ASSIGN_LSN(&log->trunc_lsn, &rd_lsn);
             /*
              * If the user asked for a specific LSN and it is not a valid LSN, return WT_NOTFOUND.
              */

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -71,7 +71,8 @@ __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
      * are reset when the slot is freed.  See log_slot_free.
      */
     slot->slot_unbuffered = 0;
-    slot->slot_start_lsn = slot->slot_end_lsn = log->alloc_lsn;
+    WT_ASSIGN_LSN(&slot->slot_start_lsn, &log->alloc_lsn);
+    WT_ASSIGN_LSN(&slot->slot_end_lsn, &log->alloc_lsn);
     slot->slot_start_offset = log->alloc_lsn.l.offset;
     slot->slot_last_offset = log->alloc_lsn.l.offset;
     slot->slot_fh = log->log_fh;
@@ -143,7 +144,7 @@ retry:
     WT_STAT_CONN_INCR(session, log_slot_closes);
     if (WT_LOG_SLOT_DONE(new_state))
         *releasep = true;
-    slot->slot_end_lsn = slot->slot_start_lsn;
+    WT_ASSIGN_LSN(&slot->slot_end_lsn, &slot->slot_start_lsn);
 /*
  * A thread setting the unbuffered flag sets the unbuffered size after setting the flag. There could
  * be a delay between a thread setting the flag, a thread closing the slot, and the original thread
@@ -182,7 +183,7 @@ retry:
     /*
      * XXX Would like to change so one piece of code advances the LSN.
      */
-    log->alloc_lsn = slot->slot_end_lsn;
+    WT_ASSIGN_LSN(&log->alloc_lsn, &slot->slot_end_lsn);
     WT_ASSERT(session, log->alloc_lsn.l.file >= log->write_lsn.l.file);
     return (0);
 }
@@ -214,7 +215,7 @@ __log_slot_dirty_max_check(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
       current->l.offset - last_sync->l.offset > conn->log_dirty_max) {
         /* Schedule the asynchronous sync */
         F_SET(slot, WT_SLOT_SYNC_DIRTY);
-        log->dirty_lsn = slot->slot_release_lsn;
+        WT_ASSIGN_LSN(&log->dirty_lsn, &slot->slot_release_lsn);
     }
 }
 
@@ -460,7 +461,7 @@ __wt_log_slot_init(WT_SESSION_IMPL *session, bool alloc)
      * called after a log file switch. The release LSN is usually the same as the slot_start_lsn
      * except around a log file switch.
      */
-    slot->slot_release_lsn = log->alloc_lsn;
+    WT_ASSIGN_LSN(&slot->slot_release_lsn, &log->alloc_lsn);
     __wt_log_slot_activate(session, slot);
     log->active_slot = slot;
     log->pool_index = 0;


### PR DESCRIPTION
@keitharnoldsmith and @ddanderson please review. This sets the 64-bit field of the LSN explicitly to avoid asan_memcpy from causing the overwritten non-atomic LSN assignment. This change only modifies places where we read the LSN into a visible structure, I did not change it when we read into a local variable on the stack.