### PR TITLE
WT-7250 Fix the test to perform explicit eviction instead of low cache size

### DIFF
--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -26,13 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import fnmatch, os, shutil, threading, time
+import threading
 from helper import copy_wiredtiger_home, simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wtthread import checkpoint_thread, op_thread
+from wtthread import checkpoint_thread
 
 # test_rollback_to_stable10.py
 # Test the rollback to stable operation performs sweeping history store.
@@ -52,8 +52,20 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
     scenarios = make_scenarios(key_format_values, prepare_values)
 
     def conn_config(self):
-        config = 'cache_size=6MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[history_store_checkpoint_delay]'
+        config = 'cache_size=25MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[history_store_checkpoint_delay]'
         return config
+
+    def evict_cursor(self, uri, nrows, check_value):
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        self.session.begin_transaction("ignore_prepare=true")
+        for i in range (1, nrows + 1):
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            self.assertEqual(evict_cursor.get_value(), check_value)
+            evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
 
     def test_rollback_to_stable(self):
         nrows = 1000
@@ -125,10 +137,14 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
                            lambda: self.large_updates(uri_1, value_e, ds_1, nrows, self.prepare, 70))
             self.retry_rollback('update ds2, e', None,
                            lambda: self.large_updates(uri_2, value_e, ds_2, nrows, self.prepare, 70))
+            self.evict_cursor(uri_1, nrows, value_e)
+            self.evict_cursor(uri_2, nrows, value_e)
             self.retry_rollback('update ds1, f', None,
                            lambda: self.large_updates(uri_1, value_f, ds_1, nrows, self.prepare, 80))
             self.retry_rollback('update ds2, f', None,
                            lambda: self.large_updates(uri_2, value_f, ds_2, nrows, self.prepare, 80))
+            self.evict_cursor(uri_1, nrows, value_f)
+            self.evict_cursor(uri_2, nrows, value_f)
         finally:
             done.set()
             ckpt.join()
@@ -173,10 +189,6 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
     def test_rollback_to_stable_prepare(self):
         nrows = 1000
 
-        # FIXME-WT-7250 This test fails because of cache stuck on Windows.
-        if os.name == "nt":
-            self.skipTest('rollback_to_stable10 prepare test skipped on Windows')
-
         # Create a table without logging.
         self.pr("create/populate tables")
         uri_1 = "table:rollback_to_stable10_1"
@@ -199,7 +211,6 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         value_c = "ccccc" * 100
         value_d = "ddddd" * 100
         value_e = "eeeee" * 100
-        value_f = "fffff" * 100
 
         # Perform several updates.
         self.pr("large updates")
@@ -216,13 +227,11 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         # Verify data is visible and correct.
         self.check(value_d, uri_1, nrows, 20)
         self.check(value_c, uri_1, nrows, 30)
-        self.session.breakpoint()
         self.check(value_b, uri_1, nrows, 40)
         self.check(value_a, uri_1, nrows, 50)
 
         self.check(value_d, uri_2, nrows, 20)
         self.check(value_c, uri_2, nrows, 30)
-        self.session.breakpoint()
         self.check(value_b, uri_2, nrows, 40)
         self.check(value_a, uri_2, nrows, 50)
 
@@ -268,6 +277,8 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
                            lambda: prepare_range_updates(
                                session_p2, cursor_p2, ds_2, value_e, nrows,
                                'prepare_timestamp=' + self.timestamp_str(69)))
+            self.evict_cursor(uri_1, nrows, value_a)
+            self.evict_cursor(uri_2, nrows, value_a)
         finally:
             done.set()
             ckpt.join()

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -26,13 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import fnmatch, os, shutil, threading, time
+import threading
 from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wtthread import checkpoint_thread, op_thread
+from wtthread import checkpoint_thread
 
 def mod_val(value, char, location, nbytes=1):
     return value[0:location] + char + value[location+nbytes:]
@@ -58,11 +58,23 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
     scenarios = make_scenarios(key_format_values, prepare_values)
 
     def conn_config(self):
-        config = 'cache_size=8MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[history_store_checkpoint_delay]'
+        config = 'cache_size=25MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[history_store_checkpoint_delay]'
         return config
 
+    def evict_cursor(self, uri, nrows, check_value):
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        self.session.begin_transaction("ignore_prepare=true")
+        for i in range (1, nrows + 1):
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            self.assertEqual(evict_cursor.get_value(), check_value)
+            evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
+
     def test_rollback_to_stable(self):
-        nrows = 1500
+        nrows = 100
 
         # Create a table without logging.
         self.pr("create/populate table")
@@ -81,6 +93,10 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         value_modR = mod_val(value_modQ, 'R', 1)
         value_modS = mod_val(value_modR, 'S', 2)
         value_modT = mod_val(value_modS, 'T', 3)
