### PR TITLE
WT-7974 More column fixes and tests.

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -594,6 +594,9 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *page
 
     /* Finally remove that update from history store. */
     if (valid_update_found) {
+        /* Avoid freeing the updates while still in use if hs_cursor->remove fails. */
+        upd = tombstone = NULL;
+
         WT_ERR(hs_cursor->remove(hs_cursor));
         WT_STAT_CONN_DATA_INCR(session, txn_rts_hs_removed);
         WT_STAT_CONN_DATA_INCR(session, cache_hs_key_truncate_rts);
@@ -785,7 +788,7 @@ __rollback_abort_col_var(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
     WT_PAGE *page;
     uint64_t recno, rle;
     uint32_t i, j;
-    bool stable_update_found;
+    bool is_ondisk_stable, stable_update_found;
 
     page = ref->page;
     /*
@@ -804,26 +807,46 @@ __rollback_abort_col_var(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
             WT_RET(__rollback_abort_insert_list(
               session, page, ins, rollback_timestamp, &stable_update_found));
 
-        if (!stable_update_found && page->dsk != NULL) {
+        if (page->dsk != NULL) {
+            /* Unpack the cell. We need its RLE count whether or not we're going to iterate it. */
             kcell = WT_COL_PTR(page, cip);
             __wt_cell_unpack_kv(session, page->dsk, kcell, &unpack);
             rle = __wt_cell_rle(&unpack);
-            if (unpack.type != WT_CELL_DEL) {
+
+            /*
+             * If we found a stable update on the insert list, this key needs no further attention.
+             * Any other keys in this cell with stable updates also do not require attention. But
+             * beyond that, the on-disk value must be older than
+             * the update we found. That means it too is stable(*), so any keys in the cell that
+             * _don't_ have stable updates on the update list don't need further attention either.
+             * (And any unstable updates were just handled above.) Thus we can skip iterating over
+             * the cell.
+             *
+             * Furthermore, if the cell is deleted it must be
+             * itself stable, because cells only appear as deleted if there is no older value that
+             * might need to be restored. We can skip iterating over the cell.
+             *
+             * (*) Either that, or the update is not timestamped, in which case the on-disk value
+             * might not be stable but the non-timestamp update will hide it until the next
+             * reconciliation and then overwrite it.
+             */
+            if (stable_update_found)
+                WT_STAT_CONN_DATA_INCR(session, txn_rts_stable_rle_skipped);
+            else if (unpack.type == WT_CELL_DEL)
+                WT_STAT_CONN_DATA_INCR(session, txn_rts_delete_rle_skipped);
+            else {
                 for (j = 0; j < rle; j++) {
-                    WT_RET(__rollback_abort_ondisk_kv(session, ref, cip, NULL, rollback_timestamp,
-                      recno + j, &stable_update_found));
-                    /* Skip processing all RLE if the on-disk version is stable. */
-                    if (stable_update_found) {
+                    WT_RET(__rollback_abort_ondisk_kv(
+                      session, ref, cip, NULL, rollback_timestamp, recno + j, &is_ondisk_stable));
+                    /* We can stop right away if the on-disk version is stable. */
+                    if (is_ondisk_stable) {
                         if (rle > 1)
                             WT_STAT_CONN_DATA_INCR(session, txn_rts_stable_rle_skipped);
                         break;
                     }
                 }
-            } else
-                WT_STAT_CONN_DATA_INCR(session, txn_rts_delete_rle_skipped);
+            }
             recno += rle;
-        } else {
-            recno++;
         }
     }
 

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -92,6 +92,7 @@ define_c_test(
     TARGET test_truncated_log
     SOURCES truncated_log/main.c
     DIR_NAME truncated_log
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 
@@ -109,12 +110,11 @@ define_c_test(
     DEPENDS "WT_POSIX"
 )
 
-# Temporarily disabled (WT-5790).
-#define_c_test(
-#    TARGET test_wt2246_col_append
-#    SOURCES wt2246_col_append/main.c
-#    DIR_NAME wt2246_col_append
-#)
+define_c_test(
+    TARGET test_wt2246_col_append
+    SOURCES wt2246_col_append/main.c
+    DIR_NAME wt2246_col_append
+)
 
 define_c_test(
     TARGET test_wt2323_join_visibility
@@ -273,6 +273,7 @@ define_c_test(
     TARGET test_wt6185_modify_ts
     SOURCES wt6185_modify_ts/main.c
     DIR_NAME wt6185_modify_ts
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 
@@ -280,6 +281,7 @@ define_c_test(
     TARGET test_wt6616_checkpoint_oldest_ts
     SOURCES wt6616_checkpoint_oldest_ts/main.c
     DIR_NAME wt6616_checkpoint_oldest_ts
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -37,7 +37,7 @@ all_TESTS += timestamp_abort/smoke.sh
 
 test_truncated_log_SOURCES = truncated_log/main.c
 noinst_PROGRAMS += test_truncated_log
-all_TESTS += test_truncated_log
+all_TESTS += truncated_log/smoke.sh
 
 test_wt1965_col_efficiency_SOURCES = wt1965_col_efficiency/main.c
 noinst_PROGRAMS += test_wt1965_col_efficiency
@@ -49,8 +49,7 @@ all_TESTS += test_wt2403_lsm_workload
 
 test_wt2246_col_append_SOURCES = wt2246_col_append/main.c
 noinst_PROGRAMS += test_wt2246_col_append
-# Temporarily disabled (WT-5790)
-# all_TESTS += test_wt2246_col_append
+all_TESTS += test_wt2246_col_append
 
 test_wt2323_join_visibility_SOURCES = wt2323_join_visibility/main.c
 noinst_PROGRAMS += test_wt2323_join_visibility
@@ -146,11 +145,11 @@ all_TESTS += test_wt4891_meta_ckptlist_get_alloc
 
 test_wt6185_modify_ts_SOURCES = wt6185_modify_ts/main.c
 noinst_PROGRAMS += test_wt6185_modify_ts
-all_TESTS += test_wt6185_modify_ts
+all_TESTS += wt6185_modify_ts/smoke.sh
 
 test_wt6616_checkpoint_oldest_ts_SOURCES = wt6616_checkpoint_oldest_ts/main.c
 noinst_PROGRAMS += test_wt6616_checkpoint_oldest_ts
-all_TESTS += test_wt6616_checkpoint_oldest_ts
+all_TESTS += wt6616_checkpoint_oldest_ts/smoke.sh
 
 # Run this during a "make check" smoke test.
 TESTS = $(all_TESTS)

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -75,7 +75,7 @@ static const char *const uri_collection = "table:collection";
 
 static const char *const ckpt_file = "checkpoint_done";
 
-static bool compat, inmem, stable_set, use_ts, use_txn;
+static bool compat, inmem, stable_set, use_columns, use_ts, use_txn;
 static volatile uint64_t global_ts = 1;
 static volatile uint64_t uid = 1;
 typedef struct {
@@ -96,9 +96,10 @@ static volatile THREAD_TS th_ts[MAX_TH];
 
 /*
  * A minimum width of 10, along with zero filling, means that all the keys sort according to their
- * integer value, making each thread's key space distinct.
+ * integer value, making each thread's key space distinct. For column-store we just use the integer
+ * values and that has the same effect.
  */
-#define KEY_FORMAT ("%010" PRIu64)
+#define ROW_KEY_FORMAT ("%010" PRIu64)
 
 typedef struct {
     uint64_t absent_key; /* Last absent key */
@@ -670,14 +671,20 @@ thread_run(void *arg)
             }
         if (use_ts)
             stable_ts = __wt_atomic_addv64(&global_ts, 1);
-        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, i));
 
         testutil_check(session->begin_transaction(session, NULL));
         if (use_prep)
             testutil_check(oplog_session->begin_transaction(oplog_session, NULL));
-        cur_coll->set_key(cur_coll, kname);
-        cur_local->set_key(cur_local, kname);
-        cur_oplog->set_key(cur_oplog, kname);
+        if (use_columns) {
+            cur_coll->set_key(cur_coll, i + 1);
+            cur_local->set_key(cur_local, i + 1);
+            cur_oplog->set_key(cur_oplog, i + 1);
+        } else {
+            testutil_check(__wt_snprintf(kname, sizeof(kname), ROW_KEY_FORMAT, i));
+            cur_coll->set_key(cur_coll, kname);
+            cur_local->set_key(cur_local, kname);
+            cur_oplog->set_key(cur_oplog, kname);
+        }
         /*
          * Put an informative string into the value so that it can be viewed well in a binary dump.
          */
@@ -764,7 +771,7 @@ run_workload(uint32_t nth)
     THREAD_DATA *td;
     wt_thread_t *thr;
     uint32_t ckpt_id, i, ts_id;
-    char envconf[512];
+    char envconf[512], tableconf[128];
 
     thr = dcalloc(nth + 2, sizeof(*thr));
     td = dcalloc(nth + 2, sizeof(THREAD_DATA));
@@ -783,10 +790,13 @@ run_workload(uint32_t nth)
     /*
      * Create all the tables.
      */
-    testutil_check(
-      session->create(session, uri_collection, "key_format=S,value_format=u,log=(enabled=false)"));
-    testutil_check(session->create(session, uri_local, "key_format=S,value_format=u"));
-    testutil_check(session->create(session, uri_oplog, "key_format=S,value_format=u"));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
+      "key_format=%s,value_format=u,log=(enabled=false)", use_columns ? "r" : "S"));
+    testutil_check(session->create(session, uri_collection, tableconf));
+    testutil_check(__wt_snprintf(
+      tableconf, sizeof(tableconf), "key_format=%s,value_format=u", use_columns ? "r" : "S"));
+    testutil_check(session->create(session, uri_local, tableconf));
+    testutil_check(session->create(session, uri_oplog, tableconf));
     /*
      * Don't log the stable timestamp table so that we know what timestamp was stored at the
      * checkpoint.
@@ -909,10 +919,14 @@ main(int argc, char *argv[])
     verify_only = false;
     working_dir = "WT_TEST.schema-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "Ch:mT:t:vxz")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cch:mT:t:vxz")) != EOF)
         switch (ch) {
         case 'C':
             compat = true;
+            break;
+        case 'c':
+            /* Variable-length columns only; fixed would require considerable changes */
+            use_columns = true;
             break;
         case 'h':
             working_dir = __wt_optarg;
@@ -1087,10 +1101,16 @@ main(int argc, char *argv[])
                   key, last_key);
                 break;
             }
