### PR TITLE
WT-6872 Replace the yield instructions with an ISB

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -893,6 +893,7 @@ io
 ip
 isalnum
 isalpha
+isb
 iscntrl
 isdigit
 isgraph

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -217,7 +217,14 @@ WT_ATOMIC_FUNC(size, size_t, size_t *vp, size_t v)
     } while (0)
 
 #elif defined(__aarch64__)
-#define WT_PAUSE() __asm__ volatile("yield" ::: "memory")
+/*
+ * Use an isb instruction here to be closer to the original x86 pause instruction. The yield
+ * instruction that was previously here is a nop that is intended to provide a hint that a
+ * thread is a SMT systems could yield. This is different from the x86 pause instruction
+ * which delays exeuction by O(100) cycles. The isb will typically delay exeuction by about
+ * 50 cycles so it's a reasonable alternative.
+ */
+#define WT_PAUSE() __asm__ volatile("isb" ::: "memory")
 
 /*
  * dmb are chosen here because they are sufficient to guarantee the ordering described above. We


### PR DESCRIPTION
Use an isb instruction here to be closer to the original x86 pause instruction.
The yield instruction that was previously here is a nop that is intended to
provide a hint that a thread is a SMT systems could yield. This is different
from the x86 pause instruction which delays exeuction by O(100) cycles. The isb
will typically delay exeuction by about 50 cycles so it's a reasonable
alternative.

I've marked this with RFC beacuse while we've seen similar changes improve
performance on other projects, I don't know what the best way is to test a
high-contention senario that would result in the pausing being impactful here.
I'm looking for suggestions of tests that would illustrate the benefit.