### PR TITLE
WT-8463 Fix 'format-pedantic' error in ex_verbose

### DIFF
--- a/examples/c/ex_verbose.c
+++ b/examples/c/ex_verbose.c
@@ -43,7 +43,7 @@ handle_wiredtiger_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, const 
 {
     /* Unused parameters */
     (void)handler;
-    printf("WiredTiger Message - Session: %p, Message: %s\n", session, message);
+    printf("WiredTiger Message - Session: %p, Message: %s\n", (void *)session, message);
 
     return (0);
 }


### PR DESCRIPTION
Explicitly cast the session pointer in ex_verbose to meet the
print format argument. This fixing a warning triggered by the
'format-pedantic' compiler diagnostic.