### PR TITLE
WT-7996 More column-store C tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -457,6 +457,7 @@ WTPERF
 WaitForSingleObject
 WakeAllConditionVariable
 Wconditional
+Wduplicated
 WeakHashLen
 Werror
 Wformat

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -816,11 +816,10 @@ __rollback_abort_col_var(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
             /*
              * If we found a stable update on the insert list, this key needs no further attention.
              * Any other keys in this cell with stable updates also do not require attention. But
-             * beyond that, the on-disk value must be older than
-             * the update we found. That means it too is stable(*), so any keys in the cell that
-             * _don't_ have stable updates on the update list don't need further attention either.
-             * (And any unstable updates were just handled above.) Thus we can skip iterating over
-             * the cell.
+             * beyond that, the on-disk value must be older than the update we found. That means it
+             * too is stable(*), so any keys in the cell that _don't_ have stable updates on the
+             * update list don't need further attention either. (And any unstable updates were just
+             * handled above.) Thus we can skip iterating over the cell.
              *
              * Furthermore, if the cell is deleted it must be
              * itself stable, because cells only appear as deleted if there is no older value that

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -127,6 +127,7 @@ define_c_test(
     TARGET test_wt2535_insert_race
     SOURCES wt2535_insert_race/main.c
     DIR_NAME wt2535_insert_race
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 
@@ -134,6 +135,7 @@ define_c_test(
     TARGET test_wt2447_join_main_table
     SOURCES wt2447_join_main_table/main.c
     DIR_NAME wt2447_join_main_table
+    SMOKE
 )
 
 define_c_test(
@@ -158,6 +160,7 @@ define_c_test(
     TARGET test_wt2853_perf
     SOURCES wt2853_perf/main.c
     DIR_NAME wt2853_perf
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 
@@ -170,6 +173,7 @@ define_c_test(
     # produces in build_posix.
     FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
     ARGUMENTS -b ${CMAKE_BINARY_DIR}
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 
@@ -227,6 +231,7 @@ define_c_test(
     TARGET test_wt4105_large_doc_small_upd
     SOURCES wt4105_large_doc_small_upd/main.c
     DIR_NAME wt4105_large_doc_small_upd
+    SMOKE
     DEPENDS "WT_POSIX"
 )
 

--- a/test/csuite/Makefile.am
+++ b/test/csuite/Makefile.am
@@ -57,11 +57,11 @@ all_TESTS += test_wt2323_join_visibility
 
 test_wt2535_insert_race_SOURCES = wt2535_insert_race/main.c
 noinst_PROGRAMS += test_wt2535_insert_race
-all_TESTS += test_wt2535_insert_race
+all_TESTS += wt2535_insert_race/smoke.sh
 
 test_wt2447_join_main_table_SOURCES = wt2447_join_main_table/main.c
 noinst_PROGRAMS += test_wt2447_join_main_table
-all_TESTS += test_wt2447_join_main_table
+all_TESTS += wt2447_join_main_table/smoke.sh
 
 test_wt2695_checksum_SOURCES = wt2695_checksum/main.c
 noinst_PROGRAMS += test_wt2695_checksum
@@ -81,11 +81,11 @@ all_TESTS += test_wt2834_join_bloom_fix
 
 test_wt2853_perf_SOURCES = wt2853_perf/main.c
 noinst_PROGRAMS += test_wt2853_perf
-all_TESTS += test_wt2853_perf
+all_TESTS += wt2853_perf/smoke.sh
 
 test_wt2909_checkpoint_integrity_SOURCES = wt2909_checkpoint_integrity/main.c
 noinst_PROGRAMS += test_wt2909_checkpoint_integrity
-all_TESTS += test_wt2909_checkpoint_integrity
+all_TESTS += wt2909_checkpoint_integrity/smoke.sh
 
 test_wt2999_join_extractor_SOURCES = wt2999_join_extractor/main.c
 noinst_PROGRAMS += test_wt2999_join_extractor
@@ -117,7 +117,7 @@ all_TESTS += test_wt3874_pad_byte_collator
 
 test_wt4105_large_doc_small_upd_SOURCES = wt4105_large_doc_small_upd/main.c
 noinst_PROGRAMS += test_wt4105_large_doc_small_upd
-all_TESTS += test_wt4105_large_doc_small_upd
+all_TESTS += wt4105_large_doc_small_upd/smoke.sh
 
 test_wt4117_checksum_SOURCES = wt4117_checksum/main.c
 noinst_PROGRAMS += test_wt4117_checksum

--- a/test/csuite/wt2447_join_main_table/smoke.sh
+++ b/test/csuite/wt2447_join_main_table/smoke.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt2447_join_main_table as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt2447_join_main_table
+fi
+
+$TEST_WRAPPER $test_bin -t r
+$TEST_WRAPPER $test_bin -t c
+

--- a/test/csuite/wt2535_insert_race/smoke.sh
+++ b/test/csuite/wt2535_insert_race/smoke.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt2535_insert_race as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt2535_insert_race
+fi
+
+$TEST_WRAPPER $test_bin -t r
+$TEST_WRAPPER $test_bin -t c
+$TEST_WRAPPER $test_bin -t f

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -62,6 +62,7 @@ typedef struct {
     char baluri[256];
     char flaguri[256];
     bool bloom;
+    bool usecolumns;
 } SHARED_OPTS;
 
 typedef struct {
@@ -83,7 +84,8 @@ main(int argc, char *argv[])
     WT_CURSOR *maincur;
     WT_SESSION *session;
     pthread_t get_tid[N_GET_THREAD], insert_tid[N_INSERT_THREAD];
-    int i, nfail;
+    char tableconf[128];
+    int i, key, nfail;
     const char *tablename;
 
     /*
@@ -96,6 +98,7 @@ main(int argc, char *argv[])
     opts = &_opts;
     sharedopts = &_sharedopts;
     memset(opts, 0, sizeof(*opts));
+    opts->table_type = TABLE_ROW;
     memset(sharedopts, 0, sizeof(*sharedopts));
     memset(insert_args, 0, sizeof(insert_args));
     memset(get_args, 0, sizeof(get_args));
@@ -103,6 +106,10 @@ main(int argc, char *argv[])
 
     sharedopts->bloom = BLOOM;
     testutil_check(testutil_parse_opts(argc, argv, opts));
+    if (opts->table_type == TABLE_FIX)
+        testutil_die(ENOTSUP, "Fixed-length column store not supported");
+    sharedopts->usecolumns = (opts->table_type == TABLE_COL);
+
     testutil_make_work_dir(opts->home);
     testutil_progress(opts, "start");
 
@@ -116,8 +123,10 @@ main(int argc, char *argv[])
      * Note: id is repeated as id2. This makes it easier to identify the primary key in dumps of the
      * index files.
      */
-    testutil_check(session->create(
-      session, opts->uri, "key_format=i,value_format=iiSii,columns=(id,post,bal,extra,flag,id2)"));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
+      "key_format=%s,value_format=iiSii,columns=(id,post,bal,extra,flag,id2)",
+      sharedopts->usecolumns ? "r" : "i"));
+    testutil_check(session->create(session, opts->uri, tableconf));
 
     tablename = strchr(opts->uri, ':');
     testutil_assert(tablename != NULL);
