### PR TITLE
WT-8256 Create new tests capturing different verbose configuration scenarios

### DIFF
--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -59,8 +59,7 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         # to ensure we've only generated verbose messages for the expected categories.
         verbose_messages = output.splitlines()
 
-        # Check if we are expecting any output. We should not expect anything if no categories were
-        # passed.
+        # Check if we are expecting any output.
         if expect_output:
             self.assertGreater(len(verbose_messages), 0)
         else:

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -84,46 +84,53 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
         # this test.
         self.close_conn()
 
-        # Test passing a single verbose category, 'api'. Ensuring the only verbose output generated is related to
-        # the 'api' category.
-        with self.expect_verbose(['api'], ['WT_VERB_API']) as conn:
-            # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
-            # messages.
-            uri = 'table:test_verbose01_api'
-            session = conn.open_session()
-            session.create(uri, self.collection_cfg)
-            c = session.open_cursor(uri)
-            c['api'] = 'api'
-            c.close()
-            session.close()
+        # Test passing a single verbose category, 'api'. Ensuring the only verbose output generated
+        # is related to the 'api' category. The verbosity level WT_VERBOSE_INFO will be tested
+        # separately.
+        cfgs = ['api', 'api:1']
+        for cfg in cfgs:
+            with self.expect_verbose([cfg], ['WT_VERB_API']) as conn:
+                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
+                # messages.
+                uri = 'table:test_verbose01_api'
+                session = conn.open_session()
+                session.create(uri, self.collection_cfg)
+                c = session.open_cursor(uri)
+                c['api'] = 'api'
+                c.close()
+                session.close()
 
         # Test passing another single verbose category, 'compact'. Ensuring the only verbose output generated is related to
         # the 'compact' category.
-        with self.expect_verbose(['compact'], ['WT_VERB_COMPACT']) as conn:
-            # Create a simple table to invoke compaction on. We aren't doing anything interesting with the table
-            # such that the data source will be compacted. Rather we want to simply invoke a compaction pass to
-            # generate verbose messages.
-            uri = 'table:test_verbose01_compact'
-            session = conn.open_session()
-            session.create(uri, self.collection_cfg)
-            session.compact(uri)
-            session.close()
+        cfgs = ['compact', 'compact:0', 'compact:1']
+        for cfg in cfgs:
+            with self.expect_verbose([cfg], ['WT_VERB_COMPACT']) as conn:
+                # Create a simple table to invoke compaction on. We aren't doing anything interesting with the table
+                # such that the data source will be compacted. Rather we want to simply invoke a compaction pass to
+                # generate verbose messages.
+                uri = 'table:test_verbose01_compact'
+                session = conn.open_session()
+                session.create(uri, self.collection_cfg)
+                session.compact(uri)
+                session.close()
 
     # Test use cases passing multiple verbose categories, ensuring we only produce verbose output for specified categories.
     def test_verbose_multiple(self):
         self.close_conn()
         # Test passing multiple verbose categories, being 'api' & 'version'. Ensuring the only verbose output generated
         # is related to those two categories.
