### PR TITLE
WT-8545 WiredTiger error messages are truncated unnecessarily

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -188,7 +188,8 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
 \t\tWT_RET(__wt_scr_alloc(session, needed, escapedp));
 \telse
 \tWT_RET(__wt_buf_grow(session, *escapedp, needed));
-\t(void)__wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size);
+\tWT_IGNORE_RET(
+\t\t__wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size));
 \treturn (0);
 }
 

--- a/dist/log.py
+++ b/dist/log.py
@@ -178,39 +178,14 @@ __wt_logop_read(WT_SESSION_IMPL *session,
 \t    session, *pp, WT_PTRDIFF(end, *pp), "II", optypep, opsizep));
 }
 
-static size_t
-__logrec_json_unpack_str(char *dest, size_t destlen, const u_char *src,
-    size_t srclen)
-{
-\tsize_t total;
-\tsize_t n;
-
-\ttotal = 0;
-\twhile (srclen > 0) {
-\t\tn = __wt_json_unpack_char(
-\t\t    *src++, (u_char *)dest, destlen, false);
-\t\tsrclen--;
-\t\tif (n > destlen)
-\t\t\tdestlen = 0;
-\t\telse {
-\t\t\tdestlen -= n;
-\t\t\tdest += n;
-\t\t}
-\t\ttotal += n;
-\t}
-\tif (destlen > 0)
-\t\t*dest = '\\0';
-\treturn (total + 1);
-}
-
 static int
 __logrec_make_json_str(WT_SESSION_IMPL *session, char **destp, WT_ITEM *item)
 {
 \tsize_t needed;
 
-\tneeded = __logrec_json_unpack_str(NULL, 0, item->data, item->size);
+\tneeded = __wt_json_unpack_str(NULL, 0, item->data, item->size) + 1;
 \tWT_RET(__wt_realloc(session, NULL, needed, destp));
-\t(void)__logrec_json_unpack_str(*destp, needed, item->data, item->size);
+\t(void)__wt_json_unpack_str((u_char *)*destp, needed, item->data, item->size);
 \treturn (0);
 }
 

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -306,7 +306,7 @@ __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 
 /*
  * __wt_json_unpack_char --
- *     Unpack a single character into JSON escaped format. Can be called with null buf for sizing.
+ *     Unpack a single character into JSON escaped format.
  */
 size_t
 __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
@@ -357,6 +357,23 @@ __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
         *buf++ = __wt_hex(ch & 0x0f);
     }
     return (6);
+}
+
+/*
+ * __wt_json_unpack_str --
+ *     Unpack a string into JSON escaped format.
+ */
+void
+__wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len)
+{
+    size_t n;
+
+    for (; src_len > 0; ++src, --src_len) {
+        n = __wt_json_unpack_char(*src, dest, dest_len, false);
+        dest_len -= n;
+        dest += n;
+    }
+    *dest = '\0';
 }
 
 /*

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -306,7 +306,8 @@ __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 
 /*
  * __wt_json_unpack_char --
- *     Unpack a single character into JSON escaped format.
+ *     Unpack a single character into JSON escaped format. Can be called with NULL buf for sizing,
+ *     and won't overwrite the buffer end in any case.
  */
 size_t
 __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
@@ -361,19 +362,24 @@ __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 
 /*
  * __wt_json_unpack_str --
- *     Unpack a string into JSON escaped format.
+ *     Unpack a string into JSON escaped format. Can be called with NULL buf for sizing and won't
+ *     overwrite the buffer end in any case.
  */
