### PR TITLE
WT-7956 RTS to skip deleted or stable RLE cells

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -876,6 +876,7 @@ conn_dsrc_stats = [
     ##########################################
     TxnStat('txn_checkpoint_obsolete_applied', 'transaction checkpoints due to obsolete pages'),
     TxnStat('txn_read_race_prepare_update', 'race to read prepared update retry'),
+    TxnStat('txn_rts_delete_rle_skipped', 'rollback to stable skipping delete rle'),
     TxnStat('txn_rts_hs_removed', 'rollback to stable updates removed from history store'),
     TxnStat('txn_rts_hs_restore_updates', 'rollback to stable restored updates from history store'),
     TxnStat('txn_rts_hs_restore_tombstones', 'rollback to stable restored tombstones from history store'),
@@ -883,6 +884,7 @@ conn_dsrc_stats = [
     TxnStat('txn_rts_inconsistent_ckpt', 'rollback to stable inconsistent checkpoint'),
     TxnStat('txn_rts_keys_removed', 'rollback to stable keys removed'),
     TxnStat('txn_rts_keys_restored', 'rollback to stable keys restored'),
+    TxnStat('txn_rts_stable_rle_skipped', 'rollback to stable skipping stable rle'),
     TxnStat('txn_rts_sweep_hs_keys', 'rollback to stable sweeping history store keys'),
     TxnStat('txn_update_conflict', 'update conflicts'),
 ]

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -743,6 +743,8 @@ struct __wt_connection_stats {
     int64_t txn_rts_pages_visited;
     int64_t txn_rts_hs_restore_tombstones;
     int64_t txn_rts_hs_restore_updates;
+    int64_t txn_rts_delete_rle_skipped;
+    int64_t txn_rts_stable_rle_skipped;
     int64_t txn_rts_sweep_hs_keys;
     int64_t txn_rts_tree_walk_skip_pages;
     int64_t txn_rts_upd_aborted;
@@ -1014,6 +1016,8 @@ struct __wt_dsrc_stats {
     int64_t txn_rts_keys_restored;
     int64_t txn_rts_hs_restore_tombstones;
     int64_t txn_rts_hs_restore_updates;
+    int64_t txn_rts_delete_rle_skipped;
+    int64_t txn_rts_stable_rle_skipped;
     int64_t txn_rts_sweep_hs_keys;
     int64_t txn_rts_hs_removed;
     int64_t txn_checkpoint_obsolete_applied;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6008,140 +6008,144 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1428
 /*! transaction: rollback to stable restored updates from history store */
 #define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1429
+/*! transaction: rollback to stable skipping delete rle */
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1430
+/*! transaction: rollback to stable skipping stable rle */
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1431
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1430
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1432
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1431
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1433
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1432
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1434
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1433
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1435
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1434
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1436
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1435
+#define	WT_STAT_CONN_TXN_SET_TS				1437
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1436
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1438
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1437
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1439
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1438
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1440
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1439
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1441
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1440
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1442
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1441
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1443
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1442
+#define	WT_STAT_CONN_TXN_BEGIN				1444
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1443
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1445
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1444
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1446
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1445
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1447
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1446
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1448
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1447
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1449
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1448
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1450
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1449
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1451
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1450
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1452
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1451
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1453
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1452
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1454
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1453
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1455
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1454
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1456
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1455
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1457
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1456
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1458
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1457
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1459
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1458
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1460
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1459
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1461
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1460
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1462
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1461
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1463
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1462
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1464
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1463
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1465
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1464
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1466
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1465
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1467
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1466
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1468
 /*! transaction: transaction failures due to history store */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1467
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1469
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1468
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1470
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1469
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1471
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1470
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1472
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1471
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1473
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1472
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1474
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1473
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1475
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1474
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1476
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1475
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1477
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1476
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1478
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1477
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1479
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1478
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1480
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1479
+#define	WT_STAT_CONN_TXN_COMMIT				1481
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1480
+#define	WT_STAT_CONN_TXN_ROLLBACK			1482
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1481
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1483
 
 /*!
  * @}
@@ -6772,14 +6776,18 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2210
 /*! transaction: rollback to stable restored updates from history store */
 #define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2211
+/*! transaction: rollback to stable skipping delete rle */
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2212
+/*! transaction: rollback to stable skipping stable rle */
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2213
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2212
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2214
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2213
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2215
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2214
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2216
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2215
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2217
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -221,6 +221,8 @@ static const char *const __stats_dsrc_desc[] = {
   "transaction: rollback to stable keys restored",
   "transaction: rollback to stable restored tombstones from history store",
   "transaction: rollback to stable restored updates from history store",
+  "transaction: rollback to stable skipping delete rle",
+  "transaction: rollback to stable skipping stable rle",
   "transaction: rollback to stable sweeping history store keys",
   "transaction: rollback to stable updates removed from history store",
   "transaction: transaction checkpoints due to obsolete pages",
@@ -477,6 +479,8 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->txn_rts_keys_restored = 0;
     stats->txn_rts_hs_restore_tombstones = 0;
     stats->txn_rts_hs_restore_updates = 0;
+    stats->txn_rts_delete_rle_skipped = 0;
+    stats->txn_rts_stable_rle_skipped = 0;
     stats->txn_rts_sweep_hs_keys = 0;
     stats->txn_rts_hs_removed = 0;
     stats->txn_checkpoint_obsolete_applied = 0;
@@ -720,6 +724,8 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->txn_rts_keys_restored += from->txn_rts_keys_restored;
     to->txn_rts_hs_restore_tombstones += from->txn_rts_hs_restore_tombstones;
     to->txn_rts_hs_restore_updates += from->txn_rts_hs_restore_updates;
+    to->txn_rts_delete_rle_skipped += from->txn_rts_delete_rle_skipped;
+    to->txn_rts_stable_rle_skipped += from->txn_rts_stable_rle_skipped;
     to->txn_rts_sweep_hs_keys += from->txn_rts_sweep_hs_keys;
     to->txn_rts_hs_removed += from->txn_rts_hs_removed;
     to->txn_checkpoint_obsolete_applied += from->txn_checkpoint_obsolete_applied;
@@ -971,6 +977,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->txn_rts_keys_restored += WT_STAT_READ(from, txn_rts_keys_restored);
     to->txn_rts_hs_restore_tombstones += WT_STAT_READ(from, txn_rts_hs_restore_tombstones);
     to->txn_rts_hs_restore_updates += WT_STAT_READ(from, txn_rts_hs_restore_updates);
+    to->txn_rts_delete_rle_skipped += WT_STAT_READ(from, txn_rts_delete_rle_skipped);
+    to->txn_rts_stable_rle_skipped += WT_STAT_READ(from, txn_rts_stable_rle_skipped);
     to->txn_rts_sweep_hs_keys += WT_STAT_READ(from, txn_rts_sweep_hs_keys);
     to->txn_rts_hs_removed += WT_STAT_READ(from, txn_rts_hs_removed);
     to->txn_checkpoint_obsolete_applied += WT_STAT_READ(from, txn_checkpoint_obsolete_applied);
@@ -1419,6 +1427,8 @@ static const char *const __stats_connection_desc[] = {
   "transaction: rollback to stable pages visited",
   "transaction: rollback to stable restored tombstones from history store",
   "transaction: rollback to stable restored updates from history store",
+  "transaction: rollback to stable skipping delete rle",
+  "transaction: rollback to stable skipping stable rle",
   "transaction: rollback to stable sweeping history store keys",
   "transaction: rollback to stable tree walk skipping pages",
   "transaction: rollback to stable updates aborted",
@@ -1942,6 +1952,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_rts_pages_visited = 0;
     stats->txn_rts_hs_restore_tombstones = 0;
     stats->txn_rts_hs_restore_updates = 0;
+    stats->txn_rts_delete_rle_skipped = 0;
+    stats->txn_rts_stable_rle_skipped = 0;
     stats->txn_rts_sweep_hs_keys = 0;
     stats->txn_rts_tree_walk_skip_pages = 0;
     stats->txn_rts_upd_aborted = 0;
@@ -2476,6 +2488,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_rts_pages_visited += WT_STAT_READ(from, txn_rts_pages_visited);
     to->txn_rts_hs_restore_tombstones += WT_STAT_READ(from, txn_rts_hs_restore_tombstones);
     to->txn_rts_hs_restore_updates += WT_STAT_READ(from, txn_rts_hs_restore_updates);
+    to->txn_rts_delete_rle_skipped += WT_STAT_READ(from, txn_rts_delete_rle_skipped);
+    to->txn_rts_stable_rle_skipped += WT_STAT_READ(from, txn_rts_stable_rle_skipped);
     to->txn_rts_sweep_hs_keys += WT_STAT_READ(from, txn_rts_sweep_hs_keys);
     to->txn_rts_tree_walk_skip_pages += WT_STAT_READ(from, txn_rts_tree_walk_skip_pages);
     to->txn_rts_upd_aborted += WT_STAT_READ(from, txn_rts_upd_aborted);


### PR DESCRIPTION
Rollback to stable doesn't fix any of the deleted or stable
RLE cells as part aborting any unstable updates present on the
page. Skipping them improves the rollback to stable performance.