### PR TITLE
WT-8535 Wiredtiger-perf-stress-jobs failed for fixed-length column store due to page size larger than 128Kb

### DIFF
--- a/bench/wtperf/runners/large-lsm-large.wtperf
+++ b/bench/wtperf/runners/large-lsm-large.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: large lsm configuration
 conn_config="cache_size=20G,mmap=false,lsm_manager=(worker_thread_max=8)"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=128KB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 compact=true
 compression="snappy"
 icount=4000000000

--- a/bench/wtperf/runners/large-lsm.wtperf
+++ b/bench/wtperf/runners/large-lsm.wtperf
@@ -1,6 +1,6 @@
 # wtperf options file: large lsm configuration
 conn_config="cache_size=20G,mmap=false,lsm_manager=(worker_thread_max=8)"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=128KB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_max=5GB,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 compact=true
 compression="snappy"
 icount=250000000

--- a/bench/wtperf/runners/overflow-10k.wtperf
+++ b/bench/wtperf/runners/overflow-10k.wtperf
@@ -5,7 +5,7 @@ conn_config="cache_size=21G,checkpoint_sync=false,mmap=false,lsm_manager=(worker
 compact=true
 compression="snappy"
 sess_config="isolation=snapshot"
-table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=8MB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
+table_config="internal_page_max=128K,lsm=(bloom_config=(leaf_page_max=128KB),bloom_bit_count=28,bloom_hash_count=19,bloom_oldest=true,chunk_size=100MB),type=lsm,leaf_page_max=16K,os_cache_dirty_max=16MB"
 icount=15000
 key_sz=40
 value_sz=10000


### PR DESCRIPTION
The history-store/timestamp rework of FLCS limits the maximum leaf page size to 128KB.

@jeremythorp, I wasn't able to reproduce this failure, maybe my build is off or something, but the fix seems obvious.