### PR TITLE
WT-8036 Added connection panic flag in two assert statements in wt_evict_thread_run and _wt_evict_thread_stop.

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -285,7 +285,7 @@ __wt_evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
      * busy and then opens a different file (in this case, the HS file), it can deadlock with a
      * thread waiting for the first file to drain from the eviction queue. See WT-5946 for details.
      */
-    WT_RET(__wt_curhs_cache(session));
+    WT_ERR(__wt_curhs_cache(session));
     if (conn->evict_server_running && __wt_spin_trylock(session, &cache->evict_pass_lock) == 0) {
         /*
          * Cannot use WT_WITH_PASS_LOCK because this is a try lock. Fix when that is supported. We
@@ -349,10 +349,11 @@ __wt_evict_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
     WT_WITH_PASS_LOCK(session, ret = __evict_clear_all_walks(session));
     WT_ERR(ret);
     /*
-     * The only two cases when the eviction server is expected to stop are when recovery is finished
-     * or when the connection is closing.
+     * The only three cases when the eviction server is expected to stop are when recovery is
+     * finished, when the connection is closing or when an error has occurred and connection panic
+     * flag is set.
      */
-    WT_ASSERT(session, F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_RECOVERING));
+    WT_ASSERT(session, F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_RECOVERING | WT_CONN_PANIC));
 
     /* Clear the eviction thread session flag. */
     F_CLR(session, WT_SESSION_EVICTION);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -349,11 +349,11 @@ __wt_evict_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
     WT_WITH_PASS_LOCK(session, ret = __evict_clear_all_walks(session));
     WT_ERR(ret);
     /*
-     * The only three cases when the eviction server is expected to stop are when recovery is
-     * finished, when the connection is closing or when an error has occurred and connection panic
-     * flag is set.
+     * The only cases when the eviction server is expected to stop are when recovery is finished,
+     * when the connection is closing or when an error has occurred and connection panic flag is
+     * set.
      */
-    WT_ASSERT(session, F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_RECOVERING | WT_CONN_PANIC));
+    WT_ASSERT(session, F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_PANIC | WT_CONN_RECOVERING));
 
     /* Clear the eviction thread session flag. */
     F_CLR(session, WT_SESSION_EVICTION);

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -42,7 +42,7 @@ err:
         WT_IGNORE_RET(__wt_panic(session, ret, "Unrecoverable utility thread error"));
 
     /*
-     * The four cases when threads are expected to stop are:
+     * The cases when threads are expected to stop are:
      * 1.  When recovery is done.
      * 2.  When the connection is closing.
      * 3.  When a shutdown has been requested via clearing the run flag.
@@ -50,7 +50,7 @@ err:
      */
     WT_ASSERT(session,
       !F_ISSET(thread, WT_THREAD_RUN) ||
-        F_ISSET(S2C(session), WT_CONN_CLOSING | WT_CONN_RECOVERING | WT_CONN_PANIC));
+        F_ISSET(S2C(session), WT_CONN_CLOSING | WT_CONN_PANIC | WT_CONN_RECOVERING));
 
     return (WT_THREAD_RET_VALUE);
 }

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -42,14 +42,15 @@ err:
         WT_IGNORE_RET(__wt_panic(session, ret, "Unrecoverable utility thread error"));
 
     /*
-     * The three cases when threads are expected to stop are:
+     * The four cases when threads are expected to stop are:
      * 1.  When recovery is done.
      * 2.  When the connection is closing.
      * 3.  When a shutdown has been requested via clearing the run flag.
+     * 4.  When an error has occurred and the connection panic flag is set.
      */
     WT_ASSERT(session,
       !F_ISSET(thread, WT_THREAD_RUN) ||
-        F_ISSET(S2C(session), WT_CONN_CLOSING | WT_CONN_RECOVERING));
+        F_ISSET(S2C(session), WT_CONN_CLOSING | WT_CONN_RECOVERING | WT_CONN_PANIC));
 
     return (WT_THREAD_RET_VALUE);
 }


### PR DESCRIPTION
I believe that since the eviction threads are also stopped (or __wt_evict_thread_stop is called) if an error has occurred in __thread_run, we should also expect the same. Hence, added the WT_CONN_PANIC flag in two assert statements in wt_evict_thread_run and _wt_evict_thread_stop.