### PR TITLE
WT-8369 - Filter perf stats on PerfStatCollection construction

### DIFF
--- a/bench/wtperf/wtperf_run_py/perf_stat.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat.py
@@ -84,13 +84,6 @@ class PerfStat:
             as_dict['values'] = self.values
         return [as_dict]
 
-    def are_values_all_zero(self):
-        result = True
-        for value in self.values:
-            if value != 0:
-                result = False
-        return result
-
 
 class PerfStatMin(PerfStat):
     def get_value(self):

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -29,7 +29,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os
-from perf_stat import PerfStat
+from perf_stat import PerfStat, PerfStatCount, PerfStatLatency, PerfStatMax, PerfStatMin
 from typing import List
 
 
@@ -38,16 +38,83 @@ def create_test_stat_path(test_home_path: str, test_stats_file: str):
 
 
 class PerfStatCollection:
-    def __init__(self):
-        self.perf_stats = {}
+    def __init__(self, operations: List[str]):
+        self.to_report: List[PerfStat] = [stat for stat in self.all_stats() if stat.short_label in operations]
 
-    def add_stat(self, perf_stat: PerfStat):
-        self.perf_stats[perf_stat.short_label] = perf_stat
+    def find_stats(self, test_home: str):
+        for stat in self.to_report:
+            test_stat_path = create_test_stat_path(test_home, stat.stat_file)
+            values = stat.find_stat(test_stat_path=test_stat_path)
+            stat.add_values(values=values)
 
-    def find_stats(self, test_home: str, operations: List[str]):
-        for stat in self.perf_stats.values():
-            if not operations or stat.short_label in operations:
-                test_stat_path = create_test_stat_path(test_home, stat.stat_file)
-                values = stat.find_stat(test_stat_path=test_stat_path)
-                stat.add_values(values=values)
-
+    def all_stats(self):
+        return [
+            PerfStat(short_label="load",
+                        pattern='Load time:',
+                        input_offset=2,
+                        output_label='Load time',
+                        output_precision=2,
+                        conversion_function=float),
+            PerfStat(short_label="insert",
+                        pattern=r'Executed \d+ insert operations',
+                        input_offset=1,
+                        output_label='Insert count'),
+            PerfStat(short_label="modify",
+                        pattern=r'Executed \d+ modify operations',
+                        input_offset=1,
+                        output_label='Modify count'),
+            PerfStat(short_label="read",
+                        pattern=r'Executed \d+ read operations',
+                        input_offset=1,
+                        output_label='Read count'),
+            PerfStat(short_label="truncate",
+                        pattern=r'Executed \d+ truncate operations',
+                        input_offset=1,
+                        output_label='Truncate count'),
+            PerfStat(short_label="update",
+                        pattern=r'Executed \d+ update operations',
+                        input_offset=1,
+                        output_label='Update count'),
+            PerfStat(short_label="checkpoint",
+                        pattern=r'Executed \d+ checkpoint operations',
+                        input_offset=1,
+                        output_label='Checkpoint count'),
+            PerfStatMax(short_label="max_update_throughput",
+                        pattern=r'updates,',
+                        input_offset=8,
+                        output_label='Max update throughput'),
+            PerfStatMin(short_label="min_update_throughput",
+                        pattern=r'updates,',
+                        input_offset=8,
+                        output_label='Min update throughput'),
+            PerfStatCount(short_label="warnings",
+                            pattern='WARN',
+                            output_label='Latency warnings'),
+            PerfStatLatency(short_label="top5_latencies_read_update",
+                            stat_file='monitor.json',
+                            output_label='Latency(read, update) Max',
+                            ops = ['read', 'update'],
+                            num_max = 5),
+            PerfStatCount(short_label="eviction_page_seen",
+                            stat_file='WiredTigerStat*',
+                            pattern='[0-9].wt cache: pages seen by eviction',
+                            output_label='Pages seen by eviction'),
+            PerfStatLatency(short_label="max_latency_insert",
+                            stat_file='monitor.json',
+                            output_label='Latency(insert) Max',
+                            ops = ['insert'],
+                            num_max = 1),
+            PerfStatLatency(short_label="max_latency_read_update",
+                            stat_file='monitor.json',
+                            output_label='Latency(read, update) Max',
+                            ops = ['read', 'update'],
+                            num_max = 1),
+            PerfStatMax(short_label="max_read_throughput",
+                        pattern=r'updates,',
+                        input_offset=4,
+                        output_label='Max read throughput'),
+            PerfStatMin(short_label="min_read_throughput",
+                        pattern=r'updates,',
+                        input_offset=4,
+                        output_label='Min read throughput')
+        ]

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -51,10 +51,3 @@ class PerfStatCollection:
                 values = stat.find_stat(test_stat_path=test_stat_path)
                 stat.add_values(values=values)
 
