### PR TITLE
WT-7692 fix make check test failure on osx10 14 cmake

### DIFF
--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -7,15 +7,15 @@ find_cmake ()
 {
     if [ ! -z "$CMAKE" ]; then
         return 0
-    elif command -v cmake 2>/dev/null; then
-        CMAKE=cmake
-        CTEST=ctest
-    elif [ -f "/Applications/Cmake.app/Contents/bin/cmake" ]; then
-        CMAKE="/Applications/Cmake.app/Contents/bin/cmake"
-        CTEST="/Applications/Cmake.app/Contents/bin/ctest"
+    elif [ -f "/Applications/CMake.app/Contents/bin/cmake" ]; then
+        CMAKE="/Applications/CMake.app/Contents/bin/cmake"
+        CTEST="/Applications/CMake.app/Contents/bin/ctest"
     elif [ -f "/opt/cmake/bin/cmake" ]; then
         CMAKE="/opt/cmake/bin/cmake"
         CTEST="/opt/cmake/bin/ctest"
+    elif command -v cmake 2>/dev/null; then
+        CMAKE=cmake
+        CTEST=ctest
     elif uname -a | grep -iq 'x86_64 GNU/Linux'; then
         if [ -f "$(pwd)/cmake-3.11.0/bin/cmake" ]; then
             CMAKE="$(pwd)/cmake-3.11.0/bin/cmake"

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -35,6 +35,7 @@ find_cmake ()
         CMAKE="$(readlink -f cmake-install)/bin/cmake"
         CTEST="$(readlink -f cmake-install)/bin/ctest"
     fi
+
     if [ -z "$CMAKE" -o -z "$( $CMAKE --version 2>/dev/null )" ]; then
         # Some images have no cmake yet, or a broken cmake (see: BUILD-8570)
         echo "-- MAKE CMAKE --"

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -30,7 +30,7 @@ find_cmake ()
     elif [ -f "/cygdrive/c/cmake/bin/cmake" ]; then
         CMAKE="/cygdrive/c/cmake/bin/cmake"
         CTEST="/cygdrive/c/cmake/bin/ctest"
-    elif [ -f $(readlink -f cmake-install)/bin/cmake ]; then
+    elif [ -f "$(readlink -f cmake-install)"/bin/cmake ]; then
         # If we have a custom cmake install from an earlier build step.
         CMAKE="$(readlink -f cmake-install)/bin/cmake"
         CTEST="$(readlink -f cmake-install)/bin/ctest"

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -50,6 +50,16 @@ find_cmake ()
         CTEST="${CMAKE_INSTALL_DIR}/bin/ctest"
         echo "-- DONE MAKING CMAKE --"
     fi
+
+    echo "=========================================================="
+    echo "CMake and CTest environment variables, paths and versions:"
+    echo "CMAKE: ${CMAKE}"
+    echo "CTEST: ${CTEST}"
+    command -v ${CMAKE}
+    command -v ${CTEST}
+    ${CMAKE} --version
+    ${CTEST} --version
+    echo "=========================================================="
 }
 
 find_cmake


### PR DESCRIPTION
Re-ordered the steps to match the paths for cmake and ctest. This does two things:
1. The order of steps is more consistent with the code from https://github.com/mongodb/mongo-c-driver/blob/master/.evergreen/find-cmake.sh 
2. The code doesn't assume that as a first step that if cmake is found on the path, that ctest is also available on the path.

In addition, the code now logs the CMake and CTest environment variables, paths and versions.
This makes it easier to check that CMake and CTest are configured correctly and being used consistently. It will assist should problems such as WT-7692 occur again in the future.