### PR TITLE
WT-7023 Extend how many snapshot operations format tracks

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -377,7 +377,7 @@ typedef struct {
 } TINFO;
 extern TINFO **tinfo_list;
 
-#define SNAP_LIST_SIZE 512
+#define SNAP_LIST_SIZE 20 * 1024
 
 WT_THREAD_RET alter(void *);
 WT_THREAD_RET backup(void *);


### PR DESCRIPTION
Trying to catch more complex snapshot isolation problems by remembering and doing repeated reads on more operations.