### PR TITLE
WT-7666 Add assertion to check whether duplicate history store inserts are modifies

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -157,10 +157,10 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
              * 3. it came from the same transaction but with a different timestamp
              */
             if (cmp == 0) {
-                if (__wt_txn_tw_stop_visible_all(session, &hs_cbt->upd_value->tw) ||
-                  tw->start_txn == WT_TXN_NONE ||
-                  tw->start_txn != hs_cbt->upd_value->tw.start_txn ||
-                  tw->start_ts != hs_cbt->upd_value->tw.start_ts) {
+                if (!__wt_txn_tw_stop_visible_all(session, &hs_cbt->upd_value->tw) &&
+                  tw->start_txn != WT_TXN_NONE &&
+                  tw->start_txn == hs_cbt->upd_value->tw.start_txn &&
+                  tw->start_ts == hs_cbt->upd_value->tw.start_ts) {
                     /*
                      * If we have issues with duplicate history store records, we want to be able to
                      * distinguish between modifies and full updates. Since modifies are not

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -169,7 +169,7 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
                      */
                     WT_ASSERT(session,
                       type != WT_UPDATE_MODIFY && (uint8_t)upd_type_full_diag != WT_UPDATE_MODIFY);
-                    WT_ASSERT(session, !"Duplicate values inserted into history store");
+                    WT_ASSERT(session, false && "Duplicate values inserted into history store");
                 }
             }
             counter = hs_counter + 1;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -150,16 +150,28 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
               &upd_type_full_diag, existing_val));
             WT_ERR(__wt_compare(session, NULL, existing_val, hs_value, &cmp));
             /*
-             *  Same value should not be inserted again unless 1. previous entry is already
-             * deleted(i.e. the stop timestamp is globally visible), 2. from a different
-             * transaction 3. with a different timestamp if from the same transaction.
+             * The same value should not be inserted again unless:
+             * 1. the previous entry is already deleted (i.e. the stop timestamp is globally
+             * visible)
+             * 2. it came from a different transaction
+             * 3. it came from the same transaction but with a different timestamp
              */
-            if (cmp == 0)
-                WT_ASSERT(session,
-                  __wt_txn_tw_stop_visible_all(session, &hs_cbt->upd_value->tw) ||
-                    tw->start_txn == WT_TXN_NONE ||
-                    tw->start_txn != hs_cbt->upd_value->tw.start_txn ||
-                    tw->start_ts != hs_cbt->upd_value->tw.start_ts);
+            if (cmp == 0) {
+                if (__wt_txn_tw_stop_visible_all(session, &hs_cbt->upd_value->tw) ||
+                  tw->start_txn == WT_TXN_NONE ||
+                  tw->start_txn != hs_cbt->upd_value->tw.start_txn ||
+                  tw->start_ts != hs_cbt->upd_value->tw.start_ts) {
+                    /*
+                     * If we have issues with duplicate history store records, we want to be able to
+                     * distinguish between modifies and full updates. Since modifies are not
+                     * idempotent, having them inserted multiple times can cause invalid values to
+                     * be read.
+                     */
+                    WT_ASSERT(session,
+                      type != WT_UPDATE_MODIFY && (uint8_t)upd_type_full_diag != WT_UPDATE_MODIFY);
+                    WT_ASSERT(session, !"Duplicate values inserted into history store");
+                }
+            }
             counter = hs_counter + 1;
         }
 #else


### PR DESCRIPTION
We're currently having issues with duplicate insertions into the history store. This is not harmful in the case of full updates but could cause invalid values to be read for modifies.

While we're trying to solve this, I want to gain an understanding of whether this can only happen with full updates so I'm adding an assertion to distinguish between these two cases.