### PR TITLE
WT-7770 Fix issue linking TCMalloc in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,10 @@ if(HAVE_LIBDL)
     target_link_libraries(wiredtiger "dl")
 endif()
 
+if(ENABLE_TCMALLOC AND HAVE_LIBTCMALLOC)
+    target_link_libraries(wiredtiger ${HAVE_LIBTCMALLOC})
+endif()
+
 if(HAVE_BUILTIN_EXTENSION_LZ4)
     target_link_libraries(wiredtiger wiredtiger_lz4)
 endif()

--- a/build_cmake/configs/auto.cmake
+++ b/build_cmake/configs/auto.cmake
@@ -229,28 +229,24 @@ config_lib(
     HAVE_LIBPTHREAD
     "Pthread library exists."
     LIB "pthread"
-    FUNC "pthread_create"
 )
 
 config_lib(
     HAVE_LIBRT
     "rt library exists."
     LIB "rt"
-    FUNC "timer_create"
 )
 
 config_lib(
     HAVE_LIBDL
     "dl library exists."
     LIB "dl"
-    FUNC "dlopen"
 )
 
 config_lib(
     HAVE_LIBLZ4
     "lz4 library exists."
     LIB "lz4"
-    FUNC "LZ4_versionNumber"
     HEADER "lz4.h"
 )
 
@@ -258,7 +254,6 @@ config_lib(
     HAVE_LIBSNAPPY
     "snappy library exists."
     LIB "snappy"
-    FUNC "snappy_compress"
     HEADER "snappy.h"
 )
 
@@ -266,7 +261,6 @@ config_lib(
     HAVE_LIBZ
     "zlib library exists."
     LIB "z"
-    FUNC "zlibVersion"
     HEADER "zlib.h"
 )
 
@@ -274,7 +268,6 @@ config_lib(
     HAVE_LIBZSTD
     "zstd library exists."
     LIB "zstd"
-    FUNC "ZSTD_versionString"
     HEADER "zstd.h"
 )
 
@@ -282,7 +275,6 @@ config_lib(
     HAVE_LIBTCMALLOC
     "tcmalloc library exists."
     LIB "tcmalloc"
-    FUNC "tc_malloc"
 )
 
 config_compile(

--- a/build_cmake/configs/wiredtiger_config.h.in
+++ b/build_cmake/configs/wiredtiger_config.h.in
@@ -63,8 +63,19 @@
 /* Define to 1 if you have the `snappy' library (-lsnappy). */
 #cmakedefine HAVE_LIBSNAPPY 1
 
-/* Define to 1 if you have the `tcmalloc' library (-ltcmalloc). */
-#cmakedefine HAVE_LIBTCMALLOC 1
+/* Define to 1 if the user has explictly enabled TCMalloc builds. */
+#cmakedefine ENABLE_TCMALLOC 1
+
+/*
+ * To remain compatible with autoconf & scons builds, we
+ * define HAVE_LIBTCMALLOC for configuring our sources to actually
+ * include the tcmalloc headers, as opposed to the sources
+ * using ENABLE_TCMALLOC.
+ */
+#if defined ENABLE_TCMALLOC
+  /* Define to 1 if you have the `tcmalloc' library (-ltcmalloc). */
+  #cmakedefine HAVE_LIBTCMALLOC 1
+#endif
 
 /* Define to 1 if you have the `z' library (-lz). */
 #cmakedefine HAVE_LIBZ 1

--- a/build_cmake/helpers.cmake
+++ b/build_cmake/helpers.cmake
@@ -401,7 +401,7 @@ function(config_lib config_name description)
         2
         "CONFIG_LIB"
         ""
-        "LIB;FUNC;DEPENDS;HEADER"
+        "LIB;DEPENDS;HEADER"
         ""
     )
 
@@ -411,10 +411,6 @@ function(config_lib config_name description)
     # We require a library (not optional).
     if ("${CONFIG_LIB_LIB}" STREQUAL "")
         message(FATAL_ERROR "No library passed")
-    endif()
-    # We require a function within the library (not optional).
-    if ("${CONFIG_LIB_FUNC}" STREQUAL "")
-        message(FATAL_ERROR "No library function passed")
     endif()
 
     # Check that the configs dependencies are enabled before setting it to a visible enabled state.
@@ -428,7 +424,6 @@ function(config_lib config_name description)
             set(CMAKE_REQUIRED_FLAGS "-DWT_ARCH=${WT_ARCH} -DWT_OS=${WT_OS}")
         endif()
         find_library(has_lib_${config_name} ${CONFIG_LIB_LIB})
-        #check_library_exists(${CONFIG_LIB_LIB} ${CONFIG_LIB_FUNC} "" has_lib_${config_name})
         set(CMAKE_REQUIRED_FLAGS)
         set(has_lib "0")
         if(has_lib_${config_name})

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -42,6 +42,10 @@ target_include_directories(wt
 )
 target_link_libraries(wt wiredtiger)
 
+if(ENABLE_TCMALLOC AND HAVE_LIBTCMALLOC)
+    target_link_libraries(wt ${HAVE_LIBTCMALLOC})
+endif()
+
 # Our test suite expects `wt` to sit at the top level build directory.
 # Set the output binary location to the top level directory for backwards
 # compatibility.

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -104,6 +104,10 @@ function(create_test_executable target)
         target_link_libraries(${target} ${CREATE_TEST_LIBS})
     endif()
 
+    if(ENABLE_TCMALLOC AND HAVE_LIBTCMALLOC)
+        target_link_libraries(${target} ${HAVE_LIBTCMALLOC})
+    endif()
+
     # If compiling for windows, additionally link in the shim library.
     if(WT_WIN)
         target_include_directories(


### PR DESCRIPTION
This PR fixes the following issues:
* CMake didn't link TCMalloc when the `ENABLE_TCMALLOC` option. Updated CMake to link the tcmalloc library when tcmalloc builds are enabled.
* If CMake detects tcmalloc on the user system it will set the `HAVE_LIBTCMALLOC` CPP variable. This is an issue since our C sources will include the tcmalloc headers when `HAVE_LIBTCMALLOC` is defined (Autoconf and SCons will define `HAVE_LIBTCMALLOC` to indicate enabling tcmalloc build). In CMake, we want to reserve the CPP definition `HAVE_LIBTCMALLOC` to just check if the library exists, not to necessarily enable a tcmalloc build. We  want to use the `ENABLE_TCMALLOC` option to actually create a tcmalloc build.
* Removes some dead code in `config_lib` helper