### PR TITLE
WT-8361 Increase assert limit in search near 01 cppsuite test

### DIFF
--- a/test/cppsuite/configs/search_near_01_stress.txt
+++ b/test/cppsuite/configs/search_near_01_stress.txt
@@ -13,10 +13,11 @@ workload_generator=
     (
         collection_count=3,
         key_count_per_collection=100,
+        value_size=30
     ),
     read_config=
     (
         op_rate=10ms,
-        thread_count=10
+        thread_count=40
     )
 ),

--- a/test/cppsuite/configs/search_near_01_stress.txt
+++ b/test/cppsuite/configs/search_near_01_stress.txt
@@ -18,6 +18,6 @@ workload_generator=
     read_config=
     (
         op_rate=10ms,
-        thread_count=40
+        thread_count=10
     )
 ),

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -241,11 +241,11 @@ class search_near_01 : public test_harness::test {
                  * Due to the concurrency of multiple threads and how WiredTiger increments the
                  * entries skipped stat, it is possible that a thread can perform multiple search
                  * nears before another can finish one. Account for this problem by creating a
-                 * buffer roughly equivalent to the calculated expected entries. Assert that the
+                 * buffer roughly equivalent to the calculated 2 * expected entries. Assert that the
                  * number of expected entries is the upper limit which the prefix search near can
                  * traverse and the prefix fast path is incremented.
                  */
-                buffer = std::max(expected_entries, static_cast<int64_t>(20));
+                buffer = std::max(2 * expected_entries, static_cast<int64_t>(40));
                 testutil_assert((expected_entries + buffer) >= entries_stat - prev_entries_stat);
 
                 /*

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -45,6 +45,7 @@ class search_near_01 : public test_harness::test {
     uint64_t srchkey_len = 0;
     const std::string ALPHABET{"abcdefghijklmnopqrstuvwxyz"};
     const uint64_t PREFIX_KEY_LEN = 3;
+    const int64_t MINIMUM_EXPECTED_ENTRIES = 40;
 
     static void
     populate_worker(thread_context *tc, const std::string &ALPHABET, uint64_t PREFIX_KEY_LEN)
@@ -241,11 +242,13 @@ class search_near_01 : public test_harness::test {
                  * Due to the concurrency of multiple threads and how WiredTiger increments the
                  * entries skipped stat, it is possible that a thread can perform multiple search
                  * nears before another can finish one. Account for this problem by creating a
-                 * buffer roughly equivalent to the calculated 2 * expected entries. Assert that the
-                 * number of expected entries is the upper limit which the prefix search near can
-                 * traverse and the prefix fast path is incremented.
+                 * buffer taking the maximum of either calculated 2 * expected entries or the
+                 * minimum expected entries. The minimum expected entries is necessary in the case
+                 * that expected entries is a low number. Assert that the number of expected
+                 * entries is the upper limit which the prefix search near can traverse and the
+                 * prefix fast path is incremented.
                  */
-                buffer = std::max(2 * expected_entries, static_cast<int64_t>(40));
+                buffer = std::max(2 * expected_entries, MINIMUM_EXPECTED_ENTRIES);
                 testutil_assert((expected_entries + buffer) >= entries_stat - prev_entries_stat);
 
                 /*

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -178,7 +178,7 @@ class search_near_01 : public test_harness::test {
         std::map<uint64_t, scoped_cursor> cursors;
         tc->stat_cursor = tc->session.open_scoped_cursor(STATISTICS_URI);
         std::string srch_key;
-        int64_t entries_stat, prefix_stat, prev_entries_stat, prev_prefix_stat, expected_entries;
+        int64_t entries_stat, prefix_stat, prev_entries_stat, prev_prefix_stat, expected_entries, buffer;
         int cmpp;
 
         cmpp = 0;
@@ -243,8 +243,9 @@ class search_near_01 : public test_harness::test {
                  * the number of expected entries is the upper limit which the prefix search near
                  * can traverse and the prefix fast path is incremented.
                  */
+                buffer = std::max(2 * tc->thread_count, 2 * expected_entries);
                 testutil_assert(
-                  (expected_entries + (2 * tc->thread_count)) >= entries_stat - prev_entries_stat);
+                  (expected_entries + buffer) >= entries_stat - prev_entries_stat);
                 /*
                  * There is an edge case where we may not early exit the prefix search near call
                  * because the specified prefix matches the rest of the entries in the tree.

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -178,7 +178,8 @@ class search_near_01 : public test_harness::test {
         std::map<uint64_t, scoped_cursor> cursors;
         tc->stat_cursor = tc->session.open_scoped_cursor(STATISTICS_URI);
         std::string srch_key;
-        int64_t entries_stat, prefix_stat, prev_entries_stat, prev_prefix_stat, expected_entries, buffer;
+        int64_t entries_stat, prefix_stat, prev_entries_stat, prev_prefix_stat, expected_entries,
+          buffer;
         int cmpp;
 
         cmpp = 0;
@@ -237,15 +238,16 @@ class search_near_01 : public test_harness::test {
                     " prefix fash path:  " + std::to_string(prefix_stat - prev_prefix_stat));
 
                 /*
-                 * It is possible that WiredTiger increments the entries skipped stat irrelevant to
-                 * prefix search near. This is dependent on how many read threads are present in the
-                 * test. Account for this by creating a small buffer using thread count. Assert that
-                 * the number of expected entries is the upper limit which the prefix search near
-                 * can traverse and the prefix fast path is incremented.
+                 * Due to the concurrency of multiple threads and how WiredTiger increments the
+                 * entries skipped stat, it is possible that a thread can perform multiple search
+                 * nears before another can finish one. Account for this problem by creating a
+                 * buffer roughly equivalent to the calculated expected entries. Assert that the
+                 * number of expected entries is the upper limit which the prefix search near can
+                 * traverse and the prefix fast path is incremented.
                  */
