### PR TITLE
WT-8520 Reorder csuite tests in the long-test task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2261,6 +2261,12 @@ tasks:
       - func: "csuite test"
         vars:
           test_binary: test_random_abort
+
+      # truncated-log
+      - func: "csuite test"
+        vars:
+          test_binary: test_truncated_log
+
       # random-abort - minimum time, random number of threads
       - func: "csuite test"
         vars:
@@ -2276,11 +2282,6 @@ tasks:
         vars:
           test_args: -c -t 60
           test_binary: test_random_abort
-
-      # truncated-log
-      - func: "csuite test"
-        vars:
-          test_binary: test_truncated_log
 
       # format test
       - func: "format test"


### PR DESCRIPTION
In Evergreen, variables live within the scope of a task. If a function
defines a variable once, it will persist and be visible to the
subsequent function calls within that task. If a test should not use
extra variables, it should be executed before the extra variables are
defined.