### PR TITLE
WT-8426 Clean up csuite test artifacts on test success

### DIFF
--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -802,7 +802,9 @@ main(int argc, char *argv[])
     int ch, ncheckpoints, nreopens, status;
     const char *backup_verbose, *working_dir;
     char conf[1024], home[1024], backup_check[1024], backup_dir[1024], command[4096];
+    bool preserve;
 
+    preserve = false;
     ncheckpoints = nreopens = 0;
     (void)testutil_set_progname(argv);
     custom_die = die; /* Set our own abort handler */
@@ -811,10 +813,13 @@ main(int argc, char *argv[])
 
     working_dir = "WT_TEST.incr_backup";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "h:S:v:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "h:pS:v:")) != EOF)
         switch (ch) {
         case 'h':
             working_dir = __wt_optarg;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 'S':
             seed = (uint64_t)atoll(__wt_optarg);
@@ -950,5 +955,10 @@ main(int argc, char *argv[])
     tables_free(&tinfo);
 
     printf("Success.\n");
-    return (0);
+    if (!preserve) {
+        testutil_clean_backup_data(home);
+        testutil_clean_work_dir(home);
+    }
+
+    return (EXIT_SUCCESS);
 }

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -841,8 +841,8 @@ main(int argc, char *argv[])
         rnd.v = seed;
 
     testutil_work_dir_from_path(home, sizeof(home), working_dir);
-    testutil_check(__wt_snprintf(backup_dir, sizeof(backup_dir), "%s.BACKUP", home));
-    testutil_check(__wt_snprintf(backup_check, sizeof(backup_check), "%s.CHECK", home));
+    testutil_check(__wt_snprintf(backup_dir, sizeof(backup_dir), "../%s.BACKUP", home));
+    testutil_check(__wt_snprintf(backup_check, sizeof(backup_check), "../%s.CHECK", home));
     printf("Seed: %" PRIu64 "\n", seed);
 
     testutil_check(
@@ -956,7 +956,7 @@ main(int argc, char *argv[])
 
     printf("Success.\n");
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         testutil_clean_work_dir(home);
     }
 

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -761,6 +761,10 @@ main(int argc, char *argv[])
     ret = recover_and_verify(nth);
     if (ret == EXIT_SUCCESS && !preserve) {
         testutil_clean_backup_data(home);
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
     }
     return ret;
 }

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -760,7 +760,7 @@ main(int argc, char *argv[])
      */
     ret = recover_and_verify(nth);
     if (ret == EXIT_SUCCESS && !preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
         if (chdir("../") != 0)
             testutil_die(errno, "root chdir: %s", home);

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -612,21 +612,22 @@ main(int argc, char *argv[])
     WT_RAND_STATE rnd;
     pid_t pid;
     uint32_t i, j, nth, timeout;
-    int ch, status;
+    int ch, status, ret;
     char buf[1024], fname[MAX_RECORD_FILES][64];
     const char *working_dir;
-    bool rand_th, rand_time, verify_only;
+    bool preserve, rand_th, rand_time, verify_only;
 
     (void)testutil_set_progname(argv);
 
     compaction = compat = inmem = false;
     nth = MIN_TH;
+    preserve = false;
     rand_th = rand_time = true;
     timeout = MIN_TIME;
     verify_only = false;
     working_dir = "WT_TEST.random-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "Cch:mT:t:v")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cch:mpT:t:v")) != EOF)
         switch (ch) {
         case 'C':
             compat = true;
@@ -639,6 +640,9 @@ main(int argc, char *argv[])
             break;
         case 'm':
             inmem = true;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 'T':
             rand_th = false;
@@ -754,5 +758,9 @@ main(int argc, char *argv[])
     /*
      * Recover the database and verify whether all the records from all threads are present or not?
      */
-    return recover_and_verify(nth);
+    ret = recover_and_verify(nth);
+    if (ret == EXIT_SUCCESS && !preserve) {
+        testutil_clean_backup_data(home);
+    }
+    return ret;
 }

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -806,9 +806,9 @@ check_db(uint32_t nth, uint32_t datasize, pid_t pid, bool directio, uint32_t fla
         large_arr[th] = dcalloc(LARGE_WRITE_SIZE, 1);
         large_buf(large_arr[th], LARGE_WRITE_SIZE, th, true);
     }
