### PR TITLE
WT-7426 Set write generation number when the page image gets created (#6474) (v4.4 backport)

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -970,7 +970,8 @@ __cell_unpack_window_cleanup(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk
      * No delete              txnid=MAX, ts=MAX,            txnid=MAX, ts=MAX,
      *                        durable_ts=NONE               durable_ts=NONE
      */
-    if (dsk->write_gen == 0 || dsk->write_gen > S2BT(session)->base_write_gen)
+    WT_ASSERT(session, dsk->write_gen != 0);
+    if (dsk->write_gen > S2BT(session)->base_write_gen)
         return;
 
     /* Tell reconciliation we cleared the transaction ids and the cell needs to be rebuilt. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1514,6 +1514,32 @@ err:
 }
 
 /*
+ * __rec_set_page_write_gen --
+ *     Initialize the page write generation number.
+ */
+static void
+__rec_set_page_write_gen(WT_PAGE_HEADER *dsk, WT_BTREE *btree)
+{
+    /*
+     * We increment the block's write generation so it's easy to identify newer versions of blocks
+     * during salvage. (It's common in WiredTiger, at least for the default block manager, for
+     * multiple blocks to be internally consistent with identical first and last keys, so we need a
+     * way to know the most recent state of the block. We could check which leaf is referenced by a
+     * valid internal page, but that implies salvaging internal pages, which I don't want to do, and
+     * it's not as good anyway, because the internal page may not have been written after the leaf
+     * page was updated. So, write generations it is.
+     *
+     * Nothing is locked at this point but two versions of a page with the same generation is pretty
+     * unlikely, and if we did, they're going to be roughly identical for the purposes of salvage,
+     * anyway.
+     *
+     * Other than salvage, the write generation number is used to reset the stale transaction id's
+     * present on the page upon server restart.
+     */
+    dsk->write_gen = ++btree->write_gen;
+}
+
+/*
  * __rec_split_write_header --
  *     Initialize a disk page's header.
  */
@@ -1528,7 +1554,8 @@ __rec_split_write_header(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK
     page = r->page;
 
     dsk->recno = btree->type == BTREE_ROW ? WT_RECNO_OOB : multi->key.recno;
-    dsk->write_gen = 0;
+
+    __rec_set_page_write_gen(dsk, btree);
     dsk->mem_size = multi->size;
     dsk->u.entries = chunk->entries;
     dsk->type = page->type;
@@ -2341,6 +2368,7 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
         dsk = tmp->mem;
         memset(dsk, 0, WT_PAGE_HEADER_SIZE);
         dsk->type = WT_PAGE_OVFL;
+        __rec_set_page_write_gen(dsk, btree);
         dsk->u.datalen = (uint32_t)kv->buf.size;
         memcpy(WT_PAGE_HEADER_BYTE(btree, dsk), kv->buf.data, kv->buf.size);
         dsk->mem_size = WT_PAGE_HEADER_BYTE_SIZE(btree) + (uint32_t)kv->buf.size;


### PR DESCRIPTION
Set write generation number whenever the page image is created instead of
waiting for it to be written to disk. In scenarios, when the page image is instantiated
it can lead to misuse of the stale transaction ids present on the page.

(cherry picked from commit b3e3b2580ce14e7609e7ba269d3c7432f81339b7)