### PR TITLE
WT-8233 Fix data-validation-stress-test-checkpoint ignoring failures

### DIFF
--- a/tools/run_parallel.sh
+++ b/tools/run_parallel.sh
@@ -42,14 +42,22 @@ for i in $(seq $num_iter); do
   echo "Starting iteration $i" >> $outf
   echo "Starting iteration $i"
 
+  process_ids=()
   # start the commands in parallel
   for((t=1; t<=num_parallel; t++)); do
     echo "Starting parallel command $t (of $num_parallel) in iteration $i (of $num_iter)" >> nohup.out.$t
     eval nohup $command >> nohup.out.$t 2>&1 &
+    process_ids[$t]=$!
   done
 
   # Wait for the commands to all complete
   for((t=1; t<=num_parallel; t++)); do
-    wait || exit $?
+    wait ${process_ids[$t]}
+    err=$?
+    if [[ $err -ne 0 ]]
+    then
+      echo "iteration $i of parallel command $t failed with $err error code"
+      exit $err
+    fi
   done
 done


### PR DESCRIPTION
Changed bash script to wait on specific process, this allows us to check the error code when the process is finished.