### PR TITLE
WT-6559 Use the session id from the new session to determine statistics bucket (v4.0 backport)

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2113,8 +2113,14 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         session_ret->nhazard = 0;
     }
 
-    /* Cache the offset of this session's statistics bucket. */
-    session_ret->stat_bucket = WT_STATS_SLOT_ID(session);
+    /*
+     * Cache the offset of this session's statistics bucket. It's important we pass the correct
+     * session to the hash define here or we'll calculate the stat bucket with the wrong session id.
+     */
+    session_ret->stat_bucket = WT_STATS_SLOT_ID(session_ret);
+
+    /* Safety check to make sure we're doing the right thing. */
+    WT_ASSERT(session, session_ret->stat_bucket == session_ret->id % WT_COUNTER_SLOTS);
 
     /* Allocate the buffer for operation tracking */
     if (F_ISSET(conn, WT_CONN_OPTRACK)) {


### PR DESCRIPTION
cb2fa3547fa15efcf632426627aedd90e703ed24