### PR TITLE
WT-7914 Update the documentation correctly and only when required

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -238,7 +238,12 @@ functions:
 
           # Generate docs.
           cd ../dist
-          sh s_docs
+          if ./s_docs; then
+              echo "The documentation was successfully generated"
+          else
+              echo "./s_docs failed with error $?"
+          fi
+
   "update wiredtiger docs":
     - command: shell.exec
       params:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -219,9 +219,6 @@ functions:
           # Clean checkout of the current branch.
           echo "Checking out branch ${branch_name} ..."
           git checkout "${branch_name}"
-          git pull --ff-only
-          git reset --hard origin/"${branch_name}"
-          git clean -fdqx
 
           # Compile docs.
           sh reconf

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -292,7 +292,7 @@ functions:
         silent: true
         script: |
           set -o errexit
-          git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
+          git push https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
 
   "make check directory":
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -266,8 +266,7 @@ functions:
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          # Go through each supported WiredTiger Github branch to generate and stage the doc
-          # changes.
+          # Go through each supported WiredTiger Github branch to stage the doc changes.
           for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
             # Synchronize the generated documentation with the current one.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,33 +216,37 @@ functions:
           set -o errexit
           set -o verbose
 
-          echo "Checking out branch ${branch_name} ..."
-          git checkout "${branch_name}"
+          # Go through each supported WiredTiger Github branch to build the docs.
+          # Please note the "branch" variable used here is a normal shell variable to store the name
+          # of a WiredTiger Github branch, while the "branch_name" is an Evergreen built-in variable
+          # to store the name of the branch being tested by the Evergreen project.
+          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
-          # Compile and generate docs.
-          sh reconf
+            # Checkout, compile and generate the docs for each branch.
+            echo "Checking out $branch ..."
+            git checkout "$branch"
 
