### PR TITLE
WT-7104 Redact user data from printlog, 4.2 branch.

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -88,12 +88,12 @@ def n_setup(f):
 
 # Check for an operation that has a file id type. Redact any user data
 # if the redact flag is set, but print operations for file id 0, known
-# to be the metadta.
+# to be the metadata.
 def check_redact(optype):
     for f  in optype.fields:
         if f[0] == 'uint32_id':
             redact_str = '\tif (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && '
-            redact_str += '%s != 0) {\n' % (f[1])
+            redact_str += '%s != WT_METAFILE_ID) {\n' % (f[1])
             redact_str += '\t\tWT_RET(__wt_fprintf(session, args->fs, " REDACTED"));\n'
             redact_str += '\t\treturn (0);\n\t}\n'
             return redact_str

--- a/dist/log.py
+++ b/dist/log.py
@@ -86,6 +86,19 @@ def printf_setup(f, i, nl_indent):
 def n_setup(f):
     return len(field_types[f[0]][4])
 
+# Check for an operation that has a file id type. Redact any user data
+# if the redact flag is set, but print operations for file id 0, known
+# to be the metadta.
+def check_redact(optype):
+    for f  in optype.fields:
+        if f[0] == 'uint32_id':
+            redact_str = '\tif (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && '
+            redact_str += '%s != 0) {\n' % (f[1])
+            redact_str += '\t\tWT_RET(__wt_fprintf(session, args->fs, " REDACTED"));\n'
+            redact_str += '\t\treturn (0);\n\t}\n'
+            return redact_str
+    return ''
+
 # Create a printf line, with an optional setup function.
 # ishex indicates that the the field name in the output is modified
 # (to add "-hex"), and that the setup and printf are conditional
