### PR TITLE
WT-7389 Remove on positioned tiered cursor should leave cursor positioned

### DIFF
--- a/src/tiered/tiered_cursor.c
+++ b/src/tiered/tiered_cursor.c
@@ -818,7 +818,7 @@ __curtiered_put(WT_CURSOR_TIERED *curtiered, const WT_ITEM *key, const WT_ITEM *
     func = primary->insert;
     if (position)
         func = reserve ? primary->reserve : primary->update;
-    if (func != primary->reserve)
+    if (!reserve)
         primary->set_value(primary, value);
     return (func(primary));
 }

--- a/src/tiered/tiered_cursor.c
+++ b/src/tiered/tiered_cursor.c
@@ -796,6 +796,7 @@ __curtiered_put(WT_CURSOR_TIERED *curtiered, const WT_ITEM *key, const WT_ITEM *
 {
     WT_CURSOR *primary;
     WT_TIERED *tiered;
+    int (*func)(WT_CURSOR *);
 
     tiered = curtiered->tiered;
 
@@ -811,14 +812,15 @@ __curtiered_put(WT_CURSOR_TIERED *curtiered, const WT_ITEM *key, const WT_ITEM *
         curtiered->current = primary;
 
     primary->set_key(primary, key);
-    if (reserve) {
-        WT_RET(primary->reserve(primary));
-    } else {
-        primary->set_value(primary, value);
-        WT_RET(primary->insert(primary));
-    }
 
-    return (0);
+    /* Our API always leaves the cursor positioned after a reserve call. */
+    WT_ASSERT(CUR2S(curtiered), !reserve || position);
+    func = primary->insert;
+    if (position)
+        func = reserve ? primary->reserve : primary->update;
+    if (func != primary->reserve)
+        primary->set_value(primary, value);
+    return (func(primary));
 }
 
 /*


### PR DESCRIPTION
Rather than always using `cursor->insert()` to store the tombstone, we should use `insert()` or `update()` according to whether we need to leave the cursor positioned (i.e., whether it was positioned at the time of the `remove()`). This happens in `curtiered_put()` which is the common code for inserting something into the tables under the tiered cursor.

This change basically copies the relevant code from {{clam_put()}}.  After puzzling over what to do for a reserve operation that wants an unpositioned cursor, I realized that's impossible give the current implementation and API. So I've added an ASSERT that this doesn't happen.  