### PR TITLE
WT-6835 Add API to consolidate incremental backup information (#6100)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1240,6 +1240,12 @@ methods = {
         configure the cursor for block incremental backup usage. These formats
         are only compatible with the backup data source; see @ref backup''',
         type='category', subconfig=[
+        Config('consolidate', 'false', r'''
+            causes block incremental backup information to be consolidated if adjacent
+            granularity blocks are modified. If false, information will be returned in
+            granularity sized blocks only. This must be set on the primary backup cursor and it
+            applies to all files for this backup''',
+            type='boolean'),
         Config('enabled', 'false', r'''
             whether to configure this backup as the starting point for a subsequent
             incremental backup''',

--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -333,7 +333,8 @@ take_incr_backup(WT_SESSION *session, int i)
     tmp = NULL;
     tmp_sz = 0;
     /* Open the backup data source for incremental backup. */
-    (void)snprintf(buf, sizeof(buf), "incremental=(src_id=\"ID%d\",this_id=\"ID%d\")", i - 1, i);
+    (void)snprintf(buf, sizeof(buf), "incremental=(src_id=\"ID%d\",this_id=\"ID%d\"%s)", i - 1, i,
+      i % 2 == 0 ? "" : ",consolidate=true");
     error_check(session->open_cursor(session, "backup:", NULL, buf, &backup_cur));
     rfd = wfd = -1;
     count = 0;

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -308,7 +308,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_open_cursor[] = {
   {"checkpoint", "string", NULL, NULL, NULL, 0},
   {"checkpoint_wait", "boolean", NULL, NULL, NULL, 0},
   {"dump", "string", NULL, "choices=[\"hex\",\"json\",\"print\"]", NULL, 0},
-  {"incremental", "category", NULL, NULL, confchk_WT_SESSION_open_cursor_incremental_subconfigs, 6},
+  {"incremental", "category", NULL, NULL, confchk_WT_SESSION_open_cursor_incremental_subconfigs, 7},
   {"next_random", "boolean", NULL, NULL, NULL, 0},
   {"next_random_sample_size", "string", NULL, NULL, NULL, 0},
   {"overwrite", "boolean", NULL, NULL, NULL, 0}, {"raw", "boolean", NULL, NULL, NULL, 0},

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -297,8 +297,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_log_flush[] = {
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_open_cursor_incremental_subconfigs[] = {
-  {"enabled", "boolean", NULL, NULL, NULL, 0}, {"file", "string", NULL, NULL, NULL, 0},
-  {"force_stop", "boolean", NULL, NULL, NULL, 0},
+  {"consolidate", "boolean", NULL, NULL, NULL, 0}, {"enabled", "boolean", NULL, NULL, NULL, 0},
+  {"file", "string", NULL, NULL, NULL, 0}, {"force_stop", "boolean", NULL, NULL, NULL, 0},
   {"granularity", "int", NULL, "min=4KB,max=2GB", NULL, 0},
   {"src_id", "string", NULL, NULL, NULL, 0}, {"this_id", "string", NULL, NULL, NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
@@ -912,11 +912,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
   {"WT_SESSION.log_printf", "", NULL, 0},
   {"WT_SESSION.open_cursor",
     "append=false,bulk=false,checkpoint=,checkpoint_wait=true,dump=,"
-    "incremental=(enabled=false,file=,force_stop=false,"
-    "granularity=16MB,src_id=,this_id=),next_random=false,"
-    "next_random_sample_size=0,overwrite=true,raw=false,"
-    "read_once=false,readonly=false,skip_sort_check=false,statistics="
-    ",target=",
+    "incremental=(consolidate=false,enabled=false,file=,"
+    "force_stop=false,granularity=16MB,src_id=,this_id=),"
+    "next_random=false,next_random_sample_size=0,overwrite=true,"
+    "raw=false,read_once=false,readonly=false,skip_sort_check=false,"
+    "statistics=,target=",
     confchk_WT_SESSION_open_cursor, 15},
   {"WT_SESSION.prepare_transaction", "prepare_timestamp=", confchk_WT_SESSION_prepare_transaction,
     1},

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -111,8 +111,10 @@ __curbackup_incr_next(WT_CURSOR *cursor)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     wt_off_t size;
+    uint64_t start_bitoff, total_len;
     uint32_t raw;
     const char *file;
+    bool found;
 
     cb = (WT_CURSOR_BACKUP *)cursor;
     btree = cb->incr_cursor == NULL ? NULL : ((WT_CURSOR_BTREE *)cb->incr_cursor)->btree;
@@ -144,18 +146,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
         F_SET(cb, WT_CURBACKUP_INCR_INIT);
         __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
     } else {
-        if (F_ISSET(cb, WT_CURBACKUP_INCR_INIT)) {
-            /* Look for the next chunk that had modifications.  */
-            while (cb->bit_offset < cb->nbits)
-                if (__bit_test(cb->bitstring.mem, cb->bit_offset))
-                    break;
-                else
-                    ++cb->bit_offset;
-
-            /* We either have this object's incremental information or we're done. */
-            if (cb->bit_offset >= cb->nbits)
-                WT_ERR(WT_NOTFOUND);
-        } else {
+        if (!F_ISSET(cb, WT_CURBACKUP_INCR_INIT)) {
             /*
              * We don't have this object's incremental information, and it's not a full file copy.
              * Get a list of the block modifications for the file. The block modifications are from
@@ -186,8 +177,37 @@ __curbackup_incr_next(WT_CURSOR *cursor)
                 WT_ERR(WT_NOTFOUND);
             }
         }
-        __wt_cursor_set_key(cursor, cb->offset + cb->granularity * cb->bit_offset++,
-          cb->granularity, WT_BACKUP_RANGE);
+        /* We have initialized incremental information. */
+        start_bitoff = cb->bit_offset;
+        total_len = cb->granularity;
+        found = false;
+        /* The bit offset can be less than or equal to but never greater than the number of bits. */
+        WT_ASSERT(session, cb->bit_offset <= cb->nbits);
+        /* Look for the next chunk that had modifications.  */
+        while (cb->bit_offset < cb->nbits)
+            if (__bit_test(cb->bitstring.mem, cb->bit_offset)) {
+                found = true;
+                /*
+                 * Care must be taken to leave the bit_offset field set to the next offset bit so
+                 * that the next call is set to the correct offset.
+                 */
+                start_bitoff = cb->bit_offset++;
+                if (F_ISSET(cb, WT_CURBACKUP_CONSOLIDATE)) {
+                    while (
+                      cb->bit_offset < cb->nbits && __bit_test(cb->bitstring.mem, cb->bit_offset++))
+                        total_len += cb->granularity;
+                }
+                break;
+            } else
+                ++cb->bit_offset;
+
+        /* We either have this object's incremental information or we're done. */
+        if (!found)
+            WT_ERR(WT_NOTFOUND);
+        WT_ASSERT(session, cb->granularity != 0);
+        WT_ASSERT(session, total_len != 0);
+        __wt_cursor_set_key(
+          cursor, cb->offset + cb->granularity * start_bitoff, total_len, WT_BACKUP_RANGE);
     }
 
 done:
@@ -245,6 +265,11 @@ __wt_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *o
           cb->incr_file, other_cb->incr_src->id_str);
         F_SET(cb, WT_CURBACKUP_FORCE_FULL);
     }
+    if (F_ISSET(other_cb, WT_CURBACKUP_CONSOLIDATE))
+        F_SET(cb, WT_CURBACKUP_CONSOLIDATE);
+    else
+        F_CLR(cb, WT_CURBACKUP_CONSOLIDATE);
+
     /*
      * Set up the incremental backup information, if we are not forcing a full file copy. We need an
      * open cursor on the file. Open the backup checkpoint, confirming it exists.

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -68,7 +68,7 @@ struct __wt_cursor_backup {
 #define WT_CURBACKUP_INCR_INIT 0x080u   /* Cursor traversal initialized */
 #define WT_CURBACKUP_LOCKER 0x100u      /* Hot-backup started */
 #define WT_CURBACKUP_RENAME 0x200u      /* Object had a rename */
-/* AUTOMATIC FLAG VALUE GENERATION STOP */
+                                        /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -59,15 +59,16 @@ struct __wt_cursor_backup {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_CURBACKUP_CKPT_FAKE 0x001u   /* Object has fake checkpoint */
-#define WT_CURBACKUP_DUP 0x002u         /* Duplicated backup cursor */
-#define WT_CURBACKUP_FORCE_FULL 0x004u  /* Force full file copy for this cursor */
-#define WT_CURBACKUP_FORCE_STOP 0x008u  /* Force stop incremental backup */
-#define WT_CURBACKUP_HAS_CB_INFO 0x010u /* Object has checkpoint backup info */
-#define WT_CURBACKUP_INCR 0x020u        /* Incremental backup cursor */
-#define WT_CURBACKUP_INCR_INIT 0x040u   /* Cursor traversal initialized */
-#define WT_CURBACKUP_LOCKER 0x080u      /* Hot-backup started */
-#define WT_CURBACKUP_RENAME 0x100u      /* Object had a rename */
-                                        /* AUTOMATIC FLAG VALUE GENERATION STOP */
+#define WT_CURBACKUP_CONSOLIDATE 0x002u /* Consolidate returned info on this object */
+#define WT_CURBACKUP_DUP 0x004u         /* Duplicated backup cursor */
+#define WT_CURBACKUP_FORCE_FULL 0x008u  /* Force full file copy for this cursor */
+#define WT_CURBACKUP_FORCE_STOP 0x010u  /* Force stop incremental backup */
+#define WT_CURBACKUP_HAS_CB_INFO 0x020u /* Object has checkpoint backup info */
+#define WT_CURBACKUP_INCR 0x040u        /* Incremental backup cursor */
+#define WT_CURBACKUP_INCR_INIT 0x080u   /* Cursor traversal initialized */
+#define WT_CURBACKUP_LOCKER 0x100u      /* Hot-backup started */
+#define WT_CURBACKUP_RENAME 0x200u      /* Object had a rename */
+/* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1067,29 +1067,33 @@ struct __wt_session {
 	 * @config{incremental = (, configure the cursor for block incremental backup usage.  These
 	 * formats are only compatible with the backup data source; see @ref backup., a set of
 	 * related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled,
-	 * whether to configure this backup as the starting point for a subsequent incremental
-	 * backup., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;file, the
-	 * file name when opening a duplicate incremental backup cursor.  That duplicate cursor will
-	 * return the block modifications relevant to the given file name., a string; default
-	 * empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;force_stop, causes all block incremental backup
-	 * information to be released.  This is on an open_cursor call and the resources will be
-	 * released when this cursor is closed.  No other operations should be done on this open
-	 * cursor., a boolean flag; default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;granularity,
-	 * this setting manages the granularity of how WiredTiger maintains modification maps
-	 * internally.  The larger the granularity\, the smaller amount of information WiredTiger
-	 * need to maintain., an integer between 4KB and 2GB; default \c 16MB.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;src_id, a string that identifies a previous checkpoint
-	 * backup source as the source of this incremental backup.  This identifier must have
-	 * already been created by use of the 'this_id' configuration in an earlier backup.  A
-	 * source id is required to begin an incremental backup., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a string that identifies the current system
-	 * state as a future backup source for an incremental backup via 'src_id'. This identifier
-	 * is required when opening an incremental backup cursor and an error will be returned if
-	 * one is not provided., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * consolidate, causes block incremental backup information to be consolidated if adjacent
+	 * granularity blocks are modified.  If false\, information will be returned in granularity
+	 * sized blocks only.  This must be set on the primary backup cursor and it applies to all
+	 * files for this backup., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether to configure this backup as the starting
+	 * point for a subsequent incremental backup., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;file, the file name when opening a duplicate incremental
+	 * backup cursor.  That duplicate cursor will return the block modifications relevant to the
+	 * given file name., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;force_stop,
+	 * causes all block incremental backup information to be released.  This is on an
+	 * open_cursor call and the resources will be released when this cursor is closed.  No other
+	 * operations should be done on this open cursor., a boolean flag; default \c false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;granularity, this setting manages the granularity of how
+	 * WiredTiger maintains modification maps internally.  The larger the granularity\, the
+	 * smaller amount of information WiredTiger need to maintain., an integer between 4KB and
+	 * 2GB; default \c 16MB.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;src_id, a string that identifies a
+	 * previous checkpoint backup source as the source of this incremental backup.  This
+	 * identifier must have already been created by use of the 'this_id' configuration in an
+	 * earlier backup.  A source id is required to begin an incremental backup., a string;
+	 * default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a string that identifies the
+	 * current system state as a future backup source for an incremental backup via 'src_id'.
+	 * This identifier is required when opening an incremental backup cursor and an error will
+	 * be returned if one is not provided., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{next_random, configure the cursor to return a pseudo-random record from the
 	 * object when the WT_CURSOR::next method is called; valid only for row-store cursors.  See

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -567,9 +567,10 @@ backup(void *arg)
                 else
                     active_now = &active[0];
                 src_id = g.backup_id - 1;
+                /* Use consolidation too. */
                 testutil_check(__wt_snprintf(cfg, sizeof(cfg),
-                  "incremental=(enabled,src_id=%" PRIu64 ",this_id=%" PRIu64 ")", src_id,
-                  g.backup_id));
+                  "incremental=(enabled,consolidate=true,src_id=%" PRIu64 ",this_id=%" PRIu64 ")",
+                  src_id, g.backup_id));
                 /* Restart a full incremental every once in a while. */
                 full = false;
                 incr_full = mmrand(NULL, 1, 8) == 1;

--- a/test/suite/test_backup11.py
+++ b/test/suite/test_backup11.py
@@ -136,6 +136,16 @@ class test_backup11(wttest.WiredTigerTestCase, suite_subprocess):
         self.pr("Opened backup for error testing")
 
         # Now test all the error cases with an incremental primary open.
+        # - We cannot specify consolidate on the duplicate cursor.
+        config = 'incremental=(consolidate=true,file=test.wt)'
+        msg = "/consolidation can only be specified on a primary/"
+        self.pr("Test consolidation on a dup")
+        self.pr("=========")
+        # Test multiple duplicate backup cursors.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda:self.assertEquals(self.session.open_cursor(None,
+            bkup_c, config), 0), msg)
+
         # - We cannot make multiple incremental duplcate backup cursors.
         # - We cannot duplicate the duplicate backup cursor.
         config = 'incremental=(file=test.wt)'

--- a/test/suite/test_backup17.py
+++ b/test/suite/test_backup17.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+import os, shutil
+from helper import compare_files
+from suite_subprocess import suite_subprocess
+from wtdataset import simple_key
+from wtscenario import make_scenarios
+
+# test_backup17.py
+# Test cursor backup with a block-based incremental cursor and consolidate.
+class test_backup17(wttest.WiredTigerTestCase, suite_subprocess):
+    dir='backup.dir'                    # Backup directory name
+    gran="100K"
+    granval=100*1024
+    logmax="100K"
+    uri="table:test"
+    uri2="table:test2"
+    nops=1000
+    mult=0
+
+    conn_config='cache_size=1G,log=(enabled,file_max=%s)' % logmax
+
+    pfx = 'test_backup'
+    # Set the key and value big enough that we modify a few blocks.
+    bigkey = 'Key' * 100
+    bigval = 'Value' * 100
+
+    def add_data(self, uri):
+        c = self.session.open_cursor(uri)
+        for i in range(0, self.nops):
+            num = i + (self.mult * self.nops)
+            key = self.bigkey + str(num)
+            val = self.bigval + str(num)
+            c[key] = val
+        self.session.checkpoint()
+        c.close()
+
+    def take_incr_backup(self, id, consolidate):
+        # Open the backup data source for incremental backup.
+        buf = 'incremental=(src_id="ID' +  str(id - 1) + '",this_id="ID' + str(id) + '"'
+        if consolidate:
+            buf += ',consolidate=true'
+        buf += ')'
+        bkup_c = self.session.open_cursor('backup:', None, buf)
+        lens = []
+        saw_multiple = False
+        while True:
+            ret = bkup_c.next()
+            if ret != 0:
+                break
+            newfile = bkup_c.get_key()
+            config = 'incremental=(file=' + newfile + ')'
+            self.pr('Open incremental cursor with ' + config)
+            dup_cnt = 0
+            dupc = self.session.open_cursor(None, bkup_c, config)
+            while True:
+                ret = dupc.next()
+                if ret != 0:
+                    break
+                incrlist = dupc.get_keys()
+                offset = incrlist[0]
+                size = incrlist[1]
+                curtype = incrlist[2]
+                # 1 is WT_BACKUP_FILE
+                # 2 is WT_BACKUP_RANGE
+                self.assertTrue(curtype == 1 or curtype == 2)
+                if curtype == 1:
+                    self.pr('Copy from: ' + newfile + ' (' + str(size) + ') to ' + self.dir)
+                    shutil.copy(newfile, self.dir)
+                else:
+                    self.pr('Range copy file ' + newfile + ' offset ' + str(offset) + ' len ' + str(size))
+                    lens.append(size)
+                    rfp = open(newfile, "r+b")
+                    wfp = open(self.dir + '/' + newfile, "w+b")
+                    rfp.seek(offset, 0)
+                    wfp.seek(offset, 0)
+                    if size > self.granval:
+                        saw_multiple = True
+                    buf = rfp.read(size)
+                    wfp.write(buf)
+                    rfp.close()
+                    wfp.close()
+                dup_cnt += 1
+            dupc.close()
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+        bkup_c.close()
+        if consolidate:
+            self.assertTrue(saw_multiple)
+        else:
+            self.assertFalse(saw_multiple)
+        return lens
+
+    def test_backup17(self):
+
+        self.session.create(self.uri, "key_format=S,value_format=S")
+        self.session.create(self.uri2, "key_format=S,value_format=S")
+        self.add_data(self.uri)
+        self.add_data(self.uri2)
+        self.mult += 1
+
+        # Open up the backup cursor. This causes a new log file to be created.
+        # That log file is not part of the list returned. This is a full backup
+        # primary cursor with incremental configured.
+        os.mkdir(self.dir)
+        config = 'incremental=(enabled,granularity=%s,this_id="ID1")' % self.gran
+        bkup_c = self.session.open_cursor('backup:', None, config)
+
+        # Now copy the files returned by the backup cursor.
+        all_files = []
+        while True:
+            ret = bkup_c.next()
+            if ret != 0:
+                break
+            newfile = bkup_c.get_key()
+            sz = os.path.getsize(newfile)
+            self.pr('Copy from: ' + newfile + ' (' + str(sz) + ') to ' + self.dir)
+            shutil.copy(newfile, self.dir)
+            all_files.append(newfile)
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+        bkup_c.close()
+
+        # This is the main part of the test for consolidate. Add data to the first table.
+        # Then perform the incremental backup with consolidate off (the default). Then add the
+        # same data to the second table. Perform an incremental backup with consolidate on and
+        # verify we get fewer, consolidated values.
+        self.add_data(self.uri)
+        uri1_lens = self.take_incr_backup(2, False)
+
+        self.add_data(self.uri2)
+        uri2_lens = self.take_incr_backup(3, True)
+
+        # Assert that we recorded fewer lengths on the consolidated backup.
+        self.assertLess(len(uri2_lens), len(uri1_lens))
+        # Assert that we recorded the same total data length for both.
+        self.assertEqual(sum(uri2_lens), sum(uri1_lens))
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
* WT-6835 Add consolidate API for incremental backup.

* Add python test for new backup API setting.

* Fix compiler warning.

* Remove extraneous increment.

* Review comments. Some fixes, a new test condition.

* clang-format whitespace

* Remove erroneous open_cursor line.

* Fix typo

(cherry picked from commit 56bac0f71605e24767a1002e4271ee2ff2271893)