### PR TITLE
WT-7721 Update test-format to reopen an existing database with different config

### DIFF
--- a/test/format/t.c
+++ b/test/format/t.c
@@ -218,8 +218,12 @@ main(int argc, char *argv[])
      * file, used when running checks.
      */
     if (g.reopen) {
-        if (config != NULL)
-            testutil_die(EINVAL, "-c incompatible with -R");
+        /*
+         * The test-format binary can now reopen an already existing database with different CONFIG
+         * file because some configurations are not supported by the older release and in
+         * compatibility testing we want the test format binary to operate on the CONFIG that it
+         * understands.
+         */
         if (access(g.home_config, R_OK) != 0)
             testutil_die(ENOENT, "%s", g.home_config);
         config = g.home_config;

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -218,12 +218,6 @@ main(int argc, char *argv[])
      * file, used when running checks.
      */
     if (g.reopen) {
-        /*
-         * The test-format binary can now reopen an already existing database with different CONFIG
-         * file because some configurations are not supported by the older release and in
-         * compatibility testing we want the test format binary to operate on the CONFIG that it
-         * understands.
-         */
         if (access(g.home_config, R_OK) != 0)
             testutil_die(ENOENT, "%s", g.home_config);
         config = g.home_config;


### PR DESCRIPTION
The test-format binary can now reopen an already existing database with different CONFIG files because some configurations are not supported by the older release. In compatibility testing, we want the test format binary to operate on the CONFIG that it understands.