### PR TITLE
WT-7065 Add check for WT_DHANDLE_DEAD to assertion.

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -39,7 +39,8 @@ __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, __wt_hazard_check_assert(session, ref, true));
 
     WT_ASSERT(session,
-      !F_ISSET(ref, WT_REF_FLAG_INTERNAL) || F_ISSET(session->dhandle, WT_DHANDLE_EXCLUSIVE) ||
+      !F_ISSET(ref, WT_REF_FLAG_INTERNAL) ||
+        F_ISSET(session->dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_EXCLUSIVE) ||
         !__wt_gen_active(session, WT_GEN_SPLIT, ref->page->pg_intl_split_gen));
 
     __wt_page_out(session, &ref->page);


### PR DESCRIPTION
@michaelcahill this is a change to the assertion added with the split generation code change from a few weeks ago. It is failing when a file is being swept. I added a clause for a dead dhandle. Please review that it fits your understanding of that new assertion.