### PR TITLE
WT-6555 Fix memory error in test_txn13

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2546,6 +2546,7 @@ buildvariants:
     - name: configure-combinations
     - name: checkpoint-filetypes-test
     - name: unit-test-long
+      distros: ubuntu1804-large
     - name: unit-test-random-seed
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
@@ -2669,6 +2670,7 @@ buildvariants:
     - name: syscall-linux
     - name: checkpoint-filetypes-test
     - name: unit-test-long
+      distros: rhel80-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf


### PR DESCRIPTION
I updated `evergreen.yml` to use the `ubuntu1804-large` and `rhel80-large` distros for `unit-test-long`. These distros have 64GB of memory which should be more than enough to resolve the memory issues in the tests.