### PR TITLE
WT-8384 Coverity analysis defect 121118: Explicit null dereferenced

### DIFF
--- a/test/format/format.i
+++ b/test/format/format.i
@@ -243,8 +243,6 @@ wiredtiger_open_cursor(
 {
     WT_DECL_RET;
 
-    *cursorp = NULL;
-
     /* WT_SESSION.open_cursor can return EBUSY if concurrent with a metadata operation, retry. */
     while ((ret = session->open_cursor(session, uri, NULL, config, cursorp)) == EBUSY)
         __wt_yield();


### PR DESCRIPTION
Setting a side-effect variable to NULL makes Coverity think it can be NULL when the function returns, remove the set to NULL.