### PR TITLE
WT-8169 - Restrict the timestamp API to avoid transactions with timestamped and non-timestamped updates

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1780,9 +1780,9 @@ methods = {
         set the commit timestamp for the current transaction.  The supplied
         value must not be older than the first commit timestamp set for the
         current transaction.  The value must also not be older than the
-        current oldest and stable timestamps. If a transaction already contains 
-        updates with no timestamp then commit_timestamp cannot be set for 
-        non-prepared transactions. See @ref transaction_timestamps'''),
+        current oldest and stable timestamps. timestamp_transaction cannot 
+        be called on a transaction that contains non-timestamped commits. 
+        See @ref transaction_timestamps'''),
     Config('durable_timestamp', '', r'''
         set the durable timestamp for the current transaction.  The supplied
         value must not be older than the commit timestamp set for the

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1780,8 +1780,9 @@ methods = {
         set the commit timestamp for the current transaction.  The supplied
         value must not be older than the first commit timestamp set for the
         current transaction.  The value must also not be older than the
-        current oldest and stable timestamps.  See
-        @ref transaction_timestamps'''),
+        current oldest and stable timestamps. If a transaction already contains 
+        updates with no timestamp then commit_timestamp cannot be set for 
+        non-prepared transactions. See @ref transaction_timestamps'''),
     Config('durable_timestamp', '', r'''
         set the durable timestamp for the current transaction.  The supplied
         value must not be older than the commit timestamp set for the

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1831,9 +1831,8 @@ struct __wt_session {
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
 	 * supplied value must not be older than the first commit timestamp set for the current
 	 * transaction.  The value must also not be older than the current oldest and stable
-	 * timestamps.  If a transaction already contains updates with no timestamp then
-	 * commit_timestamp cannot be set for non-prepared transactions.  See @ref
-	 * transaction_timestamps., a string; default empty.}
+	 * timestamps.  timestamp_transaction cannot be called on a transaction that contains
+	 * non-timestamped commits.  See @ref transaction_timestamps., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.  The
 	 * supplied value must not be older than the commit timestamp set for the current
 	 * transaction.  The value must also not be older than the current stable timestamp.  See

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1831,7 +1831,9 @@ struct __wt_session {
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
 	 * supplied value must not be older than the first commit timestamp set for the current
 	 * transaction.  The value must also not be older than the current oldest and stable
-	 * timestamps.  See @ref transaction_timestamps., a string; default empty.}
+	 * timestamps.  If a transaction already contains updates with no timestamp then
+	 * commit_timestamp cannot be set for non-prepared transactions.  See @ref
+	 * transaction_timestamps., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.  The
 	 * supplied value must not be older than the commit timestamp set for the current
 	 * transaction.  The value must also not be older than the current stable timestamp.  See

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1764,8 +1764,7 @@ __session_timestamp_transaction(WT_SESSION *wt_session, const char *config)
      * transactions are an exception to this rule as we can guarantee that no new updates will be
      * added after a timestamp_transaction.
      */
