### PR TITLE
WT-8199 Make s_all accept Python PEP8 compliant line breaks

### DIFF
--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -1,12 +1,14 @@
 import re
 from perf_stat import PerfStat
 
+
 def find_stat(test_stat_path: str, pattern: str, position_of_value: int):
     for line in open(test_stat_path):
         match = re.match(pattern, line)
         if match:
             return float(line.split()[position_of_value])
     return 0
+
 
 class PerfStatCollection:
     def __init__(self):

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -11,17 +11,18 @@ from wtperf_config import WTPerfConfig
 from perf_stat import PerfStat
 from perf_stat_collection import PerfStatCollection
 
-# example parameters: -p /Users/jeremy.thorp/Git/wiredtiger/build/bench/wtperf/wtperf -t ../runners/small-lsm.wtperf -v -ho WT_TEST -m 3
-
 # the 'test.stat' file is where wt-perf.c writes out it's statistics
 # (within the directory specified by the 'home' parameter)
 test_stats_file = 'test.stat'
 
+
 def create_test_home_path(home: str, test_run: int):
     return '{}_{}'.format(home, test_run)
 
+
 def create_test_stat_path(test_home_path: str):
     return os.path.join(test_home_path, test_stats_file)
+
 
 def find_stat(test_stat_path: str, pattern: str, position_of_value: int):
     for line in open(test_stat_path):
@@ -29,6 +30,7 @@ def find_stat(test_stat_path: str, pattern: str, position_of_value: int):
         if match:
             return line.split()[position_of_value]
     return 0
+
 
 def construct_wtperf_command_line(wtperf: str, env: str, test: str, home: str):
     command_line = []
@@ -43,6 +45,7 @@ def construct_wtperf_command_line(wtperf: str, env: str, test: str, home: str):
         command_line.append(home)
     return command_line
 
+
 def run_test(config: WTPerfConfig, test_run: int):
     test_home = create_test_home_path(home=config.home_dir, test_run=test_run)
     command_line = construct_wtperf_command_line(
@@ -52,6 +55,7 @@ def run_test(config: WTPerfConfig, test_run: int):
         home=test_home)
     # print('Command Line for test: {}'.format(command_line))
     subprocess.run(command_line)
+
 
 def process_results(config: WTPerfConfig, perf_stats: PerfStatCollection):
     for test_run in range(config.run_max):
@@ -72,6 +76,7 @@ def process_results(config: WTPerfConfig, perf_stats: PerfStatCollection):
                }
     return as_dict
 
+
 def setup_perf_stats():
     perf_stats = PerfStatCollection()
     perf_stats.add_stat(PerfStat(short_label="load",
@@ -81,26 +86,27 @@ def setup_perf_stats():
                                  output_precision=2,
                                  conversion_function=float))
     perf_stats.add_stat(PerfStat(short_label="insert",
-                                 pattern='Executed \d+ insert operations',
+                                 pattern=r'Executed \d+ insert operations',
                                  input_offset=1,
                                  output_label='Insert count:'))
     perf_stats.add_stat(PerfStat(short_label="modify",
-                                 pattern='Executed \d+ modify operations',
+                                 pattern=r'Executed \d+ modify operations',
                                  input_offset=1,
                                  output_label='Modify count:'))
     perf_stats.add_stat(PerfStat(short_label="read",
-                                 pattern='Executed \d+ read operations',
+                                 pattern=r'Executed \d+ read operations',
                                  input_offset=1,
                                  output_label='Read count:'))
     perf_stats.add_stat(PerfStat(short_label="truncate",
-                                 pattern='Executed \d+ truncate operations',
+                                 pattern=r'Executed \d+ truncate operations',
                                  input_offset=1,
                                  output_label='Truncate count:'))
     perf_stats.add_stat(PerfStat(short_label="update",
-                                 pattern='Executed \d+ update operations',
+                                 pattern=r'Executed \d+ update operations',
                                  input_offset=1,
                                  output_label='Update count:'))
     return perf_stats
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -162,6 +168,7 @@ def main():
     if args.outfile:
         with open(args.outfile, 'w') as outfile:
             json.dump(perf_dict, outfile, indent=4, sort_keys=True)
+
 
 if __name__ == '__main__':
     main()

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -21,7 +21,6 @@ find bench dist examples ext src test \
     -name '*.[ch]' -o \
     -name '*.dox' -o \
     -name '*.in' -o \
-    -name '*.py' -o \
     -name 's_*' -o \
     -name 'Makefile.am' |
     sed -e '/Makefile.in/d' \


### PR DESCRIPTION
* Removed Python checking from s_whitespace as it was rejecting PEP8 compliant line-break usage.
* Modified the wtperf_run_py Python code to be PEP8 compatible, as checked by the pycodestyle tool. This includes introducing double line-breaks where required to comply with the PEP8 requirement to "Surround top-level function and class definitions with two blank lines.".