### PR TITLE
WT-8487 FLCS reconciliation zeroes the entire disk buffer in advance

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -728,7 +728,7 @@ __debug_dsk_col_fix(WT_DBG *ds, const WT_PAGE_HEADER *dsk)
         WT_RET(ds->f(ds, "}\n"));
     }
 
-    if (auxhdr.offset > dsk->mem_size)
+    if (auxhdr.dataoffset > dsk->mem_size)
         /* Print something useful instead of crashing or failing. */
         WT_RET(ds->f(ds, "page is corrupt: offset to time windows is past end of page"));
     else if (auxhdr.version == WT_COL_FIX_VERSION_TS) {

--- a/src/include/bitstring_inline.h
+++ b/src/include/bitstring_inline.h
@@ -370,3 +370,49 @@ __bit_setv(uint8_t *bitf, uint64_t entry, uint8_t width, uint8_t value)
 		break;
 	}
 }
+
+/*
+ * __bit_clear_end --
+ *     Clear the leftover end bits of a fixed-length column store bitstring.
+ */
+static inline void
+__bit_clear_end(uint8_t *bitf, uint64_t numentries, uint8_t width)
+{
+	uint64_t byte, firstbit;
+        uint8_t mask;
+
+	firstbit = numentries * width;
+        byte = __bit_byte(firstbit);
+        mask = __bit_mask(firstbit);
+
+        /* If mask is the first bit of the next byte, we don't need to do anything. */
+        if (mask == 0x01)
+            return;
+
+        /* Convert e.g. 0b01000000 to 0b01111111 and use the resulting mask to clear. */
+        mask = (mask << 1) - 1;
+        bitf[byte] &= ~mask;
+}
+
+/*
+ * __bit_end_is_clear --
+ *     Check the leftover end bits of a fixed-length column store bitstring.
+ */
+static inline bool
+__bit_end_is_clear(const uint8_t *bitf, uint64_t numentries, uint8_t width)
+{
+	uint64_t byte, firstbit;
+        uint8_t mask;
+
+	firstbit = numentries * width;
+        byte = __bit_byte(firstbit);
+        mask = __bit_mask(firstbit);
+
+        /* If mask is the first bit of the next byte, there's nothing to check. */
+        if (mask == 0x01)
+            return (true);
+
+        /* Convert e.g. 0b01000000 to 0b01111111 and read with the resulting mask. */
+        mask = (mask << 1) - 1;
+        return ((bitf[byte] & mask) == 0);
+}

--- a/src/include/bitstring_inline.h
+++ b/src/include/bitstring_inline.h
@@ -383,14 +383,14 @@ __bit_clear_end(uint8_t *bitf, uint64_t numentries, uint8_t width)
 
 	firstbit = numentries * width;
         byte = __bit_byte(firstbit);
-        mask = __bit_mask(firstbit);
+        mask = (uint8_t)__bit_mask(firstbit);
 
         /* If mask is the first bit of the next byte, we don't need to do anything. */
         if (mask == 0x01)
             return;
 
         /* Convert e.g. 0b01000000 to 0b01111111 and use the resulting mask to clear. */
-        mask = (mask << 1) - 1;
+        mask = (uint8_t)((uint16_t)mask << 1) - 1;
         bitf[byte] &= ~mask;
 }
 
@@ -406,13 +406,13 @@ __bit_end_is_clear(const uint8_t *bitf, uint64_t numentries, uint8_t width)
 
 	firstbit = numentries * width;
         byte = __bit_byte(firstbit);
-        mask = __bit_mask(firstbit);
+        mask = (uint8_t)__bit_mask(firstbit);
 
         /* If mask is the first bit of the next byte, there's nothing to check. */
         if (mask == 0x01)
             return (true);
 
         /* Convert e.g. 0b01000000 to 0b01111111 and read with the resulting mask. */
