### PR TITLE
WT-7755 YSCB: Add a native implementation of YCSB to WTPERF.

### DIFF
--- a/bench/wtperf/runners/ycsb-a.wtperf
+++ b/bench/wtperf/runners/ycsb-a.wtperf
@@ -1,0 +1,12 @@
+conn_config="cache_size=40G,log=(enabled=true)"
+pareto=20
+table_config="type=file"
+key_sz=100
+value_sz=1024
+icount=120000000
+run_time=3600
+threads=((count=10,reads=1),(count=10,updates=1))
+warmup=120
+sample_interval=5
+populate_threads=8
+report_interval=5

--- a/bench/wtperf/runners/ycsb-b.wtperf
+++ b/bench/wtperf/runners/ycsb-b.wtperf
@@ -1,0 +1,12 @@
+conn_config="cache_size=40G,log=(enabled=true)"
+pareto=20
+table_config="type=file"
+key_sz=100
+value_sz=1024
+icount=180000000
+run_time=3600
+threads=((count=20,reads=95,updates=5))
+warmup=120
+sample_interval=5
+populate_threads=8
+report_interval=5

--- a/bench/wtperf/runners/ycsb-b.wtperf
+++ b/bench/wtperf/runners/ycsb-b.wtperf
@@ -3,7 +3,7 @@ pareto=20
 table_config="type=file"
 key_sz=100
 value_sz=1024
-icount=180000000
+icount=90000000
 run_time=3600
 threads=((count=20,reads=95,updates=5))
 warmup=120

--- a/bench/wtperf/runners/ycsb-c.wtperf
+++ b/bench/wtperf/runners/ycsb-c.wtperf
@@ -1,0 +1,12 @@
+conn_config="cache_size=40G,log=(enabled=true)"
+pareto=20
+table_config="type=file"
+key_sz=100
+value_sz=1024
+icount=240000000
+run_time=3600
+threads=((count=20,reads=1))
+warmup=120
+sample_interval=5
+populate_threads=8
+report_interval=5

--- a/bench/wtperf/runners/ycsb-c.wtperf
+++ b/bench/wtperf/runners/ycsb-c.wtperf
@@ -3,7 +3,7 @@ pareto=20
 table_config="type=file"
 key_sz=100
 value_sz=1024
-icount=240000000
+icount=120000000
 run_time=3600
 threads=((count=20,reads=1))
 warmup=120

--- a/bench/wtperf/runners/ycsb-d.wtperf
+++ b/bench/wtperf/runners/ycsb-d.wtperf
@@ -2,7 +2,7 @@ conn_config="cache_size=40G,log=(enabled=true)"
 table_config="type=file"
 key_sz=100
 value_sz=1024
-icount=120000000
+icount=60000000
 run_time=3600
 select_latest=true
 threads=((count=100,reads=95,inserts=5))

--- a/bench/wtperf/runners/ycsb-d.wtperf
+++ b/bench/wtperf/runners/ycsb-d.wtperf
@@ -1,0 +1,12 @@
+conn_config="cache_size=40G,log=(enabled=true)"
+table_config="type=file"
+key_sz=100
+value_sz=1024
+icount=120000000
+run_time=3600
+select_latest=true
+threads=((count=100,reads=95,inserts=5))
+warmup=120
+sample_interval=5
+populate_threads=8
+report_interval=5

--- a/bench/wtperf/runners/ycsb-e.wtperf
+++ b/bench/wtperf/runners/ycsb-e.wtperf
@@ -3,7 +3,7 @@ pareto=20
 table_config="type=file"
 key_sz=100
 value_sz=1024
-icount=180000000
+icount=90000000
 run_time=3600
 threads=((count=20,reads=95,inserts=5))
 read_range=100

--- a/bench/wtperf/runners/ycsb-e.wtperf
+++ b/bench/wtperf/runners/ycsb-e.wtperf
@@ -1,0 +1,14 @@
+conn_config="cache_size=40G,log=(enabled=true)"
+pareto=20
+table_config="type=file"
+key_sz=100
+value_sz=1024
+icount=180000000
+run_time=3600
+threads=((count=20,reads=95,inserts=5))
+read_range=100
+read_range_random=true
+warmup=120
+sample_interval=5
+populate_threads=8
+report_interval=5

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2768,7 +2768,6 @@ wtperf_rand(WTPERF_THREAD *thread)
          * recently inserted records.
          */
         (void)i;
