### PR TITLE
WT-7724 Fix race when running concurrent checkpoint and flush_tier

### DIFF
--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -384,9 +384,11 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
      */
     __flush_tier_wait(session);
     if (wait)
-        WT_WITH_SCHEMA_LOCK(session, ret = __flush_tier_once(session, flags));
+        WT_WITH_CHECKPOINT_LOCK(
+          session, WT_WITH_SCHEMA_LOCK(session, ret = __flush_tier_once(session, flags)));
     else
-        WT_WITH_SCHEMA_LOCK_NOWAIT(session, ret, ret = __flush_tier_once(session, flags));
+        WT_WITH_CHECKPOINT_LOCK_NOWAIT(session, ret,
+          WT_WITH_SCHEMA_LOCK_NOWAIT(session, ret, ret = __flush_tier_once(session, flags)));
     __wt_spin_unlock(session, &conn->flush_tier_lock);
 
     if (ret == 0 && LF_ISSET(WT_FLUSH_TIER_ON))

--- a/test/suite/test_tiered02.py
+++ b/test/suite/test_tiered02.py
@@ -41,7 +41,6 @@ class test_tiered02(wttest.WiredTigerTestCase):
     bucket = "mybucket"
     bucket_prefix = "pfx_"
     extension_name = "local_store"
-    prefix = "pfx-"
 
     def conn_config(self):
         if not os.path.exists(self.bucket):
@@ -50,7 +49,7 @@ class test_tiered02(wttest.WiredTigerTestCase):
           'statistics=(all),' + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
-          'bucket_prefix=%s,' % self.prefix + \
+          'bucket_prefix=%s,' % self.bucket_prefix + \
           'name=%s),tiered_manager=(wait=0)' % self.extension_name
 
     # Load the local store extension, but skip the test if it is missing.

--- a/test/suite/test_tiered03.py
+++ b/test/suite/test_tiered03.py
@@ -51,7 +51,6 @@ class test_tiered03(wttest.WiredTigerTestCase):
     bucket = "mybucket"
     bucket_prefix = "pfx_"
     extension_name = "local_store"
-    prefix = "pfx-"
 
     def conn_config(self):
         if not os.path.exists(self.bucket):
@@ -60,7 +59,7 @@ class test_tiered03(wttest.WiredTigerTestCase):
           'statistics=(all),' + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
-          'bucket_prefix=%s,' % self.prefix + \
+          'bucket_prefix=%s,' % self.bucket_prefix + \
           'name=%s)' % self.extension_name
 
     # Load the local store extension, but skip the test if it is missing.

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# checkpoints:correctness:checkpoint_data
+# [END_TAGS]
+#
+
+import os, threading, time, wiredtiger, wttest
+from wtthread import checkpoint_thread, flush_tier_thread
+
+# test_tiered08.py
+#   Run background checkpoings and flush_tier operations while inserting
+#   data into a table from another thread.
+class test_tiered08(wttest.WiredTigerTestCase):
+
+    nkeys = 200000
+    ckpt_freq = nkeys / 12
+    flush_freq = nkeys / 10
+
+    uri = "table:test_tiered08"
+
+    auth_token = "test_token"
+    bucket = "mybucket"
+    bucket_prefix = "pfx_"
+    extension_name = "local_store"
+    prefix = "pfx-"
+
+    def conn_config(self):
+        if not os.path.exists(self.bucket):
+            os.mkdir(self.bucket)
+        return \
+          'statistics=(all),' + \
+          'tiered_storage=(auth_token=%s,' % self.auth_token + \
+          'bucket=%s,' % self.bucket + \
+          'bucket_prefix=%s,' % self.prefix + \
+          'name=%s),tiered_manager=(wait=0)' % self.extension_name
+
+    # Load the local store extension, but skip the test if it is missing.
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('storage_sources', self.extension_name)
+
+    def key_gen(self, i):
+        return 'KEY' + str(i)
+
+    def value_gen(self, i):
+        return 'VALUE_' + 'filler' * (i % 12) + str(i)
+
+    def populate(self):
+        self.pr('Populating tiered table')
+        c = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nkeys):
+            c[self.key_gen(i)] = self.value_gen(i)
+        c.close()
+
+    def verify(self):
+        self.pr('Verifying tiered table')
+        c = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nkeys):
+            self.assertEqual(c[self.key_gen(i)], self.value_gen(i))
+        c.close()
+
+    def test_tiered08(self):
+        intl_page = 'internal_page_max=16K'
+        base_create = 'key_format=S,value_format=S,' + intl_page
+        self.session.create(self.uri, base_create)
+
+        done = threading.Event()
+        ckpt = checkpoint_thread(self.conn, done)
+        flush = flush_tier_thread(self.conn, done)
+
+        ckpt.start()
+        flush.start()
+
+        self.populate()
+
+        done.set()
+        flush.join()
+        ckpt.join()
+
+        self.verify()
+
+        self.close_conn()
+        self.pr('Reopening tiered table')
+        self.reopen_conn()
+
+        # FIXME-WT-7729 Opening the table for the final verify runs into trouble
+        if True:
+            return
+
+        self.verify()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -35,7 +35,7 @@ import os, threading, time, wiredtiger, wttest
 from wtthread import checkpoint_thread, flush_tier_thread
 
 # test_tiered08.py
