### PR TITLE
WT-7442 RTS to open dhandle only when the dhandle has unstable updates (#6506) (v4.4 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -554,6 +554,7 @@ connection_stats = [
     TxnStat('txn_prepared_updates_count', 'Number of prepared updates'),
     TxnStat('txn_query_ts', 'query timestamp calls'),
     TxnStat('txn_rollback', 'transactions rolled back'),
+    TxnStat('txn_rollback_to_stable_running', 'transaction rollback to stable currently running', 'no_clear,no_scale'),
     TxnStat('txn_rts', 'rollback to stable calls'),
     TxnStat('txn_rts_pages_visited', 'rollback to stable pages visited'),
     TxnStat('txn_rts_tree_walk_skip_pages', 'rollback to stable tree walk skipping pages'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -675,6 +675,7 @@ struct __wt_connection_stats {
     int64_t txn_pinned_timestamp_reader;
     int64_t txn_pinned_timestamp_oldest;
     int64_t txn_timestamp_oldest_active_read;
+    int64_t txn_rollback_to_stable_running;
     int64_t txn_sync;
     int64_t txn_walk_sessions;
     int64_t txn_commit;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5866,305 +5866,307 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1360
 /*! transaction: transaction read timestamp of the oldest active reader */
 #define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1361
+/*! transaction: transaction rollback to stable currently running */
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1362
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1362
+#define	WT_STAT_CONN_TXN_SYNC				1363
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1363
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1364
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1364
+#define	WT_STAT_CONN_TXN_COMMIT				1365
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1365
+#define	WT_STAT_CONN_TXN_ROLLBACK			1366
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1366
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1367
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1367
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1368
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1368
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1369
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1369
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1370
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1370
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1371
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1371
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1372
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1372
+#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1373
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1373
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1374
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1374
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1375
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1375
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1376
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1376
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1377
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1377
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1378
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1378
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1379
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1379
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1380
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1380
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1381
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1381
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1382
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1382
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1383
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1383
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1384
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1384
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1385
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1385
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1386
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1386
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1387
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1387
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1388
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1388
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1389
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1389
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1390
 /*!
  * cache: history store table out-of-order resolved updates that lose
  * their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1390
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1391
 /*!
  * cache: history store table out-of-order updates that were fixed up by
  * moving existing records
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_FIXUP_MOVE		1391
+#define	WT_STAT_CONN_CACHE_HS_ORDER_FIXUP_MOVE		1392
 /*!
  * cache: history store table out-of-order updates that were fixed up
  * during insertion
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_FIXUP_INSERT	1392
+#define	WT_STAT_CONN_CACHE_HS_ORDER_FIXUP_INSERT	1393
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1393
+#define	WT_STAT_CONN_CACHE_HS_READ			1394
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1394
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1395
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1395
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1396
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1396
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1397
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1397
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1398
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1398
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1399
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1399
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1400
 /*!
  * cache: history store table truncation to remove range of updates due
  * to non timestamped update on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_NON_TS	1400
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_NON_TS	1401
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1401
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1402
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1402
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1403
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1403
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1404
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1404
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1405
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1405
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1406
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1406
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1407
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1407
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1408
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1408
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1409
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1409
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1410
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1410
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1411
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1411
+#define	WT_STAT_CONN_CACHE_READ				1412
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1412
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1413
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1413
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1414
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1414
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1415
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1415
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1416
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1416
+#define	WT_STAT_CONN_CACHE_WRITE			1417
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1417
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1418
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1418
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1419
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1419
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1420
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1420
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1421
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1421
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1422
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1422
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1423
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1423
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1424
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1424
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1425
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1425
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1426
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1426
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1427
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1427
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1428
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1428
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1429
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1429
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1430
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1430
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1431
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1431
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1432
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1432
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1433
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1433
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1434
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1434
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1435
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1435
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1436
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1436
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1437
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1437
+#define	WT_STAT_CONN_REC_PAGES				1438
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1438
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1439
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1439
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1440
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1440
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1441
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1441
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1442
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1442
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1443
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1443
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1444
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1444
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1445
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1445
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1446
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1446
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1447
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1447
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1448
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1448
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1449
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1449
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1450
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1450
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1451
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1452
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1453
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1454
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1455
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1456
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1457
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1457
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1458
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1458
+#define	WT_STAT_CONN_TIERED_RETENTION			1459
 /*! session: tiered storage object size */
-#define	WT_STAT_CONN_TIERED_OBJECT_SIZE			1459
+#define	WT_STAT_CONN_TIERED_OBJECT_SIZE			1460
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1460
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1461
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1461
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1462
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1462
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1463
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1463
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1464
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1464
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1465
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1465
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1466
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1466
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1467
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1467
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1468
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1468
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1469
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1469
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1470
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1470
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1471
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1325,6 +1325,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: transaction range of timestamps pinned by the oldest active read timestamp",
   "transaction: transaction range of timestamps pinned by the oldest timestamp",
   "transaction: transaction read timestamp of the oldest active reader",
+  "transaction: transaction rollback to stable currently running",
   "transaction: transaction sync calls",
   "transaction: transaction walk of concurrent sessions",
   "transaction: transactions committed",
@@ -1839,6 +1840,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing txn_pinned_timestamp_reader */
     /* not clearing txn_pinned_timestamp_oldest */
     /* not clearing txn_timestamp_oldest_active_read */
+    /* not clearing txn_rollback_to_stable_running */
     stats->txn_sync = 0;
     stats->txn_walk_sessions = 0;
     stats->txn_commit = 0;
@@ -2350,6 +2352,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_pinned_timestamp_reader += WT_STAT_READ(from, txn_pinned_timestamp_reader);
     to->txn_pinned_timestamp_oldest += WT_STAT_READ(from, txn_pinned_timestamp_oldest);
     to->txn_timestamp_oldest_active_read += WT_STAT_READ(from, txn_timestamp_oldest_active_read);
+    to->txn_rollback_to_stable_running += WT_STAT_READ(from, txn_rollback_to_stable_running);
     to->txn_sync += WT_STAT_READ(from, txn_sync);
     to->txn_walk_sessions += WT_STAT_READ(from, txn_walk_sessions);
     to->txn_commit += WT_STAT_READ(from, txn_commit);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1363,10 +1363,12 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
     wt_timestamp_t max_durable_ts, newest_start_durable_ts, newest_stop_durable_ts,
       rollback_timestamp;
     uint64_t rollback_txnid;
+    uint32_t btree_id;
     size_t addr_size;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     const char *config, *uri;
     bool durable_ts_found, prepared_updates, has_txn_updates_gt_than_ckpt_snap;
+    bool dhandle_allocated, perform_rts;
 
     txn_global = &S2C(session)->txn_global;
     rollback_txnid = 0;
@@ -1395,6 +1397,7 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
 
     while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
+        dhandle_allocated = perform_rts = false;
 
         /* Ignore metadata and history store files. */
         if (strcmp(uri, WT_METAFILE_URI) == 0 || strcmp(uri, WT_HS_URI) == 0)
@@ -1408,6 +1411,11 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
         /* Find out the max durable timestamp of the object from checkpoint. */
         newest_start_durable_ts = newest_stop_durable_ts = WT_TS_NONE;
         durable_ts_found = prepared_updates = has_txn_updates_gt_than_ckpt_snap = false;
+
+        /* Get the btree ID. */
+        WT_ERR(__wt_config_getones(session, config, "id", &cval));
+        btree_id = (uint32_t)cval.val;
+
         WT_ERR(__wt_config_getones(session, config, "checkpoint", &cval));
         __wt_config_subinit(session, &ckptconf, &cval);
         for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
@@ -1464,33 +1472,41 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
             continue;
         }
 
-        /* Set this flag to return error instead of panic if file is corrupted. */
-        F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
-        ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
-        F_CLR(session, WT_SESSION_QUIET_CORRUPT_FILE);
-
-        /*
-         * Ignore performing rollback to stable on files that does not exist or the files where
-         * corruption is detected.
-         */
-        if ((ret == ENOENT) ||
-          (ret == WT_ERROR && F_ISSET(S2C(session), WT_CONN_DATA_CORRUPTION))) {
-            __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),
-              "ignore performing rollback to stable on %s because the file %s", uri,
-              ret == ENOENT ? "does not exist" : "is corrupted.");
-            continue;
-        }
-        WT_ERR(ret);
-
         /*
          * The rollback operation should be performed on this file based on the following:
-         * 1. The tree is modified.
+         * 1. The dhandle is present in the cache and tree is modified.
          * 2. The checkpoint durable start/stop timestamp is greater than the rollback timestamp.
          * 3. There is no durable timestamp in any checkpoint.
          * 4. The checkpoint newest txn is greater than snapshot min txn id
          */
