### PR TITLE
WT-6884 Clarify README to explain that PRs should target develop

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,8 @@ The WiredTiger source code can be found at:
 
 	https://github.com/wiredtiger/wiredtiger
 
+All GitHub pull requests should be based off of the "develop" branch.
+
 WiredTiger uses JIRA for issue management:
 
 	https://jira.mongodb.org/browse/WT


### PR DESCRIPTION
Most external PRs are based on master so we almost always have to retarget the PR and get the contributor to resolve merge conflicts or rebase the changes.

We should add a line to the `README` to make this more clear.