### PR TITLE
WT-7361 Remove doc-update task from patch build

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2010,6 +2010,7 @@ tasks:
             env CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:/opt/java/jdk11/bin:$PATH sh s_release `date +%Y%m%d`
 
   - name: doc-update
+    patchable: false
     commands:
       - func: "get project"
       - func: "compile wiredtiger docs"


### PR DESCRIPTION
According to [Evergreen wiki](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#commit-only-patch-only-and-git-tag-only-tasks), the `patchable: false` attribute setting can be used to make a task run only in commit builds (not patch builds). 

The `doc-update` task is such a task that we expect to run only in commit builds. 