### PR TITLE
WT-7760 Support array parsing in CppSuite config handling

### DIFF
--- a/test/cppsuite/test_harness/core/configuration.h
+++ b/test/cppsuite/test_harness/core/configuration.h
@@ -224,7 +224,7 @@ class configuration {
 
     /*
      * Split a config string into keys and values, taking care to not split incorrectly when we have
-     * a sub config.
+     * a sub config or array.
      */
     static std::vector<std::pair<std::string, std::string>>
     split_config(const std::string &config)
@@ -234,7 +234,7 @@ class configuration {
         std::string key = "", value = "";
         bool in_subconfig = false;
         bool expect_value = false;
-        std::stack<char> subconfig_parens;
+        std::stack<char> parens;
 
         /* All configuration strings must be at least 2 characters. */
         testutil_assert(config.size() > 1);
@@ -245,13 +245,13 @@ class configuration {
 
         size_t start = 0, len = 0;
         for (size_t i = 0; i < cut_config.size(); ++i) {
-            if (cut_config[i] == '(') {
-                subconfig_parens.push(cut_config[i]);
+            if (cut_config[i] == '(' || cut_config[i] == '[') {
+                parens.push(cut_config[i]);
                 in_subconfig = true;
             }
-            if (cut_config[i] == ')') {
-                subconfig_parens.pop();
-                in_subconfig = !subconfig_parens.empty();
+            if (cut_config[i] == ')' || cut_config[i] == ']') {
+                parens.pop();
+                in_subconfig = !parens.empty();
             }
             if (cut_config[i] == '=' && !in_subconfig) {
                 expect_value = true;

--- a/test/cppsuite/test_harness/core/configuration.h
+++ b/test/cppsuite/test_harness/core/configuration.h
@@ -37,7 +37,26 @@ extern "C" {
 #include "test_util.h"
 }
 
-enum class types { BOOL, INT, STRING, STRUCT };
+inline std::vector<std::string>
+split_string(const std::string &str, const char delim)
+{
+    std::vector<std::string> splits;
+    std::string current_str;
+    for (const auto c : str) {
+        if (c == delim) {
+            if (!current_str.empty()) {
+                splits.push_back(current_str);
+                current_str.clear();
+            }
+        } else
+            current_str.push_back(c);
+    }
+    if (!current_str.empty())
+        splits.push_back(std::move(current_str));
+    return (splits);
+}
+
+enum class types { BOOL, INT, LIST, STRING, STRUCT };
 
 namespace test_harness {
 class configuration {
@@ -143,6 +162,18 @@ class configuration {
           [](WT_CONFIG_ITEM item) { return new configuration(item); });
     }
 
+    std::vector<std::string>
+    get_list(const std::string &key)
+    {
+        return get<std::vector<std::string>>(key, false, types::LIST, {}, config_item_to_list);
+    }
+
+    std::vector<std::string>
+    get_optional_list(const std::string &key)
+    {
+        return get<std::vector<std::string>>(key, true, types::LIST, {}, config_item_to_list);
+    }
+
     private:
     static bool
     config_item_to_bool(const WT_CONFIG_ITEM item)
@@ -160,6 +191,19 @@ class configuration {
     config_item_to_string(const WT_CONFIG_ITEM item)
     {
         return std::string(item.str, item.len);
+    }
+
+    static std::vector<std::string>
+    config_item_to_list(const WT_CONFIG_ITEM item)
+    {
+        auto str = config_item_to_string(item);
+
+        /* Get rid of the brackets. */
+        testutil_assert(!str.empty() && str.front() == '[' && str.back() == ']');
+        str.pop_back();
+        str.erase(0, 1);
+
+        return (split_string(str, ','));
     }
 
     template <typename T>
@@ -185,6 +229,8 @@ class configuration {
         else if (type == types::INT && value.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_NUM)
             testutil_die(-1, error_msg);
         else if (type == types::STRUCT && value.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRUCT)
+            testutil_die(-1, error_msg);
+        else if (type == types::LIST && value.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRUCT)
             testutil_die(-1, error_msg);
 
         return func(value);


### PR DESCRIPTION
This seems to do the trick. I don't think we want to merge array contents so we just need to ignore the commas within the array.