-    testutil_check(__wt_snprintf(checkdir, sizeof(checkdir), "%s.CHECK", home));
-    testutil_check(__wt_snprintf(dbgdir, sizeof(savedir), "%s.DEBUG", home));
-    testutil_check(__wt_snprintf(savedir, sizeof(savedir), "%s.SAVE", home));
+    testutil_check(__wt_snprintf(checkdir, sizeof(checkdir), "../%s.CHECK", home));
+    testutil_check(__wt_snprintf(dbgdir, sizeof(savedir), "../%s.DEBUG", home));
+    testutil_check(__wt_snprintf(savedir, sizeof(savedir), "../%s.SAVE", home));
 
     /*
      * We make a copy of the directory (possibly using direct I/O) for recovery and checking, and an
@@ -1256,7 +1256,7 @@ main(int argc, char *argv[])
     printf("SUCCESS\n");
 
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         testutil_clean_work_dir(home);
     }
 

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -1051,7 +1051,7 @@ main(int argc, char *argv[])
     char *arg, *p;
     char args[1024], buf[1024];
     const char *method, *working_dir;
-    bool populate_only, rand_th, rand_time, verify_only;
+    bool populate_only, preserve, rand_th, rand_time, verify_only;
 
     (void)testutil_set_progname(argv);
 
@@ -1062,7 +1062,7 @@ main(int argc, char *argv[])
     timeout = MIN_TIME;
     interval = DEFAULT_INTERVAL;
     flags = 0;
-    populate_only = verify_only = false;
+    populate_only = preserve = verify_only = false;
     working_dir = "WT_TEST.random-directio";
     method = "none";
     pid = 0;
@@ -1111,6 +1111,9 @@ main(int argc, char *argv[])
             break;
         case 'p':
             populate_only = true;
+            break;
+        case 'P':
+            preserve = true;
             break;
         case 'S':
             p = __wt_optarg;
@@ -1251,5 +1254,11 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     }
     printf("SUCCESS\n");
+
+    if (!preserve) {
+        testutil_clean_backup_data(home);
+        testutil_clean_work_dir(home);
+    }
+
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -1215,7 +1215,12 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
-    if (!preserve)
+    if (!preserve) {
         testutil_clean_backup_data(home);
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
+    }
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -903,7 +903,7 @@ main(int argc, char *argv[])
     char buf[512], statname[1024];
     char fname[64], kname[64];
     const char *working_dir;
-    bool fatal, rand_th, rand_time, verify_only;
+    bool fatal, preserve, rand_th, rand_time, verify_only;
 
     (void)testutil_set_progname(argv);
 
@@ -915,12 +915,13 @@ main(int argc, char *argv[])
      */
     use_txn = false;
     nth = MIN_TH;
