### PR TITLE
WT-7871 Remove barrier comment that is no longer true (v4.2 backport)

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -718,8 +718,6 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
      * Get a generation for this split, mark the page. This must be after the new index is swapped
      * into place in order to know that no readers with the new generation will look at the old
      * index.
-     *
-     * Getting a new split generation implies a full barrier, no additional barrier is needed.
      */
     WT_FULL_BARRIER();
     split_gen = __wt_gen(session, WT_GEN_SPLIT);
@@ -1036,8 +1034,6 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
      * Get a generation for this split, mark the parent page. This must be after the new index is
      * swapped into place in order to know that no readers with the new generation will look at the
      * old index.
-     *
-     * Getting a new split generation implies a full barrier, no additional barrier is needed.
      */
     WT_FULL_BARRIER();
     split_gen = __wt_gen(session, WT_GEN_SPLIT);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -527,8 +527,6 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
      *
      * Note: as the root page cannot currently be evicted, the root split generation isn't ever
      * used. That said, it future proofs eviction and isn't expensive enough to special-case.
-     *
-     * Getting a new split generation implies a full barrier, no additional barrier is needed.
      */
     WT_FULL_BARRIER();
     split_gen = __wt_gen(session, WT_GEN_SPLIT);


### PR DESCRIPTION
This is a bulk backport of the following related changes:

- WT-7871 Remove barrier comment that is no longer true
- WT-7874 Remove two other stale barrier comments