-            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
-            cur_coll->set_key(cur_coll, kname);
-            cur_local->set_key(cur_local, kname);
-            cur_oplog->set_key(cur_oplog, kname);
+            if (use_columns) {
+                cur_coll->set_key(cur_coll, key + 1);
+                cur_local->set_key(cur_local, key + 1);
+                cur_oplog->set_key(cur_oplog, key + 1);
+            } else {
+                testutil_check(__wt_snprintf(kname, sizeof(kname), ROW_KEY_FORMAT, key));
+                cur_coll->set_key(cur_coll, kname);
+                cur_local->set_key(cur_local, kname);
+                cur_oplog->set_key(cur_oplog, kname);
+            }
             /*
              * The collection table should always only have the data as of the checkpoint.
              */

--- a/test/csuite/schema_abort/smoke.sh
+++ b/test/csuite/schema_abort/smoke.sh
@@ -21,6 +21,14 @@ $TEST_WRAPPER $test_bin -t 10 -T 5
 $TEST_WRAPPER $test_bin -m -t 10 -T 5
 $TEST_WRAPPER $test_bin -C -t 10 -T 5
 $TEST_WRAPPER $test_bin -C -m -t 10 -T 5
+
+$TEST_WRAPPER $test_bin -c -t 10 -T 5
+$TEST_WRAPPER $test_bin -c -m -t 10 -T 5
+$TEST_WRAPPER $test_bin -c -C -t 10 -T 5
+$TEST_WRAPPER $test_bin -c -C -m -t 10 -T 5
+
 # FIXME: In WT-6116 the test is failing if timestamps are turned off.
 #$TEST_WRAPPER $test_bin -m -t 10 -T 5 -z
