### PR TITLE
WT-8515 Remove unit-test-with-compile function as it is redundant.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1731,13 +1731,6 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
 
-  - name: unit-test-with-compile
-    tags: ["python"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "unit test"
-
   - name: unit-test-zstd
     tags: ["python"]
     depends_on:
@@ -4211,7 +4204,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: unit-test-with-compile
+    - name: unit-test
     - name: fops
 
 - name: macos-1014-cmake


### PR DESCRIPTION
the `unit-test-with-compile` task is only called in the` macos-1014` build variant. 