### PR TITLE
WT-8093 Improve the CPP testing framework for better flexibility

### DIFF
--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -52,14 +52,14 @@ VALUE="#include \"$1.cxx\""
 sed -i "/$SEARCH/a $VALUE" $FILE
 
 # Add the new test to the run_test() method
-SEARCH="example_test(test_harness::test_args{config, test_name, wt_open_config}).run();"
+SEARCH="example_test("
 LINE_1="\else if (test_name == \"$1\")\n"
 LINE_2="\ $1(test_harness::test_args{config, test_name, wt_open_config}).run();"
 sed -i "/$SEARCH/a $LINE_1$LINE_2" $FILE
 
 # Add the new test to all existing tests.
-SEARCH="all_tests = {\"example_test\""
-REPLACE="$SEARCH, \"$1\""
+SEARCH="all_tests = {"
+REPLACE="$SEARCH\"$1\", "
 sed -i "s/$SEARCH/$REPLACE/" $FILE
 echo "Updated $FILE."
 

--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -54,7 +54,7 @@ sed -i "/$SEARCH/a $VALUE" $FILE
 # Add the new test to the run_test() method
 SEARCH="example_test(test_harness::test_args{config, test_name, wt_open_config}).run();"
 LINE_1="\else if (test_name == \"$1\")\n"
-LINE_2="\\$1(test_harness::test_args{config, test_name, wt_open_config}).run();"
+LINE_2="\ $1(test_harness::test_args{config, test_name, wt_open_config}).run();"
 sed -i "/$SEARCH/a $LINE_1$LINE_2" $FILE
 
 # Add the new test to all existing tests.

--- a/test/cppsuite/test_harness/workload/database_operation.cxx
+++ b/test/cppsuite/test_harness/workload/database_operation.cxx
@@ -188,7 +188,7 @@ database_operation::insert_operation(thread_context *tc)
         /* Reset our cursor to avoid pinning content. */
         testutil_check(cc.cursor->reset(cc.cursor.get()));
         counter++;
-        if (counter == collections_per_thread)
+        if (counter >= collections_per_thread)
             counter = 0;
     }
     /* Make sure the last transaction is rolled back now the work is finished. */

--- a/test/cppsuite/test_harness/workload/database_operation.cxx
+++ b/test/cppsuite/test_harness/workload/database_operation.cxx
@@ -156,7 +156,6 @@ database_operation::insert_operation(thread_context *tc)
     while (tc->running()) {
         uint64_t start_key = ccv[counter].coll.get_key_count();
         uint64_t added_count = 0;
-        bool committed = true;
         tc->transaction.begin();
 
         /* Collection cursor. */

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -40,7 +40,7 @@ random_generator::instance()
 std::string
 random_generator::generate_string(std::size_t length)
 {
-    std::string str = _characters;
+    std::string str = _pseudo_alphanum;
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));
 }
@@ -52,8 +52,8 @@ random_generator::generate_pseudo_random_string(std::size_t length)
     std::size_t start_location = _distribution(_generator);
 
     for (std::size_t i = 0; i < length; ++i) {
-        random_string += _characters[start_location];
-        if (start_location == _characters.size() - 1)
+        random_string += _pseudo_alphanum[start_location];
+        if (start_location == _pseudo_alphanum.size() - 1)
             start_location = 0;
         else
             start_location++;
@@ -64,6 +64,6 @@ random_generator::generate_pseudo_random_string(std::size_t length)
 random_generator::random_generator()
 {
     _generator = std::mt19937(std::random_device{}());
-    _distribution = std::uniform_int_distribution<>(0, _characters.size() - 1);
+    _distribution = std::uniform_int_distribution<>(0, _pseudo_alphanum.size() - 1);
 }
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -29,6 +29,10 @@
 #include "random_generator.h"
 #include <algorithm>
 
+extern "C" {
+#include "test_util.h"
+}
+
 namespace test_harness {
 random_generator &
 random_generator::instance()
@@ -38,22 +42,36 @@ random_generator::instance()
 }
 
 std::string
-random_generator::generate_string(std::size_t length)
+random_generator::generate_string(std::size_t length, characters_type type)
 {
-    std::string str = _pseudo_alphanum;
+    std::string str;
+
+    switch (type) {
+    case characters_type::ALPHABET:
+        str = _alphabet;
+        break;
+    case characters_type::PSEUDO_ALPHANUMERIC:
+        str = _pseudo_alphanum;
+    default:
+        testutil_die(type, "Unexpected characters_type");
+        break;
+    }
+
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));
 }
 
 std::string
