### PR TITLE
WT-8048 Remove split_8 timing stress configuration

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -805,7 +805,7 @@ connection_runtime_config = [
         'failpoint_history_store_delete_key_from_ts', 'failpoint_history_store_insert_1',
         'failpoint_history_store_insert_2', 'history_store_checkpoint_delay',
         'history_store_search', 'history_store_sweep_race', 'prepare_checkpoint_delay', 'split_1',
-        'split_2', 'split_3', 'split_4', 'split_5', 'split_6', 'split_7', 'split_8']),
+        'split_2', 'split_3', 'split_4', 'split_5', 'split_6', 'split_7']),
     Config('verbose', '[]', r'''
         enable messages for various events. Options are given as a
         list, such as <code>"verbose=[evictserver,read]"</code>''',

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -375,9 +375,6 @@ restart:
                 empty_internal = false;
             }
 
-            /* Encourage races. */
-            __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_8);
-
             /* Optionally return internal pages. */
             if (LF_ISSET(WT_READ_SKIP_INTL))
                 continue;

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -145,7 +145,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
     "\"split_1\",\"split_2\",\"split_3\",\"split_4\",\"split_5\","
-    "\"split_6\",\"split_7\",\"split_8\"]",
+    "\"split_6\",\"split_7\"]",
     NULL, 0},
   {"verbose", "list", NULL,
     "choices=[\"api\",\"backup\",\"block\",\"checkpoint\","
@@ -877,7 +877,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
     "\"split_1\",\"split_2\",\"split_3\",\"split_4\",\"split_5\","
-    "\"split_6\",\"split_7\",\"split_8\"]",
+    "\"split_6\",\"split_7\"]",
     NULL, 0},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2},
@@ -959,7 +959,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
     "\"split_1\",\"split_2\",\"split_3\",\"split_4\",\"split_5\","
-    "\"split_6\",\"split_7\",\"split_8\"]",
+    "\"split_6\",\"split_7\"]",
     NULL, 0},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2},
@@ -1038,7 +1038,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
     "\"split_1\",\"split_2\",\"split_3\",\"split_4\",\"split_5\","
-    "\"split_6\",\"split_7\",\"split_8\"]",
+    "\"split_6\",\"split_7\"]",
     NULL, 0},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2},
@@ -1115,7 +1115,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
     "\"split_1\",\"split_2\",\"split_3\",\"split_4\",\"split_5\","
-    "\"split_6\",\"split_7\",\"split_8\"]",
+    "\"split_6\",\"split_7\"]",
     NULL, 0},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2},

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2148,7 +2148,7 @@ __wt_timing_stress_config(WT_SESSION_IMPL *session, const char *cfg[])
       {"split_1", WT_TIMING_STRESS_SPLIT_1}, {"split_2", WT_TIMING_STRESS_SPLIT_2},
       {"split_3", WT_TIMING_STRESS_SPLIT_3}, {"split_4", WT_TIMING_STRESS_SPLIT_4},
       {"split_5", WT_TIMING_STRESS_SPLIT_5}, {"split_6", WT_TIMING_STRESS_SPLIT_6},
