### PR TITLE
WT-7901 test suite cleanup

### DIFF
--- a/test/suite/test_assert01.py
+++ b/test/suite/test_assert01.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert01(wttest.WiredTigerTestCase, suite_subprocess):
     base = 'assert01'
     base_uri = 'file:' + base
@@ -63,7 +60,7 @@ class test_assert01(wttest.WiredTigerTestCase, suite_subprocess):
         # Commit with a timestamp
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(self.count))
+            'commit_timestamp=' + self.timestamp_str(self.count))
         c[key] = val
         # All settings other than never should commit successfully
         if (use_ts != 'never'):

--- a/test/suite/test_assert02.py
+++ b/test/suite/test_assert02.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert02(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 
@@ -68,7 +65,7 @@ class test_assert02(wttest.WiredTigerTestCase, suite_subprocess):
         c_never = self.session.open_cursor(uri_never)
         c_none = self.session.open_cursor(uri_none)
         self.session.begin_transaction()
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(1))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(1))
         c_always['key1'] = 'value1'
         c_def['key1'] = 'value1'
         c_never['key1'] = 'value1'
@@ -91,7 +88,7 @@ class test_assert02(wttest.WiredTigerTestCase, suite_subprocess):
         c_never.set_key('key1')
         c_none.set_key('key1')
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(1))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(1))
         c_always.search()
         c_def.search()
         c_none.search()

--- a/test/suite/test_assert04.py
+++ b/test/suite/test_assert04.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 
@@ -56,7 +53,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(2))
+            'commit_timestamp=' + self.timestamp_str(2))
         c['key_ts1'] = 'value2'
         self.session.commit_transaction()
         c.close()
@@ -65,7 +62,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(1))
+            'commit_timestamp=' + self.timestamp_str(1))
         c['key_ts1'] = 'value1'
         self.session.commit_transaction()
         c.close()
@@ -81,7 +78,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(2))
+            'commit_timestamp=' + self.timestamp_str(2))
         c['key_nots'] = 'value2'
         self.session.commit_transaction()
         c.close()
@@ -94,7 +91,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
 
         # We must move the oldest timestamp forward in order to alter.
         # Otherwise alter closing the file will fail with EBUSY.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(2))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(2))
 
         # Now alter the setting and make sure we detect incorrect usage.
         self.session.alter(uri, cfg_on)
@@ -103,7 +100,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(5))
+            'commit_timestamp=' + self.timestamp_str(5))
         c['key_ts1'] = 'value5'
         self.session.commit_transaction()
         c.close()
@@ -111,7 +108,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(4))
+            'commit_timestamp=' + self.timestamp_str(4))
         c['key_ts1'] = 'value4'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_ooo)
@@ -138,7 +135,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(3))
+            'commit_timestamp=' + self.timestamp_str(3))
         c['key_nots'] = 'value3'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_usage)
@@ -150,7 +147,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c.close()
 
         # Now alter the setting again and detection is off.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
         self.session.alter(uri, cfg_off)
 
         # Detection is off we can successfully change the same key with and
@@ -164,7 +161,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(6))
+            'commit_timestamp=' + self.timestamp_str(6))
         c['key_nots'] = 'value6'
         self.session.commit_transaction()
         c.close()
@@ -185,7 +182,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(2))
+            'commit_timestamp=' + self.timestamp_str(2))
         c['key_ts1'] = 'value2'
         self.session.commit_transaction()
         c.close()
@@ -194,7 +191,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(1))
+            'commit_timestamp=' + self.timestamp_str(1))
         c['key_ts1'] = 'value1'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_ooo)
@@ -204,7 +201,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(1))
+            'commit_timestamp=' + self.timestamp_str(1))
         c['key_ts2'] = 'value1'
         self.session.commit_transaction()
         c.close()
@@ -218,19 +215,19 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(10))
+            'commit_timestamp=' + self.timestamp_str(10))
         c['key_ts3'] = 'value10'
         self.session.commit_transaction()
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(15))
+            'commit_timestamp=' + self.timestamp_str(15))
         c['key_ts4'] = 'value15'
         self.session.commit_transaction()
 
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(13))
+            'commit_timestamp=' + self.timestamp_str(13))
         c['key_ts3'] = 'value13'
         c['key_ts4'] = 'value13'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
@@ -249,14 +246,14 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(13))
+            'commit_timestamp=' + self.timestamp_str(13))
         c['key_ts3'] = 'value13'
         self.session.commit_transaction()
 
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(13))
+            'commit_timestamp=' + self.timestamp_str(13))
         c['key_ts4'] = 'value13'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_ooo)
@@ -268,7 +265,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(14))
+            'commit_timestamp=' + self.timestamp_str(14))
         c['key_ts4'] = 'value14'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_ooo)
@@ -280,7 +277,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(16))
+            'commit_timestamp=' + self.timestamp_str(16))
         c['key_ts4'] = 'value16'
         self.session.commit_transaction()
         c.close()
@@ -319,7 +316,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(16))
+            'commit_timestamp=' + self.timestamp_str(16))
         c['key_nots'] = 'value16'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_usage)
@@ -334,7 +331,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(17))
+            'commit_timestamp=' + self.timestamp_str(17))
         c['key_nots'] = 'value17'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(), msg_usage)
@@ -350,7 +347,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         c['key_ts5'] = 'value_notsyet'
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(20))
+            'commit_timestamp=' + self.timestamp_str(20))
         c['key_ts5'] = 'value20'
         self.session.commit_transaction()
         c.close()
@@ -364,7 +361,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c['key_ts6'] = 'value_notsyet'
         c['key_ts6'] = 'value21_after'
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(21))
+            'commit_timestamp=' + self.timestamp_str(21))
         self.session.commit_transaction()
         c.close()
 
@@ -379,7 +376,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c['key_ts6'] = 'value_committs1'
         c['key_ts6'] = 'value22'
         self.session.commit_transaction('commit_timestamp=' +
-            timestamp_str(22))
+            self.timestamp_str(22))
         c.close()
 
         c = self.session.open_cursor(uri)
@@ -387,7 +384,7 @@ class test_assert04(wttest.WiredTigerTestCase, suite_subprocess):
         c['key_nots'] = 'value23'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(23)), msg_usage)
+            'commit_timestamp=' + self.timestamp_str(23)), msg_usage)
         c.close()
 
 if __name__ == '__main__':

--- a/test/suite/test_assert05.py
+++ b/test/suite/test_assert05.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert05(wttest.WiredTigerTestCase, suite_subprocess):
     base = 'assert05'
     base_uri = 'file:' + base
@@ -64,11 +61,11 @@ class test_assert05(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         c[key] = val
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(self.count))
+            'prepare_timestamp=' + self.timestamp_str(self.count))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(self.count))
+            'commit_timestamp=' + self.timestamp_str(self.count))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(self.count))
+            'durable_timestamp=' + self.timestamp_str(self.count))
         # All settings other than never should commit successfully
         if (use_ts != 'never'):
             self.session.commit_transaction()
@@ -93,10 +90,10 @@ class test_assert05(wttest.WiredTigerTestCase, suite_subprocess):
         c[key] = val
         if (use_ts == 'always'):
             self.session.prepare_transaction(
-                'prepare_timestamp=' + timestamp_str(self.count))
+                'prepare_timestamp=' + self.timestamp_str(self.count))
 
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(self.count))
+            'commit_timestamp=' + self.timestamp_str(self.count))
         # All settings other than always should commit successfully
         if (use_ts != 'always' and use_ts != 'never'):
             self.session.commit_transaction()

--- a/test/suite/test_assert06.py
+++ b/test/suite/test_assert06.py
@@ -33,19 +33,16 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 
     def apply_timestamps(self, timestamp):
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(timestamp))
+            'prepare_timestamp=' + self.timestamp_str(timestamp))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(timestamp))
+            'commit_timestamp=' + self.timestamp_str(timestamp))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(timestamp))
+            'durable_timestamp=' + self.timestamp_str(timestamp))
 
     def test_timestamp_alter(self):
         base = 'assert06'
@@ -98,7 +95,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
 
         # We must move the oldest timestamp forward in order to alter.
         # Otherwise alter closing the file will fail with EBUSY.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(2))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(2))
 
         # Now alter the setting and make sure we detect incorrect usage.
         self.session.alter(uri, cfg_on)
@@ -161,7 +158,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Test to make sure that key consistency can be turned off
         # after turning it on.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
         self.session.alter(uri, cfg_off)
 
         # Detection is off we can successfully change the same key with and
@@ -399,11 +396,11 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         c['key_ts6'] = 'value_committs1'
         c['key_ts6'] = 'value22'
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(22))
+            'prepare_timestamp=' + self.timestamp_str(22))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(22))
+            'commit_timestamp=' + self.timestamp_str(22))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(22))
+            'durable_timestamp=' + self.timestamp_str(22))
         self.session.commit_transaction()
         c.close()
 
@@ -414,12 +411,12 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         c['key_nots'] = 'value23'
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(23))
+            'prepare_timestamp=' + self.timestamp_str(23))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(23))
+            'commit_timestamp=' + self.timestamp_str(23))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-            'durable_timestamp=' + timestamp_str(23)), msg_usage)
+            'durable_timestamp=' + self.timestamp_str(23)), msg_usage)
         c.close()
         '''
 

--- a/test/suite/test_assert07.py
+++ b/test/suite/test_assert07.py
@@ -34,17 +34,14 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
     def apply_timestamps(self, timestamp):
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(timestamp))
+            'prepare_timestamp=' + self.timestamp_str(timestamp))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(timestamp))
+            'commit_timestamp=' + self.timestamp_str(timestamp))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(timestamp))
+            'durable_timestamp=' + self.timestamp_str(timestamp))
 
     def test_timestamp_alter(self):
         base = 'assert07'

--- a/test/suite/test_backup08.py
+++ b/test/suite/test_backup08.py
@@ -34,9 +34,6 @@ import os, shutil
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_backup08(wttest.WiredTigerTestCase):
     conn_config = 'config_base=false,create,log=(enabled)'
     session_config = 'isolation=snapshot'
@@ -85,12 +82,12 @@ class test_backup08(wttest.WiredTigerTestCase):
                 curs[i] = i
                 self.pr("i: " + str(i))
                 self.session.commit_transaction(
-                  'commit_timestamp=' + timestamp_str(i))
+                  'commit_timestamp=' + self.timestamp_str(i))
             # Set the oldest and stable timestamp a bit earlier than the data
             # we inserted. Take a checkpoint to the stable timestamp.
             self.pr("stable ts: " + str(ts))
-            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(ts) +
-                ',stable_timestamp=' + timestamp_str(ts))
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(ts) +
+                ',stable_timestamp=' + self.timestamp_str(ts))
             # This forces a different checkpoint timestamp for each table.
             # Default is to use the stable timestamp.
             expected = ts
@@ -102,7 +99,7 @@ class test_backup08(wttest.WiredTigerTestCase):
                 ckpt_config = 'use_timestamp=true'
             self.session.checkpoint(ckpt_config)
             q = self.conn.query_timestamp('get=last_checkpoint')
-            self.assertTimestampsEqual(q, timestamp_str(expected))
+            self.assertTimestampsEqual(q, self.timestamp_str(expected))
         return expected
 
     def backup_and_recover(self, expected_rec_ts):
@@ -123,7 +120,7 @@ class test_backup08(wttest.WiredTigerTestCase):
         backup_conn = self.wiredtiger_open(self.dir)
         q = backup_conn.query_timestamp('get=recovery')
         self.pr("query recovery ts: " + q)
-        self.assertTimestampsEqual(q, timestamp_str(expected_rec_ts))
+        self.assertTimestampsEqual(q, self.timestamp_str(expected_rec_ts))
 
     def test_timestamp_backup(self):
         # Add some data and checkpoint using the timestamp or not

--- a/test/suite/test_bug022.py
+++ b/test/suite/test_bug022.py
@@ -31,9 +31,6 @@
 
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_bug022(wttest.WiredTigerTestCase):
     uri = 'file:test_bug022'
     conn_config = 'cache_size=50MB'
@@ -41,21 +38,21 @@ class test_bug022(wttest.WiredTigerTestCase):
 
     def test_apply_modifies_on_onpage_tombstone(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
 
         value = 'a' * 500
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[str(i)] = value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Apply tombstones for every key.
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor.set_key(str(i))
             cursor.remove()
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         self.session.checkpoint()
 

--- a/test/suite/test_checkpoint03.py
+++ b/test/suite/test_checkpoint03.py
@@ -39,9 +39,6 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_checkpoint03(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_checkpoint03'
     conn_config = 'statistics=(all)'

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -33,9 +33,6 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_checkpoint04(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint06.py
+++ b/test/suite/test_checkpoint06.py
@@ -29,9 +29,6 @@
 import time
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_checkpoint06.py
 # Verify that we rollback the truncation that is committed after stable
 # timestamp in the checkpoint.
@@ -44,14 +41,14 @@ class test_checkpoint06(wttest.WiredTigerTestCase):
         self.session.create(self.uri, 'key_format=i,value_format=S')
 
         value = "abcdefghijklmnopqrstuvwxyz" * 3
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         # Setup: Insert some data
         for i in range(10000):
             cursor[i] = value
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
 
         # Flush everything to disk
         self.reopen_conn()
@@ -63,7 +60,7 @@ class test_checkpoint06(wttest.WiredTigerTestCase):
         end = self.session.open_cursor(self.uri)
         end.set_key(9995)
         self.session.truncate(None, start, None, None)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Do a checkpoint
         self.session.checkpoint()

--- a/test/suite/test_checkpoint07.py
+++ b/test/suite/test_checkpoint07.py
@@ -33,9 +33,6 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_checkpoint07(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint08.py
+++ b/test/suite/test_checkpoint08.py
@@ -37,9 +37,6 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_checkpoint08(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -61,8 +58,8 @@ class test_checkpoint08(wttest.WiredTigerTestCase):
         self.session.create(self.uri2, 'key_format=i,value_format=i')
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         # Setup: Insert some data and checkpoint it. Then modify only
         # the data in the first table and checkpoint. Verify the clean skip
@@ -73,23 +70,23 @@ class test_checkpoint08(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         c1[1] = 1
         c2[1] = 1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         self.session.begin_transaction()
         c1[1] = 10
         c2[1] = 10
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(3))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
         self.session.checkpoint(None)
 
         # Modify the both tables and reverify.
         self.session.begin_transaction()
         c1[3] = 3
         c2[3] = 3
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(4))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4))
         self.session.checkpoint(None)
 
         val = self.get_stat(self.uri1)
@@ -100,13 +97,13 @@ class test_checkpoint08(wttest.WiredTigerTestCase):
         self.assertNotEqual(hsval, 0)
 
         # Modify the both tables and reverify when oldest timestamp moved.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(4))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(4))
         self.session.begin_transaction()
         c1[4] = 4
         c2[4] = 4
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
         self.session.checkpoint(None)
 
         val = self.get_stat(self.uri1)

--- a/test/suite/test_checkpoint_snapshot01.py
+++ b/test/suite/test_checkpoint_snapshot01.py
@@ -42,7 +42,7 @@ from wiredtiger import stat
 #
 
 class test_checkpoint_snapshot01(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,statistics=(fast)'
+    conn_config = 'cache_size=50MB'
 
     # Create a table.
     uri = "table:test_checkpoint_snapshot01"

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -38,9 +38,6 @@ from wiredtiger import stat
 #   This test is to run checkpoint and eviction in parallel with timing
 #   stress for checkpoint and let eviction write more data than checkpoint.
 #
-
-def timestamp_str(t):
-    return '%x' % t
 class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
 
     # Create a table.
@@ -68,7 +65,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             if commit_ts == 0:
                 session.commit_transaction()
             else:
-                session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def check(self, check_value, uri, nrows, read_ts):
@@ -76,7 +73,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         if read_ts == 0:
             session.begin_transaction()
         else:
-            session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -137,8 +134,8 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         valuea = "aaaaa" * 100
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         self.large_updates(self.uri, valuea, ds, self.nrows, 20)
         self.check(valuea, self.uri, self.nrows, 20)
@@ -151,10 +148,10 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             cursor1.set_key(ds.key(i))
             cursor1.set_value(valuea)
             self.assertEqual(cursor1.insert(), 0)
-        session1.timestamp_transaction('commit_timestamp=' + timestamp_str(30))
+        session1.timestamp_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         # Set stable timestamp to 40
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         # Create a checkpoint thread
         done = threading.Event()
@@ -191,8 +188,8 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         valueb = "bbbbb" * 100
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         session1 = self.conn.open_session()
         session1.begin_transaction()
@@ -208,10 +205,10 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             cursor2.set_key(ds.key(i))
             cursor2.set_value(valuea)
             self.assertEqual(cursor2.insert(), 0)
-        session1.timestamp_transaction('commit_timestamp=' + timestamp_str(30))
+        session1.timestamp_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         # Set stable timestamp to 40
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         # Create a checkpoint thread
         done = threading.Event()

--- a/test/suite/test_compress02.py
+++ b/test/suite/test_compress02.py
@@ -39,11 +39,7 @@ from wiredtiger import stat
 #   we are using zstd as the block compressor. Tables created before reconfiguration
 #   will still use the previous compression level.
 #
-
-def timestamp_str(t):
-    return '%x' % t
 class test_compress02(wttest.WiredTigerTestCase):
-
     # Create a table.
     uri = "table:test_compress02"
     nrows = 1000

--- a/test/suite/test_config07.py
+++ b/test/suite/test_config07.py
@@ -83,7 +83,7 @@ class test_config07(wttest.WiredTigerTestCase):
         msg = '/invalid log extend length/'
 
         config = 'log=(enabled,file_max=1M),file_extend=' + self.log_extend_len
-        configarg = 'create,statistics=(fast)' + ',' + config
+        configarg = 'create,' + config
 
         # Expect an error when an invalid log extend size is provided.
         if self.expected_log_size is None:

--- a/test/suite/test_cursor15.py
+++ b/test/suite/test_cursor15.py
@@ -37,7 +37,7 @@ class test_cursor15(wttest.WiredTigerTestCase):
     tablename = 'test_read_once'
     uri = 'table:' + tablename
 
-    conn_config = 'cache_size=1M,statistics=(all)'
+    conn_config = 'cache_size=1M'
 
     def test_cursor15(self):
         # This test is configured to use 1MB of cache. It will insert 20
@@ -51,7 +51,7 @@ class test_cursor15(wttest.WiredTigerTestCase):
             cursor[key] = '1' * (100 * 1024)
         cursor.close()
 
-        # Restart the database to clear the cache and reset statistics.
+        # Restart the database to clear the cache.
         self.reopen_conn()
 
         # We don't restart the database between runs to exercise that read_once

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -28,9 +28,6 @@
 
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_debug_mode05.py
 #     As per WT-5046, the debug table logging settings prevent rollback to
 #     stable in the presence of prepared transactions.
@@ -44,7 +41,7 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
     def test_table_logging_rollback_to_stable(self):
         self.session.create(self.uri, 'key_format=i,value_format=u,log=(enabled=false)')
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.session.checkpoint()
 
         # Try doing a normal prepared txn and then rollback to stable.
@@ -53,11 +50,11 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         for i in range(1, 50):
             cursor[i] = b'a' * 100
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(150))
+            'prepare_timestamp=' + self.timestamp_str(150))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(200))
+            'commit_timestamp=' + self.timestamp_str(200))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(250))
+            'durable_timestamp=' + self.timestamp_str(250))
         self.session.commit_transaction()
         cursor.close()
 
@@ -70,11 +67,11 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         # Therefore, we're specifically not doing any operations here.
         self.session.begin_transaction()
         self.session.prepare_transaction(
-            'prepare_timestamp=' + timestamp_str(300))
+            'prepare_timestamp=' + self.timestamp_str(300))
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(350))
+            'commit_timestamp=' + self.timestamp_str(350))
         self.session.timestamp_transaction(
-            'durable_timestamp=' + timestamp_str(400))
+            'durable_timestamp=' + self.timestamp_str(400))
         self.session.commit_transaction()
 
         # The aforementioned bug resulted in a failure in rollback to stable.
@@ -88,7 +85,7 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         for i in range(1, 50):
             cursor[i] = b'b' * 100
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(450))
+            'commit_timestamp=' + self.timestamp_str(450))
         cursor.close()
 
         self.conn.rollback_to_stable()

--- a/test/suite/test_debug_mode07.py
+++ b/test/suite/test_debug_mode07.py
@@ -31,7 +31,7 @@ import wttest, wiredtiger
 # test_debug_mode07.py
 #   Test the debug mode settings. Test realloc_exact use (from WT-4919).
 class test_debug_mode07(wttest.WiredTigerTestCase):
-    conn_config = 'log=(enabled=true),debug_mode=(realloc_exact=true),statistics=(all)'
+    conn_config = 'log=(enabled=true),debug_mode=(realloc_exact=true)'
     uri = 'file:test_debug_mode07'
 
     # Insert some data to ensure setting/unsetting the flag does not

--- a/test/suite/test_durable_ts01.py
+++ b/test/suite/test_durable_ts01.py
@@ -31,9 +31,6 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_durable_ts01.py
 #    Checking visibility and durability of updates with durable_timestamp and
 #    with restart.
@@ -77,7 +74,7 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
         cursor = session.open_cursor(uri, None)
 
         # Set stable timestamp to checkpoint initial data set.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.session.checkpoint()
 
         # Update all values with value 111 i.e. first update value.
@@ -88,15 +85,15 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.update(), 0)
             self.assertEquals(cursor.next(), 0)
 
-        session.prepare_transaction('prepare_timestamp=' + timestamp_str(150))
-        session.timestamp_transaction('commit_timestamp=' + timestamp_str(200))
-        session.timestamp_transaction('durable_timestamp=' + timestamp_str(220))
+        session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
+        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
+        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(220))
         session.commit_transaction()
 
         # Check the values read are correct with different timestamps.
         # Read the initial dataset.
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + timestamp_str(150))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(150))
         self.assertEquals(cursor.next(), 0)
         for i in range(1, 50):
             self.assertEquals(cursor.get_value(), ds.value(i))
@@ -105,7 +102,7 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
 
         # Read the first update value with timestamp.
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + timestamp_str(200))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(200))
         self.assertEquals(cursor.next(), 0)
         for i in range(1, 50):
             self.assertEquals(cursor.get_value(), ds.value(111))
@@ -122,7 +119,7 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
         session.commit_transaction()
 
         # Set a stable timestamp so that first update value is durable.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
 
         # Update all values with value 222 i.e. second update value.
         self.assertEquals(cursor.reset(), 0)
@@ -133,12 +130,12 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.update(), 0)
             self.assertEquals(cursor.next(), 0)
 
-        session.prepare_transaction('prepare_timestamp=' + timestamp_str(200))
+        session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(200))
 
         # Commit timestamp is earlier to stable timestamp but durable timestamp
         # is later than stable timestamp. Hence second update value is not durable.
-        session.timestamp_transaction('commit_timestamp=' + timestamp_str(240))
-        session.timestamp_transaction('durable_timestamp=' + timestamp_str(300))
+        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(240))
+        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(300))
         session.commit_transaction()
 
         # Checkpoint so that first update value will be visible and durable,
@@ -159,8 +156,8 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
         self.reopen_conn()
         session = self.conn.open_session(self.session_config)
         cursor = session.open_cursor(uri, None)
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(250))
         self.assertEquals(cursor.next(), 0)
         for i in range(1, 50):
             self.assertEquals(cursor.get_value(), ds.value(111))

--- a/test/suite/test_durable_ts02.py
+++ b/test/suite/test_durable_ts02.py
@@ -31,9 +31,6 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_durable_ts03.py
 #    Checking visibility and durability of updates with durable_timestamp
 class test_durable_ts03(wttest.WiredTigerTestCase):
@@ -75,7 +72,7 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         cursor = session.open_cursor(uri, None)
 
         # Set stable timestamp to checkpoint initial data set.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.session.checkpoint()
 
         '''
