### PR TITLE
WT-7506 Allow single and double quotes inside auto-formatted comments.

### DIFF
--- a/bench/wtperf/config.c
+++ b/bench/wtperf/config.c
@@ -462,8 +462,7 @@ config_opt(WTPERF *wtperf, WT_CONFIG_ITEM *k, WT_CONFIG_ITEM *v)
         break;
     case STRING_TYPE:
         /*
-         * Thread configuration is the one case where the type isn't a
-         * "string", it's a "struct".
+         * Thread configuration is the one case where the type isn't a "string", it's a "struct".
          */
         if (v->type == WT_CONFIG_ITEM_STRUCT && STRING_MATCH("threads", k->str, k->len))
             return (config_threads(wtperf, v->str, v->len));
@@ -821,12 +820,10 @@ config_consolidate(CONFIG_OPTS *opts)
     char *string_key;
 
     /*
-     * This loop iterates over the config queue and for each entry checks if
-     * a later queue entry has the same key. If there's a match, and key is
-     * "conn_config" or "table_config", the later queue entry is replaced
-     * with a concatenated entry of the two queue entries, the current queue
-     * entry is removed. For any other key, if there is a match, the current
-     * queue entry is removed.
+     * This loop iterates over the config queue and for each entry checks if a later queue entry has
+     * the same key. If there's a match, and key is "conn_config" or "table_config", the later queue
+     * entry is replaced with a concatenated entry of the two queue entries, the current queue entry
+     * is removed. For any other key, if there is a match, the current queue entry is removed.
      */
     conf_line = TAILQ_FIRST(&opts->config_head);
     while (conf_line != NULL) {

--- a/dist/s_comment.py
+++ b/dist/s_comment.py
@@ -104,11 +104,11 @@ for line in sys.stdin:
             (sline[2].islower() or sline[2] == '_') and sline.endswith('--')):
             function_desc = True
         # We're only reformatting block comments where each line begins with a space and an
-        # alphabetic character after the asterisk, or a parenthetical. The only exceptions
+        # normal comment character after the asterisk, or a parenthetical. The only exceptions
         # are function descriptions.
         block = block and \
             len(sline) >= 3 and sline.startswith('*') and sline[1] == ' ' and \
