### PR TITLE
WT-8546 verbose/JSON output configurations shouldn't reset without reason

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -69,7 +69,7 @@ __wt_debug_set_verbose(WT_SESSION_IMPL *session, const char *v)
 
     WT_RET(__wt_snprintf(buf, sizeof(buf), "verbose=[%s]", v));
     cfg[0] = buf;
-    return (__wt_verbose_config(session, cfg));
+    return (__wt_verbose_config(session, cfg, true));
 }
 
 /*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2004,7 +2004,6 @@ __wt_json_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
      * When reconfiguring, check if there are any configurations we care about, otherwise leave the
      * current settings in place.
      */
-    ret = 0;
     if (reconfig && (ret = __wt_config_gets(session, cfg + 1, "json_output", &cval)) == WT_NOTFOUND)
         return (0);
     WT_RET(ret);
@@ -2059,7 +2058,6 @@ __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
      * When reconfiguring, check if there are any configurations we care about, otherwise leave the
      * current settings in place.
      */
-    ret = 0;
     if (reconfig && (ret = __wt_config_gets(session, cfg + 1, "verbose", &cval)) == WT_NOTFOUND)
         return (0);
     WT_RET(ret);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1983,11 +1983,51 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __wt_json_config --
+ *     Set JSON output configuration.
+ */
+int
+__wt_json_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
+{
+    static const WT_NAME_FLAG jsontypes[] = {
+      {"error", WT_JSON_OUTPUT_ERROR}, {"message", WT_JSON_OUTPUT_MESSAGE}, {NULL, 0}};
+
+    WT_CONFIG_ITEM cval, sval;
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    const WT_NAME_FLAG *ft;
+    uint8_t flags;
+
+    conn = S2C(session);
+
+    /*
+     * When reconfiguring, check if there are any configurations we care about, otherwise leave the
+     * current settings in place.
+     */
+    ret = 0;
+    if (reconfig && (ret = __wt_config_gets(session, cfg + 1, "json_output", &cval)) == WT_NOTFOUND)
+        return (0);
+    WT_RET(ret);
+
+    /* Check if JSON-encoded message strings are enabled, per event handler category. */
+    WT_RET(__wt_config_gets(session, cfg, "json_output", &cval));
+    flags = 0;
+    for (ft = jsontypes; ft->name != NULL; ft++) {
+        if ((ret = __wt_config_subgets(session, &cval, ft->name, &sval)) == 0 && sval.val != 0)
+            LF_SET(ft->flag);
+        WT_RET_NOTFOUND_OK(ret);
+    }
+    conn->json_output = flags;
+
+    return (0);
+}
+
+/*
  * __wt_verbose_config --
  *     Set verbose configuration.
  */
 int
-__wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[])
+__wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 {
     static const WT_NAME_FLAG verbtypes[] = {{"api", WT_VERB_API}, {"backup", WT_VERB_BACKUP},
       {"block", WT_VERB_BLOCK}, {"block_cache", WT_VERB_BLKCACHE},
@@ -2007,29 +2047,24 @@ __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[])
       {"thread_group", WT_VERB_THREAD_GROUP}, {"timestamp", WT_VERB_TIMESTAMP},
       {"tiered", WT_VERB_TIERED}, {"transaction", WT_VERB_TRANSACTION}, {"verify", WT_VERB_VERIFY},
       {"version", WT_VERB_VERSION}, {"write", WT_VERB_WRITE}, {NULL, 0}};
-    static const WT_NAME_FLAG jsontypes[] = {
-      {"error", WT_JSON_OUTPUT_ERROR}, {"message", WT_JSON_OUTPUT_MESSAGE}, {NULL, 0}};
 
     WT_CONFIG_ITEM cval, sval;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     const WT_NAME_FLAG *ft;
-    uint8_t flags;
 
     conn = S2C(session);
 
-    /* Check if JSON-encoded message strings are enabled, per event handler category. */
-    WT_RET(__wt_config_gets(session, cfg, "json_output", &cval));
-    flags = 0;
-    for (ft = jsontypes; ft->name != NULL; ft++) {
-        if ((ret = __wt_config_subgets(session, &cval, ft->name, &sval)) == 0 && sval.val != 0)
-            LF_SET(ft->flag);
-        WT_RET_NOTFOUND_OK(ret);
-    }
-    conn->json_output = flags;
+    /*
+     * When reconfiguring, check if there are any configurations we care about, otherwise leave the
+     * current settings in place.
+     */
+    ret = 0;
+    if (reconfig && (ret = __wt_config_gets(session, cfg + 1, "verbose", &cval)) == WT_NOTFOUND)
+        return (0);
+    WT_RET(ret);
 
     WT_RET(__wt_config_gets(session, cfg, "verbose", &cval));
-
     for (ft = verbtypes; ft->name != NULL; ft++) {
         ret = __wt_config_subgets(session, &cval, ft->name, &sval);
         WT_RET_NOTFOUND_OK(ret);
@@ -2724,7 +2759,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
         __wt_free(session, conn->error_prefix);
         WT_ERR(__wt_strndup(session, cval.str, cval.len, &conn->error_prefix));
     }
-    WT_ERR(__wt_verbose_config(session, cfg));
+    WT_ERR(__wt_json_config(session, cfg, false));
+    WT_ERR(__wt_verbose_config(session, cfg, false));
     WT_ERR(__wt_timing_stress_config(session, cfg));
     WT_ERR(__wt_block_cache_setup(session, cfg, false));
     WT_ERR(__wt_conn_optrack_setup(session, cfg, false));

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -430,7 +430,8 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     WT_ERR(__wt_tiered_conn_config(session, cfg, true));
     WT_ERR(__wt_sweep_config(session, cfg));
     WT_ERR(__wt_timing_stress_config(session, cfg));
-    WT_ERR(__wt_verbose_config(session, cfg));
+    WT_ERR(__wt_json_config(session, cfg, true));
+    WT_ERR(__wt_verbose_config(session, cfg, true));
 
     /* Third, merge everything together, creating a new connection state. */
     WT_ERR(__wt_config_merge(session, cfg, NULL, &p));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -823,6 +823,8 @@ extern int __wt_json_alloc_unpack(WT_SESSION_IMPL *session, const void *buffer, 
 extern int __wt_json_column_init(WT_CURSOR *cursor, const char *uri, const char *keyformat,
   const WT_CONFIG_ITEM *idxconf, const WT_CONFIG_ITEM *colconf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_json_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char *src,
   size_t srclen) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1633,7 +1635,7 @@ extern int __wt_upgrade(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_value_return_buf(WT_CURSOR_BTREE *cbt, WT_REF *ref, WT_ITEM *buf,
   WT_TIME_WINDOW *tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[])
+extern int __wt_verbose_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_verbose_dump_cache(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
Don't reconfigure JSON or verbose settings just because some other setting is being reconfigured.

Split JSON configuration out into its own function for simplicity.