### PR TITLE
WT-8398 test_rollback_to_stable10 is timing-dependent

### DIFF
--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -332,8 +332,14 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.assertEqual(keys_restored, 0)
         self.assertGreaterEqual(upd_aborted, 0)
         self.assertGreater(pages_visited, 0)
-        self.assertGreaterEqual(hs_removed, 0)
-        self.assertGreater(hs_sweep, 0)
+        # Each row that gets processed by RTS can be counted by either hs_removed or hs_sweep,
+        # but not both. If the data store page for the row appears in the last checkpoint, it
+        # gets counted in hs_removed; if not, it gets counted in hs_sweep, unless the history
+        # store page for the row didn't make it out, in which case nothing gets counted at all.
+        # We expect at least some history store pages to appear, so assert that some rows get
+        # processed, but the balance between the two counts depends on test timing and we
+        # should not depend on it.
+        self.assertGreater(hs_removed + hs_sweep, 0)
 
         # The test may output the following message in eviction under cache pressure. Ignore that.
         self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")


### PR DESCRIPTION
Adjust HS assertions in the "prepare" test of rts10.

Currently, adding time.sleep(50) before stopping the background checkpointer makes the hs_sweep > 0 assertion fail. This is because under these circmstances all the outdated HS entries are removed by the data-store RTS and counted in hs_removed instead of hs_sweep. Since tests shouldn't be timing-dependent, assert about the sum of hs_removed and hs_sweep instead of each individually.