### PR TITLE
WT-7045 Fix FileNotFoundError in simulate_crash_restart

### DIFF
--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -135,3 +135,15 @@ def copy_wiredtiger_home(self, olddir, newdir, aligned=True):
                 cmd_list = ['dd', inpf, outf, 'bs=300']
                 a = subprocess.Popen(cmd_list)
                 a.wait()
+
+# Simulate a crash from olddir and restart in newdir.
+def simulate_crash_restart(self, olddir, newdir):
+    # with the connection still open, copy files to new directory.
+    copy_wiredtiger_home(self, olddir, newdir)
+    # close the original connection and open to new directory.
+    # NOTE:  This really cannot test the difference between the
+    # write-no-sync (off) version of log_flush and the sync
+    # version since we're not crashing the system itself.
+    self.close_conn()
+    self.conn = self.setUpConnectionOpen(newdir)
+    self.session = self.setUpSessionOpen(self.conn)

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -126,7 +126,7 @@ def copy_wiredtiger_home(self, olddir, newdir, aligned=True):
                     if "WiredTigerLog" not in fullname:
                         raise e
                     else:
-                        self.printVerbose(2, 'Skipping logfile %s: No longer exists' % fname)
+                        self.pr('Skipping logfile %s: No longer exists' % fname)
                         continue
             else:
                 fullname = os.path.join(olddir, fname)

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -32,7 +32,7 @@ import wiredtiger
 
 from wtdataset import SimpleDataSet, SimpleIndexDataSet, ComplexDataSet
 
-# python has a filecmp.cmp function, but different versions of python approach
+# Python has a filecmp.cmp function, but different versions of python approach
 # file comparison differently.  To make sure we get byte for byte comparison,
 # we define it here.
 def compare_files(self, filename1, filename2):
@@ -50,7 +50,7 @@ def compare_files(self, filename1, filename2):
                 b2 = fp2.read(bufsize)
                 if b1 != b2:
                     return False
-                # files are identical size
+                # Files are identical size.
                 if not b1:
                     return True
 
@@ -78,7 +78,7 @@ def compare_tables(self, session, uris, config=None):
         for c in cursors:
             c.close()
 
-# confirm a URI doesn't exist.
+# Confirm a URI doesn't exist.
 def confirm_does_not_exist(self, uri):
     self.pr('confirm_does_not_exist: ' + uri)
     self.assertRaises(wiredtiger.WiredTigerError,
@@ -87,7 +87,7 @@ def confirm_does_not_exist(self, uri):
         'confirm_does_not_exist: URI exists, file name matching \"' +
         uri.split(":")[1] + '\" found')
 
-# confirm a URI exists and is empty.
+# Confirm a URI exists and is empty.
 def confirm_empty(self, uri):
     self.pr('confirm_empty: ' + uri)
     cursor = self.session.open_cursor(uri, None)
@@ -98,9 +98,9 @@ def confirm_empty(self, uri):
         self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
     cursor.close()
 
-# copy a WT home directory
+# Copy a WT home directory.
 def copy_wiredtiger_home(self, olddir, newdir, aligned=True):
-    # unaligned copy requires 'dd', which may not be available on Windows
+    # Unaligned copy requires 'dd', which may not be available on Windows.
     if not aligned and os.name == "nt":
         raise AssertionError(
             'copy_wiredtiger_home: unaligned copy impossible on Windows')
@@ -138,9 +138,9 @@ def copy_wiredtiger_home(self, olddir, newdir, aligned=True):
 
 # Simulate a crash from olddir and restart in newdir.
 def simulate_crash_restart(self, olddir, newdir):
-    # with the connection still open, copy files to new directory.
+    # With the connection still open, copy files to new directory.
     copy_wiredtiger_home(self, olddir, newdir)
-    # close the original connection and open to new directory.
+    # Close the original connection and open to new directory.
     # NOTE:  This really cannot test the difference between the
     # write-no-sync (off) version of log_flush and the sync
     # version since we're not crashing the system itself.

--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -54,7 +54,7 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
         # Half the time use an unaligned copy.
         even = i % (self.freq * 2) == 0
         aligned = even or os.name == "nt"
-        copy_wiredtiger_home(olddir, newdir, aligned)
+        copy_wiredtiger_home(self, olddir, newdir, aligned)
 
         # Half the time try to rename a table and the other half try
         # to remove a table.  They should fail.

--- a/test/suite/test_backup09.py
+++ b/test/suite/test_backup09.py
@@ -88,7 +88,7 @@ class test_backup09(wttest.WiredTigerTestCase):
         log_files_to_copy = 0
         os.mkdir(self.backup_dir)
         if self.all_log_files:
