### PR TITLE
WT-7254 clean function names inside cur_hs

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -136,8 +136,8 @@ func_ok()
 	    -e '/int zstd_error$/d' \
 	    -e '/int zstd_pre_size$/d' \
 	    -e '/int zstd_terminate$/d' \
-	    -e '/int __wt_hs_cursor_search_near_after$/d' \
-	    -e '/int __wt_hs_cursor_search_near_before$/d'
+	    -e '/int __wt_curhs_search_near_after$/d' \
+	    -e '/int __wt_curhs_search_near_before$/d'
 }
 
 for f in `find bench ext src test -name '*.c' -o -name '*_inline.h'`; do

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -476,7 +476,7 @@ __debug_hs_key(WT_DBG *ds, WT_CURSOR *hs_cursor)
      * and iterate backwards until we reach a different key or btree.
      */
     hs_cursor->set_key(hs_cursor, 4, hs_btree_id, ds->key, WT_TS_MAX, WT_TXN_MAX);
-    ret = __wt_hs_cursor_search_near_before(session, hs_cursor);
+    ret = __wt_curhs_search_near_before(session, hs_cursor);
 
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor))
         WT_RET(__debug_hs_cursor(ds, hs_cursor));

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -71,7 +71,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
             return (0);
         }
 
-        WT_RET(__wt_hs_cursor_cache(session));
+        WT_RET(__wt_curhs_cache(session));
         (void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
         ret = __wt_evict(session, ref, previous_state, 0);
         (void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -795,7 +795,7 @@ __verify_key_hs(
      * and iterate backwards until we reach a different key or btree.
      */
     hs_cursor->set_key(hs_cursor, 4, hs_btree_id, tmp1, WT_TS_MAX, WT_TXN_MAX);
-    ret = __wt_hs_cursor_search_near_before(session, hs_cursor);
+    ret = __wt_curhs_search_near_before(session, hs_cursor);
 
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor)) {
         WT_RET(hs_cursor->get_key(hs_cursor, &hs_btree_id, vs->tmp2, &older_start_ts, &hs_counter));

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -9,12 +9,12 @@
 
 #include "wt_internal.h"
 
-static int __file_cursor_open(WT_SESSION_IMPL *, WT_CURSOR **);
-static int __file_cursor_prev(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __curhs_prev_visible(WT_SESSION_IMPL *, WT_CURSOR_HS *);
-static int __file_cursor_next(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __curhs_next_visible(WT_SESSION_IMPL *, WT_CURSOR_HS *);
 static int __curhs_search_near_helper(WT_SESSION_IMPL *, WT_CURSOR *, bool);
+static int __file_cursor_next(WT_SESSION_IMPL *, WT_CURSOR *);
+static int __file_cursor_open(WT_SESSION_IMPL *, WT_CURSOR **);
+static int __file_cursor_prev(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __file_cursor_search_near(WT_SESSION_IMPL *, WT_CURSOR *, int *);
 /*
  * __file_cursor_open --

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -80,7 +80,6 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
     return (0);
 }
 
-
 /*
  * __curhs_next_int --
  *     Execute a next operation on a history store cursor with the appropriate isolation level.

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -80,14 +80,9 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
     return (0);
 }
 
-<<<<<<< HEAD
-/*
- * __wt_hs_cursor_next --
-=======
 
 /*
  * __curhs_next_int --
->>>>>>> Inital change to cleaning the PR
  *     Execute a next operation on a history store cursor with the appropriate isolation level.
  */
 static int

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -9,19 +9,19 @@
 
 #include "wt_internal.h"
 
-static int __curhs_open_int(WT_SESSION_IMPL *, WT_CURSOR **);
-static int __curhs_prev_int(WT_SESSION_IMPL *, WT_CURSOR *);
+static int __file_cursor_open(WT_SESSION_IMPL *, WT_CURSOR **);
+static int __file_cursor_prev(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __curhs_prev_visible(WT_SESSION_IMPL *, WT_CURSOR_HS *);
-static int __curhs_next_int(WT_SESSION_IMPL *, WT_CURSOR *);
+static int __file_cursor_next(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __curhs_next_visible(WT_SESSION_IMPL *, WT_CURSOR_HS *);
 static int __curhs_search_near_helper(WT_SESSION_IMPL *, WT_CURSOR *, bool);
-static int __curhs_search_near_int(WT_SESSION_IMPL *, WT_CURSOR *, int *);
+static int __file_cursor_search_near(WT_SESSION_IMPL *, WT_CURSOR *, int *);
 /*
- * __curhs_open_int --
+ * __file_cursor_open --
  *     Open a new history store table cursor, internal function.
  */
 static int
-__curhs_open_int(WT_SESSION_IMPL *session, WT_CURSOR **cursorp)
+__file_cursor_open(WT_SESSION_IMPL *session, WT_CURSOR **cursorp)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -75,17 +75,17 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
       (session->dhandle != NULL && WT_IS_METADATA(S2BT(session)->dhandle)) ||
       session == conn->default_session)
         return (0);
-    WT_RET(__curhs_open_int(session, &cursor));
+    WT_RET(__file_cursor_open(session, &cursor));
     WT_RET(cursor->close(cursor));
     return (0);
 }
 
 /*
- * __curhs_next_int --
+ * __file_cursor_next --
  *     Execute a next operation on a history store cursor with the appropriate isolation level.
  */
 static int
-__curhs_next_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+__file_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 {
     WT_DECL_RET;
 
@@ -94,11 +94,11 @@ __curhs_next_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 }
 
 /*
- * __curhs_prev_int --
+ * __file_cursor_prev --
  *     Execute a prev operation on a history store cursor with the appropriate isolation level.
  */
 static int
-__curhs_prev_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+__file_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 {
     WT_DECL_RET;
 
@@ -107,12 +107,12 @@ __curhs_prev_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 }
 
 /*
- * __curhs_search_near_int --
+ * __file_cursor_search_near --
  *     Execute a search near operation on a history store cursor with the appropriate isolation
  *     level.
  */
 static int
-__curhs_search_near_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
+__file_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
 {
     WT_DECL_RET;
 
@@ -163,7 +163,7 @@ __curhs_next(WT_CURSOR *cursor)
     file_cursor = hs_cursor->file_cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, next, CUR2BT(file_cursor));
 
-    WT_ERR(__curhs_next_int(session, file_cursor));
+    WT_ERR(__file_cursor_next(session, file_cursor));
     /*
      * We need to check if the history store record is visible to the current session. If not, the
      * __curhs_next_visible() will also keep iterating forward through the records until it finds a
@@ -197,7 +197,7 @@ __curhs_prev(WT_CURSOR *cursor)
     file_cursor = hs_cursor->file_cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, prev, CUR2BT(file_cursor));
 
-    WT_ERR(__curhs_prev_int(session, file_cursor));
+    WT_ERR(__file_cursor_prev(session, file_cursor));
     /*
      * We need to check if the history store record is visible to the current session. If not, the
      * __curhs_prev_visible() will also keep iterating backwards through the records until it finds
@@ -359,7 +359,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
 
     WT_ERR(__wt_scr_alloc(session, 0, &datastore_key));
 
-    for (; ret == 0; ret = __curhs_prev_int(session, file_cursor)) {
+    for (; ret == 0; ret = __file_cursor_prev(session, file_cursor)) {
         WT_ERR(file_cursor->get_key(file_cursor, &btree_id, datastore_key, &start_ts, &counter));
 
         /* Stop before crossing over to the next btree. */
@@ -448,7 +448,7 @@ __curhs_next_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
 
     WT_ERR(__wt_scr_alloc(session, 0, &datastore_key));
 
-    for (; ret == 0; ret = __curhs_next_int(session, file_cursor)) {
+    for (; ret == 0; ret = __file_cursor_next(session, file_cursor)) {
         WT_ERR(file_cursor->get_key(file_cursor, &btree_id, datastore_key, &start_ts, &counter));
 
         /* Stop before crossing over to the next btree. */
@@ -608,7 +608,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
     WT_ASSERT(session, F_ISSET(hs_cursor, WT_HS_CUR_BTREE_ID_SET));
     WT_ERR(__wt_buf_set(session, srch_key, file_cursor->key.data, file_cursor->key.size));
     /* Reset cursor if we get WT_NOTFOUND. */
-    WT_ERR(__curhs_search_near_int(session, file_cursor, &exact));
+    WT_ERR(__file_cursor_search_near(session, file_cursor, &exact));
 
     if (exact >= 0) {
         /*
@@ -622,7 +622,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
              * as we may have crossed the boundary. Do that in a loop as there may be content
              * inserted concurrently.
              */
-            while ((ret = __curhs_prev_int(session, file_cursor)) == 0) {
+            while ((ret = __file_cursor_prev(session, file_cursor)) == 0) {
                 WT_ERR(
                   file_cursor->get_key(file_cursor, &btree_id, datastore_key, &start_ts, &counter));
 
@@ -686,7 +686,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
              * as we may have crossed the boundary. Do that in a loop as there may be content
              * inserted concurrently.
              */
-            while ((ret = __curhs_next_int(session, file_cursor)) == 0) {
+            while ((ret = __file_cursor_next(session, file_cursor)) == 0) {
                 WT_ERR(
                   file_cursor->get_key(file_cursor, &btree_id, datastore_key, &start_ts, &counter));
 
@@ -1038,7 +1038,7 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
     WT_ERR(__wt_strdup(session, WT_HS_URI, &cursor->uri));
 
     /* Open the file cursor for operations on the regular history store .*/
-    WT_ERR(__curhs_open_int(session, &hs_cursor->file_cursor));
+    WT_ERR(__file_cursor_open(session, &hs_cursor->file_cursor));
 
     WT_ERR(__wt_cursor_init(cursor, WT_HS_URI, owner, NULL, cursorp));
     WT_TIME_WINDOW_INIT(&hs_cursor->time_window);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -285,7 +285,7 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
      * busy and then opens a different file (in this case, the HS file), it can deadlock with a
      * thread waiting for the first file to drain from the eviction queue. See WT-5946 for details.
      */
-    WT_RET(__wt_hs_cursor_cache(session));
+    WT_RET(__wt_curhs_cache(session));
     if (conn->evict_server_running && __wt_spin_trylock(session, &cache->evict_pass_lock) == 0) {
         /*
          * Cannot use WT_WITH_PASS_LOCK because this is a try lock. Fix when that is supported. We
@@ -2353,7 +2353,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
      * session will have a handle list write lock and will be waiting on eviction to drain, we'll be
      * inside eviction waiting on a handle list read lock to open a history store cursor.
      */
-    WT_ERR(__wt_hs_cursor_cache(session));
+    WT_ERR(__wt_curhs_cache(session));
 
     /*
      * It is not safe to proceed if the eviction server threads aren't setup yet.

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -76,7 +76,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     evict_flags = LF_ISSET(WT_READ_NO_SPLIT) ? WT_EVICT_CALL_NO_SPLIT : 0;
     FLD_SET(evict_flags, WT_EVICT_CALL_URGENT);
 
-    WT_RET(__wt_hs_cursor_cache(session));
+    WT_RET(__wt_curhs_cache(session));
     (void)__wt_atomic_addv32(&btree->evict_busy, 1);
     ret = __wt_evict(session, ref, previous_state, evict_flags);
     (void)__wt_atomic_subv32(&btree->evict_busy, 1);

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -174,7 +174,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
       txn_shared->read_timestamp == WT_TS_NONE ? WT_TS_MAX : txn_shared->read_timestamp;
 
     hs_cursor->set_key(hs_cursor, 4, btree_id, key, read_timestamp, UINT64_MAX);
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_before(session, hs_cursor), true);
+    WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_before(session, hs_cursor), true);
     if (ret == WT_NOTFOUND) {
         ret = 0;
         goto done;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -114,7 +114,7 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
      * one can lead to wrong order.
      */
     cursor->set_key(cursor, 4, btree->id, key, tw->start_ts, UINT64_MAX);
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_before(session, cursor), true);
+    WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_before(session, cursor), true);
 
     if (ret == 0) {
         WT_ERR(cursor->get_key(cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
@@ -155,7 +155,7 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
             WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
         else {
             cursor->set_key(cursor, 3, btree->id, key, tw->start_ts + 1);
-            WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_after(session, cursor), true);
+            WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_after(session, cursor), true);
         }
         if (ret == 0)
             WT_ERR(__hs_fixup_out_of_order_from_pos(
@@ -662,7 +662,7 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
         F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     hs_cursor->set_key(hs_cursor, 3, btree_id, key, ts);
-    WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_after(session, hs_cursor), true);
+    WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_after(session, hs_cursor), true);
     /* Empty history store is fine. */
     if (ret == WT_NOTFOUND) {
         ret = 0;
@@ -866,7 +866,7 @@ __hs_delete_key_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_
         F_SET(insert_cursor, WT_CURSTD_HS_READ_COMMITTED);
         WT_ERR(ret);
         insert_cursor->set_key(insert_cursor, 4, btree_id, key, WT_TS_NONE, UINT64_MAX);
-        WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_before(session, insert_cursor), true);
+        WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_before(session, insert_cursor), true);
 
         if (ret == WT_NOTFOUND) {
             hs_insert_counter = 0;

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -109,7 +109,7 @@ __wt_hs_verify_one(WT_SESSION_IMPL *session)
     btree_id = S2BT(session)->id;
 
     hs_cursor->set_key(hs_cursor, 1, btree_id);
-    WT_ERR(__wt_hs_cursor_search_near_after(session, hs_cursor));
+    WT_ERR(__wt_curhs_search_near_after(session, hs_cursor));
 
     /*
      * If we positioned the cursor there is something to verify.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -752,7 +752,7 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_cache(WT_SESSION_IMPL *session)
+extern int __wt_curhs_cache(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -760,9 +760,9 @@ extern int __wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+extern int __wt_curhs_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_search_near_before(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+extern int __wt_curhs_search_near_before(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
   uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -497,7 +497,13 @@ extern int __wt_curfile_next_random(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curhs_cache(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curhs_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curhs_search_near_before(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -751,18 +757,6 @@ extern int __wt_hex2byte(const u_char *from, u_char *to)
 extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *to)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_cache(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_prev(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_search_near_before(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
   uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert)

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1091,7 +1091,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * the search point to the last version of the key.
          */
         hs_cursor->set_key(hs_cursor, 4, hs_btree_id, &op->u.op_row.key, WT_TS_MAX, UINT64_MAX);
-        WT_ERR_NOTFOUND_OK(__wt_hs_cursor_search_near_before(session, hs_cursor), true);
+        WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_before(session, hs_cursor), true);
         if (ret == WT_NOTFOUND && !commit) {
             /*
              * Allocate a tombstone and prepend it to the row so when we reconcile the update chain

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -269,7 +269,7 @@ __rollback_row_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW 
      * the given timestamp, the key is removed from data store.
      */
     hs_cursor->set_key(hs_cursor, 4, hs_btree_id, key, WT_TS_MAX, UINT64_MAX);
-    ret = __wt_hs_cursor_search_near_before(session, hs_cursor);
+    ret = __wt_curhs_search_near_before(session, hs_cursor);
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));
 
@@ -1126,7 +1126,7 @@ __rollback_to_stable_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_
 
     /* Walk the history store for the given btree. */
     hs_cursor->set_key(hs_cursor, 1, btree_id);
-    ret = __wt_hs_cursor_search_near_after(session, hs_cursor);
+    ret = __wt_curhs_search_near_after(session, hs_cursor);
 
     for (; ret == 0; ret = hs_cursor->next(hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter));


### PR DESCRIPTION
This ticket involves renaming some of the functions inside cur_hs.c, some of the functions need **__wt** removed as it is only used inside the file. This ticket also involves changing the **hs_cursor** name back to old convention of **curhs**