### PR TITLE
Update packing.py

### DIFF
--- a/lang/python/wiredtiger/packing.py
+++ b/lang/python/wiredtiger/packing.py
@@ -180,7 +180,7 @@ def pack(fmt, *values):
             if _is_string(val) and f in 'Ss':
                 result += str(val[:l]).encode()
             else:
-                result += val[:l]
+                result += val[:l].encode()
             if f == 'S' and not havesize:
                 result += x00
             elif size > l and havesize:


### PR DESCRIPTION
In python 3 you can't concat str to bytes

```Traceback (most recent call last):
  File "PyWT.py", line 156, in <module>
    print(wt.dump_catalog())
  File "PyWT.py", line 108, in dump_catalog
    sizes.set_key('table:'+str(table))
  File "/usr/local/lib/python3.8/site-packages/wiredtiger/wiredtiger.py", line 410, in set_key
    self._key = pack(self.key_format, *args)
  File "/usr/local/lib/python3.8/site-packages/wiredtiger/packing.py", line 184, in pack
    result += val[:l]
TypeError: can't concat str to bytes