-        if (S2BT(session)->modified || max_durable_ts > rollback_timestamp || prepared_updates ||
+        WT_WITH_HANDLE_LIST_READ_LOCK(session, (ret = __wt_conn_dhandle_find(session, uri, NULL)));
+
+        if (ret == 0 && S2BT(session)->modified)
+            perform_rts = true;
+
+        WT_ERR_NOTFOUND_OK(ret, false);
+
+        if (perform_rts || max_durable_ts > rollback_timestamp || prepared_updates ||
           !durable_ts_found || has_txn_updates_gt_than_ckpt_snap) {
+            /* Set this flag to return error instead of panic if file is corrupted. */
+            F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
+            ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
+            F_CLR(session, WT_SESSION_QUIET_CORRUPT_FILE);
+
+            /*
+             * Ignore performing rollback to stable on files that does not exist or the files where
+             * corruption is detected.
+             */
+            if ((ret == ENOENT) ||
+              (ret == WT_ERROR && F_ISSET(S2C(session), WT_CONN_DATA_CORRUPTION))) {
+                __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),
+                  "ignore performing rollback to stable on %s because the file %s", uri,
+                  ret == ENOENT ? "does not exist" : "is corrupted.");
+                continue;
+            }
+            WT_ERR(ret);
+
+            dhandle_allocated = true;
             __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),
               "tree rolled back with durable timestamp: %s, or when tree is modified: %s or "
               "prepared updates: %s or when durable time is not found: %s or txnid: %" PRIu64
