### PR TITLE
WT-7738 Fix thread-safety issue in `random_generator`

### DIFF
--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -43,7 +43,7 @@ class random_generator {
     static random_generator &
     instance()
     {
-        static random_generator _instance;
+        thread_local random_generator _instance;
         return (_instance);
     }
 


### PR DESCRIPTION
Neither `std::uniform_int_distribution` or `std::mt19937` are thread-safe so it's not ok to be calling `random_generator::generate_string` concurrently. To fix this, I've marked the singleton instance as `thread_local` so each thread has its own copy.