### PR TITLE
WT-5137 Switch to macos-1014 Evergreen distro

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2615,10 +2615,10 @@ buildvariants:
     - name: ".unit_test"
     - name: fops
 
-- name: macos-1012
-  display_name: OS X 10.12
+- name: macos-1014
+  display_name: OS X 10.14
   run_on:
-  - macos-1012
+  - macos-1014
   expansions:
     configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH ADD_CFLAGS="-ggdb -fPIC"
     posix_configure_flags: --enable-silent-rules --enable-diagnostic --enable-python --enable-zlib --enable-strict --enable-static --prefix=$(pwd)/LOCAL_INSTALL


### PR DESCRIPTION
My testing patch build ran into the failure of WT-7045 3 times in a row, which may indicate the failure would become more frequently hit after switching to macos-1014. WT-7045 failed frequent enough on waterfall builds, and I labelled it as a CI-blocker so that it could be planned for the next sprint. 