### PR TITLE
WT-8214 Only publish the docs from the WiredTiger develop Evergreen project

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -313,11 +313,18 @@ functions:
           done
     - command: shell.exec
       params:
-        working_dir: "wiredtiger.github.com"
         shell: bash
         silent: true
         script: |
           set -o errexit
+
+          # We could have exited the previous command for the same reason.
+          if [[ "${branch_name}" != "develop" ]]; then
+            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
+            exit 0
+          fi
+
+          cd wiredtiger.github.com
           git push https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
 
   "make check directory":


### PR DESCRIPTION
The failure reported in the ticket was due to a failure of "git push" under the WiredTiger (mongodb-5.0) or WiredTiger (mongodb-4.4) project, as by design we only expect the task to take effect under the WiredTiger (develop) project. 

The solution is to add a check in the 2nd shell command of the `update wiredtiger docs` function, and only run "git push" if the task is running under the WiredTiger (develop) Evergreen project. 