-void
+size_t
 __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len)
 {
-    size_t n;
+    size_t n, total;
 
-    for (; src_len > 0; ++src, --src_len) {
+    for (total = 0; src_len > 0; ++src, --src_len, total += n) {
         n = __wt_json_unpack_char(*src, dest, dest_len, false);
-        dest_len -= n;
-        dest += n;
+        if (dest_len >= n) {
+            dest_len -= n;
+            dest += n;
+        }
     }
-    *dest = '\0';
+    if (dest_len > 0)
+        *dest = '\0';
+    return (total);
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1665,6 +1665,8 @@ extern int64_t __wt_log_slot_release(WT_MYSLOT *myslot, int64_t size)
 extern size_t __wt_json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern size_t __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern ssize_t __wt_json_strlen(const char *src, size_t srclen) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern u_int __wt_hazard_count(WT_SESSION_IMPL *session, WT_REF *ref)
@@ -1800,7 +1802,6 @@ extern void __wt_hs_close(WT_SESSION_IMPL *session);
 extern void __wt_hs_upd_time_window(WT_CURSOR *hs_cursor, WT_TIME_WINDOW **twp);
 extern void __wt_huffman_close(WT_SESSION_IMPL *session, void *huffman_arg);
 extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
-extern void __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len);
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn);
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern void __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1800,6 +1800,7 @@ extern void __wt_hs_close(WT_SESSION_IMPL *session);
 extern void __wt_hs_upd_time_window(WT_CURSOR *hs_cursor, WT_TIME_WINDOW **twp);
 extern void __wt_huffman_close(WT_SESSION_IMPL *session, void *huffman_arg);
 extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
+extern void __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len);
 extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn);
 extern void __wt_log_slot_activate(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);
 extern void __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -57,6 +57,9 @@
 #define WT_ERR_STRING "[Error]"
 #define WT_NO_ADDR_STRING "[NoAddr]"
 
