### PR TITLE
WT-7494 Add Python test to trigger update restore eviction during recovery

### DIFF
--- a/test/suite/test_debug_mode10.py
+++ b/test/suite/test_debug_mode10.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, shutil, re
+from wiredtiger import stat
+import wttest
+from wtdataset import SimpleDataSet
+
+# test_debug_mode10.py
+# Test the debug mode setting for update_restore_evict during recovery.
+# Force update restore eviction, whenever we evict a page. We want to
+# perform this in recovery to ensure that all the in-memory images have
+# the proper write generation number and we don't end up reading stale
+# transaction ID's stored on the page.
+class test_debug_mode10(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled=true),statistics=(all)'
+    # Recovery connection config: The debug mode is only effective on high cache pressure as WiredTiger can potentially decide
+    # to do an update restore evict on a page when the cache pressure requirements are not met.
+    # This means setting eviction target low and cache size high.
+    conn_recon = conn_config + ',eviction_updates_trigger=5,eviction_dirty_trigger=5,cache_size=15MB,' + \
+            'debug_mode=(update_restore_evict=true),log=(recover=on)'
+
+    def large_updates(self, uri, value, ds, nrows, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value
+        session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, nrows, read_ts):
+        # Scan our records at a given timestamp, asserting the values match our expected value.
+        session = self.session
+        if read_ts == 0:
+            session.begin_transaction()
+        else:
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, check_value)
+            count += 1
+        session.commit_transaction()
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def simulate_crash(self, olddir, newdir):
+        # Simulate a crash from olddir and restart in newdir.
+        shutil.rmtree(newdir, ignore_errors=True)
+        # With the connection still open, copy files to new directory.
+        os.mkdir(newdir)
+        for fname in os.listdir(olddir):
+            fullname = os.path.join(olddir, fname)
+            # Skip lock file on Windows since it is locked.
+            if os.path.isfile(fullname) and \
+                "WiredTiger.lock" not in fullname and \
+                "Tmplog" not in fullname and \
+                "Preplog" not in fullname:
+                shutil.copy(fullname, newdir)
+
+    def parse_write_gen(self, uri):
+        meta_cursor = self.session.open_cursor('metadata:')
+        config = meta_cursor[uri]
+        meta_cursor.close()
+        # The search string will look like: 'run_write_gen=<num>'.
+        # Just reverse the string and take the digits from the back until we hit '='.
+        write_gen = re.search('write_gen=\d+', config)
+        run_write_gen = re.search('run_write_gen=\d+', config)
+        self.assertTrue(write_gen is not None)
+        write_gen_str = str()
+        run_write_gen_str = str()
+        for c in reversed(write_gen.group(0)):
+            if not c.isdigit():
+                self.assertEqual(c, '=')
+                break
+            write_gen_str = c + write_gen_str
+        for c in reversed(run_write_gen.group(0)):
+            if not c.isdigit():
+                self.assertEqual(c, '=')
+                break
+            run_write_gen_str = c + run_write_gen_str
+
+        return int(write_gen_str), int(run_write_gen_str)
+
+    def test_update_restore_evict_recovery(self):
+        uri = 'table:test_debug_mode10'
+        nrows = 20000
+
+        # Create our table.
+        ds = SimpleDataSet(self, uri, 0, key_format='i', value_format='S',config='log=(enabled=false)')
+        ds.populate()
+
+        value_a = 'a' * 200
+        value_b = 'b' * 200
+        value_c = 'c' * 200
+        value_d = 'd' * 200
+
+        # Perform several updates.
+        self.large_updates(uri, value_a, ds, nrows, 20)
+        self.large_updates(uri, value_b, ds, nrows, 30)
+        self.large_updates(uri, value_c, ds, nrows, 40)
+        # Verify data is visible and correct.
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
+
+        # Pin the stable timestamp to 40. We will be validating the state of the data post-stable timestamp
+        # after we perform a recovery.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
+
+        # Perform additional updates post-stable timestamp.
+        self.large_updates(uri, value_d, ds, nrows, 50)
+        self.large_updates(uri, value_a, ds, nrows, 60)
+        self.large_updates(uri, value_b, ds, nrows, 70)
+
+        # Verify additional updated data is visible and correct.
+        self.check(value_d, uri, nrows, 50)
+        self.check(value_a, uri, nrows, 60)
+        self.check(value_b, uri, nrows, 70)
+
+        # Checkpoint to ensure the data is flushed to disk.
+        self.session.checkpoint()
+
+        # Extract the most recent checkpoints write gen & run write gen. As we are still on a new DB connection,
+        # the run write gen should be 1 at this point, equal to the connection-wide base write gen.
+        # Since we checkpointed after a series of large writes/updates, the write gen of the pages should
+        # definitely be greater than 1.
+        checkpoint_write_gen, checkpoint_run_write_gen = self.parse_write_gen("file:test_debug_mode10.wt")
+        self.assertEqual(checkpoint_run_write_gen, 1)
+        self.assertGreater(checkpoint_write_gen, checkpoint_run_write_gen)
+
+        olddir = "."
+        newdir = "RESTART"
+        self.simulate_crash(olddir, newdir)
+        # Close out the original connection.
+        self.close_conn()
+
+        # Open our new DB in recovery, additionally using the 'update_restore_evict' debug option to
+        # trigger update restore eviction during recovery.
+        self.conn = self.wiredtiger_open(newdir, self.conn_recon)
+        self.session = self.setUpSessionOpen(self.conn)
+
+        # As we've created a new DB connection post-shutdown, the connection-wide
+        # base write gen should eventually initialise from the previous checkpoint's base 'write_gen' during the recovery process,
+        # ('write_gen'+1). This should be reflected in the initialisation of the 'run_write_gen' field of the newest
+        # checkpoint post-recovery. As the recovery/rts process updates our pages, we'd also expect the lastest checkpoint's
+        # 'write_gen' to again be greater than its 'run_write_gen'.
+        recovery_write_gen, recovery_run_write_gen = self.parse_write_gen("file:test_debug_mode10.wt")
+        self.assertGreater(recovery_run_write_gen, checkpoint_write_gen)
+        self.assertGreater(recovery_write_gen, recovery_run_write_gen)
+
+        # Read the statistics of pages that have been update restored (to check the mechanism was used).
+        stat_cursor = self.session.open_cursor('statistics:')
+        pages_update_restored = stat_cursor[stat.conn.cache_write_restore][2]
+        stat_cursor.close()
+        self.assertGreater(pages_update_restored, 0)
+
+        # Check that after recovery, we see the correct data with respect to our previous stable timestamp (40).
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_c, uri, nrows, 50)
+        self.check(value_c, uri, nrows, 60)
+        self.check(value_c, uri, nrows, 70)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_a, uri, nrows, 20)
+        # Passing 0 results in opening a transaction with no read timestamp.
+        self.check(value_c, uri, nrows, 0)

