### PR TITLE
WT-7602 Fix MacOS CMake Compilation Issues

### DIFF
--- a/build_cmake/configs/auto.cmake
+++ b/build_cmake/configs/auto.cmake
@@ -284,6 +284,9 @@ config_compile(
 
 include(TestBigEndian)
 test_big_endian(is_big_endian)
+if(NOT is_big_endian)
+    set(is_big_endian FALSE)
+endif()
 config_bool(
     WORDS_BIGENDIAN
     "If the target system is big endian"

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -76,6 +76,14 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUA
         -Wno-incompatible-pointer-types
         -Wno-int-conversion
         -Wno-sign-conversion
+        -Wno-unused-parameter
+        -Wno-missing-prototypes
+        -Wno-conditional-uninitialized
+        -Wno-shorten-64-to-32
+        -Wno-used-but-marked-unused
+        -Wno-unused-macros
+        -Wno-unused-variable
+        -Wno-strict-prototypes
     )
 else()
     set(swig_c_flags


### PR DESCRIPTION
This PR adds some small fixes encountered with newer toolchains on MacOS. This PR adds the following:
* The CMake 'test_big_endian' can return an unset variable, capture this case as to avoid having an empty default value. This will fail to configure otherwise.
* The SWIG generated code for the Python API triggers additional on-by-default Clang diagnostic errors on newer versions of Clang on MacOS. Turn these off to avoid compilation failures.