+/* Maximum length of an encoded JSON character. */
+#define WT_MAX_JSON_ENCODE 6
+
 /*
  * Sizes that cannot be larger than 2**32 are stored in uint32_t fields in common structures to save
  * space. To minimize conversions from size_t to uint32_t through the code, we use the following

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -40,37 +40,14 @@ __wt_logop_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end
     return (__wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), "II", optypep, opsizep));
 }
 
-static size_t
-__logrec_json_unpack_str(char *dest, size_t destlen, const u_char *src, size_t srclen)
-{
-    size_t total;
-    size_t n;
-
-    total = 0;
-    while (srclen > 0) {
-        n = __wt_json_unpack_char(*src++, (u_char *)dest, destlen, false);
-        srclen--;
-        if (n > destlen)
-            destlen = 0;
-        else {
-            destlen -= n;
-            dest += n;
-        }
-        total += n;
-    }
-    if (destlen > 0)
-        *dest = '\0';
-    return (total + 1);
-}
-
 static int
 __logrec_make_json_str(WT_SESSION_IMPL *session, char **destp, WT_ITEM *item)
 {
     size_t needed;
 
-    needed = __logrec_json_unpack_str(NULL, 0, item->data, item->size);
+    needed = __wt_json_unpack_str(NULL, 0, item->data, item->size) + 1;
     WT_RET(__wt_realloc(session, NULL, needed, destp));
-    (void)__logrec_json_unpack_str(*destp, needed, item->data, item->size);
+    (void)__wt_json_unpack_str((u_char *)*destp, needed, item->data, item->size);
     return (0);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -41,24 +41,32 @@ __wt_logop_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end
 }
 
 static int
-__logrec_make_json_str(WT_SESSION_IMPL *session, char **destp, WT_ITEM *item)
+__logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
     size_t needed;
 
-    needed = __wt_json_unpack_str(NULL, 0, item->data, item->size) + 1;
-    WT_RET(__wt_realloc(session, NULL, needed, destp));
-    (void)__wt_json_unpack_str((u_char *)*destp, needed, item->data, item->size);
+    needed = (item->size * WT_MAX_JSON_ENCODE) + 1;
+
+    if (*escapedp == NULL)
+        WT_RET(__wt_scr_alloc(session, needed, escapedp));
+    else
+        WT_RET(__wt_buf_grow(session, *escapedp, needed));
+    (void)__wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size);
     return (0);
 }
 
 static int
-__logrec_make_hex_str(WT_SESSION_IMPL *session, char **destp, WT_ITEM *item)
+__logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
     size_t needed;
 
-    needed = item->size * 2 + 1;
-    WT_RET(__wt_realloc(session, NULL, needed, destp));
-    __wt_fill_hex(item->data, item->size, (uint8_t *)*destp, needed, NULL);
+    needed = (item->size * 2) + 1;
+
+    if (*escapedp == NULL)
+        WT_RET(__wt_scr_alloc(session, needed, escapedp));
+    else
+        WT_RET(__wt_buf_grow(session, *escapedp, needed));
+    __wt_fill_hex(item->data, item->size, (*escapedp)->mem, (*escapedp)->memsize, NULL);
     return (0);
 }
 
@@ -108,29 +116,27 @@ __wt_logop_col_modify_print(
     uint32_t fileid;
     uint64_t recno;
     WT_ITEM value;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_col_modify_unpack(session, pp, end, &fileid, &recno, &value));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_modify\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__wt_fprintf(session, args->fs, "        \"recno\": %" PRIu64 ",\n", recno));
     WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-        WT_ERR(__wt_fprintf(session, args->fs, ",\n        \"value-hex\": \"%s\"", escaped));
+        WT_ERR(__wt_fprintf(
+          session, args->fs, ",\n        \"value-hex\": \"%s\"", (char *)escaped->mem));
     }
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 
@@ -180,29 +186,27 @@ __wt_logop_col_put_print(
     uint32_t fileid;
     uint64_t recno;
     WT_ITEM value;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_col_put_unpack(session, pp, end, &fileid, &recno, &value));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_put\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__wt_fprintf(session, args->fs, "        \"recno\": %" PRIu64 ",\n", recno));
     WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-        WT_ERR(__wt_fprintf(session, args->fs, ",\n        \"value-hex\": \"%s\"", escaped));
+        WT_ERR(__wt_fprintf(
+          session, args->fs, ",\n        \"value-hex\": \"%s\"", (char *)escaped->mem));
     }
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 
@@ -253,10 +257,8 @@ __wt_logop_col_remove_print(
 
     WT_RET(__wt_logop_col_remove_unpack(session, pp, end, &fileid, &recno));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_remove\",\n"));
     WT_RET(__wt_fprintf(
@@ -313,10 +315,8 @@ __wt_logop_col_truncate_print(
 
     WT_RET(__wt_logop_col_truncate_unpack(session, pp, end, &fileid, &start, &stop));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"col_truncate\",\n"));
     WT_RET(__wt_fprintf(
@@ -372,34 +372,33 @@ __wt_logop_row_modify_print(
     uint32_t fileid;
     WT_ITEM key;
     WT_ITEM value;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_row_modify_unpack(session, pp, end, &fileid, &key, &value));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_modify\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__logrec_make_json_str(session, &escaped, &key));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\",\n", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\",\n", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &key));
-        WT_ERR(__wt_fprintf(session, args->fs, "        \"key-hex\": \"%s\",\n", escaped));
+        WT_ERR(
+          __wt_fprintf(session, args->fs, "        \"key-hex\": \"%s\",\n", (char *)escaped->mem));
     }
     WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-        WT_ERR(__wt_fprintf(session, args->fs, ",\n        \"value-hex\": \"%s\"", escaped));
+        WT_ERR(__wt_fprintf(
+          session, args->fs, ",\n        \"value-hex\": \"%s\"", (char *)escaped->mem));
     }
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 
@@ -449,34 +448,33 @@ __wt_logop_row_put_print(
     uint32_t fileid;
     WT_ITEM key;
     WT_ITEM value;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_row_put_unpack(session, pp, end, &fileid, &key, &value));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_put\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__logrec_make_json_str(session, &escaped, &key));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\",\n", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\",\n", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &key));
-        WT_ERR(__wt_fprintf(session, args->fs, "        \"key-hex\": \"%s\",\n", escaped));
+        WT_ERR(
+          __wt_fprintf(session, args->fs, "        \"key-hex\": \"%s\",\n", (char *)escaped->mem));
     }
     WT_ERR(__logrec_make_json_str(session, &escaped, &value));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"value\": \"%s\"", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &value));
-        WT_ERR(__wt_fprintf(session, args->fs, ",\n        \"value-hex\": \"%s\"", escaped));
+        WT_ERR(__wt_fprintf(
+          session, args->fs, ",\n        \"value-hex\": \"%s\"", (char *)escaped->mem));
     }
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 
@@ -524,28 +522,26 @@ __wt_logop_row_remove_print(
     WT_DECL_RET;
     uint32_t fileid;
     WT_ITEM key;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_row_remove_unpack(session, pp, end, &fileid, &key));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_remove\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__logrec_make_json_str(session, &escaped, &key));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\"", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"key\": \"%s\"", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &key));
-        WT_ERR(__wt_fprintf(session, args->fs, ",\n        \"key-hex\": \"%s\"", escaped));
+        WT_ERR(
+          __wt_fprintf(session, args->fs, ",\n        \"key-hex\": \"%s\"", (char *)escaped->mem));
     }
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 
@@ -596,35 +592,34 @@ __wt_logop_row_truncate_print(
     WT_ITEM start;
     WT_ITEM stop;
     uint32_t mode;
-    char *escaped;
+    WT_DECL_ITEM(escaped);
 
-    escaped = NULL;
     WT_RET(__wt_logop_row_truncate_unpack(session, pp, end, &fileid, &start, &stop, &mode));
 
-    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID) {
-        WT_RET(__wt_fprintf(session, args->fs, " REDACTED"));
-        return (0);
-    }
+    if (!FLD_ISSET(args->flags, WT_TXN_PRINTLOG_UNREDACT) && fileid != WT_METAFILE_ID)
+        return (__wt_fprintf(session, args->fs, " REDACTED"));
 
     WT_RET(__wt_fprintf(session, args->fs, " \"optype\": \"row_truncate\",\n"));
     WT_ERR(__wt_fprintf(
       session, args->fs, "        \"fileid\": %" PRIu32 " 0x%" PRIx32 ",\n", fileid, fileid));
     WT_ERR(__logrec_make_json_str(session, &escaped, &start));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"start\": \"%s\",\n", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"start\": \"%s\",\n", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &start));
-        WT_ERR(__wt_fprintf(session, args->fs, "        \"start-hex\": \"%s\",\n", escaped));
+        WT_ERR(__wt_fprintf(
+          session, args->fs, "        \"start-hex\": \"%s\",\n", (char *)escaped->mem));
     }
     WT_ERR(__logrec_make_json_str(session, &escaped, &stop));
-    WT_ERR(__wt_fprintf(session, args->fs, "        \"stop\": \"%s\",\n", escaped));
+    WT_ERR(__wt_fprintf(session, args->fs, "        \"stop\": \"%s\",\n", (char *)escaped->mem));
     if (FLD_ISSET(args->flags, WT_TXN_PRINTLOG_HEX)) {
         WT_ERR(__logrec_make_hex_str(session, &escaped, &stop));
-        WT_ERR(__wt_fprintf(session, args->fs, "        \"stop-hex\": \"%s\",\n", escaped));
+        WT_ERR(
+          __wt_fprintf(session, args->fs, "        \"stop-hex\": \"%s\",\n", (char *)escaped->mem));
     }
     WT_ERR(__wt_fprintf(session, args->fs, "        \"mode\": %" PRIu32 "", mode));
 
 err:
-    __wt_free(session, escaped);
+    __wt_scr_free(session, &escaped);
     return (ret);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -51,7 +51,8 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
         WT_RET(__wt_scr_alloc(session, needed, escapedp));
     else
         WT_RET(__wt_buf_grow(session, *escapedp, needed));
-    (void)__wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size);
+    WT_IGNORE_RET(
+      __wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size));
     return (0);
 }
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -194,8 +194,6 @@ __eventv_append_error(const char *err, char *start, char *p, size_t *remainp)
         *remainp = 0;
 }
 
-#define WT_MAX_JSON_ENCODE 6 /* Maximum length of an encoded JSON character. */
-
 #define WT_ERROR_APPEND(p, remain, ...)                                \
     do {                                                               \
         size_t __len;                                                  \

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -685,24 +685,15 @@ dump_suffix(WT_SESSION *session, bool json)
 static int
 dup_json_string(const char *str, char **result)
 {
-    size_t left, nchars;
+    size_t nchars;
     char *q;
-    const char *p;
 
-    nchars = 0;
-    for (p = str; *p; p++, nchars++)
-        nchars += __wt_json_unpack_char((u_char)*p, NULL, 0, false);
-    q = malloc(nchars + 1);
+    nchars = __wt_json_unpack_str(NULL, 0, (const u_char *)str, strlen(str)) + 1;
+    q = malloc(nchars);
     if (q == NULL)
         return (1);
+    (void)__wt_json_unpack_str((u_char *)q, nchars, (const u_char *)str, strlen(str));
     *result = q;
-    left = nchars;
-    for (p = str; *p; p++, nchars++) {
-        nchars = __wt_json_unpack_char((u_char)*p, (u_char *)q, left, false);
-        left -= nchars;
-        q += nchars;
-    }
-    *q = '\0';
     return (0);
 }
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -692,7 +692,7 @@ dup_json_string(const char *str, char **result)
     q = malloc(nchars);
     if (q == NULL)
         return (1);
-    (void)__wt_json_unpack_str((u_char *)q, nchars, (const u_char *)str, strlen(str));
+    WT_IGNORE_RET(__wt_json_unpack_str((u_char *)q, nchars, (const u_char *)str, strlen(str)));
     *result = q;
     return (0);
 }


