### PR TITLE
WT-8519 Use csuite functions in evergreen.yml

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2187,13 +2187,9 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           posix_configure_flags: --enable-strict ac_cv_func_ftruncate=no
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/build_posix"
-          script: |
-            set -o errexit
-            set -o verbose
-            # ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
+      - func: "csuite smoke test"
+        vars:
+          test_name: random_abort
       - func: "csuite test"
         vars:
           test_binary: test_truncated_log

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2194,7 +2194,9 @@ tasks:
             set -o errexit
             set -o verbose
             # ${test_env_vars|} $(pwd)/../test/csuite/random_abort/smoke.sh 2>&1
-            ${test_env_vars|} $(pwd)/test/csuite/test_truncated_log 2>&1
+      - func: "csuite test"
+        vars:
+          test_binary: test_truncated_log
       - func: "csuite smoke test"
         vars:
           test_name: timestamp_abort


### PR DESCRIPTION
The `ftruncate-test` was updated with the following changes:
- Use the `csuite test` function for `test_truncated_log`
- Enable and use the `csuite smoke test` for `random_abort`