### PR TITLE
WT-8355 Coverity analysis defect 121096: Uninitialized pointer read

### DIFF
--- a/test/format/format.i
+++ b/test/format/format.i
@@ -243,6 +243,8 @@ wiredtiger_open_cursor(
 {
     WT_DECL_RET;
 
+    *cursorp = NULL;
+
     /* WT_SESSION.open_cursor can return EBUSY if concurrent with a metadata operation, retry. */
     while ((ret = session->open_cursor(session, uri, NULL, config, cursorp)) == EBUSY)
         __wt_yield();


### PR DESCRIPTION
Coverity reports the statistics cursors can be used uninitialized because it's not seeing that the WiredTiger library will return an error in any path where a cursor isn't initialized. Change the statistics functions to use format's underlying cursor-open function and change that function to initialize the returned cursor for clarity and to hopefully avoid these complaints in the future.

While I'm in the area:

Abstract out the code to dump a cursor's worth of statistics, it's identical between tables and the connection, no need to have two copies.

Assert the printf's into the output file succeed.