### PR TITLE
WT-7856 Enable flush test with open cursor in test_tiered04

### DIFF
--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -133,12 +133,7 @@ class test_tiered04(wttest.WiredTigerTestCase):
         self.check(c, 3)
 
         self.pr("flush tier again, holding open cursor")
-        # FIXME-WT-7591 Remove the extra cursor close and open surrounding the flush_tier call.
-        # Having a cursor open during a flush_tier does not yet work, so the test closes it,
-        # and reopens after the flush_tier.
-        c.close()
         self.session.flush_tier(None)
-        c = self.session.open_cursor(self.uri)
 
         c["3"] = "3"
         self.check(c, 4)


### PR DESCRIPTION
I should have removed this code when I fixed WT-7591.  I'm addressing that now.

I ran the test a few thousand times without incident.  (I.e., left it running while I made a some tea)