### PR TITLE
WT-7802 Remove data store same transaction update squash logic

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -476,10 +476,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
             /* The beginning of the validity window is the selected update's time point. */
             WT_TIME_WINDOW_SET_START(select_tw, upd);
         else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
-            /*
-             * We only have a tombstone on the update list or all the updates are from the same
-             * transaction.
-             */
+            /* We only have a tombstone on the update list. */
             WT_ASSERT(session, tombstone != NULL);
 
             /* We must have an ondisk value and it can't be a prepared update. */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -484,14 +484,8 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
 
             /* Move the pointer to the last update on the update chain. */
             for (last_upd = tombstone; last_upd->next != NULL; last_upd = last_upd->next)
-                /*
-                 * Tombstone is the only non-aborted update on the update chain or all the updates
-                 * are from the same transaction.
-                 */
-                WT_ASSERT(session,
-                  last_upd->next->txnid == WT_TXN_ABORTED ||
-                    (last_upd->next->txnid == tombstone->txnid &&
-                      last_upd->next->start_ts == tombstone->start_ts));
+                /* Tombstone is the only non-aborted update on the update chain. */
+                WT_ASSERT(session, last_upd->next->txnid == WT_TXN_ABORTED);
 
             /*
              * It's possible to have a tombstone as the only update in the update list. If we

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -223,30 +223,6 @@ __rec_need_save_upd(
 }
 
 /*
- * __get_valid_upd --
- *     Loop until a valid update from a different transaction is found in the update list. As a side
- *     effect method saves the latest update from the same transaction into the WT_UPDATE output
- *     argument. Method returns a valid update from a different transaction.
- */
-static inline WT_UPDATE *
-__get_valid_upd(WT_UPDATE *upd, WT_UPDATE *tombstone, WT_UPDATE **same_txn_valid_upd)
-{
-    while (upd->next != NULL) {
-        if (upd->next->txnid == WT_TXN_ABORTED)
-            upd = upd->next;
-        else if (upd->next->txnid != WT_TXN_NONE && tombstone->txnid == upd->next->txnid) {
-            upd = upd->next;
-            /* Save the latest update from the same transaction. */
-            if (*same_txn_valid_upd == NULL)
-                *same_txn_valid_upd = upd;
-        } else
-            break;
-    }
-
-    return upd;
-}
-
-/*
  * __timestamp_out_of_order_fix --
  *     If we found a tombstone with a time point earlier than the update it applies to, which can
  *     happen if the application performs operations with timestamps out-of-order, make it invisible
@@ -284,7 +260,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     WT_DECL_RET;
     WT_PAGE *page;
     WT_TIME_WINDOW *select_tw;
-    WT_UPDATE *first_txn_upd, *first_upd, *upd, *last_upd, *same_txn_valid_upd, *tombstone;
+    WT_UPDATE *first_txn_upd, *first_upd, *upd, *last_upd, *tombstone;
     wt_timestamp_t max_ts;
     size_t upd_memsize;
     uint64_t max_txn, session_txnid, txnid;
@@ -300,7 +276,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
     WT_TIME_WINDOW_INIT(select_tw);
 
     page = r->page;
-    first_txn_upd = upd = last_upd = same_txn_valid_upd = tombstone = NULL;
+    first_txn_upd = upd = last_upd = tombstone = NULL;
     upd_memsize = 0;
     max_ts = WT_TS_NONE;
     max_txn = WT_TXN_NONE;
@@ -488,48 +464,14 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, v
 
             /* Find the update this tombstone applies to. */
             if (!__wt_txn_upd_visible_all(session, upd)) {
-                upd = __get_valid_upd(upd, tombstone, &same_txn_valid_upd);
+                while (upd->next != NULL && upd->next->txnid == WT_TXN_ABORTED)
+                    upd = upd->next;
 
                 WT_ASSERT(session, upd->next == NULL || upd->next->txnid != WT_TXN_ABORTED);
                 upd_select->upd = upd = upd->next;
-
-                /*
-                 * If there is no on-disk update and any valid update from a different transaction
-                 * is not found in the update list, write the same transaction update itself to disk
-                 * to avoid blocking the eviction.
-                 */
-                if (vpack == NULL && upd == NULL)
-                    upd_select->upd = upd = same_txn_valid_upd;
-                else if (upd != NULL && upd->type == WT_UPDATE_TOMBSTONE) {
-                    /*
-                     * The selected update from a different transaction is also a tombstone, use the
-                     * update from the same transaction as the selected update.
-                     */
-                    WT_ASSERT(session,
-                      same_txn_valid_upd != NULL &&
-                        same_txn_valid_upd->type != WT_UPDATE_TOMBSTONE);
-                    upd_select->upd = upd = same_txn_valid_upd;
-                } else if (same_txn_valid_upd != NULL && vpack != NULL &&
-                  WT_TIME_WINDOW_HAS_STOP(&vpack->tw)) {
-                    /*
-                     * The on-disk version has a valid stop timestamp, use the update from the same
-                     * transaction as the selected update.
-                     */
-                    WT_ASSERT(session, same_txn_valid_upd->type != WT_UPDATE_TOMBSTONE);
-                    upd_select->upd = upd = same_txn_valid_upd;
-
-                } else if (same_txn_valid_upd != NULL && vpack != NULL && vpack->tw.prepare) {
-                    /*
-                     * The on-disk version is from an aborted prepare transaction. Therefore, use
-                     * the update from the same transaction as the selected update. We are sure that
-                     * the on-disk prepared update has been aborted because otherwise we would have
-                     * chosen it as an update this tombstone can be applied to.
-                     */
-                    WT_ASSERT(session, same_txn_valid_upd->type != WT_UPDATE_TOMBSTONE);
-                    upd_select->upd = upd = same_txn_valid_upd;
-                }
             }
         }
