### PR TITLE
WT-8363 Redeliver Validate stats output by perf tests

### DIFF
--- a/bench/wtperf/wtperf_run_py/validate_expected_stats.py
+++ b/bench/wtperf/wtperf_run_py/validate_expected_stats.py
@@ -31,6 +31,7 @@
 import argparse
 import json
 import os
+import re
 
 
 def main():
@@ -46,8 +47,9 @@ def main():
     parser.add_argument('stat_file', type=str, help='The evergreen stat file produced by the perf test')
     args = parser.parse_args()
 
-    if os.path.basename(args.stat_file) != 'evergreen_out.json':
-        print("ERROR: argument 'stat_file' should be the path to an evergreen_out.json file")
+    stat_file_regex = re.compile(r"evergreen_out\w*\.json")
+    if not re.match(stat_file_regex, os.path.basename(args.stat_file)):
+        print("ERROR: argument 'stat_file' should be the path to an evergreen_out*.json file")
         exit(1)
 
     expected_stats = json.loads(args.expected_stats)

--- a/bench/wtperf/wtperf_run_py/validate_expected_stats.py
+++ b/bench/wtperf/wtperf_run_py/validate_expected_stats.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import argparse
+import json
+
+
+def main():
+    """
+    Validate the expected output from the last run of wtperf_run.py
+    Take in a list of stats and their values as json and verify them against the contents of evergreen_out.json.
+    Example usage:
+        ./validate_perf_stats.py '{"Pages seen by eviction": 200, "Insert count": 1153326}'
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('expected_stats', type=str, help='The expected stats and their values')
+    args = parser.parse_args()
+
+    expected_stats = json.loads(args.expected_stats)
+
+    stat_file = json.load(open("./test_stats/evergreen_out.json", 'r'))
+    test_output = {stat['name']: stat['value'] for stat in stat_file[0]["metrics"]}
+
+    errors = []
+    for stat in expected_stats:
+        if stat not in test_output:
+            errors.append(f"'{stat}'\t not present in evergreen_out.json")
+        elif expected_stats[stat] != test_output[stat]:
+            errors.append(f"'{stat}'\t value mismatch. Expected: {expected_stats[stat]}, Actual: {test_output[stat]}")
+
+    if errors:
+        print("ERROR: Expected values not found:")
+        print('\n'.join(errors))
+        exit(1)
+    else:
+        print("Expected stats and values found")
+
+
+if __name__ == '__main__':
+    main()

--- a/bench/wtperf/wtperf_run_py/validate_expected_stats.py
+++ b/bench/wtperf/wtperf_run_py/validate_expected_stats.py
@@ -47,9 +47,9 @@ def main():
     parser.add_argument('stat_file', type=str, help='The evergreen stat file produced by the perf test')
     args = parser.parse_args()
 
-    stat_file_regex = re.compile(r"evergreen_out\w*\.json")
+    stat_file_regex = re.compile(r"evergreen_out[\w-]*\.json")
     if not re.match(stat_file_regex, os.path.basename(args.stat_file)):
-        print("ERROR: argument 'stat_file' should be the path to an evergreen_out*.json file")
+        print(f"ERROR: '{args.stat_file}' should be the path to an evergreen_out*.json file")
         exit(1)
 
     expected_stats = json.loads(args.expected_stats)

--- a/bench/wtperf/wtperf_run_py/validate_expected_stats.py
+++ b/bench/wtperf/wtperf_run_py/validate_expected_stats.py
@@ -30,6 +30,7 @@
 
 import argparse
 import json
+import os
 
 
 def main():
@@ -37,16 +38,21 @@ def main():
     Validate the expected output from the last run of wtperf_run.py
     Take in a list of stats and their values as json and verify them against the contents of evergreen_out.json.
     Example usage:
-        ./validate_perf_stats.py '{"Pages seen by eviction": 200, "Insert count": 1153326}'
+        ./validate_perf_stats.py '{"Pages seen by eviction": 200, "Insert count": 1153326}' './evergreen_out.json'
     """
 
     parser = argparse.ArgumentParser()
     parser.add_argument('expected_stats', type=str, help='The expected stats and their values')
+    parser.add_argument('stat_file', type=str, help='The evergreen stat file produced by the perf test')
     args = parser.parse_args()
