### PR TITLE
WT-6902 Metadata subpage for Architecture Guide

### DIFF
--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -1,6 +1,6 @@
 /*! @arch_page arch-metadata Metadata
 
-Metadata in WiredTiger captures important information about the users database.
+Metadata in WiredTiger captures important information about the user's database.
 Metadata includes tracking essential information such as the files and tables
 present in the database, their associated configurations, as well as the latest checkpoints of
 each those files.
@@ -33,8 +33,8 @@ the latest checkpoint information for each btree in the system. The checkpoint m
 point in time in which WiredTiger can recover from (e.g after a crash or unexpected shutdown).
 The checkpoint metadata for a given btree is stored within the configuration string under its
 associated \c uri key within the \c WiredTiger.wt table. Metadata configuration entries relevant to capturing
-a given btrees checkpoint state include:
-- \c checkpoint: The files checkpoint entries, including their timestamp, transaction ID and write generation.
+a given btree's checkpoint state include:
+- \c checkpoint: The file's checkpoint entries, including their timestamp, transaction ID and write generation.
 - \c checkpoint_lsn: The LSN of the last checkpoint.
 - \c checkpoint_backup_info:  Incremental checkpoint backup information.
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -10,10 +10,9 @@ The main metadata in WiredTiger is stored in the \c WiredTiger.wt file.
 
 @section metadata_table Metadata Table
 
-The keys in the \c WiredTiger.wt table are \c uri strings. The keys representing a
-range of the available URIs in the system. This for example can include \c "table:" & \c "file:"
+The keys in the \c WiredTiger.wt table are \c uri strings. For example, keys can include \c "table:" & \c "file:"
 prefixed URIs, representing typical row-store WiredTiger tables. A non-exhaustive list of other
-example keys could also include \c "index:", \c "colgroups:" \& \c "system:" prefixed URIs, representing
+example keys could also include \c "index:", \c "colgroups:" and \c "system:" prefixed URIs, representing
 indexes, colgroups and special system values respectively.
 
 The value corresponding to a given \c uri key in the metadata table is its
@@ -23,7 +22,7 @@ type of \c uri.  Thus, a metadata entry with a \c uri key beginning with \c "tab
 a configuration string having entries such as \c key_format and \c value_format to
 describe the data encoding for the uri. A metadata key beginning with
 \c "file:" will have a different set of configuration entries associated
-with it.
+with it. See @ref config_strings "Configuration Strings" for more details about WiredTiger configuration strings.
 
 @section metadata_checkpoint Storing Checkpoint Metadata
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -1,19 +1,78 @@
 /*! @arch_page arch-metadata Metadata
 
-Metadata in WiredTiger is stored as a table in the \c "WiredTiger.wt" file.
-The table's key is a \c uri string, and the value is its complete
-configuration string.  The configuration itself is a list of key/value
-pairs in string form.  The configuration's keys are dependent on the
-type of \c uri.  Thus, a metadata entry with a \c uri key beginning with
-\c "table:" will be a configuration string
-having configuration entries like \c key_format and \c value_format to
-describe the data encoding for the uri.  A metadata key beginning with
+Metadata in WiredTiger captures important information about the users database.
+Metadata includes tracking essential information such as the files and tables
+present in the database, their associated configurations, as well as the latest checkpoints of
+each those files.
+
+The main metadata in WiredTiger is stored in the \c WiredTiger.wt file. The
+\c WiredTiger.wt file being a table itself.
+
+@section metadata_table Metadata Table
+
+The keys in the \c WiredTiger.wt table are \c uri strings. The \c uri keys can be strings
+representing:
+- WiredTiger Tables and Files: \c "table:" & \c "file:"
+- Indexes: \c "index:"
+- Colgroups: \c "colgroup:"
+- System values: \c "system". Representing special system values.
+
+The value corresponding to a given \c uri key in the metadata table is its
+associated configuration string.  The configuration value itself is a list of key/value
+pairs in string form.  The key/value pairs in the configuration strings are dependent on the
+type of \c uri.  Thus, a metadata entry with a \c uri key beginning with \c "table:" will be
+a configuration string having entries such as \c key_format and \c value_format to
+describe the data encoding for the uri. A metadata key beginning with
 \c "file:" will have a different set of configuration entries associated
 with it.
 
-A caller of WiredTiger can use WT_SESSION::open_cursor with a \c uri equal to
-\c "meta:" to read the metadata.  Using this interface, metadata can only
-be queried, not changed.  Changes to the metadata are affected by API calls
-such as WT_SESSION::create, WT_SESSION::drop, WT_SESSION::rename.
+@section metadata_checkpoint Storing Checkpoint Metadata
 
+Metadata plays an important role in the WiredTiger checkpointing process. Metadata is used to store
+the latest checkpoint information for each btree in the system. The checkpoint metadata providing a known
+point in time in which WiredTiger can recover from (e.g after a crash or unexpected shutdown).
+The checkpoint metadata for a given btree is stored within the configuration string under its
+associated \c uri key within the \c WiredTiger.wt table. Metadata configuration entries relevant to capturing
+a given btrees checkpoint state include:
+- \c checkpoint: The files checkpoint entries, including their timestamp, transaction ID and write generation.
+- \c checkpoint_lsn: The LSN of the last checkpoint.
+- \c checkpoint_backup_info:  Incremental checkpoint backup information.
+
+Additionally, the metadata table \c WiredTiger.wt is a btree itself that needs to be checkpointed. Since a
+new metadata entry needs to be created for each btree at the time of checkpointing, the metadata table is the last
+file to be checkpointed in the process. Checkpointing the metadata table last is important
+for capturing a consistent metadata state of the btrees in the database at the time of the last checkpoint.
+
+@section metadata_turtle Turtle file
+
+WiredTiger maintains a special turtle file called \c "WiredTiger.turtle" inside the db directory. This containing the
+most recent checkpointing information of the \c WiredTiger.wt metadata file. Using the turtle file, WiredTiger can
+read the latest checkpoint information when recovering the \c WiredTiger.wt table. Recovering the checkpoint
+of the \c WiredTiger.wt table in turn helps restore a consistent view of the checkpointing information for the other btrees in
+the system.
+
+@section metadata_reading Reading Metadata
+
+The contents of the metadata table is ASCII printable. The URIs and configuration values
+are all printable \c C strings.
+
+@subsection metadata_cursor "metadata:" cursor
+
+To read the metadata, a caller can open a cursor with a \c uri equal
+to \c "metadata:". When opening a metadata cursor (through \c WT_SESSION::open_cursor), a user can
+only read the available metadata. Changes to the metadata cannot be written through the metadata
+cursor interface i.e. the metadata cursor is a read-only interface. Metadata is only changed/affected 
+by API calls such as WT_SESSION::create, WT_SESSION::drop, WT_SESSION::rename & WT_SESSION::alter.
+
+@subsection metadata_create_cursor "metadata:create" cursor
+
+Additionally, if you want to only read strings relating to creation configurations of the various
+\c uri keys present, you can open a cursor with a \c uri equal to \c "metadata:create". This stripping out
+internal metadata when querying.
+
+@subsection metadata_wt_util Printing metadata with the wt utility
+
+Lastly you can dump the metadata in the \c WiredTiger.wt table using the \c wt utility. Running
+\c "wt dump file:WiredTiger.wt" will display the various \c uri key strings with their associated
+configuration strings.
 */

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -11,12 +11,11 @@ The main metadata in WiredTiger is stored in the \c WiredTiger.wt file. The
 
 @section metadata_table Metadata Table
 
