### PR TITLE
WT-7696 Fix coverity error - Unused variable in _rollback_to_stable_btree_apply_all

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1545,12 +1545,13 @@ __rollback_to_stable_btree_apply_all(WT_SESSION_IMPL *session, uint64_t rollback
     struct timespec rollback_timer;
     WT_CURSOR *cursor;
     WT_DECL_RET;
-    uint64_t rollback_count, rollback_msg_count, rollback_txnid;
+    uint64_t rollback_count, rollback_msg_count;
     const char *config, *uri;
 
     /* Initialize the verbose tracking timer. */
     __wt_epoch(session, &rollback_timer);
-    rollback_count = rollback_msg_count = rollback_txnid = 0;
+    rollback_count = 0;
+    rollback_msg_count = 0;
 
     WT_RET(__wt_metadata_cursor(session, &cursor));
     while ((ret = cursor->next(cursor)) == 0) {


### PR DESCRIPTION
A visual inspection of the code shows that the Coverity analysis is correct, and the variable rollback_txnid is not used after it is set. 

The issue is not detected by the compiler because of the chained assignment used to initialise the three variables. The compiler thinks that rollback_txnid is being used to assign to rollback_msg_count. If rollback_txnid were the left-most variable in the chained assignment (ie assigned last) then the compiler would display an error because it would consider rollback_txnid unused. 

So, whether the error is triggered in the case of one of the variables being unused after being set is entirely dependent on the order of variables in the chained assignment. This means that the correct fix is to both remove rollback_txnid and, to avoid potential issues generated by subsequent code changes, to break the chained assignment for those variables that are required.

There is a longer discussion on this issue in the JIRA ticket.