### PR TITLE
WT-7648 Improve error messaging in the test framework

### DIFF
--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -100,5 +100,4 @@ __F
 __WIREDTIGER_EXT_H_
 __WIREDTIGER_H_
 __WT_INTERNAL_H
-__func__
 __wt_bswap16

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -147,6 +147,7 @@ FOREACH
 FS
 FTRUNCATE
 FULLFSYNC
+FUNCSIG
 Facebook
 FindClose
 FindFirstFile

--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -116,8 +116,8 @@ __wt_block_addr_invalid(
      * In diagnostic mode, verify the address isn't on the available list, or for live systems, the
      * discard list.
      */
-    WT_RET(
-      __wt_block_misplaced(session, block, "addr-valid", offset, size, live, __func__, __LINE__));
+    WT_RET(__wt_block_misplaced(
+      session, block, "addr-valid", offset, size, live, __PRETTY_FUNCTION__, __LINE__));
 #endif
 
     /* Check if the address is past the end of the file. */

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -575,7 +575,8 @@ __wt_block_free(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr, 
       (intmax_t)offset, (intmax_t)size);
 
 #ifdef HAVE_DIAGNOSTIC
-    WT_RET(__wt_block_misplaced(session, block, "free", offset, size, true, __func__, __LINE__));
+    WT_RET(__wt_block_misplaced(
+      session, block, "free", offset, size, true, __PRETTY_FUNCTION__, __LINE__));
 #endif
     if (objectid == block->objectid) {
         WT_RET(__wt_block_ext_prealloc(session, 5));

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -95,8 +95,8 @@ __wt_bm_read(
      * In diagnostic mode, verify the block we're about to read isn't on the available list, or for
      * live systems, the discard list.
      */
-    WT_RET(
-      __wt_block_misplaced(session, block, "read", offset, size, bm->is_live, __func__, __LINE__));
+    WT_RET(__wt_block_misplaced(
+      session, block, "read", offset, size, bm->is_live, __PRETTY_FUNCTION__, __LINE__));
 #endif
     /* Read the block. */
     __wt_capacity_throttle(session, size, WT_THROTTLE_READ);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -929,10 +929,10 @@ struct __wt_ref {
         (ref)->hist[(ref)->histoff].state = (uint16_t)(s);                \
         (ref)->histoff = ((ref)->histoff + 1) % WT_ELEMENTS((ref)->hist); \
     } while (0)
-#define WT_REF_SET_STATE(ref, s)                       \
-    do {                                               \
-        WT_REF_SAVE_STATE(ref, s, __func__, __LINE__); \
-        WT_PUBLISH((ref)->state, s);                   \
+#define WT_REF_SET_STATE(ref, s)                                  \
+    do {                                                          \
+        WT_REF_SAVE_STATE(ref, s, __PRETTY_FUNCTION__, __LINE__); \
+        WT_PUBLISH((ref)->state, s);                              \
     } while (0)
 #else
 #define WT_REF_SET_STATE(ref, s) WT_PUBLISH((ref)->state, s)
@@ -951,7 +951,7 @@ struct __wt_ref {
 
 /* A macro wrapper allowing us to remember the callers code location */
 #define WT_REF_CAS_STATE(session, ref, old_state, new_state) \
-    __wt_ref_cas_state_int(session, ref, old_state, new_state, __func__, __LINE__)
+    __wt_ref_cas_state_int(session, ref, old_state, new_state, __PRETTY_FUNCTION__, __LINE__)
 
 #define WT_REF_LOCK(session, ref, previous_statep)                             \
     do {                                                                       \

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -20,11 +20,13 @@
 #define WT_DIAGNOSTIC_YIELD
 #endif
 
-#define __wt_err(session, error, ...) __wt_err_func(session, error, __func__, __LINE__, __VA_ARGS__)
-#define __wt_errx(session, ...) __wt_errx_func(session, __func__, __LINE__, __VA_ARGS__)
+#define __wt_err(session, error, ...) \
+    __wt_err_func(session, error, __PRETTY_FUNCTION__, __LINE__, __VA_ARGS__)
+#define __wt_errx(session, ...) __wt_errx_func(session, __PRETTY_FUNCTION__, __LINE__, __VA_ARGS__)
 #define __wt_panic(session, error, ...) \
-    __wt_panic_func(session, error, __func__, __LINE__, __VA_ARGS__)
-#define __wt_set_return(session, error) __wt_set_return_func(session, __func__, __LINE__, error)
+    __wt_panic_func(session, error, __PRETTY_FUNCTION__, __LINE__, __VA_ARGS__)
+#define __wt_set_return(session, error) \
+    __wt_set_return_func(session, __PRETTY_FUNCTION__, __LINE__, error)
 
 /* Set "ret" and branch-to-err-label tests. */
 #define WT_ERR(a)             \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -287,12 +287,13 @@
  */
 #ifdef HAVE_DIAGNOSTIC
 #define __wt_hazard_set(session, walk, busyp) \
-    __wt_hazard_set_func(session, walk, busyp, __func__, __LINE__)
+    __wt_hazard_set_func(session, walk, busyp, __PRETTY_FUNCTION__, __LINE__)
 #define __wt_scr_alloc(session, size, scratchp) \
-    __wt_scr_alloc_func(session, size, scratchp, __func__, __LINE__)
-#define __wt_page_in(session, ref, flags) __wt_page_in_func(session, ref, flags, __func__, __LINE__)
+    __wt_scr_alloc_func(session, size, scratchp, __PRETTY_FUNCTION__, __LINE__)
+#define __wt_page_in(session, ref, flags) \
+    __wt_page_in_func(session, ref, flags, __PRETTY_FUNCTION__, __LINE__)
 #define __wt_page_swap(session, held, want, flags) \
-    __wt_page_swap_func(session, held, want, flags, __func__, __LINE__)
+    __wt_page_swap_func(session, held, want, flags, __PRETTY_FUNCTION__, __LINE__)
 #else
 #define __wt_hazard_set(session, walk, busyp) __wt_hazard_set_func(session, walk, busyp)
 #define __wt_scr_alloc(session, size, scratchp) __wt_scr_alloc_func(session, size, scratchp)

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -13,9 +13,9 @@
 
 #define inline __inline
 
-/* MSVC Doesn't provide __func__, it has __FUNCTION__ */
+/* MSVC Doesn't provide __PRETTY_FUNCTION__, it has __FUNCSIG__ */
 #ifdef _MSC_VER
-#define __func__ __FUNCTION__
+#define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
 #define WT_PTRDIFFT_FMT "Id" /* ptrdiff_t format string */

--- a/src/include/optrack.h
+++ b/src/include/optrack.h
@@ -73,11 +73,11 @@ struct __wt_optrack_record {
  * is also used in error paths during failed open calls.
  */
 #define WT_TRACK_OP_DECL static uint16_t __func_id = 0
-#define WT_TRACK_OP_INIT(s)                                      \
-    if (F_ISSET(S2C(s), WT_CONN_OPTRACK) && (s)->id != 0) {      \
-        if (__func_id == 0)                                      \
-            __wt_optrack_record_funcid(s, __func__, &__func_id); \
-        WT_TRACK_OP(s, 0);                                       \
+#define WT_TRACK_OP_INIT(s)                                                 \
+    if (F_ISSET(S2C(s), WT_CONN_OPTRACK) && (s)->id != 0) {                 \
+        if (__func_id == 0)                                                 \
+            __wt_optrack_record_funcid(s, __PRETTY_FUNCTION__, &__func_id); \
+        WT_TRACK_OP(s, 0);                                                  \
     }
 
 #define WT_TRACK_OP_END(s)                                \

--- a/test/cppsuite/test_harness/test.h
+++ b/test/cppsuite/test_harness/test.h
@@ -57,6 +57,9 @@ class test : public database_operation {
     public:
     test(const std::string &config, const std::string &name)
     {
+        /* Set the program name for error messages. */
+        progname = name.c_str();
+
         _config = new configuration(name, config);
         _checkpoint_manager = new checkpoint_manager(_config->get_subconfig(CHECKPOINT_MANAGER));
         _runtime_monitor = new runtime_monitor(_config->get_subconfig(RUNTIME_MONITOR), _database);

--- a/test/cppsuite/test_harness/test.h
+++ b/test/cppsuite/test_harness/test.h
@@ -57,9 +57,6 @@ class test : public database_operation {
     public:
     test(const std::string &config, const std::string &name)
     {
-        /* Set the program name for error messages. */
-        progname = name.c_str();
-
         _config = new configuration(name, config);
         _checkpoint_manager = new checkpoint_manager(_config->get_subconfig(CHECKPOINT_MANAGER));
         _runtime_monitor = new runtime_monitor(_config->get_subconfig(RUNTIME_MONITOR), _database);

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -100,8 +100,8 @@ value_missing_error(const std::string &str)
 
 /*
  * Run a specific test.
- * test_name: specifies which test to run.
- * config: defines the configuration used for the test.
+ * - test_name: specifies which test to run.
+ * - config: defines the configuration used for the test.
  */
 int64_t
 run_test(const std::string &test_name, const std::string &config)
@@ -131,6 +131,9 @@ main(int argc, char *argv[])
     std::string cfg, config_filename, test_name, current_test_name;
     int64_t error_code = 0;
     const std::vector<std::string> all_tests = {"example_test", "poc_test"};
+
+    /* Set the program name for error messages. */
+    (void)testutil_set_progname(argv);
 
     /* Parse args
      * -C   : Configuration. Cannot be used with -f. If no specific test is specified to be run, the

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -102,31 +102,31 @@ typedef struct {
  * testutil_assert --
  *     Complain and quit if something isn't true.
  */
-#define testutil_assert(a)                                        \
-    do {                                                          \
-        if (!(a))                                                 \
-            testutil_die(0, "%s/%d: %s", __func__, __LINE__, #a); \
+#define testutil_assert(a)                                                   \
+    do {                                                                     \
+        if (!(a))                                                            \
+            testutil_die(0, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #a); \
     } while (0)
 
 /*
  * testutil_assertfmt --
  *     Complain and quit if something isn't true.
  */
-#define testutil_assertfmt(a, fmt, ...)                                              \
-    do {                                                                             \
-        if (!(a))                                                                    \
-            testutil_die(0, "%s/%d: %s: " fmt, __func__, __LINE__, #a, __VA_ARGS__); \
+#define testutil_assertfmt(a, fmt, ...)                                                         \
+    do {                                                                                        \
+        if (!(a))                                                                               \
+            testutil_die(0, "%s/%d: %s: " fmt, __PRETTY_FUNCTION__, __LINE__, #a, __VA_ARGS__); \
     } while (0)
 
 /*
  * testutil_check --
  *     Complain and quit if a function call fails.
  */
-#define testutil_check(call)                                           \
-    do {                                                               \
-        int __r;                                                       \
-        if ((__r = (call)) != 0)                                       \
-            testutil_die(__r, "%s/%d: %s", __func__, __LINE__, #call); \
+#define testutil_check(call)                                                      \
+    do {                                                                          \
+        int __r;                                                                  \
+        if ((__r = (call)) != 0)                                                  \
+            testutil_die(__r, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
     } while (0)
 
 /*
@@ -134,10 +134,10 @@ typedef struct {
  *     Complain and quit if a function call fails, returning errno. The error test must be
  *     specified, not just the call, because system calls fail in a variety of ways.
  */
-#define testutil_checksys(call)                                          \
-    do {                                                                 \
-        if (call)                                                        \
-            testutil_die(errno, "%s/%d: %s", __func__, __LINE__, #call); \
+#define testutil_checksys(call)                                                     \
+    do {                                                                            \
+        if (call)                                                                   \
+            testutil_die(errno, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
     } while (0)
 
 /*
@@ -148,7 +148,8 @@ typedef struct {
     do {                                                                                  \
         int __r;                                                                          \
         if ((__r = (call)) != 0)                                                          \
-            testutil_die(__r, "%s/%d: %s: " fmt, __func__, __LINE__, #call, __VA_ARGS__); \
+            testutil_die(                                                                 \
+              __r, "%s/%d: %s: " fmt, __PRETTY_FUNCTION__, __LINE__, #call, __VA_ARGS__); \
     } while (0)
 
 /*
@@ -156,11 +157,11 @@ typedef struct {
  *     Complain and quit if a function call fails. A special name because it appears in the
  *     documentation. Allow any non-negative values.
  */
-#define error_sys_check(call)                                          \
-    do {                                                               \
-        int __r;                                                       \
-        if ((__r = (int)(call)) < 0 && __r != ENOTSUP)                 \
-            testutil_die(__r, "%s/%d: %s", __func__, __LINE__, #call); \
+#define error_sys_check(call)                                                     \
+    do {                                                                          \
+        int __r;                                                                  \
+        if ((__r = (int)(call)) < 0 && __r != ENOTSUP)                            \
+            testutil_die(__r, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
     } while (0)
 
 /*
@@ -169,11 +170,11 @@ typedef struct {
  *     documentation. Ignore ENOTSUP to allow library calls which might not be included in any
  *     particular build.
  */
-#define error_check(call)                                              \
-    do {                                                               \
-        int __r;                                                       \
-        if ((__r = (call)) != 0 && __r != ENOTSUP)                     \
-            testutil_die(__r, "%s/%d: %s", __func__, __LINE__, #call); \
+#define error_check(call)                                                         \
+    do {                                                                          \
+        int __r;                                                                  \
+        if ((__r = (call)) != 0 && __r != ENOTSUP)                                \
+            testutil_die(__r, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
     } while (0)
 
 /*


### PR DESCRIPTION
Hitting an assert in the test framework now looks like this:
```
$ ./run 
example_test: FAILED: void test_harness::connection_manager::create(const string&, const string&)/72: false
example_test: process aborting
Aborted (core dumped)
```

In C code, it remains unchanged. Here's an example in `format`:
```
t: FAILED: row_update/1601: false
t: process aborting
```