### PR TITLE
WT-7594 Use key_consistent mode on format TS runs

### DIFF
--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -358,7 +358,7 @@ create_object(WT_CONNECTION *conn)
         CONFIG_APPEND(p, ",assert=(read_timestamp=%s)", g.c_txn_timestamps ? "always" : "never");
     if (g.c_assert_write_timestamp)
         CONFIG_APPEND(p, ",assert=(write_timestamp=on),write_timestamp_usage=%s",
-          g.c_txn_timestamps ? "always" : "never");
+          g.c_txn_timestamps ? "key_consistent" : "never");
 
     /* Configure LSM. */
     if (DATASOURCE("lsm")) {


### PR DESCRIPTION
Updated test/format to configure the table with 'write_timestamp_usage=key_consistent' when doing timestamp runs.
Using 'write_timestamp_usage=always' end up being incompatible when trying to use the test/format produced database with other wt utilities and applications that are not timestamp aware. Resulting in assertion failures.