### PR TITLE
WT-8147 Detect invalid syntax in cppsuite configs

### DIFF
--- a/test/cppsuite/test_harness/core/configuration.cxx
+++ b/test/cppsuite/test_harness/core/configuration.cxx
@@ -258,13 +258,13 @@ configuration::split_config(const std::string &config)
             in_subconfig = !parens.empty();
         }
         if (cut_config[i] == '=' && !in_subconfig) {
+            if (len == 0) {
+                testutil_die(EINVAL, "error parsing config: detected empty key");
+            }
             if (expect_value) {
                 testutil_die(EINVAL,
                   "error parsing config: syntax error parsing value for key ['%s']: '%s'",
                   key.c_str(), cut_config.substr(start, len).c_str());
-            }
-            if (len == 0) {
-                testutil_die(EINVAL, "error parsing config: detected empty key");
             }
             expect_value = true;
             key = cut_config.substr(start, len);
@@ -273,14 +273,14 @@ configuration::split_config(const std::string &config)
             continue;
         }
         if (cut_config[i] == ',' && !in_subconfig) {
+            if (len == 0) {
+                testutil_die(
+                  EINVAL, "error parsing config: detected empty value for key:'%s'", key.c_str());
+            }
             if (!expect_value) {
                 testutil_die(EINVAL,
                   "error parsing config: syntax error parsing key value pair: '%s'",
                   cut_config.substr(start, len).c_str());
-            }
-            if (len == 0) {
-                testutil_die(
-                  EINVAL, "error parsing config: detected empty value for key:'%s'", key.c_str());
             }
             expect_value = false;
             if (start + len >= cut_config.size())


### PR DESCRIPTION
Updated the cppsuite parsing logic to detect syntax errors when defining key/value definitions. This changes detects and raises errors for the following syntax mistakes:
- If we start parsing a new key without having resolved the value of the previous key i.e. due to a missing comma ','.
- Incomplete key/value pair definitions i.e due to a missing equals '='.
- Detect when empty string is used for a key.
- Detect when empty string is used for a value.