### PR TITLE
WT-8390 Assert table cannot be NULL within config_table in test/format

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -212,6 +212,8 @@ config_table(TABLE *table, void *arg)
 
     (void)arg; /* unused argument */
 
+    testutil_assert(table != NULL);
+
     /*
      * Choose a file format and a data source: they're interrelated (LSM is only compatible with
      * row-store) and other items depend on them.


### PR DESCRIPTION
Coverity doesn't understand the relationship between ntables and the tables array, clarify it.