### PR TITLE
WT-7942 Release timestamp lock in test/format when all_durable timestamp is not found

### DIFF
--- a/test/format/util.c
+++ b/test/format/util.c
@@ -280,6 +280,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
             testutil_timestamp_parse(buf, &all_durable);
         else {
             testutil_assert(ret == WT_NOTFOUND);
+            lock_writeunlock(session, &g.ts_lock);
             return;
         }
 


### PR DESCRIPTION
- Added a missed unlock from WT-7708