### PR TITLE
WT-7689 Fix double free in `__curhs_insert`

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -939,8 +939,7 @@ __curhs_insert(WT_CURSOR *cursor)
 
     /* Insert doesn't maintain a position across calls, clear resources. */
 err:
-    __wt_free(session, hs_tombstone);
-    __wt_free(session, hs_upd);
+    __wt_free_update_list(session, &hs_upd);
     WT_TRET(cursor->reset(cursor));
     API_END_RET(session, ret);
 }


### PR DESCRIPTION
If the insertion code path fails in the history store cursor, we can free the same update twice. We can easily reproduce this by injecting an error with a patch like this:

```
modified   src/cursor/cur_hs.c                                                                                                                                                        
@@ -914,6 +914,11 @@ __curhs_insert(WT_CURSOR *cursor)                                                                                                                                
         hs_upd = hs_tombstone;                                                                                                                                                       
     }                                                                                                                                                                                
                                                                                                                                                                                      
+    /* Randomly produce errors. */                                                                                                                                                   
+    if (rand() % 5 == 0)                                                                                                                                                             
+        ret = EBUSY;                                                                                                                                                                 
+    WT_ERR(ret);                                                                                                                                                                     
+                                                                                                                                                                                     
     do {                                                                                                                                                                             
         WT_WITH_PAGE_INDEX(session, ret = __curhs_search(cbt, true));                                                                                                                
         WT_ERR(ret);
```