### PR TITLE
WT-7741 Fix misaligned address in crc32-x86.c

### DIFF
--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -49,8 +49,8 @@ __wt_checksum_hw(const void *chunk, size_t len)
 
     crc = 0xffffffff;
 
-    /* Checksum one byte at a time to the first 4B boundary. */
-    for (p = chunk; ((uintptr_t)p & (sizeof(uint32_t) - 1)) != 0 && len > 0; ++p, --len) {
+    /* Checksum one byte at a time to the first 8B boundary. */
+    for (p = chunk; ((uintptr_t)p & (sizeof(uint64_t) - 1)) != 0 && len > 0; ++p, --len) {
         __asm__ __volatile__(".byte 0xF2, 0x0F, 0x38, 0xF0, 0xF1" : "=S"(crc) : "0"(crc), "c"(*p));
     }
 


### PR DESCRIPTION
UBSAN complains about loading of misaligned address during  the second step of the algorithm where we process 8B chunks. It stops complaining if during the first step we go to the first 8 bytes boundary instead of 4.