### PR TITLE
WT-8400 Disable test_rollback_to_stable28 for VLCS

### DIFF
--- a/test/suite/test_rollback_to_stable28.py
+++ b/test/suite/test_rollback_to_stable28.py
@@ -47,12 +47,15 @@ class test_rollback_to_stable28(test_rollback_to_stable_base):
     conn_recon = ',eviction_updates_trigger=10,eviction_dirty_trigger=5,eviction_dirty_target=1,' \
             'cache_size=1MB,debug_mode=(update_restore_evict=true),log=(recover=on)'
 
+    # In principle this test should be run on VLCS and FLCS; but it doesn't run reliably, in that
+    # while it always works in the sense of producing the right values, it doesn't always trigger
+    # update restore eviction, and then the assertions about that fail. For FLCS, using small
+    # pages and twice as many rows makes it work most of the time, but not always (especially on
+    # the test machines...) and it also apparently fails some of the time on VLCS. For the moment
+    # we've concluded that the marginal benefit of running on VLCS and particularly FLCS is small
+    # so disabling these scenarios seems like the best strategy.
     format_values = [
-        ('column', dict(key_format='r', value_format='S', extraconfig='')),
-        # Does not run reliably; does not always trigger update restore eviction and fails that
-        # assertion, even with small pages and more rows. Probably needs a lot more rows. For
-        # the moment we've concluded that the marginal benefit of running it on FLCS is small so
-        # just disabling the scenario seems to be the best way forward.
+        #('column', dict(key_format='r', value_format='S', extraconfig='')),
         #('column_fix', dict(key_format='r', value_format='8t', 
         #    extraconfig=',allocation_size=512,leaf_page_max=512')),
         ('integer_row', dict(key_format='i', value_format='S', extraconfig='')),


### PR DESCRIPTION
Disable rts28 on VLCS as well as FLCS.

It seems the test is timing-dependent and fails sometimes on the test machines because it doesn't always trigger the update restore eviction it's supposed to exercise.