-            helper.copy_wiredtiger_home('.', self.backup_dir)
+            helper.copy_wiredtiger_home(self, '.', self.backup_dir)
             log_files_copied = [x for x in os.listdir(self.backup_dir) if x.startswith('WiredTigerLog.')]
             self.assertEqual(len(log_files_copied), 2)
         else:

--- a/test/suite/test_bug014.py
+++ b/test/suite/test_bug014.py
@@ -59,7 +59,7 @@ class test_bug014(wttest.WiredTigerTestCase):
         ckpt_session.close()
 
         # Simulate a crash by copying to a new directory.
-        copy_wiredtiger_home(".", "RESTART")
+        copy_wiredtiger_home(self, ".", "RESTART")
 
         # Open the new directory.
         conn = self.setUpConnectionOpen("RESTART")

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -119,7 +119,7 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Make a backup for forensics in case something goes wrong.
         backup_dir = 'BACKUP'
-        copy_wiredtiger_home(new_home_dir, backup_dir, True)
+        copy_wiredtiger_home(self, new_home_dir, backup_dir, True)
 
         # After reopening and running recovery both tables should be in
         # sync even though table 1 was successfully written and table 2

--- a/test/suite/test_checkpoint_snapshot01.py
+++ b/test/suite/test_checkpoint_snapshot01.py
@@ -73,7 +73,7 @@ class test_checkpoint_snapshot01(wttest.WiredTigerTestCase):
         session_p2.checkpoint()
 
         #Simulate a crash by copying to a new directory(RESTART).
-        copy_wiredtiger_home(".", "RESTART")
+        copy_wiredtiger_home(self, ".", "RESTART")
 
         # Open the new directory.
         self.conn = self.setUpConnectionOpen("RESTART")

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -330,7 +330,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
 
         # Crash and recover in a new directory.
         newdir = 'RESTART'
-        copy_wiredtiger_home('.', newdir)
+        copy_wiredtiger_home(self, '.', newdir)
         self.conn.close()
         self.conn = self.setUpConnectionOpen(newdir)
         self.session = self.setUpSessionOpen(self.conn)

--- a/test/suite/test_durability01.py
+++ b/test/suite/test_durability01.py
@@ -43,7 +43,7 @@ class test_durability01(wttest.WiredTigerTestCase, suite_subprocess):
     def check_crash_restart(self, olddir, newdir):
         ''' Simulate a crash from olddir and restart in newdir. '''
         # with the connection still open, copy files to new directory
-        copy_wiredtiger_home(olddir, newdir)
+        copy_wiredtiger_home(self, olddir, newdir)
 
         # Open the new directory
         conn = self.setUpConnectionOpen(newdir)

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -82,7 +82,7 @@ class test_hs01(wttest.WiredTigerTestCase):
         # Checkpoint and backup so as to simulate recovery
         self.session.checkpoint()
         newdir = "BACKUP"
-        copy_wiredtiger_home('.', newdir, True)
+        copy_wiredtiger_home(self, '.', newdir, True)
 
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -160,7 +160,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Simulate a crash by copying to a new directory(RESTART).
-        copy_wiredtiger_home(".", "RESTART")
+        copy_wiredtiger_home(self, ".", "RESTART")
 
         # Open the new directory.
         self.conn = self.setUpConnectionOpen("RESTART")

--- a/test/suite/test_prepare_hs04.py
+++ b/test/suite/test_prepare_hs04.py
@@ -156,7 +156,7 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Simulate a crash by copying to a new directory(RESTART).
-        copy_wiredtiger_home(".", "RESTART")
+        copy_wiredtiger_home(self, ".", "RESTART")
 
         # Open the new directory.
         self.conn = self.setUpConnectionOpen("RESTART")

--- a/test/suite/test_readonly02.py
+++ b/test/suite/test_readonly02.py
@@ -86,7 +86,7 @@ class test_readonly02(wttest.WiredTigerTestCase, suite_subprocess):
 
     def check_unclean(self):
         backup = "WT_COPYDIR"
-        copy_wiredtiger_home(self.home, backup, True)
+        copy_wiredtiger_home(self, self.home, backup, True)
         msg = '/needs recovery/'
         #   2. an unclean shutdown and reopening readonly
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import fnmatch, os, shutil, time
-from helper import copy_wiredtiger_home
+from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
@@ -54,29 +54,6 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
     def conn_config(self):
         config = 'cache_size=5MB,statistics=(all),log=(enabled=true)'
         return config
