### PR TITLE
WT-8514 Apply an explicit page size limit to FLCS pages

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -383,7 +383,9 @@ file_config = format_meta + file_runtime_config + tiered_config + [
         applications wanting to maximize sequential data transfer from
         a storage device.  The page maximum is the bytes of uncompressed
         data, that is, the limit is applied before any block compression
-        is done''',
+        is done.  For fixed-length column store, the size includes only the
+        bitmap data; pages containing timestamp information can be larger,
+        and the size is limited to 128KB rather than 512MB''',
         min='512B', max='512MB'),
     Config('leaf_value_max', '0', r'''
         the largest value stored in a leaf node, in bytes.  If set, values

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -886,6 +886,20 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
           btree->allocsize);
 
     /*
+     * FLCS leaf pages have a lower size limit than the default, because the size configures the
+     * bitmap data size and the timestamp data adds on to that. Each time window can be up to 63
+     * bytes and the total page size must not exceed 4G. Thus for an 8t table there can be 64M
+     * entries (so 64M of bitmap data and up to 63*64M == 4032M of time windows), less a bit for
+     * headers. For a 1t table there can be (64 7/8)M entries because the bitmap takes less space,
+     * but that corresponds to a configured page size of a bit over 8M. Consequently the absolute
+     * limit on the page size is 8M, but since pages this large make no sense and perform poorly
+     * even if they don't get bloated out with timestamp data, we'll cut down by a factor of 16 and
+     * set the limit to 128KB.
+     */
+    if (btree->type == BTREE_COL_FIX && btree->maxleafpage > 128 * WT_KILOBYTE)
+        WT_RET_MSG(session, EINVAL, "page size for fixed-length column store is limited to 128KB");
+
+    /*
      * Default in-memory page image size for compression is 4x the maximum internal or leaf page
      * size, and enforce the on-disk page sizes as a lower-limit for the in-memory image size.
      */

--- a/src/docs/tune-page-size-and-comp.dox
+++ b/src/docs/tune-page-size-and-comp.dox
@@ -152,6 +152,9 @@ An example of such a configuration string is as follows:
 The maximum page size for the reconciled on-disk leaf pages of the B-Tree, in
 bytes. When a leaf page grows past this size, it splits into multiple pages.
  - An integer, with acceptable values between 512B and 512MB
+(fixed-length column store pages are limited to 128KB; the configured
+size does not include the additional size of timestamp information
+when timestamps are in use)
  - Default size: 32 KB (*appropriate for applications with relatively small keys
 and values)
  - Additionally constrained by the condition: must be a multiple of the

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1202,7 +1202,9 @@ struct __wt_session {
 	 * a multiple of the allocation size\, and is significant for applications wanting to
 	 * maximize sequential data transfer from a storage device.  The page maximum is the bytes
 	 * of uncompressed data\, that is\, the limit is applied before any block compression is
-	 * done., an integer between 512B and 512MB; default \c 32KB.}
+	 * done.  For fixed-length column store\, the size includes only the bitmap data; pages
+	 * containing timestamp information can be larger\, and the size is limited to 128KB rather
+	 * than 512MB., an integer between 512B and 512MB; default \c 32KB.}
 	 * @config{leaf_value_max, the largest value stored in a leaf node\, in bytes.  If set\,
 	 * values larger than the specified size are stored as overflow items (which may require
 	 * additional I/O to access). If the size is larger than the maximum leaf page size\, the


### PR DESCRIPTION
Because the configured page size is used to size the bitmap data and the time windows come along for the ride, and the time windows (if present) are much larger than the data itself, the default page size limit of 512M allows generating pages far larger than 4G.

The hard limit on the page size is around 8M; an 8M bitmap in a 1t table has 64 million entries, each of which can in theory have a time window as large as 63 bytes attached, for a total space of just under 4G.

However, because FLCS pages that size perform poorly even when they aren't bloated out with timestamps, set the limit much lower, to a somewhat arbitrarily selected 128K, which is still considerably larger than you'd actually want to use in practice.