+
         if (upd != NULL)
             /* The beginning of the validity window is the selected update's time point. */
             WT_TIME_WINDOW_SET_START(select_tw, upd);

--- a/test/suite/test_rollback_to_stable13.py
+++ b/test/suite/test_rollback_to_stable13.py
@@ -183,3 +183,73 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
         self.assertEqual(restored_tombstones, nrows)
+
+    def test_rollback_to_stable_with_history_tombstone(self):
+        nrows = 1000
+
+        # Prepare transactions for column store table is not yet supported.
+        if self.prepare and self.key_format == 'r':
+            self.skipTest('Prepare transactions for column store table is not yet supported')
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable13"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format="S", config='split_pct=50,log=(enabled=false)')
+        ds.populate()
+
+        # Pin oldest and stable to timestamp 10.
+        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
+            ',stable_timestamp=' + timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+
+        # Perform several updates.
+        self.large_updates(uri, value_a, ds, nrows, self.prepare, 20)
+
+        # Perform several removes.
+        self.large_removes(uri, ds, nrows, self.prepare, 30)
+
+        # Perform several updates and removes in a single transaction.
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_b
+            cursor.set_key(ds.key(i))
+            cursor.remove()
+            self.session.commit_transaction('commit_timestamp=' + timestamp_str(40))
+        cursor.close()
+
+        # Pin stable to timestamp 50 if prepare otherwise 40.
+        if self.prepare:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+        else:
+            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+
+        self.session.checkpoint()
+
+        # Perform several updates and checkpoint.
+        self.large_updates(uri, value_c, ds, nrows, self.prepare, 60)
+        self.session.checkpoint()
+
+        # Verify data is visible and correct.
+        self.check(value_a, uri, nrows, 20)
+        self.check(None, uri, 0, 40)
+        self.check(value_c, uri, nrows, 60)
+
+        # Simulate a server crash and restart.
+        simulate_crash_restart(self, ".", "RESTART")
+
+        # Check that the correct data is seen at and after the stable timestamp.
+        self.check(None, uri, 0, 50)
+
+        # Check that we restore the correct value from the history store.
+        self.check(value_a, uri, nrows, 20)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
+        self.assertEqual(restored_tombstones, nrows)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The logic of stable update in RTS and reconciliation select is
diverged due to the data store squash logic. The history store
properly handles the squash logic, there is no point in having
it multiple places. Removing it from the reconciliation select makes
the code in sync with RTS.