### PR TITLE
WT-7864 Add support to run.py for running lists/ranges of scenarios in a test

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -131,7 +131,8 @@ Options:\n\
   -p      | --preserve           preserve output files in WT_TEST/<testname>\n\
   -r N    | --random-sample N    randomly sort scenarios to be run, then\n\
                                  execute every Nth (2<=N<=1000) scenario.\n\
-  -s N    | --scenario N         use scenario N (N can be number or symbolic)\n\
+  -s N    | --scenario N         use scenario N (N can be symbolic, number, or\n\
+                                 list of numbers and ranges in the form 1,3-5,7)\n\
   -t      | --timestamp          name WT_TEST according to timestamp\n\
   -v N    | --verbose N          set verboseness to N (0<=N<=3, default=1)\n\
   -i      | --ignore-stdout      dont fail on unexpected stdout or stderr\n\
@@ -178,7 +179,7 @@ def show_env(verbose, envvar):
 # e.g. test_util03 -> util
 reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
 
-# look for a list of the form 0-9,11,15-17
+# Look for a list of the form 0-9,11,15-17.
 def parse_int_list(str):
     ret = {}
     # divide into ranges separated by commas

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -182,21 +182,21 @@ reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
 # Look for a list of the form 0-9,11,15-17.
 def parse_int_list(str):
     ret = {}
-    # divide into ranges separated by commas
+    # Divide the input into ranges separated by commas.
     for r in str.split(","):
-        # split the range
+        # Split the range we got (if it is one).
         bounds = r.split("-")
         if len(bounds) == 1 and bounds[0].isdigit():
-            # single number with no dash
+            # It's a single number with no dash.
             scenario = int(bounds[0])
             ret[scenario] = True
             continue
         if len(bounds) == 2 and bounds[0].isdigit() and bounds[1].isdigit():
-            # two numbers separated by a dash
+            # It's two numbers separated by a dash.
             for scenario in range(int(bounds[0]), int(bounds[1]) + 1):
                 ret[scenario] = True
             continue
-        # not valid syntax, give up
+        # It's not valid syntax; give up.
         return None
     return ret
 

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -181,6 +181,8 @@ reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
 
 # Look for a list of the form 0-9,11,15-17.
 def parse_int_list(str):
+    # Use a dictionary as the result set to avoid repeated list scans.
+    # (Only the keys are used; the values are ignored.)
     ret = {}
     # Divide the input into ranges separated by commas.
     for r in str.split(","):

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -178,16 +178,38 @@ def show_env(verbose, envvar):
 # e.g. test_util03 -> util
 reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
 
+# look for a list of the form 0-9,11,15-17
+def parse_int_list(str):
+    ret = {}
+    # divide into ranges separated by commas
+    for r in str.split(","):
+        # split the range
+        bounds = r.split("-")
+        if len(bounds) == 1 and bounds[0].isdigit():
+            # single number with no dash
+            scenario = int(bounds[0])
+            ret[scenario] = True
+            continue
+        if len(bounds) == 2 and bounds[0].isdigit() and bounds[1].isdigit():
+            # two numbers separated by a dash
+            for scenario in range(int(bounds[0]), int(bounds[1]) + 1):
+                ret[scenario] = True
+            continue
+        # not valid syntax, give up
+        return None
+    return ret
+
 def restrictScenario(testcases, restrict):
     if restrict == '':
         return testcases
-    elif restrict.isdigit():
-        s = int(restrict)
-        return [t for t in testcases
-            if hasattr(t, 'scenario_number') and t.scenario_number == s]
     else:
-        return [t for t in testcases
-            if hasattr(t, 'scenario_name') and t.scenario_name == restrict]
+        scenarios = parse_int_list(restrict)
+        if scenarios is not None:
+            return [t for t in testcases
+                if hasattr(t, 'scenario_number') and t.scenario_number in scenarios]
+        else:
+            return [t for t in testcases
+                if hasattr(t, 'scenario_name') and t.scenario_name == restrict]
 
 def addScenarioTests(tests, loader, testname, scenario):
     loaded = loader.loadTestsFromName(testname)


### PR DESCRIPTION
Add support to run.py for running lists/ranges of scenarios with -s.

The syntax supported matches e.g. 1-3,5,7-9. A single number is handled
as a trivial list.