### PR TITLE
WT-8055 Fix issue when compact quits when running at the same time as a checkpoint

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1363,8 +1363,6 @@ extern int __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_search_insert(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_INSERT_HEAD *ins_head, WT_ITEM *srch_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_session_blocking_checkpoint(WT_SESSION_IMPL *session, bool force, uint64_t seconds)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_breakpoint(WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_close_internal(WT_SESSION_IMPL *session)

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -165,7 +165,7 @@ run_test(bool stress_test, const char *home, const char *uri)
 
     testutil_check(session->close(session, NULL));
     session = NULL;
-    
+
     testutil_check(conn->close(conn, NULL));
     conn = NULL;
 

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -69,8 +69,8 @@ static void set_timing_stress_checkpoint(WT_CONNECTION *conn);
 int
 main(int argc, char *argv[])
 {
-    char home_cv[512];
     TEST_OPTS *opts, _opts;
+    char home_cv[512];
 
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
@@ -102,11 +102,11 @@ main(int argc, char *argv[])
 static void
 run_test(bool stress_test, const char *home, const char *uri)
 {
-    pthread_t thread_checkpoint, thread_compact;
     struct thread_data td;
-    uint64_t file_sz_after, file_sz_before;
     WT_CONNECTION *conn;
     WT_SESSION *session;
+    pthread_t thread_checkpoint, thread_compact;
+    uint64_t file_sz_after, file_sz_before;
 
     testutil_make_work_dir(home);
     testutil_check(wiredtiger_open(home, NULL, conn_config, &conn));
@@ -218,12 +218,12 @@ wait_run_check(WT_SESSION_IMPL *session)
 static void *
 thread_func_checkpoint(void *arg)
 {
-    bool signalled;
-    int i;
     struct thread_data *td;
-    uint64_t sleep_sec;
     WT_RAND_STATE rnd;
     WT_SESSION *session;
+    uint64_t sleep_sec;
+    int i;
+    bool signalled;
 
     td = (struct thread_data *)arg;
 
@@ -265,10 +265,10 @@ thread_func_checkpoint(void *arg)
 static void
 populate(WT_SESSION *session, const char *uri)
 {
-    int i, str_len;
-    uint64_t val;
     WT_CURSOR *cursor;
     WT_RAND_STATE rnd;
+    uint64_t val;
+    int i, str_len;
 
     __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
 
@@ -292,8 +292,8 @@ populate(WT_SESSION *session, const char *uri)
 static void
 remove_records(WT_SESSION *session, const char *uri)
 {
-    int i;
     WT_CURSOR *cursor;
+    int i;
 
     testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
@@ -309,9 +309,9 @@ remove_records(WT_SESSION *session, const char *uri)
 static uint64_t
 get_file_size(WT_SESSION *session, const char *uri)
 {
-    char *descr, *str_val, stat_uri[128];
-    uint64_t val;
     WT_CURSOR *cur_stat;
+    uint64_t val;
+    char *descr, *str_val, stat_uri[128];
 
     sprintf(stat_uri, "statistics:%s", uri);
     testutil_check(session->open_cursor(session, stat_uri, NULL, "statistics=(all)", &cur_stat));

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -170,7 +170,7 @@ run_test(bool stress_test, const char *home, const char *uri)
       file_sz_after / (1024.0 * 1024), file_sz_before / (1024.0 * 1024));
 
     /* Make sure the compact operation has reduced the file size by at least 20%. */
-    testutil_assert(file_sz_before * 0.8 > file_sz_after);
+    testutil_assert((file_sz_before / 100) * 80 > file_sz_after);
 }
 
 static void *

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -164,6 +164,10 @@ run_test(bool stress_test, const char *home, const char *uri)
     }
 
     testutil_check(session->close(session, NULL));
+    session = NULL;
+    
+    testutil_check(conn->close(conn, NULL));
+    conn = NULL;
 
     /* Check if there's at least 10% compaction. */
     printf(" - Compressed file size MB: %f\n - Original file size MB: %f\n",
@@ -199,6 +203,7 @@ thread_func_compact(void *arg)
     testutil_check(session->compact(session, td->uri, NULL));
 
     testutil_check(session->close(session, NULL));
+    session = NULL;
 
     return (NULL);
 }
@@ -258,6 +263,7 @@ thread_func_checkpoint(void *arg)
     }
 
     testutil_check(session->close(session, NULL));
+    session = NULL;
 
     return (NULL);
 }
@@ -287,6 +293,7 @@ populate(WT_SESSION *session, const char *uri)
     }
 
     testutil_check(cursor->close(cursor));
+    cursor = NULL;
 }
 
 static void
@@ -304,6 +311,7 @@ remove_records(WT_SESSION *session, const char *uri)
     }
 
     testutil_check(cursor->close(cursor));
+    cursor = NULL;
 }
 
 static uint64_t
@@ -319,6 +327,7 @@ get_file_size(WT_SESSION *session, const char *uri)
     testutil_check(cur_stat->search(cur_stat));
     testutil_check(cur_stat->get_value(cur_stat, &descr, &str_val, &val));
     testutil_check(cur_stat->close(cur_stat));
+    cur_stat = NULL;
 
     return (val);
 }


### PR DESCRIPTION
This pull request implements the following changes:
1. Change all checkpoints in compact to "wait" checkpoints. This eliminates all conflicts between external (system/application) and internal compact checkpoints. If wait happens, additional checkpoint call shouldn't add too much overhead. Compact operation is expected to take a fairly long time. Adding a little extra delay shouldn't affect general performance too much.
2. "wt7989_compact_checkpoint" test now runs multiple checkpoints in parallel with compact. The first one starts immediately and the following checkpoints start after a random delay.