@@ -1510,16 +1526,18 @@ __rollback_to_stable_btree_apply(WT_SESSION_IMPL *session)
          * Truncate history store entries for the non-timestamped table.
          * Exceptions:
          * 1. Modified tree - Scenarios where the tree is never checkpointed lead to zero
-         * durable timestamp even they are timestamped tables. Until we have a special indication
-         * of letting to know the table type other than checking checkpointed durable timestamp
-         * to WT_TS_NONE, We need this exception.
+         * durable timestamp even they are timestamped tables. Until we have a special
+         * indication of letting to know the table type other than checking checkpointed durable
+         * timestamp to WT_TS_NONE, We need this exception.
          * 2. In-memory database - In this scenario, there is no history store to truncate.
          */
-        if (!S2BT(session)->modified && max_durable_ts == WT_TS_NONE &&
-          !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-            WT_TRET(__rollback_to_stable_btree_hs_truncate(session, S2BT(session)->id));
 
-        WT_TRET(__wt_session_release_dhandle(session));
+        if ((!dhandle_allocated || !S2BT(session)->modified) && max_durable_ts == WT_TS_NONE &&
+          !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
+            WT_TRET(__rollback_to_stable_btree_hs_truncate(session, btree_id));
+
+        if (dhandle_allocated)
+            WT_TRET(__wt_session_release_dhandle(session));
 
         /*
          * Continue when the table is corrupted and proceed to perform rollback to stable on other
@@ -1591,9 +1609,11 @@ __wt_rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckp
      * Rollback to stable should ignore tombstones in the history store since it needs to scan the
      * entire table sequentially.
      */
+    WT_STAT_CONN_SET(session, txn_rollback_to_stable_running, 1);
     F_SET(session, WT_SESSION_ROLLBACK_TO_STABLE);
     ret = __rollback_to_stable(session);
     F_CLR(session, WT_SESSION_ROLLBACK_TO_STABLE);
+    WT_STAT_CONN_SET(session, txn_rollback_to_stable_running, 0);
     WT_RET(ret);
 
     /* Rollback the global durable timestamp to the stable timestamp. */

--- a/test/suite/test_rollback_to_stable20.py
+++ b/test/suite/test_rollback_to_stable20.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+from helper import copy_wiredtiger_home
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+from helper import simulate_crash_restart
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# Test that rollback to stable does not open any dhandles that don't have unstable updates.
+class test_rollback_to_stable20(test_rollback_to_stable_base):
+    session_config = 'isolation=snapshot'
+
+    def conn_config(self):
+        config = 'cache_size=50MB,statistics=(all)'
+        return config
+
+    def test_rollback_to_stable(self):
+        nrows = 10000
+        ntables = 100
+        create_params = 'key_format=i,value_format=S'
+        uri = "table:rollback_to_stable20"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format="i", value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable timestamp to 1.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
+            ',stable_timestamp=' + timestamp_str(1))
+
+        valuea = "aaaaa" * 100
+
+        for i in range(0, ntables):
+            uri = 'table:rollback_to_stable20_' + str(i)
+            self.session.create(uri, create_params)
+            self.large_updates(uri, valuea, ds, nrows, 0, 10)
+
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+
+        self.session.checkpoint()
+
+        # Simulate a server crash and restart.
+        self.pr("restart")
+        simulate_crash_restart(self, ".", "RESTART")
+        self.pr("restart complete")
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        open_dhandle_count = stat_cursor[stat.conn.dh_conn_handle_count][2]
+        stat_cursor.close()
+
+        self.assertLess(open_dhandle_count, 5)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_txn16.py
+++ b/test/suite/test_txn16.py
@@ -92,10 +92,11 @@ class test_txn16(wttest.WiredTigerTestCase, suite_subprocess):
                 cur_logs = fnmatch.filter(os.listdir(homedir), "*gerLog*")
                 scur = set(cur_logs)
                 sorig = set(orig_logs)
-                # There can be overlap with the log files that were
-                # there originally. Because some pages are rolled back
-                # as part of RTS.
-                self.assertEqual(scur.isdisjoint(sorig), False)
+                # There should never be overlap with the log files that
+                # were there originally.  Mostly this checks that after
+                # opening with logging disabled and then re-enabled, we
+                # don't see log file 1.
+                self.assertEqual(scur.isdisjoint(sorig), True)
                 if loop > 1:
                     # We should be creating the same log files each time.
                     for l in cur_logs:


### PR DESCRIPTION
The main changes are for rollback to stable to open dhandles only when the dhandle has unstable updates.

(cherry picked from commit e3efbee8a31d9802b20f96f67a2f0f6191aeedb0)