### PR TITLE
WT-7748 cmake: fix library probes for libs not on the default linker path

### DIFF
--- a/build_cmake/configs/auto.cmake
+++ b/build_cmake/configs/auto.cmake
@@ -251,6 +251,7 @@ config_lib(
     "lz4 library exists."
     LIB "lz4"
     FUNC "LZ4_versionNumber"
+    HEADER "lz4.h"
 )
 
 config_lib(
@@ -258,6 +259,7 @@ config_lib(
     "snappy library exists."
     LIB "snappy"
     FUNC "snappy_compress"
+    HEADER "snappy.h"
 )
 
 config_lib(
@@ -265,6 +267,7 @@ config_lib(
     "zlib library exists."
     LIB "z"
     FUNC "zlibVersion"
+    HEADER "zlib.h"
 )
 
 config_lib(
@@ -272,6 +275,7 @@ config_lib(
     "zstd library exists."
     LIB "zstd"
     FUNC "ZSTD_versionString"
+    HEADER "zstd.h"
 )
 
 config_lib(

--- a/build_cmake/helpers.cmake
+++ b/build_cmake/helpers.cmake
@@ -343,7 +343,7 @@ function(config_include config_name description)
     )
 
     if (NOT "${CONFIG_INCLUDE_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to config_func: ${CONFIG_INCLUDE_UNPARSED_ARGUMENTS}")
+        message(FATAL_ERROR "Unknown arguments to config_include: ${CONFIG_INCLUDE_UNPARSED_ARGUMENTS}")
     endif()
     # We require a include header (not optional).
     if ("${CONFIG_INCLUDE_FILE}" STREQUAL "")

--- a/build_cmake/helpers.cmake
+++ b/build_cmake/helpers.cmake
@@ -386,7 +386,7 @@ function(config_include config_name description)
     endif()
 endfunction()
 
-# config_lib(config_name description LIB <library> FUNC <function-symbol> [DEPENDS <deps>])
+# config_lib(config_name description LIB <library> FUNC <function-symbol> [DEPENDS <deps>] [HEADER <file>])
 # Defines a boolean (0/1) configuration option based on whether a given library exists.
 # The configuration option is stored in the cmake cache and can be exported to the wiredtiger config header.
 #   config_name - name of the configuration option.
@@ -401,7 +401,7 @@ function(config_lib config_name description)
         2
         "CONFIG_LIB"
         ""
-        "LIB;FUNC;DEPENDS"
+        "LIB;FUNC;DEPENDS;HEADER"
         ""
     )
 
@@ -420,17 +420,33 @@ function(config_lib config_name description)
     # Check that the configs dependencies are enabled before setting it to a visible enabled state.
     eval_dependency("${CONFIG_LIB_DEPENDS}" enabled)
     if(enabled)
+        message("-- Looking for library ${CONFIG_LIB_LIB}")
         # 'check_library_exists' won't use our current cache when test compiling the library.
         # To get around this we need to ensure we manually forward WT_ARCH and WT_OS as a minimum. This is particularly
         # needed if 'check_library_exists' will leverage one of our toolchain files.
         if((NOT "${WT_ARCH}" STREQUAL "") AND (NOT "${WT_ARCH}" STREQUAL ""))
             set(CMAKE_REQUIRED_FLAGS "-DWT_ARCH=${WT_ARCH} -DWT_OS=${WT_OS}")
         endif()
-        check_library_exists(${CONFIG_LIB_LIB} ${CONFIG_LIB_FUNC} "" has_lib_${config_name})
+        find_library(has_lib_${config_name} ${CONFIG_LIB_LIB})
+        #check_library_exists(${CONFIG_LIB_LIB} ${CONFIG_LIB_FUNC} "" has_lib_${config_name})
         set(CMAKE_REQUIRED_FLAGS)
         set(has_lib "0")
         if(has_lib_${config_name})
             set(has_lib ${has_lib_${config_name}})
+            if (CONFIG_LIB_HEADER)
+                find_path(include_path_${config_name} ${CONFIG_LIB_HEADER})
+                if (include_path_${config_name})
+                    message("-- Looking for library ${CONFIG_LIB_LIB}: found ${has_lib_${config_name}}, include path ${include_path_${config_name}}")
+                    include_directories(${include_path_${config_name}})
+                else()
+                    message("-- Looking for library ${CONFIG_LIB_LIB}: found ${has_lib$_{config_name}}")
+                endif()
+                unset(include_path_${config_name} CACHE)
+            else()
+                message("-- Looking for library ${CONFIG_LIB_LIB}: found ${has_lib_${config_name}}")
+            endif()
+        else()
+            message("-- Looking for library ${CONFIG_LIB_LIB}: NOT found")
         endif()
         # Set an internal cache variable "${config_name}_DISABLED" to capture its enabled/disabled state.
         # We want to ensure we capture a transition from a disabled to enabled state when dependencies are met.
@@ -444,6 +460,7 @@ function(config_lib config_name description)
         # configuration runs.
         unset(has_lib_${config_name} CACHE)
     else()
+        message("-- Not looking for library ${CONFIG_LIB_LIB}: disabled")
         set(${config_name} 0 CACHE INTERNAL "" FORCE)
         set(${config_name}_DISABLED ON CACHE INTERNAL "" FORCE)
     endif()

--- a/build_cmake/strict/clang_strict.cmake
+++ b/build_cmake/strict/clang_strict.cmake
@@ -53,5 +53,13 @@ if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
     list(APPEND clang_base_c_flags "-Wno-implicit-int-float-conversion")
 endif()
 
+if(WT_DARWIN AND NOT CMAKE_CROSSCOMPILING)
+    # If we are not cross-compiling, we can safely disable this diagnostic.
+    # Its incompatible with strict diagnostics when including external
+    # libraries that are not in the default linker path
+    # e.g. linking zlib/snappy/... from /usr/local/.
+    list(APPEND clang_base_c_flags "-Wno-poison-system-directories")
+endif()
+
 # Set our base clang flags to ensure it propogates to the rest of our build.
 set(COMPILER_DIAGNOSTIC_FLAGS "${COMPILER_DIAGNOSTIC_FLAGS};${clang_base_c_flags}" CACHE  INTERNAL "" FORCE)

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -59,7 +59,6 @@ if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
     add_library(wiredtiger_lz4 ${link_type} ${sources})
     # HAVE_LIBLZ4 contains the full pathname to the lib, which is
     # what the cmake docs recommend using
-    #target_link_libraries(wiredtiger_lz4 "lz4")
     target_link_libraries(wiredtiger_lz4 ${HAVE_LIBLZ4})
     target_include_directories(
         wiredtiger_lz4

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -57,7 +57,10 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
     add_library(wiredtiger_lz4 ${link_type} ${sources})
-    target_link_libraries(wiredtiger_lz4 "lz4")
+    # HAVE_LIBLZ4 contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    #target_link_libraries(wiredtiger_lz4 "lz4")
+    target_link_libraries(wiredtiger_lz4 ${HAVE_LIBLZ4})
     target_include_directories(
         wiredtiger_lz4
         PRIVATE

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -58,7 +58,6 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
     add_library(wiredtiger_snappy ${link_type} ${sources})
     # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
     # what the cmake docs recommend using
-    #target_link_libraries(wiredtiger_snappy "snappy")
     target_link_libraries(wiredtiger_snappy ${HAVE_LIBSNAPPY})
     target_include_directories(
         wiredtiger_snappy

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -56,7 +56,10 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
     add_library(wiredtiger_snappy ${link_type} ${sources})
-    target_link_libraries(wiredtiger_snappy "snappy")
+    # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    #target_link_libraries(wiredtiger_snappy "snappy")
+    target_link_libraries(wiredtiger_snappy ${HAVE_LIBSNAPPY})
     target_include_directories(
         wiredtiger_snappy
         PRIVATE

--- a/ext/compressors/zlib/CMakeLists.txt
+++ b/ext/compressors/zlib/CMakeLists.txt
@@ -56,7 +56,9 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
     add_library(wiredtiger_zlib ${link_type} ${sources})
-    target_link_libraries(wiredtiger_zlib "z")
+    # HAVE_LIBZ contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_zlib ${HAVE_LIBZ})
     target_include_directories(
         wiredtiger_zlib
         PRIVATE

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -58,7 +58,6 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
     add_library(wiredtiger_zstd ${link_type} ${sources})
     # HAVE_LIBZSTD contains the full pathname to the lib, which is
     # what the cmake docs recommend using
-    #target_link_libraries(wiredtiger_zstd "zstd")
     target_link_libraries(wiredtiger_zstd ${HAVE_LIBZSTD})
     target_include_directories(
         wiredtiger_zstd

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -43,6 +43,7 @@ if (HAVE_BUILTIN_EXTENSION_ZSTD AND ENABLE_ZSTD)
 endif()
 
 set(sources "zstd_compress.c")
+set(link_type)
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
     if(ENABLE_STATIC)
         set(link_type "STATIC")
@@ -55,7 +56,10 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
     add_library(wiredtiger_zstd ${link_type} ${sources})
-    target_link_libraries(wiredtiger_zstd "zstd")
+    # HAVE_LIBZSTD contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    #target_link_libraries(wiredtiger_zstd "zstd")
+    target_link_libraries(wiredtiger_zstd ${HAVE_LIBZSTD})
     target_include_directories(
         wiredtiger_zstd
         PRIVATE


### PR DESCRIPTION
On a lot of systems external libraries are in places like /usr/local
or /usr/pkg or /opt that aren't in the default linker path. Use
find_library() instead of check_library_exists() so they can be found
according to user-supplied cmake paths.

When linking with the library, use the path found instead of just the
library name. This is what the cmake manual recommends, rather than
adding to the library path and generating -L linker options.

Also add a HEADER option to config_lib(), use it to look for the
library's header files, and add the resulting dir to the include
path. Pass a header name to uses of config_lib() where this makes
sense.

And, print what's happening in config_lib() since otherwise it's
completely silent.