### PR TITLE
WT-5886 Compatibility with older versions of WT

### DIFF
--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -252,13 +252,14 @@ AH_TEMPLATE(WT_STANDALONE_BUILD,
 AC_MSG_CHECKING(if --disable-standalone-build option specified)
 AC_ARG_ENABLE(standalone-build,
        [AS_HELP_STRING([--disable-standalone-build],
-           [Disable standalone build support.])], r=$disableval, r=no)
+           [Disable standalone build support.])], r=$enableval, r=yes)
 case "$r" in
 no)    wt_cv_disable_standalone_build=no
-       AC_DEFINE(WT_STANDALONE_BUILD);;
-*)     wt_cv_disable_standalone_build=yes;;
+	   AC_MSG_RESULT(yes);;
+*)     wt_cv_disable_standalone_build=yes
+	   AC_DEFINE(WT_STANDALONE_BUILD)
+	   AC_MSG_RESULT(no);;
 esac
-AC_MSG_RESULT($wt_cv_disable_standalone_build)
 
 AC_MSG_CHECKING(if --enable-llvm option specified)
 AC_ARG_ENABLE(llvm,

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -249,17 +249,16 @@ esac
 
 AH_TEMPLATE(WT_STANDALONE_BUILD,
     [Define to 1 to support standalone build.])
-AC_MSG_CHECKING(if --disable-standalone-release option specified)
-AC_ARG_ENABLE(standalone-release,
-       [AS_HELP_STRING([--disable-standalone-release],
-           [Disable standalone release support.])], r=$enableval, r=yes)
+AC_MSG_CHECKING(if --disable-standalone-build option specified)
+AC_ARG_ENABLE(standalone-build,
+       [AS_HELP_STRING([--disable-standalone-build],
+           [Disable standalone build support.])], r=$disableval, r=no)
 case "$r" in
-no)    wt_cv_disable_standalone_release=no
-       AC_MSG_RESULT(yes);;
-*)     wt_cv_disable_standalone_release=yes
-       AC_DEFINE(WT_STANDALONE_BUILD)
-       AC_MSG_RESULT(no);;
+no)    wt_cv_disable_standalone_build=no
+       AC_DEFINE(WT_STANDALONE_BUILD);;
+*)     wt_cv_disable_standalone_build=yes;;
 esac
