### PR TITLE
WT-6868 Don't cache history store cursor for operations on metadata

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -63,10 +63,14 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
          * the write will fail with EBUSY. Our caller handles that error, retrying later.
          */
         if (syncop == WT_SYNC_CLOSE && __wt_page_is_modified(page)) {
+            /*
+             * When setting the reconciliation flags, remember to not enable history store eviction
+             * for the history store file itself. Also metadata file doesn't have any associated
+             * history.
+             */
             rec_flags = WT_REC_EVICT | WT_REC_CLEAN_AFTER_REC | WT_REC_VISIBLE_ALL;
             if (!WT_IS_HS(btree) && !WT_IS_METADATA(dhandle))
                 rec_flags |= WT_REC_HS;
-
             WT_ERR(__wt_reconcile(session, ref, NULL, rec_flags));
         }
 

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -20,7 +20,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     WT_DECL_RET;
     WT_PAGE *page;
     WT_REF *next_ref, *ref;
-    uint32_t walk_flags;
+    uint32_t rec_flags, walk_flags;
 
     dhandle = session->dhandle;
     btree = dhandle->handle;
@@ -62,9 +62,13 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
          * sets of files open, updates in a no-longer-referenced file may not yet be visible, and
          * the write will fail with EBUSY. Our caller handles that error, retrying later.
          */
-        if (syncop == WT_SYNC_CLOSE && __wt_page_is_modified(page))
-            WT_ERR(__wt_reconcile(session, ref, NULL,
-              WT_REC_EVICT | WT_REC_HS | WT_REC_CLEAN_AFTER_REC | WT_REC_VISIBLE_ALL));
+        if (syncop == WT_SYNC_CLOSE && __wt_page_is_modified(page)) {
+            rec_flags = WT_REC_EVICT | WT_REC_CLEAN_AFTER_REC | WT_REC_VISIBLE_ALL;
+            if (!WT_IS_HS(btree) && !WT_IS_METADATA(dhandle))
+                rec_flags |= WT_REC_HS;
+
+            WT_ERR(__wt_reconcile(session, ref, NULL, rec_flags));
+        }
 
         /*
          * We can't evict the page just returned to us (it marks our place in the tree), so move the

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -900,10 +900,11 @@ __wt_rec_row_leaf(
                  * If we're removing a key due to a tombstone with a durable timestamp of "none",
                  * also remove the history store contents associated with that key. Even if we fail
                  * reconciliation after this point, we're safe to do this. The history store content
-                 * must be obsolete in order for us to consider removing the key.
+                 * must be obsolete in order for us to consider removing the key. Ignore if this is
+                 * metadata, as metadata doesn't have any history.
                  */
                 if (tw.durable_stop_ts == WT_TS_NONE && F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
-                  !WT_IS_HS(btree)) {
+                  !WT_IS_HS(btree) && !WT_IS_METADATA(btree->dhandle)) {
                     WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
                     /*
                      * Start from WT_TS_NONE to delete all the history store content of the key.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -58,6 +58,8 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     /* Can't do history store eviction for history store itself or for metadata. */
     WT_ASSERT(
       session, !LF_ISSET(WT_REC_HS) || (!WT_IS_HS(btree) && !WT_IS_METADATA(btree->dhandle)));
+    /* Flag as unused for non diagnostic builds. */
+    WT_UNUSED(btree);
 
     /* It's an error to be called with a clean page. */
     WT_ASSERT(session, __wt_page_is_modified(page));
@@ -2281,10 +2283,12 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     btree = S2BT(session);
 
     /*
-     * Sanity check: Can't insert into history store for history store itself or from the metadata
-     * file.
+     * Sanity check: Can't insert updates into history store from the history store itself or from
+     * the metadata file.
      */
     WT_ASSERT(session, !WT_IS_HS(btree) && !WT_IS_METADATA(btree->dhandle));
+    /* Flag as unused for non diagnostic builds. */
+    WT_UNUSED(btree);
 
     /* Check if there's work to do. */
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -29,13 +29,16 @@ static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_
 int
 __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, uint32_t flags)
 {
+    WT_BTREE *btree;
     WT_DECL_RET;
     WT_PAGE *page;
     uint64_t start, now;
     bool no_reconcile_set, page_locked;
 
-    __wt_seconds(session, &start);
+    btree = S2BT(session);
     page = ref->page;
+
+    __wt_seconds(session, &start);
 
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconcile %s (%s%s)", (void *)ref,
       __wt_page_type_string(page->type), LF_ISSET(WT_REC_EVICT) ? "evict" : "checkpoint",
@@ -51,6 +54,10 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     WT_ASSERT(session,
       !LF_ISSET(WT_REC_EVICT) || LF_ISSET(WT_REC_VISIBLE_ALL) ||
         F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
+
+    /* Can't do history store eviction for history store itself or for metadata. */
+    WT_ASSERT(
+      session, !LF_ISSET(WT_REC_HS) || (!WT_IS_HS(btree) && !WT_IS_METADATA(btree->dhandle)));
 
     /* It's an error to be called with a clean page. */
     WT_ASSERT(session, __wt_page_is_modified(page));
@@ -316,12 +323,13 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
         /*
          * Eviction should only be here if allowing writes to history store or in the in-memory
-         * eviction case. Otherwise, we must be reconciling a fixed length column store page (which
-         * does not allow history store content).
+         * eviction case. Otherwise, we must be reconciling a fixed length column store page or the
+         * metadata (which does not allow history store content).
          */
         WT_ASSERT(session,
           !F_ISSET(r, WT_REC_EVICT) ||
-            (F_ISSET(r, WT_REC_HS | WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX));
+            (F_ISSET(r, WT_REC_HS | WT_REC_IN_MEMORY) || page->type == WT_PAGE_COL_FIX ||
+              WT_IS_METADATA(btree->dhandle)));
     } else {
         /*
          * Track the page's maximum transaction ID (used to decide if we can evict a clean page and
@@ -2265,9 +2273,18 @@ __rec_write_wrapup_err(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 static int
 __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 {
+    WT_BTREE *btree;
     WT_DECL_RET;
     WT_MULTI *multi;
     uint32_t i;
+
+    btree = S2BT(session);
+
+    /*
+     * Sanity check: Can't insert into history store for history store itself or from the metadata
+     * file.
+     */
+    WT_ASSERT(session, !WT_IS_HS(btree) && !WT_IS_METADATA(btree->dhandle));
 
     /* Check if there's work to do. */
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)


### PR DESCRIPTION
Do not cache HS cursor when operating on the metadata. Also do not set history store reconciliation flag, WT_REC_HS, when reconciling metadata or the history store itself. Some new asserts have been added and others modified to validate these assumptions.