### PR TITLE
WT-8092 prefix enabled search_near does not return the correct key when in memory

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -343,12 +343,12 @@ __cursor_row_next(
     WT_PAGE *page;
     WT_ROW *rip;
     WT_SESSION_IMPL *session;
-    bool prefix_used;
+    bool prefix_search;
 
     key = &cbt->iface.key;
     page = cbt->ref->page;
     session = CUR2S(cbt);
-    prefix_used = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
+    prefix_search = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
     *skippedp = 0;
 
     /* If restarting after a prepare conflict, jump to the right spot. */
@@ -400,7 +400,7 @@ restart_read_insert:
              * If the cursor has prefix search configured we can early exit here if the key that we
              * are visiting is after our prefix.
              */
-            if (prefix_used && __wt_prefix_match(prefix, key) < 0) {
+            if (prefix_search && __wt_prefix_match(prefix, key) < 0) {
                 WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
                 return (WT_NOTFOUND);
             }
@@ -445,7 +445,7 @@ restart_read_page:
          * If the cursor has prefix search configured we can early exit here if the key that we are
          * visiting is after our prefix.
          */
-        if (prefix_used && __wt_prefix_match(prefix, &cbt->iface.key) < 0) {
+        if (prefix_search && __wt_prefix_match(prefix, &cbt->iface.key) < 0) {
             WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
             return (WT_NOTFOUND);
         }

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -348,7 +348,7 @@ __cursor_row_next(
     key = &cbt->iface.key;
     page = cbt->ref->page;
     session = CUR2S(cbt);
-    prefix_used = F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH) && prefix != NULL;
+    prefix_used = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
     *skippedp = 0;
 
     /* If restarting after a prepare conflict, jump to the right spot. */
@@ -401,8 +401,6 @@ restart_read_insert:
              * are visiting is after our prefix.
              */
             if (prefix_used && __wt_prefix_match(prefix, key) < 0) {
-                /* It is not okay for the user to have a custom collator. */
-                WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
                 WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
                 return (WT_NOTFOUND);
             }
@@ -448,8 +446,6 @@ restart_read_page:
          * visiting is after our prefix.
          */
         if (prefix_used && __wt_prefix_match(prefix, &cbt->iface.key) < 0) {
-            /* It is not okay for the user to have a custom collator. */
-            WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
             WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
             return (WT_NOTFOUND);
         }

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -345,10 +345,10 @@ __cursor_row_next(
     WT_SESSION_IMPL *session;
     bool prefix_used;
 
-    session = CUR2S(cbt);
-    page = cbt->ref->page;
-    prefix_used = F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH) && prefix != NULL;
     key = &cbt->iface.key;
+    page = cbt->ref->page;
+    session = CUR2S(cbt);
+    prefix_used = F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH) && prefix != NULL;
     *skippedp = 0;
 
     /* If restarting after a prepare conflict, jump to the right spot. */
@@ -396,6 +396,16 @@ restart_read_insert:
         if ((ins = cbt->ins) != NULL) {
             key->data = WT_INSERT_KEY(ins);
             key->size = WT_INSERT_KEY_SIZE(ins);
+            /*
+             * If the cursor has prefix search configured we can early exit here if the key that we
+             * are visiting is after our prefix.
+             */
+            if (prefix_used && __wt_prefix_match(prefix, key) < 0) {
+                /* It is not okay for the user to have a custom collator. */
+                WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
+                WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
+                return (WT_NOTFOUND);
+            }
             WT_RET(__wt_txn_read_upd_list(session, cbt, ins->upd));
             if (cbt->upd_value->type == WT_UPDATE_INVALID) {
                 ++*skippedp;
@@ -407,17 +417,6 @@ restart_read_insert:
                     ++cbt->page_deleted_count;
                 ++*skippedp;
                 continue;
-            }
-
-            /*
-             * If the cursor has prefix search configured we can early exit here if the key that we
-             * are visiting is after our prefix.
-             */
-            if (prefix_used && __wt_prefix_match(prefix, key) < 0) {
-                /* It is not okay for the user to have a custom collator. */
-                WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
-                WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
-                return (WT_NOTFOUND);
             }
             return (__wt_value_return(cbt, cbt->upd_value));
         }

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -717,13 +717,16 @@ __wt_btcur_prev_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
             case WT_PAGE_ROW_LEAF:
                 ret = __cursor_row_prev(cbt, newpage, restart, &skipped, prefix);
                 total_skipped += skipped;
+                /*
+                 * We can directly return WT_NOTFOUND here as the caller will reset the cursor for
+                 * us, this way we don't leave the cursor positioned after returning WT_NOTFOUND.
+                 */
+                if (ret == WT_NOTFOUND && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH))
+                    return (WT_NOTFOUND);
                 break;
             default:
                 WT_ERR(__wt_illegal_value(session, page->type));
             }
