### PR TITLE
WT-8291 AddressSanitizer reported attempting double-free during test_wt4803_history_store_abort

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -694,7 +694,7 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_assert((pid = fork()) >= 0);
+        testutil_checksys((pid = fork()) < 0);
 
         if (pid == 0) { /* child */
             fill_db(nth);
@@ -738,10 +738,8 @@ main(int argc, char *argv[])
          * here.
          */
         printf("Kill child\n");
-        if (kill(pid, SIGKILL) != 0)
-            testutil_die(errno, "kill");
-        if (waitpid(pid, &status, 0) == -1)
-            testutil_die(errno, "waitpid");
+        testutil_checksys(kill(pid, SIGKILL) != 0);
+        testutil_checksys(waitpid(pid, &status, 0) == -1);
     }
     /*
      * !!! If we wanted to take a copy of the directory before recovery,

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -694,12 +694,11 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        if ((pid = fork()) < 0)
-            testutil_die(errno, "fork");
+        testutil_assert((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             fill_db(nth);
-            return (EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         /* parent */

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -346,7 +346,7 @@ fill_db(uint32_t nth)
      */
     free(thr);
     free(td);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 extern int __wt_optind;
@@ -698,7 +698,7 @@ main(int argc, char *argv[])
 
         if (pid == 0) { /* child */
             fill_db(nth);
-            _exit(EXIT_SUCCESS);
+            /* NOTREACHED */
         }
 
         /* parent */

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -622,7 +622,7 @@ fill_db(uint32_t nth, uint32_t datasize, const char *method, uint32_t flags)
      */
     free(thr);
     free(td);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 /*
@@ -1215,7 +1215,7 @@ main(int argc, char *argv[])
         }
         if (pid == 0) { /* child, or populate_only */
             fill_db(nth, datasize, method, flags);
-            _exit(EXIT_SUCCESS);
+            /* NOTREACHED */
         }
 
         /* parent */

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -1211,12 +1211,11 @@ main(int argc, char *argv[])
             memset(&sa, 0, sizeof(sa));
             sa.sa_handler = handler;
             testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-            if ((pid = fork()) < 0)
