### PR TITLE
WT-7374 Add missing branch checking logic for doc-update task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -205,13 +205,19 @@ functions:
     # Use separate shell.exec with "silent" directive to avoid exposing credentail in task log.
     - command: shell.exec
       params:
-        working_dir: "wiredtiger/wiredtiger.github.com"
+        working_dir: "wiredtiger"
         shell: bash
         silent: true
         script: |
           set -o errexit
           set -o verbose
 
+          if [[ "${branch_name}" != "develop" ]]; then
+            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
+            exit 0
+          fi
+
+          cd wiredtiger.github.com
           git push https://${doc-update-github-token}@github.com/wiredtiger/wiredtiger.github.com
   "make check directory":
     command: shell.exec


### PR DESCRIPTION
There is a build failure reported against doc-update [task](https://evergreen.mongodb.com/task/wiredtiger_mongo_v4.4_doc_update_doc_update_8f90c3c2923040725fb424b3a5c510bacc4ce380_21_03_26_04_39_34) on the `mongodb-4.4` branch waterfall page, regarding the non-existent `wiredtiger.github.com` directory. The directory is supposed to be created when checking out the corresponding git repo, only if the task is running on the Evergreen project that's configured for the wiredtiger 'develop' branch. 

The shell that is to run git push command did not have the branch checking logic in place to bypass the remaining code, and ran into this directory-not-found issue. 

The fix is simply adding the branch checking logic in for the affected Evergreen shell. 