-        (void)rval128;
         range =
           (SELECT_LATEST_RANGE < wtperf->insert_key) ? SELECT_LATEST_RANGE : wtperf->insert_key;
         start_range = wtperf->insert_key - range;

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -266,16 +266,14 @@ do_range_reads(WTPERF_THREAD *thread, WT_CURSOR *cursor, int64_t read_range)
     extract_key(range_key_buf, &next_val);
 
     /*
-     * If an option tells us to randomly select the number of
-     * values to read in a range, we use the value of read_range
-     * as the upper bound on the number of values to read.
-     * YCSB-E stipulates that we use a uniform random distribution
-     * for the number of values, so we do not use the wtperf random
-     * routine, which may take us to Pareto.
+     * If an option tells us to randomly select the number of values to read in a range, we use the
+     * value of read_range as the upper bound on the number of values to read. YCSB-E stipulates
+     * that we use a uniform random distribution for the number of values, so we do not use the
+     * wtperf random routine, which may take us to Pareto.
      */
     if (wtperf->opts->read_range_random) {
-	rand_range = __wt_random(&thread->rnd) % read_range;
-	read_range = rand_range;
+        rand_range = __wt_random(&thread->rnd) % read_range;
+        read_range = rand_range;
     }
 
     for (range = 0; range < read_range; ++range) {
@@ -2722,48 +2720,41 @@ wtperf_rand(WTPERF_THREAD *thread)
     }
 
     /*
-     * A distribution that selects the record with a higher key with
-     * higher probability. This was added to support the YCSB-D workload,
-     * which calls for "read latest" selection for records that are read.
+     * A distribution that selects the record with a higher key with higher probability. This was
+     * added to support the YCSB-D workload, which calls for "read latest" selection for records
+     * that are read.
      *
-     * We generate a random number that is in the range between 0 and
-     * largest * largest, where largest is the last inserted key. Then we
-     * take a square root of that random number -- this is our target
-     * selection. With this formula, larger keys are more likely to get
-     * selected than smaller keys, and the probability of selection is
-     * proportional to the value of the key, which is what we want.
+     * We generate a random number that is in the range between 0 and largest * largest, where
+     * largest is the last inserted key. Then we take a square root of that random number -- this is
+     * our target selection. With this formula, larger keys are more likely to get selected than
+     * smaller keys, and the probability of selection is proportional to the value of the key, which
+     * is what we want.
      */
     if (opts->select_latest) {
 
-	/*
-	 * First we need a 64-bit random number, and the WiredTiger
-	 * random number function gives us only a 32-bit random value.
-	 * With only a 32-bit value, the range of the random number
-	 * will always be smaller than the square of the largest insert key
-	 * for workloads with a large number of keys. So we need a longer
-	 * random number for that.
-	 *
-	 * We get a 64-bit random number by concatenating two 32-bit
-	 * numbers. We get less entropy this way than via a true 64-bit
-	 * generator, but we are not defending against cryptographic attacks
-	 * here, so this is good enough.
-	 */
-	rval2 = __wt_random(&thread->rnd);
-	rval64 = rval | (rval2 << 32);
+        /*
+         * First we need a 64-bit random number, and the WiredTiger random number function gives us
+         * only a 32-bit random value. With only a 32-bit value, the range of the random number will
+         * always be smaller than the square of the largest insert key for workloads with a large
+         * number of keys. So we need a longer random number for that.
+         *
+         * We get a 64-bit random number by concatenating two 32-bit numbers. We get less entropy
+         * this way than via a true 64-bit generator, but we are not defending against cryptographic
+         * attacks here, so this is good enough.
+         */
+        rval2 = __wt_random(&thread->rnd);
+        rval64 = rval | (rval2 << 32);
 
-	/*
-	 * Now we limit the random value to be within the range of square
-	 * of the latest insert key and take a square root of that value.
-	 */
-	rval64 = (rval64 % (wtperf->insert_key * wtperf->insert_key));
-	rval64 = sqrt((long double)rval64);
+        /*
+         * Now we limit the random value to be within the range of square of the latest insert key
+         * and take a square root of that value.
+         */
+        rval64 = (rval64 % (wtperf->insert_key * wtperf->insert_key));
+        rval64 = sqrt((long double)rval64);
 
-	/*
-	 * Assign the generated value back to rval, so it works with the
-	 * subsequent code. The rval is declared as a 64-bit variable, so
-	 * we don't need to perform a cast.
-	 */
-	rval = rval64;
+        /* This assignment is needed so that the code below returns the generated value to the
+         * caller */
+        rval = rval64;
     }
 
     /*

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2760,7 +2760,7 @@ wtperf_rand(WTPERF_THREAD *thread)
          * and take a square root of that value.
          */
         rval128 = (rval128 % (wtperf->insert_key * wtperf->insert_key));
