### PR TITLE
WT-7672 Remove make-check-test from Windows CMake Evergreen build variant

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2802,7 +2802,6 @@ buildvariants:
     windows_configure_flags: -vcvars_bat "'C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat'"
   tasks:
     - name: compile
-    - name: make-check-test
     - name: unit-test
 
 - name: macos-1014


### PR DESCRIPTION
We did not turn "make check" tests on Windows previously, and it's not very surprising certain tests fail. Let's disable the make-check-test task from Windows CMake builder for now to address the test (manydbs) fallout. 