### PR TITLE
WT-7866 Update cache_hs_insert limits in cppsuite-hs-cleanup-stress

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -26,9 +26,9 @@ runtime_monitor=
         enabled=true,
         limit=1900000000,
     ),
-    # Seems to insert around 490K records. Give it +-25K margin.
+    # Seems to insert around 477K records. Give it +-20K margin.
     # Seems to remove 180K records. Give it a similar margin.
-    postrun_statistics=[cache_hs_insert:470000:515000, cc_pages_removed:170000:200000]
+    postrun_statistics=[cache_hs_insert:457000:497000, cc_pages_removed:170000:200000]
 ),
 timestamp_manager=
 (

--- a/test/cppsuite/test_harness/test.cxx
+++ b/test/cppsuite/test_harness/test.cxx
@@ -137,8 +137,8 @@ test::run()
     /* The test will run for the duration as defined in the config. */
     duration_seconds = _config->get_int(DURATION_SECONDS);
     testutil_assert(duration_seconds >= 0);
-    logger::log_msg(
-      LOG_INFO, "Waiting {" + std::to_string(duration_seconds) + "} for testing to complete.");
+    logger::log_msg(LOG_INFO,
+      "Waiting {" + std::to_string(duration_seconds) + "} seconds for testing to complete.");
     std::this_thread::sleep_for(std::chrono::seconds(duration_seconds));
 
     /* End the test by calling finish on all known components. */

--- a/test/cppsuite/test_harness/timestamp_manager.cxx
+++ b/test/cppsuite/test_harness/timestamp_manager.cxx
@@ -69,7 +69,7 @@ timestamp_manager::load()
 void
 timestamp_manager::do_work()
 {
-    std::string config, log;
+    std::string config, log_msg;
     /* latest_ts_s represents the time component of the latest timestamp provided. */
     wt_timestamp_t latest_ts_s;
 
@@ -82,7 +82,7 @@ timestamp_manager::do_work()
      */
     testutil_assert(latest_ts_s >= _stable_ts);
     if ((latest_ts_s - _stable_ts) > _stable_lag) {
-        log = "Timestamp_manager: Stable timestamp expired.";
+        log_msg = "Timestamp_manager: Stable timestamp expired.";
         _stable_ts = latest_ts_s;
         config += std::string(STABLE_TS) + "=" + decimal_to_hex(_stable_ts);
     }
@@ -94,18 +94,18 @@ timestamp_manager::do_work()
     wt_timestamp_t new_oldest_ts = _oldest_ts;
     testutil_assert(_stable_ts >= _oldest_ts);
     if ((_stable_ts - _oldest_ts) > _oldest_lag) {
-        if (log.empty())
-            log = "Timestamp_manager: Oldest timestamp expired.";
+        if (log_msg.empty())
+            log_msg = "Timestamp_manager: Oldest timestamp expired.";
         else
-            log += " Oldest timestamp expired.";
+            log_msg += " Oldest timestamp expired.";
         new_oldest_ts = _stable_ts - _oldest_lag;
         if (!config.empty())
             config += ",";
         config += std::string(OLDEST_TS) + "=" + decimal_to_hex(new_oldest_ts);
     }
 
-    if (!log.empty())
-        logger::log_msg(LOG_INFO, log);
+    if (!log_msg.empty())
+        logger::log_msg(LOG_INFO, log_msg);
 
     /*
      * Save the new timestamps. Any timestamps that we're viewing from another thread should be set

--- a/test/cppsuite/test_harness/timestamp_manager.cxx
+++ b/test/cppsuite/test_harness/timestamp_manager.cxx
@@ -94,7 +94,7 @@ timestamp_manager::do_work()
     wt_timestamp_t new_oldest_ts = _oldest_ts;
     testutil_assert(_stable_ts >= _oldest_ts);
     if ((_stable_ts - _oldest_ts) > _oldest_lag) {
-        if(log.empty())
+        if (log.empty())
             log = "Timestamp_manager: Oldest timestamp expired.";
         else
             log += " Oldest timestamp expired.";
@@ -104,7 +104,7 @@ timestamp_manager::do_work()
         config += std::string(OLDEST_TS) + "=" + decimal_to_hex(new_oldest_ts);
     }
 
-    if(!log.empty())
+    if (!log.empty())
         logger::log_msg(LOG_INFO, log);
 
     /*

--- a/test/cppsuite/test_harness/timestamp_manager.cxx
+++ b/test/cppsuite/test_harness/timestamp_manager.cxx
@@ -69,7 +69,7 @@ timestamp_manager::load()
 void
 timestamp_manager::do_work()
 {
-    std::string config;
+    std::string config, log;
     /* latest_ts_s represents the time component of the latest timestamp provided. */
     wt_timestamp_t latest_ts_s;
 
@@ -82,7 +82,7 @@ timestamp_manager::do_work()
      */
     testutil_assert(latest_ts_s >= _stable_ts);
     if ((latest_ts_s - _stable_ts) > _stable_lag) {
-        logger::log_msg(LOG_INFO, "Timestamp_manager: Stable timestamp expired.");
+        log = "Timestamp_manager: Stable timestamp expired.";
         _stable_ts = latest_ts_s;
         config += std::string(STABLE_TS) + "=" + decimal_to_hex(_stable_ts);
     }
@@ -94,12 +94,18 @@ timestamp_manager::do_work()
     wt_timestamp_t new_oldest_ts = _oldest_ts;
     testutil_assert(_stable_ts >= _oldest_ts);
     if ((_stable_ts - _oldest_ts) > _oldest_lag) {
-        logger::log_msg(LOG_INFO, "Timestamp_manager: Oldest timestamp expired.");
+        if(log.empty())
+            log = "Timestamp_manager: Oldest timestamp expired.";
+        else
+            log += " Oldest timestamp expired.";
         new_oldest_ts = _stable_ts - _oldest_lag;
         if (!config.empty())
             config += ",";
         config += std::string(OLDEST_TS) + "=" + decimal_to_hex(new_oldest_ts);
     }
+
+    if(!log.empty())
+        logger::log_msg(LOG_INFO, log);
 
     /*
      * Save the new timestamps. Any timestamps that we're viewing from another thread should be set


### PR DESCRIPTION
- Updated limits for cache_hs_insert
- Updated logs for timestamps
- Added the units to the duration of the test in the logs