### PR TITLE
WT-7766 Fix null pointer passed to memset in test_wt3338_partial_update

### DIFF
--- a/test/csuite/wt3338_partial_update/main.c
+++ b/test/csuite/wt3338_partial_update/main.c
@@ -126,7 +126,8 @@ slow_apply_api(WT_ITEM *orig)
     tb = &_tb;
 
     /* Mess up anything not initialized in the buffers. */
-    memset((uint8_t *)ta->mem + ta->size, 0xff, ta->memsize - ta->size);
+    if ((ta->memsize - ta->size) > 0)
+        memset((uint8_t *)ta->mem + ta->size, 0xff, ta->memsize - ta->size);
 
     if (tb->memsize > 0)
         memset((uint8_t *)tb->mem, 0xff, tb->memsize);


### PR DESCRIPTION
The cause and fix are similar to WT-7744.

The C standard states that the behaviour of memset (and other mem* functions) is undefined when NULL pointers are passed to them. This is the case even if the 'n' count parameter is 0.

The UBSAN tests were picking up a case where a NULL pointer was being passed into this memset call. This was occurring when the 'n' count parameter was 0.

To address this, a conditional guard has been added around the call to memset that was generating an UBSAN error to ensure that the 'n' count parameter is greater than 0.