### PR TITLE
WT-8593 Let UBSAN hosts abort and dump core instead of simply exiting

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4035,7 +4035,7 @@ buildvariants:
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
     test_env_vars:
-      UBSAN_OPTIONS="detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:halt_on_error=1:print_stacktrace=1"
+      UBSAN_OPTIONS="detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:abort_on_error=1:print_stacktrace=1"
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so
       PATH=/opt/mongodbtoolchain/v3/bin:$PATH
       top_dir=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
This is intended to help with debugging WT-8198, which is tricky to repro locally but happens reasonably often in Evergreen. Unfortunately it isn't leaving cores behind right now, making debugging hard.