### PR TITLE
WT-7698 Reduce max_latency value in many-dhandle-stress.py.

### DIFF
--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=100
+workload.options.max_latency=50
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=25
+workload.options.max_latency=75
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=25
+workload.options.max_latency=26
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=250
+workload.options.max_latency=50
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=40
+workload.options.max_latency=30
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=15
+workload.options.max_latency=20
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=1
+workload.options.max_latency=10
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=35
+workload.options.max_latency=37
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=1000
+workload.options.max_latency=250
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=30
+workload.options.max_latency=35
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=250
+workload.options.max_latency=100
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=26
+workload.options.max_latency=250
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=20
+workload.options.max_latency=25
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=27
+workload.options.max_latency=15
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=75
+workload.options.max_latency=60
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=50
+workload.options.max_latency=1
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=37
+workload.options.max_latency=27
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=25
+workload.options.max_latency=40
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=50
+workload.options.max_latency=25
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -115,7 +115,7 @@ checkpoint_thread = Thread(ops)
 workload = Workload(context, 10 * thread0 + 10 * thread1 + checkpoint_thread)
 workload.options.report_interval=5
 workload.options.run_time=900
-workload.options.max_latency=10
+workload.options.max_latency=25
 workload.options.sample_rate=1
 workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning


### PR DESCRIPTION
This PR is to set the threshold max_latency that is used for Jenkins plots: http://build.wiredtiger.com:8080/job/wiredtiger-many-dhandles/plot/