### PR TITLE
WT-6901 Fix warning for doc spelling check

### DIFF
--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -203,6 +203,7 @@ dbformat
 dbm
 dbt
 decl
+decrement
 decrementing
 decrypt
 decrypted


### PR DESCRIPTION
A doc spelling check warning was captured by the "aws-perf" machine which was running a relatively old version of aspell. Adding the related word into the spell.ok list to make spelling check happy. 
```
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Documentation spelling notes
Update src/docs/spell.ok to remove warnings.
	decrement
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
```