### PR TITLE
WT-7360 Fix batchtime setting for some Evergreen builders

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2616,7 +2616,7 @@ buildvariants:
 
 - name: doc-update
   display_name: "~ Documentation update"
-  batchtime: 10080 # 1 day
+  batchtime: 1440 # 1 day
   run_on:
   - ubuntu1804-test
   tasks:
@@ -2626,7 +2626,7 @@ buildvariants:
 
 - name: linux-no-ftruncate
   display_name: Linux no ftruncate
-  batchtime: 10080 # 1 day
+  batchtime: 1440 # 1 day
   run_on:
   - ubuntu1804-test
   expansions:


### PR DESCRIPTION
The comment and `batchtime` setting conflict with each others. Fix the batchtime setting to line up with the comment (intended testing frequency) for the 2 builders.