### PR TITLE
WT-7787 Don't read pages for checkpoint cleanup when the cache is in aggressive mode

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -385,6 +385,12 @@ __sync_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *ski
     if (ref->state != WT_REF_DISK)
         return (0);
 
+    /* Don't read any pages when the cache is operating in aggressive mode. */
+    if (__wt_cache_aggressive(session)) {
+        *skipp = true;
+        return (0);
+    }
+
     /* Don't read pages into cache during startup or shutdown phase. */
     if (F_ISSET(S2C(session), WT_CONN_RECOVERING | WT_CONN_CLOSING_TIMESTAMP)) {
         *skipp = true;


### PR DESCRIPTION
When a checkpoint is tasked with garbage collection, it has to
clean up the older content from a file that is now obsolete. To
do so, the checkpoint-cleanup process can effectively visit and
load all of the internal pages in a file. Doing so when the cache
has already reached an aggressive state can be counterproductive.
Not only reading of the pages into the cache for the cleanup can
be slower, but the checkpoint itself could hold eviction in the
aggressive state longer.

When the eviction is set to aggressive, this change allows
checkpointing to skip loading the internal pages that are not
already in cache. This will help a faster checkpoint, and a higher
chance for the cache to get back to normal.

Co-authored-by: Haribabu Kommi <haribabu.kommi@mongodb.com>
Co-authored-by: Sulabh Mahajan <sulabh.mahajan@mongodb.com>