### PR TITLE
WT-7585 Cyclomatic-complexity test failing

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -252,8 +252,7 @@ __get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid
  *     happen if the application performs operations with timestamps out-of-order, make it invisible
  *     by making the start time point match the stop time point of the tombstone. We don't guarantee
  *     that older readers will be able to continue reading content that has been made invisible by
- *     out-of-order updates. 
- *     Note that we carefully don't take this path when the stop time point is
+ *     out-of-order updates. Note that we carefully don't take this path when the stop time point is
  *     equal to the start time point. While unusual, it is permitted for a single transaction to
  *     insert and then remove a record. We don't want to generate a warning in that case.
  */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -247,7 +247,7 @@ __get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid
 }
 
 /*
- * __timestamp_sanity_check --
+ * __timestamp_out_of_order_fix --
  *     If we found a tombstone with a time point earlier than the update it applies to, which can
  *     happen if the application performs operations with timestamps out-of-order, make it invisible
  *     by making the start time point match the stop time point of the tombstone. We don't guarantee
@@ -257,7 +257,7 @@ __get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid
  *     insert and then remove a record. We don't want to generate a warning in that case.
  */
 static inline void
-__timestamp_sanity_check(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
+__timestamp_out_of_order_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
 {
     char time_string[WT_TIME_STRING_SIZE];
 
@@ -596,7 +596,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         }
     }
 
-    __timestamp_sanity_check(session, select_tw);
+    __timestamp_out_of_order_fix(session, select_tw);
 
     /*
      * Track the most recent transaction in the page. We store this in the tree at the end of

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -224,21 +224,17 @@ __rec_need_save_upd(
 
 /*
  * __get_valid_upd --
- * Loop until a valid update from a different transaction is found in the update list.
- * As a side effect method saves the latest update from the same transaction into 
- * same_txn_valid_upd.
- * 
- * Returns a valid update from a different transaction
+ *     Loop until a valid update from a different transaction is found in the update list. As a side
+ *     effect method saves the latest update from the same transaction into same_txn_valid_upd.
+ *     Returns a valid update from a different transaction
  */