-        with self.expect_verbose(['api','version'], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
-            # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
-            # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
-            # category.
-            uri = 'table:test_verbose01_multiple'
-            session = conn.open_session()
-            session.create(uri, self.collection_cfg)
-            c = session.open_cursor(uri)
-            c['multiple'] = 'multiple'
-            c.close()
+        cfgs = ['api,version', 'api:1,version', 'api,version:1', 'api:1,version:1']
+        for cfg in cfgs:
+            with self.expect_verbose([cfg], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
+                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
+                # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
+                # category.
+                uri = 'table:test_verbose01_multiple'
+                session = conn.open_session()
+                session.create(uri, self.collection_cfg)
+                c = session.open_cursor(uri)
+                c['multiple'] = 'multiple'
+                c.close()
 
     # Test use cases passing no verbose categories, ensuring we don't produce unexpected verbose output.
     def test_verbose_none(self):

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -89,25 +89,11 @@ class test_verbose01(test_verbose_base):
         # this test.
         self.close_conn()
 
-        # Test passing a single verbose category, 'api'. Ensuring the only verbose output generated
-        # is related to the 'api' category. The verbosity level WT_VERBOSE_INFO is tested
-        # separately.
-        cfgs = ['api', 'api:1']
-        for cfg in cfgs:
-            with self.expect_verbose([cfg], ['WT_VERB_API']) as conn:
-                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
-                # messages.
-                uri = 'table:test_verbose01_api'
-                session = conn.open_session()
-                session.create(uri, self.collection_cfg)
-                c = session.open_cursor(uri)
-                c['api'] = 'api'
-                c.close()
-                session.close()
-
-        # There is no WT_VERB_API messages used with the WT_VERBOSE_INFO level, hence we don't
-        # expect any output.
-        with self.expect_verbose(['api:0'], ['WT_VERB_API'], False) as conn:
+        # Test passing a single verbose category, 'api'. Ensuring the only verbose output generated is related to
+        # the 'api' category.
+        with self.expect_verbose(['api'], ['WT_VERB_API']) as conn:
+            # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
+            # messages.
             uri = 'table:test_verbose01_api'
             session = conn.open_session()
             session.create(uri, self.collection_cfg)
@@ -118,35 +104,31 @@ class test_verbose01(test_verbose_base):
 
         # Test passing another single verbose category, 'compact'. Ensuring the only verbose output generated is related to
         # the 'compact' category.
-        cfgs = ['compact', 'compact:0', 'compact:1']
-        for cfg in cfgs:
-            with self.expect_verbose([cfg], ['WT_VERB_COMPACT']) as conn:
-                # Create a simple table to invoke compaction on. We aren't doing anything interesting with the table
-                # such that the data source will be compacted. Rather we want to simply invoke a compaction pass to
-                # generate verbose messages.
-                uri = 'table:test_verbose01_compact'
-                session = conn.open_session()
-                session.create(uri, self.collection_cfg)
-                session.compact(uri)
-                session.close()
+        with self.expect_verbose(['compact'], ['WT_VERB_COMPACT']) as conn:
+            # Create a simple table to invoke compaction on. We aren't doing anything interesting with the table
+            # such that the data source will be compacted. Rather we want to simply invoke a compaction pass to
+            # generate verbose messages.
+            uri = 'table:test_verbose01_compact'
+            session = conn.open_session()
+            session.create(uri, self.collection_cfg)
+            session.compact(uri)
+            session.close()
 
     # Test use cases passing multiple verbose categories, ensuring we only produce verbose output for specified categories.
     def test_verbose_multiple(self):
         self.close_conn()
         # Test passing multiple verbose categories, being 'api' & 'version'. Ensuring the only verbose output generated
         # is related to those two categories.
-        cfgs = ['api,version', 'api:1,version', 'api,version:1', 'api:1,version:1']
-        for cfg in cfgs:
-            with self.expect_verbose([cfg], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
-                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
-                # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
-                # category.
-                uri = 'table:test_verbose01_multiple'
-                session = conn.open_session()
-                session.create(uri, self.collection_cfg)
-                c = session.open_cursor(uri)
-                c['multiple'] = 'multiple'
-                c.close()
+        with self.expect_verbose(['api','version'], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
+            # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
+            # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
+            # category.
+            uri = 'table:test_verbose01_multiple'
+            session = conn.open_session()
+            session.create(uri, self.collection_cfg)
+            c = session.open_cursor(uri)
+            c['multiple'] = 'multiple'
+            c.close()
 
     # Test use cases passing no verbose categories, ensuring we don't produce unexpected verbose output.
     def test_verbose_none(self):

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -32,12 +32,8 @@ from contextlib import contextmanager
 import wiredtiger, wttest
 import re
 
-# test_verbose01.py
-# Tests that basic uses of the verbose configuration API work as intended i.e. passing
-# single & multiple valid and invalid verbose categories. This test is mainly focused on uses
-# of the interface prior to the introduction of verbosity levels, ensuring 'legacy'-style
-# uses of the interface are still supported.
-class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
+# Shared base class used by verbose tests.
+class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
     collection_cfg = 'key_format=S,value_format=S'
     # The maximum number of lines we will read from stdout in any given context.
     nlines = 30000
@@ -81,6 +77,12 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
         conn.close()
         self.cleanStdout()
 
+# test_verbose01.py
+# Verify basic uses of the verbose configuration API work as intended i.e. passing
+# single & multiple valid and invalid verbose categories. These tests are mainly focused on uses
+# of the interface prior to the introduction of verbosity levels, ensuring 'legacy'-style
+# uses of the interface are still supported.
+class test_verbose01(test_verbose_base):
     # Test use cases passing single verbose categories, ensuring we only produce verbose output for the single category.
     def test_verbose_single(self):
         # Close the initial connection. We will be opening new connections with different verbosity settings throughout

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -34,6 +34,8 @@ import re
 
 # Shared base class used by verbose tests.
 class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
+    # The maximum number of lines we will read from stdout in any given context.
+    nlines = 30000
 
     def create_verbose_configuration(self, categories):
         if len(categories) == 0:
@@ -52,8 +54,7 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         # operations on the connection (for generating the expected verbose output).
         yield conn
         # Read the contents of stdout to extract our verbose messages.
-        nlines = 30000
-        output = self.readStdout(nlines)
+        output = self.readStdout(self.nlines)
         # Split the output into their individual messages. We want validate the contents of each message
         # to ensure we've only generated verbose messages for the expected categories.
         verbose_messages = output.splitlines()

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -34,8 +34,6 @@ import re
 
 # Shared base class used by verbose tests.
 class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
-    # The maximum number of lines we will read from stdout in any given context.
-    nlines = 30000
 
     def create_verbose_configuration(self, categories):
         if len(categories) == 0:
@@ -54,7 +52,8 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         # operations on the connection (for generating the expected verbose output).
         yield conn
         # Read the contents of stdout to extract our verbose messages.
-        output = self.readStdout(self.nlines)
+        nlines = 30000
+        output = self.readStdout(nlines)
         # Split the output into their individual messages. We want validate the contents of each message
         # to ensure we've only generated verbose messages for the expected categories.
         verbose_messages = output.splitlines()

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -61,10 +61,10 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Check if we are expecting any output. We should not expect anything if no categories were
         # passed.
-        if len(categories) == 0 or not expect_output:
-            self.assertEqual(len(verbose_messages), 0)
-        else:
+        if expect_output:
             self.assertGreater(len(verbose_messages), 0)
+        else:
+            self.assertEqual(len(verbose_messages), 0)
 
         # Test the contents of each verbose message, ensuring it satisfies the expected pattern.
         verb_pattern = re.compile('|'.join(patterns))
@@ -134,7 +134,7 @@ class test_verbose01(test_verbose_base):
     def test_verbose_none(self):
         self.close_conn()
         # Testing passing an empty set of categories. Ensuring no verbose output is generated.
-        with self.expect_verbose([], []) as conn:
+        with self.expect_verbose([], [], False) as conn:
             # Perform a set of simple API operations (table creations and cursor operations). Ensuring no verbose messages
             # are generated.
             uri = 'table:test_verbose01_none'

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -152,18 +152,5 @@ class test_verbose01(test_verbose_base):
                 lambda:self.wiredtiger_open(self.home, 'verbose=[test_verbose_invalid]'),
                 '/\'test_verbose_invalid\' not a permitted choice for key \'verbose\'/')
 
-    # Test use cases passing invalid verbose levels, ensuring the appropriate error message is
-    # raised.
-    def test_verbose_level_invalid(self):
-        self.close_conn()
-        # Any negative value is invalid.
-        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
-                lambda:self.wiredtiger_open(self.home, 'verbose=[api:-1]'),
-                '/Failed to parse verbose option \'api\'/')
-        # Any value greater than WT_VERBOSE_DEBUG is invalid.
-        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
-                lambda:self.wiredtiger_open(self.home, 'verbose=[api:2]'),
-                '/Failed to parse verbose option \'api\'/')
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -160,12 +160,26 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
             c['none'] = 'none'
             c.close()
 
-    # Test use cases passing invalid verbose categories, ensuring the appropriate error message is raised.
+    # Test use cases passing invalid verbose categories, ensuring the appropriate error message is
+    # raised.
     def test_verbose_invalid(self):
         self.close_conn()
         self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
                 lambda:self.wiredtiger_open(self.home, 'verbose=[test_verbose_invalid]'),
-                '/\'test_verbose_invalid\' not a permitted choice/')
+                '/\'test_verbose_invalid\' not a permitted choice for key \'verbose\'/')
+
+    # Test use cases passing invalid verbose levels, ensuring the appropriate error message is
+    # raised.
+    def test_verbose_level_invalid(self):
+        self.close_conn()
+        # Any negative value is invalid.
+        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
+                lambda:self.wiredtiger_open(self.home, 'verbose=[api:-1]'),
+                '/Failed to parse verbose option \'api\'/')
+        # Any value greater than WT_VERBOSE_DEBUG is invalid.
+        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
+                lambda:self.wiredtiger_open(self.home, 'verbose=[api:2]'),
+                '/Failed to parse verbose option \'api\'/')
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -38,6 +38,7 @@ import re
 # of the interface prior to the introduction of verbosity levels, ensuring 'legacy'-style
 # uses of the interface are still supported.
 class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
