### PR TITLE
WT-7150 Trailing uninitialized mem in schema_project_in

### DIFF
--- a/src/schema/schema_project.c
+++ b/src/schema/schema_project.c
@@ -113,14 +113,14 @@ __wt_schema_project_in(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *pro
 
                 WT_RET(__pack_size(session, &pv, &len));
                 offset = WT_PTRDIFF(p, buf->mem);
-                WT_RET(__wt_buf_grow(session, buf, buf->size + len));
+                WT_RET(__wt_buf_grow(session, buf, (buf->size + len) - old_len));
                 p = (uint8_t *)buf->mem + offset;
-                end = (uint8_t *)buf->mem + buf->size + len;
+                end = (uint8_t *)buf->mem + (buf->size + len) - old_len;
                 /* Make room if we're inserting out-of-order. */
                 if (offset + old_len < buf->size)
                     memmove(p + len, p + old_len, buf->size - (offset + old_len));
                 WT_RET(__pack_write(session, &pv, &p, len));
-                buf->size += len;
+                buf->size += len - old_len;
                 break;
 
             default:


### PR DESCRIPTION
When performing a schema project on a set of input columns we grow our input cursors buffer with more memory than is required to write out a given applications columns. Whilst this doesn't impact the overall functionality we do create trailing uninitialised memory that will be flagged by Clang's 'msan' as it gets reconciled.

The following changes adjust the buffer allocation calculations to account for when the schema projection is re-using/overwriting the memory of a previously allocated column.