-The keys in the \c WiredTiger.wt table are \c uri strings. The \c uri keys can be strings
-representing:
-- WiredTiger Tables and Files: \c "table:" & \c "file:"
-- Indexes: \c "index:"
-- Colgroups: \c "colgroup:"
-- System values: \c "system". Representing special system values.
+The keys in the \c WiredTiger.wt table are \c uri strings. The keys representing a
+range of the available URIs in the system. This for example can include \c "table:" & \c "file:"
+prefixed URIs, representing typical row-store WiredTiger tables. A non-exhaustive list of other
+example keys could also include \c "index:", \c "colgroups:" \& \c "system:" prefixed URIs, representing
+indexes, colgroups and special system values respectively.
 
 The value corresponding to a given \c uri key in the metadata table is its
 associated configuration string.  The configuration value itself is a list of key/value

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -6,8 +6,7 @@ present in the database, their associated configurations, as well as the latest 
 each those files. In particular, the checkpoint metadata also tells WiredTiger where to the find
 root page and all other parts of its tree when accessing the file.
 
-The main metadata in WiredTiger is stored in the \c WiredTiger.wt file. The
-\c WiredTiger.wt file being a table itself.
+The main metadata in WiredTiger is stored in the \c WiredTiger.wt file.
 
 @section metadata_table Metadata Table
 