@@ -138,8 +147,17 @@ main(int argc, char *argv[])
      * easier.
      */
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &maincur));
-    maincur->set_key(maincur, N_RECORDS);
-    maincur->set_value(maincur, 54321, 0, "", 0, N_RECORDS);
+    /*
+     * Do not constant-fold this assignment: in gcc 10.3, if you pass the constant directly to
+     * set_key, -Wduplicated-branches fails to notice the type difference between the two cases and
+     * gives a spurious warning, and diagnostic builds fail.
+     */
+    key = N_RECORDS + 1;
+    if (sharedopts->usecolumns)
+        maincur->set_key(maincur, (uint64_t)key);
+    else
+        maincur->set_key(maincur, key);
+    maincur->set_value(maincur, 54321, 0, "", 0, N_RECORDS + 1);
     testutil_check(maincur->insert(maincur));
     testutil_check(maincur->close(maincur));
     testutil_check(session->close(session, NULL));
@@ -199,6 +217,7 @@ main(int argc, char *argv[])
 static void *
 thread_insert(void *arg)
 {
+    SHARED_OPTS *sharedopts;
     TEST_OPTS *opts;
     THREAD_ARGS *threadargs;
     WT_CURSOR *maincur;
@@ -210,6 +229,7 @@ thread_insert(void *arg)
 
     threadargs = (THREAD_ARGS *)arg;
     opts = threadargs->testopts;
+    sharedopts = threadargs->sharedopts;
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 
@@ -223,9 +243,12 @@ thread_insert(void *arg)
         /*
          * Insert threads may stomp on each other's records; that's okay.
          */
-        key = (int)(__wt_random(&rnd) % N_RECORDS);
+        key = (int)(__wt_random(&rnd) % N_RECORDS) + 1;
         testutil_check(session->begin_transaction(session, NULL));
-        maincur->set_key(maincur, key);
+        if (sharedopts->usecolumns)
+            maincur->set_key(maincur, (uint64_t)key);
+        else
+            maincur->set_key(maincur, key);
         if (__wt_random(&rnd) % 2 == 0)
             post = 54321;
         else
@@ -299,7 +322,11 @@ thread_get(void *arg)
             testutil_check(postcur->get_value(postcur, &post2, &bal, &extra, &flag, &key));
             testutil_assert((flag > 0 && bal < 0) || (flag == 0 && bal >= 0));
 
-            maincur->set_key(maincur, key);
+            if (sharedopts->usecolumns)
+                maincur->set_key(maincur, (uint64_t)key);
+            else
+                maincur->set_key(maincur, key);
+            fflush(stdout);
             testutil_check(maincur->search(maincur));
             testutil_check(maincur->get_value(maincur, &post2, &bal2, &extra, &flag2, &key2));
             testutil_check(maincur->reset(maincur));

--- a/test/csuite/wt2853_perf/smoke.sh
+++ b/test/csuite/wt2853_perf/smoke.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt2853_perf as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt2853_perf
+fi
+
+$TEST_WRAPPER $test_bin -t r
+$TEST_WRAPPER $test_bin -t c

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -102,7 +102,7 @@ check_results(TEST_OPTS *opts, uint64_t *foundp)
 {
     WT_CURSOR *maincur, *maincur2, *v0cur, *v1cur, *v2cur;
     WT_SESSION *session;
-    uint64_t count, idxcount, nrecords;
+    uint64_t count, idxcount, nrecords, key64;
     uint32_t rndint;
     int key, key_got, ret, v0, v1, v2;
     char *big, *bigref;
@@ -121,7 +121,12 @@ check_results(TEST_OPTS *opts, uint64_t *foundp)
     count = 0;
     while ((ret = maincur->next(maincur)) == 0) {
         testutil_check(maincur2->next(maincur2));
-        testutil_check(maincur2->get_key(maincur2, &key_got));
+        if (opts->table_type == TABLE_ROW)
+            testutil_check(maincur2->get_key(maincur2, &key_got));
+        else {
+            testutil_check(maincur2->get_key(maincur2, &key64));
+            key_got = key64;
+        }
         testutil_check(maincur2->get_value(maincur2, &rndint));
 
         generate_key(count, &key);
@@ -129,7 +134,12 @@ check_results(TEST_OPTS *opts, uint64_t *foundp)
         testutil_assert(key == key_got);
 
         /* Check the key/values in main table. */
-        testutil_check(maincur->get_key(maincur, &key_got));
+        if (opts->table_type == TABLE_ROW)
+            testutil_check(maincur->get_key(maincur, &key_got));
+        else {
+            testutil_check(maincur->get_key(maincur, &key64));
+            key_got = key64;
+        }
         testutil_assert(key == key_got);
         check_values(maincur, v0, v1, v2, big);
 
@@ -260,7 +270,7 @@ enable_failures(uint64_t allow_writes, uint64_t allow_reads)
 static void
 generate_key(uint64_t i, int *keyp)
 {
-    *keyp = (int)i;
+    *keyp = (int)i + 1;
 }
 
 /*
@@ -313,6 +323,8 @@ run_check_subtest(
     subtest_args[narg++] = (char *)"-n";
     testutil_check(__wt_snprintf(rarg, sizeof(rarg), "%" PRIu64, opts->nrecords));
     subtest_args[narg++] = rarg; /* number of records */
+    subtest_args[narg++] = (char *)"-t";
+    subtest_args[narg++] = (char *)(opts->table_type == TABLE_ROW ? "r" : "c");
     subtest_args[narg++] = NULL;
     testutil_assert(narg <= MAX_ARGS);
     if (opts->verbose)
@@ -485,10 +497,11 @@ subtest_main(int argc, char *argv[], bool close_test)
     struct rlimit rlim;
     TEST_OPTS *opts, _opts;
     WT_SESSION *session;
-    char config[1024], filename[1024], buf[1024];
+    char buf[1024], config[1024], filename[1024], tableconf[128];
 
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
+    opts->table_type = TABLE_ROW;
     memset(&rlim, 0, sizeof(rlim));
 
     /* No core files during fault injection tests. */
@@ -513,10 +526,14 @@ subtest_main(int argc, char *argv[], bool close_test)
     testutil_check(wiredtiger_open(opts->home, &event_handler, config, &opts->conn));
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
-    testutil_check(session->create(
-      session, "table:subtest", "key_format=i,value_format=iiiS,columns=(id,v0,v1,v2,big)"));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
+      "key_format=%s,value_format=iiiS,columns=(id,v0,v1,v2,big)",
+      opts->table_type == TABLE_ROW ? "i" : "r"));
+    testutil_check(session->create(session, "table:subtest", tableconf));
 
-    testutil_check(session->create(session, "table:subtest2", "key_format=i,value_format=i"));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf), "key_format=%s,value_format=i",
+      opts->table_type == TABLE_ROW ? "i" : "r"));
+    testutil_check(session->create(session, "table:subtest2", tableconf));
 
     testutil_check(session->create(session, "index:subtest:v0", "columns=(v0)"));
     testutil_check(session->create(session, "index:subtest:v1", "columns=(v1)"));
