### PR TITLE
WT-8161 Reduce verbosity of CMake Evergreen smoke

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -317,7 +317,7 @@ functions:
         if [ ${is_cmake_build|false} = true ]; then
           . test/evergreen/find_cmake.sh
           cd cmake_build
-          ${test_env_vars|} $CTEST -L check ${smp_command|} -VV 2>&1
+          ${test_env_vars|} $CTEST -L check ${smp_command|} --output-on-failure 2>&1
         else
           cd build_posix
           ${test_env_vars|} ${make_command|make} VERBOSE=1 check ${smp_command|} 2>&1


### PR DESCRIPTION
Currently when ctest executes the smoke target, it does so with the verbosity option '-VV'. When parsing the logs for potential failures, this gets extremely noisy and hard to parse, since multiple parallel test outputs are interleaved with each other. 

To simplify this, remove the 'VV' option and replace it with 'output-on-failure'. This ensures all the output for a failing test will be logged, whilst successful test output will not be logged.