@@ -90,15 +87,15 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.update(), 0)
             self.assertEquals(cursor.next(), 0)
 
-        session.prepare_transaction('prepare_timestamp=' + timestamp_str(150))
+        session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
         msg = "/is less than the commit timestamp/"
         # Check for error when commit timestamp > durable timestamp.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: session.commit_transaction('commit_timestamp=' +\
-            timestamp_str(200) + ',durable_timestamp=' + timestamp_str(180)), msg)
+            self.timestamp_str(200) + ',durable_timestamp=' + self.timestamp_str(180)), msg)
 
         # Set a stable timestamp so that first update value is durable.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
 
         # Scenario: 2
         # Check to see durable timestamp < stable timestamp, returns error.
@@ -111,13 +108,13 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.update(), 0)
             self.assertEquals(cursor.next(), 0)
 
-        session.prepare_transaction('prepare_timestamp=' + timestamp_str(150))
+        session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
 
         msg = "/is less than the stable timestamp/"
         # Check that error is returned when durable timestamp < stable timestamp.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: session.commit_transaction('commit_timestamp=' +\
-            timestamp_str(200) + ',durable_timestamp=' + timestamp_str(240)), msg)
+            self.timestamp_str(200) + ',durable_timestamp=' + self.timestamp_str(240)), msg)
         '''
 
 if __name__ == '__main__':

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -29,9 +29,6 @@
 from helper import copy_wiredtiger_home
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_durable_ts03.py
 #    Check that the checkpoint honors the durable timestamp of updates.
 class test_durable_ts03(wttest.WiredTigerTestCase):
@@ -48,8 +45,8 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         valueC = b"ccccc" * 100
 
         # Start with setting a stable and oldest timestamp.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1) + \
-                                ',oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) + \
+                                ',oldest_timestamp=' + self.timestamp_str(1))
 
         # Load the data into the table.
         session = self.conn.open_session(self.session_config)
@@ -57,12 +54,12 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             session.begin_transaction()
             cursor[i] = valueA
-            session.commit_transaction('commit_timestamp=' + timestamp_str(50))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(50))
         cursor.close()
 
         # Set the stable and the oldest timestamp to checkpoint initial data.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100) + \
-                                ',oldest_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100) + \
+                                ',oldest_timestamp=' + self.timestamp_str(100))
         self.session.checkpoint()
 
         # Update all the values within transaction. Commit the transaction with
@@ -71,9 +68,9 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             session.begin_transaction()
             cursor[i] = valueB
-            session.prepare_transaction('prepare_timestamp=' + timestamp_str(150))
-            session.timestamp_transaction('commit_timestamp=' + timestamp_str(200))
-            session.timestamp_transaction('durable_timestamp=' + timestamp_str(220))
+            session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
+            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
+            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(220))
             session.commit_transaction()
 
         # Check the checkpoint wrote only the durable updates.
@@ -83,14 +80,14 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             self.assertEqual(value, valueA)
 
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + timestamp_str(150))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(150))
         for key, value in cursor:
             self.assertEqual(value, valueA)
         session.commit_transaction()
 
         # Read the updated data to confirm that it is visible.
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + timestamp_str(210))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(210))
         for key, value in cursor:
             self.assertEqual(value, valueB)
         session.commit_transaction()
@@ -102,8 +99,8 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         self.reopen_conn()
         session = self.conn.open_session(self.session_config)
         cursor = session.open_cursor(uri, None)
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(210) + \
-                                ',oldest_timestamp=' + timestamp_str(210))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(210) + \
+                                ',oldest_timestamp=' + self.timestamp_str(210))
         for key, value in cursor:
             self.assertEqual(value, valueA)
 
@@ -111,12 +108,12 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             session.begin_transaction()
             cursor[i] = valueC
-            session.prepare_transaction('prepare_timestamp=' + timestamp_str(220))
-            session.timestamp_transaction('commit_timestamp=' + timestamp_str(230))
-            session.timestamp_transaction('durable_timestamp=' + timestamp_str(240))
+            session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(220))
+            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(230))
+            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(240))
             session.commit_transaction()
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
         self.session.checkpoint()
         cursor.close()
         session.close()
@@ -124,8 +121,8 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
         self.reopen_conn()
         session = self.conn.open_session(self.session_config)
         cursor = session.open_cursor(uri, None)
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250) + \
-                                ',oldest_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250) + \
+                                ',oldest_timestamp=' + self.timestamp_str(250))
         for key, value in cursor:
             self.assertEqual(value, valueC)
 

--- a/test/suite/test_gc01.py
+++ b/test/suite/test_gc01.py
@@ -36,11 +36,7 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wiredtiger import stat
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_gc01.py
-
 # Shared base class used by gc tests.
 class test_gc_base(wttest.WiredTigerTestCase):
 
@@ -51,7 +47,7 @@ class test_gc_base(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             session.begin_transaction()
             cursor[ds.key(i)] = value
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def large_modifies(self, uri, value, ds, location, nbytes, nrows, commit_ts):
@@ -63,12 +59,12 @@ class test_gc_base(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify(value, location, nbytes)]
             self.assertEqual(cursor.modify(mods), 0)
-        session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+        session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def check(self, check_value, uri, nrows, read_ts):
         session = self.session
-        session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -100,8 +96,8 @@ class test_gc01(test_gc_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         bigvalue2 = "ddddd" * 100
@@ -119,8 +115,8 @@ class test_gc01(test_gc_base):
         self.check(bigvalue, uri, nrows, 10)
 
         # Pin oldest and stable to timestamp 100.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(100) +
-            ',stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(100) +
+            ',stable_timestamp=' + self.timestamp_str(100))
 
         # Checkpoint to ensure that the history store is cleaned.
         self.session.checkpoint()
@@ -152,8 +148,8 @@ class test_gc01(test_gc_base):
         self.check(bigvalue2, uri, nrows, 100)
 
         # Pin oldest and stable to timestamp 200.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(200) +
-            ',stable_timestamp=' + timestamp_str(200))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(200) +
+            ',stable_timestamp=' + self.timestamp_str(200))
 
         # Checkpoint to ensure that the history store is cleaned.
         self.session.checkpoint()
@@ -185,8 +181,8 @@ class test_gc01(test_gc_base):
         self.check(bigvalue, uri, nrows, 200)
 
         # Pin oldest and stable to timestamp 300.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(300) +
-            ',stable_timestamp=' + timestamp_str(300))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(300) +
+            ',stable_timestamp=' + self.timestamp_str(300))
 
         # Checkpoint to ensure that the history store is cleaned.
         self.session.checkpoint()

--- a/test/suite/test_gc02.py
+++ b/test/suite/test_gc02.py
@@ -30,9 +30,6 @@ from test_gc01 import test_gc_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_gc02.py
 # Test that checkpoint cleans the obsolete history store internal pages.
 class test_gc02(test_gc_base):
@@ -49,8 +46,8 @@ class test_gc02(test_gc_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         bigvalue2 = "ddddd" * 100
@@ -76,8 +73,8 @@ class test_gc02(test_gc_base):
         c.close()
 
         # Pin oldest and stable to timestamp 100.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(100) +
-            ',stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(100) +
+            ',stable_timestamp=' + self.timestamp_str(100))
 
         # Check that the new updates are only seen after the update timestamp.
         self.check(bigvalue2, uri, nrows, 100)
@@ -114,8 +111,8 @@ class test_gc02(test_gc_base):
         self.check(bigvalue, uri, nrows, 200)
 
         # Pin oldest and stable to timestamp 200.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(200) +
-            ',stable_timestamp=' + timestamp_str(200))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(200) +
+            ',stable_timestamp=' + self.timestamp_str(200))
 
         # Checkpoint to ensure that the history store is cleaned.
         self.session.checkpoint()

--- a/test/suite/test_gc03.py
+++ b/test/suite/test_gc03.py
@@ -30,9 +30,6 @@ from test_gc01 import test_gc_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_gc03.py
 # Test that checkpoint cleans the obsolete history store pages that are in-memory.
 class test_gc03(test_gc_base):
@@ -61,8 +58,8 @@ class test_gc03(test_gc_base):
         ds_extra.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         bigvalue2 = "ddddd" * 100
@@ -84,8 +81,8 @@ class test_gc03(test_gc_base):
         self.assertGreater(self.get_stat(stat.conn.cc_pages_visited), 0)
 
         # Pin oldest and stable to timestamp 100.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(100) +
-            ',stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(100) +
+            ',stable_timestamp=' + self.timestamp_str(100))
 
         # Check that the new updates are only seen after the update timestamp.
         self.check(bigvalue2, uri, nrows, 100)
@@ -113,8 +110,8 @@ class test_gc03(test_gc_base):
         self.check(bigvalue2, uri, nrows, 100)
 
         # Pin oldest and stable to timestamp 200.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(200) +
-            ',stable_timestamp=' + timestamp_str(200))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(200) +
+            ',stable_timestamp=' + self.timestamp_str(200))
 
         # Update on extra table.
         self.large_updates(uri_extra, bigvalue, ds_extra, 100, 210)
@@ -129,8 +126,8 @@ class test_gc03(test_gc_base):
         self.check(bigvalue, uri, nrows, 200)
 
         # Pin oldest and stable to timestamp 300.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(300) +
-            ',stable_timestamp=' + timestamp_str(300))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(300) +
+            ',stable_timestamp=' + self.timestamp_str(300))
 
         self.large_updates(uri_extra, bigvalue, ds_extra, 100, 310)
         self.large_updates(uri_extra, bigvalue2, ds_extra, 100, 320)

--- a/test/suite/test_gc04.py
+++ b/test/suite/test_gc04.py
@@ -30,9 +30,6 @@ from test_gc01 import test_gc_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_gc04.py
 # Test that checkpoint must not clean the pages that are not obsolete.
 class test_gc04(test_gc_base):
@@ -55,8 +52,8 @@ class test_gc04(test_gc_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         bigvalue2 = "ddddd" * 100

--- a/test/suite/test_gc05.py
+++ b/test/suite/test_gc05.py
@@ -29,9 +29,6 @@
 from test_gc01 import test_gc_base
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_gc05.py
 # Verify a locked checkpoint is not removed during garbage collection.
 class test_gc05(test_gc_base):
@@ -52,8 +49,8 @@ class test_gc05(test_gc_base):
         ds.populate()
 
         # Set the oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         # Insert values with varying timestamps.
         self.large_updates(uri, value_x, ds, nrows, 20)
@@ -70,8 +67,8 @@ class test_gc05(test_gc_base):
         ckpt_cursor = self.session.open_cursor(uri, None, "checkpoint=checkpoint_one")
 
         # Move the oldest and stable timestamps to 40.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(40) +
-            ',stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(40) +
+            ',stable_timestamp=' + self.timestamp_str(40))
 
         # Insert values with varying timestamps.
         self.large_updates(uri, value_z, ds, nrows, 50)
@@ -79,8 +76,8 @@ class test_gc05(test_gc_base):
         self.large_updates(uri, value_x, ds, nrows, 70)
 
         # Move the oldest and stable timestamps to 70.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(70) +
-            ',stable_timestamp=' + timestamp_str(70))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(70) +
+            ',stable_timestamp=' + self.timestamp_str(70))
 
         # Perform a checkpoint.
         self.session.checkpoint()

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -31,9 +31,6 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs01.py
 # Smoke tests to ensure history store tables are working.
 class test_hs01(wttest.WiredTigerTestCase):
@@ -58,7 +55,7 @@ class test_hs01(wttest.WiredTigerTestCase):
             cursor.set_value(value)
             self.assertEqual(cursor.update(), 0)
             if timestamp == True:
-                session.commit_transaction('commit_timestamp=' + timestamp_str(i + 1))
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(i + 1))
         cursor.close()
 
     def large_modifies(self, session, uri, offset, ds, nrows, timestamp=False):
@@ -75,7 +72,7 @@ class test_hs01(wttest.WiredTigerTestCase):
 
             self.assertEqual(cursor.modify(mods), 0)
             if timestamp == True:
-                session.commit_transaction('commit_timestamp=' + timestamp_str(i + 1))
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(i + 1))
         cursor.close()
 
     def durable_check(self, check_value, uri, ds, nrows):
@@ -151,12 +148,12 @@ class test_hs01(wttest.WiredTigerTestCase):
         # Scenario: 3
         # Check to see if the history store is working with the old timestamp.
         bigvalue4 = b"ddddd" * 100
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.large_updates(self.session, uri, bigvalue4, ds, nrows, timestamp=True)
         # Check to see data can be see only till the stable_timestamp
         self.durable_check(bigvalue3, uri, ds, nrows)
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(i + 1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(i + 1))
         # Check that the latest data can be seen.
         self.durable_check(bigvalue4, uri, ds, nrows)
 

--- a/test/suite/test_hs02.py
+++ b/test/suite/test_hs02.py
@@ -31,9 +31,6 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs02.py
 # Test that truncate with history store entries and timestamps gives expected results.
 class test_hs02(wttest.WiredTigerTestCase):
@@ -55,12 +52,12 @@ class test_hs02(wttest.WiredTigerTestCase):
         for i in range(1, nrows + 1):
             session.begin_transaction()
             cursor[ds.key(i)] = value
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def check(self, check_value, uri, nrows, read_ts):
         session = self.session
-        session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -84,8 +81,8 @@ class test_hs02(wttest.WiredTigerTestCase):
         ds2.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         self.large_updates(uri, bigvalue, ds, nrows // 3, 1)
@@ -110,7 +107,7 @@ class test_hs02(wttest.WiredTigerTestCase):
         end.set_key(ds.key(nrows // 2))
         self.session.truncate(None, None, end)
         end.close()
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(200))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(200))
 
         # Check that the truncate is visible after commit
         self.check(bigvalue2, uri, nrows // 2, 200)

--- a/test/suite/test_hs03.py
+++ b/test/suite/test_hs03.py
@@ -32,9 +32,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs03.py
 # Ensure checkpoints don't read too unnecessary history store entries.
 class test_hs03(wttest.WiredTigerTestCase):
@@ -61,7 +58,7 @@ class test_hs03(wttest.WiredTigerTestCase):
         for i in range(nrows + 1, nrows + nops + 1):
             session.begin_transaction()
             cursor[ds.key(i)] = value
-            session.commit_transaction('commit_timestamp=' + timestamp_str(i))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(i))
         cursor.close()
 
     def test_checkpoint_hs_reads(self):
@@ -81,7 +78,7 @@ class test_hs03(wttest.WiredTigerTestCase):
 
         # Check to see the history store working with old timestamp.
         bigvalue2 = b"ddddd" * 100
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         hs_writes_start = self.get_stat(stat.conn.cache_write_hs)
         self.large_updates(self.session, uri, bigvalue2, ds, nrows, 10000)
 
@@ -91,7 +88,7 @@ class test_hs03(wttest.WiredTigerTestCase):
         self.assertGreaterEqual(hs_writes, 0)
 
         for ts in range(2, 4):
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(ts))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(ts))
 
             # Now just update one record and checkpoint again.
             self.large_updates(self.session, uri, bigvalue2, ds, nrows, 1)

--- a/test/suite/test_hs07.py
+++ b/test/suite/test_hs07.py
@@ -32,9 +32,6 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs07.py
 # Test that the history store sweep cleans the obsolete history store entries and gives expected results.
 class test_hs07(wttest.WiredTigerTestCase):
@@ -56,12 +53,12 @@ class test_hs07(wttest.WiredTigerTestCase):
         for i in range(1, nrows + 1):
             session.begin_transaction()
             cursor[ds.key(i)] = value
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def check(self, check_value, uri, nrows, read_ts):
         session = self.session
-        session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -85,8 +82,8 @@ class test_hs07(wttest.WiredTigerTestCase):
         ds2.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         bigvalue = "aaaaa" * 100
         bigvalue2 = "ddddd" * 100
@@ -102,8 +99,8 @@ class test_hs07(wttest.WiredTigerTestCase):
         self.check(bigvalue, uri, nrows, 100)
 
         # Pin oldest and stable to timestamp 100.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(100) +
-            ',stable_timestamp=' + timestamp_str(100))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(100) +
+            ',stable_timestamp=' + self.timestamp_str(100))
 
         # Sleep here to let that sweep server to trigger cleanup of obsolete entries.
         time.sleep(10)
@@ -118,7 +115,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('A', 10, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(110))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(110))
 
         # Load a slight modification with a later timestamp.
         self.session.begin_transaction()
@@ -126,7 +123,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('B', 20, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(120))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(120))
 
         # Load a slight modification with a later timestamp.
         self.session.begin_transaction()
@@ -134,7 +131,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('C', 30, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(130))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(130))
         cursor.close()
 
         # Second set of update operations with increased timestamp
@@ -147,8 +144,8 @@ class test_hs07(wttest.WiredTigerTestCase):
         self.check(bigvalue2, uri, nrows, 200)
 
         # Pin oldest and stable to timestamp 300.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(200) +
-            ',stable_timestamp=' + timestamp_str(200))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(200) +
+            ',stable_timestamp=' + self.timestamp_str(200))
 
         # Sleep here to let that sweep server to trigger cleanup of obsolete entries.
         time.sleep(10)
@@ -163,7 +160,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('A', 10, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(210))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(210))
 
         # Load a slight modification with a later timestamp.
         self.session.begin_transaction()
@@ -171,7 +168,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('B', 20, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(220))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(220))
 
         # Load a slight modification with a later timestamp.
         self.session.begin_transaction()
@@ -179,7 +176,7 @@ class test_hs07(wttest.WiredTigerTestCase):
             cursor.set_key(i)
             mods = [wiredtiger.Modify('C', 30, 1)]
             self.assertEqual(cursor.modify(mods), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(230))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(230))
         cursor.close()
 
         # Third set of update operations with increased timestamp
@@ -192,8 +189,8 @@ class test_hs07(wttest.WiredTigerTestCase):
         self.check(bigvalue, uri, nrows, 300)
 
         # Pin oldest and stable to timestamp 400.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(300) +
-            ',stable_timestamp=' + timestamp_str(300))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(300) +
+            ',stable_timestamp=' + self.timestamp_str(300))
 
         # Sleep here to let that sweep server to trigger cleanup of obsolete entries.
         time.sleep(10)

--- a/test/suite/test_hs09.py
+++ b/test/suite/test_hs09.py
@@ -42,7 +42,7 @@ def timestamp_str(t):
 # second newest committed version to history store.
 class test_hs09(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=20MB,statistics=(fast)'
+    conn_config = 'cache_size=20MB'
     session_config = 'isolation=snapshot'
     uri = "table:test_hs09"
     key_format_values = [

--- a/test/suite/test_hs09.py
+++ b/test/suite/test_hs09.py
@@ -34,9 +34,6 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs09.py
 # Verify that we write the newest committed version to data store and the
 # second newest committed version to history store.
@@ -101,18 +98,18 @@ class test_hs09(wttest.WiredTigerTestCase):
         value3 = 'c' * 500
 
         # Load 500KB of data.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Load another 500KB of data with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Uncommitted changes.
         self.session.begin_transaction()
@@ -136,30 +133,30 @@ class test_hs09(wttest.WiredTigerTestCase):
         value3 = 'c' * 500
 
         # Load 1MB of data.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for i in range(1, 2000):
             cursor[self.create_key(i)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Load another 1MB of data with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 2000):
             cursor[self.create_key(i)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Prepare some updates.
         self.session.begin_transaction()
         for i in range(1, 11):
             cursor[self.create_key(i)] = value3
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(4))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(4))
 
         # We can expect prepared values to show up in data store if the eviction runs between now
         # and the time when we open a cursor on the user table.
         self.check_ckpt_hs(value2, value1, 2, 3, True)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5) +
-            ',durable_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5) +
+            ',durable_timestamp=' + self.timestamp_str(5))
 
     def test_write_newest_version_to_data_store(self):
         # Create a small table.
@@ -170,18 +167,18 @@ class test_hs09(wttest.WiredTigerTestCase):
         value2 = 'b' * 500
 
         # Load 500KB of data.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Load another 500KB of data with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         self.check_ckpt_hs(value2, value1, 2, 3)
 
@@ -194,18 +191,18 @@ class test_hs09(wttest.WiredTigerTestCase):
         value2 = 'b' * 500
 
         # Load 500KB of data.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Load another 500KB of data with a later timestamp.
         self.session.begin_transaction()
         for i in range(1, 1000):
             cursor[self.create_key(i)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Delete records.
         self.session.begin_transaction()
@@ -213,7 +210,7 @@ class test_hs09(wttest.WiredTigerTestCase):
             cursor = self.session.open_cursor(self.uri)
             cursor.set_key(self.create_key(i))
             self.assertEqual(cursor.remove(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
         self.check_ckpt_hs(value2, value1, 2, 3)
 

--- a/test/suite/test_hs10.py
+++ b/test/suite/test_hs10.py
@@ -30,9 +30,6 @@ import wiredtiger, wttest, time
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs10.py
 # Verify modify read after eviction.
 class test_hs10(wttest.WiredTigerTestCase):
@@ -61,28 +58,28 @@ class test_hs10(wttest.WiredTigerTestCase):
         session2.create(uri2, create_params)
         cursor2 = session2.open_cursor(uri2)
         # Insert a full value.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
         cursor[1] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Insert 3 modifies in separate transactions.
         self.session.begin_transaction()
         cursor.set_key(1)
         self.assertEqual(cursor.modify([wiredtiger.Modify('A', 1000, 1)]), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         self.session.begin_transaction()
         cursor.set_key(1)
         self.assertEqual(cursor.modify([wiredtiger.Modify('B', 1001, 1)]), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
         self.session.begin_transaction()
         cursor.set_key(1)
         self.assertEqual(cursor.modify([wiredtiger.Modify('C', 1002, 1)]), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
         self.session.checkpoint()
 
         # Insert a whole bunch of data into the other table to force wiredtiger to evict data
@@ -91,20 +88,20 @@ class test_hs10(wttest.WiredTigerTestCase):
             cursor2[i] = value2
 
         # Validate that we see the correct value at each of the timestamps.
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(3))
         cursor.set_key(1)
         cursor.search()
         self.assertEqual(cursor[1], value1 + 'A')
         self.session.commit_transaction()
 
         cursor2 = self.session.open_cursor(uri)
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(4))
         cursor2.set_key(1)
         cursor2.search()
         self.assertEqual(cursor2.get_value(), value1 + 'AB')
         self.session.commit_transaction()
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(5))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(5))
         self.assertEqual(cursor[1], value1 + 'ABC')
         self.session.commit_transaction()
 

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -30,9 +30,6 @@ import wiredtiger, wttest
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs11.py
 # Ensure that updates without timestamps clear the history store records.
 class test_hs11(wttest.WiredTigerTestCase):
@@ -68,13 +65,13 @@ class test_hs11(wttest.WiredTigerTestCase):
         value2 = 'b' * 500
 
         # Apply a series of updates from timestamps 1-4.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
         for ts in range(1, 5):
             for i in range(1, 10000):
                 self.session.begin_transaction()
                 cursor[self.create_key(i)] = value1
-                self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
@@ -95,7 +92,7 @@ class test_hs11(wttest.WiredTigerTestCase):
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value2
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # FIXME-WT-7120: Remove for column store until rollback to stable is implemented for column
         # store.
@@ -104,7 +101,7 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Ensure that we blew away history store content.
         for ts in range(1, 5):
-            self.session.begin_transaction('read_timestamp=' + timestamp_str(ts))
+            self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
             for i in range(1, 10000):
                 if i % 2 == 0:
                     if self.update_type == 'deletion':
@@ -129,13 +126,13 @@ class test_hs11(wttest.WiredTigerTestCase):
         value2 = 'b' * 500
 
         # Apply a series of updates from timestamps 1-4.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
         for ts in range(1, 5):
             for i in range(1, 10000):
                 self.session.begin_transaction()
                 cursor[self.create_key(i)] = value1
-                self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
@@ -146,20 +143,20 @@ class test_hs11(wttest.WiredTigerTestCase):
                 self.session.begin_transaction()
                 cursor.set_key(self.create_key(i))
                 cursor.remove()
-                self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Reconcile and remove the obsolete entries.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.session.checkpoint()
 
         # Now apply an update at timestamp 20.
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value2
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Ensure that we didn't select old history store content even if it is not blew away.
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(10))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
         for i in range(1, 10000):
             if i % 2 == 0:
                 cursor.set_key(self.create_key(i))

--- a/test/suite/test_hs12.py
+++ b/test/suite/test_hs12.py
@@ -29,13 +29,10 @@
 import wiredtiger, wttest, time
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs12.py
 # Verify we can correctly append modifies to the end of string values
 class test_hs12(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=2MB,statistics=(all),eviction=(threads_max=1)'
+    conn_config = 'cache_size=2MB,eviction=(threads_max=1)'
     session_config = 'isolation=snapshot'
     key_format_values = [
         # FIXME-WT-7120: The commented columnar tests needs to be enabled once columnar

--- a/test/suite/test_hs13.py
+++ b/test/suite/test_hs13.py
@@ -29,13 +29,10 @@
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs13.py
 # Verify reverse modify traversal after eviction.
 class test_hs13(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=2MB,statistics=(all),eviction=(threads_max=1)'
+    conn_config = 'cache_size=2MB,eviction=(threads_max=1)'
     session_config = 'isolation=snapshot'
     key_format_values = [
         # FIXME-WT-5550: The commented columnar tests needs to be enabled once columnar modify type

--- a/test/suite/test_hs14.py
+++ b/test/suite/test_hs14.py
@@ -29,9 +29,6 @@
 import time, wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs14.py
 # Ensure that point in time reads with few visible history store records don't
 # damage performance.
@@ -52,7 +49,7 @@ class test_hs14(wttest.WiredTigerTestCase):
     def test_hs14(self):
         uri = 'table:test_hs14'
         self.session.create(uri, 'key_format={},value_format=S'.format(self.key_format))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
 
         value1 = 'a' * 500
@@ -64,22 +61,22 @@ class test_hs14(wttest.WiredTigerTestCase):
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value1
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value2
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value3
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value4
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
         # A checkpoint will ensure that older values are written to the history store.
         self.session.checkpoint()
 
         start = time.time()
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(3))
         for i in range(1, 10000):
             self.assertEqual(cursor[self.create_key(i)], value3)
         self.session.rollback_transaction()
@@ -92,16 +89,16 @@ class test_hs14(wttest.WiredTigerTestCase):
             self.session.begin_transaction()
             cursor.set_key(self.create_key(i))
             cursor.remove()
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
             self.session.begin_transaction()
             cursor[self.create_key(i)] = value5
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # A checkpoint will ensure that older values are written to the history store.
         self.session.checkpoint()
 
         start = time.time()
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(9))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(9))
         for i in range(1, 10000):
             cursor.set_key(self.create_key(i))
             self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)

--- a/test/suite/test_hs16.py
+++ b/test/suite/test_hs16.py
@@ -29,9 +29,6 @@
 import time, wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs16.py
 # Ensure that we don't panic when inserting an update without timestamp to the history store.
 class test_hs16(wttest.WiredTigerTestCase):
@@ -62,7 +59,7 @@ class test_hs16(wttest.WiredTigerTestCase):
         # Update an update at timestamp 1
         self.session.begin_transaction()
         cursor[self.create_key(1)] = 'b'
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(1))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
 
         # Open anther session to make the next update without timestamp non-globally visible
         session2 = self.setUpSessionOpen(self.conn)
@@ -78,7 +75,7 @@ class test_hs16(wttest.WiredTigerTestCase):
         # Update an update at timestamp 2
         self.session.begin_transaction()
         cursor[self.create_key(1)] = 'd'
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Do a checkpoint, it should not panic
         self.session.checkpoint()

--- a/test/suite/test_hs18.py
+++ b/test/suite/test_hs18.py
@@ -29,9 +29,6 @@
 import time, wiredtiger, wttest, unittest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs18.py
 # Test various older reader scenarios
 class test_hs18(wttest.WiredTigerTestCase):
@@ -76,7 +73,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 3
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value0
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Start a long running transaction which could see update 0.
         session2.begin_transaction()
@@ -85,12 +82,12 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Insert another update at timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Insert a bunch of contents to fill the cache
         for i in range(2000, 10000):
@@ -106,7 +103,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 15
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value5
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Check our value is still correct.
         self.check_value(cursor2, value0)
@@ -144,20 +141,20 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 3
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Start a long running transaction which could see update 0.
-        session2.begin_transaction('read_timestamp=' + timestamp_str(5))
+        session2.begin_transaction('read_timestamp=' + self.timestamp_str(5))
         # Check our value is still correct.
         self.check_value(cursor2, value1)
 
         # Insert another update at timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Start a long running transaction which could see update 0.
-        session3.begin_transaction('read_timestamp=' + timestamp_str(5))
+        session3.begin_transaction('read_timestamp=' + self.timestamp_str(5))
         # Check our value is still correct.
         self.check_value(cursor3, value1)
 
@@ -175,7 +172,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 15
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value5
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Check our value is still correct.
         self.check_value(cursor2, value1)
@@ -219,12 +216,12 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Insert another update at timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Insert a bunch of other contents to trigger eviction
         for i in range(2, 10000):
@@ -274,7 +271,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 3
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[0]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Start a transaction that will see update 0.
         self.start_txn(sessions, cursors, values, 0)
@@ -282,7 +279,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[1]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Start a transaction that will see update 1.
         self.start_txn(sessions, cursors, values, 1)
@@ -290,7 +287,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert another update at timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[2]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Start a transaction that will see update 2.
         self.start_txn(sessions, cursors, values, 2)
@@ -312,7 +309,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 15
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[4]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Insert a bunch of other contents to trigger eviction
         for i in range(10001, 20000):
@@ -351,7 +348,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 3
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[0]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Start a transaction that will see update 0.
         self.start_txn(sessions, cursors, values, 0)
@@ -359,7 +356,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[1]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Start a transaction that will see update 1.
         self.start_txn(sessions, cursors, values, 1)
@@ -367,7 +364,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert another update at timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[2]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Start a transaction that will see update 2.
         self.start_txn(sessions, cursors, values, 2)
@@ -389,7 +386,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[4]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Start a transaction that will see update 4.
         self.start_txn(sessions, cursors, values, 4)
@@ -397,7 +394,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 10
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[5]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Start a transaction that will see update 5.
         self.start_txn(sessions, cursors, values, 5)
@@ -405,7 +402,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 15
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[6]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Start a transaction that will see update 6.
         self.start_txn(sessions, cursors, values, 6)
@@ -434,7 +431,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Commit an update with timestamp 5
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[8]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         # Insert a bunch of other contents to trigger eviction
         for i in range(10001, 20000):
@@ -480,7 +477,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         # Insert an update at timestamp 3
         self.session.begin_transaction()
         cursor[self.create_key(1)] = values[0]
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Start a long running transaction which could see update 0.
         self.start_txn(sessions, cursors, values, 0)
@@ -489,7 +486,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         cursor.set_key(self.create_key(1))
         cursor.modify([wiredtiger.Modify('a', 0, 0)])
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
 
         session_ts_reader.begin_transaction('read_timestamp=3')
         self.check_value(cursor_ts_reader, values[0])
@@ -501,7 +498,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         cursor.set_key(self.create_key(1))
         cursor.modify([wiredtiger.Modify('b', 0, 0)])
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Start a long running transaction which could see modify 1.
         self.start_txn(sessions, cursors, values, 2)
@@ -524,7 +521,7 @@ class test_hs18(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         cursor.set_key(self.create_key(1))
         cursor.modify([wiredtiger.Modify('e', 0, 0)])
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Start a long running transaction which could see modify 2.
         sessions[4].begin_transaction()

--- a/test/suite/test_hs22.py
+++ b/test/suite/test_hs22.py
@@ -28,9 +28,6 @@
 
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs22.py
 # Test the case that out of order timestamp
 # update is followed by a tombstone.
@@ -43,7 +40,7 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + timestamp_str(1) + ',stable_timestamp=' + timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
 
         value1 = 'a'
         value2 = 'b'
@@ -51,30 +48,30 @@ class test_hs22(wttest.WiredTigerTestCase):
         # Insert a key.
         self.session.begin_transaction()
         cursor[str(0)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Remove the key.
         self.session.begin_transaction()
         cursor.set_key(str(0))
         self.assertEqual(cursor.remove(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Do an out of order timestamp
         # update and write it to the data
         # store later.
         self.session.begin_transaction()
         cursor[str(0)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Insert another key.
         self.session.begin_transaction()
         cursor[str(1)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Update the key.
         self.session.begin_transaction()
         cursor[str(1)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         # Do a checkpoint to trigger
         # history store reconciliation.
@@ -83,13 +80,13 @@ class test_hs22(wttest.WiredTigerTestCase):
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search the key to evict it.
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(15))
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(15))
         self.assertEqual(evict_cursor[str(0)], value2)
         self.assertEqual(evict_cursor.reset(), 0)
         self.session.rollback_transaction()
 
         # Search the key again to verify the data is still as expected.
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(15))
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(15))
         self.assertEqual(cursor[str(0)], value2)
         self.session.rollback_transaction()
 
@@ -98,7 +95,7 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + timestamp_str(1) + ',stable_timestamp=' + timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
 
         value1 = 'a'
         value2 = 'b'
@@ -106,35 +103,35 @@ class test_hs22(wttest.WiredTigerTestCase):
         # Insert a key.
         self.session.begin_transaction()
         cursor[str(0)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Remove a key.
         self.session.begin_transaction()
         cursor.set_key(str(0))
         self.assertEqual(cursor.remove(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Do an out of order timestamp
         # update and write it to the
         # history store later.
         self.session.begin_transaction()
         cursor[str(0)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(15))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
         # Add another update.
         self.session.begin_transaction()
         cursor[str(0)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Insert another key.
         self.session.begin_transaction()
         cursor[str(1)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         # Update the key.
         self.session.begin_transaction()
         cursor[str(1)] = value2
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         # Do a checkpoint to trigger
         # history store reconciliation.
@@ -143,12 +140,12 @@ class test_hs22(wttest.WiredTigerTestCase):
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search the key to evict it.
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(15))
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(15))
         self.assertEqual(evict_cursor[str(0)], value2)
         self.assertEqual(evict_cursor.reset(), 0)
         self.session.rollback_transaction()
 
         # Search the key again to verify the data is still as expected.
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(15))
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(15))
         self.assertEqual(cursor[str(0)], value2)
         self.session.rollback_transaction()

--- a/test/suite/test_hs23.py
+++ b/test/suite/test_hs23.py
@@ -28,9 +28,6 @@
 
 import wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs23.py
 # Test the case that we have update, out of order timestamp
 # update, and update again in the same transaction
@@ -43,7 +40,7 @@ class test_hs23(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + timestamp_str(1) + ',stable_timestamp=' + timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
 
         value1 = 'a'
         value2 = 'b'
@@ -54,7 +51,7 @@ class test_hs23(wttest.WiredTigerTestCase):
         # Insert a key.
         self.session.begin_transaction()
         cursor[str(0)] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Update at 10, update at 20, update at 15 (out of order), and
         # update at 20 in the same transaction
@@ -62,25 +59,25 @@ class test_hs23(wttest.WiredTigerTestCase):
         cursor.set_key(str(0))
         cursor.set_value(value2)
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(10))
+            'commit_timestamp=' + self.timestamp_str(10))
         self.assertEquals(cursor.update(), 0)
 
         cursor.set_key(str(0))
         cursor.set_value(value3)
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(20))
+            'commit_timestamp=' + self.timestamp_str(20))
         self.assertEquals(cursor.update(), 0)
 
         cursor.set_key(str(0))
         cursor.set_value(value4)
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(15))
+            'commit_timestamp=' + self.timestamp_str(15))
         self.assertEquals(cursor.update(), 0)
 
         cursor.set_key(str(0))
         cursor.set_value(value5)
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(20))
+            'commit_timestamp=' + self.timestamp_str(20))
         self.assertEquals(cursor.update(), 0)
         self.session.commit_transaction()
 
@@ -97,11 +94,11 @@ class test_hs23(wttest.WiredTigerTestCase):
         self.session.rollback_transaction()
 
         # Search the latest update
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(20))
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(20))
         self.assertEqual(cursor[str(0)], value5)
         self.session.rollback_transaction()
 
-        # Serarch the out of order timestamp update
-        self.session.begin_transaction("read_timestamp=" + timestamp_str(15))
+        # Search the out of order timestamp update
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(15))
         self.assertEqual(cursor[str(0)], value4)
         self.session.rollback_transaction()

--- a/test/suite/test_hs25.py
+++ b/test/suite/test_hs25.py
@@ -28,9 +28,6 @@
 
 import wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_hs25.py
 # Ensure updates structure is correct when processing each key.
 class test_hs25(wttest.WiredTigerTestCase):
@@ -39,8 +36,8 @@ class test_hs25(wttest.WiredTigerTestCase):
     uri = 'table:test_hs25'
 
     def test_insert_updates_hs(self):
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.create(self.uri, 'key_format=i,value_format=S')
         s = self.conn.open_session()
 
@@ -48,21 +45,21 @@ class test_hs25(wttest.WiredTigerTestCase):
         cursor1 = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         cursor1[1] = 'a'
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Update the second key.
         self.session.begin_transaction()
         cursor1[2] = 'a'
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
         self.session.begin_transaction()
         cursor1[2] = 'b'
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Prepared update on the first key.
         self.session.begin_transaction()
         cursor1[1] = 'b'
         cursor1[1] = 'c'
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(4))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(4))
 
         # Run eviction cursor.
         s.begin_transaction('ignore_prepare=true')

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -110,7 +110,7 @@ class test_import_base(wttest.WiredTigerTestCase):
 # test_import01
 class test_import01(test_import_base):
 
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     original_db_file = 'original_db_file'

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -103,10 +103,6 @@ class test_import_base(wttest.WiredTigerTestCase):
             "Tmplog" not in file_name and "Preplog" not in file_name:
             shutil.copy(src_path, dest_dir)
 
-    # Convert a WiredTiger timestamp to a string.
-    def timestamp_str(self, t):
-        return '%x' % t
-
 # test_import01
 class test_import01(test_import_base):
 

--- a/test/suite/test_import02.py
+++ b/test/suite/test_import02.py
@@ -34,7 +34,7 @@ import wiredtiger, wttest
 from test_import01 import test_import_base
 
 class test_import02(test_import_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     original_db_file = 'original_db_file'

--- a/test/suite/test_import03.py
+++ b/test/suite/test_import03.py
@@ -34,7 +34,7 @@ from wtscenario import make_scenarios
 from test_import01 import test_import_base
 
 class test_import03(test_import_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     ntables = 10

--- a/test/suite/test_import04.py
+++ b/test/suite/test_import04.py
@@ -54,7 +54,7 @@ from wtscenario import make_scenarios
 from test_import01 import test_import_base
 
 class test_import04(test_import_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     ntables = 10

--- a/test/suite/test_import05.py
+++ b/test/suite/test_import05.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 from test_import01 import test_import_base
 
 class test_import05(test_import_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     ntables = 10

--- a/test/suite/test_import06.py
+++ b/test/suite/test_import06.py
@@ -87,7 +87,7 @@ class test_import06(test_import_base):
         extlist.extension('encryptors', self.encryptor)
 
     def conn_config(self):
-        return 'cache_size=50MB,log=(enabled),statistics=(all),encryption=(name={})'.format(
+        return 'cache_size=50MB,log=(enabled),encryption=(name={})'.format(
             self.encryptor + self.encryptor_args)
 
     def test_import_repair(self):

--- a/test/suite/test_import08.py
+++ b/test/suite/test_import08.py
@@ -34,7 +34,7 @@ from test_import01 import test_import_base
 from wtscenario import make_scenarios
 
 class test_import08(test_import_base):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     original_db_file = 'original_db_file'

--- a/test/suite/test_import09.py
+++ b/test/suite/test_import09.py
@@ -100,7 +100,7 @@ class test_import09(test_import_base):
         extlist.extension('encryptors', self.encryptor)
 
     def conn_config(self):
-        return 'cache_size=50MB,log=(enabled),statistics=(all),encryption=(name={})'.format(
+        return 'cache_size=50MB,log=(enabled),encryption=(name={})'.format(
             self.encryptor + self.encryptor_args)
 
     def test_import_table_repair(self):

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_prepare08.py
+++ b/test/suite/test_prepare08.py
@@ -31,9 +31,6 @@ from helper import copy_wiredtiger_home
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare08.py
 # Test to ensure prepared tombstones are properly aborted/committed even when they are written
 # to the data store.
@@ -48,7 +45,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
             cursor.set_key(ds.key(i))
             cursor.set_value(value)
             self.assertEquals(cursor.update(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
     def removes(self, ds, uri, nrows, ts):
@@ -57,7 +54,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
         for i in range(1, nrows):
             cursor.set_key(ds.key(i))
             self.assertEquals(cursor.remove(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
     def check(self, ds, uri, nrows, value, ts, release_evict):
@@ -65,7 +62,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
             cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
         else:
             cursor = self.session.open_cursor(uri)
-        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + timestamp_str(ts))
+        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + self.timestamp_str(ts))
         for i in range(1, nrows):
             cursor.set_key(ds.key(i))
             if value == None:
@@ -96,8 +93,8 @@ class test_prepare08(wttest.WiredTigerTestCase):
         value_e = b"eeeee" * 100
 
         # Commit some updates along with a prepared update, which is not resolved.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         # Initially load huge data
         self.updates(ds_1, uri_1, nrows, value_a, 20)
@@ -124,7 +121,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
         for i in range(1, nrows):
             cursor_p.set_key(ds_1.key(i))
             self.assertEquals(cursor_p.remove(), 0)
-        session_p.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+        session_p.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
         # Adding more updates to other table should trigger eviction on uri_1
         self.updates(ds_2, uri_2, nrows, value_c, 40)
@@ -165,8 +162,8 @@ class test_prepare08(wttest.WiredTigerTestCase):
         value_e = b"eeeee" * 100
 
         # Commit some updates along with a prepared update, which is not resolved.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         # Initially load huge data
         self.updates(ds_1, uri_1, nrows, value_a, 20)
@@ -196,7 +193,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
             self.assertEquals(cursor_p.update(), 0)
             cursor_p.set_key(ds_1.key(i))
             self.assertEquals(cursor_p.remove(), 0)
-        session_p.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+        session_p.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
         # Adding more updates to other table should trigger eviction on uri_1
         self.updates(ds_2, uri_2, nrows, value_c, 40)
@@ -208,7 +205,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
         self.check(ds_1, uri_1, nrows, value_b, 50, True)
 
         # Commit the prepared session
-        session_p.commit_transaction('commit_timestamp=' + timestamp_str(50) + ',durable_timestamp=' + timestamp_str(60))
+        session_p.commit_transaction('commit_timestamp=' + self.timestamp_str(50) + ',durable_timestamp=' + self.timestamp_str(60))
 
         self.check(ds_1, uri_1, nrows, value_a, 20, False)
         self.check(ds_1, uri_1, nrows, value_b, 30, False)
@@ -239,8 +236,8 @@ class test_prepare08(wttest.WiredTigerTestCase):
         value_e = b"eeeee" * 100
 
         # Commit some updates along with a prepared update, which is not resolved.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         # Initially load huge data
         self.updates(ds_1, uri_1, nrows, value_a, 20)
@@ -266,7 +263,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
             self.assertEquals(cursor_p.update(), 0)
             cursor_p.set_key(ds_1.key(i))
             self.assertEquals(cursor_p.remove(), 0)
-        session_p.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+        session_p.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
         # Adding more updates to other table should trigger eviction on uri_1
         self.updates(ds_2, uri_2, nrows, value_c, 40)
@@ -278,7 +275,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
         self.check(ds_1, uri_1, 0, None, 50, True)
 
         # Commit the prepared session
-        session_p.commit_transaction('commit_timestamp=' + timestamp_str(50) + ',durable_timestamp=' + timestamp_str(60))
+        session_p.commit_transaction('commit_timestamp=' + self.timestamp_str(50) + ',durable_timestamp=' + self.timestamp_str(60))
 
         self.check(ds_1, uri_1, nrows, value_a, 20, False)
         self.check(ds_1, uri_1, 0, None, 30, False)

--- a/test/suite/test_prepare09.py
+++ b/test/suite/test_prepare09.py
@@ -31,8 +31,6 @@
 # [END_TAGS]
 
 import wiredtiger, wttest
-def timestamp_str(t):
-    return '%x' % t
 
 # test_prepare09.py
 # Validate scenarios involving inserting tombstones when rolling back prepares
@@ -47,8 +45,8 @@ class test_prepare09(wttest.WiredTigerTestCase):
         value2 = 'b' * 10000
         value3 = 'c' * 10000
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-        ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+        ',stable_timestamp=' + self.timestamp_str(1))
 
         self.session.create(uri, create_params)
         cursor = self.session.open_cursor(uri)
@@ -58,7 +56,7 @@ class test_prepare09(wttest.WiredTigerTestCase):
         # Insert a new value.
         self.session.begin_transaction()
         cursor[1] = value1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Get the previous update onto disk.
         for i in range(2, 10000):
@@ -68,7 +66,7 @@ class test_prepare09(wttest.WiredTigerTestCase):
         # Prepare a full value and roll it back.
         self.session.begin_transaction()
         cursor[1] = value3
-        self.assertEqual(self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(3)), 0)
+        self.assertEqual(self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(3)), 0)
         self.session.rollback_transaction()
 
         # Get the previous update onto disk.
@@ -89,8 +87,8 @@ class test_prepare09(wttest.WiredTigerTestCase):
         value2 = 'b' * 10000
         value3 = 'e' * 10000
         value4 = 'd' * 10000
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-        ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+        ',stable_timestamp=' + self.timestamp_str(1))
 
         self.session.create(uri, create_params)
         cursor = self.session.open_cursor(uri)
@@ -102,7 +100,7 @@ class test_prepare09(wttest.WiredTigerTestCase):
         cursor[1] = value1
         cursor[2] = value2
         cursor[3] = value3
-        self.assertEqual(self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(3)), 0)
+        self.assertEqual(self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(3)), 0)
 
         # Get the prepare onto disk.
         for i in range(4, 10000):

--- a/test/suite/test_prepare09.py
+++ b/test/suite/test_prepare09.py
@@ -37,7 +37,7 @@ def timestamp_str(t):
 # test_prepare09.py
 # Validate scenarios involving inserting tombstones when rolling back prepares
 class test_prepare09(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=2MB,statistics=(all)'
+    conn_config = 'cache_size=2MB'
     session_config = 'isolation=snapshot'
 
     def test_prepared_update_is_aborted_correctly_with_on_disk_value(self):

--- a/test/suite/test_prepare10.py
+++ b/test/suite/test_prepare10.py
@@ -31,9 +31,6 @@ from helper import copy_wiredtiger_home
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare10.py
 # Test to ensure prepared tombstones are properly aborted even when they are written
 # to the data store.
@@ -49,7 +46,7 @@ class test_prepare10(wttest.WiredTigerTestCase):
             cursor.set_key(ds.key(i))
             cursor.set_value(value)
             self.assertEquals(cursor.insert(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
     def removes(self, ds, uri, nrows, ts):
@@ -58,12 +55,12 @@ class test_prepare10(wttest.WiredTigerTestCase):
         for i in range(1, nrows):
             cursor.set_key(ds.key(i))
             self.assertEquals(cursor.remove(), 0)
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
     def check(self, ds, uri, nrows, value, ts):
         cursor = self.session.open_cursor(uri)
-        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + timestamp_str(ts))
+        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + self.timestamp_str(ts))
         for i in range(1, nrows):
             cursor.set_key(ds.key(i))
             self.assertEquals(cursor.search(), 0)
@@ -73,7 +70,7 @@ class test_prepare10(wttest.WiredTigerTestCase):
 
     def check_not_found(self, ds, uri, nrows, ts):
         cursor = self.session.open_cursor(uri)
-        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + timestamp_str(ts))
+        self.session.begin_transaction('ignore_prepare=true,read_timestamp=' + self.timestamp_str(ts))
         for i in range(1, nrows):
             cursor.set_key(ds.key(i))
             self.assertEquals(cursor.search(), wiredtiger.WT_NOTFOUND)
@@ -92,8 +89,8 @@ class test_prepare10(wttest.WiredTigerTestCase):
         value_c = b"ccccc" * 100
 
         # Commit some updates along with a prepared update, which is not resolved.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         # Initially load huge data
         self.updates(ds, uri, nrows, value_a, 20)
@@ -141,7 +138,7 @@ class test_prepare10(wttest.WiredTigerTestCase):
             cursor_p.set_key(ds.key(i))
             cursor_p.set_value(value_c)
             self.assertEquals(cursor_p.insert(), 0)
-        session_p.prepare_transaction('prepare_timestamp=' + timestamp_str(50))
+        session_p.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
 
         self.check(ds, uri, nrows, value_a, 20)
         self.check(ds, uri, nrows, value_b, 35)

--- a/test/suite/test_prepare11.py
+++ b/test/suite/test_prepare11.py
@@ -29,9 +29,6 @@
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare11.py
 # Test prepare rollback with a reserved update between updates.
 class test_prepare11(wttest.WiredTigerTestCase):
@@ -59,8 +56,8 @@ class test_prepare11(wttest.WiredTigerTestCase):
         c['key1'] = 'yyyy'
         self.session.prepare_transaction('prepare_timestamp=10')
         if self.commit:
-            self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(20))
-            self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(30))
+            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
+            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(30))
             self.session.commit_transaction()
         else:
             self.session.rollback_transaction()

--- a/test/suite/test_prepare11.py
+++ b/test/suite/test_prepare11.py
@@ -35,7 +35,7 @@ def timestamp_str(t):
 # test_prepare11.py
 # Test prepare rollback with a reserved update between updates.
 class test_prepare11(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=2MB,statistics=(all)'
+    conn_config = 'cache_size=2MB'
     session_config = 'isolation=snapshot'
 
     commit_values = [

--- a/test/suite/test_prepare12.py
+++ b/test/suite/test_prepare12.py
@@ -31,8 +31,6 @@
 # [END_TAGS]
 
 import wiredtiger, wttest
-def timestamp_str(t):
-    return '%x' % t
 
 # test_prepare12.py
 # Test update restore of a page with prepared update.
@@ -48,7 +46,7 @@ class test_prepare12(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None)
         self.session.begin_transaction()
         cursor[0] = 'a'
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(1))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(1))
 
         # Insert an uncommitted key
         session2 = self.conn.open_session(None)
@@ -65,8 +63,8 @@ class test_prepare12(wttest.WiredTigerTestCase):
             session3.commit_transaction()
 
         # Commit the prepared update
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(1) + ',durable_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1) + ',durable_timestamp=' + self.timestamp_str(2))
 
         # Read the prepared update
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(2))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(2))
         self.assertEqual(cursor[0], 'a')

--- a/test/suite/test_prepare12.py
+++ b/test/suite/test_prepare12.py
@@ -37,7 +37,7 @@ def timestamp_str(t):
 # test_prepare12.py
 # Test update restore of a page with prepared update.
 class test_prepare12(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=2MB,statistics=(all)'
+    conn_config = 'cache_size=2MB'
     session_config = 'isolation=snapshot'
 
     def test_prepare_update_restore(self):

--- a/test/suite/test_prepare13.py
+++ b/test/suite/test_prepare13.py
@@ -35,8 +35,6 @@
 import wiredtiger, wttest
 from wtdataset import simple_key, simple_value
 
-def timestamp_str(t):
-    return '%x' % t
 class test_prepare13(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = 'cache_size=10MB'
@@ -44,8 +42,8 @@ class test_prepare13(wttest.WiredTigerTestCase):
     def test_prepare(self):
         nrows = 20000
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         # Create a large table with lots of pages.
         uri = "table:test_prepare13"
@@ -61,12 +59,12 @@ class test_prepare13(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
         cursor[simple_key(cursor, 1000)] = "replacement_value"
         cursor.close()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(10))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
 
         try:
             # Pin oldest and stable to timestamp 10.
-            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-                ',stable_timestamp=' + timestamp_str(10))
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+                ',stable_timestamp=' + self.timestamp_str(10))
 
             # Open a separate session and cursor and perform updates to let prepared update to evict.
             s = self.conn.open_session()
@@ -74,7 +72,7 @@ class test_prepare13(wttest.WiredTigerTestCase):
             for i in range(2000, nrows):
                 s.begin_transaction()
                 cursor[simple_key(cursor, i)] = simple_value(cursor, i)
-                s.commit_transaction('commit_timestamp=' + timestamp_str(20))
+                s.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
             cursor.close()
 
             # Truncate the middle chunk and expect a conflict.
@@ -90,8 +88,8 @@ class test_prepare13(wttest.WiredTigerTestCase):
             s.rollback_transaction()
 
         finally:
-            self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(50))
-            self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(50))
+            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(50))
+            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(50))
             self.session.commit_transaction()
 
         s.close()

--- a/test/suite/test_prepare13.py
+++ b/test/suite/test_prepare13.py
@@ -39,7 +39,7 @@ def timestamp_str(t):
     return '%x' % t
 class test_prepare13(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=10MB,statistics=(all),statistics_log=(json,on_close,wait=1)'
+    conn_config = 'cache_size=10MB'
 
     def test_prepare(self):
         nrows = 20000

--- a/test/suite/test_prepare14.py
+++ b/test/suite/test_prepare14.py
@@ -30,9 +30,6 @@ import wttest
 from wiredtiger import WT_NOTFOUND
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare14.py
 # Test that the transaction visibility of an on-disk update
 # that has both the start and the stop time points from the
@@ -71,8 +68,8 @@ class test_prepare14(wttest.WiredTigerTestCase):
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value = 'a'
 
@@ -84,7 +81,7 @@ class test_prepare14(wttest.WiredTigerTestCase):
         cursor.set_key(str(0))
         cursor.remove()
         cursor.close()
-        s.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")

--- a/test/suite/test_prepare15.py
+++ b/test/suite/test_prepare15.py
@@ -30,9 +30,6 @@ import wttest
 from wiredtiger import WT_NOTFOUND
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare15.py
 # Test that the prepare transaction rollback removes the on-disk key
 # or replace it with history store and commit retains the changes when
@@ -74,8 +71,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = 'a'
         valueb = 'a'
@@ -84,12 +81,12 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
         cursor[str(0)] = valuea
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(20))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         self.session.begin_transaction()
         cursor.set_key(str(0))
         cursor.remove()
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
         cursor.close()
 
         # Perform an update and remove.
@@ -100,7 +97,7 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.set_key(str(0))
         cursor.remove()
         cursor.close()
-        s.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+        s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
@@ -115,8 +112,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
 
         if self.commit:
             # Commit the prepared transaction
-            s.timestamp_transaction('commit_timestamp=' + timestamp_str(50))
-            s.timestamp_transaction('durable_timestamp=' + timestamp_str(60))
+            s.timestamp_transaction('commit_timestamp=' + self.timestamp_str(50))
+            s.timestamp_transaction('durable_timestamp=' + self.timestamp_str(60))
             s.commit_transaction()
         else:
             # Rollback the prepared transaction
@@ -133,7 +130,7 @@ class test_prepare15(wttest.WiredTigerTestCase):
         evict_cursor.close()
         self.session.commit_transaction()
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(20))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
         cursor2 = self.session.open_cursor(uri)
         cursor2.set_key(str(0))
         self.assertEquals(cursor2.search(), 0)
@@ -151,8 +148,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value = 'a'
 
@@ -164,7 +161,7 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.set_key(str(0))
         cursor.remove()
         cursor.close()
-        s.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
@@ -179,8 +176,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
 
         if self.commit:
             # Commit the prepared transaction
-            s.timestamp_transaction('commit_timestamp=' + timestamp_str(30))
-            s.timestamp_transaction('durable_timestamp=' + timestamp_str(40))
+            s.timestamp_transaction('commit_timestamp=' + self.timestamp_str(30))
+            s.timestamp_transaction('durable_timestamp=' + self.timestamp_str(40))
             s.commit_transaction()
         else:
             # Rollback the prepared transaction

--- a/test/suite/test_prepare16.py
+++ b/test/suite/test_prepare16.py
@@ -30,9 +30,6 @@ import wttest
 from wiredtiger import WT_NOTFOUND
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare16.py
 # Test that the prepare transaction rollback/commit multiple keys
 # and each key can occupy a leaf page.
@@ -75,8 +72,8 @@ class test_prepare16(wttest.WiredTigerTestCase):
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = 'a' * 400
 
@@ -87,7 +84,7 @@ class test_prepare16(wttest.WiredTigerTestCase):
 
         cursor.reset()
         cursor.close()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(10))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
 
         s = self.conn.open_session()
         s.begin_transaction('ignore_prepare = true')
@@ -100,17 +97,17 @@ class test_prepare16(wttest.WiredTigerTestCase):
             evict_cursor.reset()
 
         if self.commit:
-            self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(20))
-            self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(30))
+            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
+            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(30))
             self.session.commit_transaction()
         else:
             self.session.rollback_transaction()
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         if not self.in_memory:
             self.session.checkpoint()
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(20))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
         cursor = self.session.open_cursor(uri)
         for i in range(1, nrows + 1):
             cursor.set_key(str(i))

--- a/test/suite/test_prepare_conflict.py
+++ b/test/suite/test_prepare_conflict.py
@@ -33,9 +33,6 @@
 import wiredtiger, wttest
 from wtdataset import simple_key, simple_value
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_prepare_conflict(wttest.WiredTigerTestCase):
     def test_prepare(self):
         # Create a large table with lots of pages.
@@ -68,9 +65,9 @@ class test_prepare_conflict(wttest.WiredTigerTestCase):
         cursor.close()
 
         # Prepare and commit the transaction.
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(10))
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(20))
-        self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(20))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
+        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(20))
         self.session.commit_transaction()
 
         # WT-6325 reports WT_PREPARE_CONFLICT while iterating the cursor.

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -35,9 +35,6 @@ from wtdataset import SimpleDataSet, SimpleIndexDataSet
 from wtdataset import SimpleLSMDataSet, ComplexDataSet, ComplexLSMDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_prepare_cursor01.py
 #    WT_CURSOR navigation (next/prev) tests with prepared transactions
 class test_prepare_cursor01(wttest.WiredTigerTestCase):
@@ -103,18 +100,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_cursor.set_key(ds.key(51))
         prep_cursor.set_value(ds.value(51))
         prep_cursor.insert()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100))
 
         # Point all cursors to key 50.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(50))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(50))
         before_ts_c.set_key(ds.key(50))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(150))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(150))
         between_ts_c.set_key(ds.key(50))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(250))
         after_ts_c.set_key(ds.key(50))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -138,8 +135,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(200))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(200))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(200))
         prep_session.commit_transaction()
 
         before_ts_s.commit_transaction()
@@ -160,18 +157,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_cursor.set_key(ds.key(1))
         prep_cursor.set_value(ds.value(1))
         prep_cursor.insert()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100))
 
         # Point all cursors to key 2.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(50))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(50))
         before_ts_c.set_key(ds.key(2))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(150))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(150))
         between_ts_c.set_key(ds.key(2))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(250))
         after_ts_c.set_key(ds.key(2))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -196,8 +193,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(200))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(200))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(200))
         prep_session.commit_transaction()
 
         # As read is between(i.e before commit), prev is not found.
@@ -223,18 +220,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_cursor.set_key(ds.key(51))
         prep_cursor.set_value(ds.value(151))
         prep_cursor.update()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(300))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(300))
 
         # Point all cursors to key 51.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(250))
         before_ts_c.set_key(ds.key(50))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(350))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(350))
         between_ts_c.set_key(ds.key(50))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(450))
         after_ts_c.set_key(ds.key(50))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -256,8 +253,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(400))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(400))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(400))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(400))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.
@@ -287,18 +284,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_cursor.set_key(ds.key(1))
         prep_cursor.set_value(ds.value(111))
         prep_cursor.update()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(300))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(300))
 
         # Point all cursors to key 2.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(250))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(250))
         before_ts_c.set_key(ds.key(2))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(350))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(350))
         between_ts_c.set_key(ds.key(2))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(450))
         after_ts_c.set_key(ds.key(2))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -320,8 +317,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(400))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(400))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(400))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(400))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.
@@ -355,18 +352,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(51))
         prep_cursor.remove()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(500))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(500))
 
         # Point all cursors to key 51.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(450))
         before_ts_c.set_key(ds.key(50))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(550))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(550))
         between_ts_c.set_key(ds.key(50))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(650))
         after_ts_c.set_key(ds.key(50))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -387,8 +384,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(600))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(600))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(600))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(600))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.
@@ -411,18 +408,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(1))
         prep_cursor.remove()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(500))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(500))
 
         # Point all cursors to key 2.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(450))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(450))
         before_ts_c.set_key(ds.key(2))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(550))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(550))
         between_ts_c.set_key(ds.key(2))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(650))
         after_ts_c.set_key(ds.key(2))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -443,8 +440,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(600))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(600))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(600))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(600))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.
@@ -474,18 +471,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(49))
         prep_cursor.remove()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(700))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(700))
 
         # Point all cursors to key 48.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(650))
         before_ts_c.set_key(ds.key(48))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(750))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(750))
         between_ts_c.set_key(ds.key(48))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(850))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(850))
         after_ts_c.set_key(ds.key(48))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -506,8 +503,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(800))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(800))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(800))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(800))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.
@@ -532,18 +529,18 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         prep_session.begin_transaction()
         prep_cursor.set_key(ds.key(3))
         prep_cursor.remove()
-        prep_session.prepare_transaction('prepare_timestamp=' + timestamp_str(700))
+        prep_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(700))
 
         # Point all cursors to key 4.
-        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(650))
+        before_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(650))
         before_ts_c.set_key(ds.key(4))
         self.assertEquals(before_ts_c.search(), 0)
 
-        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(750))
+        between_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(750))
         between_ts_c.set_key(ds.key(4))
         self.assertEquals(between_ts_c.search(), 0)
 
-        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + timestamp_str(850))
+        after_ts_s.begin_transaction('isolation=' + self.isolation + ',read_timestamp=' + self.timestamp_str(850))
         after_ts_c.set_key(ds.key(4))
         self.assertEquals(after_ts_c.search(), 0)
 
@@ -564,8 +561,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + timestamp_str(800))
-        prep_session.timestamp_transaction('durable_timestamp=' + timestamp_str(800))
+        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(800))
+        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(800))
         prep_session.commit_transaction()
 
         # Check to see before cursor still gets the old value.

--- a/test/suite/test_prepare_cursor02.py
+++ b/test/suite/test_prepare_cursor02.py
@@ -31,9 +31,6 @@ from wtdataset import SimpleDataSet, SimpleIndexDataSet
 from wtdataset import SimpleLSMDataSet, ComplexDataSet, ComplexLSMDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' %t
-
 # test_prepare_cursor02.py
 #    WT_CURSOR navigation (next/prev) tests with prepared transactions
 class test_prepare_cursor02(wttest.WiredTigerTestCase):
@@ -69,7 +66,7 @@ class test_prepare_cursor02(wttest.WiredTigerTestCase):
         cursor.set_key(ds.key(1))
         cursor.set_value(ds.value(1))
         cursor.insert()
-        session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
+        session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100))
 
         prep_session = self.conn.open_session(self.session_config)
         prep_cursor = prep_session.open_cursor(uri, None)

--- a/test/suite/test_prepare_hs02.py
+++ b/test/suite/test_prepare_hs02.py
@@ -36,9 +36,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_prepare_cursor'
     uri = 'table:' + tablename
@@ -72,16 +69,16 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction(self.txn_config)
         c[1] = 1
         # update the value with in this transaction
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(100))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100))
         if self.txn_commit == True:
             self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(101) + ',durable_timestamp=' + timestamp_str(101))
+                'commit_timestamp=' + self.timestamp_str(101) + ',durable_timestamp=' + self.timestamp_str(101))
         else:
             self.session.rollback_transaction()
 
         # Trigger a checkpoint, which could trigger reconciliation
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(150))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(150))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(150))
         self.session.checkpoint()
 
         # Scenario: 2
@@ -94,16 +91,16 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         # update a uncommitted value, insert and update a key.
         c[2] = 1
         c[2] = 2
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(200))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(200))
         if self.txn_commit == True:
             self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(201) + ',durable_timestamp=' + timestamp_str(201))
+                'commit_timestamp=' + self.timestamp_str(201) + ',durable_timestamp=' + self.timestamp_str(201))
         else:
             self.session.rollback_transaction()
 
         # Trigger a checkpoint, which could trigger reconciliation
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(250))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(250))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(250))
         self.session.checkpoint()
 
         # Scenario: 3
@@ -121,10 +118,10 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         c[3] = 2
         c.set_key(3)
         c.remove()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(300))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(300))
         if self.txn_commit == True:
             self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(301) + ',durable_timestamp=' + timestamp_str(301))
+                'commit_timestamp=' + self.timestamp_str(301) + ',durable_timestamp=' + self.timestamp_str(301))
         else:
             self.session.rollback_transaction()
 
@@ -133,11 +130,11 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         c[1] = 1
         c[2] = 1
         c[3] = 1
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(302))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(302))
 
         # Trigger a checkpoint, which could trigger reconciliation
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(350))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(350))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(350))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(350))
         self.session.checkpoint()
 
         #Scenario: 4
@@ -145,8 +142,8 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         # creating the modify update_chain for key instead of insert update
         # chain.
         self.reopen_conn()
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(350))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(350))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(350))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(350))
 
         self.session.create(self.uri, self.s_config)
         cur = self.session.open_cursor(self.uri)
@@ -159,16 +156,16 @@ class test_prepare_hs02(wttest.WiredTigerTestCase, suite_subprocess):
         # Remove a updated key
         cur.set_key(3)
         cur.remove()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(400))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(400))
         if self.txn_commit == True:
             self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(401) + ',durable_timestamp=' + timestamp_str(401))
+                'commit_timestamp=' + self.timestamp_str(401) + ',durable_timestamp=' + self.timestamp_str(401))
         else:
             self.session.rollback_transaction()
 
         # Trigger a checkpoint, which could trigger reconciliation
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(450))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(450))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(450))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(450))
         self.session.checkpoint()
 
         cur.close()

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -38,9 +38,6 @@ import os, shutil
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare_hs03.py
 # test to ensure salvage, verify & simulating crash are working for prepared transactions.
 class test_prepare_hs03(wttest.WiredTigerTestCase):
@@ -96,12 +93,12 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
             cursor.set_key(ds.key(nrows + i))
             cursor.set_value(commit_value)
             self.assertEquals(cursor.insert(), 0)
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(1))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
         cursor.close()
 
         # Set the stable/oldest timstamps.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
 
         # Corrupt the table, call salvage to recover data from the corrupted table and call verify
         self.corrupt_salvage_verify()
@@ -124,7 +121,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
                 cursors[j].set_key(ds.key(nrows + i))
                 cursors[j].set_value(prepare_value)
                 self.assertEquals(cursors[j].insert(), 0)
-            sessions[j].prepare_transaction('prepare_timestamp=' + timestamp_str(4))
+            sessions[j].prepare_transaction('prepare_timestamp=' + self.timestamp_str(4))
 
         hs_writes = self.get_stat(stat.conn.cache_write_hs) - hs_writes_start
 
@@ -133,7 +130,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
         # Test if we can read prepared updates from the history store.
         cursor = self.session.open_cursor(self.uri)
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(3))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(3))
         for i in range(1, nsessions * nkeys):
             cursor.set_key(ds.key(nrows + i))
             # The search should pass.
@@ -156,7 +153,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # Finally, search for the keys inserted with commit timestamp
         cursor = self.session.open_cursor(self.uri)
         self.pr('Read Keys')
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(4))
         for i in range(1, nkeys):
             cursor.set_key(ds.key(nrows + i))
             # The search should pass
@@ -177,7 +174,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(self.uri)
 
         # Search the keys inserted with commit timestamp after crash
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(4))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(4))
         for i in range(1, nkeys):
             cursor.set_key(ds.key(nrows + i))
             # The search should pass

--- a/test/suite/test_prepare_hs04.py
+++ b/test/suite/test_prepare_hs04.py
@@ -32,9 +32,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare_hs04.py
 # Read prepared updates from on-disk with ignore_prepare.
 # Committing or aborting a prepared update when there exists a tombstone for that key already.
@@ -82,8 +79,8 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
     def prepare_updates(self, ds):
 
         # Set oldest and stable timestamp for the database.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
 
         # Commit some updates to get eviction and history store fired up.
         # Insert a key at timestamp 1.
@@ -96,7 +93,7 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
             cursor.set_key(key)
             cursor.set_value(commit_value)
             self.assertEquals(cursor.insert(), 0)
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(1))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
         cursor.close()
 
         # Call checkpoint.
@@ -108,11 +105,11 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
             key = commit_key + ds.key(self.nrows + i)
             cursor.set_key(key)
             self.assertEquals(cursor.remove(), 0)
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
         cursor.close()
 
         # Move the stable timestamp to match the timestamp for the last update.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         hs_writes_start = self.get_stat(stat.conn.cache_write_hs)
         # Have prepared updates in multiple sessions. This should ensure writing prepared updates to
@@ -131,22 +128,22 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
                 cursors[j].set_key(commit_key + ds.key(self.nrows + i))
                 cursors[j].set_value(prepare_value)
                 self.assertEquals(cursors[j].insert(), 0)
-            sessions[j].prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+            sessions[j].prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         hs_writes = self.get_stat(stat.conn.cache_write_hs) - hs_writes_start
         # Assert if not writing anything to the history store.
         self.assertGreaterEqual(hs_writes, 0)
 
-        txn_config = 'read_timestamp=' + timestamp_str(5) + ',ignore_prepare=true'
+        txn_config = 'read_timestamp=' + self.timestamp_str(5) + ',ignore_prepare=true'
         # Search keys with timestamp 5, ignore_prepare=true and expect the cursor search to return 0 (key found)
         self.search_keys_timestamp_and_ignore(ds, txn_config, commit_value)
 
-        txn_config = 'read_timestamp=' + timestamp_str(20) + ',ignore_prepare=true'
+        txn_config = 'read_timestamp=' + self.timestamp_str(20) + ',ignore_prepare=true'
         # Search keys with timestamp 20, ignore_prepare=true, expect the cursor to return wiredtiger.WT_NOTFOUND
         self.search_keys_timestamp_and_ignore(ds, txn_config, None)
 
         prepare_conflict_msg = '/conflict with a prepared update/'
-        txn_config = 'read_timestamp=' + timestamp_str(20) + ',ignore_prepare=false'
+        txn_config = 'read_timestamp=' + self.timestamp_str(20) + ',ignore_prepare=false'
         # Search keys with timestamp 20, ignore_prepare=false and expect the cursor the cursor search to return prepare conflict message
         self.search_keys_timestamp_and_ignore(ds, txn_config, prepare_conflict_msg, True)
 
@@ -156,9 +153,9 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
             # Commit the prepared_transactions with timestamp 30.
             for j in range (0, self.nsessions):
                 sessions[j].commit_transaction(
-                    'commit_timestamp=' + timestamp_str(30) + ',durable_timestamp=' + timestamp_str(30))
+                    'commit_timestamp=' + self.timestamp_str(30) + ',durable_timestamp=' + self.timestamp_str(30))
             # Move the stable timestamp to match the durable timestamp for prepared updates.
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
 
         self.session.checkpoint()
 
@@ -174,38 +171,38 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
 
         # Search keys with timestamp 5, ignore_prepare=true and expect the cursor search to return
         # value committed before prepared update.
-        txn_config = 'read_timestamp=' + timestamp_str(5) + ',ignore_prepare=false'
+        txn_config = 'read_timestamp=' + self.timestamp_str(5) + ',ignore_prepare=false'
         self.search_keys_timestamp_and_ignore(ds, txn_config, commit_value)
 
         # Search keys with timestamp 20, ignore_prepare=true and expect the cursor search to return
         # WT_NOTFOUND.
-        txn_config = 'read_timestamp=' + timestamp_str(20) + ',ignore_prepare=true'
+        txn_config = 'read_timestamp=' + self.timestamp_str(20) + ',ignore_prepare=true'
         self.search_keys_timestamp_and_ignore(ds, txn_config, None)
 
         # Search keys with timestamp 20, ignore_prepare=false and expect the cursor search to return WT_NOTFOUND.
-        txn_config = 'read_timestamp=' + timestamp_str(20) + ',ignore_prepare=false'
+        txn_config = 'read_timestamp=' + self.timestamp_str(20) + ',ignore_prepare=false'
         self.search_keys_timestamp_and_ignore(ds, txn_config, None)
 
         # If commit is true then the commit_tramsactions was called and we will expect prepare_value.
         if self.commit == True:
-            txn_config = 'read_timestamp=' + timestamp_str(30) + ',ignore_prepare=true'
+            txn_config = 'read_timestamp=' + self.timestamp_str(30) + ',ignore_prepare=true'
             # Search keys with timestamp 30, ignore_prepare=true and expect the cursor value to be prepare_value.
             self.search_keys_timestamp_and_ignore(ds, txn_config, prepare_value)
         else:
             # Commit is false and we simulated a crash/restart which would have rolled-back the transactions, therefore we expect the
             # cursor search to return WT_NOTFOUND.
-            txn_config = 'read_timestamp=' + timestamp_str(30) + ',ignore_prepare=true'
+            txn_config = 'read_timestamp=' + self.timestamp_str(30) + ',ignore_prepare=true'
             # Search keys with timestamp 30, ignore_prepare=true and expect the cursor value to return WT_NOTFOUND.
             self.search_keys_timestamp_and_ignore(ds, txn_config, None)
 
         if self.commit == True:
-            txn_config = 'read_timestamp=' + timestamp_str(30) + ',ignore_prepare=false'
+            txn_config = 'read_timestamp=' + self.timestamp_str(30) + ',ignore_prepare=false'
             # Search keys with timestamp 30, ignore_prepare=false and expect the cursor value to be prepare_value.
             self.search_keys_timestamp_and_ignore(ds, txn_config, prepare_value)
         else:
             # Commit is false and we simulated a crash/restart which would have rolled-back the transactions, therefore we expect the
             # cursor search to return WT_NOTFOUND.
-            txn_config = 'read_timestamp=' + timestamp_str(30) + ',ignore_prepare=false'
+            txn_config = 'read_timestamp=' + self.timestamp_str(30) + ',ignore_prepare=false'
             # Search keys with timestamp 30, ignore_prepare=false and expect the cursor value to return WT_NOTFOUND.
             self.search_keys_timestamp_and_ignore(ds, txn_config, None)
 

--- a/test/suite/test_prepare_hs05.py
+++ b/test/suite/test_prepare_hs05.py
@@ -30,9 +30,6 @@ import wiredtiger, wttest
 from wtscenario import make_scenarios
 from wiredtiger import stat, WT_NOTFOUND
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_prepare_hs05.py
 # Test that after aborting prepare transaction, correct update from the history store is restored.
 class test_prepare_hs05(wttest.WiredTigerTestCase):
@@ -48,7 +45,7 @@ class test_prepare_hs05(wttest.WiredTigerTestCase):
         value2 = 'b' * 5
         value3 = 'c' * 5
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
 
         key = 1
@@ -56,19 +53,19 @@ class test_prepare_hs05(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         cursor[str(key)] = value1
         cursor.set_key(str(key))
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Commit update and remove operation in the same transaction.
         self.session.begin_transaction()
         cursor[str(key)] = value2
         cursor.set_key(str(key))
         cursor.remove()
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         # Add a prepared update for the key.
         self.session.begin_transaction()
         cursor[str(key)] = value3
-        self.session.prepare_transaction('prepare_timestamp='+ timestamp_str(4))
+        self.session.prepare_transaction('prepare_timestamp='+ self.timestamp_str(4))
 
         # Try to evict the page with prepared update. This will ensure that prepared update is
         # written as the on-disk version and the older versions are moved to the history store.
@@ -85,7 +82,7 @@ class test_prepare_hs05(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # We should be able to read the older version of the key from the history store.
-        self.session.begin_transaction('read_timestamp='+timestamp_str(2))
+        self.session.begin_transaction('read_timestamp='+self.timestamp_str(2))
         cursor.set_key(str(key))
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.get_value(), value1)

--- a/test/suite/test_readonly02.py
+++ b/test/suite/test_readonly02.py
@@ -42,15 +42,15 @@ class test_readonly02(wttest.WiredTigerTestCase, suite_subprocess):
     entries = 10
 
     conn_params = \
-        'create,statistics=(fast),' + \
+        'create,' + \
         'log=(enabled,file_max=100K,zero_fill=true),' + \
         'operation_tracking=(enabled=false),'
     conn_params_rd = \
-        'create,readonly=true,statistics=(fast),' + \
+        'create,readonly=true,' + \
         'log=(enabled,zero_fill=false),' + \
         'operation_tracking=(enabled=false),'
     conn_params_rdcfg = \
-        'create,readonly=true,statistics=(fast),log=(enabled),' + \
+        'create,readonly=true,log=(enabled),' + \
         'operation_tracking=(enabled=false),'
 
     #

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -34,9 +34,6 @@ from wiredtiger import stat, wiredtiger_strerror, WiredTigerError, WT_ROLLBACK
 from wtscenario import make_scenarios
 from time import sleep
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable01.py
 # Shared base class used by rollback to stable tests.
 class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
@@ -77,12 +74,12 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                 if commit_ts == 0:
                     session.commit_transaction()
                 elif prepare:
-                    session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-                    session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-                    session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+                    session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+                    session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+                    session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
                     session.commit_transaction()
                 else:
-                    session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+                    session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()
         except WiredTigerError as e:
             rollback_str = wiredtiger_strerror(WT_ROLLBACK)
@@ -104,12 +101,12 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
             if commit_ts == 0:
                 session.commit_transaction()
             elif prepare:
-                session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-                session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-                session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+                session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+                session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+                session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
                 session.commit_transaction()
             else:
-                session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()
         except WiredTigerError as e:
             rollback_str = wiredtiger_strerror(WT_ROLLBACK)
@@ -129,12 +126,12 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                 if commit_ts == 0:
                     session.commit_transaction()
                 elif prepare:
-                    session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-                    session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-                    session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+                    session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+                    session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+                    session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
                     session.commit_transaction()
                 else:
-                    session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+                    session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()
         except WiredTigerError as e:
             rollback_str = wiredtiger_strerror(WT_ROLLBACK)
@@ -147,7 +144,7 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
         if read_ts == 0:
             session.begin_transaction()
         else:
-            session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -200,8 +197,8 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         valuea = "aaaaa" * 100
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
@@ -215,9 +212,9 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 20 if prepare otherwise 10.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         # Checkpoint to ensure that all the updates are flushed to disk.
         if not self.in_memory:
             self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -34,9 +34,6 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable02.py
 # Test that rollback to stable brings back the history value to replace on-disk value.
 class test_rollback_to_stable02(test_rollback_to_stable_base):
@@ -81,8 +78,8 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         valuea = "aaaaa" * 100
         valueb = "bbbbb" * 100
@@ -106,9 +103,9 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         # Checkpoint to ensure that all the data is flushed.
         if not self.in_memory:
             self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -34,9 +34,6 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable03.py
 # Test that rollback to stable clears the history store updates from reconciled pages.
 class test_rollback_to_stable01(test_rollback_to_stable_base):
@@ -81,8 +78,8 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         valuea = "aaaaa" * 100
         valueb = "bbbbb" * 100
@@ -101,9 +98,9 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         # Checkpoint to ensure that all the updates are flushed to disk.
         if not self.in_memory:
             self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -31,9 +31,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 def mod_val(value, char, location, nbytes=1):
     return value[0:location] + char + value[location+nbytes:]
 
@@ -82,8 +79,8 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -131,9 +128,9 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 40 if prepare otherwise 30.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
 
         # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
         if not self.in_memory:

--- a/test/suite/test_rollback_to_stable05.py
+++ b/test/suite/test_rollback_to_stable05.py
@@ -34,9 +34,6 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable05.py
 # Test that rollback to stable cleans history store for non-timestamp tables.
 class test_rollback_to_stable05(test_rollback_to_stable_base):

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -31,9 +31,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable06.py
 # Test that rollback to stable removes all keys when the stable timestamp is earlier than
 # all commit timestamps.
@@ -79,8 +76,8 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -33,9 +33,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable07.py
 # Test the rollback to stable operation performs as expected following a server crash and
 # recovery. Verify that
@@ -74,8 +71,8 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -96,9 +93,9 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         # Perform additional updates.
         self.large_updates(uri, value_b, ds, nrows, self.prepare, 60)

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -31,9 +31,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable08.py
 # Test that rollback to stable does not abort updates when the stable timestamp is
 # set to the latest commit.
@@ -79,8 +76,8 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -101,9 +98,9 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(60))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(60))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
         if not self.in_memory:

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -32,9 +32,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable09.py
 # Test that rollback to stable does not abort schema operations that are done
 # as they don't have transaction support
@@ -73,12 +70,12 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
         if commit_ts == 0:
                 session.commit_transaction()
         elif self.prepare:
-            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
             session.commit_transaction()
         else:
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
     def drop_table(self, commit_ts):
         self.pr('drop table')
@@ -88,12 +85,12 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
         if commit_ts == 0:
                 session.commit_transaction()
         elif self.prepare:
-            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
             session.commit_transaction()
         else:
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
     def create_index(self, commit_ts):
         session = self.session
@@ -102,17 +99,17 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
         if commit_ts == 0:
                 session.commit_transaction()
         elif self.prepare:
-            session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
             session.commit_transaction()
         else:
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
     def test_rollback_to_stable(self):
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         # Create table and index at a later timestamp
         self.create_table(20)

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -58,7 +58,7 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
     scenarios = make_scenarios(in_memory_values, prepare_values)
 
     def conn_config(self):
-        config = 'cache_size=250MB,statistics=(all)'
+        config = 'cache_size=250MB'
         if self.in_memory:
             config += ',in_memory=true'
         else:

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -34,9 +34,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from wtthread import checkpoint_thread, op_thread
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable10.py
 # Test the rollback to stable operation performs sweeping history store.
 class test_rollback_to_stable10(test_rollback_to_stable_base):
@@ -79,8 +76,8 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         ds_2.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -114,9 +111,9 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(60))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(60))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Create a checkpoint thread
         done = threading.Event()
@@ -198,8 +195,8 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         ds_2.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -235,9 +232,9 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(60))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(60))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Here's the update operations we'll perform, encapsulated so we can easily retry
         # it if we get a rollback. Rollbacks may occur when checkpoint is running.
@@ -265,7 +262,7 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
             self.retry_rollback('update ds1', session_p1,
                            lambda: prepare_range_updates(
                                session_p1, cursor_p1, ds_1, value_e, nrows,
-                               'prepare_timestamp=' + timestamp_str(69)))
+                               'prepare_timestamp=' + self.timestamp_str(69)))
 
             # Perform several updates in parallel with checkpoint.
             session_p2 = self.conn.open_session()
@@ -274,7 +271,7 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
             self.retry_rollback('update ds2', session_p2,
                            lambda: prepare_range_updates(
                                session_p2, cursor_p2, ds_2, value_e, nrows,
-                               'prepare_timestamp=' + timestamp_str(69)))
+                               'prepare_timestamp=' + self.timestamp_str(69)))
         finally:
             done.set()
             ckpt.join()
@@ -290,8 +287,8 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         copy_wiredtiger_home(self, ".", "RESTART")
 
         # Commit the prepared transaction.
-        session_p1.commit_transaction('commit_timestamp=' + timestamp_str(70) + ',durable_timestamp=' + timestamp_str(71))
-        session_p2.commit_transaction('commit_timestamp=' + timestamp_str(70) + ',durable_timestamp=' + timestamp_str(71))
+        session_p1.commit_transaction('commit_timestamp=' + self.timestamp_str(70) + ',durable_timestamp=' + self.timestamp_str(71))
+        session_p2.commit_transaction('commit_timestamp=' + self.timestamp_str(70) + ',durable_timestamp=' + self.timestamp_str(71))
         session_p1.close()
         session_p2.close()
 

--- a/test/suite/test_rollback_to_stable11.py
+++ b/test/suite/test_rollback_to_stable11.py
@@ -33,9 +33,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable11.py
 # Test the rollback to stable is retrieving the proper history store update.
 class test_rollback_to_stable11(test_rollback_to_stable_base):
@@ -71,8 +68,8 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -90,9 +87,9 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
 
         # Checkpoint to ensure that all the updates are flushed to disk.
         self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable12.py
+++ b/test/suite/test_rollback_to_stable12.py
@@ -33,9 +33,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable12.py
 # Test the rollback to stable operation skipping subtrees in during tree walk.
 class test_rollback_to_stable12(test_rollback_to_stable_base):
@@ -71,8 +68,8 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -85,9 +82,9 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
 
         # Load a single row modification to be removed.
         commit_ts = 30
@@ -95,12 +92,12 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         self.session.begin_transaction()
         cursor[ds.key(1)] = value_b
         if self.prepare:
-            self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(commit_ts-1))
-            self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(commit_ts))
-            self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(commit_ts+1))
+            self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
+            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
             self.session.commit_transaction()
         else:
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
         self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable13.py
+++ b/test/suite/test_rollback_to_stable13.py
@@ -31,9 +31,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable13.py
 # Test the rollback to stable should retain/restore the tombstone from
 # the update list or from the history store for on-disk database.
@@ -70,8 +67,8 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -92,9 +89,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         self.session.checkpoint()
         # Simulate a server crash and restart.
@@ -124,8 +121,8 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -164,9 +161,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         self.session.checkpoint()
         # Simulate a server crash and restart.
@@ -196,8 +193,8 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
@@ -216,14 +213,14 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
             cursor[ds.key(i)] = value_b
             cursor.set_key(ds.key(i))
             cursor.remove()
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(40))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(40))
         cursor.close()
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
         self.session.checkpoint()
 
@@ -260,8 +257,8 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
             self, uri, 0, key_format=self.key_format, value_format="S", config='split_pct=50,log=(enabled=false)')
         ds.populate()
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100
         value_c = "ccccc" * 100
@@ -273,9 +270,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.large_removes(uri, ds, nrows, self.prepare, 40)
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         # Perform several updates and checkpoint.
         self.large_updates(uri, value_c, ds, nrows, self.prepare, 60)
         self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -34,9 +34,6 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from wtthread import checkpoint_thread, op_thread
 
-def timestamp_str(t):
-    return '%x' % t
-
 def mod_val(value, char, location, nbytes=1):
     return value[0:location] + char + value[location+nbytes:]
 
@@ -79,8 +76,8 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
 
@@ -106,9 +103,9 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(60))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(60))
         else:
-            self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Create a checkpoint thread
         done = threading.Event()
@@ -184,8 +181,8 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
 
@@ -213,7 +210,7 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.check(value_modQ, uri, nrows, 30)
         self.check(value_modT, uri, nrows, 60)
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Create a checkpoint thread
         done = threading.Event()
@@ -287,8 +284,8 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
 
@@ -316,7 +313,7 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.check(value_modQ, uri, nrows, 30)
         self.check(value_modT, uri, nrows, 60)
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(50))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
         # Create a checkpoint thread
         done = threading.Event()

--- a/test/suite/test_rollback_to_stable15.py
+++ b/test/suite/test_rollback_to_stable15.py
@@ -32,9 +32,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable15.py
 # Test that roll back to stable handles updates present in the
 # update-list for both fixed length and variable length column store.
@@ -70,7 +67,7 @@ class test_rollback_to_stable15(wttest.WiredTigerTestCase):
         if read_ts == 0:
             session.begin_transaction()
         else:
-            session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
         for k, v in cursor:
@@ -89,8 +86,8 @@ class test_rollback_to_stable15(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         value20 = 0x20
         value30 = 0x30
@@ -101,17 +98,17 @@ class test_rollback_to_stable15(wttest.WiredTigerTestCase):
         for i in range(1, nrows):
             self.session.begin_transaction()
             cursor[i] = value20
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         #First Update to value 30 at timestamp 5
         for i in range(1, nrows):
             self.session.begin_transaction()
             cursor[i] = value30
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(5))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
         cursor.close()
 
         #Set stable timestamp to 2
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(2))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
         self.conn.rollback_to_stable()
         # Check that only value20 is available
         self.check(value20, uri, nrows - 1, 2)
@@ -121,17 +118,17 @@ class test_rollback_to_stable15(wttest.WiredTigerTestCase):
         for i in range(1, nrows):
             self.session.begin_transaction()
             cursor[i] = value30
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(7))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(7))
 
         #Third Update to value40 at timestamp 9
         for i in range(1, nrows):
             self.session.begin_transaction()
             cursor[i] = value40
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(9))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(9))
         cursor.close()
 
         #Set stable timestamp to 7
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(7))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(7))
         self.conn.rollback_to_stable()
         #Check that only value30 is available
         self.check(value30, uri, nrows - 1, 7)

--- a/test/suite/test_rollback_to_stable16.py
+++ b/test/suite/test_rollback_to_stable16.py
@@ -37,9 +37,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable16.py
 # Test that rollback to stable removes updates present on disk for column store.
 class test_rollback_to_stable16(wttest.WiredTigerTestCase):
@@ -81,7 +78,7 @@ class test_rollback_to_stable16(wttest.WiredTigerTestCase):
                 cursor[i] = value + str(i)
             else:
                 cursor[i] = value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(timestamp))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp))
         cursor.close()
 
     def check(self, check_value, uri, nrows, start_row, read_ts):
@@ -89,7 +86,7 @@ class test_rollback_to_stable16(wttest.WiredTigerTestCase):
         if read_ts == 0:
             session.begin_transaction()
         else:
-            session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
 
         count = 0
@@ -128,14 +125,14 @@ class test_rollback_to_stable16(wttest.WiredTigerTestCase):
         self.session.create(uri, create_params)
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         for i in range(len(values)):
             self.insert_update_data(uri, values[i], start_row, nrows, ts[i])
             start_row += nrows
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
 
         if not self.in_memory:
             # Checkpoint to ensure that all the updates are flushed to disk.

--- a/test/suite/test_rollback_to_stable17.py
+++ b/test/suite/test_rollback_to_stable17.py
@@ -33,9 +33,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable17.py
 # Test that rollback to stable handles updates present on history store and data store for variable
 # length column store.
@@ -67,12 +64,12 @@ class test_rollback_to_stable17(wttest.WiredTigerTestCase):
         for i in range(start_row, end_row):
             self.session.begin_transaction()
             cursor[i] = value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(timestamp))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp))
         cursor.close()
 
     def check(self, check_value, uri, nrows, read_ts):
         session = self.session
-        session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
 
         count = 0
@@ -96,15 +93,15 @@ class test_rollback_to_stable17(wttest.WiredTigerTestCase):
         self.session.create(uri, create_params)
 
         # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         # Make a series of updates for the same keys with different values at different timestamps.
         for i in range(len(values)):
             self.insert_update_data(uri, values[i], start_row, nrows, ts[i])
 
         # Set the stable timestamp to 5.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
 
         if not self.in_memory:
             # Checkpoint to ensure that all the updates are flushed to disk.

--- a/test/suite/test_rollback_to_stable18.py
+++ b/test/suite/test_rollback_to_stable18.py
@@ -38,9 +38,6 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable18.py
 # Test the rollback to stable shouldn't skip any pages that don't have aggregated time window.
 class test_rollback_to_stable18(test_rollback_to_stable_base):
@@ -76,8 +73,8 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
 
@@ -102,11 +99,11 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
 
         # Pin stable and oldest to timestamp 30 if prepare otherwise 20.
         if self.prepare:
-            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(30) +
-                ',stable_timestamp=' + timestamp_str(30))
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(30) +
+                ',stable_timestamp=' + self.timestamp_str(30))
         else:
-            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(20) +
-                ',stable_timestamp=' + timestamp_str(20))
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
+                ',stable_timestamp=' + self.timestamp_str(20))
 
         # Perform rollback to stable.
         self.conn.rollback_to_stable()

--- a/test/suite/test_rollback_to_stable19.py
+++ b/test/suite/test_rollback_to_stable19.py
@@ -33,9 +33,6 @@ from wiredtiger import stat, WT_NOTFOUND
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable19.py
 # Test that rollback to stable aborts both insert and remove updates from a single prepared transaction
 class test_rollback_to_stable19(test_rollback_to_stable_base):
@@ -80,8 +77,8 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = "aaaaa" * 100
 
@@ -94,7 +91,7 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
             cursor.set_key(i)
             cursor.remove()
         cursor.close()
-        s.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
@@ -116,7 +113,7 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         cursor2.close()
 
         # Pin stable timestamp to 20.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(20))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
         if not self.in_memory:
             self.session.checkpoint()
 
@@ -155,8 +152,8 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = "aaaaa" * 100
         valueb = "bbbbb" * 100
@@ -176,7 +173,7 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
             cursor.set_key(i)
             cursor.remove()
         cursor.close()
-        s.prepare_transaction('prepare_timestamp=' + timestamp_str(40))
+        s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
@@ -198,7 +195,7 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         cursor2.close()
 
         # Pin stable timestamp to 40.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         if not self.in_memory:
             self.session.checkpoint()
 

--- a/test/suite/test_rollback_to_stable20.py
+++ b/test/suite/test_rollback_to_stable20.py
@@ -34,9 +34,6 @@ from wiredtiger import stat
 from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # Test that rollback to stable does not open any dhandles that don't have unstable updates.
 class test_rollback_to_stable20(test_rollback_to_stable_base):
     session_config = 'isolation=snapshot'
@@ -55,8 +52,8 @@ class test_rollback_to_stable20(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamp to 1.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1) +
-            ',stable_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         valuea = "aaaaa" * 100
 
@@ -65,7 +62,7 @@ class test_rollback_to_stable20(test_rollback_to_stable_base):
             self.session.create(uri, create_params)
             self.large_updates(uri, valuea, ds, nrows, 0, 10)
 
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         self.session.checkpoint()
 

--- a/test/suite/test_rollback_to_stable21.py
+++ b/test/suite/test_rollback_to_stable21.py
@@ -37,9 +37,6 @@ from helper import simulate_crash_restart
 from wtdataset import SimpleDataSet
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable21.py
 # Test rollback to stable when an out of order prepared transaction is written to disk
 class test_rollback_to_stable21(test_rollback_to_stable_base):
@@ -68,8 +65,8 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = 'a' * 400
         valueb = 'b' * 400
@@ -79,7 +76,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
         for i in range(1, nrows + 1):
             cursor[i] = valuea
 
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
@@ -87,7 +84,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
 
         cursor.reset()
         cursor.close()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         s = self.conn.open_session()
         s.begin_transaction('ignore_prepare = true')
@@ -101,7 +98,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
             evict_cursor.reset()
 
         s.rollback_transaction()
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         s.checkpoint()
 
         # Rollback the prepared transaction
@@ -134,8 +131,8 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = 'a' * 400
         valueb = 'b' * 400
@@ -144,13 +141,13 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
             cursor[i] = valuea
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
             cursor.set_key(i)
             cursor.remove()
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(40))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(40))
 
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
@@ -158,10 +155,10 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
 
         cursor.reset()
         cursor.close()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         s = self.conn.open_session()
-        s.begin_transaction('ignore_prepare = true, read_timestamp = ' + timestamp_str(30))
+        s.begin_transaction('ignore_prepare = true, read_timestamp = ' + self.timestamp_str(30))
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
 
@@ -172,7 +169,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
             evict_cursor.reset()
 
         s.rollback_transaction()
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         s.checkpoint()
 
         # Rollback the prepared transaction
@@ -208,8 +205,8 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
         ds.populate()
 
         # Pin oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         valuea = 'a' * 400
         valueb = 'b' * 400
@@ -221,7 +218,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
             cursor.set_key(i)
             cursor.remove()
 
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(30))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         self.session.begin_transaction()
         for i in range(1, nrows + 1):
@@ -229,7 +226,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
 
         cursor.reset()
         cursor.close()
-        self.session.prepare_transaction('prepare_timestamp=' + timestamp_str(20))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
         s = self.conn.open_session()
         s.begin_transaction('ignore_prepare = true')
@@ -242,7 +239,7 @@ class test_rollback_to_stable21(test_rollback_to_stable_base):
             evict_cursor.reset()
 
         s.rollback_transaction()
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
         s.checkpoint()
 
         # Rollback the prepared transaction

--- a/test/suite/test_rollback_to_stable22.py
+++ b/test/suite/test_rollback_to_stable22.py
@@ -38,7 +38,7 @@ def timestamp_str(t):
 # the cache size to 100MB and performing 100MB worth of inserts while periodically calling rollback
 # to stable.
 class test_rollback_to_stable22(test_rollback_to_stable_base):
-    conn_config = 'cache_size=100MB,statistics=(fast),statistics_log=(wait=1,json)'
+    conn_config = 'cache_size=100MB'
     session_config = 'isolation=snapshot'
     prepare = False
 

--- a/test/suite/test_rollback_to_stable22.py
+++ b/test/suite/test_rollback_to_stable22.py
@@ -29,9 +29,6 @@
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_rollback_to_stable22
 # Test history store operations conflicting with rollback to stable. We're trying to trigger a
 # history store eviction concurrently to a rollback to stable call. We'll do this by limiting
@@ -82,5 +79,5 @@ class test_rollback_to_stable22(test_rollback_to_stable_base):
             if i % 100 == 0:
                 # Put the timestamp backwards so we can rollback the updates we just did.
                 stable_ts = (i - 1) * 10
-                self.conn.set_timestamp('stable_timestamp=' + timestamp_str(stable_ts))
+                self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable_ts))
                 self.conn.rollback_to_stable()

--- a/test/suite/test_search_near01.py
+++ b/test/suite/test_search_near01.py
@@ -30,9 +30,6 @@
 import time, wiredtiger, wttest, unittest
 from wiredtiger import stat
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_search_near01.py
 # Test various prefix search near scenarios.
 class test_search_near01(wttest.WiredTigerTestCase):

--- a/test/suite/test_stat09.py
+++ b/test/suite/test_stat09.py
@@ -31,10 +31,6 @@ import wiredtiger, wttest
 
 # test_stat09.py
 #    Check oldest active read timestamp statistic
-
-def timestamp_str(t):
-    return '%x' % t
-
 class test_stat09(wttest.WiredTigerTestCase):
     tablename = 'test_stat09'
     uri = 'table:' + tablename
@@ -88,7 +84,7 @@ class test_stat09(wttest.WiredTigerTestCase):
         for k in keys:
             self.session.begin_transaction()
             c[k] = 1
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(k))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(k))
 
         # Create a cursor on statistics that we can use repeatedly
         allstat_cursor = self.session.open_cursor('statistics:', None, None)
@@ -98,15 +94,15 @@ class test_stat09(wttest.WiredTigerTestCase):
 
         # Introduce multiple transactions with varying read_timestamp
         s1 = self.conn.open_session()
-        s1.begin_transaction('read_timestamp=' + timestamp_str(10))
+        s1.begin_transaction('read_timestamp=' + self.timestamp_str(10))
         s2 = self.conn.open_session()
-        s2.begin_transaction('read_timestamp=' + timestamp_str(20))
+        s2.begin_transaction('read_timestamp=' + self.timestamp_str(20))
         s3 = self.conn.open_session()
-        s3.begin_transaction('read_timestamp=' + timestamp_str(30))
+        s3.begin_transaction('read_timestamp=' + self.timestamp_str(30))
         s4 = self.conn.open_session()
-        s4.begin_transaction('read_timestamp=' + timestamp_str(40))
+        s4.begin_transaction('read_timestamp=' + self.timestamp_str(40))
         s5 = self.conn.open_session()
-        s5.begin_transaction('read_timestamp=' + timestamp_str(50))
+        s5.begin_transaction('read_timestamp=' + self.timestamp_str(50))
 
         # Check oldest reader
         self.check_stat_oldest_read(allstat_cursor, 10, commit_range)
@@ -117,18 +113,18 @@ class test_stat09(wttest.WiredTigerTestCase):
 
         # Set and advance the oldest timestamp, it should be ignored for
         # determining the oldest active read.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
         self.check_stat_oldest_read(allstat_cursor, 20, commit_range)
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(30))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(30))
         self.check_stat_oldest_read(allstat_cursor, 20, commit_range)
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(150))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(150))
         self.check_stat_oldest_read(allstat_cursor, 20, commit_range)
 
         # Move the commit timestamp and check again
         commit_range = 200
-        s2.commit_transaction('commit_timestamp=' + timestamp_str(commit_range))
+        s2.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_range))
         self.check_stat_oldest_read(allstat_cursor, 30, commit_range)
 
         # Close all the readers and check the oldest reader, it should be back to 0

--- a/test/suite/test_tiered03.py
+++ b/test/suite/test_tiered03.py
@@ -56,7 +56,6 @@ class test_tiered03(wttest.WiredTigerTestCase):
         if not os.path.exists(self.bucket):
             os.mkdir(self.bucket)
         return \
-          'statistics=(all),' + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
           'bucket_prefix=%s,' % self.bucket_prefix + \

--- a/test/suite/test_tiered05.py
+++ b/test/suite/test_tiered05.py
@@ -50,7 +50,6 @@ class test_tiered05(wttest.WiredTigerTestCase):
     def conn_config(self):
         os.mkdir(self.bucket)
         return \
-          'statistics=(fast),' + \
           'tiered_manager=(wait=%d),' % self.wait + \
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \

--- a/test/suite/test_timestamp01.py
+++ b/test/suite/test_timestamp01.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp01(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 
@@ -43,28 +40,28 @@ class test_timestamp01(wttest.WiredTigerTestCase, suite_subprocess):
         # Cannot set a timestamp on a non-running transaction
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                'commit_timestamp=' + timestamp_str(1 << 5000)),
+                'commit_timestamp=' + self.timestamp_str(1 << 5000)),
                 '/only permitted in a running/')
 
         # Zero is not permitted
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(0)),
+                'commit_timestamp=' + self.timestamp_str(0)),
                 '/zero not permitted/')
 
         # Too big is also not permitted
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(1 << 5000)),
+                'commit_timestamp=' + self.timestamp_str(1 << 5000)),
                 '/too long/')
 
         # Anything other than lower case hexadecimal characters is not permitted
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(-1)),
+                'commit_timestamp=' + self.timestamp_str(-1)),
                 '/Failed to parse commit timestamp/')
 
         self.session.begin_transaction()
@@ -88,13 +85,13 @@ class test_timestamp01(wttest.WiredTigerTestCase, suite_subprocess):
         # One is okay, as is upper case hex and 2**64 - 1
         self.session.begin_transaction()
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(1))
+            'commit_timestamp=' + self.timestamp_str(1))
         self.session.begin_transaction()
         self.session.commit_transaction(
             'commit_timestamp=0A78F')
         self.session.begin_transaction()
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(1 << 64 - 1))
+            'commit_timestamp=' + self.timestamp_str(1 << 64 - 1))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_timestamp03.py
+++ b/test/suite/test_timestamp03.py
@@ -36,9 +36,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
     table_ts_log     = 'ts03_ts_logged'
     table_ts_nolog   = 'ts03_ts_nologged'
@@ -187,7 +184,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             cur_ts_log[k] = self.value
             cur_ts_nolog[k] = self.value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(k))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(k))
 
         # Scenario: 1
         # Check that we see all the inserted values as per transaction
@@ -207,19 +204,19 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
         for i, t in enumerate(orig_keys):
             # Tables using the timestamps should see the values as per the
             # given read_timestamp
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t),
                 self.table_ts_log, dict((k, self.value) for k in orig_keys[:i+1]))
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t),
                 self.table_ts_nolog, dict((k, self.value) for k in orig_keys[:i+1]))
             # Tables not using the timestamps should see all the values.
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t),
                 self.table_nots_log, dict((k, self.value) for k in orig_keys))
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t),
                 self.table_nots_nolog, dict((k, self.value) for k in orig_keys))
 
         # Bump the oldest_timestamp, we're not going back...
-        self.assertTimestampsEqual(self.conn.query_timestamp(), timestamp_str(100))
-        old_ts = timestamp_str(100)
+        self.assertTimestampsEqual(self.conn.query_timestamp(), self.timestamp_str(100))
+        old_ts = self.timestamp_str(100)
         self.conn.set_timestamp('oldest_timestamp=' + old_ts)
         self.conn.set_timestamp('stable_timestamp=' + old_ts)
 
@@ -248,7 +245,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             cur_ts_log[k] = self.value2
             cur_ts_nolog[k] = self.value2
-            ts = timestamp_str(k + 100)
+            ts = self.timestamp_str(k + 100)
             self.session.commit_transaction('commit_timestamp=' + ts)
             count += 1
 
@@ -270,7 +267,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
         # This scenario is same as earlier one with read_timestamp earlier than
         # oldest_timestamp and using the option of rounding read_timestamp to
         # the oldest_timestamp
-        earlier_ts = timestamp_str(90)
+        earlier_ts = self.timestamp_str(90)
         self.check(self.session,
             'read_timestamp=' + earlier_ts +',roundup_timestamps=(read=true)',
             self.table_ts_log, dict((k, self.value) for k in orig_keys))
@@ -294,15 +291,15 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
             expected_dict[i+1] = self.value2
             # Tables using the timestamps should see the updated values as per
             # the given read_timestamp
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t + 100),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t + 100),
                 self.table_ts_log, expected_dict)
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t + 100),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t + 100),
                 self.table_ts_nolog, expected_dict)
             # Tables not using the timestamps should see all the data values as
             # updated values (i.e. value2).
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t + 100),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t + 100),
                 self.table_nots_log, dict((k, self.value2) for k in orig_keys))
-            self.check(self.session, 'read_timestamp=' + timestamp_str(t + 100),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(t + 100),
                 self.table_nots_nolog, dict((k, self.value2) for k in orig_keys))
 
         # Take a checkpoint using the given configuration.  Then verify
@@ -359,7 +356,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
         # Update the stable_timestamp to the latest, but not the
         # oldest_timestamp and make sure we can see the data.  Once the
         # stable_timestamp is moved we should see all keys with value2.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(100+nkeys))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100+nkeys))
         self.ckpt_backup(self.value2, nkeys, nkeys, nkeys, nkeys)
 
         # If we're not using the log we're done.
@@ -378,7 +375,7 @@ class test_timestamp03(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             cur_ts_log[k] = self.value3
             cur_ts_nolog[k] = self.value3
-            ts = timestamp_str(k + 200)
+            ts = self.timestamp_str(k + 200)
             self.session.commit_transaction('commit_timestamp=' + ts)
             count += 1
 

--- a/test/suite/test_timestamp05.py
+++ b/test/suite/test_timestamp05.py
@@ -35,9 +35,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp05(wttest.WiredTigerTestCase, suite_subprocess):
     uri = 'table:ts05'
     session_config = 'isolation=snapshot'
@@ -52,7 +49,7 @@ class test_timestamp05(wttest.WiredTigerTestCase, suite_subprocess):
         # Commit at 100
         s.begin_transaction()
         s.create(self.uri, 'key_format=i,value_format=S')
-        s.commit_transaction('commit_timestamp=' + timestamp_str(100))
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(100))
 
         # Make sure the tree is dirty
         c = s.open_cursor(self.uri)
@@ -79,7 +76,7 @@ class test_timestamp05(wttest.WiredTigerTestCase, suite_subprocess):
         # Commit at 100
         s.begin_transaction()
         c.close()
-        s.commit_transaction('commit_timestamp=' + timestamp_str(100))
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(100))
 
         # Make sure the tree is dirty
         c = s.open_cursor(self.uri)

--- a/test/suite/test_timestamp06.py
+++ b/test/suite/test_timestamp06.py
@@ -36,9 +36,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp06(wttest.WiredTigerTestCase, suite_subprocess):
     table_ts_log     = 'table:ts06_ts_logged'
     table_ts_nolog   = 'table:ts06_ts_nologged'
@@ -138,22 +135,22 @@ class test_timestamp06(wttest.WiredTigerTestCase, suite_subprocess):
 
         self.session.begin_transaction()
         # Make three updates with different timestamps.
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(1))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(1))
         for k in keys:
             cur_ts_log[k] = 1
             cur_ts_nolog[k] = 1
 
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(101))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(101))
         for k in keys:
             cur_ts_log[k] = 2
             cur_ts_nolog[k] = 2
 
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(201))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(201))
         for k in keys:
             cur_ts_log[k] = 3
             cur_ts_nolog[k] = 3
 
-        self.session.commit_transaction('commit_timestamp=' + timestamp_str(301))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(301))
         cur_ts_log.close()
         cur_ts_nolog.close()
 
@@ -170,9 +167,9 @@ class test_timestamp06(wttest.WiredTigerTestCase, suite_subprocess):
         # Check that we see the values till correctly from checkpointed data
         # files in case of multistep transactions.
         # Set oldest and stable timestamps
-        old_ts = timestamp_str(100)
+        old_ts = self.timestamp_str(100)
         # Set the stable timestamp such that last update is beyond it.
-        stable_ts = timestamp_str(200)
+        stable_ts = self.timestamp_str(200)
         self.conn.set_timestamp('oldest_timestamp=' + old_ts)
         self.conn.set_timestamp('stable_timestamp=' + stable_ts)
 

--- a/test/suite/test_timestamp07.py
+++ b/test/suite/test_timestamp07.py
@@ -36,9 +36,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'ts07_ts_nologged'
     tablename2 = 'ts07_nots_logged'
@@ -201,23 +198,23 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             c[k] = self.value
             c3[k] = self.value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(k))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(k))
 
         # print "value inserted in all tables, reading..."
 
         # Now check that we see the expected state when reading at each
         # timestamp.
         for k in orig_keys:
-            self.check(self.session, 'read_timestamp=' + timestamp_str(k),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(k),
                 k, self.value)
-            self.check(self.session, 'read_timestamp=' + timestamp_str(k),
+            self.check(self.session, 'read_timestamp=' + self.timestamp_str(k),
                 k + 1, None)
 
         # print "all values read, updating timestamps"
 
         # Bump the oldest timestamp, we're not going back...
-        self.assertTimestampsEqual(self.conn.query_timestamp(), timestamp_str(self.nkeys))
-        self.oldts = self.stablets = timestamp_str(self.nkeys)
+        self.assertTimestampsEqual(self.conn.query_timestamp(), self.timestamp_str(self.nkeys))
+        self.oldts = self.stablets = self.timestamp_str(self.nkeys)
         self.conn.set_timestamp('oldest_timestamp=' + self.oldts)
         self.conn.set_timestamp('stable_timestamp=' + self.stablets)
         # print "Oldest " + self.oldts
@@ -237,7 +234,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             c[k] = self.value2
             c3[k] = self.value2
-            ts = timestamp_str(k + self.nkeys)
+            ts = self.timestamp_str(k + self.nkeys)
             self.session.commit_transaction('commit_timestamp=' + ts)
             # print "Commit key " + str(k) + " ts " + ts
             count += 1
@@ -252,7 +249,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
         # Update the stable timestamp to the latest, but not the oldest
         # timestamp and make sure we can see the data.  Once the stable
         # timestamp is moved we should see all keys with value2.
-        self.stablets = timestamp_str(self.nkeys*2)
+        self.stablets = self.timestamp_str(self.nkeys*2)
         self.conn.set_timestamp('stable_timestamp=' + self.stablets)
         # print "check_stable 2"
         self.check_stable(self.value2, self.nkeys, self.nkeys, self.nkeys)
@@ -274,7 +271,7 @@ class test_timestamp07(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.begin_transaction()
             c[k] = self.value3
             c3[k] = self.value3
-            ts = timestamp_str(k + self.nkeys*2)
+            ts = self.timestamp_str(k + self.nkeys*2)
             self.session.commit_transaction('commit_timestamp=' + ts)
             # print "Commit key " + str(k) + " ts " + ts
             count += 1

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_timestamp09'
     uri = 'table:' + tablename
@@ -48,7 +45,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # Begin by adding some data.
         self.session.begin_transaction()
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(1))
+            'commit_timestamp=' + self.timestamp_str(1))
         c[1] = 1
 
         # In a single transaction it is illegal to set a commit timestamp
@@ -56,21 +53,21 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         # Check both timestamp_transaction and commit_transaction APIs.
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(3))
+            'commit_timestamp=' + self.timestamp_str(3))
         c[3] = 3
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                'commit_timestamp=' + timestamp_str(2)),
+                'commit_timestamp=' + self.timestamp_str(2)),
                 '/older than the first commit timestamp/')
         self.session.rollback_transaction()
 
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(4))
+            'commit_timestamp=' + self.timestamp_str(4))
         c[4] = 4
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(3)),
+                'commit_timestamp=' + self.timestamp_str(3)),
                 '/older than the first commit timestamp/')
 
         # Commit timestamp >= Oldest timestamp
@@ -78,13 +75,13 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         c[3] = 3
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(3))
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(3))
+            'commit_timestamp=' + self.timestamp_str(3))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(3))
 
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                'commit_timestamp=' + timestamp_str(2)),
+                'commit_timestamp=' + self.timestamp_str(2)),
                 '/less than the oldest timestamp/')
         self.session.rollback_transaction()
 
@@ -92,48 +89,48 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         c[2] = 2
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(2)),
+                'commit_timestamp=' + self.timestamp_str(2)),
                 '/less than the oldest timestamp/')
 
         self.session.begin_transaction()
         c[4] = 4
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(4))
+            'commit_timestamp=' + self.timestamp_str(4))
 
         # Oldest timestamp <= Stable timestamp and both oldest and stable
         # timestamp should proceed forward.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
-                timestamp_str(3) + ',stable_timestamp=' + timestamp_str(1)),
+                self.timestamp_str(3) + ',stable_timestamp=' + self.timestamp_str(1)),
                 '/oldest timestamp \(0, 3\) must not be later than stable timestamp \(0, 1\)/')
 
         # Oldest timestamp is 3 at the moment, trying to set it to an earlier
         # timestamp is a no-op.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), timestamp_str(3))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), self.timestamp_str(3))
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(3) +
-            ',stable_timestamp=' + timestamp_str(3))
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(3) +
+            ',stable_timestamp=' + self.timestamp_str(3))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
         # Stable timestamp is 5 at the moment, trying to set it to an earlier
         # timestamp is a no-op.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(4))
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), timestamp_str(5))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), self.timestamp_str(5))
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(5))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.set_timestamp('oldest_timestamp=' +
-                timestamp_str(6)),
+                self.timestamp_str(6)),
                 '/oldest timestamp \(0, 6\) must not be later than stable timestamp \(0, 5\)/')
 
         # Commit timestamp >= Stable timestamp.
         # Check both timestamp_transaction and commit_transaction APIs.
         # Oldest and stable timestamp are set to 5 at the moment.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(6))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(6))
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                'commit_timestamp=' + timestamp_str(5)),
+                'commit_timestamp=' + self.timestamp_str(5)),
                 '/less than the stable timestamp/')
         self.session.rollback_transaction()
 
@@ -141,7 +138,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         c[5] = 5
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
-                'commit_timestamp=' + timestamp_str(5)),
+                'commit_timestamp=' + self.timestamp_str(5)),
                 '/less than the stable timestamp/')
 
         # When explicitly set, commit timestamp for a transaction can be earlier
@@ -149,48 +146,48 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         c[6] = 6
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(6))
+            'commit_timestamp=' + self.timestamp_str(6))
         self.session.begin_transaction()
         c[8] = 8
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(8))
+            'commit_timestamp=' + self.timestamp_str(8))
         self.session.begin_transaction()
         c[7] = 7
         self.session.commit_transaction(
-            'commit_timestamp=' + timestamp_str(7))
+            'commit_timestamp=' + self.timestamp_str(7))
 
         # Read timestamp >= Oldest timestamp
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(7) +
-            ',stable_timestamp=' + timestamp_str(7))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(7) +
+            ',stable_timestamp=' + self.timestamp_str(7))
         with self.expectedStdoutPattern('less than the oldest timestamp'):
             self.assertRaisesException(wiredtiger.WiredTigerError,
-                lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(6)))
+                lambda: self.session.begin_transaction('read_timestamp=' + self.timestamp_str(6)))
 
         # c[8] is not visible at read_timestamp < 8
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(7))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(7))
         self.assertEqual(c[6], 6)
         self.assertEqual(c[7], 7)
         c.set_key(8)
         self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND)
         self.session.commit_transaction()
 
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(8))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(8))
         self.assertEqual(c[6], 6)
         self.assertEqual(c[7], 7)
         self.assertEqual(c[8], 8)
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(8))
+            self.conn.query_timestamp('get=oldest_reader'), self.timestamp_str(8))
         self.session.commit_transaction()
 
         # We can move the oldest timestamp backwards with "force"
         self.conn.set_timestamp(
-            'oldest_timestamp=' + timestamp_str(5) + ',force')
+            'oldest_timestamp=' + self.timestamp_str(5) + ',force')
         with self.expectedStdoutPattern('less than the oldest timestamp'):
             self.assertRaisesException(wiredtiger.WiredTigerError,
-                lambda: self.session.begin_transaction('read_timestamp=' + timestamp_str(4)))
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(6))
+                lambda: self.session.begin_transaction('read_timestamp=' + self.timestamp_str(4)))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(6))
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=oldest_reader'), timestamp_str(6))
+            self.conn.query_timestamp('get=oldest_reader'), self.timestamp_str(6))
         self.session.commit_transaction()
 
 if __name__ == '__main__':

--- a/test/suite/test_timestamp10.py
+++ b/test/suite/test_timestamp10.py
@@ -34,9 +34,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp10(wttest.WiredTigerTestCase, suite_subprocess):
     conn_config = 'config_base=false,create,log=(enabled)'
     session_config = 'isolation=snapshot'
@@ -90,16 +87,16 @@ class test_timestamp10(wttest.WiredTigerTestCase, suite_subprocess):
                 curs[i] = i
                 self.pr("i: " + str(i))
                 self.session.commit_transaction(
-                  'commit_timestamp=' + timestamp_str(i))
+                  'commit_timestamp=' + self.timestamp_str(i))
             # Set the oldest and stable timestamp a bit earlier than the data
             # we inserted. Take a checkpoint to the stable timestamp.
             self.pr("stable ts: " + str(ts))
-            self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(ts) +
-                ',stable_timestamp=' + timestamp_str(ts))
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(ts) +
+                ',stable_timestamp=' + self.timestamp_str(ts))
             # This forces a different checkpoint timestamp for each table.
             self.session.checkpoint()
             q = self.conn.query_timestamp('get=last_checkpoint')
-            self.assertTimestampsEqual(q, timestamp_str(ts))
+            self.assertTimestampsEqual(q, self.timestamp_str(ts))
         return ts
 
     def close_and_recover(self, expected_rec_ts):
@@ -124,7 +121,7 @@ class test_timestamp10(wttest.WiredTigerTestCase, suite_subprocess):
         self.open_conn()
         q = self.conn.query_timestamp('get=recovery')
         self.pr("query recovery ts: " + q)
-        self.assertTimestampsEqual(q, timestamp_str(expected_rec_ts))
+        self.assertTimestampsEqual(q, self.timestamp_str(expected_rec_ts))
 
     def test_timestamp_recovery(self):
         # Add some data and checkpoint at a stable timestamp.

--- a/test/suite/test_timestamp11.py
+++ b/test/suite/test_timestamp11.py
@@ -33,9 +33,6 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
     session_config = 'isolation=snapshot'
 
@@ -51,7 +48,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(2))
+            'commit_timestamp=' + self.timestamp_str(2))
         c['key'] = 'value2'
         c['key2'] = 'value2'
         self.session.commit_transaction()
@@ -64,7 +61,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(5))
+            'commit_timestamp=' + self.timestamp_str(5))
         c['key'] = 'value5'
         self.session.commit_transaction()
         c.close()
@@ -81,7 +78,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         # remain at the non-timestamped value. Also the non-timestamped value
         # stays regardless of rollbacks or reading at a timestamp.
         #
-        stable_ts = timestamp_str(2)
+        stable_ts = self.timestamp_str(2)
         self.conn.set_timestamp('stable_timestamp=' + stable_ts)
         self.session.checkpoint()
         self.conn.rollback_to_stable()
@@ -106,7 +103,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         self.session.timestamp_transaction(
-            'commit_timestamp=' + timestamp_str(5))
+            'commit_timestamp=' + self.timestamp_str(5))
         c['key2'] = 'value5'
         self.session.commit_transaction()
         c.close()
@@ -140,7 +137,7 @@ class test_timestamp11(wttest.WiredTigerTestCase, suite_subprocess):
         # one at that timestamp and inserted without a timestamp. For the second
         # we inserted at timestamp 5 after the non-timestamped insert.
         c = self.session.open_cursor(uri)
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(5))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(5))
         self.assertEquals(c['key'], 'valueNOTS')
         self.assertEquals(c['key2'], 'value5')
         self.session.commit_transaction()

--- a/test/suite/test_timestamp12.py
+++ b/test/suite/test_timestamp12.py
@@ -33,9 +33,6 @@
 import shutil, os, wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp12(wttest.WiredTigerTestCase):
     conn_config = 'config_base=false,create,log=(enabled)'
     session_config = 'isolation=snapshot'
@@ -85,10 +82,10 @@ class test_timestamp12(wttest.WiredTigerTestCase):
             c_op[i] = 1
             c_coll[i] = 1
             self.session.commit_transaction(
-              'commit_timestamp=' + timestamp_str(i))
+              'commit_timestamp=' + self.timestamp_str(i))
         # Set the oldest and stable timestamp to the end.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(nentries-1) +
-        ',stable_timestamp=' + timestamp_str(nentries-1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(nentries-1) +
+        ',stable_timestamp=' + self.timestamp_str(nentries-1))
 
         # Add more data but don't advance the stable timestamp.
         for i in second_range:
@@ -97,7 +94,7 @@ class test_timestamp12(wttest.WiredTigerTestCase):
             c_coll[i] = 1
             self.pr("i: " + str(i))
             self.session.commit_transaction(
-              'commit_timestamp=' + timestamp_str(i))
+              'commit_timestamp=' + self.timestamp_str(i))
 
         # Close and reopen the connection. We cannot use reopen_conn because
         # we want to test the specific close configuration string.

--- a/test/suite/test_timestamp14.py
+++ b/test/suite/test_timestamp14.py
@@ -35,9 +35,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_timestamp14'
     uri = 'table:' + tablename

--- a/test/suite/test_timestamp16.py
+++ b/test/suite/test_timestamp16.py
@@ -36,9 +36,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp16(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_timestamp16'
     uri = 'table:' + tablename

--- a/test/suite/test_timestamp17.py
+++ b/test/suite/test_timestamp17.py
@@ -38,9 +38,6 @@ from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp17(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_timestamp17'
     uri = 'table:' + tablename

--- a/test/suite/test_timestamp18.py
+++ b/test/suite/test_timestamp18.py
@@ -38,9 +38,6 @@
 import wiredtiger, wttest
 from wtscenario import make_scenarios
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp18(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
@@ -53,7 +50,7 @@ class test_timestamp18(wttest.WiredTigerTestCase):
     def test_ts_writes_with_non_ts_write(self):
         uri = 'table:test_timestamp18'
         self.session.create(uri, 'key_format=S,value_format=S')
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
 
         value1 = 'a' * 500
@@ -65,17 +62,17 @@ class test_timestamp18(wttest.WiredTigerTestCase):
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[str(i)] = value1
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[str(i)] = value2
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(3))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
         for i in range(1, 10000):
             self.session.begin_transaction()
             cursor[str(i)] = value3
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
         # Add a non-timestamped delete.
         # Let's do every second key to ensure that we get the truncation right and don't
@@ -91,7 +88,7 @@ class test_timestamp18(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         for ts in range(2, 4):
-            self.session.begin_transaction('read_timestamp=' + timestamp_str(ts))
+            self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
             for i in range(1, 10000):
                 # The non-timestamped delete should cover all the previous writes and make them effectively
                 # invisible.

--- a/test/suite/test_timestamp19.py
+++ b/test/suite/test_timestamp19.py
@@ -31,9 +31,6 @@
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp19(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
@@ -44,7 +41,7 @@ class test_timestamp19(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             session.begin_transaction()
             cursor[ds.key(i)] = value
-            session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def test_timestamp(self):
@@ -62,8 +59,8 @@ class test_timestamp19(wttest.WiredTigerTestCase):
         value_z = 'z' * 1000
 
         # Set the oldest and stable timestamps to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-          ', stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+          ', stable_timestamp=' + self.timestamp_str(10))
 
         # Insert values with varying timestamps.
         self.updates(uri, value_x, ds, nrows, 20)
@@ -74,8 +71,8 @@ class test_timestamp19(wttest.WiredTigerTestCase):
         self.session.checkpoint('use_timestamp=true')
 
         # Move the oldest and stable timestamps to 40.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(40) +
-          ', stable_timestamp=' + timestamp_str(40))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(40) +
+          ', stable_timestamp=' + self.timestamp_str(40))
 
         # Update values.
         self.updates(uri, value_z, ds, nrows, 50)
@@ -91,20 +88,20 @@ class test_timestamp19(wttest.WiredTigerTestCase):
         self.session = self.setUpSessionOpen(self.conn)
 
         # The oldest timestamp on recovery is 40. Trying to set it earlier is a no-op.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10))
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), timestamp_str(40))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), self.timestamp_str(40))
 
         # Trying to set an earlier stable timestamp is an error.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10)),
+            lambda: self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10)),
             '/oldest timestamp \(0, 40\) must not be later than stable timestamp \(0, 10\)/')
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), timestamp_str(40))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), self.timestamp_str(40))
 
         # Move the oldest and stable timestamps to 70.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(70) +
-          ', stable_timestamp=' + timestamp_str(70))
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), timestamp_str(70))
-        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), timestamp_str(70))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(70) +
+          ', stable_timestamp=' + self.timestamp_str(70))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=oldest'), self.timestamp_str(70))
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=stable'), self.timestamp_str(70))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_timestamp19.py
+++ b/test/suite/test_timestamp19.py
@@ -35,7 +35,7 @@ def timestamp_str(t):
     return '%x' % t
 
 class test_timestamp19(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     def updates(self, uri, value, ds, nrows, commit_ts):

--- a/test/suite/test_timestamp22.py
+++ b/test/suite/test_timestamp22.py
@@ -32,9 +32,6 @@ import wiredtiger, wttest, re, suite_random
 from wtdataset import SimpleDataSet
 from contextlib import contextmanager
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_timestamp22(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
@@ -124,7 +121,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
             this_commit_ts = -1
             if self.do_illegal():
                 # setting durable timestamp must be after prepare call
-                config += ',durable_timestamp=' + timestamp_str(self.gen_ts(commit_ts))
+                config += ',durable_timestamp=' + self.timestamp_str(self.gen_ts(commit_ts))
                 ok = False
 
             # ODDITY: if we set the durable timestamp (which is illegal at this point), and set a
@@ -143,7 +140,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
                 else:
                     # It's possible this will succeed, we'll check below.
                     this_commit_ts = self.gen_ts(commit_ts)
-                config += ',commit_timestamp=' + timestamp_str(this_commit_ts)
+                config += ',commit_timestamp=' + self.timestamp_str(this_commit_ts)
 
             if this_commit_ts >= 0:
                 if this_commit_ts < running_commit_ts:
@@ -161,7 +158,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
         session = self.session
         needs_rollback = False
         prepare_config = None
-        commit_config = 'commit_timestamp=' + timestamp_str(commit_ts)
+        commit_config = 'commit_timestamp=' + self.timestamp_str(commit_ts)
         tstxn1_config = ''
         tstxn2_config = ''
 
@@ -173,11 +170,11 @@ class test_timestamp22(wttest.WiredTigerTestCase):
         # Occasionally put a durable timestamp on a commit without a prepare,
         # that will be an error.
         if do_prepare or not ok_commit:
-            commit_config += ',durable_timestamp=' + timestamp_str(durable_ts)
+            commit_config += ',durable_timestamp=' + self.timestamp_str(durable_ts)
         cursor = session.open_cursor(self.uri)
         prepare_ts = self.gen_ts(commit_ts)
-        prepare_config = 'prepare_timestamp=' + timestamp_str(prepare_ts)
-        begin_config = '' if read_ts < 0 else 'read_timestamp=' + timestamp_str(read_ts)
+        prepare_config = 'prepare_timestamp=' + self.timestamp_str(prepare_ts)
+        begin_config = '' if read_ts < 0 else 'read_timestamp=' + self.timestamp_str(read_ts)
 
         # We might do timestamp_transaction calls either before/after inserting
         # values, or both.
@@ -302,7 +299,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
         for ts_name in ['oldest', 'stable', 'commit', 'durable']:
             val = eval(ts_name)
             if val >= 0:
-                configs.append(ts_name + '_timestamp=' + timestamp_str(val))
+                configs.append(ts_name + '_timestamp=' + self.timestamp_str(val))
         return ','.join(configs)
 
     # Determine whether we expect the set_timestamp to succeed.
@@ -357,8 +354,8 @@ class test_timestamp22(wttest.WiredTigerTestCase):
                 self.pr('updating stable: ' + str(stable))
 
         # Make sure the state of global timestamps is what we think.
-        expect_query_oldest = timestamp_str(self.oldest_ts)
-        expect_query_stable = timestamp_str(self.stable_ts)
+        expect_query_oldest = self.timestamp_str(self.oldest_ts)
+        expect_query_stable = self.timestamp_str(self.stable_ts)
         query_oldest = self.conn.query_timestamp('get=oldest')
         query_stable = self.conn.query_timestamp('get=stable')
 

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -28,9 +28,6 @@
 
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_truncate05.py
 # Test various fast truncate visibility scenarios
 class test_truncate05(wttest.WiredTigerTestCase):
@@ -49,7 +46,7 @@ class test_truncate05(wttest.WiredTigerTestCase):
         for i in range(1, 1000):
             self.session.begin_transaction()
             cursor[i] = value1
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Reopen the connection to force all content to disk.
         self.reopen_conn()
@@ -59,17 +56,17 @@ class test_truncate05(wttest.WiredTigerTestCase):
         # Insert a single update at a later timestamp.
         self.session.begin_transaction()
         cursor[500] = value2
-        self.assertEqual(self.session.commit_transaction('commit_timestamp=' + timestamp_str(3)), 0)
+        self.assertEqual(self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3)), 0)
 
         # Insert a bunch of other content to fill the database and evict the committed update.
         for i in range(1000, 20000):
             self.session.begin_transaction()
             cursor[i] = value1
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(4))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
 
         # Start a transaction with an earlier read timestamp than the commit timestamp of the
         # previous update.
-        self.session.begin_transaction('read_timestamp=' + timestamp_str(2))
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(2))
 
         # Truncate from key 1 to 1000.
         start = self.session.open_cursor(uri, None)

--- a/test/suite/test_txn17.py
+++ b/test/suite/test_txn17.py
@@ -35,16 +35,13 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_txn17(wttest.WiredTigerTestCase, suite_subprocess):
     def test_txn_api(self):
         # Test API functionality tagged as requires_transaction.
         # Cannot set a timestamp on a non-running transaction.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
-                'commit_timestamp=' + timestamp_str(1 << 5000)),
+                'commit_timestamp=' + self.timestamp_str(1 << 5000)),
                 '/only permitted in a running/')
 
         # Cannot call commit on a non-running transaction.

--- a/test/suite/test_txn23.py
+++ b/test/suite/test_txn23.py
@@ -33,9 +33,6 @@
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 
-def timestamp_str(t):
-    return '%x' % t
-
 class test_txn23(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=5MB'
@@ -46,12 +43,12 @@ class test_txn23(wttest.WiredTigerTestCase):
         for i in range(0, nrows):
             self.session.begin_transaction()
             cursor[ds.key(i)] = value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(commit_ts))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
     def check(self, check_value, uri, ds, nrows, read_ts):
         for i in range(0, nrows):
-            self.session.begin_transaction('read_timestamp=' + timestamp_str(read_ts))
+            self.session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
             cursor = self.session.open_cursor(uri)
             self.assertEqual(cursor[ds.key(i)], check_value)
             cursor.close()
@@ -73,8 +70,8 @@ class test_txn23(wttest.WiredTigerTestCase):
         ds_2.populate()
 
         # Pin oldest and stable to timestamp 10.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(10) +
-            ',stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100

--- a/test/suite/test_txn25.py
+++ b/test/suite/test_txn25.py
@@ -33,7 +33,7 @@
 import wiredtiger, wttest
 
 class test_txn25(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    conn_config = 'cache_size=50MB,log=(enabled)'
     session_config = 'isolation=snapshot'
 
     def test_txn25(self):

--- a/test/suite/test_txn26.py
+++ b/test/suite/test_txn26.py
@@ -33,9 +33,9 @@
 import wiredtiger, wttest
 
 # test_txn26.py
-#   Test that commit should fail if commit timestamp is smaller or equal to the active timestamp. Our handling of out of order timestamp relies on this to ensure repeated reads are working as expected.
-def timestamp_str(t):
-    return '%x' % t
+#   Test that commit should fail if commit timestamp is smaller or equal to the active timestamp.
+#   Our handling of out of order timestamp relies on this to ensure repeated reads are working as
+#   expected.
 class test_txn26(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB'
     session_config = 'isolation=snapshot'
@@ -48,20 +48,20 @@ class test_txn26(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + timestamp_str(1) + ',stable_timestamp=' + timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
 
         value = 'a'
 
         # Start a session with timestamp 10
         session2 = self.conn.open_session(self.session_config)
-        session2.begin_transaction('read_timestamp=' + timestamp_str(10))
+        session2.begin_transaction('read_timestamp=' + self.timestamp_str(10))
 
         # Try to commit at timestamp 10
         self.session.begin_transaction()
         cursor[str(0)] = value
         with self.expectedStderrPattern("must be greater than the latest active read timestamp"):
             try:
-                self.session.commit_transaction('commit_timestamp=' + timestamp_str(10))
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
             except wiredtiger.WiredTigerError as e:
                 gotException = True
                 self.pr('got expected exception: ' + str(e))

--- a/test/suite/test_util01.py
+++ b/test/suite/test_util01.py
@@ -30,9 +30,6 @@ import string, os, sys, random
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_util01.py
 #    Utilities: wt dump, as well as the dump cursor
 class test_util01(wttest.WiredTigerTestCase, suite_subprocess):
@@ -164,7 +161,7 @@ class test_util01(wttest.WiredTigerTestCase, suite_subprocess):
                 expectout.write(self.dumpstr(key, hexoutput))
                 expectout.write(self.dumpstr(value, hexoutput))
         if commit_timestamp is not None:
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(commit_timestamp))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_timestamp))
 
     def dump(self, usingapi, hexoutput, commit_timestamp, read_timestamp):
         params = self.table_config()

--- a/test/suite/test_util21.py
+++ b/test/suite/test_util21.py
@@ -30,9 +30,6 @@ import wttest
 from suite_subprocess import suite_subprocess
 from helper import compare_files
 
-def timestamp_str(t):
-    return '%x' % t
-
 # test_util21.py
 # Ensure that wt dump can dump obsolete data in the history store.
 class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
@@ -45,7 +42,7 @@ class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
         for i in range(1, 5):
             self.session.begin_transaction()
             cursor[str(i)] = value
-            self.session.commit_transaction('commit_timestamp=' + timestamp_str(ts))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
     def test_dump_obsolete_data(self):
@@ -58,7 +55,7 @@ class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
         value3 = 'c' * 100
         value4 = 'd' * 100
 
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
 
         self.add_data_with_timestamp(uri, value1, 2)
         self.add_data_with_timestamp(uri, value2, 3)
@@ -68,14 +65,14 @@ class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.checkpoint()
 
         # Set stable timestamp, so we don't lose data when closing/opening connection when using wt dump.
-        self.conn.set_timestamp('stable_timestamp=' + timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
         # Call dump on the values before the oldest timestamp is set
         self.runWt(['dump', 'file:WiredTigerHS.wt'], outfilename="before_oldest")
 
         # Set oldest timestamp, and checkpoint, the obsolete data should not removed as
         # the pages are clean.
-        self.conn.set_timestamp('oldest_timestamp=' + timestamp_str(6))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(6))
         self.session.checkpoint()
         self.runWt(['dump', 'file:WiredTigerHS.wt'], outfilename="after_oldest")
 

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -653,6 +653,9 @@ class WiredTigerTestCase(unittest.TestCase):
         """
         self.assertEqual(int(ts1, 16), int(ts2, 16))
 
+    def timestamp_str(self, t):
+        return '%x' % t
+
     def exceptionToStderr(self, expr):
         """
         Used by assertRaisesHavingMessage to convert an expression


### PR DESCRIPTION
Remove unnecessary `timestamp_str` implementations and statistics configurations.

Second pass, create a generally available `timestamp_str` implementation (if somebody hates this for some reason, it can be separately reverted).