### PR TITLE
WT-7214 Run macOS compile task on macos-1012 Evergreen distro

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2631,6 +2631,8 @@ buildvariants:
     test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH DYLD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
   tasks:
     - name: compile
+      # macos-1012 is a more stable distro that we want to use for our PR testing task
+      distros: macos-1012
     - name: make-check-test
     - name: unit-test
     - name: fops


### PR DESCRIPTION
Switch the compile task back to using the older but more stable `macos-1012` Evergreen disto, to avoid being hit by the long queue issue on the newer `macos-1014` distro. Will add macOS compile task back into the PR testing scope once this change is merged.