### PR TITLE
WT-6309 Add support for start/stop arguments to wt printlog command (v4.2 backport)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1017,6 +1017,7 @@ multithreaded
 munmap
 mutex
 mutexes
+mx
 mytable
 mytxn
 namespace
@@ -1197,6 +1198,7 @@ rwlock
 sH
 sHQ
 sT
+sanitizer
 sanitizers
 scalability
 sched

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -208,7 +208,7 @@ __curlog_next(WT_CURSOR *cursor)
      */
     if (cl->stepp == NULL || cl->stepp >= cl->stepp_end || !*cl->stepp) {
         cl->txnid = 0;
-        ret = __wt_log_scan(session, cl->next_lsn, WT_LOGSCAN_ONE, __curlog_logrec, cl);
+        ret = __wt_log_scan(session, cl->next_lsn, NULL, WT_LOGSCAN_ONE, __curlog_logrec, cl);
         if (ret == ENOENT)
             ret = WT_NOTFOUND;
         WT_ERR(ret);
@@ -247,7 +247,7 @@ __curlog_search(WT_CURSOR *cursor)
      */
     WT_ERR(__wt_cursor_get_key(cursor, &key_file, &key_offset, &counter));
     WT_SET_LSN(&key, key_file, key_offset);
-    ret = __wt_log_scan(session, &key, WT_LOGSCAN_ONE, __curlog_logrec, cl);
+    ret = __wt_log_scan(session, &key, NULL, WT_LOGSCAN_ONE, __curlog_logrec, cl);
     if (ret == ENOENT)
         ret = WT_NOTFOUND;
     WT_ERR(ret);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -822,7 +822,8 @@ extern int __wt_log_remove(WT_SESSION_IMPL *session, const char *file_prefix, ui
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_reset(WT_SESSION_IMPL *session, uint32_t lognum)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
+extern int __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp,
+  uint32_t flags,
   int (*func)(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, WT_LSN *next_lsnp,
     void *cookie, int firstrecord),
   void *cookie) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1465,9 +1466,9 @@ extern int __wt_txn_parse_timestamp_raw(WT_SESSION_IMPL *session, const char *na
   wt_timestamp_t *timestamp, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_txn_printlog(WT_SESSION *wt_session, const char *ofile, uint32_t flags)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
-    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_printlog(WT_SESSION *wt_session, const char *ofile, uint32_t flags,
+  WT_LSN *start_lsn, WT_LSN *end_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_query_timestamp(WT_SESSION_IMPL *session, char *hex_timestamp,
   const char *cfg[], bool global_txn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -50,8 +50,11 @@ union __wt_lsn {
 #define WT_LOG_ALIGN 128
 
 /*
- * Atomically set the two components of the LSN.
+ * Atomically set the LSN. There are two forms. We need WT_ASSIGN_LSN because some compilers (at
+ * least clang address sanitizer) does not do atomic 64-bit structure assignment so we need to
+ * explicitly assign the 64-bit field. And WT_SET_LSN atomically sets the LSN given a file/offset.
  */
+#define WT_ASSIGN_LSN(dstl, srcl) (dstl)->file_offset = (srcl)->file_offset
 #define WT_SET_LSN(l, f, o) (l)->file_offset = (((uint64_t)(f) << 32) + (o))
 
 #define WT_INIT_LSN(l) WT_SET_LSN((l), 1, 0)
@@ -396,6 +399,7 @@ struct __wt_txn_printlog_args {
 
 /* AUTOMATIC FLAG VALUE GENERATION START */
 #define WT_TXN_PRINTLOG_HEX 0x1u /* Add hex output */
+#define WT_TXN_PRINTLOG_MSG 0x2u /* Messages only */
                                  /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2018,7 +2018,7 @@ __log_salvage_message(
  *     Scan the logs, calling a function on each record found.
  */
 int
-__wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
+__wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp, uint32_t flags,
   int (*func)(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, WT_LSN *next_lsnp,
     void *cookie, int firstrecord),
   void *cookie)
@@ -2056,7 +2056,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
     if (func == NULL)
         return (0);
 
-    if (lsnp != NULL && LF_ISSET(WT_LOGSCAN_FIRST | WT_LOGSCAN_FROM_CKP))
+    if (start_lsnp != NULL && LF_ISSET(WT_LOGSCAN_FIRST | WT_LOGSCAN_FROM_CKP))
         WT_RET_MSG(session, WT_ERROR, "choose either a start LSN or a start flag");
     /*
      * Set up the allocation size, starting and ending LSNs. The values for those depend on whether
@@ -2065,9 +2065,9 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
     lastlog = 0;
     if (log != NULL) {
         allocsize = log->allocsize;
-        end_lsn = log->alloc_lsn;
-        start_lsn = log->first_lsn;
-        if (lsnp == NULL) {
+        WT_ASSIGN_LSN(&end_lsn, &log->alloc_lsn);
+        WT_ASSIGN_LSN(&start_lsn, &log->first_lsn);
+        if (start_lsnp == NULL) {
             if (LF_ISSET(WT_LOGSCAN_FROM_CKP))
                 start_lsn = log->ckpt_lsn;
             else if (!LF_ISSET(WT_LOGSCAN_FIRST))
@@ -2097,16 +2097,17 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
         WT_SET_LSN(&end_lsn, lastlog, 0);
         WT_ERR(__wt_fs_directory_list_free(session, &logfiles, logcount));
     }
-    if (lsnp != NULL) {
+
+    if (start_lsnp != NULL) {
         /*
          * Offsets must be on allocation boundaries. An invalid LSN from a user should just return
          * WT_NOTFOUND. It is not an error. But if it is from recovery, we expect valid LSNs so give
          * more information about that.
          */
-        if (lsnp->l.offset % allocsize != 0) {
+        if (start_lsnp->l.offset % allocsize != 0) {
             if (LF_ISSET(WT_LOGSCAN_RECOVER | WT_LOGSCAN_RECOVER_METADATA))
                 WT_ERR_MSG(session, WT_NOTFOUND, "__wt_log_scan unaligned LSN %" PRIu32 "/%" PRIu32,
-                  lsnp->l.file, lsnp->l.offset);
+                  start_lsnp->l.file, start_lsnp->l.offset);
             else
                 WT_ERR(WT_NOTFOUND);
         }
@@ -2115,11 +2116,11 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
          * return WT_NOTFOUND. It is not an error. But if it is from recovery, we expect valid LSNs
          * so give more information about that.
          */
-        if (lsnp->l.file > lastlog) {
+        if (start_lsnp->l.file > lastlog) {
             if (LF_ISSET(WT_LOGSCAN_RECOVER | WT_LOGSCAN_RECOVER_METADATA))
                 WT_ERR_MSG(session, WT_NOTFOUND,
                   "__wt_log_scan LSN %" PRIu32 "/%" PRIu32 " larger than biggest log file %" PRIu32,
-                  lsnp->l.file, lsnp->l.offset, lastlog);
+                  start_lsnp->l.file, start_lsnp->l.offset, lastlog);
             else
                 WT_ERR(WT_NOTFOUND);
         }
@@ -2127,8 +2128,8 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *lsnp, uint32_t flags,
          * Log cursors may not know the starting LSN. If an LSN is passed in that it is equal to the
          * smallest LSN, start from the beginning of the log.
          */
-        if (!WT_IS_INIT_LSN(lsnp))
-            start_lsn = *lsnp;
+        if (!WT_IS_INIT_LSN(start_lsnp))
+            WT_ASSIGN_LSN(&start_lsn, start_lsnp);
     }
     WT_ERR(__log_open_verify(session, start_lsn.l.file, &log_fh, &prev_lsn, NULL, &need_salvage));
     if (need_salvage)
@@ -2363,7 +2364,14 @@ advance:
             if (LF_ISSET(WT_LOGSCAN_ONE))
                 break;
         }
-        rd_lsn = next_lsn;
+
+        /*
+         * Exit the scanning loop if the next LSN seen is greater than our user set end range LSN.
+         */
+        if (end_lsnp != NULL && __wt_log_cmp(&next_lsn, end_lsnp) > 0)
+            break;
+
+        WT_ASSIGN_LSN(&rd_lsn, &next_lsn);
     }
 
     /* Truncate if we're in recovery. */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -717,8 +717,8 @@ __txn_printlog(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, WT_LSN *
  *     Print the log in a human-readable format.
  */
 int
-__wt_txn_printlog(WT_SESSION *wt_session, const char *ofile, uint32_t flags)
-  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+__wt_txn_printlog(WT_SESSION *wt_session, const char *ofile, uint32_t flags, WT_LSN *start_lsn,
+  WT_LSN *end_lsn) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
     WT_DECL_RET;
     WT_FSTREAM *fs;
@@ -735,8 +735,9 @@ __wt_txn_printlog(WT_SESSION *wt_session, const char *ofile, uint32_t flags)
     WT_ERR(__wt_fprintf(session, fs, "[\n"));
     args.fs = fs;
     args.flags = flags;
-    WT_ERR(__wt_log_scan(session, NULL, WT_LOGSCAN_FIRST, __txn_printlog, &args));
-    ret = __wt_fprintf(session, fs, "\n]\n");
+    WT_ERR(__wt_log_scan(session, start_lsn, end_lsn, 0x0, __txn_printlog, &args));
+    if (!LF_ISSET(WT_TXN_PRINTLOG_MSG))
+        ret = __wt_fprintf(session, fs, "\n]\n");
 
 err:
     if (ofile != NULL)

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -595,15 +595,15 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
                 WT_ERR_MSG(session, WT_RUN_RECOVERY, "Read-only database needs recovery");
         }
         if (WT_IS_INIT_LSN(&metafile->ckpt_lsn))
-            ret = __wt_log_scan(session, NULL, WT_LOGSCAN_FIRST, __txn_log_recover, &r);
+            ret = __wt_log_scan(session, NULL, NULL, WT_LOGSCAN_FIRST, __txn_log_recover, &r);
         else {
             /*
              * Start at the last checkpoint LSN referenced in the metadata. If we see the end of a
              * checkpoint while scanning, we will change the full scan to start from there.
              */
-            r.ckpt_lsn = metafile->ckpt_lsn;
-            ret = __wt_log_scan(
-              session, &metafile->ckpt_lsn, WT_LOGSCAN_RECOVER_METADATA, __txn_log_recover, &r);
+            WT_ASSIGN_LSN(&r.ckpt_lsn, &metafile->ckpt_lsn);
+            ret = __wt_log_scan(session, &metafile->ckpt_lsn, NULL, WT_LOGSCAN_RECOVER_METADATA,
+              __txn_log_recover, &r);
         }
         if (F_ISSET(conn, WT_CONN_SALVAGE))
             ret = 0;
@@ -674,9 +674,9 @@ __wt_txn_recover(WT_SESSION_IMPL *session)
         FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY);
     if (WT_IS_INIT_LSN(&r.ckpt_lsn))
         ret = __wt_log_scan(
-          session, NULL, WT_LOGSCAN_FIRST | WT_LOGSCAN_RECOVER, __txn_log_recover, &r);
+          session, NULL, NULL, WT_LOGSCAN_FIRST | WT_LOGSCAN_RECOVER, __txn_log_recover, &r);
     else
-        ret = __wt_log_scan(session, &r.ckpt_lsn, WT_LOGSCAN_RECOVER, __txn_log_recover, &r);
+        ret = __wt_log_scan(session, &r.ckpt_lsn, NULL, WT_LOGSCAN_RECOVER, __txn_log_recover, &r);
     if (F_ISSET(conn, WT_CONN_SALVAGE))
         ret = 0;
     WT_ERR(ret);

--- a/src/utilities/util.h
+++ b/src/utilities/util.h
@@ -53,5 +53,6 @@ int util_str2num(WT_SESSION *, const char *, bool, uint64_t *);
 int util_truncate(WT_SESSION *, int, char *[]);
 int util_upgrade(WT_SESSION *, int, char *[]);
 char *util_uri(WT_SESSION *, const char *, const char *);
+void util_usage(const char *, const char *, const char *[]);
 int util_verify(WT_SESSION *, int, char *[]);
 int util_write(WT_SESSION *, int, char *[]);

--- a/src/utilities/util_misc.c
+++ b/src/utilities/util_misc.c
@@ -152,3 +152,21 @@ util_flush(WT_SESSION *session, const char *uri)
         (void)util_err(session, ret, "%s: session.drop", uri);
     return (1);
 }
