### PR TITLE
WT-8320 Do not append the on-disk update if it was an aborted prepared update

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -153,7 +153,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
              */
             if (F_ISSET(last_upd, WT_UPDATE_RESTORED_FROM_HS) && *upd_entry != NULL &&
               (*upd_entry)->prepare_state == WT_PREPARE_INPROGRESS &&
-              F_ISSET(*upd_entry, WT_UPDATE_RESTORED_FROM_DS)) {
+              F_ISSET(*upd_entry, WT_UPDATE_PREPARE_RESTORED_FROM_DS)) {
                 __wt_free_update_list(session, upd_entry);
                 *upd_entry = NULL;
             }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -153,8 +153,10 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
              */
             if (F_ISSET(last_upd, WT_UPDATE_RESTORED_FROM_HS) && *upd_entry != NULL &&
               (*upd_entry)->prepare_state == WT_PREPARE_INPROGRESS &&
-              F_ISSET(*upd_entry, WT_UPDATE_RESTORED_FROM_DS))
+              F_ISSET(*upd_entry, WT_UPDATE_RESTORED_FROM_DS)) {
+                __wt_free_update_list(session, upd_entry);
                 *upd_entry = NULL;
+            }
             last_upd->next = *upd_entry;
 
             /*


### PR DESCRIPTION
While restoring a new update chain to the key for an update-restore eviction path, do not append the on-disk update if it was an aborted prepared update. There shouldn't be an update newer than a prepared update on the update chain and in this case the the prepared update should be discarded as it is not required anymore.