### PR TITLE
WT-8320 Remove existing prepared update before restoring update chain

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1476,6 +1476,11 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             /* Search the page. */
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
 
+            /* If required, remove the existing prepared update restored from the disk. */
+            if (supd->restore && supd->ins == NULL && prepare &&
+              !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
+                WT_ERR(__wt_page_inmem_remove_prepared(session, &cbt));
+
             /* Apply the modification. */
 #ifdef HAVE_DIAGNOSTIC
             WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, true));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1204,6 +1204,8 @@ extern int __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *im
   WT_PAGE **pagep, bool *preparedp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_page_inmem_remove_prepared(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)


### PR DESCRIPTION
@kommiharibabu @quchenhao @bvpvamsikrishna, this is the alternate approach I have implemented. We explicitly remove existing update chain with prepared update in update-restore scenario using a new function `__wt_page_inmem_remove_prepared()` 