### PR TITLE
WT-8448 - s_mentions finds content that should not be matching

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -63,13 +63,18 @@ errchk()
 	    errfound=1;
 	fi
 
+	# Ignore errors if the script is marked warning-only
+	if [ "$3" = "--warning-only" ]; then
+		errfound=0;
+	fi
+
 	rm -f $2
 }
 
 run()
 {
 	2>&1 $1 > $t
-	errchk "$1" $t
+	errchk "$1" $t "$2"
 }
 
 # Non parallelizable scripts The following scripts either modify files or
@@ -88,7 +93,7 @@ run "python prototypes.py"
 run "sh ./s_typedef -b"
 run "python test_tag.py"
 # The s_mentions script requires bash.
-run "./s_mentions"
+run "./s_mentions" "--warning-only"
 if command -v evergreen > /dev/null; then
 	run "evergreen validate ../test/evergreen.yml"
 fi

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -7,17 +7,27 @@
 branch_name=$(git rev-parse --abbrev-ref HEAD 2>&1 || echo "BRANCH_NOT_FOUND")
 
 # We expect the following syntax (case insensitive): wt-<digits>[-<alphanum>].
-regex="^(wt|WT|wT|Wt)-[0-9]+(-[a-zA-Z0-9-]+)?"
-if [[ ! $branch_name =~ $regex ]]; then
+wt_ticket_regex="(wt|WT|wT|Wt)-[0-9]+(-[a-zA-Z0-9-]+)?"
+if [[ ! $branch_name =~ ^$wt_ticket_regex ]]; then
     exit 0
 fi
 
 # Get what could be the ticket id.
 ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
+search_function="grep -Iinr --exclude-dir=.git $ticket_id ../"
+
+wt_src_path=$(realpath --relative-to="$HOME" ../) # Relative to HOME as some scripts strip home from the path.
+if [[ $wt_src_path =~ .*${wt_ticket_regex}.* ]]; then
+    # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/wt-8448/wiredtiger) then we will match a lot of
+    # generated build scripts containing this path. Filter these results from the search.
+    search_function="$search_function | grep -v $wt_src_path"
+fi
+
 # Check for comments related to the ticket.
-if grep -inr --exclude-dir=.git "$ticket_id" ../. > /dev/null 2>&1; then
-    echo "There are comments mentioning $ticket_id in the code, please check them."
+if eval "$search_function >/dev/null" ; then
+    echo "There are comments mentioning $ticket_id in the code, please check if they need to be resolved."
+    eval "$search_function -m 10"
 fi
 
 exit 0

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -15,24 +15,23 @@ fi
 # Get what could be the ticket id.
 ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
-search_function="grep -Iinr --exclude-dir=.git $ticket_id ../"
+search_function="grep -Iinr --exclude-dir=.git $ticket_id ../ 2>&1"
 
-# The wiredtiger source path need to be relative to $HOME
-# as some scripts will strip $HOME from the path.
+# The wiredtiger file path needs to be relative to $HOME as some scripts strip $HOME from the path.
 wt_src_path=$(readlink -f ../)
 wt_src_path=${wt_src_path#"$(readlink -f "$HOME")/"}
 
 if [[ $wt_src_path =~ .*${wt_ticket_regex}.* ]]; then
     # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/$ticket_id/wiredtiger) then we will
     # match generated build scripts containing this path. Filter these results from the search.
-    search_function="$search_function | grep -v $wt_src_path"
+    search_function="$search_function | grep -v $wt_src_path 2>&1"
 fi
 
 # Check for comments related to the ticket.
 if eval "$search_function >/dev/null" ; then
     echo "There are comments mentioning $ticket_id in the code, please check if they need to be \
-resolved."
-    eval "$search_function -m 10"
+resolved:"
+    eval "$search_function"
 fi
 
 exit 0

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -17,8 +17,11 @@ ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
 search_function="grep -Iinr --exclude-dir=.git $ticket_id ../"
 
-# Relative to HOME as some scripts strip home from the path.
-wt_src_path=$(realpath --relative-to="$HOME" ../)
+# The wiredtiger source path need to be relative to $HOME
+# as some scripts will strip $HOME from the path.
+wt_src_path=$(readlink -f ../)
+wt_src_path=${wt_src_path#"$(readlink -f "$HOME")/"}
+
 if [[ $wt_src_path =~ .*${wt_ticket_regex}.* ]]; then
     # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/$ticket_id/wiredtiger) then we will
     # match generated build scripts containing this path. Filter these results from the search.

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -17,16 +17,18 @@ ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
 search_function="grep -Iinr --exclude-dir=.git $ticket_id ../"
 
-wt_src_path=$(realpath --relative-to="$HOME" ../) # Relative to HOME as some scripts strip home from the path.
+# Relative to HOME as some scripts strip home from the path.
+wt_src_path=$(realpath --relative-to="$HOME" ../)
 if [[ $wt_src_path =~ .*${wt_ticket_regex}.* ]]; then
-    # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/wt-8448/wiredtiger) then we will match a lot of
-    # generated build scripts containing this path. Filter these results from the search.
+    # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/$ticket_id/wiredtiger) then we will
+    # match generated build scripts containing this path. Filter these results from the search.
     search_function="$search_function | grep -v $wt_src_path"
 fi
 
 # Check for comments related to the ticket.
 if eval "$search_function >/dev/null" ; then
-    echo "There are comments mentioning $ticket_id in the code, please check if they need to be resolved."
+    echo "There are comments mentioning $ticket_id in the code, please check if they need to be \
+resolved."
     eval "$search_function -m 10"
 fi
 


### PR DESCRIPTION
Generated build scripts in `build_posix` and `cmake_build` will contain wiredtiger's filepath, and when the filepath contains the ticket that `s_mentions` is checking for (e.g. `~/src/wt-8448/wiredtiger`) then `s_mentions` will return false positive matches.

Update `s_mentions` to handle this case.

Additionally ensure that any reported matches by `s_mentions` are treated as warnings only and `s_all` does not fail when they are detected. 