@@ -287,6 +300,7 @@ __wt_logop_%(name)s_print(WT_SESSION_IMPL *session,
 \t%(arg_init)sWT_RET(__wt_logop_%(name)s_unpack(
 \t    session, pp, end%(arg_addrs)s));
 
+\t%(redact)s
 \tWT_RET(__wt_fprintf(session, args->fs,
 \t    " \\"optype\\": \\"%(name)s\\",\\n"));
 %(print_args)s
@@ -303,6 +317,7 @@ __wt_logop_%(name)s_print(WT_SESSION_IMPL *session,
     'arg_fini' : ('\nerr:\t__wt_free(session, escaped);\n\treturn (ret);'
     if has_escape(optype.fields) else '\treturn (0);'),
     'arg_addrs' : ''.join(', &%s' % f[1] for f in optype.fields),
+    'redact' : check_redact(optype),
     'print_args' : ('\t' + '\n\t'.join(printf_line(f, optype, i, s)
         for i,f in enumerate(optype.fields) for s in range(0, n_setup(f)))
         if optype.fields else ''),

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -458,6 +458,7 @@ Wpedantic
 WriteFile
 Wuninitialized
 Wunused
+Wx
 XP
 Xcode
 Xcode/

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -395,8 +395,9 @@ struct __wt_txn_printlog_args {
     WT_FSTREAM *fs;
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_TXN_PRINTLOG_HEX 0x1u /* Add hex output */
-                                 /* AUTOMATIC FLAG VALUE GENERATION STOP */
+#define WT_TXN_PRINTLOG_HEX 0x1u    /* Add hex output */
+#define WT_TXN_PRINTLOG_REDACT 0x2u /* Redact user data from output */
+                                    /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -136,6 +136,11 @@ __wt_logop_col_modify_print(
     escaped = NULL;
     WT_RET(__wt_logop_col_modify_unpack(session, pp, end, &fileid, &recno, &value));
 
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
+
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_modify\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
@@ -203,6 +208,11 @@ __wt_logop_col_put_print(
     escaped = NULL;
     WT_RET(__wt_logop_col_put_unpack(session, pp, end, &fileid, &recno, &value));
 
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
+
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_put\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
@@ -266,6 +276,11 @@ __wt_logop_col_remove_print(
 
     WT_RET(__wt_logop_col_remove_unpack(session, pp, end, &fileid, &recno));
 
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
+
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_remove\",\n"));
     WT_RET(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
@@ -320,6 +335,11 @@ __wt_logop_col_truncate_print(
     uint64_t stop;
 
     WT_RET(__wt_logop_col_truncate_unpack(session, pp, end, &fileid, &start, &stop));
+
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_truncate\",\n"));
     WT_RET(__wt_fprintf(
@@ -379,6 +399,11 @@ __wt_logop_row_modify_print(
 
     escaped = NULL;
     WT_RET(__wt_logop_row_modify_unpack(session, pp, end, &fileid, &key, &value));
+
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_modify\",\n"));
     WT_ERR(__wt_fprintf(
@@ -452,6 +477,11 @@ __wt_logop_row_put_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_put_unpack(session, pp, end, &fileid, &key, &value));
 
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
+
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_put\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
@@ -522,6 +552,11 @@ __wt_logop_row_remove_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_remove_unpack(session, pp, end, &fileid, &key));
 
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
+
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_remove\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
@@ -588,6 +623,11 @@ __wt_logop_row_truncate_print(
 
     escaped = NULL;
     WT_RET(__wt_logop_row_truncate_unpack(session, pp, end, &fileid, &start, &stop, &mode));
+
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
+        return (0);
+    }
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_truncate\",\n"));
     WT_ERR(__wt_fprintf(

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -136,7 +136,7 @@ __wt_logop_col_modify_print(
     escaped = NULL;
     WT_RET(__wt_logop_col_modify_unpack(session, pp, end, &fileid, &recno, &value));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -208,7 +208,7 @@ __wt_logop_col_put_print(
     escaped = NULL;
     WT_RET(__wt_logop_col_put_unpack(session, pp, end, &fileid, &recno, &value));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -276,7 +276,7 @@ __wt_logop_col_remove_print(
 
     WT_RET(__wt_logop_col_remove_unpack(session, pp, end, &fileid, &recno));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -336,7 +336,7 @@ __wt_logop_col_truncate_print(
 
     WT_RET(__wt_logop_col_truncate_unpack(session, pp, end, &fileid, &start, &stop));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -400,7 +400,7 @@ __wt_logop_row_modify_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_modify_unpack(session, pp, end, &fileid, &key, &value));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -477,7 +477,7 @@ __wt_logop_row_put_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_put_unpack(session, pp, end, &fileid, &key, &value));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -552,7 +552,7 @@ __wt_logop_row_remove_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_remove_unpack(session, pp, end, &fileid, &key));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }
@@ -624,7 +624,7 @@ __wt_logop_row_truncate_print(
     escaped = NULL;
     WT_RET(__wt_logop_row_truncate_unpack(session, pp, end, &fileid, &start, &stop, &mode));
 
-    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != 0) {
+    if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_REDACT) && fileid != WT_METAFILE_ID) {
         WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
         return (0);
     }

--- a/src/utilities/util_printlog.c
+++ b/src/utilities/util_printlog.c
@@ -20,13 +20,20 @@ util_printlog(WT_SESSION *session, int argc, char *argv[])
 
     flags = 0;
     ofile = NULL;
+
+    /*
+     * By default redact user data. This way if any support people are using this on customer data,
+     * it is redacted unless they make the effort to keep it in. It lessens the risk of doing the
+     * wrong command.
+     */
+    LF_SET(WT_TXN_PRINTLOG_REDACT);
     while ((ch = __wt_getopt(progname, argc, argv, "f:Wx")) != EOF)
         switch (ch) {
         case 'f': /* output file */
             ofile = __wt_optarg;
             break;
-        case 'W': /* redact user data, WiredTiger info only */
-            LF_SET(WT_TXN_PRINTLOG_REDACT);
+        case 'W': /* don't redact user data */
+            LF_CLR(WT_TXN_PRINTLOG_REDACT);
             break;
         case 'x': /* hex output */
             LF_SET(WT_TXN_PRINTLOG_HEX);

--- a/src/utilities/util_printlog.c
+++ b/src/utilities/util_printlog.c
@@ -20,10 +20,13 @@ util_printlog(WT_SESSION *session, int argc, char *argv[])
 
     flags = 0;
     ofile = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "f:x")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "f:Wx")) != EOF)
         switch (ch) {
         case 'f': /* output file */
             ofile = __wt_optarg;
+            break;
+        case 'W': /* redact user data, WiredTiger info only */
+            LF_SET(WT_TXN_PRINTLOG_REDACT);
             break;
         case 'x': /* hex output */
             LF_SET(WT_TXN_PRINTLOG_HEX);

--- a/test/suite/test_txn08.py
+++ b/test/suite/test_txn08.py
@@ -64,10 +64,10 @@ class test_txn08(wttest.WiredTigerTestCase, suite_subprocess):
         #
         # Run printlog and make sure it exits with zero status.
         #
-        self.runWt(['printlog'], outfilename='printlog.out')
+        self.runWt(['printlog', '-W'], outfilename='printlog.out')
         self.check_file_contains('printlog.out',
             '\\u0001\\u0002abcd\\u0003\\u0004')
-        self.runWt(['printlog', '-x'], outfilename='printlog-hex.out')
+        self.runWt(['printlog', '-W', '-x'], outfilename='printlog-hex.out')
         self.check_file_contains('printlog-hex.out',
             '\\u0001\\u0002abcd\\u0003\\u0004')
         self.check_file_contains('printlog-hex.out',


### PR DESCRIPTION
@agorrod and @quchenhao here's a 4.2 version of the printlog redact changes. Again, this is only lightly tested and may not be what we want for the final code changes. But it gets the job done and can be used against a 4.2 generated log. Again this is NOT ready for merge.