+    collection_cfg = 'key_format=S,value_format=S'
     # The maximum number of lines we will read from stdout in any given context.
     nlines = 30000
 
@@ -90,7 +91,7 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
             # messages.
             uri = 'table:test_verbose01_api'
             session = conn.open_session()
-            session.create(uri, 'key_format=S,value_format=S')
+            session.create(uri, self.collection_cfg)
             c = session.open_cursor(uri)
             c['api'] = 'api'
             c.close()
@@ -104,7 +105,7 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
             # generate verbose messages.
             uri = 'table:test_verbose01_compact'
             session = conn.open_session()
-            session.create(uri, 'key_format=S,value_format=S')
+            session.create(uri, self.collection_cfg)
             session.compact(uri)
             session.close()
 
@@ -119,7 +120,7 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
             # category.
             uri = 'table:test_verbose01_multiple'
             session = conn.open_session()
-            session.create(uri, 'key_format=S,value_format=S')
+            session.create(uri, self.collection_cfg)
             c = session.open_cursor(uri)
             c['multiple'] = 'multiple'
             c.close()
@@ -133,7 +134,7 @@ class test_verbose01(wttest.WiredTigerTestCase, suite_subprocess):
             # are generated.
             uri = 'table:test_verbose01_none'
             session = conn.open_session()
