### PR TITLE
WT-8114 Revert allow setting the prepare timestamp smaller than or equal to the latest active read timestamp with roundup prepare config

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1728,11 +1728,10 @@ methods = {
             applicable only for prepared transactions. Indicates if the prepare
             timestamp and the commit timestamp of this transaction can be
             rounded up. If the prepare timestamp is less than the oldest
-            timestamp, the prepare timestamp will be rounded to the oldest
+            timestamp, the prepare timestamp  will be rounded to the oldest
             timestamp. If the commit timestamp is less than the prepare
             timestamp, the commit timestamp will be rounded up to the prepare
-            timestamp. Allows setting the prepared timestamp smaller than or equal
-            to the latest active read timestamp''', type='boolean'),
+            timestamp''', type='boolean'),
         Config('read', 'false', r'''
             if the read timestamp is less than the oldest timestamp, the
             read timestamp will be rounded up to the oldest timestamp''',

--- a/src/docs/transactions.dox
+++ b/src/docs/transactions.dox
@@ -246,15 +246,6 @@ For example, for the timestamp values <code>prepare_timestamp=100,
     timestamp is rounded up to the new prepare timestamp as
     <code>commit_timestamp=200</code>.
 
-Configuring <code>roundup_timestamps=(prepared=true)</code> also allows setting
-the prepared timestamps smaller than or equal to the latest active read timestamps.
-Use this feature carefully as it may break repeated read. For example, consider a
-transaction with a read timestamp set to 30 and a key that has a value with
-timestamp 20. Before a prepared transaction (in another thread), reading the key
-returns the value. Now a prepared transaction elsewhere in the system sets a prepared
-timestamp at 30. The reader, trying to do a repeat read of the key, gets return a
-prepared conflict error instead of the value.
-
 Configuring <code>roundup_timestamps=(read=true)</code> causes the read
 timestamp to be rounded up to the oldest timestamp, if the read timestamp is
 greater than the oldest timestamp no change will be made.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1695,12 +1695,11 @@ struct __wt_session {
 	 * and the commit timestamp of this transaction can be rounded up.  If the prepare timestamp
 	 * is less than the oldest timestamp\, the prepare timestamp will be rounded to the oldest
 	 * timestamp.  If the commit timestamp is less than the prepare timestamp\, the commit
-	 * timestamp will be rounded up to the prepare timestamp.  Allows setting the prepared
-	 * timestamp smaller than or equal to the latest active read timestamp., a boolean flag;
-	 * default \c false.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read, if the read timestamp is less
-	 * than the oldest timestamp\, the read timestamp will be rounded up to the oldest
-	 * timestamp., a boolean flag; default \c false.}
+	 * timestamp will be rounded up to the prepare timestamp., a boolean flag; default \c
+	 * false.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read, if the read timestamp is less than the
+	 * oldest timestamp\, the read timestamp will be rounded up to the oldest timestamp., a
+	 * boolean flag; default \c false.}
 	 * @config{ ),,}
 	 * @config{sync, whether to sync log records when the transaction commits\, inherited from
 	 * ::wiredtiger_open \c transaction_sync., a boolean flag; default empty.}

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -715,19 +715,7 @@ __wt_txn_set_prepare_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t prepare_
         WT_RET_MSG(session, EINVAL,
           "commit timestamp should not have been set before the prepare timestamp");
 
-        /*
-         * Allows setting the prepared timestamp smaller than or equal to the latest active read
-         * timestamp. This feature is necessary to find the largest key in the table even if that
-         * key has been deleted. Set this flag cautiously as it breaks repeated reads.
-         */
-#ifdef HAVE_DIAGNOSTIC
-    if (!F_ISSET(txn, WT_TXN_TS_ROUND_PREPARED))
-        WT_RET(__txn_assert_after_reads(session, "prepare", prepare_ts));
-    else
-        WT_RET(__wt_msg(session,
-          "Skip checking prepare timestamp %s against the latest active read timestamp.",
-          __wt_timestamp_to_string(prepare_ts, ts_string[0])));
-#endif
+    WT_RET(__txn_assert_after_reads(session, "prepare", prepare_ts));
 
     /*
      * Check whether the prepare timestamp is less than the oldest timestamp.


### PR DESCRIPTION
This reverts commit c371a9cd2ac4ced5790fe256bfa4408d1973d77b.