### PR DESCRIPTION
@alisonfel, @etienneptl, here are the changes so we don't truncate error/verbose messages.

BTW, the motivation for this change is that `format` test program (and other test or application programs, I guess), want to trace operations on key/value pairs that are potentially quite large. Currently we truncate big verbose and error messages, and it's especially problematic since the actual error information follows the message, so big messages likely discard error information. Additionally, because format will run 100s of verbose messages a second through message processing, we want to avoid copying and memory allocation if possible.

The heart of the change is using allocated scratch buffers when the stack buffer isn't sufficient. In the JSON path, I immediately allocate a scratch buffer and format the message into it (as was done before), then allocate a second scratch buffer that's known to be large enough to hold the encoded message, and encode the message into that second buffer. We could potentially speed that up:
* As the previous code did, we could figure out how many bytes we'll need to JSON encode the message, and only allocate that size scratch buffer. Because I'm using scratch buffers, I thought it would be reasonable to skip that step and just allocate a large enough scratch buffer, on the grounds that if this is a single call it's no big deal to allocate a new scratch buffer, but if this session is logging hundreds of messages, then it likely has a large enough scratch buffer around and we can just use it.
* I was also thinking a middle ground might be to walk the message, stopping at the first byte we find that needs to be encoded (where `__wt_json_unpack_char()` returns something other than 1), and then do the encoding step. Basically, it seems to me we're likely to not need to JSON encode these messages, so we could walk the message and only encode stuff if encoding is actually needed.
* As noted, I'm allocating 2 scratch buffers, and we could avoid that in some cases: imagine first trying to format the message into the scratch buffer (or a stack buffer), and if that all works, and we don't need to JSON encode the message, we'd be done. I started down that path in a couple of ways, and it got complicated, so I backed off. If you think the performance is worth chasing, I'd be happy to take another run at it, now that it's working it would be easier to iterate to a faster solution.

The non-JSON path doesn't do any unnecessary data copies at all, and only allocates memory if everything doesn't fit into the stack buffer.

I ended up merging `__eventv()` and `__eventv_gen_msg()` back into one function because the final contents of the message can now end up in one of several places. I'm happy to split that back up if you see a cleaner way to do it.

I swapped the category/level output in the non-JSON path as we discussed on Slack.
