### PR TITLE
WT-7925 Add rollback reason logging before WT_ROLLBACK error is returned

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -412,8 +412,11 @@ __curfile_remove(WT_CURSOR *cursor)
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
 
     /* If we've lost an initial position, we must fail. */
-    if (positioned && !F_ISSET(cursor, WT_CURSTD_KEY_INT))
+    if (positioned && !F_ISSET(cursor, WT_CURSTD_KEY_INT)) {
+        WT_IGNORE_RET(__wt_msg(
+          session, "WT_ROLLBACK: rolling back cursor remove as initial position was lost"));
         WT_ERR(WT_ROLLBACK);
+    }
 
     /*
      * Remove with a search-key is fire-and-forget, no position and no key. Remove starting from a

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2175,7 +2175,6 @@ int
 __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
 {
     session->txn->rollback_reason = reason;
-    WT_IGNORE_RET(__wt_msg(session, "rollback_reason: %s\n", session->txn->rollback_reason));
     return (WT_ROLLBACK);
 }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2175,6 +2175,7 @@ int
 __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
 {
     session->txn->rollback_reason = reason;
+    WT_IGNORE_RET(__wt_msg(session, "rollback_reason: %s\n", session->txn->rollback_reason));
     return (WT_ROLLBACK);
 }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -287,6 +287,8 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
              * rollback error. We will ignore this dhandle as part of this checkpoint by returning
              * from here.
              */
+            WT_IGNORE_RET(__wt_msg(
+              session, "WT_ROLLBACK: checkpoint raced with transaction operating on dhandle"));
             WT_TRET(__wt_metadata_cursor_release(session, &meta_cursor));
             return (0);
         }


### PR DESCRIPTION
I propose that we log the exact rollback reason before returning the WT_ROLLBACK error code. The __wt_wiredtiger_error function which checks for WiredTiger specific errors only seems to return a "WT_ROLLBACK: conflict between concurrent operations" message, leading me to believe that the real rollback reason is being lost. The __wt_txn_rollback_required function looks like the only one that is setting the rollback_reason. 