### PR TITLE
WT-7159 Always write on-disk update as a full update to history store

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -691,8 +691,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
             /*
              * Calculate reverse modify and clear the history store records with timestamps when
              * inserting the first update. Always write on-disk data store updates to the history
-             * store as a full update, because the on-disk update will be the base update for all
-             * the updates are previous to the on-disk update.
+             * store as a full update because the on-disk update will be the base update for all the
+             * updates that are older than the on-disk update.
              *
              * Due to concurrent operation of checkpoint and eviction, it is possible that history
              * store may have more recent versions of a key than the on-disk version. Without a

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -683,7 +683,14 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
 
             /*
              * Calculate reverse modify and clear the history store records with timestamps when
-             * inserting the first update.
+             * inserting the first update. Always write on-disk data store updates to the history
+             * store as a full update, because the on-disk update will be the base update for all
+             * the updates are previous to the on-disk update.
+             *
+             * Due to concurrent operation of checkpoint and eviction, it is possible that history
+             * store may have more recent versions of a key than the on-disk version. Without a
+             * proper base value in the history store, it can lead to wrong value being restored by
+             * the RTS.
              */
             nentries = MAX_REVERSE_MODIFY_NUM;
             if (!F_ISSET(upd, WT_UPDATE_DS) && upd->type == WT_UPDATE_MODIFY &&

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -686,7 +686,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi)
              * inserting the first update.
              */
             nentries = MAX_REVERSE_MODIFY_NUM;
-            if (upd->type == WT_UPDATE_MODIFY && enable_reverse_modify &&
+            if (!F_ISSET(upd, WT_UPDATE_DS) && upd->type == WT_UPDATE_MODIFY &&
+              enable_reverse_modify &&
               __wt_calc_modify(session, prev_full_value, full_value, prev_full_value->size / 10,
                 entries, &nentries) == 0) {
                 WT_ERR(__wt_modify_pack(cursor, entries, nentries, &modify_value));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -254,13 +254,17 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
 
         /*
          * Do not include history store updates greater than on-disk data store version to construct
-         * a full update to restore. Comparing with timestamps here has no problem unlike in search
-         * flow where the timestamps may be reset during reconciliation. RTS detects an on-disk
-         * update is unstable based on the written proper timestamp, so comparing against it with
-         * history store shouldn't have any problem.
+         * a full update to restore. Even if we include the most recent updates than the on-disk
+         * version shouldn't be problem as the on-disk version in history store is always a full
+         * update. It is better to not to include those updates as it unnecessarily increases the
+         * rollback to stable time.
+         *
+         * Comparing with timestamps here has no problem unlike in search flow where the timestamps
+         * may be reset during reconciliation. RTS detects an on-disk update is unstable based on
+         * the written proper timestamp, so comparing against it with history store shouldn't have
+         * any problem.
          */
         if (hs_start_ts <= unpack->tw.start_ts) {
-            WT_ASSERT(session, (hs_start_ts != unpack->tw.start_ts) || type == WT_UPDATE_STANDARD);
             if (type == WT_UPDATE_MODIFY)
                 WT_ERR(__wt_modify_apply_item(
                   session, S2BT(session)->value_format, &full_value, hs_value->data));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -260,6 +260,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
          * history store shouldn't have any problem.
          */
         if (hs_start_ts <= unpack->tw.start_ts) {
+            WT_ASSERT(session, (hs_start_ts != unpack->tw.start_ts) || type == WT_UPDATE_STANDARD);
             if (type == WT_UPDATE_MODIFY)
                 WT_ERR(__wt_modify_apply_item(
                   session, S2BT(session)->value_format, &full_value, hs_value->data));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -267,7 +267,13 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
                 WT_ASSERT(session, type == WT_UPDATE_STANDARD);
                 WT_ERR(__wt_buf_set(session, &full_value, hs_value->data, hs_value->size));
             }
-        }
+        } else
+            __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),
+              "history store update more recent than on-disk update with start timestamp: %s,"
+              " durable timestamp: %s, stop timestamp: %s and type: %" PRIu8,
+              __wt_timestamp_to_string(hs_start_ts, ts_string[0]),
+              __wt_timestamp_to_string(hs_durable_ts, ts_string[1]),
+              __wt_timestamp_to_string(hs_stop_durable_ts, ts_string[2]), type);
 
         /*
          * Verify the history store timestamps are in order. The start timestamp may be equal to the

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -254,10 +254,10 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
 
         /*
          * Do not include history store updates greater than on-disk data store version to construct
-         * a full update to restore. Even if we include the most recent updates than the on-disk
-         * version shouldn't be problem as the on-disk version in history store is always a full
-         * update. It is better to not to include those updates as it unnecessarily increases the
-         * rollback to stable time.
+         * a full update to restore. Include the most recent updates than the on-disk version
+         * shouldn't be problem as the on-disk version in history store is always a full update. It
+         * is better to not to include those updates as it unnecessarily increases the rollback to
+         * stable time.
          *
          * Comparing with timestamps here has no problem unlike in search flow where the timestamps
          * may be reset during reconciliation. RTS detects an on-disk update is unstable based on


### PR DESCRIPTION
The updates written to the data store are always full updates, but
when these updates are moved into the history store by eviction due
to further updates on the key, make sure that on-disk update is always
written as full update even in the update list it is a modify, because
the on-disk update will be the base update for all the history store
updates that are previous to the on-disk update.

Due to concurrent operation of checkpoint and eviction, it is possible
that history store may have more recent versions of a key than the
on-disk version. Without a proper base value in the history store,
it can lead to wrong value being restored by the RTS.