### PR TITLE
WT-6755 Add a glossary to the architecture guide.

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -53,6 +53,17 @@ wtperf_config()
 	 echo 'q') | ed ../src/docs/wtperf.dox 1>/dev/null 2>/dev/null
 }
 
+glossarychk()
+{
+	(cd ../src/docs && grep '^<tr><td>' arch-glossary.dox | cut -d'>' -f3 | sed -e 's/<.*//') > $t
+	if ! diff $t <(sort --ignore-case $t); then
+		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+		echo "arch-glossary.dox entries out of order"
+		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+		e=1
+	fi
+}
+
 structurechk()
 {
 	# @page names should match the source file name
@@ -116,7 +127,7 @@ spellchk()
 
 	(cd ../src/docs &&
 	# Separate quoted newlines "line\nline" so "nline" is not reported.
-        sed -e 's/\("[^"]*\)\\n\([^"]*"\)/\1 \2/' *.dox | \
+	sed -e 's/\("[^"]*\)\\n\([^"]*"\)/\1 \2/' -e 's/[@\\]sic  *\([^ ]*\) //g' *.dox | \
 	aspell --encoding=iso-8859-1 --lang=en_US --personal=./spell.ok list) |
 	sort -u > $t
 	test -s $t && {
@@ -160,6 +171,7 @@ build()
 {
 	# Build from scratch on demand.
 	[ "$1" -eq 0 ] || (cd .. && rm -rf docs && mkdir docs)
+	cp ../src/docs/js/* ../docs/
 
 	# Run doxygen to generate warnings for the base HTML documentation.
 	#
@@ -243,6 +255,7 @@ wtperf_config
 asciichk
 spellchk
 structurechk
+glossarychk
 
 # Check the docs data input file.
 check_docs_data

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -171,7 +171,6 @@ build()
 {
 	# Build from scratch on demand.
 	[ "$1" -eq 0 ] || (cd .. && rm -rf docs && mkdir docs)
-	cp ../src/docs/js/* ../docs/
 
 	# Run doxygen to generate warnings for the base HTML documentation.
 	#
@@ -188,6 +187,9 @@ EOF
 		cat $t
 		e=1
 	}
+
+	# Copy any needed javascript
+	cp ../src/docs/js/* ../docs/
 
 	# Fix up bad links doxygen generates in navtree.js
 	(cd ../docs &&

--- a/src/docs/Doxyfile
+++ b/src/docs/Doxyfile
@@ -297,6 +297,7 @@ ALIASES                = "arch_page_table{2}=<div class= arch_head><table><tr><t
                          "row{7}=<tr><td>\1</td><td>\2</td><td>\3</td><td>\4</td><td>\5</td><td>\6</td><td>\7</td></tr>" \
                          "row{8}=<tr><td>\1</td><td>\2</td><td>\3</td><td>\4</td><td>\5</td><td>\6</td><td>\7</td><td>\8</td></tr>" \
                          "row{9}=<tr><td>\1</td><td>\2</td><td>\3</td><td>\4</td><td>\5</td><td>\6</td><td>\7</td><td>\8</td><td>\9</td></tr>" \
+                         "sic=" \
                          "subpage_single=@subpage"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources

--- a/src/docs/arch-glossary.dox
+++ b/src/docs/arch-glossary.dox
@@ -61,7 +61,7 @@ they are used in other settings.
 <tr><td>overflow page<td>btree<td>either in-memory or on disk, a page in a Btree that has a key or value that is too large to appear on a leaf or internal page.
 <tr><td>pack<td>general<td>convert in-memory representations of keys or values to a compact format for file storage
 <tr><td>page<td>btree<td>one logical node of a Btree, in memory, or on disk, that may store keys and/or values.  See internal page, leaf page, overflow page.
-<tr><td>page reference<td>btree<td>an indirect reference to a key on a page in a Btree.  The reference struct (WT_REF) acts as the indirection and may include a pointer to an in memory object or a an address cookie to find the object on disk.  "ref" for short.
+<tr><td>page reference<td>btree<td>an indirect reference to a key on a page in a Btree.  The reference struct (WT_REF) acts as the indirection and may include a pointer to an in memory object or an address cookie to find the object on disk.  "ref" for short.
 <tr><td>pthread<td>general<td>a thread implementation used on POSIX systems
 <tr><td>raw<td>schema<td>data as it appears on-disk, typically in a packed format.
 <tr><td>read timestamp<td>transactions<td>a timestamp that specifies what data should be visible.

--- a/src/docs/arch-glossary.dox
+++ b/src/docs/arch-glossary.dox
@@ -93,7 +93,7 @@ they are used in other settings.
 <tr><td>timestamp<td>transactions<td>refers to one of several types of 64 bit values used to control transactional visibility of data in WiredTiger.  See oldest timestamp, stable timestamp, commit timestamp, read timestamp.
 <tr><td>transaction<td>transactions<td>a unit of work performed in WiredTiger that is atomic and consistent with the specified isolation level and durability level.
 <tr><td>truncate<td>btree<td>an operation to remove a range of key/values from a Btree.  See also fast truncate
-<tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, that correspond to values written to the key previously.
+<tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, these correspond to values written to the key previously.
 <tr><td>update chain<td>btree<td>a list of updates.
 <tr><td>verify<td>general<td>functionality to check integrity of Btree disk files.
 </table>

--- a/src/docs/arch-glossary.dox
+++ b/src/docs/arch-glossary.dox
@@ -13,18 +13,18 @@ they are used in other settings.
 
 <table class="doxtable sortable">
 <tr><th>Term<th>Category<th>Definition
-<tr><td>address cookie<td>block manager<td>an opaque set of bytes returned by the block manager to reference a block in a Btree file, it includes an offset, size and checksum.
+<tr><td>address cookie<td>block manager<td>an opaque set of bytes returned by the block manager to reference a block in a Btree file, it includes an offset, size, checksum, and object id.
 <tr><td>atomicity<td>transactions<td>a guarantee provided within the context of a transaction that all operations made within that transaction either succeed or fail.
 <tr><td>barrier<td>general<td>a call that forces the CPU and compiler to enforce ordering constraints on memory operations, used in multithreaded code.
-<tr><td>block<td>block manager<td>the smallest granularity of a Btree that is written or read.  A btree page, when it appears on disk, may consist of one or more blocks.
+<tr><td>block<td>block manager<td>the smallest granularity of data that is read from or written to a Btree file.  A btree page, when it appears on disk, may consist of one or more blocks.
 <tr><td>block compression<td>btree<td>after pages of btrees are encoded to be written, they may be compressed according to a configured algorithm.  Compressors may be added to WiredTiger via the extension mechanism.
-<tr><td>block manager<td>block manager<td>an internal API that abstracts writing and reading blocks to and from files.  A block manager is associated with a Btree.
+<tr><td>block manager<td>block manager<td>an internal API that abstracts writing, reading and allocating blocks to and from files.  A block manager is associated with a Btree.
 <tr><td>Bloom filter<td>lsm<td>a data structure that identifies that a key cannot be present.  Used by LSM.
 <tr><td>btree<td>btree<td>a data structure on disk or in memory that stores keys, it with its associated value. In WiredTiger, all btrees are in fact B+trees, meaning that adjacent keys and values are grouped into pages.
-<tr><td>bulk insert<td>btree<td>the capability to rapidly push a set of ordered key value pairs into a Btree. In WiredTiger, a Btree's dhandle must be obtained exclusively, guaranteeing that the inserts can be done single threaded.
+<tr><td>bulk insert<td>btree<td>the capability to rapidly insert a set of ordered key value pairs into a Btree. In WiredTiger, a Btree's dhandle must be obtained exclusively, guaranteeing that the inserts can be done single threaded.
 <tr><td>cell<td>file format<td>a key or value packed as it appears on disk for a Btree.
 <tr><td>checkpoint<td>checkpoint<td>a stable point that bounds how much work recovery must do. Data committed before a checkpoint is guaranteed to reside in data files. Thus, recovery must replay log files starting at the last completed checkpoint.
-<tr><td>chunk<td>lsm<td>a single file withing an LSM tree.
+<tr><td>chunk<td>lsm<td>a single file within an LSM tree.
 <tr><td>collator<td>general<td>a comparison function that determines how keys will be ordered in a Btree. The default collator is byte oriented. A custom collator may be packaged as an extension and attached to a Btree.
 <tr><td>column<td>schema<td>a single field in a record, which must be unpacked from a raw key or value.
 <tr><td>column group<td>schema<td>a set of column store Btrees, whose record ids logically correspond. Together, a column group represents a table of data, with its columns being the union of columns in the individual Btrees.
@@ -62,7 +62,8 @@ they are used in other settings.
 <tr><td>merge<td>btree<td>the process of making a single page out of two adjacent smaller pages in a Btree.  This can occur with leaf pages or internal pages.
 <tr><td>metadata<td>general<td>a set of data that is used to help manage files, tables, indices and column groups in WiredTiger.
 <tr><td>metadata tracking<td>general<td>a technique to track a set of changes to the metadata, so they can be "rolled back" when an error occurs.
-<tr><td>mutex<td>general<td>a locking algorithm that waits, with CPU idle, when the lock cannot be immediately acquired, and is woken to retry when the lock is available.  Although more heavyweight than a spin lock, it consumes fewer resources while waiting.  Appropriate for resources that may be in contention and may be held for longer periods.
+<tr><td>mutex<td>general<td>a locking algorithm that waits, allowing other threads to execute, when the lock cannot be immediately acquired, and is woken to retry when the lock is available.  Although more heavyweight than a spin lock, it consumes fewer resources while waiting.  Appropriate for resources that may be in contention and may be held for longer periods.
+<tr><td>btree<td>tiered storage<td>an integer that indicates an individual file that is a part of a Btree.
 <tr><td>oldest timestamp<td>transactions<td>a connection-wide value, specifies the oldest timestamp that must be tracked by the system. Values with stop timestamps older than this value do not have to be retained.
 <tr><td>on disk<td>general<td>a shorthand meaning "in the file system", and may or may not be stored on a physical disk.
 <tr><td>overflow page<td>btree<td>either in-memory or on disk, a page in a Btree that has a key or value that is too large to appear on a leaf or internal page.
@@ -75,7 +76,7 @@ they are used in other settings.
 <tr><td>read timestamp<td>transactions<td>a timestamp that specifies what data should be visible.
 <tr><td>recno<td>general<td>a 64 bit integer. When used as a key, the Btree is said to be a column store, and the keys are assigned incrementally by WiredTiger when new records are inserted.
 <tr><td>reconcile<td>general<td>convert the in-memory version of a page to a more compact form for file storage.
-<tr><td>recover<td>general<td>a procedure used on opening WiredTiger whereby, starting at the last checkpoint written, log records are played back to bring the database up to date.
+<tr><td>recovery<td>general<td>a procedure used on opening WiredTiger whereby, starting at the last checkpoint written, log records are played back to bring the database up to date.
 <tr><td>ref<td>btree<td>see page reference
 <tr><td>RLE<td>general<td>see run length encoding
 <tr><td>run length encoding<td>general<td>also known as "RLE".  A technique to save space whereby repeated items can be represented by a count followed by the item.  For example the string of letters \sic "AAAAAAABBBCDDDD" might be encoded as \sic "7A3BC4D" using "out of band" digits.
@@ -88,11 +89,11 @@ they are used in other settings.
 <tr><td>stable timestamp<td>transactions<td>a connection-wide value, checkpoints will not include commits newer than this value.
 <tr><td>table<td>schema<td>an abstraction that allows one or more btrees to be used in a coordinated way, which is specified by the schema.  The table coordinates indices and column groups.
 <tr><td>thread<td>general<td>a thread of control.  WiredTiger uses pthreads for POSIX systems.
-<tr><td>thread group<td>general<td>a group of threads that work together.  Eviction is performed by a thread group.
+<tr><td>thread group<td>general<td>a group of threads that perform a common task.  Eviction is performed by a thread group.
 <tr><td>timestamp<td>transactions<td>refers to one of several types of 64 bit values used to control transactional visibility of data in WiredTiger.  See oldest timestamp, stable timestamp, commit timestamp, read timestamp.
-<tr><td>transaction<td>transactions<td>a unit of work performed in WiredTiger that is atomic and consistent with the specified isolation levels, and durability levels.
+<tr><td>transaction<td>transactions<td>a unit of work performed in WiredTiger that is atomic and consistent with the specified isolation level and durability level.
 <tr><td>truncate<td>btree<td>an operation to remove a range of key/values from a Btree.  See also fast truncate
-<tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, that relate to values seen by various transactions.
+<tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, that correspond to values written to the key previously.
 <tr><td>update chain<td>btree<td>a list of updates.
 <tr><td>verify<td>general<td>functionality to check integrity of Btree disk files.
 </table>

--- a/src/docs/arch-glossary.dox
+++ b/src/docs/arch-glossary.dox
@@ -4,31 +4,86 @@ WiredTiger has a lot of domain specific nomenclature - this page attempts
 to decode it. This is intended for those navigating the WiredTiger source
 tree - it describes terms internal to the storage engine.
 
-@section arch-glossary-general General Terms Used in WiredTiger
+The definitions list how the terms are used in WiredTiger, which may not match how
+they are used in other settings.
 
-<table>
-<caption id="general_terms">General Term Table</caption>
-<tr><th>Term <th>Definition
-<tr><td>Hello<td>The typical next word is World
-</table>
+@section arch-glossary-transactions Glossary (click headings to sort)
 
-@section arch-glossary-checkpoint Terms Related to Checkpoints
-
-<table>
-<caption id="checkpoint_terms">Checkpoint Term Table</caption>
-<tr><th>Term <th>Definition
-<tr><td>Hello<td>The typical next word is World
-</table>
-@section arch-glossary-transactions Terms Related to Transactions
-
-<table>
-<caption id="transaction_terms">Transaction Term Table</caption>
-<tr><th>Term <th>Definition
-<tr><td>transaction<td>A unit of work performed in WiredTiger that is atomic and consistent with the specified isolation levels, and durability levels.
-<tr><td>session<td>The container that manages transactions and performs the transactional operations on behalf of the users in a single thread.
-<tr><td>atomicity<td>Atomicity is a guarantee provided within the context of a transaction that all operations made within that transaction either succeed or fail.
-<tr><td>isolation<td>Isolation determines which versions of data are visible to a running transaction, and whether it can see changes made by concurrently running transactions.
-<tr><td>durability<td>Durability is the property that guarantees that transactions that have been committed will survive permanently.
+<table class="doxtable sortable">
+<!-- Please keep glossary formatted a single entry to a line, and sorted alphabetically (case insensitive). -->
+<tr><th>Term<th>Category<th>Definition
+<tr><td>address cookie<td>block manager<td>an opaque set of bytes returned by the block manager to reference a block in a Btree file.
+<tr><td>atomicity<td>transactions<td>a guarantee provided within the context of a transaction that all operations made within that transaction either succeed or fail.
+<tr><td>barrier<td>general<td>a call that forces the CPU and compiler to enforce ordering constraints on memory operations, used in multithreaded code.
+<tr><td>block<td>block manager<td>the smallest granularity of a Btree that is written or read.  A btree page, when it appears on disk, may consist of one or more blocks.
+<tr><td>block compression<td>btree<td>after pages of btrees are encoded to be written, they may be compressed according to a configured algorithm.  Compressors may be added to WiredTiger via the extension mechanism.
+<tr><td>block manager<td>block manager<td>an internal API that abstracts writing and reading blocks to and from files.  A block manager is associated with a Btree.
+<tr><td>Bloom filter<td>lsm<td>a data structure that identifies that a key cannot be present.  Used by LSM.
+<tr><td>btree<td>btree<td>a data structure on disk or in memory that stores keys, it with its associated value. In WiredTiger, all btrees are in fact B+trees, meaning that adjacent keys and values are grouped into pages.
+<tr><td>cell<td>file format<td>a key or value packed as it appears on disk for a Btree.
+<tr><td>checkpoint<td>checkpoint<td>a stable point that bounds how much work recovery must do. Data committed before a checkpoint is guaranteed to reside in data files. Thus, recovery must replay log files starting at the last completed checkpoint.
+<tr><td>collator<td>general<td>a comparison function that determines how keys will be ordered in a Btree. The default collator is byte oriented. A custom collator may be packaged as an extension and attached to a Btree.
+<tr><td>column<td>schema<td>a single field in a record, which must be unpacked from a raw key or value.
+<tr><td>column group<td>schema<td>a set of column store Btrees, whose record ids logically correspond. Together, a column group represents a table of data, with its columns being the union of columns in the individual Btrees.
+<tr><td>column store<td>btree<td>a Btrees that has as its key a record id
+<tr><td>commit timestamp<td>transactions<td>values in this transaction become visible at this timestamp.
+<tr><td>compression<td>general<td>one of several techniques to reduce the size of data on disk and memory.  See block compression, run length encoding, Huffman encoding, key prefix compression.
+<tr><td>connection<td>general<td>an encapsulation of information stored for an application's use of a WiredTiger instance attached to a specific home directory. This encapsulation is kept in a handle that is used in the API.
+<tr><td>cursor<td>general<td>a handle in the WiredTiger API that encapsulates a position in a Btree, and may hold the key and value associated with that position.
+<tr><td>data handle<td>general<td>an abstraction of a named file, table or other data source in WiredTiger
+<tr><td>data source<td>general<td>an abstraction that extends the uri name space.  A custom data source defines APIs that are invoked when objects are created in, or cursors are opened on, the new name space.
+<tr><td>dhandle<td>general<td>see data handle
+<tr><td>diagnostic build<td>general<td>a build of WiredTiger that includes extra code to check invariants, and abort if they fail.
+<tr><td>durability<td>transactions<td>the property that guarantees that transactions that have been committed will survive permanently.
+<tr><td>encryption<td>btree<td>in WiredTiger, encryption is applied to data files, log files and metadata.  Encryption algorithms may be added to WiredTiger via the extension mechanism.
+<tr><td>encryptor<td>btree<td>an encryption algorithm packaged as an extension.
+<tr><td>eviction<td>general<td>the process of freeing memory in the cache, which often includes reconciling and writing dirty pages. This term generally includes the process of deciding which pages should be evicted.
+<tr><td>extension<td>general<td>a module that uses the WiredTiger extension interface, allowing it to be added in an encapsulated way, without altering the core of the WiredTiger library.  Extensions are typically compiled into shared libraries.
+<tr><td>extent list<td>block manager<td>a list of contiguous sets of blocks in a file.  Extent lists are used to track available blocks and/or used blocks.
+<tr><td>frag<td>verify<td>in verify, a part of a file that is the minimum allocation size and aligned the same.  The smallest blocks may be the same as a frag, other blocks may be composed of multiple contiguous frags.
+<tr><td>hazard pointer<td>general<td>a data structure that assists in lock free algorithms, used by WiredTiger Btrees
+<tr><td>history store<td>general<td>storage in WiredTiger (currently implemented as a Btree) that keeps previous values associated with a key.
+<tr><td>home directory<td>general<td>the directory containing all the data for a WiredTiger connection.  The connection is attached to this directory via a call to ::wiredtiger_open.
+<tr><td>Huffman encoding<td>btree<td>data in a btree may optionally be encoded using a Huffman encoding, based on either English letter frequencies or a custom encoding.  See @subpage_single huffman for details.
+<tr><td>index<td>schema<td>a Btree with records having values that are keys to another Btree. An index (or set of indices) become associated with a primary Btree via the table construct.
+<tr><td>insert<td>btree<td>an in-memory structure holding a key and a set of updates for a Btree.
+<tr><td>internal page<td>btree<td>either in-memory or on disk, a page in a Btree that has a set of keys that reference pages beneath it.
+<tr><td>isolation<td>transactions<td>determines which versions of data are visible to a running transaction, and whether it can see changes made by concurrently running transactions.
+<tr><td>key prefix compression<td>btree<td>a technique to store identical key prefixes only once per page.  See @ref file_formats_compression
+<tr><td>kv<td>btree<td>a key/value pair in a Btree.
+<tr><td>leaf page<td>btree<td>either in-memory or on disk, a page in a Btree that has a pairs of keys and values, and no pages beneath it.
+<tr><td>log structured merge tree (or LSM tree)<td>lsm<td>a data structure that stores keys and values (as a Btree), but composed of potentially many trees (Btrees in WiredTiger).
+<tr><td>LSM<td>lsm<td>see log structured merge tree
+<tr><td>metadata<td>general<td>a set of data that is used to help manage files, tables, indices and column groups in WiredTiger.
+<tr><td>mutex<td>general<td>a locking algorithm that waits, with CPU idle, when the lock cannot be immediately acquired, and is woken to retry when the lock is available.  Although more heavyweight than a spin lock, it consumes fewer resources while waiting.  Appropriate for resources that may be in contention and may be held for longer periods.
+<tr><td>oldest timestamp<td>transactions<td>a connection-wide value, specifies the oldest timestamp that must be tracked by the system. Values with stop timestamps older than this value do not have to be retained.
+<tr><td>on disk<td>general<td>a shorthand meaning "in the file system", and may or may not be stored on a physical disk.
+<tr><td>overflow page<td>btree<td>either in-memory or on disk, a page in a Btree that has a key or value that is too large to appear on a leaf or internal page.
+<tr><td>pack<td>general<td>convert in-memory representations of keys or values to a compact format for file storage
+<tr><td>page<td>btree<td>one logical node of a Btree, in memory, or on disk, that may store keys and/or values.  See internal page, leaf page, overflow page.
+<tr><td>page reference<td>btree<td>an indirect reference to a key on a page in a Btree.  The reference struct (WT_REF) acts as the indirection and may include a pointer to an in memory object or a an address cookie to find the object on disk.  "ref" for short.
+<tr><td>pthread<td>general<td>a thread implementation used on POSIX systems
+<tr><td>raw<td>schema<td>data as it appears on-disk, typically in a packed format.
+<tr><td>read timestamp<td>transactions<td>a timestamp that specifies what data should be visible.
+<tr><td>recno<td>general<td>a 64 bit integer. When used as a key, the Btree is said to be a column store, and the keys are assigned incrementally by WiredTiger when new records are inserted.
+<tr><td>reconcile<td>general<td>convert the in-memory version of a page to a more compact form for file storage.
+<tr><td>recover<td>general<td>a procedure used on opening WiredTiger whereby, starting at the last checkpoint written, log records are played back to bring the database up to date.
+<tr><td>ref<td>btree<td>see page reference
+<tr><td>RLE<td>general<td>see run length encoding
+<tr><td>run length encoding<td>general<td>also known as "RLE".  A technique to save space whereby repeated items can be represented by a count followed by the item.  For example the string of letters \sic "AAAAAAABBBCDDDD" might be encoded as \sic "7A3BC4D" using "out of band" digits.
+<tr><td>salvage<td>general<td>functionality to repair Btree disk files.
+<tr><td>schema<td>schema<td>the algorithms that use metadata to map the raw keys and values in Btrees to higher level abstractions like tables with typed columns.
+<tr><td>session<td>general<td>an encapsulation of information stored for single thread of control in the application. This encapsulation is kept in a handle that is used in the API.  Sessions manage transactions and performs the transactional operations.
+<tr><td>skip list<td>general<td>a variation of a sorted linked list that allows for faster (O(log(N))) searching. It is used in WiredTiger as a lock-free data structure for keys inserted on a page.
+<tr><td>spin lock<td>general<td>a simple locking algorithm that continually attempts to acquire a lock, appropriate for resources that are likely to be available and may be held for a short time.  This lock is CPU intensive while it is waiting.  Contrast with mutex
+<tr><td>stable timestamp<td>transactions<td>a connection-wide value, checkpoints will not include commits newer than this value.
+<tr><td>table<td>general<td>an abstraction that allows one or more btrees to be used in a coordinated way, which is specified by the schema.  The table coordinates indices and column groups.
+<tr><td>thread<td>general<td>a thread of control.  WiredTiger uses pthreads for POSIX systems.
+<tr><td>timestamp<td>transactions<td>refers to one of several types of 64 bit values used to control transactional visibility of data in WiredTiger.  See oldest timestamp, stable timestamp, commit timestamp, read timestamp.
+<tr><td>transaction<td>transactions<td>a unit of work performed in WiredTiger that is atomic and consistent with the specified isolation levels, and durability levels.
+<tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, that relate to values seen by various transactions.
+<tr><td>update chain<td>btree<td>a list of updates.
+<tr><td>verify<td>general<td>functionality to check integrity of Btree disk files.
 </table>
 
 */

--- a/src/docs/arch-glossary.dox
+++ b/src/docs/arch-glossary.dox
@@ -9,10 +9,11 @@ they are used in other settings.
 
 @section arch-glossary-transactions Glossary (click headings to sort)
 
-<table class="doxtable sortable">
 <!-- Please keep glossary formatted a single entry to a line, and sorted alphabetically (case insensitive). -->
+
+<table class="doxtable sortable">
 <tr><th>Term<th>Category<th>Definition
-<tr><td>address cookie<td>block manager<td>an opaque set of bytes returned by the block manager to reference a block in a Btree file.
+<tr><td>address cookie<td>block manager<td>an opaque set of bytes returned by the block manager to reference a block in a Btree file, it includes an offset, size and checksum.
 <tr><td>atomicity<td>transactions<td>a guarantee provided within the context of a transaction that all operations made within that transaction either succeed or fail.
 <tr><td>barrier<td>general<td>a call that forces the CPU and compiler to enforce ordering constraints on memory operations, used in multithreaded code.
 <tr><td>block<td>block manager<td>the smallest granularity of a Btree that is written or read.  A btree page, when it appears on disk, may consist of one or more blocks.
@@ -20,13 +21,16 @@ they are used in other settings.
 <tr><td>block manager<td>block manager<td>an internal API that abstracts writing and reading blocks to and from files.  A block manager is associated with a Btree.
 <tr><td>Bloom filter<td>lsm<td>a data structure that identifies that a key cannot be present.  Used by LSM.
 <tr><td>btree<td>btree<td>a data structure on disk or in memory that stores keys, it with its associated value. In WiredTiger, all btrees are in fact B+trees, meaning that adjacent keys and values are grouped into pages.
+<tr><td>bulk insert<td>btree<td>the capability to rapidly push a set of ordered key value pairs into a Btree. In WiredTiger, a Btree's dhandle must be obtained exclusively, guaranteeing that the inserts can be done single threaded.
 <tr><td>cell<td>file format<td>a key or value packed as it appears on disk for a Btree.
 <tr><td>checkpoint<td>checkpoint<td>a stable point that bounds how much work recovery must do. Data committed before a checkpoint is guaranteed to reside in data files. Thus, recovery must replay log files starting at the last completed checkpoint.
+<tr><td>chunk<td>lsm<td>a single file withing an LSM tree.
 <tr><td>collator<td>general<td>a comparison function that determines how keys will be ordered in a Btree. The default collator is byte oriented. A custom collator may be packaged as an extension and attached to a Btree.
 <tr><td>column<td>schema<td>a single field in a record, which must be unpacked from a raw key or value.
 <tr><td>column group<td>schema<td>a set of column store Btrees, whose record ids logically correspond. Together, a column group represents a table of data, with its columns being the union of columns in the individual Btrees.
 <tr><td>column store<td>btree<td>a Btrees that has as its key a record id
 <tr><td>commit timestamp<td>transactions<td>values in this transaction become visible at this timestamp.
+<tr><td>compare and swap (CAS)<td>general<td>a CPU instruction that can be used to coordinate the activity of multiple threads. Specifically, the instruction atomically changes a memory location to a new value only if the existing value matches a second value.
 <tr><td>compression<td>general<td>one of several techniques to reduce the size of data on disk and memory.  See block compression, run length encoding, Huffman encoding, key prefix compression.
 <tr><td>connection<td>general<td>an encapsulation of information stored for an application's use of a WiredTiger instance attached to a specific home directory. This encapsulation is kept in a handle that is used in the API.
 <tr><td>cursor<td>general<td>a handle in the WiredTiger API that encapsulates a position in a Btree, and may hold the key and value associated with that position.
@@ -40,6 +44,7 @@ they are used in other settings.
 <tr><td>eviction<td>general<td>the process of freeing memory in the cache, which often includes reconciling and writing dirty pages. This term generally includes the process of deciding which pages should be evicted.
 <tr><td>extension<td>general<td>a module that uses the WiredTiger extension interface, allowing it to be added in an encapsulated way, without altering the core of the WiredTiger library.  Extensions are typically compiled into shared libraries.
 <tr><td>extent list<td>block manager<td>a list of contiguous sets of blocks in a file.  Extent lists are used to track available blocks and/or used blocks.
+<tr><td>fast truncate<td>btree<td>a truncate that spans a key range over more than one leaf page may be performed quickly by deleting entire data pages at a time.
 <tr><td>frag<td>verify<td>in verify, a part of a file that is the minimum allocation size and aligned the same.  The smallest blocks may be the same as a frag, other blocks may be composed of multiple contiguous frags.
 <tr><td>hazard pointer<td>general<td>a data structure that assists in lock free algorithms, used by WiredTiger Btrees
 <tr><td>history store<td>general<td>storage in WiredTiger (currently implemented as a Btree) that keeps previous values associated with a key.
@@ -50,11 +55,13 @@ they are used in other settings.
 <tr><td>internal page<td>btree<td>either in-memory or on disk, a page in a Btree that has a set of keys that reference pages beneath it.
 <tr><td>isolation<td>transactions<td>determines which versions of data are visible to a running transaction, and whether it can see changes made by concurrently running transactions.
 <tr><td>key prefix compression<td>btree<td>a technique to store identical key prefixes only once per page.  See @ref file_formats_compression
-<tr><td>kv<td>btree<td>a key/value pair in a Btree.
+<tr><td>kv or k/v<td>btree<td>a key/value pair in a Btree.
 <tr><td>leaf page<td>btree<td>either in-memory or on disk, a page in a Btree that has a pairs of keys and values, and no pages beneath it.
 <tr><td>log structured merge tree (or LSM tree)<td>lsm<td>a data structure that stores keys and values (as a Btree), but composed of potentially many trees (Btrees in WiredTiger).
 <tr><td>LSM<td>lsm<td>see log structured merge tree
+<tr><td>merge<td>btree<td>the process of making a single page out of two adjacent smaller pages in a Btree.  This can occur with leaf pages or internal pages.
 <tr><td>metadata<td>general<td>a set of data that is used to help manage files, tables, indices and column groups in WiredTiger.
+<tr><td>metadata tracking<td>general<td>a technique to track a set of changes to the metadata, so they can be "rolled back" when an error occurs.
 <tr><td>mutex<td>general<td>a locking algorithm that waits, with CPU idle, when the lock cannot be immediately acquired, and is woken to retry when the lock is available.  Although more heavyweight than a spin lock, it consumes fewer resources while waiting.  Appropriate for resources that may be in contention and may be held for longer periods.
 <tr><td>oldest timestamp<td>transactions<td>a connection-wide value, specifies the oldest timestamp that must be tracked by the system. Values with stop timestamps older than this value do not have to be retained.
 <tr><td>on disk<td>general<td>a shorthand meaning "in the file system", and may or may not be stored on a physical disk.
@@ -62,6 +69,7 @@ they are used in other settings.
 <tr><td>pack<td>general<td>convert in-memory representations of keys or values to a compact format for file storage
 <tr><td>page<td>btree<td>one logical node of a Btree, in memory, or on disk, that may store keys and/or values.  See internal page, leaf page, overflow page.
 <tr><td>page reference<td>btree<td>an indirect reference to a key on a page in a Btree.  The reference struct (WT_REF) acts as the indirection and may include a pointer to an in memory object or an address cookie to find the object on disk.  "ref" for short.
+<tr><td>page split<td>btree<td>the process of breaking up a large page in a Btree into multiple smaller pages.  This may occur with either leaf pages or internal pages.
 <tr><td>pthread<td>general<td>a thread implementation used on POSIX systems
 <tr><td>raw<td>schema<td>data as it appears on-disk, typically in a packed format.
 <tr><td>read timestamp<td>transactions<td>a timestamp that specifies what data should be visible.
@@ -76,11 +84,14 @@ they are used in other settings.
 <tr><td>session<td>general<td>an encapsulation of information stored for single thread of control in the application. This encapsulation is kept in a handle that is used in the API.  Sessions manage transactions and performs the transactional operations.
 <tr><td>skip list<td>general<td>a variation of a sorted linked list that allows for faster (O(log(N))) searching. It is used in WiredTiger as a lock-free data structure for keys inserted on a page.
 <tr><td>spin lock<td>general<td>a simple locking algorithm that continually attempts to acquire a lock, appropriate for resources that are likely to be available and may be held for a short time.  This lock is CPU intensive while it is waiting.  Contrast with mutex
+<tr><td>split<td>btree<td>see page split
 <tr><td>stable timestamp<td>transactions<td>a connection-wide value, checkpoints will not include commits newer than this value.
-<tr><td>table<td>general<td>an abstraction that allows one or more btrees to be used in a coordinated way, which is specified by the schema.  The table coordinates indices and column groups.
+<tr><td>table<td>schema<td>an abstraction that allows one or more btrees to be used in a coordinated way, which is specified by the schema.  The table coordinates indices and column groups.
 <tr><td>thread<td>general<td>a thread of control.  WiredTiger uses pthreads for POSIX systems.
+<tr><td>thread group<td>general<td>a group of threads that work together.  Eviction is performed by a thread group.
 <tr><td>timestamp<td>transactions<td>refers to one of several types of 64 bit values used to control transactional visibility of data in WiredTiger.  See oldest timestamp, stable timestamp, commit timestamp, read timestamp.
 <tr><td>transaction<td>transactions<td>a unit of work performed in WiredTiger that is atomic and consistent with the specified isolation levels, and durability levels.
+<tr><td>truncate<td>btree<td>an operation to remove a range of key/values from a Btree.  See also fast truncate
 <tr><td>update<td>btree<td>a value associated with a key in a Btree.  A key may have many updates, that relate to values seen by various transactions.
 <tr><td>update chain<td>btree<td>a list of updates.
 <tr><td>verify<td>general<td>functionality to check integrity of Btree disk files.

--- a/src/docs/js/sorttable.js
+++ b/src/docs/js/sorttable.js
@@ -1,0 +1,501 @@
+/*
+  SortTable
+  version 2
+  7th April 2007
+  Stuart Langridge, http://www.kryogenix.org/code/browser/sorttable/
+
+  Instructions:
+  Download this file
+  Add <script src="sorttable.js"></script> to your HTML
+  Add class="sortable" to any table you'd like to make sortable
+  Click on the headers to sort
+
+  Thanks to many, many people for contributions and suggestions.
+  Licenced as X11: http://www.kryogenix.org/code/browser/licence.html
+  This basically means: do what you want with it.
+*/
+/* Modified for WiredTiger to sort alphabetic items with insensitive case. */
+
+
+var stIsIE = /*@cc_on!@*/false;
+
+sorttable = {
+  init: function() {
+    // quit if this function has already been called
+    if (arguments.callee.done) return;
+    // flag this function so we don't do the same thing twice
+    arguments.callee.done = true;
+    // kill the timer
+    if (_timer) clearInterval(_timer);
+
+    if (!document.createElement || !document.getElementsByTagName) return;
+
+    sorttable.DATE_RE = /^(\d\d?)[\/\.-](\d\d?)[\/\.-]((\d\d)?\d\d)$/;
+
+    forEach(document.getElementsByTagName('table'), function(table) {
+      if (table.className.search(/\bsortable\b/) != -1) {
+        sorttable.makeSortable(table);
+      }
+    });
+
+  },
+
+  makeSortable: function(table) {
+    if (table.getElementsByTagName('thead').length == 0) {
+      // table doesn't have a tHead. Since it should have, create one and
+      // put the first table row in it.
+      the = document.createElement('thead');
+      the.appendChild(table.rows[0]);
+      table.insertBefore(the,table.firstChild);
+    }
+    // Safari doesn't support table.tHead, sigh
+    if (table.tHead == null) table.tHead = table.getElementsByTagName('thead')[0];
+
+    if (table.tHead.rows.length != 1) return; // can't cope with two header rows
+
+    // Sorttable v1 put rows with a class of "sortbottom" at the bottom (as
+    // "total" rows, for example). This is B&R, since what you're supposed
+    // to do is put them in a tfoot. So, if there are sortbottom rows,
+    // for backwards compatibility, move them to tfoot (creating it if needed).
+    sortbottomrows = [];
+    for (var i=0; i<table.rows.length; i++) {
+      if (table.rows[i].className.search(/\bsortbottom\b/) != -1) {
+        sortbottomrows[sortbottomrows.length] = table.rows[i];
+      }
+    }
+    if (sortbottomrows) {
+      if (table.tFoot == null) {
+        // table doesn't have a tfoot. Create one.
+        tfo = document.createElement('tfoot');
+        table.appendChild(tfo);
+      }
+      for (var i=0; i<sortbottomrows.length; i++) {
+        tfo.appendChild(sortbottomrows[i]);
+      }
+      delete sortbottomrows;
+    }
+
+    // work through each column and calculate its type
+    headrow = table.tHead.rows[0].cells;
+    for (var i=0; i<headrow.length; i++) {
+      // manually override the type with a sorttable_type attribute
+      if (!headrow[i].className.match(/\bsorttable_nosort\b/)) { // skip this col
+        mtch = headrow[i].className.match(/\bsorttable_([a-z0-9]+)\b/);
+        if (mtch) { override = mtch[1]; }
+	      if (mtch && typeof sorttable["sort_"+override] == 'function') {
+	        headrow[i].sorttable_sortfunction = sorttable["sort_"+override];
+	      } else {
+	        headrow[i].sorttable_sortfunction = sorttable.guessType(table,i);
+	      }
+	      // make it clickable to sort
+	      headrow[i].sorttable_columnindex = i;
+	      headrow[i].sorttable_tbody = table.tBodies[0];
+	      dean_addEvent(headrow[i],"click", sorttable.innerSortFunction = function(e) {
+
+          if (this.className.search(/\bsorttable_sorted\b/) != -1) {
+            // if we're already sorted by this column, just
+            // reverse the table, which is quicker
+            sorttable.reverse(this.sorttable_tbody);
+            this.className = this.className.replace('sorttable_sorted',
+                                                    'sorttable_sorted_reverse');
+            this.removeChild(document.getElementById('sorttable_sortfwdind'));
+            sortrevind = document.createElement('span');
+            sortrevind.id = "sorttable_sortrevind";
+            sortrevind.innerHTML = stIsIE ? '&nbsp<font face="webdings">5</font>' : '&nbsp;&#x25B4;';
+            this.appendChild(sortrevind);
+            return;
+          }
+          if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
+            // if we're already sorted by this column in reverse, just
+            // re-reverse the table, which is quicker
+            sorttable.reverse(this.sorttable_tbody);
+            this.className = this.className.replace('sorttable_sorted_reverse',
+                                                    'sorttable_sorted');
+            this.removeChild(document.getElementById('sorttable_sortrevind'));
+            sortfwdind = document.createElement('span');
+            sortfwdind.id = "sorttable_sortfwdind";
+            sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+            this.appendChild(sortfwdind);
+            return;
+          }
+
+          // remove sorttable_sorted classes
+          theadrow = this.parentNode;
+          forEach(theadrow.childNodes, function(cell) {
+            if (cell.nodeType == 1) { // an element
+              cell.className = cell.className.replace('sorttable_sorted_reverse','');
+              cell.className = cell.className.replace('sorttable_sorted','');
+            }
+          });
+          sortfwdind = document.getElementById('sorttable_sortfwdind');
+          if (sortfwdind) { sortfwdind.parentNode.removeChild(sortfwdind); }
+          sortrevind = document.getElementById('sorttable_sortrevind');
+          if (sortrevind) { sortrevind.parentNode.removeChild(sortrevind); }
+
+          this.className += ' sorttable_sorted';
+          sortfwdind = document.createElement('span');
+          sortfwdind.id = "sorttable_sortfwdind";
+          sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;&#x25BE;';
+          this.appendChild(sortfwdind);
+
+	        // build an array to sort. This is a Schwartzian transform thing,
+	        // i.e., we "decorate" each row with the actual sort key,
+	        // sort based on the sort keys, and then put the rows back in order
+	        // which is a lot faster because you only do getInnerText once per row
+	        row_array = [];
+	        col = this.sorttable_columnindex;
+	        rows = this.sorttable_tbody.rows;
+	        for (var j=0; j<rows.length; j++) {
+	          row_array[row_array.length] = [sorttable.getInnerText(rows[j].cells[col]), rows[j]];
+	        }
+	        /* If you want a stable sort, uncomment the following line */
+	        //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
+	        /* and comment out this one */
+	        row_array.sort(this.sorttable_sortfunction);
+
+	        tb = this.sorttable_tbody;
+	        for (var j=0; j<row_array.length; j++) {
+	          tb.appendChild(row_array[j][1]);
+	        }
+
+	        delete row_array;
+	      });
+	    }
+    }
+  },
+
+  guessType: function(table, column) {
+    // guess the type of a column based on its first non-blank row
+    sortfn = sorttable.sort_alpha;
+    for (var i=0; i<table.tBodies[0].rows.length; i++) {
+      text = sorttable.getInnerText(table.tBodies[0].rows[i].cells[column]);
+      if (text != '') {
+        if (text.match(/^-?[£$¤]?[\d,.]+%?$/)) {
+          return sorttable.sort_numeric;
+        }
+        // check for a date: dd/mm/yyyy or dd/mm/yy
+        // can have / or . or - as separator
+        // can be mm/dd as well
+        possdate = text.match(sorttable.DATE_RE)
+        if (possdate) {
+          // looks like a date
+          first = parseInt(possdate[1]);
+          second = parseInt(possdate[2]);
+          if (first > 12) {
+            // definitely dd/mm
+            return sorttable.sort_ddmm;
+          } else if (second > 12) {
+            return sorttable.sort_mmdd;
+          } else {
+            // looks like a date, but we can't tell which, so assume
+            // that it's dd/mm (English imperialism!) and keep looking
+            sortfn = sorttable.sort_ddmm;
+          }
+        }
+      }
+    }
+    return sortfn;
+  },
+
+  getInnerText: function(node) {
+    // gets the text we want to use for sorting for a cell.
+    // strips leading and trailing whitespace.
+    // this is *not* a generic getInnerText function; it's special to sorttable.
+    // for example, you can override the cell text with a customkey attribute.
+    // it also gets .value for <input> fields.
+
+    if (!node) return "";
+
+    hasInputs = (typeof node.getElementsByTagName == 'function') &&
+                 node.getElementsByTagName('input').length;
+
+    if (node.getAttribute("sorttable_customkey") != null) {
+      return node.getAttribute("sorttable_customkey");
+    }
+    else if (typeof node.textContent != 'undefined' && !hasInputs) {
+      return node.textContent.replace(/^\s+|\s+$/g, '');
+    }
+    else if (typeof node.innerText != 'undefined' && !hasInputs) {
+      return node.innerText.replace(/^\s+|\s+$/g, '');
+    }
+    else if (typeof node.text != 'undefined' && !hasInputs) {
+      return node.text.replace(/^\s+|\s+$/g, '');
+    }
+    else {
+      switch (node.nodeType) {
+        case 3:
+          if (node.nodeName.toLowerCase() == 'input') {
+            return node.value.replace(/^\s+|\s+$/g, '');
+          }
+        case 4:
+          return node.nodeValue.replace(/^\s+|\s+$/g, '');
+          break;
+        case 1:
+        case 11:
+          var innerText = '';
+          for (var i = 0; i < node.childNodes.length; i++) {
+            innerText += sorttable.getInnerText(node.childNodes[i]);
+          }
+          return innerText.replace(/^\s+|\s+$/g, '');
+          break;
+        default:
+          return '';
+      }
+    }
+  },
+
+  reverse: function(tbody) {
+    // reverse the rows in a tbody
+    newrows = [];
+    for (var i=0; i<tbody.rows.length; i++) {
+      newrows[newrows.length] = tbody.rows[i];
+    }
+    for (var i=newrows.length-1; i>=0; i--) {
+       tbody.appendChild(newrows[i]);
+    }
+    delete newrows;
+  },
+
+  /* sort functions
+     each sort function takes two parameters, a and b
+     you are comparing a[0] and b[0] */
+  sort_numeric: function(a,b) {
+    aa = parseFloat(a[0].replace(/[^0-9.-]/g,''));
+    if (isNaN(aa)) aa = 0;
+    bb = parseFloat(b[0].replace(/[^0-9.-]/g,''));
+    if (isNaN(bb)) bb = 0;
+    return aa-bb;
+  },
+    sort_alpha: function(a,b) {
+    /*
+     * Now we sort case insensitive.  This code was:
+
+    if (a[0]==b[0]) return 0;
+    if (a[0]<b[0]) return -1;
+    */
+    if (a[0].toLowerCase()==b[0].toLowerCase()) return 0;
+    if (a[0].toLowerCase()<b[0].toLowerCase()) return -1;    
+    return 1;
+  },
+  sort_ddmm: function(a,b) {
+    mtch = a[0].match(sorttable.DATE_RE);
+    y = mtch[3]; m = mtch[2]; d = mtch[1];
+    if (m.length == 1) m = '0'+m;
+    if (d.length == 1) d = '0'+d;
+    dt1 = y+m+d;
+    mtch = b[0].match(sorttable.DATE_RE);
+    y = mtch[3]; m = mtch[2]; d = mtch[1];
+    if (m.length == 1) m = '0'+m;
+    if (d.length == 1) d = '0'+d;
+    dt2 = y+m+d;
+    if (dt1==dt2) return 0;
+    if (dt1<dt2) return -1;
+    return 1;
+  },
+  sort_mmdd: function(a,b) {
+    mtch = a[0].match(sorttable.DATE_RE);
+    y = mtch[3]; d = mtch[2]; m = mtch[1];
+    if (m.length == 1) m = '0'+m;
+    if (d.length == 1) d = '0'+d;
+    dt1 = y+m+d;
+    mtch = b[0].match(sorttable.DATE_RE);
+    y = mtch[3]; d = mtch[2]; m = mtch[1];
+    if (m.length == 1) m = '0'+m;
+    if (d.length == 1) d = '0'+d;
+    dt2 = y+m+d;
+    if (dt1==dt2) return 0;
+    if (dt1<dt2) return -1;
+    return 1;
+  },
+
+  shaker_sort: function(list, comp_func) {
+    // A stable sort function to allow multi-level sorting of data
+    // see: http://en.wikipedia.org/wiki/Cocktail_sort
+    // thanks to Joseph Nahmias
+    var b = 0;
+    var t = list.length - 1;
+    var swap = true;
+
+    while(swap) {
+        swap = false;
+        for(var i = b; i < t; ++i) {
+            if ( comp_func(list[i], list[i+1]) > 0 ) {
+                var q = list[i]; list[i] = list[i+1]; list[i+1] = q;
+                swap = true;
+            }
+        } // for
+        t--;
+
+        if (!swap) break;
+
+        for(var i = t; i > b; --i) {
+            if ( comp_func(list[i], list[i-1]) < 0 ) {
+                var q = list[i]; list[i] = list[i-1]; list[i-1] = q;
+                swap = true;
+            }
+        } // for
+        b++;
+
+    } // while(swap)
+  }
+}
+
+/* ******************************************************************
+   Supporting functions: bundled here to avoid depending on a library
+   ****************************************************************** */
+
+// Dean Edwards/Matthias Miller/John Resig
+
+/* for Mozilla/Opera9 */
+if (document.addEventListener) {
+    document.addEventListener("DOMContentLoaded", sorttable.init, false);
+}
+
+/* for Internet Explorer */
+/*@cc_on @*/
+/*@if (@_win32)
+    document.write("<script id=__ie_onload defer src=javascript:void(0)><\/script>");
+    var script = document.getElementById("__ie_onload");
+    script.onreadystatechange = function() {
+        if (this.readyState == "complete") {
+            sorttable.init(); // call the onload handler
+        }
+    };
+/*@end @*/
+
+/* for Safari */
+if (/WebKit/i.test(navigator.userAgent)) { // sniff
+    var _timer = setInterval(function() {
+        if (/loaded|complete/.test(document.readyState)) {
+            sorttable.init(); // call the onload handler
+        }
+    }, 10);
+}
+
+/* for other browsers */
+window.onload = sorttable.init;
+
+// written by Dean Edwards, 2005
+// with input from Tino Zijdel, Matthias Miller, Diego Perini
+
+// http://dean.edwards.name/weblog/2005/10/add-event/
+
+function dean_addEvent(element, type, handler) {
+	if (element.addEventListener) {
+		element.addEventListener(type, handler, false);
+	} else {
+		// assign each event handler a unique ID
+		if (!handler.$$guid) handler.$$guid = dean_addEvent.guid++;
+		// create a hash table of event types for the element
+		if (!element.events) element.events = {};
+		// create a hash table of event handlers for each element/event pair
+		var handlers = element.events[type];
+		if (!handlers) {
+			handlers = element.events[type] = {};
+			// store the existing event handler (if there is one)
+			if (element["on" + type]) {
+				handlers[0] = element["on" + type];
+			}
+		}
+		// store the event handler in the hash table
+		handlers[handler.$$guid] = handler;
+		// assign a global event handler to do all the work
+		element["on" + type] = handleEvent;
+	}
+};
+// a counter used to create unique IDs
+dean_addEvent.guid = 1;
+
+function removeEvent(element, type, handler) {
+	if (element.removeEventListener) {
+		element.removeEventListener(type, handler, false);
+	} else {
+		// delete the event handler from the hash table
+		if (element.events && element.events[type]) {
+			delete element.events[type][handler.$$guid];
+		}
+	}
+};
+
+function handleEvent(event) {
+	var returnValue = true;
+	// grab the event object (IE uses a global event object)
+	event = event || fixEvent(((this.ownerDocument || this.document || this).parentWindow || window).event);
+	// get a reference to the hash table of event handlers
+	var handlers = this.events[event.type];
+	// execute each event handler
+	for (var i in handlers) {
+		this.$$handleEvent = handlers[i];
+		if (this.$$handleEvent(event) === false) {
+			returnValue = false;
+		}
+	}
+	return returnValue;
+};
+
+function fixEvent(event) {
+	// add W3C standard event methods
+	event.preventDefault = fixEvent.preventDefault;
+	event.stopPropagation = fixEvent.stopPropagation;
+	return event;
+};
+fixEvent.preventDefault = function() {
+	this.returnValue = false;
+};
+fixEvent.stopPropagation = function() {
+  this.cancelBubble = true;
+}
+
+// Dean's forEach: http://dean.edwards.name/base/forEach.js
+/*
+	forEach, version 1.0
+	Copyright 2006, Dean Edwards
+	License: http://www.opensource.org/licenses/mit-license.php
+*/
+
+// array-like enumeration
+if (!Array.forEach) { // mozilla already supports this
+	Array.forEach = function(array, block, context) {
+		for (var i = 0; i < array.length; i++) {
+			block.call(context, array[i], i, array);
+		}
+	};
+}
+
+// generic enumeration
+Function.prototype.forEach = function(object, block, context) {
+	for (var key in object) {
+		if (typeof this.prototype[key] == "undefined") {
+			block.call(context, object[key], key, object);
+		}
+	}
+};
+
+// character enumeration
+String.forEach = function(string, block, context) {
+	Array.forEach(string.split(""), function(chr, index) {
+		block.call(context, chr, index, string);
+	});
+};
+
+// globally resolve forEach enumeration
+var forEach = function(object, block, context) {
+	if (object) {
+		var resolve = Object; // default
+		if (object instanceof Function) {
+			// functions have a "length" property
+			resolve = Function;
+		} else if (object.forEach instanceof Function) {
+			// the object implements a custom forEach method so use that
+			object.forEach(block, context);
+			return;
+		} else if (typeof object == "string") {
+			// the object is a string
+			resolve = String;
+		} else if (typeof object.length == "number") {
+			// the object is array-like
+			resolve = Array;
+		}
+		resolve.forEach(object, block, context);
+	}
+};

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -108,6 +108,7 @@ PPC
 PRELOAD
 PROFDATA
 README
+RLE
 RedHat
 RepMgr
 Riak
@@ -267,6 +268,7 @@ dl
 dll
 dlp
 dontlock
+doxtable
 dp
 ds
 dsrc
@@ -362,6 +364,7 @@ insn
 intl
 intpack
 inuse
+invariants
 io
 ip
 je
@@ -565,6 +568,7 @@ sess
 sid
 skinparam
 skiplist
+sortable
 spinlock
 spinlocks
 sql

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -8,6 +8,7 @@ Adler's
 Atomicity
 BLOBs
 BLRrVv
+CAS
 CFLAGS
 CMake
 COV

--- a/src/docs/style/header-web.html
+++ b/src/docs/style/header-web.html
@@ -8,6 +8,7 @@
 <link href="$relpath$tabs.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="$relpath$jquery.js"></script>
 <script type="text/javascript" src="$relpath$dynsections.js"></script>
+<script type="text/javascript" src="$relpath$sorttable.js"></script>
 $treeview
 $search
 $mathjax

--- a/src/docs/style/header.html
+++ b/src/docs/style/header.html
@@ -8,6 +8,7 @@
 <link href="$relpath$tabs.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="$relpath$jquery.js"></script>
 <script type="text/javascript" src="$relpath$dynsections.js"></script>
+<script type="text/javascript" src="$relpath$sorttable.js"></script>
 $treeview
 $search
 $mathjax


### PR DESCRIPTION
Included a way to have sortable tables.
Included \sic, a new way to indicate that the chosen spelling is correct,
without entering it into the dictionary.