### PR TITLE
WT-7905 Fix incorrect builtin behaviour for builds in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,8 @@ if(ENABLE_TCMALLOC AND HAVE_LIBTCMALLOC)
     target_link_libraries(wiredtiger ${HAVE_LIBTCMALLOC})
 endif()
 
-# When handling builtins, its still ideal to call 'target_link_libraries'
-# despite already having linked the individual objects in the builtin library.
 # We want to capture any transitive dependencies associated with the builtin library
-# target and ensure they propogate to which ever target links against wiredtiger e.g
-# installed 3rd party libraries.
+# target and ensure we are explicitly linking the 3rd party libraries.
 if(HAVE_BUILTIN_EXTENSION_LZ4)
     target_link_libraries(wiredtiger ${HAVE_LIBLZ4})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(HAVE_BUILTIN_EXTENSION_SODIUM)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
 endif()
 
-# Establish wiredtiger library target
+# Establish wiredtiger library target.
 add_library(wiredtiger ${link_type} ${wt_sources} ${builtin_objs})
 
 # Generate wiredtiger.h include file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,16 +88,16 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_snappy>)
 endif()
 
+if(HAVE_BUILTIN_EXTENSION_SODIUM)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
+endif()
+
 if(HAVE_BUILTIN_EXTENSION_ZLIB)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zlib>)
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zstd>)
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_SODIUM)
-    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
 endif()
 
 # Establish wiredtiger library target.
@@ -156,16 +156,16 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY)
     target_link_libraries(wiredtiger ${HAVE_LIBSNAPPY})
 endif()
 
+if(HAVE_BUILTIN_EXTENSION_SODIUM)
+    target_link_libraries(wiredtiger ${HAVE_LIBSODIUM})
+endif()
+
 if(HAVE_BUILTIN_EXTENSION_ZLIB)
     target_link_libraries(wiredtiger ${HAVE_LIBZ})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
     target_link_libraries(wiredtiger ${HAVE_LIBZSTD})
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_SODIUM)
-    target_link_libraries(wiredtiger ${HAVE_LIBSODIUM})
 endif()
 
 # Build the wt utility.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zstd>)
 endif()
 
-+if(HAVE_BUILTIN_EXTENSION_SODIUM)
-+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
-+endif()
+if(HAVE_BUILTIN_EXTENSION_SODIUM)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
+endif()
 
 # Establish wiredtiger library target
 add_library(wiredtiger ${link_type} ${wt_sources} ${builtin_objs})
@@ -152,23 +152,23 @@ endif()
 # target and ensure they propogate to which ever target links against wiredtiger e.g
 # installed 3rd party libraries.
 if(HAVE_BUILTIN_EXTENSION_LZ4)
-    target_link_libraries(wiredtiger wiredtiger_lz4)
+    target_link_libraries(wiredtiger ${HAVE_LIBLZ4})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_SNAPPY)
-    target_link_libraries(wiredtiger wiredtiger_snappy)
+    target_link_libraries(wiredtiger  ${HAVE_LIBSNAPPY})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZLIB)
-    target_link_libraries(wiredtiger wiredtiger_zlib)
+    target_link_libraries(wiredtiger ${HAVE_LIBZ})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
-    target_link_libraries(wiredtiger wiredtiger_zstd)
+    target_link_libraries(wiredtiger ${HAVE_LIBZSTD})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_SODIUM)
-    target_link_libraries(wiredtiger wiredtiger_sodium)
+    target_link_libraries(wiredtiger ${HAVE_LIBSODIUM})
 endif()
 
 # Build the wt utility.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(ENABLE_STATIC)
     set(link_type "STATIC")
 else()
     set(link_type "SHARED")
-    SET_PROPERTY(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 endif()
 
 # Include the extensions to the build.
@@ -78,8 +78,30 @@ if(WT_WIN)
     list(APPEND wt_source ${CMAKE_SOURCE_DIR}/build_win/wiredtiger.def)
     set_source_files_properties(${CMAKE_SOURCE_DIR}/build_win/wiredtiger.def PROPERTIES HEADER_FILE_ONLY TRUE)
 endif()
+
+set(builtin_objs)
+if(HAVE_BUILTIN_EXTENSION_LZ4)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_lz4>)
+endif()
+
+if(HAVE_BUILTIN_EXTENSION_SNAPPY)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_snappy>)
+endif()
+
+if(HAVE_BUILTIN_EXTENSION_ZLIB)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zlib>)
+endif()
+
+if(HAVE_BUILTIN_EXTENSION_ZSTD)
+    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zstd>)
+endif()
+
++if(HAVE_BUILTIN_EXTENSION_SODIUM)
++    list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_sodium>)
++endif()
+
 # Establish wiredtiger library target
