### PR TITLE
WT-8022 Verify WT_CURSOR.modify return values in format test program.

### DIFF
--- a/test/csuite/wt3338_partial_update/main.c
+++ b/test/csuite/wt3338_partial_update/main.c
@@ -111,94 +111,6 @@ modify_build(void)
 }
 
 /*
- * slow_apply_api --
- *     Apply a set of modification changes using a different algorithm.
- */
-static void
-slow_apply_api(WT_ITEM *orig)
-{
-    static WT_ITEM _tb;
-    WT_ITEM *ta, *tb, *tmp, _tmp;
-    size_t len, size;
-    int i;
-
-    ta = orig;
-    tb = &_tb;
-
-    /* Mess up anything not initialized in the buffers. */
-    if ((ta->memsize - ta->size) > 0)
-        memset((uint8_t *)ta->mem + ta->size, 0xff, ta->memsize - ta->size);
-
-    if (tb->memsize > 0)
-        memset((uint8_t *)tb->mem, 0xff, tb->memsize);
-
-    /*
-     * Process the entries to figure out how large a buffer we need. This is a bit pessimistic
-     * because we're ignoring replacement bytes, but it's a simpler calculation.
-     */
-    for (size = ta->size, i = 0; i < nentries; ++i) {
-        if (entries[i].offset >= size)
-            size = entries[i].offset;
-        size += entries[i].data.size;
-    }
-
-    testutil_check(__wt_buf_grow(NULL, ta, size));
-    testutil_check(__wt_buf_grow(NULL, tb, size));
-
-#if DEBUG
-    show(ta, "slow-apply start");
-#endif
-    /*
-     * From the starting buffer, create a new buffer b based on changes in the entries array. We're
-     * doing a brute force solution here to test the faster solution implemented in the library.
-     */
-    for (i = 0; i < nentries; ++i) {
-        /* Take leading bytes from the original, plus any gap bytes. */
-        if (entries[i].offset >= ta->size) {
-            memcpy(tb->mem, ta->mem, ta->size);
-            if (entries[i].offset > ta->size)
-                memset((uint8_t *)tb->mem + ta->size, '\0', entries[i].offset - ta->size);
-        } else if (entries[i].offset > 0)
-            memcpy(tb->mem, ta->mem, entries[i].offset);
-        tb->size = entries[i].offset;
-
-        /* Take replacement bytes. */
-        if (entries[i].data.size > 0) {
-            memcpy((uint8_t *)tb->mem + tb->size, entries[i].data.data, entries[i].data.size);
-            tb->size += entries[i].data.size;
-        }
-
-        /* Take trailing bytes from the original. */
-        len = entries[i].offset + entries[i].size;
-        if (ta->size > len) {
-            memcpy((uint8_t *)tb->mem + tb->size, (uint8_t *)ta->mem + len, ta->size - len);
-            tb->size += ta->size - len;
-        }
-        testutil_assert(tb->size <= size);
-
-        /* Swap the buffers and do it again. */
-        tmp = ta;
-        ta = tb;
-        tb = tmp;
-    }
-    ta->data = ta->mem;
-    tb->data = tb->mem;
-
-    /*
-     * The final results may not be in the original buffer, in which case we swap them back around.
-     */
-    if (ta != orig) {
-        _tmp = *ta;
-        *ta = *tb;
-        *tb = _tmp;
-    }
-
-#if DEBUG
-    show(ta, "slow-apply finish");
-#endif
-}
-
-/*
  * compare --
  *     Compare two results.
  */
@@ -249,6 +161,7 @@ modify_run(TEST_OPTS *opts)
     WT_CURSOR *cursor, _cursor;
     WT_DECL_RET;
     WT_ITEM *localA, _localA, *localB, _localB;
+    WT_ITEM modtmp;
     WT_SESSION_IMPL *session;
     size_t len;
     int i, j;
@@ -264,7 +177,6 @@ modify_run(TEST_OPTS *opts)
     /* Set up replacement information. */
     modify_repl_init();
 
-    /* We need three WT_ITEMs, one of them part of a fake cursor. */
     localA = &_localA;
     memset(&_localA, 0, sizeof(_localA));
     localB = &_localB;
@@ -273,6 +185,7 @@ modify_run(TEST_OPTS *opts)
     memset(&_cursor, 0, sizeof(_cursor));
     cursor->session = (WT_SESSION *)session;
     cursor->value_format = "u";
+    memset(&modtmp, 0, sizeof(modtmp));
 
 #define NRUNS 10000
     for (i = 0; i < NRUNS; ++i) {
@@ -295,7 +208,7 @@ modify_run(TEST_OPTS *opts)
             modify_build();
             testutil_check(__wt_buf_set(session, &cursor->value, localA->data, localA->size));
             testutil_check(__wt_modify_apply_api(cursor, entries, nentries));
-            slow_apply_api(localA);
+            testutil_modify_apply(localA, &modtmp, entries, nentries);
             compare(localB, localA, &cursor->value);
 
             /*

--- a/test/csuite/wt3338_partial_update/main.c
+++ b/test/csuite/wt3338_partial_update/main.c
@@ -237,6 +237,7 @@ modify_run(TEST_OPTS *opts)
     __wt_buf_free(session, localA);
     __wt_buf_free(session, localB);
     __wt_buf_free(session, &cursor->value);
+    __wt_buf_free(session, &modtmp);
 }
 
 int

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -398,7 +398,8 @@ typedef struct {
     uint64_t insert_list[256]; /* column-store inserted records */
     u_int insert_list_cnt;
 
-    WT_ITEM vprint; /* Temporary buffer for printable values */
+    WT_ITEM vprint;     /* Temporary buffer for printable values */
+    WT_ITEM moda, modb; /* Temporary buffer for modify operations */
 
 #define TINFO_RUNNING 1  /* Running */
 #define TINFO_COMPLETE 2 /* Finished */

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -30,6 +30,7 @@ project(libtest C)
 
 set(sources
     misc.c
+    modify.c
     parse_opts.c
     thread.c
 )

--- a/test/utility/Makefile.am
+++ b/test/utility/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir)/src/include
 
