### PR TITLE
WT-7223 WT_CALL_FUNCTION should not print out a message

### DIFF
--- a/src/os_posix/os_fallocate.c
+++ b/src/os_posix/os_fallocate.c
@@ -20,28 +20,28 @@
  */
 #if defined(HAVE_FALLOCATE) || (defined(__linux__) && defined(SYS_fallocate)) || \
   defined(HAVE_POSIX_FALLOCATE)
-#define WT_CALL_FUNCTION(op)                                                   \
-    do {                                                                       \
-        WT_DECL_RET;                                                           \
-        WT_FILE_HANDLE_POSIX *pfh;                                             \
-        bool remap;                                                            \
-                                                                               \
-        pfh = (WT_FILE_HANDLE_POSIX *)file_handle;                             \
-                                                                               \
-        remap = (offset != pfh->mmap_size);                                    \
-        if (remap)                                                             \
-            __wt_prepare_remap_resize_file(file_handle, wt_session);           \
-                                                                               \
-        WT_SYSCALL_RETRY(op, ret);                                             \
-        if (remap) {                                                           \
-            if (ret == 0)                                                      \
-                __wt_remap_resize_file(file_handle, wt_session);               \
-            else {                                                             \
-                __wt_release_without_remap(file_handle);                       \
-                WT_RET(ret);                                          \
-            }                                                                  \
-        }                                                                      \
-        return (0);                                                            \
+#define WT_CALL_FUNCTION(op)                                         \
+    do {                                                             \
+        WT_DECL_RET;                                                 \
+        WT_FILE_HANDLE_POSIX *pfh;                                   \
+        bool remap;                                                  \
+                                                                     \
+        pfh = (WT_FILE_HANDLE_POSIX *)file_handle;                   \
+                                                                     \
+        remap = (offset != pfh->mmap_size);                          \
+        if (remap)                                                   \
+            __wt_prepare_remap_resize_file(file_handle, wt_session); \
+                                                                     \
+        WT_SYSCALL_RETRY(op, ret);                                   \
+        if (remap) {                                                 \
+            if (ret == 0)                                            \
+                __wt_remap_resize_file(file_handle, wt_session);     \
+            else {                                                   \
+                __wt_release_without_remap(file_handle);             \
+                WT_RET(ret);                                         \
+            }                                                        \
+        }                                                            \
+        return (0);                                                  \
     } while (0)
 #endif
 

--- a/src/os_posix/os_fallocate.c
+++ b/src/os_posix/os_fallocate.c
@@ -24,10 +24,8 @@
     do {                                                                       \
         WT_DECL_RET;                                                           \
         WT_FILE_HANDLE_POSIX *pfh;                                             \
-        WT_SESSION_IMPL *session;                                              \
         bool remap;                                                            \
                                                                                \
-        session = (WT_SESSION_IMPL *)wt_session;                               \
         pfh = (WT_FILE_HANDLE_POSIX *)file_handle;                             \
                                                                                \
         remap = (offset != pfh->mmap_size);                                    \
@@ -40,7 +38,7 @@
                 __wt_remap_resize_file(file_handle, wt_session);               \
             else {                                                             \
                 __wt_release_without_remap(file_handle);                       \
-                WT_RET_MSG(session, ret, "%s: fallocate:", file_handle->name); \
+                WT_RET(ret);                                          \
             }                                                                  \
         }                                                                      \
         return (0);                                                            \


### PR DESCRIPTION
This ticket involves removing the printing of an error message when calling WT_CALL_FUNCTION. WT_CALL_FUNCTION is used for checking suitable `fallocate` functions. The reason is that customers are worried with the error messages that are produced, is that wiredtiger tests multiple `fallocate` solutions, and when they don't exist an ENOTSUP error message is printed towards the logs. 

Therefore it has been requested that the error messages to be removed, to remove confusion. This functionality has been tested with the `mongod` binary inside a testing machine, and successfully removed the messages.
Assumption: System configurations are all setup for ENOTSUPP messages to occur.(For more information refer to ticket).
Steps taken to confirm fix:
1. Tested mongod 4.2 and found no ENOTSUP messages (Expected)
2. Tested mongod 4.4 and found ENOTSUPP messages
3. Tested mongod (with requested changes) and found no ENOTSUPP messages