### PR TITLE
WT-8171 Implement a C style test in the CPP testing framework

### DIFF
--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -69,7 +69,6 @@ create_test_executable(csuite_style_example_test
     CXX
 )
 
-
 if(ENABLE_SNAPPY)
     # We use Snappy compression to avoid excessive disk spage usage.
     target_compile_options(run PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -28,41 +28,44 @@
 
 project(cppsuite CXX)
 
-create_test_executable(run
-    SOURCES test_harness/core/component.cxx 
-            test_harness/core/configuration.cxx 
-            test_harness/core/throttle.cxx 
-            test_harness/util/logger.cxx
-            test_harness/util/scoped_types.cxx 
-            test_harness/workload/database_model.cxx 
-            test_harness/workload/database_operation.cxx 
-            test_harness/workload/random_generator.cxx 
-            test_harness/workload/thread_context.cxx 
-            test_harness/workload/workload_tracking.cxx 
-            test_harness/workload/workload_validation.cxx 
-            test_harness/checkpoint_manager.cxx 
-            test_harness/connection_manager.cxx 
-            test_harness/runtime_monitor.cxx 
-            test_harness/test.cxx 
-            test_harness/thread_manager.cxx 
-            test_harness/timestamp_manager.cxx 
-            test_harness/workload_generator.cxx 
-            tests/run.cxx
-    FLAGS -std=c++11
-    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+# Create the cppsuite lib.
+add_library(cppsuite_test_harness STATIC
+    ../utility/test_util.h
+    test_harness/core/component.cxx 
+    test_harness/core/configuration.cxx 
+    test_harness/core/throttle.cxx 
+    test_harness/util/logger.cxx
+    test_harness/util/scoped_types.cxx 
+    test_harness/workload/database_model.cxx 
+    test_harness/workload/database_operation.cxx 
+    test_harness/workload/random_generator.cxx 
+    test_harness/workload/thread_context.cxx 
+    test_harness/workload/workload_tracking.cxx 
+    test_harness/workload/workload_validation.cxx 
+    test_harness/checkpoint_manager.cxx 
+    test_harness/connection_manager.cxx 
+    test_harness/runtime_monitor.cxx 
+    test_harness/test.cxx 
+    test_harness/thread_manager.cxx 
+    test_harness/timestamp_manager.cxx 
+    test_harness/workload_generator.cxx 
+)
+
+target_include_directories(cppsuite_test_harness PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(cppsuite_test_harness PUBLIC -std=c++11)
+target_link_libraries(cppsuite_test_harness PRIVATE test_util)
+
+# Create the different executables.
+create_test_executable(run 
+    SOURCES tests/run.cxx
+    LIBS cppsuite_test_harness
     ADDITIONAL_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/configs
     CXX
 )
 
-create_test_executable(csuite_style_example_test
-    SOURCES test_harness/connection_manager.cxx
-            test_harness/thread_manager.cxx
-            test_harness/util/logger.cxx
-            test_harness/util/scoped_types.cxx
-            test_harness/workload/random_generator.cxx
-            tests/csuite_style_example_test.cxx
-    FLAGS -std=c++11
-    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+create_test_executable(csuite_style_example_test 
+    SOURCES tests/csuite_style_example_test.cxx
+    LIBS cppsuite_test_harness
     CXX
 )
 

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -69,12 +69,17 @@ create_test_executable(csuite_style_example_test
     CXX
 )
 
+
 if(ENABLE_SNAPPY)
     # We use Snappy compression to avoid excessive disk spage usage.
     target_compile_options(run PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")
 endif()
 
+# Test definitions.
 add_test(NAME cppsuite COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run)
+
+add_test(NAME csuite_style_example COMMAND csuite_style_example_test)
+set_tests_properties(csuite_style_example PROPERTIES LABELS "check")
 
 # Run this during a "ctest check" smoke test.
 set_tests_properties(cppsuite PROPERTIES LABELS "check")

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 project(cppsuite CXX)
 
-# Create the cppsuite lib.
+# Create an intermediate static lib.
 add_library(cppsuite_test_harness STATIC
     ../utility/test_util.h
     test_harness/core/component.cxx 

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -63,6 +63,8 @@ create_test_executable(run
     CXX
 )
 
+# If you prefer to not use the run binary you can add a test via this mechanism but it is generally
+# frowned upon.
 create_test_executable(csuite_style_example_test 
     SOURCES tests/csuite_style_example_test.cxx
     LIBS cppsuite_test_harness

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -54,6 +54,18 @@ create_test_executable(run
     CXX
 )
 
+create_test_executable(csuite_style_example_test
+    SOURCES test_harness/connection_manager.cxx
+            test_harness/thread_manager.cxx
+            test_harness/util/logger.cxx
+            test_harness/util/scoped_types.cxx
+            test_harness/workload/random_generator.cxx
+            tests/csuite_style_example_test.cxx
+    FLAGS -std=c++11
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+    CXX
+)
+
 if(ENABLE_SNAPPY)
     # We use Snappy compression to avoid excessive disk spage usage.
     target_compile_options(run PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -30,7 +30,6 @@ project(cppsuite CXX)
 
 # Create an intermediate static lib.
 add_library(cppsuite_test_harness STATIC
-    ../utility/test_util.h
     test_harness/core/component.cxx 
     test_harness/core/configuration.cxx 
     test_harness/core/throttle.cxx 

--- a/test/cppsuite/Makefile.am
+++ b/test/cppsuite/Makefile.am
@@ -32,9 +32,9 @@ test_harness = test_harness/core/component.cxx \
 
 # If you prefer to not use the run binary you can add a test via this
 # mechanism but it is generally frowned upon.
-basic_test_SOURCES = $(test_harness) tests/basic_test.cxx
-noinst_PROGRAMS += basic_test
-all_TESTS += basic_test
+csuite_style_example_test_SOURCES = $(test_harness) tests/csuite_style_example_test.cxx
+noinst_PROGRAMS += csuite_style_example_test
+all_TESTS += csuite_style_example_test
 
 run_SOURCES = $(test_harness) tests/run.cxx
 noinst_PROGRAMS += run

--- a/test/cppsuite/Makefile.am
+++ b/test/cppsuite/Makefile.am
@@ -11,7 +11,7 @@ all:
 all_TESTS=
 noinst_PROGRAMS=
 
-run_SOURCES = test_harness/core/component.cxx \
+test_harness = test_harness/core/component.cxx \
               test_harness/core/configuration.cxx \
               test_harness/core/throttle.cxx \
               test_harness/util/logger.cxx \
@@ -28,9 +28,15 @@ run_SOURCES = test_harness/core/component.cxx \
               test_harness/test.cxx \
               test_harness/thread_manager.cxx \
               test_harness/timestamp_manager.cxx \
-              test_harness/workload_generator.cxx \
-              tests/run.cxx
+              test_harness/workload_generator.cxx
 
+# If you prefer to not use the run binary you can add a test via this
+# mechanism but it is generally frowned upon.
+basic_test_SOURCES = $(test_harness) tests/basic_test.cxx
+noinst_PROGRAMS += basic_test
+all_TESTS += basic_test
+
+run_SOURCES = $(test_harness) tests/run.cxx
 noinst_PROGRAMS += run
 all_TESTS += run
 

--- a/test/cppsuite/test_harness/connection_manager.cxx
+++ b/test/cppsuite/test_harness/connection_manager.cxx
@@ -47,7 +47,7 @@ connection_manager::close()
     }
 }
 
-void
+WT_CONNECTION *
 connection_manager::create(const std::string &config, const std::string &home)
 {
     if (_conn != nullptr) {
@@ -61,6 +61,8 @@ connection_manager::create(const std::string &config, const std::string &home)
 
     /* Open conn. */
     testutil_check(wiredtiger_open(home.c_str(), nullptr, config.c_str(), &_conn));
+
+    return _conn;
 }
 
 scoped_session

--- a/test/cppsuite/test_harness/connection_manager.cxx
+++ b/test/cppsuite/test_harness/connection_manager.cxx
@@ -47,7 +47,7 @@ connection_manager::close()
     }
 }
 
-WT_CONNECTION *
+void
 connection_manager::create(const std::string &config, const std::string &home)
 {
     if (_conn != nullptr) {
@@ -61,8 +61,6 @@ connection_manager::create(const std::string &config, const std::string &home)
 
     /* Open conn. */
     testutil_check(wiredtiger_open(home.c_str(), nullptr, config.c_str(), &_conn));
-
-    return _conn;
 }
 
 scoped_session
@@ -80,6 +78,12 @@ connection_manager::create_session()
     _conn_mutex.unlock();
 
     return (session);
+}
+
+WT_CONNECTION *
+connection_manager::get_connection()
+{
+    return (_conn);
 }
 
 /*

--- a/test/cppsuite/test_harness/connection_manager.h
+++ b/test/cppsuite/test_harness/connection_manager.h
@@ -57,7 +57,7 @@ class connection_manager {
     connection_manager &operator=(connection_manager const &) = delete;
 
     void close();
-    void create(const std::string &config, const std::string &home = DEFAULT_DIR);
+    WT_CONNECTION *create(const std::string &config, const std::string &home = DEFAULT_DIR);
     scoped_session create_session();
 
     /*

--- a/test/cppsuite/test_harness/connection_manager.h
+++ b/test/cppsuite/test_harness/connection_manager.h
@@ -57,8 +57,10 @@ class connection_manager {
     connection_manager &operator=(connection_manager const &) = delete;
 
     void close();
-    WT_CONNECTION *create(const std::string &config, const std::string &home = DEFAULT_DIR);
+    void create(const std::string &config, const std::string &home = DEFAULT_DIR);
     scoped_session create_session();
+
+    WT_CONNECTION *get_connection();
 
     /*
      * set_timestamp calls into the connection API in a thread safe manner to set global timestamps.

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -44,10 +44,11 @@ random_generator::instance()
 std::string
 random_generator::generate_random_string(std::size_t length, characters_type type)
 {
-    std::string str = get_characters(type);
+    const std::string characters = get_characters(type);
+    std::string str;
 
     while (str.size() < length)
-        str += str;
+        str += characters;
 
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));

--- a/test/cppsuite/test_harness/workload/random_generator.cxx
+++ b/test/cppsuite/test_harness/workload/random_generator.cxx
@@ -44,10 +44,10 @@ random_generator::instance()
 std::string
 random_generator::generate_random_string(std::size_t length, characters_type type)
 {
-    std::string str;
+    std::string str = get_characters(type);
 
     while (str.size() < length)
-        str += get_characters(type);
+        str += str;
 
     std::shuffle(str.begin(), str.end(), _generator);
     return (str.substr(0, length));

--- a/test/cppsuite/tests/basic_test.cxx
+++ b/test/cppsuite/tests/basic_test.cxx
@@ -1,0 +1,70 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test_harness/util/logger.h"
+#include "test_harness/thread_manager.h"
+
+
+extern "C" {
+#include "wiredtiger.h"
+}
+
+void
+thread_op2()
+{
+    test_harness::logger::log_msg(LOG_INFO, "called thread_op2");
+}
+
+void
+thread_op1()
+{
+    test_harness::logger::log_msg(LOG_INFO, "called thread_op1");
+}
+
+int
+main(int argc, char *argv[])
+{
+    /* Set the program name for error messages. */
+    (void)testutil_set_progname(argv);
+
+    /* Set the tracing level for the logger component. */
+    test_harness::logger::trace_level = LOG_INFO;
+    test_harness::logger::log_msg(LOG_INFO, "Starting test basic_test.cxx");
+
+    /* Create a thread_manager and spawn some threads. */
+    test_harness::thread_manager t;
+
+    test_harness::connection_manager
+
+    t.add_thread(thread_op1);
+    t.add_thread(thread_op2);
+
+    t.join();
+
+    return (0);
+}

--- a/test/cppsuite/tests/basic_test.cxx
+++ b/test/cppsuite/tests/basic_test.cxx
@@ -88,21 +88,23 @@ main(int argc, char *argv[])
     const std::string conn_config = std::string(CONNECTION_CREATE) + ",cache_size=500MB";
     WT_CONNECTION *conn = connection_manager::instance().create(conn_config, DEFAULT_DIR);
 
-    /* Open a session. */
-    WT_SESSION *session;
-    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+    /* Open different sessions. */
+    WT_SESSION *insert_session, *read_session;
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &insert_session));
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &read_session));
 
     /* Create a collection. */
     const std::string collection_name = "table:my_collection";
-    testutil_check(session->create(session, collection_name.c_str(), DEFAULT_FRAMEWORK_SCHEMA));
+    testutil_check(
+      insert_session->create(insert_session, collection_name.c_str(), DEFAULT_FRAMEWORK_SCHEMA));
 
     /* Open different cursors. */
     WT_CURSOR *insert_cursor, *read_cursor;
     const std::string cursor_config = "";
-    testutil_check(session->open_cursor(
-      session, collection_name.c_str(), nullptr, cursor_config.c_str(), &insert_cursor));
-    testutil_check(session->open_cursor(
-      session, collection_name.c_str(), nullptr, cursor_config.c_str(), &read_cursor));
+    testutil_check(insert_session->open_cursor(
+      insert_session, collection_name.c_str(), nullptr, cursor_config.c_str(), &insert_cursor));
+    testutil_check(read_session->open_cursor(
+      read_session, collection_name.c_str(), nullptr, cursor_config.c_str(), &read_cursor));
 
     /* Store cursors. */
     std::vector<WT_CURSOR *> cursors;

--- a/test/cppsuite/tests/basic_test.cxx
+++ b/test/cppsuite/tests/basic_test.cxx
@@ -64,11 +64,11 @@ read_op(WT_CURSOR *cursor, int key_size)
 
     /* Read random data. */
     std::string key;
-    // while (do_reads) {
-    //     key = random_generator::instance().generate_random_string(key_size);
-    //     cursor->set_key(cursor, key.c_str());
-    //     cursor->search(cursor);
-    // }
+    while (do_reads) {
+        key = random_generator::instance().generate_random_string(key_size);
+        cursor->set_key(cursor, key.c_str());
+        cursor->search(cursor);
+    }
 }
 
 int

