### PR TITLE
WT-6772 Add support for prepared updates in datastore for test_hs09

### DIFF
--- a/test/suite/test_hs09.py
+++ b/test/suite/test_hs09.py
@@ -55,8 +55,7 @@ class test_hs09(wttest.WiredTigerTestCase):
         return i
 
     def check_ckpt_hs(self, expected_data_value, expected_hs_value, expected_hs_start_ts,
-                      expected_hs_stop_ts, expect_prepared_in_datastore = False,
-                      expected_prepared_value = None):
+                      expected_hs_stop_ts, expect_prepared_in_datastore = False):
         session = self.conn.open_session(self.session_config)
         session.checkpoint()
         # Check the data file value.
@@ -68,8 +67,6 @@ class test_hs09(wttest.WiredTigerTestCase):
             session.begin_transaction("ignore_prepare=true")
 
         for _, value in cursor:
-            if expect_prepared_in_datastore and value == expected_prepared_value:
-                continue
             self.assertEqual(value, expected_data_value)
 
         if expect_prepared_in_datastore:
@@ -152,7 +149,7 @@ class test_hs09(wttest.WiredTigerTestCase):
 
         # We can expect prepared values to show up in data store if the eviction runs between now
         # and the time when we open a cursor on the user table.
-        self.check_ckpt_hs(value2, value1, 2, 3, True, value3)
+        self.check_ckpt_hs(value2, value1, 2, 3, True)
         self.session.commit_transaction('commit_timestamp=' + timestamp_str(5) +
             ',durable_timestamp=' + timestamp_str(5))
 

--- a/test/suite/test_hs09.py
+++ b/test/suite/test_hs09.py
@@ -38,7 +38,7 @@ def timestamp_str(t):
 # second newest committed version to history store.
 class test_hs09(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=10MB,statistics=(fast)'
+    conn_config = 'cache_size=20MB,statistics=(fast)'
     session_config = 'isolation=snapshot'
     uri = "table:test_hs09"
     key_format_values = [
@@ -59,7 +59,7 @@ class test_hs09(wttest.WiredTigerTestCase):
         session = self.conn.open_session(self.session_config)
         session.checkpoint()
         # Check the data file value.
-        cursor = session.open_cursor(self.uri)
+        cursor = session.open_cursor(self.uri, None, 'checkpoint=WiredTigerCheckpoint')
 
         # If we are expecting prepapred updates in the datastore, start an explicit transaction with
         # ignore prepare flag to avoid getting a WT_PREPARE_CONFLICT error.
@@ -74,7 +74,7 @@ class test_hs09(wttest.WiredTigerTestCase):
 
         cursor.close()
         # Check the history store file value.
-        cursor = session.open_cursor("file:WiredTigerHS.wt")
+        cursor = session.open_cursor("file:WiredTigerHS.wt", None, 'checkpoint=WiredTigerCheckpoint')
         for _, _, hs_start_ts, _, hs_stop_ts, _, type, value in cursor:
             # No WT_UPDATE_TOMBSTONE in the history store.
             self.assertNotEqual(type, 5)


### PR DESCRIPTION
This change allows the test to skip prepared updates in the datastore if eviction runs. 