### PR TITLE
WT-7349 Free memory access when walking through HS during eviction

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -894,6 +894,7 @@ indx
 infeasible
 inflateInit
 infmt
+informations
 init
 initCStream
 initializers

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -279,7 +279,12 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
 
         page->modify->obsolete_check_txn = WT_TXN_NONE;
     }
-
+    /* 
+     * We don't want to remove obsolete updates in the history store, 
+     * since another reader might be reading these updates.
+     */
+    if (WT_IS_HS(session->dhandle))
+        return (0);
     /* If we can't lock it, don't scan, that's okay. */
     if (WT_PAGE_TRYLOCK(session, page) != 0)
         return (0);

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -279,9 +279,9 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
 
         page->modify->obsolete_check_txn = WT_TXN_NONE;
     }
-    /* 
-     * We don't want to remove obsolete updates in the history store, 
-     * since another reader might be reading these updates.
+    /*
+     * We don't want to remove obsolete updates in the history store, since another reader might be
+     * reading these updates.
      */
     if (WT_IS_HS(session->dhandle))
         return (0);


### PR DESCRIPTION
This ticket involves removing running **__wt_update_obsolete_check** when dealing with the history store. This is because it is possible that we access freed memory when there are two internal readers reading the history store. The ticket describes the scenario in detail on how this can be possible.