### PR TITLE
WT-7644 Implement python hooks for tiered storage

### DIFF
--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -47,7 +47,7 @@
 #    but we should add others.
 #
 # 4. We stub out some functions that aren't supported by tiered tables.  This will
-#    break tests of those functions.  But often when they are used in other tests, we 
+#    break tests of those functions.  But often when they are used in other tests, we
 #    can get away with returning success without performing the operation.
 #
 # To run, for example, the cursor tests with these hooks enabled:

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -77,7 +77,7 @@ def wiredtiger_open_tiered(ignored_self, args):
       'bucket=%s,' % bucket + \
       'bucket_prefix=%s,' % prefix + \
       'name=%s),tiered_manager=(wait=0),' % extension_name + \
-      'extensions=[\"%s\"],,,' % extension_library
+      'extensions=[\"%s\"],' % extension_library
 
     args = list(args)         # convert from a readonly tuple to a writeable list
     args[-1] += tier_string   # Modify the list

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -41,7 +41,7 @@
 #
 # 2. If we create an object that is *not* a table:, we add options to its config
 #    so that it will be stored local-only.  Tiered storage isn't intended (yet?) for
-#    use with LSM or colstore.
+#    use with lsm or column store.
 #
 # 3. We add a call to flush_tier() after each call to checkpoint().
 #
@@ -93,7 +93,7 @@ def session_create_replace(orig_session_create, session_self, uri, config):
     else:
         new_config = config
 
-    # If the test isn't creating a table (i.e., it's a colstore or lsm) create it as a
+    # If the test isn't creating a table (i.e., it's a column store or lsm) create it as a
     # "local only" object.  Otherwise we get tiered storage from the connection defaults.
     if not uri.startswith("table:") or "key_format=r" in new_config or "type=lsm" in new_config:
         new_config = new_config + ',tiered_storage=(name=none)'

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -137,7 +137,8 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
         # Skip any test that contains one of these strings as a substring
         skip = ["backup",              # Can't backup a tiered table
                 "lsm",                 # If the test name tells us it uses lsm ignore it
-                "test_config_json"]    # create replacement can't handle a json config string
+                "test_config_json",    # create replacement can't handle a json config string
+                "tiered"]
         for item in skip:
             if item in str(test):
                 return True

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -67,9 +67,9 @@ def wiredtiger_open_tiered(ignored_self, args):
     bucket = "mybucket"
     extension_name = "local_store"
     prefix = "pfx-"
-    extension_names = WiredTigerTestCase.findExtension('storage_sources', 'local_store')
-    if len(extension_names) == 0:
-        raise Exception('local_store storage source extension not found')
+    extension_libs = WiredTigerTestCase.findExtension('storage_sources', extension_name)
+    if len(extension_libs) == 0:
+        raise Exception(extension_name + ' storage source extension not found')
 
     if not os.path.exists(bucket):
         os.mkdir(bucket)
@@ -77,7 +77,7 @@ def wiredtiger_open_tiered(ignored_self, args):
       'bucket=%s,' % bucket + \
       'bucket_prefix=%s,' % prefix + \
       'name=%s),tiered_manager=(wait=0),' % extension_name + \
-      'extensions=[\"%s\"],' % extension_names[0]
+      'extensions=[\"%s\"],' % extension_libs[0]
 
     args = list(args)         # convert from a readonly tuple to a writeable list
     args[-1] += tier_string   # Modify the list

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -95,12 +95,14 @@ def session_checkpoint_replace(orig_session_checkpoint, session_self, config):
     if ret != 0:
         return ret
     WiredTigerTestCase.verbose(None, 3,
-        '    Calling flush_tier()')
+        '    Calling flush_tier() after checkpoint')
     return session_self.flush_tier(None)
 
 # Called to replace Session.checkpoint.
 # Add a call to flush_tier before closing
 def session_close(orig_session_close, session_self, config):
+    WiredTigerTestCase.verbose(None, 3,
+        '    Calling flush_tier() before close')
     ret = session_self.flush_tier(None)
     if ret != 0:
         return ret

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -284,7 +284,7 @@ class WiredTigerTestCase(unittest.TestCase):
         self.skipped = True
         super(WiredTigerTestCase, self).skipTest(reason)
 
-    # Construct the expected filename for an extension library and return 
+    # Construct the expected filename for an extension library and return
     # the name if the file exists.
     @staticmethod
     def findExtension(dirname, libname):

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -284,6 +284,18 @@ class WiredTigerTestCase(unittest.TestCase):
         self.skipped = True
         super(WiredTigerTestCase, self).skipTest(reason)
 
+    # Construct the expected filename for an extension library and return 
+    # the name if the file exists.
+    @staticmethod
+    def findExtension(dirname, libname):
+        pat = os.path.join(WiredTigerTestCase._builddir, 'ext',
+            dirname, libname, '.libs', 'libwiredtiger_*.so')
+        filenames = glob.glob(pat)
+        if len(filenames) > 1:
+            raise Exception(self.shortid() + ": " + ext +
+                ": multiple extensions libraries found matching: " + pat)
+        return filenames
+
     # Return the wiredtiger_open extension argument for
     # any needed shared library.
     def extensionsConfig(self):
@@ -312,9 +324,7 @@ class WiredTigerTestCase(unittest.TestCase):
                     ": extension is not named <dir>/<name>")
             libname = splits[1]
             dirname = splits[0]
-            pat = os.path.join(WiredTigerTestCase._builddir, 'ext',
-                dirname, libname, '.libs', 'libwiredtiger_*.so')
-            filenames = glob.glob(pat)
+            filenames = self.findExtension(dirname, libname)
             if len(filenames) == 0:
                 if skipIfMissing:
                     self.skipTest('extension "' + ext + '" not built')
@@ -323,10 +333,6 @@ class WiredTigerTestCase(unittest.TestCase):
                     raise Exception(self.shortid() +
                         ": " + ext +
                         ": no extensions library found matching: " + pat)
-            elif len(filenames) > 1:
-                raise Exception(self.shortid() +
-                    ": " + ext +
-                    ": multiple extensions libraries found matching: " + pat)
             complete = '"' + filenames[0] + '"' + extconf
             if ext in extfiles:
                 if extfiles[ext] != complete:


### PR DESCRIPTION
Updated test to add tiered storage options to config for
wiredtiger_open().  The test then ignores tiered storage
for tests that aren't on simple row-store tables.  It also
calls flush_tier() after every checkpoint call.