### PR TITLE
WT-7234 prefix compressed memory amplification

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -313,7 +313,6 @@ __cursor_row_next(WT_CURSOR_BTREE *cbt, bool newpage, bool restart, size_t *skip
     WT_PAGE *page;
     WT_ROW *rip;
     WT_SESSION_IMPL *session;
-    bool kpack_used;
 
     session = CUR2S(cbt);
     page = cbt->ref->page;
@@ -401,7 +400,7 @@ restart_read_insert:
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
 restart_read_page:
         rip = &page->pg_row[cbt->slot];
-        WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack, &kpack_used));
+        WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack));
         WT_RET(__wt_txn_read(
           session, cbt, &cbt->iface.key, WT_RECNO_OOB, WT_ROW_UPDATE(page, rip), NULL));
         if (cbt->upd_value->type == WT_UPDATE_INVALID) {

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -452,7 +452,6 @@ __cursor_row_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart, size_t *skip
     WT_PAGE *page;
     WT_ROW *rip;
     WT_SESSION_IMPL *session;
-    bool kpack_used;
 
     session = CUR2S(cbt);
     page = cbt->ref->page;
@@ -552,7 +551,7 @@ restart_read_insert:
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
 restart_read_page:
         rip = &page->pg_row[cbt->slot];
-        WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack, &kpack_used));
+        WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack));
         WT_RET(__wt_txn_read(
           session, cbt, &cbt->iface.key, WT_RECNO_OOB, WT_ROW_UPDATE(page, rip), NULL));
         if (cbt->upd_value->type == WT_UPDATE_INVALID) {

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1345,7 +1345,7 @@ __debug_page_row_leaf(WT_DBG *ds, WT_PAGE *page, WT_CURSOR *hs_cursor)
         WT_RET(__wt_row_leaf_key(session, page, rip, ds->key, false));
         WT_RET(__debug_item_key(ds, "K", ds->key->data, ds->key->size));
 
-        __wt_row_leaf_value_cell(session, page, rip, NULL, unpack);
+        __wt_row_leaf_value_cell(session, page, rip, unpack);
         WT_RET(__debug_cell_kv(ds, page, WT_PAGE_ROW_LEAF, "V", unpack));
 
         if ((upd = WT_ROW_UPDATE(page, rip)) != NULL)

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -360,22 +360,12 @@ __free_page_col_var(WT_SESSION_IMPL *session, WT_PAGE *page)
 static void
 __free_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-    WT_IKEY *ikey;
     WT_ROW *rip;
     uint32_t i;
-    void *copy;
 
-    /*
-     * Free the in-memory index array.
-     *
-     * For each entry, see if the key was an allocation (that is, if it points somewhere other than
-     * the original page), and if so, free the memory.
-     */
-    WT_ROW_FOREACH (page, rip, i) {
-        copy = WT_ROW_KEY_COPY(rip);
-        WT_IGNORE_RET_BOOL(__wt_row_leaf_key_info(page, copy, &ikey, NULL, NULL, NULL));
-        __wt_free(session, ikey);
-    }
+    /* Free any allocated memory used by instantiated keys. */
+    WT_ROW_FOREACH (page, rip, i)
+        __wt_row_leaf_key_free(session, page, rip);
 }
 
 /*

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -595,6 +595,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
              * useful entry for the purpose of finding the best group of prefix-compressed keys,
              * either.
              */
+            slot = WT_ROW_SLOT(page, rip);
             if (unpack.prefix == 0) {
                 __wt_row_leaf_key_set(page, rip, &unpack);
 
@@ -603,16 +604,15 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
                     best_prefix_start = prefix_start;
                     best_prefix_stop = prefix_stop;
                     best_prefix_count = prefix_count;
-                    prefix_count = 0;
                 }
+                prefix_count = 0;
+                prefix_start = slot;
             } else {
                 __wt_row_leaf_key_set_cell(page, rip, unpack.cell);
 
                 /* Check for starting or continuing a prefix group. */
-                slot = WT_ROW_SLOT(page, rip);
                 if (prefix_count == 0) {
                     first_prefix = last_prefix = unpack.prefix;
-                    prefix_start = slot - 1;
                     last_slot = prefix_stop = slot;
                     prefix_count = 1;
                 } else if (last_slot == slot - 1 &&

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -545,9 +545,14 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     btree = S2BT(session);
     tombstone = upd = NULL;
-    best_prefix_count = prefix_count = 0;
     last_slot = 0;
     size = total_size = 0;
+
+    /* The code depends on the prefix count variables, other initialization shouldn't matter. */
+    best_prefix_count = prefix_count = 0;
+    first_prefix = last_prefix = 0;           /* [-Wconditional-uninitialized] */
+    prefix_start = prefix_stop = 0;           /* [-Wconditional-uninitialized] */
+    best_prefix_start = best_prefix_stop = 0; /* [-Wconditional-uninitialized] */
 
     /*
      * Optionally instantiate prepared updates. In-memory databases restore non-obsolete updates on

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -603,8 +603,6 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
              */
             slot = WT_ROW_SLOT(page, rip);
             if (unpack.prefix == 0) {
-                __wt_row_leaf_key_set(page, rip, &unpack);
-
                 /* If the last prefix group was the best, track it. */
                 if (prefix_count > best_prefix_count) {
                     best_prefix_start = prefix_start;
@@ -614,8 +612,6 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
                 prefix_count = 0;
                 prefix_start = slot;
             } else {
-                __wt_row_leaf_key_set_cell(page, rip, unpack.cell);
-
                 /* Check for starting or continuing a prefix group. */
                 if (prefix_count == 0 ||
                   (last_slot == slot - 1 && unpack.prefix <= smallest_prefix)) {
@@ -624,12 +620,10 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
                     ++prefix_count;
                 }
             }
-
+            __wt_row_leaf_key_set(page, rip, &unpack);
             ++rip;
             continue;
         case WT_CELL_KEY_OVFL:
-            __wt_row_leaf_key_set_cell(page, rip, unpack.cell);
-
             /*
              * Prefix compression skips overflow items, ignore this slot. The last slot value is
              * only used inside a group of prefix-compressed keys, so blindly increment it, it's not
@@ -637,6 +631,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
              */
             ++last_slot;
 
+            __wt_row_leaf_key_set(page, rip, &unpack);
             ++rip;
             continue;
         case WT_CELL_VALUE:

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -646,7 +646,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page)
               (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
                 (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&
                   __wt_txn_tw_start_visible_all(session, &unpack.tw))))
-                __wt_row_leaf_value_set(page, rip - 1, &unpack);
+                __wt_row_leaf_value_set(rip - 1, &unpack);
             break;
         case WT_CELL_VALUE_OVFL:
             break;

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -100,7 +100,7 @@ __wt_read_row_time_window(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, 
         return;
     }
 
-    __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
+    __wt_row_leaf_value_cell(session, page, rip, &unpack);
     WT_TIME_WINDOW_COPY(tw, &unpack.tw);
 }
 
