### PR TITLE
WT-7599 Compatibility test - create multiple config files for each release

### DIFF
--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -53,43 +53,111 @@ build_branch()
 }
 
 #############################################################
+# get_config_file_name:
+#       arg1: branch name
+#############################################################
+get_config_file_name()
+{
+    branch_name=$1
+    release=$(echo $branch_name |  cut -c9-)
+
+    local file_name="CONFIG_${release}"
+
+    # Special case to generate develop branch CONFIG
+    if [ -z "$release" ] && [ ${branch_name} == "develop" ] ; then
+        release="develop"
+        file_name="CONFIG_${release}"
+    fi
+    echo $file_name
+}
+
+#############################################################
+# create_configs:
+#       arg1: branch name
+#############################################################
+create_configs()
+{
+    branch_name=$1
+
+    file_name=$(get_config_file_name $branch_name)
+
+    if [ -f $file_name ] ; then
+        return
+    fi
+
+cat > $file_name << EOF
+runs.type=row               # Temporarily disable column store tests
+btree.prefix=0              # Prefix testing isn't portable between releases
+cache=80                    # Medium cache so there's eviction
+checkpoints=1               # Force periodic writes
+compression=snappy          # We only built with snappy, force the choice
+data_source=table
+huffman_key=0               # Not supoprted by newer releases
+in_memory=0                 # Interested in the on-disk format
+leak_memory=1               # Faster runs
+logging=1                   # Test log compatibility
+logging_compression=snappy  # We only built with snappy, force the choice
+rows=1000000
+salvage=0                   # Faster runs
+timer=4
+verify=0                    # Faster runs
+EOF
+
+    # Append older release configs
+    for i in "${older_release_branches[@]}"
+    do
+        if [ "$i" == "$branch_name" ] ; then
+            echo "transaction.isolation=snapshot    # Older releases can't do lower isolation levels" >> $file_name
+            echo "transaction.timestamps=1          # Older releases can't do non-timestamp transactions" >> $file_name
+            break
+        fi
+    done
+}
+
+#############################################################
+# create_configs_per_release:
+#############################################################
+create_configs_per_release()
+{
+    # Create configs for all the newer releases
+    for b in ${newer_release_branches[@]}; do
+        (create_configs $b)
+    done
+
+    # Copy per-release configs in the newer release branches
+    for b in ${newer_release_branches[@]}; do
+        cp -rf CONFIG* $b/test/format/
+    done
+
+    # Delete configs from the top folder
+    rm -rf CONFIG*
+
+}
+
+#############################################################
 # run_format:
 #       arg1: branch name
 #       arg2: access methods list
 #############################################################
 run_format()
 {
+        branch_name=$1
         echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-        echo "Running format in branch: \"$1\""
+        echo "Running format in branch: \"$branch_name\""
         echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 
-        cd "$1/test/format"
+        cd "$branch_name/test/format"
+        release=$(echo $branch_name |  cut -c9-)
 
-        flags="-1q $(bflag $1)"
-
-        args=""
-        args+="runs.type=row "                  # Temporarily disable column store tests
-        args+="btree.prefix=0 "                 # Prefix testing isn't portable between releases
-        args+="cache=80 "                       # Medium cache so there's eviction
-        args+="checkpoints=1 "                  # Force periodic writes
-        args+="compression=snappy "             # We only built with snappy, force the choice
-        args+="data_source=table "
-        args+="huffman_key=0 "                  # Not supoprted by newer releases
-        args+="in_memory=0 "                    # Interested in the on-disk format
-        args+="leak_memory=1 "                  # Faster runs
-        args+="logging=1 "                      # Test log compatibility
-        args+="logging_compression=snappy "     # We only built with snappy, force the choice
-        args+="rows=1000000 "
-        args+="salvage=0 "                      # Faster runs
-        args+="timer=4 "
-        args+="transaction.isolation=snapshot " # Older releases can't do lower isolation levels
-        args+="transaction.timestamps=1 "       # Older releases can't do non-timestamp transactions
-        args+="verify=0 "                       # Faster runs
+        flags="-1q $(bflag $branch_name)"
+        if [ -z "$release" ] && [ ${branch_name} == "develop" ] ; then
+            release="develop"
+        fi
 
         for am in $2; do
             dir="RUNDIR.$am"
             echo "./t running $am access method..."
-            ./t $flags -h $dir "file_type=$am" $args
+            ./t $flags -c "CONFIG_${release}" -h $dir "file_type=$am"
 
             # Remove the version string from the base configuration file. (MongoDB does not create
             # a base configuration file, but format does, so we need to remove its version string
@@ -144,6 +212,9 @@ upgrade_downgrade()
         echo "Upgrade/downgrade testing with \"$1\" and \"$2\""
         echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 
+        file_name_1=$(get_config_file_name $1)
+        file_name_2=$(get_config_file_name $2)
+
         # Alternate running each branch format test program on the second branch's build.
         # Loop twice, that is, run format twice using each branch.
         top="$PWD"
@@ -151,13 +222,13 @@ upgrade_downgrade()
             for reps in {1..2}; do
                 echo "$1 format running on $2 access method $am..."
                 cd "$top/$1/test/format"
-                flags="-1qR $(bflag $1)"
-                ./t $flags -h "$top/$2/test/format/RUNDIR.$am" timer=2
+                flags="-1q $(bflag $1)"
+                ./t $flags -c "$top/$2/test/format/${file_name_1}" -h "$top/$2/test/format/RUNDIR.$am" timer=2
 
                 echo "$2 format running on $2 access method $am..."
                 cd "$top/$2/test/format"
-                flags="-1qR $(bflag $2)"
-                ./t $flags -h "RUNDIR.$am" timer=2
+                flags="-1q $(bflag $2)"
+                ./t $flags -c $file_name_2 -h "RUNDIR.$am" timer=2
             done
         done
 }
@@ -251,6 +322,8 @@ if [ "${wt_standalone}" = true ]; then
     cd develop; wt2=$(get_prev_version 2); cd ..
     (build_branch "$wt2")
 fi
+
+create_configs_per_release
 
 # Run format in each branch for supported access methods.
 if [ "$newer" = true ]; then

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -222,12 +222,12 @@ upgrade_downgrade()
             for reps in {1..2}; do
                 echo "$1 format running on $2 access method $am..."
                 cd "$top/$1/test/format"
-                flags="-1q $(bflag $1)"
+                flags="-1Rq $(bflag $1)"
                 ./t $flags -c "$top/$2/test/format/${file_name_1}" -h "$top/$2/test/format/RUNDIR.$am" timer=2
 
                 echo "$2 format running on $2 access method $am..."
                 cd "$top/$2/test/format"
-                flags="-1q $(bflag $2)"
+                flags="-1Rq $(bflag $2)"
                 ./t $flags -c $file_name_2 -h "RUNDIR.$am" timer=2
             done
         done

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -131,7 +131,6 @@ create_configs_per_release()
 
     # Delete configs from the top folder
     rm -rf CONFIG*
-
 }
 
 #############################################################


### PR DESCRIPTION
Updated the compatibility script to create multiple config files each per release, so that each branch is provided a CONFIG file that it understands.