### PR TITLE
WT-8410 Conversion from floats to integers changed overhead computation formula in block cache.

### DIFF
--- a/src/block/block_cache.c
+++ b/src/block/block_cache.c
@@ -132,7 +132,7 @@ __blkcache_high_overhead(WT_SESSION_IMPL *session)
     blkcache = &S2C(session)->blkcache;
 
     ops = blkcache->inserts + blkcache->removals;
-    return (blkcache->lookups > ops && ((ops * 100) / blkcache->lookups) > blkcache->overhead_pct);
+    return (blkcache->lookups == 0 || ((ops * 100) / blkcache->lookups) > blkcache->overhead_pct);
 }
 
 /*


### PR DESCRIPTION
The rewriting of the formula caused it to report no overhead when the number of lookups was smaller than the number of insertions and removals, but this is precisely the situation when the overhead is high. As a result, performance dropped by 30-70%. The proposed changed reverses the performance regression.