### PR TITLE
WT-8475 isblank() build failure on NetBSD

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1280,7 +1280,7 @@ config_file(const char *name)
 
         /* Skip any leading whitespace. */
         for (p = buf; *p != '\0'; ++p)
-            if (!isblank(*p))
+            if (!isblank((unsigned char)*p))
                 break;
 
         /* Skip any Evergreen timestamp. */
@@ -1293,7 +1293,7 @@ config_file(const char *name)
 
         /* Skip any trailing whitespace. */
         for (; *p != '\0'; ++p)
-            if (!isblank(*p))
+            if (!isblank((unsigned char)*p))
                 break;
 
         /* Skip any comments or empty lines. */


### PR DESCRIPTION
Fix calls to isblank(); they're supposed to be passed 0..255 (or EOF) but not -2..-128. NetBSD's libc has been arranged to generate a warning (and thus fail statically) if char is passed; it should be cast to unsigned char.