### PR TITLE
WT-8386 Coverity analysis defect 121104: Dereference after null check

### DIFF
--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -691,6 +691,6 @@ snap_repeat_rollback(TINFO **tinfo_array, size_t tinfo_count)
     } else
         g.rts_no_check = 0;
 
-    if (session == NULL)
+    if (session != NULL)
         testutil_check(session->close(session, NULL));
 }


### PR DESCRIPTION
Fix a bug in format (which is  one of the principle reasons RTS can't acquire exclusive handlelocks), found by Coverity, where a test was swapped and we weren't closing WT_SESSION handles.