-            (sline[2].isalpha() or (len(sline) >= 5 and \
+            (sline[2].isalpha() or sline[2] == '"' or sline[2] == "'" or (len(sline) >= 5 and \
             (sline[2] == '(' and sline[3].isalpha() and sline[4] != ')'))) or function_desc
         # Trim asterisks at the beginning of each line in a multiline comment.
         if sline.startswith('*'):

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1012,9 +1012,9 @@ connection_ops(WT_CONNECTION *conn)
      *
      * Functions are specified by name (for example, "wiredtiger_open").
      *
-     * Methods are specified using a concatenation of the handle name, a
-     * period and the method name (for example, session create would be
-     * "WT_SESSION.create" and cursor close would be WT_CURSOR.close").
+     * Methods are specified using a concatenation of the handle name, a period and the method name
+     * (for example, session create would be "WT_SESSION.create" and cursor close would be
+     * "WT_CURSOR.close").
      */
     error_check(
       wiredtiger_config_validate(NULL, NULL, "WT_SESSION.create", "allocation_size=32KB"));

--- a/examples/c/ex_backup.c
+++ b/examples/c/ex_backup.c
@@ -50,13 +50,12 @@ compare_backups(int i)
     char buf[1024], msg[32];
 
     /*
-     * We run 'wt dump' on both the full backup directory and the
-     * incremental backup directory for this iteration.  Since running
-     * 'wt' runs recovery and makes both directories "live", we need
-     * a new directory for each iteration.
+     * We run 'wt dump' on both the full backup directory and the incremental backup directory for
+     * this iteration. Since running 'wt' runs recovery and makes both directories "live", we need a
+     * new directory for each iteration.
      *
-     * If i == 0, we're comparing against the main, original directory
-     * with the final incremental directory.
+     * If i == 0, we're comparing against the main, original directory with the final incremental
+     * directory.
      */
     if (i == 0)
         (void)snprintf(

--- a/examples/c/ex_backup_block.c
+++ b/examples/c/ex_backup_block.c
@@ -65,13 +65,12 @@ compare_backups(int i)
     char buf[1024], msg[32];
 
     /*
-     * We run 'wt dump' on both the full backup directory and the
-     * incremental backup directory for this iteration.  Since running
-     * 'wt' runs recovery and makes both directories "live", we need
-     * a new directory for each iteration.
+     * We run 'wt dump' on both the full backup directory and the incremental backup directory for
+     * this iteration. Since running 'wt' runs recovery and makes both directories "live", we need a
+     * new directory for each iteration.
      *
-     * If i == 0, we're comparing against the main, original directory
-     * with the final incremental directory.
+     * If i == 0, we're comparing against the main, original directory with the final incremental
+     * directory.
      */
     if (i == 0)
         (void)snprintf(buf, sizeof(buf), "../../wt -R -h %s dump main > %s.%d", home, full_out, i);

--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -351,8 +351,7 @@ my_open_cursor(WT_DATA_SOURCE *dsrc, WT_SESSION *session, const char *uri, WT_CO
             int my_data_source_overwrite;
 
             /*
-             * Retrieve the value of the boolean type configuration string
-             * "overwrite".
+             * Retrieve the value of the boolean type configuration string "overwrite".
              */
             error_check(wt_api->config_get(wt_api, session, config, "overwrite", &v));
             my_data_source_overwrite = v.val != 0;
@@ -367,8 +366,7 @@ my_open_cursor(WT_DATA_SOURCE *dsrc, WT_SESSION *session, const char *uri, WT_CO
             int64_t my_data_source_page_size;
 
             /*
-             * Retrieve the value of the integer type configuration string
-             * "page_size".
+             * Retrieve the value of the integer type configuration string "page_size".
              */
             error_check(wt_api->config_get(wt_api, session, config, "page_size", &v));
             my_data_source_page_size = v.val;
@@ -383,8 +381,7 @@ my_open_cursor(WT_DATA_SOURCE *dsrc, WT_SESSION *session, const char *uri, WT_CO
             const char *my_data_source_key;
 
             /*
-             * Retrieve the value of the string type configuration string
-             * "key_format".
+             * Retrieve the value of the string type configuration string "key_format".
              */
             error_check(wt_api->config_get(wt_api, session, config, "key_format", &v));
 

--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -28,16 +28,13 @@ __block_buffer_to_addr(WT_BLOCK *block, const uint8_t **pp, uint32_t *logidp, wt
     WT_RET(__wt_vunpack_uint(pp, 0, &c));
 
     /*
-     * To avoid storing large offsets, we minimize the value by subtracting
-     * a block for description information, then storing a count of block
-     * allocation units.  That implies there is no such thing as an
-     * "invalid" offset though, they could all be valid (other than very
-     * large numbers), which is what we didn't want to store in the first
-     * place.  Use the size: writing a block of size 0 makes no sense, so
-     * that's the out-of-band value.  Once we're out of this function and
-     * are working with a real file offset, size and checksum triplet, there
-     * can be invalid offsets, that's simpler than testing sizes of 0 all
-     * over the place.
+     * To avoid storing large offsets, we minimize the value by subtracting a block for description
+     * information, then storing a count of block allocation units. That implies there is no such
+     * thing as an "invalid" offset though, they could all be valid (other than very large numbers),
+     * which is what we didn't want to store in the first place. Use the size: writing a block of
+     * size 0 makes no sense, so that's the out-of-band value. Once we're out of this function and
+     * are working with a real file offset, size and checksum triplet, there can be invalid offsets,
+     * that's simpler than testing sizes of 0 all over the place.
      */
     if (s == 0) {
         *offsetp = 0;

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -280,18 +280,16 @@ __wt_block_misplaced(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *list
         return (0);
 
     /*
-     * Verify a block the btree engine thinks it "owns" doesn't appear on
-     * the available or discard lists (it might reasonably be on the alloc
-     * list, if it was allocated since the last checkpoint).  The engine
-     * "owns" a block if it's trying to read or free the block, and those
+     * Verify a block the btree engine thinks it "owns" doesn't appear on the available or discard
+     * lists (it might reasonably be on the alloc list, if it was allocated since the last
+     * checkpoint). The engine "owns" a block if it's trying to read or free the block, and those
      * functions make this check.
      *
      * Any block being read or freed should not be "available".
      *
-     * Any block being read or freed in the live system should not be on the
-     * discard list.  (A checkpoint handle might be reading a block which is
-     * on the live system's discard list; any attempt to free a block from a
-     * checkpoint handle has already failed.)
+     * Any block being read or freed in the live system should not be on the discard list. (A
+     * checkpoint handle might be reading a block which is on the live system's discard list; any
+     * attempt to free a block from a checkpoint handle has already failed.)
      */
     __wt_spin_lock(session, &block->live_lock);
     if (__block_off_match(&block->live.avail, offset, size))

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -389,9 +389,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
         F_CLR(btree, WT_BTREE_IGNORE_CACHE);
 
     /*
-     * The metadata isn't blocked by in-memory cache limits because metadata
-     * "unroll" is performed by updates that are potentially blocked by the
-     * cache-full checks.
+     * The metadata isn't blocked by in-memory cache limits because metadata "unroll" is performed
+     * by updates that are potentially blocked by the cache-full checks.
      */
     if (WT_IS_METADATA(btree->dhandle))
         F_SET(btree, WT_BTREE_IGNORE_CACHE);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1782,14 +1782,12 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 
     if (type == WT_PAGE_ROW_LEAF) {
         /*
-         * Copy the first key from the original page into first ref in
-         * the new parent. Pages created in memory always have a
-         * "smallest" insert list, so look there first.  If we don't
-         * find one, get the first key from the disk image.
+         * Copy the first key from the original page into first ref in the new parent. Pages created
+         * in memory always have a "smallest" insert list, so look there first. If we don't find
+         * one, get the first key from the disk image.
          *
-         * We can't just use the key from the original ref: it may have
-         * been suffix-compressed, and after the split the truncated key
-         * may not be valid.
+         * We can't just use the key from the original ref: it may have been suffix-compressed, and
+         * after the split the truncated key may not be valid.
          */
         WT_ERR(__wt_scr_alloc(session, 0, &key));
         if ((ins = WT_SKIP_FIRST(WT_ROW_INSERT_SMALLEST(page))) != NULL) {

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -32,22 +32,18 @@ __wt_row_leaf_keys(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /*
-     * Row-store leaf pages are written as one big prefix-compressed chunk,
-     * that is, only the first key on the page is not prefix-compressed, and
-     * to instantiate the last key on the page, you have to take the first
-     * key on the page and roll it forward to the end of the page.  We don't
-     * want to do that on every page access, of course, so we instantiate a
-     * set of keys, essentially creating prefix chunks on the page, where we
-     * can roll forward from the closest, previous, instantiated key.  The
-     * complication is that not all keys on a page are equal: we're doing a
-     * binary search on the  page, which means there are keys we look at a
-     * lot (every time we search the page), and keys we never look at unless
-     * they are actually being searched for.  This function figures out the
-     * "interesting" keys on a page, and then we sequentially walk that list
-     * instantiating those keys.
+     * Row-store leaf pages are written as one big prefix-compressed chunk, that is, only the first
+     * key on the page is not prefix-compressed, and to instantiate the last key on the page, you
+     * have to take the first key on the page and roll it forward to the end of the page. We don't
+     * want to do that on every page access, of course, so we instantiate a set of keys, essentially
+     * creating prefix chunks on the page, where we can roll forward from the closest, previous,
+     * instantiated key. The complication is that not all keys on a page are equal: we're doing a
+     * binary search on the page, which means there are keys we look at a lot (every time we search
+     * the page), and keys we never look at unless they are actually being searched for. This
+     * function figures out the "interesting" keys on a page, and then we sequentially walk that
+     * list instantiating those keys.
      *
-     * Allocate a bit array and figure out the set of "interesting" keys,
-     * marking up the array.
+     * Allocate a bit array and figure out the set of "interesting" keys, marking up the array.
      */
     WT_RET(__wt_scr_alloc(session, 0, &key));
     WT_RET(__wt_scr_alloc(session, (uint32_t)__bitstr_size(page->entries), &tmp));

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -222,9 +222,8 @@ __config_merge_format_next(WT_SESSION_IMPL *session, const char *prefix, size_t 
                 continue;
 
             /*
-             * The test is complicated by matching empty entries
-             * "foo=" against nested structures "foo,bar=", where
-             * the latter is a replacement for the former.
+             * The test is complicated by matching empty entries "foo=" against nested structures
+             * "foo,bar=", where the latter is a replacement for the former.
              */
             if (len2 > len1 && (ep + 1)->k[len1] == SEPC && memcmp(ep->k, (ep + 1)->k, len1) == 0)
                 continue;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2810,16 +2810,13 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_ERR(__wt_tiered_conn_config(session, cfg, false));
 
     /*
-     * The metadata/log encryptor is configured after extensions, since
-     * extensions may load encryptors.  We have to do this before creating
-     * the metadata file.
+     * The metadata/log encryptor is configured after extensions, since extensions may load
+     * encryptors. We have to do this before creating the metadata file.
      *
-     * The encryption customize callback needs the fully realized set of
-     * encryption args, as simply grabbing "encryption" doesn't work.
-     * As an example, configuration for the current call may just be
-     * "encryption=(secretkey=xxx)", with encryption.name,
-     * encryption.keyid being 'inherited' from the stored base
-     * configuration.
+     * The encryption customize callback needs the fully realized set of encryption args, as simply
+     * grabbing "encryption" doesn't work. As an example, configuration for the current call may
+     * just be "encryption=(secretkey=xxx)", with encryption.name, encryption.keyid being
+     * 'inherited' from the stored base configuration.
      */
     WT_ERR(__wt_config_gets_none(session, cfg, "encryption.name", &cval));
     WT_ERR(__wt_config_gets_none(session, cfg, "encryption.keyid", &keyid));

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -1422,9 +1422,8 @@ __wt_curjoin_join(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin, WT_INDEX *idx
             WT_RET(__curjoin_open_main(session, cjoin, entry));
 
             /*
-             * When we are repacking index keys to remove the
-             * primary key, we never want to transform trailing
-             * 'u'.  Use no-op padding to force this.
+             * When we are repacking index keys to remove the primary key, we never want to
+             * transform trailing 'u'. Use no-op padding to force this.
              */
             cindex = (WT_CURSOR_INDEX *)ref_cursor;
             len = strlen(cindex->iface.key_format) + 3;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1301,10 +1301,9 @@ struct __wt_insert_head {
         NULL :                                                          \
         (page)->modify->mod_row_update[WT_ROW_SLOT(page, ip)])
 /*
- * WT_ROW_INSERT_SMALLEST references an additional slot past the end of the
- * "one per WT_ROW slot" insert array.  That's because the insert array requires
- * an extra slot to hold keys that sort before any key found on the original
- * page.
+ * WT_ROW_INSERT_SMALLEST references an additional slot past the end of the "one per WT_ROW slot"
+ * insert array. That's because the insert array requires an extra slot to hold keys that sort
+ * before any key found on the original page.
  */
 #define WT_ROW_INSERT_SMALLEST(page)                                    \
     ((page)->modify == NULL || (page)->modify->mod_row_insert == NULL ? \

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1726,14 +1726,13 @@ __wt_page_swap_func(WT_SESSION_IMPL *session, WT_REF *held, WT_REF *want, uint32
     bool acquired;
 
     /*
-     * This function is here to simplify the error handling during hazard
-     * pointer coupling so we never leave a hazard pointer dangling.  The
-     * assumption is we're holding a hazard pointer on "held", and want to
-     * acquire a hazard pointer on "want", releasing the hazard pointer on
+     * This function is here to simplify the error handling during hazard pointer coupling so we
+     * never leave a hazard pointer dangling. The assumption is we're holding a hazard pointer on
+     * "held", and want to acquire a hazard pointer on "want", releasing the hazard pointer on
      * "held" when we're done.
      *
-     * When walking the tree, we sometimes swap to the same page. Fast-path
-     * that to avoid thinking about error handling.
+     * When walking the tree, we sometimes swap to the same page. Fast-path that to avoid thinking
+     * about error handling.
      */
     if (held == want)
         return (0);

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1281,10 +1281,9 @@ __clsm_search_near(WT_CURSOR *cursor, int *exactp)
         }
 
         /*
-         * Prefer larger cursors.  There are two reasons: (1) we expect
-         * prefix searches to be a common case (as in our own indices);
-         * and (2) we need a way to unambiguously know we have the
-         * "closest" result.
+         * Prefer larger cursors. There are two reasons: (1) we expect prefix searches to be a
+         * common case (as in our own indices); and (2) we need a way to unambiguously know we have
+         * the "closest" result.
          */
         if (cmp < 0) {
             if ((ret = c->next(c)) == WT_NOTFOUND) {

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -426,8 +426,8 @@ __wt_meta_track_update(WT_SESSION_IMPL *session, const char *key)
     WT_ERR(__wt_strdup(session, key, &trk->a));
 
     /*
-     * If there was a previous value, keep it around -- if not, then this
-     * "update" is really an insert.
+     * If there was a previous value, keep it around -- if not, then this "update" is really an
+     * insert.
      */
     if ((ret = __wt_metadata_search(session, key, &trk->b)) == WT_NOTFOUND) {
         trk->op = WT_ST_REMOVE;

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -49,18 +49,15 @@ __posix_sync(WT_SESSION_IMPL *session, int fd, const char *name, const char *fun
 
 #if defined(F_FULLFSYNC)
     /*
-     * OS X fsync documentation:
-     * "Note that while fsync() will flush all data from the host to the
-     * drive (i.e. the "permanent storage device"), the drive itself may
-     * not physically write the data to the platters for quite some time
-     * and it may be written in an out-of-order sequence. For applications
-     * that require tighter guarantees about the integrity of their data,
-     * Mac OS X provides the F_FULLFSYNC fcntl. The F_FULLFSYNC fcntl asks
-     * the drive to flush all buffered data to permanent storage."
+     * OS X fsync documentation: "Note that while fsync() will flush all data from the host to the
+     * drive (i.e. the "permanent storage device"), the drive itself may not physically write the
+     * data to the platters for quite some time and it may be written in an out-of-order sequence.
+     * For applications that require tighter guarantees about the integrity of their data, Mac OS X
+     * provides the F_FULLFSYNC fcntl. The F_FULLFSYNC fcntl asks the drive to flush all buffered
+     * data to permanent storage."
      *
-     * OS X F_FULLFSYNC fcntl documentation:
-     * "This is currently implemented on HFS, MS-DOS (FAT), and Universal
-     * Disk Format (UDF) file systems."
+     * OS X F_FULLFSYNC fcntl documentation: "This is currently implemented on HFS, MS-DOS (FAT),
+     * and Universal Disk Format (UDF) file systems."
      *
      * See comment in __posix_sync(): sync cannot be retried or fail.
      */
@@ -1032,11 +1029,10 @@ __wt_map_file(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
  * file while others might be reading or writing it:
  *
  * Every time someone reads or writes from the mapped region, they increment the "use" count via
- * cas. If someone wants to change the file size, they set the "stop" flag. If a session sees
- * the stop flag, it does not read via mmap, but resorts to the regular syscall. The session
- * that set the stop flag spin-waits until the "use" count goes to zero. Then it changes the
- * file size and remaps the region without synchronization. Once all that is done, it resets the
- * "stop" flag.
+ * cas. If someone wants to change the file size, they set the "stop" flag. If a session sees the
+ * stop flag, it does not read via mmap, but resorts to the regular syscall. The session that set
+ * the stop flag spin-waits until the "use" count goes to zero. Then it changes the file size and
+ * remaps the region without synchronization. Once all that is done, it resets the "stop" flag.
  */
 
 /*

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -18,29 +18,24 @@ __rec_key_state_update(WT_RECONCILE *r, bool ovfl_key)
     WT_ITEM *a;
 
     /*
-     * If writing an overflow key onto the page, don't update the "last key"
-     * value, and leave the state of prefix compression alone.  (If we are
-     * currently doing prefix compression, we have a key state which will
-     * continue to work, we're just skipping the key just created because
-     * it's an overflow key and doesn't participate in prefix compression.
-     * If we are not currently doing prefix compression, we can't start, an
-     * overflow key doesn't give us any state.)
+     * If writing an overflow key onto the page, don't update the "last key" value, and leave the
+     * state of prefix compression alone. (If we are currently doing prefix compression, we have a
+     * key state which will continue to work, we're just skipping the key just created because it's
+     * an overflow key and doesn't participate in prefix compression. If we are not currently doing
+     * prefix compression, we can't start, an overflow key doesn't give us any state.)
      *
-     * Additionally, if we wrote an overflow key onto the page, turn off the
-     * suffix compression of row-store internal node keys.  (When we split,
-     * "last key" is the largest key on the previous page, and "cur key" is
-     * the first key on the next page, which is being promoted.  In some
-     * cases we can discard bytes from the "cur key" that are not needed to
-     * distinguish between the "last key" and "cur key", compressing the
-     * size of keys on internal nodes.  If we just built an overflow key,
-     * we're not going to update the "last key", making suffix compression
-     * impossible for the next key. Alternatively, we could remember where
-     * the last key was on the page, detect it's an overflow key, read it
-     * from disk and do suffix compression, but that's too much work for an
-     * unlikely event.)
+     * Additionally, if we wrote an overflow key onto the page, turn off the suffix compression of
+     * row-store internal node keys. (When we split, "last key" is the largest key on the previous
+     * page, and "cur key" is the first key on the next page, which is being promoted. In some cases
+     * we can discard bytes from the "cur key" that are not needed to distinguish between the "last
+     * key" and "cur key", compressing the size of keys on internal nodes. If we just built an
+     * overflow key, we're not going to update the "last key", making suffix compression impossible
+     * for the next key. Alternatively, we could remember where the last key was on the page, detect
+     * it's an overflow key, read it from disk and do suffix compression, but that's too much work
+     * for an unlikely event.)
      *
-     * If we're not writing an overflow key on the page, update the last-key
-     * value and turn on both prefix and suffix compression.
+     * If we're not writing an overflow key on the page, update the last-key value and turn on both
+     * prefix and suffix compression.
      */
     if (ovfl_key)
         r->key_sfx_compress = false;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1217,15 +1217,13 @@ __wt_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len, bool 
 
 done:
     /*
-     * Overflow values can be larger than the maximum page size but still be
-     * "on-page". If the next key/value pair is larger than space available
-     * after a split has happened (in other words, larger than the maximum
-     * page size), create a page sized to hold that one key/value pair. This
-     * generally splits the page into key/value pairs before a large object,
-     * the object, and key/value pairs after the object. It's possible other
-     * key/value pairs will also be aggregated onto the bigger page before
-     * or after, if the page happens to hold them, but it won't necessarily
-     * happen that way.
+     * Overflow values can be larger than the maximum page size but still be "on-page". If the next
+     * key/value pair is larger than space available after a split has happened (in other words,
+     * larger than the maximum page size), create a page sized to hold that one key/value pair. This
+     * generally splits the page into key/value pairs before a large object, the object, and
+     * key/value pairs after the object. It's possible other key/value pairs will also be aggregated
+     * onto the bigger page before or after, if the page happens to hold them, but it won't
+     * necessarily happen that way.
      */
     if (r->space_avail < next_len)
         WT_RET(__rec_split_grow(session, r, next_len));

--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -214,10 +214,9 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns,
                 WT_RET(__wt_buf_catfmt(session, plan, "%c", WT_PROJ_SKIP));
             }
             /*
-             * Now copy the value in / out.  In the common case,
-             * where each value is used in one column, we do a
-             * "next" operation.  If the value is used again, we do
-             * a "reuse" operation to avoid making another copy.
+             * Now copy the value in / out. In the common case, where each value is used in one
+             * column, we do a "next" operation. If the value is used again, we do a "reuse"
+             * operation to avoid making another copy.
              */
             if (!have_it) {
                 WT_RET(__wt_buf_catfmt(session, plan, "%c", WT_PROJ_NEXT));

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -135,8 +135,7 @@ __rename_tree(WT_SESSION_IMPL *session, WT_TABLE *table, const char *newuri, con
     /*
      * Create the new data source URI and update the schema value.
      *
-     * 'name' has the format (colgroup|index):<tablename>[:<suffix>];
-     * we need the suffix.
+     * 'name' has the format (colgroup|index):<tablename>[:<suffix>]; we need the suffix.
      */
     is_colgroup = WT_PREFIX_MATCH(name, "colgroup:");
     if (!is_colgroup && !WT_PREFIX_MATCH(name, "index:"))

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -141,9 +141,9 @@ __wt_str_name_check(WT_SESSION_IMPL *session, const char *str)
     bool skip;
 
     /*
-     * Check if name is somewhere in the WiredTiger name space: it would be
-     * "bad" if the application truncated the metadata file.  Skip any
-     * leading URI prefix if needed, check and then skip over a table name.
+     * Check if name is somewhere in the WiredTiger name space: it would be "bad" if the application
+     * truncated the metadata file. Skip any leading URI prefix if needed, check and then skip over
+     * a table name.
      */
     name = str;
     skip = false;

--- a/src/tiered/tiered_cursor.c
+++ b/src/tiered/tiered_cursor.c
@@ -696,10 +696,9 @@ __curtiered_search_near(WT_CURSOR *cursor, int *exactp)
         }
 
         /*
-         * Prefer larger cursors.  There are two reasons: (1) we expect
-         * prefix searches to be a common case (as in our own indices);
-         * and (2) we need a way to unambiguously know we have the
-         * "closest" result.
+         * Prefer larger cursors. There are two reasons: (1) we expect prefix searches to be a
+         * common case (as in our own indices); and (2) we need a way to unambiguously know we have
+         * the "closest" result.
          */
         if (cmp < 0) {
             if ((ret = c->next(c)) == WT_NOTFOUND) {

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1470,15 +1470,13 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     WT_ERR(__wt_config_gets_def(session, cfg, "sync", 0, &cval));
 
     /*
-     * If the user chose the default setting, check whether sync is enabled
-     * for this transaction (either inherited or via begin_transaction).
-     * If sync is disabled, clear the field to avoid the log write being
-     * flushed.
+     * If the user chose the default setting, check whether sync is enabled for this transaction
+     * (either inherited or via begin_transaction). If sync is disabled, clear the field to avoid
+     * the log write being flushed.
      *
-     * Otherwise check for specific settings.  We don't need to check for
-     * "on" because that is the default inherited from the connection.  If
-     * the user set anything in begin_transaction, we only override with an
-     * explicit setting.
+     * Otherwise check for specific settings. We don't need to check for "on" because that is the
+     * default inherited from the connection. If the user set anything in begin_transaction, we only
+     * override with an explicit setting.
      */
     if (cval.len == 0) {
         if (!FLD_ISSET(txn->txn_logsync, WT_LOG_SYNC_ENABLED) && !F_ISSET(txn, WT_TXN_SYNC_SET))

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -440,12 +440,12 @@ config_update(WT_SESSION *session, char **list)
         return (util_err(session, errno, NULL));
 
     /*
-     * For each match, rewrite the dump configuration as described by any
-     * command-line configuration arguments.
+     * For each match, rewrite the dump configuration as described by any command-line configuration
+     * arguments.
      *
-     * New filenames will be chosen as part of the table load, remove all
-     * "filename=", "source=" and other configurations that foil loading
-     * from the values; we call an unpublished API to do the work.
+     * New filenames will be chosen as part of the table load, remove all "filename=", "source=" and
+     * other configurations that foil loading from the values; we call an unpublished API to do the
+     * work.
      */
     for (listp = list; *listp != NULL; listp += 2) {
         cnt = 0;

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -382,11 +382,9 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
         }
 
         /*
-         * Allow any ordering of 'config', 'colgroups',
-         * 'indices' before 'data', which must appear last.
-         * The non-'data' items build up a list of entries
-         * that created in our session before the data is
-         * inserted.
+         * Allow any ordering of 'config', 'colgroups', 'indices' before 'data', which must appear
+         * last. The non-'data' items build up a list of entries that created in our session before
+         * the data is inserted.
          */
         for (;;) {
             if (json_skip(session, ins, json_markers) != 0)

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -74,8 +74,8 @@ static bool do_rename = true;
     } while (0)
 
 /*
- * We keep an array of tables, each one may or may not be in use.
- * "In use" means it has been created, and will be updated from time to time.
+ * We keep an array of tables, each one may or may not be in use. "In use" means it has been
+ * created, and will be updated from time to time.
  */
 typedef struct {
     char *name;            /* non-null entries represent tables in use */
@@ -189,8 +189,7 @@ key_value(uint64_t change_count, char *key, size_t key_size, WT_ITEM *item, OPER
      * is inserted, it is all the letter 'a'. When the value is updated, is it mostly 'b', with some
      * 'c' mixed in. When the value is to modified, we'll end up with a value with mostly 'b' and
      * 'M' mixed in, in different spots. Thus the modify operation will have both additions ('M')
-     * and
-     * subtractions ('c') from the previous version.
+     * and subtractions ('c') from the previous version.
      */
     if (op_type == INSERT)
         ch = 'a';

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -183,9 +183,8 @@ main(int argc, char *argv[])
     /*
      * A linear pass through the list, adding random elements.
      *
-     * WiredTiger configurations are usually "the last one set wins", but
-     * "shared_cache" and "cache_set" options aren't allowed in the same
-     * configuration string.
+     * WiredTiger configurations are usually "the last one set wins", but "shared_cache" and
+     * "cache_set" options aren't allowed in the same configuration string.
      */
     for (i = 0; i < WT_ELEMENTS(list); ++i) {
         p = list[i];

--- a/test/format/util.c
+++ b/test/format/util.c
@@ -282,7 +282,7 @@ timestamp_once(bool allow_lag, bool final)
 
         /*
          * If a lag is permitted, move the oldest timestamp half the way to the current
-         * "all_durable" timestamp.  Move the stable timestamp to "all_durable".
+         * "all_durable" timestamp. Move the stable timestamp to "all_durable".
          */
         if (allow_lag)
             g.oldest_timestamp = (all_durable + g.oldest_timestamp) / 2;


### PR DESCRIPTION
Allow single and double quotes inside auto-formatted comments.