### PR TITLE
Wt 7591 Fixes to allow cursors to be open during flush_tier

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -503,7 +503,6 @@ connection_stats = [
     ##########################################
     StorageStat('flush_state_races', 'flush state races'),
     StorageStat('flush_tier', 'flush_tier operation calls'),
-    StorageStat('flush_tier_busy', 'flush_tier busy retries'),
 
     ##########################################
     # Thread Count statistics

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -226,7 +226,6 @@ __wt_tier_do_flush(
     WT_DECL_RET;
     WT_FILE_SYSTEM *bucket_fs;
     WT_STORAGE_SOURCE *storage_source;
-    uint32_t msec, retry;
     const char *local_name, *obj_name;
 
     storage_source = tiered->bstorage->storage_source;
@@ -241,21 +240,8 @@ __wt_tier_do_flush(
     WT_RET(storage_source->ss_flush(
       storage_source, &session->iface, bucket_fs, local_name, obj_name, NULL));
 
-    /*
-     * Flushing the metadata grabs the data handle with exclusive access, and the data handle may be
-     * held by the thread that queues the flush tier work item. As a result, the handle may be busy,
-     * so retry as needed, up to a few seconds.
-     */
-    for (msec = 10, retry = 0; msec < 3000; msec *= 2, retry++) {
-        if (retry != 0)
-            __wt_sleep(0, msec * WT_THOUSAND);
-        WT_WITH_CHECKPOINT_LOCK(session,
-          WT_WITH_SCHEMA_LOCK(
-            session, ret = __tier_flush_meta(session, tiered, local_uri, obj_uri)));
-        if (ret != EBUSY)
-            break;
-        WT_STAT_CONN_INCR(session, flush_tier_busy);
-    }
+    WT_WITH_CHECKPOINT_LOCK(session,
+      WT_WITH_SCHEMA_LOCK(session, ret = __tier_flush_meta(session, tiered, local_uri, obj_uri)));
     WT_RET(ret);
 
     /*

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -90,7 +90,7 @@ __flush_tier_once(WT_SESSION_IMPL *session, uint32_t flags)
         if (WT_PREFIX_MATCH(key, "tiered:")) {
             __wt_verbose(session, WT_VERB_TIERED, "FLUSH_TIER_ONCE: %s %s", key, value);
             /* Is this instantiating every handle even if it is not opened or in use? */
-            WT_ERR(__wt_session_get_dhandle(session, key, NULL, NULL, WT_DHANDLE_EXCLUSIVE));
+            WT_ERR(__wt_session_get_dhandle(session, key, NULL, NULL, 0));
             /*
              * When we call wt_tiered_switch the session->dhandle points to the tiered: entry and
              * the arg is the config string that is currently in the metadata.
@@ -188,7 +188,7 @@ __tier_flush_meta(
     WT_ERR(__wt_meta_track_on(session));
     tracking = true;
 
-    WT_ERR(__wt_session_get_dhandle(session, dhandle->name, NULL, NULL, WT_DHANDLE_EXCLUSIVE));
+    WT_ERR(__wt_session_get_dhandle(session, dhandle->name, NULL, NULL, 0));
     release = true;
     /*
      * Once the flush call succeeds we want to first remove the file: entry from the metadata and

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -587,7 +587,6 @@ struct __wt_connection_stats {
     int64_t rec_split_stashed_bytes;
     int64_t rec_split_stashed_objects;
     int64_t flush_state_races;
-    int64_t flush_tier_busy;
     int64_t flush_tier;
     int64_t session_open;
     int64_t session_query_ts;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5575,543 +5575,541 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1272
 /*! session: flush state races */
 #define	WT_STAT_CONN_FLUSH_STATE_RACES			1273
-/*! session: flush_tier busy retries */
-#define	WT_STAT_CONN_FLUSH_TIER_BUSY			1274
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1275
+#define	WT_STAT_CONN_FLUSH_TIER				1274
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1276
+#define	WT_STAT_CONN_SESSION_OPEN			1275
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1277
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1276
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1278
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1277
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1279
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1278
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1280
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1279
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1281
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1280
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1282
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1281
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1283
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1282
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1284
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1283
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1285
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1284
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1286
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1285
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1287
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1286
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1288
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1287
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1289
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1288
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1290
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1289
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1291
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1290
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1292
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1291
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1293
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1292
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1294
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1293
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1295
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1294
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1296
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1295
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1297
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1296
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1298
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1297
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1299
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1298
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1300
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1299
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1301
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1300
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1302
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1301
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1303
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1302
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1304
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1303
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1305
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1304
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1306
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1305
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1307
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1306
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1308
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1307
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1309
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1308
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1310
+#define	WT_STAT_CONN_PAGE_SLEEP				1309
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1311
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1310
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1312
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1311
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1313
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1312
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1314
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1313
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1315
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1314
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1316
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1315
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1317
+#define	WT_STAT_CONN_TXN_PREPARE			1316
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1318
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1317
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1319
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1318
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1320
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1319
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1321
+#define	WT_STAT_CONN_TXN_QUERY_TS			1320
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1322
+#define	WT_STAT_CONN_TXN_RTS				1321
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1323
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1322
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1324
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1323
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1325
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1324
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1326
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1325
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1327
+#define	WT_STAT_CONN_TXN_SET_TS				1326
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1328
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1327
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1329
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1328
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1330
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1329
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1331
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1330
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1332
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1331
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1333
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1332
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1334
+#define	WT_STAT_CONN_TXN_BEGIN				1333
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1335
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1334
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1336
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1335
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1337
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1336
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1338
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1337
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1339
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1338
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1340
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1339
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1341
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1340
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1342
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1341
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1343
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1342
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1344
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1343
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1345
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1344
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1346
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1345
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1347
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1346
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1348
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1347
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1349
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1348
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1350
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1349
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1351
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1350
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1352
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1351
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1353
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1352
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1354
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1353
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1355
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1354
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1356
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1355
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1357
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1356
 /*! transaction: transaction failures due to history store */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1358
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1357
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1359
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1358
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1360
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1359
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1361
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1360
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1362
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1361
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1363
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1362
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1364
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1363
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1365
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1364
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1366
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1365
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1367
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1366
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1368
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1367
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1369
+#define	WT_STAT_CONN_TXN_SYNC				1368
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1370
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1369
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1371
+#define	WT_STAT_CONN_TXN_COMMIT				1370
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1372
+#define	WT_STAT_CONN_TXN_ROLLBACK			1371
 /*! LSM: sleep for LSM checkpoint throttle */
-#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1373
+#define	WT_STAT_CONN_LSM_CHECKPOINT_THROTTLE		1372
 /*! LSM: sleep for LSM merge throttle */
-#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1374
+#define	WT_STAT_CONN_LSM_MERGE_THROTTLE			1373
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1375
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1374
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1376
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1375
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1377
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1376
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1378
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1377
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1379
+#define	WT_STAT_CONN_CACHE_EVICTION_CHECKPOINT		1378
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1380
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1379
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1381
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1380
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1382
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1381
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1383
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1382
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1384
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1383
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1385
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1384
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1386
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1385
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1387
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1386
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1388
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1387
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1389
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1388
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1390
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1389
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1391
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1390
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1392
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1391
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1393
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1392
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1394
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1393
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1395
+#define	WT_STAT_CONN_CACHE_EVICTION_HAZARD		1394
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1396
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1395
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1397
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1396
 /*!
  * cache: history store table out-of-order resolved updates that lose
  * their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1398
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1397
 /*!
  * cache: history store table out-of-order updates that were fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1399
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1398
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1400
+#define	WT_STAT_CONN_CACHE_HS_READ			1399
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1401
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1400
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1402
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1401
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1403
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1402
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1404
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1403
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1405
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1404
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1406
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1405
 /*!
  * cache: history store table truncation to remove range of updates due
  * to out-of-order timestamp update on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1407
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1406
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1408
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1407
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1409
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1408
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1410
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1409
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1411
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1410
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1412
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1411
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1413
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1412
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1414
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1413
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1415
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1414
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1416
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1415
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1417
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1416
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1418
+#define	WT_STAT_CONN_CACHE_READ				1417
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1419
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1418
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1420
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1419
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1421
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1420
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1422
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1421
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1423
+#define	WT_STAT_CONN_CACHE_WRITE			1422
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1424
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1423
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1425
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1424
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1426
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1425
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1427
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1426
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1428
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1427
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1429
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1428
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1430
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1429
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1431
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1430
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1432
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1431
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1433
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1432
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1434
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1433
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1435
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1434
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1436
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1435
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1437
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1436
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1438
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1437
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1439
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1438
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1440
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1439
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1441
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1440
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1442
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1441
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1443
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1442
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1444
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1443
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1445
+#define	WT_STAT_CONN_REC_PAGES				1444
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1446
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1445
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1447
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1446
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1448
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1447
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1449
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1448
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1450
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1449
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1451
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1450
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1452
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1451
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1453
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1452
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1454
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1453
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1454
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1455
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1457
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1456
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1458
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1457
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1459
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1458
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1460
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1459
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1461
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1460
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1462
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1461
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1463
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1462
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1464
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1463
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1465
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1464
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1466
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1465
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1467
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1466
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1468
+#define	WT_STAT_CONN_TIERED_RETENTION			1467
 /*! session: tiered storage object size */
-#define	WT_STAT_CONN_TIERED_OBJECT_SIZE			1469
+#define	WT_STAT_CONN_TIERED_OBJECT_SIZE			1468
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1470
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1469
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1471
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1470
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1472
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1471
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1473
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1472
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1474
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1473
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1475
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1474
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1476
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1475
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1477
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1476
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1478
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1477
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1479
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1478
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1480
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1479
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1250,7 +1250,6 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: split bytes currently awaiting free",
   "reconciliation: split objects currently awaiting free",
   "session: flush state races",
-  "session: flush_tier busy retries",
   "session: flush_tier operation calls",
   "session: open session count",
   "session: session query timestamp calls",
@@ -1776,7 +1775,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing rec_split_stashed_bytes */
     /* not clearing rec_split_stashed_objects */
     stats->flush_state_races = 0;
-    stats->flush_tier_busy = 0;
     stats->flush_tier = 0;
     /* not clearing session_open */
     stats->session_query_ts = 0;
@@ -2294,7 +2292,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_split_stashed_bytes += WT_STAT_READ(from, rec_split_stashed_bytes);
     to->rec_split_stashed_objects += WT_STAT_READ(from, rec_split_stashed_objects);
     to->flush_state_races += WT_STAT_READ(from, flush_state_races);
-    to->flush_tier_busy += WT_STAT_READ(from, flush_tier_busy);
     to->flush_tier += WT_STAT_READ(from, flush_tier);
     to->session_open += WT_STAT_READ(from, session_open);
     to->session_query_ts += WT_STAT_READ(from, session_query_ts);

--- a/test/suite/test_tiered02.py
+++ b/test/suite/test_tiered02.py
@@ -141,7 +141,6 @@ class test_tiered02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         self.progress('flush_tier')
         self.session.flush_tier(None)
-        self.progress('flush_tier complete')
         self.confirm_flush()
 
         self.progress('Create simple data set (200)')

--- a/test/suite/test_tiered02.py
+++ b/test/suite/test_tiered02.py
@@ -122,6 +122,8 @@ class test_tiered02(wttest.WiredTigerTestCase):
         self.progress('populate')
         ds.populate()
         ds.check()
+        self.progress('open extra cursor on ' + self.uri)
+        cursor = self.session.open_cursor(self.uri, None, None)
         self.progress('checkpoint')
         self.session.checkpoint()
 
@@ -139,6 +141,7 @@ class test_tiered02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         self.progress('flush_tier')
         self.session.flush_tier(None)
+        self.progress('flush_tier complete')
         self.confirm_flush()
 
         self.progress('Create simple data set (200)')

--- a/test/suite/test_tiered02.py
+++ b/test/suite/test_tiered02.py
@@ -148,6 +148,7 @@ class test_tiered02(wttest.WiredTigerTestCase):
         self.progress('populate')
         ds.populate()
         ds.check()
+        cursor.close()
         self.progress('close_conn')
         self.close_conn()
 


### PR DESCRIPTION
Eliminated a pair of places where we don't need exclusive dhandles (i.e., we now get shared dhandles instead).  Also updated the `tiered02` test to hold an open cursor across a bunch of flush_tier and other operations.