-            session.create(uri, 'key_format=S,value_format=S')
+            session.create(uri, self.collection_cfg)
             c = session.open_cursor(uri)
             c['none'] = 'none'
             c.close()

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -34,7 +34,6 @@ import re
 
 # Shared base class used by verbose tests.
 class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
-    collection_cfg = 'key_format=S,value_format=S'
     # The maximum number of lines we will read from stdout in any given context.
     nlines = 30000
 
@@ -83,6 +82,7 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
 # of the interface prior to the introduction of verbosity levels, ensuring 'legacy'-style
 # uses of the interface are still supported.
 class test_verbose01(test_verbose_base):
+    collection_cfg = 'key_format=S,value_format=S'
     # Test use cases passing single verbose categories, ensuring we only produce verbose output for the single category.
     def test_verbose_single(self):
         # Close the initial connection. We will be opening new connections with different verbosity settings throughout

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -58,7 +58,6 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         # to ensure we've only generated verbose messages for the expected categories.
         verbose_messages = output.splitlines()
 
-        # Check if we are expecting any output.
         if expect_output:
             self.assertGreater(len(verbose_messages), 0)
         else:

--- a/test/suite/test_verbose02.py
+++ b/test/suite/test_verbose02.py
@@ -43,11 +43,11 @@ class test_verbose02(test_verbose_base):
         # settings throughout this test.
         self.close_conn()
 
-        # Test passing a single verbose category, 'api' along with the verbosity level 1. Ensuring
-        # the only verbose output generated is related to the 'api' category.
+        # Test passing a single verbose category, 'api' along with the verbosity level
+        # WT_VERBOSE_DEBUG (1). Ensuring the only verbose output generated is related to the 'api'
+        # category.
         with self.expect_verbose(['api:1'], ['WT_VERB_API']) as conn:
