### PR TITLE
WT-7352 Fix test_hs01 conflict between concurrent operations in cursor modify.

### DIFF
--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -123,7 +123,7 @@ class test_hs01(wttest.WiredTigerTestCase):
         # Large updates with session 1.
         self.large_updates(self.session, uri, bigvalue2, ds, nrows)
 
-        # Checkpoint and then assert that the 9999 insertions were moved to history store from data store.
+        # Checkpoint and then assert that the (nrows-1) insertions were moved to history store from data store.
         self.session.checkpoint()
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
         self.assertEqual(hs_writes, nrows-1)
@@ -144,13 +144,13 @@ class test_hs01(wttest.WiredTigerTestCase):
         self.large_modifies(self.session, uri, 0, ds, nrows)
         self.large_modifies(self.session, uri, 1, ds, nrows)
 
-        # Checkpoint and then assert if updates (9999) and first large modifies (9999) were moved to history store.
+        # Checkpoint and then assert if updates (nrows-1) and first large modifies (nrows-1) were moved to history store.
         self.session.checkpoint()
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
-        # The updates in data store: 9999
-        # The first modifies in cache: 9999
-        # The stats was already set at: 9999 (previous hs stats)
-        # Total: 29997
+        # The updates in data store: nrows-1
+        # The first modifies in cache: nrows-1
+        # The stats was already set at: nrows-1 (previous hs stats)
+        # Total: (nrows-1)*3
         self.assertEqual(hs_writes, (nrows-1) * 3)
 
         # Check to see the modified value after recovery.
@@ -170,9 +170,9 @@ class test_hs01(wttest.WiredTigerTestCase):
         self.large_updates(self.session, uri, bigvalue4, ds, nrows, timestamp=True)
 
         self.session.checkpoint()
-        # Check if the 9999 modifications were moved to history store from data store.
-        # The stats was already set at: 29997 (previous hs stats)
-        # Total: 39996
+        # Check if the (nrows-1) modifications were moved to history store from data store.
+        # The stats was already set at: (nrows-1)*3 (previous hs stats)
+        # Total: (nrows-1)*4
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
         self.assertEqual(hs_writes, (nrows-1) * 4)
 

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 # Smoke tests to ensure history store tables are working.
 class test_hs01(wttest.WiredTigerTestCase):
     # Force a small cache.
-    conn_config = 'cache_size=50MB'
+    conn_config = 'cache_size=200MB'
     session_config = 'isolation=snapshot'
     key_format_values = [
         ('column', dict(key_format='r')),

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -135,7 +135,7 @@ class test_hs01(wttest.WiredTigerTestCase):
         # Open session 2.
         session2 = self.conn.open_session()
         session2.begin_transaction('isolation=snapshot')
-        # Apply two modify operations (session 1)- replacing the first two items with 'A'.
+        # Apply two modify operations (session1)- replacing the first two items with 'A'.
         self.large_modifies(self.session, uri, 0, ds, nrows)
         self.large_modifies(self.session, uri, 1, ds, nrows)
         # Check to see the value after recovery.

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -105,7 +105,7 @@ class test_hs01(wttest.WiredTigerTestCase):
         ds = SimpleDataSet(self, uri, nrows, key_format=self.key_format, value_format='u')
         ds.populate()
 
-        # Initially insert a huge number of data.
+        # Initially insert a lot of data.
         bigvalue = b"aaaaa" * 100
         cursor = self.session.open_cursor(uri)
         for i in range(1, 10000):


### PR DESCRIPTION
Rollback error at small cache (often at 5MB cache). Hence, increased the cache from 50MB to 200MB, as an extremely constrained cache is not necessary for the test. (As with the large_modify(), where the error occurs, we are not testing eviction but checking for the modified content in the history store after recovery. )