-    if (txn->mod_count != 0 && !F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) &&
-      !F_ISSET(txn, WT_TXN_PREPARE)) {
+    if (txn->mod_count != 0 && !F_ISSET(txn, WT_TXN_HAS_TS_COMMIT)) {
         WT_ERR_MSG(session, EINVAL,
           "Cannot set a timestamp for transaction %" PRIu64
           " as it already contains updates with no timestamp",

--- a/test/csuite/wt6185_modify_ts/main.c
+++ b/test/csuite/wt6185_modify_ts/main.c
@@ -226,8 +226,7 @@ modify(WT_SESSION *session, WT_CURSOR *c)
         trace("returned {%s}", v);
 
         testutil_check(__wt_snprintf(tmp, sizeof(tmp), "commit_timestamp=%" PRIx64, ts + 1));
-        testutil_check(session->timestamp_transaction(session, tmp));
-        testutil_check(session->commit_transaction(session, NULL));
+        testutil_check(session->commit_transaction(session, tmp));
 
         list[lnext].ts = ts + 1; /* Reread at commit timestamp */
         ++lnext;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -509,16 +509,20 @@ commit_transaction(TINFO *tinfo, bool prepared)
         lock_writelock(session, &g.ts_lock);
 
         ts = __wt_atomic_addv64(&g.timestamp, 1);
-        testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
-        testutil_check(session->timestamp_transaction(session, buf));
 
         if (prepared) {
+            testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
+            testutil_check(session->timestamp_transaction(session, buf));
             testutil_check(__wt_snprintf(buf, sizeof(buf), "durable_timestamp=%" PRIx64, ts));
             testutil_check(session->timestamp_transaction(session, buf));
+            testutil_check(session->commit_transaction(session, NULL));
+        } else {
+            testutil_check(__wt_snprintf(buf, sizeof(buf), "commit_timestamp=%" PRIx64, ts));
+            testutil_check(session->commit_transaction(session, buf));
         }
 
         lock_writeunlock(session, &g.ts_lock);
-        testutil_check(session->commit_transaction(session, NULL));
+
         if (prepared)
             lock_readunlock(session, &g.prepare_commit_lock);
     } else

--- a/test/suite/test_assert05.py
+++ b/test/suite/test_assert05.py
@@ -66,22 +66,18 @@ class test_assert05(wttest.WiredTigerTestCase, suite_subprocess):
         # Commit with a timestamp
         self.session.begin_transaction()
         c[key] = val
-        self.session.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(self.count))
-        self.session.timestamp_transaction(
-            'commit_timestamp=' + self.timestamp_str(self.count))
-        self.session.timestamp_transaction(
-            'durable_timestamp=' + self.timestamp_str(self.count))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(self.count))
+        timestamps = 'commit_timestamp=' + self.timestamp_str(self.count) + ',durable_timestamp=' + self.timestamp_str(self.count)
         # All settings other than never should commit successfully
         if (use_ts != 'never'):
-            self.session.commit_transaction()
+            self.session.commit_transaction(timestamps)
         else:
             '''
             Commented out for now: the system panics if we fail after preparing a transaction.
 
             msg = "/timestamp set on this transaction/"
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                lambda:self.assertEquals(self.session.commit_transaction(),
+                lambda:self.assertEquals(self.session.commit_transaction(timestamps),
                 0), msg)
             '''
             self.session.rollback_transaction()

--- a/test/suite/test_assert05.py
+++ b/test/suite/test_assert05.py
@@ -98,11 +98,9 @@ class test_assert05(wttest.WiredTigerTestCase, suite_subprocess):
             self.session.prepare_transaction(
                 'prepare_timestamp=' + self.timestamp_str(self.count))
 
-        self.session.timestamp_transaction(
-            'commit_timestamp=' + self.timestamp_str(self.count))
         # All settings other than always should commit successfully
         if (use_ts != 'always' and use_ts != 'never'):
