### PR TITLE
Revert "WT-7708 Add an assert to ensure stable timestamp is not moved during prepared commit"

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1714,13 +1714,6 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
      */
     if (!readonly)
         WT_IGNORE_RET(__wt_cache_eviction_check(session, false, false, NULL));
-
-    /*
-     * Stable timestamp cannot be concurrently increased beyond or equal to the prepared
-     * transaction's durable timestamp. Otherwise, checkpoint may only write partial updates of the
-     * transaction.
-     */
-    WT_ASSERT(session, !prepare || txn->durable_timestamp > txn_global->stable_timestamp);
     return (0);
 
 err:


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#6689