### PR TITLE
WT-7640 Fix test_backup02 where checkpoint tables differ due to checkpoint cursor not supported

### DIFF
--- a/test/suite/test_backup02.py
+++ b/test/suite/test_backup02.py
@@ -75,7 +75,7 @@ class test_backup02(wttest.WiredTigerTestCase):
                 my_data = str(more_time) + 'a' * (self.dsize - len(str(more_time)))
                 more_time = more_time - 0.1
                 for i in range(self.nops):
-                    work_queue.put_nowait(('gu', i, my_data + str(i)))
+                    work_queue.put_nowait(('gu', i, my_data))
         except:
             # Deplete the work queue if there's an error.
             while not work_queue.empty():

--- a/test/suite/test_backup02.py
+++ b/test/suite/test_backup02.py
@@ -33,7 +33,6 @@ from wtthread import backup_thread, checkpoint_thread, op_thread
 #   Run background checkpoints and backups repeatedly while doing inserts
 #   in another thread
 class test_backup02(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=10MB,eviction_target=10'
     uri = 'table:test_backup02'
     fmt = 'L'
     dsize = 100
@@ -76,7 +75,7 @@ class test_backup02(wttest.WiredTigerTestCase):
                 my_data = str(more_time) + 'a' * (self.dsize - len(str(more_time)))
                 more_time = more_time - 0.1
                 for i in range(self.nops):
-                    work_queue.put_nowait(('gu', i, my_data))
+                    work_queue.put_nowait(('gu', i, my_data + str(i)))
         except:
             # Deplete the work queue if there's an error.
             while not work_queue.empty():

--- a/test/suite/test_backup02.py
+++ b/test/suite/test_backup02.py
@@ -33,6 +33,7 @@ from wtthread import backup_thread, checkpoint_thread, op_thread
 #   Run background checkpoints and backups repeatedly while doing inserts
 #   in another thread
 class test_backup02(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=10MB,eviction_target=10'
     uri = 'table:test_backup02'
     fmt = 'L'
     dsize = 100

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -82,7 +82,7 @@ class backup_thread(threading.Thread):
                     uris.append(uri)
 
                 # Add an assert to stop running the test if any difference in table contents
-                # is found. We would have liked to use self.assertTrue instead, but are unable 
+                # is found. We would have liked to use self.assertTrue instead, but are unable
                 # to because backup_thread does not support this method unless it is a wttest.
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if checkpoint tables match:")
                 assert compare_tables(self, sess, uris) == True

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -81,11 +81,9 @@ class backup_thread(threading.Thread):
                     uri = "file:" + next_file
                     uris.append(uri)
 
-                # TODO: We want a self.assertTrue here - be need to be a
-                # wttest to do that..
-
                 # Add an assert to stop running the test if any difference in table contents
-                # is found.
+                # is found. We would have liked to use self.assertTrue instead, but are unable 
+                # to because backup_thread does not support this method unless it is a wttest.
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if checkpoint tables match:")
                 assert compare_tables(self, sess, uris) == True
                 wttest.WiredTigerTestCase.printVerbose(3, "Checkpoint tables match")

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -84,30 +84,16 @@ class backup_thread(threading.Thread):
                 # TODO: We want a self.assertTrue here - be need to be a
                 # wttest to do that..
 
-                # Make WT panic and test stop if tables don't match.
-                # More descriptive error message - which tables differ.
-
+                # Add an assert to stop running the test if any difference in table contents
+                # is found.
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if checkpoint tables match:")
                 assert compare_tables(
                         self, sess, uris, "checkpoint=WiredTigerCheckpoint") == True
                 wttest.WiredTigerTestCase.printVerbose(3, "Checkpoint tables match")
 
-                # if not compare_tables(
-                #         self, sess, uris, "checkpoint=WiredTigerCheckpoint"):
-                #     print("Error: checkpoint tables differ.")
-                # else:
-                #     wttest.WiredTigerTestCase.printVerbose(
-                #         3, "Checkpoint tables match")
-
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if backup tables match:")
                 assert compare_tables(self, bkp_session, uris) == True
                 wttest.WiredTigerTestCase.printVerbose(3, "Backup tables match")
-
-                # if not compare_tables(self, bkp_session, uris):
-                #     print("Error: backup tables differ.")
-                # else:
-                #     wttest.WiredTigerTestCase.printVerbose(
-                #         3, "Backup tables match")
             finally:
                 if bkp_conn != None:
                     bkp_conn.close()

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -83,18 +83,31 @@ class backup_thread(threading.Thread):
 
                 # TODO: We want a self.assertTrue here - be need to be a
                 # wttest to do that..
-                if not compare_tables(
-                        self, sess, uris, "checkpoint=WiredTigerCheckpoint"):
-                    print("Error: checkpoint tables differ.")
-                else:
-                    wttest.WiredTigerTestCase.printVerbose(
-                        3, "Checkpoint tables match")
 
-                if not compare_tables(self, bkp_session, uris):
-                    print("Error: backup tables differ.")
-                else:
-                    wttest.WiredTigerTestCase.printVerbose(
-                        3, "Backup tables match")
+                # Make WT panic and test stop if tables don't match.
+                # More descriptive error message - which tables differ.
+
+                wttest.WiredTigerTestCase.printVerbose(3, "Testing if checkpoint tables match:")
+                assert compare_tables(
+                        self, sess, uris, "checkpoint=WiredTigerCheckpoint") == True
+                wttest.WiredTigerTestCase.printVerbose(3, "Checkpoint tables match")
+
+                # if not compare_tables(
+                #         self, sess, uris, "checkpoint=WiredTigerCheckpoint"):
+                #     print("Error: checkpoint tables differ.")
+                # else:
+                #     wttest.WiredTigerTestCase.printVerbose(
+                #         3, "Checkpoint tables match")
+
+                wttest.WiredTigerTestCase.printVerbose(3, "Testing if backup tables match:")
+                assert compare_tables(self, bkp_session, uris) == True
+                wttest.WiredTigerTestCase.printVerbose(3, "Backup tables match")
+
+                # if not compare_tables(self, bkp_session, uris):
+                #     print("Error: backup tables differ.")
+                # else:
+                #     wttest.WiredTigerTestCase.printVerbose(
+                #         3, "Backup tables match")
             finally:
                 if bkp_conn != None:
                     bkp_conn.close()

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -87,8 +87,7 @@ class backup_thread(threading.Thread):
                 # Add an assert to stop running the test if any difference in table contents
                 # is found.
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if checkpoint tables match:")
-                assert compare_tables(
-                        self, sess, uris, "checkpoint=WiredTigerCheckpoint") == True
+                assert compare_tables(self, sess, uris) == True
                 wttest.WiredTigerTestCase.printVerbose(3, "Checkpoint tables match")
 
                 wttest.WiredTigerTestCase.printVerbose(3, "Testing if backup tables match:")


### PR DESCRIPTION
I removed the use of "checkpoint=WiredTigerCheckpoint" in compare tables as checkpoint cursor is not supported. This may need to be revisited once PM-1982 project is completed.