### PR TITLE
WT-7414 Create a python test to ensure that all tables that are dropped during backup are exists in the backup

### DIFF
--- a/test/suite/test_backup21.py
+++ b/test/suite/test_backup21.py
@@ -35,7 +35,7 @@ from wtthread import op_thread
 #    Run create/drop operations while backup is ongoing.
 class test_backup21(backup_base):
     # Backup directory name.
-    dir='backup.dir'
+    dir = 'backup.dir'
     uri = 'test_backup21'
     ops = 50
     key_fmt = "S"

--- a/test/suite/test_backup21.py
+++ b/test/suite/test_backup21.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import queue, threading, wiredtiger, wttest
+from wtbackup import backup_base
+from wtscenario import make_scenarios
+from wtthread import op_thread
+
+# test_backup21.py
+#    Run create/drop operations while backup is ongoing.
+# Two scenarios running in parallel while performing backup:
+# 1. Create a new table
+# 2. Drop one the original table
+class test_backup21(backup_base):
+    dir='backup.dir'                    # Backup directory name
+    uri = 'test_backup21'
+    key_fmt = "S"
+
+    scenarios = make_scenarios([
+        ('create_new_table', dict(op='t',key='second',value='value')),
+        ('drop_table', dict(op='d',key='',value=None)),
+    ])
+
+    def test_concurrent_operations_with_backup(self):
+        done = threading.Event()
+        table_uri = 'table:' + self.uri
+
+        # Create and populate the table.
+        self.session.create(table_uri, "key_format=S,value_format=S")
+        self.add_data(table_uri, 'key', 'value', True)
+
+        work_queue = queue.Queue()
+        t = op_thread(self.conn, [table_uri], self.key_fmt, work_queue, done)
+        # Open backup cursor.
+        bkup_c = self.session.open_cursor('backup:', None, None)
+        try:
+            t.start()
+            # Place create or drop operation into work queue
+            work_queue.put_nowait((self.op, self.key, self.value))
+
+            all_files = self.take_full_backup(self.dir, bkup_c)
+            if self.op == 't':
+                # newly created table shouldn't be present in backup
+                self.assertTrue(self.uri + "second.wt" not in all_files)
+            else:
+                # dropped table should still be present in backup
+                self.assertTrue(self.uri + ".wt" in all_files)
+        except:
+            # Deplete the work queue if there's an error.
+            while not work_queue.empty():
+                work_queue.get()
+                work_queue.task_done()
+            raise
+        finally:
+            work_queue.join()
+            done.set()
+            t.join()
+        bkup_c.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_backup21.py
+++ b/test/suite/test_backup21.py
@@ -34,7 +34,8 @@ from wtthread import op_thread
 # test_backup21.py
 #    Run create/drop operations while backup is ongoing.
 class test_backup21(backup_base):
-    dir='backup.dir'                    # Backup directory name.
+    # Backup directory name.
+    dir='backup.dir'
     uri = 'test_backup21'
     ops = 50
     key_fmt = "S"

--- a/test/suite/test_backup21.py
+++ b/test/suite/test_backup21.py
@@ -49,13 +49,13 @@ class test_backup21(backup_base):
 
         work_queue = queue.Queue()
         t = op_thread(self.conn, [table_uri], self.key_fmt, work_queue, done)
-        # Open backup cursor.
         try:
             t.start()
             # Place create or drop operation into work queue.
             iteration = 0
             op = 't'
-            for i in range(0, self.ops):
+            for _ in range(0, self.ops):
+                # Open backup cursor.
                 bkup_c = self.session.open_cursor('backup:', None, None)
                 work_queue.put_nowait((op, str(iteration), 'value'))
 

--- a/test/suite/test_backup21.py
+++ b/test/suite/test_backup21.py
@@ -58,7 +58,7 @@ class test_backup21(backup_base):
             for i in range(0, self.ops):
                 bkup_c = self.session.open_cursor('backup:', None, None)
                 work_queue.put_nowait((op, str(iteration), 'value'))
-                
+
                 all_files = self.take_full_backup(self.dir, bkup_c)
                 if op == 't':
                     # Newly created table shouldn't be present in backup.

--- a/test/suite/test_import10.py
+++ b/test/suite/test_import10.py
@@ -87,7 +87,7 @@ class test_import10(backup_base):
         cursor.close()
 
         all_files = self.take_full_backup(self.dir, bkup_c)
-        self.assertTrue(self.uri + "wt" not in all_files)
+        self.assertTrue(self.uri + ".wt" not in all_files)
         bkup_c.close()
 
 if __name__ == '__main__':

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -153,6 +153,7 @@ class op_thread(threading.Thread):
                             sess.drop(self.uris[0] + str(key))
                             break
                         except wiredtiger.WiredTigerError as e:
+                            #print("continued... " + self.uris[0] + str(key))
                             continue
                 elif op == 't': # Create a table, add an entry
                     sess.create(self.uris[0] + str(key),

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -153,7 +153,6 @@ class op_thread(threading.Thread):
                             sess.drop(self.uris[0] + str(key))
                             break
                         except wiredtiger.WiredTigerError as e:
-                            #print("continued... " + self.uris[0] + str(key))
                             continue
                 elif op == 't': # Create a table, add an entry
                     sess.create(self.uris[0] + str(key),


### PR DESCRIPTION
This ticket involves creating a python test to testing create/drop operations while a backup is ongoing. The behaviour is that no changes should occur while analysing the backup cursor files. 