### PR TITLE
WT-7746 Improve directory syncing with CMake helper 'create_test_executable'

### DIFF
--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -10,7 +10,7 @@ project(python_swig C)
 
 # UseSWIG: Policy option to use the standard target name over a generated name.
 if(POLICY CMP0078)
-    cmake_policy(SET CMP0078 NEW)
+    cmake_policy(SET CMP0078 OLD)
 endif()
 
 # UseSWIG: Policy option to honor SWIG_MODULE_NAME.
@@ -148,18 +148,4 @@ add_custom_command(TARGET ${swig_wt_target}
         ${CMAKE_CURRENT_BINARY_DIR}/wiredtiger/swig_wiredtiger.py
 )
 
-# `swig_add_library` will end up prepending an extra '_' to our target name, resulting in
-# an output the  file '__wiredtiger.[so|pyd]'. We are unable to manually specify the output file
-# name.
-set(swig_lib_suffix)
-if(WT_WIN)
-    set(swig_lib_suffix ".pyd")
-else()
-    set(swig_lib_suffix ".so")
-endif()
-add_custom_command(TARGET ${swig_wt_target}
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E rename
-        $<TARGET_FILE:${swig_wt_target}>
-        $<TARGET_FILE_DIR:${swig_wt_target}>/_wiredtiger${swig_lib_suffix}
-)
+set_target_properties(${swig_wt_target} PROPERTIES OUTPUT_NAME "_wiredtiger")

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -149,3 +149,9 @@ add_custom_command(TARGET ${swig_wt_target}
 )
 
 set_target_properties(${swig_wt_target} PROPERTIES OUTPUT_NAME "_wiredtiger")
+
+# Manually changing the suffix on macOS/Darwin builds since DYLD_LIBRARY_PATH
+# doesn't work well for dynamic modules loaded by python.
+if(WT_DARWIN)
+    set_target_properties(${swig_wt_target} PROPERTIES SUFFIX ".so")
+endif()

--- a/test/ctest_dir_sync.cmake
+++ b/test/ctest_dir_sync.cmake
@@ -1,0 +1,48 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+cmake_minimum_required(VERSION 3.10.0)
+
+if(NOT SYNC_DIR_SRC)
+    message(FATAL_ERROR "Missing a source directory to sync")
+endif()
+
+if(NOT SYNC_DIR_DST)
+    message(FATAL_ERROR "Missing a destination directory to sync")
+endif()
+
+# Get the list of files in the sync directory
+file(GLOB files ${SYNC_DIR_SRC}/*)
+# Check each file and copy over if it has changed
+foreach (sync_file IN LISTS files)
+    get_filename_component(sync_file_basename ${sync_file} NAME)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${sync_file}
+        ${SYNC_DIR_DST}/${sync_file_basename}
+    )
+endforeach()

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -136,14 +136,14 @@ function(create_test_executable target)
     # Useful if we need to setup an additional configs and environments needed to run the test executable.
     foreach(dir IN LISTS CREATE_TEST_ADDITIONAL_DIRECTORIES)
         get_filename_component(dir_basename ${dir} NAME)
-        # Copy the file to the given test/targets build directory.
-        add_custom_command(OUTPUT ${test_binary_dir}/${dir_basename}
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${dir}
-                ${test_binary_dir}/${dir_basename}
+        # Copy the directory to the given test/targets build directory.
+        add_custom_target(sync_dir_${target}_${dir_basename} ALL
+            COMMAND ${CMAKE_COMMAND}
+                -DSYNC_DIR_SRC=${dir}
+                -DSYNC_DIR_DST=${test_binary_dir}/${dir_basename}
+                -P ${CMAKE_SOURCE_DIR}/test/ctest_dir_sync.cmake
         )
-        add_custom_target(copy_dir_${target}_${dir_basename} DEPENDS ${test_binary_dir}/${dir_basename})
-        add_dependencies(${target} copy_dir_${target}_${dir_basename})
+        add_dependencies(${target} sync_dir_${target}_${dir_basename})
     endforeach()
 endfunction()
 

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -181,16 +181,18 @@ function(define_test_variants target)
             separate_arguments(variant_args UNIX_COMMAND ${curr_variant_args})
         endif()
         # Create a variant directory to run the test in.
-        add_custom_target(${curr_variant_name}_test_dir
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name})
+        add_custom_command(OUTPUT ${curr_variant_name}_test_dir
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name}_test_dir
+        )
+        add_custom_target(create_dir_${curr_variant_name} DEPENDS ${curr_variant_name}_test_dir)
         # Ensure the variant target is created prior to building the test.
-        add_dependencies(${target} ${curr_variant_name}_test_dir)
+        add_dependencies(${target} create_dir_${curr_variant_name})
         add_test(
             NAME ${curr_variant_name}
             COMMAND $<TARGET_FILE:${target}> ${variant_args}
             # Run each variant in its own subdirectory, allowing us to execute variants in
             # parallel.
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name}_test_dir
         )
         list(APPEND defined_tests ${curr_variant_name})
     endforeach()


### PR DESCRIPTION
The CMake helper `create_test_executable` supports an option to sync a directory over to the build directory:  `ADDITIONAL_DIRECTORIES`. When creating a test executable we may want to sync the contents of a directory (such as a set of configs). Additionally we want this directory to be re-synced on subsequent builds. CMake didn't detect and sync over new files and changes added to the source directory. The commit overhauls the `ADDITIONAL_DIRECTORIES` feature to ensure new files & changes get synced over if present. 

The slight downside of this change is this process needs to be added to the `all` target since CMake can't automatically detect if new files have been added (which is reasonable). 

This PR additionally fixes up issues in the `define_test_variants` helper and SWIG compilation to avoid constantly being re-run on clean builds. This just cleaning up the commands being run on our `all` target every build invocation (adding extra care/maintenance since introducing the directory syncing).