### PR TITLE
WT-7739 Switch back to using MacOS 10.14 for Evergreen compile task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2820,8 +2820,6 @@ buildvariants:
     test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH DYLD_LIBRARY_PATH=$(pwd)/.libs top_srcdir=$(pwd)/.. top_builddir=$(pwd)
   tasks:
     - name: compile
-      # macos-1012 is a more stable distro that we want to use for our PR testing task
-      distros: macos-1012
     - name: make-check-test
     - name: unit-test-with-compile
     - name: fops


### PR DESCRIPTION
Since we've disabled MacOS PR testing, let's switch back to 10.14. MacOS 10.12 is giving us issues because the system compilers are quite old (don't support the `thread_local` keyword) and the MongoDB toolchain seems busted.