### PR TITLE
WT-8522 Don't report error in Evergreen when there are no Hang Analyzer artifacts to upload

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -514,6 +514,7 @@ functions:
         aws_key: ${aws_key}
         local_file: wt-hang-analyzer.tgz
         bucket: build_external
+        optional: true
         permissions: public-read
         content_type: application/tar
         display_name: WT Hang Analyzer Output - Execution ${execution}


### PR DESCRIPTION
Don't report an error in the `save wt hang analyzer core/debugger files` task when there are no Hang Analyzer artifacts to upload.

Evergreen now prints the trace
    `file '/data/mci/a4f3beb3412bf6dd9816880952165975/wt-hang-analyzer.tgz' not found but skip missing true`
instead of the (red font) error 
    `Command failed: missing file '/data/mci/a4f3beb3412bf6dd9816880952165975/wt-hang-analyzer.tgz': problem opening file /data/mci/a4f3beb3412bf6dd9816880952165975/wt-hang-analyzer.tgz: open /data/mci/a4f3beb3412bf6dd9816880952165975/wt-hang-analyzer.tgz: no such file or directory`
in the `s3.put` step.