### PR TITLE
WT-8419 Disable test_inmem01.test_insert_over_delete_replace for FLCS

### DIFF
--- a/test/suite/test_inmem01.py
+++ b/test/suite/test_inmem01.py
@@ -131,8 +131,13 @@ class test_inmem01(wttest.WiredTigerTestCase):
         # Note that with 141676 rows there are several retries in the bottom loop, so things are
         # working as designed and the desired scenario is being tested.
 
-        if self.valuefmt == '8t' and last_key >= 141677:
-            self.skipTest('Load too high; test will get stuck')
+        # While I'm pretty sure the above analysis is sound, the threshold is not as portable as
+        # I'd hoped, so just skip the test entirely until someone has the patience to track down
+        # a suitable threshold value for the test environment.
+        #if self.valuefmt == '8t' and last_key >= 141677:
+        #    self.skipTest('Load too high; test will get stuck')
+        if self.valuefmt == '8t':
+            self.skipTest('Gets stuck and fails sometimes under load')
 
         # Now that the database contains as much data as will fit into
         # the configured cache, verify removes succeed.


### PR DESCRIPTION
Always skip the inmem01.insert_over_delete_replace test on FLCS.

While I'm pretty sure the previous change was sound in principle, it seems that the threshold that works for me is not portable to the test environment, and since I don't myself have direct access tracking down a suitable threshold value is not currently worthwhile.