### PR TITLE
WT-7419 Tiered local storage changes to use WT file system.

### DIFF
--- a/ext/storage_sources/local_store/local_store.c
+++ b/ext/storage_sources/local_store/local_store.c
@@ -311,12 +311,11 @@ local_is_flushed(LOCAL_STORAGE *local, WT_SESSION *session, const char *name, bo
     struct stat sb;
     int ret;
 
-    ret = stat(name, &sb);
-
     /*
      * If a file is not flushed, it must exist locally. Therefore if it doesn't exist locally (and
-     * we knew its name via metadata), then it must be flushed, and locally removed.
+     * we know it exists somewhere), then it must have been flushed, and locally removed.
      */
+    ret = stat(name, &sb);
     if (ret == ENOENT) {
         *flushedp = true;
         ret = 0;

--- a/ext/storage_sources/local_store/local_store.c
+++ b/ext/storage_sources/local_store/local_store.c
@@ -320,8 +320,8 @@ local_writeable(LOCAL_STORAGE *local, WT_SESSION *session, const char *name, boo
         *writeablep = ((sb.st_mode & 0222) != 0);
     } else if (errno == ENOENT) {
         /*
-         * Does not exist locally.  It could be in the cloud,
-         * at any rate it is not writeable, but not an error.
+         * Does not exist locally. It could be in the cloud, at any rate it is not writeable, but
+         * not an error.
          */
         ret = 0;
     } else if (ret != 0)

--- a/ext/storage_sources/local_store/local_store.c
+++ b/ext/storage_sources/local_store/local_store.c
@@ -182,8 +182,6 @@ static int local_file_write(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, co
  * macro will too.
  */
 #define FS2LOCAL(fs) (((LOCAL_FILE_SYSTEM *)(fs))->local_storage)
-#define local_file_err(fh, session, ret, str) \
-    local_err((fh)->local, session, ret, "\"%s\": %s", fh->iface.name, str)
 
 #define VERBOSE(local, ...)               \
     do {                                  \

--- a/ext/storage_sources/local_store/local_store.c
+++ b/ext/storage_sources/local_store/local_store.c
@@ -94,6 +94,7 @@ typedef struct {
 typedef struct {
     WT_FILE_SYSTEM file_system; /* Must come first */
     LOCAL_STORAGE *local_storage;
+    WT_FILE_SYSTEM *wt_fs; /* WiredTiger's file system */
 
     char *auth_token; /* Identifier for key management system */
     char *bucket;     /* Actually a directory path for local implementation */
@@ -104,8 +105,7 @@ typedef struct {
  * Indicates a object that has not yet been flushed.
  */
 typedef struct local_flush_item {
-    char *src_path;    /* File name to copy from, object name derived from this */
-    char *marker_path; /* Marker name to remove when done */
+    char *src_path; /* File name to copy from, object name derived from this */
 
     /*
      * These fields would be used in performing a flush.
@@ -120,9 +120,8 @@ typedef struct local_file_handle {
     WT_FILE_HANDLE iface; /* Must come first */
 
     LOCAL_STORAGE *local;    /* Enclosing storage source */
-    int fd;                  /* File descriptor */
+    WT_FILE_HANDLE *fh;      /* File handle */
     char *path;              /* Path name of file */
-    char *temp_path;         /* Temporary (hidden) name, set if newly created */
     LOCAL_FLUSH_ITEM *flush; /* Flush information, set if newly created */
 
     TAILQ_ENTRY(local_file_handle) q; /* Queue of handles */
@@ -136,7 +135,8 @@ static int local_configure_int(LOCAL_STORAGE *, WT_CONFIG_ARG *, const char *, u
 static int local_delay(LOCAL_STORAGE *);
 static int local_err(LOCAL_STORAGE *, WT_SESSION *, int, const char *, ...);
 static void local_flush_free(LOCAL_FLUSH_ITEM *);
-static int local_location_path(WT_FILE_SYSTEM *, const char *, const char *, char **);
+static int local_is_flushed(LOCAL_STORAGE *, WT_SESSION *, const char *, bool *);
+static int local_location_path(WT_FILE_SYSTEM *, const char *, char **);
 
 /*
  * Forward function declarations for storage source API implementation
@@ -170,7 +170,7 @@ static int local_size(WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *);
  * Forward function declarations for file handle API implementation
  */
 static int local_file_close(WT_FILE_HANDLE *, WT_SESSION *);
-static int local_file_close_internal(LOCAL_STORAGE *, WT_SESSION *, LOCAL_FILE_HANDLE *, bool);
+static int local_file_close_internal(LOCAL_STORAGE *, WT_SESSION *, LOCAL_FILE_HANDLE *);
 static int local_file_lock(WT_FILE_HANDLE *, WT_SESSION *, bool);
 static int local_file_read(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, void *);
 static int local_file_size(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t *);
@@ -191,22 +191,6 @@ static int local_file_write(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t, size_t, co
             fprintf(stderr, __VA_ARGS__); \
     } while (0);
 #define SHOW_STRING(s) (((s) == NULL) ? "<null>" : (s))
-
-/*
- * Some files are created with "marker" prefixes in their name.
- *
- * When an object is created and the file handle has not been closed, the contents are written into
- * a file marked as temporary. When that file handle closes, the temporary file will be renamed to
- * its final name, without the marker. At that point the object becomes "visible" to other API
- * calls.
- *
- * Additionally, when an object is created, an empty marker file is created that indicates that the
- * file will need to be flushed (transferred to the cloud). That empty marker file is removed when
- * the object has been flushed. We already track in memory what objects need to be flushed, but
- * having a file representation gives us a record of what needs to be done if we were to crash.
- */
-static const char *MARKER_NEED_FLUSH = "FLUSH_";
-static const char *MARKER_TEMPORARY = "TEMP_";
 
 /*
  * local_configure
@@ -314,10 +298,39 @@ local_flush_free(LOCAL_FLUSH_ITEM *flush)
     if (flush != NULL) {
         free(flush->auth_token);
         free(flush->bucket);
-        free(flush->marker_path);
         free(flush->src_path);
         free(flush);
     }
+}
+
+/*
+ * local_is_flushed --
+ *     Check if a file has been flushed.
+ */
+static int
+local_is_flushed(LOCAL_STORAGE *local, WT_SESSION *session, const char *name, bool *flushedp)
+{
+    struct stat sb;
+    int ret;
+
+    ret = stat(name, &sb);
+
+    /*
+     * If a file is not flushed, it must exist locally. Therefore if it doesn't exist locally (and
+     * we knew its name via metadata), then it must be flushed, and locally removed.
+     */
+    if (ret == ENOENT) {
+        *flushedp = true;
+        ret = 0;
+    } else if (ret != 0)
+        ret = local_err(local, session, errno, "%s: ss_rename stat", name);
+    else
+        /*
+         * Check the write bits. If the file is not writeable, it has been flushed.
+         */
+        *flushedp = ((sb.st_mode & 0x222) == 0);
+
+    return (ret);
 }
 
 /*
@@ -325,7 +338,7 @@ local_flush_free(LOCAL_FLUSH_ITEM *flush)
  *     Construct a pathname from the file system and local name.
  */
 int
-local_location_path(WT_FILE_SYSTEM *file_system, const char *name, const char *marker, char **pathp)
+local_location_path(WT_FILE_SYSTEM *file_system, const char *name, char **pathp)
 {
     LOCAL_FILE_SYSTEM *local_fs;
     size_t len;
@@ -335,14 +348,10 @@ local_location_path(WT_FILE_SYSTEM *file_system, const char *name, const char *m
     ret = 0;
     local_fs = (LOCAL_FILE_SYSTEM *)file_system;
 
-    /* If this is a marker file, it will be hidden from all namespaces. */
-    if (marker == NULL)
-        marker = "";
-    len =
-      strlen(local_fs->bucket) + strlen(marker) + strlen(local_fs->fs_prefix) + strlen(name) + 2;
+    len = strlen(local_fs->bucket) + strlen(local_fs->fs_prefix) + strlen(name) + 2;
     if ((p = malloc(len)) == NULL)
         return (local_err(FS2LOCAL(file_system), NULL, ENOMEM, "local_location_path"));
-    snprintf(p, len, "%s/%s%s%s", local_fs->bucket, marker, local_fs->fs_prefix, name);
+    snprintf(p, len, "%s/%s%s", local_fs->bucket, local_fs->fs_prefix, name);
     *pathp = p;
     return (ret);
 }
@@ -358,6 +367,7 @@ local_customize_file_system(WT_STORAGE_SOURCE *storage_source, WT_SESSION *sessi
 {
     LOCAL_STORAGE *local;
     LOCAL_FILE_SYSTEM *fs;
+    WT_FILE_SYSTEM *wt_fs;
     int ret;
 
     local = (LOCAL_STORAGE *)storage_source;
@@ -367,11 +377,17 @@ local_customize_file_system(WT_STORAGE_SOURCE *storage_source, WT_SESSION *sessi
     if (config != NULL)
         return local_err(local, session, EINVAL, "customize file system: config must be NULL");
 
+    if ((ret = local->wt_api->file_system_get(local->wt_api, session, &wt_fs)) != 0) {
+        ret =
+          local_err(local, session, ret, "local_file_system: cannot get WiredTiger file system");
+        goto err;
+    }
     if ((fs = calloc(1, sizeof(LOCAL_FILE_SYSTEM))) == NULL) {
         ret = local_err(local, session, ENOMEM, "local_file_system");
         goto err;
     }
     fs->local_storage = local;
+    fs->wt_fs = wt_fs;
 
     if ((fs->auth_token = strdup(auth_token)) == NULL) {
         ret = local_err(local, session, ENOMEM, "local_file_system.auth_token");
@@ -419,7 +435,7 @@ local_exist(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name, 
     path = NULL;
 
     local->op_count++;
-    if ((ret = local_location_path(file_system, name, NULL, &path)) != 0)
+    if ((ret = local_location_path(file_system, name, &path)) != 0)
         goto err;
 
     ret = stat(path, &sb);
@@ -464,7 +480,7 @@ local_flush(WT_STORAGE_SOURCE *storage_source, WT_SESSION *session, WT_FILE_SYST
 
     local->op_count++;
     if (file_system != NULL) {
-        if ((ret = local_location_path(file_system, name == NULL ? "" : name, NULL, &match)) != 0)
+        if ((ret = local_location_path(file_system, name == NULL ? "" : name, &match)) != 0)
             goto err;
     }
     VERBOSE(local, "Flush: match=%s\n", SHOW_STRING(match));
@@ -544,10 +560,9 @@ local_flush_one(LOCAL_STORAGE *local, WT_SESSION *session, LOCAL_FLUSH_ITEM *flu
         if ((ret = local_delay(local)) != 0)
             return (ret);
     }
-    /* When we're done with flushing this file, remove the flush marker file. */
-    if (ret == 0 && (ret = unlink(flush->marker_path)) < 0)
-        ret = local_err(
-          local, session, errno, "%s: unlink flush marker file failed", flush->marker_path);
+    /* When we're done with flushing this file, set the file to readonly. */
+    if (ret == 0 && (ret = chmod(flush->src_path, 0444)) < 0)
+        ret = local_err(local, session, errno, "%s: chmod flushed file failed", flush->src_path);
 
     return (ret);
 }
@@ -599,7 +614,7 @@ local_directory_list_free(
 
 /*
  * local_location_list_internal --
- *     Return a list of object names for the given location, matching the given marker if needed.
+ *     Return a list of object names for the given location.
  */
 static int
 local_directory_list_internal(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
@@ -638,11 +653,6 @@ local_directory_list_internal(WT_FILE_SYSTEM *file_system, WT_SESSION *session,
         /* Skip . and .. */
         basename = dp->d_name;
         if (strcmp(basename, ".") == 0 || strcmp(basename, "..") == 0)
-            continue;
-
-        /* Skip over any marker files. */
-        if (strncmp(basename, MARKER_TEMPORARY, strlen(MARKER_TEMPORARY)) == 0 ||
-          strncmp(basename, MARKER_NEED_FLUSH, strlen(MARKER_NEED_FLUSH)) == 0)
             continue;
 
         /* Match only the indicated directory files. */
@@ -729,58 +739,58 @@ local_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name,
     LOCAL_FILE_SYSTEM *local_fs;
     LOCAL_FLUSH_ITEM *flush;
     LOCAL_STORAGE *local;
-    WT_FILE_HANDLE *file_handle;
-    int fd, oflags, ret;
-    char *open_name;
+    WT_FILE_HANDLE *file_handle, *wt_fh;
+    WT_FILE_SYSTEM *wt_fs;
+    struct stat sb;
+    int ret;
+    bool exists;
 
     (void)flags; /* Unused */
 
-    fd = oflags = ret = 0;
+    ret = 0;
     *file_handlep = NULL;
     local_fh = NULL;
     local_fs = (LOCAL_FILE_SYSTEM *)file_system;
     local = local_fs->local_storage;
+    wt_fs = local_fs->wt_fs;
 
-    if (file_type != WT_FS_OPEN_FILE_TYPE_DATA)
-        return (
-          local_err(local, session, EINVAL, "%s: open: only data file types supported", name));
-
-    local->op_count++;
-    if (flags == WT_FS_OPEN_CREATE)
-        oflags = O_WRONLY | O_CREAT;
-    else if (flags == WT_FS_OPEN_READONLY)
-        oflags = O_RDONLY;
-    else
-        return (local_err(local, session, EINVAL, "open: invalid flags: 0x%x", flags));
+    /*
+     * If needed we could relax this, and allow opens of other kinds of files to use the regular
+     * WiredTiger file system.
+     */
+    if (file_type != WT_FS_OPEN_FILE_TYPE_DATA && file_type != WT_FS_OPEN_FILE_TYPE_REGULAR)
+        return (local_err(
+          local, session, EINVAL, "%s: open: only data file and regular types supported", name));
 
     /* Create a new handle. */
     if ((local_fh = calloc(1, sizeof(LOCAL_FILE_HANDLE))) == NULL) {
         ret = ENOMEM;
         goto err;
     }
-    if ((ret = local_location_path(file_system, name, NULL, &local_fh->path)) != 0)
+    if ((ret = local_location_path(file_system, name, &local_fh->path)) != 0)
         goto err;
-    if (flags == WT_FS_OPEN_CREATE) {
+
+    ret = stat(local_fh->path, &sb);
+    if (ret != 0 && errno != ENOENT)
+        ret = local_err(local, session, errno, "%s: local_open stat", local_fh->path);
+    exists = (ret == 0);
+
+    /*
+     * TODO: tiered: If the file doesn't exist locally, make a copy of it from the cloud here.
+     *
+     */
+#if 0
+    if ((flags & WT_FS_OPEN_READONLY) != 0 && !exists) {
+    }
+#endif
+
+    if ((flags & WT_FS_OPEN_CREATE) != 0 && !exists) {
         if ((flush = calloc(1, sizeof(LOCAL_FLUSH_ITEM))) == NULL) {
             ret = ENOMEM;
             goto err;
         }
         local_fh->flush = flush;
 
-        /*
-         * Create a marker file that indicates that the file will need to be flushed.
-         */
-        if ((ret = local_location_path(
-               file_system, name, MARKER_NEED_FLUSH, &flush->marker_path)) != 0)
-            goto err;
-        if ((fd = open(flush->marker_path, O_WRONLY | O_CREAT, 0666)) < 0) {
-            ret = local_err(local, session, errno, "ss_open_object: open: %s", flush->marker_path);
-            goto err;
-        }
-        if (close(fd) < 0) {
-            ret = local_err(local, session, errno, "ss_open_object: close: %s", flush->marker_path);
-            goto err;
-        }
         if ((flush->auth_token = strdup(local_fs->auth_token)) == NULL) {
             ret = local_err(local, session, ENOMEM, "open.auth_token");
             goto err;
@@ -789,25 +799,13 @@ local_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name,
             ret = local_err(local, session, ENOMEM, "open.bucket");
             goto err;
         }
+    }
 
-        /*
-         * For the file handle, we will be writing into a file marked as temporary. When the handle
-         * is closed, we'll move it to its final name.
-         */
-        if ((ret = local_location_path(
-               file_system, name, MARKER_TEMPORARY, &local_fh->temp_path)) != 0)
-            goto err;
-
-        open_name = local_fh->temp_path;
-    } else
-        open_name = local_fh->path;
-
-    /* Set file mode so it can only be reopened as readonly. */
-    if ((fd = open(open_name, oflags, 0444)) < 0) {
-        ret = local_err(local, session, errno, "ss_open_object: open: %s", open_name);
+    if ((wt_fs->fs_open_file(wt_fs, session, local_fh->path, file_type, flags, &wt_fh)) < 0) {
+        ret = local_err(local, session, errno, "ss_open_object: open: %s", local_fh->path);
         goto err;
     }
-    local_fh->fd = fd;
+    local_fh->fh = wt_fh;
     local_fh->local = local;
 
     /* Initialize public information. */
@@ -849,31 +847,89 @@ local_open(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name,
 
     *file_handlep = file_handle;
 
-    VERBOSE(local, "File opened: %s final path=%s, temp path=%s\n", SHOW_STRING(name),
-      SHOW_STRING(local_fh->path), SHOW_STRING(local_fh->temp_path));
+    VERBOSE(
+      local, "File opened: %s final path=%s\n", SHOW_STRING(name), SHOW_STRING(local_fh->path));
 
 err:
     if (ret != 0) {
         if (local_fh != NULL)
-            local_file_close_internal(local, session, local_fh, true);
+            local_file_close_internal(local, session, local_fh);
     }
     return (ret);
 }
 
 /*
  * local_rename --
- *     POSIX rename. Currently not implemented, as cloud implementations may not support it.
+ *     POSIX rename. This must work for files not yet flushed to the cloud. If a file has been
+ *     flushed, we don't support this operation, as cloud implementations may not support it.
  */
 static int
 local_rename(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *from, const char *to,
   uint32_t flags)
 {
+    LOCAL_FILE_SYSTEM *local_fs;
+    LOCAL_FLUSH_ITEM *flush;
+    LOCAL_STORAGE *local;
+    WT_FILE_SYSTEM *wt_fs;
+    int ret, t_ret;
+    char *copy, *from_path, *to_path;
+    bool flushed;
 
-    (void)from;  /* Unused */
-    (void)to;    /* Unused */
-    (void)flags; /* Unused */
+    local = FS2LOCAL(file_system);
+    local_fs = (LOCAL_FILE_SYSTEM *)file_system;
+    wt_fs = local_fs->wt_fs;
+    from_path = to_path = NULL;
+    flushed = false;
 
-    return (local_err(FS2LOCAL(file_system), session, ENOTSUP, "local remove not supported"));
+    local->op_count++;
+    if ((ret = local_location_path(file_system, from, &from_path)) != 0)
+        goto err;
+    if ((ret = local_is_flushed(local, session, from_path, &flushed)) != 0)
+        goto err;
+    if (flushed) {
+        ret = local_err(
+          FS2LOCAL(file_system), session, ENOTSUP, "%s: rename of flushed file not allowed", from);
+        goto err;
+    }
+    if ((ret = local_location_path(file_system, to, &to_path)) != 0)
+        goto err;
+
+    if ((ret = wt_fs->fs_rename(wt_fs, session, from_path, to_path, flags)) != 0) {
+        ret = local_err(FS2LOCAL(file_system), session, ret, "fs_rename");
+        goto err;
+    }
+
+    /*
+     * Find any flush entry that matches, and rename that too.
+     */
+    if ((ret = pthread_rwlock_wrlock(&local->flush_lock)) != 0) {
+        ret = local_err(local, session, ret, "ss_remove: pthread_rwlock_wrlock");
+        goto err;
+    }
+
+    TAILQ_FOREACH (flush, &local->flushq, q) {
+        if (strcmp(flush->src_path, from_path) == 0) {
+            if ((copy = strdup(to_path)) == NULL)
+                ret = ENOMEM;
+            else {
+                free(flush->src_path);
+                flush->src_path = to_path;
+            }
+            break;
+        }
+    }
+
+    if ((t_ret = pthread_rwlock_unlock(&local->flush_lock)) != 0) {
+        (void)local_err(local, session, t_ret, "ss_remove: pthread_rwlock_unlock");
+        if (ret == 0)
+            ret = t_ret;
+        goto err;
+    }
+
+err:
+    free(from_path);
+    free(to_path);
+    return (ret);
 }
 
 /*
@@ -883,6 +939,7 @@ local_rename(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *from,
 static int
 local_remove(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name, uint32_t flags)
 {
+    LOCAL_FLUSH_ITEM *flush;
     LOCAL_STORAGE *local;
     int ret;
     char *path;
@@ -893,12 +950,33 @@ local_remove(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name,
     path = NULL;
 
     local->op_count++;
-    if ((ret = local_location_path(file_system, name, NULL, &path)) != 0)
+    if ((ret = local_location_path(file_system, name, &path)) != 0)
         goto err;
 
     ret = unlink(path);
     if (ret != 0) {
         ret = local_err(local, session, errno, "%s: ss_remove unlink", path);
+        goto err;
+    }
+
+    /*
+     * Find any flush entry that matches, and remove that too.
+     */
+    if ((ret = pthread_rwlock_wrlock(&local->flush_lock)) != 0) {
+        ret = local_err(local, session, ret, "ss_remove: pthread_rwlock_wrlock");
+        goto err;
+    }
+
+    TAILQ_FOREACH (flush, &local->flushq, q) {
+        if (strcmp(flush->src_path, path) == 0) {
+            TAILQ_REMOVE(&local->flushq, flush, q);
+            local_flush_free(flush);
+            break;
+        }
+    }
+
+    if ((ret = pthread_rwlock_unlock(&local->flush_lock)) != 0) {
+        ret = local_err(local, session, ret, "ss_remove: pthread_rwlock_unlock");
         goto err;
     }
 
@@ -923,7 +1001,7 @@ local_size(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name, w
     path = NULL;
 
     local->op_count++;
-    if ((ret = local_location_path(file_system, name, NULL, &path)) != 0)
+    if ((ret = local_location_path(file_system, name, &path)) != 0)
         goto err;
 
     ret = stat(path, &sb);
@@ -961,7 +1039,7 @@ local_terminate(WT_STORAGE_SOURCE *storage, WT_SESSION *session)
         (void)local_err(local, session, ret, "terminate: pthread_rwlock_destroy");
 
     TAILQ_FOREACH_SAFE(local_fh, &local->fileq, q, safe_fh)
-    local_file_close_internal(local, session, local_fh, true);
+    local_file_close_internal(local, session, local_fh);
 
     free(local);
     return (ret);
@@ -1015,7 +1093,7 @@ local_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
         }
     }
 
-    if ((t_ret = local_file_close_internal(local, session, local_fh, false)) != 0) {
+    if ((t_ret = local_file_close_internal(local, session, local_fh)) != 0) {
         if (ret == 0)
             ret = t_ret;
     }
@@ -1028,26 +1106,17 @@ local_file_close(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
  *     Internal file handle close.
  */
 static int
-local_file_close_internal(
-  LOCAL_STORAGE *local, WT_SESSION *session, LOCAL_FILE_HANDLE *local_fh, bool final)
+local_file_close_internal(LOCAL_STORAGE *local, WT_SESSION *session, LOCAL_FILE_HANDLE *local_fh)
 {
     int ret;
+    WT_FILE_HANDLE *wt_fh;
 
     ret = 0;
-    if ((close(local_fh->fd)) < 0)
-        ret = local_err(local, session, errno, "WT_FILE_HANDLE->close: close");
-
-    /*
-     * If this is a normal close (not a termination cleanup), and this handle creates an object,
-     * move the temp file to its final position.
-     */
-    if (!final && ret == 0 && local_fh->temp_path != NULL) {
-        if ((ret = rename(local_fh->temp_path, local_fh->path)) < 0)
-            ret = local_err(local, session, errno, "FILE_HANDLE->close: rename");
-    }
+    wt_fh = local_fh->fh;
+    if ((ret = wt_fh->close(wt_fh, session)) != 0)
+        ret = local_err(local, session, ret, "WT_FILE_HANDLE->close: close");
 
     local_flush_free(local_fh->flush);
-    free(local_fh->temp_path);
     free(local_fh->path);
     free(local_fh->iface.name);
     free(local_fh);
@@ -1080,25 +1149,13 @@ local_file_read(
   WT_FILE_HANDLE *file_handle, WT_SESSION *session, wt_off_t offset, size_t len, void *buf)
 {
     LOCAL_FILE_HANDLE *local_fh;
-    ssize_t nbytes;
-    int ret;
-    uint8_t *addr;
+    WT_FILE_HANDLE *wt_fh;
 
     local_fh = (LOCAL_FILE_HANDLE *)file_handle;
-    ret = 0;
+    wt_fh = local_fh->fh;
 
     local_fh->local->read_ops++;
-    for (addr = buf; ret == 0 && len > 0;) {
-        nbytes = pread(local_fh->fd, addr, len, offset);
-        if (nbytes < 0)
-            ret = local_file_err(local_fh, session, errno, "pread");
-        else {
-            addr += nbytes;
-            len -= (size_t)nbytes;
-            offset += nbytes;
-        }
-    }
-    return (ret);
+    return (wt_fh->fh_read(wt_fh, session, offset, len, buf));
 }
 
 /*
@@ -1108,20 +1165,14 @@ local_file_read(
 static int
 local_file_size(WT_FILE_HANDLE *file_handle, WT_SESSION *session, wt_off_t *sizep)
 {
-    struct stat sb;
     LOCAL_FILE_HANDLE *local_fh;
-    int ret;
+    WT_FILE_HANDLE *wt_fh;
 
     local_fh = (LOCAL_FILE_HANDLE *)file_handle;
+    wt_fh = local_fh->fh;
 
     local_fh->local->fh_ops++;
-    ret = fstat(local_fh->fd, &sb);
-    if (ret == 0)
-        *sizep = sb.st_size;
-    else
-        ret = local_file_err(local_fh, session, ret, "fh_size fstat");
-
-    return (ret);
+    return (wt_fh->fh_size(wt_fh, session, sizep));
 }
 
 /*
@@ -1132,15 +1183,13 @@ static int
 local_file_sync(WT_FILE_HANDLE *file_handle, WT_SESSION *session)
 {
     LOCAL_FILE_HANDLE *local_fh;
-    int ret;
+    WT_FILE_HANDLE *wt_fh;
 
     local_fh = (LOCAL_FILE_HANDLE *)file_handle;
+    wt_fh = local_fh->fh;
 
     local_fh->local->fh_ops++;
-    if ((ret = fsync(local_fh->fd)) < 0)
-        ret = local_file_err(local_fh, session, errno, "fsync");
-
-    return (ret);
+    return (wt_fh->fh_sync(wt_fh, session));
 }
 
 /*
@@ -1152,25 +1201,13 @@ local_file_write(
   WT_FILE_HANDLE *file_handle, WT_SESSION *session, wt_off_t offset, size_t len, const void *buf)
 {
     LOCAL_FILE_HANDLE *local_fh;
-    ssize_t nbytes;
-    int ret;
-    const uint8_t *addr;
+    WT_FILE_HANDLE *wt_fh;
 
     local_fh = (LOCAL_FILE_HANDLE *)file_handle;
-    ret = 0;
+    wt_fh = local_fh->fh;
 
     local_fh->local->write_ops++;
-    for (addr = buf; ret == 0 && len > 0;) {
-        nbytes = pwrite(local_fh->fd, addr, len, offset);
-        if (nbytes < 0)
-            ret = local_file_err(local_fh, session, errno, "pwrite");
-        else {
-            addr += nbytes;
-            len -= (size_t)nbytes;
-            offset += nbytes;
-        }
-    }
-    return (ret);
+    return (wt_fh->fh_write(wt_fh, session, offset, len, buf));
 }
 
 /*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -888,6 +888,25 @@ __wt_conn_remove_storage_source(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __conn_ext_file_system_get --
+ *     WT_EXTENSION.file_system_get method. Get file system in use.
+ */
+static int
+__conn_ext_file_system_get(
+  WT_EXTENSION_API *wt_api, WT_SESSION *session, WT_FILE_SYSTEM **file_system)
+{
+    WT_FILE_SYSTEM *fs;
+
+    WT_UNUSED(session);
+
+    fs = ((WT_CONNECTION_IMPL *)wt_api->conn)->file_system;
+    if (fs == NULL)
+        return (WT_NOTFOUND);
+    *file_system = fs;
+    return (0);
+}
+
+/*
  * __conn_get_extension_api --
  *     WT_CONNECTION.get_extension_api method.
  */
@@ -911,6 +930,7 @@ __conn_get_extension_api(WT_CONNECTION *wt_conn)
     conn->extension_api.config_get_string = __wt_ext_config_get_string;
     conn->extension_api.config_parser_open = __wt_ext_config_parser_open;
     conn->extension_api.config_parser_open_arg = __wt_ext_config_parser_open_arg;
+    conn->extension_api.file_system_get = __conn_ext_file_system_get;
     conn->extension_api.metadata_insert = __wt_ext_metadata_insert;
     conn->extension_api.metadata_remove = __wt_ext_metadata_remove;
     conn->extension_api.metadata_search = __wt_ext_metadata_search;

--- a/src/include/wiredtiger_ext.h
+++ b/src/include/wiredtiger_ext.h
@@ -245,7 +245,7 @@ struct __wt_extension_api {
      * @param session the session handle (or NULL if none available)
      * @param file_system the returned file system handle.
      * @errors
-     * If called when from an extension's initialization routine, this may
+     * If called from an extension's initialization routine, this may
      * return WT_NOTFOUND if the file system has not yet been established.
      *
      * @snippet ex_data_source.c WT_EXTENSION metadata insert

--- a/src/include/wiredtiger_ext.h
+++ b/src/include/wiredtiger_ext.h
@@ -239,6 +239,21 @@ struct __wt_extension_api {
       WT_CONFIG_ARG *config, WT_CONFIG_PARSER **config_parserp);
 
     /*!
+     * Get the file system abstraction used by WiredTiger.
+     *
+     * @param wt_api the extension handle
+     * @param session the session handle (or NULL if none available)
+     * @param file_system the returned file system handle.
+     * @errors
+     * If called when from an extension's initialization routine, this may
+     * return WT_NOTFOUND if the file system has not yet been established.
+     *
+     * @snippet ex_data_source.c WT_EXTENSION metadata insert
+     */
+    int (*file_system_get)(
+      WT_EXTENSION_API *wt_api, WT_SESSION *session, WT_FILE_SYSTEM **file_system);
+
+    /*!
      * Insert a row into the metadata if it does not already exist.
      *
      * @param wt_api the extension handle

--- a/test/suite/test_tiered06.py
+++ b/test/suite/test_tiered06.py
@@ -117,6 +117,18 @@ class test_tiered06(wttest.WiredTigerTestCase):
         local.ss_flush(session, fs, None, '')
         self.assertEquals(fs.fs_directory_list(session, '', ''), ['foobar'])
 
+        # Files that have been flushed cannot be manipulated.
+        with self.expectedStderrPattern('foobar: rename of flushed file not allowed'):
+            self.assertRaisesException(wiredtiger.WiredTigerError,
+                lambda: fs.fs_rename(session, 'foobar', 'barfoo', 0))
+        self.assertEquals(fs.fs_directory_list(session, '', ''), ['foobar'])
+
+        # Files that have been flushed cannot be manipulated through the custom file system.
+        with self.expectedStderrPattern('foobar: remove of flushed file not allowed'):
+            self.assertRaisesException(wiredtiger.WiredTigerError,
+                lambda: fs.fs_remove(session, 'foobar', 0))
+        self.assertEquals(fs.fs_directory_list(session, '', ''), ['foobar'])
+
         fs.terminate(session)
 
     def test_local_write_read(self):

--- a/test/suite/test_tiered06.py
+++ b/test/suite/test_tiered06.py
@@ -105,8 +105,12 @@ class test_tiered06(wttest.WiredTigerTestCase):
         fh.close(session)    # zero length
         self.assertEquals(sorted(fs.fs_directory_list(session, '', '')), ['foobar', 'zzz' ])
 
+        # See that we can rename objects.
+        fs.fs_rename(session, 'zzz', 'yyy', 0)
+        self.assertEquals(sorted(fs.fs_directory_list(session, '', '')), ['foobar', 'yyy' ])
+
         # See that we can remove objects.
-        fs.fs_remove(session, 'zzz', 0)
+        fs.fs_remove(session, 'yyy', 0)
         self.assertEquals(fs.fs_directory_list(session, '', ''), ['foobar'])
 
         # Flushing doesn't do anything that's visible.


### PR DESCRIPTION
For the local file system open, use the WT file system to get a file handle, rather than using POSIX file descriptors directly.
This makes for a cleaner implementation.  Get rid of marker files and temp files. We don't need temp files because our model is to behave exactly like a "regular" file system until flush occurs. We also don't need a flush marker, when a flush occurs, we chmod the file to readonly.  That matches the semantics - flushed files are by definition immutable.