### PR TITLE
WT-8529 MongoDB V4 toolchain can't build cppsuite

### DIFF
--- a/test/cppsuite/test_harness/test.cxx
+++ b/test/cppsuite/test_harness/test.cxx
@@ -28,6 +28,7 @@
 
 /* Required to build using older versions of g++. */
 #include <cinttypes>
+#include <memory>
 #include <mutex>
 
 #include "connection_manager.h"

--- a/test/cppsuite/test_harness/test.h
+++ b/test/cppsuite/test_harness/test.h
@@ -29,8 +29,9 @@
 #ifndef TEST_H
 #define TEST_H
 
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include "wiredtiger.h"


### PR DESCRIPTION
Add a couple of missing includes to some files in the cppsuite tests.

I tested this by changing every v3 reference in evergreen.yml to v4, as well as in the cmake/toolchains directory and running the same set of tests we run on pull requests. See the ticket for details/output.