### PR TITLE
WT-6996 Fix suite_random.rand32() in python test suite

### DIFF
--- a/test/suite/suite_random.py
+++ b/test/suite/suite_random.py
@@ -31,8 +31,8 @@
 class suite_random:
     """
     Generate random 32 bit integers that are predictable,
-    and use no global state.  We use the Multiply-with-carry
-    method invented by George Marsaglia, because it is quick
+        and use no global state.  We use the Multiply-with-carry
+        method invented by George Marsaglia, because it is quick
     and easy to implement.
     """
     def __init__(self, *args):
@@ -59,7 +59,7 @@ class suite_random:
 
         self.seedz = (36969 * (z & 65535) + (z >> 16)) & 0xffffffff
         self.seedw = (18000 * (w & 65535) + (w >> 16)) & 0xffffffff
-        return ((z << 16) + w & 65535) & 0xffffffff
+        return ((z << 16) + (w & 65535)) & 0xffffffff
 
     def rand_range(self, n, m):
         """

--- a/test/suite/suite_random.py
+++ b/test/suite/suite_random.py
@@ -31,8 +31,8 @@
 class suite_random:
     """
     Generate random 32 bit integers that are predictable,
-        and use no global state.  We use the Multiply-with-carry
-        method invented by George Marsaglia, because it is quick
+    and use no global state.  We use the Multiply-with-carry
+    method invented by George Marsaglia, because it is quick
     and easy to implement.
     """
     def __init__(self, *args):


### PR DESCRIPTION
Currently the suite_random.rand32() only returns values that are < 2^16, this PR fixes the precedence of operations to return 2^32 values. This PR needed to double check if it exposes any other tests through having a bigger value being returned