-          # Java API is removed in newer branches via WT-6675.
-          if [ "${branch_name}" == "mongodb-4.2" ] || [ "${branch_name}" == "mongodb-4.0" ]; then
-            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
-            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-            (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
-          else
-            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
-            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-          fi
+            sh reconf
 
-          cd ../dist
-          if ./s_docs; then
-              echo "The documentation was successfully generated"
-          else
-              echo "./s_docs failed with error $?"
-          fi
+            # Java API is removed in newer branches via WT-6675.
+            if [ "$branch" == "mongodb-4.2" ] || [ "$branch" == "mongodb-4.0" ]; then
+              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
+              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+              (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
+            else
+              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
+              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+            fi
+
+            (cd ../dist && sh s_docs && echo "The documentation for $branch was successfully generated.")
+            # Save the generated docs for later use.
+            (cd .. && mv docs docs-"$branch")
+
+          done
 
   "update wiredtiger docs":
     - command: shell.exec
       params:
-        working_dir: "wiredtiger"
         shell: bash
         script: |
           set -o errexit
@@ -250,19 +254,24 @@ functions:
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          echo "Copying over doc directory for branch ${branch_name} ..."
-          rsync -avq ../docs/ "${branch_name}"/ --delete
+          # Checks the docs from each WT branch, update remote if required.
+          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
-          # Only update docs if outdated.
-          if [[ $(git status "${branch_name}" --porcelain) ]]; then
-            git add "${branch_name}"
-            git commit -m "Update auto-generated develop docs" \
-                      --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
-            git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
-            echo "Successfully updated documentation for branch ${branch_name}."
-          else
-            echo "No documentation changes to update for branch ${branch_name}."
-          fi
+            echo "Copying over doc directory for $branch ..."
+            rsync -avq ../wiredtiger/docs-"$branch"/ "$branch"/ --delete
+
+            # Check if the docs need to be updated.
+            if [[ $(git status "$branch" --porcelain) ]]; then
+              git add "$branch"
+              git commit -m "Update auto-generated docs for $branch" \
+                        --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
+              git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
+              echo "Successfully updated documentation for branch "$branch"."
+            else
+              echo "No documentation changes for $branch."
+            fi
+
+          done
 
   "make check directory":
     command: shell.exec
@@ -2043,7 +2052,7 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
-    patchable: false
+    # patchable: false
     commands:
       - func: "get project"
       - func: "compile wiredtiger docs"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -217,10 +217,10 @@ functions:
           set -o verbose
 
           # Check whether specific branches have been provided to the function
-          if [ -z ${branches} ]; then
+          if [ -z ${doc_update_branches} ]; then
             wt_branches=${branch_name}
           else
-            wt_branches=${branches}
+            wt_branches=${doc_update_branches}
           fi
 
           # Because of Evergreen's expansion syntax, this is used to process each branch separately.
@@ -2069,7 +2069,7 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger docs"
         vars:
-          branches: develop,mongodb-5.0,mongodb-4.4,mongodb-4.2,mongodb-4.0
+          doc_update_branches: develop,mongodb-5.0,mongodb-4.4,mongodb-4.2,mongodb-4.0
       - func: "update wiredtiger docs"
 
   - name: syscall-linux

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -264,12 +264,15 @@ functions:
 
           # Only update docs if outdated.
           if [[ $(git status "${branch_name}" --porcelain) ]]; then
-            echo "need to push !"
             git add "${branch_name}"
             git commit -m "Update auto-generated develop docs" \
                       --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
             git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
+            echo "Successfully updated documentation for branch ${branch_name}."
+          else
+            echo "No documentation changes to update for branch ${branch_name}."
           fi
+
   "make check directory":
     command: shell.exec
     params:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2877,6 +2877,7 @@ buildvariants:
 
 - name: documentation-update
   display_name: "~ Documentation update"
+  batchtime: 1440 # 1 day
   run_on:
   - ubuntu2004-test
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,16 +216,18 @@ functions:
           set -o errexit
           set -o verbose
 
-          # Check whether specific branches have been provided to the function
+          # Check whether specific branches have been provided to the function through the task
+          # variable defined in doc-update. If none have been specified, the built-in Evergreen
+          # expansion ${branch_name} is used.
           if [ -z ${doc_update_branches} ]; then
-            wt_branches=${branch_name}
+            branches=${branch_name}
           else
-            wt_branches=${doc_update_branches}
+            branches=${doc_update_branches}
           fi
 
           # Because of Evergreen's expansion syntax, this is used to process each branch separately.
           IFS=,
-          for branch in $wt_branches; do
+          for branch in $branches; do
 
             echo "Checking out branch $branch ..."
             git checkout $branch

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -222,7 +222,6 @@ functions:
           # to store the name of the branch being tested by the Evergreen project.
           for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
-            # Checkout, compile and generate the docs for each branch.
             echo "Checking out $branch ..."
             git checkout "$branch"
 
@@ -254,7 +253,7 @@ functions:
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          # Checks the docs from each WT branch, update remote if required.
+          # Go through each supported WiredTiger Github branch to stage the doc changes.
           for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
             echo "Copying over doc directory for $branch ..."

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2877,7 +2877,7 @@ buildvariants:
 
 - name: documentation-update
   display_name: "~ Documentation update"
-  batchtime: 1440 # 1 day
+  batchtime: 10080 # 7 days
   run_on:
   - ubuntu2004-test
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -217,7 +217,7 @@ functions:
           set -o verbose
 
           # Clean checkout of the current branch.
-          echo "[Debug] Checking out branch ${branch_name} ..."
+          echo "Checking out branch ${branch_name} ..."
           git checkout "${branch_name}"
           git pull --ff-only
           git reset --hard origin/"${branch_name}"
@@ -254,7 +254,7 @@ functions:
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          echo "[Debug] Copying over doc directory for branch ${branch_name} ..."
+          echo "Copying over doc directory for branch ${branch_name} ..."
           cp -pr ../docs-"${branch_name}"/* "${branch_name}"
 
           # Only update docs if outdated.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,9 +216,9 @@ functions:
           set -o errexit
           set -o verbose
 
-          # Check if specific branches are provided to the function through the task variable
-          # defined in doc-update. If none are specified, use the built-in Evergreen expansion
-          # ${branch_name}.
+          # Check if specific branches are provided to the function through the expansion variable
+          # defined in the documentation-update build variant. If none are specified, use the
+          # built-in Evergreen expansion ${branch_name}.
           if [ -z ${doc_update_branches} ]; then
             branches=${branch_name}
           else
@@ -268,8 +268,12 @@ functions:
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          # Go through each supported WiredTiger Github branch to stage the doc changes.
-          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
+          # Branches to update are defined through an expansion variable.
+          branches=${doc_update_branches}
+
+          # Go through each branch to stage the doc changes.
+          IFS=,
+          for branch in $branches; do
 
             # Synchronize the generated documentation with the current one.
             echo "Synchronizing documentation for branch $branch ..."
@@ -2077,8 +2081,6 @@ tasks:
     commands:
       - func: "get project"
       - func: "compile wiredtiger docs"
-        vars:
-          doc_update_branches: develop,mongodb-5.0,mongodb-4.4,mongodb-4.2,mongodb-4.0
       - func: "update wiredtiger docs"
 
   - name: syscall-linux
@@ -2906,6 +2908,7 @@ buildvariants:
   - ubuntu2004-test
   expansions:
     configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+    doc_update_branches: develop,mongodb-5.0,mongodb-4.4,mongodb-4.2,mongodb-4.0
   tasks:
     - name: doc-update
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2877,7 +2877,6 @@ buildvariants:
 
 - name: documentation-update
   display_name: "~ Documentation update"
-  batchtime: 1440 # 1 day
   run_on:
   - ubuntu2004-test
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,11 +216,10 @@ functions:
           set -o errexit
           set -o verbose
 
-          # Clean checkout of the current branch.
           echo "Checking out branch ${branch_name} ..."
           git checkout "${branch_name}"
 
-          # Compile docs.
+          # Compile and generate docs.
           sh reconf
 
           # Java API is removed in newer branches via WT-6675.
@@ -233,7 +232,6 @@ functions:
             (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
           fi
 
-          # Generate docs.
           cd ../dist
           if ./s_docs; then
               echo "The documentation was successfully generated"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,52 +216,23 @@ functions:
           set -o errexit
           set -o verbose
 
-          sh reconf
-
-          # Java API is removed in newer branches via WT-6675.
-          if [ "${branch_name}" == "mongodb-4.2" ] || [ "${branch_name}" == "mongodb-4.0" ]; then
-            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
-            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-            (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
+          # Check whether specific branches have been provided to the function
+          if [ -z ${branches} ]; then
+            wt_branches=${branch_name}
           else
-            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
-            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+            wt_branches=${branches}
           fi
 
-          cd ../dist && sh s_docs && echo "The documentation for ${branch_name} was successfully generated."
+          # Because of Evergreen's expansion syntax, this is used to process each branch separately.
+          IFS=,
+          for branch in $wt_branches; do
 
-  "compile and update wiredtiger docs":
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |
-          # Use a single function to generate and update the documentation of each supported
-          # WiredTiger branch. This is useful as not all branches have a dedicated Evergreen
-          # project. Furthermore, the documentation-update task is not triggered by every commit, we
-          # rely on the activity of the develop branch to update the documentation of all supported
-          # branches.
-          # The verbose option is not set on purpose to avoid showing credentials.
-          set -o errexit
-
-          if [[ "${branch_name}" != "develop" ]]; then
-            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
-            exit 0
-          fi
-
-          git clone git@github.com:wiredtiger/wiredtiger.github.com.git
-          cd wiredtiger/build_posix
-
-          # Go through each supported WiredTiger Github branch to generate and stage the doc
-          # changes.
-          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
-
-            echo "Checking out $branch ..."
+            echo "Checking out branch $branch ..."
             git checkout $branch
-
             sh reconf
 
             # Java API is removed in newer branches via WT-6675.
-            if [ "$branch" == "mongodb-4.2" ] || [ "$branch" == "mongodb-4.0" ]; then
+            if [ $branch == "mongodb-4.2" ] || [ $branch == "mongodb-4.0" ]; then
               ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
               (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
               (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
@@ -271,10 +242,37 @@ functions:
             fi
 
             (cd ../dist && sh s_docs && echo "The documentation for $branch was successfully generated.")
+            # Save generated documentation
+            (cd .. && mv docs docs-$branch)
+          done
+
+  "update wiredtiger docs":
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |
+          # Use a single function to update the documentation of each supported WiredTiger branch.
+          # This is useful as not all branches have a dedicated Evergreen project. Furthermore, the
+          # documentation-update task is not triggered by every commit, we rely on the activity of
+          # the develop branch to update the documentation of all supported branches.
+          # The verbose option is not set on purpose to avoid showing credentials.
+          set -o errexit
+
+          if [[ "${branch_name}" != "develop" ]]; then
+            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
+            exit 0
+          fi
+
+          git clone git@github.com:wiredtiger/wiredtiger.github.com.git
+          cd wiredtiger.github.com
+
+          # Go through each supported WiredTiger Github branch to generate and stage the doc
+          # changes.
+          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
             # Synchronize the generated documentation with the current one.
-            cd ../../wiredtiger.github.com
-            rsync -avq ../wiredtiger/docs/ $branch/ --delete
+            echo "Synchronizing documentation for branch $branch ..."
+            rsync -avq ../wiredtiger/docs-$branch/ $branch/ --delete
 
             # Commit and push the changes if any.
             if [[ $(git status "$branch" --porcelain) ]]; then
@@ -285,8 +283,6 @@ functions:
             else
               echo "No documentation changes for $branch."
             fi
-
-            cd ../wiredtiger/build_posix
 
           done
 
@@ -2072,7 +2068,10 @@ tasks:
     patchable: false
     commands:
       - func: "get project"
-      - func: "compile and update wiredtiger docs"
+      - func: "compile wiredtiger docs"
+        vars:
+          branches: develop,mongodb-5.0,mongodb-4.4,mongodb-4.2,mongodb-4.0
+      - func: "update wiredtiger docs"
 
   - name: syscall-linux
     depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2052,7 +2052,7 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
-    # patchable: false
+    patchable: false
     commands:
       - func: "get project"
       - func: "compile wiredtiger docs"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,14 +216,47 @@ functions:
           set -o errexit
           set -o verbose
 
-          # Go through each supported WiredTiger Github branch to build the docs.
-          # Please note the "branch" variable used here is a normal shell variable to store the name
-          # of a WiredTiger Github branch, while the "branch_name" is an Evergreen built-in variable
-          # to store the name of the branch being tested by the Evergreen project.
+          sh reconf
+
+          # Java API is removed in newer branches via WT-6675.
+          if [ "${branch_name}" == "mongodb-4.2" ] || [ "${branch_name}" == "mongodb-4.0" ]; then
+            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
+            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+            (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
+          else
+            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
+            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+          fi
+
+          cd ../dist && sh s_docs && echo "The documentation for ${branch_name} was successfully generated."
+
+  "compile and update wiredtiger docs":
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |
+          # Use a single function to generate and update the documentation of each supported
+          # WiredTiger branch. This is useful as not all branches have a dedicated Evergreen
+          # project. Furthermore, the documentation-update task is not triggered by every commit, we
+          # rely on the activity of the develop branch to update the documentation of all supported
+          # branches.
+          # The verbose option is not set on purpose to avoid showing credentials.
+          set -o errexit
+
+          if [[ "${branch_name}" != "develop" ]]; then
+            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
+            exit 0
+          fi
+
+          git clone git@github.com:wiredtiger/wiredtiger.github.com.git
+          cd wiredtiger/build_posix
+
+          # Go through each supported WiredTiger Github branch to generate and stage the doc
+          # changes.
           for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
 
             echo "Checking out $branch ..."
-            git checkout "$branch"
+            git checkout $branch
 
             sh reconf
 
@@ -238,37 +271,22 @@ functions:
             fi
 
             (cd ../dist && sh s_docs && echo "The documentation for $branch was successfully generated.")
-            # Save the generated docs for later use.
-            (cd .. && mv docs docs-"$branch")
 
-          done
+            # Synchronize the generated documentation with the current one.
+            cd ../../wiredtiger.github.com
+            rsync -avq ../wiredtiger/docs/ $branch/ --delete
 
-  "update wiredtiger docs":
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |
-          set -o errexit
-
-          git clone git@github.com:wiredtiger/wiredtiger.github.com.git
-          cd wiredtiger.github.com
-
-          # Go through each supported WiredTiger Github branch to stage the doc changes.
-          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
-
-            echo "Copying over doc directory for $branch ..."
-            rsync -avq ../wiredtiger/docs-"$branch"/ "$branch"/ --delete
-
-            # Check if the docs need to be updated.
+            # Commit and push the changes if any.
             if [[ $(git status "$branch" --porcelain) ]]; then
-              git add "$branch"
+              git add $branch
               git commit -m "Update auto-generated docs for $branch" \
                         --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
               git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
-              echo "Successfully updated documentation for branch "$branch"."
             else
               echo "No documentation changes for $branch."
             fi
+
+            cd ../wiredtiger/build_posix
 
           done
 
@@ -2054,8 +2072,7 @@ tasks:
     patchable: false
     commands:
       - func: "get project"
-      - func: "compile wiredtiger docs"
-      - func: "update wiredtiger docs"
+      - func: "compile and update wiredtiger docs"
 
   - name: syscall-linux
     depends_on:
@@ -2880,10 +2897,10 @@ buildvariants:
   batchtime: 10080 # 7 days
   run_on:
   - ubuntu2004-test
-  tasks:
-    - name: doc-update
   expansions:
     configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+  tasks:
+    - name: doc-update
 
 - name: linux-no-ftruncate
   display_name: Linux no ftruncate

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,9 +216,9 @@ functions:
           set -o errexit
           set -o verbose
 
-          # Check whether specific branches have been provided to the function through the task
-          # variable defined in doc-update. If none have been specified, the built-in Evergreen
-          # expansion ${branch_name} is used.
+          # Check if specific branches are provided to the function through the task variable
+          # defined in doc-update. If none are specified, use the built-in Evergreen expansion
+          # ${branch_name}.
           if [ -z ${doc_update_branches} ]; then
             branches=${branch_name}
           else
@@ -255,7 +255,7 @@ functions:
         script: |
           # Use a single function to update the documentation of each supported WiredTiger branch.
           # This is useful as not all branches have a dedicated Evergreen project. Furthermore, the
-          # documentation-update task is not triggered by every commit, we rely on the activity of
+          # documentation-update task is not triggered by every commit. We rely on the activity of
           # the develop branch to update the documentation of all supported branches.
           set -o errexit
           set -o verbose

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -249,15 +249,11 @@ functions:
         script: |
           set -o errexit
 
-          # Remove old docs and replace then with the generated ones.
-          rm -rf docs-"${branch_name}"
-          mv docs docs-"${branch_name}"
-
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
           echo "Copying over doc directory for branch ${branch_name} ..."
-          cp -pr ../docs-"${branch_name}"/* "${branch_name}"
+          cp -pr ../docs/* "${branch_name}"
 
           # Only update docs if outdated.
           if [[ $(git status "${branch_name}" --porcelain) ]]; then

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -257,7 +257,6 @@ functions:
           # This is useful as not all branches have a dedicated Evergreen project. Furthermore, the
           # documentation-update task is not triggered by every commit, we rely on the activity of
           # the develop branch to update the documentation of all supported branches.
-          # The verbose option is not set on purpose to avoid showing credentials.
           set -o errexit
 
           if [[ "${branch_name}" != "develop" ]]; then

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -251,7 +251,7 @@ functions:
           cd wiredtiger.github.com
 
           echo "Copying over doc directory for branch ${branch_name} ..."
-          cp -pr ../docs/* "${branch_name}"
+          rsync -avq ../docs/ "${branch_name}"/ --delete
 
           # Only update docs if outdated.
           if [[ $(git status "${branch_name}" --porcelain) ]]; then

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -216,33 +216,29 @@ functions:
           set -o errexit
           set -o verbose
 
-          if [[ "${branch_name}" != "develop" ]]; then
-            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
-            exit 0
+          # Clean checkout of the current branch.
+          echo "[Debug] Checking out branch ${branch_name} ..."
+          git checkout "${branch_name}"
+          git pull --ff-only
+          git reset --hard origin/"${branch_name}"
+          git clean -fdqx
+
+          # Compile docs.
+          sh reconf
+
+          # Java API is removed in newer branches via WT-6675.
+          if [ "${branch_name}" == "mongodb-4.2" ] || [ "${branch_name}" == "mongodb-4.0" ]; then
+            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
+            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
+            (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
+          else
+            ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
+            (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
           fi
 
-          # Go through each supported WiredTiger Github branch to build the docs.
-          #   Please note the "branch" variable used here is a normal shell variable to store the name of
-          #   a WiredTiger Github branch, while the "branch_name" used above is an Evergreen built-in variable
-          #   to store the name of the branch being tested by the Evergreen project.
-          for branch in develop mongodb-5.0 mongodb-4.4 mongodb-4.2 mongodb-4.0 ; do
-            echo "[Debug] Checking out branch $branch ..."
-            git checkout $branch && git pull --ff-only && git reset --hard origin/$branch && git clean -fdqx
-            sh reconf
-
-            # Java API is removed in newer branches via WT-6675.
-            if [ "$branch" = "mongodb-4.2" -o "$branch" = "mongodb-4.0" ]; then
-              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
-              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-              (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
-            else
-              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
-              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-            fi
-
-            (cd ../dist && sh s_docs)
-            (cd .. && rm -rf docs-$branch && mv docs docs-$branch)
-          done
+          # Generate docs.
+          cd ../dist
+          sh s_docs
   "update wiredtiger docs":
     - command: shell.exec
       params:
@@ -250,47 +246,25 @@ functions:
         shell: bash
         script: |
           set -o errexit
-          set -o verbose
 
-          if [[ "${branch_name}" != "develop" ]]; then
-            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
-            exit 0
-          fi
+          # Remove old docs and replace then with the generated ones.
+          rm -rf docs-"${branch_name}"
+          mv docs docs-"${branch_name}"
 
           git clone git@github.com:wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
-          # Go through each supported WiredTiger Github branch to stage the doc changes.
-          #   Please note the "branch" variable used here is a normal shell variable to store the name of
-          #   a WiredTiger Github branch, while the "branch_name" used above is an Evergreen built-in variable
-          #   to store the name of the branch being tested by the Evergreen project.
-          for branch in mongodb-4.0 mongodb-4.2 mongodb-4.4 mongodb-5.0 develop ; do
-            echo "[Debug] Copying over doc directory for branch $branch ..."
-            rsync -avq ../docs-$branch/ $branch/
+          echo "[Debug] Copying over doc directory for branch ${branch_name} ..."
+          cp -pr ../docs-"${branch_name}"/* "${branch_name}"
 
-            # Commit and push the changes (if any).
-            git add $branch > /dev/null
-          done
-
-          git commit -m "Update auto-generated develop docs" \
-                     --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>" > /dev/null
-    # Use separate shell.exec with "silent" directive to avoid exposing credentail in task log.
-    - command: shell.exec
-      params:
-        working_dir: "wiredtiger"
-        shell: bash
-        silent: true
-        script: |
-          set -o errexit
-          set -o verbose
-
-          if [[ "${branch_name}" != "develop" ]]; then
-            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
-            exit 0
+          # Only update docs if outdated.
+          if [[ $(git status "${branch_name}" --porcelain) ]]; then
+            echo "need to push !"
+            git add "${branch_name}"
+            git commit -m "Update auto-generated develop docs" \
+                      --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
+            git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
           fi
-
-          cd wiredtiger.github.com
-          git push https://${doc-update-github-token}@github.com/wiredtiger/wiredtiger.github.com
   "make check directory":
     command: shell.exec
     params:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -258,6 +258,7 @@ functions:
           # documentation-update task is not triggered by every commit, we rely on the activity of
           # the develop branch to update the documentation of all supported branches.
           set -o errexit
+          set -o verbose
 
           if [[ "${branch_name}" != "develop" ]]; then
             echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
@@ -279,12 +280,19 @@ functions:
               git add $branch
               git commit -m "Update auto-generated docs for $branch" \
                         --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
-              git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
             else
               echo "No documentation changes for $branch."
             fi
 
           done
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger.github.com"
+        shell: bash
+        silent: true
+        script: |
+          set -o errexit
+          git push --dry-run https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
 
   "make check directory":
     command: shell.exec


### PR DESCRIPTION
- The task `compile wiredtiger docs` does not process all branches anymore, it takes an input arg which defines the branches where the doc needs to be compiled. When it is triggered as part of the PR testing, it should only try to compile the current branch with the current changes. When it is triggered through `update wiredtiger docs`, it should compile all branches.
- The task `update wiredtiger docs` is now triggered once a week.