### PR TITLE
WT-7943: Do not assert timestamps when rolling back a prepared transactions.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1127,7 +1127,9 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
     if (upd == NULL || upd->prepare_state != WT_PREPARE_INPROGRESS)
         goto prepare_verify;
 
-    WT_ERR(__txn_commit_timestamps_usage_check(session, op, upd));
+    /* A prepared operation that is rolled back will not have a timestamp worth asserting on. */
+    if (commit)
+        WT_ERR(__txn_commit_timestamps_usage_check(session, op, upd));
 
     for (first_committed_upd = upd; first_committed_upd != NULL &&
          (first_committed_upd->txnid == WT_TXN_ABORTED ||

--- a/test/suite/test_assert06.py
+++ b/test/suite/test_assert06.py
@@ -204,7 +204,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         # That checking will verify any individual key is always or never
         # used with a timestamp. And if it is used with a timestamp that
         # the timestamps are in increasing order for that key.
-        self.session.create(uri, 'key_format={},value_format=S,write_timestamp_usage=key_consistent,assert=(write_timestamp=on)'.format(self.key_format))
+        self.session.create(uri, 'key_format={},value_format=S,verbose=(write_timestamp),write_timestamp_usage=key_consistent,assert=(write_timestamp=on)'.format(self.key_format))
 
         # Insert a data item at timestamp 2.
         c = self.session.open_cursor(uri)

--- a/test/suite/test_assert06.py
+++ b/test/suite/test_assert06.py
@@ -438,5 +438,14 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         c.close()
         '''
 
+        # Confirm that rolling back after preparing doesn't fire an assertion.
+        c = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        c[key_ts6] = 'value24'
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(24))
+        self.session.rollback_transaction()
+        c.close()
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
I'm struggling to get the python tests running locally (a constant struggle to import `_wiredtiger`, but for the first time I couldn't figure out how to move forward). Meaning I haven't run the test I wrote -- nor have I verified that test fails as expected without the patch.

Hoping to get partial confirmation from the automated testing. In the meantime I'll dive into the problem on my machine.