### PR TITLE
WT-8360 Remove WT_TEST output file when test finishes in recovery-test script

### DIFF
--- a/test/checkpoint/recovery-test.sh
+++ b/test/checkpoint/recovery-test.sh
@@ -40,4 +40,5 @@ while kill -STOP $pid ; do
 	./t -t r -D -v -h $recovery || exit 1
 done
 
+rm -rf $home $home.out
 exit 0

--- a/test/checkpoint/recovery-test.sh
+++ b/test/checkpoint/recovery-test.sh
@@ -40,5 +40,7 @@ while kill -STOP $pid ; do
 	./t -t r -D -v -h $recovery || exit 1
 done
 
+# Clean the home directory once the test is completed. Note that once we fail to send the signal to
+# stop the test, it means that it is completed.
 rm -rf $home $home.out
 exit 0

--- a/tools/run_parallel.sh
+++ b/tools/run_parallel.sh
@@ -60,6 +60,7 @@ for i in $(seq $num_iter); do
     if [[ $err -ne 0 ]]
     then
       echo "iteration $i of parallel command $t failed with $err error code"
+      tail -n 100 nohup.out.$t
       exit $err
     fi
   done


### PR DESCRIPTION
Currently our evergreen task, uses the parallel script to run the recovery-test.sh script through multiple iterations of parrallel jobs. We need to clear the WT_TEST.out file after we finish executing the test, because another iteration of the script will grep for WT_TEST.out on a completed test run. This is dangerous behaviour.