+
+    if os.path.basename(args.stat_file) != 'evergreen_out.json':
+        print("ERROR: argument 'stat_file' should be the path to an evergreen_out.json file")
+        exit(1)
 
     expected_stats = json.loads(args.expected_stats)
 
-    stat_file = json.load(open("./test_stats/evergreen_out.json", 'r'))
+    stat_file = json.load(open(args.stat_file, 'r'))
     test_output = {stat['name']: stat['value'] for stat in stat_file[0]["metrics"]}
 
     errors = []

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -622,6 +622,17 @@ functions:
           git clone git@github.com:wiredtiger/automation-scripts.git
           ${python_binary} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_wt_perf_test_user} -p ${atlas_wt_perf_pass} -f test_stats/atlas_out.json -b ${branch_name}
 
+  "validate-expected-stats":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build/bench/wtperf"
+        shell: bash
+        script: |
+          set -o errexit
+          ${virtualenv_binary} -p ${python_binary} venv
+          source venv/bin/activate
+          ${python_binary} ../../../bench/wtperf/wtperf_run_py/validate_expected_stats.py '${expected-stats}'
+          
     - command: perf.send
       params:
         file: ./wiredtiger/cmake_build/bench/wtperf/test_stats/evergreen_out.json
@@ -3404,6 +3415,9 @@ tasks:
           perf-test-name: evict-fairness
           maxruns: 1
           wtarg: "-a ../../../bench/wtperf/runners/evict-fairness.json"
+      - func: "validate-expected-stats"
+        vars:
+          expected-stats: '{"Pages seen by eviction": 200}'
 
   - name: perf-test-evict-btree-stress-multi
     tags: ["stress-perf"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -621,22 +621,9 @@ functions:
           ${pip3_binary} install pymongo[srv]
           git clone git@github.com:wiredtiger/automation-scripts.git
           ${python_binary} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_wt_perf_test_user} -p ${atlas_wt_perf_pass} -f test_stats/atlas_out.json -b ${branch_name}
-
-  "validate-expected-stats":
-    - command: shell.exec
-      params:
-        working_dir: "wiredtiger/cmake_build/bench/wtperf"
-        shell: bash
-        script: |
-          set -o errexit
-          ${virtualenv_binary} -p ${python_binary} venv
-          source venv/bin/activate
-          ${python_binary} ../../../bench/wtperf/wtperf_run_py/validate_expected_stats.py '${expected-stats}' '${stat_file}'
-          
     - command: perf.send
       params:
         file: ./wiredtiger/cmake_build/bench/wtperf/test_stats/evergreen_out.json
-
     # Push the json results to the 'Files' tab of the task in Evergreen
     # Parameterised using the 'perf-test-name' variable
     - command: s3.put
@@ -648,6 +635,17 @@ functions:
         permissions: public-read
         content_type: text/html
         remote_file: wiredtiger/${build_variant}/${revision}/perf-test-${perf-test-name}-${build_id}-${execution}/
+
+  "validate-expected-stats":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build/bench/wtperf"
+        shell: bash
+        script: |
+          set -o errexit
+          ${virtualenv_binary} -p ${python_binary} venv
+          source venv/bin/activate
+          ${python_binary} ../../../bench/wtperf/wtperf_run_py/validate_expected_stats.py '${expected-stats}' '${stat_file}'
 
 #######################################
 #               Variables             #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -631,7 +631,7 @@ functions:
           set -o errexit
           ${virtualenv_binary} -p ${python_binary} venv
           source venv/bin/activate
-          ${python_binary} ../../../bench/wtperf/wtperf_run_py/validate_expected_stats.py '${expected-stats}'
+          ${python_binary} ../../../bench/wtperf/wtperf_run_py/validate_expected_stats.py '${expected-stats}' '${stat_file}'
           
     - command: perf.send
       params:
@@ -3418,6 +3418,7 @@ tasks:
       - func: "validate-expected-stats"
         vars:
           expected-stats: '{"Pages seen by eviction": 200}'
+          stat_file: './test_stats/evergreen_out.json'
 
   - name: perf-test-evict-btree-stress-multi
     tags: ["stress-perf"]


### PR DESCRIPTION
Redelivery of https://github.com/wiredtiger/wiredtiger/pull/7173 (Reverted here https://github.com/wiredtiger/wiredtiger/pull/7183).

This change is identical to the original review, but moves the `perf.send` and `s3.put` commands back into `upload-perf-test-stats` with new commit 11f6785. 