### PR TITLE
WT-8459 rename test_checksys() to test_assert_errno()

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -693,8 +693,8 @@ main(int argc, char *argv[])
          */
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+        testutil_assert_errno((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             fill_db(nth);
@@ -730,7 +730,7 @@ main(int argc, char *argv[])
         }
         sleep(timeout);
         sa.sa_handler = SIG_DFL;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
         /*
          * !!! It should be plenty long enough to make sure more than
@@ -738,8 +738,8 @@ main(int argc, char *argv[])
          * here.
          */
         printf("Kill child\n");
-        testutil_checksys(kill(pid, SIGKILL) != 0);
-        testutil_checksys(waitpid(pid, &status, 0) == -1);
+        testutil_assert_errno(kill(pid, SIGKILL) == 0);
+        testutil_assert_errno(waitpid(pid, &status, 0) != -1);
     }
     /*
      * !!! If we wanted to take a copy of the directory before recovery,

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -551,9 +551,9 @@ thread_ckpt_run(void *arg)
          * timeout.
          */
         if (first_ckpt) {
-            testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
+            testutil_assert_errno((fp = fopen(ckpt_file, "w")) != NULL);
             first_ckpt = false;
-            testutil_checksys(fclose(fp) != 0);
+            testutil_assert_errno(fclose(fp) == 0);
         }
     }
     /* NOTREACHED */
@@ -589,7 +589,7 @@ thread_run(void *arg)
      */
     testutil_check(__wt_snprintf(cbuf, sizeof(cbuf), RECORDS_FILE, td->info));
     (void)unlink(cbuf);
-    testutil_checksys((fp = fopen(cbuf, "w")) == NULL);
+    testutil_assert_errno((fp = fopen(cbuf, "w")) != NULL);
     /*
      * Set to line buffering. But that is advisory only. We've seen cases where the result files end
      * up with partial lines.
@@ -994,8 +994,8 @@ main(int argc, char *argv[])
          */
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = sig_handler;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+        testutil_assert_errno((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);
@@ -1013,7 +1013,7 @@ main(int argc, char *argv[])
             testutil_sleep_wait(1, pid);
         sleep(timeout);
         sa.sa_handler = SIG_DFL;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
         /*
          * !!! It should be plenty long enough to make sure more than
@@ -1021,8 +1021,8 @@ main(int argc, char *argv[])
          * here.
          */
         printf("Kill child\n");
-        testutil_checksys(kill(pid, SIGKILL) != 0);
-        testutil_checksys(waitpid(pid, &status, 0) == -1);
+        testutil_assert_errno(kill(pid, SIGKILL) == 0);
+        testutil_assert_errno(waitpid(pid, &status, 0) != -1);
     }
     /*
      * !!! If we wanted to take a copy of the directory before recovery,
@@ -1190,7 +1190,7 @@ main(int argc, char *argv[])
         c_rep[i].last_key = last_key;
         l_rep[i].last_key = last_key;
         o_rep[i].last_key = last_key;
-        testutil_checksys(fclose(fp) != 0);
+        testutil_assert_errno(fclose(fp) == 0);
         print_missing(&c_rep[i], fname, "COLLECTION");
         print_missing(&l_rep[i], fname, "LOCAL");
         print_missing(&o_rep[i], fname, "OPLOG");

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -265,8 +265,8 @@ thread_flush_run(void *arg)
          * flush_tier calls have finished and can start its timer.
          */
         if (i == flush_calls) {
-            testutil_checksys((fp = fopen(sentinel_file, "w")) == NULL);
-            testutil_checksys(fclose(fp) != 0);
+            testutil_assert_errno((fp = fopen(sentinel_file, "w")) != NULL);
+            testutil_assert_errno(fclose(fp) == 0);
         }
     }
     /* NOTREACHED */
@@ -304,7 +304,7 @@ thread_run(void *arg)
      */
     testutil_check(__wt_snprintf(cbuf, sizeof(cbuf), RECORDS_FILE, td->info));
     (void)unlink(cbuf);
