### PR TITLE
WT-7953 Teach s_string to not look inside getopt option lists.

### DIFF
--- a/dist/s_string
+++ b/dist/s_string
@@ -32,7 +32,8 @@ replace() {
 check() {
 	# Strip out git hashes, which are seven character hex strings.
 	# Strip out double quote char literals ('"'), they confuse aspell.
-	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" ../$2 |
+	# Strip out calls to __wt_getopt so the option lists don't have to be spelling words.
+	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' ../$2 |
 	aspell --lang=en_US $1 list |
 	sort -u |
 	comm -23 /dev/stdin s_string.ok > $t

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -113,7 +113,6 @@ Decrement
 Decrypt
 DeleteFileW
 Destructor
-Dh
 EACCES
 EAGAIN
 EB
@@ -156,7 +155,6 @@ FindClose
 FindFirstFile
 FindNextFileW
 Fixup
-Fk
 FlushFileBuffers
 Fprintf
 FreeBSD
@@ -244,7 +242,6 @@ LevelDB
 Levyx
 LibFuzzer
 LmRrSVv
-LmsT
 LoadLoad
 LockFile
 Lookaside
@@ -498,7 +495,6 @@ abcdef
 abcdefghijklmnopqrstuvwxyz
 addl
 addr
-af
 agc
 alfred
 alloc
@@ -587,7 +583,6 @@ ccc
 ccr
 cd
 ce
-ceh
 celsius
 centric
 cfg
@@ -962,7 +957,6 @@ iter
 iteratively
 iters
 jjj
-jnr
 jprx
 json
 kb
@@ -1036,7 +1030,6 @@ lwsync
 lx
 lz
 lzo
-mT
 madvise
 majmin
 majorp
@@ -1159,8 +1152,6 @@ osfhandle
 other's
 ovfl
 ownp
-pR
-pS
 packv
 pagedump
 pagesize
@@ -1218,7 +1209,6 @@ pv
 pvA
 pwrite
 py
-qRrT
 qdown
 qqq
 qrrSS
@@ -1279,7 +1269,6 @@ runtime
 rwlock
 sH
 sHQ
-sT
 sanitizer
 sanitizers
 scalability
@@ -1472,7 +1461,6 @@ util
 utils
 uu
 vN
-vW
 va
 valgrind
 valuep
@@ -1493,10 +1481,7 @@ vsize
 vsnprintf
 vtype
 vunpack
-vw
 vxr
-vxz
-vz
 waitpid
 waker
 wakeup


### PR DESCRIPTION
Teach s_string to not look at option lists in __wt_getopt calls.

Purge a bunch of unwanted spelling words that are no longer needed. (This doesn't get rid of all of them, because a few also appear in usage messages and those are not so easily filtered. But it helps.)