### PR TITLE
WT-7732 Add a timeout configuration for flush_tier.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1573,6 +1573,11 @@ methods = {
         \c on setting causes the caller to wait until all work queued for this call to
         be completely processed before returning''',
         choices=['off', 'on']),
+    Config('timeout', '0', r'''
+        maximum amount of time to allow for waiting for previous flushing
+        of objects, in seconds. The actual amount of time spent waiting may
+        exceed the configured value. A value of zero disables the timeout''',
+        type='int'),
 ]),
 
 'WT_SESSION.strerror' : Method([]),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -326,7 +326,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_drop[] = {
 static const WT_CONFIG_CHECK confchk_WT_SESSION_flush_tier[] = {
   {"flush_timestamp", "string", NULL, NULL, NULL, 0}, {"force", "boolean", NULL, NULL, NULL, 0},
   {"lock_wait", "boolean", NULL, NULL, NULL, 0},
-  {"sync", "string", NULL, "choices=[\"off\",\"on\"]", NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
+  {"sync", "string", NULL, "choices=[\"off\",\"on\"]", NULL, 0},
+  {"timeout", "int", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_join[] = {
   {"bloom_bit_count", "int", NULL, "min=2,max=1000", NULL, 0},
@@ -1190,8 +1191,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "checkpoint_wait=true,force=false,lock_wait=true,"
     "remove_files=true",
     confchk_WT_SESSION_drop, 4},
-  {"WT_SESSION.flush_tier", "flush_timestamp=,force=false,lock_wait=true,sync=on",
-    confchk_WT_SESSION_flush_tier, 4},
+  {"WT_SESSION.flush_tier", "flush_timestamp=,force=false,lock_wait=true,sync=on,timeout=0",
+    confchk_WT_SESSION_flush_tier, 5},
   {"WT_SESSION.join",
     "bloom_bit_count=16,bloom_false_positives=false,"
     "bloom_hash_count=8,compare=\"eq\",count=,operation=\"and\","

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -23,20 +23,27 @@
  * __flush_tier_wait --
  *     Wait for all previous work units queued to be processed.
  */
-static void
-__flush_tier_wait(WT_SESSION_IMPL *session)
+static int
+__flush_tier_wait(WT_SESSION_IMPL *session, const char **cfg)
 {
+    WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
+    uint64_t now, start, timeout;
     int yield_count;
 
     conn = S2C(session);
     yield_count = 0;
+    now = start = 0;
     /*
      * The internal thread needs the schema lock to perform its operations and flush tier also
      * acquires the schema lock. We cannot be waiting in this function while holding that lock or no
      * work will get done.
      */
     WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA));
+    WT_RET(__wt_config_gets(session, cfg, "timeout", &cval));
+    timeout = (uint64_t)cval.val;
+    if (timeout != 0)
+        __wt_seconds(session, &start);
 
     /*
      * It may be worthwhile looking at the add and decrement values and make choices of whether to
@@ -44,11 +51,17 @@ __flush_tier_wait(WT_SESSION_IMPL *session)
      * take a long time so yielding may not be effective.
      */
     while (!WT_FLUSH_STATE_DONE(conn->flush_state)) {
+        if (start != 0) {
+            __wt_seconds(session, &now);
+            if (now - start > timeout)
+                return (EBUSY);
+        }
         if (++yield_count < WT_THOUSAND)
             __wt_yield();
         else
             __wt_cond_wait(session, conn->flush_cond, 200, NULL);
     }
+    return (0);
 }
 
 /*
@@ -337,7 +350,7 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
     WT_DECL_RET;
     uint32_t flags;
     const char *cfg[3];
-    bool wait;
+    bool locked, wait;
 
     conn = S2C(session);
     WT_STAT_CONN_INCR(session, flush_tier);
@@ -368,10 +381,12 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
      * We have to hold the lock around both the wait call for a previous flush tier and the
      * execution of the current flush tier call.
      */
+    locked = false;
     if (wait)
         __wt_spin_lock(session, &conn->flush_tier_lock);
     else
         WT_RET(__wt_spin_trylock(session, &conn->flush_tier_lock));
+    locked = true;
 
     /*
      * We cannot perform another flush tier until any earlier ones are done. Often threads will wait
@@ -379,7 +394,7 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
      * turned off then any following call must wait and will do so here. We have to wait while not
      * holding the schema lock.
      */
-    __flush_tier_wait(session);
+    WT_ERR(__flush_tier_wait(session, cfg));
     if (wait)
         WT_WITH_CHECKPOINT_LOCK(
           session, WT_WITH_SCHEMA_LOCK(session, ret = __flush_tier_once(session, flags)));
@@ -387,9 +402,14 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
         WT_WITH_CHECKPOINT_LOCK_NOWAIT(session, ret,
           WT_WITH_SCHEMA_LOCK_NOWAIT(session, ret, ret = __flush_tier_once(session, flags)));
     __wt_spin_unlock(session, &conn->flush_tier_lock);
+    locked = false;
 
     if (ret == 0 && LF_ISSET(WT_FLUSH_TIER_ON))
-        __flush_tier_wait(session);
+        WT_ERR(__flush_tier_wait(session, cfg));
+
+err:
+    if (locked)
+        __wt_spin_unlock(session, &conn->flush_tier_lock);
     return (ret);
 }
 
@@ -520,6 +540,7 @@ __tiered_mgr_server(void *arg)
     WT_ITEM path, tmp;
     WT_SESSION_IMPL *session;
     WT_TIERED_MANAGER *mgr;
+    const char *cfg[2];
 
     session = arg;
     conn = S2C(session);
@@ -527,6 +548,8 @@ __tiered_mgr_server(void *arg)
 
     WT_CLEAR(path);
     WT_CLEAR(tmp);
+    cfg[0] = "timeout=0";
+    cfg[1] = NULL;
 
     for (;;) {
         /* Wait until the next event. */
@@ -542,7 +565,7 @@ __tiered_mgr_server(void *arg)
         WT_WITH_SCHEMA_LOCK(session, ret = __flush_tier_once(session, 0));
         WT_ERR(ret);
         if (ret == 0)
-            __flush_tier_wait(session);
+            WT_ERR(__flush_tier_wait(session, cfg));
         WT_ERR(__tier_storage_remove(session, false));
     }
 

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -381,7 +381,6 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
      * We have to hold the lock around both the wait call for a previous flush tier and the
      * execution of the current flush tier call.
      */
-    locked = false;
     if (wait)
         __wt_spin_lock(session, &conn->flush_tier_lock);
     else

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -815,6 +815,9 @@ struct __wt_session {
 	 * internal thread.  The \c on setting causes the caller to wait until all work queued for
 	 * this call to be completely processed before returning., a string\, chosen from the
 	 * following options: \c "off"\, \c "on"; default \c on.}
+	 * @config{timeout, maximum amount of time to allow for waiting for previous flushing of
+	 * objects\, in seconds.  The actual amount of time spent waiting may exceed the configured
+	 * value.  A value of zero disables the timeout., an integer; default \c 0.}
 	 * @configend
 	 * @errors
 	 */

--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -188,10 +188,15 @@ class test_tiered04(wttest.WiredTigerTestCase):
         retain = self.get_stat(stat.conn.tiered_retention, None)
         self.assertEqual(retain, new)
         self.pr("reconfigure flush_tier")
-        self.session.flush_tier(None)
+        # Call flush_tier with its various configuration arguments. It is difficult
+        # to force a timeout or lock contention with a unit test. So just test the
+        # call for now.
+        self.session.flush_tier('timeout=10')
+        self.session.flush_tier('lock_wait=false')
+        self.session.flush_tier('sync=off')
         self.pr("reconfigure get stat")
         calls = self.get_stat(stat.conn.flush_tier, None)
-        self.assertEqual(calls, 5)
+        self.assertEqual(calls, 7)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@keitharnoldsmith I asked a question in the ticket about whether to leave in `lock_wait` while adding `timeout`. This first version keeps both. 