@@ -579,11 +596,17 @@ subtest_populate(TEST_OPTS *opts, bool close_test)
         generate_key(i, &key);
         generate_value(rndint, i, bigref, &v0, &v1, &v2, &big);
         CHECK(session->begin_transaction(session, NULL), false);
-        maincur->set_key(maincur, key);
+        if (opts->table_type == TABLE_ROW)
+            maincur->set_key(maincur, key);
+        else
+            maincur->set_key(maincur, (uint64_t)key);
         maincur->set_value(maincur, v0, v1, v2, big);
         CHECK(maincur->insert(maincur), false);
 
-        maincur2->set_key(maincur2, key);
+        if (opts->table_type == TABLE_ROW)
+            maincur2->set_key(maincur2, key);
+        else
+            maincur2->set_key(maincur2, (uint64_t)key);
         maincur2->set_value(maincur2, rndint);
         CHECK(maincur2->insert(maincur2), false);
         CHECK(session->commit_transaction(session, NULL), false);
@@ -641,6 +664,7 @@ main(int argc, char *argv[])
 
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
+    opts->table_type = TABLE_ROW;
     debugger = NULL;
 
     testutil_check(testutil_parse_opts(argc, argv, opts));
@@ -648,6 +672,8 @@ main(int argc, char *argv[])
     argv += __wt_optind;
     if (opts->nrecords == 0)
         opts->nrecords = 50000;
