### PR TITLE
WT-8358 Pass args via command line

### DIFF
--- a/bench/wtperf/runners/evict-btree-stress-multi.json
+++ b/bench/wtperf/runners/evict-btree-stress-multi.json
@@ -1,6 +1,0 @@
-[
-    {
-      "arguments": null,
-      "operations": ["warnings", "max_latencies"]
-    }
-]

--- a/bench/wtperf/runners/evict-fairness.json
+++ b/bench/wtperf/runners/evict-fairness.json
@@ -1,6 +1,0 @@
-[
-    {
-      "arguments": ["-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"],
-      "operations": ["eviction_page_seen"]
-    }
-]

--- a/bench/wtperf/runners/log.json
+++ b/bench/wtperf/runners/log.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": [],
-    "operations": ["update", "max_update_throughput", "min_update_throughput"]
-  }
-]

--- a/bench/wtperf/runners/log_many_threads.json
+++ b/bench/wtperf/runners/log_many_threads.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": ["-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"],
-    "operations": ["update"]
-  }
-]

--- a/bench/wtperf/runners/log_no_checkpoints.json
+++ b/bench/wtperf/runners/log_no_checkpoints.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": ["-C checkpoint=(wait=0)"],
-    "operations": ["update"]
-  }
-]

--- a/bench/wtperf/runners/log_no_prealloc.json
+++ b/bench/wtperf/runners/log_no_prealloc.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": ["-C log=(enabled,file_max=1M,prealloc=false)"],
-    "operations": ["update"]
-  }
-]

--- a/bench/wtperf/runners/log_small_files.json
+++ b/bench/wtperf/runners/log_small_files.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": ["-C log=(enabled,file_max=1M)"],
-    "operations": ["update"]
-  }
-]

--- a/bench/wtperf/runners/log_zero_fill.json
+++ b/bench/wtperf/runners/log_zero_fill.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": ["-C log=(enabled,file_max=1M,zero_fill=true)"],
-    "operations": ["update"]
-  }
-]

--- a/bench/wtperf/runners/update-stress.json
+++ b/bench/wtperf/runners/update-stress.json
@@ -1,6 +1,0 @@
-[
-  {
-    "arguments": null,
-    "operations": [ "update" ]
-  }
-]

--- a/bench/wtperf/wtperf_run_py/perf_stat.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat.py
@@ -27,8 +27,9 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-import glob, re, os
+import glob
 import json
+import re
 
 
 class PerfStat:
@@ -117,15 +118,11 @@ class PerfStatCount(PerfStat):
 
 
 class PerfStatLatency(PerfStat):
-    def __init__(self,
-                 short_label: str,
-                 stat_file:str,
-                 output_label: str,
-                 num_max: int):
-                 super().__init__(short_label=short_label,
-                                  stat_file=stat_file,
-                                  output_label=output_label)
-                 self.num_max = num_max
+    def __init__(self, short_label: str, stat_file: str, output_label: str, num_max: int):
+        super().__init__(short_label=short_label,
+                         stat_file=stat_file,
+                         output_label=output_label)
+        self.num_max = num_max
 
     def find_stat(self, test_stat_path: str):
         values = []

--- a/bench/wtperf/wtperf_run_py/perf_stat.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat.py
@@ -129,11 +129,10 @@ class PerfStatLatency(PerfStat):
 
     def find_stat(self, test_stat_path: str):
         values = []
-        if os.path.isfile(test_stat_path):
-            for line in open(test_stat_path):
-                as_dict = json.loads(line)
-                values.append(as_dict["wtperf"]["read"]["max latency"])
-                values.append(as_dict["wtperf"]["update"]["max latency"])
+        for line in open(test_stat_path):
+            as_dict = json.loads(line)
+            values.append(as_dict["wtperf"]["read"]["max latency"])
+            values.append(as_dict["wtperf"]["update"]["max latency"])
         return values
 
     def get_value(self, nth_max: int):

--- a/bench/wtperf/wtperf_run_py/wtperf_config.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_config.py
@@ -33,7 +33,7 @@ class WTPerfConfig:
                  wtperf_path: str,
                  home_dir: str,
                  test: str,
-                 arg_file: str = None,
+                 batch_file: str = None,
                  arguments=None,
                  operations=None,
                  environment: str = None,
@@ -46,7 +46,7 @@ class WTPerfConfig:
         self.wtperf_path: str = wtperf_path
         self.home_dir: str = home_dir
         self.test: str = test
-        self.arg_file = arg_file
+        self.batch_file = batch_file
         self.arguments = arguments
         self.operations = operations
         self.environment: str = environment