--- a/test/cppsuite/tests/csuite_style_example_test.cxx
+++ b/test/cppsuite/tests/csuite_style_example_test.cxx
@@ -158,6 +158,9 @@ main(int argc, char *argv[])
     for (auto c : cursors)
         testutil_check(c->close(c));
 
+    /* Close the connection. */
+    connection_manager::instance().close();
+
     /* Another message. */
     logger::log_msg(LOG_INFO, "End of test.");
 

--- a/test/cppsuite/tests/csuite_style_example_test.cxx
+++ b/test/cppsuite/tests/csuite_style_example_test.cxx
@@ -26,6 +26,13 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * This file provides an example of how to create a test in C++ using a few features from the
+ * framework if any. This file can be used as a template for quick testing and/or when stress
+ * testing is not required. For any stress testing, it is encouraged to use the framework, see
+ * example_test.cxx and create_script.sh.
+ */
+
 #include "test_harness/connection_manager.h"
 #include "test_harness/thread_manager.h"
 #include "test_harness/util/api_const.h"

--- a/test/cppsuite/tests/csuite_style_example_test.cxx
+++ b/test/cppsuite/tests/csuite_style_example_test.cxx
@@ -94,7 +94,8 @@ main(int argc, char *argv[])
     /* Create a connection, set the cache size and specify the home directory. */
     const std::string conn_config = std::string(CONNECTION_CREATE) + ",cache_size=500MB";
     const std::string home_dir = std::string(DEFAULT_DIR) + '_' + progname;
