### PR TITLE
WT-8335 Support compiling both a static and shared WiredTiger library in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(CCACHE_FOUND)
 
 project(WiredTiger C CXX ASM)
 
-# Import our available build types prior to initialing the
+# Import our available build types prior to initializing the
 # project.
 include(cmake/configs/modes.cmake)
 # Import our helpers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,11 +171,13 @@ endif()
 
 # Define an alias target for the WiredTiger library. This being a general target other
 # executables can use to link against. Preference the static library build if available
-# otherwise fallback to the shared library.
+# otherwise fallback to the shared library. We also namespace (::) the target to
+# tell CMake that the target name is associated with an ALIAS target, allowing CMake
+# to issue a diagnostic message if the target isn't found on subsequent linking commands.
 if (ENABLE_STATIC)
-    add_library(wiredtiger ALIAS wiredtiger_static)
+    add_library(wt::wiredtiger ALIAS wiredtiger_static)
 else()
-    add_library(wiredtiger ALIAS wiredtiger_shared)
+    add_library(wt::wiredtiger ALIAS wiredtiger_shared)
 endif()
 
 # Build the wt utility.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ project(WiredTiger C CXX ASM)
 # Import our available build types prior to initialing the
 # project.
 include(cmake/configs/modes.cmake)
+# Import our helpers.
 include(cmake/helpers.cmake)
+include(cmake/define_libwiredtiger.cmake)
 
 # If the user doesn't manually specify the target ARCH and OS (i.e not cross-compiling)
 # we will infer the target from the host.
@@ -57,6 +59,10 @@ include(cmake/third_party/snappy.cmake)
 include(cmake/third_party/zlib.cmake)
 include(cmake/third_party/sodium.cmake)
 
+if(NOT ENABLE_SHARED AND NOT ENABLE_STATIC)
+    message(FATAL_ERROR "Both ENABLE_SHARED & ENABLE_STATIC are disabled. Need to enable at least one build flavour.")
+endif()
+
 if(ENABLE_STRICT)
     if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
         include(cmake/strict/gcc_strict.cmake)
@@ -72,14 +78,6 @@ if(ENABLE_STRICT)
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         include(cmake/strict/clxx_strict.cmake)
     endif()
-endif()
-
-set(link_type)
-if(ENABLE_STATIC)
-    set(link_type "STATIC")
-else()
-    set(link_type "SHARED")
-    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 endif()
 
 # Include the extensions to the build.
@@ -113,84 +111,71 @@ if(HAVE_BUILTIN_EXTENSION_ZSTD)
     list(APPEND builtin_objs $<TARGET_OBJECTS:wiredtiger_zstd>)
 endif()
 
-# Establish wiredtiger library target.
-add_library(wiredtiger ${link_type} ${wt_sources} ${builtin_objs})
-
 # Generate wiredtiger.h include file.
 configure_file(src/include/wiredtiger.in "include/wiredtiger.h" @ONLY)
 # Generate our wiredtiger_config.h include file.
 configure_file(cmake/configs/wiredtiger_config.h.in "config/wiredtiger_config.h" @ONLY)
-# Set our targets public and private includes.
-target_include_directories(
-    wiredtiger
-    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include
-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config ${CMAKE_CURRENT_LIST_DIR}/src/include
-)
-target_compile_options(
-    wiredtiger
-    PRIVATE ${COMPILER_DIAGNOSTIC_C_FLAGS}
-)
-# Don't treat include interface directories consumed on an imported target as system
-# directories.
-set_target_properties(wiredtiger PROPERTIES NO_SYSTEM_FROM_IMPORTED TRUE)
 
