### PR TITLE
WT-8343 Fix variable "__ignored_ret" set, never used in cppsuite

### DIFF
--- a/test/cppsuite/test_harness/workload/database_operation.cxx
+++ b/test/cppsuite/test_harness/workload/database_operation.cxx
@@ -288,7 +288,7 @@ database_operation::update_operation(thread_context *tc)
 
         /* Commit the current transaction if we're able to. */
         if (tc->transaction.can_commit())
-            WT_IGNORE_RET_BOOL(tc->transaction.commit());
+            testutil_assert(tc->transaction.commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */


### PR DESCRIPTION
WiredTiger uses WT_UNUSED inside C, to stop compiler warnings or coverity warning worrying about unused variables. Alternatively we can set it to testutil_assert instead, since it should be guaranteed that we transaction commit succeeds if `can_commit` returns true.