-                testutil_die(errno, "fork");
+            testutil_assert((pid = fork()) >= 0);
         }
         if (pid == 0) { /* child, or populate_only */
             fill_db(nth, datasize, method, flags);
-            return (EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         /* parent */

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -775,12 +775,9 @@ kill_child(pid_t pid)
      * abort, then signal continue so that the child process will process the abort and dump core.
      */
     printf("Send abort to child process ID %d\n", (int)pid);
-    if (kill(pid, SIGABRT) != 0)
-        testutil_die(errno, "kill");
-    if (kill(pid, SIGCONT) != 0)
-        testutil_die(errno, "kill");
-    if (waitpid(pid, &status, 0) == -1)
-        testutil_die(errno, "waitpid");
+    testutil_checksys(kill(pid, SIGABRT) != 0);
+    testutil_checksys(kill(pid, SIGCONT) != 0);
+    testutil_checksys(waitpid(pid, &status, 0) == -1);
 }
 
 /*
@@ -1001,7 +998,7 @@ handler(int sig)
     int status, termsig;
 
     WT_UNUSED(sig);
-    pid = waitpid(-1, &status, WNOHANG | WUNTRACED);
+    testutil_checksys((pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) == -1);
     if (pid == 0)
         return; /* Nothing to wait for. */
     if (WIFSTOPPED(status))
@@ -1211,7 +1208,7 @@ main(int argc, char *argv[])
             memset(&sa, 0, sizeof(sa));
             sa.sa_handler = handler;
             testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-            testutil_assert((pid = fork()) >= 0);
+            testutil_checksys((pid = fork()) < 0);
         }
         if (pid == 0) { /* child, or populate_only */
             fill_db(nth, datasize, method, flags);
@@ -1246,10 +1243,8 @@ main(int argc, char *argv[])
         printf("Kill child\n");
         sa.sa_handler = SIG_DFL;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        if (kill(pid, SIGKILL) != 0)
-            testutil_die(errno, "kill");
-        if (waitpid(pid, &status, 0) == -1)
-            testutil_die(errno, "waitpid");
+        testutil_checksys(kill(pid, SIGKILL) != 0);
+        testutil_checksys(waitpid(pid, &status, 0) == -1);
     }
     if (verify_only && !check_db(nth, datasize, 0, false, flags)) {
         printf("FAIL\n");

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -995,7 +995,7 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = sig_handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_assert((pid = fork()) >= 0);
+        testutil_checksys((pid = fork()) < 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -995,11 +995,11 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = sig_handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);
-            return (EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         /* parent */

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -837,7 +837,7 @@ run_workload(uint32_t nth)
      */
     free(thr);
     free(td);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 extern int __wt_optind;
@@ -999,7 +999,7 @@ main(int argc, char *argv[])
 
         if (pid == 0) { /* child */
             run_workload(nth);
-            _exit(EXIT_SUCCESS);
+            /* NOTREACHED */
         }
 
         /* parent */

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -670,7 +670,7 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_assert((pid = fork()) >= 0);
+        testutil_checksys((pid = fork()) < 0);
 
         if (pid == 0) { /* child */
             run_workload(nth, build_dir);

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -509,7 +509,7 @@ run_workload(uint32_t nth, const char *build_dir)
      */
     free(thr);
     free(td);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 extern int __wt_optind;
@@ -674,7 +674,7 @@ main(int argc, char *argv[])
 
         if (pid == 0) { /* child */
             run_workload(nth, build_dir);
-            _exit(EXIT_SUCCESS);
+            /* NOTREACHED */
         }
 
         /* parent */

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -670,11 +670,11 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth, build_dir);
-            return (EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         /* parent */

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -741,11 +741,11 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);
-            return (EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         /* parent */

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -575,7 +575,7 @@ run_workload(uint32_t nth)
      */
     free(thr);
     free(td);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 extern int __wt_optind;
@@ -745,7 +745,7 @@ main(int argc, char *argv[])
 
         if (pid == 0) { /* child */
             run_workload(nth);
-            _exit(EXIT_SUCCESS);
+            /* NOTREACHED */
         }
 
         /* parent */

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -741,7 +741,7 @@ main(int argc, char *argv[])
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
         testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_assert((pid = fork()) >= 0);
+        testutil_checksys((pid = fork()) < 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -218,8 +218,7 @@ fill_db(void)
     }
     if (fclose(fp) != 0)
         testutil_die(errno, "fclose");
-    exit(0);
-    /* NOTREACHED */
+    _exit(EXIT_SUCCESS);
 }
 
 extern int __wt_optind;
@@ -267,7 +266,7 @@ main(int argc, char *argv[])
 
     if (pid == 0) { /* child */
         fill_db();
-        _exit(EXIT_SUCCESS);
+        /* NOTREACHED */
     }
 
     /* parent */

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -262,7 +262,7 @@ main(int argc, char *argv[])
     /*
      * Fork a child to do its work. Wait for it to exit.
      */
-    testutil_assert((pid = fork()) >= 0);
+    testutil_checksys((pid = fork()) < 0);
 
     if (pid == 0) { /* child */
         fill_db();
@@ -271,8 +271,7 @@ main(int argc, char *argv[])
 
     /* parent */
     /* Wait for child to kill itself. */
-    if (waitpid(pid, &status, 0) == -1)
-        testutil_die(errno, "waitpid");
+    testutil_checksys(waitpid(pid, &status, 0) == -1);
 
     /*
      * !!! If we wanted to take a copy of the directory before recovery,

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -263,12 +263,11 @@ main(int argc, char *argv[])
     /*
      * Fork a child to do its work. Wait for it to exit.
      */
-    if ((pid = fork()) < 0)
-        testutil_die(errno, "fork");
+    testutil_assert((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
         fill_db();
-        return (EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS);
     }
 
     /* parent */

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -454,13 +454,13 @@ run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *statusp)
             printf("%s ", *arg);
         printf("\n");
     }
-    testutil_assert((pid = fork()) >= 0);
+    testutil_checksys((pid = fork()) < 0);
     if (pid == 0) {
         (void)execv(prog, argv);
         _exit(EXIT_FAILURE);
     }
 
-    testutil_assert(waitpid(pid, statusp, 0) != -1);
+    testutil_checksys(waitpid(pid, statusp, 0) == -1);
 }
 
 /*

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -89,7 +89,7 @@ static void generate_value(uint32_t, uint64_t, char *, int *, int *, int *, char
 static void run_check_subtest(TEST_OPTS *, const char *, uint64_t, bool, uint64_t *);
 static int run_check_subtest_range(TEST_OPTS *, const char *, bool);
 static void run_check_subtest_range_retry(TEST_OPTS *, const char *, bool);
-static int run_process(TEST_OPTS *, const char *, char *[], int *);
+static void run_process(TEST_OPTS *, const char *, char *[], int *);
 static void subtest_main(int, char *[], bool);
 static void subtest_populate(TEST_OPTS *, bool);
 
@@ -332,8 +332,7 @@ run_check_subtest(
     if (opts->verbose)
         printf("running a separate process with %" PRIu64 " operations until fail...\n", nops);
     testutil_clean_work_dir(opts->home);
-    testutil_check(
-      run_process(opts, debugger != NULL ? debugger : opts->argv0, subtest_args, &estatus));
+    run_process(opts, debugger != NULL ? debugger : opts->argv0, subtest_args, &estatus);
     if (opts->verbose)
         printf("process exited %d\n", estatus);
 
@@ -443,8 +442,8 @@ run_check_subtest_range_retry(TEST_OPTS *opts, const char *debugger, bool close_
  * run_process --
  *     Run a program with arguments, wait until it completes.
  */
-static int
-run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *status)
+static void
+run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *statusp)
 {
     int pid;
     char **arg;
@@ -455,14 +454,13 @@ run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *status)
             printf("%s ", *arg);
         printf("\n");
     }