-
-    def simulate_crash_restart(self, uri, olddir, newdir):
-        ''' Simulate a crash from olddir and restart in newdir. '''
-        # with the connection still open, copy files to new directory
-        shutil.rmtree(newdir, ignore_errors=True)
-        os.mkdir(newdir)
-        for fname in os.listdir(olddir):
-            fullname = os.path.join(olddir, fname)
-            # Skip lock file on Windows since it is locked
-            if os.path.isfile(fullname) and \
-                "WiredTiger.lock" not in fullname and \
-                "Tmplog" not in fullname and \
-                "Preplog" not in fullname:
-                shutil.copy(fullname, newdir)
-        #
-        # close the original connection and open to new directory
-        # NOTE:  This really cannot test the difference between the
-        # write-no-sync (off) version of log_flush and the sync
-        # version since we're not crashing the system itself.
-        #
-        self.close_conn()
-        self.conn = self.setUpConnectionOpen(newdir)
-        self.session = self.setUpSessionOpen(self.conn)
 
     def test_rollback_to_stable(self):
         nrows = 1000
@@ -128,7 +105,7 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.check(value_d, uri, nrows, 80)
 
         # Simulate a server crash and restart.
-        self.simulate_crash_restart(uri, ".", "RESTART")
+        simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
         self.check(value_b, uri, nrows, 40)
@@ -153,7 +130,7 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.assertGreaterEqual(hs_removed, nrows * 4)
 
         # Simulate another server crash and restart.
-        self.simulate_crash_restart(uri, "RESTART", "RESTART2")
+        simulate_crash_restart(self, "RESTART", "RESTART2")
 
         # Check that the correct data is seen at and after the stable timestamp.
         self.check(value_b, uri, nrows, 40)

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import fnmatch, os, shutil, threading, time
-from helper import copy_wiredtiger_home
+from helper import copy_wiredtiger_home, simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat, wiredtiger_strerror, WiredTigerError, WT_ROLLBACK
 from wtdataset import SimpleDataSet
@@ -79,29 +79,6 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
     def conn_config(self):
         config = 'cache_size=6MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[history_store_checkpoint_delay]'
         return config
-
-    def simulate_crash_restart(self, olddir, newdir):
-        ''' Simulate a crash from olddir and restart in newdir. '''
-        # with the connection still open, copy files to new directory
-        shutil.rmtree(newdir, ignore_errors=True)
-        os.mkdir(newdir)
-        for fname in os.listdir(olddir):
-            fullname = os.path.join(olddir, fname)
-            # Skip lock file on Windows since it is locked
-            if os.path.isfile(fullname) and \
-                "WiredTiger.lock" not in fullname and \
-                "Tmplog" not in fullname and \
-                "Preplog" not in fullname:
-                shutil.copy(fullname, newdir)
-        #
-        # close the original connection and open to new directory
-        # NOTE:  This really cannot test the difference between the
-        # write-no-sync (off) version of log_flush and the sync
-        # version since we're not crashing the system itself.
-        #
-        self.close_conn()
-        self.conn = self.setUpConnectionOpen(newdir)
-        self.session = self.setUpSessionOpen(self.conn)
 
     def test_rollback_to_stable(self):
         nrows = 1000
@@ -183,7 +160,7 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
 
         # Simulate a server crash and restart.
         self.pr("restart")
-        self.simulate_crash_restart(".", "RESTART")
+        simulate_crash_restart(self, ".", "RESTART")
         self.pr("restart complete")
 
         # Check that the correct data is seen at and after the stable timestamp.

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -317,7 +317,7 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
             ckpt.join()
 
         # Simulate a crash by copying to a new directory(RESTART).
-        copy_wiredtiger_home(".", "RESTART")
+        copy_wiredtiger_home(self, ".", "RESTART")
 
         # Commit the prepared transaction.
         session_p1.commit_transaction('commit_timestamp=' + timestamp_str(70) + ',durable_timestamp=' + timestamp_str(71))

--- a/test/suite/test_rollback_to_stable12.py
+++ b/test/suite/test_rollback_to_stable12.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import fnmatch, os, shutil, time
-from helper import copy_wiredtiger_home
+from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
@@ -51,29 +51,6 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
     def conn_config(self):
         config = 'cache_size=500MB,statistics=(all),log=(enabled=true)'
         return config
