### PR TITLE
WT-8568 fix reference count race in block cache

### DIFF
--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -363,7 +363,7 @@ __wt_blkcache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_siz
             if (blkcache_item->freq_rec_counter < 0)
                 blkcache_item->freq_rec_counter = 0;
             blkcache_item->freq_rec_counter++;
-            blkcache_item->ref_count++;
+            (void)__wt_atomic_addv32(&blkcache_item->ref_count, 1);
             break;
         }
     }

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -211,8 +211,6 @@ create_database(const char *home, WT_CONNECTION **connp)
     if (GV(RUNS_IN_MEMORY) != 0)
         CONFIG_APPEND(p, ",in_memory=1");
 
-#if 0
-    /* FIXME: WT-8568 */
     /* Block cache configuration. */
     if (GV(BLOCK_CACHE) != 0)
         CONFIG_APPEND(p,
@@ -222,7 +220,6 @@ create_database(const char *home, WT_CONNECTION **connp)
           ",size=%" PRIu32 "MB)",
           GV(BLOCK_CACHE_CACHE_ON_CHECKPOINT) == 0 ? "false" : "true",
           GV(BLOCK_CACHE_CACHE_ON_WRITES) == 0 ? "false" : "true", GV(BLOCK_CACHE_SIZE));
-#endif
 
     /* LSM configuration. */
     if (g.lsm_config)


### PR DESCRIPTION
Incrementing the block-item reference count is a read-modify-write, so can race with another thread decrementing the reference count without holding the hash bucket lock.