+    if (opts->table_type == TABLE_FIX)
+        testutil_die(ENOTSUP, "Fixed-length column store not supported");
 
     while (argc > 0) {
         if (strcmp(argv[0], "subtest") == 0) {

--- a/test/csuite/wt2909_checkpoint_integrity/smoke.sh
+++ b/test/csuite/wt2909_checkpoint_integrity/smoke.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt2909_checkpoint_integrity as part of running "make check".
+
+# The cmake build passes in the builddir with -b; it should be passed through.
+builddir_arg=
+while getopts ":b:" opt; do
+    case $opt in
+        b) builddir_arg="-b $OPTARG" ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt2909_checkpoint_integrity
+fi
+
+$TEST_WRAPPER $test_bin $builddir_arg -t r
+$TEST_WRAPPER $test_bin $builddir_arg -t c

--- a/test/csuite/wt4105_large_doc_small_upd/smoke.sh
+++ b/test/csuite/wt4105_large_doc_small_upd/smoke.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+set -e
+
+# Smoke-test wt4105_large_doc_small_upd as part of running "make check".
+
+if [ -n "$1" ]
+then
+    # If the test binary is passed in manually.
+    test_bin=$1
+else
+    # If $top_builddir/$top_srcdir aren't set, default to building in build_posix
+    # and running in test/csuite.
+    top_builddir=${top_builddir:-../../build_posix}
+    top_srcdir=${top_srcdir:-../..}
+    test_bin=$top_builddir/test/csuite/test_wt4105_large_doc_small_upd
+fi
+
+$TEST_WRAPPER $test_bin -t r
+$TEST_WRAPPER $test_bin -t c


### PR DESCRIPTION
Make the wt{2447,2535,2853,2909,4105} tests honor -t c for columns. Add these cases to make check.

Also handle -t f for fixed-length columns in wt2535 as the change was simple and the test appears to work.