### PR TITLE
WT-7725 Add missing brackets around parameter in macro definition

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -9,7 +9,7 @@
 #include "wt_internal.h"
 
 #define WT_CHECK_RECOVERY_FLAG_TS_TXNID(session, txnid, durablets)           \
-    (durablets == WT_TS_NONE && F_ISSET(S2C(session), WT_CONN_RECOVERING) && \
+    ((durablets) == WT_TS_NONE && F_ISSET(S2C(session), WT_CONN_RECOVERING) && \
       (txnid) >= S2C(session)->recovery_ckpt_snap_min)
 
 /* Enable rollback to stable verbose messaging during recovery. */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -8,7 +8,7 @@
 
 #include "wt_internal.h"
 
-#define WT_CHECK_RECOVERY_FLAG_TS_TXNID(session, txnid, durablets)           \
+#define WT_CHECK_RECOVERY_FLAG_TS_TXNID(session, txnid, durablets)             \
     ((durablets) == WT_TS_NONE && F_ISSET(S2C(session), WT_CONN_RECOVERING) && \
       (txnid) >= S2C(session)->recovery_ckpt_snap_min)
 


### PR DESCRIPTION
In the definition of macro `WT_CHECK_RECOVERY_FLAG_TS_TXNID`, the `durablets` parameter is not surrounded by parentheses in the implementation. This could cause unexpected behaviour should an expression be passed in as a parameter. 

The macro is used three times in the .c file that it is declared in. Each of the three uses passes a single variable (ie not an unbracketed expression) as the `duablets` parameter, so the missing parentheses in the macro definition do not currently result in incorrect behaviour in the code that uses the macro.

However, subsequent code changes could change the parameters to the macro and expose the missing parentheses.

Hence the code has been changed to add the parentheses, but there is no immediate concern that the un-corrected code is causing bugs right now.