### PR TITLE
WT-8069 Coverity analysis defect 120706: Redundant test

### DIFF
--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -332,9 +332,6 @@ real_worker(void)
         /* If we have specified to run with mix mode deletes we need to do it in it's own txn. */
         if (g.use_timestamps && g.mixed_mode_deletes && new_txn && __wt_random(&rnd) % 72 == 0) {
             new_txn = false;
-            printf("AAA\n");
-            if (ret != 0)
-                printf("AAA_fail\n");
             for (j = 0; j < g.ntables; j++) {
                 ret = worker_mm_delete(cursors[j], keyno);
                 if (ret == WT_ROLLBACK || ret == WT_PREPARE_CONFLICT)

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -332,7 +332,10 @@ real_worker(void)
         /* If we have specified to run with mix mode deletes we need to do it in it's own txn. */
         if (g.use_timestamps && g.mixed_mode_deletes && new_txn && __wt_random(&rnd) % 72 == 0) {
             new_txn = false;
-            for (j = 0; ret == 0 && j < g.ntables; j++) {
+            printf("AAA\n");
+            if (ret != 0)
+                printf("AAA_fail\n");
+            for (j = 0; j < g.ntables; j++) {
                 ret = worker_mm_delete(cursors[j], keyno);
                 if (ret == WT_ROLLBACK || ret == WT_PREPARE_CONFLICT)
                     break;


### PR DESCRIPTION
In the current implementation, there's no way `ret` can be non-zero. It's safe to just remove the redundant check.