-            # Perform a set of simple API operations (table creations and cursor operations) to
-            # generate verbose API messages.
+            # Perform a set of simple API operations to generate verbose API messages.
             uri = 'table:test_verbose01_api'
             session = conn.open_session()
             session.create(uri, self.collection_cfg)
@@ -56,8 +56,8 @@ class test_verbose02(test_verbose_base):
             c.close()
             session.close()
 
-        # There is no WT_VERB_API messages used with the WT_VERBOSE_INFO level for now, hence we
-        # don't expect any output.
+        # At this time, there is no verbose messages with the category WT_VERB_API and the verbosity
+        # level WT_VERBOSE_INFO (0), hence we don't expect any output.
         with self.expect_verbose(['api:0'], ['WT_VERB_API'], False) as conn:
             uri = 'table:test_verbose01_api'
             session = conn.open_session()
@@ -68,8 +68,8 @@ class test_verbose02(test_verbose_base):
             session.close()
 
         # Test passing another single verbose category, 'compact' with different verbosity levels.
-        # Since the category WT_VERB_COMPACT is used with verbose message of verbosity level
-        # WT_VERBOSE_INFO and WT_VERBOSE_DEBUG, we can test them both.
+        # Since there are verbose message with the category WT_VERB_COMPACT and the verbosity levels
+        #  WT_VERBOSE_INFO (0) and WT_VERBOSE_DEBUG (1), we can test them both.
         cfgs = ['compact:0', 'compact:1']
         for cfg in cfgs:
             with self.expect_verbose([cfg], ['WT_VERB_COMPACT']) as conn:
@@ -92,9 +92,9 @@ class test_verbose02(test_verbose_base):
         cfgs = ['api:1,version', 'api,version:1', 'api:1,version:1']
         for cfg in cfgs:
             with self.expect_verbose([cfg], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
-                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
-                # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
-                # category.
+                # Perform a set of simple API operations (table creations and cursor operations) to
+                # generate verbose API messages. Beyond opening the connection resource, we
+                # shouldn't need to do anything special for the version category.
                 uri = 'table:test_verbose01_multiple'
                 session = conn.open_session()
                 session.create(uri, self.collection_cfg)
@@ -102,7 +102,7 @@ class test_verbose02(test_verbose_base):
                 c['multiple'] = 'multiple'
                 c.close()
 
-    # Test use cases passing invalid verbose levels, ensuring the appropriate error message is
+    # Test use cases passing invalid verbosity levels, ensuring the appropriate error message is
     # raised.
     def test_verbose_level_invalid(self):
         self.close_conn()
@@ -110,7 +110,7 @@ class test_verbose02(test_verbose_base):
         self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
                 lambda:self.wiredtiger_open(self.home, 'verbose=[api:-1]'),
                 '/Failed to parse verbose option \'api\'/')
-        # Any value greater than WT_VERBOSE_DEBUG is invalid.
+        # Any value greater than WT_VERBOSE_DEBUG (1) is invalid.
         self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
                 lambda:self.wiredtiger_open(self.home, 'verbose=[api:2]'),
                 '/Failed to parse verbose option \'api\'/')