+
+/*
+ * util_usage --
+ *     Display a usage statement.
+ */
+void
+util_usage(const char *usage, const char *tag, const char *list[])
+{
+    const char **p;
+
+    if (usage != NULL)
+        fprintf(stderr, "usage: %s %s %s\n", progname, usage_prefix, usage);
+    if (tag != NULL)
+        fprintf(stderr, "%s\n", tag);
+    if (list != NULL)
+        for (p = list; *p != NULL; p += 2)
+            fprintf(stderr, "    %s%s%s\n", p[0], strlen(p[0]) > 2 ? "\n        " : "  ", p[1]);
+}

--- a/src/utilities/util_printlog.c
+++ b/src/utilities/util_printlog.c
@@ -8,22 +8,59 @@
 
 #include "util.h"
 
-static int usage(void);
+static int
+usage(void)
+{
+    static const char *options[] = {"-f", "output to the specified file", "-x",
+      "display key and value items in hexadecimal format", "-l",
+      "the start LSN from which the log will be printed, optionally the end LSN can also be "
+      "specified",
+      NULL, NULL};
+
+    util_usage(
+      "printlog [-x] [-f output-file] [-l start-file,start-offset]|[-l "
+      "start-file,start-offset,end-file,end-offset]",
+      "options:", options);
+    return (1);
+}
 
 int
 util_printlog(WT_SESSION *session, int argc, char *argv[])
 {
     WT_DECL_RET;
+    WT_LSN end_lsn, start_lsn;
+    uint32_t end_lsnfile, end_lsnoffset, start_lsnfile, start_lsnoffset;
     uint32_t flags;
     int ch;
-    char *ofile;
+    int n_args;
+    char *ofile, *start_str;
+    bool end_set, start_set;
 
+    end_set = start_set = false;
     flags = 0;
     ofile = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "f:x")) != EOF)
