### PR TITLE
WT-8576 Enabled logging in test checkpoint.

### DIFF
--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -288,8 +288,8 @@ wt_connect(const char *config_open)
           config_open == NULL ? "" : ",", config_open == NULL ? "" : config_open));
     else {
         testutil_check(__wt_snprintf(config, sizeof(config),
-          "create,cache_cursors=false,statistics=(fast),statistics_log=(json,wait=1),error_prefix="
-          "\"%s\"%s%s%s%s",
+          "create,cache_cursors=false,statistics=(fast),statistics_log=(json,wait=1),log=(enabled),"
+          "error_prefix=\"%s\"%s%s%s%s",
           progname, g.debug_mode ? DEBUG_MODE_CFG : "", config_open == NULL ? "" : ",",
           config_open == NULL ? "" : config_open, timing_stress ? timing_stress_cofing : ""));
     }


### PR DESCRIPTION
This change is required for WT-8554 (Automated testing for upgrade from 4.4 releases). It has to go in a separate commit because we need to backport it to 4.4 and 5.0.