### PR TITLE
WT-6204 Possible race between backup and checkpoint at file close

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1949,6 +1949,14 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
         return (__wt_set_return(session, EBUSY));
 
     /*
+     * Checkpoint shouldn't occur when final is set to false, without either checkpoint lock or
+     * schema lock. Potential race condition arises when backup is ongoing, causing inconsistencies
+     * between the versions of data.
+     */
+    WT_ASSERT(session,
+      FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT | WT_SESSION_LOCKED_SCHEMA) &&
+        !final);
+    /*
      * Turn on metadata tracking if:
      * - The session is not already doing metadata tracking.
      * - The file was not bulk loaded.

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1954,8 +1954,8 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * between the versions of data.
      */
     WT_ASSERT(session,
-      FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT | WT_SESSION_LOCKED_SCHEMA) &&
-        !final);
+       ((FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT) ||
+         FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)) && !final) || final);
     /*
      * Turn on metadata tracking if:
      * - The session is not already doing metadata tracking.

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1949,15 +1949,15 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
         return (__wt_set_return(session, EBUSY));
 
     /*
-     * Checkpoint shouldn't occur when final is set to false, without either checkpoint lock or
-     * schema lock. Potential race condition arises when backup is ongoing, causing inconsistencies
-     * between the versions of data.
+     * Make sure there isn't a potential race between backup copying the metadata and a checkpoint
+     * changing the metadata. Backup holds both the checkpoint and schema locks. Checkpoint should
+     * hold those also except on the final checkpoint during close. Confirm the caller either is the
+     * final checkpoint or holds at least one of the locks.
      */
     WT_ASSERT(session,
       final ||
-        ((FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT) ||
-           FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)) &&
-          !final));
+        (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT) ||
+          FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)));
     /*
      * Turn on metadata tracking if:
      * - The session is not already doing metadata tracking.

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1954,8 +1954,10 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * between the versions of data.
      */
     WT_ASSERT(session,
-       ((FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT) ||
-         FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)) && !final) || final);
+      final ||
+        ((FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT) ||
+           FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA)) &&
+          !final));
     /*
      * Turn on metadata tracking if:
      * - The session is not already doing metadata tracking.


### PR DESCRIPTION
This ticket involves researching if there could be a potential race condition between backup and checkpoint at file close. This race condition can only happen if:

- It is not the last checkpoint for the system
- We don't have the schema lock
- We don't have the checkpoint lock 

Thus, upon researching, the assert was never hit. It would be useful to still include this assert to prevent future possible race conditions.