### PR TITLE
WT-7745 Add macro to identify uris for btree objects

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -30,10 +30,10 @@ __curfile_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     CURSOR_API_CALL(a, session, compare, CUR2BT(cbt));
 
     /*
-     * Check both cursors are a "file:" type then call the underlying function, it can handle
-     * cursors pointing to different objects.
+     * Check both cursors are a btree type then call the underlying function, it can handle cursors
+     * pointing to different objects.
      */
-    if (!WT_PREFIX_MATCH(a->internal_uri, "file:") || !WT_PREFIX_MATCH(b->internal_uri, "file:"))
+    if (!WT_BTREE_PREFIX(a->internal_uri) || !WT_BTREE_PREFIX(b->internal_uri))
         WT_ERR_MSG(session, EINVAL, "Cursors must reference the same object");
 
     WT_ERR(__cursor_checkkey(a));
@@ -60,10 +60,10 @@ __curfile_equals(WT_CURSOR *a, WT_CURSOR *b, int *equalp)
     CURSOR_API_CALL(a, session, equals, CUR2BT(cbt));
 
     /*
-     * Check both cursors are a "file:" type then call the underlying function, it can handle
-     * cursors pointing to different objects.
+     * Check both cursors are a btree type then call the underlying function, it can handle cursors
+     * pointing to different objects.
      */
-    if (!WT_PREFIX_MATCH(a->internal_uri, "file:") || !WT_PREFIX_MATCH(b->internal_uri, "file:"))
+    if (!WT_BTREE_PREFIX(a->internal_uri) || !WT_BTREE_PREFIX(b->internal_uri))
         WT_ERR_MSG(session, EINVAL, "Cursors must reference the same object");
 
     WT_ERR(__cursor_checkkey(a));
@@ -821,7 +821,7 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
     if (bulk)
         LF_SET(WT_BTREE_BULK | WT_DHANDLE_EXCLUSIVE);
 
-    WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:") || WT_PREFIX_MATCH(uri, "tiered:"));
+    WT_ASSERT(session, WT_BTREE_PREFIX(uri));
 
     /* Get the handle and lock it while the cursor is using it. */
     /*

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -861,7 +861,7 @@ __wt_cursor_cache_get(WT_SESSION_IMPL *session, const char *uri, uint64_t hash_v
             /*
              * If this is a btree cursor, clear its read_once flag.
              */
-            if (WT_PREFIX_MATCH(cursor->internal_uri, "file:")) {
+            if (WT_BTREE_PREFIX(cursor->internal_uri)) {
                 cbt = (WT_CURSOR_BTREE *)cursor;
                 F_CLR(cbt, WT_CBT_READ_ONCE);
             } else {

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -46,6 +46,9 @@
 #define WT_SYSTEM_BASE_WRITE_GEN_URI "system:checkpoint_base_write_gen" /* Base write gen URI */
 #define WT_SYSTEM_BASE_WRITE_GEN "base_write_gen"                       /* Base write gen name */
 
+/* Check whether a string is a legal URI for a btree object */
+#define WT_BTREE_PREFIX(str) (WT_PREFIX_MATCH(str, "file:") || WT_PREFIX_MATCH(str, "tiered:"))
+
 /*
  * Optimize comparisons against the metafile URI, flag handles that reference the metadata file.
  */

--- a/src/meta/meta_apply.c
+++ b/src/meta/meta_apply.c
@@ -37,8 +37,7 @@ __meta_btree_apply(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
             continue;
         }
 
-        if (file_func == NULL || skip ||
-          (!WT_PREFIX_MATCH(uri, "file:") && !WT_PREFIX_MATCH(uri, "tiered:")))
+        if (file_func == NULL || skip || !WT_BTREE_PREFIX(uri))
             continue;
 
         /*

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -990,7 +990,7 @@ __wt_metadata_correct_base_write_gen(WT_SESSION_IMPL *session)
     while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
 
-        if (!WT_PREFIX_MATCH(uri, "file:") && !WT_PREFIX_MATCH(uri, "tiered:"))
+        if (!WT_BTREE_PREFIX(uri))
             continue;
 
         WT_ERR(cursor->get_value(cursor, &config));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -142,7 +142,7 @@ __wt_session_copy_values(WT_SESSION_IMPL *session)
             WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session);
             WT_ASSERT(session,
               txn_shared->pinned_id != WT_TXN_NONE ||
-                (WT_PREFIX_MATCH(cursor->uri, "file:") &&
+                (WT_BTREE_PREFIX(cursor->uri) &&
                   F_ISSET((WT_CURSOR_BTREE *)cursor, WT_CBT_NO_TXN)));
 #endif
             WT_RET(__cursor_localvalue(cursor));
@@ -1323,7 +1323,7 @@ __wt_session_range_truncate(
 
     local_start = false;
     if (uri != NULL) {
-        WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:"));
+        WT_ASSERT(session, WT_BTREE_PREFIX(uri));
         /*
          * A URI file truncate becomes a range truncate where we set a start cursor at the
          * beginning. We already know the NULL stop goes to the end of the range.
@@ -1471,7 +1471,7 @@ __session_truncate(
                 WT_ERR_MSG(session, EINVAL,
                   "the truncate method should not specify any target after the log: URI prefix");
             WT_ERR(__wt_log_truncate_files(session, start, false));
-        } else if (WT_PREFIX_MATCH(uri, "file:"))
+        } else if (WT_BTREE_PREFIX(uri))
             WT_ERR(__wt_session_range_truncate(session, uri, start, stop));
         else
             /* Wait for checkpoints to avoid EBUSY errors. */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1400,9 +1400,8 @@ __rollback_to_stable_btree_apply(
     bool dhandle_allocated, durable_ts_found, has_txn_updates_gt_than_ckpt_snap, perform_rts;
     bool prepared_updates;
 
-    /* Ignore non-file objects as well as the metadata and history store files. */
-    if (!WT_PREFIX_MATCH(uri, "file:") || strcmp(uri, WT_HS_URI) == 0 ||
-      strcmp(uri, WT_METAFILE_URI) == 0)
+    /* Ignore non-btree objects as well as the metadata and history store files. */
+    if (!WT_BTREE_PREFIX(uri) || strcmp(uri, WT_HS_URI) == 0 || strcmp(uri, WT_METAFILE_URI) == 0)
         return (0);
 
     txn_global = &S2C(session)->txn_global;
@@ -1554,7 +1553,7 @@ __wt_rollback_to_stable_one(WT_SESSION_IMPL *session, const char *uri, bool *ski
      * may contain, so set the caller's skip argument to true on all file objects, else set the
      * caller's skip argument to false so our caller continues down the tree of objects.
      */
-    *skipp = WT_PREFIX_MATCH(uri, "file:");
+    *skipp = WT_BTREE_PREFIX(uri);
     if (!*skipp)
         return (0);
 


### PR DESCRIPTION
I've added a new macro, `WT_BTREE_PREFIX` for checking if a uri starts with `file:` or `tiered:`.  I wasn't sure of the best place to put the macro.  It's in `meta.h`, but I could imagine it going in `btree.h`, as well, or maybe elsewhere.