-random_generator::generate_pseudo_random_string(std::size_t length)
+random_generator::generate_pseudo_random_string(std::size_t length, characters_type type)
 {
     std::string random_string;
-    std::size_t start_location = _distribution(_generator);
+    std::uniform_int_distribution<> &distribution = get_distribution(type);
+    std::size_t start_location = distribution(_generator);
+    const std::string &characters = get_characters(type);
 
     for (std::size_t i = 0; i < length; ++i) {
-        random_string += _pseudo_alphanum[start_location];
-        if (start_location == _pseudo_alphanum.size() - 1)
+        random_string += characters[start_location];
+        if (start_location == characters.size() - 1)
             start_location = 0;
         else
             start_location++;
@@ -64,6 +82,38 @@ random_generator::generate_pseudo_random_string(std::size_t length)
 random_generator::random_generator()
 {
     _generator = std::mt19937(std::random_device{}());
-    _distribution = std::uniform_int_distribution<>(0, _pseudo_alphanum.size() - 1);
+    _alphanum_distrib = std::uniform_int_distribution<>(0, _pseudo_alphanum.size() - 1);
+    _alpha_distrib = std::uniform_int_distribution<>(0, _alphabet.size() - 1);
 }
+
+std::uniform_int_distribution<> &
+random_generator::get_distribution(characters_type type)
+{
+    switch (type) {
+    case characters_type::ALPHABET:
+        return (_alpha_distrib);
+        break;
+    case characters_type::PSEUDO_ALPHANUMERIC:
+        return (_alphanum_distrib);
+    default:
+        testutil_die(type, "Unexpected characters_type");
+        break;
+    }
+}
+
+const std::string &
+random_generator::get_characters(characters_type type)
+{
+    switch (type) {
+    case characters_type::ALPHABET:
+        return (_alphabet);
+        break;
+    case characters_type::PSEUDO_ALPHANUMERIC:
+        return (_pseudo_alphanum);
+    default:
+        testutil_die(type, "Unexpected characters_type");
+        break;
+    }
+}
+
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -42,7 +42,7 @@ random_generator::instance()
 }
 
 std::string
-random_generator::generate_string(std::size_t length, characters_type type)
+random_generator::generate_random_string(std::size_t length, characters_type type)
 {
     std::string str;
 

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -27,6 +27,7 @@
  */
 
 #include "random_generator.h"
+#include <algorithm>
 
 namespace test_harness {
 random_generator &
@@ -39,12 +40,9 @@ random_generator::instance()
 std::string
 random_generator::generate_string(std::size_t length)
 {
-    std::string random_string;
-
-    for (std::size_t i = 0; i < length; ++i)
-        random_string += _characters[_distribution(_generator)];
-
-    return (random_string);
+    std::string str = _characters;
+    std::shuffle(str.begin(), str.end(), _generator);
+    return (str.substr(0, length));
 }
 
 std::string

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -47,7 +47,7 @@ random_generator::generate_string(std::size_t length, characters_type type)
     std::string str;
 
     while (str.size() < length)
-        str += std::string(get_characters(type));
+        str += get_characters(type);
 
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -44,7 +44,11 @@ random_generator::instance()
 std::string
 random_generator::generate_string(std::size_t length, characters_type type)
 {
-    std::string str(get_characters(type));
+    std::string str;
+
+    while (str.size() < length)
+        str += std::string(get_characters(type));
+
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));
 }

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -44,20 +44,7 @@ random_generator::instance()
 std::string
 random_generator::generate_string(std::size_t length, characters_type type)
 {
-    std::string str;
-
-    switch (type) {
-    case characters_type::ALPHABET:
-        str = _alphabet;
-        break;
-    case characters_type::PSEUDO_ALPHANUMERIC:
-        str = _pseudo_alphanum;
-        break;
-    default:
-        testutil_die(type, "Unexpected characters_type");
-        break;
-    }
-
+    std::string str(get_characters(type));
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));
 }

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -52,6 +52,7 @@ random_generator::generate_string(std::size_t length, characters_type type)
         break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         str = _pseudo_alphanum;
+        break;
     default:
         testutil_die(type, "Unexpected characters_type");
         break;
@@ -95,6 +96,7 @@ random_generator::get_distribution(characters_type type)
         break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_alphanum_distrib);
+        break;
     default:
         testutil_die(type, "Unexpected characters_type");
         break;
@@ -110,6 +112,7 @@ random_generator::get_characters(characters_type type)
         break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_pseudo_alphanum);
+        break;
     default:
         testutil_die(type, "Unexpected characters_type");
         break;

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -63,7 +63,7 @@ class random_generator {
 
     std::mt19937 _generator;
     std::uniform_int_distribution<> _distribution;
-    const std::string _characters =
+    const std::string _pseudo_alphanum =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 };
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -29,6 +29,10 @@
 #ifndef RANDOM_GENERATOR_H
 #define RANDOM_GENERATOR_H
 
