### PR TITLE
WT-7907 Add dependencies to swig module definition in CMake build

### DIFF
--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -70,9 +70,7 @@ list(APPEND swig_flags "-I${CMAKE_BINARY_DIR}/config")
 set(CMAKE_SWIG_FLAGS ${swig_flags})
 
 # Add dependencies to the swig module.
-set(SWIG_MODULE__wiredtiger_EXTRA_DEPS
-    ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in
-    ${CMAKE_SOURCE_DIR}/src/include/wt_internal.h)
+set(SWIG_MODULE__wiredtiger_EXTRA_DEPS ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in)
 
 swig_add_library(_wiredtiger
   TYPE SHARED

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -70,7 +70,9 @@ list(APPEND swig_flags "-I${CMAKE_BINARY_DIR}/config")
 set(CMAKE_SWIG_FLAGS ${swig_flags})
 
 # Add dependencies to the swig module
-set(SWIG_MODULE__wiredtiger_EXTRA_DEPS ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in)
+set(SWIG_MODULE__wiredtiger_EXTRA_DEPS
+    ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in
+    ${CMAKE_SOURCE_DIR}/src/include/wt_internal.h)
 
 swig_add_library(_wiredtiger
   TYPE SHARED

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -69,7 +69,7 @@ list(APPEND swig_flags "-I${CMAKE_BINARY_DIR}/config")
 
 set(CMAKE_SWIG_FLAGS ${swig_flags})
 
-# Add dependencies to the swig module
+# Add dependencies to the swig module.
 set(SWIG_MODULE__wiredtiger_EXTRA_DEPS
     ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in
     ${CMAKE_SOURCE_DIR}/src/include/wt_internal.h)

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -69,6 +69,9 @@ list(APPEND swig_flags "-I${CMAKE_BINARY_DIR}/config")
 
 set(CMAKE_SWIG_FLAGS ${swig_flags})
 
+# Add dependencies to the swig module
+set(SWIG_MODULE__wiredtiger_EXTRA_DEPS ${CMAKE_SOURCE_DIR}/src/include/wiredtiger.in)
+
 swig_add_library(_wiredtiger
   TYPE SHARED
   LANGUAGE python


### PR DESCRIPTION
The [CMake documentation](https://cmake.org/cmake/help/latest/module/UseSWIG.html) describes the possibility of adding extra dependencies through `SWIG_MODULE_<name>_EXTRA_DEPS` when defining the swig module.
The change made in this PR will ensure the last version of `wiredtiger.in` is used to generate `wiredtigerPYTHON_wrap.c`.