@@ -38,18 +37,19 @@ this information also tracks an encoded address cookie that describes the blocks
 - \c checkpoint_lsn: The LSN of the last checkpoint.
 - \c checkpoint_backup_info:  Incremental checkpoint backup information.
 
-Additionally, the metadata table \c WiredTiger.wt is a btree itself that needs to be checkpointed. Since a
-new metadata entry needs to be created for each btree at the time of checkpointing, the metadata table is the last
+@section metadata_turtle Turtle file
+
+The metadata file \c WiredTiger.wt is a regular WiredTiger table itself. As such, the metadata table has a btree that also needs to be
+checkpointed. Since a new metadata entry needs to be created for each btree at the time of checkpointing, the metadata table is the last
 file to be checkpointed in the process. Checkpointing the metadata table last is important
 for capturing a consistent metadata state of the btrees in the database at the time of the last checkpoint.
 
-@section metadata_turtle Turtle file
-
-WiredTiger maintains a special turtle file called \c "WiredTiger.turtle" inside the db directory. This containing the
-most recent checkpointing information of the \c WiredTiger.wt metadata file. Using the turtle file, WiredTiger can
-read the latest checkpoint information when recovering the \c WiredTiger.wt table. Recovering the checkpoint
-of the \c WiredTiger.wt table in turn helps restore a consistent view of the checkpointing information for the other btrees in
-the system.
+Due to this ordering, to successfully restore the checkpoint of the \c WiredTiger.wt file, WiredTiger captures the most
+recent checkpointing information of the metadata table in a separate file. This being a special turtle file inside the db directory called
+\c "WiredTiger.turtle". The turtle file itself can be considered as being metadata for the WiredTiger metadata. Using the
+turtle file, WiredTiger can read the latest checkpoint information from the file when recovering the \c WiredTiger.wt table.
+Recovering the checkpoint of the \c WiredTiger.wt table in turn helps restore a consistent view of the checkpointing information
+for the other btrees in the system.
 
 @section metadata_reading Reading Metadata
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -67,8 +67,8 @@ by API calls.
 @subsection metadata_create_cursor "metadata:create" cursor
 
 Additionally, to only read strings relating to creation configurations of the various
-\c uri keys present, a cursor can be opened with a \c uri equal to \c "metadata:create". This stripping out
-internal metadata when querying.
+\c uri keys present, a cursor can be opened with a \c uri equal to \c "metadata:create". This type of
+cursor causes WiredTiger to strip out internal metadata when querying.
 
 @subsection metadata_wt_util Printing metadata with the wt utility
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -2,8 +2,8 @@
 
 Metadata in WiredTiger captures important information about the user's database.
 Metadata includes tracking essential information such as the files and tables
-present in the database, their associated configurations, as well as the latest checkpoints of
-each those files. In particular, the checkpoint metadata also tells WiredTiger where to the find
+present in the database, their associated configurations, as well as the latest checkpoints.
+The checkpoint information tells WiredTiger where to the find
 root page and all other parts of its tree when accessing the file.
 
 The main metadata in WiredTiger is stored in the \c WiredTiger.wt file.

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -41,13 +41,13 @@ this information also tracks an encoded address cookie that describes the blocks
 The metadata file \c WiredTiger.wt is a regular WiredTiger table itself. As such, the metadata table has a btree that also needs to be
 checkpointed. Since a new metadata entry needs to be created for each btree at the time of checkpointing, the metadata table is the last
 file to be checkpointed in the process. Checkpointing the metadata table last is important
