### PR TITLE
WT-8602 Moved s_version package.spec to autoconf

### DIFF
--- a/dist/s_version
+++ b/dist/s_version
@@ -55,6 +55,10 @@ GenAutoconfVersion(){
 	VERSION_NOPATCH=${WIREDTIGER_VERSION_MAJOR}.${WIREDTIGER_VERSION_MINOR}
 	AC_SUBST(VERSION_NOPATCH)
 	END
+
+    echo "Building $rpmspec"
+    sed -e "s/Version:	.*/Version:	${dotted_version}/" $rpmspec	\
+        > $tmp_file && mv $tmp_file $rpmspec
 }
 
 GenCmakeVersion(){
@@ -79,7 +83,3 @@ GenCmakeVersion(){
 
 GenAutoconfVersion
 GenCmakeVersion
-
-echo "Building $rpmspec"
-sed -e "s/Version:	.*/Version:	${dotted_version}/" $rpmspec	\
-        > $tmp_file && mv $tmp_file $rpmspec


### PR DESCRIPTION
Moved the generation of the package.spec to the autoconf generation
function in s_version. This logic is not needed for the CMake
build system.