+/* Following definitions are required in order to use printing format specifiers in C++. */
+#define __STDC_LIMIT_MACROS
+#define __STDC_FORMAT_MACROS
+
 #include <random>
 #include <string>
 

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -48,7 +48,10 @@ class random_generator {
     /* Generate a random string of a given length. */
     std::string generate_string(std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
 
-    /* Generate a pseudo random string which compresses better. */
+    /*
+     * Generate a pseudo random string which compresses better. It should not be used to generate
+     * keys due to the limited randomness.
+     */
     std::string generate_pseudo_random_string(
       std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
 

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -46,7 +46,8 @@ class random_generator {
     random_generator &operator=(random_generator const &) = delete;
 
     /* Generate a random string of a given length. */
-    std::string generate_string(std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
+    std::string generate_random_string(
+      std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
 
     /*
      * Generate a pseudo random string which compresses better. It should not be used to generate

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -41,7 +41,6 @@ class random_generator {
     public:
     static random_generator &instance();
 
-    public:
     /* No copies of the singleton allowed. */
     random_generator(random_generator const &) = delete;
     random_generator &operator=(random_generator const &) = delete;

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -34,6 +34,9 @@
 
 namespace test_harness {
 /* Helper class to generate random values using uniform distributions. */
+
+enum characters_type { PSEUDO_ALPHANUMERIC, ALPHABET };
+
 class random_generator {
     public:
     static random_generator &instance();
@@ -44,10 +47,11 @@ class random_generator {
     random_generator &operator=(random_generator const &) = delete;
 
     /* Generate a random string of a given length. */
-    std::string generate_string(std::size_t length);
+    std::string generate_string(std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
 
     /* Generate a pseudo random string which compresses better. */
-    std::string generate_pseudo_random_string(std::size_t length);
+    std::string generate_pseudo_random_string(
+      std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
 
     /* Generate a random integer between min and max. */
     template <typename T>
@@ -60,9 +64,12 @@ class random_generator {
 
     private:
     random_generator();
+    std::uniform_int_distribution<> &get_distribution(characters_type type);
+    const std::string &get_characters(characters_type type);
 
     std::mt19937 _generator;
-    std::uniform_int_distribution<> _distribution;
+    std::uniform_int_distribution<> _alphanum_distrib, _alpha_distrib;
+    const std::string _alphabet = "abcdefghijklmnopqrstuvwxyz";
     const std::string _pseudo_alphanum =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 };

--- a/test/cppsuite/test_harness/workload/thread_context.cxx
+++ b/test/cppsuite/test_harness/workload/thread_context.cxx
@@ -219,7 +219,8 @@ thread_context::update(scoped_cursor &cursor, uint64_t collection_id, const std:
 }
 
 bool
-thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id)
+thread_context::insert(
+  scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id, wt_timestamp_t ts)
 {
     WT_DECL_RET;
     std::string key, value;
@@ -227,10 +228,11 @@ thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, uint64_t k
     testutil_assert(cursor.get() != nullptr);
 
     /*
-     * Get a timestamp to apply to the update. We still do this even if timestamps aren't enabled as
-     * it will return a value for the tracking table.
+     * When no timestamp is specified, get one to apply to the update. We still do this even
+     * if the timestamp manager is not enabled as it will return a value for the tracking table.
      */
-    wt_timestamp_t ts = tsm->get_next_ts();
+    if(ts == 0)
+        ts = tsm->get_next_ts();
     transaction.set_commit_timestamp(ts);
 
     key = key_to_string(key_id);

--- a/test/cppsuite/test_harness/workload/thread_context.cxx
+++ b/test/cppsuite/test_harness/workload/thread_context.cxx
@@ -222,8 +222,15 @@ bool
 thread_context::insert(
   scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id, wt_timestamp_t ts)
 {
+    return insert(cursor, collection_id, key_to_string(key_id), ts);
+}
+
+bool
+thread_context::insert(
+  scoped_cursor &cursor, uint64_t collection_id, const std::string &key, wt_timestamp_t ts)
+{
     WT_DECL_RET;
-    std::string key, value;
+    std::string value;
     testutil_assert(tracking != nullptr);
     testutil_assert(cursor.get() != nullptr);
 
@@ -231,11 +238,10 @@ thread_context::insert(
      * When no timestamp is specified, get one to apply to the update. We still do this even
      * if the timestamp manager is not enabled as it will return a value for the tracking table.
      */
-    if(ts == 0)
+    if (ts == 0)
         ts = tsm->get_next_ts();
     transaction.set_commit_timestamp(ts);
 
-    key = key_to_string(key_id);
     value = random_generator::instance().generate_pseudo_random_string(value_size);
 
     cursor->set_key(cursor.get(), key.c_str());

--- a/test/cppsuite/test_harness/workload/thread_context.cxx
+++ b/test/cppsuite/test_harness/workload/thread_context.cxx
@@ -235,8 +235,8 @@ thread_context::insert(
     testutil_assert(cursor.get() != nullptr);
 
     /*
-     * When no timestamp is specified, get one to apply to the update. We still do this even
-     * if the timestamp manager is not enabled as it will return a value for the tracking table.
+     * When no timestamp is specified, get one to apply to the update. We still do this even if the
+     * timestamp manager is not enabled as it will return a value for the tracking table.
      */
     if (ts == 0)
         ts = tsm->get_next_ts();

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -148,6 +148,8 @@ class thread_context {
      */
     bool insert(
       scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id, wt_timestamp_t ts = 0);
+    bool insert(
+      scoped_cursor &cursor, uint64_t collection_id, const std::string &key, wt_timestamp_t ts = 0);
 
     void sleep();
     bool running() const;

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -141,11 +141,13 @@ class thread_context {
     bool update(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
 
     /*
-     * Generic insert function, takes a collection_id and key_id, will generate the value.
+     * Generic insert function, takes a collection_id and key_id, will generate the value. If a
+     * timestamp is not specified, the timestamp manager will generate one.
      *
      * Returns true if a rollback is required.
      */
-    bool insert(scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id);
+    bool insert(
+      scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id, wt_timestamp_t ts = 0);
 
     void sleep();
     bool running() const;

--- a/test/cppsuite/tests/example_test.cxx
+++ b/test/cppsuite/tests/example_test.cxx
@@ -37,27 +37,26 @@ class example_test : public test_harness::test {
     example_test(const test_harness::test_args &args) : test(args) {}
 
     void
-    populate(test_harness::database &database, test_harness::timestamp_manager *_timestamp_manager,
-      test_harness::configuration *_config,
-      test_harness::workload_tracking *tracking) override final
+    populate(test_harness::database &database, test_harness::timestamp_manager *tsm,
+      test_harness::configuration *config, test_harness::workload_tracking *tracking) override final
     {
         std::cout << "populate: nothing done." << std::endl;
     }
 
     void
-    insert_operation(test_harness::thread_context *context) override final
+    insert_operation(test_harness::thread_context *tc) override final
     {
         std::cout << "insert_operation: nothing done." << std::endl;
     }
 
     void
-    read_operation(test_harness::thread_context *context) override final
+    read_operation(test_harness::thread_context *tc) override final
     {
         std::cout << "read_operation: nothing done." << std::endl;
     }
 
     void
-    update_operation(test_harness::thread_context *context) override final
+    update_operation(test_harness::thread_context *tc) override final
     {
         std::cout << "update_operation: nothing done." << std::endl;
     }

--- a/test/cppsuite/tests/example_test.cxx
+++ b/test/cppsuite/tests/example_test.cxx
@@ -45,6 +45,12 @@ class example_test : public test_harness::test {
     }
 
     void
+    insert_operation(test_harness::thread_context *context) override final
+    {
+        std::cout << "insert_operation: nothing done." << std::endl;
+    }
+
+    void
     read_operation(test_harness::thread_context *context) override final
     {
         std::cout << "read_operation: nothing done." << std::endl;

--- a/test/cppsuite/tests/example_test.cxx
+++ b/test/cppsuite/tests/example_test.cxx
@@ -37,26 +37,26 @@ class example_test : public test_harness::test {
     example_test(const test_harness::test_args &args) : test(args) {}
 
     void
-    populate(test_harness::database &database, test_harness::timestamp_manager *tsm,
-      test_harness::configuration *config, test_harness::workload_tracking *tracking) override final
+    populate(test_harness::database &, test_harness::timestamp_manager *,
+      test_harness::configuration *, test_harness::workload_tracking *) override final
     {
         std::cout << "populate: nothing done." << std::endl;
     }
 
     void
-    insert_operation(test_harness::thread_context *tc) override final
+    insert_operation(test_harness::thread_context *) override final
     {
         std::cout << "insert_operation: nothing done." << std::endl;
     }
 
     void
-    read_operation(test_harness::thread_context *tc) override final
+    read_operation(test_harness::thread_context *) override final
     {
         std::cout << "read_operation: nothing done." << std::endl;
     }
 
     void
-    update_operation(test_harness::thread_context *tc) override final
+    update_operation(test_harness::thread_context *) override final
     {
         std::cout << "update_operation: nothing done." << std::endl;
     }


### PR DESCRIPTION
On top of https://github.com/wiredtiger/wiredtiger/pull/6997:

- Added required macros for old gcc versions, see a4d5132e0f81962b8d36c730d5c913ee2b9d33d8