### PR TITLE
WT-6983 Make wiredtiger.in text wrapping consistent across Python versions

### DIFF
--- a/dist/api_config.py
+++ b/dist/api_config.py
@@ -132,7 +132,7 @@ for line in open(f, 'r'):
             fix_sentence_endings=True)
     # Separate at spaces, and after a set of non-breaking space indicators.
     w.wordsep_re = w.wordsep_simple_re = \
-        re.compile(r'(\s+|(?<=&nbsp;)[\w_,.;:]*)')
+        re.compile(r'(\s+|(?<=&nbsp;)[\w_,.;:]+)')
     for c in api_data.methods[config_name].config:
         if 'undoc' in c.flags:
             continue


### PR DESCRIPTION
It was recently found the text wrapping for `src/include/wiredtiger.in` when running `s_all` or `python api_config.py` under the `dist` directory became different for various versions of Python (2.7, 3.6, 3.7). It's suspected some updates to `re` or `textwrap` Python standard libraries may have triggered the text wrapping difference.

The solution is to make the line break regex to account for "one or more" word or certain punctuation, to make all `&nbsp;` stay on the same line (not wrapped in between). 