### PR TITLE
WT-7973 Skip deleting updates in the history store if all the record in history store for that key is obsolete

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -757,6 +757,7 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
 {
     WT_DECL_RET;
     WT_ITEM hs_key;
+    WT_TIME_WINDOW *twp;
     wt_timestamp_t hs_ts;
     uint64_t hs_counter;
     uint32_t hs_btree_id;
@@ -779,6 +780,10 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
         goto done;
     } else {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, &hs_key, &hs_ts, &hs_counter));
+        /* If the record is obsolete, no need to do anything. */
+        __wt_hs_upd_time_window(hs_cursor, &twp);
+        if (__wt_txn_tw_stop_visible_all(session, twp))
+            goto done;
         ++hs_counter;
     }
 

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -764,6 +764,16 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
     bool hs_read_all_flag;
 
     /*
+     * We might be entering this code from application thread's context. We should make sure that we
+     * are not using snapshot associated with application session to perform visibility checks on
+     * history store records. Note that the history store cursor performs visibility checks based on
+     * snapshot if none of WT_CURSTD_HS_READ_ALL or WT_CURSTD_HS_READ_COMMITTED flags are set.
+     */
+    WT_ASSERT(session,
+      F_ISSET(session, WT_SESSION_INTERNAL) ||
+        F_ISSET(cursor, WT_CURSTD_HS_READ_ALL | WT_CURSTD_HS_READ_COMMITTED));
+
+    /*
      * If we will delete all the updates of the key from the history store, we should not reinsert
      * any update.
      */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -924,8 +924,15 @@ __wt_rec_row_leaf(
                     WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
 
                     /* Open a history store cursor if we don't yet have one. */
-                    if (hs_cursor == NULL)
+                    if (hs_cursor == NULL) {
                         WT_ERR(__wt_curhs_open(session, NULL, &hs_cursor));
+                        /*
+                         * If we enter here from an application thread, we should not use
+                         * application thread's snapshot to check the visibility of records in the
+                         * history store.
+                         */
+                        F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+                    }
 
                     /* From WT_TS_NONE to delete all the history store content of the key. */
                     WT_ERR(__wt_hs_delete_key_from_ts(session, hs_cursor, btree->id, tmpkey,


### PR DESCRIPTION
I noticed that a lot of times we are unnecessarily failing eviction when we try to remove already obsolete updates from the history store. With this change, we should be able to mitigate this problem.