+#$TEST_WRAPPER $test_bin -c -m -t 10 -T 5 -z
 $TEST_WRAPPER $test_bin -m -t 10 -T 5 -x
+$TEST_WRAPPER $test_bin -c -m -t 10 -T 5 -x

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -79,7 +79,7 @@ static const char *const uri_shadow = "shadow";
 
 static const char *const ckpt_file = "checkpoint_done";
 
-static bool compat, inmem, stress, use_ts;
+static bool columns, compat, inmem, stress, use_ts;
 static volatile uint64_t global_ts = 1;
 
 /*
@@ -107,9 +107,10 @@ static volatile uint64_t global_ts = 1;
 
 /*
  * A minimum width of 10, along with zero filling, means that all the keys sort according to their
- * integer value, making each thread's key space distinct.
+ * integer value, making each thread's key space distinct. For column-store we just use the integer
+ * values and that has the same effect.
  */
-#define KEY_FORMAT ("%010" PRIu64)
+#define KEY_STRINGFORMAT ("%010" PRIu64)
 
 typedef struct {
     uint64_t absent_key; /* Last absent key */
@@ -334,8 +335,6 @@ thread_run(void *arg)
     printf("Thread %" PRIu32 " starts at %" PRIu64 "\n", td->info, td->start);
     active_ts = 0;
     for (i = td->start;; ++i) {
-        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, i));
-
         testutil_check(session->begin_transaction(session, NULL));
         if (use_prep)
             testutil_check(prepared_session->begin_transaction(prepared_session, NULL));
@@ -354,10 +353,18 @@ thread_run(void *arg)
             testutil_check(pthread_rwlock_unlock(&ts_lock));
         }
 
-        cur_coll->set_key(cur_coll, kname);
-        cur_local->set_key(cur_local, kname);
-        cur_oplog->set_key(cur_oplog, kname);
-        cur_shadow->set_key(cur_shadow, kname);
+        if (columns) {
+            cur_coll->set_key(cur_coll, i + 1);
+            cur_local->set_key(cur_local, i + 1);
+            cur_oplog->set_key(cur_oplog, i + 1);
+            cur_shadow->set_key(cur_shadow, i + 1);
+        } else {
+            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_STRINGFORMAT, i));
+            cur_coll->set_key(cur_coll, kname);
+            cur_local->set_key(cur_local, kname);
+            cur_oplog->set_key(cur_oplog, kname);
+            cur_shadow->set_key(cur_shadow, kname);
+        }
         /*
          * Put an informative string into the value so that it can be viewed well in a binary dump.
          */
@@ -459,6 +466,7 @@ run_workload(uint32_t nth)
     wt_thread_t *thr;
     uint32_t cache_mb, ckpt_id, i, ts_id;
     char envconf[512], uri[128];
+    const char *table_config, *table_config_nolog;
 
     thr = dcalloc(nth + 2, sizeof(*thr));
     td = dcalloc(nth + 2, sizeof(THREAD_DATA));
@@ -495,19 +503,25 @@ run_workload(uint32_t nth)
     printf("wiredtiger_open configuration: %s\n", envconf);
     testutil_check(wiredtiger_open(NULL, NULL, envconf, &conn));
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
+
     /*
      * Create all the tables.
      */
+    if (columns) {
+        table_config_nolog = "key_format=r,value_format=u,log=(enabled=false)";
+        table_config = "key_format=r,value_format=u";
+    } else {
+        table_config_nolog = "key_format=S,value_format=u,log=(enabled=false)";
+        table_config = "key_format=S,value_format=u";
+    }
     testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_collection));
-    testutil_check(
-      session->create(session, uri, "key_format=S,value_format=u,log=(enabled=false)"));
+    testutil_check(session->create(session, uri, table_config_nolog));
     testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow));
-    testutil_check(
-      session->create(session, uri, "key_format=S,value_format=u,log=(enabled=false)"));
+    testutil_check(session->create(session, uri, table_config_nolog));
     testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local));
-    testutil_check(session->create(session, uri, "key_format=S,value_format=u"));
+    testutil_check(session->create(session, uri, table_config));
     testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog));
