### PR TITLE
WT-7720 Fix POSIX CMAKE doxygen documentation 

### DIFF
--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -161,6 +161,6 @@ unless manually specified through the \c -DCC_OPTIMIZE_LEVEL configuration optio
 a different level of optimization:
 
 @code
-cmake -DCC_OPTIMIZE_LEVEL=-01 -G Ninja ../.
+cmake -DCC_OPTIMIZE_LEVEL=-O1 -G Ninja ../.
 @endcode
 */

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -167,29 +167,28 @@ cmake -DCC_OPTIMIZE_LEVEL=-O1 -G Ninja ../.
 @section posix_ctest Running WiredTiger C/C++ Tests
 
 The WiredTiger CMake build makes available a suite of C/C++ based tests.
-To run all the tests available, ensure you're in the build directory and execute:
+To run the available tests you can use our smoke test alias (\c check). Ensure you're in the build directory and execute:
+
+@code
+ctest -j$(nproc) -L check
+@endcode
+
+Alternatively to just run all the tests available:
 
 @code
 ctest -j$(nproc)
 @endcode
 
-To run with verbose output:
+In addition, to get verbose output with your test run you can use the \c -VV flag:
 
 @code
 ctest -j$(nproc) -VV
 @endcode
 
-To run a specific test:
+If you want to focus on running a specific test (i.e. run a test that may be failing) you can use the \c -R flag:
 
 @code
 # Note: -R specifies a regex, where any matching test will be run
-ctest -R <test_name> -j$(nproc)
-@endcode
-
-To run our smoke tests, you can use the \c check alias:
-
-@code
-# Note: -R specifies a regex, where any matching test will be run
-ctest -L check -j$(nproc)
+ctest -j$(nproc) -R test_name
 @endcode
 */

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -163,4 +163,33 @@ a different level of optimization:
 @code
 cmake -DCC_OPTIMIZE_LEVEL=-O1 -G Ninja ../.
 @endcode
+
+@section posix_ctest Running WiredTiger C/C++ Tests
+
+The WiredTiger CMake build makes available a suite of C/C++ based tests.
+To run all the tests available, ensure you're in the build directory and execute:
+
+@code
+ctest -j$(nproc)
+@endcode
+
+To run with verbose output:
+
+@code
+ctest -j$(nproc) -VV
+@endcode
+
+To run a specific test:
+
+@code
+# Note: -R specifies a regex, where any matching test will be run
+ctest -R <test_name> -j$(nproc)
+@endcode
+
+To run our smoke tests, you can use the \c check alias:
+
+@code
+# Note: -R specifies a regex, where any matching test will be run
+ctest -L check -j$(nproc)
+@endcode
 */

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -23,6 +23,7 @@ CURSTD
 CXX
 Cheng
 Christoph
+ctest
 Collet's
 Coverity
 Coverity's
@@ -456,6 +457,7 @@ nosync
 notgranted
 notyet
 nowait
+nproc
 ns
 nul
 num
@@ -631,6 +633,7 @@ versa
 viewable
 vm
 vpmsum
+VV
 warmup
 wget
 whitespace


### PR DESCRIPTION
* Fixes CC_OPTIMIZE_LEVEL typo in doxygen: The flag value should be 'O1' instead of '01'
* Doxygen description on running CTest: Expanded the CMake doxygen docs to also describe on how to run the CTest smoke tests.