### PR TITLE
WT-7373 Investigate slow random cursor operations on oplog

### DIFF
--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -290,10 +290,11 @@ __random_leaf(WT_CURSOR_BTREE *cbt)
         return (__cursor_kv_return(cbt, cbt->upd_value));
 
     /*
-     * Try again if there are at least a few hundred disk-based entries: this may be a normal leaf
-     * page with big items.
+     * Try again if there are at least a few hundred disk-based entries or this is a page as we read
+     * it from disk, it might be a normal leaf page with big items.
      */
-    if (cbt->ref->page->entries > WT_RANDOM_DISK_ENOUGH / 2) {
+    if (cbt->ref->page->entries > WT_RANDOM_DISK_ENOUGH / 5 ||
+      (cbt->ref->page->dsk != NULL && cbt->ref->page->modify == NULL)) {
         WT_RET(__random_leaf_disk(cbt, &valid));
         if (valid)
             return (__cursor_kv_return(cbt, cbt->upd_value));


### PR DESCRIPTION
If the tree is entirely populated with large items (MongoDB configures the maximum leaf page item to avoid overflow objects), we can still end up reading huge amounts of data on every random cursor sample. If the page is clean (that is, just read from disk), it can't be fully populated with deleted items, use it as our sample.