### PR TITLE
WT-7348 WT_BUILDDIR option in python test runner

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -52,8 +52,11 @@ wt_3rdpartydir = os.path.join(wt_disttop, 'test', '3rdparty')
 # could pick the wrong one. We also need to account for the fact that there
 # may be an executable 'wt' file the build directory and a subordinate .libs
 # directory.
+env_builddir = os.getenv('WT_BUILDDIR')
 curdir = os.getcwd()
-if os.path.basename(curdir) == '.libs' and \
+if(env_builddir and os.path.isfile(os.path.join(env_builddir, 'wt'))):
+    wt_builddir = env_builddir
+elif os.path.basename(curdir) == '.libs' and \
    os.path.isfile(os.path.join(curdir, os.pardir, 'wt')):
     wt_builddir = os.path.join(curdir, os.pardir)
 elif os.path.isfile(os.path.join(curdir, 'wt')):

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -54,7 +54,7 @@ wt_3rdpartydir = os.path.join(wt_disttop, 'test', '3rdparty')
 # directory.
 env_builddir = os.getenv('WT_BUILDDIR')
 curdir = os.getcwd()
-if(env_builddir and os.path.isfile(os.path.join(env_builddir, 'wt'))):
+if env_builddir and os.path.isfile(os.path.join(env_builddir, 'wt')):
     wt_builddir = env_builddir
 elif os.path.basename(curdir) == '.libs' and \
    os.path.isfile(os.path.join(curdir, os.pardir, 'wt')):


### PR DESCRIPTION
When running the python test suite with a CMake generated build we can no longer depend on falling back to a build directory of `build_posix`. Users can dynamically define the name of their CMake build directory and create multiple working builds of varying names. To avoid incorrectly assuming the build exists in `build_posix`, provide an opportunity to read an env variable 'WT_BUILDDIR' indicating the location of the build we want to use for the test.

Note: We can mostly depend on invoking the python test in the working build directory e.g. `python3 ../test/suite/run.py`, however this approach doesn't work when the test starts spawning sub processes from different working directories e.g. invoking `run_subprocess_function`(or the user generally wants to invoke the test in a different working directory).