-            self.session.commit_transaction()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.count))
         else:
             '''
             Commented out for now: the system panics if we fail after preparing a transaction.

--- a/test/suite/test_assert07.py
+++ b/test/suite/test_assert07.py
@@ -42,13 +42,10 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
     ]
     scenarios = make_scenarios(key_format_values)
 
-    def apply_timestamps(self, timestamp):
-        self.session.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(timestamp))
-        self.session.timestamp_transaction(
-            'commit_timestamp=' + self.timestamp_str(timestamp))
-        self.session.timestamp_transaction(
-            'durable_timestamp=' + self.timestamp_str(timestamp))
+    def apply_timestamps_and_commit(self, timestamp):
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(timestamp))
+        timestamps = 'commit_timestamp=' + self.timestamp_str(timestamp) + ',durable_timestamp=' + self.timestamp_str(timestamp)
+        self.session.commit_transaction(timestamps)
 
     def test_timestamp_alter(self):
         base = 'assert07'
@@ -61,24 +58,21 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction('isolation=snapshot')
         c[key_ts1] = 'value1'
-        self.apply_timestamps(1)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(1)
 
         # Reserved at the start of the chain, with one update.
         self.session.begin_transaction('isolation=snapshot')
         c.set_key(key_ts1)
         c.reserve()
         c[key_ts1] = 'value2'
-        self.apply_timestamps(2)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(2)
 
         # Reserved at the end of the chain, with one update.
         self.session.begin_transaction('isolation=snapshot')
         c[key_ts1] = 'value3'
         c.set_key(key_ts1)
         c.reserve()
-        self.apply_timestamps(3)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(3)
 
         # Reserved at the start of the chain, with multiple.
         self.session.begin_transaction('isolation=snapshot')
@@ -86,8 +80,7 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c.reserve()
         c[key_ts1] = 'value4'
         c[key_ts1] = 'value5'
-        self.apply_timestamps(4)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(4)
 
         # Reserved at the end of the chain, with multiple updates.
         self.session.begin_transaction('isolation=snapshot')
@@ -95,8 +88,7 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c[key_ts1] = 'value7'
         c.set_key(key_ts1)
         c.reserve()
-        self.apply_timestamps(5)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(5)
 
         # Reserved between two updates.
         self.session.begin_transaction('isolation=snapshot')
@@ -104,8 +96,7 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c.set_key(key_ts1)
         c.reserve()
         c[key_ts1] = 'value9'
-        self.apply_timestamps(6)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(6)
 
         # Reserved update with multiple extra updates.
         self.session.begin_transaction('isolation=snapshot')
@@ -115,8 +106,7 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c[key_ts1] = 'value11'
         c[key_ts1] = 'value12'
         c[key_ts1] = 'value13'
-        self.apply_timestamps(7)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(7)
 
         # Reserved updates with multiple extra updates.
         self.session.begin_transaction('isolation=snapshot')
@@ -128,8 +118,7 @@ class test_assert07(wttest.WiredTigerTestCase, suite_subprocess):
         c.set_key(key_ts1)
         c.reserve()
         c[key_ts1] = 'value17'
-        self.apply_timestamps(8)
-        self.session.commit_transaction()
+        self.apply_timestamps_and_commit(8)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -144,6 +144,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         session1.begin_transaction()
         cursor1 = session1.open_cursor(self.uri)
 
+        session1.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
         for i in range(self.nrows+1, (self.nrows*2)+1):
             cursor1.set_key(ds.key(i))
             cursor1.set_value(valuea)
@@ -200,6 +201,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         session2 = self.conn.open_session()
         session2.begin_transaction()
         cursor2 = session2.open_cursor(self.uri)
+        session2.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
 
         for i in range((self.nrows+1), (self.nrows*2)+1):
             cursor2.set_key(ds.key(i))

--- a/test/suite/test_debug_mode05.py
+++ b/test/suite/test_debug_mode05.py
@@ -51,11 +51,8 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
             cursor[i] = b'a' * 100
         self.session.prepare_transaction(
             'prepare_timestamp=' + self.timestamp_str(150))
-        self.session.timestamp_transaction(
-            'commit_timestamp=' + self.timestamp_str(200))
-        self.session.timestamp_transaction(
-            'durable_timestamp=' + self.timestamp_str(250))
-        self.session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(200) + ',durable_timestamp=' + self.timestamp_str(250)
+        self.session.commit_transaction(timestamps)
         cursor.close()
 
         self.conn.rollback_to_stable()
@@ -68,11 +65,8 @@ class test_debug_mode05(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         self.session.prepare_transaction(
             'prepare_timestamp=' + self.timestamp_str(300))
-        self.session.timestamp_transaction(
-            'commit_timestamp=' + self.timestamp_str(350))
-        self.session.timestamp_transaction(
-            'durable_timestamp=' + self.timestamp_str(400))
-        self.session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(350) + ',durable_timestamp=' + self.timestamp_str(400)
+        self.session.commit_transaction(timestamps)
 
         # The aforementioned bug resulted in a failure in rollback to stable.
         # This is because we failed to clear out a txn id from our global state

--- a/test/suite/test_durable_rollback_to_stable.py
+++ b/test/suite/test_durable_rollback_to_stable.py
@@ -86,9 +86,8 @@ class test_durable_rollback_to_stable(wttest.WiredTigerTestCase, suite_subproces
             self.assertEquals(cursor.next(), 0)
 
         session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
-        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
-        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(220))
-        session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(200) + ',durable_timestamp=' + self.timestamp_str(220)
+        session.commit_transaction(timestamps)
 
         # Check the values read are correct with different timestamps.
         # Read the initial dataset.
@@ -134,9 +133,8 @@ class test_durable_rollback_to_stable(wttest.WiredTigerTestCase, suite_subproces
 
         # Commit timestamp is earlier to stable timestamp but durable timestamp
         # is later than stable timestamp. Hence second update value is not durable.
-        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(240))
-        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(300))
-        session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(240) + ',durable_timestamp=' + self.timestamp_str(300)
+        session.commit_transaction(timestamps)
 
         # Checkpoint so that first update value will be visible and durable,
         # but second update value will be only visible but not durable.

--- a/test/suite/test_durable_ts01.py
+++ b/test/suite/test_durable_ts01.py
@@ -85,9 +85,8 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
             self.assertEquals(cursor.next(), 0)
 
         session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
-        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
-        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(220))
-        session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(200) + ',durable_timestamp=' + self.timestamp_str(220)
+        session.commit_transaction(timestamps)
 
         # Check the values read are correct with different timestamps.
         # Read the initial dataset.
@@ -133,9 +132,8 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
 
         # Commit timestamp is earlier to stable timestamp but durable timestamp
         # is later than stable timestamp. Hence second update value is not durable.
-        session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(240))
-        session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(300))
-        session.commit_transaction()
+        timestamps = 'commit_timestamp=' + self.timestamp_str(240) + ',durable_timestamp=' + self.timestamp_str(300)
+        session.commit_transaction(timestamps)
 
         # Checkpoint so that first update value will be visible and durable,
         # but second update value will be only visible but not durable.

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -76,9 +76,8 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             session.begin_transaction()
             cursor[i] = valueB
             session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(150))
-            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
-            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(220))
-            session.commit_transaction()
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(200) +
+                ',durable_timestamp=' + self.timestamp_str(220))
 
         # Check the checkpoint wrote only the durable updates.
         cursor2 = self.session.open_cursor(
@@ -116,9 +115,8 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             session.begin_transaction()
             cursor[i] = valueC
             session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(220))
-            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(230))
-            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(240))
-            session.commit_transaction()
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(230) + 
+                ',durable_timestamp=' + self.timestamp_str(240))
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(250))
         self.session.checkpoint()

--- a/test/suite/test_prepare01.py
+++ b/test/suite/test_prepare01.py
@@ -136,8 +136,7 @@ class test_prepare01(wttest.WiredTigerTestCase):
 
         self.check(cursor, committed, self.nentries)
 
-        self.session.timestamp_transaction("prepare_timestamp=2a")
-        self.session.prepare_transaction()
+        self.session.prepare_transaction("prepare_timestamp=2a")
         self.session.timestamp_transaction("commit_timestamp=3a")
         self.session.timestamp_transaction("durable_timestamp=3a")
         self.session.commit_transaction()

--- a/test/suite/test_prepare01.py
+++ b/test/suite/test_prepare01.py
@@ -118,9 +118,7 @@ class test_prepare01(wttest.WiredTigerTestCase):
             if i > 0 and i % (self.nentries // 37) == 0:
                 self.check(cursor, committed, i)
                 self.session.prepare_transaction("prepare_timestamp=2a")
-                self.session.timestamp_transaction("commit_timestamp=3a")
-                self.session.timestamp_transaction("durable_timestamp=3a")
-                self.session.commit_transaction()
+                self.session.commit_transaction("commit_timestamp=3a, durable_timestamp=3a")
                 committed = i
                 self.session.begin_transaction()
 
@@ -137,9 +135,7 @@ class test_prepare01(wttest.WiredTigerTestCase):
         self.check(cursor, committed, self.nentries)
 
         self.session.prepare_transaction("prepare_timestamp=2a")
-        self.session.timestamp_transaction("commit_timestamp=3a")
-        self.session.timestamp_transaction("durable_timestamp=3a")
-        self.session.commit_transaction()
+        self.session.commit_transaction("commit_timestamp=3a, durable_timestamp=3a")
         self.check(cursor, self.nentries, self.nentries)
 
 if __name__ == '__main__':

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -84,7 +84,6 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda:self.session.prepare_transaction("prepare_timestamp=2a"), msg)
         # WT_SESSION.rollback_transaction permitted, tested below.
-        self.session.timestamp_transaction("commit_timestamp=2b")
         self.assertTimestampsEqual(self.session.query_timestamp('get=prepare'), '2a')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda:self.session.checkpoint(), msg)
@@ -92,25 +91,19 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Commit the transaction. Test that no "not permitted in a prepared transaction" error has
         # set a transaction error flag, that is, we should still be able to commit successfully.
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction('commit_timestamp=2a')
+        self.session.commit_transaction('commit_timestamp=2b, durable_timestamp=2b')
 
         # Commit after prepare is permitted.
         self.session.begin_transaction()
         c1 = self.session.open_cursor("table:mytable", None)
         self.session.prepare_transaction("prepare_timestamp=2a")
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction()
+        self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
 
         # Setting commit timestamp via timestamp_transaction after prepare is also permitted.
         self.session.begin_transaction()
         c1 = self.session.open_cursor("table:mytable", None)
         self.session.prepare_transaction("prepare_timestamp=2a")
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction()
+        self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
 
         # Rollback after prepare is permitted.
         self.session.begin_transaction()

--- a/test/suite/test_prepare03.py
+++ b/test/suite/test_prepare03.py
@@ -94,9 +94,7 @@ class test_prepare03(wttest.WiredTigerTestCase):
             self.session.prepare_transaction("prepare_timestamp=2a")
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda:cursor.insert(), preparemsg)
-            self.session.timestamp_transaction("commit_timestamp=2b")
-            self.session.timestamp_transaction("durable_timestamp=2b")
-            self.session.commit_transaction()
+            self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
             cursor.insert()
 
         # Check next, get_key, get_value operations.
@@ -113,9 +111,7 @@ class test_prepare03(wttest.WiredTigerTestCase):
                 lambda:cursor.get_key(), preparemsg)
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda:cursor.get_value(), preparemsg)
-            self.session.timestamp_transaction("commit_timestamp=2b")
-            self.session.timestamp_transaction("durable_timestamp=2b")
-            self.session.commit_transaction()
+            self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
             nextret = cursor.next()
             if nextret != 0:
                 break
@@ -139,9 +135,7 @@ class test_prepare03(wttest.WiredTigerTestCase):
             self.session.prepare_transaction("prepare_timestamp=2a")
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda:cursor.prev(), preparemsg)
-            self.session.timestamp_transaction("commit_timestamp=2b")
-            self.session.timestamp_transaction("durable_timestamp=2b")
-            self.session.commit_transaction()
+            self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
             prevret = cursor.prev()
             if prevret != 0:
                 break
@@ -175,9 +169,7 @@ class test_prepare03(wttest.WiredTigerTestCase):
             lambda:cursor.reserve(), preparemsg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda:cursor.reconfigure(), preparemsg)
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction()
+        self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
         cursor.search()
         cursor.set_value(self.genvalue(self.nentries + self.nentries//2))
         cursor.update()
@@ -189,9 +181,7 @@ class test_prepare03(wttest.WiredTigerTestCase):
         self.session.prepare_transaction("prepare_timestamp=2a")
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda:cursor.search_near(), preparemsg)
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction()
+        self.session.commit_transaction("commit_timestamp=2b, durable_timestamp=2b")
         # There is a bug with search_near operation when no key is set.
         # This fix is being tracked in WT-3918.
         if self.uri == 'lsm':

--- a/test/suite/test_prepare04.py
+++ b/test/suite/test_prepare04.py
@@ -118,9 +118,8 @@ class test_prepare04(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda:c_other.update(), conflictmsg)
         s_other.rollback_transaction()
 
-        self.session.timestamp_transaction('commit_timestamp=' + timestamp_str(300))
-        self.session.timestamp_transaction('durable_timestamp=' + timestamp_str(300))
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + timestamp_str(300) + 
+            ',durable_timestamp=' + timestamp_str(300))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_prepare05.py
+++ b/test/suite/test_prepare05.py
@@ -62,9 +62,8 @@ class test_prepare05(wttest.WiredTigerTestCase, suite_subprocess):
         # Check setting the prepare timestamp same as oldest timestamp is valid.
         self.session.begin_transaction()
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(2))
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(3))
-        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(3))
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3) + 
+            ',durable_timestamp=' + self.timestamp_str(3))
 
         # In a single transaction it is illegal to set a commit timestamp
         # before invoking prepare for this transaction.
@@ -121,9 +120,8 @@ class test_prepare05(wttest.WiredTigerTestCase, suite_subprocess):
         c[1] = 1
         self.session.prepare_transaction(
                 'prepare_timestamp=' + self.timestamp_str(5))
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(5))
-        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(5))
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5) + 
+            ',durable_timestamp=' + self.timestamp_str(5))
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_prepare06.py
+++ b/test/suite/test_prepare06.py
@@ -65,9 +65,8 @@ class test_prepare06(wttest.WiredTigerTestCase, suite_subprocess):
         # oldest timestamp is valid with roundup_timestamps settings.
         self.session.begin_transaction('roundup_timestamps=(prepared=true)')
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(15))
-        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(35))
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15) + 
+            ',durable_timestamp=' + self.timestamp_str(35))
 
         '''
         Commented out for now: the system panics if we fail after preparing a transaction.

