### PR TITLE
WT-7744 Fix null pointer within wt3338_partial_update csuite

### DIFF
--- a/test/csuite/wt3338_partial_update/main.c
+++ b/test/csuite/wt3338_partial_update/main.c
@@ -127,7 +127,9 @@ slow_apply_api(WT_ITEM *orig)
 
     /* Mess up anything not initialized in the buffers. */
     memset((uint8_t *)ta->mem + ta->size, 0xff, ta->memsize - ta->size);
-    memset((uint8_t *)tb->mem, 0xff, tb->memsize);
+
+    if (tb->memsize > 0)
+        memset((uint8_t *)tb->mem, 0xff, tb->memsize);
 
     /*
      * Process the entries to figure out how large a buffer we need. This is a bit pessimistic


### PR DESCRIPTION
The C standard states that the behaviour of memset (and other mem* functions) is undefined when NULL pointers are passed to them. This is the case even if the 'n' count parameter is 0.

The UBSAN tests were picking up a case where a NULL pointer was being passed into this memset call. This was occurring when the 'n' count parameter was 0.

To address this, a conditional guard has been added around the call to memset that was generating an UBSAN error to ensure that the 'n' count parameter is greater than 0.