### PR TITLE
WT-8547 MongoDB timestamp information messages are application-specific

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -601,6 +601,7 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %exception wiredtiger_strerror;
 %exception wiredtiger_version;
 %exception diagnostic_build;
+%exception standalone_build;
 
 /* WT_CURSOR customization. */
 /* First, replace the varargs get / set methods with Python equivalents. */
@@ -1130,8 +1131,18 @@ int diagnostic_build() {
 #endif
 }
 %}
-
 int diagnostic_build();
+
+%{
+int standalone_build() {
+#ifdef WT_STANDALONE_BUILD
+	return 1;
+#else
+	return 0;
+#endif
+}
+%}
+int standalone_build();
 
 /* Remove / rename parts of the C API that we don't want in Python. */
 %immutable __wt_cursor::session;

--- a/test/suite/test_timestamp21.py
+++ b/test/suite/test_timestamp21.py
@@ -57,15 +57,22 @@ class test_timestamp21(wttest.WiredTigerTestCase):
             'read_timestamp=' + self.timestamp_str(6) + ',read_before_oldest=true'), 0)
         session2.rollback_transaction()
 
-        # Begin a transaction with a read timestamp of 6 and no additional config.
-        with self.expectedStdoutPattern('less than the oldest timestamp'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda: session2.begin_transaction(
-            'read_timestamp=' + self.timestamp_str(6)))
+        # Begin a transaction with a read timestamp of 6 and no additional config. Check for
+        # informational message output when a read timestamp is older than the oldest timestamp.
+        if wiredtiger.standalone_build():
+            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+            session2.begin_transaction('read_timestamp=' + self.timestamp_str(6)))
+        else:
+            # This is a MongoDB message, not written in standalone builds.
+            with self.expectedStdoutPattern('less than the oldest timestamp'):
+                self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                session2.begin_transaction('read_timestamp=' + self.timestamp_str(6)))
 
         # Begin a transaction with the config specified but no read timestamp.
         session2.begin_transaction('read_before_oldest=true')
         # Set a read timestamp behind the oldest timestamp.
-        self.assertEqual(session2.timestamp_transaction('read_timestamp=' + self.timestamp_str(5)), 0)
+        self.assertEqual(
+            session2.timestamp_transaction('read_timestamp=' + self.timestamp_str(5)), 0)
         session2.rollback_transaction()
 
         # Begin a transaction with a read timestamp of 5 and read_before_oldest specified.
@@ -73,17 +80,31 @@ class test_timestamp21(wttest.WiredTigerTestCase):
             'read_timestamp=' + self.timestamp_str(5) + ',read_before_oldest=true'), 0)
         session2.rollback_transaction()
 
-        # Begin a transaction with a read timestamp of 4 and read_before_oldest specified. We get a
-        # different std out message in this scenario.
-        with self.expectedStdoutPattern('less than the pinned timestamp'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda: session2.begin_transaction(
-            'read_timestamp=' + self.timestamp_str(4) + ',read_before_oldest=true'))
+        # Begin a transaction with a read timestamp of 4 and read_before_oldest specified.
+        # We get a different stdout message in this scenario.
+        if wiredtiger.standalone_build():
+            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                session2.begin_transaction('read_timestamp=' +\
+                self.timestamp_str(4) + ',read_before_oldest=true'))
+        else:
+            # This is a MongoDB message, not written in standalone builds.
+            with self.expectedStdoutPattern('less than the pinned timestamp'):
+                self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                    session2.begin_transaction('read_timestamp=' +\
+                    self.timestamp_str(4) + ',read_before_oldest=true'))
 
-        # Begin a transaction with a read timestamp of 6 and read_before_oldest off, this will have
-        # the same behaviour as not specifying it.
-        with self.expectedStdoutPattern('less than the oldest timestamp'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda: session2.begin_transaction(
-            'read_timestamp=' + self.timestamp_str(6) + ',read_before_oldest=false'))
+        # Begin a transaction with a read timestamp of 6 and read_before_oldest off, this will
+        # have the same behaviour as not specifying it.
+        if wiredtiger.standalone_build():
+            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                session2.begin_transaction('read_timestamp=' +\
+                self.timestamp_str(6) + ',read_before_oldest=false'))
+        else:
+            # This is a MongoDB message, not written in standalone builds.
+            with self.expectedStdoutPattern('less than the oldest timestamp'):
+                self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                    session2.begin_transaction('read_timestamp=' +\
+                    self.timestamp_str(6) + ',read_before_oldest=false'))
 
         # Expect an error when we use roundup timestamps alongside allow read timestamp before
         # oldest.


### PR DESCRIPTION
Turn off MongoDB timestamp informational messages in standalone builds, they're too verbose if the application isn't tracking the oldest available read timestamp.