### PR TITLE
WT-7376 Initialize tiered cursor name

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1113,8 +1113,11 @@ __wt_cursor_init(
 
     session = CUR2S(cursor);
 
-    if (cursor->internal_uri == NULL)
+    if (cursor->internal_uri == NULL) {
+        /* Various cursor code assumes there is an internal URI, so there better be one to set. */
+        WT_ASSERT(session, uri != NULL);
         WT_RET(__wt_strdup(session, uri, &cursor->internal_uri));
+    }
 
     /*
      * append The append flag is only relevant to column stores.

--- a/src/include/tiered.h
+++ b/src/include/tiered.h
@@ -55,7 +55,7 @@ struct __wt_cursor_tiered {
 struct __wt_tiered {
     WT_DATA_HANDLE iface;
 
-    const char *name, *config, *filename;
+    const char *config, *filename;
     const char *key_format, *value_format;
 
     WT_DATA_HANDLE **tiers;

--- a/src/tiered/tiered_cursor.c
+++ b/src/tiered/tiered_cursor.c
@@ -1142,7 +1142,7 @@ __wt_curtiered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
     cursor = (WT_CURSOR *)curtiered;
     *cursor = iface;
     cursor->session = (WT_SESSION *)session;
-    WT_ERR(__wt_strdup(session, tiered->name, &cursor->uri));
+    WT_ERR(__wt_strdup(session, tiered->iface.name, &cursor->uri));
     cursor->key_format = tiered->key_format;
     cursor->value_format = tiered->value_format;
 


### PR DESCRIPTION
Eliminate the name field of WT_TIERED in favor of the table name/uri which is already stored in the dhandle within WT_TIERED.

Also, since there are multiple places in the cursor code that assume `cursor->uri_internal` hold a valid string, add assert that it is set in `wt_cursor_init()`.
