### PR TITLE
WT-5011 - Migrate log consolidation tests to Evergreen

### DIFF
--- a/bench/wtperf/runners/log.json
+++ b/bench/wtperf/runners/log.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": [],
+    "operations": ["update", "max_update_throughput", "min_update_throughput"]
+  }
+]

--- a/bench/wtperf/runners/log_many_threads.json
+++ b/bench/wtperf/runners/log_many_threads.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": ["-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"],
+    "operations": ["update"]
+  }
+]

--- a/bench/wtperf/runners/log_no_checkpoints.json
+++ b/bench/wtperf/runners/log_no_checkpoints.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": ["-C checkpoint=(wait=0)"],
+    "operations": ["update"]
+  }
+]

--- a/bench/wtperf/runners/log_no_prealloc.json
+++ b/bench/wtperf/runners/log_no_prealloc.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": ["-C log=(enabled,file_max=1M,prealloc=false)"],
+    "operations": ["update"]
+  }
+]

--- a/bench/wtperf/runners/log_small_files.json
+++ b/bench/wtperf/runners/log_small_files.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": ["-C log=(enabled,file_max=1M)"],
+    "operations": ["update"]
+  }
+]

--- a/bench/wtperf/runners/log_zero_fill.json
+++ b/bench/wtperf/runners/log_zero_fill.json
@@ -1,0 +1,6 @@
+[
+  {
+    "arguments": ["-C log=(enabled,file_max=1M,zero_fill=true)"],
+    "operations": ["update"]
+  }
+]

--- a/bench/wtperf/runners/update-btree.json
+++ b/bench/wtperf/runners/update-btree.json
@@ -1,14 +1,14 @@
 [
     {
-      "argument": "-o threads=((count=2,inserts=1,throttle=20000),(count=2,reads=1),(count=2,updates=1,throttle=20000))",
+      "arguments": ["-o threads=((count=2,inserts=1,throttle=20000),(count=2,reads=1),(count=2,updates=1,throttle=20000))"],
       "operations": [ "read", "load" ]
     },
     {
-      "argument": "-o threads=((count=2,inserts=1,throttle=20000),(count=2,reads=1,throttle=20000),(count=2,updates=1))",
+      "arguments": ["-o threads=((count=2,inserts=1,throttle=20000),(count=2,reads=1,throttle=20000),(count=2,updates=1))"],
       "operations": [ "update" ]
     },
     {
-      "argument": "-o threads=((count=2,inserts=1),(count=2,reads=1,throttle=20000),(count=2,updates=1,throttle=20000))",
+      "arguments": ["-o threads=((count=2,inserts=1),(count=2,reads=1,throttle=20000),(count=2,updates=1,throttle=20000))"],
       "operations": [ "insert" ]
     }
 ]

--- a/bench/wtperf/runners/update-checkpoint.json
+++ b/bench/wtperf/runners/update-checkpoint.json
@@ -1,14 +1,14 @@
 [
     {
-      "argument": "-o threads=((count=1,inserts=1,throttle=20000),(count=2,reads=1),(count=2,updates=1,throttle=20000))",
+      "arguments": ["-o threads=((count=1,inserts=1,throttle=20000),(count=2,reads=1),(count=2,updates=1,throttle=20000))"],
       "operations": [ "read", "load" ]
     },
     {
-      "argument": "-o threads=((count=1,inserts=1,throttle=20000),(count=2,reads=1,throttle=20000),(count=2,updates=1))",
+      "arguments": ["-o threads=((count=1,inserts=1,throttle=20000),(count=2,reads=1,throttle=20000),(count=2,updates=1))"],
       "operations": [ "update" ]
     },
     {
-      "argument": "-o threads=((count=1,inserts=1),(count=2,reads=1,throttle=20000),(count=2,updates=1,throttle=20000))",
+      "arguments": ["-o threads=((count=1,inserts=1),(count=2,reads=1,throttle=20000),(count=2,updates=1,throttle=20000))"],
       "operations": [ "insert" ]
     }
 ]

