### PR TITLE
WT-6354 Increase wt utility coverage with printlog, downgrade, upgrade tests

### DIFF
--- a/test/suite/test_util18.py
+++ b/test/suite/test_util18.py
@@ -34,9 +34,6 @@ from wtscenario import make_scenarios
 # test_util18.py
 #   Utilities: wt printlog
 class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
-    """
-    Test wt printlog
-    """
     tablename = 'test_util18.a'
     uri = 'table:' + tablename
     logmax = 100
@@ -54,7 +51,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
     def conn_config(self):
         return 'log=(archive=false,enabled,file_max=%dK)' % self.logmax
 
-    # Insert entries into the table
+    # Populate our test table with data we can check against in the printlog output.
     def populate(self):
         cursor = self.session.open_cursor(self.uri, None)
         for i in range(0, self.nentries):
@@ -63,12 +60,12 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
             cursor[key] = val
         cursor.close()
 
-    # Check the given printlog file reflects the data written by 'populate'
+    # Check the given printlog file reflects the data written by 'populate'.
     def check_populated_printlog(self, log_file, expect_keyval, expect_keyval_hex):
         for i in range(0, self.nentries):
             key = 'KEY' + str(i)
             val = 'VAL' + str(i)
-            # Check if the KEY/VAL commits exist in the log file
+            # Check if the KEY/VAL commits exist in the log file.
             if expect_keyval:
                 self.check_file_contains(log_file, '"key": "%s\\u0000"' % key)
                 self.check_file_contains(log_file, '"value": "%s\\u0000"' % val)
@@ -76,10 +73,10 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
                 self.check_file_not_contains(log_file, '"key": "%s\\u0000"' % key)
                 self.check_file_not_contains(log_file, '"value": "%s\\u0000"' % val)
 
-            # Convert our KEY/VAL strings to their expected hex value
+            # Convert our KEY/VAL strings to their expected hex value.
             hex_key = codecs.encode(key.encode(), 'hex')
             val_key = codecs.encode(val.encode(), 'hex')
-            # Check if the KEY/VAL commits exist in the log file (in hex form)
+            # Check if the KEY/VAL commits exist in the log file (in hex form).
             if expect_keyval_hex:
                 self.check_file_contains(log_file, '"key-hex": "%s00"' % str(hex_key, 'ascii'))
                 self.check_file_contains(log_file, '"value-hex": "%s00"' % str(val_key, 'ascii'))
@@ -89,7 +86,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_printlog_file(self):
         """
-        Test printlog on a populated table
+        Run printlog on a populated table.
         """
         self.session.create('table:' + self.tablename, self.create_params)
         self.populate()
@@ -103,7 +100,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_printlog_hex_file(self):
         """
-        Test printlog with hexadecimal formatting on a populated table
+        Run printlog with hexadecimal formatting on a populated table.
         """
         self.session.create('table:' + self.tablename, self.create_params)
         self.populate()
@@ -117,7 +114,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_printlog_message(self):
         """
-        Test printlog with messages-only formatting on a populated table
+        Run printlog with messages-only formatting on a populated table.
         """
         self.session.create('table:' + self.tablename, self.create_params)
         self.populate()
@@ -135,7 +132,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_printlog_lsn_offset(self):
         """
-        Test printlog with an LSN offset provided
+        Run printlog with an LSN offset provided.
         """
         self.session.create('table:' + self.tablename, self.create_params)
         self.populate()

--- a/test/suite/test_util18.py
+++ b/test/suite/test_util18.py
@@ -39,6 +39,8 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = 100
     nentries = 5
     create_params = 'key_format=S,value_format=S'