--- a/test/suite/test_prepare11.py
+++ b/test/suite/test_prepare11.py
@@ -61,8 +61,7 @@ class test_prepare11(wttest.WiredTigerTestCase):
         c[self.key1] = 'yyyy'
         self.session.prepare_transaction('prepare_timestamp=10')
         if self.commit:
-            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
-            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(30))
-            self.session.commit_transaction()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20) + 
+                ',durable_timestamp=' + self.timestamp_str(30))
         else:
             self.session.rollback_transaction()

--- a/test/suite/test_prepare13.py
+++ b/test/suite/test_prepare13.py
@@ -97,9 +97,8 @@ class test_prepare13(wttest.WiredTigerTestCase):
             s.rollback_transaction()
 
         finally:
-            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(50))
-            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(50))
-            self.session.commit_transaction()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(50) + 
+                ',durable_timestamp=' + self.timestamp_str(50))
 
         s.close()
 

--- a/test/suite/test_prepare15.py
+++ b/test/suite/test_prepare15.py
@@ -107,9 +107,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
 
         if self.commit:
-            s.timestamp_transaction('commit_timestamp=' + self.timestamp_str(50))
-            s.timestamp_transaction('durable_timestamp=' + self.timestamp_str(60))
-            s.commit_transaction()
+            s.commit_transaction('commit_timestamp=' + self.timestamp_str(50) + 
+                ',durable_timestamp=' + self.timestamp_str(60))
         else:
             s.rollback_transaction()
 
