### PR TITLE
WT-7952 Minor docs build fixes.

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -57,7 +57,7 @@ wtperf_config()
 glossarychk()
 {
 	(cd ../src/docs && grep '^<tr><td>' arch-glossary.dox | cut -d'>' -f3 | sed -e 's/<.*//') > $t
-	sort --ignore-case $t > $t2
+	sort -f $t > $t2
 	if ! diff $t $t2; then
 		echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 		echo "arch-glossary.dox entries out of order"

--- a/src/docs/arch-hs.dox
+++ b/src/docs/arch-hs.dox
@@ -89,7 +89,7 @@ be corrected.
 
 Consider the following update chain for a user table with btree id 1000 and data store key "AAA":
 
-@plantuml_start{hs_update_chain.png}
+@plantuml_start{hs_update_chain.png }
 @startuml{hs_update_chain.png}
 
 together {


### PR DESCRIPTION
Minor docs build fixes:
    (1) sort --ignore-case is a gnuism; -f is portable.
    (2) handle another case of needing a space at the end of @plantuml_start{file.png }  (seems to be required in doxygen 1.8.20, dunno why)