-    testutil_check(session->create(session, uri, "key_format=S,value_format=u"));
+    testutil_check(session->create(session, uri, table_config));
     /*
      * Don't log the stable timestamp table so that we know what timestamp was stored at the
      * checkpoint.
@@ -616,7 +630,7 @@ main(int argc, char *argv[])
 
     (void)testutil_set_progname(argv);
 
-    compat = inmem = stress = false;
+    columns = compat = inmem = stress = false;
     use_ts = true;
     nth = MIN_TH;
     rand_th = rand_time = true;
@@ -624,10 +638,14 @@ main(int argc, char *argv[])
     verify_only = false;
     working_dir = "WT_TEST.timestamp-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "Ch:LmsT:t:vz")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cch:LmsT:t:vz")) != EOF)
         switch (ch) {
         case 'C':
             compat = true;
+            break;
+        case 'c':
+            /* Variable-length columns only (for now) */
+            columns = true;
             break;
         case 'h':
             working_dir = __wt_optarg;
@@ -699,9 +717,9 @@ main(int argc, char *argv[])
           compat ? "true" : "false", inmem ? "true" : "false", stress ? "true" : "false",
           use_ts ? "true" : "false");
         printf("Parent: Create %" PRIu32 " threads; sleep %" PRIu32 " seconds\n", nth, timeout);
-        printf("CONFIG: %s%s%s%s%s -h %s -T %" PRIu32 " -t %" PRIu32 "\n", progname,
-          compat ? " -C" : "", inmem ? " -m" : "", stress ? " -s" : "", !use_ts ? " -z" : "",
-          working_dir, nth, timeout);
+        printf("CONFIG: %s%s%s%s%s%s -h %s -T %" PRIu32 " -t %" PRIu32 "\n", progname,
+          compat ? " -C" : "", columns ? " -c" : "", inmem ? " -m" : "", stress ? " -s" : "",
+          !use_ts ? " -z" : "", working_dir, nth, timeout);
         /*
          * Fork a child to insert as many items. We will then randomly kill the child, run recovery
          * and make sure all items we wrote exist after recovery runs.
@@ -823,11 +841,20 @@ main(int argc, char *argv[])
                   key, last_key);
                 break;
             }
-            testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, key));
-            cur_coll->set_key(cur_coll, kname);
-            cur_local->set_key(cur_local, kname);
-            cur_oplog->set_key(cur_oplog, kname);
-            cur_shadow->set_key(cur_shadow, kname);
+
+            if (columns) {
+                cur_coll->set_key(cur_coll, key + 1);
+                cur_local->set_key(cur_local, key + 1);
+                cur_oplog->set_key(cur_oplog, key + 1);
+                cur_shadow->set_key(cur_shadow, key + 1);
+            } else {
+                testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_STRINGFORMAT, key));
+                cur_coll->set_key(cur_coll, kname);
+                cur_local->set_key(cur_local, kname);
+                cur_oplog->set_key(cur_oplog, kname);
+                cur_shadow->set_key(cur_shadow, kname);
+            }
+
             /*
              * The collection table should always only have the data as of the checkpoint. The
              * shadow table should always have the exact same data (or not) as the collection table,

--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -23,8 +23,12 @@ then
 fi
 
 $TEST_WRAPPER $test_bin $default_test_args
+$TEST_WRAPPER $test_bin $default_test_args -c
 #$TEST_WRAPPER $test_bin $default_test_args -L
 $TEST_WRAPPER $test_bin -m $default_test_args
+$TEST_WRAPPER $test_bin -m $default_test_args -c
 #$TEST_WRAPPER $test_bin -m $default_test_args -L
 $TEST_WRAPPER $test_bin -C $default_test_args
+$TEST_WRAPPER $test_bin -C $default_test_args -c
 $TEST_WRAPPER $test_bin -C -m $default_test_args
+$TEST_WRAPPER $test_bin -C -m $default_test_args -c

--- a/test/csuite/truncated_log/smoke.sh
+++ b/test/csuite/truncated_log/smoke.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test truncated_log as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_truncated_log
+fi
+
+$TEST_WRAPPER $test_bin 
+$TEST_WRAPPER $test_bin -c

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -89,8 +89,8 @@ int
 main(int argc, char *argv[])
 {
     WT_SESSION *session;
-    clock_t ce, cs;
     wt_thread_t idlist[100];
+    clock_t ce, cs;
     uint64_t i, id;
     char buf[100];
 

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -90,7 +90,7 @@ main(int argc, char *argv[])
 {
     WT_SESSION *session;
     clock_t ce, cs;
-    pthread_t idlist[100];
+    wt_thread_t idlist[100];
     uint64_t i, id;
     char buf[100];
 
@@ -125,15 +125,16 @@ main(int argc, char *argv[])
 
     (void)signal(SIGINT, onsig);
 
+    memset(idlist, 0, sizeof(idlist));
     cs = clock();
     id = 0;
     for (i = 0; i < opts->n_append_threads; ++i, ++id) {
         printf("append: %" PRIu64 "\n", id);
-        testutil_check(pthread_create(&idlist[id], NULL, thread_append, opts));
+        testutil_check(__wt_thread_create(NULL, &idlist[id], thread_append, opts));
     }
 
     for (i = 0; i < id; ++i)
-        testutil_check(pthread_join(idlist[i], NULL));
+        testutil_check(__wt_thread_join(NULL, &idlist[i]));
 
     ce = clock();
     printf("%" PRIu64 "M records: %.2lf processor seconds\n", opts->max_inserted_id / MILLION,

--- a/test/csuite/wt6185_modify_ts/main.c
+++ b/test/csuite/wt6185_modify_ts/main.c
@@ -50,7 +50,10 @@ static u_int tnext;
 
 static uint64_t ts; /* Current timestamp. */
 