-add_library(wiredtiger ${link_type} ${wt_sources})
+add_library(wiredtiger ${link_type} ${wt_sources} ${builtin_objs})
 
 # Generate wiredtiger.h include file.
 configure_file(src/include/wiredtiger.in "include/wiredtiger.h" @ONLY)
@@ -124,6 +146,11 @@ if(ENABLE_TCMALLOC AND HAVE_LIBTCMALLOC)
     target_link_libraries(wiredtiger ${HAVE_LIBTCMALLOC})
 endif()
 
+# When handling builtins, its still ideal to call 'target_link_libraries'
+# despite already having linked the individual objects in the builtin library.
+# We want to capture any transitive dependencies associated with the builtin library
+# target and ensure they propogate to which ever target links against wiredtiger e.g
+# installed 3rd party libraries.
 if(HAVE_BUILTIN_EXTENSION_LZ4)
     target_link_libraries(wiredtiger wiredtiger_lz4)
 endif()
@@ -138,6 +165,10 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
     target_link_libraries(wiredtiger wiredtiger_zstd)
+endif()
+
+if(HAVE_BUILTIN_EXTENSION_SODIUM)
+    target_link_libraries(wiredtiger wiredtiger_sodium)
 endif()
 
 # Build the wt utility.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(HAVE_BUILTIN_EXTENSION_LZ4)
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_SNAPPY)
-    target_link_libraries(wiredtiger  ${HAVE_LIBSNAPPY})
+    target_link_libraries(wiredtiger ${HAVE_LIBSNAPPY})
 endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZLIB)

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -53,9 +53,6 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
     add_library(wiredtiger_lz4 ${link_type} ${sources})