-    WT_CONNECTION *conn = connection_manager::instance().create(conn_config, home_dir);
+    connection_manager::instance().create(conn_config, home_dir);
+    WT_CONNECTION *conn = connection_manager::instance().get_connection();
 
     /* Open different sessions. */
     WT_SESSION *insert_session, *read_session;

--- a/test/cppsuite/tests/csuite_style_example_test.cxx
+++ b/test/cppsuite/tests/csuite_style_example_test.cxx
@@ -75,13 +75,13 @@ int
 main(int argc, char *argv[])
 {
     /* Set the program name for error messages. */
-    (void)testutil_set_progname(argv);
+    const std::string progname = testutil_set_progname(argv);
 
     /* Set the tracing level for the logger component. */
     logger::trace_level = LOG_INFO;
 
     /* Printing some messages. */
-    logger::log_msg(LOG_INFO, "Starting test basic_test.cxx.");
+    logger::log_msg(LOG_INFO, "Starting " + progname);
     logger::log_msg(LOG_ERROR, "This could be an error.");
 
     /* Create a connection and set the cache size. */

--- a/test/cppsuite/tests/csuite_style_example_test.cxx
+++ b/test/cppsuite/tests/csuite_style_example_test.cxx
@@ -91,9 +91,10 @@ main(int argc, char *argv[])
     logger::log_msg(LOG_INFO, "Starting " + progname);
     logger::log_msg(LOG_ERROR, "This could be an error.");
 
-    /* Create a connection and set the cache size. */
+    /* Create a connection, set the cache size and specify the home directory. */
     const std::string conn_config = std::string(CONNECTION_CREATE) + ",cache_size=500MB";
-    WT_CONNECTION *conn = connection_manager::instance().create(conn_config, DEFAULT_DIR);
+    const std::string home_dir = std::string(DEFAULT_DIR) + '_' + progname;
+    WT_CONNECTION *conn = connection_manager::instance().create(conn_config, home_dir);
 
     /* Open different sessions. */
     WT_SESSION *insert_session, *read_session;

--- a/test/cppsuite/tests/example_test.cxx
+++ b/test/cppsuite/tests/example_test.cxx
@@ -37,6 +37,13 @@ class example_test : public test_harness::test {
     example_test(const test_harness::test_args &args) : test(args) {}
 
     void
+    run()
+    {
+        /* You can remove the call to the base class to fully customized your test. */
+        test::run();
+    }
+
+    void
     populate(test_harness::database &, test_harness::timestamp_manager *,
       test_harness::configuration *, test_harness::workload_tracking *) override final
     {

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -225,12 +225,21 @@ main(int argc, char *argv[])
             }
         } else {
             current_test_name = test_name;
-            /* Configuration parsing. */
-            if (!config_filename.empty())
-                cfg = parse_configuration_from_file(config_filename);
-            else if (cfg.empty())
-                cfg = parse_configuration_from_file(get_default_config_path(current_test_name));
-            error_code = run_test(current_test_name, cfg, wt_open_config);
+            /* Check the test exists. */
+            if (std::find(all_tests.begin(), all_tests.end(), current_test_name) ==
+              all_tests.end()) {
+                test_harness::logger::log_msg(
+                  LOG_ERROR, "The test " + current_test_name + " was not found.");
+                error_code = -1;
+            }
+            else {
+                /* Configuration parsing. */
+                if (!config_filename.empty())
+                    cfg = parse_configuration_from_file(config_filename);
+                else if (cfg.empty())
+                    cfg = parse_configuration_from_file(get_default_config_path(current_test_name));
+                error_code = run_test(current_test_name, cfg, wt_open_config);
+            }
         }
 
         if (error_code != 0)

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -231,8 +231,7 @@ main(int argc, char *argv[])
                 test_harness::logger::log_msg(
                   LOG_ERROR, "The test " + current_test_name + " was not found.");
                 error_code = -1;
-            }
-            else {
+            } else {
                 /* Configuration parsing. */
                 if (!config_filename.empty())
                     cfg = parse_configuration_from_file(config_filename);

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -44,8 +44,11 @@ add_library(test_util ${link_type} ${sources})
 
 target_include_directories(
     test_util
-    PUBLIC ${CMAKE_BINARY_DIR}/include
-    PRIVATE ${CMAKE_BINARY_DIR}/config ${CMAKE_SOURCE_DIR}/src/include
+    PUBLIC
+        ${CMAKE_BINARY_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_BINARY_DIR}/config
+        ${CMAKE_SOURCE_DIR}/src/include
 )
 target_link_libraries(test_util wiredtiger)
 


### PR DESCRIPTION
- Added the `run` function to `example_test.cxx` file. This way, when one creates a test with the script `create_test.sh`, they will be given the possibility to override the `run` function and have more control over their test. This was already possible before this change since `run` is a virtual function but now it is more explicit.
- Added a new test `csuite_style_example .cxx` that barely uses the framework.
- Modified the CMake build for the cpp suite.
- API change for the `connection_manager` where `create` now returns a `WT_CONNECTION*`
- Corrected a bug when a specified test with the command `./run -t` would not exist
- Improved some code in the random generator helper class