### PR TITLE
WT-7742 Fix misaligned address in wt3184_dup_index_collator/main.c

### DIFF
--- a/test/csuite/wt3184_dup_index_collator/main.c
+++ b/test/csuite/wt3184_dup_index_collator/main.c
@@ -46,11 +46,16 @@ compare_int(int32_t a, int32_t b)
 static int32_t
 item_to_int(const WT_ITEM *item)
 {
-    int32_t buf;
+    int32_t ret;
 
     testutil_assert(item->size == sizeof(int32_t));
-    memcpy(&buf, item->data, sizeof(int32_t));
-    return buf;
+
+    /*
+     * Using memcpy instead of direct type cast to avoid undefined behavior sanitizer complaining
+     * about misaligned address.
+     */
+    memcpy(&ret, item->data, sizeof(int32_t));
+    return ret;
 }
 
 static int

--- a/test/csuite/wt3184_dup_index_collator/main.c
+++ b/test/csuite/wt3184_dup_index_collator/main.c
@@ -69,9 +69,9 @@ compare_int_items(WT_ITEM *itema, WT_ITEM *itemb)
 static void
 print_int_item(const char *str, const WT_ITEM *item)
 {
-    if (item->size > 0) {
+    if (item->size > 0)
         printf("%s%" PRId32, str, item_to_int(item));
-    } else
+    else
         printf("%s<empty>", str);
 }
 

--- a/test/csuite/wt3184_dup_index_collator/main.c
+++ b/test/csuite/wt3184_dup_index_collator/main.c
@@ -44,10 +44,13 @@ compare_int(int32_t a, int32_t b)
 }
 
 static int32_t
-item_to_int(WT_ITEM *item)
+item_to_int(const WT_ITEM *item)
 {
+    int32_t buf;
+
     testutil_assert(item->size == sizeof(int32_t));
-    return (*(int32_t *)item->data);
+    memcpy(&buf, item->data, sizeof(int32_t));
+    return buf;
 }
 
 static int
@@ -62,8 +65,7 @@ static void
 print_int_item(const char *str, const WT_ITEM *item)
 {
     if (item->size > 0) {
-        testutil_assert(item->size == sizeof(int32_t));
-        printf("%s%" PRId32, str, *(int32_t *)item->data);
+        printf("%s%" PRId32, str, item_to_int(item));
     } else
         printf("%s<empty>", str);
 }


### PR DESCRIPTION
Replaced type cast with memcpy to avoid UBSAN error.