### PR TITLE
Revert "WT-7816 Disable test_tiered08 on macOS."

### DIFF
--- a/test/suite/test_tiered08.py
+++ b/test/suite/test_tiered08.py
@@ -106,12 +106,6 @@ class test_tiered08(wttest.WiredTigerTestCase):
         c.close()
 
     def test_tiered08(self):
-        # FIXME-WT-7792
-        # This test is temporarily disabled on Mac; it consistently fails for unknown reasons.
-        import platform
-        if platform.system() == 'Darwin':
-            self.skipTest('tiered08 test skipped on macOS')
-
         cfg = self.conn_config()
         self.pr('Config is: ' + cfg)
         intl_page = 'internal_page_max=16K'


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#6773

Found the reason the tiered08 test was failing.  It is an old (and fixed) bug. So we don't need this change to disable the test.