### PR TITLE
WT-7298 Remove LSM references from tiered cursor code

### DIFF
--- a/src/include/tiered.h
+++ b/src/include/tiered.h
@@ -43,6 +43,7 @@ struct __wt_cursor_tiered {
 #define WT_CURTIERED_ACTIVE 0x1u       /* Incremented the session count */
 #define WT_CURTIERED_ITERATE_NEXT 0x2u /* Forward iteration */
 #define WT_CURTIERED_ITERATE_PREV 0x4u /* Backward iteration */
+#define WT_CURTIERED_MULTIPLE 0x8u     /* Multiple cursors have values */
                                        /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint32_t flags;
 };

--- a/test/suite/test_tiered01.py
+++ b/test/suite/test_tiered01.py
@@ -37,17 +37,13 @@ class test_tiered01(wttest.WiredTigerTestCase):
     G = 1024 * M
     uri = "table:test_tiered01"
 
-    chunk_size_scenarios = wtscenario.quick_scenarios('s_chunk_size',
-        [1*M,20*M,None], [0.6,0.6,0.6])
-    # Occasionally add a lot of records, so that merges (and bloom) happen.
+    # Occasionally add a lot of records.
     record_count_scenarios = wtscenario.quick_scenarios(
         'nrecs', [10, 10000], [0.9, 0.1])
 
-    config_vars = [ 'chunk_size', ]
+    config_vars = []
 
-    scenarios = wtscenario.make_scenarios(
-        chunk_size_scenarios, record_count_scenarios,
-        prune=100, prunelong=500)
+    scenarios = wtscenario.make_scenarios(record_count_scenarios, prune=100, prunelong=500)
 
     # Test create of an object.
     def test_tiered(self):


### PR DESCRIPTION
This is a strictly mechanical change that changes "LSM" in comments and variable names to "tiered" and "chunk" to "tier.

I've also removed the chunk_size parameter from test_tiered01.py since tiered tables don't use that value.