### PR TITLE
WT-6066 Enable datafile test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2648,9 +2648,9 @@ buildvariants:
     test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
   tasks:
   - name: compile
-  # - name: generate-datafile-little-endian
-  # - name: verify-datafile-little-endian
-  # - name: verify-datafile-from-big-endian
+  - name: generate-datafile-little-endian
+  - name: verify-datafile-little-endian
+  - name: verify-datafile-from-big-endian
 
 - name: big-endian
   display_name: "~ Big-endian (s390x/zSeries)"
@@ -2665,9 +2665,9 @@ buildvariants:
     test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH LD_LIBRARY_PATH=$(pwd)/.lib top_srcdir=$(pwd)/.. top_builddir=$(pwd)
   tasks:
   - name: compile
-  # - name: generate-datafile-big-endian
-  # - name: verify-datafile-big-endian
-  # - name: verify-datafile-from-little-endian
+  - name: generate-datafile-big-endian
+  - name: verify-datafile-big-endian
+  - name: verify-datafile-from-little-endian
 
 - name: ubuntu1804-ppc
   display_name: "~ Ubuntu 18.04 PPC"

--- a/test/evergreen/verify_wt_datafiles.sh
+++ b/test/evergreen/verify_wt_datafiles.sh
@@ -60,7 +60,6 @@ do
 	echo "${d}"
 
 	# Only dump log files if they exist
-	echo "${d}/${log_file_prefix}"
 	if [ -f "${d}/${log_file_prefix}" ]; then
 		${wt_binary} -h ${d} printlog > /dev/null
 		if [ "$?" -ne "0" ]; then

--- a/test/evergreen/verify_wt_datafiles.sh
+++ b/test/evergreen/verify_wt_datafiles.sh
@@ -50,22 +50,16 @@ num_tables_verified=0
 dirs_include_datafile=$(find ./WT_TEST.[0-9]* -type f -name WiredTiger.wt -print0 | xargs -0 dirname)
 echo -e "\n[dirs_include_datafile]:\n${dirs_include_datafile}\n"
 
-# The prefix used for log files
-log_file_prefix="WiredTigerLog.*"
-
 # Loop through each data file under the TEST_DIR
 IFS=$'\n'
 for d in ${dirs_include_datafile}
 do
 	echo "${d}"
 
-	# Only dump log files if they exist
-	if [ -f "${d}/${log_file_prefix}" ]; then
-		${wt_binary} -h ${d} printlog > /dev/null
-		if [ "$?" -ne "0" ]; then
-			echo "Failed to dump '${d}' log files, exiting ..."
-			exit 1
-		fi
+	${wt_binary} -h ${d} printlog > /dev/null
+	if [ "$?" -ne "0" ]; then
+		echo "Failed to dump '${d}' log files, exiting ..."
+		exit 1
 	fi
 
 	tables=$(${wt_binary} -h "${d}" list)

--- a/test/evergreen/verify_wt_datafiles.sh
+++ b/test/evergreen/verify_wt_datafiles.sh
@@ -50,16 +50,23 @@ num_tables_verified=0
 dirs_include_datafile=$(find ./WT_TEST.[0-9]* -type f -name WiredTiger.wt -print0 | xargs -0 dirname)
 echo -e "\n[dirs_include_datafile]:\n${dirs_include_datafile}\n"
 
+# The prefix used for log files
+log_file_prefix="WiredTigerLog.*"
+
 # Loop through each data file under the TEST_DIR
 IFS=$'\n'
 for d in ${dirs_include_datafile}
 do
 	echo "${d}"
 
-	${wt_binary} -h ${d} printlog > /dev/null
-	if [ "$?" -ne "0" ]; then 
-		echo "Failed to dump '${d}' log files, exiting ..."
-		exit 1
+	# Only dump log files if they exist
+	echo "${d}/${log_file_prefix}"
+	if [ -f "${d}/${log_file_prefix}" ]; then
+		${wt_binary} -h ${d} printlog > /dev/null
+		if [ "$?" -ne "0" ]; then
+			echo "Failed to dump '${d}' log files, exiting ..."
+			exit 1
+		fi
 	fi
 
 	tables=$(${wt_binary} -h "${d}" list)

--- a/test/format/CONFIG.endian
+++ b/test/format/CONFIG.endian
@@ -4,3 +4,4 @@ logging.archive=0
 logging=1
 runs.timer=4
 runs.rows=1000000
+runs.type=row-store

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -962,6 +962,12 @@ config_transaction(void)
     if (g.c_logging && config_is_perm("logging")) {
         if (g.c_prepare)
             config_single("ops.prepare=off", false);
+        /* Rollback-to-stable doesn't operate on logged tables. */
+        if (g.c_txn_rollback_to_stable && config_is_perm("transaction.rollback_to_stable"))
+            testutil_die(
+              EINVAL, "rollback to stable and logging can not be configured at the same time");
+        else if (g.c_txn_rollback_to_stable)
+            config_single("transaction.rollback_to_stable=off", false);
     }
 
     /* FIXME-WT-6431: temporarily disable salvage with timestamps. */

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -959,16 +959,8 @@ config_transaction(void)
         if (g.c_txn_freq != 100 && config_is_perm("transaction.frequency"))
             testutil_die(EINVAL, "timestamps require transaction frequency set to 100");
     }
-    if (g.c_logging && config_is_perm("logging")) {
-        if (g.c_prepare)
-            config_single("ops.prepare=off", false);
-        /* Rollback-to-stable doesn't operate on logged tables. */
-        if (g.c_txn_rollback_to_stable && config_is_perm("transaction.rollback_to_stable"))
-            testutil_die(
-              EINVAL, "rollback to stable and logging can not be configured at the same time");
-        else if (g.c_txn_rollback_to_stable)
-            config_single("transaction.rollback_to_stable=off", false);
-    }
+    if (g.c_logging && config_is_perm("logging") && g.c_prepare)
+        config_single("ops.prepare=off", false);
 
     /* FIXME-WT-6431: temporarily disable salvage with timestamps. */
     if (g.c_txn_timestamps && g.c_salvage) {
@@ -1004,8 +996,6 @@ config_transaction(void)
     if (g.c_txn_rollback_to_stable) {
         if (!g.c_txn_timestamps)
             config_single("transaction.timestamps=on", false);
-        if (g.c_logging)
-            config_single("logging=off", false);
     }
     if (g.c_txn_timestamps) {
         if (g.c_isolation_flag != ISOLATION_SNAPSHOT)

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -959,6 +959,10 @@ config_transaction(void)
         if (g.c_txn_freq != 100 && config_is_perm("transaction.frequency"))
             testutil_die(EINVAL, "timestamps require transaction frequency set to 100");
     }
+    if (g.c_logging && config_is_perm("logging")) {
+        if (g.c_prepare)
+            config_single("ops.prepare=off", false);
+    }
 
     /* FIXME-WT-6431: temporarily disable salvage with timestamps. */
     if (g.c_txn_timestamps && g.c_salvage) {


### PR DESCRIPTION
The aim is to enable the tests for Evergreen testing. There are two major changes:
- `format` doesn't support column store configs at the moment and therefore I have disabled them by explicitly adding row-store config.
- Although we have logging selected in config, `format` can override that config if it's incompatible with other randomly selected config options. I have modified the script to look for log files only if they were created.