### PR TITLE
WT-7556 Fix test_rollback_to_stable10 failure cache_hs_ondisk is 0

### DIFF
--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -536,9 +536,12 @@ demo_fs_size(WT_FILE_SYSTEM *file_system, WT_SESSION *session, const char *name,
 
     ret = ENOENT;
     lock_file_system(&demo_fs->lock);
-    if ((demo_fh = demo_handle_search(file_system, name)) != NULL)
+    if ((demo_fh = demo_handle_search(file_system, name)) != NULL) {
+        unlock_file_system(&demo_fs->lock);
         ret = demo_file_size((WT_FILE_HANDLE *)demo_fh, session, sizep);
-    unlock_file_system(&demo_fs->lock);
+    } else {
+        unlock_file_system(&demo_fs->lock);
+    }
 
     return (ret);
 }

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -266,7 +266,7 @@ int
 __wt_hs_insert_updates(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, bool *cache_write_hs)
 {
-    WT_BTREE *btree, *hs_btree;
+    WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_ITEM(full_value);
     WT_DECL_ITEM(key);
@@ -285,8 +285,7 @@ __wt_hs_insert_updates(
     WT_UPDATE *first_globally_visible_upd, *fix_ts_upd, *min_ts_upd, *out_of_order_ts_upd;
     WT_UPDATE *non_aborted_upd, *oldest_upd, *prev_upd, *tombstone, *upd;
     WT_TIME_WINDOW tw;
-    wt_off_t hs_size;
-    uint64_t insert_cnt, max_hs_size, modify_cnt;
+    uint64_t insert_cnt, modify_cnt;
     uint32_t i;
     uint8_t *p;
     int nentries;
@@ -682,14 +681,6 @@ __wt_hs_insert_updates(
 #endif
         __wt_update_vector_clear(&out_of_order_ts_updates);
     }
-
-    WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
-    hs_btree = __wt_curhs_get_btree(hs_cursor);
-    max_hs_size = hs_btree->file_max;
-    if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
-        WT_ERR_PANIC(session, WT_PANIC,
-          "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
-          max_hs_size);
 
 err:
     if (ret == 0 && insert_cnt > 0)

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -684,7 +684,6 @@ __wt_hs_insert_updates(
     }
 
     WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
-    WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
     hs_btree = __wt_curhs_get_btree(hs_cursor);
     max_hs_size = hs_btree->file_max;
     if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -759,7 +759,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_ISOLATION saved_isolation;
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts;
-    uint64_t fsync_duration_usecs, generation, hs_ckpt_duration_usecs, max_hs_size;
+    uint64_t fsync_duration_usecs, generation, hs_ckpt_duration_usecs;
     uint64_t time_start_fsync, time_stop_fsync, time_start_hs, time_stop_hs;
     u_int i;
     bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
@@ -962,12 +962,6 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
         WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
         WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
-
-        max_hs_size = ((WT_BTREE *)hs_dhandle->handle)->file_max;
-        if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
-            WT_ERR_PANIC(session, WT_PANIC,
-              "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64,
-              (uint64_t)hs_size, max_hs_size);
     }
 
     /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -968,10 +968,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     metac->set_key(metac, WT_HS_URI);
     WT_ERR_NOTFOUND_OK(metac->search(metac), true);
 
-    if (ret == WT_NOTFOUND) {
-        hs_exists = false;
-        ret = 0;
-    } else {
+    if (ret != WT_NOTFOUND) {
         WT_ERR(__wt_fs_exist(session, WT_HS_FILE, &hs_exists));
 
         WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
@@ -986,6 +983,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
           "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
           max_hs_size);
 
+    __wt_free(session, config);
     WT_ERR(hs_cursor->close(hs_cursor));
     WT_ERR(metac->close(metac));
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -771,6 +771,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     cache = conn->cache;
     config = NULL;
+    hs_size = 0;
     hs_dhandle = NULL;
     txn = session->txn;
     txn_global = &conn->txn_global;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -750,10 +750,8 @@ static int
 __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 {
     struct timespec tsp;
-    WT_BTREE *hs_btree;
     WT_CACHE *cache;
     WT_CONNECTION_IMPL *conn;
-    WT_CURSOR *hs_cursor, *metac;
     WT_DATA_HANDLE *hs_dhandle;
     WT_DECL_RET;
     WT_TXN *txn;
@@ -764,13 +762,11 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     uint64_t fsync_duration_usecs, generation, hs_ckpt_duration_usecs, max_hs_size;
     uint64_t time_start_fsync, time_stop_fsync, time_start_hs, time_stop_hs;
     u_int i;
-    char *config;
-    bool can_skip, failed, full, hs_exists, idle, logging, tracking, use_timestamp;
+    bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
     void *saved_meta_next;
 
     conn = S2C(session);
     cache = conn->cache;
-    config = NULL;
     hs_size = 0;
     hs_dhandle = NULL;
     txn = session->txn;
@@ -963,29 +959,16 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     __checkpoint_verbose_track(session, "sync completed");
 
     /* If the history store file exists on disk, update its statistic. */
-    WT_ERR(__wt_metadata_search(session, WT_METAFILE_URI, &config));
-    WT_ERR(__wt_metadata_cursor_open(session, NULL, &metac));
-    metac->set_key(metac, WT_HS_URI);
-    WT_ERR_NOTFOUND_OK(metac->search(metac), true);
-
-    if (ret != WT_NOTFOUND) {
-        WT_ERR(__wt_fs_exist(session, WT_HS_FILE, &hs_exists));
-
+    if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
         WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
         WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
+
+        max_hs_size = ((WT_BTREE *)hs_dhandle->handle)->file_max;
+        if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
+            WT_ERR_PANIC(session, WT_PANIC,
+            "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
+            max_hs_size);
     }
-
-    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
-    hs_btree = __wt_curhs_get_btree(hs_cursor);
-    max_hs_size = hs_btree->file_max;
-    if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
-        WT_ERR_PANIC(session, WT_PANIC,
-          "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
-          max_hs_size);
-
-    __wt_free(session, config);
-    WT_ERR(hs_cursor->close(hs_cursor));
-    WT_ERR(metac->close(metac));
 
     /*
      * Commit the transaction now that we are sure that all files in the checkpoint have been

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -764,8 +764,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     uint64_t fsync_duration_usecs, generation, hs_ckpt_duration_usecs, max_hs_size;
     uint64_t time_start_fsync, time_stop_fsync, time_start_hs, time_stop_hs;
     u_int i;
-    bool can_skip, failed, full, hs_exists, idle, logging, tracking, use_timestamp;
     char *config;
+    bool can_skip, failed, full, hs_exists, idle, logging, tracking, use_timestamp;
     void *saved_meta_next;
 
     conn = S2C(session);
@@ -911,12 +911,11 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
         WT_ERR(ret);
 
         /*
-         * Once the history store checkpoint is complete, we update the statistic with the most
-         * recent history store file size on disk, and increment the checkpoint generation of the
-         * associated b-tree. The checkpoint generation controls whether we include the checkpoint
-         * transaction in our calculations of the pinned and oldest_ids for a given btree. We
-         * increment it here to ensure that the visibility checks performed on updates in the
-         * history store do not include the checkpoint transaction.
+         * Once the history store checkpoint is complete, we increment the checkpoint generation of
+         * the associated b-tree. The checkpoint generation controls whether we include the
+         * checkpoint transaction in our calculations of the pinned and oldest_ids for a given
+         * btree. We increment it here to ensure that the visibility checks performed on updates in
+         * the history store do not include the checkpoint transaction.
          */
         __checkpoint_update_generation(session);
 
@@ -988,7 +987,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ERR(hs_cursor->close(hs_cursor));
     WT_ERR(metac->close(metac));
-     
+
     /*
      * Commit the transaction now that we are sure that all files in the checkpoint have been
      * flushed to disk. It's OK to commit before checkpointing the metadata since we know that all

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -966,8 +966,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
         max_hs_size = ((WT_BTREE *)hs_dhandle->handle)->file_max;
         if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
             WT_ERR_PANIC(session, WT_PANIC,
-            "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64, (uint64_t)hs_size,
-            max_hs_size);
+              "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64,
+              (uint64_t)hs_size, max_hs_size);
     }
 
     /*


### PR DESCRIPTION
Fix the assertion failure by changing where we update the statistic that measures the history store file size.