### PR TITLE
WT-7286 Avoid bucket walking when gathering checkpoint handles

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1331,8 +1331,6 @@ extern int __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_search_ckpt_dhandle(WT_SESSION_IMPL *session, const char *checkpoint)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_breakpoint(WT_SESSION *wt_session)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1331,6 +1331,8 @@ extern int __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_search_ckpt_dhandle(WT_SESSION_IMPL *session, const char *checkpoint)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_breakpoint(WT_SESSION *wt_session)

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -404,7 +404,7 @@ int
 __wt_search_ckpt_dhandle(WT_SESSION_IMPL *session, const char *checkpoint)
 {
     if (WT_SESSION_IS_CHECKPOINT(session) && checkpoint != NULL &&
-      WT_PREFIX_MATCH(checkpoint, WT_CHECKPOINT))
+      WT_STRING_MATCH(checkpoint, WT_CHECKPOINT, strlen(WT_CHECKPOINT)))
         return (false);
 
     return (true);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -396,6 +396,21 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_search_ckpt_dhandle --
+ *     Return false if it is a checkpoint thread and checkpoint string is WT_CHECKPOINT else return
+ *     true.
+ */
+int
+__wt_search_ckpt_dhandle(WT_SESSION_IMPL *session, const char *checkpoint)
+{
+    if (WT_SESSION_IS_CHECKPOINT(session) && checkpoint != NULL &&
+      WT_PREFIX_MATCH(checkpoint, WT_CHECKPOINT))
+        return (false);
+
+    return (true);
+}
+
+/*
  * __session_find_shared_dhandle --
  *     Search for a data handle in the connection and add it to a session's cache. We must increment
  *     the handle's reference count while holding the handle list lock.
@@ -405,12 +420,25 @@ __session_find_shared_dhandle(WT_SESSION_IMPL *session, const char *uri, const c
 {
     WT_DECL_RET;
 
-    WT_WITH_HANDLE_LIST_READ_LOCK(session,
-      if ((ret = __wt_conn_dhandle_find(session, uri, checkpoint)) == 0)
-        WT_DHANDLE_ACQUIRE(session->dhandle));
+    /*
+     * Skip walking the session's dhandle cache and connection's list if it is checkpoint thread and
+     * checkpoint string is WT_CHECKPOINT.
+     */
+    if (__wt_search_ckpt_dhandle(session, checkpoint)) {
+        WT_WITH_HANDLE_LIST_READ_LOCK(session,
+          if ((ret = __wt_conn_dhandle_find(session, uri, checkpoint)) == 0)
+            WT_DHANDLE_ACQUIRE(session->dhandle));
 
-    if (ret != WT_NOTFOUND)
-        return (ret);
+        if (ret != WT_NOTFOUND)
+            return (ret);
+    }
+
+#ifdef HAVE_DIAGNOSTIC
+    /* Assert if checkpoint dhandle exists in the connection list before adding it to the list. */
+    WT_WITH_HANDLE_LIST_READ_LOCK(session,
+      if (checkpoint != NULL && (ret = __wt_conn_dhandle_find(session, uri, checkpoint)) == 0)
+        WT_ASSERT(session, __wt_search_ckpt_dhandle(session, checkpoint)));
+#endif
 
     WT_WITH_HANDLE_LIST_WRITE_LOCK(session,
       if ((ret = __wt_conn_dhandle_alloc(session, uri, checkpoint)) == 0)
@@ -428,11 +456,16 @@ __session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *che
 {
     WT_DATA_HANDLE_CACHE *dhandle_cache;
     WT_DECL_RET;
-
-    __session_find_dhandle(session, uri, checkpoint, &dhandle_cache);
-    if (dhandle_cache != NULL) {
-        session->dhandle = dhandle_cache->dhandle;
-        return (0);
+    /*
+     * Skip walking the session's dhandle cache and connection's list if it is checkpoint thread and
+     * checkpoint string is WT_CHECKPOINT.
+     */
+    if (__wt_search_ckpt_dhandle(session, checkpoint)) {
+        __session_find_dhandle(session, uri, checkpoint, &dhandle_cache);
+        if (dhandle_cache != NULL) {
+            session->dhandle = dhandle_cache->dhandle;
+            return (0);
+        }
     }
 
     /* Sweep the handle list to remove any dead handles. */

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -411,6 +411,7 @@ __session_find_shared_dhandle(WT_SESSION_IMPL *session, const char *uri, const c
      * it is guaranteed that the handle won't exist in the shared dhandle list. Skip searching
      * through the list, and directly insert into it.
      */
+
     is_checkpoint = (WT_SESSION_IS_CHECKPOINT(session) && checkpoint != NULL &&
       WT_PREFIX_MATCH(checkpoint, WT_CHECKPOINT));
     if (!is_checkpoint) {
@@ -426,10 +427,10 @@ __session_find_shared_dhandle(WT_SESSION_IMPL *session, const char *uri, const c
          * Let's check our assumption that this handle is not already there in the shared list is
          * actually correct.
          */
-        WT_WITH_HANDLE_LIST_READ_LOCK(session,
-          if ((ret = __wt_conn_dhandle_find(session, uri, checkpoint)) == 0)
-            WT_ASSERT(session, ret != WT_NOTFOUND));
-#endif // HAVE_DIAGNOSTIC
+        WT_WITH_HANDLE_LIST_READ_LOCK(
+          session, ret = __wt_conn_dhandle_find(session, uri, checkpoint));
+        WT_ASSERT(session, ret == WT_NOTFOUND);
+#endif
     }
 
     WT_WITH_HANDLE_LIST_WRITE_LOCK(session,

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -442,14 +442,16 @@ __session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *che
 {
     WT_DATA_HANDLE_CACHE *dhandle_cache;
     WT_DECL_RET;
+    bool is_checkpoint;
 
     /*
      * If we get called as part of the checkpoint, and the handle is the checkpoint to be created,
      * it is guaranteed that the handle won't exist in either session or the shared dhandle list.
      * Skip searching through the session dhandle list.
      */
-    if (WT_SESSION_IS_CHECKPOINT(session) && checkpoint != NULL &&
-      WT_STRING_MATCH(checkpoint, WT_CHECKPOINT, strlen(WT_CHECKPOINT))) {
+    is_checkpoint = (WT_SESSION_IS_CHECKPOINT(session) && checkpoint != NULL &&
+      WT_STRING_MATCH(checkpoint, WT_CHECKPOINT, strlen(WT_CHECKPOINT)));
+    if (!is_checkpoint) {
         __session_find_dhandle(session, uri, checkpoint, &dhandle_cache);
         if (dhandle_cache != NULL) {
             session->dhandle = dhandle_cache->dhandle;


### PR DESCRIPTION
Skip walking the session's dhandle cache and connection's hash bucket if we are the checkpoint thread (via WT_SESSION_IS_CHECKPOINT()) and the checkpoint string prefix matches WT_CHECKPOINT.
Assert that the checkpoint dhandle does not exist in connections list in diagnostic mode after acquiring the lock.