+
+    while ((ch = __wt_getopt(progname, argc, argv, "f:l:mx")) != EOF)
         switch (ch) {
         case 'f': /* output file */
             ofile = __wt_optarg;
+            break;
+        case 'l':
+            start_str = __wt_optarg;
+            n_args = sscanf(start_str, "%" SCNu32 ",%" SCNu32 ",%" SCNu32 ",%" SCNu32,
+              &start_lsnfile, &start_lsnoffset, &end_lsnfile, &end_lsnoffset);
+            if (n_args == 2) {
+                WT_SET_LSN(&start_lsn, start_lsnfile, start_lsnoffset);
+                start_set = true;
+            } else if (n_args == 4) {
+                WT_SET_LSN(&start_lsn, start_lsnfile, start_lsnoffset);
+                WT_SET_LSN(&end_lsn, end_lsnfile, end_lsnoffset);
+                end_set = start_set = true;
+            } else
+                return (usage());
+            break;
+        case 'm': /* messages only */
+            LF_SET(WT_TXN_PRINTLOG_MSG);
             break;
         case 'x': /* hex output */
             LF_SET(WT_TXN_PRINTLOG_HEX);
@@ -38,15 +75,9 @@ util_printlog(WT_SESSION *session, int argc, char *argv[])
     if (argc != 0)
         return (usage());
 
-    if ((ret = __wt_txn_printlog(session, ofile, flags)) != 0)
+    if ((ret = __wt_txn_printlog(session, ofile, flags, start_set == true ? &start_lsn : NULL,
+           end_set == true ? &end_lsn : NULL)) != 0)
         (void)util_err(session, ret, "printlog");
 
     return (ret);
-}
-
-static int
-usage(void)
-{
-    (void)fprintf(stderr, "usage: %s %s printlog [-x] [-f output-file]\n", progname, usage_prefix);
-    return (1);
 }

