### PR TITLE
WT-6812 Fix "out-of-order fixup" potentially corrupting historical values

### DIFF
--- a/test/suite/test_timestamp20.py
+++ b/test/suite/test_timestamp20.py
@@ -129,7 +129,7 @@ class test_timestamp20(wttest.WiredTigerTestCase):
         old_reader_session.begin_transaction('read_timestamp=' + timestamp_str(30))
 
         # Now apply the last modify.
-        # This will be the end of the chain.
+        # This will be the end of the chain of modifies.
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor.set_key(str(i))

--- a/test/suite/test_timestamp20.py
+++ b/test/suite/test_timestamp20.py
@@ -91,7 +91,7 @@ class test_timestamp20(wttest.WiredTigerTestCase):
     #
     # Corruptions to string types may go undetected since non-ASCII characters won't be included in
     # the conversion to a Python string.
-    def test_timestamp20_modifies(self):
+    def test_timestamp20_modify(self):
         uri = 'table:test_timestamp20'
         self.session.create(uri, 'key_format=S,value_format=S')
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))

--- a/test/suite/test_timestamp20.py
+++ b/test/suite/test_timestamp20.py
@@ -37,7 +37,7 @@ class test_timestamp20(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
 
-    def test_timestamp20(self):
+    def test_timestamp20_standard(self):
         uri = 'table:test_timestamp20'
         self.session.create(uri, 'key_format=S,value_format=S')
         self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
@@ -85,4 +85,81 @@ class test_timestamp20(wttest.WiredTigerTestCase):
 
         for i in range(1, 10000):
             self.assertEqual(old_reader_cursor[str(i)], value3)
+        old_reader_session.rollback_transaction()
+
+    # In this test we're using modifies since they are more sensitive to corruptions.
+    #
+    # Corruptions to string types may go undetected since non-ASCII characters won't be included in
+    # the conversion to a Python string.
+    def test_timestamp20_modifies(self):
+        uri = 'table:test_timestamp20'
+        self.session.create(uri, 'key_format=S,value_format=S')
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+
+        value1 = 'a' * 500
+        value2 = 'b' * 500
+        value3 = 'c' * 500
+
+        # Apply the base value.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[str(i)] = value1
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+
+        # Now apply a series of modifies.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.modify([wiredtiger.Modify('B', 100, 1)]), 0)
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.modify([wiredtiger.Modify('C', 200, 1)]), 0)
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+
+        # Open an old reader at this point.
+        #
+        # I'm trying to read the middle modify because I specifically don't want to read one that
+        # has been squashed into a full update.
+        old_reader_session = self.conn.open_session()
+        old_reader_cursor = old_reader_session.open_cursor(uri)
+        old_reader_session.begin_transaction('read_timestamp=' + timestamp_str(30))
+
+        # Now apply the last modify.
+        # This will be the end of the chain.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.modify([wiredtiger.Modify('D', 300, 1)]), 0)
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(40))
+
+        # Now put two updates out of order. 5 will go to the history store and will trigger a
+        # correction to the existing contents.
+        for i in range(1, 10000):
+            self.session.begin_transaction()
+            cursor[str(i)] = value2
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+            self.session.begin_transaction()
+            cursor[str(i)] = value3
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(50))
+
+        # Open up a new transaction and read at 30.
+        # We shouldn't be able to see past 5 due to txnid visibility.
+        self.session.begin_transaction('read_timestamp=' + timestamp_str(30))
+        for i in range(1, 10000):
+            self.assertEqual(cursor[str(i)], value2)
+        self.session.rollback_transaction()
+
+        # Put together expected value.
+        expected = list(value1)
+        expected[100] = 'B'
+        expected[200] = 'C'
+        expected = str().join(expected)
+
+        # On the other hand, this older transaction SHOULD be able to read past the 5.
+        for i in range(1, 10000):
+            self.assertEqual(old_reader_cursor[str(i)], expected)
         old_reader_session.rollback_transaction()


### PR DESCRIPTION
As part of WT-6811, Luke noticed that the "out-of-order fixup" code appeared to be using the wrong value. I'm not 100% sure why `timestamp20` manages to pass but I suspect it's to do with the fact that the leading garbage in the value does not translate to valid ASCII characters and may be dropped as part of the conversion to a Python string.

I wrote another test that uses modifies since I suspect that these would be more sensitive to corruption and was able to make the API return garbage and sometimes crash. I also ran into the issue that modifies aren't moved correctly since we don't pass the correct `upd_type` in (we just read a byte pattern corresponding to a modify and return it as if it were a real value).