-    # HAVE_LIBLZ4 contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_lz4 ${HAVE_LIBLZ4})
     target_include_directories(
         wiredtiger_lz4
         PRIVATE
@@ -72,6 +69,9 @@ if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
 endif()
 
 if(ENABLE_LZ4)
+    # HAVE_LIBLZ4 contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_lz4 PUBLIC ${HAVE_LIBLZ4})
     install(TARGETS wiredtiger_lz4
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -46,11 +46,7 @@ set(sources "lz4_compress.c")
 set(link_type)
 
 if(HAVE_BUILTIN_EXTENSION_LZ4)
-    if(ENABLE_STATIC)
-        set(link_type "STATIC")
-    else()
-        set(link_type "SHARED")
-    endif()
+    set(link_type "OBJECT")
 else()
     set(link_type "MODULE")
 endif()
@@ -72,10 +68,13 @@ if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
 
+    set_property(TARGET wiredtiger_lz4 PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_LZ4)
     install(TARGETS wiredtiger_lz4
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 
-    set_property(TARGET wiredtiger_lz4 PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 if(ENABLE_LZ4)
     # HAVE_LIBLZ4 contains the full pathname to the lib, which is
     # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_lz4 PUBLIC ${HAVE_LIBLZ4})
+    target_link_libraries(wiredtiger_lz4 ${HAVE_LIBLZ4})
     install(TARGETS wiredtiger_lz4
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/lz4/CMakeLists.txt
+++ b/ext/compressors/lz4/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 if(ENABLE_LZ4)
     # HAVE_LIBLZ4 contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
+    # what the cmake docs recommend using.
     target_link_libraries(wiredtiger_lz4 ${HAVE_LIBLZ4})
     install(TARGETS wiredtiger_lz4
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 if(ENABLE_SNAPPY)
     # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
+    # what the cmake docs recommend using.
     target_link_libraries(wiredtiger_snappy ${HAVE_LIBSNAPPY})
     install(TARGETS wiredtiger_snappy
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -52,9 +52,6 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
     add_library(wiredtiger_snappy ${link_type} ${sources})
-    # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_snappy ${HAVE_LIBSNAPPY})
     target_include_directories(
         wiredtiger_snappy
         PRIVATE
@@ -66,11 +63,13 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
         wiredtiger_snappy
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
-
     set_property(TARGET wiredtiger_snappy PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(ENABLE_SNAPPY)
+    # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_snappy PUBLIC ${HAVE_LIBSNAPPY})
     install(TARGETS wiredtiger_snappy
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 if(ENABLE_SNAPPY)
     # HAVE_LIBSNAPPY contains the full pathname to the lib, which is
     # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_snappy PUBLIC ${HAVE_LIBSNAPPY})
+    target_link_libraries(wiredtiger_snappy ${HAVE_LIBSNAPPY})
     install(TARGETS wiredtiger_snappy
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/snappy/CMakeLists.txt
+++ b/ext/compressors/snappy/CMakeLists.txt
@@ -45,11 +45,7 @@ endif()
 set(sources "snappy_compress.c")
 set(link_type)
 if(HAVE_BUILTIN_EXTENSION_SNAPPY)
-    if(ENABLE_STATIC)
-        set(link_type "STATIC")
-    else()
-        set(link_type "SHARED")
-    endif()
+    set(link_type "OBJECT")
 else()
     set(link_type "MODULE")
 endif()
@@ -71,10 +67,12 @@ if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
 
+    set_property(TARGET wiredtiger_snappy PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_SNAPPY)
     install(TARGETS wiredtiger_snappy
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-
-    set_property(TARGET wiredtiger_snappy PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/ext/compressors/zlib/CMakeLists.txt
+++ b/ext/compressors/zlib/CMakeLists.txt
@@ -52,9 +52,6 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
     add_library(wiredtiger_zlib ${link_type} ${sources})
-    # HAVE_LIBZ contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_zlib ${HAVE_LIBZ})
     target_include_directories(
         wiredtiger_zlib
         PRIVATE
@@ -71,6 +68,9 @@ if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
 endif()
 
 if(ENABLE_ZLIB)
+    # HAVE_LIBZ contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_zlib ${HAVE_LIBZ})
     install(TARGETS wiredtiger_zlib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/zlib/CMakeLists.txt
+++ b/ext/compressors/zlib/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if(ENABLE_ZLIB)
     # HAVE_LIBZ contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
+    # what the cmake docs recommend using.
     target_link_libraries(wiredtiger_zlib ${HAVE_LIBZ})
     install(TARGETS wiredtiger_zlib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/zlib/CMakeLists.txt
+++ b/ext/compressors/zlib/CMakeLists.txt
@@ -45,11 +45,7 @@ endif()
 set(sources "zlib_compress.c")
 set(link_type)
 if(HAVE_BUILTIN_EXTENSION_ZLIB)
-    if(ENABLE_STATIC)
-        set(link_type "STATIC")
-    else()
-        set(link_type "SHARED")
-    endif()
+    set(link_type "OBJECT")
 else()
     set(link_type "MODULE")
 endif()
@@ -71,10 +67,12 @@ if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
 
+    set_property(TARGET wiredtiger_zlib PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_ZLIB)
     install(TARGETS wiredtiger_zlib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-
-    set_property(TARGET wiredtiger_zlib PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -52,9 +52,6 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
     add_library(wiredtiger_zstd ${link_type} ${sources})
-    # HAVE_LIBZSTD contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
-    target_link_libraries(wiredtiger_zstd ${HAVE_LIBZSTD})
     target_include_directories(
         wiredtiger_zstd
         PRIVATE
@@ -71,6 +68,9 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
 endif()
 
 if(ENABLE_ZSTD)
+    # HAVE_LIBZSTD contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_zstd ${HAVE_LIBZSTD})
     install(TARGETS wiredtiger_zstd
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if(ENABLE_ZSTD)
     # HAVE_LIBZSTD contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
+    # what the cmake docs recommend using.
     target_link_libraries(wiredtiger_zstd ${HAVE_LIBZSTD})
     install(TARGETS wiredtiger_zstd
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/compressors/zstd/CMakeLists.txt
+++ b/ext/compressors/zstd/CMakeLists.txt
@@ -45,11 +45,7 @@ endif()
 set(sources "zstd_compress.c")
 set(link_type)
 if(HAVE_BUILTIN_EXTENSION_ZSTD)
-    if(ENABLE_STATIC)
-        set(link_type "STATIC")
-    else()
-        set(link_type "SHARED")
-    endif()
+    set(link_type "OBJECT")
 else()
     set(link_type "MODULE")
 endif()
@@ -71,10 +67,12 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD OR ENABLE_ZSTD)
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
 
+    set_property(TARGET wiredtiger_zstd PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_ZSTD)
     install(TARGETS wiredtiger_zstd
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-
-    set_property(TARGET wiredtiger_zstd PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/ext/encryptors/sodium/CMakeLists.txt
+++ b/ext/encryptors/sodium/CMakeLists.txt
@@ -52,10 +52,6 @@ endif()
 
 if(HAVE_BUILTIN_EXTENSION_SODIUM OR ENABLE_SODIUM)
     add_library(wiredtiger_sodium ${link_type} ${sources})
-    # HAVE_LIBSODIUM contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
-    #target_link_libraries(wiredtiger_sodium "sodium")
-    target_link_libraries(wiredtiger_sodium ${HAVE_LIBSODIUM})
     target_include_directories(
         wiredtiger_sodium
         PRIVATE
@@ -72,6 +68,9 @@ if(HAVE_BUILTIN_EXTENSION_SODIUM OR ENABLE_SODIUM)
 endif()
 
 if(ENABLE_SODIUM)
+    # HAVE_LIBSODIUM contains the full pathname to the lib, which is
+    # what the cmake docs recommend using
+    target_link_libraries(wiredtiger_sodium ${HAVE_LIBSODIUM})
     install(TARGETS wiredtiger_sodium
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/encryptors/sodium/CMakeLists.txt
+++ b/ext/encryptors/sodium/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if(ENABLE_SODIUM)
     # HAVE_LIBSODIUM contains the full pathname to the lib, which is
-    # what the cmake docs recommend using
+    # what the cmake docs recommend using.
     target_link_libraries(wiredtiger_sodium ${HAVE_LIBSODIUM})
     install(TARGETS wiredtiger_sodium
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/ext/encryptors/sodium/CMakeLists.txt
+++ b/ext/encryptors/sodium/CMakeLists.txt
@@ -45,11 +45,7 @@ endif()
 set(sources "sodium_encrypt.c")
 set(link_type)
 if(HAVE_BUILTIN_EXTENSION_SODIUM)
-    if(ENABLE_STATIC)
-        set(link_type "STATIC")
-    else()
-        set(link_type "SHARED")
-    endif()
+    set(link_type "OBJECT")
 else()
     set(link_type "MODULE")
 endif()
@@ -72,10 +68,12 @@ if(HAVE_BUILTIN_EXTENSION_SODIUM OR ENABLE_SODIUM)
         PRIVATE ${COMPILER_DIAGNOSTIC_FLAGS}
     )
 
+    set_property(TARGET wiredtiger_sodium PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_SODIUM)
     install(TARGETS wiredtiger_sodium
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-
-    set_property(TARGET wiredtiger_sodium PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -54,7 +54,7 @@ create_test_executable(run
     CXX
 )
 
-if (HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
+if(ENABLE_SNAPPY)
     # We use Snappy compression to avoid excessive disk spage usage.
     target_compile_options(run PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")
 endif()

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -116,7 +116,7 @@ functions:
             mkdir -p cmake_build
             cd cmake_build
             $CMAKE \
-            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
+            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -DHAVE_BUILTIN_EXTENSION_LZ4=1 -G "${cmake_generator|Ninja}" ./..
           fi
         elif [ "$OS" != "Windows_NT" ]; then
           # Compiling with Autoconf/Libtool.
@@ -190,6 +190,21 @@ functions:
             CC=/opt/mongodbtoolchain/v3/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fno-omit-frame-pointer -fsanitize=address" CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer -ggdb -fPIC" \
               ../configure ${configure_python_setting|} \
               --enable-diagnostic --with-builtins=lz4,snappy,zlib,zstd
+          fi
+    - *make_wiredtiger
+  "compile wiredtiger with builtins":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/build_posix"
+        shell: bash
+        script: |
+          set -o errexit
+          set -o verbose
+          sh reconf
+          if [ "$OS" != "Windows_NT" ]; then
+            CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH ADD_CFLAGS="-ggdb -fPIC" \
+              ../configure ${configure_python_setting|} \
+              --enable-strict --enable-diagnostic --with-builtins=lz4,snappy,zlib
           fi
     - *make_wiredtiger
   "compile wiredtiger with builtins":
@@ -2702,7 +2717,7 @@ buildvariants:
   - ubuntu1804-test
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
@@ -3009,7 +3024,7 @@ buildvariants:
   run_on:
   - macos-1014
   expansions:
-    posix_configure_flags: -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: 'python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
@@ -3082,7 +3097,7 @@ buildvariants:
   batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja
@@ -3121,7 +3136,7 @@ buildvariants:
   batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -116,7 +116,7 @@ functions:
             mkdir -p cmake_build
             cd cmake_build
             $CMAKE \
-            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -DHAVE_BUILTIN_EXTENSION_LZ4=1 -G "${cmake_generator|Ninja}" ./..
+            ${posix_configure_flags|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STATIC=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL} -G "${cmake_generator|Ninja}" ./..
           fi
         elif [ "$OS" != "Windows_NT" ]; then
           # Compiling with Autoconf/Libtool.
@@ -190,21 +190,6 @@ functions:
             CC=/opt/mongodbtoolchain/v3/bin/clang CXX=/opt/mongodbtoolchain/v3/bin/clang++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH CFLAGS="-ggdb -fPIC -fno-omit-frame-pointer -fsanitize=address" CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer -ggdb -fPIC" \
               ../configure ${configure_python_setting|} \
               --enable-diagnostic --with-builtins=lz4,snappy,zlib,zstd
-          fi
-    - *make_wiredtiger
-  "compile wiredtiger with builtins":
-    - command: shell.exec
-      params:
-        working_dir: "wiredtiger/build_posix"
-        shell: bash
-        script: |
-          set -o errexit
-          set -o verbose
-          sh reconf
-          if [ "$OS" != "Windows_NT" ]; then
-            CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:$PATH ADD_CFLAGS="-ggdb -fPIC" \
-              ../configure ${configure_python_setting|} \
-              --enable-strict --enable-diagnostic --with-builtins=lz4,snappy,zlib
           fi
     - *make_wiredtiger
   "compile wiredtiger with builtins":
@@ -2717,7 +2702,7 @@ buildvariants:
   - ubuntu1804-test
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
@@ -3024,7 +3009,7 @@ buildvariants:
   run_on:
   - macos-1014
   expansions:
-    posix_configure_flags: -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: 'python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
@@ -3097,7 +3082,7 @@ buildvariants:
   batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja
@@ -3136,7 +3121,7 @@ buildvariants:
   batchtime: 10080 # 7 days
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
-    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     cmake_generator: Ninja

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -63,16 +63,16 @@ if(ENABLE_SNAPPY)
     target_compile_options(test_format PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")
 endif()
 
+if(ENABLE_SODIUM)
+    target_compile_options(test_format PRIVATE -DSODIUM_PATH=\"$<TARGET_FILE:wiredtiger_sodium>\")
+endif()
+
 if(ENABLE_ZLIB)
     target_compile_options(test_format PRIVATE -DZLIB_PATH=\"$<TARGET_FILE:wiredtiger_zlib>\")
 endif()
 
 if(ENABLE_ZSTD)
     target_compile_options(test_format PRIVATE -DZSTD_PATH=\"$<TARGET_FILE:wiredtiger_zstd>\")
-endif()
-
-if(ENABLE_SODIUM)
-    target_compile_options(test_format PRIVATE -DSODIUM_PATH=\"$<TARGET_FILE:wiredtiger_sodium>\")
 endif()
 target_compile_options(test_format PRIVATE -DREVERSE_PATH=\"$<TARGET_FILE:wiredtiger_reverse_collator>\")
 target_compile_options(test_format PRIVATE -DROTN_PATH=\"$<TARGET_FILE:wiredtiger_rotn_encrypt>\")

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -55,19 +55,23 @@ create_test_executable(test_format
     ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh
 )
 
-if(HAVE_BUILTIN_EXTENSION_LZ4 OR ENABLE_LZ4)
+if(ENABLE_LZ4)
     target_compile_options(test_format PRIVATE -DLZ4_PATH=\"$<TARGET_FILE:wiredtiger_lz4>\")
 endif()
-if(HAVE_BUILTIN_EXTENSION_SNAPPY OR ENABLE_SNAPPY)
+
+if(ENABLE_SNAPPY)
     target_compile_options(test_format PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")
 endif()
-if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZLIB)
+
+if(ENABLE_ZLIB)
     target_compile_options(test_format PRIVATE -DZLIB_PATH=\"$<TARGET_FILE:wiredtiger_zlib>\")
 endif()
-if(HAVE_BUILTIN_EXTENSION_ZLIB OR ENABLE_ZSTD)
+
+if(ENABLE_ZSTD)
     target_compile_options(test_format PRIVATE -DZSTD_PATH=\"$<TARGET_FILE:wiredtiger_zstd>\")
 endif()
-if(HAVE_BUILTIN_EXTENSION_SODIUM OR ENABLE_SODIUM)
+
+if(ENABLE_SODIUM)
     target_compile_options(test_format PRIVATE -DSODIUM_PATH=\"$<TARGET_FILE:wiredtiger_sodium>\")
 endif()
 target_compile_options(test_format PRIVATE -DREVERSE_PATH=\"$<TARGET_FILE:wiredtiger_reverse_collator>\")


### PR DESCRIPTION
Currently the CMake build doesn't have correct builtin behaviour, the extension libraries that have been configured for builtins, show no symbols within the wiredtiger library. This ticket aims to fix that via compiling extension libraries for builtins as OBJECTS.