### PR TITLE
WT-7294 Re-enable VLCS evergreen endianness tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3051,7 +3051,7 @@ buildvariants:
   display_name: "~ Little-endian (x86)"
   run_on:
   - ubuntu1804-test
-  batchtime: 10080 # 7 days
+  batchtime: 4320 # 3 days
   expansions:
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
@@ -3068,7 +3068,7 @@ buildvariants:
   - enterprise
   run_on:
   - ubuntu1804-zseries-build
-  batchtime: 10080 # 7 days
+  batchtime: 4320 # 3 days
   expansions:
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)

--- a/test/format/CONFIG.endian
+++ b/test/format/CONFIG.endian
@@ -4,4 +4,4 @@ logging.archive=0
 logging=1
 runs.timer=4
 runs.rows=1000000
-runs.type=row-store
+runs.type=row,var


### PR DESCRIPTION
Enable variable-length column-store access method in `test/format/CONFIG.endian`, and increase the running frequency for endian-related Evergreen tasks.