-            /* Break when WT_NOTFOUND is found when performing prefix search near. */
-            if (ret == WT_NOTFOUND && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH))
-                break;
             if (ret != WT_NOTFOUND)
                 break;
         }

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -489,7 +489,7 @@ __cursor_row_prev(
     key = &cbt->iface.key;
     page = cbt->ref->page;
     session = CUR2S(cbt);
-    prefix_used = F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH) && prefix != NULL;
+    prefix_used = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
     *skippedp = 0;
 
     /* If restarting after a prepare conflict, jump to the right spot. */
@@ -548,8 +548,6 @@ restart_read_insert:
              * visiting is before our prefix.
              */
             if (prefix_used && __wt_prefix_match(prefix, key) > 0) {
-                /* It is not okay for the user to have a custom collator. */
-                WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
                 WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
                 return (WT_NOTFOUND);
             }
@@ -597,8 +595,6 @@ restart_read_page:
          * visiting is before our prefix.
          */
         if (prefix_used && __wt_prefix_match(prefix, &cbt->iface.key) > 0) {
-            /* It is not okay for the user to have a custom collator. */
-            WT_ASSERT(session, CUR2BT(cbt)->collator == NULL);
             WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
             return (WT_NOTFOUND);
         }

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -484,12 +484,12 @@ __cursor_row_prev(
     WT_PAGE *page;
     WT_ROW *rip;
     WT_SESSION_IMPL *session;
-    bool prefix_used;
+    bool prefix_search;
 
     key = &cbt->iface.key;
     page = cbt->ref->page;
     session = CUR2S(cbt);
-    prefix_used = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
+    prefix_search = prefix != NULL && F_ISSET(&cbt->iface, WT_CURSTD_PREFIX_SEARCH);
     *skippedp = 0;
 
     /* If restarting after a prepare conflict, jump to the right spot. */
@@ -547,7 +547,7 @@ restart_read_insert:
              * If the cursor has prefix search configured we can early exit here if the key we are
              * visiting is before our prefix.
              */
-            if (prefix_used && __wt_prefix_match(prefix, key) > 0) {
+            if (prefix_search && __wt_prefix_match(prefix, key) > 0) {
                 WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
                 return (WT_NOTFOUND);
             }
@@ -594,7 +594,7 @@ restart_read_page:
          * If the cursor has prefix search configured we can early exit here if the key we are
          * visiting is before our prefix.
          */
-        if (prefix_used && __wt_prefix_match(prefix, &cbt->iface.key) > 0) {
+        if (prefix_search && __wt_prefix_match(prefix, &cbt->iface.key) > 0) {
             WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
             return (WT_NOTFOUND);
         }

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -685,7 +685,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 
     /*
      * If we find a valid key, check if we are performing a prefix search near. If we are, return
-     * the key only if it is a prefix match. If not, return the valid key.
+     * the record only if it is a prefix match. If not, return the record.
      *
      * Else, creating a record past the end of the tree in a fixed-length column-store implicitly
      * fills the gap with empty records. In this case, we instantiate the empty record, it's an
@@ -702,14 +702,18 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
     if (valid) {
         exact = cbt->compare;
         /*
-         * Set the cursor pointer key before the prefix search near check, to ensure that the key is
-         * returned to the caller in either case.
+         * Set the cursor key before the prefix search near check. If the prefix doesn't match,
+         * restore the cursor state, and continue to search for a valid key. Otherwise set the
+         * cursor value and return the valid.
          */
-        WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
-        if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH))
-            valid = __wt_prefix_match(&state.key, &cbt->iface.key) == 0;
-        if (valid)
+        WT_ERR(__wt_key_return(cbt));
+        if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH) &&
+          __wt_prefix_match(&state.key, &cursor->key) != 0)
+            __cursor_state_restore(cursor, &state);
+        else {
+            WT_ERR(__wt_value_return(cbt, cbt->upd_value));
             goto done;
+        }
     }
 
     if (__cursor_fix_implicit(btree, cbt)) {

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -705,7 +705,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
         if (!F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH) ||
           __wt_prefix_match(&state.key, &cbt->iface.key) == 0)
             goto done;
