### PR TITLE
WT-8502 Remove duplicate key in Evergreen file

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3669,7 +3669,6 @@ tasks:
           perf-test-name: checkpoint-stress.wtperf
 
   - name: many-dhandle-stress
-    commands:
     depends_on:
       - name: compile
     commands:


### PR DESCRIPTION
The issue was not detected by the `validate` command from Evergreen. The Evergreen team was informed.