-                buffer = std::max(2 * tc->thread_count, 2 * expected_entries);
-                testutil_assert(
-                  (expected_entries + buffer) >= entries_stat - prev_entries_stat);
+                buffer = std::max(expected_entries, static_cast<int64_t>(20));
+                testutil_assert((expected_entries + buffer) >= entries_stat - prev_entries_stat);
+
                 /*
                  * There is an edge case where we may not early exit the prefix search near call
                  * because the specified prefix matches the rest of the entries in the tree.

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -247,7 +247,7 @@ class search_near_01 : public test_harness::test {
                  * that expected entries is a low number.
                  *
                  * Assert that the number of expected entries is the maximum allowed limit that the
-                 * prefix search nears can traverse and the prefix fast path is incremented.
+                 * prefix search nears can traverse.
                  */
                 buffer = std::max(2 * expected_entries, MINIMUM_EXPECTED_ENTRIES);
                 testutil_assert((expected_entries + buffer) >= entries_stat - prev_entries_stat);

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -244,9 +244,10 @@ class search_near_01 : public test_harness::test {
                  * nears before another can finish one. Account for this problem by creating a
                  * buffer taking the maximum of either calculated 2 * expected entries or the
                  * minimum expected entries. The minimum expected entries is necessary in the case
-                 * that expected entries is a low number. Assert that the number of expected
-                 * entries is the upper limit which the prefix search near can traverse and the
-                 * prefix fast path is incremented.
+                 * that expected entries is a low number.
+                 *
+                 * Assert that the number of expected entries is the maximum allowed limit that the
+                 * prefix search nears can traverse and the prefix fast path is incremented.
                  */
                 buffer = std::max(2 * expected_entries, MINIMUM_EXPECTED_ENTRIES);
                 testutil_assert((expected_entries + buffer) >= entries_stat - prev_entries_stat);


### PR DESCRIPTION
The fix involved in the PR, regards to increasing the assert limit for search near 01 cppsuite test. The reason for this change is because we previously didn't account if a thread would perform multiple search nears before another thread completing one. To account for this fact, I have doubled the expected entries to account for this anomaly. Now this change presumes that it is not possible to have all threads performing two search nears which on theory is impossible.