--- a/bench/wtperf/runners/update-stress.json
+++ b/bench/wtperf/runners/update-stress.json
@@ -1,6 +1,6 @@
 [
   {
-    "argument": null,
+    "arguments": null,
     "operations": [ "update" ]
   }
 ]

--- a/bench/wtperf/wtperf_run_py/perf_stat.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat.py
@@ -28,6 +28,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+from enum import Enum
+
+class AggregationFunc(Enum):
+    CoreAverage = 1
+    AvgMin = 2
+    AvgMax = 3
+
 class PerfStat:
     def __init__(self,
                  short_label: str,
@@ -35,44 +42,46 @@ class PerfStat:
                  input_offset: int,
                  output_label: str,
                  output_precision: int = 0,
-                 conversion_function=int):
+                 conversion_function=int,
+                 aggregation_function: AggregationFunc = AggregationFunc.CoreAverage):
         self.short_label: str = short_label
         self.pattern: str = pattern
         self.input_offset: int = input_offset
         self.output_label: str = output_label
         self.output_precision: int = output_precision
         self.conversion_function = conversion_function
+        self.aggregation_function = aggregation_function
         self.values = []
 
-    def add_value(self, value):
-        converted_value = self.conversion_function(value)
-        self.values.append(converted_value)
+    def add_values(self, values: list):
+        for val in values:
+            converted_value = self.conversion_function(val)
+            self.values.append(converted_value)
 
     def get_num_values(self):
         return len(self.values)
 
-    def get_average(self):
-        num_values = len(self.values)
-        total = sum(self.values)
-        average = self.conversion_function(total / num_values)
-        return average
+    def average(self, vals):
+        return self.conversion_function(sum(vals) / len(vals))
 
     def get_skipminmax_average(self):
-        num_values = len(self.values)
-        assert num_values >= 3
-        minimum = min(self.values)
-        maximum = max(self.values)
-        total = sum(self.values)
-        total_skipminmax = total - maximum - minimum
-        num_values_skipminmax = num_values - 2
-        skipminmax_average = self.conversion_function(total_skipminmax / num_values_skipminmax)
-        return skipminmax_average
+        assert len(self.values) >= 3
+        drop_min_and_max = sorted(self.values)[1:-1]
+        return self.average(drop_min_and_max)
 
     def get_core_average(self):
         if len(self.values) >= 3:
             return self.get_skipminmax_average()
         else:
-            return self.get_average()
+            return self.average(self.values)
+
+    def get_avg_min(self):
+        min_3_vals = sorted(self.values)[:3]
+        return self.average(min_3_vals)
+
+    def get_avg_max(self):
+        max_3_vals = sorted(self.values)[-3:]
+        return self.average(max_3_vals)
 
     def are_values_all_zero(self):
         result = True

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -50,7 +50,7 @@ class PerfStatCollection:
     def add_stat(self, perf_stat: PerfStat):
         self.perf_stats[perf_stat.short_label] = perf_stat
 
