### PR TITLE
WT-7858 Fix malloc writing out of bounds in compatibility-test-for-newer-releases

### DIFF
--- a/src/include/buf.i
+++ b/src/include/buf.i
@@ -13,10 +13,15 @@
 static inline int
 __wt_buf_grow(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size)
 {
-    return (
-      size > buf->memsize || !WT_DATA_IN_ITEM(buf) ? __wt_buf_grow_worker(session, buf, size) : 0);
+    /*
+     * Take any offset in the buffer into account when calculating the size to allocate, it saves
+     * complex calculations in our callers to decide if the buffer is large enough in the case of
+     * buffers with offset data pointers.
+     */
+    return (!WT_DATA_IN_ITEM(buf) || size + WT_PTRDIFF(buf->data, buf->mem) > buf->memsize ?
+        __wt_buf_grow_worker(session, buf, size) :
+        0);
 }
-
 /*
  * __wt_buf_extend --
  *     Grow a buffer that's currently in-use.

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -21,15 +21,23 @@ __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size)
 
     /*
      * Maintain the existing data: there are 3 cases:
-     *	No existing data: allocate the required memory, and initialize
-     * the data to reference it.
-     *	Existing data local to the buffer: set the data to the same
-     * offset in the re-allocated memory.
-     *	Existing data not-local to the buffer: copy the data into the
-     * buffer and set the data to reference it.
+     *
+     * 1. No existing data: allocate the required memory, and initialize the data to reference it.
+     * 2. Existing data local to the buffer: set the data to the same offset in the re-allocated
+     *    memory. The offset in this case is likely a read of an overflow item, the data pointer
+     *    is offset in the buffer in order to skip over the leading data block page header. For
+     *    the same reason, take any offset in the buffer into account when calculating the size
+     *    to allocate, it saves complex calculations in our callers to decide if the buffer is large
+     *    enough in the case of buffers with offset data pointers.
+     * 3. Existing data not-local to the buffer: copy the data into the buffer and set the data to
+     *    reference it.
+     *
+     * Take the offset of the data pointer in the buffer when calculating the size
+     * needed, overflow items use the data pointer to skip the leading data block page header
      */
     if (WT_DATA_IN_ITEM(buf)) {
         offset = WT_PTRDIFF(buf->data, buf->mem);
+        size += offset;
         copy_data = false;
     } else {
         offset = 0;
@@ -51,8 +59,14 @@ __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size)
         buf->data = buf->mem;
         buf->size = 0;
     } else {
-        if (copy_data)
+        if (copy_data) {
+            /*
+             * It's easy to corrupt memory if you pass in the wrong size for the final buffer size,
+             * which is harder to debug than this assert.
+             */
+            WT_ASSERT(session, buf->size <= buf->memsize);
             memcpy(buf->mem, buf->data, buf->size);
+        }
         buf->data = (uint8_t *)buf->mem + offset;
     }
 


### PR DESCRIPTION
This pull request aims to fix the memory out of bounds failure occurring within WT-7858. This problem comes from not being able to allocate enough memory from the buffer grow function. Recent changes from WT-7234 needs to be back ported, to account for the fact of overflow items, and to allocate enough memory.