### PR TITLE
WT-7060 Set the history store file size stat on startup

### DIFF
--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -84,8 +84,6 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_SESSION_IMPL *tmp_setup_session;
-    wt_off_t hs_size;
-    bool hs_exists;
 
     conn = S2C(session);
     tmp_setup_session = NULL;
@@ -127,15 +125,6 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
      */
     btree->file_max = (uint64_t)cval.val;
     WT_STAT_CONN_SET(session, cache_hs_ondisk_max, btree->file_max);
-
-    /*
-     * Set the history store file size as it may already exist after a restart.
-     */
-    WT_ERR(__wt_fs_exist(session, WT_HS_FILE, &hs_exists));
-    if (hs_exists) {
-        WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
-        WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
-    }
 
 err:
     if (tmp_setup_session != NULL)

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -302,7 +302,8 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
             done.set()
             ckpt.join()
 
-        # Check the history store file size before the simulated crash
+        # Check that the history store file has been used and has non-zero size before the simulated
+        # crash.
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         cache_hs_ondisk = stat_cursor[stat.conn.cache_hs_ondisk][2]
         stat_cursor.close()
@@ -323,7 +324,7 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.session = self.setUpSessionOpen(self.conn)
         self.pr("restart complete")
 
-        # The history store file size should be greater than 0 after the restart
+        # The history store file size should be greater than zero after the restart.
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         cache_hs_ondisk = stat_cursor[stat.conn.cache_hs_ondisk][2]
         stat_cursor.close()


### PR DESCRIPTION
- The history store file size stat is now set in __wt_txn_recover.
- The test test_rollback_to_stable10.py has been edited to check the history store file size stat before and after a simulated crash.