### PR TITLE
WT-7842 Remove explicit ulimit call for many-coll-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2606,8 +2606,6 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            sudo su
-            ulimit -n 1000000
             export "PATH=/opt/mongodbtoolchain/v3/bin:$PATH"
             virtualenv -p python3 venv
             source venv/bin/activate


### PR DESCRIPTION
`ulimit -n 1000000` is no longer needed as it is by default now.