### PR TITLE
WT-7870 Fix measurement of cyclomatic code complexity (take 2, with the correct JIRA ticket number)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2619,21 +2619,26 @@ tasks:
       - func: "get project"
       - command: shell.exec
         params:
-          working_dir: "wiredtiger/src"
+          working_dir: "wiredtiger"
           shell: bash
           script: |
             set -o verbose
 
+            # Install Metrix++, ensuring it is outside the 'src' directory
             git clone https://github.com/metrixplusplus/metrixplusplus metrixplusplus
-            python "metrixplusplus/metrix++.py" collect --std.code.lines.code --std.code.complexity.cyclomatic
-            python "metrixplusplus/metrix++.py" view
+
+            # We only want complexity measures for the 'src' directory
+            cd src
+
+            python "../metrixplusplus/metrix++.py" collect --std.code.lines.code --std.code.complexity.cyclomatic
+            python "../metrixplusplus/metrix++.py" view
 
             # Set the cyclomatic complexity limit to 20
-            python "metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20
+            python "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20
 
             # Fail if there are functions with cyclomatic complexity larger than 95
             set -o errexit
-            python "metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:95
+            python "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:95
 
 buildvariants:
 


### PR DESCRIPTION
Modified the setup for the code complexity measurements (by moving the install of Metrix++ to outside the 'src' directory. This ensures that our complexity measurements don't accidentally include the Metrix++ source code too.