### PR TITLE
WT-8115 Define macros only when necessary in cpp files

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -26,8 +26,16 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#define __STDC_LIMIT_MACROS  // needed to get UINT64_MAX in C++
-#define __STDC_FORMAT_MACROS // needed to get PRIuXX macros in C++
+/* Needed to get UINT64_MAX in C++. */
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+/* Needed to get PRIuXX macros in C++. */
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <iomanip>
 #include <iostream>
 #include <fstream>

--- a/test/cppsuite/test_harness/connection_manager.h
+++ b/test/cppsuite/test_harness/connection_manager.h
@@ -30,8 +30,12 @@
 #define CONN_API_H
 
 /* Following definitions are required in order to use printing format specifiers in C++. */
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <mutex>
 

--- a/test/cppsuite/test_harness/util/logger.h
+++ b/test/cppsuite/test_harness/util/logger.h
@@ -30,8 +30,12 @@
 #define DEBUG_UTILS_H
 
 /* Following definitions are required in order to use printing format specifiers in C++. */
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <chrono>
 #include <iostream>

--- a/test/cppsuite/test_harness/util/scoped_types.h
+++ b/test/cppsuite/test_harness/util/scoped_types.h
@@ -30,8 +30,12 @@
 #define SCOPED_TYPES_H
 
 /* Following definitions are required in order to use printing format specifiers in C++. */
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 extern "C" {
 #include "test_util.h"

--- a/test/cppsuite/test_harness/workload/random_generator.h
+++ b/test/cppsuite/test_harness/workload/random_generator.h
@@ -30,8 +30,12 @@
 #define RANDOM_GENERATOR_H
 
 /* Following definitions are required in order to use printing format specifiers in C++. */
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <random>
 #include <string>


### PR DESCRIPTION
The macros are `__STDC_LIMIT_MACROS` and `__STDC_FORMAT_MACROS`, we now check if they are already defined before defining them.