-    if ((pid = fork()) == 0) {
+    testutil_assert((pid = fork()) >= 0);
+    if (pid == 0) {
         (void)execv(prog, argv);
-        testutil_die(errno, "%s", prog);
-    } else if (pid < 0)
-        return (errno);
+        _exit(EXIT_FAILURE);
+    }
 
-    (void)waitpid(pid, status, 0);
-    return (0);
+    testutil_assert(waitpid(pid, statusp, 0) != -1);
 }
 
 /*

--- a/test/csuite/wt4803_history_store_abort/main.c
+++ b/test/csuite/wt4803_history_store_abort/main.c
@@ -147,7 +147,7 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
      * This way, we can safely check the exit code of the child process and confirm that it is what
      * we expected.
      */
-    testutil_assert((pid = fork()) >= 0);
+    testutil_checksys((pid = fork()) < 0);
 
     if (pid == 0) {
         /* Child process from here. */
@@ -167,7 +167,8 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
     }
 
     /* Parent process from here. */
-    testutil_assert(waitpid(pid, &status, 0) != -1 && status == 0);
+    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert(status == 0);
 }
 
 int

--- a/test/csuite/wt4803_history_store_abort/main.c
+++ b/test/csuite/wt4803_history_store_abort/main.c
@@ -147,8 +147,7 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
      * This way, we can safely check the exit code of the child process and confirm that it is what
      * we expected.
      */
-    pid = fork();
-    testutil_assert(pid >= 0);
+    testutil_assert((pid = fork()) >= 0);
 
     if (pid == 0) {
         /* Child process from here. */

--- a/test/csuite/wt4803_history_store_abort/main.c
+++ b/test/csuite/wt4803_history_store_abort/main.c
@@ -66,7 +66,7 @@ handle_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const 
          * panic.
          */
         if (expect_panic)
-            exit(EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
     }
 
     return (0);
@@ -81,6 +81,12 @@ hs_workload(TEST_OPTS *opts, const char *hs_file_max)
     WT_SESSION *other_session, *session;
     int i;
     char buf[WT_MEGABYTE], open_config[128];
+
+    /*
+     * We're going to run this workload for different configurations of file_max. So clean out the
+     * work directory each time.
+     */
+    testutil_make_work_dir(opts->home);
 
     testutil_check(__wt_snprintf(open_config, sizeof(open_config),
       "create,cache_size=50MB,history_store=(file_max=%s)", hs_file_max));
@@ -125,24 +131,14 @@ hs_workload(TEST_OPTS *opts, const char *hs_file_max)
      * Cleanup. We do not get here when the file_max size is small because we will have already hit
      * the maximum and exited. This code only executes on the successful path.
      */
-    testutil_check(other_session->rollback_transaction(other_session, NULL));
-    testutil_check(other_session->close(other_session, NULL));
-
-    testutil_check(cursor->close(cursor));
-    testutil_check(session->close(session, NULL));
+    testutil_check(opts->conn->close(opts->conn, NULL));
 }
 
