### PR TITLE
WT-7225 Restructure verify key function for the history store

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -421,7 +421,7 @@ __debug_hs_cursor(WT_DBG *ds, WT_CURSOR *hs_cursor)
     uint32_t hs_btree_id;
     char time_string[WT_TIME_STRING_SIZE];
 
-    cbt = (WT_CURSOR_BTREE *)hs_cursor;
+    cbt = __wt_hs_cbt(hs_cursor);
     session = ds->session;
 
     WT_TIME_WINDOW_INIT(&tw);
@@ -1016,6 +1016,7 @@ __debug_page(WT_DBG *ds, WT_REF *ref, uint32_t flags)
             WT_ERR(__wt_scr_alloc(session, 0, &ds->hs_key));
             WT_ERR(__wt_scr_alloc(session, 0, &ds->hs_value));
         }
+        F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     }
 
     /* Dump the page metadata. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -782,7 +782,6 @@ __verify_key_hs(
     wt_timestamp_t older_start_ts, older_stop_ts;
     uint64_t hs_counter;
     uint32_t hs_btree_id;
-    int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     btree = S2BT(session);
@@ -805,11 +804,6 @@ __verify_key_hs(
 
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor)) {
         WT_RET(hs_cursor->get_key(hs_cursor, &hs_btree_id, vs->tmp2, &older_start_ts, &hs_counter));
-
-        WT_RET(__wt_compare(session, NULL, tmp1, vs->tmp2, &cmp));
-        if (cmp != 0)
-            break;
-
         /* Verify the newer record's start is later than the older record's stop. */
         if (newer_start_ts < older_stop_ts) {
             WT_RET_MSG(session, WT_ERROR,

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -786,8 +786,8 @@ __verify_key_hs(
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
-    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));  
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED); 
+    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*
      * Set the data store timestamp and transactions to initiate timestamp range verification. Since

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -775,7 +775,7 @@ static int
 __verify_key_hs(
   WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_start_ts, WT_VSTUFF *vs)
 {
-//#ifdef WT_VERIFY_VALIDATE_HISTORY_STORE
+#ifdef WT_VERIFY_VALIDATE_HISTORY_STORE
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
@@ -786,6 +786,8 @@ __verify_key_hs(
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
+    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));  
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED); 
 
     /*
      * Set the data store timestamp and transactions to initiate timestamp range verification. Since
@@ -798,7 +800,6 @@ __verify_key_hs(
      * Open a history store cursor positioned at the end of the data store key (the newest record)
      * and iterate backwards until we reach a different key or btree.
      */
-    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));    
     hs_cursor->set_key(hs_cursor, 4, hs_btree_id, tmp1, WT_TS_MAX, WT_TXN_MAX);
     ret = __wt_hs_cursor_search_near_before(session, hs_cursor);
 
@@ -826,13 +827,13 @@ __verify_key_hs(
     }
 
     return (ret == WT_NOTFOUND ? 0 : ret);
-// #else
-//     WT_UNUSED(session);
-//     WT_UNUSED(tmp1);
-//     WT_UNUSED(newer_start_ts);
-//     WT_UNUSED(vs);
-//     return (0);
-// #endif
+#else
+    WT_UNUSED(session);
+    WT_UNUSED(tmp1);
+    WT_UNUSED(newer_start_ts);
+    WT_UNUSED(vs);
+    return (0);
+#endif
 }
 
 /*

--- a/test/suite/test_util21.py
+++ b/test/suite/test_util21.py
@@ -75,7 +75,7 @@ class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Set oldest timestamp, and checkpoint, the obsolete data should not removed as
         # the pages are clean.
-        #self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(6))
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(6))
         self.session.checkpoint()
         self.runWt(['dump', 'file:WiredTigerHS.wt'], outfilename="after_oldest")
 

--- a/test/suite/test_util21.py
+++ b/test/suite/test_util21.py
@@ -75,7 +75,7 @@ class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Set oldest timestamp, and checkpoint, the obsolete data should not removed as
         # the pages are clean.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(6))
+        #self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(6))
         self.session.checkpoint()
         self.runWt(['dump', 'file:WiredTigerHS.wt'], outfilename="after_oldest")
 


### PR DESCRIPTION
This ticket refactors **__verify_key_hs** to use the new history store interface. Also included in this ticket is how we grab the hs cursor when printing out the page values from the btree, and adding a read committed flag, to allow history see the values visibly when running wt verify. 