### PR TITLE
WT-6981 Add randomness to Python test suite runs

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1447,6 +1447,15 @@ tasks:
           dependent_task: compile-linux-no-ftruncate
       - func: "unit test"
 
+  # Run the tests that uses suite_random with a random starting seed
+  - name: unit-test-random-seed
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
   # Break out Python unit tests into multiple buckets/tasks.  We have a fixed number of buckets,
   # and we use the -b option of the test/suite/run.py script to split up the tests.
 
@@ -1559,16 +1568,6 @@ tasks:
       - func: "unit test"
         vars:
           unit_test_args: -v 2 -b 10/11
-
-  - name: unit-test-bucket-random-seed
-    tags: ["unit_test"]
-    depends_on:
-    - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "unit test"
-        vars:
-          unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
   # End of Python unit test tasks
 
   - name: s-all
@@ -2464,6 +2463,7 @@ buildvariants:
     - name: configure-combinations
     - name: checkpoint-filetypes-test
     - name: unit-test-long
+    - name: unit-test-random-seed
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1559,6 +1559,16 @@ tasks:
       - func: "unit test"
         vars:
           unit_test_args: -v 2 -b 10/11
+
+  - name: unit-test-bucket-random-seed
+    tags: ["unit_test"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
   # End of Python unit test tasks
 
   - name: s-all

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -303,6 +303,7 @@ if __name__ == '__main__':
     parallel = 0
     random_sample = 0
     batchtotal = batchnum = 0
+    randomSeed = 0
     configfile = None
     configwrite = False
     dirarg = None
@@ -415,6 +416,15 @@ if __name__ == '__main__':
                 configfile = args.pop(0)
                 configwrite = True
                 continue
+            if option == '-randomseed' or option == 'R':
+                randomSeed = random.randint(1, 0xffffffff)
+                continue
+            if option == '-seed' or option == 'S':
+                if randomSeed != 0 or len(args) == 0:
+                    usage()
+                    sys.exit(2)
+                randomSeed = args.pop(0)
+                continue
             print('unknown arg: ' + arg)
             usage()
             sys.exit(2)
@@ -501,7 +511,7 @@ if __name__ == '__main__':
     # That way, verbose printing can be done at the class definition level.
     wttest.WiredTigerTestCase.globalSetup(preserve, timestamp, gdbSub, lldbSub,
                                           verbose, wt_builddir, dirarg,
-                                          longtest, ignoreStdout)
+                                          longtest, ignoreStdout, randomSeed)
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
@@ -561,6 +571,8 @@ if __name__ == '__main__':
         for line in tests:
             print(line)
     else:
+        if randomSeed != 0:
+            print("Starting test suite with " + str(randomSeed))
         result = wttest.runsuite(tests, parallel)
         sys.exit(0 if result.wasSuccessful() else 1)
 

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -124,8 +124,9 @@ Options:\n\
   -t      | --timestamp          name WT_TEST according to timestamp\n\
   -v N    | --verbose N          set verboseness to N (0<=N<=3, default=1)\n\
   -i      | --ignore-stdout      dont fail on unexpected stdout or stderr\n\
-  -R      | --randomseed         run with random seeds for generating random numbers\n\
-  -S      | --seed               run with specified two specified seeds for generating random numbers\n\
+  -R      | --randomseed         run with random seeds for generates random numbers\n\
+  -S      | --seed               run with two seeds that generates random numbers, \n\
+                                 format "seed1.seed2", seed1 or seed2 can\'t be zero\n\
 \n\
 Tests:\n\
   may be a file name in test/suite: (e.g. test_base01.py)\n\
@@ -305,7 +306,7 @@ if __name__ == '__main__':
     parallel = 0
     random_sample = 0
     batchtotal = batchnum = 0
-    seedw = seedz = 0
+    seed = seedw = seedz = 0
     configfile = None
     configwrite = False
     dirarg = None
@@ -423,11 +424,14 @@ if __name__ == '__main__':
                 seedz = random.randint(1, 0xffffffff)
                 continue
             if option == '-seed' or option == 'S':
-                if seedw != 0 or seedz != 0 or len(args) < 2:
+                if seed != 0 or len(args) == 0:
                     usage()
                     sys.exit(2)