-      {"split_7", WT_TIMING_STRESS_SPLIT_7}, {"split_8", WT_TIMING_STRESS_SPLIT_8}, {NULL, 0}};
+      {"split_7", WT_TIMING_STRESS_SPLIT_7}, {NULL, 0}};
     WT_CONFIG_ITEM cval, sval;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -614,7 +614,6 @@ struct __wt_connection_impl {
 #define WT_TIMING_STRESS_SPLIT_5 0x08000u
 #define WT_TIMING_STRESS_SPLIT_6 0x10000u
 #define WT_TIMING_STRESS_SPLIT_7 0x20000u
-#define WT_TIMING_STRESS_SPLIT_8 0x40000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 64 */
     uint64_t timing_stress_flags;
 

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -353,9 +353,6 @@ static CONFIG c[] = {
   /* 2% */
   {"stress.split_7", "stress splits (#7)", C_BOOL, 2, 0, 0, &g.c_timing_stress_split_7, NULL},
 
-  /* 2% */
-  {"stress.split_8", "stress splits (#8)", C_BOOL, 2, 0, 0, &g.c_timing_stress_split_8, NULL},
-
   {"transaction.implicit", "implicit, without timestamps, transactions (percentage)", 0x0, 0, 100,
     100, &g.c_txn_implicit, NULL},
 

--- a/test/format/config_compat.c
+++ b/test/format/config_compat.c
@@ -181,8 +181,6 @@ static const char *list[] = {
   "stress.split_6",
   "timing_stress_split_7=",
   "stress.split_7",
-  "timing_stress_split_8=",
-  "stress.split_8",
   "transaction-frequency=",
   "transaction.frequency",
   "transaction_timestamps=",

--- a/test/format/config_compat.sed
+++ b/test/format/config_compat.sed
@@ -78,7 +78,6 @@ s/^stress.split_4=/timing_stress_split_4=/
 s/^stress.split_5=/timing_stress_split_5=/
 s/^stress.split_6=/timing_stress_split_6=/
 s/^stress.split_7=/timing_stress_split_7=/
-s/^stress.split_8=/timing_stress_split_8=/
 s/^transaction.frequency=/transaction-frequency=/
 s/^transaction.isolation=/isolation=/
 s/^transaction.timestamps=/transaction_timestamps=/

--- a/test/format/failure_configs/CONFIG.WT-5637
+++ b/test/format/failure_configs/CONFIG.WT-5637
@@ -91,7 +91,6 @@ stress.split_4=0
 stress.split_5=0
 stress.split_6=0
 stress.split_7=0
-stress.split_8=0
 transaction.frequency=100
 transaction.isolation=snapshot
 transaction.rollback_to_stable=0

--- a/test/format/failure_configs/CONFIG.WT-6568
+++ b/test/format/failure_configs/CONFIG.WT-6568
@@ -90,7 +90,6 @@ stress.split_4=0
 stress.split_5=0
 stress.split_6=1
 stress.split_7=0
-stress.split_8=0
 transaction.frequency=100
 transaction.isolation=snapshot
 transaction.rollback_to_stable=0

--- a/test/format/failure_configs/CONFIG.WT-6725
+++ b/test/format/failure_configs/CONFIG.WT-6725
@@ -90,7 +90,6 @@
     stress.split_5=0
     stress.split_6=0
     stress.split_7=0
-    stress.split_8=0
     transaction.frequency=100
     transaction.isolation=snapshot
     transaction.rollback_to_stable=0

--- a/test/format/failure_configs/CONFIG.WT-6727
+++ b/test/format/failure_configs/CONFIG.WT-6727
@@ -87,7 +87,6 @@ stress.split_4=0
 stress.split_5=0
 stress.split_6=0
 stress.split_7=0
-stress.split_8=0
 transaction.frequency=100
 transaction.isolation=snapshot
 transaction.timestamps=1

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -264,7 +264,6 @@ typedef struct {
     uint32_t c_timing_stress_split_5;
     uint32_t c_timing_stress_split_6;
     uint32_t c_timing_stress_split_7;
-    uint32_t c_timing_stress_split_8;
     uint32_t c_truncate;
     uint32_t c_txn_implicit;
     uint32_t c_txn_timestamps;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -292,8 +292,6 @@ create_database(const char *home, WT_CONNECTION **connp)
         CONFIG_APPEND(p, ",split_6");
     if (g.c_timing_stress_split_7)
         CONFIG_APPEND(p, ",split_7");
-    if (g.c_timing_stress_split_8)
-        CONFIG_APPEND(p, ",split_8");
     CONFIG_APPEND(p, "]");
 
     /* Extensions. */
@@ -523,8 +521,6 @@ wts_open(const char *home, WT_CONNECTION **connp, WT_SESSION **sessionp, bool al
         CONFIG_APPEND(p, ",split_6");
     if (g.c_timing_stress_split_7)
         CONFIG_APPEND(p, ",split_7");
-    if (g.c_timing_stress_split_8)
-        CONFIG_APPEND(p, ",split_8");
     CONFIG_APPEND(p, "]");
 
     /* If in-memory, there's only a single, shared WT_CONNECTION handle. */


### PR DESCRIPTION
Removing the split_8 timing configuration given this particular stress timing option hasn't really be useful in finding/detecting
any race conditions (since being added). Additionally using the split_8 timing stress during stress tests runs adds a significant
run time i.e multiple hours, slowing the system down to a crawl.