--- a/test/suite/test_verbose02.py
+++ b/test/suite/test_verbose02.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import wiredtiger, wttest
+from test_verbose01 import test_verbose_base
+
+# test_verbose02.py
+# Verify basic uses of the verbose configuration API when categories and valid/invalid verbosity
+# levels are specified.
+class test_verbose02(test_verbose_base):
+    collection_cfg = 'key_format=S,value_format=S'
+
+    # Test use cases passing single verbose categories, ensuring we only produce verbose output for
+    # the single category.
+    def test_verbose_single(self):
+        # Close the initial connection. We will be opening new connections with different verbosity
+        # settings throughout this test.
+        self.close_conn()
+
+        # Test passing a single verbose category, 'api' along with the verbosity level 1. Ensuring
+        # the only verbose output generated is related to the 'api' category.
+        with self.expect_verbose(['api:1'], ['WT_VERB_API']) as conn:
+            # Perform a set of simple API operations (table creations and cursor operations) to
+            # generate verbose API messages.
+            uri = 'table:test_verbose01_api'
+            session = conn.open_session()
+            session.create(uri, self.collection_cfg)
+            c = session.open_cursor(uri)
+            c['api'] = 'api'
+            c.close()
+            session.close()
+
+        # There is no WT_VERB_API messages used with the WT_VERBOSE_INFO level for now, hence we
+        # don't expect any output.
+        with self.expect_verbose(['api:0'], ['WT_VERB_API'], False) as conn:
+            uri = 'table:test_verbose01_api'
+            session = conn.open_session()
+            session.create(uri, self.collection_cfg)
+            c = session.open_cursor(uri)
+            c['api'] = 'api'
+            c.close()
+            session.close()
+
+        # Test passing another single verbose category, 'compact' with different verbosity levels.
+        # Since the category WT_VERB_COMPACT is used with verbose message of verbosity level
+        # WT_VERBOSE_INFO and WT_VERBOSE_DEBUG, we can test them both.
+        cfgs = ['compact:0', 'compact:1']
+        for cfg in cfgs:
+            with self.expect_verbose([cfg], ['WT_VERB_COMPACT']) as conn:
+                # Create a simple table to invoke compaction on. We aren't doing anything
+                # interesting with the table, we want to simply invoke a compaction pass to generate
+                # verbose messages.
+                uri = 'table:test_verbose01_compact'
+                session = conn.open_session()
+                session.create(uri, self.collection_cfg)
+                session.compact(uri)
+                session.close()
+
+    # Test use cases passing multiple verbose categories, ensuring we only produce verbose output
+    # for specified categories.
+    def test_verbose_multiple(self):
+        self.close_conn()
+        # Test passing multiple verbose categories, being 'api' & 'version' with different dedicated
+        # verbosity levels to each category. Ensuring the only verbose output generated is related
+        # to those two categories.
+        cfgs = ['api:1,version', 'api,version:1', 'api:1,version:1']
+        for cfg in cfgs:
+            with self.expect_verbose([cfg], ['WT_VERB_API', 'WT_VERB_VERSION']) as conn:
+                # Perform a set of simple API operations (table creations and cursor operations) to generate verbose API
+                # messages. Beyond opening the connection resource, we shouldn't need to do anything special for the version
+                # category.
+                uri = 'table:test_verbose01_multiple'
+                session = conn.open_session()
+                session.create(uri, self.collection_cfg)
+                c = session.open_cursor(uri)
+                c['multiple'] = 'multiple'
+                c.close()
+
+    # Test use cases passing invalid verbose levels, ensuring the appropriate error message is
+    # raised.
+    def test_verbose_level_invalid(self):
+        self.close_conn()
+        # Any negative value is invalid.
+        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
+                lambda:self.wiredtiger_open(self.home, 'verbose=[api:-1]'),
+                '/Failed to parse verbose option \'api\'/')
+        # Any value greater than WT_VERBOSE_DEBUG is invalid.
+        self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
+                lambda:self.wiredtiger_open(self.home, 'verbose=[api:2]'),
+                '/Failed to parse verbose option \'api\'/')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_verbose02.py
+++ b/test/suite/test_verbose02.py
@@ -69,7 +69,7 @@ class test_verbose02(test_verbose_base):
 
         # Test passing another single verbose category, 'compact' with different verbosity levels.
         # Since there are verbose message with the category WT_VERB_COMPACT and the verbosity levels
-        #  WT_VERBOSE_INFO (0) and WT_VERBOSE_DEBUG (1), we can test them both.
+        # WT_VERBOSE_INFO (0) and WT_VERBOSE_DEBUG (1), we can test them both.
         cfgs = ['compact:0', 'compact:1']
         for cfg in cfgs:
             with self.expect_verbose([cfg], ['WT_VERB_COMPACT']) as conn:


### PR DESCRIPTION
Implementation of new tests to verify the new verbose API is working as expected when specific categories along with verbosity levels are set. The main changes are:

- Creation of a class that defines common helpers that are used across the different verbose test classes.
- Creation of a new file that contains the tests related to the new verbose API