### PR TITLE
WT-8483 Use diagnostics on CMake wt_objs target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ if(WITH_PIC OR ENABLE_SHARED)
         ${CMAKE_CURRENT_BINARY_DIR}/config
         ${CMAKE_CURRENT_LIST_DIR}/src/include
     )
+    # Append any provided C flags.
+    if(COMPILER_DIAGNOSTIC_C_FLAGS)
+        target_compile_options(wt_objs PRIVATE ${COMPILER_DIAGNOSTIC_C_FLAGS})
+    endif()
     if(ENABLE_TCMALLOC)
         target_include_directories(wt_objs PRIVATE ${HAVE_LIBTCMALLOC_INCLUDES})
     endif()


### PR DESCRIPTION
If strict is enabled, the intermediate wt_objs target in CMake
needs to compile with the diagnostic flag. This change corrects a
bug where our CMake build didn't apply the diagnostic flags to
the intermediate object library.