### PR TITLE
WT-7184 add check for non-ASCII chars in documentation input files

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -94,7 +94,7 @@ asciichk()
 {
     # Make sure there are only ASCII characters in the input files.
     # Odd characters can cause our Python filter to fail.
-    (cd ../src/docs && LC_ALL=C grep -n '[^ -~	]' *.dox | cat -v) > $t
+    (cd ../src/docs && LC_ALL=C grep -n '[^[:print:]	]' *.dox | cat -v) > $t
     test -s $t && {
 	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 	echo 'Non-ASCII content in src/docs/*.dox files is not allowed.'

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -90,6 +90,20 @@ structurechk()
 	}
 }
 
+asciichk()
+{
+    # Make sure there are only ASCII characters in the input files.
+    # Odd characters can cause our Python filter to fail.
+    (cd ../src/docs && LC_ALL=C grep -n '[^ -~	]' *.dox | cat -v) > $t
+    test -s $t && {
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	echo 'Non-ASCII content in src/docs/*.dox files is not allowed.'
+	sed -e 's/^/	/' < $t
+	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+	e=1
+    }
+}
+
 spellchk()
 {
 	# If aspell has been installed, run a spell check.
@@ -236,12 +250,17 @@ changelog
 wtperf_config
 
 # Spell and structure check the documentation.
+asciichk
 spellchk
 structurechk
 
 # Check the docs data input file.
 check_docs_data
 
+# Do not build the doc if we get warnings.
+if [ $e != 0 ]; then
+    exit $e
+fi
 # Build the documentation.
 build $clean
 

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -121,7 +121,7 @@ The following is the procedure for incrementally backing up a database
 using block modifications:
 
 1. Perform a full backup of the database (as described above), with the
-additional configuration \c incremental=(enabled=true,this_id=”ID1”).
+additional configuration \c incremental=(enabled=true,this_id="ID1").
 The identifier specified in \c this_id starts block tracking and that
 identifier can be used in the future as the source of an incremental
 backup.

--- a/src/docs/tool-xray.dox
+++ b/src/docs/tool-xray.dox
@@ -35,7 +35,7 @@ $ cd bench/wtperf
 $ ../../../bench/wtperf/runners/wtperf_xray.sh  ../../../bench/wtperf/runners/small-btree.wtperf
 @endcode
 
-In general the usage is:  
+In general the usage is:
 
 @code
 wtperf_xray.sh <wtperf-config-file> [-h output-directory] [wtperf other arguments]
@@ -99,7 +99,7 @@ $ sudo apt install llvm
 LLVM needs to be version 8 or higher. Check the version like this:
 
 @code
-$ llvm-config –version
+$ llvm-config -version
 @endcode
 
 If your distribution's default \c llvm-config isn't from the 8 series, you'll


### PR DESCRIPTION
The github diff doesn't show the bad characters very well, here's what they look like with `git diff`:
```
$ git diff develop src/docs/
diff --git a/src/docs/backup.dox b/src/docs/backup.dox
index 265253d89..5f333eca1 100644
--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -121,7 +121,7 @@ The following is the procedure for incrementally backing up a database
 using block modifications:
 
 1. Perform a full backup of the database (as described above), with the
-additional configuration \c incremental=(enabled=true,this_id=<E2><80><9D>ID1<E2><80><9D>).
+additional configuration \c incremental=(enabled=true,this_id="ID1").
 The identifier specified in \c this_id starts block tracking and that
 identifier can be used in the future as the source of an incremental
 backup.
diff --git a/src/docs/tool-xray.dox b/src/docs/tool-xray.dox
index 176fcaca7..b5e1d535d 100644
--- a/src/docs/tool-xray.dox
+++ b/src/docs/tool-xray.dox
@@ -35,7 +35,7 @@ $ cd bench/wtperf
 $ ../../../bench/wtperf/runners/wtperf_xray.sh  ../../../bench/wtperf/runners/small-btree.wtperf
 @endcode
 
-In general the usage is:<E2><80><A8><E2><80><A8>
+In general the usage is:
 
 @code
 wtperf_xray.sh <wtperf-config-file> [-h output-directory] [wtperf other arguments]
@@ -99,7 +99,7 @@ $ sudo apt install llvm
 LLVM needs to be version 8 or higher. Check the version like this:
 
 @code
-$ llvm-config <E2><80><93>version
+$ llvm-config -version
 @endcode
 
 If your distribution's default \c llvm-config isn't from the 8 series, you'll

```