-static char key[100], modify_repl[256], tmp[4 * 1024];
+static char keystr[100], modify_repl[256], tmp[4 * 1024];
+static uint64_t keyrecno;
+
+static bool use_columns = false;
 
 /*
  * trace --
@@ -114,6 +117,32 @@ mmrand(u_int min, u_int max)
     v %= range;
     v += min;
     return (v);
+}
+
+/*
+ * change_key --
+ *     Switch to a different key.
+ */
+static void
+change_key(u_int n)
+{
+    if (use_columns)
+        keyrecno = n + 1;
+    else
+        testutil_check(__wt_snprintf(keystr, sizeof(keystr), "%010u.key", n));
+}
+
+/*
+ * set_key --
+ *     Set the current key in the cursor.
+ */
+static void
+set_key(WT_CURSOR *c)
+{
+    if (use_columns)
+        c->set_key(c, keyrecno);
+    else
+        c->set_key(c, keystr);
 }
 
 /*
@@ -181,13 +210,13 @@ modify(WT_SESSION *session, WT_CURSOR *c)
     for (cnt = loop = 1; loop < 5; ++cnt, ++loop)
         if (mmrand(1, 10) <= 8) {
             modify_build(entries, &nentries, cnt);
-            c->set_key(c, key);
+            set_key(c);
             testutil_check(c->modify(c, entries, nentries));
         }
 
     /* Commit 90% of the time, else rollback. */
     if (mmrand(1, 10) != 1) {
-        c->set_key(c, key);
+        set_key(c);
         testutil_check(c->search(c));
         testutil_check(c->get_value(c, &v));
         free(list[lnext].v);
@@ -223,7 +252,7 @@ repeat(WT_SESSION *session, WT_CURSOR *c)
         testutil_check(__wt_snprintf(tmp, sizeof(tmp), "read_timestamp=%" PRIx64, list[i].ts));
         testutil_check(session->timestamp_transaction(session, tmp));
 
-        c->set_key(c, key);
+        set_key(c);
         testutil_check(c->search(c));
         testutil_check(c->get_value(c, &v));
 
@@ -246,7 +275,7 @@ evict(WT_CURSOR *c)
 {
     trace("%s", "eviction");
 
-    c->set_key(c, key);
+    set_key(c);
     testutil_check(c->search(c));
     F_SET(c, WT_CURSTD_DEBUG_RESET_EVICT);
     testutil_check(c->reset(c));
@@ -286,7 +315,7 @@ main(int argc, char *argv[])
     WT_SESSION *session;
     u_int i, j;
     int ch;
-    char path[1024], value[VALUE_SIZE];
+    char path[1024], table_config[128], value[VALUE_SIZE];
     const char *home, *v;
     bool no_checkpoint, no_eviction;
 
@@ -298,8 +327,12 @@ main(int argc, char *argv[])
 
     no_checkpoint = no_eviction = false;
     home = "WT_TEST.wt6185_modify_ts";
-    while ((ch = __wt_getopt(progname, argc, argv, "ceh:S:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cceh:S:")) != EOF)
         switch (ch) {
+        case 'C':
+            /* Variable-length columns only (for now anyway) */
+            use_columns = true;
+            break;
         case 'c':
             no_checkpoint = true;
             break;
@@ -322,14 +355,17 @@ main(int argc, char *argv[])
     testutil_work_dir_from_path(path, sizeof(path), home);
     testutil_make_work_dir(path);
 
+    testutil_check(__wt_snprintf(
+      table_config, sizeof(table_config), "key_format=%s,value_format=S", use_columns ? "r" : "S"));
+
     /* Load 100 records. */
     testutil_check(wiredtiger_open(path, NULL, "create", &conn));
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    testutil_check(session->create(session, "file:xxx", "key_format=S,value_format=S"));
+    testutil_check(session->create(session, "file:xxx", table_config));
     testutil_check(session->open_cursor(session, "file:xxx", NULL, NULL, &c));
     for (i = 0; i <= 100; ++i) {
-        testutil_check(__wt_snprintf(key, sizeof(key), "%010u.key", i));
-        c->set_key(c, key);
+        change_key(i);
+        set_key(c);
         SET_VALUE(i, value);
         c->set_value(c, value);
         testutil_check(c->insert(c));
@@ -341,8 +377,8 @@ main(int argc, char *argv[])
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     testutil_check(session->create(session, "file:xxx", NULL));
     testutil_check(session->open_cursor(session, "file:xxx", NULL, NULL, &c));
-    testutil_check(__wt_snprintf(key, sizeof(key), "%010d.key", KEYNO));
-    c->set_key(c, key);
+    change_key(KEYNO);
+    set_key(c);
     testutil_check(c->search(c));
     testutil_check(c->get_value(c, &v));
     SET_VALUE(KEYNO, value);

--- a/test/csuite/wt6185_modify_ts/smoke.sh
+++ b/test/csuite/wt6185_modify_ts/smoke.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt6185_modify_ts as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt6185_modify_ts
+fi
+
+$TEST_WRAPPER $test_bin 
+$TEST_WRAPPER $test_bin -C
+

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -32,6 +32,7 @@
 #include <signal.h>
 
 static char home[1024]; /* Program working dir */
+static bool use_columns = false;
 
 /*
  * Spin up a child process to do operations and checkpoint. For each set of operations on a key,
@@ -48,7 +49,7 @@ static char home[1024]; /* Program working dir */
  * recovery by reading without a timestamp. Whether it is possible to read historical versions based
  * on timestamps from a logged table after recovery is not defined and implemented yet.
  */
-#define KEY_FORMAT ("%010" PRIu64)
+#define ROW_KEY_FORMAT ("%010" PRIu64)
 
 #define MAX_CKPT_INVL 5 /* Maximum interval between checkpoints */
 #define MAX_DATA 1000
@@ -147,11 +148,14 @@ thread_run(void *arg)
     /* Insert and then delete the keys until we're killed. */
     printf("Worker thread started.\n");
     for (oldest_ts = 0, ts = 1;; ++ts) {
-        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, ts));
+        testutil_check(__wt_snprintf(kname, sizeof(kname), ROW_KEY_FORMAT, ts));
 
         /* Insert the same value for key and value. */
         testutil_check(session->begin_transaction(session, NULL));
-        cursor->set_key(cursor, kname);
+        if (use_columns)
+            cursor->set_key(cursor, ts);
+        else
+            cursor->set_key(cursor, kname);
         data.data = kname;
         data.size = sizeof(kname);
         cursor->set_value(cursor, &data);
@@ -193,7 +197,7 @@ run_workload(void)
     WT_SESSION *session;
     wt_thread_t *thr;
     uint32_t i;
-    char envconf[512];
+    char envconf[512], tableconf[512];
 
     thr = dcalloc(2, sizeof(*thr));
 
@@ -206,8 +210,9 @@ run_workload(void)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /* Create the table. */
-    testutil_check(
-      session->create(session, uri, "key_format=S,value_format=u,log=(enabled=false)"));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
+      "key_format=%s,value_format=u,log=(enabled=false)", use_columns ? "r" : "S"));
+    testutil_check(session->create(session, uri, tableconf));
     testutil_check(session->close(session, NULL));
 
     /* The checkpoint thread is added at the end. */
@@ -268,8 +273,12 @@ main(int argc, char *argv[])
     timeout = MIN_TIME;
     working_dir = "WT_TEST.wt6616-checkpoint-oldest-ts";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "h:t:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "ch:t:")) != EOF)
         switch (ch) {
+        case 'c':
+            /* Variable-length columns only (for now) */
+            use_columns = true;
+            break;
         case 'h':
             working_dir = __wt_optarg;
             break;
@@ -363,8 +372,11 @@ main(int argc, char *argv[])
     for (ts = oldest_ts; ts <= stable_ts; ++ts) {
         testutil_check(__wt_snprintf(tscfg, sizeof(tscfg), "read_timestamp=%" PRIx64, ts));
         testutil_check(session->begin_transaction(session, tscfg));
-        testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_FORMAT, ts));
-        cursor->set_key(cursor, kname);
+        testutil_check(__wt_snprintf(kname, sizeof(kname), ROW_KEY_FORMAT, ts));
+        if (use_columns)
+            cursor->set_key(cursor, ts);
+        else
+            cursor->set_key(cursor, kname);
         ret = cursor->search(cursor);
         if (ret == WT_NOTFOUND) {
             fatal = true;

--- a/test/csuite/wt6616_checkpoint_oldest_ts/smoke.sh
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/smoke.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt6616_checkpoint_oldest_ts as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt6616_checkpoint_oldest_ts
+fi
+
+$TEST_WRAPPER $test_bin 
+$TEST_WRAPPER $test_bin -c
+

--- a/test/suite/test_rollback_to_stable24.py
+++ b/test/suite/test_rollback_to_stable24.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# test_rollback_to_stable24.py
+# Exercise a recno-counting bug in column store.
+#
+# Prior to August 2021 a cell for which there's a pending stable update was counted (in the
+# column-store RTS code) as having RLE count 1 regardless of what the actual count was.
+#
+# In order to exploit this we have to do janky things with timestamps, but I think they're
+# allowable.
+#
+# Construct a cell with RLE count of 3 by writing 3 copies of aaaaaa at timestamp 10.
+# Then at the next key write bbbbbb at timestamp 10 and cccccc at timestamp 50.
+# Evict the page to reconcile it and produce the RLE cell.
+#
+# Then post an update to the first key of the RLE cell at timestamp 30 (to dddddd), and roll
+# back to 40.
+#
+# Reading at 40, we should at that point see dddddd and two aaaaaa's followed by bbbbbb, but
+# with the bad counting we get a key error on the second key.
+#
+# This happens because it goes to process key 4 but thinks it's on key 2; it finds that it
+# needs to roll back the value it's looking at (the cccccc from timestamp 50) but because it
+# thinks it's on key to it asks the history store for key 2 and finds nothing. (The bbbbbb
+# from timestamp 10 is in the history store, but under key 4; there's nothing in the history
+# store for key 2.) So it issues a tombstone, and issues it for key 2, so key 2 improperly
+# disappears.
+#
+# Run this test on rows as well as columns to help make sure the test itself is valid (and
+# stays so over time...)
+class test_rollback_to_stable24(wttest.WiredTigerTestCase):
+    session_config = 'isolation=snapshot'
+    conn_config = 'in_memory=false'
+
+    key_format_values = [
+        ('column', dict(key_format='r')),
+        ('integer_row', dict(key_format='i')),
+    ]
+
+    scenarios = make_scenarios(key_format_values)
+
+    def test_rollback_to_stable24(self):
+        # Create a table without logging.
+        uri = "table:rollback_to_stable24"
+        format = 'key_format={},value_format=S'.format(self.key_format)
+        self.session.create(uri, format + ', log=(enabled=false)')
+
+        # Pin oldest timestamp to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+
+        # Start stable timestamp at 10.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+        value_c = "ccccc" * 100
+        value_d = "ddddd" * 100
+
+        s = self.conn.open_session()
+        cursor = s.open_cursor(uri)
+
+        # Write some keys at time 10.
+        s.begin_transaction()
+        cursor[1] = value_a
+        cursor[2] = value_a
+        cursor[3] = value_a
+        cursor[4] = value_b
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        # Update key 4 at time 50.
+        s.begin_transaction()
+        cursor[4] = value_c
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(50))
+
+        cursor.close()
+
+        # Evict the page to force reconciliation.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        s.begin_transaction()
+        # Search the key to evict it.
+        v = evict_cursor[1]
+        self.assertEqual(v, value_a)
+        self.assertEqual(evict_cursor.reset(), 0)
+        s.rollback_transaction()
+        evict_cursor.close()
+
+        # Now update key 1 at time 30.
+        cursor = s.open_cursor(uri)
+        s.begin_transaction()
+        cursor[1] = value_d
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor.close()
+
+        # Roll back to 40.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
+        self.conn.rollback_to_stable()
+
+        # Now read at 40.
+        cursor = s.open_cursor(uri)
+        s.begin_transaction('read_timestamp=' + self.timestamp_str(40))
+        self.assertEqual(cursor[1], value_d)
+        self.assertEqual(cursor[2], value_a)
+        self.assertEqual(cursor[3], value_a)
+        self.assertEqual(cursor[4], value_b)
+        s.rollback_transaction()
+        cursor.close()

--- a/test/suite/test_rollback_to_stable25.py
+++ b/test/suite/test_rollback_to_stable25.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios, filter_scenarios
+
+# test_rollback_to_stable25.py
+# Check various scenarios relating to RLE cells in column-store.
+#
+# We write at three different timestamps:
+#    10 - aaaaaa or none
+#    20 - bbbbbb or delete or none
+#    30 - cccccc or delete or none
+#
+# and we evict to push things to disk after any of these,
+# and we roll back to either 15 or 25.
+#
+# The writes can be either uniform, heterogeneous, first key, middle key, or last key.
+#
+# We do this with a group of 5 keys 2..6. Keys 1 and 6 are written with zzzzzz at
+# timestamp 5 and evicted to ensure that the group of keys we're using is isolated
+# from other unused keys.
+#
+# This generates a lot of cases, but we filter pointless combinations and they run fast.
+
+# Put these bits outside the class definition so they can be referred to both in class
+# instances and in the scenario setup logic, which doesn't have a class instance yet.
+
+my_rle_size = 5
+
+def keys_of_write(write):
+    if write == 'u' or write == 'h':
+        return range(2, 2 + my_rle_size)
+    elif write == 'f':
+        return [2]
+    elif write == 'm':
+        return [2 + my_rle_size // 2]
+    else:
+        return [2 + my_rle_size - 1]
+
+class test_rollback_to_stable25(wttest.WiredTigerTestCase):
+    session_config = 'isolation=snapshot'
+    conn_config = 'in_memory=false'
+
+    write_10_values = [
+        ('10u', dict(write_10='u')),
+        ('10h', dict(write_10='h')),
+        ('10f', dict(write_10='f')),
+        ('10m', dict(write_10='m')),
+        ('10l', dict(write_10='l')),
+    ]
+    type_10_values = [
+        ('nil', dict(type_10=None)),
+        ('upd', dict(type_10='upd')),
+    ]
+
+    write_20_values = [
+        ('20u', dict(write_20='u')),
+        ('20h', dict(write_20='h')),
+        ('20f', dict(write_20='f')),
+        ('20m', dict(write_20='m')),
+        ('20l', dict(write_20='l')),
+    ]
+    type_20_values = [
+        ('nil', dict(type_20=None)),
+        ('upd', dict(type_20='upd')),
+        ('del', dict(type_20='del')),
+    ]
+
+    write_30_values = [
+        ('30u', dict(write_30='u')),
+        ('30h', dict(write_30='h')),
+        ('30f', dict(write_30='f')),
+        ('30m', dict(write_30='m')),
+        ('30l', dict(write_30='l')),
+    ]
+    type_30_values = [
+        ('nil', dict(type_30=None)),
+        ('upd', dict(type_30='upd')),
+        ('del', dict(type_30='del')),
+    ]
+
+    evict_time_values = [
+        ('chk10', dict(evict_time=10)),
+        ('chk20', dict(evict_time=20)),
+        ('chk30', dict(evict_time=30)),
+    ]
+
+    rollback_time_values = [
+        ('roll15', dict(rollback_time=15)),
+        ('roll25', dict(rollback_time=25)),
+    ]
+
+    def is_meaningful(name, vals):
+        # The last write at evict time should be uniform, to get an RLE cell.
+        if vals['evict_time'] == 10 and vals['write_10'] != 'u':
+            return False
+        if vals['evict_time'] == 20 and vals['write_20'] != 'u':
+            return False
+        if vals['evict_time'] == 30 and vals['write_30'] != 'u':
+            return False
+        # If the type is nil, the value must be uniform.
+        if vals['type_10'] is None and vals['write_10'] != 'u':
+            return False
+        if vals['type_20'] is None and vals['write_20'] != 'u':
+            return False
+        if vals['type_30'] is None and vals['write_30'] != 'u':
+            return False
+        # Similarly, delete and heterogeneous doesn't make sense.
+        if vals['type_10'] == 'del' and vals['write_10'] == 'h':
+            return False
+        if vals['type_20'] == 'del' and vals['write_20'] == 'h':
+            return False
+        if vals['type_20'] == 'del' and vals['write_30'] == 'h':
+            return False
+        # Both 10 and 20 shouldn't be nil. That's equivalent to 10 and 30 being nil.
+        if vals['type_10'] is None and vals['type_20'] is None:
+            return False
+
+        # Avoid cases that delete nonexistent values.
+        def deletes_nonexistent():
+            present = {}
+            for k in range(2, 2 + my_rle_size):
+                present[k] = False
+            def adjust(ty, write):
+                if ty is None:
+                    return
+                for k in keys_of_write(write):
+                    if ty == 'upd':
+                         present[k] = True
+                    elif ty == 'del':
+                        if present[k]:
+                            present[k] = False
+                        else:
+                            raise KeyError
+
+            adjust(vals['type_10'], vals['write_10'])
+            adjust(vals['type_20'], vals['write_20'])
+            adjust(vals['type_30'], vals['write_30'])
+        try:
+            deletes_nonexistent()
+        except KeyError:
+            return False
+        return True
+
+    scenarios = filter_scenarios(make_scenarios(write_10_values, type_10_values,
+                                                write_20_values, type_20_values,
+                                                write_30_values, type_30_values,
+                                                evict_time_values,
+                                                rollback_time_values),
+                                 is_meaningful)
+
+    value_z = "zzzzz" * 10
+
+    def writes(self, uri, s, expected, ty, write, value, ts):
+        if ty is None:
+             # do nothing at all
+             return
+        cursor = s.open_cursor(uri)
+        s.begin_transaction()
+        for k in keys_of_write(write):
+            if ty == 'upd':
+                myval = value + str(k) if write == 'h' else value
+                cursor[k] = myval
+                expected[k] = myval
+            else:
+                cursor.set_key(k)
+                cursor.remove()
+                del expected[k]
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def evict(self, uri, s):
+        # Evict the page to force reconciliation.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        s.begin_transaction()
+        # Search the key to evict it. Use both bookends.
+        v = evict_cursor[1]
+        self.assertEqual(v, self. value_z)
+        v = evict_cursor[2 + my_rle_size]
+        self.assertEqual(v, self. value_z)
+        self.assertEqual(evict_cursor.reset(), 0)
+        s.rollback_transaction()
+        evict_cursor.close()
+
+    def check(self, uri, s, ts, expected):
+        cursor = s.open_cursor(uri)
+        s.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+        # endpoints should still be in place
+        self.assertEqual(cursor[1], self.value_z)
+        self.assertEqual(cursor[2 + my_rle_size], self.value_z)
+
+        for k in range(2, 2 + my_rle_size):
+            if k in expected:
+                self.assertEqual(cursor[k], expected[k])
+            else:
+                cursor.set_key(k)
+                r = cursor.search()
+                self.assertEqual(r, wiredtiger.WT_NOTFOUND)
+        s.rollback_transaction()
+        cursor.close()
+
+    def test_rollback_to_stable25(self):
+        # Create a table without logging.
+        uri = "table:rollback_to_stable25"
+        format = 'key_format=r,value_format=S'
+        self.session.create(uri, format + ', log=(enabled=false)')
+
+        # Pin oldest timestamp to 5.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
+
+        # Start stable timestamp at 5.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
+
+        value_a = "aaaaa" * 10
+        value_b = "bbbbb" * 10
+        value_c = "ccccc" * 10
+
+        s = self.conn.open_session()
+
+        # Write the endpoints at time 5.
+        cursor = s.open_cursor(uri)
+        s.begin_transaction()
+        cursor[1] = self.value_z
+        cursor[2 + my_rle_size] = self.value_z
+        s.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        self.evict(uri, s)
+        cursor.close()
+
+        # Do writes at time 10.
+        expected = {}
+        self.writes(uri, s, expected, self.type_10, self.write_10, value_a, 10)
+        expected10 = expected.copy()
+
+        # Evict at time 10 if requested.
+        if self.evict_time == 10:
+            self.evict(uri, s)
+
+        # Do more writes at time 20.
+        self.writes(uri, s, expected, self.type_20, self.write_20, value_b, 20)
+        expected20 = expected.copy()
+
+        # Evict at time 20 if requested.
+        if self.evict_time == 20:
+            self.evict(uri, s)
+
+        # Do still more writes at time 30.
+        self.writes(uri, s, expected, self.type_30, self.write_30, value_c, 30)
+        expected30 = expected.copy()
+
+        # Evict at time 30 if requested.
+        if self.evict_time == 30:
+            self.evict(uri, s)
+
+        # Now roll back.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(self.rollback_time))
+        self.conn.rollback_to_stable()
+
+        if self.rollback_time < 20:
+            expected20 = expected10
+            expected30 = expected10
+        elif self.rollback_time < 30:
+            expected30 = expected20
+
+        # Now make sure we see what we expect.
+        self.check(uri, s, 10, expected10)
+        self.check(uri, s, 20, expected20)
+        self.check(uri, s, 30, expected30)


### PR DESCRIPTION
Fix RLE counting bug in column rollback to stable, and an error-path
free twice in __rollback_ondisk_fixup_key.

Add column support to C tests: schema_abort, timestamp_abort,
truncated_log, wt6185_modify_ts, wt6616_checkpoint_oldest_ts.
Re-enable wt2246_col_append.

Add two new Python tests, one for the RLE-counting bug and the other
that exercises various cases of rollback-to-stable vs. column-store
RLE cells.

Condense the commit message; so far this is the same as the previous
version of this changeset.