### PR TITLE
WT-6763 Fix freeing update on the chain when insert fail after inserting to the update chain

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -54,14 +54,14 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
     size_t ins_size, upd_size;
     uint32_t ins_slot;
     u_int i, skipdepth;
-    bool logged, inserted_update_chain;
+    bool inserted_to_update_chain, logged;
 
     ins = NULL;
     page = cbt->ref->page;
     session = CUR2S(cbt);
     last_upd = NULL;
     upd = upd_arg;
-    logged = inserted_update_chain = false;
+    inserted_to_update_chain = logged = false;
 
     /*
      * We should have one of the following:
@@ -206,7 +206,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
           session, page, cbt->ins_head, cbt->ins_stack, &ins, ins_size, skipdepth, exclusive));
     }
 
-    inserted_update_chain = true;
+    inserted_to_update_chain = true;
 
     if (logged && modify_type != WT_UPDATE_RESERVE) {
         WT_ERR(__wt_txn_log_op(session, cbt));
@@ -226,7 +226,7 @@ err:
             __wt_txn_unmodify(session);
         __wt_free(session, ins);
         cbt->ins = NULL;
-        if (upd_arg == NULL && !inserted_update_chain)
+        if (upd_arg == NULL && !inserted_to_update_chain)
             __wt_free(session, upd);
         if (last_upd != NULL)
             last_upd->next = NULL;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -54,14 +54,14 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
     size_t ins_size, upd_size;
     uint32_t ins_slot;
     u_int i, skipdepth;
-    bool logged;
+    bool logged, inserted_update_chain;
 
     ins = NULL;
     page = cbt->ref->page;
     session = CUR2S(cbt);
     last_upd = NULL;
     upd = upd_arg;
-    logged = false;
+    logged = inserted_update_chain = false;
 
     /*
      * We should have one of the following:
@@ -206,6 +206,8 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
           session, page, cbt->ins_head, cbt->ins_stack, &ins, ins_size, skipdepth, exclusive));
     }
 
+    inserted_update_chain = true;
+
     if (logged && modify_type != WT_UPDATE_RESERVE) {
         WT_ERR(__wt_txn_log_op(session, cbt));
         /*
@@ -224,7 +226,7 @@ err:
             __wt_txn_unmodify(session);
         __wt_free(session, ins);
         cbt->ins = NULL;
-        if (upd_arg == NULL)
+        if (upd_arg == NULL && !inserted_update_chain)
             __wt_free(session, upd);
         if (last_upd != NULL)
             last_upd->next = NULL;


### PR DESCRIPTION
@lukech This does not fix the problem completely. The test is running out of memory. We need to move the unit test long to a larger machine.