--- a/test/suite/test_debug_mode10.py
+++ b/test/suite/test_debug_mode10.py
@@ -98,16 +98,16 @@ class test_debug_mode10(wttest.WiredTigerTestCase):
 
     def test_update_restore_evict_recovery(self):
         uri = 'table:test_debug_mode10'
-        nrows = 20000
+        nrows = 10000
 
         # Create our table.
         ds = SimpleDataSet(self, uri, 0, key_format='i', value_format='S',config='log=(enabled=false)')
         ds.populate()
 
-        value_a = 'a' * 200
-        value_b = 'b' * 200
-        value_c = 'c' * 200
-        value_d = 'd' * 200
+        value_a = 'a' * 500
+        value_b = 'b' * 500
+        value_c = 'c' * 500
+        value_d = 'd' * 500
 
         # Perform several updates.
         self.large_updates(uri, value_a, ds, nrows, 20)

--- a/test/suite/test_debug_mode10.py
+++ b/test/suite/test_debug_mode10.py
@@ -149,9 +149,9 @@ class test_debug_mode10(wttest.WiredTigerTestCase):
         simulate_crash_restart(self, ".", "RESTART")
 
         # As we've created a new DB connection post-shutdown, the connection-wide
-        # base write gen should eventually initialise from the previous checkpoint's base 'write_gen' during the recovery process,
+        # base write gen should eventually initialise from the previous checkpoint's base 'write_gen' during the recovery process
         # ('write_gen'+1). This should be reflected in the initialisation of the 'run_write_gen' field of the newest
-        # checkpoint post-recovery. As the recovery/rts process updates our pages, we'd also expect the lastest checkpoint's
+        # checkpoint post-recovery. As the recovery/rts process updates our pages, we'd also expect the latest checkpoint's
         # 'write_gen' to again be greater than its 'run_write_gen'.
         recovery_write_gen, recovery_run_write_gen = self.parse_write_gen("file:test_debug_mode10.wt")
         self.assertGreater(recovery_run_write_gen, checkpoint_write_gen)


### PR DESCRIPTION
Introduces a python suite test that enables the debug mode setting for update restore evict during recovery. The debug mode forces update restore eviction whenever we evict a page. We want to perform this in recovery to ensure that all the in-memory images have the proper write generation number and we don't end up reading stale transaction ID's stored on the page.

Let me know if I should expand the test in any way, wasn't super sure if I covered all the important behaviors/scenarios/edge cases :)