### PR TITLE
WT-7192 Fixes for cached cursor sweep.

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -569,7 +569,7 @@ __curfile_reopen_int(WT_CURSOR *cursor)
      * cache.
      */
     ret = __wt_session_lock_dhandle(session, 0, &is_dead);
-    if (!is_dead && ret == 0 && !F_ISSET(dhandle, WT_DHANDLE_OPEN)) {
+    if (!is_dead && ret == 0 && !WT_DHANDLE_CAN_REOPEN(dhandle)) {
         WT_RET(__wt_session_release_dhandle(session));
         ret = __wt_set_return(session, EBUSY);
     }
@@ -608,30 +608,26 @@ __curfile_reopen_int(WT_CURSOR *cursor)
  *     WT_CURSOR->reopen method for the btree cursor type.
  */
 static int
-__curfile_reopen(WT_CURSOR *cursor, bool check_only)
+__curfile_reopen(WT_CURSOR *cursor, bool sweep_check_only)
 {
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    bool can_reopen;
+    bool can_sweep;
 
     session = CUR2S(cursor);
     dhandle = ((WT_CURSOR_BTREE *)cursor)->dhandle;
 
-    if (check_only) {
-        can_reopen = WT_DHANDLE_CAN_REOPEN(dhandle);
+    if (sweep_check_only) {
         /*
-         * If the data handle can't be reopened, it is a candidate for sweep, and that should never
-         * happen if any session (including ours) is actively using it.
+         * The sweep check returns WT_NOTFOUND if the cursor should be swept. Generally if the
+         * associated data handle cannot be reopened we want to sweep it. But we also don't want to
+         * sweep a handle that we're currently operating on. That can occur if we're in the middle
+         * of a close on a cursor for a handle that is marked as dropped, as session cursor sweeps
+         * can happen while closing.
          */
-        if (!can_reopen && dhandle == session->dhandle)
-            WT_RET(__wt_msg(session,
-              "%s: current dhandle may be swept: flags 0x%" PRIx32 " inuse 0x%" PRId32
-              " ref 0x%" PRIu32 " xref 0x%" PRIu32,
-              dhandle->name, dhandle->flags, dhandle->session_inuse, dhandle->session_ref,
-              dhandle->excl_ref));
-        WT_ASSERT(session, can_reopen || dhandle != session->dhandle);
-        return (can_reopen ? 0 : WT_NOTFOUND);
+        can_sweep = !WT_DHANDLE_CAN_REOPEN(dhandle) && dhandle != session->dhandle;
+        return (can_sweep ? WT_NOTFOUND : 0);
     }
 
     /*

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -32,9 +32,8 @@
     (F_ISSET(dhandle, WT_DHANDLE_DEAD) || !F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_OPEN))
 
 /* Check if a handle could be reopened. */
-#define WT_DHANDLE_CAN_REOPEN(dhandle)                                     \
-    (!WT_DHANDLE_INACTIVE(dhandle) && F_ISSET(dhandle, WT_DHANDLE_OPEN) && \
-      !F_ISSET(dhandle, WT_DHANDLE_DROPPED))
+#define WT_DHANDLE_CAN_REOPEN(dhandle) \
+    (!F_ISSET(dhandle, WT_HANDLE_DEAD | WT_DHANDLE_DROPPED) && F_ISSET(dhandle, WT_DHANDLE_OPEN))
 
 /* The metadata cursor's data handle. */
 #define WT_SESSION_META_DHANDLE(s) (((WT_CURSOR_BTREE *)((s)->meta_cursor))->dhandle)

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -33,7 +33,7 @@
 
 /* Check if a handle could be reopened. */
 #define WT_DHANDLE_CAN_REOPEN(dhandle) \
-    (!F_ISSET(dhandle, WT_HANDLE_DEAD | WT_DHANDLE_DROPPED) && F_ISSET(dhandle, WT_DHANDLE_OPEN))
+    (!F_ISSET(dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_DROPPED) && F_ISSET(dhandle, WT_DHANDLE_OPEN))
 
 /* The metadata cursor's data handle. */
 #define WT_SESSION_META_DHANDLE(s) (((WT_CURSOR_BTREE *)((s)->meta_cursor))->dhandle)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -92,7 +92,7 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
         TAILQ_FOREACH_SAFE(cursor, cached_list, q, cursor_tmp)
         {
             /*
-             * First check to see if the cursor could be reopened.
+             * First check to see if the cursor could be reopened and should be swept.
              */
             ++nexamined;
             t_ret = cursor->reopen(cursor, true);


### PR DESCRIPTION
Simplify the WT_DHANDLE_CAN_REOPEN macro, it will no longer return true for some
weird flag combinations.  Use this macro when reopening as a final check.
When doing the sweep check, even if the cursor is otherwise
"reopenable", don't allow sweeping of a cursor that is using the current
dhandle. Remove the assertion that used to protect that case, as it
can no longer happen.