### PR TITLE
WT-8385 Fix unused value in test format backup

### DIFF
--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -55,13 +55,13 @@ check_copy(void)
     ret = unlink(path);
     /* Check if unlink command failed. It is fine if the file does not exist. */
     if (ret != 0 && errno != ENOENT)
-        testutil_die(errno, "unlink %s", path);
+        testutil_die(errno, "unlink command failed with error code: %s", path);
 
     testutil_check(__wt_snprintf(path, len, "%s/%s", g.home, BACKUP_INFO_FILE));
     ret = unlink(path);
     /* Check if unlink command failed. It is fine if the file does not exist. */
     if (ret != 0 && errno != ENOENT)
-        testutil_die(errno, "unlink %s", path);
+        testutil_die(errno, "unlink command failed with error code: %s", path);
 
     /* Now setup and open the path for real. */
     testutil_check(__wt_snprintf(path, len, "%s/BACKUP", g.home));

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -53,18 +53,14 @@ check_copy(void)
      */
     testutil_check(__wt_snprintf(path, len, "%s/%s", g.home, BACKUP_INFO_FILE_TMP));
     ret = unlink(path);
-    /* It is fine if the file does not exist. */
-    if (ret == 0 || errno == ENOENT)
-        ret = 0;
-    else
+    /* Check if unlink command failed. It is fine if the file does not exist. */
+    if (ret != 0 && errno != ENOENT)
         testutil_die(errno, "unlink %s", path);
 
     testutil_check(__wt_snprintf(path, len, "%s/%s", g.home, BACKUP_INFO_FILE));
     ret = unlink(path);
-    /* It is fine if the file does not exist. */
-    if (ret == 0 || errno == ENOENT)
-        ret = 0;
-    else
+    /* Check if unlink command failed. It is fine if the file does not exist. */
+    if (ret != 0 && errno != ENOENT)
         testutil_die(errno, "unlink %s", path);
 
     /* Now setup and open the path for real. */


### PR DESCRIPTION
This ticket involves fixing a previously unused return value. This error was happening on line 66, and was never used afterwards. Coverity found that the variable was being unused afterwards.

I have employed a solution where we don't need to reset ret, and instead change the if condition to check if unlink failed with errno being set other than ENOENT.