### PR TITLE
WT-8474 review clang analyzer warnings

### DIFF
--- a/build_posix/aclocal/strict.m4
+++ b/build_posix/aclocal/strict.m4
@@ -158,7 +158,6 @@ AC_DEFUN([AM_CLANG_WARNINGS], [
 	# FIXME-WT-8052: Figure out whether we want to disable these or change the code.
 	w="$w -Wno-implicit-int-float-conversion"
 	w="$w -Wno-implicit-fallthrough"
-	w="$w -Wno-maybe-uninitialized"
 
 	# Ignore unrecognized options.
 	w="$w -Wno-unknown-warning-option"

--- a/cmake/strict/strict_flags_helpers.cmake
+++ b/cmake/strict/strict_flags_helpers.cmake
@@ -169,6 +169,7 @@ function(get_clang_base_flags flags)
         list(APPEND clang_flags "-Wno-unused-command-line-argument")
     endif()
 
+    # FIXME-WT-8052: Figure out whether we want to disable these or change the code.
     if(${cmake_compiler_version} VERSION_GREATER_EQUAL 10)
         # Clang 10+ has added additional on-by-default diagnostics that isn't
         # compatible with some of the code patterns in WiredTiger.

--- a/dist/s_clang-scan.diff
+++ b/dist/s_clang-scan.diff
@@ -1,7 +1,3 @@
-src/block/block_ckpt_scan.c:273:14: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-        if ((ret = __wt_read(session, fh, offset, (size_t)WT_BTREE_MIN_ALLOC_SIZE, tmp->mem)) != 0)
-             ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
 In file included from src/block/block_write.c:9:
 In file included from ./src/include/wt_internal.h:439:
 ./src/include/intpack_inline.h:193:7: warning: Assigned value is garbage or undefined
@@ -26,91 +22,7 @@ src/btree/bt_read.c:99:18: warning: Although the value stored to 'time_stop' is 
     time_start = time_stop = 0;
                  ^           ~
 1 warning generated.
-src/btree/bt_sync.c:445:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-1 warning generated.
 src/conn/conn_capacity.c:289:5: warning: Value stored to 'capacity' is never read
     capacity = steal_capacity = 0;
     ^          ~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/conn/conn_stat.c:413:11: warning: Although the value stored to 'locked' is used in the enclosing expression, the value is never actually read from 'locked'
-    cnt = locked = 0;
-          ^        ~
-1 warning generated.
-src/conn/conn_dhandle.c:643:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-src/conn/conn_dhandle.c:696:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-2 warnings generated.
-src/cursor/cur_index.c:369:10: warning: Although the value stored to 'cp' is used in the enclosing expression, the value is never actually read from 'cp'
-    if ((cp = cindex->cg_cursors) != NULL)
-         ^    ~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/evict/evict_page.c:105:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0; /* [-Werror=maybe-uninitialized] */
-                 ^           ~
-1 warning generated.
-src/evict/evict_stat.c:34:31: warning: Although the value stored to 'size' is used in the enclosing expression, the value is never actually read from 'size'
-    pages_leaf = seen_count = size = visited_count = 0;
-                              ^      ~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/cursor/cur_stat.c:634:10: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-    if ((ret = __wt_config_gets(session, cfg, "statistics", &cval)) == 0) {
-         ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/history/hs_verify.c:180:14: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-        if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0) {
-             ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/evict/evict_lru.c:2270:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-src/evict/evict_lru.c:2336:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-2 warnings generated.
-src/lsm/lsm_merge.c:341:36: warning: Although the value stored to 'locked' is used in the enclosing expression, the value is never actually read from 'locked'
-    created_chunk = create_bloom = locked = in_sync = false;
-                                   ^        ~~~~~~~~~~~~~~~
-1 warning generated.
-src/log/log_slot.c:527:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0;
-                 ^           ~
-1 warning generated.
-src/schema/schema_alter.c:117:10: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-    if ((ret = __wt_config_getones(session, value, "source", &cval)) != 0)
-         ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/schema/schema_create.c:371:28: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-    if (cgname != NULL && (ret = __wt_config_subgets(session, &table->cgconf, cgname, &cval)) != 0)
-                           ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-src/schema/schema_create.c:586:14: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-        if ((ret = __wt_config_getones(session, config, "key_format", &kval)) != 0)
-             ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-2 warnings generated.
-src/schema/schema_rename.c:147:10: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-    if ((ret = __wt_config_getones(session, value, "source", &cval)) != 0)
-         ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/support/hazard.c:322:34: warning: Although the value stored to 'j' is used in the enclosing expression, the value is never actually read from 'j'
-    for (s = conn->sessions, i = j = max = walk_cnt = 0; i < session_cnt; ++s, ++i) {
-                                 ^   ~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/support/mtx_rw.c:181:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0; /* -Wconditional-uninitialized */
-                 ^           ~
-src/support/mtx_rw.c:372:18: warning: Although the value stored to 'time_stop' is used in the enclosing expression, the value is never actually read from 'time_stop'
-    time_start = time_stop = 0; /* -Wconditional-uninitialized */
-                 ^           ~
-2 warnings generated.
-src/tiered/tiered_handle.c:129:13: warning: Although the value stored to 'ret' is used in the enclosing expression, the value is never actually read from 'ret'
-    while ((ret = __wt_config_next(&cparser, &ck, &cv)) == 0) {
-            ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 warning generated.
-src/txn/txn_ckpt.c:775:19: warning: Although the value stored to 'logging' is used in the enclosing expression, the value is never actually read from 'logging'
-    full = idle = logging = tracking = use_timestamp = false;
-                  ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1 warning generated.

--- a/src/block/block_ckpt_scan.c
+++ b/src/block/block_ckpt_scan.c
@@ -270,7 +270,7 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
          * Read the start of a possible page and get a block length from it. Move to the next
          * allocation sized boundary, we'll never consider this one again.
          */
-        if ((ret = __wt_read(session, fh, offset, (size_t)WT_BTREE_MIN_ALLOC_SIZE, tmp->mem)) != 0)
+        if (__wt_read(session, fh, offset, (size_t)WT_BTREE_MIN_ALLOC_SIZE, tmp->mem) != 0)
             break;
         blk = WT_BLOCK_HEADER_REF(tmp->mem);
         __wt_block_header_byteswap(blk);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -438,7 +438,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     uint64_t internal_bytes, internal_pages, leaf_bytes, leaf_pages;
     uint64_t oldest_id, saved_pinned_id, time_start, time_stop;
     uint32_t flags, rec_flags;
-    bool dirty, internal_cleanup, is_hs, timer, tried_eviction;
+    bool dirty, internal_cleanup, is_hs, tried_eviction;
 
     conn = S2C(session);
     btree = S2BT(session);
@@ -446,7 +446,6 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     memset(&ref_list, 0, sizeof(ref_list));
     txn = session->txn;
     tried_eviction = false;
-    time_start = time_stop = 0;
 
     /* Don't bump page read generations. */
     flags = WT_READ_NO_GEN;
@@ -463,9 +462,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     internal_bytes = leaf_bytes = 0;
     internal_pages = leaf_pages = 0;
     saved_pinned_id = WT_SESSION_TXN_SHARED(session)->pinned_id;
-    timer = WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT);
-    if (timer)
-        time_start = __wt_clock(session);
+    time_start = WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT) ? __wt_clock(session) : 0;
 
     switch (syncop) {
     case WT_SYNC_WRITE_LEAVES:
@@ -679,7 +676,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         break;
     }
 
-    if (timer) {
+    if (time_start != 0) {
         time_stop = __wt_clock(session);
         __wt_verbose(session, WT_VERB_CHECKPOINT,
           "__sync_file WT_SYNC_%s wrote: %" PRIu64 " leaf pages (%" PRIu64 "B), %" PRIu64

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -410,7 +410,7 @@ __statlog_lsm_apply(WT_SESSION_IMPL *session)
     bool locked;
     char **p;
 
-    cnt = locked = 0;
+    cnt = 0;
 
     /*
      * Walk the list of LSM trees, checking for a match on the set of sources.

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -366,7 +366,7 @@ __curindex_close(WT_CURSOR *cursor)
     JOINABLE_CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, NULL);
 err:
 
-    if ((cp = cindex->cg_cursors) != NULL)
+    if (cindex->cg_cursors != NULL)
         for (i = 0, cp = cindex->cg_cursors; i < WT_COLGROUPS(cindex->table); i++, cp++)
             if (*cp != NULL) {
                 WT_TRET((*cp)->close(*cp));

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -632,7 +632,9 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
      */
     if (!WT_STAT_ENABLED(session))
         goto config_err;
-    if ((ret = __wt_config_gets(session, cfg, "statistics", &cval)) == 0) {
+    ret = __wt_config_gets(session, cfg, "statistics", &cval);
+    WT_ERR_NOTFOUND_OK(ret, true);
+    if (ret == 0) {
         if ((ret = __wt_config_subgets(session, &cval, "all", &sval)) == 0 && sval.val != 0) {
             if (!FLD_ISSET(conn->stat_flags, WT_STAT_TYPE_ALL))
                 goto config_err;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -102,7 +102,6 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     force_evict_hs = false;
     local_gen = false;
-    time_start = time_stop = 0; /* [-Werror=maybe-uninitialized] */
 
     __wt_verbose(
       session, WT_VERB_EVICT, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -124,6 +123,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
      * Track how long forcible eviction took. Immediately increment the forcible eviction counter,
      * we might do an in-memory split and not an eviction, which skips the other statistics.
      */
+    time_start = 0;
     if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
         time_start = __wt_clock(session);
         WT_STAT_CONN_INCR(session, cache_eviction_force);
@@ -205,7 +205,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     else
         WT_ERR(__evict_page_dirty_update(session, ref, flags));
 
-    if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+    if (time_start != 0 /* WT_EVICT_CALL_URGENT */) {
         time_stop = __wt_clock(session);
         if (force_evict_hs)
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
@@ -233,7 +233,7 @@ err:
         if (!closing)
             __evict_exclusive_clear(session, ref, previous_state);
 
-        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+        if (time_start != 0 /* WT_EVICT_CALL_URGENT */) {
             time_stop = __wt_clock(session);
             if (force_evict_hs)
                 WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -205,7 +205,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     else
         WT_ERR(__evict_page_dirty_update(session, ref, flags));
 
-    if (time_start != 0 /* WT_EVICT_CALL_URGENT */) {
+    if (time_start != 0) {
         time_stop = __wt_clock(session);
         if (force_evict_hs)
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
@@ -233,7 +233,7 @@ err:
         if (!closing)
             __evict_exclusive_clear(session, ref, previous_state);
 
-        if (time_start != 0 /* WT_EVICT_CALL_URGENT */) {
+        if (time_start != 0) {
             time_stop = __wt_clock(session);
             if (force_evict_hs)
                 WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -22,7 +22,7 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
     uint64_t dsk_size, gen_gap, gen_gap_max, gen_gap_sum, max_pagesize;
     uint64_t min_written_size, num_memory, num_not_queueable, num_queued;
     uint64_t num_smaller_allocsz, pages_clean, pages_dirty, pages_internal;
-    uint64_t pages_leaf, seen_count, size, visited_count;
+    uint64_t pages_leaf, seen_count, visited_count;
     uint64_t visited_age_gap_sum, unvisited_count, unvisited_age_gap_sum;
     uint64_t walk_count, written_size_cnt, written_size_sum;
 
@@ -31,7 +31,7 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
     gen_gap_max = gen_gap_sum = max_pagesize = 0;
     num_memory = num_not_queueable = num_queued = 0;
     num_smaller_allocsz = pages_clean = pages_dirty = pages_internal = 0;
-    pages_leaf = seen_count = size = visited_count = 0;
+    pages_leaf = seen_count = visited_count = 0;
     visited_age_gap_sum = unvisited_count = unvisited_age_gap_sum = 0;
     walk_count = written_size_cnt = written_size_sum = 0;
     min_written_size = UINT64_MAX;
@@ -42,7 +42,8 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
       next_walk != NULL) {
         ++seen_count;
         page = next_walk->page;
-        size = page->memory_footprint;
+        if (page->memory_footprint > max_pagesize)
+            max_pagesize = page->memory_footprint;
 
         if (__wt_page_is_modified(page))
             ++pages_dirty;
@@ -54,9 +55,6 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
 
         if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU))
             ++num_queued;
-
-        if (size > max_pagesize)
-            max_pagesize = size;
 
         dsk_size = page->dsk != NULL ? page->dsk->mem_size : 0;
         if (dsk_size != 0) {

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -179,7 +179,7 @@ __wt_hs_verify(WT_SESSION_IMPL *session)
         WT_ERR(hs_cursor->get_key(hs_cursor, &btree_id, &key, &hs_start_ts, &hs_counter));
         if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0) {
             F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
-            WT_ERR_PANIC(session, WT_PANIC,
+            WT_ERR_PANIC(session, ret,
               "Unable to find btree id %" PRIu32 " in the metadata file for the associated key %s",
               btree_id, __wt_buf_set_printable(session, key.data, key.size, false, buf));
         }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -524,6 +524,7 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
 
     conn = S2C(session);
     log = conn->log;
+    time_start = 0;
 
     WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
     WT_ASSERT(session, mysize != 0);
@@ -544,8 +545,6 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
         unbuffered = true;
         F_SET(myslot, WT_MYSLOT_UNBUFFERED);
     }
-
-    time_start = 0;
     for (;;) {
         WT_BARRIER();
         slot = log->active_slot;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -524,7 +524,6 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
 
     conn = S2C(session);
     log = conn->log;
-    time_start = time_stop = 0;
 
     WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
     WT_ASSERT(session, mysize != 0);
@@ -545,6 +544,8 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
         unbuffered = true;
         F_SET(myslot, WT_MYSLOT_UNBUFFERED);
     }
+
+    time_start = 0;
     for (;;) {
         WT_BARRIER();
         slot = log->active_slot;

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -338,7 +338,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
     bloom = NULL;
     chunk = NULL;
     dest = src = NULL;
-    created_chunk = create_bloom = locked = in_sync = false;
+    created_chunk = create_bloom = in_sync = false;
 
     /* Fast path if it's obvious no merges could be done. */
     if (lsm_tree->nchunks < lsm_tree->merge_min &&

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -113,9 +113,10 @@ __alter_tree(WT_SESSION_IMPL *session, const char *name, const char *newcfg[])
     /* Read the schema value. */
     WT_ERR(__wt_metadata_search(session, name, &value));
 
-    /* Get the data source URI. */
+    /* Get the data source URI, converting not-found errors to EINVAL for the application. */
     if ((ret = __wt_config_getones(session, value, "source", &cval)) != 0)
-        WT_ERR_MSG(session, EINVAL, "index or column group has no data source: %s", value);
+        WT_ERR_MSG(session, ret == WT_NOTFOUND ? EINVAL : ret,
+          "index or column group has no data source: %s", value);
 
     WT_ERR(__wt_scr_alloc(session, 0, &data_source));
     WT_ERR(__wt_buf_fmt(session, data_source, "%.*s", (int)cval.len, cval.str));

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -144,8 +144,10 @@ __rename_tree(WT_SESSION_IMPL *session, WT_TABLE *table, const char *newuri, con
     else
         WT_ERR(__wt_schema_index_source(session, table, suffix, value, ns));
 
+    /* Convert not-found errors to EINVAL for the application. */
     if ((ret = __wt_config_getones(session, value, "source", &cval)) != 0)
-        WT_ERR_MSG(session, EINVAL, "index or column group has no data source: %s", value);
+        WT_ERR_MSG(session, ret == WT_NOTFOUND ? EINVAL : ret,
+          "index or column group has no data source: %s", value);
 
     /* Take a copy of the old data source. */
     WT_ERR(__wt_scr_alloc(session, 0, &os));

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -323,7 +323,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
      * started our check.
      */
     WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    for (s = conn->sessions, i = j = max = walk_cnt = 0; i < session_cnt; ++s, ++i) {
+    for (s = conn->sessions, i = max = walk_cnt = 0; i < session_cnt; ++s, ++i) {
         if (!s->active)
             continue;
 

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -132,6 +132,7 @@ __tiered_create_local(WT_SESSION_IMPL *session, WT_TIERED *tiered)
             WT_ERR(__wt_buf_catfmt(
               session, build, "%.*s=%.*s,", (int)ck.len, ck.str, (int)cv.len, cv.str));
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
     __wt_free(session, config);
     WT_ERR(__wt_strndup(session, build->data, build->size, &config));
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -813,7 +813,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     txn = session->txn;
     txn_global = &conn->txn_global;
     saved_isolation = session->isolation;
-    full = idle = logging = tracking = use_timestamp = false;
+    full = idle = tracking = use_timestamp = false;
 
     /* Avoid doing work if possible. */
     WT_RET(__txn_checkpoint_can_skip(session, cfg, &full, &use_timestamp, &can_skip));


### PR DESCRIPTION
This branch fixes all but a few of the clang-scan warnings (there's another branch for WT-8466 that moves some files around and fixes two that remain, the ones in `bt_read.c`  and `bt_io.c`).

I did a commit per file, hopefully that makes it more obvious what got changed.