### PR TITLE
WT-7710 Fix to use history store btree while initialising HS cursor (#6694) (v4.4 backport)

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1118,7 +1118,9 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
     /* Open the file cursor for operations on the regular history store .*/
     WT_ERR(__curhs_file_cursor_open(session, &hs_cursor->file_cursor));
 
-    WT_ERR(__wt_cursor_init(cursor, WT_HS_URI, owner, NULL, cursorp));
+    WT_WITH_BTREE(session, CUR2BT(hs_cursor->file_cursor),
+      ret = __wt_cursor_init(cursor, WT_HS_URI, owner, NULL, cursorp));
+    WT_ERR(ret);
     WT_TIME_WINDOW_INIT(&hs_cursor->time_window);
     hs_cursor->btree_id = 0;
     WT_ERR(__wt_scr_alloc(session, 0, &hs_cursor->datastore_key));


### PR DESCRIPTION
(cherry picked from commit 88250b7a3ad29d4338b9d529c277c852889e9bdf)
(cherry picked from commit a41345737223a2432b548566b516ea5f3bd06131)