-                seedw = args.pop(0)
-                seedz = args.pop(0)
+                seed = args.pop(0)
+                [seedw, seedz] = seed.split('.')
+                if seedw == 0 or seedz == 0:
+                    usage()
+                    sys.exit(2)
                 continue
             print('unknown arg: ' + arg)
             usage()

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -124,6 +124,8 @@ Options:\n\
   -t      | --timestamp          name WT_TEST according to timestamp\n\
   -v N    | --verbose N          set verboseness to N (0<=N<=3, default=1)\n\
   -i      | --ignore-stdout      dont fail on unexpected stdout or stderr\n\
+  -R      | --randomseed         run with random seeds for generating random numbers\n\
+  -S      | --seed               run with specified two specified seeds for generating random numbers\n\
 \n\
 Tests:\n\
   may be a file name in test/suite: (e.g. test_base01.py)\n\
@@ -303,7 +305,7 @@ if __name__ == '__main__':
     parallel = 0
     random_sample = 0
     batchtotal = batchnum = 0
-    randomSeed = 0
+    seedw = seedz = 0
     configfile = None
     configwrite = False
     dirarg = None
@@ -417,13 +419,15 @@ if __name__ == '__main__':
                 configwrite = True
                 continue
             if option == '-randomseed' or option == 'R':
-                randomSeed = random.randint(1, 0xffffffff)
+                seedw = random.randint(1, 0xffffffff)
+                seedz = random.randint(1, 0xffffffff)
                 continue
             if option == '-seed' or option == 'S':
-                if randomSeed != 0 or len(args) == 0:
+                if seedw != 0 or seedz != 0 or len(args) < 2:
                     usage()
                     sys.exit(2)
-                randomSeed = args.pop(0)
+                seedw = args.pop(0)
+                seedz = args.pop(0)
                 continue
             print('unknown arg: ' + arg)
             usage()
@@ -511,7 +515,7 @@ if __name__ == '__main__':
     # That way, verbose printing can be done at the class definition level.
     wttest.WiredTigerTestCase.globalSetup(preserve, timestamp, gdbSub, lldbSub,
                                           verbose, wt_builddir, dirarg,
-                                          longtest, ignoreStdout, randomSeed)
+                                          longtest, ignoreStdout, seedw, seedz)
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
@@ -571,8 +575,6 @@ if __name__ == '__main__':
         for line in tests:
             print(line)
     else:
-        if randomSeed != 0:
-            print("Starting test suite with " + str(randomSeed))
         result = wttest.runsuite(tests, parallel)
         sys.exit(0 if result.wasSuccessful() else 1)
 

--- a/test/suite/suite_random.py
+++ b/test/suite/suite_random.py
@@ -39,19 +39,16 @@ class suite_random:
     """
     def __init__(self, *args):
         arglen = len(args)
-        randomSeed = wttest.getRandomSeed()
+        seedw, seedz = wttest.getseed()
         if arglen == 1:
             self.seedw = int(args[0]) & 0xffffffff
             self.seedz = int(args[0]) & 0xffffffff
         elif arglen == 2:
             self.seedw = int(args[0]) & 0xffffffff
             self.seedz = int(args[1]) & 0xffffffff
-        elif randomSeed != 0:
-            self.seedw = int(randomSeed) & 0xffffffff
-            self.seedz = int(randomSeed) & 0xffffffff
         else:
-            self.seedw = 521288629
-            self.seedz = 362436069
+            self.seedw = int(seedw) & 0xffffffff
+            self.seedz = int(seedz) & 0xffffffff
 
     def rand32(self):
         """
@@ -60,13 +57,9 @@ class suite_random:
         w = self.seedw
         z = self.seedz
         if w == 0 or z == 0:
-            randomSeed = wttest.getRandomSeed()
-            if randomSeed != 0:
-                self.seedw = int(randomSeed) & 0xffffffff
-                self.seedz = int(randomSeed) & 0xffffffff
-            else:
-                self.seedw = 521288629
-                self.seedz = 362436069
+            seedw, seedz = wttest.getRandomSeed()
+            self.seedw = int(seedw) & 0xffffffff
+            self.seedz = int(seedz) & 0xffffffff
 
         self.seedz = (36969 * (z & 65535) + (z >> 16)) & 0xffffffff
         self.seedw = (18000 * (w & 65535) + (w >> 16)) & 0xffffffff

--- a/test/suite/suite_random.py
+++ b/test/suite/suite_random.py
@@ -28,6 +28,8 @@
 
 # suite_random.py
 #    A quick and predictable pseudo random number generator.