-for capturing a consistent metadata state of the btrees in the database at the time of the last checkpoint.
+for capturing a consistent state of the btrees in the database at the time of the last checkpoint.
 
 Due to this ordering, to successfully restore the checkpoint of the \c WiredTiger.wt file, WiredTiger captures the most
-recent checkpointing information of the metadata table in a separate file. This being a special turtle file inside the db directory called
-\c "WiredTiger.turtle". The turtle file itself can be considered as being metadata for the WiredTiger metadata. Using the
+recent checkpointing information of the metadata table in a separate special turtle file called
+\c "WiredTiger.turtle". The turtle file itself is metadata for the WiredTiger metadata. Using the
 turtle file, WiredTiger can read the latest checkpoint information from the file when recovering the \c WiredTiger.wt table.
-Recovering the checkpoint of the \c WiredTiger.wt table in turn helps restore a consistent view of the checkpointing information
+Recovering the checkpoint of the \c WiredTiger.wt table in turn restores a consistent view of the checkpointing information
 for the other btrees in the system.
 
 @section metadata_reading Reading Metadata

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -53,13 +53,12 @@ for the other btrees in the system.
 @section metadata_reading Reading Metadata
 
 The contents of the metadata table is ASCII printable. The URIs and configuration values
-are all printable \c C strings.
+are all printable strings.
 
 @subsection metadata_cursor "metadata:" cursor
 
-To read the metadata, a caller can open a cursor with a \c uri equal
-to \c "metadata:". When opening a metadata cursor (through \c WT_SESSION::open_cursor), a user can
-only read the available metadata. Changes to the metadata cannot be written through the metadata
+To read the metadata, a caller can open a cursor, via \c WT_SESSION::open_cursor, with a \c uri equal
+to \c "metadata:". Changes to the metadata cannot be written through the metadata
 cursor interface i.e. the metadata cursor is a read-only interface. Metadata is only changed/affected
 by API calls.
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -34,7 +34,7 @@ a given btree's checkpoint state include:
 - \c checkpoint: The file's checkpoint entries, including their timestamp, transaction ID and write generation. Most importantly
 this information also tracks an encoded address cookie that describes the blocks that make up the checkpoint's data.
 - \c checkpoint_lsn: The LSN of the last checkpoint.
-- \c checkpoint_backup_info:  Incremental checkpoint backup information.
+- \c checkpoint_backup_info:  Incremental backup information.
 
 @section metadata_turtle Turtle file
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -61,7 +61,7 @@ are all printable \c C strings.
 To read the metadata, a caller can open a cursor with a \c uri equal
 to \c "metadata:". When opening a metadata cursor (through \c WT_SESSION::open_cursor), a user can
 only read the available metadata. Changes to the metadata cannot be written through the metadata
-cursor interface i.e. the metadata cursor is a read-only interface. Metadata is only changed/affected 
+cursor interface i.e. the metadata cursor is a read-only interface. Metadata is only changed/affected
 by API calls such as WT_SESSION::create, WT_SESSION::drop, WT_SESSION::rename & WT_SESSION::alter.
 
 @subsection metadata_create_cursor "metadata:create" cursor

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -22,7 +22,7 @@ type of \c uri.  Thus, a metadata entry with a \c uri key beginning with \c "tab
 a configuration string having entries such as \c key_format and \c value_format to
 describe the data encoding for the uri. A metadata key beginning with
 \c "file:" will have a different set of configuration entries associated
-with it. See @ref config_strings "Configuration Strings" for more details about WiredTiger configuration strings.
+with it. See @ref config_strings for more details about WiredTiger configuration strings.
 
 @section metadata_checkpoint Storing Checkpoint Metadata
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -66,13 +66,13 @@ by API calls.
 
 @subsection metadata_create_cursor "metadata:create" cursor
 
-Additionally, if you want to only read strings relating to creation configurations of the various
-\c uri keys present, you can open a cursor with a \c uri equal to \c "metadata:create". This stripping out
+Additionally, to only read strings relating to creation configurations of the various
+\c uri keys present, a cursor can be opened with a \c uri equal to \c "metadata:create". This stripping out
 internal metadata when querying.
 
 @subsection metadata_wt_util Printing metadata with the wt utility
 