-    def find_stats(self, test_stat_path: str, operations: List[str], run_max: int):
+    def find_stats(self, test_stat_path: str, operations: List[str]):
         for stat in self.perf_stats.values():
             if not operations or stat.short_label in operations:
                 values = find_stat(test_stat_path=test_stat_path,

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -31,7 +31,7 @@
 import re
 from typing import List
 
-from perf_stat import AggregationFunc, PerfStat
+from perf_stat import PerfStat
 
 
 def find_stat(test_stat_path: str, pattern: str, position_of_value: int):
@@ -62,17 +62,9 @@ class PerfStatCollection:
         as_list = []
         for stat in self.perf_stats.values():
             if not stat.are_values_all_zero():
-                
-                if stat.aggregation_function == AggregationFunc.CoreAverage:
-                    val = stat.get_core_average()
-                elif stat.aggregation_function == AggregationFunc.AvgMax:
-                    val = stat.get_avg_max() 
-                elif stat.aggregation_function == AggregationFunc.AvgMin:
-                    val = stat.get_avg_min() 
-
                 as_dict = {
                     'name': stat.output_label,
-                    'value': val
+                    'value': stat.get_value()
                 }
                 if not brief:
                     as_dict['values'] = stat.values

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -149,7 +149,11 @@ def run_test(config: WTPerfConfig, test_run: int, operations: List[str] = None, 
         arguments=arguments,
         test=config.test,
         home=test_home)
-    subprocess.run(command_line, check=True)
+    try:
+        subprocess.run(command_line, check=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
+    except subprocess.CalledProcessError as cpe:
+        print("Error: {}".format(cpe.output))
+        exit(1)
 
 
 def process_results(config: WTPerfConfig, perf_stats: PerfStatCollection, operations: List[str] = None):

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -193,13 +193,13 @@ def setup_perf_stats():
                                  input_offset=1,
                                  output_label='Update count'))
     perf_stats.add_stat(PerfStatMax(short_label="max_update_throughput",
-                                 pattern=r'updates,',
-                                 input_offset=8,
-                                 output_label='Max update throughput'))
+                                    pattern=r'updates,',
+                                    input_offset=8,
+                                    output_label='Max update throughput'))
     perf_stats.add_stat(PerfStatMin(short_label="min_update_throughput",
-                                 pattern=r'updates,',
-                                 input_offset=8,
-                                 output_label='Min update throughput'))
+                                    pattern=r'updates,',
+                                    input_offset=8,
+                                    output_label='Min update throughput'))
     return perf_stats
 
 

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -161,7 +161,7 @@ def process_results(config: WTPerfConfig, perf_stats: PerfStatCollection, operat
         test_stats_path = create_test_stat_path(test_home)
         if config.verbose:
             print('Reading test stats file: {}'.format(test_stats_path))
-        perf_stats.find_stats(test_stat_path=test_stats_path, operations=operations, run_max=config.run_max)
+        perf_stats.find_stats(test_stat_path=test_stats_path, operations=operations)
 
 
 def setup_perf_stats():

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -96,7 +96,7 @@ def get_git_info(git_working_tree_dir):
     return git_info
 
 
-def construct_wtperf_command_line(wtperf: str, env: str, test: str, home: str, argument: str):
+def construct_wtperf_command_line(wtperf: str, env: str, test: str, home: str, arguments: List[str]):
     command_line = []
     if env is not None:
         command_line.append(env)
@@ -104,8 +104,8 @@ def construct_wtperf_command_line(wtperf: str, env: str, test: str, home: str, a
     if test is not None:
         command_line.append('-O')
         command_line.append(test)
-    if argument is not None:
-        command_line.append(argument)
+    if arguments is not None:
+        command_line.extend(arguments)
     if home is not None:
         command_line.append('-h')
         command_line.append(home)
@@ -142,19 +142,19 @@ def detailed_perf_stats(config: WTPerfConfig, perf_stats: PerfStatCollection):
     return as_dict
 
 
-def run_test_wrapper(config: WTPerfConfig, operations: List[str] = None, argument: str = None):
+def run_test_wrapper(config: WTPerfConfig, operations: List[str] = None, arguments: List[str] = None):
     for test_run in range(config.run_max):
         print("Starting test  {}".format(test_run))
-        run_test(config=config, test_run=test_run, operations=operations, argument=argument)
+        run_test(config=config, test_run=test_run, operations=operations, arguments=arguments)
         print("Completed test {}".format(test_run))
 
 
-def run_test(config: WTPerfConfig, test_run: int, operations: List[str] = None, argument: str = None):
+def run_test(config: WTPerfConfig, test_run: int, operations: List[str] = None, arguments: List[str] = None):
     test_home = create_test_home_path(home=config.home_dir, test_run=test_run, operations=operations)
     command_line = construct_wtperf_command_line(
         wtperf=config.wtperf_path,
         env=config.environment,
-        argument=argument,
+        arguments=arguments,
         test=config.test,
         home=test_home)
     subprocess.run(command_line, check=True)
@@ -269,8 +269,8 @@ def main():
         if config.arg_file:
             for content in arg_file_contents:
                 if args.verbose:
-                    print("Argument: {},  Operation: {}".format(content["argument"], content["operations"]))
-                run_test_wrapper(config=config, operations=content["operations"], argument=content["argument"])
+                    print("Argument: {},  Operation: {}".format(content["arguments"], content["operations"]))
+                run_test_wrapper(config=config, operations=content["operations"], arguments=content["arguments"])
         else:
             run_test_wrapper(config=config)
 

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -40,7 +40,7 @@ from pygit2 import GIT_SORT_NONE
 from typing import List
 
 from wtperf_config import WTPerfConfig
-from perf_stat import AggregationFunc, PerfStat
+from perf_stat import PerfStat, PerfStatMax, PerfStatMin
 from perf_stat_collection import PerfStatCollection
 
 # the 'test.stat' file is where wt-perf.c writes out it's statistics
@@ -192,16 +192,14 @@ def setup_perf_stats():
                                  pattern=r'Executed \d+ update operations',
                                  input_offset=1,
                                  output_label='Update count'))
