### PR TITLE
WT-7066 Point README doc link to develop/index.html

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ WiredTiger release packages and documentation can be found at:
 
 The documentation for this specific release can be found at:
 
-	https://source.wiredtiger.com/10.0.0/index.html
+	https://source.wiredtiger.com/develop/index.html
 
 The WiredTiger source code can be found at:
 


### PR DESCRIPTION
The existing doc link is not accessible because the 10.0.0 release has not been cut. Point the doc link to `develop/index.html` for now. 