### PR TITLE
WT-8477 Enforce the use of Pymongo 3.12.2 in our Evergreen tests (v5.0 backport). (#7254)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -618,7 +618,7 @@ functions:
           set -o errexit
           ${virtualenv_binary} -p ${python_binary} venv
           source venv/bin/activate
-          ${pip3_binary} install pymongo[srv]
+          ${pip3_binary} install pymongo[srv]==3.12.2
           git clone git@github.com:wiredtiger/automation-scripts.git
           ${python_binary} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_wt_perf_test_user} -p ${atlas_wt_perf_pass} -f test_stats/atlas_out.json -b ${branch_name}
     - command: perf.send
@@ -2921,7 +2921,7 @@ tasks:
             export "PATH=/opt/mongodbtoolchain/v3/bin:$PATH"
             virtualenv -p python3 venv
             source venv/bin/activate
-            pip3 install lorem pymongo
+            pip3 install lorem pymongo==3.12.2
             ./run_many_coll.sh ../../mongo/build/opt/install/bin/mongod mongodb.log config/many-collection-testing many-collection clean-and-populate
 
       - command: shell.exec
@@ -2934,7 +2934,7 @@ tasks:
             set -o verbose
             virtualenv -p python3 venv
             source venv/bin/activate
-            pip3 install "pymongo[srv]"
+            pip3 install "pymongo[srv]==3.12.2"
             res_dir=`find ./ -type d -name "many-collection-[0-9]*" -print`
             ./upload-results-atlas.py ${atlas_wt_perf_test_user} ${atlas_wt_perf_pass} wt-perf-tests many-collection-test ${branch_name} $res_dir/results/results.json
 


### PR DESCRIPTION
(cherry picked from commit e57066854acb98f999ed78c7a69c2e999b8268b5)