### PR TITLE
WT-7348 CMake Complete POSIX support fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,15 @@ target_compile_options(
     PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
 )
 
+if(ENABLE_STATIC)
+    # Avoid compiling with fPIC for static builds, this can often lead to
+    # GCC disabling many optimizations e.g. inlining, possibly introducing
+    # an overhead.
+    set_property(TARGET wiredtiger PROPERTY POSITION_INDEPENDENT_CODE OFF)
+else()
+    set_property(TARGET wiredtiger PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # Ensure we link any available library dependencies to our wiredtiger target.
 if(HAVE_LIBPTHREAD)
     target_link_libraries(wiredtiger "pthread")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+# Import our available build types prior to initialing the
+# project.
+include(build_cmake/configs/modes.cmake)
+
 project(WiredTiger C ASM)
 
 include(build_cmake/helpers.cmake)

--- a/build_cmake/configs/base.cmake
+++ b/build_cmake/configs/base.cmake
@@ -177,8 +177,15 @@ config_string(
     DEFAULT "\"WiredTiger ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH} (${config_date})\""
 )
 
-if(HAVE_DIAGNOSTIC)
+if(HAVE_DIAGNOSTIC AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+    # Avoid setting diagnostic flags if we are building with Debug mode.
+    # CMakes Debug config sets compilation with debug symbols by default.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CC_OPTIMIZE_LEVEL}")
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    # Don't use the optimization level if we have specified a release config.
+    # CMakes Release config sets compilation to the highest optimization level
+    # by default.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CC_OPTIMIZE_LEVEL}")
+endif()

--- a/build_cmake/configs/modes.cmake
+++ b/build_cmake/configs/modes.cmake
@@ -8,8 +8,56 @@
 
 # Establishes build configuration modes we can use when compiling.
 
+# Create an ASAN build variant
+set(CMAKE_C_FLAGS_ASAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler for ASan build type or configuration." FORCE)
+
+set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler for ASan build type or configuration." FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address -static-libasan" CACHE STRING
+    "Linker flags to be used to create executables for ASan build type." FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address -static-libasan" CACHE STRING
+    "Linker lags to be used to create shared libraries for ASan build type." FORCE)
+
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_ASAN
+    CMAKE_C_FLAGS_ASAN
+    CMAKE_EXE_LINKER_FLAGS_ASAN
+    CMAKE_SHARED_LINKER_FLAGS_ASAN
+)
+
+# Create an UBSAN build variant
+set(CMAKE_C_FLAGS_UBSAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler for UBSan build type or configuration." FORCE)
+
+set(CMAKE_CXX_FLAGS_UBSAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler for UBSan build type or configuration." FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_UBSAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined -lubsan" CACHE STRING
+    "Linker flags to be used to create executables for UBSan build type." FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined -lubsan" CACHE STRING
+    "Linker lags to be used to create shared libraries for UBSan build type." FORCE)
+
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_UBSAN
+    CMAKE_C_FLAGS_UBSAN
+    CMAKE_EXE_LINKER_FLAGS_UBSAN
+    CMAKE_SHARED_LINKER_FLAGS_UBSAN
+)
+
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "None" CACHE STRING "Choose the type of build, options are: None Debug Release." FORCE)
+    set(CMAKE_BUILD_TYPE "None" CACHE STRING "Choose the type of build, options are: None Debug Release ASan UBSan." FORCE)
 endif()
 
-set(CMAKE_CONFIGURATION_TYPES None Debug Release)
+set(CMAKE_CONFIGURATION_TYPES None Debug Release ASan UBSan)

--- a/build_cmake/configs/modes.cmake
+++ b/build_cmake/configs/modes.cmake
@@ -1,0 +1,15 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#  All rights reserved.
+#
+#  See the file LICENSE for redistribution information
+#
+
+# Establishes build configuration modes we can use when compiling.
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "None" CACHE STRING "Choose the type of build, options are: None Debug Release." FORCE)
+endif()
+
+set(CMAKE_CONFIGURATION_TYPES None Debug Release)

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1449,6 +1449,7 @@ variadic
 vectorized
 versa
 vfprintf
