### PR TITLE
WT-7027 Run the metadata checkpoint for force_stop at read-committed isolation.

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -211,8 +211,14 @@ err:
          */
         cfg[0] = WT_CONFIG_BASE(session, WT_SESSION_checkpoint);
         cfg[1] = "force=true";
+        /*
+         * Metadata checkpoints rely on read-committed isolation. Use that here no matter what
+         * isolation the user's session sets for isolation.
+         */
         WT_WITH_DHANDLE(session, WT_SESSION_META_DHANDLE(session),
-          WT_WITH_METADATA_LOCK(session, ret = __wt_checkpoint(session, cfg)));
+          WT_WITH_METADATA_LOCK(session,
+            WT_WITH_TXN_ISOLATION(
+              session, WT_ISO_READ_COMMITTED, ret = __wt_checkpoint(session, cfg))));
     }
 
     /*

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -213,7 +213,7 @@ err:
         cfg[1] = "force=true";
         /*
          * Metadata checkpoints rely on read-committed isolation. Use that here no matter what
-         * isolation the user's session sets for isolation.
+         * isolation the caller's session sets for isolation.
          */
         WT_WITH_DHANDLE(session, WT_SESSION_META_DHANDLE(session),
           WT_WITH_METADATA_LOCK(session,

--- a/test/suite/test_backup13.py
+++ b/test/suite/test_backup13.py
@@ -41,8 +41,14 @@ class test_backup13(wttest.WiredTigerTestCase, suite_subprocess):
     logmax="100K"
     mult=0
     nops=1000
-    session_config='isolation=snapshot'
     uri="table:test"
+
+    scenarios = make_scenarios([
+        ('default', dict(sess_cfg='')),
+        ('read-committed', dict(sess_cfg='isolation=read_committed')),
+        ('read-uncommitted', dict(sess_cfg='isolation=read_uncommitted')),
+        ('snapshot', dict(sess_cfg='isolation=snapshot')),
+    ])
 
     pfx = 'test_backup'
     # Set the key and value big enough that we modify a few blocks.
@@ -79,8 +85,10 @@ class test_backup13(wttest.WiredTigerTestCase, suite_subprocess):
         # Increase the multiplier so that later calls insert unique items.
         self.mult += 1
 
-    def test_backup13(self):
+    def session_config(self):
+        return self.sess_cfg
 
+    def test_backup13(self):
         self.session.create(self.uri, "key_format=S,value_format=S")
         self.add_data(self.uri)
 

--- a/test/suite/test_backup13.py
+++ b/test/suite/test_backup13.py
@@ -45,8 +45,8 @@ class test_backup13(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios([
         ('default', dict(sess_cfg='')),
-        ('read-committed', dict(sess_cfg='isolation=read_committed')),
-        ('read-uncommitted', dict(sess_cfg='isolation=read_uncommitted')),
+        ('read-committed', dict(sess_cfg='isolation=read-committed')),
+        ('read-uncommitted', dict(sess_cfg='isolation=read-uncommitted')),
         ('snapshot', dict(sess_cfg='isolation=snapshot')),
     ])
 

--- a/test/suite/test_backup13.py
+++ b/test/suite/test_backup13.py
@@ -39,9 +39,10 @@ class test_backup13(wttest.WiredTigerTestCase, suite_subprocess):
     conn_config='cache_size=1G,log=(enabled,file_max=100K)'
     dir='backup.dir'                    # Backup directory name
     logmax="100K"
-    uri="table:test"
-    nops=1000
     mult=0
+    nops=1000
+    session_config='isolation=snapshot'
+    uri="table:test"
 
     pfx = 'test_backup'
     # Set the key and value big enough that we modify a few blocks.

--- a/test/suite/test_backup20.py
+++ b/test/suite/test_backup20.py
@@ -49,8 +49,8 @@ class test_backup20(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios([
         ('default', dict(sess_cfg='')),
-        ('read-committed', dict(sess_cfg='isolation=read_committed')),
-        ('read-uncommitted', dict(sess_cfg='isolation=read_uncommitted')),
+        ('read-committed', dict(sess_cfg='isolation=read-committed')),
+        ('read-uncommitted', dict(sess_cfg='isolation=read-uncommitted')),
         ('snapshot', dict(sess_cfg='isolation=snapshot')),
     ])
 

--- a/test/suite/test_backup20.py
+++ b/test/suite/test_backup20.py
@@ -39,7 +39,6 @@ from wtscenario import make_scenarios
 # because the session was created with snapshot isolation.
 class test_backup20(wttest.WiredTigerTestCase, suite_subprocess):
     conn_config='cache_size=1G,log=(enabled,file_max=100K)'
-    session_config='isolation=snapshot'
     dir='backup.dir'                    # Backup directory name
     logmax="100K"
     uri="table:test"
@@ -47,6 +46,16 @@ class test_backup20(wttest.WiredTigerTestCase, suite_subprocess):
     mult=0
 
     pfx = 'test_backup'
+
+    scenarios = make_scenarios([
+        ('default', dict(sess_cfg='')),
+        ('read-committed', dict(sess_cfg='isolation=read_committed')),
+        ('read-uncommitted', dict(sess_cfg='isolation=read_uncommitted')),
+        ('snapshot', dict(sess_cfg='isolation=snapshot')),
+    ])
+
+    def session_config(self):
+        return self.sess_cfg
 
     def test_backup20(self):
         self.session.create(self.uri, "key_format=S,value_format=S")

--- a/test/suite/test_backup20.py
+++ b/test/suite/test_backup20.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+import os, shutil
+from helper import compare_files
+from suite_subprocess import suite_subprocess
+from wtdataset import simple_key
+from wtscenario import make_scenarios
+
+# test_backup20.py
+# Test cursor backup force stop without a checkpoint.
+# This reproduces the issue from WT-7027 where we hit an assertion
+# because the session was created with snapshot isolation.
+class test_backup20(wttest.WiredTigerTestCase, suite_subprocess):
+    conn_config='cache_size=1G,log=(enabled,file_max=100K)'
+    session_config='isolation=snapshot'
+    dir='backup.dir'                    # Backup directory name
+    logmax="100K"
+    uri="table:test"
+    nops=1000
+    mult=0
+
+    pfx = 'test_backup'
+
+    def test_backup20(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+
+        # Open up the backup cursor. This causes a new log file to be created.
+        # That log file is not part of the list returned. This is a full backup
+        # primary cursor with incremental configured.
+        config = 'incremental=(enabled,granularity=1M,this_id="ID1")'
+        bkup_c = self.session.open_cursor('backup:', None, config)
+        bkup_c.close()
+
+        # Do a force stop to release resources and reset the system.
+        config = 'incremental=(force_stop=true)'
+        bkup_c = self.session.open_cursor('backup:', None, config)
+        bkup_c.close()
+
+        self.session.close()
+        self.conn.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Metadata checkpoints assume they're running at read-committed isolation. MongoDB opens sessions explicitly at snapshot isolation. I wrapped the backup force_stop checkpoint call to enforce read-committed. I also updated our incremental backup test to use snapshot isolation and added the small reproducer for this.