### PR TITLE
WT-7595 Add flag to history store cursor to track whether underlying table insertion was successful

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1133,5 +1133,5 @@ __wt_curhs_check_insert_success(WT_CURSOR *cursor)
     WT_CURSOR_HS *hs_cursor;
 
     hs_cursor = (WT_CURSOR_HS *)cursor;
-    return hs_cursor->insert_success;
+    return (hs_cursor->insert_success);
 }

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -887,7 +887,7 @@ retry:
      * Mark the insert as successful. Even if one of the calls below fails, some callers will still
      * need to know whether the actual insert went through or not.
      */
-    F_SET(hs_cursor, WT_HS_CUR_INSERT_SUCCESS);
+    hs_cursor->insert_success = true;
 
 #ifdef HAVE_DIAGNOSTIC
     /* Do a search again and call next to check the key order. */
@@ -1116,7 +1116,7 @@ __wt_curhs_clear_insert_success(WT_CURSOR *cursor)
     WT_CURSOR_HS *hs_cursor;
 
     hs_cursor = (WT_CURSOR_HS *)cursor;
-    F_CLR(hs_cursor, WT_HS_CUR_INSERT_SUCCESS);
+    hs_cursor->insert_success = false;
 }
 
 /*
@@ -1133,5 +1133,5 @@ __wt_curhs_check_insert_success(WT_CURSOR *cursor)
     WT_CURSOR_HS *hs_cursor;
 
     hs_cursor = (WT_CURSOR_HS *)cursor;
-    return (F_ISSET(hs_cursor, WT_HS_CUR_INSERT_SUCCESS));
+    return hs_cursor->insert_success;
 }

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -883,6 +883,12 @@ retry:
         goto retry;
     WT_ERR(ret);
 
+    /*
+     * Mark the insert as successful. Even if one of the calls below fails, some callers will still
+     * need to know whether the actual insert went through or not.
+     */
+    F_SET(hs_cursor, WT_HS_CUR_INSERT_SUCCESS);
+
 #ifdef HAVE_DIAGNOSTIC
     /* Do a search again and call next to check the key order. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_hs_row_search(cbt, &file_cursor->key, true));
@@ -1097,4 +1103,35 @@ err:
         *cursorp = NULL;
     }
     return (ret);
+}
+
+/*
+ * __wt_curhs_clear_insert_success --
+ *     Clear the insertion flag for the history store cursor. We should call this prior to using the
+ *     WT_CURSOR->insert method.
+ */
+void
+__wt_curhs_clear_insert_success(WT_CURSOR *cursor)
+{
+    WT_CURSOR_HS *hs_cursor;
+
+    hs_cursor = (WT_CURSOR_HS *)cursor;
+    F_CLR(hs_cursor, WT_HS_CUR_INSERT_SUCCESS);
+}
+
+/*
+ * __wt_curhs_check_insert_success --
+ *     Check whether the insertion flag for the history store cursor is set or not. This signals
+ *     whether or not the last WT_CURSOR->insert call successfully inserted the history store
+ *     record. This is distinctly different from the return value of WT_CURSOR->insert since the
+ *     return value could be non-zero due to cursor operations AFTER the actual history store
+ *     insertion.
+ */
+bool
+__wt_curhs_check_insert_success(WT_CURSOR *cursor)
+{
+    WT_CURSOR_HS *hs_cursor;
+
+    hs_cursor = (WT_CURSOR_HS *)cursor;
+    return (F_ISSET(hs_cursor, WT_HS_CUR_INSERT_SUCCESS));
 }

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -290,12 +290,13 @@ struct __wt_cursor_hs {
     uint32_t btree_id;
     WT_ITEM *datastore_key;
 
+    bool insert_success;
+
     /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_HS_CUR_BTREE_ID_SET 0x01u
-#define WT_HS_CUR_COUNTER_SET 0x02u
-#define WT_HS_CUR_INSERT_SUCCESS 0x04u
-#define WT_HS_CUR_KEY_SET 0x08u
-#define WT_HS_CUR_TS_SET 0x10u
+#define WT_HS_CUR_BTREE_ID_SET 0x1u
+#define WT_HS_CUR_COUNTER_SET 0x2u
+#define WT_HS_CUR_KEY_SET 0x4u
+#define WT_HS_CUR_TS_SET 0x8u
     /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint8_t flags;
 };

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -291,10 +291,11 @@ struct __wt_cursor_hs {
     WT_ITEM *datastore_key;
 
     /* AUTOMATIC FLAG VALUE GENERATION START */
-#define WT_HS_CUR_BTREE_ID_SET 0x1u
-#define WT_HS_CUR_COUNTER_SET 0x2u
-#define WT_HS_CUR_KEY_SET 0x4u
-#define WT_HS_CUR_TS_SET 0x8u
+#define WT_HS_CUR_BTREE_ID_SET 0x01u
+#define WT_HS_CUR_COUNTER_SET 0x02u
+#define WT_HS_CUR_INSERT_SUCCESS 0x04u
+#define WT_HS_CUR_KEY_SET 0x08u
+#define WT_HS_CUR_TS_SET 0x10u
     /* AUTOMATIC FLAG VALUE GENERATION STOP */
     uint8_t flags;
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -14,6 +14,8 @@ extern bool __wt_cell_type_check(uint8_t cell_type, uint8_t dsk_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_checksum_alt_match(const void *chunk, size_t len, uint32_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_curhs_check_insert_success(WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_evict_thread_chk(WT_SESSION_IMPL *session)
@@ -1690,6 +1692,7 @@ extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);
 extern void __wt_connection_destroy(WT_CONNECTION_IMPL *conn);
+extern void __wt_curhs_clear_insert_success(WT_CURSOR *cursor);
 extern void __wt_cursor_close(WT_CURSOR *cursor);
 extern void __wt_cursor_get_hash(
   WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *to_dup, uint64_t *hash_value);


### PR DESCRIPTION
Our history store cursor insert implementation performs a few calls after the actual insertion into the history store stable. If these fail, the insert will return non-zero.

This means that we may bail out of reconciliation without marking the inserted update with the `WT_UPDATE_HS` flag, leading us to try inserting it again in a subsequent reconciliation.

Unfortunately, this punches a hole through our cursor abstraction... but I think it's necessary for now. The priority is to fix this but we should come up with a cleaner way to deal with this in the future.