-    testutil_checksys((fp = fopen(cbuf, "w")) == NULL);
+    testutil_assert_errno((fp = fopen(cbuf, "w")) != NULL);
     /*
      * Set to line buffering. But that is advisory only. We've seen cases where the result files end
      * up with partial lines.
@@ -673,8 +673,8 @@ main(int argc, char *argv[])
          */
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+        testutil_assert_errno((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth, build_dir);
@@ -692,7 +692,7 @@ main(int argc, char *argv[])
             testutil_sleep_wait(1, pid);
         sleep(timeout);
         sa.sa_handler = SIG_DFL;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
         /*
          * !!! It should be plenty long enough to make sure more than
@@ -700,8 +700,8 @@ main(int argc, char *argv[])
          * here.
          */
         printf("Kill child\n");
-        testutil_checksys(kill(pid, SIGKILL) != 0);
-        testutil_checksys(waitpid(pid, &status, 0) == -1);
+        testutil_assert_errno(kill(pid, SIGKILL) == 0);
+        testutil_assert_errno(waitpid(pid, &status, 0) != -1);
     }
 
     /*
@@ -879,7 +879,7 @@ main(int argc, char *argv[])
         c_rep[i].last_key = last_key;
         l_rep[i].last_key = last_key;
         o_rep[i].last_key = last_key;
-        testutil_checksys(fclose(fp) != 0);
+        testutil_assert_errno(fclose(fp) == 0);
         print_missing(&c_rep[i], fname, "COLLECTION");
         print_missing(&l_rep[i], fname, "LOCAL");
         print_missing(&o_rep[i], fname, "OPLOG");

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -254,9 +254,9 @@ thread_ckpt_run(void *arg)
          * the database.
          */
         if (first_ckpt && (!use_ts || stable != WT_TS_NONE)) {
-            testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
+            testutil_assert_errno((fp = fopen(ckpt_file, "w")) != NULL);
             first_ckpt = false;
-            testutil_checksys(fclose(fp) != 0);
+            testutil_assert_errno(fclose(fp) == 0);
         }
     }
     /* NOTREACHED */
@@ -294,7 +294,7 @@ thread_run(void *arg)
      */
     testutil_check(__wt_snprintf(cbuf, sizeof(cbuf), RECORDS_FILE, td->info));
     (void)unlink(cbuf);
-    testutil_checksys((fp = fopen(cbuf, "w")) == NULL);
+    testutil_assert_errno((fp = fopen(cbuf, "w")) != NULL);
     /*
      * Set to line buffering. But that is advisory only. We've seen cases where the result files end
      * up with partial lines.
@@ -740,8 +740,8 @@ main(int argc, char *argv[])
          */
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = handler;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-        testutil_checksys((pid = fork()) < 0);
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+        testutil_assert_errno((pid = fork()) >= 0);
 
         if (pid == 0) { /* child */
             run_workload(nth);
@@ -759,7 +759,7 @@ main(int argc, char *argv[])
             testutil_sleep_wait(1, pid);
         sleep(timeout);
         sa.sa_handler = SIG_DFL;
-        testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
         /*
          * !!! It should be plenty long enough to make sure more than
@@ -767,8 +767,8 @@ main(int argc, char *argv[])
          * here.
          */
         printf("Kill child\n");
-        testutil_checksys(kill(pid, SIGKILL) != 0);
-        testutil_checksys(waitpid(pid, &status, 0) == -1);
+        testutil_assert_errno(kill(pid, SIGKILL) == 0);
+        testutil_assert_errno(waitpid(pid, &status, 0) != -1);
     }
 
     /*
@@ -967,7 +967,7 @@ main(int argc, char *argv[])
         c_rep[i].last_key = last_key;
         l_rep[i].last_key = last_key;
         o_rep[i].last_key = last_key;
-        testutil_checksys(fclose(fp) != 0);
+        testutil_assert_errno(fclose(fp) == 0);
         print_missing(&c_rep[i], fname, "COLLECTION");
         print_missing(&l_rep[i], fname, "LOCAL");
         print_missing(&o_rep[i], fname, "OPLOG");

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -262,7 +262,7 @@ main(int argc, char *argv[])
     /*
      * Fork a child to do its work. Wait for it to exit.
      */
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
         fill_db();
@@ -271,7 +271,7 @@ main(int argc, char *argv[])
 
     /* parent */
     /* Wait for child to kill itself. */
-    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 
     /*
      * !!! If we wanted to take a copy of the directory before recovery,

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -454,13 +454,13 @@ run_process(TEST_OPTS *opts, const char *prog, char *argv[], int *statusp)
             printf("%s ", *arg);
         printf("\n");
     }
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno((pid = fork()) >= 0);
     if (pid == 0) {
         (void)execv(prog, argv);
         _exit(EXIT_FAILURE);
     }
 
-    testutil_checksys(waitpid(pid, statusp, 0) == -1);
+    testutil_assert_errno(waitpid(pid, statusp, 0) != -1);
 }
 
 /*

--- a/test/csuite/wt4803_history_store_abort/main.c
+++ b/test/csuite/wt4803_history_store_abort/main.c
@@ -147,7 +147,7 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
      * This way, we can safely check the exit code of the child process and confirm that it is what
      * we expected.
      */
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno((pid = fork()) >= 0);
 
     if (pid == 0) {
         /* Child process from here. */
@@ -167,7 +167,7 @@ test_hs_workload(TEST_OPTS *opts, const char *hs_file_max)
     }
 
     /* Parent process from here. */
