### PR TITLE
WT-8364 Fix CMake bug for TCMalloc cppsuite builds

### DIFF
--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -76,6 +76,11 @@ create_test_executable(csuite_style_example_test
     CXX
 )
 
+if(ENABLE_TCMALLOC)
+    target_link_libraries(run wt::tcmalloc)
+    target_link_libraries(csuite_style_example_test wt::tcmalloc)
+endif()
+
 if(ENABLE_SNAPPY)
     # We use Snappy compression to avoid excessive disk spage usage.
     target_compile_options(run PRIVATE -DSNAPPY_PATH=\"$<TARGET_FILE:wiredtiger_snappy>\")


### PR DESCRIPTION
On CMake builds of WiredTiger with TCMalloc enabled, the cppsuite crashes due to an invalid pointer error when free()'ing memory. 
When the tcmalloc config is enabled, CMake builds the cppsuite without linking tcmalloc (defaulting to the standard libc allocator), whilst the WiredTiger library is linked against tcmalloc. This meaning two different allocators are being used at runtime. 
This becomes problematic as it appears the cppsuite is allocating/freeing/sharing memory between itself and WiredTiger, thus leading to an invalid pointer free() error. 

To fix this, update the cppsuite to also link against TCMalloc (if WiredTiger is using TCMalloc). This keeping the allocator runtime uniform between the two artifacts.