@@ -175,9 +174,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
 
         if self.commit:
-            s.timestamp_transaction('commit_timestamp=' + self.timestamp_str(50))
-            s.timestamp_transaction('durable_timestamp=' + self.timestamp_str(60))
-            s.commit_transaction()
+            s.commit_transaction('commit_timestamp=' + self.timestamp_str(50) + 
+                ',durable_timestamp=' + self.timestamp_str(60))
         else:
             s.rollback_transaction()
 
@@ -258,9 +256,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
 
         if self.commit:
-            s.timestamp_transaction('commit_timestamp=' + self.timestamp_str(30))
-            s.timestamp_transaction('durable_timestamp=' + self.timestamp_str(40))
-            s.commit_transaction()
+            s.commit_transaction('commit_timestamp=' + self.timestamp_str(30) + 
+                ',durable_timestamp=' + self.timestamp_str(40))
         else:
             s.rollback_transaction()
 

--- a/test/suite/test_prepare16.py
+++ b/test/suite/test_prepare16.py
@@ -93,9 +93,8 @@ class test_prepare16(wttest.WiredTigerTestCase):
             evict_cursor.reset()
 
         if self.commit:
-            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
-            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(30))
-            self.session.commit_transaction()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20) + 
+                ',durable_timestamp=' + self.timestamp_str(30))
         else:
             self.session.rollback_transaction()
 

