### PR TITLE
WT-8388 Increase variable type size to avoid Coverity complaint that the value could overflow in test/format

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -525,8 +525,7 @@ config_backward_compatible(void)
 static void
 config_cache(void)
 {
-    uint64_t cache;
-    uint32_t workers;
+    uint64_t cache, workers;
 
     /* Check if both min and max cache sizes have been specified and if they're consistent. */
     if (config_explicit(NULL, "cache")) {


### PR DESCRIPTION
Increase variable type size to avoid Coverity complaint that the value could overflow.