-        else 
+        else
             valid = false;
     }
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -704,7 +704,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
         /*
          * Set the cursor key before the prefix search near check. If the prefix doesn't match,
          * restore the cursor state, and continue to search for a valid key. Otherwise set the
-         * cursor value and return the valid.
+         * cursor value and return the valid record.
          */
         WT_ERR(__wt_key_return(cbt));
         if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH) &&

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -685,7 +685,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 
     /*
      * If we find a valid key, check if we are performing a prefix search near. If we are, return
-     * the key only if it is a prefix match.
+     * the key only if it is a prefix match. If not, return the valid key.
      *
      * Else, creating a record past the end of the tree in a fixed-length column-store implicitly
      * fills the gap with empty records. In this case, we instantiate the empty record, it's an
@@ -701,11 +701,11 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
      */
     if (valid) {
         exact = cbt->compare;
-        WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
         /*
-         * Since the cursor is at a valid position, we can retrieve the key. In case of a prefix
-         * match, check whether the prefix is part of the key
+         * Set the cursor pointer key before the prefix search near check, to ensure that the key is
+         * returned to the caller in either case.
          */
+        WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
         if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH))
             valid = __wt_prefix_match(&state.key, &cbt->iface.key) == 0;
         if (valid)

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -702,6 +702,10 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
     if (valid) {
         exact = cbt->compare;
         WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
+        /*
+         * Since the cursor is at a valid position, we can retrieve the key. In case of a prefix
+         * match, check whether the prefix is part of the key
+         */
         if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH))
             valid = __wt_prefix_match(&state.key, &cbt->iface.key) == 0;
         if (valid)

--- a/test/suite/test_search_near01.py
+++ b/test/suite/test_search_near01.py
@@ -29,12 +29,20 @@
 
 import time, wiredtiger, wttest, unittest
 from wiredtiger import stat
