### PR TITLE
WT-7489 rollback to stable can fail if running concurrently with a checkpoint

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1326,7 +1326,13 @@ __conn_rollback_to_stable(WT_CONNECTION *wt_conn, const char *config)
 
     CONNECTION_API_CALL(conn, session, rollback_to_stable, config, cfg);
     WT_STAT_CONN_INCR(session, txn_rts);
-    WT_TRET(__wt_rollback_to_stable(session, cfg, false));
+
+    /*
+     * Rollback-to-stable cannot run concurrently with checkpoints. Lock out checkpoints from both
+     * the application API and internal configurations.
+     */
+    WT_WITH_CHECKPOINT_LOCK(session, ret = __wt_rollback_to_stable(session, cfg, false));
+
 err:
     API_END_RET(session, ret);
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1326,13 +1326,7 @@ __conn_rollback_to_stable(WT_CONNECTION *wt_conn, const char *config)
 
     CONNECTION_API_CALL(conn, session, rollback_to_stable, config, cfg);
     WT_STAT_CONN_INCR(session, txn_rts);
-
-    /*
-     * Rollback-to-stable cannot run concurrently with checkpoints. Lock out checkpoints from both
-     * the application API and internal configurations.
-     */
-    WT_WITH_CHECKPOINT_LOCK(session, ret = __wt_rollback_to_stable(session, cfg, false));
-
+    WT_TRET(__wt_rollback_to_stable(session, cfg, false));
 err:
     API_END_RET(session, ret);
 }


### PR DESCRIPTION
RTS cannot run concurrently with checkpoints, lock them out.