### PR TITLE
WT-7504 test_hs21 cache stuck dirty

### DIFF
--- a/test/suite/test_hs21.py
+++ b/test/suite/test_hs21.py
@@ -47,7 +47,7 @@ class test_hs21(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     file_name = 'test_hs21'
     numfiles = 10
-    nrows = 10000
+    nrows = 1000
 
     def large_updates(self, uri, value, ds, nrows, commit_ts):
         # Update a large number of records, we'll hang if the history store table isn't working.


### PR DESCRIPTION
After investigating, it seems like a lot of the failures are happening on PPC machines where checkpoint is hanging after the test completes but before shutdown. The idea is to make the Python test less intensive. 