### PR TITLE
WT-7447 minor bugs (ctype, puts) in WT tests

### DIFF
--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -883,8 +883,8 @@ check_db(uint32_t nth, uint32_t datasize, pid_t pid, bool directio, uint32_t fla
         gotid = (uint64_t)strtol(gotkey, &p, 10);
         testutil_assert(*p == KEY_SEP[0]);
         p++;
-        testutil_assert(isxdigit(*p));
-        if (isdigit(*p))
+        testutil_assert(isxdigit((unsigned char)*p));
+        if (isdigit((unsigned char)*p))
             gotth = (uint32_t)(*p - '0');
         else if (*p >= 'a' && *p <= 'f')
             gotth = (uint32_t)((*p - 'a') + 10);

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1082,7 +1082,7 @@ config_file(const char *name)
                 break;
             }
             if (t == buf && *p == ']') { /* Closing brace, configuration starts after it. */
-                while (isblank(*++p))
+                while (isblank((unsigned char)*++p))
                     ;
                 t = p--;
             }

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -699,7 +699,7 @@ empty(int cnt)
 
     if (page_type == WT_PAGE_COL_FIX)
         for (i = 0; i < cnt; ++i)
-            testutil_assert(fputs("\\00\n", res_fp));
+            testutil_assert(fputs("\\00\n", res_fp) != EOF);
 }
 
 /*


### PR DESCRIPTION
Patches for two bugs: (1) use of <ctype.h> functions without casting to unsigned char (possibly undefined behavior) and (2) wrong assertion about the return value of puts().