### PR TITLE
WT-7067 Add column store to test_hs01

### DIFF
--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -143,9 +143,8 @@ class test_hs01(wttest.WiredTigerTestCase):
         session2.rollback_transaction()
         session2.close()
 
-        # Don't run durable check for columnar store. Since durable history rollback is 
-        # not implemented for columnar store. Remove this if statement once WT-5545
-        # is implemented.
+        # Rollback to stable support for column store is not implemented, and it fails only when it is used with timestamps.
+        # Remove the above comment once WT-5545 is implemented.
         if self.key_format != 'r':
             # Scenario: 3
             # Check to see if the history store is working with the old timestamp.

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -29,6 +29,7 @@
 from helper import copy_wiredtiger_home
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
 
 def timestamp_str(t):
     return '%x' % t
@@ -39,6 +40,13 @@ class test_hs01(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
+    key_format_values = [
+        # The commented columnar tests needs to be enabled once columnar page instantiated is fixed in (WT-6061).
+        ('column', dict(key_format='r')),
+        ('integer', dict(key_format='i')),
+        ('string', dict(key_format='S'))
+    ]
+    scenarios = make_scenarios(key_format_values)
 
     def large_updates(self, session, uri, value, ds, nrows, timestamp=False):
         # Update a large number of records, we'll hang if the history store table
@@ -96,7 +104,7 @@ class test_hs01(wttest.WiredTigerTestCase):
         # Create a small table.
         uri = "table:test_hs01"
         nrows = 100
-        ds = SimpleDataSet(self, uri, nrows, key_format="S", value_format='u')
+        ds = SimpleDataSet(self, uri, nrows, key_format="{}".format(self.key_format), value_format='u')
         ds.populate()
         bigvalue = b"aaaaa" * 100
 

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -41,7 +41,6 @@ class test_hs01(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
     key_format_values = [
-        # The commented columnar tests needs to be enabled once columnar page instantiated is fixed in (WT-6061).
         ('column', dict(key_format='r')),
         ('integer', dict(key_format='i')),
         ('string', dict(key_format='S'))
@@ -144,8 +143,9 @@ class test_hs01(wttest.WiredTigerTestCase):
         session2.rollback_transaction()
         session2.close()
 
-        # Don't run durable check for columnar store. Since durable history rollback 
-        # is not implemented for columnar store. 
+        # Don't run durable check for columnar store. Since durable history rollback is 
+        # not implemented for columnar store. Remove this if statement once WT-5545
+        # is implemented.
         if self.key_format != 'r':
             # Scenario: 3
             # Check to see if the history store is working with the old timestamp.


### PR DESCRIPTION
Added column store configurations to make scenarios, however, found that scenario 3 fails, so, added a conditional statement on scenario 3, as durable check when timestamp is true is not supported in columnar store yet. 

There is already a ticket to make durable check (timestamp = true) work. (WT-5545 Fix rollback to stable for fixed length columnar storage type objects)