### PR TITLE
WT-7092 Reduce hash calls during cursor open/close

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -758,7 +758,7 @@ err:
 
 /*
  * __wt_cursor_get_hash --
- *     Set hash value from the given uri.
+ *     Get hash value from the given uri.
  */
 void
 __wt_cursor_get_hash(

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -757,12 +757,29 @@ err:
 }
 
 /*
+ * __wt_cursor_get_hash --
+ *     Set hash value from the given uri.
+ */
+void
+__wt_cursor_get_hash(
+  WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup, uint64_t *hash_value)
+{
+    if (to_dup != NULL) {
+        WT_ASSERT(session, uri == NULL);
+        *hash_value = to_dup->uri_hash;
+    } else {
+        WT_ASSERT(session, uri != NULL);
+        *hash_value = __wt_hash_city64(uri, strlen(uri));
+    }
+}
+
+/*
  * __wt_cursor_cache_get --
  *     Open a matching cursor from the cache.
  */
 int
 __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_value,
-  const char *cfg[], WT_CURSOR **cursorp)
+  WT_CURSOR *to_dup, const char *cfg[], WT_CURSOR **cursorp)
 {
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;
@@ -818,6 +835,8 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_v
             return (WT_NOTFOUND);
     }
 
+    if (to_dup != NULL)
+        uri = to_dup->uri;
     /*
      * Walk through all cursors, if there is a cached cursor that matches uri and configuration, use
      * it.

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -761,14 +761,14 @@ err:
  *     Open a matching cursor from the cache.
  */
 int
-__wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup,
+__wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_value,
   const char *cfg[], WT_CURSOR **cursorp)
 {
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
-    uint64_t bucket, hash_value;
+    uint64_t bucket;
     uint32_t overwrite_flag;
     bool have_config;
 
@@ -816,18 +816,6 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_d
         WT_RET(__wt_config_gets_def(session, cfg, "checkpoint", 0, &cval));
         if (cval.val)
             return (WT_NOTFOUND);
-    }
-
-    /*
-     * Caller guarantees that exactly one of the URI and the duplicate cursor is non-NULL.
-     */
-    if (to_dup != NULL) {
-        WT_ASSERT(session, uri == NULL);
-        uri = to_dup->uri;
-        hash_value = to_dup->uri_hash;
-    } else {
-        WT_ASSERT(session, uri != NULL);
-        hash_value = __wt_hash_city64(uri, strlen(uri));
     }
 
     /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -518,7 +518,7 @@ extern int __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_C
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup,
+extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_value,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_cache_release(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool *released)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1620,6 +1620,8 @@ extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_DECL_
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint64_t __wt_cursor_get_hash(WT_SESSION_IMPL *session, const char **uri, WT_CURSOR *to_dup)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_ext_transaction_id(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -519,7 +519,8 @@ extern int __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_C
 extern int __wt_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_value,
-  const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_CURSOR *to_dup, const char *cfg[], WT_CURSOR **cursorp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_cache_release(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool *released)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_cached(WT_CURSOR *cursor) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1621,8 +1622,6 @@ extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern uint64_t __wt_cursor_get_hash(WT_SESSION_IMPL *session, const char **uri, WT_CURSOR *to_dup)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_ext_transaction_id(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_ext_transaction_oldest(WT_EXTENSION_API *wt_api)
@@ -1676,6 +1675,8 @@ extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);
 extern void __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern void __wt_cursor_close(WT_CURSOR *cursor);
+extern void __wt_cursor_get_hash(
+  WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup, uint64_t *hash_value);
 extern void __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt);
 extern void __wt_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);
 extern void __wt_cursor_set_key(WT_CURSOR *cursor, ...);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -616,8 +616,8 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
     ret = __session_open_cursor_int(
       session, uri, NULL, statjoin || dup_backup ? to_dup : NULL, cfg, &cursor);
 
-    if (*cursorp != NULL)
-        (*cursorp)->uri_hash = hash_value;
+    if (cursor != NULL)
+        cursor->uri_hash = hash_value;
 
     WT_ERR(ret);
 


### PR DESCRIPTION
This change is to set the computed hash value in `cursor->uri_hash`while opening a cursor and with this approach, we will reduce one hash computation during cursor close.