### PR TITLE
WT-7955 Copy format.sh and CONFIG.stress to the build directory with CMake

### DIFF
--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -53,9 +53,9 @@ create_test_executable(test_format
     SOURCES ${format_sources}
     EXECUTABLE_NAME "t"
     ADDITIONAL_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
-        ${CMAKE_CURRENT_SOURCE_DIR}/format.sh
         ${CMAKE_CURRENT_SOURCE_DIR}/CONFIG.stress
+        ${CMAKE_CURRENT_SOURCE_DIR}/format.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
 )
 
 if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -52,7 +52,10 @@ set(format_sources
 create_test_executable(test_format
     SOURCES ${format_sources}
     EXECUTABLE_NAME "t"
-    ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
+    ADDITIONAL_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/format.sh
+        ${CMAKE_CURRENT_SOURCE_DIR}/CONFIG.stress
 )
 
 if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)


### PR DESCRIPTION
- When `format.sh` is executed, it looks for the binary `t` within the same directory or under `build_posix/test/format`. 
- `CONFIG.stress` is the default configuration used by `format.sh`, both are under `test/format`.
-  When building with CMake, a different build directory could be used, hence `t` is not found. By copying `format.sh` to `<build_dir>/test/format`, where `t` is, we can tackle this issue. We copy the default test configuration for the same reason. 