### PR TITLE
WT-8347 Slipup in test_checkpoint modify changes

### DIFF
--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -239,6 +239,7 @@ worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
                         return (WT_ROLLBACK);
                     return (log_print_err("cursor.modify", ret, 1));
                 }
+                return (0);
             } else if (ret != WT_NOTFOUND) {
                 if (ret == WT_ROLLBACK || ret == WT_PREPARE_CONFLICT)
                     return (WT_ROLLBACK);


### PR DESCRIPTION
Fix slipup in test_checkpoint that made it immediately overwrite all its modifies.