--- a/test/suite/test_prepare_conflict.py
+++ b/test/suite/test_prepare_conflict.py
@@ -75,9 +75,8 @@ class test_prepare_conflict(wttest.WiredTigerTestCase):
 
         # Prepare and commit the transaction.
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(20))
-        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(20))
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20) + 
+            ',durable_timestamp=' + self.timestamp_str(20))
 
         # WT-6325 reports WT_PREPARE_CONFLICT while iterating the cursor.
         # Walk the table, the bug will cause a prepared conflict return.

--- a/test/suite/test_prepare_cursor01.py
+++ b/test/suite/test_prepare_cursor01.py
@@ -135,9 +135,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(200))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(200) + 
+            ',durable_timestamp=' + self.timestamp_str(200))
 
         before_ts_s.commit_transaction()
         # As read is between(i.e before commit), next is not found.
@@ -193,9 +192,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(200))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(200))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(200) + 
+            ',durable_timestamp=' + self.timestamp_str(200))
 
         # As read is between(i.e before commit), prev is not found.
         self.assertEquals(between_ts_c.prev(), wiredtiger.WT_NOTFOUND)
@@ -253,9 +251,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(400))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(400))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(400) + 
+            ',durable_timestamp=' + self.timestamp_str(400))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(51))
@@ -317,9 +314,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(400))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(400))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(400) + 
+            ',durable_timestamp=' + self.timestamp_str(400))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(1))
@@ -384,9 +380,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(600))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(600))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(600) + 
+            ',durable_timestamp=' + self.timestamp_str(600))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(51))
@@ -440,9 +435,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(600))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(600))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(600) + 
+            ',durable_timestamp=' + self.timestamp_str(600))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(1))
@@ -503,9 +497,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(800))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(800))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(800) + 
+            ',durable_timestamp=' + self.timestamp_str(800))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(49))
@@ -561,9 +554,8 @@ class test_prepare_cursor01(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
 
         # Commit the prepared transaction.
-        prep_session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(800))
-        prep_session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(800))
-        prep_session.commit_transaction()
+        prep_session.commit_transaction('commit_timestamp=' + self.timestamp_str(800) + 
+            ',durable_timestamp=' + self.timestamp_str(800))
 
         # Check to see before cursor still gets the old value.
         before_ts_c.set_key(ds.key(3))

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -75,9 +75,8 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                     session.commit_transaction()
                 elif prepare:
                     session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-                    session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-                    session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-                    session.commit_transaction()
