### PR TITLE
WT-7776 Add a hard limit on the number of modify updates before we instantiate a complete update

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1380,17 +1380,19 @@ __cursor_chain_exceeded(WT_CURSOR_BTREE *cbt)
      * of 1, the total size in memory of a set of modify updates is limited to double the size of
      * the modifies.
      *
-     * Otherwise, limit the length of the update chain to a fixed size to bound the cost of
-     * rebuilding the value during reads. When history has to be maintained, creating extra copies
-     * of large documents multiplies cache pressure because the old ones cannot be freed, so allow
-     * the modify chain to grow.
+     * Otherwise, limit the length of the update chain to bound the cost of rebuilding the value
+     * during reads. When history has to be maintained, creating extra copies of large documents
+     * multiplies cache pressure because the old ones cannot be freed, so allow the modify chain to
+     * grow.
      */
     for (i = 0, upd_size = 0; upd != NULL && upd->type == WT_UPDATE_MODIFY; ++i, upd = upd->next) {
+        if (i >= WT_MODIFY_UPDATE_MAX)
+            return (true);
         upd_size += WT_UPDATE_MEMSIZE(upd);
-        if (i >= WT_MAX_MODIFY_UPDATE && upd_size * WT_MODIFY_MEM_FRACTION >= cursor->value.size)
+        if (i >= WT_MODIFY_UPDATE_MIN && upd_size * WT_MODIFY_MEM_FRACTION >= cursor->value.size)
             return (true);
     }
-    if (i >= WT_MAX_MODIFY_UPDATE && upd != NULL && upd->type == WT_UPDATE_STANDARD &&
+    if (i >= WT_MODIFY_UPDATE_MIN && upd != NULL && upd->type == WT_UPDATE_STANDARD &&
       __wt_txn_upd_visible_all(session, upd))
         return (true);
     return (false);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1196,7 +1196,7 @@ struct __wt_update_value {
     } while (0)
 
 /*
- * WT_MAX_MODIFY_UPDATE, WT_MODIFY_VECTOR_STACK_SIZE
+ * WT_MODIFY_UPDATE_MIN/MAX, WT_MODIFY_VECTOR_STACK_SIZE
  *	Limit update chains value to avoid penalizing reads and permit truncation. Having a smaller
  * value will penalize the cases when history has to be maintained, resulting in multiplying cache
  * pressure.
@@ -1205,8 +1205,9 @@ struct __wt_update_value {
  * modifications in an update list. We use small vectors of modify updates in a couple of places to
  * avoid heap allocation, add a few additional slots to that array.
  */
-#define WT_MAX_MODIFY_UPDATE 10
-#define WT_UPDATE_VECTOR_STACK_SIZE 20
+#define WT_MODIFY_UPDATE_MIN 10  /* Update count before we bother checking anything else */
+#define WT_MODIFY_UPDATE_MAX 200 /* Update count hard limit */
+#define WT_UPDATE_VECTOR_STACK_SIZE (WT_MODIFY_UPDATE_MIN + 10)
 
 /*
  * WT_UPDATE_VECTOR --

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -503,15 +503,14 @@ struct __wt_cursor {
 	 * \c S), or raw byte arrays accessed using a WT_ITEM structure (value
 	 * format type \c u).
 	 *
-	 * The WT_CURSOR::modify method stores a change record in cache and
-	 * writes a change record to the log instead of the usual complete
-	 * values. Note that WT_CURSOR::modify is generally slower than the
-	 * WT_CURSOR::update method, and can result in slower reads because
-	 * the complete value must be assembled during retrieval. The
-	 * WT_CURSOR::modify method is intended for applications modifying
-	 * large records where there is cache or I/O pressure, that is,
-	 * applications that will benefit when data updates require less cache
-	 * and they write less logging information.
+	 * The WT_CURSOR::modify method stores a change record in cache and writes a change record
+	 * to the log instead of the usual complete values. Using WT_CURSOR::modify will result in
+	 * slower reads, and slower writes than the WT_CURSOR::insert or WT_CURSOR::update methods,
+	 * because of the need to assemble the complete value in both the read and write paths. The
+	 * WT_CURSOR::modify method is intended for applications where memory and log amplification
+	 * are issues (in other words, applications where there is cache or I/O pressure and the
+	 * application wants to trade performance for a smaller working set in cache and smaller
+	 * log records).
 	 *
 	 * @snippet ex_all.c Modify an existing record
 	 *


### PR DESCRIPTION
Add a hard limit on the number of modify updates before we instantiate a complete update