### PR TITLE
WT-8368 Avoid using wrapper in __wt_verbose_multi

### DIFF
--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -163,5 +163,13 @@ struct __wt_verbose_multi_category {
  *     Display a verbose message, given a set of multiple verbose categories using the default
  *     verbosity level.
  */
-#define __wt_verbose_multi(session, multi_category, fmt, ...) \
-    __wt_verbose_level_multi(session, multi_category, WT_VERBOSE_DEFAULT, fmt, __VA_ARGS__)
+#define __wt_verbose_multi(session, multi_category, fmt, ...)                            \
+    do {                                                                                 \
+        uint32_t __v_idx;                                                                \
+        for (__v_idx = 0; __v_idx < multi_category.cnt; __v_idx++) {                     \
+            if (WT_VERBOSE_ISSET(session, multi_category.categories[__v_idx])) {         \
+                __wt_verbose_worker(session, "[" #multi_category "] " fmt, __VA_ARGS__); \
+                break;                                                                   \
+            }                                                                            \
+        }                                                                                \
+    } while (0)


### PR DESCRIPTION
Letting 'wt_verbose_multi' wrap over another macro results in the category field completely expanding, rather than its intermediate string representation. For various uses of the macro this ends up being a string representation of the entire
WT_VERBOSE_MULTI_CATEGORY struct definition, resulting in an overly verbose message. To fix this, avoid calling an underlying macro, performing the multi-check inline.