+    preserve = false;
     rand_th = rand_time = true;
     timeout = MIN_TIME;
     verify_only = false;
     working_dir = "WT_TEST.schema-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "Cch:mT:t:vxz")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cch:mpT:t:vxz")) != EOF)
         switch (ch) {
         case 'C':
             compat = true;
@@ -934,6 +935,9 @@ main(int argc, char *argv[])
             break;
         case 'm':
             inmem = true;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 'T':
             rand_th = false;
@@ -1211,5 +1215,7 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
+    if (!preserve)
+        testutil_clean_backup_data(home);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -1216,7 +1216,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
         if (chdir("../") != 0)
             testutil_die(errno, "root chdir: %s", home);

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -911,7 +911,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
         if (chdir("../") != 0)
             testutil_die(errno, "root chdir: %s", home);

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -576,19 +576,20 @@ main(int argc, char *argv[])
     char buf[512], bucket_dir[512], build_dir[512], fname[64], kname[64];
     char envconf[1024], extconf[512];
     char ts_string[WT_TS_HEX_STRING_SIZE];
-    bool fatal, rand_th, rand_time, verify_only;
+    bool fatal, preserve, rand_th, rand_time, verify_only;
 
     (void)testutil_set_progname(argv);
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
     use_ts = true;
     nth = MIN_TH;
+    preserve = false;
     rand_th = rand_time = true;
     timeout = MIN_TIME;
     verify_only = false;
     working_dir = "WT_TEST.tiered-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "b:f:h:T:t:vz")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "b:f:h:pT:t:vz")) != EOF)
         switch (ch) {
         case 'b': /* Build directory */
             opts->build_dir = dstrdup(__wt_optarg);
@@ -598,6 +599,9 @@ main(int argc, char *argv[])
             break;
         case 'h':
             working_dir = __wt_optarg;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 'T':
             rand_th = false;
@@ -906,6 +910,8 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
+    if (!preserve)
+        testutil_clean_backup_data(home);
     testutil_cleanup(opts);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/tiered_abort/main.c
+++ b/test/csuite/tiered_abort/main.c
@@ -910,8 +910,13 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
-    if (!preserve)
+    if (!preserve) {
         testutil_clean_backup_data(home);
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
+    }
     testutil_cleanup(opts);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -997,7 +997,12 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
-    if (!preserve)
+    if (!preserve) {
         testutil_clean_backup_data(home);
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
+    }
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -640,19 +640,20 @@ main(int argc, char *argv[])
     const char *working_dir;
     char buf[512], fname[64], kname[64], statname[1024];
     char ts_string[WT_TS_HEX_STRING_SIZE];
-    bool fatal, rand_th, rand_time, verify_only;
+    bool fatal, preserve, rand_th, rand_time, verify_only;
 
     (void)testutil_set_progname(argv);
 
     columns = compat = inmem = stress = false;
     use_ts = true;
     nth = MIN_TH;
+    preserve = false;
     rand_th = rand_time = true;
     timeout = MIN_TIME;
     verify_only = false;
     working_dir = "WT_TEST.timestamp-abort";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "Cch:LmsT:t:vz")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "Cch:LmpsT:t:vz")) != EOF)
         switch (ch) {
         case 'C':
             compat = true;
@@ -669,6 +670,9 @@ main(int argc, char *argv[])
             break;
         case 'm':
             inmem = true;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 's':
             stress = true;
@@ -993,5 +997,7 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
+    if (!preserve)
+        testutil_clean_backup_data(home);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -998,7 +998,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     printf("%" PRIu64 " records verified\n", count);
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
         if (chdir("../") != 0)
             testutil_die(errno, "root chdir: %s", home);

--- a/test/csuite/truncated_log/main.c
+++ b/test/csuite/truncated_log/main.c
@@ -236,7 +236,9 @@ main(int argc, char *argv[])
     uint32_t count, max_key;
     int ch, ret, status;
     const char *working_dir;
+    bool preserve;
 
+    preserve = false;
     (void)testutil_set_progname(argv);
 
     working_dir = "WT_TEST.truncated-log";
@@ -248,6 +250,9 @@ main(int argc, char *argv[])
             break;
         case 'h':
             working_dir = __wt_optarg;
+            break;
+        case 'p':
+            preserve = true;
             break;
         default:
             usage();
@@ -328,5 +333,12 @@ main(int argc, char *argv[])
      */
     write_and_read_new(session);
     testutil_check(conn->close(conn, NULL));
+    if (!preserve) {
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
+    }
+
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -322,13 +322,14 @@ run(int argc, char *argv[])
     WT_RAND_STATE rnd;
     u_int i, n;
     int ch;
-    bool default_home;
+    bool default_home, preserve;
 
     (void)testutil_set_progname(argv);
     __wt_random_init_seed(NULL, &rnd);
 
     default_home = true;
-    while ((ch = __wt_getopt(argv[0], argc, argv, "vh:")) != EOF) {
+    preserve = false;
+    while ((ch = __wt_getopt(argv[0], argc, argv, "vh:p")) != EOF) {
         switch (ch) {
         case 'v':
             verbose = true;
@@ -337,6 +338,9 @@ run(int argc, char *argv[])
             strncpy(home, __wt_optarg, HOME_LEN);
             home[HOME_LEN - 1] = '\0';
             default_home = false;
+            break;
+        case 'p':
+            preserve = true;
             break;
         default:
             fprintf(stderr, "usage: %s [-v]\n", argv[0]);
@@ -358,6 +362,8 @@ run(int argc, char *argv[])
 
     uri_teardown();
 
+    if (!preserve)
+        testutil_clean_work_dir(home);
     return (EXIT_SUCCESS);
 }
 

--- a/test/csuite/wt6185_modify_ts/main.c
+++ b/test/csuite/wt6185_modify_ts/main.c
@@ -317,7 +317,7 @@ main(int argc, char *argv[])
     int ch;
     char path[1024], table_config[128], value[VALUE_SIZE];
     const char *home, *v;
-    bool no_checkpoint, no_eviction;
+    bool no_checkpoint, no_eviction, preserve;
 
     (void)testutil_set_progname(argv);
     custom_die = trace_die;
@@ -325,7 +325,7 @@ main(int argc, char *argv[])
     __wt_random_init_seed(NULL, &rnd);
     modify_repl_init();
 
-    no_checkpoint = no_eviction = false;
+    no_checkpoint = no_eviction = preserve = false;
     home = "WT_TEST.wt6185_modify_ts";
     while ((ch = __wt_getopt(progname, argc, argv, "Cceh:S:")) != EOF)
         switch (ch) {
@@ -341,6 +341,9 @@ main(int argc, char *argv[])
             break;
         case 'h':
             home = __wt_optarg;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 'S':
             rnd.v = strtoul(__wt_optarg, NULL, 10);
@@ -415,5 +418,8 @@ main(int argc, char *argv[])
     testutil_check(conn->close(conn, NULL));
 
     cleanup();
+
+    if (!preserve)
+        testutil_clean_work_dir(home);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -393,7 +393,12 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("Verification successful\n");
-    if (!preserve)
+    if (!preserve) {
         testutil_clean_backup_data(home);
+        /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
+        if (chdir("../") != 0)
+            testutil_die(errno, "root chdir: %s", home);
+        testutil_clean_work_dir(home);
+    }
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -265,15 +265,16 @@ main(int argc, char *argv[])
     char kname[64], statname[1024], tscfg[64];
     char ts_string[WT_TS_HEX_STRING_SIZE];
     const char *working_dir;
-    bool fatal, rand_time;
+    bool fatal, preserve, rand_time;
 
     (void)testutil_set_progname(argv);
 
+    preserve = false;
     rand_time = true;
     timeout = MIN_TIME;
     working_dir = "WT_TEST.wt6616-checkpoint-oldest-ts";
 
-    while ((ch = __wt_getopt(progname, argc, argv, "ch:t:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "ch:pt:")) != EOF)
         switch (ch) {
         case 'c':
             /* Variable-length columns only (for now) */
@@ -281,6 +282,9 @@ main(int argc, char *argv[])
             break;
         case 'h':
             working_dir = __wt_optarg;
+            break;
+        case 'p':
+            preserve = true;
             break;
         case 't':
             rand_time = false;
@@ -389,5 +393,7 @@ main(int argc, char *argv[])
     if (fatal)
         return (EXIT_FAILURE);
     printf("Verification successful\n");
+    if (!preserve)
+        testutil_clean_backup_data(home);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -394,7 +394,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     printf("Verification successful\n");
     if (!preserve) {
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
         /* At this point $PATH is inside `home`, which we intend to delete. cd to the parent dir. */
         if (chdir("../") != 0)
             testutil_die(errno, "root chdir: %s", home);

--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -207,7 +207,7 @@ run_test(bool column_store, const char *uri, bool preserve)
     /* Cleanup */
     if (!preserve) {
         testutil_clean_work_dir(home);
-        testutil_clean_backup_data(home);
+        testutil_clean_test_artifacts(home);
     }
 
     return (EXIT_SUCCESS);

--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -205,8 +205,10 @@ run_test(bool column_store, const char *uri, bool preserve)
     conn = NULL;
 
     /* Cleanup */
-    if (!preserve)
+    if (!preserve) {
         testutil_clean_work_dir(home);
+        testutil_clean_backup_data(home);
+    }
 
     return (EXIT_SUCCESS);
 }

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -258,16 +258,22 @@ testutil_copy_data(const char *dir)
 }
 
 /*
- * testutil_clean_backup_data --
- *     Delete the backed up data saved in testutil_copy_data.
+ * testutil_clean_test_artifacts --
+ *     Clean any temporary files and folders created during test execution
  */
 void
-testutil_clean_backup_data(const char *dir)
+testutil_clean_test_artifacts(const char *dir)
 {
     int status;
     char buf[512];
 
-    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf ../%s.SAVE", dir));
+    testutil_check(__wt_snprintf(buf, sizeof(buf),
+      "rm -rf ../%s.SAVE; "
+      "rm -rf ../%s.CHECK; "
+      "rm -rf ../%s.DEBUG; "
+      "rm -rf ../%s.BACKUP; ",
+      dir, dir, dir, dir));
+
     if ((status = system(buf)) < 0)
         testutil_die(status, "system: %s", buf);
 }

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -258,6 +258,22 @@ testutil_copy_data(const char *dir)
 }
 
 /*
+ * testutil_clean_backup_data --
+ *     Delete the backed up data saved in testutil_copy_data.
+ */
+void
+testutil_clean_backup_data(const char *dir)
+{
+    int status;
+    char buf[512];
+
+    testutil_check(__wt_snprintf(buf, sizeof(buf),
+      "rm -rf ../%s.SAVE", dir));
+    if ((status = system(buf)) < 0)
+        testutil_die(status, "system: %s", buf);
+}
+
+/*
  * testutil_timestamp_parse --
  *     Parse a timestamp to an integral value.
  */

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -267,8 +267,7 @@ testutil_clean_backup_data(const char *dir)
     int status;
     char buf[512];
 
-    testutil_check(__wt_snprintf(buf, sizeof(buf),
-      "rm -rf ../%s.SAVE", dir));
+    testutil_check(__wt_snprintf(buf, sizeof(buf), "rm -rf ../%s.SAVE", dir));
     if ((status = system(buf)) < 0)
         testutil_die(status, "system: %s", buf);
 }

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -268,7 +268,7 @@ void op_cursor(void *);
 void op_drop(void *);
 bool testutil_is_flag_set(const char *);
 void testutil_build_dir(TEST_OPTS *, char *, int);
-void testutil_clean_backup_data(const char *);
+void testutil_clean_test_artifacts(const char *);
 void testutil_clean_work_dir(const char *);
 void testutil_cleanup(TEST_OPTS *);
 void testutil_copy_data(const char *);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -268,6 +268,7 @@ void op_cursor(void *);
 void op_drop(void *);
 bool testutil_is_flag_set(const char *);
 void testutil_build_dir(TEST_OPTS *, char *, int);
+void testutil_clean_backup_data(const char *);
 void testutil_clean_work_dir(const char *);
 void testutil_cleanup(TEST_OPTS *);
 void testutil_copy_data(const char *);


### PR DESCRIPTION
`spinlock-pthread-adaptive-test` is failing in Evergreen due to a lack of available space on the host machines (ubuntu2004-small is capped at 50GB space) due to a large amount of artifacts left over from executing all csuite tests as part of the `make check` step.

To resolve this the artifacts and workspaces are now cleaned up on test success. If we want to retain these artifacts is can be done by passing the `-p` preserve flag.