### PR TITLE
WT-7302 Use last connection base write generation as a minimum base write generation for a btree

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -534,9 +534,14 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
      * transaction ids are retained only on the pages that are written after the restart.
      *
      * Rollback to stable does not operate on logged tables and metadata, so it is skipped.
+     *
+     * The only scenario where the checkpoint run write generation number is less than the
+     * connection last checkpoint base write generation number is when rollback to stable doesn't
+     * happen during the recovery due to the unavailability of history store file.
      */
     if (!F_ISSET(conn, WT_CONN_RECOVERING) || WT_IS_METADATA(btree->dhandle) ||
-      __wt_btree_immediately_durable(session))
+      __wt_btree_immediately_durable(session) ||
+      ckpt->run_write_gen < conn->last_ckpt_base_write_gen)
         btree->base_write_gen = btree->run_write_gen;
     else
         btree->base_write_gen = ckpt->run_write_gen;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -792,7 +792,6 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     conn->txn_global.recovery_timestamp = conn->txn_global.meta_ckpt_timestamp = WT_TS_NONE;
 
     F_SET(conn, WT_CONN_RECOVERING);
-    WT_ERR(__recovery_set_ckpt_base_write_gen(&r));
     WT_ERR(__wt_metadata_search(session, WT_METAFILE_URI, &config));
     WT_ERR(__recovery_setup_file(&r, WT_METAFILE_URI, config));
     WT_ERR(__wt_metadata_cursor_open(session, NULL, &metac));
@@ -960,6 +959,7 @@ done:
     WT_ERR(__recovery_set_checkpoint_timestamp(&r));
     WT_ERR(__recovery_set_oldest_timestamp(&r));
     WT_ERR(__recovery_set_checkpoint_snapshot(session));
+    WT_ERR(__recovery_set_ckpt_base_write_gen(&r));
 
     /*
      * Perform rollback to stable only when the following conditions met.

--- a/test/suite/test_checkpoint_snapshot04.py
+++ b/test/suite/test_checkpoint_snapshot04.py
@@ -113,6 +113,10 @@ class test_checkpoint_snapshot04(backup_base):
         session1.rollback_transaction()
 
         self.compare_backups(self.uri, self.dir, './')
+        # Due to unavailibility of history store file in targetted backup scenarios,
+        # it is possible that RTS may not occur during the first restart, so compare
+        # the backup again.
+        self.compare_backups(self.uri, self.dir, './')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint_snapshot04.py
+++ b/test/suite/test_checkpoint_snapshot04.py
@@ -114,8 +114,8 @@ class test_checkpoint_snapshot04(backup_base):
 
         self.compare_backups(self.uri, self.dir, './')
         # Due to unavailibility of history store file in targetted backup scenarios,
-        # it is possible that RTS may not occur during the first restart, so compare
-        # the backup again.
+        # RTS doesn't get performed during the first restart, so compare the backup again
+        # to confirm that RTS doesn't change the backup contents.
         self.compare_backups(self.uri, self.dir, './')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use connection base write generation as btree base write generation
when the checkpoint run write generation is less than the last checkpointed
connection base write generation number. This scenario is possible only
when rollback to stable doesn't get performed during the recovery.