### PR TITLE
WT-7423 Clear checkpoint LSN and backup metadata on import

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -205,12 +205,8 @@ __create_file(
     }
 
     /*
-     * When creating an ordinary file reconfigure parts of the metadata and insert the resulting
-     * configuration into the metadata.
-     *
-     * Strip out any incremental backup information, an imported file has not been part of a backup.
-     * Strip out the checkpoint LSN, an imported file isn't associated with any log files. Append
-     * the file ID and current version numbers to the passed-in configuration
+     * If creating an ordinary file, update the file ID and current version numbers and strip the
+     * incremental backup information and checkpoint LSN from the extracted metadata
      */
     if (!is_metadata) {
         if (!import_repair) {

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -177,7 +177,6 @@ __create_file(
                 }
                 WT_ERR(__wt_strndup(session, cval.str, cval.len, &filemeta));
                 filecfg[2] = filemeta;
-                WT_ERR(__wt_msg(session, "old %s", filemeta));
             } else {
                 /*
                  * If there is no file metadata provided, the user should be specifying a "repair".

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -206,7 +206,7 @@ __create_file(
 
     /*
      * If creating an ordinary file, update the file ID and current version numbers and strip the
-     * incremental backup information and checkpoint LSN from the extracted metadata
+     * incremental backup information and checkpoint LSN from the extracted metadata.
      */
     if (!is_metadata) {
         if (!import_repair) {


### PR DESCRIPTION
This involves clearing the checkpoint LSN and the backup information when importing a table. These values are only relevant from old database.