### PR TITLE
WT-6840 Only build with LibFuzzer when configured with --enable-libfuzzer

### DIFF
--- a/build_posix/Make.subdirs
+++ b/build_posix/Make.subdirs
@@ -34,7 +34,7 @@ test/csuite
 test/cursor_order
 test/fops
 test/format
-test/fuzz POSIX_HOST HAVE_LIBFUZZER
+test/fuzz POSIX_HOST LIBFUZZER
 test/huge
 test/import
 test/manydbs

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -266,4 +266,21 @@ if test "$wt_cv_enable_llvm" = "yes"; then
 	fi
 fi
 AM_CONDITIONAL([LLVM], [test x$wt_cv_enable_llvm = xyes])
+
+AC_MSG_CHECKING(if --enable-libfuzzer option specified)
+AC_ARG_ENABLE(libfuzzer,
+	[AS_HELP_STRING([--enable-libfuzzer],
+		[Configure with LibFuzzer.])], r=$enableval, r=no)
+case "$r" in
+no)	wt_cv_enable_libfuzzer=no;;
+*)	wt_cv_enable_libfuzzer=yes;;
+esac
+AC_MSG_RESULT($wt_cv_enable_libfuzzer)
+if test "$wt_cv_enable_libfuzzer" = "yes"; then
+	AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link], [wt_cv_libfuzzer_works=yes])
+        if test "$wt_cv_libfuzzer_works" != "yes"; then
+		AC_MSG_ERROR([--enable-libfuzzer requires a Clang version that supports -fsanitize=fuzzer-no-link])
+	fi
+fi
+AM_CONDITIONAL([LIBFUZZER], [test x$wt_cv_enable_libfuzzer = xyes])
 ])

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -157,8 +157,9 @@ if test "$wt_cv_enable_python" = "yes"; then
 fi
 
 # Check whether our compiler supports LibFuzzer.
+# FIXME-WT-7158: We've disabled building it on PPC since there's something wrong with our PPC toolchain in Evergreen.
 AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link], [wt_cv_libfuzzer_works=yes])
-AM_CONDITIONAL([HAVE_LIBFUZZER], [test "$wt_cv_libfuzzer_works" = "yes"])
+AM_CONDITIONAL([HAVE_LIBFUZZER], [test "$wt_cv_libfuzzer_works" = "yes" -a "$wt_cv_powerpc" != "yes"])
 
 AM_TYPES
 

--- a/build_posix/configure.ac.in
+++ b/build_posix/configure.ac.in
@@ -156,11 +156,6 @@ if test "$wt_cv_enable_python" = "yes"; then
 	AC_SUBST(PYTHON_INSTALL_ARG)
 fi
 
-# Check whether our compiler supports LibFuzzer.
-# FIXME-WT-7158: We've disabled building it on PPC since there's something wrong with our PPC toolchain in Evergreen.
-AX_CHECK_COMPILE_FLAG([-fsanitize=fuzzer-no-link], [wt_cv_libfuzzer_works=yes])
-AM_CONDITIONAL([HAVE_LIBFUZZER], [test "$wt_cv_libfuzzer_works" = "yes" -a "$wt_cv_powerpc" != "yes"])
-
 AM_TYPES
 
 AC_PROG_INSTALL

--- a/src/docs/tool-libfuzzer.dox
+++ b/src/docs/tool-libfuzzer.dox
@@ -10,18 +10,18 @@ A fuzzer is a program that consists of the aforementioned target function linked
 LibFuzzer runtime. The LibFuzzer runtime provides the entry-point to the program and repeatedly
 calls the target function with generated inputs.
 
-## Step 1: Select Clang as your C compiler in your build configuration
+## Step 1: Configure with Clang as your C compiler and enable LibFuzzer
 
 Support for LibFuzzer is implemented as a compiler flag in Clang. WiredTiger's build configuration
-checks whether the compiler in use supports \c -fsanitize=fuzzer and if so, elects to build the
-tests.
+checks whether the compiler in use supports \c -fsanitize=fuzzer-no-link and if so, elects to build
+the tests.
 
 Compiling with Clang's Address Sanitizer isn't mandatory but it is recommended since fuzzing often
 exposes memory bugs.
 
 @code
 $ cd build_posix/
-$ ../configure CC="clang-8" CFLAGS="-fsanitize=address"
+$ ../configure --enable-libfuzzer CC="clang-8" CFLAGS="-fsanitize=address"
 @endcode
 
 ## Step 2: Build as usual


### PR DESCRIPTION
There's been some fallout on the PPC machines due to some difference in the toolchain.

It's not worth getting into a discussion with the build team about what packages need to be installed on that variant. So I'm just going to disable it on PPC and make WT-7158 in case we see value in the future.