### PR TITLE
WT-7699 Fix RTS handling to abort an out of order prepared transaction (#6684) (v4.4 backport)

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -346,17 +346,17 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
 
         /*
          * Do not include history store updates greater than on-disk data store version to construct
-         * a full update to restore. Include the most recent updates than the on-disk version
-         * shouldn't be problem as the on-disk version in history store is always a full update. It
-         * is better to not to include those updates as it unnecessarily increases the rollback to
-         * stable time.
+         * a full update to restore except when the on-disk update is prepared. Including more
+         * recent updates than the on-disk version shouldn't be problem as the on-disk version in
+         * history store is always a full update. It is better to not to include those updates as it
+         * unnecessarily increases the rollback to stable time.
          *
          * Comparing with timestamps here has no problem unlike in search flow where the timestamps
          * may be reset during reconciliation. RTS detects an on-disk update is unstable based on
          * the written proper timestamp, so comparing against it with history store shouldn't have
          * any problem.
          */
-        if (hs_start_ts <= unpack->tw.start_ts) {
+        if (hs_start_ts <= unpack->tw.start_ts || unpack->tw.prepare) {
             if (type == WT_UPDATE_MODIFY)
                 WT_ERR(__wt_modify_apply_item(
                   session, S2BT(session)->value_format, &full_value, hs_value->data));
@@ -423,7 +423,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
               __wt_timestamp_to_string(hs_durable_ts, ts_string[1]),
               __wt_timestamp_to_string(hs_stop_durable_ts, ts_string[2]),
               __wt_timestamp_to_string(rollback_timestamp, ts_string[3]), hs_tw->start_txn, type);
-            WT_ASSERT(session, hs_tw->start_ts <= unpack->tw.start_ts);
+            WT_ASSERT(session, unpack->tw.prepare || hs_tw->start_ts <= unpack->tw.start_ts);
             valid_update_found = true;
             break;
         }

--- a/test/suite/test_rollback_to_stable21.py
+++ b/test/suite/test_rollback_to_stable21.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from wiredtiger import stat
+from wtscenario import make_scenarios
+from helper import simulate_crash_restart
+from wtdataset import SimpleDataSet
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def timestamp_str(t):
+    return '%x' % t
+
+# test_rollback_to_stable21.py
+# Test rollback to stable when an out of order prepared transaction is written to disk
+class test_rollback_to_stable21(test_rollback_to_stable_base):
+    key_format_values = [
+        ('column', dict(key_format='r')),
+        ('integer_row', dict(key_format='i')),
+    ]
+
+    scenarios = make_scenarios(key_format_values)
+
+    def conn_config(self):
+        config = 'cache_size=250MB,statistics=(all),statistics_log=(json,on_close,wait=1)'
+        return config
+
+    def test_rollback_to_stable(self):
+        nrows = 1000
+
+        # Prepare transactions for column store table is not yet supported.
+        if self.key_format == 'r':
+            self.skipTest('Prepare transactions for column store table is not yet supported')
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable21"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format="S", config='log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable timestamps to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        valuea = 'a' * 400
+        valueb = 'b' * 400
+
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[i] = valuea
+
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[i] = valueb
+
+        cursor.reset()
+        cursor.close()
+        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+
+        s = self.conn.open_session()
+        s.begin_transaction('ignore_prepare = true')
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(i)
+            self.assertEquals(evict_cursor.search(), 0)
+            self.assertEqual(evict_cursor.get_value(), valuea)
+            evict_cursor.reset()
+
+        s.rollback_transaction()
+        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        s.checkpoint()
+
+        # Rollback the prepared transaction
+        self.session.rollback_transaction()
+
+        # Simulate a server crash and restart.
+        self.pr("restart")
+        simulate_crash_restart(self, ".", "RESTART")
+        self.pr("restart complete")
+
+        self.check(valuea, uri, nrows, 40)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
+        stat_cursor.close()
+
+        self.assertGreater(hs_removed, 0)


### PR DESCRIPTION
When an out of order update is performed by a prepared transaction
the earlier updates are not adjusted to the out of order prepared
timestamp. While aborting these updates properly frame the update
that needs to be restored.

(cherry picked from commit c5620904105f2e2f092f0d08d13e610d1fc39c97)
(cherry picked from commit 086b09040dbd291ebf82eba7ccd2012ac2523718)