-        mask = (mask << 1) - 1;
+        mask = (uint8_t)(((uint16_t)mask << 1) - 1);
         return ((bitf[byte] & mask) == 0);
 }

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1408,7 +1408,8 @@ struct __wt_insert_head {
  * 2^32 versions.
  *
  * This struct is the in-memory representation. The number of entries is the number of time windows
- * (there are twice as many cells) and the offset is from the beginning of the page.
+ * (there are twice as many cells) and the offsets is from the beginning of the page. The space
+ * between the empty offset and the data offset is not used and is expected to be zeroed.
  *
  * This structure is only used when handling on-disk pages; once the page is read in, one should
  * instead use the time window index in the page structure, which is a different type found above.
@@ -1416,7 +1417,8 @@ struct __wt_insert_head {
 struct __wt_col_fix_auxiliary_header {
     uint32_t version;
     uint32_t entries;
-    uint32_t offset;
+    uint32_t emptyoffset;
+    uint32_t dataoffset;
 };
 
 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1189,12 +1189,12 @@ __wt_page_cell_data_ref(WT_SESSION_IMPL *session, WT_PAGE *page, void *unpack_ar
              __cell += (unpack).__len, --__i) {                                                 \
             __wt_cell_unpack_kv(session, dsk, (WT_CELL *)__cell, &(unpack));
 
-#define WT_CELL_FOREACH_FIX_TIMESTAMPS(session, dsk, aux, unpack)                          \
-    do {                                                                                   \
-        uint32_t __i;                                                                      \
-        uint8_t *__cell;                                                                   \
-        for (__cell = (uint8_t *)(dsk) + (aux)->offset, __i = (aux)->entries * 2; __i > 0; \
-             __cell += (unpack).__len, --__i) {                                            \
+#define WT_CELL_FOREACH_FIX_TIMESTAMPS(session, dsk, aux, unpack)                              \
+    do {                                                                                       \
+        uint32_t __i;                                                                          \
+        uint8_t *__cell;                                                                       \
+        for (__cell = (uint8_t *)(dsk) + (aux)->dataoffset, __i = (aux)->entries * 2; __i > 0; \
+             __cell += (unpack).__len, --__i) {                                                \
             __wt_cell_unpack_kv(session, dsk, (WT_CELL *)__cell, &(unpack));
 
 #define WT_CELL_FOREACH_END \

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -942,6 +942,10 @@ __wt_rec_col_fix(
                 WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &unpack.tw);
             }
 
+            /* Make sure the trailing bits in the bitmap get cleared. */
+            __bit_clear_end(
+              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+
             /* Now split. */
             WT_ERR(__wt_rec_split(session, r, 0));
 
@@ -972,6 +976,9 @@ __wt_rec_col_fix(
         WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &unpack.tw);
     }
 
+    /* Make sure the trailing bits in the bitmap get cleared. */
+    __bit_clear_end(WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+
     /* Write the remnant page. */
     WT_ERR(__wt_rec_split_finish(session, r));
 
@@ -991,7 +998,7 @@ __wt_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint
   uint32_t auxentries, uint8_t *image, size_t size)
 {
     WT_BTREE *btree;
-    uint32_t auxdataoffset, auxheaderoffset, bitmapsize, offset;
+    uint32_t auxdataoffset, auxheaderoffset, bitmapsize, offset, space;
     uint8_t *endp, *p;
 
     btree = S2BT(session);
@@ -1078,9 +1085,6 @@ __wt_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint
      */
     WT_STATIC_ASSERT(WT_COL_FIX_AUXHEADER_SIZE_MAX < POS_1BYTE_MAX);
 
-    /* Should not be overwriting anything. */
-    WT_ASSERT(session, image[auxheaderoffset] == 0);
-
     p = image + auxheaderoffset;
     endp = image + auxdataoffset;
 
@@ -1088,6 +1092,11 @@ __wt_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint
     WT_IGNORE_RET(__wt_vpack_uint(&p, WT_PTRDIFF32(endp, p), auxentries));
     WT_IGNORE_RET(__wt_vpack_uint(&p, WT_PTRDIFF32(endp, p), offset));
     WT_ASSERT(session, p <= endp);
+
+    /* Zero the empty space, if any. */
+    space = WT_PTRDIFF32(endp, p);
+    if (space > 0)
+        memset(p, 0, space);
 }
 
 /*

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -35,6 +35,8 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
              */
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
+            __bit_clear_end(
+              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
             WT_RET(__wt_rec_split(session, r, 0));
         }
         cbulk->entry = 0;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -883,7 +883,8 @@ __rec_split_chunk_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *
 
 #ifdef HAVE_DIAGNOSTIC
     /*
-     * For fixed-length column-store, poison the rest of the buffer.
+     * For fixed-length column-store, poison the rest of the buffer. This helps verify ensure that
+     * all the bytes in the buffer are explicitly set and not left uninitialized.
      */
     if (r->page->type == WT_PAGE_COL_FIX)
         memset((uint8_t *)chunk->image.mem + WT_PAGE_HEADER_SIZE, 0xa9,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2097,9 +2097,12 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 
     switch (btree->type) {
     case BTREE_COL_FIX:
-        if (cbulk->entry != 0)
+        if (cbulk->entry != 0) {
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
+            __bit_clear_end(
+              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
+        }
         break;
     case BTREE_COL_VAR:
         if (cbulk->rle != 0)


### PR DESCRIPTION
Don't zero the whole FLCS disk buffer up front.
- Explicitly zero the leftover bits in the last byte of the bitmap data, if any.
- Explicitly zero the empty/wasted space on odd-sized pages.
- Check both these points in __verify_dsk_col_fix.

This requires adjusting the auxiliary header read code slightly to expose the empty space, which previously had been abstracted away.

While here, remove accidental doubled check in __verify_dsk_col_fix.