### PR TITLE
WT-6828 Fix doc link in README

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ WiredTiger release packages and documentation can be found at:
 
 The documentation for this specific release can be found at:
 
-	https://source.wiredtiger.com/develop/index.html
+	https://source.wiredtiger.com/10.0.0/index.html
 
 The WiredTiger source code can be found at:
 


### PR DESCRIPTION
As part of #6088, the doc link got changed (I assume they did this because it's a dead link). I couldn't fix this in the PR because it was from a fork that I didn't have write permissions for.

I believe we still want this to point at 10.0.0 because the docs will be at this address when our 10.0.0 release is distributed.