### PR TITLE
WT-6924 Heuristics to limit cache growth beyond size limit

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -69,11 +69,12 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
     conn = S2C(session);
     page = ref->page;
 
-#define WT_EVICT_HS_HIGH_PRIORTY 1000
+#define WT_EVICT_HS_HIGH_PRIORTY 10
 
     /* If cache is almost full, give high priority to modified HS pages. */
     if (WT_IS_HS(btree) && __wt_cache_almost_full(session) && page->modify != NULL &&
-      conn->cache->bytes_hs >= conn->cache_size / 2 && !F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+      __wt_cache_bytes_plus_overhead(conn->cache, conn->cache->bytes_hs) >= conn->cache_size / 3 &&
+      !F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (WT_EVICT_HS_HIGH_PRIORTY);
 
     /* Any page set to the oldest generation should be discarded. */
@@ -1736,7 +1737,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
      * the cache pressure and will probably just amplify it further.
      */
     if (!WT_IS_HS(btree) && __wt_cache_almost_full(session) &&
-      cache->bytes_hs >= conn->cache_size / 2)
+      __wt_cache_bytes_plus_overhead(cache, cache->bytes_hs) >= conn->cache_size / 3)
         return (0);
 
     /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -69,10 +69,12 @@ __evict_entry_priority(WT_SESSION_IMPL *session, WT_REF *ref)
     conn = S2C(session);
     page = ref->page;
 
+#define WT_EVICT_HS_HIGH_PRIORTY 1000
+
     /* If cache is almost full, give high priority to modified HS pages. */
     if (WT_IS_HS(btree) && __wt_cache_almost_full(session) && page->modify != NULL &&
-      conn->cache->bytes_hs >= conn->cache_size / 3 && !F_ISSET(ref, WT_REF_FLAG_INTERNAL))
-        return (WT_READGEN_OLDEST);
+      conn->cache->bytes_hs >= conn->cache_size / 2 && !F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+        return (WT_EVICT_HS_HIGH_PRIORTY);
 
     /* Any page set to the oldest generation should be discarded. */
     if (WT_READGEN_EVICT_SOON(page->read_gen))
@@ -1734,7 +1736,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
      * the cache pressure and will probably just amplify it further.
      */
     if (!WT_IS_HS(btree) && __wt_cache_almost_full(session) &&
-      cache->bytes_hs >= conn->cache_size / 3)
+      cache->bytes_hs >= conn->cache_size / 2)
         return (0);
 
     /*

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -430,6 +430,22 @@ __wt_eviction_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double 
 }
 
 /*
+ * __wt_cache_almost_full --
+ *     Return if the cache is almost reaching capacity.
+ */
+static inline bool
+__wt_cache_almost_full(WT_SESSION_IMPL *session)
+{
+    WT_CACHE *cache;
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    cache = conn->cache;
+
+    return (__wt_cache_bytes_inuse(cache) >= ((conn->cache_size / 100) * 90));
+}
+
+/*
  * __wt_cache_full --
  *     Return if the cache is at (or over) capacity.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1799,6 +1799,8 @@ static inline bool __wt_btree_lsm_over_size(WT_SESSION_IMPL *session, uint64_t m
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_cache_aggressive(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_cache_almost_full(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_cache_full(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_cache_stuck(WT_SESSION_IMPL *session)

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1133,7 +1133,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
  * transaction.
  */
 #undef WT_CHECKPOINT_SESSION_FLAGS
-#define WT_CHECKPOINT_SESSION_FLAGS (WT_SESSION_CAN_WAIT)
+#define WT_CHECKPOINT_SESSION_FLAGS (WT_SESSION_CAN_WAIT | WT_SESSION_IGNORE_CACHE_SIZE)
     orig_flags = F_MASK(session, WT_CHECKPOINT_SESSION_FLAGS);
     F_SET(session, WT_CHECKPOINT_SESSION_FLAGS);
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1133,7 +1133,7 @@ __wt_txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[], bool waiting)
  * transaction.
  */
 #undef WT_CHECKPOINT_SESSION_FLAGS
-#define WT_CHECKPOINT_SESSION_FLAGS (WT_SESSION_CAN_WAIT | WT_SESSION_IGNORE_CACHE_SIZE)
+#define WT_CHECKPOINT_SESSION_FLAGS (WT_SESSION_CAN_WAIT)
     orig_flags = F_MASK(session, WT_CHECKPOINT_SESSION_FLAGS);
     F_SET(session, WT_CHECKPOINT_SESSION_FLAGS);
 


### PR DESCRIPTION
Existing mechanisms for eviction are very fair system. WT queues pages for pages based on the relative space each btree is occupying in the cache. Moreover, the queues are sorted often to evict the least recently used (LRU) pages first. This all worked relatively well before history store (HS) architecture landed. With HS, reconciling a non-HS page can generate even more HS contents. Therefore, any mechanism that evicts non-HS in hope for reducing cache pressure might make the situation even worse. Therefore, my current approach is to introduce some prioritisation for HS pages when cache pressure is high.