-if(ENABLE_STATIC AND NOT ENABLE_PYTHON)
-    # Avoid compiling with fPIC for static builds, this can often lead to
-    # GCC disabling many optimizations e.g. inlining, possibly introducing
-    # an overhead. We additionally can't turn off fPIC if we are compiling
-    # with python support as the python API library depends on shared library
-    # support.
-    set_property(TARGET wiredtiger PROPERTY POSITION_INDEPENDENT_CODE OFF)
+# If compiling with fPIC, we can create a intermediate library of
+# position independent objects, that both the static and shared builds
+# can use. This saving on the cost of recompiling the WiredTiger sources
+# two times over.
+if(WITH_PIC OR ENABLE_SHARED)
+    add_library(wt_objs OBJECT ${wt_sources})
+    target_include_directories(wt_objs
+        PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/config
+        ${CMAKE_CURRENT_LIST_DIR}/src/include
+    )
+    if(ENABLE_TCMALLOC)
+        target_include_directories(wt_objs PRIVATE ${HAVE_LIBTCMALLOC_INCLUDES})
+    endif()
+    if(HAVE_LIBPTHREAD)
+        target_include_directories(wt_objs PRIVATE ${HAVE_LIBPTHREAD_INCLUDES})
+    endif()
+    if(HAVE_LIBRT)
+        target_include_directories(wt_objs PRIVATE ${HAVE_LIBRT_INCLUDES})
+    endif()
+    if(HAVE_LIBDL)
+        target_include_directories(wt_objs PRIVATE ${HAVE_LIBDL_INCLUDES})
+    endif()
+    set_property(TARGET wt_objs PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
+
+if(ENABLE_STATIC)
+    if(WITH_PIC)
+        define_wiredtiger_library(wiredtiger_static STATIC
+            SOURCES $<TARGET_OBJECTS:wt_objs> ${builtin_objs}
+            PUBLIC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/include
+            PRIVATE_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/config ${CMAKE_CURRENT_LIST_DIR}/src/include
+        )
+    else()
+        define_wiredtiger_library(wiredtiger_static STATIC
+            SOURCES ${wt_sources} ${builtin_objs}
+            PUBLIC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/include
+            PRIVATE_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/config ${CMAKE_CURRENT_LIST_DIR}/src/include
+        )
+    endif()
+endif()
+
+if(ENABLE_SHARED)
+    define_wiredtiger_library(wiredtiger_shared SHARED
+        SOURCES $<TARGET_OBJECTS:wt_objs> ${builtin_objs}
+        PUBLIC_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/include
+        PRIVATE_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/config ${CMAKE_CURRENT_LIST_DIR}/src/include
+    )
+    # Set the SOVERSION property of the wiredtiger library, so we can export the appropriately versioned symlinks.
+    set_target_properties(wiredtiger_shared PROPERTIES SOVERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+endif()
+
+# Define an alias target for the WiredTiger library. This being a general target other
+# executables can use to link against. Preference the static library build if available
+# otherwise fallback to the shared library.
+if (ENABLE_STATIC)
+    add_library(wiredtiger ALIAS wiredtiger_static)
 else()
-    set_property(TARGET wiredtiger PROPERTY POSITION_INDEPENDENT_CODE ON)
-endif()
-
-# Ensure we link any available library dependencies to our wiredtiger target.
-if(HAVE_LIBPTHREAD)
-    target_link_libraries(wiredtiger PUBLIC ${HAVE_LIBPTHREAD})
-    if(HAVE_LIBPTHREAD_INCLUDES)
-        target_include_directories(wiredtiger PUBLIC ${HAVE_LIBPTHREAD_INCLUDES})
-    endif()
-endif()
-
-if(HAVE_LIBRT)
-    target_link_libraries(wiredtiger PUBLIC ${HAVE_LIBRT})
-    if(HAVE_LIBRT_INCLUDES)
-        target_include_directories(wiredtiger PUBLIC ${HAVE_LIBRT_INCLUDES})
-    endif()
-endif()
-
-if(HAVE_LIBDL)
-    target_link_libraries(wiredtiger PUBLIC ${HAVE_LIBDL})
-    if(HAVE_LIBDL_INCLUDES)
-        target_include_directories(wiredtiger PUBLIC ${HAVE_LIBDL_INCLUDES})
-    endif()
-endif()
-
-if(ENABLE_TCMALLOC)
-    target_link_libraries(wiredtiger PRIVATE wt::tcmalloc)
-endif()
-
-# We want to capture any transitive dependencies associated with the builtin library
-# target and ensure we are explicitly linking the 3rd party libraries.
-if(HAVE_BUILTIN_EXTENSION_LZ4)
-    target_link_libraries(wiredtiger PRIVATE wt::lz4)
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_SNAPPY)
-    target_link_libraries(wiredtiger PRIVATE wt::snappy)
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_SODIUM)
-    target_link_libraries(wiredtiger PRIVATE wt::sodium)
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_ZLIB)
-    target_link_libraries(wiredtiger PRIVATE wt::zlib)
-endif()
-
-if(HAVE_BUILTIN_EXTENSION_ZSTD)
-    target_link_libraries(wiredtiger PRIVATE wt::zstd)
+    add_library(wiredtiger ALIAS wiredtiger_shared)
 endif()
 
 # Build the wt utility.

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -38,7 +38,7 @@ config_bool(
 
 config_string(
     WT_BUFFER_ALIGNMENT_DEFAULT
-    "WiredTiger buffer boundary aligment"
+    "WiredTiger buffer boundary alignment"
     DEFAULT 0
 )
 

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -61,6 +61,12 @@ config_bool(
 )
 
 config_bool(
+    ENABLE_SHARED
+    "Compile as a shared library"
+    DEFAULT ON
+)
+
+config_bool(
     ENABLE_STRICT
     "Compile with strict compiler warnings enabled"
     DEFAULT OFF

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -67,6 +67,13 @@ config_bool(
 )
 
 config_bool(
+    WITH_PIC
+    "Generate position-independent code. Note PIC will always \
+    be used on shared targets, irrespective of the value of this configuration."
+    DEFAULT OFF
+)
+
+config_bool(
     ENABLE_STRICT
     "Compile with strict compiler warnings enabled"
     DEFAULT OFF

--- a/cmake/configs/x86/windows/config.cmake
+++ b/cmake/configs/x86/windows/config.cmake
@@ -13,6 +13,8 @@ set(SPINLOCK_TYPE "msvc" CACHE STRING "" FORCE)
 # We force a static compilation to generate a ".lib" file. We can then
 # additionally generate a dll file using a *DEF file.
 set(ENABLE_STATIC ON CACHE BOOL "" FORCE)
+set(ENABLE_SHARED OFF CACHE BOOL "" FORCE)
+set(WITH_PIC ON CACHE BOOL "" FORCE)
 
 # Compile as C code .
 add_compile_options(/TC)

--- a/cmake/define_libwiredtiger.cmake
+++ b/cmake/define_libwiredtiger.cmake
@@ -1,0 +1,103 @@
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#  All rights reserved.
+#
+#  See the file LICENSE for redistribution information
+#
+
+# define_wiredtiger_library(target type)
+# A helper that defines a wiredtiger library target. This defining a set of common targets and properties we
+# want to associated to any given 'libwiredtiger' target. Having this as a macro allows us to de-duplicate common
+# definitions if want to create multiple versions of libwiredtiger i.e. static and shared builds. Note: this
+# macro assumes you only call it once per libwiredtiger flavour (e.g. only one 'static' definition), use carefully.
+#   target - Name of the libwiredtiger target.
+#   type - Library type of wiredtiger target e.g. STATIC, SHARED or MODULE.
+#   SOURCES - Sources to be compiled under the wiredtiger library. Requires that at least one source file/object is defined.
+#   PUBLIC_INCLUDES - Public interface includes of the wiredtiger library.
+#   PRIVATE_INCLUDES - Private interface includes of the wiredtiger library.
+macro(define_wiredtiger_library target type)
+    cmake_parse_arguments(
+        "DEFINE_WT"
+        ""
+        ""
+        "SOURCES;PUBLIC_INCLUDES;PRIVATE_INCLUDES"
+        ${ARGN}
+    )
+    if (NOT "${DEFINE_WT_UNPARSED_ARGUMENTS}" STREQUAL "")
+        message(FATAL_ERROR "Unknown arguments to define_wiredtiger_library: ${DEFINE_WT_ARGUMENTS_UNPARSED_ARGUMENTS}")
+    endif()
+    if ("${DEFINE_WT_SOURCES}" STREQUAL "")
+        message(FATAL_ERROR "No sources given to define_wiredtiger_library")
+    endif()
+
+    # Define the wiredtiger library target.
+    add_library(${target} ${type} ${DEFINE_WT_SOURCES})
+    # Append any include directories to the library target.
+    if(DEFINE_WT_PUBLIC_INCLUDES)
+        target_include_directories(${target} PUBLIC ${DEFINE_WT_PUBLIC_INCLUDES})
+    endif()
+    if(DEFINE_WT_PRIVATE_INCLUDES)
+        target_include_directories(${target} PRIVATE ${DEFINE_WT_PRIVATE_INCLUDES})
+    endif()
+    # Append any provided C flags.
+    if(COMPILER_DIAGNOSTIC_C_FLAGS)
+        target_compile_options(${target} PRIVATE ${COMPILER_DIAGNOSTIC_C_FLAGS})
+    endif()
+
+    # We want to set the following target properties:
+    # OUTPUT_NAME - Generate a library with the name "libwiredtiger[.so|.a". Note this assumes each invocation
+    #   of this macro is specifying a unique libwiredtiger target type (e.g 'SHARED', 'STATIC'), multiple declarations
+    #   of a 'SHARED' wiredtiger library would conflict.
+    # NO_SYSTEM_FROM_IMPORTED - don't treat include interface directories consumed on an imported target as system
+    #   directories.
+    set_target_properties(${target} PROPERTIES
+        OUTPUT_NAME "wiredtiger"
+        NO_SYSTEM_FROM_IMPORTED TRUE
+    )
+
+    # Ensure we link any available library dependencies to our wiredtiger target.
+    if(HAVE_LIBPTHREAD)
+        target_link_libraries(${target} PUBLIC ${HAVE_LIBPTHREAD})
+        if(HAVE_LIBPTHREAD_INCLUDES)
+            target_include_directories(${target} PUBLIC ${HAVE_LIBPTHREAD_INCLUDES})
+        endif()
+    endif()
+    if(HAVE_LIBRT)
+        target_link_libraries(${target} PUBLIC ${HAVE_LIBRT})
+        if(HAVE_LIBRT_INCLUDES)
+            target_include_directories(${target} PUBLIC ${HAVE_LIBRT_INCLUDES})
+        endif()
+    endif()
+    if(HAVE_LIBDL)
+        target_link_libraries(${target} PUBLIC ${HAVE_LIBDL})
+        if(HAVE_LIBDL_INCLUDES)
+            target_include_directories(${target} PUBLIC ${HAVE_LIBDL_INCLUDES})
+        endif()
+    endif()
+    if(ENABLE_TCMALLOC)
+        target_link_libraries(${target} PRIVATE wt::tcmalloc)
+    endif()
+
+    # We want to capture any transitive dependencies associated with the builtin library
+    # target and ensure we are explicitly linking the 3rd party libraries.
+    if(HAVE_BUILTIN_EXTENSION_LZ4)
+        target_link_libraries(${target} PRIVATE wt::lz4)
+    endif()
+
+    if(HAVE_BUILTIN_EXTENSION_SNAPPY)
+        target_link_libraries(${target} PRIVATE wt::snappy)
+    endif()
+
+    if(HAVE_BUILTIN_EXTENSION_SODIUM)
+        target_link_libraries(${target} PRIVATE wt::sodium)
+    endif()
+
+    if(HAVE_BUILTIN_EXTENSION_ZLIB)
+        target_link_libraries(${target} PRIVATE wt::zlib)
+    endif()
+
+    if(HAVE_BUILTIN_EXTENSION_ZSTD)
+        target_link_libraries(${target} PRIVATE wt::zstd)
+    endif()
+endmacro()

--- a/cmake/define_libwiredtiger.cmake
+++ b/cmake/define_libwiredtiger.cmake
@@ -25,7 +25,7 @@ macro(define_wiredtiger_library target type)
         ${ARGN}
     )
     if (NOT "${DEFINE_WT_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to define_wiredtiger_library: ${DEFINE_WT_ARGUMENTS_UNPARSED_ARGUMENTS}")
+        message(FATAL_ERROR "Unknown arguments to define_wiredtiger_library: ${DEFINE_WT_UNPARSED_ARGUMENTS}")
     endif()
     if ("${DEFINE_WT_SOURCES}" STREQUAL "")
         message(FATAL_ERROR "No sources given to define_wiredtiger_library")

--- a/cmake/define_libwiredtiger.cmake
+++ b/cmake/define_libwiredtiger.cmake
@@ -8,8 +8,8 @@
 
 # define_wiredtiger_library(target type)
 # A helper that defines a wiredtiger library target. This defining a set of common targets and properties we
-# want to associated to any given 'libwiredtiger' target. Having this as a macro allows us to de-duplicate common
-# definitions if want to create multiple versions of libwiredtiger i.e. static and shared builds. Note: this
+# want to be associated to any given 'libwiredtiger' target. Having this as a macro allows us to de-duplicate common
+# definitions when creating multiple versions of libwiredtiger i.e. static and shared builds. Note: this
 # macro assumes you only call it once per libwiredtiger flavour (e.g. only one 'static' definition), use carefully.
 #   target - Name of the libwiredtiger target.
 #   type - Library type of wiredtiger target e.g. STATIC, SHARED or MODULE.

--- a/cmake/install/install.cmake
+++ b/cmake/install/install.cmake
@@ -10,7 +10,7 @@ include(GNUInstallDirs)
 
 # Library installs
 
-# Define the public headers for wiredtiger library to be used when installing the target.
+# Define the wiredtiger public headers we want to export when running the install target.
 install(
     FILES ${CMAKE_BINARY_DIR}/include/wiredtiger.h ${CMAKE_SOURCE_DIR}/src/include/wiredtiger_ext.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/cmake/install/install.cmake
+++ b/cmake/install/install.cmake
@@ -11,20 +11,24 @@ include(GNUInstallDirs)
 # Library installs
 
 # Define the public headers for wiredtiger library to be used when installing the target.
-set_property(
-    TARGET wiredtiger
-    PROPERTY PUBLIC_HEADER
-    ${CMAKE_BINARY_DIR}/include/wiredtiger.h
-    ${CMAKE_SOURCE_DIR}/src/include/wiredtiger_ext.h
+install(
+    FILES ${CMAKE_BINARY_DIR}/include/wiredtiger.h ${CMAKE_SOURCE_DIR}/src/include/wiredtiger_ext.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-# Set the version property of the wiredtiger library so we can export a versioned install.
-set_target_properties(wiredtiger PROPERTIES VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
-# Install the wiredtiger library target.
-install(TARGETS wiredtiger
+# Define the wiredtiger library targets we will install.
+set(wt_targets)
+if(ENABLE_SHARED)
+    list(APPEND wt_targets wiredtiger_shared)
+endif()
+if(ENABLE_STATIC)
+    list(APPEND wt_targets wiredtiger_static)
+endif()
+
+# Install the wiredtiger library targets.
+install(TARGETS ${wt_targets}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 # Create our wiredtiger pkgconfig (for POSIX builds).

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -21,6 +21,23 @@ endif()
 find_package(SWIG 3.0 COMPONENTS python REQUIRED)
 include(${SWIG_USE_FILE})
 
+# Determine which wiredtiger target we should use to link against the
+# Python API. For linking purposes, we need to ensure the wiredtiger
+# library was compiled as position independent code (fPIC). This being achieved
+# either using the 'WITH_PIC' configuration option or building a shared library
+# version of WiredTiger ('ENABLE_SHARED'). Default to whichever option is available
+# (with a preference for a PIC static build), otherwise throw an error if neither
+# build is available.
+set(wiredtiger_target)
+if(ENABLE_STATIC AND WITH_PIC)
+    set(wiredtiger_target wiredtiger_static)
+elseif(ENABLE_SHARED)
+    set(wiredtiger_target wiredtiger_shared)
+else()
+    message(FATAL_ERROR "Unable to build the Python API. Requires either a shared \
+        library (ENABLE_SHARED) or a PIC-enabled (WITH_PIC) build of wiredtiger.")
+endif()
+
 set(python_libs)
 set(python_version)
 
@@ -141,7 +158,7 @@ target_compile_options(${swig_wt_target}
     PRIVATE ${swig_c_flags}
 )
 
-swig_link_libraries(_wiredtiger wiredtiger ${python_libs})
+swig_link_libraries(_wiredtiger ${wiredtiger_target} ${python_libs})
 
 # Setup our output 'wiredtiger' directory to hold the python module sources.
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/wiredtiger

--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -217,7 +217,7 @@ builtin_libraries = [b[1] for b in builtins]
 # Here's the configure/make operations we perform before the python extension
 # is linked.
 configure_cmds = [
-    'cmake -B cmake_pip_build -G Ninja -DENABLE_STATIC=1 -DCMAKE_C_FLAGS="${CFLAGS:-}" -DENABLE_PYTHON=1 ' + \
+    'cmake -B cmake_pip_build -G Ninja -DENABLE_STATIC=1 -DENABLE_SHARED=0 -DWITH_PIC=1 -DCMAKE_C_FLAGS="${CFLAGS:-}" -DENABLE_PYTHON=1 ' + \
     ' '.join(map(lambda name: '-DHAVE_BUILTIN_EXTENSION_' + name.upper() + '=1', builtin_names)),
 ]
 
@@ -280,12 +280,7 @@ wt_ext = Extension('_wiredtiger',
     extra_compile_args = cflags + cppflags,
     extra_link_args = ldflags,
     libraries = builtin_libraries,
-    # FIXME-WT-7905: Remove manual linking of static extension libraries.
-    # Unfortunately CMake's use of the builtin doesn't currently support linking in the extension
-    # objects into a static libwiredtiger archive. As a workaround, we need to manually link
-    # the ext/compressor libraries.
-    extra_objects = [ os.path.join(build_dir, 'libwiredtiger.a') ] + \
-        list(map(lambda name: os.path.join(build_dir, 'ext', 'compressors', name) + '/libwiredtiger_' + name + '.a', builtin_names)),
+    extra_objects = [ os.path.join(build_dir, 'libwiredtiger.a') ],
     include_dirs = inc_paths,
     library_dirs = lib_paths,
 )

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_options(wt PRIVATE ${COMPILER_DIAGNOSTIC_C_FLAGS})
 target_include_directories(wt
     PRIVATE ${CMAKE_SOURCE_DIR}/src/include  ${CMAKE_BINARY_DIR}/config
 )
-target_link_libraries(wt wiredtiger)
+target_link_libraries(wt wt::wiredtiger)
 
 if(ENABLE_TCMALLOC)
     target_link_libraries(wt wt::tcmalloc)

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -100,7 +100,7 @@ function(create_test_executable target)
     endif()
 
     # Link the base set of libraries for a wiredtiger C/CXX test.
-    target_link_libraries(${target} wiredtiger test_util)
+    target_link_libraries(${target} wt::wiredtiger test_util)
     if(NOT "${CREATE_TEST_LIBS}" STREQUAL "")
         target_link_libraries(${target} ${CREATE_TEST_LIBS})
     endif()

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -44,6 +44,17 @@ if(NOT libclangfuzzer)
     return()
 endif()
 
+# We require either a PIC-enabled or shared library build to build
+# our dynamic fuzz_util library. Avoid building the fuzz test if not available.
+set(wiredtiger_target)
+if(ENABLE_STATIC AND WITH_PIC)
+    set(wiredtiger_target wiredtiger_static)
+elseif(ENABLE_SHARED)
+    set(wiredtiger_target wiredtiger_shared)
+else()
+    return()
+endif()
+
 set(fuzz_c_flags "${COMPILER_DIAGNOSTIC_C_FLAGS};-fsanitize=fuzzer-no-link")
 
 # Compile the fuzz util library.
@@ -56,7 +67,7 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/include
         ${CMAKE_SOURCE_DIR}/test/utility
 )
-target_link_libraries(fuzz_util wt::wiredtiger test_util)
+target_link_libraries(fuzz_util ${wiredtiger_target} test_util)
 target_link_libraries(fuzz_util "-fsanitize=fuzzer")
 target_compile_options(
     fuzz_util

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -56,7 +56,7 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/include
         ${CMAKE_SOURCE_DIR}/test/utility
 )
-target_link_libraries(fuzz_util wiredtiger test_util)
+target_link_libraries(fuzz_util wt::wiredtiger test_util)
 target_link_libraries(fuzz_util "-fsanitize=fuzzer")
 target_compile_options(
     fuzz_util

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -52,6 +52,8 @@ if(ENABLE_STATIC AND WITH_PIC)
 elseif(ENABLE_SHARED)
     set(wiredtiger_target wiredtiger_shared)
 else()
+    message(STATUS "Skipping fuzz test compilation: Requires either a shared library (ENABLE_SHARED)"
+                    "or a PIC-enabled (WITH_PIC) build of wiredtiger")
     return()
 endif()
 

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(
         ${CMAKE_BINARY_DIR}/config
         ${CMAKE_SOURCE_DIR}/src/include
 )
-target_link_libraries(test_util wiredtiger)
+target_link_libraries(test_util wt::wiredtiger)
 
 if(WT_WIN)
     target_include_directories(


### PR DESCRIPTION
Currently we only support compiling either a static or shared build of the WiredTiger library in CMake (being a binary option). For some uses case, it can be ideal to compile both the static and shared artifacts in a single build e.g. for a system installation. This change overhauls the CMake build of the wiredtiger target such that we can compile both a static and shared wiredtiger in the same build run i.e. no longer limited to either a static or shared build. This change brings a bit more feature parity with autoconf (before we officially deprecate it).
More specifically, the key changes this PR introduces:
- CMake configuration option `ENABLE_SHARED` : Introduces a seperate configuration option, `ENABLE_SHARED`, in conjunction to `ENABLE_STATIC`. The intention is to support the capability for building both shared and static wiredtiger artifacts in a single build.
- CMake configuration option `WITH_PIC` : Introduces a new configuration option, `WITH_PIC`, which can be used to force compile all build objects as position independent sources. The motivation behind this option is to provide a means for the end user to manually control the way libwiredtiger is compiled. If building a static version of wiredtiger, `WITH_PIC` allows the end user to configure whether the sources should be position independent, based on their needs for linking the wiredtiger artifact i.e. needed if wanting to link a static wiredtiger archive into a dynamic library.
- A macro to define the libwiredtiger target, having a common set of targets and properties we want to associate to any given 'libwiredtiger' target. Having this as a macro allows us to  de-duplicate common definitions if wanting to create multiple versions of libwiredtiger within the same build.
- Namespace wiredtiger ALIAS target: As the 'wiredtiger' library target is now an alias target, we should namespace the target under `wt::`. This having the benefit of letting CMake throw diagnostic errors if `wt::wiredtiger` is not found when using `target_link_libraries`.
- Other miscellaneous fixes 