### PR TITLE
WT-7935 add arm64 implementation of rdtsc equivalent instruction

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -619,6 +619,7 @@ clsm
 cmd
 cmp
 cnt
+cntvct
 colcheck
 colgroup
 colgroups
@@ -1070,6 +1071,7 @@ mmap
 mmrand
 mnt
 movemask
+mrs
 msecs
 msg
 msvc

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -29,6 +29,13 @@ __wt_rdtsc(void)
         __asm__ volatile("rdtsc" : "=a"(a), "=d"(d));
         return ((d << 32) | a);
     }
+#elif defined(__aarch64__)
+    {
+        uint64_t t;
+
+        __asm__ volatile("mrs %0,  cntvct_el0" : "=r"(t));
+        return (t);
+    }
 #else
     return (0);
 #endif

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -52,7 +52,7 @@ __global_calibrate_ticks(void)
     __wt_process.tsc_nsec_ratio = WT_TSC_DEFAULT_RATIO;
     __wt_process.use_epochtime = true;
 
-#if defined(__i386) || defined(__amd64)
+#if defined(__i386) || defined(__amd64) || defined(__aarch64__)
     {
         struct timespec start, stop;
         double ratio;


### PR DESCRIPTION
The instruction isn't exactly the same as instead of cpu cycles its a system
clock. However, this is the same clocksource used for clock_gettime() and
similar calls so it has the same true resolution as those.