### PR TITLE
Switch Evergreen performance tests to use ubuntu2004-large instance

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3307,7 +3307,7 @@ buildvariants:
 - name: ubuntu2004-perf-tests
   display_name: Ubuntu 20.04 Performance tests
   run_on:
-    - ubuntu2004-test
+    - ubuntu2004-large
   expansions:
     test_env_vars: LD_LIBRARY_PATH=$(pwd) WT_BUILDDIR=$(pwd)
     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DCMAKE_C_FLAGS="-ggdb" -DHAVE_DIAGNOSTIC=1 -DENABLE_ZLIB=1  -DENABLE_SNAPPY=1 -DENABLE_STRICT=1 -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL


### PR DESCRIPTION
WT-8298 Switch Evergreen performance tests to use ubuntu2004-large instance