### PR TITLE
WT-7191 Use of hash_city64 over hash_fnv64

### DIFF
--- a/src/reconcile/rec_dictionary.c
+++ b/src/reconcile/rec_dictionary.c
@@ -156,7 +156,7 @@ __wt_rec_dictionary_lookup(
     *dpp = NULL;
 
     /* Search the dictionary, and return any match we find. */
-    hash = __wt_hash_fnv64(val->buf.data, val->buf.size);
+    hash = __wt_hash_city64(val->buf.data, val->buf.size);
     for (dp = __rec_dictionary_skip_search(r->dictionary_head, hash);
          dp != NULL && dp->hash == hash; dp = dp->next[0]) {
         WT_RET(


### PR DESCRIPTION
Replacement of FNV hash function to City hash function as the latter hashes 8 bytes at a time, while the former hashes 1 byte at a time.