-        rval = sqrtl((long double)rval128);
+        rval = (uint64_t)(double)sqrtl((long double)rval128);
 
 #else
 #define SELECT_LATEST_RANGE 1000

--- a/bench/wtperf/wtperf_opt.i
+++ b/bench/wtperf/wtperf_opt.i
@@ -140,6 +140,11 @@ DEF_OPT_AS_UINT32(random_range, 0,
   "if non zero choose a value from within this range as the key for insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
 DEF_OPT_AS_BOOL(range_partition, 0, "partition data by range (vs hash)")
+DEF_OPT_AS_UINT32(read_range, 0,
+  "read a sequential range of keys upon each read operation. This value tells us how many keys "
+  "to read each time, or an upper bound on the number of keys read if read_range_random is set.")
+DEF_OPT_AS_BOOL(read_range_random, 0, "if doing range reads, select the number of keys to read "
+   "in a range uniformly at random.")
 DEF_OPT_AS_BOOL(readonly, 0,
   "reopen the connection between populate and workload phases in readonly mode.  Requires "
   "reopen_connection turned on (default).  Requires that read be the only workload specified")
@@ -161,6 +166,8 @@ DEF_OPT_AS_UINT32(
 DEF_OPT_AS_UINT32(scan_table_count, 0,
   "number of separate tables to be used for scanning. Zero indicates that tables are shared with "
   "other operations")
+DEF_OPT_AS_BOOL(select_latest, 0, "in workloads that involve inserts and another type of operation,"
+		"select the recently inserted records with higher probability")
 DEF_OPT_AS_CONFIG_STRING(sess_config, "", "session configuration string")
 DEF_OPT_AS_UINT32(session_count_idle, 0, "number of idle sessions to create. Default 0.")
 /* The following table configuration is based on the configuration MongoDB uses for collections. */

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -478,6 +478,7 @@ Wunused
 XP
 Xcode
 Xcode/
+YCSB
 Yann
 ZSTD
 Zlib
@@ -641,6 +642,7 @@ create's
 createCStream
 crypto
 cryptobad
+cryptographic
 cstring
 csuite
 csv

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -190,6 +190,10 @@ if non zero choose a value from within this range as the key for insert operatio
 generate random content for the value
 @par range_partition (boolean, default=false)
 partition data by range (vs hash)
+@par read_range (unsigned int, default=0)
+read a sequential range of keys upon each read operation. This value tells us how many keys  to read each time, or an upper bound on the number of keys read if read_range_random is set.
+@par read_range_random (boolean, default=false)
+if doing range reads, select the number of keys to read  in a range uniformly at random.
 @par readonly (boolean, default=false)
 reopen the connection between populate and workload phases in readonly mode.  Requires  reopen_connection turned on (default).  Requires that read be the only workload specified
 @par reopen_connection (boolean, default=true)
@@ -212,6 +216,8 @@ scan tables every interval seconds during the workload phase, 0 to disable
 percentage of entire data set scanned, if scan_interval is enabled
 @par scan_table_count (unsigned int, default=0)
 number of separate tables to be used for scanning. Zero indicates that tables are shared with  other operations
+@par select_latest (boolean, default=false)
+in workloads that involve inserts and another type of operation, select the recently inserted records with higher probability
 @par sess_config (string, default="")
 session configuration string
 @par session_count_idle (unsigned int, default=0)


### PR DESCRIPTION
Created a native implementation of YCSB in WTPERF. This includes small changes to WTPERF, such as enhanced support for range reads and a new "select-latest" random distribution, as well as new runners for workloads YCSB-A through YCSB-E. There is no runner for YCSB-F, because in WTPERF it is the same as YCSB-A: YCSB-A is 50% reads / 50% updates, and YCSB-F is 50% reads / 50% read-modify-write.