### PR TITLE
WT-8395 Save connection write generation number along with checkpoint snapshot

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -377,6 +377,9 @@ struct __wt_connection_impl {
     /* Connection's base write generation. */
     uint64_t base_write_gen;
 
+    /* Connection's write generation number excluding metadata. */
+    uint64_t write_gen;
+
     /* Last checkpoint connection's base write generation */
     uint64_t last_ckpt_base_write_gen;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1136,8 +1136,8 @@ extern int __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *config)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *uri,
+  const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -38,6 +38,7 @@
 #define WT_SYSTEM_CKPT_URI "system:checkpoint"                   /* Checkpoint timestamp URI */
 #define WT_SYSTEM_OLDEST_TS "oldest_timestamp"                   /* Oldest timestamp name */
 #define WT_SYSTEM_OLDEST_URI "system:oldest"                     /* Oldest timestamp URI */
+#define WT_SYSTEM_WRITE_GEN "write_gen"                          /* Connection write gen name */
 #define WT_SYSTEM_CKPT_SNAPSHOT "snapshots"                      /* List of snapshots */
 #define WT_SYSTEM_CKPT_SNAPSHOT_MIN "snapshot_min"               /* Snapshot minimum */
 #define WT_SYSTEM_CKPT_SNAPSHOT_MAX "snapshot_max"               /* Snapshot maximum */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1077,7 +1077,7 @@ __wt_meta_ckptlist_to_meta(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, WT_ITEM 
          * generation informations as this information is going to be saved in the metadata file
          * itself for every checkpoint.
          */
-        if (!WT_IS_METADATA(session->dhandle))
+        if (session->dhandle == NULL || !WT_IS_METADATA(session->dhandle))
             S2C(session)->write_gen = WT_MAX(ckpt->write_gen, S2C(session)->write_gen);
     }
     WT_RET(__wt_buf_catfmt(session, buf, ")"));


### PR DESCRIPTION
To identify the saved checkpoint snapshot in the metadata file during recovery,
WiredTiger calculates the connection level write generation number from all the
btree checkpoints and compares it against the saved write generation number in
the checkpoint snapshot before proceeding with RTS based on that checkpoint
snapshot.

The versions where the connection write generation number is not saved, during
the restart, the comparison fails and RTS doesn't perform using the checkpoint
snapshot.