### PR TITLE
WT-8350 format uses the wrong syntax to turn off common prefix configuration

### DIFF
--- a/test/format/config.sh
+++ b/test/format/config.sh
@@ -77,7 +77,7 @@ CONFIG configuration_list[] = {
 
 {"backup", "configure backups", C_BOOL, 20, 0, 0}
 
-{"backup.incremental", "backup type (block | log | off)", C_IGNORE | C_STRING, 0, 0, 0}
+{"backup.incremental", "backup type (off | block | log)", C_IGNORE | C_STRING, 0, 0, 0}
 
 {"backup.incr_granularity", "incremental backup block granularity (KB)", 0x0, 4, 16384, 16384}
 
@@ -91,7 +91,7 @@ CONFIG configuration_list[] = {
 
 {"btree.bitcnt", "fixed-length column-store object size (number of bits)", C_TABLE | C_TYPE_FIX, 1, 8, 8}
 
-{"btree.compression", "data compression (none | lz4 | snappy | zlib | zstd)", C_IGNORE | C_STRING | C_TABLE, 0, 0, 0}
+{"btree.compression", "data compression (off | lz4 | snappy | zlib | zstd)", C_IGNORE | C_STRING | C_TABLE, 0, 0, 0}
 
 {"btree.dictionary", "configure dictionary compressed values", C_BOOL | C_TABLE | C_TYPE_ROW | C_TYPE_VAR, 20, 0, 0}
 
@@ -143,7 +143,7 @@ CONFIG configuration_list[] = {
 
 {"disk.direct_io", "configure direct I/O for data objects", C_BOOL | C_IGNORE, 0, 0, 1}
 
-{"disk.encryption", "encryption type (none | rotn-7)", C_IGNORE | C_STRING, 0, 0, 0}
+{"disk.encryption", "encryption type (off | rotn-7)", C_IGNORE | C_STRING, 0, 0, 0}
 
 {"disk.firstfit", "configure first-fit allocation", C_BOOL | C_TABLE, 10, 0, 0}
 
@@ -168,7 +168,7 @@ CONFIG configuration_list[] = {
 
 {"logging.archive", "configure log file archival", C_BOOL, 50, 0, 0}
 
-{"logging.compression", "logging compression (none | lz4 | snappy | zlib | zstd)", C_IGNORE | C_STRING, 0, 0, 0}
+{"logging.compression", "logging compression (off | lz4 | snappy | zlib | zstd)", C_IGNORE | C_STRING, 0, 0, 0}
 
 {"logging.file_max", "maximum log file size (KB)", 0x0, 100, 512000, 2097152}
 

--- a/test/format/config_def.c
+++ b/test/format/config_def.c
@@ -33,7 +33,7 @@ CONFIG configuration_list[] = {
   {"btree.bitcnt", "fixed-length column-store object size (number of bits)",
     C_TABLE | C_TYPE_FIX, 1, 8, 8, V_TABLE_BTREE_BITCNT},
 
-  {"btree.compression", "data compression (none | lz4 | snappy | zlib | zstd)",
+  {"btree.compression", "data compression (off | lz4 | snappy | zlib | zstd)",
     C_IGNORE | C_STRING | C_TABLE, 0, 0, 0, V_TABLE_BTREE_COMPRESSION},
 
   {"btree.dictionary", "configure dictionary compressed values",
@@ -111,7 +111,7 @@ CONFIG configuration_list[] = {
   {"disk.direct_io", "configure direct I/O for data objects",
     C_BOOL | C_IGNORE, 0, 0, 1, V_GLOBAL_DISK_DIRECT_IO},
 
-  {"disk.encryption", "encryption type (none | rotn-7)",
+  {"disk.encryption", "encryption type (off | rotn-7)",
     C_IGNORE | C_STRING, 0, 0, 0, V_GLOBAL_DISK_ENCRYPTION},
 
   {"disk.firstfit", "configure first-fit allocation",
@@ -146,7 +146,7 @@ CONFIG configuration_list[] = {
   {"logging.archive", "configure log file archival",
     C_BOOL, 50, 0, 0, V_GLOBAL_LOGGING_ARCHIVE},
 
-  {"logging.compression", "logging compression (none | lz4 | snappy | zlib | zstd)",
+  {"logging.compression", "logging compression (off | lz4 | snappy | zlib | zstd)",
     C_IGNORE | C_STRING, 0, 0, 0, V_GLOBAL_LOGGING_COMPRESSION},
 
   {"logging.file_max", "maximum log file size (KB)",

--- a/test/format/config_def.c
+++ b/test/format/config_def.c
@@ -12,7 +12,7 @@ CONFIG configuration_list[] = {
   {"backup", "configure backups",
     C_BOOL, 20, 0, 0, V_GLOBAL_BACKUP},
 
-  {"backup.incremental", "backup type (block | log | off)",
+  {"backup.incremental", "backup type (off | block | log)",
     C_IGNORE | C_STRING, 0, 0, 0, V_GLOBAL_BACKUP_INCREMENTAL},
 
   {"backup.incr_granularity", "incremental backup block granularity (KB)",

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -159,12 +159,14 @@ extern u_int ntables;
  * Global and table-specific macros to retrieve configuration information. All of the tables contain
  * all of the possible configuration entries, but the first table slot contains all of the global
  * configuration information. The offset names a prefixed with "V_GLOBAL" and "V_TABLE" to reduce
- * the chance of a coding error retrieving the wrong configuration item.
+ * the chance of a coding error retrieving the wrong configuration item. If returning string values,
+ * convert NULL, where a configuration has never been set, to "off" for consistency.
  */
 #define GV(off) (tables[0]->v[V_GLOBAL_##off].v)
-#define GVS(off) (tables[0]->v[V_GLOBAL_##off].vstr)
+#define GVS(off) \
+    (tables[0]->v[V_GLOBAL_##off].vstr == NULL ? "off" : tables[0]->v[V_GLOBAL_##off].vstr)
 #define TV(off) (table->v[V_TABLE_##off].v)
-#define TVS(off) (table->v[V_TABLE_##off].vstr)
+#define TVS(off) (table->v[V_TABLE_##off].vstr == NULL ? "off" : table->v[V_TABLE_##off].vstr)
 
 #define DATASOURCE(table, ds) (strcmp((table)->v[V_TABLE_RUNS_SOURCE].vstr, ds) == 0)
 

--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -4,9 +4,9 @@ set -e
 
 # Smoke-test format as part of running "make check".
 args="-c . "
-args="$args btree.compression=none "
+args="$args btree.compression=off "
 args="$args cache.minimum=40 "
-args="$args logging_compression=none"
+args="$args logging_compression=off"
 args="$args runs.rows=100000 "
 args="$args runs.source=table "
 args="$args runs.tables=3 "

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -309,6 +309,8 @@ main(int argc, char *argv[])
     tables_apply(val_init, NULL);
     if (!g.reopen)
         TIMED_MAJOR_OP(tables_apply(wts_load, NULL));
+    if (!g.reopen)
+        goto done;
     TIMED_MAJOR_OP(tables_apply(wts_verify, g.wts_conn));
     if (GV(OPS_VERIFY) == 0)
         TIMED_MAJOR_OP(tables_apply(wts_read_scan, g.wts_conn));
@@ -346,6 +348,7 @@ main(int argc, char *argv[])
 
     trace_teardown();
 
+done:
     /* Overwrite the progress line with a completion line. */
     if (!GV(QUIET))
         printf("\r%78s\r", " ");

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -309,8 +309,6 @@ main(int argc, char *argv[])
     tables_apply(val_init, NULL);
     if (!g.reopen)
         TIMED_MAJOR_OP(tables_apply(wts_load, NULL));
-    if (!g.reopen)
-        goto done;
     TIMED_MAJOR_OP(tables_apply(wts_verify, g.wts_conn));
     if (GV(OPS_VERIFY) == 0)
         TIMED_MAJOR_OP(tables_apply(wts_read_scan, g.wts_conn));
@@ -348,7 +346,6 @@ main(int argc, char *argv[])
 
     trace_teardown();
 
-done:
     /* Overwrite the progress line with a completion line. */
     if (!GV(QUIET))
         printf("\r%78s\r", " ");

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -37,11 +37,10 @@ static void create_object(TABLE *, void *);
 static const char *
 encryptor(void)
 {
-    char *s;
-    const char *p;
+    const char *p, *s;
 
     s = GVS(DISK_ENCRYPTION);
-    if (strcmp(s, "none") == 0)
+    if (strcmp(s, "off") == 0)
         p = "none";
     else if (strcmp(s, "rotn-7") == 0)
         p = "rotn,keyid=7";
@@ -49,6 +48,8 @@ encryptor(void)
         p = "sodium,secretkey=" SODIUM_TESTKEY;
     else
         testutil_die(EINVAL, "illegal encryption configuration: %s", s);
+
+    /* Returns "none" or the name of an encryptor. */
     return (p);
 }
 
@@ -61,11 +62,10 @@ encryptor(void)
 static const char *
 encryptor_at_open(void)
 {
-    char *s;
-    const char *p;
+    const char *p, *s;
 
     s = GVS(DISK_ENCRYPTION);
-    if (strcmp(s, "none") == 0)
+    if (strcmp(s, "off") == 0)
         p = NULL;
     else if (strcmp(s, "rotn-7") == 0)
         p = NULL;
@@ -73,6 +73,8 @@ encryptor_at_open(void)
         p = "sodium,secretkey=" SODIUM_TESTKEY;
     else
         testutil_die(EINVAL, "illegal encryption configuration: %s", s);
+
+    /* Returns NULL or the name of an encryptor. */
     return (p);
 }
 
@@ -194,8 +196,8 @@ create_database(const char *home, WT_CONNECTION **connp)
 {
     WT_CONNECTION *conn;
     size_t max;
-    char config[8 * 1024], *p, *s;
-    const char *enc;
+    char config[8 * 1024], *p;
+    const char *s;
 
     p = config;
     max = sizeof(config);
@@ -243,13 +245,11 @@ create_database(const char *home, WT_CONNECTION **connp)
         CONFIG_APPEND(p,
           ",log=(enabled=true,archive=%d,prealloc=%d,file_max=%" PRIu32 ",compressor=\"%s\")",
           GV(LOGGING_ARCHIVE) ? 1 : 0, GV(LOGGING_PREALLOC) ? 1 : 0, KILOBYTE(GV(LOGGING_FILE_MAX)),
-          s == NULL ? "none" : s);
+          strcmp(s, "off") == 0 ? "none" : s);
     }
 
     /* Encryption. */
-    enc = encryptor();
-    if (enc != NULL)
-        CONFIG_APPEND(p, ",encryption=(name=%s)", enc);
+    CONFIG_APPEND(p, ",encryption=(name=%s)", encryptor());
 
 /* Miscellaneous. */
 #ifdef HAVE_POSIX_MEMALIGN
@@ -296,7 +296,7 @@ create_database(const char *home, WT_CONNECTION **connp)
      * options at the end. Do this so they override the standard configuration.
      */
     s = GVS(WIREDTIGER_CONFIG);
-    if (s != NULL)
+    if (strcmp(s, "off") != 0)
         CONFIG_APPEND(p, ",%s", s);
     if (g.config_open != NULL)
         CONFIG_APPEND(p, ",%s", g.config_open);
@@ -320,7 +320,8 @@ create_object(TABLE *table, void *arg)
     WT_SESSION *session;
     size_t max;
     uint32_t maxintlkey, maxleafkey, maxleafvalue;
-    char config[4096], *p, *s;
+    char config[4096], *p;
+    const char *s;
 
     conn = (WT_CONNECTION *)arg;
     p = config;
@@ -368,12 +369,11 @@ create_object(TABLE *table, void *arg)
     }
 
     /* Configure checksums. */
-    if ((s = TVS(DISK_CHECKSUM)) != NULL)
-        CONFIG_APPEND(p, ",checksum=\"%s\"", s);
+    CONFIG_APPEND(p, ",checksum=\"%s\"", TVS(DISK_CHECKSUM));
 
     /* Configure compression. */
-    if ((s = TVS(BTREE_COMPRESSION)) != NULL)
-        CONFIG_APPEND(p, ",block_compressor=\"%s\"", s);
+    s = TVS(BTREE_COMPRESSION);
+    CONFIG_APPEND(p, ",block_compressor=\"%s\"", strcmp(s, "off") == 0 ? "none" : s);
 
     /* Configure Btree. */
     CONFIG_APPEND(
@@ -475,7 +475,7 @@ wts_open(const char *home, WT_CONNECTION **connp, WT_SESSION **sessionp, bool al
     if (enc != NULL)
         CONFIG_APPEND(p, ",encryption=(name=%s)", enc);
 
-    CONFIG_APPEND(p, "error_prefix=\"%s\"", progname);
+    CONFIG_APPEND(p, ",error_prefix=\"%s\"", progname);
 
     /* Optional timing stress. */
     configure_timing_stress(p, max);


### PR DESCRIPTION
Fix problems where the wrong type of value was used to turn a configuration value off.

Add new functionality to configure a value "off" so we don't have to do it manually.

Switch from a mixture of "none" and "off" for "not configured" or "configured off" strings, always use "off".