+                    session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                        ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
                 else:
                     session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()
@@ -102,9 +101,8 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                 session.commit_transaction()
             elif prepare:
                 session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-                session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-                session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-                session.commit_transaction()
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                    ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
             else:
                 session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()
@@ -127,9 +125,8 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                     session.commit_transaction()
                 elif prepare:
                     session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-                    session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-                    session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-                    session.commit_transaction()
+                    session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                        ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
                 else:
                     session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
             cursor.close()

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -28,6 +28,7 @@
 
 import os
 import wiredtiger
+import wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from test_rollback_to_stable01 import test_rollback_to_stable_base
@@ -80,9 +81,8 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
                 session.commit_transaction()
         elif self.prepare:
             session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-            session.commit_transaction()
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
         else:
             session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
@@ -95,9 +95,8 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
                 session.commit_transaction()
         elif self.prepare:
             session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-            session.commit_transaction()
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
         else:
             session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 
@@ -109,9 +108,8 @@ class test_rollback_to_stable09(test_rollback_to_stable_base):
                 session.commit_transaction()
         elif self.prepare:
             session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-            session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-            session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-            session.commit_transaction()
+            session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
         else:
             session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
 

--- a/test/suite/test_rollback_to_stable12.py
+++ b/test/suite/test_rollback_to_stable12.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import wttest
 import fnmatch, os, shutil, time
 from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