-static int
+static void
 test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
 {
     pid_t pid;
     int status;
-
-    /*
-     * We're going to run this workload for different configurations of file_max. So clean out the
-     * work directory each time.
-     */
-    testutil_make_work_dir(opts->home);
 
     /*
      * Since it's possible that the workload will panic and abort, we will fork the process and
@@ -152,10 +148,9 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
      * we expected.
      */
     pid = fork();
-    if (pid < 0)
-        /* Failed fork. */
-        testutil_die(errno, "fork");
-    else if (pid == 0) {
+    testutil_assert(pid >= 0);
+
+    if (pid == 0) {
         /* Child process from here. */
         hs_workload(opts, hs_file_max);
 
@@ -167,16 +162,13 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
           expect_panic ? "true" : "false");
 
         if (expect_panic)
-            exit(EXIT_FAILURE);
+            _exit(EXIT_FAILURE);
         else
-            exit(EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
     }
 
     /* Parent process from here. */
-    if (waitpid(pid, &status, 0) == -1)
-        testutil_die(errno, "waitpid");
-
-    return (status);
+    testutil_assert(waitpid(pid, &status, 0) != -1 && status == 0);
 }
 
 int
@@ -192,23 +184,23 @@ main(int argc, char **argv)
      * needed.
      */
     expect_panic = false;
-    testutil_check(test_hs_workload(&opts, "0"));
+    test_hs_workload(&opts, "0");
 
     /*
      * The history store is limited to 5GB. This is more than enough for this workload so we don't
      * expect any failure.
      */
     expect_panic = false;
-    testutil_check(test_hs_workload(&opts, "5GB"));
+    test_hs_workload(&opts, "5GB");
 
     /*
      * The history store is limited to 100MB. This is insufficient for this workload so we're
      * expecting a failure.
      */
     expect_panic = true;
-    testutil_check(test_hs_workload(&opts, "100MB"));
+    test_hs_workload(&opts, "100MB");
 
     testutil_cleanup(&opts);
 
-    return (0);
+    return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -312,7 +312,7 @@ main(int argc, char *argv[])
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = handler;
     testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_assert((pid = fork()) >= 0);
+    testutil_checksys((pid = fork()) < 0);
 
     if (pid == 0) { /* child */
         run_workload();

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -228,7 +228,7 @@ run_workload(void)
 
     /* NOTREACHED */
     free(thr);
-    exit(EXIT_SUCCESS);
+    _exit(EXIT_SUCCESS);
 }
 
 /*
@@ -316,7 +316,7 @@ main(int argc, char *argv[])
 
     if (pid == 0) { /* child */
         run_workload();
-        _exit(EXIT_SUCCESS);
+        /* NOTREACHED */
     }
 
     /* parent */

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -312,11 +312,11 @@ main(int argc, char *argv[])
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = handler;
     testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
         run_workload();
-        return (EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS);
     }
 
     /* parent */

