### PR TITLE
WT-6861 Disable assertion when fetching prev_durable_ts

### DIFF
--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1295,9 +1295,10 @@ __wt_txn_update_check(
         /*
          * The durable timestamp must be greater than or equal to the commit timestamp unless it is
          * an in-progress prepared update.
+         *
+         * FIXME-WT-7020: We should be able to assert this but we're seeing some fallout in format.
+         * We should investigate why and assert the above statement.
          */
-        WT_ASSERT(
-          session, upd->durable_ts >= upd->start_ts || upd->prepare_state == WT_PREPARE_INPROGRESS);
         *prev_tsp = upd->durable_ts;
     }
     if (ignore_prepare_set)


### PR DESCRIPTION
There seems to be some issue with `upd->durable_ts` being written to when it is already in the chain and visible to other threads. If I copy the `upd->durable_ts` and check it, I see that it was previously 0 and then soon after, gets written with the same value as `upd->start_ts`. I'm thinking that there may be a missing write barrier somewhere.

I'm temporarily removing this assertion to stop the testing fallout and we can take our time to figure out what's going wrong here. I think the actual culprit is not related to WT-6861 so the rest of the code can remain.