### PR TITLE
WT-7045 Disable log archiving in test_backup13 

### DIFF
--- a/test/suite/test_backup13.py
+++ b/test/suite/test_backup13.py
@@ -36,7 +36,7 @@ from wtscenario import make_scenarios
 # test_backup13.py
 # Test cursor backup with a block-based incremental cursor and force_stop.
 class test_backup13(backup_base):
-    conn_config='cache_size=1G,log=(enabled,file_max=100K)'
+    conn_config='cache_size=1G,log=(enabled,archive=false,file_max=100K)'
     dir='backup.dir'                    # Backup directory name
     logmax="100K"
     uri="table:test"


### PR DESCRIPTION
Added a small mitigation fix to test_backup13 to avoid a potential race condition after the backup test force stops an incremental backup. A race condition occurs as the python testing thread starts copying visible database files in the backup directory (at the OS-level) whilst a WT thread is archiving log files.

The race condition was hard to consistently reproduce leaving the code as it is. However I was able tweak the timing in testing to confirm the race was occurring between the test thread detecting the file (`os.listdir` & `os.path.isfile`) and it being archived by the time it attempts to copy the file `shutil.copy`. More specifically, if you modify the python test to very briefly yield/sleep between `os.path.isfile` and `shutil.copy` (in `simulate_crash_restart`) it reproduces the error consistently. 

I adopted a similar fix seen in WT-6425 to ensure the log files don't get archived before they get copied. 