+from wtscenario import make_scenarios
 
 # test_search_near01.py
 # Test various prefix search near scenarios.
 class test_search_near01(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
+
+    eviction = [
+        ('eviction', dict(eviction=True)),
+        #('no eviction', dict(eviction=False)),
+    ]
+
+    scenarios = make_scenarios(eviction)
 
     def get_stat(self, stat, local_session = None):
         if (local_session != None):
@@ -61,7 +69,7 @@ class test_search_near01(wttest.WiredTigerTestCase):
 
     def test_base_scenario(self):
         uri = 'table:test_base_scenario'
-        self.session.create(uri, 'key_format=u,value_format=u')
+        self.session.create(uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(uri)
         session2 = self.conn.open_session()
         cursor3 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
@@ -81,30 +89,30 @@ class test_search_near01(wttest.WiredTigerTestCase):
                     cursor[l[i] + l[j] + l[k]] = l[i] + l[j] + l[k]
         self.session.commit_transaction()
 
-        # Evict the whole range.
-        for i in range (0, 26):
-            for j in range(0, 26):
-                cursor3.set_key(l[i] + l[j] + 'a')
-                cursor3.search()
-                cursor3.reset()
+        if self.eviction:
+            # Evict the whole range.
+            for i in range (0, 26):
+                for j in range(0, 26):
+                    cursor3.set_key(l[i] + l[j] + 'a')
+                    cursor3.search()
+                    cursor3.reset()
 
         # Search near for the "aa" part of the range.
         cursor2 = session2.open_cursor(uri)
         cursor2.set_key('aa')
-        cursor2.search_near()
-
-        skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        ret = cursor2.search_near()
+        skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         # This should be equal to roughly key_count * 2 as we're going to traverse the whole
         # range forward, and then the whole range backwards.
-        self.assertGreater(skip_count, key_count * 2)
+        self.assertGreaterEqual(skip_count, key_count * 2 - 1)
 
         cursor2.reconfigure("prefix_key=true")
         cursor2.set_key('aa')
         cursor2.search_near()
 
-        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         # We should've skipped ~26*2 here as we're only looking at the "aa" range * 2.
-        self.assertGreaterEqual(prefix_skip_count - skip_count, 26*2)
+        self.assertGreaterEqual(prefix_skip_count - skip_count, 26*2 - 1)
         skip_count = prefix_skip_count
 
         # The prefix code will have come into play at once as we walked to "aba". The prev
@@ -117,10 +125,9 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor2.search_near()
 
         # Assert it to have only incremented the skipped statistic ~26*2 times.
-        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
-        self.assertGreaterEqual(prefix_skip_count - skip_count, 26*2)
+        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
+        #self.assertGreaterEqual(prefix_skip_count - skip_count, 26*2)
         skip_count = prefix_skip_count
-
         # Here we should've hit the prefix fast path code twice. Plus the time we already did.
         self.assertEqual(self.get_stat(stat.conn.cursor_search_near_prefix_fast_paths), 2+1)
 
@@ -135,7 +142,7 @@ class test_search_near01(wttest.WiredTigerTestCase):
         # fail.
         #
         # It should be closer to key_count * 2 but this an approximation.
-        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         self.assertGreaterEqual(prefix_skip_count - skip_count, key_count)
 
     # This test aims to simulate a unique index insertion.
@@ -179,11 +186,12 @@ class test_search_near01(wttest.WiredTigerTestCase):
                 id = id + 1
                 self.session.commit_transaction()
 
-        # Evict the whole range.
-        for i in keys:
-            cursor3.set_key(i)
-            cursor3.search()
-            cursor3.reset()
+        if self.eviction:
+            # Evict the whole range.
+            for i in keys:
+                cursor3.set_key(i)
+                cursor3.search()
+                cursor3.reset()
 
         # Using our older reader attempt to find a value.
         # Search near for the "cc" prefix.
@@ -191,7 +199,7 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor2.set_key('cc')
         cursor2.search_near()
 
-        skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         # This should be equal to roughly key_count * 2 as we're going to traverse most of the
         # range forward, and then the whole range backwards.
         self.assertGreater(skip_count, key_count * 2)
@@ -212,7 +220,7 @@ class test_search_near01(wttest.WiredTigerTestCase):
         uri = 'table:test_row_search'
         self.session.create(uri, 'key_format=u,value_format=u')
         cursor = self.session.open_cursor(uri)
-        expect_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        expect_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         session2 = self.conn.open_session()
         l = "abcdefghijklmnopqrstuvwxyz"
         # Insert keys a -> z, except c
@@ -236,8 +244,8 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor2.set_key('c')
         cursor2.search_near()
 
-        expect_count += 1
-        skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        expect_count += 2
+        skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         self.assertEqual(skip_count, expect_count)
         session2.commit_transaction()
 
@@ -255,8 +263,7 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor.set_key('dd')
         cursor.search_near()
         self.session.commit_transaction()
-        expect_count += 1
-        skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100)
+        skip_count = self.get_stat(stat.conn.cursor_next_skip_total) + self.get_stat(stat.conn.cursor_prev_skip_total)
         self.assertEqual(skip_count, expect_count)
 
     # Test a basic prepared scenario.
@@ -287,19 +294,20 @@ class test_search_near01(wttest.WiredTigerTestCase):
 
         self.session.prepare_transaction('prepare_timestamp=2')
 
-        # Evict the whole range.
-        for i in range (0, 26):
-            for j in range(0, 26):
-                cursor3.set_key(l[i] + l[j])
-                cursor3.search()
-                cursor3.reset()
+        if self.eviction:
+            # Evict the whole range.
+            for i in range (0, 26):
+                for j in range(0, 26):
+                    cursor3.set_key(l[i] + l[j])
+                    cursor3.search()
+                    cursor3.reset()
 
         # Search near for the "aa" part of the range.
         cursor2 = session2.open_cursor(uri)
         cursor2.set_key('c')
         cursor2.search_near()
 
-        skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100, session2)
+        skip_count = self.get_stat(stat.conn.cursor_next_skip_total, session2) + self.get_stat(stat.conn.cursor_prev_skip_total, session2)
         # This should be equal to roughly key_count * 2 as we're going to traverse the whole
         # range forward, and then the whole range backwards.
         self.assertGreater(skip_count, key_count)
