### PR TITLE
WT-7649 Skip timestamp assert during recovery

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1246,7 +1246,6 @@ err:
 static inline int
 __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_TXN *txn;
@@ -1258,20 +1257,18 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
     wt_timestamp_t prev_op_durable_ts, prev_op_ts;
     u_int i;
     bool op_zero_ts, upd_zero_ts, used_ts;
-    bool recovery_conn;
 
     txn = session->txn;
     cursor = NULL;
-    conn = S2C(session);
 
     used_ts = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) || F_ISSET(txn, WT_TXN_HAS_TS_DURABLE);
-    recovery_conn = F_ISSET(conn, WT_CONN_RECOVERING);
     /*
      * Debugging checks on timestamps, if user requested them. We additionally don't expect recovery
      * to be using timestamps when applying commits. If recovery is running, skip this assert to
      * avoid failing the recovery process.
      */
-    if (F_ISSET(txn, WT_TXN_TS_WRITE_ALWAYS) && !used_ts && txn->mod_count != 0 && !recovery_conn)
+    if (F_ISSET(txn, WT_TXN_TS_WRITE_ALWAYS) && !used_ts && txn->mod_count != 0 &&
+      !F_ISSET(S2C(session), WT_CONN_RECOVERING))
         WT_RET_MSG(session, EINVAL, "commit_timestamp required and none set on this transaction");
     if (F_ISSET(txn, WT_TXN_TS_WRITE_NEVER) && used_ts && txn->mod_count != 0)
         WT_RET_MSG(

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1246,12 +1246,12 @@ err:
 static inline int
 __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_TXN *txn;
     WT_TXN_OP *op;
     WT_UPDATE *upd;
-    WT_CONNECTION_IMPL *conn;
 #ifdef HAVE_DIAGNOSTIC
     wt_timestamp_t op_ts;
 #endif
@@ -1267,9 +1267,9 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
     used_ts = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) || F_ISSET(txn, WT_TXN_HAS_TS_DURABLE);
     recovery_conn = F_ISSET(conn, WT_CONN_RECOVERING);
     /*
-     * Debugging checks on timestamps, if user requested them.
-     * We additionally don't expect recovery to be using timestamps when applying commits. If
-     * recovery is running, skip this assert to avoid failing the recovery process.
+     * Debugging checks on timestamps, if user requested them. We additionally don't expect recovery
+     * to be using timestamps when applying commits. If recovery is running, skip this assert to
+     * avoid failing the recovery process.
      */
     if (F_ISSET(txn, WT_TXN_TS_WRITE_ALWAYS) && !used_ts && txn->mod_count != 0 && !recovery_conn)
         WT_RET_MSG(session, EINVAL, "commit_timestamp required and none set on this transaction");


### PR DESCRIPTION
We don't expect recovery to be using timestamps when applying commits. If a table is configured with write timestamp asserts, being `assert=(write_timestamp=on),write_timestamp_usage=always)`, the recovery process will trigger asserts and fail. To avoid failing/blocking recovery, updated the timestamp assert to be skipped on a recovery connection.