-Lastly you can dump the metadata in the \c WiredTiger.wt table using the \c wt utility. Running
+Lastly the metadata in the \c WiredTiger.wt table can be dumped using the \c wt utility. Running
 \c "wt dump file:WiredTiger.wt" will display the various \c uri key strings with their associated
 configuration strings.
 */

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -3,7 +3,8 @@
 Metadata in WiredTiger captures important information about the user's database.
 Metadata includes tracking essential information such as the files and tables
 present in the database, their associated configurations, as well as the latest checkpoints of
-each those files.
+each those files. In particular, the checkpoint metadata also tells WiredTiger where to the find
+root page and all other parts of its tree when accessing the file.
 
 The main metadata in WiredTiger is stored in the \c WiredTiger.wt file. The
 \c WiredTiger.wt file being a table itself.
@@ -34,7 +35,8 @@ point in time in which WiredTiger can recover from (e.g after a crash or unexpec
 The checkpoint metadata for a given btree is stored within the configuration string under its
 associated \c uri key within the \c WiredTiger.wt table. Metadata configuration entries relevant to capturing
 a given btree's checkpoint state include:
-- \c checkpoint: The file's checkpoint entries, including their timestamp, transaction ID and write generation.
+- \c checkpoint: The file's checkpoint entries, including their timestamp, transaction ID and write generation. Most importantly
+this information also tracks an encoded address cookie that describes the blocks that make up the checkpoint's data.
 - \c checkpoint_lsn: The LSN of the last checkpoint.
 - \c checkpoint_backup_info:  Incremental checkpoint backup information.
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -28,9 +28,8 @@ with it.
 
 @section metadata_checkpoint Storing Checkpoint Metadata
 
-Metadata plays an important role in the WiredTiger checkpointing process. Metadata is used to store
-the latest checkpoint information for each btree in the system. The checkpoint metadata providing a known
-point in time in which WiredTiger can recover from (e.g after a crash or unexpected shutdown).
+The latest checkpoint information for each btree in the system is stored in its metadata entry. The checkpoint metadata
+provides a known point in time from which WiredTiger can recover a btree's data after a restart.
 The checkpoint metadata for a given btree is stored within the configuration string under its
 associated \c uri key within the \c WiredTiger.wt table. Metadata configuration entries relevant to capturing
 a given btree's checkpoint state include:

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -62,7 +62,7 @@ To read the metadata, a caller can open a cursor with a \c uri equal
 to \c "metadata:". When opening a metadata cursor (through \c WT_SESSION::open_cursor), a user can
 only read the available metadata. Changes to the metadata cannot be written through the metadata
 cursor interface i.e. the metadata cursor is a read-only interface. Metadata is only changed/affected
-by API calls such as WT_SESSION::create, WT_SESSION::drop, WT_SESSION::rename & WT_SESSION::alter.
+by API calls.
 
 @subsection metadata_create_cursor "metadata:create" cursor
 

--- a/src/docs/arch-metadata.dox
+++ b/src/docs/arch-metadata.dox
@@ -72,7 +72,7 @@ cursor causes WiredTiger to strip out internal metadata when querying.
 
 @subsection metadata_wt_util Printing metadata with the wt utility
 
-Lastly the metadata in the \c WiredTiger.wt table can be dumped using the \c wt utility. Running
-\c "wt dump file:WiredTiger.wt" will display the various \c uri key strings with their associated
+Lastly the metadata in the \c WiredTiger.wt table can be dumped using the \c wt utility. A command option for
+specifically printing the metadata is \c "wt list -v". This will display the various \c uri key strings with their associated
 configuration strings.
 */

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -178,6 +178,7 @@ br
 btmem
 btree
 btrees
+btree's
 bufs
 builtin
 builtins

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -192,6 +192,7 @@ cdb
 cds
 changelog
 checkpointed
+checkpointing
 checksum
 checksums
 ckp


### PR DESCRIPTION
This PR reworks the metadata subpage entry for the Architecture Guide. This subpage being expanded to discuss the format of the WiredTiger.wt table, the role of metadata when checkpointing and how to read WiredTiger metadata.

Please let me know if I should add any additional sections on WT metadata or expand on any points! I was a bit uncertain with what areas should be covered under this topic. Happy to iterate on anything :) 