### PR TITLE
WT-6986 Add UndoDB support to format.sh

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -30,7 +30,7 @@ usage() {
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
 	echo "    -R           run timing stress split test configurations (defaults to off)"
-        echo "    -r           record with UndoDB (defaults to off)"
+	echo "    -r           record with UndoDB (defaults to off)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -129,6 +129,7 @@ while :; do
 		live_record_binary="$2"
 		if [ ! $(command -v "$live_record_binary") ]; then
 			echo "$name: -r option argument \"${live_record_binary}\" does not exist in path"
+			echo "$name: Usage and setup instructions can be found at: https://wiki.corp.mongodb.com/display/KERNEL/UndoDB+Usage"
 			exit 1
 		fi
 		shift; shift ;;

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -30,7 +30,7 @@ usage() {
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
 	echo "    -R           run timing stress split test configurations (defaults to off)"
-	echo "    -r binary    record with UndoDB (defaults to no recording)"
+	echo "    -r binary    record with UndoDB binary (defaults to no recording)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -129,7 +129,7 @@ while :; do
 		live_record_binary="$2"
 		if [ ! $(command -v "$live_record_binary") ]; then
 			echo "$name: -r option argument \"${live_record_binary}\" does not exist in path"
-			echo "$name: Usage and setup instructions can be found at: https://wiki.corp.mongodb.com/display/KERNEL/UndoDB+Usage"
+			echo "$name: usage and setup instructions can be found at: https://wiki.corp.mongodb.com/display/KERNEL/UndoDB+Usage"
 			exit 1
 		fi
 		shift; shift ;;

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -127,7 +127,7 @@ while :; do
 		shift ;;
         -r)
 		live_record_binary="$2"
-		if ! [ $(command -v "$live_record_binary") ]; then
+		if [ ! $(command -v "$live_record_binary") ]; then
 			echo "$name: -r option argument \"${live_record_binary}\" does not exist in path"
 			exit 1
 		fi

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -18,7 +18,7 @@ trap 'onintr' 2
 
 usage() {
 	echo "usage: $0 [-aEFRSv] [-b format-binary] [-c config] [-e env-var]"
-	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-R live-record-binary] [-t minutes] [format-configuration]"
+	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-r live-record-binary] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -b binary    format binary (defaults to "./t")"

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -460,6 +460,14 @@ format()
 		echo "$name: starting job in $dir ($(date))"
 	fi
 
+	# If we're using UndoDB, append our default arguments.
+	#
+	# This script is typically left running until a failure is hit. To avoid filling up the
+	# disk, we should avoid keeping recordings from successful runs.
+	if [[ ! -z $live_record_binary ]]; then
+		live_record_binary="$live_record_binary --save-on=error"
+	fi
+
 	cmd="$live_record_binary $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
 	echo "$name: $cmd"
 

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -17,8 +17,8 @@ onintr()
 trap 'onintr' 2
 
 usage() {
-	echo "usage: $0 [-aEFRrSv] [-b format-binary] [-c config] [-e env-var]"
-	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-t minutes] [format-configuration]"
+	echo "usage: $0 [-aEFRSv] [-b format-binary] [-c config] [-e env-var]"
+	echo "    [-h home] [-j parallel-jobs] [-n total-jobs] [-R live-record-binary] [-t minutes] [format-configuration]"
 	echo
 	echo "    -a           abort/recovery testing (defaults to off)"
 	echo "    -b binary    format binary (defaults to "./t")"
@@ -30,7 +30,7 @@ usage() {
 	echo "    -j parallel  jobs to execute in parallel (defaults to 8)"
 	echo "    -n total     total jobs to execute (defaults to no limit)"
 	echo "    -R           run timing stress split test configurations (defaults to off)"
-	echo "    -r           record with UndoDB (defaults to off)"
+	echo "    -r binary    record with UndoDB (defaults to no recording)"
 	echo "    -S           run smoke-test configurations (defaults to off)"
 	echo "    -t minutes   minutes to run (defaults to no limit)"
 	echo "    -v           verbose output (defaults to off)"
@@ -77,7 +77,7 @@ format_args=""
 home="."
 minutes=0
 parallel_jobs=8
-record=""
+live_record_binary=""
 skip_errors=0
 smoke_test=0
 timing_stress_split_test=0
@@ -126,12 +126,12 @@ while :; do
 		timing_stress_split_test=1
 		shift ;;
         -r)
-                record=live-record
-                if ! [ $(command -v live-record) ]; then
-                    echo "$name: -r option requires live-record binary in PATH"
-                    exit 1
-                fi
-                shift ;;
+		live_record_binary="$2"
+		if ! [ $(command -v "$live_record_binary") ]; then
+			echo "$name: -r option argument \"${live_record_binary}\" does not exist in path"
+			exit 1
+		fi
+		shift; shift ;;
 	-S)
 		smoke_test=1
 		shift ;;
@@ -460,7 +460,7 @@ format()
 		echo "$name: starting job in $dir ($(date))"
 	fi
 
-	cmd="$record $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
+	cmd="$live_record_binary $format_binary -c "$config" -h "$dir" -1 $args quiet=1"
 	echo "$name: $cmd"
 
 	# Disassociate the command from the shell script so we can exit and let the command


### PR DESCRIPTION
I've finally got around to doing this and am planning to do a session with the team next week introducing UndoDB to them.

One thing I wanted to do was to add basic integration for running `live-record` via our `format.sh` script since we use it all the time. This is pretty primitive and doesn't support forwarding arguments to `live-record` but I think that's ok since `resmoke` doesn't do that either. The `resmoke` script does set some arguments to change the way that the recording is named but I don't think that's necessary for us.