### PR TITLE
WT-6083 Fix test/checkpoint problem and enable associated row-store test cases.

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -41,6 +41,8 @@ define_test_variants(test_checkpoint
         "test_checkpoint_6_row_named;-c TeSt -T 6 -t r"
         "test_checkpoint_6_row_prepare;-T 6 -t r -p"
         "test_checkpoint_6_row_named_prepare;-c TeSt -T 6 -t r -p"
+        "test_checkpoint_row_stress_sweep_timestamps;-t r -W 3 -r 2 -D -s -x -n 100000 -k 100000 -C cache_size=100MB"
+        "test_checkpoint_row_sweep_timestamps;-t r -W 3 -r 2 -s -x -n 100000 -k 100000 -C cache_size=100MB"
     LABELS
         check
         test_checkpoint

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -82,7 +82,6 @@ clock_thread(void *arg)
     testutil_check(g.conn->open_session(g.conn, NULL, NULL, &wt_session));
     session = (WT_SESSION_IMPL *)wt_session;
 
-    g.ts_stable = 0;
     while (g.running) {
         __wt_writelock(session, &g.clock_lock);
         ++g.ts_stable;

--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -34,13 +34,11 @@ $TEST_WRAPPER ./t -T 6 -t r -p
 echo "checkpoint: 6 row-store tables, named checkpoint with prepare"
 $TEST_WRAPPER ./t -c 'TeSt' -T 6 -t r -p
 
-# Temporarily disabled
-#echo "checkpoint: row-store tables, stress history store. Sweep and timestamps"
-#$TEST_WRAPPER ./t -t r -W 3 -r 2 -D -s -x -n 100000 -k 100000 -C cache_size=100MB
+echo "checkpoint: row-store tables, stress history store. Sweep and timestamps"
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -D -s -x -n 100000 -k 100000 -C cache_size=100MB
 
-# Temporarily disabled
-#echo "checkpoint: row-store tables, Sweep and timestamps"
-#$TEST_WRAPPER ./t -t r -W 3 -r 2 -s -x -n 100000 -k 100000 -C cache_size=100MB
+echo "checkpoint: row-store tables, Sweep and timestamps"
+$TEST_WRAPPER ./t -t r -W 3 -r 2 -s -x -n 100000 -k 100000 -C cache_size=100MB
 
 # Temporarily disabled
 #echo "checkpoint: 3 mixed tables, with sweep"

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -140,6 +140,8 @@ main(int argc, char *argv[])
 
     testutil_work_dir_from_path(g.home, 512, working_dir);
 
+    g.ts_stable = 0;
+
     printf("%s: process %" PRIu64 "\n", progname, (uint64_t)getpid());
     for (cnt = 1; (runs == 0 || cnt <= runs) && g.status == 0; ++cnt) {
         cleanup(cnt == 1); /* Clean up previous runs */
@@ -171,7 +173,7 @@ main(int argc, char *argv[])
         free(g.cookies);
         g.cookies = NULL;
         if ((ret = wt_shutdown()) != 0) {
-            (void)log_print_err("Start workers failed", ret, 1);
+            (void)log_print_err("Shutdown failed", ret, 1);
             break;
         }
     }
@@ -250,7 +252,6 @@ cleanup(bool remove_dir)
     g.running = 0;
     g.ntables_created = 0;
     g.ts_oldest = 0;
-    g.ts_stable = 0;
 
     if (remove_dir)
         testutil_make_work_dir(g.home);

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -280,11 +280,12 @@ real_worker(void)
                         } else
                             testutil_check(__wt_snprintf(
                               buf, sizeof(buf), "commit_timestamp=%x", g.ts_stable + 1));
-                        __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
                         if ((ret = session->commit_transaction(session, buf)) != 0) {
+                            __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
                             (void)log_print_err("real_worker:commit_transaction", ret, 1);
                             goto err;
                         }
+                        __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
                         start_txn = true;
                         /* Occasionally reopen cursors after committing. */
                         if (next_rnd % 13 == 0) {


### PR DESCRIPTION
The test code thought it could rewind time to 0 on each run, but that doesn't work, so any invocation asking for multiple runs blew up. Instead, just let time(stamps) roll forward from one run to the next.

Enable the cases in smoke.sh that had been disabled due to this problem, and also add them to the corresponding cmake test run.