### PR TITLE
WT-2298 Rewrite overflow items during compact

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1322,6 +1322,9 @@ methods = {
         actual amount of time spent in compact may exceed the configured
         value. A value of zero disables the timeout''',
         type='int'),
+    Config('ovfl_rewrite', 'false', r'''
+        rewrite overflow items as part of compact''',
+        type='boolean'),
 ]),
 
 'WT_SESSION.create' : Method(file_config + lsm_config + tiered_config +

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -189,7 +189,7 @@ __compact_page(WT_SESSION_IMPL *session, WT_REF *ref, bool ovfl_rewrite, bool *s
                 WT_ERR(__compact_page_replace_addr(session, ref, &copy));
                 WT_STAT_DATA_INCR(session, btree_compact_pages_rewritten);
             }
-        } else if (copy.type == WT_ADDR_LEAF_NO) {
+        } else {
             WT_REF_UNLOCK(ref, previous_state);
             WT_ERR(__wt_page_in_func(session, ref, 0
 #ifdef HAVE_DIAGNOSTIC

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -466,6 +466,7 @@ __wt_compact(WT_SESSION_IMPL *session, bool ovfl_rewrite)
             /* Rewrite the page: mark the page and tree dirty. */
             WT_ERR(__wt_page_modify_init(session, ref->page));
             __wt_page_modify_set(session, ref->page);
+            ref->page->modify->compact_rewrite_ovfl = true;
 
             session->compact_state = WT_COMPACT_SUCCESS;
         }

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -190,7 +190,7 @@ __compact_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
                 WT_RET(__wt_page_modify_init(session, ref->page));
                 __wt_page_modify_set(session, ref->page);
                 F_SET_ATOMIC(ref->page, WT_PAGE_COMPACTION_WRITE);
-                ref->page.compact_rewrite_ovfl = true;
+                ref->page->modify->compact_rewrite_ovfl = true;
             }
         } else {
             WT_ERR(bm->compact_page_rewrite(bm, session, copy.addr, &addr_size, skipp));

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -234,7 +234,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_commit_transaction[] = {
   {"sync", "string", NULL, "choices=[\"off\",\"on\"]", NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_compact[] = {
-  {"timeout", "int", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
+  {"ovfl_rewrite", "boolean", NULL, NULL, NULL, 0}, {"timeout", "int", NULL, NULL, NULL, 0},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_create_encryption_subconfigs[] = {
   {"keyid", "string", NULL, NULL, NULL, 0}, {"name", "string", NULL, NULL, NULL, 0},
@@ -1203,7 +1204,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "commit_timestamp=,durable_timestamp=,operation_timeout_ms=0,"
     "sync=",
     confchk_WT_SESSION_commit_transaction, 4},
-  {"WT_SESSION.compact", "timeout=1200", confchk_WT_SESSION_compact, 1},
+  {"WT_SESSION.compact", "ovfl_rewrite=false,timeout=1200", confchk_WT_SESSION_compact, 2},
   {"WT_SESSION.create",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -353,6 +353,9 @@ struct __wt_page_modify {
     size_t bytes_dirty;
     size_t bytes_updates;
 
+    /* Track request from compact to rewrite overflow items. */
+    bool compact_rewrite_ovfl;
+
     /*
      * When pages are reconciled, the result is one or more replacement blocks. A replacement block
      * can be in one of two states: it was written to disk, and so we have a block address, or it

--- a/src/include/compact.h
+++ b/src/include/compact.h
@@ -7,6 +7,7 @@
  */
 
 struct __wt_compact_state {
+    bool ovfl_rewrite;
     uint32_t lsm_count;  /* Number of LSM trees seen */
     uint32_t file_count; /* Number of files seen */
     uint64_t max_time;   /* Configured timeout */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -400,8 +400,6 @@ extern int __wt_collator_config(WT_SESSION_IMPL *session, const char *uri, WT_CO
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_compact(WT_SESSION_IMPL *session, bool ovfl_rewrite)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *skipp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_compressor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval,
   WT_COMPRESSOR **compressorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cond_auto_alloc(WT_SESSION_IMPL *session, const char *name, uint64_t min,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -398,7 +398,10 @@ extern int __wt_col_search(WT_CURSOR_BTREE *cbt, uint64_t search_recno, WT_REF *
 extern int __wt_collator_config(WT_SESSION_IMPL *session, const char *uri, WT_CONFIG_ITEM *cname,
   WT_CONFIG_ITEM *metadata, WT_COLLATOR **collatorp, int *ownp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_compact(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_compact(WT_SESSION_IMPL *session, bool ovfl_rewrite)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_compact_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *skipp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_compressor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval,
   WT_COMPRESSOR **compressorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cond_auto_alloc(WT_SESSION_IMPL *session, const char *name, uint64_t min,

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1351,6 +1351,8 @@ struct __wt_session {
 	 * @param name the URI of the object to compact, such as
 	 * \c "table:stock"
 	 * @configstart{WT_SESSION.compact, see dist/api_data.py}
+	 * @config{ovfl_rewrite, rewrite overflow items as part of compact., a boolean flag; default
+	 * \c false.}
 	 * @config{timeout, maximum amount of time to allow for compact in seconds.  The actual
 	 * amount of time spent in compact may exceed the configured value.  A value of zero
 	 * disables the timeout., an integer; default \c 1200.}

--- a/test/suite/test_compact03.py
+++ b/test/suite/test_compact03.py
@@ -154,10 +154,11 @@ class test_compact03(wttest.WiredTigerTestCase):
         # 7 & 8. Call compact. We expect that the overflow values at the end of the file are not
         #        rewritten and therefore the file size will mostly remain the same. Give a leeway
         #        of 10%.
-        self.session.compact(self.uri)
+        self.session.compact(self.uri, "ovfl_rewrite=true")
         sizeAfterCompact = self.getSize()
         self.pr('After deleting values and compactions ' + str(sizeAfterCompact // mb) + 'MB')
-        self.assertGreater(sizeAfterCompact, (sizeWithOverflow // 10) * 9)
+        #self.assertGreater(sizeAfterCompact, (sizeWithOverflow // 10) * 9)
+        self.assertLess(sizeAfterCompact, (sizeWithOverflow // 100) * 95)
 
         # Verify that we did indeed rewrote some pages but that didn't help with the file size.
         statDict = self.getCompactProgressStats()


### PR DESCRIPTION
The idea is to have two code paths based on the configuration provided by caller as part of `session->compact()` call. If the caller asks for overflow items to be rewritten, we can follow the old method of walking leaf pages and marking them dirty if they can be rewritten. As part of rewriting the page, we also rewrite the overflow items.

The code is still WIP pending resolving some test failures.