-    def to_value_list(self, brief: bool):
-        stats_list = []
-        for stat in self.perf_stats.values():
-            if not stat.are_values_all_zero():
-                stat_list = stat.get_value_list(brief = brief)
-                stats_list.extend(stat_list)
-        return stats_list

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -39,7 +39,9 @@ def create_test_stat_path(test_home_path: str, test_stats_file: str):
 
 class PerfStatCollection:
     def __init__(self, operations: List[str]):
-        self.to_report: List[PerfStat] = [stat for stat in self.all_stats() if stat.short_label in operations]
+        self.to_report: List[PerfStat] = []
+        if operations:
+            self.to_report = [stat for stat in self.all_stats() if stat.short_label in operations]
 
     def find_stats(self, test_home: str):
         for stat in self.to_report:

--- a/bench/wtperf/wtperf_run_py/perf_stat_collection.py
+++ b/bench/wtperf/wtperf_run_py/perf_stat_collection.py
@@ -41,7 +41,7 @@ class PerfStatCollection:
     def __init__(self, operations: List[str]):
         self.to_report: List[PerfStat] = []
         if operations:
-            self.to_report = [stat for stat in self.all_stats() if stat.short_label in operations]
+            self.to_report = [stat for stat in PerfStatCollection.all_stats() if stat.short_label in operations]
 
     def find_stats(self, test_home: str):
         for stat in self.to_report:
@@ -49,7 +49,8 @@ class PerfStatCollection:
             values = stat.find_stat(test_stat_path=test_stat_path)
             stat.add_values(values=values)
 
-    def all_stats(self):
+    @staticmethod
+    def all_stats():
         return [
             PerfStat(short_label="load",
                         pattern='Load time:',

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -44,7 +44,7 @@ from wtperf_config import WTPerfConfig
 
 
 def create_test_home_path(home: str, test_run: int, index:int):
-    home_path = "{}_{}_{}".format(home, test_run, index)
+    home_path = "{}_{}_{}".format(home, index, test_run)
     return home_path
 
 

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -280,14 +280,14 @@ def run_perf_tests(config: WTPerfConfig,
             if args.verbose:
                 print("Batch test {}: Arguments: {}, Operations: {}".
                         format(index,  content["arguments"], content["operations"]))
+                perf_stats = PerfStatCollection(content["operations"])
                 if not args.reuse:
                     run_test_wrapper(config=config, index=index, arguments=content["arguments"])
-                perf_stats = PerfStatCollection(content["operations"])
                 reported_stats += process_results(config, perf_stats, index=index)
     else:
+        perf_stats = PerfStatCollection(operations)
         if not args.reuse:
             run_test_wrapper(config=config, index=0, arguments=arguments)
-        perf_stats = PerfStatCollection(operations)
         reported_stats = process_results(config, perf_stats)
 
     return reported_stats

--- a/bench/wtperf/wtperf_run_py/wtperf_run.py
+++ b/bench/wtperf/wtperf_run_py/wtperf_run.py
@@ -258,6 +258,13 @@ def validate_operations(config: WTPerfConfig, batch_file_contents: Dict, operati
     if len(all_operations_nodups) != len(all_operations):
         sys.exit("List of all operations ({}) contains duplicates".format(all_operations))
 
+    # Also check that all operations provided have an associated PerfStat.
+    all_stat_names = [stat.short_label for stat in PerfStatCollection.all_stats()]
+    for oper in all_operations:
+        if oper not in all_stat_names:
+            sys.exit(f"Provided operation '{oper}' does not match any known PerfStats.\n"
+                     f"Possible names are: {sorted(all_stat_names)}")
+
 def run_perf_tests(config: WTPerfConfig, 
                    batch_file_contents: Dict, 
                    args: argparse.Namespace, 


### PR DESCRIPTION
Instead of reading all PerfStats and then filtering them out at the reporting stage, define the list of required PerfStats when we build PerfStatCollection and only read these values.

Additionally wtperf_run.py::main() has been split into subfunctions to make things cleaner
