### PR TITLE
WT-7706 Prepared transaction abort should restore correct update from the history store. (#6687) (v4.4 backport)

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -483,6 +483,16 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
                      */
                     WT_ASSERT(session, same_txn_valid_upd->type != WT_UPDATE_TOMBSTONE);
                     upd_select->upd = upd = same_txn_valid_upd;
+
+                } else if (same_txn_valid_upd != NULL && vpack != NULL && vpack->tw.prepare) {
+                    /*
+                     * The on-disk version is from an aborted prepare transaction. Therefore, use
+                     * the update from the same transaction as the selected update. We are sure that
+                     * the on-disk prepared update has been aborted because otherwise we would have
+                     * chosen it as an update this tombstone can be applied to.
+                     */
+                    WT_ASSERT(session, same_txn_valid_upd->type != WT_UPDATE_TOMBSTONE);
+                    upd_select->upd = upd = same_txn_valid_upd;
                 }
             }
         }

--- a/test/suite/test_prepare_hs05.py
+++ b/test/suite/test_prepare_hs05.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-2020 MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+from wiredtiger import stat, WT_NOTFOUND
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_prepare_hs05.py
+# Test that after aborting prepare transaction, correct update from the history store is restored.
+class test_prepare_hs05(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB'
+    session_config = 'isolation=snapshot'
+
+    def test_check_prepare_abort_hs_restore(self):
+        uri = 'table:test_prepare_hs05'
+        create_params = 'key_format=S,value_format=S'
+        self.session.create(uri, create_params)
+
+        value1 = 'a' * 5
+        value2 = 'b' * 5
+        value3 = 'c' * 5
+
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+
+        key = 1
+
+        self.session.begin_transaction()
+        cursor[str(key)] = value1
+        cursor.set_key(str(key))
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+
+        # Commit update and remove operation in the same transaction.
+        self.session.begin_transaction()
+        cursor[str(key)] = value2
+        cursor.set_key(str(key))
+        cursor.remove()
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+
+        # Add a prepared update for the key.
+        self.session.begin_transaction()
+        cursor[str(key)] = value3
+        self.session.prepare_transaction('prepare_timestamp='+ timestamp_str(4))
+
+        # Try to evict the page with prepared update. This will ensure that prepared update is
+        # written as the on-disk version and the older versions are moved to the history store.
+        session2 = self.conn.open_session()
+        session2.begin_transaction('ignore_prepare=true')
+        cursor2 = session2.open_cursor(uri, None, "debug=(release_evict=true)")
+        cursor2.set_key(str(key))
+        self.assertEquals(cursor2.search(), WT_NOTFOUND)
+        cursor2.reset()
+
+        # This should abort the prepared transaction.
+        self.session.rollback_transaction()
+
+        self.session.checkpoint()
+
+        # We should be able to read the older version of the key from the history store.
+        self.session.begin_transaction('read_timestamp='+timestamp_str(2))
+        cursor.set_key(str(key))
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), value1)
+        self.session.rollback_transaction()
+
+        # The latest version should be marked deleted.
+        self.session.begin_transaction()
+        cursor.set_key(str(key))
+        self.assertEqual(cursor.search(), WT_NOTFOUND)
+        self.session.rollback_transaction()


### PR DESCRIPTION
* Use same transaction update when on-disk value is an aborted prepared update

* add a test to verify correct restoration of update from HS after prepared transaction abort

(cherry picked from commit 7074f12888e3e7e93c7ca2fc6f541ebd40b58749)
(cherry picked from commit f63a096cf08f8b5e72b3b36bbaba9bf54c7ba5a9)