### PR TITLE
WT-7783 Fix RTS to restore tombstone when an on-disk update is out of order prepared

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -512,6 +512,12 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
              * stable timestamp, we need to restore that as well.
              */
             if (hs_stop_durable_ts <= rollback_timestamp) {
+                /*
+                 * The restoring tombstone timestamp must be less than previous update start
+                 * timestamp or the on-disk update is an out of order prepared.
+                 */
+                WT_ASSERT(session, hs_stop_durable_ts < newer_hs_durable_ts || unpack->tw.prepare);
+
                 WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
                 /*
                  * Set the transaction id of updates to WT_TXN_NONE when called from recovery,

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -508,11 +508,10 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
             WT_STAT_CONN_DATA_INCR(session, txn_rts_hs_restore_updates);
 
             /*
-             * We have a tombstone on the original update chain and it is behind the stable
-             * timestamp, we need to restore that as well.
+             * We have a tombstone on the original update chain and it is behind or equal to the
+             * stable timestamp, we need to restore that as well.
              */
-            if (hs_stop_durable_ts <= rollback_timestamp &&
-              hs_stop_durable_ts < newer_hs_durable_ts) {
+            if (hs_stop_durable_ts <= rollback_timestamp) {
                 WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
                 /*
                  * Set the transaction id of updates to WT_TXN_NONE when called from recovery,


### PR DESCRIPTION
When a prepared update is an out of order update, as part of reconciliation
the earlier updates doesn't modified until it gets committed. while aborting these
uncommitted prepared updates by RTS, it missed to restore the tombstone
from the history store as it is greater than the on-disk update.