-    perf_stats.add_stat(PerfStat(short_label="max_update_throughput",
+    perf_stats.add_stat(PerfStatMax(short_label="max_update_throughput",
                                  pattern=r'updates,',
                                  input_offset=8,
-                                 output_label='Max update throughput',
-                                 aggregation_function=AggregationFunc.AvgMax))
-    perf_stats.add_stat(PerfStat(short_label="min_update_throughput",
+                                 output_label='Max update throughput'))
+    perf_stats.add_stat(PerfStatMin(short_label="min_update_throughput",
                                  pattern=r'updates,',
                                  input_offset=8,
-                                 output_label='Min update throughput',
-                                 aggregation_function=AggregationFunc.AvgMin))
+                                 output_label='Min update throughput'))
     return perf_stats
 
 

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -31,13 +31,12 @@
 import argparse
 import json
 import os.path
-import re
 import subprocess
 import sys
 import platform
 import psutil
 from pygit2 import discover_repository, Repository
-from pygit2 import GIT_SORT_TOPOLOGICAL, GIT_SORT_REVERSE, GIT_SORT_NONE
+from pygit2 import GIT_SORT_NONE
 from typing import List
 
 from wtperf_config import WTPerfConfig

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3445,6 +3445,99 @@ tasks:
         vars:
           perf-test-name: evict-lsm-1
 
+    ###########################################
+    # Performance Tests for log consolidation #
+    ###########################################
+
+  - name: perf-test-log
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log
+
+  - name: perf-test-log-small-files
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log_small_files.json"
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log-small-files
+
+  - name: perf-test-log-no-checkpoints
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log_no_checkpoints.json"
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log-no-checkpoints
+
+  - name: perf-test-log-no-prealloc
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log_no_prealloc.json"
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log-no-prealloc
+
+  - name: perf-test-log-zero-fill
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log_zero_fill.json"
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log-zero-fill
+
+  - name: perf-test-log-many-threads
+    tags: ["log-perf"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: log
+          maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log_many_threads.json"
+      - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: log-many-threads
+
 #######################################
 #            Buildvariants            #
 #######################################
@@ -3728,6 +3821,7 @@ buildvariants:
     - name: ".stress-perf"
     - name: ".checkpoint-perf"
     - name: ".evict-perf"
+    - name: ".log-perf"
   display_tasks:
     - name: Wiredtiger-perf-btree-jobs
       execution_tasks:
@@ -3744,6 +3838,9 @@ buildvariants:
     - name: Wiredtiger-perf-evict-jobs
       execution_tasks:
       - ".evict-perf"
+    - name: Wiredtiger-perf-log-jobs
+      execution_tasks:
+      - ".log-perf"
 
 - name: large-scale-tests
   display_name: "Large scale tests"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3459,6 +3459,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
+          wtarg: "-a ../../../bench/wtperf/runners/log.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log


### PR DESCRIPTION
Migration of the log-consolidation performance tests from Jenkins to Evergreen.
Also in the commit:
- In Arg files (e.g. update-btree.json) multiple arguments can now be passed into wtperf
- Introduction of the min/max_throughput stats
- When wtperf fails print the stderr output for debugging purposes