+import wttest
+
 class suite_random:
     """
     Generate random 32 bit integers that are predictable,
@@ -37,12 +39,16 @@ class suite_random:
     """
     def __init__(self, *args):
         arglen = len(args)
+        randomSeed = wttest.getRandomSeed()
         if arglen == 1:
             self.seedw = int(args[0]) & 0xffffffff
             self.seedz = int(args[0]) & 0xffffffff
         elif arglen == 2:
             self.seedw = int(args[0]) & 0xffffffff
             self.seedz = int(args[1]) & 0xffffffff
+        elif randomSeed != 0:
+            self.seedw = int(randomSeed) & 0xffffffff
+            self.seedz = int(randomSeed) & 0xffffffff
         else:
             self.seedw = 521288629
             self.seedz = 362436069
@@ -54,8 +60,13 @@ class suite_random:
         w = self.seedw
         z = self.seedz
         if w == 0 or z == 0:
-            self.seedw = 521288629
-            self.seedz = 362436069
+            randomSeed = wttest.getRandomSeed()
+            if randomSeed != 0:
+                self.seedw = int(randomSeed) & 0xffffffff
+                self.seedz = int(randomSeed) & 0xffffffff
+            else:
+                self.seedw = 521288629
+                self.seedz = 362436069
 
         self.seedz = (36969 * (z & 65535) + (z >> 16)) & 0xffffffff
         self.seedw = (18000 * (w & 65535) + (w >> 16)) & 0xffffffff

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -489,7 +489,7 @@ class test_cursor13_sweep(test_cursor13_big_base):
     uri = 'table:cursor13_sweep_b'
     opens_per_round = 100000
     rounds = 5
-    
+
     @wttest.longtest('cursor sweep tests require wait times')
     def test_cursor_sweep(self):
         rand = suite_random()

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -456,7 +456,6 @@ class test_cursor13_big(test_cursor13_big_base):
 
     nopens = 500000
 
-    @wttest.randomseed()
     def test_cursor_big(self):
         rand = suite_random()
         uri_map = self.create_uri_map(self.uri)

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -456,6 +456,7 @@ class test_cursor13_big(test_cursor13_big_base):
 
     nopens = 500000
 
+    @wttest.randomseed()
     def test_cursor_big(self):
         rand = suite_random()
         uri_map = self.create_uri_map(self.uri)
@@ -488,7 +489,7 @@ class test_cursor13_sweep(test_cursor13_big_base):
     uri = 'table:cursor13_sweep_b'
     opens_per_round = 100000
     rounds = 5
-
+    
     @wttest.longtest('cursor sweep tests require wait times')
     def test_cursor_sweep(self):
         rand = suite_random()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -198,7 +198,7 @@ class WiredTigerTestCase(unittest.TestCase):
     @staticmethod
     def globalSetup(preserveFiles = False, useTimestamp = False,
                     gdbSub = False, lldbSub = False, verbose = 1, builddir = None, dirarg = None,
-                    longtest = False, ignoreStdout = False):
+                    longtest = False, ignoreStdout = False, randomSeed = False):
         WiredTigerTestCase._preserveFiles = preserveFiles
         d = 'WT_TEST' if dirarg == None else dirarg
         if useTimestamp:
@@ -221,6 +221,7 @@ class WiredTigerTestCase(unittest.TestCase):
         WiredTigerTestCase._concurrent = False
         WiredTigerTestCase._globalSetup = True
         WiredTigerTestCase._ttyDescriptor = None
+        WiredTigerTestCase._randomSeed = randomSeed
 
     def fdSetUp(self):
         self.captureout = CapturedFd('stdout.txt', 'standard output')
@@ -756,6 +757,9 @@ def longtest(description):
 
 def islongtest():
     return WiredTigerTestCase._longtest
+
+def getRandomSeed():
+    return WiredTigerTestCase._randomSeed
 
 def runsuite(suite, parallel):
     suite_to_run = suite

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -227,7 +227,7 @@ class WiredTigerTestCase(unittest.TestCase):
             WiredTigerTestCase._randomseeds = [seedw, seedz]
         else:
             WiredTigerTestCase._randomseed = False