@@ -166,7 +166,7 @@ __wt_value_return_buf(WT_CURSOR_BTREE *cbt, WT_REF *ref, WT_ITEM *buf, WT_TIME_W
         }
 
         /* Take the value from the original page cell. */
-        __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
+        __wt_row_leaf_value_cell(session, page, rip, &unpack);
         if (tw != NULL)
             WT_TIME_WINDOW_COPY(tw, &unpack.tw);
         return (__wt_page_cell_data_ref(session, page, &unpack, buf));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -91,13 +91,14 @@ __wt_read_row_time_window(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, 
 {
     WT_CELL_UNPACK_KV unpack;
 
-    WT_TIME_WINDOW_INIT(tw);
     /*
-     * If a value is simple and is globally visible at the time of reading a page into cache, we set
-     * the start time point as globally visible.
+     * Simple values are encoded at the time of reading a page into cache, in which case we set the
+     * start time point as globally visible.
      */
-    if (__wt_row_leaf_value_exists(rip))
+    if (__wt_row_leaf_value_is_encoded(rip)) {
+        WT_TIME_WINDOW_INIT(tw);
         return;
+    }
 
     __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
     WT_TIME_WINDOW_COPY(tw, &unpack.tw);

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1993,7 +1993,7 @@ __slvg_row_ovfl(
      */
     for (rip = page->pg_row + start; start < stop; ++start, ++rip) {
         copy = WT_ROW_KEY_COPY(rip);
-        WT_IGNORE_RET_BOOL(__wt_row_leaf_key_info(page, copy, NULL, &cell, NULL, NULL));
+        __wt_row_leaf_key_info(page, copy, NULL, &cell, NULL, NULL, NULL);
         if (cell != NULL) {
             __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
             WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1994,10 +1994,8 @@ __slvg_row_ovfl(
     for (rip = page->pg_row + start; start < stop; ++start, ++rip) {
         copy = WT_ROW_KEY_COPY(rip);
         __wt_row_leaf_key_info(page, copy, NULL, &cell, NULL, NULL, NULL);
-        if (cell != NULL) {
-            __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
-            WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
-        }
+        __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
+        WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
         __wt_row_leaf_value_cell(session, page, rip, &unpack);
         WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
     }

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1998,7 +1998,7 @@ __slvg_row_ovfl(
             __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
             WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
         }
-        __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
+        __wt_row_leaf_value_cell(session, page, rip, &unpack);
         WT_RET(__slvg_row_ovfl_single(session, trk, &unpack));
     }
     return (0);

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -274,7 +274,7 @@ __stat_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **st
         if (upd == NULL || (upd->type != WT_UPDATE_RESERVE && upd->type != WT_UPDATE_TOMBSTONE))
             ++entry_cnt;
         if (upd == NULL) {
-            __wt_row_leaf_value_cell(session, page, rip, NULL, &unpack);
+            __wt_row_leaf_value_cell(session, page, rip, &unpack);
             if (unpack.type == WT_CELL_VALUE_OVFL)
                 ++ovfl_cnt;
         }

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -6,8 +6,6 @@
  * See the file LICENSE for redistribution information.
  */
 
-/* KEITH: reformat the comments. */
-
 #include "wt_internal.h"
 
 static void __inmem_row_leaf_slots(uint8_t *, uint32_t, uint32_t, uint32_t);

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -34,22 +34,18 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /*
-     * Row-store leaf pages are written as one big prefix-compressed chunk,
-     * that is, only the first key on the page is not prefix-compressed, and
-     * to instantiate the last key on the page, you have to take the first
-     * key on the page and roll it forward to the end of the page.  We don't
-     * want to do that on every page access, of course, so we instantiate a
-     * set of keys, essentially creating prefix chunks on the page, where we
-     * can roll forward from the closest, previous, instantiated key.  The
-     * complication is that not all keys on a page are equal: we're doing a
-     * binary search on the  page, which means there are keys we look at a
-     * lot (every time we search the page), and keys we never look at unless
-     * they are actually being searched for.  This function figures out the
-     * "interesting" keys on a page, and then we sequentially walk that list
-     * instantiating those keys.
+     * Row-store leaf pages are written as one big prefix-compressed chunk, that is, only the first
+     * key on the page is not prefix-compressed, and to instantiate the last key on the page, you
+     * have to take the first key on the page and roll it forward to the end of the page. We don't
+     * want to do that on every page access, of course, so we instantiate a set of keys, essentially
+     * creating prefix chunks on the page, where we can roll forward from the closest, previous,
+     * instantiated key. The complication is that not all keys on a page are equal: we're doing a
+     * binary search on the page, which means there are keys we look at a lot (every time we search
+     * the page), and keys we never look at unless they are actually being searched for. This
+     * function figures out the "interesting" keys on a page, and then we sequentially walk that
+     * list instantiating those keys.
      *
-     * Allocate a bit array and figure out the set of "interesting" keys,
-     * marking up the array.
+     * Allocate a bit array and figure out the set of "interesting" keys, marking up the array.
      */
     WT_RET(__wt_scr_alloc(session, 0, &key));
     WT_RET(__wt_scr_alloc(session, (uint32_t)__bitstr_size(page->entries), &tmp));
@@ -85,13 +81,10 @@ __inmem_row_leaf_slots(uint8_t *list, uint32_t base, uint32_t entries, uint32_t 
         return;
 
     /*
-     * !!!
-     * Don't clean this code up -- it deliberately looks like the binary
-     * search code.
+     * Don't clean this code up -- it deliberately looks like the binary search code.
      *
-     * !!!
-     * There's got to be a function that would give me this information, but
-     * I don't see any performance reason we can't just do this recursively.
+     * There's got to be a function that would give me this information, but I don't see any
+     * performance reason we can't just do this recursively.
      */
     limit = entries;
     indx = base + (limit >> 1);
@@ -144,10 +137,8 @@ __wt_row_leaf_key_work(
     const void *key_data;
 
     /*
-     * !!!
-     * It is unusual to call this function: most code should be calling the
-     * front-end, __wt_row_leaf_key, be careful if you're calling this code
-     * directly.
+     * It is unusual to call this function: most code should be calling the front-end,
+     * __wt_row_leaf_key, be careful if you're calling this code directly.
      */
 
     btree = S2BT(session);
@@ -209,12 +200,13 @@ switch_and_jump:
                 goto done;
 
             /*
-             * This key is not an overflow key by definition and
-             * isn't compressed in any way, we can use it to roll
-             * forward.
-             *	If rolling backward, switch directions.
-             *	If rolling forward: there's a bug somewhere,
-             * we should have hit this key when rolling backward.
+             * This key is not an overflow key by definition and isn't compressed in any way, we can
+             * use it to roll forward.
+             *
+             * If rolling backward, switch directions.
+             *
+             * If rolling forward: there's a bug somewhere, we should have hit this key when rolling
+             * backward.
              */
             goto switch_and_jump;
         }
@@ -235,28 +227,28 @@ switch_and_jump:
             }
 
             /*
-             * If we wanted a different key and this key is an
-             * overflow key:
-             *	If we're rolling backward, this key is useless
-             * to us because it doesn't have a valid prefix: keep
-             * rolling backward.
-             *	If we're rolling forward, there's no work to be
-             * done because prefixes skip overflow keys: keep
-             * rolling forward.
+             * If we wanted a different key and this key is an overflow key:
+             *
+             * If we're rolling backward, this key is useless to us because it doesn't have a valid
+             * prefix: keep rolling backward.
+             *
+             * If we're rolling forward, there's no work to be done because prefixes skip overflow
+             * keys: keep rolling forward.
              */
             if (__wt_cell_type(cell) == WT_CELL_KEY_OVFL)
                 goto next;
 
             /*
-             * If we wanted a different key and this key is not an
-             * overflow key, it has a valid prefix, we can use it.
-             *	If rolling backward, take a copy of the key and
-             * switch directions, we can roll forward from this key.
-             *	If rolling forward, replace the key we've been
-             * building with this key, it's what we would have built
-             * anyway.
-             * In short: if it's not an overflow key, take a copy
-             * and roll forward.
+             * If we wanted a different key and this key is not an overflow key, it has a valid
+             * prefix, we can use it.
+             *
+             * If rolling backward, take a copy of the key and switch directions, we can roll
+             * forward from this key.
+             *
+             * If rolling forward, replace the key we've been building with this key, it's what we
+             * would have built anyway.
+             *
+             * In short: if it's not an overflow key, take a copy and roll forward.
              */
             keyb->data = key_data;
             keyb->size = key_size;
@@ -292,12 +284,12 @@ switch_and_jump:
 
             /*
              * If we wanted a different key:
-             *	If we're rolling backward, this key is useless
-             * to us because it doesn't have a valid prefix: keep
-             * rolling backward.
-             *	If we're rolling forward, there's no work to be
-             * done because prefixes skip overflow keys: keep
-             * rolling forward.
+             *
+             * If we're rolling backward, this key is useless to us because it doesn't have a valid
+             * prefix: keep rolling backward.
+             *
+             * If we're rolling forward, there's no work to be done because prefixes skip overflow
+             * keys: keep rolling forward.
              */
             goto next;
         }
@@ -308,20 +300,18 @@ switch_and_jump:
          */
         if (unpack->prefix == 0) {
             /*
-             * If this is the key we originally wanted, we don't
-             * care if we're rolling forward or backward, it's
-             * what we want.  Take a copy and wrap up.
+             * If this is the key we originally wanted, we don't care if we're rolling forward or
+             * backward, it's what we want. Take a copy and wrap up.
              *
-             * If we wanted a different key, this key has a valid
-             * prefix, we can use it.
-             *	If rolling backward, take a copy of the key and
-             * switch directions, we can roll forward from this key.
-             *	If rolling forward there's a bug, we should have
-             * found this key while rolling backwards and switched
-             * directions then.
+             * If we wanted a different key, this key has a valid prefix, we can use it.
              *
-             * The key doesn't need to be instantiated, skip past
-             * that test.
+             * If rolling backward, take a copy of the key and switch directions, we can roll
+             * forward from this key.
+             *
+             * If rolling forward there's a bug, we should have found this key while rolling
+             * backwards and switched directions then.
+             *
+             * The key doesn't need to be instantiated, skip past that test.
              */
             WT_ERR(__wt_dsk_cell_data_ref(session, WT_PAGE_ROW_LEAF, unpack, keyb));
             if (slot_offset == 0)
@@ -336,10 +326,10 @@ switch_and_jump:
 prefix_continue:
         /*
          * 5: an on-page reference to a key that's prefix compressed.
-         *	If rolling backward, keep looking for something we can
-         * use.
-         *	If rolling forward, build the full key and keep rolling
-         * forward.
+         *
+         * If rolling backward, keep looking for something we can use.
+         *
+         * If rolling forward, build the full key and keep rolling forward.
          */
         if (direction == BACKWARD) {
             /*

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -386,7 +386,7 @@ prefix_continue:
              * space, then append the suffix to the prefix already in the buffer.
              *
              * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's
-             * data length to the prefix bytes.
+             * CURRENT data length to the prefix bytes before growing the buffer.
              */
             WT_ASSERT(session, keyb->size >= key_prefix);
             keyb->size = key_prefix;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -975,6 +975,11 @@ __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp, WT_CELL **cel
             *ikeyp = NULL;
         if (cellp != NULL)
             *cellp = (WT_CELL *)WT_PAGE_REF_OFFSET(page, WT_CELL_DECODE_OFFSET(v));
+        if (datap != NULL) {
+            *(void **)datap = NULL;
+            *sizep = 0;
+            *prefixp = 0;
+        }
         return;
     case WT_K_FLAG:
         /* Encoded key: no instantiated key, no cell. */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1083,7 +1083,12 @@ static inline int
 __wt_row_leaf_key(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_ITEM *key, bool instantiate)
 {
-    void *copy;
+    WT_CELL *cell;
+    WT_CELL_UNPACK_KV unpack;
+    size_t pp_size;
+    uint32_t slot;
+    bool pp_key_found;
+    void *copy, *pp_key;
 
     /*
      * A front-end for __wt_row_leaf_key_work, here to inline fast paths.
@@ -1093,12 +1098,37 @@ __wt_row_leaf_key(
     copy = WT_ROW_KEY_COPY(rip);
 
     /*
-     * All we handle here are on-page keys (which should be a common case), and instantiated keys
-     * (which start out rare, but become more common as a leaf page is searched, instantiating
-     * prefix-compressed keys).
+     * Handle on-page keys (which should be a common case), keys built using the page-wide prefix,
+     * and instantiated keys (which are rare initially, but become more common as leaf pages are
+     * searched, instantiating prefix-compressed keys).
      */
-    if (__wt_row_leaf_key_info(page, copy, NULL, NULL, &key->data, &key->size))
+    if (__wt_row_leaf_key_info(page, copy, NULL, &cell, &key->data, &key->size))
         return (0);
+
+    /*
+     * The longest group of compressed key prefixes on the page was tracked when it was read. Build
+     * keys within that group by appending this key's bytes to the key from which it was compressed.
+     * Note the check if the key's prefix is less than or equal to the starting key's length: it's
+     * possible for the prefix to grow and shrink within the group, and we can't build keys with a
+     * prefix larger than the original key's length.
+     */
+    slot = WT_ROW_SLOT(page, rip);
+    if (cell != NULL && slot > page->prefix_start && slot <= page->prefix_stop) {
+        __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
+        WT_RET_PANIC_ASSERT(session, unpack.prefix != 0, WT_PANIC,
+          "key without prefix found in prefix-compressed key group");
+        pp_key_found = __wt_row_leaf_key_info(
+          page, WT_ROW_KEY_COPY(&page->pg_row[page->prefix_start]), NULL, NULL, &pp_key, &pp_size);
+        WT_RET_PANIC_ASSERT(
+          session, pp_key_found, WT_PANIC, "starting key of prefix-compressed key group not found");
+        if (unpack.prefix <= pp_size) {
+            WT_RET(__wt_buf_grow(session, key, unpack.prefix + unpack.size));
+            memcpy((uint8_t *)key->data, pp_key, unpack.prefix);
+            memcpy((uint8_t *)key->data + unpack.prefix, unpack.data, unpack.size);
+            key->size = unpack.prefix + unpack.size;
+            return (0);
+        }
+    }
 
     /*
      * The alternative is an on-page cell with some kind of compressed or overflow key that's never

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1009,7 +1009,7 @@ __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp, WT_CELL **cel
             *(void **)datap =
               WT_PAGE_REF_OFFSET(page, WT_K_DECODE_KEY_CELL_OFFSET(v) + WT_K_DECODE_KEY_OFFSET(v));
             *sizep = WT_K_DECODE_KEY_LEN(v);
-            *prefixp = WT_K_DECODE_KEY_PREFIX(v);
+            *prefixp = (uint8_t)WT_K_DECODE_KEY_PREFIX(v);
         }
         break;
     case WT_KV_FLAG: /* Encoded key/value pair. */
@@ -1021,7 +1021,7 @@ __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp, WT_CELL **cel
             *(void **)datap = WT_PAGE_REF_OFFSET(
               page, WT_KV_DECODE_KEY_CELL_OFFSET(v) + WT_KV_DECODE_KEY_OFFSET(v));
             *sizep = WT_KV_DECODE_KEY_LEN(v);
-            *prefixp = WT_KV_DECODE_KEY_PREFIX(v);
+            *prefixp = (uint8_t)WT_KV_DECODE_KEY_PREFIX(v);
         }
         break;
     default: /* Instantiated key. */

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -446,16 +446,16 @@ __cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)
  *     Return a row-store leaf page slot's key.
  */
 static inline int
-__cursor_row_slot_key_return(
-  WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_CELL_UNPACK_KV *kpack, bool *kpack_used)
+__cursor_row_slot_key_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_CELL_UNPACK_KV *kpack)
 {
     WT_CELL *cell;
     WT_ITEM *kb;
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
+    size_t key_size;
+    uint8_t key_prefix;
     void *copy;
-
-    *kpack_used = false;
+    const void *key_data;
 
     session = CUR2S(cbt);
     page = cbt->ref->page;
@@ -468,47 +468,58 @@ __cursor_row_slot_key_return(
     copy = WT_ROW_KEY_COPY(rip);
 
     /*
-     * Get a key: we could just call __wt_row_leaf_key, but as a cursor is running through the tree,
-     * we may have additional information here (we may have the fully-built key that's immediately
-     * before the prefix-compressed key we want, so it's a faster construction).
-     *
      * First, check for an immediately available key.
      */
-    if (__wt_row_leaf_key_info(page, copy, NULL, &cell, &kb->data, &kb->size))
+    __wt_row_leaf_key_info(page, copy, NULL, &cell, &key_data, &key_size, &key_prefix);
+    if (cell == NULL && key_prefix == 0) {
+        kb->data = key_data;
+        kb->size = key_size;
         return (0);
+    }
 
     /*
-     * Unpack the cell and deal with overflow and prefix-compressed keys. Inline building simple
-     * prefix-compressed keys from a previous key, otherwise build from scratch.
-     *
-     * Clear the key cell structure. It shouldn't be necessary (as far as I can tell, and we don't
-     * do it in lots of other places), but disabling shared builds (--disable-shared) results in the
-     * compiler complaining about uninitialized field use.
+     * Get a key: we could just call __wt_row_leaf_key, but as a cursor is running through the tree,
+     * we may have the fully-built key that's immediately before the prefix-compressed key we want,
+     * so it's a faster construction.
      */
-    memset(kpack, 0, sizeof(*kpack));
-    __wt_cell_unpack_kv(session, page->dsk, cell, kpack);
-    *kpack_used = true;
-    if (kpack->type == WT_CELL_KEY && cbt->rip_saved != NULL && cbt->rip_saved == rip - 1) {
-        WT_ASSERT(session, cbt->row_key->size >= kpack->prefix);
+    if (cbt->rip_saved == NULL || cbt->rip_saved != rip - 1)
+        goto slow;
 
-        /*
-         * Grow the buffer as necessary as well as ensure data has been copied into local buffer
-         * space, then append the suffix to the prefix already in the buffer.
-         *
-         * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's data
-         * length to the prefix bytes.
-         */
-        cbt->row_key->size = kpack->prefix;
-        WT_RET(__wt_buf_grow(session, cbt->row_key, cbt->row_key->size + kpack->size));
-        memcpy((uint8_t *)cbt->row_key->data + cbt->row_key->size, kpack->data, kpack->size);
-        cbt->row_key->size += kpack->size;
-    } else {
-        /*
-         * Call __wt_row_leaf_key_work instead of __wt_row_leaf_key: we already did
-         * __wt_row_leaf_key's fast-path checks inline.
-         */
+    /*
+     * We either have a prefix-compressed on-page key or a reference to the cell. If it's a cell,
+     * unpack it and deal with overflow keys.
+     */
+    if (cell != NULL) {
+        __wt_cell_unpack_kv(session, page->dsk, cell, kpack);
+        if (kpack->type != WT_CELL_KEY)
+            goto slow;
+        key_data = kpack->data;
+        key_size = kpack->size;
+        key_prefix = kpack->prefix;
+    }
+
+    /*
+     * Inline building simple prefix-compressed keys from a previous key.
+     *
+     * Grow the buffer as necessary as well as ensure data has been copied into local buffer space,
+     * then append the suffix to the prefix already in the buffer.
+     *
+     * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's data
+     * length to the prefix bytes.
+     */
+    WT_ASSERT(session, cbt->row_key->size >= key_prefix);
+    WT_RET(__wt_buf_grow(session, cbt->row_key, key_prefix + key_size));
+    memcpy((uint8_t *)cbt->row_key->data + key_prefix, key_data, key_size);
+    cbt->row_key->size = key_prefix + key_size;
+
+    if (0) {
+slow: /*
+       * Call __wt_row_leaf_key_work instead of __wt_row_leaf_key: we already did
+       * __wt_row_leaf_key's fast-path checks inline.
+       */
         WT_RET(__wt_row_leaf_key_work(session, page, rip, cbt->row_key, false));
     }
+
     kb->data = cbt->row_key->data;
     kb->size = cbt->row_key->size;
     cbt->rip_saved = rip;

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -492,7 +492,6 @@ __cursor_row_slot_key_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_CELL_UNPACK_K
      */
     if (cbt->rip_saved == NULL || cbt->rip_saved != rip - 1)
         goto slow;
-    WT_ASSERT(session, cbt->row_key->size >= key_prefix);
 
     /*
      * Inline building simple prefix-compressed keys from a previous key.
@@ -500,9 +499,10 @@ __cursor_row_slot_key_return(WT_CURSOR_BTREE *cbt, WT_ROW *rip, WT_CELL_UNPACK_K
      * Grow the buffer as necessary as well as ensure data has been copied into local buffer space,
      * then append the suffix to the prefix already in the buffer.
      *
-     * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's data
-     * length to the prefix bytes.
+     * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's CURRENT
+     * data length to the prefix bytes before growing the buffer.
      */
+    WT_ASSERT(session, cbt->row_key->size >= key_prefix);
     cbt->row_key->size = key_prefix;
     WT_RET(__wt_buf_grow(session, cbt->row_key, key_prefix + key_size));
     memcpy((uint8_t *)cbt->row_key->data + key_prefix, key_data, key_size);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2242,8 +2242,8 @@ static inline void __wt_row_leaf_key_free(WT_SESSION_IMPL *session, WT_PAGE *pag
 static inline void __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp,
   WT_CELL **cellp, void *datap, size_t *sizep, uint8_t *prefixp);
 static inline void __wt_row_leaf_key_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
-static inline void __wt_row_leaf_value_cell(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
-  WT_CELL_UNPACK_KV *kpack, WT_CELL_UNPACK_KV *vpack);
+static inline void __wt_row_leaf_value_cell(
+  WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *vpack);
 static inline void __wt_row_leaf_value_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
 static inline void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static inline void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1875,11 +1875,9 @@ static inline bool __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_
 static inline bool __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t old_state,
   uint8_t new_state, const char *func, int line) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_ref_is_root(WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp,
-  WT_CELL **cellp, void *datap, size_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_row_leaf_value(WT_PAGE *page, WT_ROW *rip, WT_ITEM *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_row_leaf_value_exists(WT_ROW *rip)
+static inline bool __wt_row_leaf_value_is_encoded(WT_ROW *rip)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_session_can_wait(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2026,6 +2024,9 @@ static inline int __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_row_leaf_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
   WT_ITEM *key, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_row_leaf_key_prefix_group(WT_SESSION_IMPL *session, WT_PAGE *page,
+  WT_ITEM *key, const void *key_data, size_t key_size, uint8_t key_prefix)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_snprintf(char *buf, size_t size, const char *fmt, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 3, 4)))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2237,8 +2238,10 @@ static inline void __wt_rec_incr(
 static inline void __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep);
 static inline void __wt_ref_key_clear(WT_REF *ref);
 static inline void __wt_ref_key_onpage_set(WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK_ADDR *unpack);
+static inline void __wt_row_leaf_key_free(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip);
+static inline void __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **ikeyp,
+  WT_CELL **cellp, void *datap, size_t *sizep, uint8_t *prefixp);
 static inline void __wt_row_leaf_key_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
-static inline void __wt_row_leaf_key_set_cell(WT_PAGE *page, WT_ROW *rip, WT_CELL *cell);
 static inline void __wt_row_leaf_value_cell(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
   WT_CELL_UNPACK_KV *kpack, WT_CELL_UNPACK_KV *vpack);
 static inline void __wt_row_leaf_value_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2024,9 +2024,6 @@ static inline int __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_row_leaf_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
   WT_ITEM *key, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline int __wt_row_leaf_key_prefix_group(WT_SESSION_IMPL *session, WT_PAGE *page,
-  WT_ITEM *key, const void *key_data, size_t key_size, uint8_t key_prefix)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_snprintf(char *buf, size_t size, const char *fmt, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 3, 4)))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2244,7 +2241,7 @@ static inline void __wt_row_leaf_key_info(WT_PAGE *page, void *copy, WT_IKEY **i
 static inline void __wt_row_leaf_key_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
 static inline void __wt_row_leaf_value_cell(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *vpack);
-static inline void __wt_row_leaf_value_set(WT_PAGE *page, WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
+static inline void __wt_row_leaf_value_set(WT_ROW *rip, WT_CELL_UNPACK_KV *unpack);
 static inline void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static inline void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 static inline void __wt_seconds32(WT_SESSION_IMPL *session, uint32_t *secondsp);

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -254,7 +254,7 @@ struct __wt_reconcile {
 
 /* Don't increase key prefix-compression unless there's a significant gain. */
 #define WT_KEY_PREFIX_PREVIOUS_MINIMUM 10
-    u_int key_pfx_last; /* Last prefix compression */
+    uint8_t key_pfx_last; /* Last prefix compression */
 
     bool key_pfx_compress;      /* If can prefix-compress next key */
     bool key_pfx_compress_conf; /* If prefix compression configured */

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -252,6 +252,10 @@ struct __wt_reconcile {
     WT_ITEM *cur, _cur;   /* Key/Value being built */
     WT_ITEM *last, _last; /* Last key/value built */
 
+/* Don't increase key prefix-compression unless there's a significant gain. */
+#define WT_KEY_PREFIX_PREVIOUS_MINIMUM 10
+    u_int key_pfx_last; /* Last prefix compression */
+
     bool key_pfx_compress;      /* If can prefix-compress next key */
     bool key_pfx_compress_conf; /* If prefix compression configured */
     bool key_sfx_compress;      /* If can suffix-compress next key */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -792,7 +792,7 @@ __wt_rec_row_leaf(
         }
 
         /* Unpack the on-page value cell. */
-        __wt_row_leaf_value_cell(session, page, rip, NULL, vpack);
+        __wt_row_leaf_value_cell(session, page, rip, vpack);
 
         /* Look for an update. */
         WT_ERR(__wt_rec_upd_select(session, r, NULL, rip, vpack, &upd_select));

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1010,8 +1010,9 @@ __wt_rec_row_leaf(
              * then append the suffix to the prefix already in the buffer.
              *
              * Don't grow the buffer unnecessarily or copy data we don't need, truncate the item's
-             * data length to the prefix bytes.
+             * CURRENT data length to the prefix bytes before growing the buffer.
              */
+            WT_ASSERT(session, tmpkey->size >= key_prefix);
             tmpkey->size = key_prefix;
             WT_ERR(__wt_buf_grow(session, tmpkey, key_prefix + key_size));
             memcpy((uint8_t *)tmpkey->mem + key_prefix, key_data, key_size);

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -51,8 +51,14 @@ __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size)
         buf->data = buf->mem;
         buf->size = 0;
     } else {
-        if (copy_data)
+        if (copy_data) {
+            /*
+             * It's easy to corrupt memory if you pass in the wrong size for the final buffer size,
+             * which is harder to debug than this assert.
+             */
+            WT_ASSERT(session, buf->size <= buf->memsize);
             memcpy(buf->mem, buf->data, buf->size);
+        }
         buf->data = (uint8_t *)buf->mem + offset;
     }
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -300,7 +300,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
 
         /* Get the full update value from the data store. */
         unpack = &_unpack;
-        __wt_row_leaf_value_cell(session, page, rip, NULL, unpack);
+        __wt_row_leaf_value_cell(session, page, rip, unpack);
     } else {
         /* Unpack a column cell. */
         WT_ERR(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, &key));
@@ -584,7 +584,7 @@ __rollback_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_COL *cip, W
     WT_ASSERT(session, (rip != NULL && cip == NULL) || (rip == NULL && cip != NULL));
 
     if (rip != NULL)
-        __wt_row_leaf_value_cell(session, page, rip, NULL, vpack);
+        __wt_row_leaf_value_cell(session, page, rip, vpack);
     else {
         kcell = WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, kcell, vpack);

--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -113,7 +113,6 @@ wts_load(void)
         bulk_begin_transaction(session);
 
     for (committed_keyno = keyno = 0; ++keyno <= g.c_rows;) {
-        key_gen(&key, keyno);
         val_gen(NULL, &value, keyno);
 
         switch (g.type) {
@@ -132,6 +131,7 @@ wts_load(void)
                 trace_msg("bulk %" PRIu32 " {%.*s}", keyno, (int)value.size, (char *)value.data);
             break;
         case ROW:
+            key_gen(&key, keyno);
             cursor->set_key(cursor, &key);
             cursor->set_value(cursor, &value);
             if (g.trace_all)

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -53,6 +53,7 @@ static void config_map_encryption(const char *, u_int *);
 static void config_map_file_type(const char *, u_int *);
 static void config_map_isolation(const char *, u_int *);
 static void config_pct(void);
+static void config_prefix(void);
 static void config_reset(void);
 static void config_transaction(void);
 
@@ -202,6 +203,7 @@ config_run(void)
     config_compression("btree.compression");
     config_compression("logging.compression");
     config_encryption();
+    config_prefix();
 
     /* Configuration based on the configuration already chosen. */
     config_directio();
@@ -917,6 +919,19 @@ config_pct(void)
 
     testutil_assert(
       g.c_delete_pct + g.c_insert_pct + g.c_modify_pct + g.c_read_pct + g.c_write_pct == 100);
+}
+
+/*
+ * config_prefix --
+ *     Prefix configuration.
+ */
+static void
+config_prefix(void)
+{
+    /* Add prefix compression if prefixes are configured and no explicit choice was made. */
+    if (g.c_prefix != 0 && g.c_prefix_compression == 0 &&
+      !config_is_perm("btree.prefix_compression"))
+        config_single("btree.prefix_compression=on", false);
 }
 
 /*

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -113,6 +113,8 @@ static CONFIG c[] = {
 
   {"btree.memory_page_max", "maximum cache page size", 0x0, 1, 10, 128, &g.c_memory_page_max, NULL},
 
+  {"btree.prefix", "common key prefix", C_BOOL, 5, 0, 0, &g.c_prefix, NULL},
+
   /* 80% */
   {"btree.prefix_compression", "configure prefix compressed keys", C_BOOL, 80, 0, 0,
     &g.c_prefix_compression, NULL},

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -196,6 +196,7 @@ typedef struct {
     uint32_t c_mmap_all;
     uint32_t c_modify_pct;
     uint32_t c_ops;
+    uint32_t c_prefix;
     uint32_t c_prefix_compression;
     uint32_t c_prefix_compression_min;
     uint32_t c_prepare;
@@ -283,6 +284,7 @@ typedef struct {
 
     uint64_t rows; /* Total rows */
 
+    uint32_t prefix_len;         /* Common key prefix length */
     uint32_t key_rand_len[1031]; /* Key lengths */
 } GLOBAL;
 extern GLOBAL g;

--- a/test/format/kv.c
+++ b/test/format/kv.c
@@ -75,6 +75,10 @@ key_init(void)
     for (i = 0; i < WT_ELEMENTS(g.key_rand_len); ++i)
         fprintf(fp, "%" PRIu32 "\n", g.key_rand_len[i]);
     fclose_and_clear(&fp);
+
+    /* Fill in the common key prefix length (which is added to the key min/max). */
+    if (g.c_prefix != 0)
+        g.prefix_len = mmrand(NULL, 15, 80);
 }
 
 /*
@@ -87,7 +91,7 @@ key_gen_init(WT_ITEM *key)
     size_t i, len;
     char *p;
 
-    len = WT_MAX(KILOBYTE(100), g.c_key_max);
+    len = WT_MAX(KILOBYTE(100), g.c_key_max + g.prefix_len);
     p = dmalloc(len);
     for (i = 0; i < len; ++i)
         p[i] = "abcdefghijklmnopqrstuvwxyz"[i % 26];
@@ -111,45 +115,49 @@ key_gen_teardown(WT_ITEM *key)
 
 /*
  * key_gen_common --
- *     Key generation code shared between normal and insert key generation.
+ *     Row-store key generation code shared between normal and insert key generation.
  */
 void
 key_gen_common(WT_ITEM *key, uint64_t keyno, const char *const suffix)
 {
-    int len;
     char *p;
+
+    testutil_assert(g.type == ROW);
 
     p = key->mem;
 
     /*
-     * The key always starts with a 10-digit string (the specified row) followed by two digits, a
-     * random number between 1 and 15 if it's an insert, otherwise 00.
+     * The workload we're trying to mimic with a common prefix is a long path followed by a record
+     * number. Use a leading string of characters. The standard key prefix sorts lexicographically
+     * but will adjust up-and-down by a few bytes as the number increments, causing the common key
+     * prefix to grow and shrink by a few bytes, which is a good thing for testing.
      */
-    u64_to_string_zf(keyno, key->mem, 11);
+    if (g.prefix_len > 0) {
+        memset(p, 'C', g.prefix_len);
+        p += g.prefix_len;
+    }
+
+    /*
+     * After any common prefix, the key starts with a 10-digit string (the specified row) followed
+     * by two digits (a random number between 1 and 15 if it's an insert, otherwise 00).
+     */
+    u64_to_string_zf(keyno, p, 11);
     p[10] = '.';
     p[11] = suffix[0];
     p[12] = suffix[1];
-    len = 13;
+    p[13] = '/';
 
     /*
-     * In a column-store, the key isn't used, it doesn't need a random length.
+     * Because we're doing table lookup for key sizes, we can't set overflow key sizes in the table,
+     * the table isn't big enough to keep our hash from selecting too many big keys and blowing out
+     * the cache. Handle that here, use a really big key 1 in 2500 times.
      */
-    if (g.type == ROW) {
-        p[len] = '/';
-
-        /*
-         * Because we're doing table lookup for key sizes, we weren't able to set really big keys
-         * sizes in the table, the table isn't big enough to keep our hash from selecting too many
-         * big keys and blowing out the cache. Handle that here, use a really big key 1 in 2500
-         * times.
-         */
-        len = keyno % 2500 == 0 && g.c_key_max < KILOBYTE(80) ?
-          KILOBYTE(80) :
-          (int)g.key_rand_len[keyno % WT_ELEMENTS(g.key_rand_len)];
-    }
-
     key->data = key->mem;
-    key->size = (size_t)len;
+    key->size = g.prefix_len;
+    key->size += keyno % 2500 == 0 && g.c_key_max < KILOBYTE(80) ?
+      KILOBYTE(80) :
+      g.key_rand_len[keyno % WT_ELEMENTS(g.key_rand_len)];
+    testutil_assert(key->size <= key->memsize);
 }
 
 static char *val_base;            /* Base/original value */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1346,8 +1346,8 @@ order_error_col:
                  * to the row's key.) Keys are strings with terminating '/' values, so absent key
                  * corruption, we can simply do the underlying string conversion on the key string.
                  */
-                keyno_prev = strtoul(tinfo->key->data, NULL, 10);
-                keyno = strtoul(key.data, NULL, 10);
+                keyno_prev = strtoul((char *)tinfo->key->data + g.prefix_len, NULL, 10);
+                keyno = strtoul((char *)key.data + g.prefix_len, NULL, 10);
                 if (incrementing) {
                     if (keyno_prev != keyno && keyno_prev + 1 != keyno)
                         goto order_error_row;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -319,10 +319,8 @@ create_object(WT_CONNECTION *conn)
         CONFIG_APPEND(p, ",value_format=%" PRIu32 "t", g.c_bitcnt);
         break;
     case ROW:
-        if (g.c_prefix_compression)
-            CONFIG_APPEND(p, ",prefix_compression_min=%" PRIu32, g.c_prefix_compression_min);
-        else
-            CONFIG_APPEND(p, ",prefix_compression=false");
+        CONFIG_APPEND(p, ",prefix_compression=%s,prefix_compression_min=%" PRIu32,
+          g.c_prefix_compression == 0 ? "false" : "true", g.c_prefix_compression_min);
         if (g.c_reverse)
             CONFIG_APPEND(p, ",collator=reverse");
     /* FALLTHROUGH */


### PR DESCRIPTION
Reduce memory amplification for sets of prefix-compressed keys by tracking the "base" key for the longest string of prefix-compressed keys on each row-store leaf page.

Store encoded information about prefix-compressed keys in each row-store leaf page index to avoid decoding cells on every access of a prefix-compressed key.