### PR TITLE
WT-8387 Assert table cannot be NULL when tables_apply is used in test/format

### DIFF
--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -90,6 +90,7 @@ wts_load(TABLE *table, void *arg)
     bool is_bulk;
 
     (void)arg; /* unused argument */
+    testutil_assert(table != NULL);
 
     conn = g.wts_conn;
 

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -482,6 +482,7 @@ static void
 config_backward_compatible_table(TABLE *table, void *arg)
 {
     (void)arg; /* unused argument */
+    testutil_assert(table != NULL);
 
 #undef BC_CHECK
 #define BC_CHECK(name, flag)                                                               \

--- a/test/format/kv.c
+++ b/test/format/kv.c
@@ -41,6 +41,7 @@ key_init(TABLE *table, void *arg)
     char buf[MAX_FORMAT_PATH];
 
     (void)arg; /* unused argument */
+    testutil_assert(table != NULL);
 
     if (ntables == 0)
         testutil_check(__wt_snprintf(buf, sizeof(buf), "%s", g.home_key));
@@ -226,6 +227,7 @@ val_init(TABLE *table, void *arg)
     uint32_t len;
 
     (void)arg; /* unused argument */
+    testutil_assert(table != NULL);
 
     /* Discard any previous value initialization. */
     free(table->val_base);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1122,6 +1122,7 @@ wts_read_scan(TABLE *table, void *arg)
     uint32_t max_rows;
 
     conn = (WT_CONNECTION *)arg;
+    testutil_assert(table != NULL);
 
     /*
      * We're not configuring transactions or read timestamps, if there's a diagnostic check, skip
@@ -1696,6 +1697,8 @@ col_insert_resolve(TABLE *table, void *arg)
     u_int i;
 
     tinfo = arg;
+    testutil_assert(table != NULL);
+
     cip = &tinfo->col_insert[table->id - 1];
     if (cip->insert_list_cnt == 0)
         return;

--- a/test/format/salvage.c
+++ b/test/format/salvage.c
@@ -127,6 +127,7 @@ wts_salvage(TABLE *table, void *arg)
     char buf[MAX_FORMAT_PATH * 5], path[MAX_FORMAT_PATH];
 
     (void)arg; /* unused argument */
+    testutil_assert(table != NULL);
 
     if (GV(OPS_SALVAGE) == 0 || DATASOURCE(table, "lsm"))
         return;

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -324,6 +324,8 @@ create_object(TABLE *table, void *arg)
     const char *s;
 
     conn = (WT_CONNECTION *)arg;
+    testutil_assert(table != NULL);
+
     p = config;
     max = sizeof(config);
 
@@ -534,6 +536,7 @@ wts_verify(TABLE *table, void *arg)
     WT_SESSION *session;
 
     conn = (WT_CONNECTION *)arg;
+    testutil_assert(table != NULL);
 
     if (GV(OPS_VERIFY) == 0)
         return;
@@ -587,6 +590,8 @@ stats_data_source(TABLE *table, void *arg)
     char buf[1024];
 
     args = arg;
+    testutil_assert(table != NULL);
+
     fp = args->fp;
     session = args->session;
 


### PR DESCRIPTION
Coverity doesn't understand the relationship between ntables and the tables array, clarify it.