-static inline WT_UPDATE*
-__get_valid_upd(
-  WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid_upd)
+static inline WT_UPDATE *
+__get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid_upd)
 {
     while (upd->next != NULL) {
         if (upd->next->txnid == WT_TXN_ABORTED)
             upd = upd->next;
-        else if (upd->next->txnid != WT_TXN_NONE &&
-            tombstone->txnid == upd->next->txnid) {
+        else if (upd->next->txnid != WT_TXN_NONE && tombstone->txnid == upd->next->txnid) {
             upd = upd->next;
             /* Save the latest update from the same transaction. */
             if (*same_txn_valid_upd == NULL)
@@ -252,19 +248,17 @@ __get_valid_upd(
 
 /*
  * __timestamp_sanity_check --
- * If we found a tombstone with a time point earlier than the update it applies to, which can
- * happen if the application performs operations with timestamps out-of-order, make it invisible
- * by making the start time point match the stop time point of the tombstone. We don't guarantee
- * that older readers will be able to continue reading content that has been made invisible by
- * out-of-order updates.
- *
- * Note that we carefully don't take this path when the stop time point is equal to the start
- * time point. While unusual, it is permitted for a single transaction to insert and then remove
- * a record. We don't want to generate a warning in that case.
+ *     If we found a tombstone with a time point earlier than the update it applies to, which can
+ *     happen if the application performs operations with timestamps out-of-order, make it invisible
+ *     by making the start time point match the stop time point of the tombstone. We don't guarantee
+ *     that older readers will be able to continue reading content that has been made invisible by
+ *     out-of-order updates. 
+ *     Note that we carefully don't take this path when the stop time point is
+ *     equal to the start time point. While unusual, it is permitted for a single transaction to
+ *     insert and then remove a record. We don't want to generate a warning in that case.
  */
 static inline void
-__timestamp_sanity_check(
-  WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw, char *time_string)
+__timestamp_sanity_check(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw, char *time_string)
 {
     if (select_tw->stop_ts < select_tw->start_ts ||
       (select_tw->stop_ts == select_tw->start_ts && select_tw->stop_txn < select_tw->start_txn)) {
@@ -494,7 +488,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
 
             /* Find the update this tombstone applies to. */
             if (!__wt_txn_upd_visible_all(session, upd)) {
-                upd  = __get_valid_upd(upd, tombstone, &same_txn_valid_upd);
+                upd = __get_valid_upd(upd, tombstone, &same_txn_valid_upd);
 
                 WT_ASSERT(session, upd->next == NULL || upd->next->txnid != WT_TXN_ABORTED);
                 upd_select->upd = upd = upd->next;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -225,8 +225,8 @@ __rec_need_save_upd(
 /*
  * __get_valid_upd --
  *     Loop until a valid update from a different transaction is found in the update list. As a side
- *     effect method saves the latest update from the same transaction into same_txn_valid_upd.
- *     Returns a valid update from a different transaction
+ *     effect method saves the latest update from the same transaction into the WT_UPDATE output
+ *     argument. Method returns a valid update from a different transaction.
  */
 static inline WT_UPDATE *
 __get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid_upd)
@@ -257,8 +257,10 @@ __get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid
  *     insert and then remove a record. We don't want to generate a warning in that case.
  */
 static inline void
-__timestamp_sanity_check(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw, char *time_string)
+__timestamp_sanity_check(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
 {
+    char time_string[WT_TIME_STRING_SIZE];
+
     if (select_tw->stop_ts < select_tw->start_ts ||
       (select_tw->stop_ts == select_tw->start_ts && select_tw->stop_txn < select_tw->start_txn)) {
         __wt_verbose(session, WT_VERB_TIMESTAMP,
@@ -286,7 +288,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     wt_timestamp_t max_ts;
     size_t upd_memsize;
     uint64_t max_txn, session_txnid, txnid;
-    char time_string[WT_TIME_STRING_SIZE];
     bool has_newer_updates, is_hs_page, supd_restore, upd_saved;
 
     /*
@@ -595,7 +596,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
         }
     }
 
-    __timestamp_sanity_check(session, select_tw, time_string);
+    __timestamp_sanity_check(session, select_tw);
 
     /*
      * Track the most recent transaction in the page. We store this in the tree at the end of

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -223,6 +223,7 @@ __rec_need_save_upd(
 }
 
 /*
+ * __get_valid_upd --
  * Loop until a valid update from a different transaction is found in the update list.
  * As a side effect method saves the latest update from the same transaction into 
  * same_txn_valid_upd.
@@ -250,6 +251,7 @@ __get_valid_upd(
 }
 
 /*
+ * __timestamp_sanity_check --
  * If we found a tombstone with a time point earlier than the update it applies to, which can
  * happen if the application performs operations with timestamps out-of-order, make it invisible
  * by making the start time point match the stop time point of the tombstone. We don't guarantee

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -223,13 +223,14 @@ __rec_need_save_upd(
 }
 
 /*
- * Loop until a valid update from a different transaction is found in the update
- * list.
- * Saves the latest update from the same transaction into same_txn_valid_upd.
- * Returns a valid update
+ * Loop until a valid update from a different transaction is found in the update list.
+ * As a side effect method saves the latest update from the same transaction into 
+ * same_txn_valid_upd.
+ * 
+ * Returns a valid update from a different transaction
  */
 static inline WT_UPDATE*
-__wait_valid_upd(
+__get_valid_upd(
   WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid_upd)
 {
     while (upd->next != NULL) {
@@ -273,6 +274,7 @@ __timestamp_sanity_check(
         select_tw->start_ts = select_tw->stop_ts;
     }
 }
+
 /*
  * __wt_rec_upd_select --
  *     Return the update in a list that should be written (or NULL if none can be written).
@@ -490,7 +492,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
 
             /* Find the update this tombstone applies to. */
             if (!__wt_txn_upd_visible_all(session, upd)) {
-                upd  = __wait_valid_upd(upd, tombstone, &same_txn_valid_upd);
+                upd  = __get_valid_upd(upd, tombstone, &same_txn_valid_upd);
 
                 WT_ASSERT(session, upd->next == NULL || upd->next->txnid != WT_TXN_ABORTED);
                 upd_select->upd = upd = upd->next;


### PR DESCRIPTION
In order to reduce complexity of __wt_rec_upd_select two methods were extracted: ___timestamp_sanity_check_ and ___rec_need_save_upd_ Ideally, there should be more refactoring done. The method is still quite long.