+vh
 vm
 vpack
 vpmsum

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -35,7 +35,7 @@ macro(define_csuite_test)
         "CSUITE"
         "SMOKE"
         "TARGET;DIR_NAME"
-        "SOURCES"
+        "SOURCES;FLAGS;ARGUMENTS"
         ${ARGN}
     )
     if (NOT "${CSUITE_UNPARSED_ARGUMENTS}" STREQUAL "")
@@ -50,21 +50,27 @@ macro(define_csuite_test)
     if ("${CSUITE_DIR_NAME}" STREQUAL "")
         message(FATAL_ERROR "No directory given to define_csuite_test")
     endif()
+    set(additional_executable_args)
+    if(NOT "${CSUITE_FLAGS}" STREQUAL "")
+        list(APPEND additional_executable_args FLAGS ${CSUITE_FLAGS})
+    endif()
     if (CSUITE_SMOKE)
         # csuite test comes with a smoke execution wrapper.
         create_test_executable(${CSUITE_TARGET}
             SOURCES ${CSUITE_SOURCES}
             ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${CSUITE_DIR_NAME}/smoke.sh
             BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
+            ${additional_executable_args}
         )
         add_test(NAME ${CSUITE_TARGET}
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh $<TARGET_FILE:${CSUITE_TARGET}>)
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh $<TARGET_FILE:${CSUITE_TARGET}> ${CSUITE_ARGUMENTS})
     else()
         create_test_executable(${CSUITE_TARGET}
             SOURCES ${CSUITE_SOURCES}
             BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
+            ${additional_executable_args}
         )
-        add_test(NAME ${CSUITE_TARGET} COMMAND ${CSUITE_TARGET})
+        add_test(NAME ${CSUITE_TARGET} COMMAND ${CSUITE_TARGET} ${CSUITE_ARGUMENTS})
     endif()
     list(APPEND csuite_tests ${CSUITE_TARGET})
 endmacro(define_csuite_test)

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -63,7 +63,7 @@ macro(define_csuite_test)
             ${additional_executable_args}
         )
         add_test(NAME ${CSUITE_TARGET}
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh $<TARGET_FILE:${CSUITE_TARGET}> ${CSUITE_ARGUMENTS}
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh ${CSUITE_ARGUMENTS} $<TARGET_FILE:${CSUITE_TARGET}>
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
         )
     else()
@@ -133,6 +133,7 @@ define_csuite_test(
     SOURCES timestamp_abort/main.c
     DIR_NAME timestamp_abort
     SMOKE
+    ARGUMENTS -b $<TARGET_FILE:test_timestamp_abort>
 )
 
 define_csuite_test(

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -206,6 +206,11 @@ define_csuite_test(
     TARGET test_wt2909_checkpoint_integrity
     SOURCES wt2909_checkpoint_integrity/main.c
     DIR_NAME wt2909_checkpoint_integrity
+    # We need to manually specify the location of the fail fs library
+    # and build directory as this path is more dynamic compared to layout autoconf
+    # produces in build_posix.
+    FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
+    ARGUMENTS -b ${CMAKE_BINARY_DIR}
 )
 
 define_csuite_test(
@@ -218,6 +223,11 @@ define_csuite_test(
     TARGET test_wt3120_filesys
     SOURCES wt3120_filesys/main.c
     DIR_NAME wt3120_filesys
+    # We need to manually specify the location of the fail fs library
+    # and build directory as this path is more dynamic compared to layout autoconf
+    # produces in build_posix.
+    FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
+    ARGUMENTS -b ${CMAKE_BINARY_DIR}
 )
 
 define_csuite_test(

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -63,14 +63,25 @@ macro(define_csuite_test)
             ${additional_executable_args}
         )
         add_test(NAME ${CSUITE_TARGET}
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh $<TARGET_FILE:${CSUITE_TARGET}> ${CSUITE_ARGUMENTS})
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/smoke.sh $<TARGET_FILE:${CSUITE_TARGET}> ${CSUITE_ARGUMENTS}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
+        )
     else()
         create_test_executable(${CSUITE_TARGET}
             SOURCES ${CSUITE_SOURCES}
             BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
             ${additional_executable_args}
         )
-        add_test(NAME ${CSUITE_TARGET} COMMAND ${CSUITE_TARGET} ${CSUITE_ARGUMENTS})
+        # Take a CMake-based path and convert it to a platform-specfic path (/ for Unix, \ for Windows).
+        set(wt_test_home_dir ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}/WT_HOME_${CSUITE_TARGET})
+        file(TO_NATIVE_PATH "${wt_test_home_dir}" wt_test_home_dir)
+        # Ensure each DB home directory is run under the tests working directory.
+        set(command_args -h ${wt_test_home_dir})
+        list(APPEND command_args ${CSUITE_ARGUMENTS})
+        add_test(NAME ${CSUITE_TARGET}
+            COMMAND ${CSUITE_TARGET} ${command_args}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CSUITE_DIR_NAME}
+        )
     endif()
     list(APPEND csuite_tests ${CSUITE_TARGET})
 endmacro(define_csuite_test)