+    key_prefix = 'KEY'
+    val_prefix = 'VAL'
 
     # Whether user data is redacted or printed.
     print_user_data = [
@@ -55,16 +57,16 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
     def populate(self):
         cursor = self.session.open_cursor(self.uri, None)
         for i in range(0, self.nentries):
-            key = 'KEY' + str(i)
-            val = 'VAL' + str(i)
+            key = self.key_prefix + str(i)
+            val = self.val_prefix + str(i)
             cursor[key] = val
         cursor.close()
 
     # Check the given printlog file reflects the data written by 'populate'.
     def check_populated_printlog(self, log_file, expect_keyval, expect_keyval_hex):
         for i in range(0, self.nentries):
-            key = 'KEY' + str(i)
-            val = 'VAL' + str(i)
+            key = self.key_prefix + str(i)
+            val = self.val_prefix + str(i)
             # Check if the KEY/VAL commits exist in the log file.
             if expect_keyval:
                 self.check_file_contains(log_file, '"key": "%s\\u0000"' % key)

--- a/test/suite/test_util18.py
+++ b/test/suite/test_util18.py
@@ -119,17 +119,18 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
         """
         Test printlog with messages-only formatting on a populated table
         """
-        # Run reconfigure with compatibility to force 'COMPATIBILITY' message
-        self.conn.reconfigure('compatibility=(release=3.2.0)')
         self.session.create('table:' + self.tablename, self.create_params)
         self.populate()
+        # Write a log message that we can specifically test the presence of.
+        log_message = "Test Message: %s" % self.tablename
+        self.session.log_printf(log_message)
         wt_args = ["printlog", "-m"]
         # Append "-u" if we expect printlog to print user data.
         if self.print_user_data:
             wt_args.append("-u")
         self.runWt(wt_args, outfilename='printlog-message.out')
         self.check_non_empty_file('printlog-message.out')
-        self.check_file_contains('printlog-message.out', 'COMPATIBILITY: Version now 3')
+        self.check_file_contains('printlog-message.out', log_message)
         self.check_populated_printlog('printlog-message.out', False, False)
 
     def test_printlog_lsn_offset(self):

--- a/test/suite/test_util18.py
+++ b/test/suite/test_util18.py
@@ -98,7 +98,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
             wt_args.append("-u")
         self.runWt(wt_args, outfilename='printlog.out')
         self.check_non_empty_file('printlog.out')
-        self.check_populated_printlog('printlog.out', True & self.print_user_data, False)
+        self.check_populated_printlog('printlog.out', self.print_user_data, False)
 
     def test_printlog_hex_file(self):
         """
@@ -112,7 +112,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
             wt_args.append("-u")
         self.runWt(wt_args, outfilename='printlog-hex.out')
         self.check_non_empty_file('printlog-hex.out')
-        self.check_populated_printlog('printlog-hex.out', True & self.print_user_data, True & self.print_user_data)
+        self.check_populated_printlog('printlog-hex.out', self.print_user_data, self.print_user_data)
 
     def test_printlog_message(self):
         """
@@ -176,7 +176,7 @@ class test_util18(wttest.WiredTigerTestCase, suite_subprocess):
         if self.print_user_data:
             wt_args.append("-u")
         self.runWt(wt_args, outfilename='printlog-lsn-offset.out')
-        self.check_populated_printlog('printlog-lsn-offset.out', True & self.print_user_data, False)
+        self.check_populated_printlog('printlog-lsn-offset.out', self.print_user_data, False)
 
         # Test that using LSN '1,0' and our first LSN value produce the same output when passed to printlog.
         # We expect printing from LSN '1,0' (which should denote to the beginning of the first log file)

--- a/test/suite/test_util19.py
+++ b/test/suite/test_util19.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2021 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# test_util19.py
+#   Utilities: wt downgrade
+class test_util19(wttest.WiredTigerTestCase, suite_subprocess):
+    """
+    Test wt downgrade
+    """
+    tablename = 'test_util19.a'
+    uri = 'table:' + tablename
+    entries = 100
+    log_max = "100K"
+    log_latest_compat = 5
+
+    create_release = [
+        ('def', dict(create_rel='none')),
+        ('100', dict(create_rel="10.0")),
+        ('33', dict(create_rel="3.3")),
+        ('32', dict(create_rel="3.2")),
+        ('31', dict(create_rel="3.1")),
+        ('30', dict(create_rel="3.0")),
+        ('26', dict(create_rel="2.6")),
+    ]
+
+    downgrade_release = [
+        ('100_rel', dict(downgrade_rel="10.0", log_downgrade_compat=5)),
+        ('33_rel', dict(downgrade_rel="3.3", log_downgrade_compat=4)),
+        ('32_rel', dict(downgrade_rel="3.2", log_downgrade_compat=3)),
+        ('31_rel', dict(downgrade_rel="3.1", log_downgrade_compat=3)),
+        ('30_rel', dict(downgrade_rel="3.0", log_downgrade_compat=2)),
+        ('26_rel', dict(downgrade_rel="2.6", log_downgrade_compat=1)),
+    ]
+
+    scenarios = make_scenarios(create_release, downgrade_release)
+
+    def conn_config(self):
+        conf_str = 'log=(archive=false,enabled,file_max=%s),' % self.log_max
+        if (self.create_rel != 'none'):
+            conf_str += 'compatibility=(release="%s"),' % (self.create_rel)
+        return conf_str
+
+    def test_downgrade(self):
+        """
+        Test wt downgrade on our created table
+        """
+        # Create the initial database at the compatibility level established by
+        # the connection config ('create_rel')
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        c = self.session.open_cursor(self.uri, None)
+        # Populate the table to generate log files
+        for i in range(self.entries):
+            key = 'KEY' + str(i)
+            val = 'VAL' + str(i)
+            c[key] = val
+        c.close()
+
+        # Call the downgrade utility to reconfigure with the specified compatibility version.
+        # Based on the downgrade version we can test if the corresponding log compatibility version
+        # has been set
+        wt_config = 'log=(archive=false,enabled,file_max=%s),verbose=[log]' % self.log_max
+        downgrade_opt = '-V %s' % self.downgrade_rel
+        self.runWt(['-C', wt_config , 'downgrade', downgrade_opt], reopensession=False, outfilename='downgrade.out')
+
+        compat_str = '/WT_CONNECTION\.reconfigure: .*: COMPATIBILITY: Version now %d/' % self.log_downgrade_compat
+        if self.log_downgrade_compat != self.log_latest_compat:
+            self.check_file_contains('downgrade.out', compat_str)
+        else:
+            self.check_file_not_contains('downgrade.out', compat_str)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_util20.py
+++ b/test/suite/test_util20.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2021 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from suite_subprocess import suite_subprocess
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet, ComplexDataSet
+
+# test_util20.py
+#   Utilities: wt upgrade
+class test_util20(wttest.WiredTigerTestCase, suite_subprocess):
+    """
+    Test wt upgrade
+    """
+    name = 'test_util20.a'
+    create_params = 'key_format=S,value_format=S'
+    num_rows = 10
+
+    def test_upgrade_table_complex_data(self):
+        uri = 'table:' + self.name
+        ComplexDataSet(self, uri, self.num_rows).populate()
+        self.runWt(['upgrade', uri])
+
+    def test_upgrade_table_simple_data(self):
+        uri = 'table:' + self.name
+        SimpleDataSet(self, uri, self.num_rows).populate()
+        self.runWt(['upgrade', uri])

--- a/test/suite/test_util20.py
+++ b/test/suite/test_util20.py
@@ -33,19 +33,18 @@ from wtdataset import SimpleDataSet, ComplexDataSet
 # test_util20.py
 #   Utilities: wt upgrade
 class test_util20(wttest.WiredTigerTestCase, suite_subprocess):
-    """
-    Test wt upgrade
-    """
     name = 'test_util20.a'
     create_params = 'key_format=S,value_format=S'
     num_rows = 10
 
     def test_upgrade_table_complex_data(self):
+        # Run wt upgrade on a complex dataset and test for successful completion.
         uri = 'table:' + self.name
         ComplexDataSet(self, uri, self.num_rows).populate()
         self.runWt(['upgrade', uri])
 
     def test_upgrade_table_simple_data(self):
+        # Run wt upgrade on a simple dataset and test for successful completion.
         uri = 'table:' + self.name
         SimpleDataSet(self, uri, self.num_rows).populate()
         self.runWt(['upgrade', uri])


### PR DESCRIPTION
Extended the python util test set (test_utilX.py) with a series of small tests for the `upgrade`, `downgrade`, `printlog` functionality. This is intended to extend the wt utility test coverage where it was missing specific test coverage for the above functions.