### PR TITLE
WT-7348 Fix Darwin POSIX issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,11 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+project(WiredTiger C ASM)
+
 # Import our available build types prior to initialing the
 # project.
 include(build_cmake/configs/modes.cmake)
-
-project(WiredTiger C ASM)
 
 include(build_cmake/helpers.cmake)
 

--- a/build_cmake/configs/modes.cmake
+++ b/build_cmake/configs/modes.cmake
@@ -9,6 +9,15 @@
 # Establishes build configuration modes we can use when compiling.
 
 # Create an ASAN build variant
+
+# Clang and GCC have slightly different linker names for the ASAN library.
+set(libasan)
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+    set(libasan "-static-libsan")
+else()
+    set(libasan "-static-libasan")
+endif()
+
 set(CMAKE_C_FLAGS_ASAN
     "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
     "Flags used by the C compiler for ASan build type or configuration." FORCE)
@@ -18,11 +27,11 @@ set(CMAKE_CXX_FLAGS_ASAN
     "Flags used by the C++ compiler for ASan build type or configuration." FORCE)
 
 set(CMAKE_EXE_LINKER_FLAGS_ASAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address -static-libasan" CACHE STRING
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address ${libasan}" CACHE STRING
     "Linker flags to be used to create executables for ASan build type." FORCE)
 
 set(CMAKE_SHARED_LINKER_FLAGS_ASAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address -static-libasan" CACHE STRING
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address ${libasan}" CACHE STRING
     "Linker lags to be used to create shared libraries for ASan build type." FORCE)
 
 mark_as_advanced(
@@ -33,6 +42,13 @@ mark_as_advanced(
 )
 
 # Create an UBSAN build variant
+
+# Clang doesn't need to link ubsan, this is only a GCC requirement.
+set(libubsan "")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    set(libubsan "-lubsan")
+endif()
+
 set(CMAKE_C_FLAGS_UBSAN
     "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
     "Flags used by the C compiler for UBSan build type or configuration." FORCE)
@@ -42,11 +58,11 @@ set(CMAKE_CXX_FLAGS_UBSAN
     "Flags used by the C++ compiler for UBSan build type or configuration." FORCE)
 
 set(CMAKE_EXE_LINKER_FLAGS_UBSAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined -lubsan" CACHE STRING
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined ${libubsan}" CACHE STRING
     "Linker flags to be used to create executables for UBSan build type." FORCE)
 
 set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined -lubsan" CACHE STRING
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined ${libubsan}" CACHE STRING
     "Linker lags to be used to create shared libraries for UBSan build type." FORCE)
 
 mark_as_advanced(

--- a/build_cmake/install/install.cmake
+++ b/build_cmake/install/install.cmake
@@ -35,32 +35,3 @@ if(WT_POSIX)
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
 endif()
-
-# Install our wiredtiger compressor extensions (provided we have enabled/built them).
-if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
-    install(TARGETS wiredtiger_lz4
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    )
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
-    install(TARGETS wiredtiger_snappy
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    )
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
-    install(TARGETS wiredtiger_zlib
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    )
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
-    install(TARGETS wiredtiger_zstd
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    )
-endif()

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -28,6 +28,8 @@
 
 project(lz4 C)
 
+include(GNUInstallDirs)
+
 config_bool(
     HAVE_BUILTIN_EXTENSION_LZ4
     "Builtin lz4 compression library."
@@ -66,5 +68,10 @@ if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
     target_compile_options(
         wiredtiger_lz4
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
+    )
+
+    install(TARGETS wiredtiger_lz4
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -28,6 +28,8 @@
 
 project(snappy C)
 
+include(GNUInstallDirs)
+
 config_bool(
     HAVE_BUILTIN_EXTENSION_SNAPPY
     "Builtin snappy compression library."
@@ -65,5 +67,10 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
     target_compile_options(
         wiredtiger_snappy
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
+    )
+
+    install(TARGETS wiredtiger_snappy
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()

--- a/ext/compressors/zlib/CMakeLists.txt
+++ b/ext/compressors/zlib/CMakeLists.txt
@@ -28,6 +28,8 @@
 
 project(zlib C)
 
+include(GNUInstallDirs)
+
 config_bool(
     HAVE_BUILTIN_EXTENSION_ZLIB
     "Builtin zlib compression library."
@@ -65,5 +67,10 @@ if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
     target_compile_options(
         wiredtiger_zlib
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
+    )
+
+    install(TARGETS wiredtiger_zlib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -28,6 +28,8 @@
 
 project(zstd C)
 
+include(GNUInstallDirs)
+
 config_bool(
     HAVE_BUILTIN_EXTENSION_ZSTD
     "Builtin zstd compression library."
@@ -64,5 +66,10 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
     target_compile_options(
         wiredtiger_zstd
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
+    )
+
+    install(TARGETS wiredtiger_zstd
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()


### PR DESCRIPTION
Adds two small fixes to the Darwin POSIX support merged as a result of WT-7348. This changes include:
* Check whether compiling with GCC or Clang for ASAN and UBSAN since they have slightly different linker definition. We also need to move the inclusion of the modes config file to after the project definition to ensure 'CMAKE_C_COMPILER_ID' has been defined.
* Older versions of CMake 3.10 & 3.11 are unable to have install definitions referring to subdirectory projects. We need to have these definitions at the same project scope when defining extension install targets.