-#   Run background checkpoings and flush_tier operations while inserting
+#   Run background checkpoints and flush_tier operations while inserting
 #   data into a table from another thread.
 class test_tiered08(wttest.WiredTigerTestCase):
 
@@ -97,7 +97,7 @@ class test_tiered08(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         flush = flush_tier_thread(self.conn, done)
 
-        # Start background threads and give them a chance to start
+        # Start background threads and give them a chance to start.
         ckpt.start()
         flush.start()
         time.sleep(0.5)
@@ -115,7 +115,7 @@ class test_tiered08(wttest.WiredTigerTestCase):
         self.pr('Reopening tiered table')
         self.reopen_conn()
 
-        # FIXME-WT-7729 Opening the table for the final verify runs into trouble
+        # FIXME-WT-7729 Opening the table for the final verify runs into trouble.
         if True:
             return
         self.verify()

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -40,8 +40,6 @@ from wtthread import checkpoint_thread, flush_tier_thread
 class test_tiered08(wttest.WiredTigerTestCase):
 
     nkeys = 200000
-    ckpt_freq = nkeys / 12
-    flush_freq = nkeys / 10
 
     uri = "table:test_tiered08"
 

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -56,7 +56,7 @@ class test_tiered08(wttest.WiredTigerTestCase):
         if not os.path.exists(self.bucket):
             os.mkdir(self.bucket)
         return \
-          'statistics=(all),' + \
+          'statistics=(fast),' + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
           'bucket_prefix=%s,' % self.bucket_prefix + \

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -31,7 +31,7 @@
 # [END_TAGS]
 #
 
-import os, re, threading, time, wiredtiger, wttest
+import os, threading, time, wiredtiger, wttest
 from wiredtiger import stat
 from wtthread import checkpoint_thread, flush_tier_thread
 
@@ -122,8 +122,6 @@ class test_tiered08(wttest.WiredTigerTestCase):
 
         key_count = self.populate()
 
-        # How many checkpoints have we created
-        #mcursor = self.session.open_cursor('metadata:', None, None)
         done.set()
         flush.join()
         ckpt.join()

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -147,7 +147,6 @@ class test_tiered08(wttest.WiredTigerTestCase):
         self.verify(key_count)
 
         self.close_conn()
-        return
         self.pr('Reopening tiered table')
         self.reopen_conn()
 

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -50,7 +50,6 @@ class test_tiered08(wttest.WiredTigerTestCase):
     bucket = "mybucket"
     bucket_prefix = "pfx_"
     extension_name = "local_store"
-    prefix = "pfx-"
 
     def conn_config(self):
         if not os.path.exists(self.bucket):
@@ -59,7 +58,7 @@ class test_tiered08(wttest.WiredTigerTestCase):
           'statistics=(all),' + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
-          'bucket_prefix=%s,' % self.prefix + \
+          'bucket_prefix=%s,' % self.bucket_prefix + \
           'name=%s),tiered_manager=(wait=0)' % self.extension_name
 
     # Load the local store extension, but skip the test if it is missing.

--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -87,6 +87,8 @@ class test_tiered08(wttest.WiredTigerTestCase):
         c.close()
 
     def test_tiered08(self):
+        cfg = self.conn_config()
+        self.pr('Config is: ' + cfg)
         intl_page = 'internal_page_max=16K'
         base_create = 'key_format=S,value_format=S,' + intl_page
         self.session.create(self.uri, base_create)
@@ -95,8 +97,10 @@ class test_tiered08(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         flush = flush_tier_thread(self.conn, done)
 
+        # Start background threads and give them a chance to start
         ckpt.start()
         flush.start()
+        time.sleep(0.5)
 
         self.populate()
 
@@ -107,13 +111,13 @@ class test_tiered08(wttest.WiredTigerTestCase):
         self.verify()
 
         self.close_conn()
+        return
         self.pr('Reopening tiered table')
         self.reopen_conn()
 
         # FIXME-WT-7729 Opening the table for the final verify runs into trouble
         if True:
             return
-
         self.verify()
 
 if __name__ == '__main__':

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -43,6 +43,20 @@ class checkpoint_thread(threading.Thread):
             sess.checkpoint()
         sess.close()
 
+class flush_tier_thread(threading.Thread):
+    def __init__(self, conn, done):
+        self.conn = conn
+        self.done = done
+        threading.Thread.__init__(self)
+
+    def run(self):
+        sess = self.conn.open_session()
+        while not self.done.isSet():
+            # Sleep for 25 milliseconds.
+            time.sleep(0.0025)
+            sess.flush_tier()
+        sess.close()
+
 class backup_thread(threading.Thread):
     def __init__(self, conn, backup_dir, done):
         self.backup_dir = backup_dir

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -2,5 +2,5 @@
 |---|---|---|---|---|
 |Backup|Correctness|Full Backup|Full backup contains correct data|[../test/suite/test_backup01.py](../test/suite/test_backup01.py)
 |Caching Eviction|Correctness|Written Data|Ensure that the data written out by eviction is correct after reading|[../test/suite/test_hs15.py](../test/suite/test_hs15.py)
-|Checkpoints|Correctness|Checkpoint Data|On system with a complex, concurrent workload the correct versions of data appear in checkpoints|[../test/suite/test_checkpoint02.py](../test/suite/test_checkpoint02.py), [../test/suite/test_checkpoint03.py](../test/suite/test_checkpoint03.py)
+|Checkpoints|Correctness|Checkpoint Data|On system with a complex, concurrent workload the correct versions of data appear in checkpoints|[../test/suite/test_checkpoint02.py](../test/suite/test_checkpoint02.py), [../test/suite/test_checkpoint03.py](../test/suite/test_checkpoint03.py), [../test/suite/test_tiered08.py](../test/suite/test_tiered08.py)
 |Checkpoints|Liveness|Liveness|Identify bugs and race conditions related to checkpoints that can cause deadlocks or livelocks|[../test/csuite/wt3363_checkpoint_op_races/main.c](../test/csuite/wt3363_checkpoint_op_races/main.c)


### PR DESCRIPTION
@ddanderson and @sueloverso. This is a heavy handed way of solving a race between checkpoint and flush_tier. But I think it's better as we wrap up the project to support this functionality.  I will create a follow-on ticket to understand and fix the underlying issue with flush-tier and the cached checkpoint metadata and tag it for POC2.