### PR TITLE
WT-7231 Evergreen jobs for compiling WiredTiger using CMAKE

### DIFF
--- a/build_cmake/toolchains/cl.cmake
+++ b/build_cmake/toolchains/cl.cmake
@@ -1,0 +1,13 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#  All rights reserved.
+#
+# See the file LICENSE for redistribution information.
+#
+
+cmake_minimum_required(VERSION 3.10.0)
+
+set(CMAKE_C_COMPILER "cl.exe")
+set(CMAKE_CXX_COMPILER "cl.exe")
+set(CMAKE_ASM_COMPILER "cl.exe")

--- a/build_cmake/toolchains/mongodbtoolchain_v3_clang.cmake
+++ b/build_cmake/toolchains/mongodbtoolchain_v3_clang.cmake
@@ -1,0 +1,17 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#  All rights reserved.
+#
+# See the file LICENSE for redistribution information.
+#
+
+cmake_minimum_required(VERSION 3.10.0)
+
+if(NOT TOOLCHAIN_ROOT)
+    set(TOOLCHAIN_ROOT "/opt/mongodbtoolchain/v3")
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_ROOT}/bin/clang")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_ROOT}/bin/clang++")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_ROOT}/bin/clang")

--- a/build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+++ b/build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
@@ -1,0 +1,17 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#  All rights reserved.
+#
+# See the file LICENSE for redistribution information.
+#
+
+cmake_minimum_required(VERSION 3.10.0)
+
+if(NOT TOOLCHAIN_ROOT)
+    set(TOOLCHAIN_ROOT "/opt/mongodbtoolchain/v3")
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_ROOT}/bin/gcc")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_ROOT}/bin/g++")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_ROOT}/bin/gcc")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,7 +34,7 @@ add_subdirectory(c)
 # their own binary directory (../../wt). This being the directory structure produced by the autoconf
 # build. Symlink the wt binary in an expected path for backwards compatibility.
 add_custom_command(OUTPUT wt
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:wt>
     ${CMAKE_CURRENT_BINARY_DIR}/wt
     DEPENDS wt

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(c)
 
 # Some of the examples expect to find the `wt` binary at a specific location relative to
 # their own binary directory (../../wt). This being the directory structure produced by the autoconf
-# build. Symlink the wt binary in an expected path for backwards compatibility.
+# build. Copy the wt binary in an expected path for backwards compatibility.
 add_custom_command(OUTPUT wt
     COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:wt>

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2608,6 +2608,23 @@ buildvariants:
     - name: static-wt-build-test
     - name: format-failure-configs-test
 
+- name: ubuntu1804-cmake
+  display_name: "! Ubuntu 18.04 CMake"
+  run_on:
+  - ubuntu1804-test
+  expansions:
+    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
+    cmake_generator: Ninja
+    make_command: ninja
+    is_cmake_build: true
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: ".unit_test"
+
 - name: ubuntu1804-asan
   display_name: "! Ubuntu 18.04 ASAN"
   run_on:
@@ -2780,6 +2797,18 @@ buildvariants:
     - name: ".unit_test"
     - name: fops
 
+- name: windows-64-cmake
+  display_name: "! Windows 64-bit CMake"
+  run_on:
+  - windows-64-vs2017-test
+  expansions:
+    python_binary: 'python'
+    is_cmake_build: true
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: ".unit_test"
+
 - name: macos-1014
   display_name: OS X 10.14
   run_on:
@@ -2798,6 +2827,26 @@ buildvariants:
     - name: make-check-test
     - name: unit-test-with-compile
     - name: fops
+
+- name: macos-1014-cmake
+  display_name: "! OS X 10.14 CMake"
+  run_on:
+  - macos-1014
+  expansions:
+    configure_env_vars: -DCMAKE_C_FLAGS="-ggdb"
+    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: 'python3'
+    smp_command: -j $(sysctl -n hw.logicalcpu)
+    cmake_generator: "Unix Makefiles"
+    make_command: make
+    test_env_vars: DYLD_LIBRARY_PATH=$(pwd)
+    is_cmake_build: true
+  tasks:
+    - name: compile
+      # macos-1012 is a more stable distro that we want to use for our PR testing task
+      distros: macos-1012
+    - name: make-check-test
+    - name: unit-test-with-compile
 
 - name: little-endian
   display_name: "~ Little-endian (x86)"
@@ -2853,6 +2902,23 @@ buildvariants:
   - name: ".stress-test-ppc-1"
   - name: ".stress-test-ppc-2"
 
+- name: ubuntu1804-ppc-cmake
+  display_name: "~ Ubuntu 18.04 PPC CMake"
+  run_on:
+  - ubuntu1804-power8-test
+  expansions:
+    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    cmake_generator: Ninja
+    make_command: ninja
+    is_cmake_build: true
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: ".unit_test"
+
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"
   run_on:
@@ -2873,3 +2939,20 @@ buildvariants:
   - name: ".stress-test-zseries-1"
   - name: ".stress-test-zseries-2"
   - name: ".stress-test-zseries-3"
+
+- name: ubuntu1804-zseries-cmake
+  display_name: "~ Ubuntu 18.04 zSeries CMake"
+  run_on:
+  - ubuntu1804-zseries-test
+  expansions:
+    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    cmake_generator: Ninja
+    make_command: ninja
+    is_cmake_build: true
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: ".unit_test"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -54,7 +54,7 @@ functions:
         set -o errexit
         set -o verbose
         # Check if the build variant has specified a build type, always default to
-        # autoconf if $is_cmake_build is not declared.
+        # Autoconf/Libtool if $is_cmake_build is not declared.
         if [ ${is_cmake_build|false} = true ]; then
           if [ "$OS" = "Windows_NT" ]; then
             # Use the Windows powershell script to configure the CMake build.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2608,7 +2608,7 @@ buildvariants:
     - name: format-failure-configs-test
 
 - name: ubuntu1804-cmake
-  display_name: "# Ubuntu 18.04 CMake"
+  display_name: "* Ubuntu 18.04 CMake"
   run_on:
   - ubuntu1804-test
   expansions:
@@ -2797,7 +2797,7 @@ buildvariants:
     - name: fops
 
 - name: windows-64-cmake
-  display_name: "# Windows 64-bit CMake"
+  display_name: "* Windows 64-bit CMake"
   run_on:
   - windows-64-vs2017-test
   expansions:
@@ -2830,7 +2830,7 @@ buildvariants:
     - name: fops
 
 - name: macos-1014-cmake
-  display_name: "# OS X 10.14 CMake"
+  display_name: "* OS X 10.14 CMake"
   run_on:
   - macos-1014
   expansions:
@@ -2901,7 +2901,7 @@ buildvariants:
   - name: ".stress-test-ppc-2"
 
 - name: ubuntu1804-ppc-cmake
-  display_name: "# Ubuntu 18.04 PPC CMake"
+  display_name: "* Ubuntu 18.04 PPC CMake"
   run_on:
   - ubuntu1804-power8-test
   expansions:
@@ -2939,7 +2939,7 @@ buildvariants:
   - name: ".stress-test-zseries-3"
 
 - name: ubuntu1804-zseries-cmake
-  display_name: "# Ubuntu 18.04 zSeries CMake"
+  display_name: "* Ubuntu 18.04 zSeries CMake"
   run_on:
   - ubuntu1804-zseries-test
   expansions:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2843,8 +2843,6 @@ buildvariants:
     is_cmake_build: true
   tasks:
     - name: compile
-      # macos-1012 is a more stable distro that we want to use for our PR testing task
-      distros: macos-1012
     - name: make-check-test
     - name: unit-test-with-compile
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -259,16 +259,22 @@ functions:
   "make check all":
     command: shell.exec
     params:
-      working_dir: "wiredtiger/build_posix"
+      working_dir: "wiredtiger"
       script: |
         set -o errexit
         set -o verbose
-
-        ${test_env_vars|} ${make_command|make} VERBOSE=1 check ${smp_command|} 2>&1
+        if [ ${is_cmake_build|false} = true ]; then
+          . test/evergreen/find_cmake.sh
+          cd cmake_build
+          ${test_env_vars|} $CTEST -L check ${smp_command|} -VV 2>&1
+        else
+          cd build_posix
+          ${test_env_vars|} ${make_command|make} VERBOSE=1 check ${smp_command|} 2>&1
+        fi
   "unit test":
     command: shell.exec
     params:
-      working_dir: "wiredtiger/build_posix"
+      working_dir: "wiredtiger"
       script: |
         set -o errexit
         set -o verbose
@@ -277,7 +283,13 @@ functions:
           export "PATH=/cygdrive/c/Python39:/cygdrive/c/Python39/Scripts:$PATH"
           export "PYTHONPATH=$(pwd)/../lang/python/wiredtiger):$(cygpath -w $(pwd)/../lang/python)"
         fi
-        ${test_env_vars|} ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
+        if [ ${is_cmake_build|false} = true ]; then
+          cd cmake_build
+          ${test_env_vars|} WT_BUILDDIR=$(pwd) ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
+        else
+          cd build_posix
+          ${test_env_vars|} ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
+        fi
   "format test":
     command: shell.exec
     params:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2609,7 +2609,7 @@ buildvariants:
     - name: format-failure-configs-test
 
 - name: ubuntu1804-cmake
-  display_name: "! Ubuntu 18.04 CMake"
+  display_name: "# Ubuntu 18.04 CMake"
   run_on:
   - ubuntu1804-test
   expansions:
@@ -2798,7 +2798,7 @@ buildvariants:
     - name: fops
 
 - name: windows-64-cmake
-  display_name: "! Windows 64-bit CMake"
+  display_name: "# Windows 64-bit CMake"
   run_on:
   - windows-64-vs2017-test
   expansions:
@@ -2829,7 +2829,7 @@ buildvariants:
     - name: fops
 
 - name: macos-1014-cmake
-  display_name: "! OS X 10.14 CMake"
+  display_name: "# OS X 10.14 CMake"
   run_on:
   - macos-1014
   expansions:
@@ -2903,7 +2903,7 @@ buildvariants:
   - name: ".stress-test-ppc-2"
 
 - name: ubuntu1804-ppc-cmake
-  display_name: "~ Ubuntu 18.04 PPC CMake"
+  display_name: "# Ubuntu 18.04 PPC CMake"
   run_on:
   - ubuntu1804-power8-test
   expansions:
@@ -2941,7 +2941,7 @@ buildvariants:
   - name: ".stress-test-zseries-3"
 
 - name: ubuntu1804-zseries-cmake
-  display_name: "~ Ubuntu 18.04 zSeries CMake"
+  display_name: "# Ubuntu 18.04 zSeries CMake"
   run_on:
   - ubuntu1804-zseries-test
   expansions:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2622,7 +2622,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: ".unit_test"
+    - name: unit-test
 
 - name: ubuntu1804-asan
   display_name: "! Ubuntu 18.04 ASAN"
@@ -2808,7 +2808,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: ".unit_test"
+    - name: unit-test
 
 - name: macos-1014
   display_name: OS X 10.14
@@ -2844,7 +2844,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: unit-test-with-compile
+    - name: unit-test
 
 - name: little-endian
   display_name: "~ Little-endian (x86)"
@@ -2915,7 +2915,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: ".unit_test"
+    - name: unit-test
 
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"
@@ -2953,4 +2953,4 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: ".unit_test"
+    - name: unit-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -714,7 +714,7 @@ tasks:
     depends_on:
       - name: compile
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
       - func: "compile wiredtiger"
       - func: "make check all"
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2904,6 +2904,7 @@ buildvariants:
   display_name: "* Ubuntu 18.04 PPC CMake"
   run_on:
   - ubuntu1804-power8-test
+  batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
@@ -2942,6 +2943,7 @@ buildvariants:
   display_name: "* Ubuntu 18.04 zSeries CMake"
   run_on:
   - ubuntu1804-zseries-test
+  batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -285,11 +285,10 @@ functions:
         fi
         if [ ${is_cmake_build|false} = true ]; then
           cd cmake_build
-          ${test_env_vars|} WT_BUILDDIR=$(pwd) ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
         else
           cd build_posix
-          ${test_env_vars|} ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
         fi
+        ${test_env_vars|} ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
   "format test":
     command: shell.exec
     params:
@@ -2613,7 +2612,7 @@ buildvariants:
   run_on:
   - ubuntu1804-test
   expansions:
-    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
@@ -2804,6 +2803,7 @@ buildvariants:
   expansions:
     python_binary: 'python'
     is_cmake_build: true
+    test_env_vars: WT_BUILDDIR=$(pwd)
     windows_configure_flags: -vcvars_bat "'C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat'"
   tasks:
     - name: compile
@@ -2839,7 +2839,7 @@ buildvariants:
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
     make_command: make
-    test_env_vars: DYLD_LIBRARY_PATH=$(pwd)
+    test_env_vars: DYLD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     is_cmake_build: true
   tasks:
     - name: compile
@@ -2907,7 +2907,7 @@ buildvariants:
   run_on:
   - ubuntu1804-power8-test
   expansions:
-    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
@@ -2945,7 +2945,7 @@ buildvariants:
   run_on:
   - ubuntu1804-zseries-test
   expansions:
-    test_env_vars: LD_LIBRARY_PATH=$(pwd)
+    test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -48,12 +48,30 @@ functions:
   "configure wiredtiger": &configure_wiredtiger
     command: shell.exec
     params:
-      working_dir: "wiredtiger/build_posix"
+      working_dir: "wiredtiger"
       shell: bash
       script: |
         set -o errexit
         set -o verbose
-        if [ "$OS" != "Windows_NT" ]; then
+        # Check if the build variant has specified a build type, always default to
+        # autoconf if $is_cmake_build is not declared.
+        if [ ${is_cmake_build|false} = true ]; then
+          if [ "$OS" = "Windows_NT" ]; then
+            # Use the Windows powershell script to configure the CMake build.
+            # We execute it in a powershell environment as its easier to detect and source the Visual Studio
+            # toolchain in a native Windows environment. We can't easily execute the build in a cygwin environment.
+            powershell.exe '.\test\evergreen\build_windows.ps1 -configure 1'
+          else
+            # Compiling with CMake.
+            . test/evergreen/find_cmake.sh
+            mkdir -p cmake_build
+            cd cmake_build
+            $CMAKE ${configure_env_vars|-DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb"} \
+            ${posix_configure_flags|-DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
+          fi
+        elif [ "$OS" != "Windows_NT" ]; then
+          # Compiling with Autoconf/Libtool.
+          cd build_posix
           sh reconf
           ${configure_env_vars|CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH ADD_CFLAGS="-ggdb -fPIC"} PYTHON="python3" \
             ../configure ${configure_python_setting|} \
@@ -67,13 +85,23 @@ functions:
       script: |
         set -o errexit
         set -o verbose
-        if [ "Windows_NT" == "$OS" ]; then
+        if [ ${is_cmake_build|false} = true ]; then
+          if [ "$OS" = "Windows_NT" ]; then
+            # Use the Windows powershell script to execute Ninja build (can't execute directly in a cygwin environment).
+            powershell.exe '.\test\evergreen\build_windows.ps1 -build 1'
+          else
+            # Compiling with CMake generated Ninja file.
+            cd cmake_build
+            ${make_command|ninja} ${smp_command|} 2>&1
+          fi
+        elif [ "Windows_NT" == "$OS" ]; then
           export "PATH=/cygdrive/c/Python39:/cygdrive/c/Python39/Scripts:$PATH"
 
           python --version
           python -m pip install scons==3.1.1
           scons-3.1.1.bat "LIBPATH=c:\\python\\Python39\\libs" --enable-python=c:\\swigwin-3.0.2\\swig.exe --enable-diagnostic ${scons_smp_command|}
         else
+          # Compiling with Autoconf/Libtool Makefiles.
           cd build_posix
           ${make_command|make} ${smp_command|} 2>&1
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -66,8 +66,8 @@ functions:
             . test/evergreen/find_cmake.sh
             mkdir -p cmake_build
             cd cmake_build
-            $CMAKE ${configure_env_vars|-DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb"} \
-            ${posix_configure_flags|-DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
+            $CMAKE \
+            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
           fi
         elif [ "$OS" != "Windows_NT" ]; then
           # Compiling with Autoconf/Libtool.
@@ -2614,7 +2614,7 @@ buildvariants:
   - ubuntu1804-test
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd)
-    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
@@ -2834,8 +2834,7 @@ buildvariants:
   run_on:
   - macos-1014
   expansions:
-    configure_env_vars: -DCMAKE_C_FLAGS="-ggdb"
-    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: 'python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
@@ -2909,7 +2908,7 @@ buildvariants:
   - ubuntu1804-power8-test
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd)
-    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja
@@ -2947,7 +2946,7 @@ buildvariants:
   - ubuntu1804-zseries-test
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd)
-    posix_configure_flags: -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -60,7 +60,7 @@ functions:
             # Use the Windows powershell script to configure the CMake build.
             # We execute it in a powershell environment as its easier to detect and source the Visual Studio
             # toolchain in a native Windows environment. We can't easily execute the build in a cygwin environment.
-            powershell.exe '.\test\evergreen\build_windows.ps1 -configure 1'
+            powershell.exe  -NonInteractive '.\test\evergreen\build_windows.ps1' -configure 1 ${windows_configure_flags|}
           else
             # Compiling with CMake.
             . test/evergreen/find_cmake.sh
@@ -2804,6 +2804,7 @@ buildvariants:
   expansions:
     python_binary: 'python'
     is_cmake_build: true
+    windows_configure_flags: -vcvars_bat "'C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat'"
   tasks:
     - name: compile
     - name: make-check-test

--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -1,0 +1,37 @@
+param (
+    [bool]$configure = $false,
+    [bool]$build = $false
+)
+
+# Source the vcvars to ensure we have access to the Visual Studio toolchain
+pushd "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build"
+cmd /c "vcvars64.bat&set" |
+foreach {
+  if ($_ -match "=") {
+    $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
+  }
+}
+popd
+
+# Ensure the PROCESSOR_ARCHITECTURE environment variable is set. This is sometimes not set
+# when entering from a cygwin environment.
+$env:PROCESSOR_ARCHITECTURE = "AMD64"
+
+# Ensure the swig binary location is in our PATH.
+$env:Path += ";C:\swigwin-3.0.2"
+
+if (-not (Test-Path cmake_build)) {
+    mkdir cmake_build
+}
+
+cd cmake_build
+
+# Configure build with CMake.
+if( $configure -eq $true) {
+    C:\cmake\bin\cmake --no-warn-unused-cli -DSWIG_DIR="C:\swigwin-3.0.2" -DSWIG_EXECUTABLE="C:\swigwin-3.0.2\swig.exe" -DCMAKE_BUILD_TYPE='None' -DENABLE_PYTHON=1 -DCMAKE_TOOLCHAIN_FILE='..\build_cmake\toolchains\cl.cmake' -G "Ninja" ..\.
+}
+
+# Execute Ninja build.
+if( $build -eq $true) {
+    ninja
+}

--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -1,17 +1,16 @@
 param (
     [bool]$configure = $false,
-    [bool]$build = $false
+    [bool]$build = $false,
+    [string]$vcvars_bat = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 )
 
 # Source the vcvars to ensure we have access to the Visual Studio toolchain
-pushd "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build"
-cmd /c "vcvars64.bat&set" |
+cmd /c "`"$vcvars_bat`"&set" |
 foreach {
   if ($_ -match "=") {
     $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
   }
 }
-popd
 
 # Ensure the PROCESSOR_ARCHITECTURE environment variable is set. This is sometimes not set
 # when entering from a cygwin environment.

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -5,51 +5,51 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #   https://github.com/mongodb/mongo-c-driver/blob/master/.evergreen/find-cmake.sh
 find_cmake ()
 {
-  if [ ! -z "$CMAKE" ]; then
-    return 0
-  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
-    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
-    CTEST="/Applications/Cmake.app/Contents/bin/ctest"
-  elif [ -f "/opt/cmake/bin/cmake" ]; then
-    CMAKE="/opt/cmake/bin/cmake"
-    CTEST="/opt/cmake/bin/ctest"
-  elif command -v cmake 2>/dev/null; then
-     CMAKE=cmake
-     CTEST=ctest
-  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
-     if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
-      CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"
-      CTEST="$(pwd)/cmake-3.11.0/bin/ctest"
-      return 0
-     fi
-     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
-     mkdir cmake-3.11.0
-     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
-     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
-     CTEST=$(pwd)/cmake-3.11.0/bin/ctest
-  elif [ -f "/cygdrive/c/cmake/bin/cmake" ]; then
-     CMAKE="/cygdrive/c/cmake/bin/cmake"
-     CTEST="/cygdrive/c/cmake/bin/ctest"
-  elif [ -f $(readlink -f cmake-install)/bin/cmake ]; then
-     # If we have a custom cmake install from an earlier build step.
-     CMAKE="$(readlink -f cmake-install)/bin/cmake"
-     CTEST="$(readlink -f cmake-install)/bin/ctest"
-  fi
-  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
-     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
-     echo "-- MAKE CMAKE --"
-     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
-     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
-     tar xzf cmake.tar.gz
-     cd cmake-3.11.0
-     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
-     make -j8
-     make install
-     cd ..
-     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
-     CTEST="${CMAKE_INSTALL_DIR}/bin/ctest"
-     echo "-- DONE MAKING CMAKE --"
-  fi
+    if [ ! -z "$CMAKE" ]; then
+        return 0
+    elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+        CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+        CTEST="/Applications/Cmake.app/Contents/bin/ctest"
+    elif [ -f "/opt/cmake/bin/cmake" ]; then
+        CMAKE="/opt/cmake/bin/cmake"
+        CTEST="/opt/cmake/bin/ctest"
+    elif command -v cmake 2>/dev/null; then
+         CMAKE=cmake
+        CTEST=ctest
+    elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+        if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
+            CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"
+            CTEST="$(pwd)/cmake-3.11.0/bin/ctest"
+            return 0
+        fi
+        curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+        mkdir cmake-3.11.0
+        tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+        CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+        CTEST=$(pwd)/cmake-3.11.0/bin/ctest
+    elif [ -f "/cygdrive/c/cmake/bin/cmake" ]; then
+        CMAKE="/cygdrive/c/cmake/bin/cmake"
+        CTEST="/cygdrive/c/cmake/bin/ctest"
+    elif [ -f $(readlink -f cmake-install)/bin/cmake ]; then
+        # If we have a custom cmake install from an earlier build step.
+        CMAKE="$(readlink -f cmake-install)/bin/cmake"
+        CTEST="$(readlink -f cmake-install)/bin/ctest"
+    fi
+    if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+        # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+        echo "-- MAKE CMAKE --"
+        CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+        curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+        tar xzf cmake.tar.gz
+        cd cmake-3.11.0
+        ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+        make -j8
+        make install
+        cd ..
+        CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+        CTEST="${CMAKE_INSTALL_DIR}/bin/ctest"
+        echo "-- DONE MAKING CMAKE --"
+    fi
 }
 
 find_cmake

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -7,15 +7,15 @@ find_cmake ()
 {
     if [ ! -z "$CMAKE" ]; then
         return 0
+    elif command -v cmake 2>/dev/null; then
+        CMAKE=cmake
+        CTEST=ctest
     elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
         CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
         CTEST="/Applications/Cmake.app/Contents/bin/ctest"
     elif [ -f "/opt/cmake/bin/cmake" ]; then
         CMAKE="/opt/cmake/bin/cmake"
         CTEST="/opt/cmake/bin/ctest"
-    elif command -v cmake 2>/dev/null; then
-         CMAKE=cmake
-        CTEST=ctest
     elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
         if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
             CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Adapted 'find_cmake' from mongo-c-driver evergreen infrastructure:
+#   https://github.com/mongodb/mongo-c-driver/blob/master/.evergreen/find-cmake.sh
+find_cmake ()
+{
+  if [ ! -z "$CMAKE" ]; then
+    return 0
+  elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
+    CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
+    CTEST="/Applications/Cmake.app/Contents/bin/ctest"
+  elif [ -f "/opt/cmake/bin/cmake" ]; then
+    CMAKE="/opt/cmake/bin/cmake"
+    CTEST="/opt/cmake/bin/ctest"
+  elif command -v cmake 2>/dev/null; then
+     CMAKE=cmake
+     CTEST=ctest
+  elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
+     if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
+      CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"
+      CTEST="$(pwd)/cmake-3.11.0/bin/ctest"
+      return 0
+     fi
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     mkdir cmake-3.11.0
+     tar xzf cmake.tar.gz -C cmake-3.11.0 --strip-components=1
+     CMAKE=$(pwd)/cmake-3.11.0/bin/cmake
+     CTEST=$(pwd)/cmake-3.11.0/bin/ctest
+  elif [ -f "/cygdrive/c/cmake/bin/cmake" ]; then
+     CMAKE="/cygdrive/c/cmake/bin/cmake"
+     CTEST="/cygdrive/c/cmake/bin/ctest"
+  elif [ -f $(readlink -f cmake-install)/bin/cmake ]; then
+     # If we have a custom cmake install from an earlier build step.
+     CMAKE="$(readlink -f cmake-install)/bin/cmake"
+     CTEST="$(readlink -f cmake-install)/bin/ctest"
+  fi
+  if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
+     # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
+     echo "-- MAKE CMAKE --"
+     CMAKE_INSTALL_DIR=$(readlink -f cmake-install)
+     curl --retry 5 https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz
+     tar xzf cmake.tar.gz
+     cd cmake-3.11.0
+     ./bootstrap --prefix="${CMAKE_INSTALL_DIR}"
+     make -j8
+     make install
+     cd ..
+     CMAKE="${CMAKE_INSTALL_DIR}/bin/cmake"
+     CTEST="${CMAKE_INSTALL_DIR}/bin/ctest"
+     echo "-- DONE MAKING CMAKE --"
+  fi
+}
+
+find_cmake

--- a/test/fops/CMakeLists.txt
+++ b/test/fops/CMakeLists.txt
@@ -35,7 +35,7 @@ create_test_executable(test_fops
         t.c
 )
 
-# If on windows, explicitly run the test under a seperate process, fops
+# If on windows, explicitly run the test under a separate process, fops
 # has issues running under a ctest process (possibly resource-bound).
 if(WT_WIN)
     add_test(NAME test_fops COMMAND powershell.exe $<TARGET_FILE:test_fops>)

--- a/test/fops/CMakeLists.txt
+++ b/test/fops/CMakeLists.txt
@@ -35,7 +35,14 @@ create_test_executable(test_fops
         t.c
 )
 
-add_test(NAME test_fops COMMAND test_fops)
+# If on windows, explicitly run the test under a seperate process, fops
+# has issues running under a ctest process (possibly resource-bound).
+if(WT_WIN)
+    add_test(NAME test_fops COMMAND powershell.exe $<TARGET_FILE:test_fops>)
+else()
+    add_test(NAME test_fops COMMAND test_fops)
+endif()
+
 
 # Run this during a "ctest check" smoke test.
 set_tests_properties(test_fops PROPERTIES LABELS "check")

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -55,5 +55,17 @@ create_test_executable(test_format
     ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
 )
 
+if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
+    target_compile_options(test_format PRIVATE -DLZ4_PATH=\"$<TARGET_FILE:wiredtiger_lz4>\")
+endif()
+if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
+    target_compile_options(test_format PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")
+endif()
+if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
+    target_compile_options(test_format PRIVATE -DZLIB_PATH=\"$<TARGET_FILE:wiredtiger_zlib>\")
+endif()
+target_compile_options(test_format PRIVATE -DREVERSE_PATH=\"$<TARGET_FILE:wiredtiger_reverse_collator>\")
+target_compile_options(test_format PRIVATE -DROTN_PATH=\"$<TARGET_FILE:wiredtiger_rotn_encrypt>\")
+
 add_test(NAME test_format COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smoke.sh)
 set_tests_properties(test_format PROPERTIES LABELS "check")

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -35,14 +35,29 @@
 
 #define EXTPATH "../../ext/" /* Extensions path */
 
+#ifndef LZ4_PATH
 #define LZ4_PATH EXTPATH "compressors/lz4/.libs/libwiredtiger_lz4.so"
+#endif
+
+#ifndef SNAPPY_PATH
 #define SNAPPY_PATH EXTPATH "compressors/snappy/.libs/libwiredtiger_snappy.so"
+#endif
+
+#ifndef ZLIB_PATH
 #define ZLIB_PATH EXTPATH "compressors/zlib/.libs/libwiredtiger_zlib.so"
+#endif
+
+#ifndef ZSTD_PATH
 #define ZSTD_PATH EXTPATH "compressors/zstd/.libs/libwiredtiger_zstd.so"
+#endif
 
+#ifndef REVERSE_PATH
 #define REVERSE_PATH EXTPATH "collators/reverse/.libs/libwiredtiger_reverse_collator.so"
+#endif
 
+#ifndef ROTN_PATH
 #define ROTN_PATH EXTPATH "encryptors/rotn/.libs/libwiredtiger_rotn.so"
+#endif
 
 #undef M
 #define M(v) ((v)*WT_MILLION) /* Million */

--- a/test/manydbs/CMakeLists.txt
+++ b/test/manydbs/CMakeLists.txt
@@ -32,7 +32,14 @@ create_test_executable(test_manydbs
     SOURCES manydbs.c
 )
 
-add_test(NAME test_manydbs COMMAND test_manydbs)
+
+# If on windows, explicitly run the test under a seperate process, manydbs
+# has issues running under a ctest process (possibly resource-bound).
+if(WT_WIN)
+    add_test(NAME test_manydbs COMMAND powershell.exe $<TARGET_FILE:test_manydbs>)
+else()
+    add_test(NAME test_manydbs COMMAND test_manydbs)
+endif()
 
 # Run this during a "ctest check" smoke test.
 set_tests_properties(test_manydbs PROPERTIES LABELS "check")

--- a/test/manydbs/CMakeLists.txt
+++ b/test/manydbs/CMakeLists.txt
@@ -33,7 +33,7 @@ create_test_executable(test_manydbs
 )
 
 
-# If on windows, explicitly run the test under a seperate process, manydbs
+# If on windows, explicitly run the test under a separate process, manydbs
 # has issues running under a ctest process (possibly resource-bound).
 if(WT_WIN)
     add_test(NAME test_manydbs COMMAND powershell.exe $<TARGET_FILE:test_manydbs>)


### PR DESCRIPTION
This PR adds evergreen support for building WiredTiger with CMake. It also adds build variants that run the compilation & unit testing tasks with our CMake builds.

Whilst we continue to support autoconf and SCons, I've left most of the evergreen build tasks as they currently are. The tests under the CMake variants are only a small subset of what is currently being tested. This is done to avoid unnecessary duplicate test runs. The main objective of these new tests are to ensure the CMake builds are always working as expected and correctly configures+compiles the WiredTiger library and its associated binaries.

---

More specifically this PR adds the following features:
- Updated the evergreen configure and build functions to optionally support a CMake build.
- Extended 'make check' and 'unit test' for CMake
-  Added CMake Evergreen build variants
- Added specific CMake toolchain files to source the installed MongoDB V3 toolchain. This being the toolchain we use to build WiredTiger on evergreen.
- Evergreen CMake helper scripts:
   - Added evergreen 'find_cmake.sh' script - Due to inconsistent CMake installation locations across different evergreen testing instances
   - Added a powershell script to configure and compile our CMake build on our Windows evergreen instance
- CMake Bug Fix: Provide the ability to pass the path of the extension libraries e.g. compressors, as a CPP compiliation flags. This avoiding assuming the build location of the libraries e.g. static locations in build_posix. This is needed to run the format smoke/check test on evergreen.
---

As with the previous PR's, to make it a bit easier to review I broke this PR into individual feature-based commits. This should highlight the different changes; hopefully making it easier to assess.