### PR TITLE
WT-7765 Fix signed integer overflow in intpack-test3

### DIFF
--- a/test/packing/intpack-test3.c
+++ b/test/packing/intpack-test3.c
@@ -110,19 +110,22 @@ test_spread(int64_t start, int64_t before, int64_t after)
 int
 main(void)
 {
-    int64_t i;
+    int64_t i, range, start_int64;
+
+    range = 1025;
+    start_int64 = INT64_MAX - range; /* reduce start point by range to avoid integer overflow */
 
     /*
      * Test all values in a range, to ensure pack/unpack of small numbers (which most actively use
      * different numbers of bits) works.
      */
     test_spread(0, 100000, 100000);
-    test_spread(INT16_MAX, 1025, 1025);
-    test_spread(INT32_MAX, 1025, 1025);
-    test_spread(INT64_MAX, 1025, 1025);
+    test_spread(INT16_MAX, range, range);
+    test_spread(INT32_MAX, range, range);
+    test_spread(start_int64, range, range);
     /* Test bigger numbers */
-    for (i = INT64_MAX; i > 0; i = i / 2)
-        test_spread(i, 1025, 1025);
+    for (i = start_int64; i > 0; i = i / 2)
+        test_spread(i, range, range);
     printf("\n");
 
     return (0);


### PR DESCRIPTION
The C standard specifies that overflow in signed integers has undefined behaviour.

This test code tests a range of values around a signed start value. If the test value is (or close to) the maximum value for that int type (in this case INT64_MAX) then the range will overflow, and this is what was being detected by the UBSAN test.

The fix is to change the test ranges where required so that overflows are no longer possible.