### PR TITLE
WT-7964 Fix rollback to stable incorrectly not rolling back updates at snap_max (v5.0 backport) (#6908)

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1966,6 +1966,8 @@ static inline bool __wt_txn_visible(WT_SESSION_IMPL *session, uint64_t id, wt_ti
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id,
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_txn_visible_id_snapshot(uint64_t id, uint64_t snap_min, uint64_t snap_max,
+  uint64_t *snapshot, uint32_t snapshot_count) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline double __wt_eviction_dirty_target(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_btree_block_free(WT_SESSION_IMPL *session, const uint8_t *addr,

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -244,8 +244,8 @@ struct __wt_txn {
 
     /*
      * Snapshot data:
+     *	ids >= snap_max are invisible,
      *	ids < snap_min are visible,
-     *	ids > snap_max are invisible,
      *	everything else is visible unless it is in the snapshot.
      */
     uint64_t snap_min, snap_max;


### PR DESCRIPTION
(cherry picked from commit d384ce4385d1827e36fd4eeed893cc9b45b42111)