### PR TITLE
WT-6764 Wait for stable timestamp to move before publishing checkpoint information

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -230,9 +230,9 @@ thread_ckpt_run(void *arg)
         fflush(stdout);
         /*
          * Create the checkpoint file so that the parent process knows at least one checkpoint has
-         * finished and can start its timer. If running with timestamps, wait until stable timestamp
-         * has moved past WT_TS_NONE to give a chance to writer threads to add something to the
-         * database.
+         * finished and can start its timer. If running with timestamps, wait until the stable
+         * timestamp has moved past WT_TS_NONE to give writer threads a chance to add something to
+         * the database.
          */
         if (first_ckpt && (!use_ts || stable != WT_TS_NONE)) {
             testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -230,9 +230,11 @@ thread_ckpt_run(void *arg)
         fflush(stdout);
         /*
          * Create the checkpoint file so that the parent process knows at least one checkpoint has
-         * finished and can start its timer.
+         * finished and can start its timer. If running with timestamps, wait until stable timestamp
+         * has moved past WT_TS_NONE to give a chance to writer threads to add something to the
+         * database.
          */
-        if (first_ckpt) {
+        if (first_ckpt && (!use_ts || stable != WT_TS_NONE)) {
             testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
             first_ckpt = false;
             testutil_checksys(fclose(fp) != 0);


### PR DESCRIPTION
There is a possible race condition in test timestamp_abort where checkpoint thread is able to perform a checkpoint before writer threads get a chance to start and write something into the database. With this change checkpoint thread waits for the checkpoint timestamp to move beyond 0 before signalling to parent process via a file.