-        
+
     def fdSetUp(self):
         self.captureout = CapturedFd('stdout.txt', 'standard output')
         self.captureerr = CapturedFd('stderr.txt', 'error output')

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -226,7 +226,7 @@ class WiredTigerTestCase(unittest.TestCase):
         if seedw != 0 and seedz != 0:
             WiredTigerTestCase._randomseed = True
             WiredTigerTestCase._seeds = [seedw, seedz]
-           
+
     def fdSetUp(self):
         self.captureout = CapturedFd('stdout.txt', 'standard output')
         self.captureerr = CapturedFd('stderr.txt', 'error output')

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -222,12 +222,11 @@ class WiredTigerTestCase(unittest.TestCase):
         WiredTigerTestCase._globalSetup = True
         WiredTigerTestCase._ttyDescriptor = None
         WiredTigerTestCase._seeds = [521288629, 362436069]
+        WiredTigerTestCase._randomseed = False
         if seedw != 0 and seedz != 0:
             WiredTigerTestCase._randomseed = True
-            WiredTigerTestCase._randomseeds = [seedw, seedz]
-        else:
-            WiredTigerTestCase._randomseed = False
-
+            WiredTigerTestCase._seeds = [seedw, seedz]
+           
     def fdSetUp(self):
         self.captureout = CapturedFd('stdout.txt', 'standard output')
         self.captureerr = CapturedFd('stderr.txt', 'error output')
@@ -759,23 +758,6 @@ def longtest(description):
     else:
         return runit_decorator
 
-def randomseed():
-    """
-    Used as a function decorator, for example, @wttest.randomseed("description").
-    The decorator uses the generated random seed which is used for number generation in suite_random
-    """
-    def runit_decorator(func):
-        def wrapper(self, *args, **kwargs):
-            if WiredTigerTestCase._randomseed:
-                WiredTigerTestCase._seeds[0] = WiredTigerTestCase._randomseeds[0]
-                WiredTigerTestCase._seeds[1] = WiredTigerTestCase._randomseeds[1]
-            retVal = func(self, *args, **kwargs)
-            WiredTigerTestCase._seeds[0] = 521288629
-            WiredTigerTestCase._seeds[1] = 362436069
-            return retVal
-        return wrapper
-    return runit_decorator
-
 def islongtest():
     return WiredTigerTestCase._longtest
 
@@ -792,7 +774,7 @@ def runsuite(suite, parallel):
         suite_to_run = ConcurrentTestSuite(suite, fork_for_tests(parallel))
     try:
         if WiredTigerTestCase._randomseed:
-            WiredTigerTestCase.prout("Starting test suite with seedw=" + str(WiredTigerTestCase._randomseeds[0]) + " and seedz=" + str(WiredTigerTestCase._randomseeds[1]))
+            WiredTigerTestCase.prout("Starting test suite with seedw=" + str(WiredTigerTestCase._seeds[0]) + " and seedz=" + str(WiredTigerTestCase._seeds[1]))
         return unittest.TextTestRunner(
             verbosity=WiredTigerTestCase._verbose).run(suite_to_run)
     except BaseException as e:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -774,7 +774,8 @@ def runsuite(suite, parallel):
         suite_to_run = ConcurrentTestSuite(suite, fork_for_tests(parallel))
     try:
         if WiredTigerTestCase._randomseed:
-            WiredTigerTestCase.prout("Starting test suite with seedw=" + str(WiredTigerTestCase._seeds[0]) + " and seedz=" + str(WiredTigerTestCase._seeds[1]))
+            WiredTigerTestCase.prout("Starting test suite with seedw={0} and seedz={1}. Rerun this test with -seed {0}.{1} to get the same randomness"
+                .format(str(WiredTigerTestCase._seeds[0]), str(WiredTigerTestCase._seeds[1])))
         return unittest.TextTestRunner(
             verbosity=WiredTigerTestCase._verbose).run(suite_to_run)
     except BaseException as e:


### PR DESCRIPTION
The purpose of this ticket is to investigate the possibility of adding more randomness to the python test suite. This can be done through giving the option to randomise the seed for random numbers. This achieves more test coverage through generating unpredictable random numbers through the option of **-R**,  and the option of running two specific random integer seeds is now available through **-S**

The reason for the generating the random seed from 1-2^32, is to make sure that the seed doesn't get 0, which isn't allowed in the formula for generating random numbers

The random seed will only be used in a test case when the "@wttest.randomseed()" is applied to the test case, therefore using the random seed for specific tests.