+AC_MSG_RESULT($wt_cv_disable_standalone_build)
 
 AC_MSG_CHECKING(if --enable-llvm option specified)
 AC_ARG_ENABLE(llvm,

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -248,7 +248,7 @@ no)	wt_cv_crc32_hardware=no
 esac
 
 AH_TEMPLATE(WT_STANDALONE_BUILD,
-    [Define to 1 to support standalone release.])
+    [Define to 1 to support standalone build.])
 AC_MSG_CHECKING(if --disable-standalone-release option specified)
 AC_ARG_ENABLE(standalone-release,
        [AS_HELP_STRING([--disable-standalone-release],

--- a/build_posix/aclocal/options.m4
+++ b/build_posix/aclocal/options.m4
@@ -247,6 +247,20 @@ no)	wt_cv_crc32_hardware=no
 	AC_MSG_RESULT(no);;
 esac
 
+AH_TEMPLATE(WT_STANDALONE_BUILD,
+    [Define to 1 to support standalone release.])
+AC_MSG_CHECKING(if --disable-standalone-release option specified)
+AC_ARG_ENABLE(standalone-release,
+       [AS_HELP_STRING([--disable-standalone-release],
+           [Disable standalone release support.])], r=$enableval, r=yes)
+case "$r" in
+no)    wt_cv_disable_standalone_release=no
+       AC_MSG_RESULT(yes);;
+*)     wt_cv_disable_standalone_release=yes
+       AC_DEFINE(WT_STANDALONE_BUILD)
+       AC_MSG_RESULT(no);;
+esac
+
 AC_MSG_CHECKING(if --enable-llvm option specified)
 AC_ARG_ENABLE(llvm,
 	[AS_HELP_STRING([--enable-llvm],

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -130,7 +130,7 @@
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
-/* Define to 1 to support standalone release. */
+/* Define to 1 to support standalone build. */
 #define WT_STANDALONE_BUILD 1
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most

--- a/build_win/wiredtiger_config.h
+++ b/build_win/wiredtiger_config.h
@@ -130,6 +130,9 @@
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
+/* Define to 1 to support standalone release. */
+#define WT_STANDALONE_BUILD 1
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/src/docs/upgrade.dox
+++ b/src/docs/upgrade.dox
@@ -87,6 +87,7 @@ To downgrade to a previous release of WiredTiger:
 -# Start the old version of the application.
 <br><br>
 -# The database created with version 10.0 cannot be downgraded to older
-   versions.
+   versions because underlying file formats changed between the 10.0.0
+   release and the 3.2.1 release.
 
 */

--- a/src/docs/upgrade.dox
+++ b/src/docs/upgrade.dox
@@ -85,5 +85,8 @@ To downgrade to a previous release of WiredTiger:
 -# Shut down the new version of the application.
 <br><br>
 -# Start the old version of the application.
+<br><br>
+-# The database created with version 10.0 cannot be downgraded to older
+   versions.
 
 */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -12,7 +12,13 @@
 #define WT_BTREE_MAJOR_VERSION_MIN 1 /* Oldest version supported */
 #define WT_BTREE_MINOR_VERSION_MIN 1
 
+/* Increase the version number for standalone build. */
+#ifdef WT_STANDALONE_BUILD
+#define WT_BTREE_MAJOR_VERSION_MAX 2 /* Newest version supported */
+#else
 #define WT_BTREE_MAJOR_VERSION_MAX 1 /* Newest version supported */
+#endif
+
 #define WT_BTREE_MINOR_VERSION_MAX 1
 
 #define WT_BTREE_MIN_ALLOC_SIZE 512

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -12,7 +12,6 @@
 #define WT_BTREE_MAJOR_VERSION_MIN 1 /* Oldest version supported */
 #define WT_BTREE_MINOR_VERSION_MIN 1
 
-
 /* Increase the version number for standalone build. */
 #ifdef WT_STANDALONE_BUILD
 #define WT_BTREE_MAJOR_VERSION_MAX 2 /* Newest version supported */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -12,6 +12,7 @@
 #define WT_BTREE_MAJOR_VERSION_MIN 1 /* Oldest version supported */
 #define WT_BTREE_MINOR_VERSION_MIN 1
 
+
 /* Increase the version number for standalone build. */
 #ifdef WT_STANDALONE_BUILD
 #define WT_BTREE_MAJOR_VERSION_MAX 2 /* Newest version supported */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -111,8 +111,18 @@ __wt_meta_checkpoint(
     /* Retrieve the metadata entry for the file. */
     WT_ERR(__wt_metadata_search(session, fname, &config));
 
+/*
+ * Check for the version mismatch in wiredtiger standalone release when compatibility has not been
+ * configured.
+ */
+#ifdef WT_STANDALONE_BUILD
+    if (!F_ISSET(S2C(session), WT_CONN_COMPATIBILITY))
+        /* Check the major/minor version numbers. */
+        WT_ERR(__ckpt_version_chk(session, fname, config));
+#else
     /* Check the major/minor version numbers. */
     WT_ERR(__ckpt_version_chk(session, fname, config));
+#endif
 
     /*
      * Retrieve the named checkpoint or the last checkpoint.

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -112,7 +112,7 @@ __wt_meta_checkpoint(
     WT_ERR(__wt_metadata_search(session, fname, &config));
 
 /*
- * Check for the version mismatch in wiredtiger standalone release when compatibility has not been
+ * Check for the version mismatch in wiredtiger standalone build when compatibility has not been
  * configured.
  */
 #ifdef WT_STANDALONE_BUILD


### PR DESCRIPTION
The overall changes are 
- Enable WT_STANDALONE_BUILD by default in WiredTiger build.
- Check for a version mismatch if WT_STANDALONE_BUILD is defined and if compatibility has not been configured.
- Add a configuration option --disable-standalone-build to build WiredTiger similar to MongoDB.
- Update documentation page.