--- a/test/suite/test_txn08.py
+++ b/test/suite/test_txn08.py
@@ -72,6 +72,47 @@ class test_txn08(wttest.WiredTigerTestCase, suite_subprocess):
             '\\u0001\\u0002abcd\\u0003\\u0004')
         self.check_file_contains('printlog-hex.out',
             '0102616263640304')
+        # Check the printlog start LSN and stop LSN feature.
+        self.runWt(['printlog', '-l 2,128'], outfilename='printlog-range01.out')
+        self.check_file_contains('printlog-range01.out',
+            '"lsn" : [2,128],')
+        self.check_file_contains('printlog-range01.out',
+            '"lsn" : [2,256],')
+        self.check_file_not_contains('printlog-range01.out',
+            '"lsn" : [1,128],')
+        self.runWt(['printlog', '-l 2,128,3,128'], outfilename='printlog-range02.out')
+        self.check_file_contains('printlog-range02.out',
+            '"lsn" : [2,128],')
+        self.check_file_not_contains('printlog-range02.out',
+            '"lsn" : [1,128],')
+        self.check_file_not_contains('printlog-range02.out',
+            '"lsn" : [3,256],')
+        # Test for invalid LSN, return WT_NOTFOUND
+        self.runWt(['printlog', '-l 2,300'], outfilename='printlog-range03.out', errfilename='printlog-range03.err', failure=True)
+        self.check_file_contains('printlog-range03.err','WT_NOTFOUND')
+        # Test for Start > end, print the start lsn and then stop
+        self.runWt(['printlog', '-l 3,128,2,128'], outfilename='printlog-range04.out')
+        self.check_file_contains('printlog-range04.out','"lsn" : [3,128],')
+        self.check_file_not_contains('printlog-range04.out','"lsn" : [3,256],')
+        # Test for usage error, print the usage message if arguments are invalid
+        self.runWt(['printlog', '-l'], outfilename='printlog-range05.out', errfilename='printlog-range05.err', failure=True)
+        self.check_file_contains('printlog-range05.err','wt: option requires an argument -- l')
+        # Test start and end offset of 0
+        self.runWt(['printlog', '-l 2,0,3,0'], outfilename='printlog-range06.out')
+        self.check_file_contains('printlog-range06.out',
+            '"lsn" : [2,128],')
+        self.check_file_not_contains('printlog-range06.out',
+            '"lsn" : [1,128],')
+        self.check_file_not_contains('printlog-range06.out',
+            '"lsn" : [3,256],')
+        # Test for start == end
+        self.runWt(['printlog', '-l 1,256,1,256'], outfilename='printlog-range07.out')
+        self.check_file_contains('printlog-range07.out',
+            '"lsn" : [1,256],')
+        self.check_file_not_contains('printlog-range07.out',
+            '"lsn" : [1,128],')
+        self.check_file_not_contains('printlog-range07.out',
+            '"lsn" : [1,384],')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -519,7 +519,7 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
 
         if expect_fail:
             self.check_file_contains_one_of(errfile,
-                ['WT_TRY_SALVAGE: database corruption detected'])
+                ['WT_TRY_SALVAGE: database corruption detected'], True)
 
         for salvagedir in [ newdir, newdir2 ]:
             # Removing the 'WiredTiger.turtle' file has weird behavior:


### PR DESCRIPTION
* Added optional arguments [-l start-file,start-offset]|[-l start-file,start-offset,end-file,end-offset] to start and stop the printlog at given LSN's. Details included in the printlog usage string.
* Added python tests to test_txn08 to test the start, stop functionality.

(cherry picked from commit e39ffb554160de902060cd063c4b1547ff6d5e1e)