### PR TITLE
WT-7703 Fix timeout in test_checkpoint_snapshot04

### DIFF
--- a/test/suite/test_checkpoint_snapshot04.py
+++ b/test/suite/test_checkpoint_snapshot04.py
@@ -50,7 +50,7 @@ class test_checkpoint_snapshot04(backup_base):
     scenarios = make_scenarios(target_backup)
 
     def conn_config(self):
-        config = 'cache_size=25MB'
+        config = 'cache_size=200MB'
         return config
 
     def large_updates(self, uri, value, ds, nrows):


### PR DESCRIPTION
If the page gets evicted by an eviction thread all the written updates can be written to disk, because eviction threads operate with a transaction snapshot. It seems that all the pages are trying to evict with the application thread after the transaction is finished can write only the globally visible updates. As this issue is happening only on Z-series machines, this could be the reason behind the cache stuck issue.

The better solution to fix this problem is to increase the cache size of the test to not let the eviction be triggered. The test intention is to verify the backup database, so there is no point in triggering the eviction.