-
-    def simulate_crash_restart(self, olddir, newdir):
-        ''' Simulate a crash from olddir and restart in newdir. '''
-        # with the connection still open, copy files to new directory
-        shutil.rmtree(newdir, ignore_errors=True)
-        os.mkdir(newdir)
-        for fname in os.listdir(olddir):
-            fullname = os.path.join(olddir, fname)
-            # Skip lock file on Windows since it is locked
-            if os.path.isfile(fullname) and \
-                "WiredTiger.lock" not in fullname and \
-                "Tmplog" not in fullname and \
-                "Preplog" not in fullname:
-                shutil.copy(fullname, newdir)
-        #
-        # close the original connection and open to new directory
-        # NOTE:  This really cannot test the difference between the
-        # write-no-sync (off) version of log_flush and the sync
-        # version since we're not crashing the system itself.
-        #
-        self.close_conn()
-        self.conn = self.setUpConnectionOpen(newdir)
-        self.session = self.setUpSessionOpen(self.conn)
 
     def test_rollback_to_stable(self):
         nrows = 1000000
@@ -120,7 +97,7 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Simulate a server crash and restart.
-        self.simulate_crash_restart(".", "RESTART")
+        simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
         self.check(value_a, uri, nrows, 30)

--- a/test/suite/test_rollback_to_stable13.py
+++ b/test/suite/test_rollback_to_stable13.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import fnmatch, os, shutil, time
-from helper import copy_wiredtiger_home
+from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
@@ -51,29 +51,6 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
     def conn_config(self):
         config = 'cache_size=500MB,statistics=(all),log=(enabled=true)'
         return config
-
-    def simulate_crash_restart(self, olddir, newdir):
-        ''' Simulate a crash from olddir and restart in newdir. '''
-        # with the connection still open, copy files to new directory
-        shutil.rmtree(newdir, ignore_errors=True)
-        os.mkdir(newdir)
-        for fname in os.listdir(olddir):
-            fullname = os.path.join(olddir, fname)
-            # Skip lock file on Windows since it is locked
-            if os.path.isfile(fullname) and \
-                "WiredTiger.lock" not in fullname and \
-                "Tmplog" not in fullname and \
-                "Preplog" not in fullname:
-                shutil.copy(fullname, newdir)
-        #
-        # close the original connection and open to new directory
-        # NOTE:  This really cannot test the difference between the
-        # write-no-sync (off) version of log_flush and the sync
-        # version since we're not crashing the system itself.
-        #
-        self.close_conn()
-        self.conn = self.setUpConnectionOpen(newdir)
-        self.session = self.setUpSessionOpen(self.conn)
 
     def test_rollback_to_stable(self):
         nrows = 1000
@@ -114,7 +91,7 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Simulate a server crash and restart.
-        self.simulate_crash_restart(".", "RESTART")
+        simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
         self.check(None, uri, 0, 50)

--- a/test/suite/test_timestamp03.py
+++ b/test/suite/test_timestamp03.py
@@ -98,7 +98,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
         expected_nots_nolog):
 
         newdir = "BACKUP"
-        copy_wiredtiger_home('.', newdir, True)
+        copy_wiredtiger_home(self, '.', newdir, True)
 
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)

--- a/test/suite/test_timestamp06.py
+++ b/test/suite/test_timestamp06.py
@@ -87,7 +87,7 @@ class test_timestamp06(wttest.WiredTigerTestCase, suite_subprocess):
     # check exists in the tables the expected number of times.
     def backup_check(self, check_value, expected_ts_log, expected_ts_nolog):
         newdir = "BACKUP"
-        copy_wiredtiger_home('.', newdir, True)
+        copy_wiredtiger_home(self, '.', newdir, True)
 
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)

--- a/test/suite/test_timestamp07.py
+++ b/test/suite/test_timestamp07.py
@@ -117,7 +117,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
     #
     def backup_check(self, check_value, valcnt, valcnt2, valcnt3):
         newdir = "BACKUP"
-        copy_wiredtiger_home('.', newdir, True)
+        copy_wiredtiger_home(self, '.', newdir, True)
 
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)


### PR DESCRIPTION
This PR updates usages of the `simulate_crash_restart` and `copy_wiredtiger_home` helpers to be able to tolerate a potential race condition in the python tests. The error more specifically being a `FileNotFoundError` as a testing thread starts copying wiredtiger log files whilst they are being archived/removed by a background log server thread. In particular this PR adds the following key changes:
* Try/Except block in`copy_wiredtiger_home` : To catch the case when a wiredtiger log file gets removed as its being copied
* Updated the implementation of `simulate_crash_restart` to be a small wrapper around `copy_wiredtiger_home` due to near identical functionality + centralized the helper to remove code duplication.