### PR TITLE
WT-8253 Fix disk space issue in stress tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2623,7 +2623,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 6" WT_TEST.$t' 120
+            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 6" WT_TEST.$t' 100
 
   - name: data-validation-stress-test-checkpoint-fp-hs-insert-s7
     depends_on:
@@ -2637,7 +2637,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 7" WT_TEST.$t' 120
+            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 7" WT_TEST.$t' 25
 
   - name: format-failure-configs-test
     depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2623,7 +2623,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 6" WT_TEST.$t' 100
+            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 6" WT_TEST.$t' 120
 
   - name: data-validation-stress-test-checkpoint-fp-hs-insert-s7
     depends_on:
@@ -2637,7 +2637,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 7" WT_TEST.$t' 25
+            ${test_env_vars|} ../../../tools/run_parallel.sh 'nice ../../../test/checkpoint/recovery-test.sh "${data_validation_stress_test_args} -s 7" WT_TEST.$t' 120
 
   - name: format-failure-configs-test
     depends_on:

--- a/tools/run_parallel.sh
+++ b/tools/run_parallel.sh
@@ -39,8 +39,11 @@ echo "  num_iter:        $num_iter"
 outf=./outfile.txt
 
 for i in $(seq $num_iter); do
-  echo "Starting iteration $i" >> $outf
-  echo "Starting iteration $i"
+  echo "==== Starting iteration $i ====" >> $outf
+  echo "==== Starting iteration $i ===="
+
+  echo "Disk usage and free space for the current drive:"
+  df -h .
 
   process_ids=()
   # start the commands in parallel

--- a/tools/run_parallel.sh
+++ b/tools/run_parallel.sh
@@ -48,8 +48,8 @@ for i in $(seq $num_iter); do
   process_ids=()
   # start the commands in parallel
   for((t=1; t<=num_parallel; t++)); do
-    echo "Starting parallel command $t (of $num_parallel) in iteration $i (of $num_iter)" >> nohup.out.$t
-    eval nohup $command >> nohup.out.$t 2>&1 &
+    echo "Starting parallel command $t (of $num_parallel) in iteration $i (of $num_iter)" >> $outf
+    eval nohup $command > nohup.out.$t 2>&1 &
     process_ids[$t]=$!
   done
 


### PR DESCRIPTION
- Reduced the number of test iterations for those stress tests that have been running out of disk space.
- Log disk usage info at the start of each iteration to help diagnose future disk space issues.