### PR TITLE
WT-6782 test_prepare_hs02 WT_ROLLBACK failure: conflict between concurrent operations

### DIFF
--- a/test/suite/test_prepare_hs02.py
+++ b/test/suite/test_prepare_hs02.py
@@ -133,7 +133,7 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         c[1] = 1
         c[2] = 1
         c[3] = 1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(301))
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(302))
 
         # Trigger a checkpoint, which could trigger reconciliation
         self.conn.set_timestamp('stable_timestamp=' + timestamp_str(350))


### PR DESCRIPTION
Even though it's not enforced at the moment but documentation clearly states that during commit in unprepared transaction **commit_timestamp** must be greater than **stable_timestamp**. To avoid ambiguity and possible crashes in the future changing commit timestamp from 301 to 302. 