-libtest_util_la_SOURCES = misc.c parse_opts.c thread.c
+libtest_util_la_SOURCES = misc.c modify.c parse_opts.c thread.c
 noinst_LTLIBRARIES = libtest_util.la

--- a/test/utility/modify.c
+++ b/test/utility/modify.c
@@ -1,0 +1,110 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * testutil_modify_apply --
+ *     Implement a modify using a completely separate algorithm as a check on the internal library
+ *     algorithms.
+ */
+void
+testutil_modify_apply(WT_ITEM *orig, WT_ITEM *modified, WT_MODIFY *entries, int nentries)
+{
+    WT_ITEM *ta, *tb, *tmp, _tmp;
+    size_t len, size;
+    int i;
+
+    /* Mess up anything not initialized in the original buffer. */
+    if ((orig->memsize - orig->size) > 0)
+        memset((uint8_t *)orig->mem + orig->size, 0xff, orig->memsize - orig->size);
+
+    /* Overwrite the modified buffer. */
+    if (modified->memsize > 0)
+        memset((uint8_t *)modified->mem, 0xff, modified->memsize);
+
+    ta = orig;
+    tb = modified;
+
+    /*
+     * Process the entries to figure out how large a buffer we need. This is a bit pessimistic
+     * because we're ignoring replacement bytes, but it's a simpler calculation.
+     */
+    for (size = ta->size, i = 0; i < nentries; ++i) {
+        if (entries[i].offset >= size)
+            size = entries[i].offset;
+        size += entries[i].data.size;
+    }
+
+    testutil_check(__wt_buf_grow(NULL, ta, size));
+    testutil_check(__wt_buf_grow(NULL, tb, size));
+
+    /*
+     * From the starting buffer, create a new buffer b based on changes in the entries array. We're
+     * doing a brute force solution here to test the faster solution implemented in the library.
+     */
+    for (i = 0; i < nentries; ++i) {
+        /* Take leading bytes from the original, plus any gap bytes. */
+        if (entries[i].offset >= ta->size) {
+            memcpy(tb->mem, ta->mem, ta->size);
+            if (entries[i].offset > ta->size)
+                memset((uint8_t *)tb->mem + ta->size, '\0', entries[i].offset - ta->size);
+        } else if (entries[i].offset > 0)
+            memcpy(tb->mem, ta->mem, entries[i].offset);
+        tb->size = entries[i].offset;
+
+        /* Take replacement bytes. */
+        if (entries[i].data.size > 0) {
+            memcpy((uint8_t *)tb->mem + tb->size, entries[i].data.data, entries[i].data.size);
+            tb->size += entries[i].data.size;
+        }
+
+        /* Take trailing bytes from the original. */
+        len = entries[i].offset + entries[i].size;
+        if (ta->size > len) {
+            memcpy((uint8_t *)tb->mem + tb->size, (uint8_t *)ta->mem + len, ta->size - len);
+            tb->size += ta->size - len;
+        }
+        testutil_assert(tb->size <= size);
+
+        /* Swap the buffers and do it again. */
+        tmp = ta;
+        ta = tb;
+        tb = tmp;
+    }
+    ta->data = ta->mem;
+    tb->data = tb->mem;
+
+    /*
+     * The final results may not be in the original buffer, in which case we swap them back around.
+     */
+    if (ta != orig) {
+        _tmp = *ta;
+        *ta = *tb;
+        *tb = _tmp;
+    }
+}

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -266,21 +266,22 @@ void op_create(void *);
 void op_create_unique(void *);
 void op_cursor(void *);
 void op_drop(void *);
+bool testutil_is_flag_set(const char *);
+void testutil_build_dir(TEST_OPTS *, char *, int);
 void testutil_clean_work_dir(const char *);
 void testutil_cleanup(TEST_OPTS *);
 void testutil_copy_data(const char *);
-bool testutil_is_flag_set(const char *);
-void testutil_build_dir(TEST_OPTS *, char *, int);
+void testutil_copy_file(WT_SESSION *, const char *);
+void testutil_create_backup_directory(const char *);
 void testutil_make_work_dir(const char *);
+void testutil_modify_apply(WT_ITEM *, WT_ITEM *, WT_MODIFY *, int);
 int testutil_parse_opts(int, char *const *, TEST_OPTS *);
 void testutil_print_command_line(int argc, char *const *argv);
 void testutil_progress(TEST_OPTS *, const char *);
-void testutil_timestamp_parse(const char *, uint64_t *);
-void testutil_create_backup_directory(const char *);
-void testutil_copy_file(WT_SESSION *, const char *);
 #ifndef _WIN32
 void testutil_sleep_wait(uint32_t, pid_t);
 #endif
+void testutil_timestamp_parse(const char *, uint64_t *);
 void testutil_work_dir_from_path(char *, size_t, const char *);
 WT_THREAD_RET thread_append(void *);
 


### PR DESCRIPTION
@quchenhao, based on our discussions on WT-8019, I added code to format to validate the returned data from `WT_CURSOR.modify()`. I think it's generally useful, so this is a branch for that work.