--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -6,18 +6,15 @@ set -e
 # to add a stress timing in checkpoint prepare.
 
 default_test_args="-t 10 -T 5"
-while getopts ":s" opt; do
+while getopts ":sb:" opt; do
     case $opt in
         s) default_test_args="$default_test_args -s" ;;
+        b) test_bin=$OPTARG ;;
     esac
 done
 
-
-if [ -n "$1" ]
+if [ -z "$test_bin" ]
 then
-    # If the test binary is passed in manually.
-    test_bin=$1
-else
     # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
     # and running in test/csuite.
     top_builddir=${top_builddir:-../../build_posix}

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -502,8 +502,9 @@ subtest_main(int argc, char *argv[], bool close_test)
     testutil_check(__wt_snprintf(filename, sizeof(filename), "%s/%s", opts->home, STDOUT_FILE));
     testutil_assert(freopen(filename, "a", stdout) != NULL);
 
+#ifndef WT_FAIL_FS_LIB
 #define WT_FAIL_FS_LIB "ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so"
-
+#endif
     testutil_build_dir(opts, buf, 1024);
     testutil_check(__wt_snprintf(config, sizeof(config),
       "create,cache_size=250M,log=(enabled),transaction_sync=(enabled,method=none),extensions=(%s/"

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -301,6 +301,10 @@ run_check_subtest(
         subtest_args[narg++] = (char *)"subtest";
     subtest_args[narg++] = (char *)"-h";
     subtest_args[narg++] = opts->home;
+    if (opts->build_dir != NULL) {
+        subtest_args[narg++] = (char *)"-b";
+        subtest_args[narg++] = opts->build_dir;
+    }
     subtest_args[narg++] = (char *)"-v"; /* subtest is always verbose */
     subtest_args[narg++] = (char *)"-p";
     subtest_args[narg++] = (char *)"-o";
@@ -500,7 +504,7 @@ subtest_main(int argc, char *argv[], bool close_test)
 
 #define WT_FAIL_FS_LIB "ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so"
 
-    testutil_build_dir(buf, 1024);
+    testutil_build_dir(opts, buf, 1024);
     testutil_check(__wt_snprintf(config, sizeof(config),
       "create,cache_size=250M,log=(enabled),transaction_sync=(enabled,method=none),extensions=(%s/"
       "%s=(early_load,config={environment=true,verbose=true}))",

--- a/test/csuite/wt3120_filesys/main.c
+++ b/test/csuite/wt3120_filesys/main.c
@@ -46,7 +46,9 @@ main(int argc, char *argv[])
     testutil_check(testutil_parse_opts(argc, argv, opts));
     testutil_make_work_dir(opts->home);
 
+#ifndef WT_FAIL_FS_LIB
 #define WT_FAIL_FS_LIB "ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so"
+#endif
     testutil_build_dir(opts, buf, 1024);
     testutil_check(__wt_snprintf(
       config, sizeof(config), "create,extensions=(%s/%s=(early_load=true))", buf, WT_FAIL_FS_LIB));

--- a/test/csuite/wt3120_filesys/main.c
+++ b/test/csuite/wt3120_filesys/main.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
     testutil_make_work_dir(opts->home);
 
 #define WT_FAIL_FS_LIB "ext/test/fail_fs/.libs/libwiredtiger_fail_fs.so"
-    testutil_build_dir(buf, 1024);
+    testutil_build_dir(opts, buf, 1024);
     testutil_check(__wt_snprintf(
       config, sizeof(config), "create,extensions=(%s/%s=(early_load=true))", buf, WT_FAIL_FS_LIB));
     testutil_check(wiredtiger_open(opts->home, NULL, config, &opts->conn));

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -327,6 +327,7 @@ run(int argc, char *argv[])
     (void)testutil_set_progname(argv);
     __wt_random_init_seed(NULL, &rnd);
 
+    default_home = true;
     while ((ch = __wt_getopt(argv[0], argc, argv, "vh:")) != EOF) {
         switch (ch) {
         case 'v':

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -335,6 +335,7 @@ run(int argc, char *argv[])
             break;
         case 'h':
             strncpy(home, __wt_optarg, HOME_LEN);
+            home[HOME_LEN - 1] = '\0';
             default_home = false;
             break;
         default:

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -31,6 +31,7 @@
 
 #define MAXKEY 10000
 #define PERIOD 60
+#define HOME_LEN 256
 
 static WT_CONNECTION *conn;
 static uint64_t worker, worker_busy, verify, verify_busy;
@@ -38,6 +39,8 @@ static u_int workers, uris;
 static bool done = false;
 static bool verbose = false;
 static char *uri_list[750];
+static char home[HOME_LEN];
+extern char *__wt_optarg;
 
 static void
 uri_init(void)
@@ -248,11 +251,10 @@ runone(bool config_cache)
 {
     pthread_t idlist[1000];
     u_int i, j;
-    char buf[256], home[256];
+    char buf[256];
 
     done = false;
 
-    testutil_work_dir_from_path(home, sizeof(home), "WT_TEST.wt4333_handle_locks");
     testutil_make_work_dir(home);
 
     testutil_check(__wt_snprintf(buf, sizeof(buf),
@@ -320,22 +322,29 @@ run(int argc, char *argv[])
     WT_RAND_STATE rnd;
     u_int i, n;
     int ch;
+    bool default_home;
 
     (void)testutil_set_progname(argv);
     __wt_random_init_seed(NULL, &rnd);
 
-    while ((ch = __wt_getopt(argv[0], argc, argv, "v")) != EOF) {
+    while ((ch = __wt_getopt(argv[0], argc, argv, "vh:")) != EOF) {
         switch (ch) {
         case 'v':
             verbose = true;
+            break;
+        case 'h':
+            strncpy(home, __wt_optarg, HOME_LEN);
+            default_home = false;
             break;
         default:
             fprintf(stderr, "usage: %s [-v]\n", argv[0]);
             return (EXIT_FAILURE);
         }
     }
-
     (void)signal(SIGALRM, on_alarm);
+
+    if (default_home)
+        testutil_work_dir_from_path(home, sizeof(home), "WT_TEST.wt4333_handle_locks");
 
     /* Each test in the table runs for a minute, run 5 tests at random. */
     for (i = 0; i < 5; ++i) {

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -114,6 +114,7 @@ function(create_test_executable target)
             COMMAND ${CMAKE_COMMAND} -E copy
                 ${file}
                 ${test_binary_dir}/${file_basename}
+            DEPENDS ${file}
         )
         add_custom_target(copy_file_${target}_${file_basename} DEPENDS ${test_binary_dir}/${file_basename})
         add_dependencies(${target} copy_file_${target}_${file_basename})

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -34,7 +34,13 @@ set(sources
     thread.c
 )
 
-add_library(test_util SHARED ${sources})
+set(link_type)
+if(ENABLE_STATIC)
+    set(link_type "STATIC")
+else()
+    set(link_type "SHARED")
+endif()
+add_library(test_util ${link_type} ${sources})
 
 target_include_directories(
     test_util

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -146,9 +146,7 @@ testutil_build_dir(TEST_OPTS *opts, char *buf, int size)
     FILE *fp;
     char *p;
 
-    /* If a build directory was manually given as an option we can directly
-     * return this instead.
-     */
+    /* If a build directory was manually given as an option we can directly return this instead. */
     if (opts->build_dir != NULL) {
         strncpy(buf, opts->build_dir, (size_t)size);
         return;

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -141,10 +141,18 @@ testutil_clean_work_dir(const char *dir)
  *     Get the git top level directory and concatenate the build directory.
  */
 void
-testutil_build_dir(char *buf, int size)
+testutil_build_dir(TEST_OPTS *opts, char *buf, int size)
 {
     FILE *fp;
     char *p;
+
+    /* If a build directory was manually given as an option we can directly
+     * return this instead.
+     */
+    if (opts->build_dir != NULL) {
+        strncpy(buf, opts->build_dir, (size_t)size);
+        return;
+    }
 
     /* Get the git top level directory. */
 #ifdef _WIN32

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -49,7 +49,7 @@ testutil_parse_opts(int argc, char *const *argv, TEST_OPTS *opts)
 
     testutil_print_command_line(argc, argv);
 
-    while ((ch = __wt_getopt(opts->progname, argc, argv, "A:dh:n:o:pR:T:t:vW:")) != EOF)
+    while ((ch = __wt_getopt(opts->progname, argc, argv, "A:dh:b:n:o:pR:T:t:vW:")) != EOF)
         switch (ch) {
         case 'A': /* Number of append threads */
             opts->n_append_threads = (uint64_t)atoll(__wt_optarg);
@@ -59,6 +59,9 @@ testutil_parse_opts(int argc, char *const *argv, TEST_OPTS *opts)
             break;
         case 'h': /* Home directory */
             opts->home = dstrdup(__wt_optarg);
+            break;
+        case 'b': /* Build directory */
+            opts->build_dir = dstrdup(__wt_optarg);
             break;
         case 'n': /* Number of records */
             opts->nrecords = (uint64_t)atoll(__wt_optarg);
@@ -104,6 +107,7 @@ testutil_parse_opts(int argc, char *const *argv, TEST_OPTS *opts)
               "[-A append thread count] "
               "[-d add data] "
               "[-h home] "
+              "[-b build directory] "
               "[-n record count] "
               "[-o op count] "
               "[-p] "

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -54,6 +54,7 @@ typedef struct {
     char *home;
     const char *argv0;    /* Exec name */
     const char *progname; /* Truncated program name */
+    char *build_dir;      /* Build directory path */
 
     enum {
         TABLE_COL = 1, /* Fixed-length column store */
@@ -268,7 +269,7 @@ void testutil_clean_work_dir(const char *);
 void testutil_cleanup(TEST_OPTS *);
 void testutil_copy_data(const char *);
 bool testutil_is_flag_set(const char *);
-void testutil_build_dir(char *, int);
+void testutil_build_dir(TEST_OPTS *, char *, int);
 void testutil_make_work_dir(const char *);
 int testutil_parse_opts(int, char *const *, TEST_OPTS *);
 void testutil_print_command_line(int argc, char *const *argv);


### PR DESCRIPTION
This PR appends some additional fixes to the final CMake POSIX support, to be merged with all the other changes under WT-7348.
More specifically, this PR adds:
* Fixes to `define_csuite_test` helper so we can run csuite tests in parallel without them running over each other
* Adjustments to the following C tests:
   *  Prevent `wt2909_checkpoint_integrity` & `wt3120_filesys` from assuming the build location of the fail fs extension
library/module
   * Avoid `syscall` test assuming the layout of `build_posix`
* Avoid compiling with `fPIC` for static builds
*  Respect CMake Build Modes: Making it IDE friendly
*  ASAN and UBSan build mode 