### PR TITLE
WT-7675 Query last ckpt timestamp changes without taking checkpoint

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -187,10 +187,11 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
          */
         if (ts == WT_TS_NONE)
             return (WT_NOTFOUND);
-    } else if (WT_STRING_MATCH("last_checkpoint", cval.str, cval.len))
-        /* Read-only value forever. No lock needed. */
+    } else if (WT_STRING_MATCH("last_checkpoint", cval.str, cval.len)) {
+        /* Read-only value forever. Make sure we don't used a cached version. */
+        WT_BARRIER();
         ts = txn_global->last_ckpt_timestamp;
-    else if (WT_STRING_MATCH("oldest", cval.str, cval.len)) {
+    } else if (WT_STRING_MATCH("oldest", cval.str, cval.len)) {
         if (!txn_global->has_oldest_timestamp)
             return (WT_NOTFOUND);
         ts = txn_global->oldest_timestamp;


### PR DESCRIPTION
Using barrier call before querying last_checkpoint timestamp to make sure we are not reading a stale or cached value.