-    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
     testutil_assert(status == 0);
 }
 

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -117,9 +117,9 @@ thread_ckpt_run(void *arg)
          * finished and can start its timer.
          */
         if (first_ckpt) {
-            testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
+            testutil_assert_errno((fp = fopen(ckpt_file, "w")) != NULL);
             first_ckpt = false;
-            testutil_checksys(fclose(fp) != 0);
+            testutil_assert_errno(fclose(fp) == 0);
         }
     }
     /* NOTREACHED */
@@ -311,8 +311,8 @@ main(int argc, char *argv[])
      */
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = handler;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+    testutil_assert_errno((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
         run_workload();
@@ -330,11 +330,11 @@ main(int argc, char *argv[])
         testutil_sleep_wait(1, pid);
     sleep(timeout);
     sa.sa_handler = SIG_DFL;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
     printf("Kill child\n");
-    testutil_checksys(kill(pid, SIGKILL) != 0);
-    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert_errno(kill(pid, SIGKILL) == 0);
+    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 
     /*
      * !!! If we wanted to take a copy of the directory before recovery,

--- a/test/csuite/wt8057_compact_stress/main.c
+++ b/test/csuite/wt8057_compact_stress/main.c
@@ -150,8 +150,8 @@ run_test(bool column_store, bool preserve)
     /* Fork a child to create tables and perform operations on them. */
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sig_handler;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+    testutil_assert_errno((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
 
@@ -177,12 +177,12 @@ run_test(bool column_store, bool preserve)
     /* Sleep for a while. Let the child process do some operations on the tables. */
     sleep(TIMEOUT);
     sa.sa_handler = SIG_DFL;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
     /* Kill the child process. */
     printf("Kill child\n");
-    testutil_checksys(kill(pid, SIGKILL) != 0);
-    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert_errno(kill(pid, SIGKILL) == 0);
+    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 
     /* Reopen the connection and verify that the tables match each other. */
     testutil_check(wiredtiger_open(home, &event_handler, conn_config, &conn));
@@ -242,8 +242,8 @@ workload_compact(const char *home, const char *table_config)
          */
         if (!first_ckpt) {
             testutil_check(__wt_snprintf(ckpt_file, sizeof(ckpt_file), ckpt_file_fmt, home));
-            testutil_checksys((fp = fopen(ckpt_file, "w")) == NULL);
-            testutil_checksys(fclose(fp) != 0);
+            testutil_assert_errno((fp = fopen(ckpt_file, "w")) != NULL);
+            testutil_assert_errno(fclose(fp) == 0);
             first_ckpt = true;
         }
 

--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -132,8 +132,8 @@ run_test(bool column_store, const char *uri, bool preserve)
     /* Fork a child to create tables and perform operations on them. */
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sig_handler;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
-    testutil_checksys((pid = fork()) < 0);
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+    testutil_assert_errno((pid = fork()) >= 0);
 
     if (pid == 0) { /* child */
 
@@ -160,12 +160,12 @@ run_test(bool column_store, const char *uri, bool preserve)
     /* Sleep for a while. Let the child process do some operations on the tables. */
     sleep(TIMEOUT);
     sa.sa_handler = SIG_DFL;
-    testutil_checksys(sigaction(SIGCHLD, &sa, NULL));
+    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
     /* Kill the child process. */
     printf("Kill child\n");
-    testutil_checksys(kill(pid, SIGKILL) != 0);
-    testutil_checksys(waitpid(pid, &status, 0) == -1);
+    testutil_assert_errno(kill(pid, SIGKILL) == 0);
+    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 
     printf("Compact process interrupted and killed...\n");
 
@@ -263,8 +263,8 @@ workload_compact(const char *home, const char *table_config, const char *uri)
      * Create the compact_started file so that the parent process can start its timer.
      */
     testutil_check(__wt_snprintf(compact_file, sizeof(compact_file), compact_file_fmt, home));
-    testutil_checksys((fp = fopen(compact_file, "w")) == NULL);
-    testutil_checksys(fclose(fp) != 0);
+    testutil_assert_errno((fp = fopen(compact_file, "w")) != NULL);
+    testutil_assert_errno(fclose(fp) == 0);
 
     run_compact(session, uri);
 }

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -159,7 +159,7 @@ run(int r)
 
     testutil_make_work_dir(HOME);
 
-    testutil_checksys((res_fp = fopen(RSLT, "w")) == NULL);
+    testutil_assert_errno((res_fp = fopen(RSLT, "w")) != NULL);
 
     /*
      * Each run builds the LOAD file, and then appends the first page of the LOAD file into the SLVG
@@ -587,16 +587,16 @@ copy(u_int gen, u_int recno)
     uint32_t cksum32, gen32;
     char buf[PSIZE];
 
-    testutil_checksys((ifp = fopen(LOAD, "r")) == NULL);
+    testutil_assert_errno((ifp = fopen(LOAD, "r")) != NULL);
 
     /*
      * If the salvage file doesn't exist, then we're creating it: copy the first sector (the file
      * description). Otherwise, we are appending to an existing file.
      */
     if (file_exists(SLVG))
-        testutil_checksys((ofp = fopen(SLVG, "a")) == NULL);
+        testutil_assert_errno((ofp = fopen(SLVG, "a")) != NULL);
     else {
-        testutil_checksys((ofp = fopen(SLVG, "w")) == NULL);
+        testutil_assert_errno((ofp = fopen(SLVG, "w")) != NULL);
         testutil_assert(fread(buf, 1, PSIZE, ifp) == PSIZE);
         testutil_assert(fwrite(buf, 1, PSIZE, ofp) == PSIZE);
     }
@@ -670,7 +670,7 @@ process(void)
     testutil_check(conn->close(conn, 0));
 
     /* Dump. */
-    testutil_checksys((fp = fopen(DUMP, "w")) == NULL);
+    testutil_assert_errno((fp = fopen(DUMP, "w")) != NULL);
     testutil_check(wiredtiger_open(HOME, NULL, config, &conn));
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     testutil_check(session->open_cursor(session, SLVG_URI, NULL, "dump=print", &cursor));

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -212,7 +212,7 @@ testutil_progress(TEST_OPTS *opts, const char *message)
     uint64_t now;
 
     if (opts->progress_fp == NULL)
-        testutil_checksys((opts->progress_fp = fopen(opts->progress_file_name, "w")) == NULL);
+        testutil_assert_errno((opts->progress_fp = fopen(opts->progress_file_name, "w")) != NULL);
 
     fp = opts->progress_fp;
     __wt_seconds(NULL, &now);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -100,7 +100,7 @@ typedef struct {
 
 /*
  * testutil_assert --
- *     Complain and quit if something isn't true.
+ *     Complain and quit if something isn't true, with no error value.
  */
 #define testutil_assert(a)                                                   \
     do {                                                                     \
@@ -109,8 +109,18 @@ typedef struct {
     } while (0)
 
 /*
+ * testutil_assert_errno --
+ *     Complain and quit if something isn't true, with errno.
+ */
+#define testutil_assert_errno(call)                                                 \
+    do {                                                                            \
+        if (call)                                                                   \
+            testutil_die(errno, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
+    } while (0)
+
+/*
  * testutil_assertfmt --
- *     Complain and quit if something isn't true.
+ *     Complain and quit if something isn't true, with no error value, with formatted output.
  */
 #define testutil_assertfmt(a, fmt, ...)                                                         \
     do {                                                                                        \
@@ -130,19 +140,8 @@ typedef struct {
     } while (0)
 
 /*
- * testutil_checksys --
- *     Complain and quit if a function call fails, returning errno. The error test must be
- *     specified, not just the call, because system calls fail in a variety of ways.
- */
-#define testutil_checksys(call)                                                     \
-    do {                                                                            \
-        if (call)                                                                   \
-            testutil_die(errno, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
-    } while (0)
-
-/*
  * testutil_checkfmt --
- *     Complain and quit if a function call fails, with additional arguments.
+ *     Complain and quit if a function call fails, with formatted output.
  */
 #define testutil_checkfmt(call, fmt, ...)                                                 \
     do {                                                                                  \

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -112,10 +112,10 @@ typedef struct {
  * testutil_assert_errno --
  *     Complain and quit if something isn't true, with errno.
  */
-#define testutil_assert_errno(call)                                                 \
-    do {                                                                            \
-        if (call)                                                                   \
-            testutil_die(errno, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #call); \
+#define testutil_assert_errno(a)                                                 \
+    do {                                                                         \
+        if (!(a))                                                                \
+            testutil_die(errno, "%s/%d: %s", __PRETTY_FUNCTION__, __LINE__, #a); \
     } while (0)
 
 /*


### PR DESCRIPTION
Rename test_checksys() to test_assert_errno(), flipping the sense of the test.