### PR TITLE
WT-8157 Fix format-abort-recovery-stress-test timeout condition

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2860,6 +2860,8 @@ tasks:
 
   - name: format-abort-recovery-stress-test
     commands:
+      # Allow 30 minutes beyond test runtime because recovery under load can cause the test to
+      # run longer.
       - command: timeout.update
         params:
           exec_timeout_secs: 3600

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2862,7 +2862,7 @@ tasks:
     commands:
       - command: timeout.update
         params:
-          exec_timeout_secs: 2500
+          exec_timeout_secs: 3600
       - func: "get project"
       - func: "compile wiredtiger with builtins"
       - func: "format test script"


### PR DESCRIPTION
Increase evergreen timeout to 1 hr to allow time for test to do recovery.