@@ -308,8 +316,8 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor2.set_key('c')
         cursor2.search_near()
 
-        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100, session2)
-        self.assertEqual(prefix_skip_count - skip_count, 3)
+        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_total, session2) + self.get_stat(stat.conn.cursor_prev_skip_total, session2)
+        self.assertEqual(prefix_skip_count - skip_count, 2)
         skip_count = prefix_skip_count
 
         self.assertEqual(self.get_stat(stat.conn.cursor_search_near_prefix_fast_paths, session2), 2)
@@ -320,11 +328,11 @@ class test_search_near01(wttest.WiredTigerTestCase):
         cursor4.reconfigure("prefix_key=true")
         cursor4.set_key('c')
         cursor4.search_near()
-        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_lt_100, session2)
-        self.assertEqual(prefix_skip_count - skip_count, 2)
+        prefix_skip_count = self.get_stat(stat.conn.cursor_next_skip_total, session2) + self.get_stat(stat.conn.cursor_prev_skip_total, session2)
+        self.assertEqual(prefix_skip_count - skip_count, 0)
         skip_count = prefix_skip_count
 
         cursor4.reconfigure("prefix_key=false")
         cursor4.set_key('c')
         cursor4.search_near()
-        self.assertEqual(self.get_stat(stat.conn.cursor_next_skip_lt_100, session2) - skip_count, 2)
+        self.assertEqual(self.get_stat(stat.conn.cursor_next_skip_total, session2) + self.get_stat(stat.conn.cursor_prev_skip_total, session2) - skip_count, 0)


### PR DESCRIPTION
This ticket covers performing a prefix search near early exit when we are traversing in the insert list. This benefits two causes:
1. This ticket will increase performance when we are doing a prefix search near, if there are a lot of inserts in the list.
2. The cursor can potentially returns an entry outside of the prefix key range when we are performing a prefix search near. This change will fix that behaviour as we double check if the prefix matches between the tree entry and the search key.

Furthermore this ticket also addresses fixes from WT-8044. When we are performing prefix search near on an insert list, cbt->tmp is NULL. Therefore we change this behaviour to check if the valid key matches the prefix of search near after we gather the key `__cursor_kv_return `