### PR TITLE
WT-7865 Disable timeout assert while waiting for eviction to quiesce prior to RTS and test

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1672,7 +1672,13 @@ __rollback_to_stable(WT_SESSION_IMPL *session, bool no_ckpt)
     if (retries == WT_RTS_EVICT_MAX_RETRIES) {
         WT_ERR(__wt_msg(
           session, "timed out waiting for eviction to quiesce, running rollback to stable"));
-        WT_ASSERT(session, false && "Timed out waiting for eviction to quiesce prior to rts");
+        /*
+         * FIXME: WT-7877 RTS fails when there are active transactions running in parallel to it.
+         * The above loop of waiting them to finish is not efficient in some scenarios where the
+         * cache is not cleared in 2 minutes. Enable the following assert and
+         * test_rollback_to_stable22.py when the cache issue is addressed.
+         */
+        /* WT_ASSERT(session, false && "Timed out waiting for eviction to quiesce prior to rts"); */
     }
 
     /*

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1674,7 +1674,7 @@ __rollback_to_stable(WT_SESSION_IMPL *session, bool no_ckpt)
           session, "timed out waiting for eviction to quiesce, running rollback to stable"));
         /*
          * FIXME: WT-7877 RTS fails when there are active transactions running in parallel to it.
-         * The above loop of waiting them to finish is not efficient in some scenarios where the
+         * Waiting in a loop for eviction to quiesce is not efficient in some scenarios where the
          * cache is not cleared in 2 minutes. Enable the following assert and
          * test_rollback_to_stable22.py when the cache issue is addressed.
          */

--- a/test/suite/test_rollback_to_stable22.py
+++ b/test/suite/test_rollback_to_stable22.py
@@ -46,6 +46,8 @@ class test_rollback_to_stable22(test_rollback_to_stable_base):
         nrows = 1000
         nds = 10
 
+        self.skipTest('Skip it until the fix is provided to handle concurrent internal transactions running in parallel.')
+
         # Create a few tables and populate them with some initial data.
         #
         # Our way of preventing history store operations from interfering with rollback to stable's


### PR DESCRIPTION
Enable this assert and the test once the reason behind the active transactions
that are still clearing the cache for more than two minutes in an idle system of 
no more operations.