### PR TITLE
WT-7137 Update an assert to consider globally visible stop time for HS values

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -227,7 +227,8 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
                 WT_ERR(__wt_compare(session, NULL, existing_val, hs_value, &cmp));
                 /*
                  * Check if the existing HS value is same as the new value we are about to insert.
-                 * We can skip this check if the existing value has a globally visible stop time.
+                 * We can skip this check if the existing value has a globally visible stop time,
+                 * i.e., the value has been deleted from the HS.
                  */
                 if (cmp == 0)
                     WT_ASSERT(session,

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -225,9 +225,15 @@ __hs_insert_record_with_btree(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BT
                 WT_ERR(cursor->get_value(cursor, &hs_stop_durable_ts_diag, &durable_timestamp_diag,
                   &upd_type_full_diag, existing_val));
                 WT_ERR(__wt_compare(session, NULL, existing_val, hs_value, &cmp));
+                /*
+                 * Check if the existing HS value is same as the new value we are about to insert.
+                 * We can skip this check if the existing value has a globally visible stop time.
+                 */
                 if (cmp == 0)
                     WT_ASSERT(session,
-                      tw->start_txn == WT_TXN_NONE ||
+                      (WT_TIME_WINDOW_HAS_STOP(&hs_cbt->upd_value->tw) &&
+                        __wt_txn_tw_stop_visible_all(session, &hs_cbt->upd_value->tw)) ||
+                        tw->start_txn == WT_TXN_NONE ||
                         tw->start_txn != hs_cbt->upd_value->tw.start_txn ||
                         tw->start_ts != hs_cbt->upd_value->tw.start_ts);
                 counter = hs_counter + 1;


### PR DESCRIPTION
We added a new assert WT-6751 to verify we are not inserting duplicate key-value pairs to history store. This check doesn't consider the globally visible stop time on the existing values.