### PR TITLE
WT-8162 Remove SMOKE arg in 'define_c_test' helper

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -34,18 +34,21 @@ define_c_test(
     TARGET ex_access
     SOURCES ex_access.c
     DIR_NAME ex_access
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_access>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_all
     SOURCES ex_all.c
     DIR_NAME ex_all
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_all>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_backup
     SOURCES ex_backup.c
     DIR_NAME ex_backup
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_backup>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -53,6 +56,7 @@ define_c_test(
     TARGET ex_backup_block
     SOURCES ex_backup_block.c
     DIR_NAME ex_backup_block
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_backup_block>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -60,71 +64,83 @@ define_c_test(
     TARGET ex_call_center
     SOURCES ex_call_center.c
     DIR_NAME ex_call_center
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_call_center>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_col_store
     SOURCES ex_col_store.c
     DIR_NAME ex_col_store
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_col_store>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_config_parse
     SOURCES ex_config_parse.c
     DIR_NAME ex_config_parse
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_config_parse>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_cursor
     SOURCES ex_cursor.c
     DIR_NAME ex_cursor
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_cursor>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_data_source
     SOURCES ex_data_source.c
     DIR_NAME ex_data_source
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_data_source>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_encrypt
     SOURCES ex_encrypt.c
     DIR_NAME ex_encrypt
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_encrypt>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_event_handler
     SOURCES ex_event_handler.c
     DIR_NAME ex_event_handler
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_event_handler>/WT_HOME
 )
 define_c_test(
     TARGET ex_extending
     SOURCES ex_extending.c
     DIR_NAME ex_extending
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_extending>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_extractor
     SOURCES ex_extractor.c
     DIR_NAME ex_extractor
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_extractor>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_file_system
     SOURCES ex_file_system.c
     DIR_NAME ex_file_system
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_file_system>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_hello
     SOURCES ex_hello.c
     DIR_NAME ex_hello
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_hello>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_log
     SOURCES ex_log.c
     DIR_NAME ex_log
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_log>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -132,24 +148,28 @@ define_c_test(
     TARGET ex_pack
     SOURCES ex_pack.c
     DIR_NAME ex_pack
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_pack>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_process
     SOURCES ex_process.c
     DIR_NAME ex_process
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_process>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_schema
     SOURCES ex_schema.c
     DIR_NAME ex_schema
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_schema>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_smoke
     SOURCES ex_smoke.c
     DIR_NAME ex_smoke
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_smoke>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -157,12 +177,14 @@ define_c_test(
     TARGET ex_stat
     SOURCES ex_stat.c
     DIR_NAME ex_stat
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_stat>/WT_HOME
 )
 
 define_c_test(
     TARGET ex_thread
     SOURCES ex_thread.c
     DIR_NAME ex_thread
+    ARGUMENTS -h $<TARGET_FILE_DIR:ex_thread>/WT_HOME
 )
 
 if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
@@ -170,6 +192,3 @@ if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     target_link_libraries(ex_encrypt "-rdynamic")
     target_link_libraries(ex_file_system "-rdynamic")
 endif()
-
-# Run this during a "ctest check" or "ctest examples" smoke test
-set_tests_properties(${c_tests} PROPERTIES LABELS "check;examples")

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -34,21 +34,21 @@ define_c_test(
     TARGET ex_access
     SOURCES ex_access.c
     DIR_NAME ex_access
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_access>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_access>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_all
     SOURCES ex_all.c
     DIR_NAME ex_all
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_all>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_all>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_backup
     SOURCES ex_backup.c
     DIR_NAME ex_backup
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_backup>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_backup>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -56,7 +56,7 @@ define_c_test(
     TARGET ex_backup_block
     SOURCES ex_backup_block.c
     DIR_NAME ex_backup_block
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_backup_block>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_backup_block>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -64,83 +64,83 @@ define_c_test(
     TARGET ex_call_center
     SOURCES ex_call_center.c
     DIR_NAME ex_call_center
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_call_center>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_call_center>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_col_store
     SOURCES ex_col_store.c
     DIR_NAME ex_col_store
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_col_store>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_col_store>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_config_parse
     SOURCES ex_config_parse.c
     DIR_NAME ex_config_parse
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_config_parse>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_config_parse>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_cursor
     SOURCES ex_cursor.c
     DIR_NAME ex_cursor
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_cursor>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_cursor>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_data_source
     SOURCES ex_data_source.c
     DIR_NAME ex_data_source
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_data_source>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_data_source>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_encrypt
     SOURCES ex_encrypt.c
     DIR_NAME ex_encrypt
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_encrypt>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_encrypt>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_event_handler
     SOURCES ex_event_handler.c
     DIR_NAME ex_event_handler
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_event_handler>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_event_handler>/WT_HOME>
 )
 define_c_test(
     TARGET ex_extending
     SOURCES ex_extending.c
     DIR_NAME ex_extending
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_extending>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_extending>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_extractor
     SOURCES ex_extractor.c
     DIR_NAME ex_extractor
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_extractor>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_extractor>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_file_system
     SOURCES ex_file_system.c
     DIR_NAME ex_file_system
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_file_system>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_file_system>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_hello
     SOURCES ex_hello.c
     DIR_NAME ex_hello
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_hello>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_hello>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_log
     SOURCES ex_log.c
     DIR_NAME ex_log
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_log>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_log>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -148,28 +148,28 @@ define_c_test(
     TARGET ex_pack
     SOURCES ex_pack.c
     DIR_NAME ex_pack
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_pack>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_pack>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_process
     SOURCES ex_process.c
     DIR_NAME ex_process
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_process>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_process>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_schema
     SOURCES ex_schema.c
     DIR_NAME ex_schema
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_schema>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_schema>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_smoke
     SOURCES ex_smoke.c
     DIR_NAME ex_smoke
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_smoke>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_smoke>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -177,14 +177,14 @@ define_c_test(
     TARGET ex_stat
     SOURCES ex_stat.c
     DIR_NAME ex_stat
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_stat>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_stat>/WT_HOME>
 )
 
 define_c_test(
     TARGET ex_thread
     SOURCES ex_thread.c
     DIR_NAME ex_thread
-    ARGUMENTS -h $<TARGET_FILE_DIR:ex_thread>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:ex_thread>/WT_HOME>
 )
 
 if(NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -346,6 +346,3 @@ define_c_test(
     ARGUMENTS -h $<TARGET_FILE_DIR:test_wt8057_compact_stress>/WT_HOME
     DEPENDS "WT_POSIX"
 )
-
-# Run this during a "ctest check" or "ctest csuite" smoke test
-set_tests_properties(${c_tests} PROPERTIES LABELS "check;csuite")

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -156,8 +156,9 @@ define_c_test(
     TARGET test_wt2447_join_main_table
     SOURCES wt2447_join_main_table/main.c
     DIR_NAME wt2447_join_main_table
-    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2447_join_main_table/smoke.sh
-    ARGUMENTS $<TARGET_FILE:test_wt2447_join_main_table>
+    VARIANTS
+        "test_wt2447_join_main_table_row;-t r"
+        "test_wt2447_join_main_table_col;-t c"
 )
 
 define_c_test(

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -65,7 +65,7 @@ define_c_test(
     TARGET test_rwlock
     SOURCES rwlock/main.c
     DIR_NAME rwlock
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_rwlock>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_rwlock>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -82,7 +82,7 @@ define_c_test(
     TARGET test_scope
     SOURCES scope/main.c
     DIR_NAME scope
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_scope>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_scope>/WT_HOME>
 )
 
 define_c_test(
@@ -116,7 +116,7 @@ define_c_test(
     TARGET test_wt1965_col_efficiency
     SOURCES wt1965_col_efficiency/main.c
     DIR_NAME wt1965_col_efficiency
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt1965_col_efficiency>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt1965_col_efficiency>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -124,7 +124,7 @@ define_c_test(
     TARGET test_wt2403_lsm_workload
     SOURCES wt2403_lsm_workload/main.c
     DIR_NAME wt2403_lsm_workload
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -132,14 +132,14 @@ define_c_test(
     TARGET test_wt2246_col_append
     SOURCES wt2246_col_append/main.c
     DIR_NAME wt2246_col_append
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2246_col_append>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2246_col_append>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt2323_join_visibility
     SOURCES wt2323_join_visibility/main.c
     DIR_NAME wt2323_join_visibility
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -165,21 +165,21 @@ define_c_test(
     TARGET test_wt2695_checksum
     SOURCES wt2695_checksum/main.c
     DIR_NAME wt2695_checksum
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2695_checksum>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2695_checksum>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt2592_join_schema
     SOURCES wt2592_join_schema/main.c
     DIR_NAME wt2592_join_schema
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2592_join_schema>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2592_join_schema>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt2834_join_bloom_fix
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME>
 )
 
 define_c_test(
@@ -208,7 +208,7 @@ define_c_test(
     TARGET test_wt2999_join_extractor
     SOURCES wt2999_join_extractor/main.c
     DIR_NAME wt2999_join_extractor
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2999_join_extractor>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2999_join_extractor>/WT_HOME>
 )
 
 define_c_test(
@@ -219,7 +219,7 @@ define_c_test(
     # and build directory as this path is more dynamic compared to layout autoconf
     # produces in build_posix.
     FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
-    ARGUMENTS -b ${CMAKE_BINARY_DIR} -h $<TARGET_FILE_DIR:test_wt3120_filesys>/WT_HOME
+    ARGUMENTS -b ${CMAKE_BINARY_DIR} -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3120_filesys>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -227,21 +227,21 @@ define_c_test(
     TARGET test_wt3135_search_near_collator
     SOURCES wt3135_search_near_collator/main.c
     DIR_NAME wt3135_search_near_collator
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3135_search_near_collator>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3135_search_near_collator>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt3184_dup_index_collator
     SOURCES wt3184_dup_index_collator/main.c
     DIR_NAME wt3184_dup_index_collator
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3184_dup_index_collator>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3184_dup_index_collator>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt3338_partial_update
     SOURCES wt3338_partial_update/main.c
     DIR_NAME wt3338_partial_update
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -249,7 +249,7 @@ define_c_test(
     TARGET test_wt3363_checkpoint_op_races
     SOURCES wt3363_checkpoint_op_races/main.c
     DIR_NAME wt3363_checkpoint_op_races
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3363_checkpoint_op_races>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3363_checkpoint_op_races>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -257,7 +257,7 @@ define_c_test(
     TARGET test_wt3874_pad_byte_collator
     SOURCES wt3874_pad_byte_collator/main.c
     DIR_NAME wt3874_pad_byte_collator
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3874_pad_byte_collator>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3874_pad_byte_collator>/WT_HOME>
 )
 
 define_c_test(
@@ -273,14 +273,14 @@ define_c_test(
     TARGET test_wt4117_checksum
     SOURCES wt4117_checksum/main.c
     DIR_NAME wt4117_checksum
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4117_checksum>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4117_checksum>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt4156_metadata_salvage
     SOURCES wt4156_metadata_salvage/main.c
     DIR_NAME wt4156_metadata_salvage
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4156_metadata_salvage>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4156_metadata_salvage>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -288,7 +288,7 @@ define_c_test(
     TARGET test_wt4333_handle_locks
     SOURCES wt4333_handle_locks/main.c
     DIR_NAME wt4333_handle_locks
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4333_handle_locks>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4333_handle_locks>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -296,14 +296,14 @@ define_c_test(
     TARGET test_wt4699_json
     SOURCES wt4699_json/main.c
     DIR_NAME wt4699_json
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4699_json>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4699_json>/WT_HOME>
 )
 
 define_c_test(
     TARGET test_wt4803_history_store_abort
     SOURCES wt4803_history_store_abort/main.c
     DIR_NAME wt4803_history_store_abort
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4803_history_store_abort>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4803_history_store_abort>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -311,7 +311,7 @@ define_c_test(
     TARGET test_wt4891_meta_ckptlist_get_alloc
     SOURCES wt4891_meta_ckptlist_get_alloc/main.c
     DIR_NAME wt4891_meta_ckptlist_get_alloc
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4891_meta_ckptlist_get_alloc>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt4891_meta_ckptlist_get_alloc>/WT_HOME>
 )
 
 define_c_test(
@@ -336,7 +336,7 @@ define_c_test(
     TARGET test_wt7989_compact_checkpoint
     SOURCES wt7989_compact_checkpoint/main.c
     DIR_NAME wt7989_compact_checkpoint
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
 
@@ -344,6 +344,6 @@ define_c_test(
     TARGET test_wt8057_compact_stress
     SOURCES wt8057_compact_stress/main.c
     DIR_NAME wt8057_compact_stress
-    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt8057_compact_stress>/WT_HOME
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8057_compact_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
 )

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -36,7 +36,8 @@ define_c_test(
     TARGET test_incr_backup
     SOURCES incr_backup/main.c
     DIR_NAME incr_backup
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/incr_backup/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_incr_backup>
     DEPENDS "WT_POSIX"
 )
 
@@ -44,7 +45,8 @@ define_c_test(
     TARGET test_random_abort
     SOURCES random_abort/main.c
     DIR_NAME random_abort
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/random_abort/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_random_abort>
     DEPENDS "WT_POSIX"
 )
 
@@ -54,7 +56,8 @@ define_c_test(
         random_directio/main.c
         random_directio/util.c
     DIR_NAME random_directio
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/random_directio/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_random_directio>
     DEPENDS "WT_POSIX"
 )
 
@@ -69,7 +72,8 @@ define_c_test(
     TARGET test_schema_abort
     SOURCES schema_abort/main.c
     DIR_NAME schema_abort
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/schema_abort/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_schema_abort>
     DEPENDS "WT_POSIX"
 )
 
@@ -83,7 +87,7 @@ define_c_test(
     TARGET test_tiered_abort
     SOURCES tiered_abort/main.c
     DIR_NAME tiered_abort
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/tiered_abort/smoke.sh
     ARGUMENTS -b $<TARGET_FILE:test_tiered_abort>
     DEPENDS "WT_POSIX"
 )
@@ -92,7 +96,7 @@ define_c_test(
     TARGET test_timestamp_abort
     SOURCES timestamp_abort/main.c
     DIR_NAME timestamp_abort
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/timestamp_abort/smoke.sh
     ARGUMENTS -b $<TARGET_FILE:test_timestamp_abort>
     DEPENDS "WT_POSIX"
 )
@@ -101,7 +105,8 @@ define_c_test(
     TARGET test_truncated_log
     SOURCES truncated_log/main.c
     DIR_NAME truncated_log
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/truncated_log/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_truncated_log>
     DEPENDS "WT_POSIX"
 )
 
@@ -136,7 +141,8 @@ define_c_test(
     TARGET test_wt2535_insert_race
     SOURCES wt2535_insert_race/main.c
     DIR_NAME wt2535_insert_race
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2535_insert_race/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt2535_insert_race>
     DEPENDS "WT_POSIX"
 )
 
@@ -144,7 +150,8 @@ define_c_test(
     TARGET test_wt2447_join_main_table
     SOURCES wt2447_join_main_table/main.c
     DIR_NAME wt2447_join_main_table
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2447_join_main_table/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt2447_join_main_table>
 )
 
 define_c_test(
@@ -169,7 +176,8 @@ define_c_test(
     TARGET test_wt2853_perf
     SOURCES wt2853_perf/main.c
     DIR_NAME wt2853_perf
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2853_perf/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt2853_perf>
     DEPENDS "WT_POSIX"
 )
 
@@ -181,8 +189,8 @@ define_c_test(
     # and build directory as this path is more dynamic compared to layout autoconf
     # produces in build_posix.
     FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
-    ARGUMENTS -b ${CMAKE_BINARY_DIR}
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2909_checkpoint_integrity/smoke.sh
+    ARGUMENTS -b ${CMAKE_BINARY_DIR} $<TARGET_FILE:test_wt2909_checkpoint_integrity>
     DEPENDS "WT_POSIX"
 )
 
@@ -240,7 +248,8 @@ define_c_test(
     TARGET test_wt4105_large_doc_small_upd
     SOURCES wt4105_large_doc_small_upd/main.c
     DIR_NAME wt4105_large_doc_small_upd
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt4105_large_doc_small_upd/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt4105_large_doc_small_upd>
     DEPENDS "WT_POSIX"
 )
 
@@ -287,7 +296,8 @@ define_c_test(
     TARGET test_wt6185_modify_ts
     SOURCES wt6185_modify_ts/main.c
     DIR_NAME wt6185_modify_ts
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt6185_modify_ts/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt6185_modify_ts>
     DEPENDS "WT_POSIX"
 )
 
@@ -295,7 +305,8 @@ define_c_test(
     TARGET test_wt6616_checkpoint_oldest_ts
     SOURCES wt6616_checkpoint_oldest_ts/main.c
     DIR_NAME wt6616_checkpoint_oldest_ts
-    SMOKE
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt6616_checkpoint_oldest_ts/smoke.sh
+    ARGUMENTS $<TARGET_FILE:test_wt6616_checkpoint_oldest_ts>
     DEPENDS "WT_POSIX"
 )
 

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -65,6 +65,7 @@ define_c_test(
     TARGET test_rwlock
     SOURCES rwlock/main.c
     DIR_NAME rwlock
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_rwlock>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -81,6 +82,7 @@ define_c_test(
     TARGET test_scope
     SOURCES scope/main.c
     DIR_NAME scope
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_scope>/WT_HOME
 )
 
 define_c_test(
@@ -114,6 +116,7 @@ define_c_test(
     TARGET test_wt1965_col_efficiency
     SOURCES wt1965_col_efficiency/main.c
     DIR_NAME wt1965_col_efficiency
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt1965_col_efficiency>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -121,6 +124,7 @@ define_c_test(
     TARGET test_wt2403_lsm_workload
     SOURCES wt2403_lsm_workload/main.c
     DIR_NAME wt2403_lsm_workload
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -128,12 +132,14 @@ define_c_test(
     TARGET test_wt2246_col_append
     SOURCES wt2246_col_append/main.c
     DIR_NAME wt2246_col_append
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2246_col_append>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt2323_join_visibility
     SOURCES wt2323_join_visibility/main.c
     DIR_NAME wt2323_join_visibility
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -158,18 +164,21 @@ define_c_test(
     TARGET test_wt2695_checksum
     SOURCES wt2695_checksum/main.c
     DIR_NAME wt2695_checksum
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2695_checksum>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt2592_join_schema
     SOURCES wt2592_join_schema/main.c
     DIR_NAME wt2592_join_schema
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2592_join_schema>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt2834_join_bloom_fix
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME
 )
 
 define_c_test(
@@ -198,6 +207,7 @@ define_c_test(
     TARGET test_wt2999_join_extractor
     SOURCES wt2999_join_extractor/main.c
     DIR_NAME wt2999_join_extractor
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt2999_join_extractor>/WT_HOME
 )
 
 define_c_test(
@@ -208,7 +218,7 @@ define_c_test(
     # and build directory as this path is more dynamic compared to layout autoconf
     # produces in build_posix.
     FLAGS "-DWT_FAIL_FS_LIB=\"ext/test/fail_fs/libwiredtiger_fail_fs.so\""
-    ARGUMENTS -b ${CMAKE_BINARY_DIR}
+    ARGUMENTS -b ${CMAKE_BINARY_DIR} -h $<TARGET_FILE_DIR:test_wt3120_filesys>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -216,18 +226,21 @@ define_c_test(
     TARGET test_wt3135_search_near_collator
     SOURCES wt3135_search_near_collator/main.c
     DIR_NAME wt3135_search_near_collator
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3135_search_near_collator>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt3184_dup_index_collator
     SOURCES wt3184_dup_index_collator/main.c
     DIR_NAME wt3184_dup_index_collator
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3184_dup_index_collator>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt3338_partial_update
     SOURCES wt3338_partial_update/main.c
     DIR_NAME wt3338_partial_update
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -235,6 +248,7 @@ define_c_test(
     TARGET test_wt3363_checkpoint_op_races
     SOURCES wt3363_checkpoint_op_races/main.c
     DIR_NAME wt3363_checkpoint_op_races
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3363_checkpoint_op_races>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -242,6 +256,7 @@ define_c_test(
     TARGET test_wt3874_pad_byte_collator
     SOURCES wt3874_pad_byte_collator/main.c
     DIR_NAME wt3874_pad_byte_collator
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt3874_pad_byte_collator>/WT_HOME
 )
 
 define_c_test(
@@ -257,12 +272,14 @@ define_c_test(
     TARGET test_wt4117_checksum
     SOURCES wt4117_checksum/main.c
     DIR_NAME wt4117_checksum
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4117_checksum>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt4156_metadata_salvage
     SOURCES wt4156_metadata_salvage/main.c
     DIR_NAME wt4156_metadata_salvage
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4156_metadata_salvage>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -270,6 +287,7 @@ define_c_test(
     TARGET test_wt4333_handle_locks
     SOURCES wt4333_handle_locks/main.c
     DIR_NAME wt4333_handle_locks
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4333_handle_locks>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -277,12 +295,14 @@ define_c_test(
     TARGET test_wt4699_json
     SOURCES wt4699_json/main.c
     DIR_NAME wt4699_json
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4699_json>/WT_HOME
 )
 
 define_c_test(
     TARGET test_wt4803_history_store_abort
     SOURCES wt4803_history_store_abort/main.c
     DIR_NAME wt4803_history_store_abort
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4803_history_store_abort>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -290,6 +310,7 @@ define_c_test(
     TARGET test_wt4891_meta_ckptlist_get_alloc
     SOURCES wt4891_meta_ckptlist_get_alloc/main.c
     DIR_NAME wt4891_meta_ckptlist_get_alloc
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt4891_meta_ckptlist_get_alloc>/WT_HOME
 )
 
 define_c_test(
@@ -314,6 +335,7 @@ define_c_test(
     TARGET test_wt7989_compact_checkpoint
     SOURCES wt7989_compact_checkpoint/main.c
     DIR_NAME wt7989_compact_checkpoint
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 
@@ -321,6 +343,7 @@ define_c_test(
     TARGET test_wt8057_compact_stress
     SOURCES wt8057_compact_stress/main.c
     DIR_NAME wt8057_compact_stress
+    ARGUMENTS -h $<TARGET_FILE_DIR:test_wt8057_compact_stress>/WT_HOME
     DEPENDS "WT_POSIX"
 )
 

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -237,7 +237,7 @@ macro(define_c_test)
             set(exec_wrapper "powershell.exe")
         endif()
         if (C_TEST_EXEC_SCRIPT)
-            # csuite test comes with a smoke execution wrapper.
+            # Define the c test to be executed with a script, rather than invoking the binary directly.
             create_test_executable(${C_TEST_TARGET}
                 SOURCES ${C_TEST_SOURCES}
                 ADDITIONAL_FILES ${C_TEST_EXEC_SCRIPT}

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -255,14 +255,8 @@ macro(define_c_test)
                 BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
                 ${additional_executable_args}
             )
-            # Take a CMake-based path and convert it to a platform-specfic path (/ for Unix, \ for Windows).
-            set(wt_test_home_dir ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}/WT_HOME_${C_TEST_TARGET})
-            file(TO_NATIVE_PATH "${wt_test_home_dir}" wt_test_home_dir)
-            # Ensure each DB home directory is run under the tests working directory.
-            set(command_args -h ${wt_test_home_dir})
-            list(APPEND command_args ${C_TEST_ARGUMENTS})
             add_test(NAME ${C_TEST_TARGET}
-                COMMAND ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}> ${command_args}
+                COMMAND ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}> ${C_TEST_ARGUMENTS}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
             )
         endif()

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -204,8 +204,8 @@ endfunction()
 macro(define_c_test)
     cmake_parse_arguments(
         "C_TEST"
-        "SMOKE"
-        "TARGET;DIR_NAME;DEPENDS"
+        ""
+        "TARGET;DIR_NAME;DEPENDS;EXEC_SCRIPT"
         "SOURCES;FLAGS;ARGUMENTS"
         ${ARGN}
     )
@@ -236,16 +236,17 @@ macro(define_c_test)
             # Which while technically valid breaks assumptions in our testing utilities. Wrap the execution in powershell to avoid this.
             set(exec_wrapper "powershell.exe")
         endif()
-        if (C_TEST_SMOKE)
+        if (C_TEST_EXEC_SCRIPT)
             # csuite test comes with a smoke execution wrapper.
             create_test_executable(${C_TEST_TARGET}
                 SOURCES ${C_TEST_SOURCES}
-                ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${C_TEST_DIR_NAME}/smoke.sh
+                ADDITIONAL_FILES ${C_TEST_EXEC_SCRIPT}
                 BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
                 ${additional_executable_args}
             )
+            get_filename_component(exec_script_basename ${C_TEST_EXEC_SCRIPT} NAME)
             add_test(NAME ${C_TEST_TARGET}
-                COMMAND ${exec_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}/smoke.sh ${C_TEST_ARGUMENTS} $<TARGET_FILE:${C_TEST_TARGET}>
+                COMMAND ${exec_wrapper} ${exec_script_basename} ${C_TEST_ARGUMENTS}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
             )
         else()

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -153,14 +153,21 @@ function(define_test_variants target)
         1
         "DEFINE_TEST"
         ""
-        ""
+        "CMD;DIR_NAME"
         "VARIANTS;LABELS"
     )
     if (NOT "${DEFINE_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to define_test_variants: ${DEFINE_TEST_VARIANTS_UNPARSED_ARGUMENTS}")
+        message(FATAL_ERROR "Unknown arguments to define_test_variants: ${DEFINE_TEST_UNPARSED_ARGUMENTS}")
     endif()
     if ("${DEFINE_TEST_VARIANTS}" STREQUAL "")
         message(FATAL_ERROR "Need at least one variant for define_test_variants")
+    endif()
+
+    set(dir_prefix)
+    if(DEFINE_TEST_DIR_NAME)
+        set(dir_prefix ${CMAKE_CURRENT_BINARY_DIR}/${DEFINE_TEST_DIR_NAME})
+    else()
+        set(dir_prefix ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 
     set(defined_tests)
@@ -182,17 +189,23 @@ function(define_test_variants target)
         endif()
         # Create a variant directory to run the test in.
         add_custom_command(OUTPUT ${curr_variant_name}_test_dir
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name}_test_dir
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${dir_prefix}/${curr_variant_name}_test_dir
         )
         add_custom_target(create_dir_${curr_variant_name} DEPENDS ${curr_variant_name}_test_dir)
         # Ensure the variant target is created prior to building the test.
         add_dependencies(${target} create_dir_${curr_variant_name})
+        set(test_cmd)
+        if(DEFINE_TEST_CMD)
+            set(test_cmd ${DEFINE_TEST_CMD})
+        else()
+            set(test_cmd $<TARGET_FILE:${target}>)
+        endif()
         add_test(
             NAME ${curr_variant_name}
-            COMMAND $<TARGET_FILE:${target}> ${variant_args}
+            COMMAND ${test_cmd} ${variant_args}
             # Run each variant in its own subdirectory, allowing us to execute variants in
             # parallel.
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${curr_variant_name}_test_dir
+            WORKING_DIRECTORY ${dir_prefix}/${curr_variant_name}_test_dir
         )
         list(APPEND defined_tests ${curr_variant_name})
     endforeach()
@@ -201,13 +214,14 @@ function(define_test_variants target)
     endif()
 endfunction()
 
-macro(define_c_test)
+function(define_c_test)
     cmake_parse_arguments(
+        PARSE_ARGV
+        0
         "C_TEST"
         ""
         "TARGET;DIR_NAME;DEPENDS;EXEC_SCRIPT"
-        "SOURCES;FLAGS;ARGUMENTS"
-        ${ARGN}
+        "SOURCES;FLAGS;ARGUMENTS;VARIANTS"
     )
     if (NOT "${C_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
         message(FATAL_ERROR "Unknown arguments to define_c_test: ${C_TEST_UNPARSED_ARGUMENTS}")
@@ -220,6 +234,10 @@ macro(define_c_test)
     endif()
     if ("${C_TEST_DIR_NAME}" STREQUAL "")
         message(FATAL_ERROR "No directory given to define_c_test")
+    endif()
+
+    if("${C_TEST_ARGUMENTS}" AND "${C_TEST_VARIANTS}")
+        message(FATAL_ERROR "Can't pass both ARGUMENTS and VARIANTS, use only one")
     endif()
 
     # Check that the csuite dependencies are enabled before compiling and creating the test.
@@ -236,6 +254,7 @@ macro(define_c_test)
             # Which while technically valid breaks assumptions in our testing utilities. Wrap the execution in powershell to avoid this.
             set(exec_wrapper "powershell.exe")
         endif()
+        set(test_cmd)
         if (C_TEST_EXEC_SCRIPT)
             # Define the c test to be executed with a script, rather than invoking the binary directly.
             create_test_executable(${C_TEST_TARGET}
@@ -245,21 +264,32 @@ macro(define_c_test)
                 ${additional_executable_args}
             )
             get_filename_component(exec_script_basename ${C_TEST_EXEC_SCRIPT} NAME)
-            add_test(NAME ${C_TEST_TARGET}
-                COMMAND ${exec_wrapper} ${exec_script_basename} ${C_TEST_ARGUMENTS}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
-            )
+            set(test_cmd ${exec_wrapper} ${exec_script_basename})
         else()
             create_test_executable(${C_TEST_TARGET}
                 SOURCES ${C_TEST_SOURCES}
                 BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
                 ${additional_executable_args}
             )
+            set(test_cmd ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}>)
+        endif()
+        # Define the ctest target.
+        if(C_TEST_VARIANTS)
+            # We need to pass a string literal to 'define_test_variants' as 'CMD' is a single value parameter.
+            string (REPLACE ";" " " test_cmd "${test_cmd}")
+            # If we want to define multiple variant executions of the test script/binary.
+            define_test_variants(${C_TEST_TARGET}
+                VARIANTS ${C_TEST_VARIANTS}
+                CMD "${test_cmd}"
+                DIR_NAME ${C_TEST_DIR_NAME}
+                LABELS "check;csuite"
+            )
+        else()
             add_test(NAME ${C_TEST_TARGET}
-                COMMAND ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}> ${C_TEST_ARGUMENTS}
+                COMMAND ${test_cmd} ${C_TEST_ARGUMENTS}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
             )
+            set_tests_properties(${C_TEST_TARGET} PROPERTIES LABELS "check;csuite")
         endif()
-        list(APPEND c_tests ${C_TEST_TARGET})
     endif()
-endmacro(define_c_test)
+endfunction(define_c_test)

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -153,8 +153,8 @@ function(define_test_variants target)
         1
         "DEFINE_TEST"
         ""
-        "CMD;DIR_NAME"
-        "VARIANTS;LABELS"
+        "DIR_NAME"
+        "VARIANTS;LABELS;CMDS"
     )
     if (NOT "${DEFINE_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
         message(FATAL_ERROR "Unknown arguments to define_test_variants: ${DEFINE_TEST_UNPARSED_ARGUMENTS}")
@@ -195,8 +195,8 @@ function(define_test_variants target)
         # Ensure the variant target is created prior to building the test.
         add_dependencies(${target} create_dir_${curr_variant_name})
         set(test_cmd)
-        if(DEFINE_TEST_CMD)
-            set(test_cmd ${DEFINE_TEST_CMD})
+        if(DEFINE_TEST_CMDS)
+            set(test_cmd ${DEFINE_TEST_CMDS})
         else()
             set(test_cmd $<TARGET_FILE:${target}>)
         endif()
@@ -275,12 +275,10 @@ function(define_c_test)
         endif()
         # Define the ctest target.
         if(C_TEST_VARIANTS)
-            # We need to pass a string literal to 'define_test_variants' as 'CMD' is a single value parameter.
-            string (REPLACE ";" " " test_cmd "${test_cmd}")
             # If we want to define multiple variant executions of the test script/binary.
             define_test_variants(${C_TEST_TARGET}
                 VARIANTS ${C_TEST_VARIANTS}
-                CMD "${test_cmd}"
+                CMDS ${test_cmd}
                 DIR_NAME ${C_TEST_DIR_NAME}
                 LABELS "check;csuite"
             )


### PR DESCRIPTION
We currently use a CMake helper, `define_c_test`, for defining our csuite tests. An argument you can give is `SMOKE`, which is shorthand for "execute the test with a script named smoke.sh, where the script is located in the tests source sub-directory". Using `SMOKE` can be quite confusing as it assumes multiple things about the test and abstracts important details e.g. test arguments, script location (mistakes have been made in the past using `SMOKE`). 
Defining test definitions should be clear and easy to read, i.e. should be easy to determine how the test is run from its definition,  where uses of `SMOKE` achieves the opposite of this (for background, `define_c_test` used to be a macro where uses of `SMOKE` in context of the csuite tests was useful. However`define_c_test` has since been redefined as a general purpose function, meaning it needs to be usable/flexible outside the context of the csuite).

Removing `SMOKE` and replacing it with a parameter to define a custom script `EXEC_SCRIPT`, introduces additional flexibility to define any custom wrapper script i.e. a script not named 'smoke.sh'. 

Though this change adds extra verbosity and duplicate code patterns, I think its necessary so each test definition is clear, defining the exact command and arguments to run when ctest is invoked. There's been a couple of issues & errors in the past when it comes to using `define_c_test` (since the function abstracted important execution details). These changes should hopefully make it a bit more clear and predictable when defining a C test.