### PR TITLE
WT-7719 Change default value of "ENABLE_STRICT" to "OFF" in CMake

### DIFF
--- a/build_cmake/configs/base.cmake
+++ b/build_cmake/configs/base.cmake
@@ -63,7 +63,7 @@ config_bool(
 config_bool(
     ENABLE_STRICT
     "Compile with strict compiler warnings enabled"
-    DEFAULT ON
+    DEFAULT OFF
 )
 
 config_bool(

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -98,7 +98,7 @@ functions:
             mkdir -p cmake_build
             cd cmake_build
             $CMAKE \
-            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
+            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../build_cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
           fi
         elif [ "$OS" != "Windows_NT" ]; then
           # Compiling with Autoconf/Libtool.

--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -27,7 +27,7 @@ cd cmake_build
 
 # Configure build with CMake.
 if( $configure -eq $true) {
-    C:\cmake\bin\cmake --no-warn-unused-cli -DSWIG_DIR="C:\swigwin-3.0.2" -DSWIG_EXECUTABLE="C:\swigwin-3.0.2\swig.exe" -DCMAKE_BUILD_TYPE='None' -DENABLE_PYTHON=1 -DCMAKE_TOOLCHAIN_FILE='..\build_cmake\toolchains\cl.cmake' -G "Ninja" ..\.
+    C:\cmake\bin\cmake --no-warn-unused-cli -DSWIG_DIR="C:\swigwin-3.0.2" -DSWIG_EXECUTABLE="C:\swigwin-3.0.2\swig.exe" -DCMAKE_BUILD_TYPE='None' -DENABLE_PYTHON=1 -DENABLE_STRICT=1 -DCMAKE_TOOLCHAIN_FILE='..\build_cmake\toolchains\cl.cmake' -G "Ninja" ..\.
 }
 
 # Execute Ninja build.


### PR DESCRIPTION
We want to avoid assuming the default build environment requires a development/debug configuration for WiredTiger standalone builds. Change the default value of ENABLE_STRICT to 'OFF' to avoid bringing random warnings and diagnostics into default standalone builds.