### PR TITLE
WT-7239 Fix unit-test of OS X 10.14 machine.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1425,10 +1425,9 @@ tasks:
   # Start of Python unit test tasks
 
   - name: unit-test
-    depends_on:
-    - name: compile
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
+      - func: "compile wiredtiger"
       - func: "unit test"
 
   - name: unit-test-long

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1425,6 +1425,13 @@ tasks:
   # Start of Python unit test tasks
 
   - name: unit-test
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+
+  - name: unit-test-with-compile
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -2633,7 +2640,7 @@ buildvariants:
       # macos-1012 is a more stable distro that we want to use for our PR testing task
       distros: macos-1012
     - name: make-check-test
-    - name: unit-test
+    - name: unit-test-with-compile
     - name: fops
 
 - name: little-endian


### PR DESCRIPTION
With this change `unit-test` does not depend on the compile task, it gets the project and compiles it in the current machine.