### PR TITLE
WT-7780 Guarantee log message sequencing in the test framework.

### DIFF
--- a/test/cppsuite/test_harness/util/debug_utils.h
+++ b/test/cppsuite/test_harness/util/debug_utils.h
@@ -46,6 +46,10 @@ namespace test_harness {
 #define LOG_ERROR 0
 #define LOG_WARN 1
 #define LOG_INFO 2
+/*
+ * The trace log level can incur a performance overhead since the current logging implementation
+ * requires per-line locking.
+ */
 #define LOG_TRACE 3
 
 /* Order of elements in this array corresponds to the definitions above. */

--- a/test/cppsuite/test_harness/util/debug_utils.h
+++ b/test/cppsuite/test_harness/util/debug_utils.h
@@ -31,6 +31,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <thread>
 
@@ -55,6 +56,9 @@ static int64_t _trace_level = LOG_WARN;
 
 /* Include date in the logs if enabled. */
 static bool _include_date = true;
+
+/* Mutex used by logger to synchronize printing. */
+extern std::mutex _logger_mtx;
 
 void
 get_time(char *time_buf, size_t buf_size)
@@ -94,6 +98,7 @@ log_msg(int64_t trace_type, const std::string &str)
         ss << time_buf << "[TID:" << std::this_thread::get_id() << "][" << LOG_LEVELS[trace_type]
            << "]: " << str << std::endl;
 
+        std::lock_guard<std::mutex> lg(_logger_mtx);
         if (trace_type == LOG_ERROR)
             std::cerr << ss.str();
         else

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -37,6 +37,14 @@
 #include "example_test.cxx"
 #include "hs_cleanup.cxx"
 
+namespace test_harness {
+/*
+ * FIXME-WT-7782: This needs to exist in a single translation unit. At the moment, almost everything
+ * is in headers so the only reasonable spot to put it is here.
+ */
+std::mutex _logger_mtx;
+} // namespace test_harness
+
 std::string
 parse_configuration_from_file(const std::string &filename)
 {


### PR DESCRIPTION
This change is wrapping the use of `std::cout` and `std::cerr` behind a mutex. Since the utility header is used everywhere, we need to make the mutex global (which I've put in the `run` translation unit).