--- a/test/csuite/wt8057_compact_stress/main.c
+++ b/test/csuite/wt8057_compact_stress/main.c
@@ -82,7 +82,7 @@ static WT_EVENT_HANDLER event_handler = {
 static void sig_handler(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /* Forward declarations. */
-static int run_test(bool, bool);
+static void run_test(bool, bool);
 static void workload_compact(const char *, const char *);
 static void populate(WT_SESSION *, uint64_t, uint64_t);
 static void remove_records(WT_SESSION *, const char *, uint64_t, uint64_t);
@@ -119,16 +119,16 @@ main(int argc, char *argv[])
     memset(opts, 0, sizeof(*opts));
     testutil_check(testutil_parse_opts(argc, argv, opts));
 
-    testutil_assert(run_test(false, opts->preserve) == EXIT_SUCCESS);
+    run_test(false, opts->preserve);
 
-    testutil_assert(run_test(true, opts->preserve) == EXIT_SUCCESS);
+    run_test(true, opts->preserve);
 
     testutil_cleanup(opts);
 
     return (EXIT_SUCCESS);
 }
 
-static int
+static void
 run_test(bool column_store, bool preserve)
 {
     WT_CONNECTION *conn;
@@ -151,7 +151,7 @@ run_test(bool column_store, bool preserve)
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sig_handler;
     testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
 
@@ -161,7 +161,7 @@ run_test(bool column_store, bool preserve)
          * parent process.
          */
         printf("Child finished processing...\n");
-        return (EXIT_FAILURE);
+        _exit(EXIT_FAILURE);
     }
 
     /* parent */
@@ -170,7 +170,7 @@ run_test(bool column_store, bool preserve)
      * time we notice that child process has written a checkpoint. That allows the test to run
      * correctly on really slow machines.
      */
-    sprintf(ckpt_file, ckpt_file_fmt, home);
+    testutil_check(__wt_snprintf(ckpt_file, sizeof(ckpt_file), ckpt_file_fmt, home));
     while (stat(ckpt_file, &sb) != 0)
         testutil_sleep_wait(1, pid);
 
@@ -198,8 +198,6 @@ run_test(bool column_store, bool preserve)
 
     if (!preserve)
         testutil_clean_work_dir(home);
-
-    return (EXIT_SUCCESS);
 }
 
 static void
@@ -243,7 +241,7 @@ workload_compact(const char *home, const char *table_config)
          * finished and can start its timer.
          */
         if (!first_ckpt) {
-            sprintf(ckpt_file, ckpt_file_fmt, home);
+            testutil_check(__wt_snprintf(ckpt_file, sizeof(ckpt_file), ckpt_file_fmt, home));
             testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
             testutil_checksys(fclose(fp) != 0);
             first_ckpt = true;
@@ -275,7 +273,6 @@ workload_compact(const char *home, const char *table_config)
     }
 
     /* Clean-up. */
-    testutil_check(session->close(session, NULL));
     testutil_check(conn->close(conn, NULL));
 }
 
@@ -392,7 +389,7 @@ get_file_stats(WT_SESSION *session, const char *uri, uint64_t *file_sz, uint64_t
     WT_CURSOR *cur_stat;
     char *descr, stat_uri[128], *str_val;
 
-    sprintf(stat_uri, "statistics:%s", uri);
+    testutil_check(__wt_snprintf(stat_uri, sizeof(stat_uri), "statistics:%s", uri));
     testutil_check(session->open_cursor(session, stat_uri, NULL, "statistics=(all)", &cur_stat));
 
     /* Get file size. */
@@ -429,10 +426,9 @@ get_compact_progress(WT_SESSION *session, const char *uri, uint64_t *pages_revie
 {
 
     WT_CURSOR *cur_stat;
-    char *descr, *str_val;
-    char stat_uri[128];
+    char *descr, *str_val, stat_uri[128];
 
-    sprintf(stat_uri, "statistics:%s", uri);
+    testutil_check(__wt_snprintf(stat_uri, sizeof(stat_uri), "statistics:%s", uri));
     testutil_check(session->open_cursor(session, stat_uri, NULL, "statistics=(all)", &cur_stat));
 
     cur_stat->set_key(cur_stat, WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED);

--- a/test/csuite/wt8057_compact_stress/main.c
+++ b/test/csuite/wt8057_compact_stress/main.c
@@ -151,7 +151,7 @@ run_test(bool column_store, bool preserve)
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sig_handler;
     testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_assert((pid = fork()) >= 0);
+    testutil_checksys((pid = fork()) < 0);
 
     if (pid == 0) { /* child */
 


### PR DESCRIPTION
Don't call exit() without an exec, call _exit() instead.

While I'm in the area...

Close the WiredTiger connection when we're done, that cleans up everything else.
Remove/re-create the WiredTiger directory near where we open it.
Simplify a couple of failure checks.