@@ -89,9 +90,8 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         cursor[ds.key(1)] = value_b
         if self.prepare:
             self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(commit_ts-1))
-            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(commit_ts+1))
-            self.session.commit_transaction()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts) + 
+                ',durable_timestamp=' + self.timestamp_str(commit_ts+1))
         else:
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()

--- a/test/suite/test_timestamp14.py
+++ b/test/suite/test_timestamp14.py
@@ -262,8 +262,8 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
         # We have a running transaction with a lower commit_timestamp than we've
         # seen before. So all_durable should return (lowest commit timestamp - 1).
         session1.begin_transaction()
-        cur1[2] = 2
         session1.timestamp_transaction('commit_timestamp=2')
+        cur1[2] = 2
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=all_durable'), '1')
         session1.commit_transaction()
@@ -313,8 +313,8 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Now test a scenario with multiple commit timestamps for a single txn.
         session1.begin_transaction()
-        cur1[5] = 5
         session1.timestamp_transaction('commit_timestamp=6')
+        cur1[5] = 5
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=all_durable'), '5')
 

--- a/test/suite/test_timestamp14.py
+++ b/test/suite/test_timestamp14.py
@@ -271,52 +271,12 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
         # After committing, go back to the value we saw previously.
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=all_durable'), '3')
-
-        # For prepared transactions, we take into account the durable timestamp
-        # when calculating all_durable.
-        session1.begin_transaction()
-        cur1[3] = 3
-        session1.prepare_transaction('prepare_timestamp=6')
-
-        # If we have a commit timestamp for a prepared transaction, then we
-        # don't want that to be visible in the all_durable calculation.
-        session1.timestamp_transaction('commit_timestamp=7')
-        self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '3')
-
-        # Now take into account the durable timestamp.
-        session1.timestamp_transaction('durable_timestamp=8')
-        session1.commit_transaction()
-        self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '8')
-
-        # All durable moves back when we have a running prepared transaction
-        # with a lower durable timestamp than has previously been committed.
-        session1.begin_transaction()
-        cur1[4] = 4
-        session1.prepare_transaction('prepare_timestamp=3')
-
-        # If we have a commit timestamp for a prepared transaction, then we
-        # don't want that to be visible in the all_durable calculation.
-        session1.timestamp_transaction('commit_timestamp=4')
-        self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '8')
-
-        # Now take into account the durable timestamp.
-        session1.timestamp_transaction('durable_timestamp=5')
-        self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '4')
-        session1.commit_transaction()
-
-        self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '8')
-
         # Now test a scenario with multiple commit timestamps for a single txn.
         session1.begin_transaction()
         session1.timestamp_transaction('commit_timestamp=6')
         cur1[5] = 5
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '5')
+            self.conn.query_timestamp('get=all_durable'), '3')
 
         # Make more changes and set a new commit timestamp.
         # Our calculation should use the first commit timestamp so there should
@@ -324,12 +284,12 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
         cur1[6] = 6
         session1.timestamp_transaction('commit_timestamp=7')
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '5')
+            self.conn.query_timestamp('get=all_durable'), '3')
 
-        # Once committed, we go back to 8.
+        # Once committed, we go back to 7.
         session1.commit_transaction()
         self.assertTimestampsEqual(
-            self.conn.query_timestamp('get=all_durable'), '8')
+            self.conn.query_timestamp('get=all_durable'), '7')
 
     def test_all(self):
         all_uri = self.uri + 'pinned_oldest'


### PR DESCRIPTION
A restriction of the timestamp API such that timestamp_transactions cannot be called on transactions containing a non-timestamped update.
In previous behaviour WT would backfill un-timestamped updates with the transaction commit time, which could result in out-of-order timestamps.

Note with this change prepared transactions can only set `durable_timestamp` at commit time, and `all_durable` can no longer be impacted by the `durable_timestamp` of a running prepared transaction.