### PR TITLE
WT-7246 Remove old HS cursor from session

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -285,9 +285,6 @@ __debug_wrapup(WT_DBG *ds)
     session = ds->session;
     msg = ds->msg;
 
-    if (session->hs_cursor != NULL)
-        WT_TRET(__wt_hs_cursor_close(session));
-
     __wt_scr_free(session, &ds->key);
     __wt_scr_free(session, &ds->hs_key);
     __wt_scr_free(session, &ds->hs_value);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -278,9 +278,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              */
             if (ret == 0 && (ckpt + 1)->name == NULL && !skip_hs) {
                 /* Open a history store cursor. */
-                WT_ERR(__wt_hs_cursor_open(session));
                 WT_TRET(__wt_hs_verify_one(session));
-                WT_TRET(__wt_hs_cursor_close(session));
                 /*
                  * We cannot error out here. If we got an error verifying the history store, we need
                  * to follow through with reacquiring the exclusive call below. We'll error out

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -77,34 +77,6 @@ __wt_hs_cursor_cache(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_hs_cursor_open --
- *     Open a new history store table cursor wrapper function.
- */
-int
-__wt_hs_cursor_open(WT_SESSION_IMPL *session)
-{
-    /* Not allowed to open a cursor if you already have one */
-    WT_ASSERT(session, session->hs_cursor == NULL);
-
-    return (__hs_cursor_open_int(session, &session->hs_cursor));
-}
-
-/*
- * __wt_hs_cursor_close --
- *     Discard a history store cursor.
- */
-int
-__wt_hs_cursor_close(WT_SESSION_IMPL *session)
-{
-    /* Should only be called when session has an open history store cursor */
-    WT_ASSERT(session, session->hs_cursor != NULL);
-
-    WT_RET(session->hs_cursor->close(session->hs_cursor));
-    session->hs_cursor = NULL;
-    return (0);
-}
-
-/*
  * __wt_hs_cursor_next --
  *     Execute a next operation on a history store cursor with the appropriate isolation level.
  */

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -131,7 +131,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         /*
          * Track history store pages being force evicted while holding a history store cursor open.
          */
-        if (session->hs_cursor != NULL && WT_IS_HS(session->dhandle)) {
+        if (session->hs_cursor_counter > 0 && WT_IS_HS(session->dhandle)) {
             force_evict_hs = true;
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs);
         }

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -60,16 +60,16 @@ __hs_cleanup_las(WT_SESSION_IMPL *session)
 int
 __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 {
-    WT_CURSOR_HS *hs_cursor;
+    WT_CURSOR *hs_cursor;
+    WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
     *hs_btreep = NULL;
 
     WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
-    *hs_btreep = CUR2BT(hs_cursor->file_cursor);
+    cbt = __wt_hs_cbt(hs_cursor);
+    *hs_btreep = CUR2BT(cbt);
     WT_ASSERT(session, *hs_btreep != NULL);
-
-    WT_TRET(__wt_hs_cursor_close(session));
-
+    WT_TRET(hs_cursor->close(hs_cursor));
     return (ret);
 }
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -60,13 +60,12 @@ __hs_cleanup_las(WT_SESSION_IMPL *session)
 int
 __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 {
+    WT_CURSOR_HS *hs_cursor;
     WT_DECL_RET;
-
     *hs_btreep = NULL;
 
-    WT_RET(__wt_hs_cursor_open(session));
-
-    *hs_btreep = CUR2BT(session->hs_cursor);
+    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
+    *hs_btreep = CUR2BT(hs_cursor->file_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
 
     WT_TRET(__wt_hs_cursor_close(session));

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -188,8 +188,6 @@ __wt_hs_verify(WT_SESSION_IMPL *session)
         WT_ERR_NOTFOUND_OK(ret, false);
     }
 err:
-    WT_TRET(__wt_hs_cursor_close(session));
-
     __wt_scr_free(session, &buf);
     WT_ASSERT(session, key.mem == NULL && key.memsize == 0);
     __wt_free(session, uri_data);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -754,11 +754,7 @@ extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_cache(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_close(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_open(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -92,7 +92,6 @@ struct __wt_session_impl {
     WT_COMPACT_STATE *compact; /* Compaction information */
     enum { WT_COMPACT_NONE = 0, WT_COMPACT_RUNNING, WT_COMPACT_SUCCESS } compact_state;
 
-    WT_CURSOR *hs_cursor;    /* History store table cursor */
     u_int hs_cursor_counter; /* Number of open history store cursors */
 
     WT_CURSOR *meta_cursor;  /* Metadata file */


### PR DESCRIPTION
Remove the deprecated HS cursor as part of the history store project. This also involves the code that affects running the **hs_cursor** from the session. Also added in some close to cursors that would be left open. Ran a patch build to make sure that deleted changes are fine.