### PR TITLE
WT-8013 Re-enable FLCS smoke testing in format.

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -47,8 +47,7 @@ smoke_base_2="$smoke_base_1 leaf_page_max=9 internal_page_max=9"
 smoke_list=(
 	# Three access methods.
 	"$smoke_base_1 file_type=row"
-    # Temporarily disabled: FIXME FLCS
-	# "$smoke_base_1 file_type=fix"
+	"$smoke_base_1 file_type=fix"
 	"$smoke_base_1 file_type=var"
 
 	# Huffman value encoding.

--- a/test/format/smoke.sh
+++ b/test/format/smoke.sh
@@ -14,9 +14,9 @@ args="$args runs.threads=6 "
 args="$args runs.timer=1 "
 args="$args transaction.timestamps=1 "
 
-# Temporarily disable LSM and FLCS.
-# $TEST_WRAPPER ./t $args runs.type=fix
-# $TEST_WRAPPER ./t $args runs.type=row runs.source=lsm
-
+$TEST_WRAPPER ./t $args runs.type=fix
 $TEST_WRAPPER ./t $args runs.type=row
 $TEST_WRAPPER ./t $args runs.type=var
+
+# Temporarily disable LSM.
+# $TEST_WRAPPER ./t $args runs.type=row runs.source=lsm


### PR DESCRIPTION
Re-enable FLCS smoke testing in format.