### PR TITLE
WT-6022 Investigate how to restructure WT to use NVRAM as a cache

### DIFF
--- a/src/block/block_cache.c
+++ b/src/block/block_cache.c
@@ -95,14 +95,13 @@ __blkcache_print_reference_hist(WT_SESSION_IMPL *session, const char *header, ui
 {
     int j;
 
-    __wt_verbose(session, WT_VERB_BLKCACHE, "%s:\n", header);
-    __wt_verbose(session, WT_VERB_BLKCACHE, "%s\n", "Reuses \t Number of blocks");
-    __wt_verbose(session, WT_VERB_BLKCACHE, "%s\n", "-----------------------------");
+    __wt_verbose(session, WT_VERB_BLKCACHE, "%s:", header);
+    __wt_verbose(session, WT_VERB_BLKCACHE, "%s", "Reuses \t Number of blocks");
+    __wt_verbose(session, WT_VERB_BLKCACHE, "%s", "-----------------------------");
     for (j = 0; j < BLKCACHE_HIST_BUCKETS; j++) {
-        __wt_verbose(session, WT_VERB_BLKCACHE, "[%d - %d] \t %u \n", j * BLKCACHE_HIST_BOUNDARY,
+        __wt_verbose(session, WT_VERB_BLKCACHE, "[%d - %d] \t %u", j * BLKCACHE_HIST_BOUNDARY,
           (j + 1) * BLKCACHE_HIST_BOUNDARY, hist[j]);
     }
-    __wt_verbose(session, WT_VERB_BLKCACHE, "%s", "\n");
 }
 
 /*
@@ -198,7 +197,7 @@ __blkcache_eviction_thread(void *arg)
     blkcache = &conn->blkcache;
 
     __wt_verbose(session, WT_VERB_BLKCACHE,
-      "Block cache eviction thread starting... Aggressive target = %d, full target = %f\n",
+      "Block cache eviction thread starting... Aggressive target = %d, full target = %f",
       blkcache->evict_aggressive, blkcache->full_target);
 
     while (!blkcache->blkcache_exiting) {
@@ -663,7 +662,7 @@ __wt_block_cache_destroy(WT_SESSION_IMPL *session)
         blkcache->blkcache_exiting = true;
         __wt_cond_signal(session, blkcache->blkcache_cond);
         WT_TRET(__wt_thread_join(session, &blkcache->evict_thread_tid));
-        __wt_verbose(session, WT_VERB_BLKCACHE, "%s\n", "block cache eviction thread exited...");
+        __wt_verbose(session, WT_VERB_BLKCACHE, "%s", "block cache eviction thread exited...");
         __wt_cond_destroy(session, &blkcache->blkcache_cond);
     }
 

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -87,6 +87,7 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
     F_CLR(session, WT_SESSION_NO_DATA_HANDLES);
 
     __wt_block_cache_destroy(session);
+
     /*
      * Shut down server threads. Some of these threads access btree handles and eviction, shut them
      * down before the eviction server, and shut all servers down before closing open data handles.

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -455,12 +455,11 @@ config_cache(void)
     g.c_cache = WT_MAX(g.c_cache, 2 * workers * g.c_memory_page_max);
 
     /*
-     * Ensure cache size sanity for LSM runs. An LSM tree open requires 3
-     * chunks plus a page for each participant in up to three concurrent
-     * merges. Integrate a thread count into that calculation by requiring
-     * 3 chunks/pages per configured thread. That might be overkill, but
-     * LSM runs are more sensitive to small caches than other runs, and a
-     * generous cache avoids stalls we're not interested in chasing.
+     * Ensure cache size sanity for LSM runs. An LSM tree open requires 3 chunks plus a page for
+     * each participant in up to three concurrent merges. Integrate a thread count into that
+     * calculation by requiring 3 chunks/pages per configured thread. That might be overkill, but
+     * LSM runs are more sensitive to small caches than other runs, and a generous cache avoids
+     * stalls we're not interested in chasing.
      */
     if (DATASOURCE("lsm")) {
         required = WT_LSM_TREE_MINIMUM_SIZE(

--- a/test/format/config.h
+++ b/test/format/config.h
@@ -77,6 +77,24 @@ static CONFIG c[] = {
   {"backup.incr_granularity", "incremental backup block granularity (KB)", 0x0, 4, 16384, 16384,
     &g.c_backup_incr_granularity, NULL},
 
+  /* 10% */
+  {"block_cache", "enable the block cache", C_BOOL, 10, 0, 0, &g.c_block_cache, NULL},
+
+  /* 30 */
+  {"block_cache.checkpoint_write_bypass", "block cache: don't cache checkpoint writes", C_BOOL, 30,
+    0, 0, &g.c_block_cache_checkpoint_write_bypass, NULL},
+
+  /* 80% */
+  {"block_cache.eviction_on", "block cache: evict blocks", C_BOOL, 80, 0, 0,
+    &g.c_block_cache_eviction_on, NULL},
+
+  {"block_cache.size", "block cache size (MB)", 0x0, 1, 100, 100 * 1024, &g.c_block_cache_size,
+    NULL},
+
+  /* 60% */
+  {"block_cache.write_allocate", "block cache: populate the cache on writes", C_BOOL, 60, 0, 0,
+    &g.c_block_cache_write_allocate, NULL},
+
   {"btree.bitcnt", "fixed-length column-store object size (number of bits)", 0x0, 1, 8, 8,
     &g.c_bitcnt, NULL},
 

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -182,6 +182,11 @@ typedef struct {
     uint32_t c_backup_incr_granularity;
     uint32_t c_backups;
     uint32_t c_bitcnt;
+    uint32_t c_block_cache;
+    uint32_t c_block_cache_checkpoint_write_bypass;
+    uint32_t c_block_cache_eviction_on;
+    uint32_t c_block_cache_size;
+    uint32_t c_block_cache_write_allocate;
     uint32_t c_bloom;
     uint32_t c_bloom_bit_count;
     uint32_t c_bloom_hash_count;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -209,6 +209,19 @@ create_database(const char *home, WT_CONNECTION **connp)
     if (DATASOURCE("lsm") || g.c_cache < 20)
         CONFIG_APPEND(p, ",eviction_dirty_trigger=95");
 
+    /* Block cache */
+    CONFIG_APPEND(p,
+      ",block_cache=(enabled=%s,type=\"dram\""
+      ",checkpoint_write_bypass=%s"
+      ",eviction_on=%s"
+      ",size=%" PRIu32
+      "MB"
+      ",write_allocate=%s)",
+      g.c_block_cache == 0 ? "false" : "true",
+      g.c_block_cache_checkpoint_write_bypass == 0 ? "false" : "true",
+      g.c_block_cache_eviction_on == 0 ? "false" : "true", g.c_block_cache_size,
+      g.c_block_cache_write_allocate == 0 ? "false" : "true");
+
     /* Eviction worker configuration. */
     if (g.c_evict_max != 0)
         CONFIG_APPEND(p, ",eviction=(threads_max=%" PRIu32 ")", g.c_evict_max);


### PR DESCRIPTION
Hook the NVRAM block cache code into format, supporting the checkpoint_write_bypass, eviction_on, size and  write_allocate configuration options.

Remove explicit newline characters in __wt_verbose() messages.