### PR TITLE
WT-7458 Coverity redundant condition check in evict page

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -584,7 +584,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * while checkpoint is operating on the HS file, we can end up in a situation where we exceed
      * the cache size limits.
      */
-    if (modified && conn->txn_global.checkpoint_running_hs && !WT_IS_HS(btree->dhandle) &&
+    if (conn->txn_global.checkpoint_running_hs && !WT_IS_HS(btree->dhandle) &&
       __wt_cache_hs_dirty(session) && __wt_cache_full(session)) {
         WT_STAT_CONN_INCR(session, cache_eviction_blocked_checkpoint_hs);
         return (__wt_set_return(session, EBUSY));


### PR DESCRIPTION
The modified variable will always be true if this part of the code is reached.