### PR TITLE
WT-7947 Allow CMake to take in a specific Python version

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -72,6 +72,15 @@ config_bool(
     DEFAULT OFF
 )
 
+config_string(
+    PYTHON3_REQUIRED_VERSION
+    "Exact Python version to use when building the Python API. \
+    By default, when this configuration is unset, CMake will preference the \
+    highest python version found to be installed in the users system path."
+    DEFAULT ""
+    DEPENDS "ENABLE_PYTHON"
+)
+
 config_bool(
     WT_STANDALONE_BUILD
     "Support standalone build"

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -76,7 +76,8 @@ config_string(
     PYTHON3_REQUIRED_VERSION
     "Exact Python version to use when building the Python API. \
     By default, when this configuration is unset, CMake will preference the \
-    highest python version found to be installed in the users system path."
+    highest python version found to be installed in the users system path. \
+    Expected format of version string: major[.minor[.patch]]"
     DEFAULT ""
     DEPENDS "ENABLE_PYTHON"
 )

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -61,10 +61,6 @@ function(config_string config_name description)
     if (NOT "${CONFIG_STR_UNPARSED_ARGUMENTS}" STREQUAL "")
         message(FATAL_ERROR "Unknown arguments to config_str: ${CONFIG_STR_UNPARSED_ARGUMENTS}")
     endif()
-    # We require a default value (not optional).
-    if ("${CONFIG_STR_DEFAULT}" STREQUAL "")
-        message(FATAL_ERROR "No default value passed")
-    endif()
 
     # Check that the configs dependencies are enabled before setting it to a visible enabled state.
     eval_dependency("${CONFIG_STR_DEPENDS}" enabled)

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -26,6 +26,13 @@ set(python_version)
 
 set(required_version)
 if(PYTHON3_REQUIRED_VERSION)
+    if(NOT PYTHON3_REQUIRED_VERSION MATCHES "^([0-9]+)(\\.[0-9]+(\\.[0-9]+)?)?$")
+        message(FATAL_ERROR "Invalid value for PYTHON3_REQUIRED_VERSION: Requires a valid version string \
+            Provide a version number following the format: major[.minor[.patch]]")
+    endif()
+    if ("${PYTHON3_REQUIRED_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Invalid value for PYTHON3_REQUIRED_VERSION: Requires a Python version >= 3")
+    endif()
     set(required_version ${PYTHON3_REQUIRED_VERSION} EXACT)
 endif()
 

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -23,17 +23,23 @@ include(${SWIG_USE_FILE})
 
 set(python_libs)
 set(python_version)
+
+set(required_version)
+if(PYTHON3_REQUIRED_VERSION)
+    set(required_version ${PYTHON3_REQUIRED_VERSION} EXACT)
+endif()
+
 if("${CMAKE_VERSION}" VERSION_LESS "3.12.0")
     # This method of finding python libs has been deprecated since version 3.12.
     # If we are running with a greater CMake version, opt to use the Python3 package.
     set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5)
-    find_package(PythonInterp REQUIRED)
-    find_package(PythonLibs REQUIRED)
+    find_package(PythonInterp ${required_version} REQUIRED)
+    find_package(PythonLibs ${required_version} REQUIRED)
     include_directories(${PYTHON_INCLUDE_DIRS})
     set(python_libs ${PYTHON_LIBRARIES})
     set(python_version ${PYTHON_VERSION_STRING})
 else()
-    find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python3 ${required_version} COMPONENTS Interpreter Development REQUIRED)
     include_directories(${Python3_INCLUDE_DIRS})
     set(python_libs ${Python3_LIBRARIES})
     set(python_version ${Python3_VERSION})


### PR DESCRIPTION
If a users system has multiple python installations, when building the Python API, CMake will preference using the highest python version found in the system path. This may be un-ideal if the user wants to preference a specific python version to build the API with e.g. ignore another installation.
    
This change adds the ability to pass a preferred Python version through a CMake config option. If unset, behaviour will default to the previous functionality, taking the newest Python version it can find.