@@ -58,7 +58,7 @@ class WTPerfConfig:
     def to_value_dict(self):
         as_dict = {'wt_perf_path': self.wtperf_path,
                    'test': self.test,
-                   'arg_file': self.arg_file,
+                   'batch_file': self.batch_file,
                    'arguments': self.arguments,
                    'operations': self.operations,
                    'home_dir': self.home_dir,

--- a/bench/wtperf/wtperf_run_py/wtperf_config.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_config.py
@@ -34,6 +34,8 @@ class WTPerfConfig:
                  home_dir: str,
                  test: str,
                  arg_file: str = None,
+                 arguments=None,
+                 operations=None,
                  environment: str = None,
                  run_max: int = 1,
                  verbose: bool = False,
@@ -45,6 +47,8 @@ class WTPerfConfig:
         self.home_dir: str = home_dir
         self.test: str = test
         self.arg_file = arg_file
+        self.arguments = arguments
+        self.operations = operations
         self.environment: str = environment
         self.run_max: int = run_max
         self.verbose: bool = verbose
@@ -55,6 +59,8 @@ class WTPerfConfig:
         as_dict = {'wt_perf_path': self.wtperf_path,
                    'test': self.test,
                    'arg_file': self.arg_file,
+                   'arguments': self.arguments,
+                   'operations': self.operations,
                    'home_dir': self.home_dir,
                    'environment': self.environment,
                    'run_max': self.run_max,

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -140,7 +140,8 @@ def run_test(config: WTPerfConfig, test_run: int, operations: List[str] = None, 
         test=config.test,
         home=test_home)
     try:
-        subprocess.run(command_line, check=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, universal_newlines=True)
+        subprocess.run(command_line, check=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE,
+                       universal_newlines=True)
     except subprocess.CalledProcessError as cpe:
         print("Error: {}".format(cpe.output))
         exit(1)
@@ -219,7 +220,7 @@ def main():
                         help='reuse and reanalyse results from previous tests rather than running tests again')
     parser.add_argument('-g', '--git_root', help='path of the Git working directory')
     parser.add_argument('-i', '--json_info', help='additional test information in a json format string')
-    parser.add_argument('-a', '--arg_file', help='additional wtperf arguments in a json format file')
+    parser.add_argument('-bf', '--batch_file', help='Run all specified configurations for a single test')
     parser.add_argument('-args', '--arguments', help='Additional arguments to pass into wtperf')
     parser.add_argument('-ops', '--operations', help='List of operations to report metrics for')
     parser.add_argument('-v', '--verbose', action="store_true", help='be verbose')
@@ -229,19 +230,19 @@ def main():
         print('WTPerfPy')
         print('========')
         print("Configuration:")
-        print("  WtPerf path:              {}".format(args.wtperf))
-        print("  Environment:              {}".format(args.env))
-        print("  Test path:                {}".format(args.test))
-        print("  Home base:                {}".format(args.home))
-        print("  Addition arguments(file): {}".format(args.arg_file))
-        print("  Arguments:                {}".format(args.arguments))
-        print("  Operations:               {}".format(args.operations))
-        print("  Git root:                 {}".format(args.git_root))
-        print("  Outfile:                  {}".format(args.outfile))
-        print("  Runmax:                   {}".format(args.runmax))
-        print("  JSON info                 {}".format(args.json_info))
-        print("  Reuse results:            {}".format(args.reuse))
-        print("  Brief output:             {}".format(args.brief_output))
+        print("  WtPerf path:       {}".format(args.wtperf))
+        print("  Environment:       {}".format(args.env))
+        print("  Test path:         {}".format(args.test))
+        print("  Home base:         {}".format(args.home))
+        print("  Batch file:        {}".format(args.batch_file))
+        print("  Arguments:         {}".format(args.arguments))
+        print("  Operations:        {}".format(args.operations))
+        print("  Git root:          {}".format(args.git_root))
+        print("  Outfile:           {}".format(args.outfile))
+        print("  Runmax:            {}".format(args.runmax))
+        print("  JSON info          {}".format(args.json_info))
+        print("  Reuse results:     {}".format(args.reuse))
+        print("  Brief output:      {}".format(args.brief_output))
 
     if args.wtperf is None:
         sys.exit('The path to the wtperf executable is required')
@@ -249,10 +250,10 @@ def main():
         sys.exit('The path to the test file is required')
     if args.home is None:
         sys.exit('The path to the "home" directory is required')
-    if args.arg_file and not os.path.isfile(args.arg_file):
-        sys.exit("arg_file: {} not found!".format(args.arg_file))
-    if args.arg_file and (args.arguments or args.operations):
-        sys.exit("An arg_file (-a) should not be defined at the same time as -ops or -args")
+    if args.batch_file and not os.path.isfile(args.batch_file):
+        sys.exit("batch_file: {} not found!".format(args.batch_file))
+    if args.batch_file and (args.arguments or args.operations):
+        sys.exit("A batch file (-bf) should not be defined at the same time as -ops or -args")
 
     json_info = json.loads(args.json_info) if args.json_info else {}
     arguments = json.loads(args.arguments) if args.arguments else []
@@ -261,7 +262,7 @@ def main():
     config = WTPerfConfig(wtperf_path=args.wtperf,
                           home_dir=args.home,
                           test=args.test,
-                          arg_file=args.arg_file,
+                          batch_file=args.batch_file,
                           arguments=arguments,
                           operations=operations,
                           environment=args.env,
@@ -272,16 +273,16 @@ def main():
 
     perf_stats: PerfStatCollection = setup_perf_stats()
 
-    if config.arg_file:
+    if config.batch_file:
         if args.verbose:
-            print("Reading arguments file {}".format(config.arg_file))
-        with open(config.arg_file, "r") as file:
-            arg_file_contents = json.load(file)
+            print("Reading batch file {}".format(config.batch_file))
+        with open(config.batch_file, "r") as file:
+            batch_file_contents = json.load(file)
 
     # Run test
     if not args.reuse:
-        if config.arg_file:
-            for content in arg_file_contents:
+        if config.batch_file:
+            for content in batch_file_contents:
                 if args.verbose:
                     print("Argument: {},  Operation: {}".format(content["arguments"], content["operations"]))
                 run_test_wrapper(config=config, operations=content["operations"], arguments=content["arguments"])
@@ -293,8 +294,8 @@ def main():
                  "Try 'python3 wtperf_run.py --help' for more information.")
 
     # Process result
-    if config.arg_file:
-        for content in arg_file_contents:
+    if config.batch_file:
+        for content in batch_file_contents:
             process_results(config, perf_stats, operations=content["operations"])
     else:
         process_results(config, perf_stats, operations=operations)

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -256,8 +256,8 @@ def main():
         sys.exit("A batch file (-bf) should not be defined at the same time as -ops or -args")
 
     json_info = json.loads(args.json_info) if args.json_info else {}
-    arguments = json.loads(args.arguments) if args.arguments else []
-    operations = json.loads(args.operations) if args.operations else []
+    arguments = json.loads(args.arguments) if args.arguments else None
+    operations = json.loads(args.operations) if args.operations else None
 
     config = WTPerfConfig(wtperf_path=args.wtperf,
                           home_dir=args.home,

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3151,7 +3151,7 @@ tasks:
         vars:
           perf-test-name: update-btree
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-btree.json"
+          wtarg: "-bf ../../../bench/wtperf/runners/update-btree.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-btree
@@ -3212,7 +3212,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-btree
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-checkpoint.json"
+          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-btree
@@ -3227,7 +3227,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-lsm
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-checkpoint.json"
+          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-lsm

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3288,7 +3288,7 @@ tasks:
         vars:
           perf-test-name: update-grow-stress
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-stress.json"
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-grow-stress
@@ -3303,7 +3303,7 @@ tasks:
         vars:
           perf-test-name: update-shrink-stress
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-stress.json"
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-shrink-stress
@@ -3318,7 +3318,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix1
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-stress.json"
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix1
@@ -3333,7 +3333,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix2
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-stress.json"
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix2
@@ -3348,7 +3348,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix3
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/update-stress.json"
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix3
@@ -3403,7 +3403,7 @@ tasks:
         vars:
           perf-test-name: evict-fairness
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/evict-fairness.json"
+          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"']
 
   - name: perf-test-evict-btree-stress-multi
     tags: ["stress-perf"]
@@ -3415,7 +3415,7 @@ tasks:
         vars:
           perf-test-name: evict-btree-stress-multi
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/evict-btree-stress-multi.json"
+          wtarg: -ops ['"warnings", "max_latencies"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-stress-multi
@@ -3494,7 +3494,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log.json"
+          wtarg: -ops ['"update", "max_update_throughput", "min_update_throughput"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log
@@ -3509,7 +3509,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log_small_files.json"
+          wtarg: -args ['"-C log=(enabled,file_max=1M)"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log-small-files
@@ -3524,7 +3524,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log_no_checkpoints.json"
+          wtarg: -args ['"-C checkpoint=(wait=0)"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log-no-checkpoints
@@ -3539,7 +3539,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log_no_prealloc.json"
+          wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log-no-prealloc
@@ -3554,7 +3554,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log_zero_fill.json"
+          wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log-zero-fill
@@ -3569,7 +3569,7 @@ tasks:
         vars:
           perf-test-name: log
           maxruns: 1
-          wtarg: "-a ../../../bench/wtperf/runners/log_many_threads.json"
+          wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log-many-threads

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3178,7 +3178,7 @@ tasks:
         vars:
           perf-test-name: update-large-record-btree
           maxruns: 3
-          wtarg: -ops ['"load"']
+          wtarg: -ops ['"load", "update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-large-record-btree
@@ -3381,6 +3381,7 @@ tasks:
         vars:
           perf-test-name: multi-btree-zipfian-populate
           maxruns: 1
+          wtarg: -ops ['"read"']
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-workload

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2979,6 +2979,7 @@ tasks:
         vars:
           perf-test-name: small-lsm
           maxruns: 3
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-lsm
@@ -2993,6 +2994,7 @@ tasks:
         vars:
           perf-test-name: medium-lsm
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm
@@ -3007,6 +3009,7 @@ tasks:
         vars:
           perf-test-name: medium-lsm-compact
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm-compact
@@ -3021,6 +3024,7 @@ tasks:
         vars:
           perf-test-name: medium-multi-lsm
           maxruns: 1
+          wtarg: -ops ['"load", "read", "update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-multi-lsm
@@ -3035,6 +3039,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-lsm
           maxruns: 1
+          wtarg: -ops ['"load"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-lsm
@@ -3049,6 +3054,7 @@ tasks:
         vars:
           perf-test-name: update-lsm
           maxruns: 1
+          wtarg: -ops ['"load", "read", "update", "insert"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-lsm
@@ -3067,6 +3073,7 @@ tasks:
         vars:
           perf-test-name: small-btree
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-btree
@@ -3081,6 +3088,7 @@ tasks:
         vars:
           perf-test-name: small-btree-backup
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-btree-backup
@@ -3095,6 +3103,7 @@ tasks:
         vars:
           perf-test-name: medium-btree
           maxruns: 3
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree
@@ -3109,6 +3118,7 @@ tasks:
         vars:
           perf-test-name: medium-btree-backup
           maxruns: 3
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree-backup
@@ -3123,6 +3133,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-btree
           maxruns: 1
+          wtarg: -ops ['"load"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-btree
@@ -3137,6 +3148,7 @@ tasks:
         vars:
           perf-test-name: update-only-btree
           maxruns: 3
+          wtarg: -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-only-btree
@@ -3166,6 +3178,7 @@ tasks:
         vars:
           perf-test-name: update-large-record-btree
           maxruns: 3
+          wtarg: -ops ['"load"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-large-record-btree
@@ -3180,6 +3193,7 @@ tasks:
         vars:
           perf-test-name: modify-large-record-btree
           maxruns: 3
+          wtarg: -ops ['"load", "modify"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-large-record-btree
@@ -3194,6 +3208,7 @@ tasks:
         vars:
           perf-test-name: modify-force-update-large-record-btree
           maxruns: 3
+          wtarg: -ops ['"load", "modify"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-force-update-large-record-btree
@@ -3246,6 +3261,7 @@ tasks:
         vars:
           perf-test-name: overflow-10k
           maxruns: 1
+          wtarg: -ops ['"load", "read", "update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-10k
@@ -3260,6 +3276,7 @@ tasks:
         vars:
           perf-test-name: overflow-130k
           maxruns: 1
+          wtarg: -ops ['"load", "read", "update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-130k
@@ -3274,6 +3291,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-stress
           maxruns: 1
+          wtarg: -ops ['"load"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-stress
@@ -3367,6 +3385,7 @@ tasks:
         vars:
           perf-test-name: multi-btree-zipfian-workload
           maxruns: 1
+          wtarg: -ops ['"read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: multi-btree-zipfian
@@ -3434,6 +3453,7 @@ tasks:
         vars:
           perf-test-name: evict-btree
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree
@@ -3448,6 +3468,7 @@ tasks:
         vars:
           perf-test-name: evict-btree-1
           maxruns: 1
+          wtarg: -ops ['"read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-1
@@ -3462,6 +3483,7 @@ tasks:
         vars:
           perf-test-name: evict-lsm
           maxruns: 1
+          wtarg: -ops ['"load", "read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm
@@ -3476,6 +3498,7 @@ tasks:
         vars:
           perf-test-name: evict-lsm-1
           maxruns: 1
+          wtarg: -ops ['"read"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm-1


### PR DESCRIPTION
Pass the `operations` and `arguments` parameters to wtperf_run.py via command line instead of through an `arg_file`. Now these parameters can be passed via `-ops` and `-args` instead of via `-a path/to/arg_file.json`

Additionally `arg_file` (-a) has been renamed to `batch_file` (-bf) to indicate it is intended for running multiple jobs with slightly different wtperf arguments, and shouldn't be used for a single test