### PR TITLE
WT-5580 Dump the wtperf command into logs in Evergreen wtperf test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2367,8 +2367,7 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
-              echo
-              echo "==== Initiating wtperf test using $dir/$file ===="
+              echo -e "\n==== Initiating wtperf test using $dir/$file ===="
               ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               cp -rf WT_TEST WT_TEST_$file
             done

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2367,6 +2367,7 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
+              echo
               echo "==== Initiating wtperf test using $dir/$file ===="
               ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               cp -rf WT_TEST WT_TEST_$file

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2367,6 +2367,7 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
+              echo "==== Initiating wtperf test using $dir/$file ===="
               ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               cp -rf WT_TEST WT_TEST_$file
             done

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2367,7 +2367,9 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
-              echo "\n==== Initiating wtperf test using $dir/$file ===="
+              echo "===="
+              echo "==== Initiating wtperf test using $dir/$file ===="
+              echo "===="
               ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               cp -rf WT_TEST WT_TEST_$file
             done

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2367,7 +2367,7 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
-              echo -e "\n==== Initiating wtperf test using $dir/$file ===="
+              echo "\n==== Initiating wtperf test using $dir/$file ===="
               ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               cp -rf WT_TEST WT_TEST_$file
             done


### PR DESCRIPTION
In the wtperf-test Evergreen task, display the path of the wtperf config file in the logs for each test executed.