+        value_modW = mod_val(value_modT, 'W', 4)
+        value_modX = mod_val(value_modW, 'X', 5)
+        value_modY = mod_val(value_modX, 'Y', 6)
+        value_modZ = mod_val(value_modY, 'Z', 7)
 
         # Perform a combination of modifies and updates.
         self.pr("large updates and modifies")
@@ -117,10 +133,12 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
                            lambda: self.large_modifies(uri, 'W', ds, 4, 1, nrows, self.prepare, 70))
             self.retry_rollback('modify ds1, X', None,
                            lambda: self.large_modifies(uri, 'X', ds, 5, 1, nrows, self.prepare, 80))
+            self.evict_cursor(uri, nrows, value_modX)
             self.retry_rollback('modify ds1, Y', None,
                            lambda: self.large_modifies(uri, 'Y', ds, 6, 1, nrows, self.prepare, 90))
             self.retry_rollback('modify ds1, Z', None,
                            lambda: self.large_modifies(uri, 'Z', ds, 7, 1, nrows, self.prepare, 100))
+            self.evict_cursor(uri, nrows, value_modZ)
         finally:
             done.set()
             ckpt.join()
@@ -163,7 +181,7 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
 
     def test_rollback_to_stable_same_ts(self):
-        nrows = 1500
+        nrows = 100
 
         # Create a table without logging.
         self.pr("create/populate table")
@@ -182,6 +200,10 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         value_modR = mod_val(value_modQ, 'R', 1)
         value_modS = mod_val(value_modR, 'S', 2)
         value_modT = mod_val(value_modS, 'T', 3)
+        value_modW = mod_val(value_modT, 'W', 4)
+        value_modX = mod_val(value_modW, 'X', 5)
+        value_modY = mod_val(value_modX, 'Y', 6)
+        value_modZ = mod_val(value_modY, 'Z', 7)
 
         # Perform a combination of modifies and updates.
         self.pr("large updates and modifies")
@@ -218,10 +240,12 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
                            lambda: self.large_modifies(uri, 'W', ds, 4, 1, nrows, self.prepare, 70))
             self.retry_rollback('modify ds1, X', None,
                            lambda: self.large_modifies(uri, 'X', ds, 5, 1, nrows, self.prepare, 80))
+            self.evict_cursor(uri, nrows, value_modX)
             self.retry_rollback('modify ds1, Y', None,
                            lambda: self.large_modifies(uri, 'Y', ds, 6, 1, nrows, self.prepare, 90))
             self.retry_rollback('modify ds1, Z', None,
                            lambda: self.large_modifies(uri, 'Z', ds, 7, 1, nrows, self.prepare, 100))
+            self.evict_cursor(uri, nrows, value_modZ)
         finally:
             done.set()
             ckpt.join()
@@ -262,7 +286,7 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
 
     def test_rollback_to_stable_same_ts_append(self):
-        nrows = 1500
+        nrows = 100
 
         # Create a table without logging.
         self.pr("create/populate table")
@@ -281,6 +305,10 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         value_modR = append_val(value_modQ, 'R')
         value_modS = append_val(value_modR, 'S')
         value_modT = append_val(value_modS, 'T')
+        value_modW = append_val(value_modT, 'W')
+        value_modX = append_val(value_modW, 'X')
+        value_modY = append_val(value_modX, 'Y')
+        value_modZ = append_val(value_modY, 'Z')
 
         # Perform a combination of modifies and updates.
         self.pr("large updates and modifies")
@@ -316,11 +344,13 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
             self.retry_rollback('modify ds1, W', None,
                            lambda: self.large_modifies(uri, 'W', ds, len(value_modT), 1, nrows, self.prepare, 70))
             self.retry_rollback('modify ds1, X', None,
-                           lambda: self.large_modifies(uri, 'X', ds, len(value_modT) + 1, 1, nrows, self.prepare, 80))
+                           lambda: self.large_modifies(uri, 'X', ds, len(value_modW), 1, nrows, self.prepare, 80))
+            self.evict_cursor(uri, nrows, value_modX)
             self.retry_rollback('modify ds1, Y', None,
-                           lambda: self.large_modifies(uri, 'Y', ds, len(value_modT) + 2, 1, nrows, self.prepare, 90))
+                           lambda: self.large_modifies(uri, 'Y', ds, len(value_modX), 1, nrows, self.prepare, 90))
             self.retry_rollback('modify ds1, Z', None,
-                           lambda: self.large_modifies(uri, 'Z', ds, len(value_modT) + 3, 1, nrows, self.prepare, 100))
+                           lambda: self.large_modifies(uri, 'Z', ds, len(value_modY), 1, nrows, self.prepare, 100))
+            self.evict_cursor(uri, nrows, value_modZ)
         finally:
             done.set()
             ckpt.join()


### PR DESCRIPTION
Instead of relying on low cache size to trigger the eviction in
parallel to the checkpoint, better to control the eviction explicitly
with the debug cursor