### PR TITLE
WT-6193 Re-enable VLCS testing in format-test

### DIFF
--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -5,15 +5,16 @@ set -e
 # Smoke-test format as part of running "make check".
 args="-1 -c . "
 args="$args btree.compression=none "
+args="$args cache.minimum=40 "
 args="$args logging_compression=none"
-args="$args runs.ops=50000 "
-args="$args runs.rows=10000 "
+args="$args runs.ops=500000 "
+args="$args runs.rows=100000 "
 args="$args runs.source=table "
 args="$args runs.threads=4 "
 
-# Temporarily disabled
+# Temporarily disable LSM and FLCS.
 # $TEST_WRAPPER ./t $args runs.type=fix
 # $TEST_WRAPPER ./t $args runs.type=row runs.source=lsm
-# $TEST_WRAPPER ./t $args runs.type=var
 
 $TEST_WRAPPER ./t $args runs.type=row
+$TEST_WRAPPER ./t $args runs.type=var


### PR DESCRIPTION
Enable VLCS format testing in "make check'.

While I'm in the area, pick a minimum cache size so we don't time out during the run and increase
the number of rows/operations to a larger number so there's at least a little work being done.