### PR TITLE
WT-7147 Extend s_string utility to .cxx files

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -911,7 +911,7 @@ pareto_calculation(uint32_t randint, uint64_t recno_max, ParetoOptions &pareto)
     // of the time, depending on pareto_param.  For param of 0, it is
     // never out of range, for param of 100, 19.2%. For the default
     // pareto_param of 20, it will be out of range 2.7% of the time.
-    // Out of range values are channelled into the first key,
+    // Out of range values are channeled into the first key,
     // making it "hot".  Unfortunately, that means that using a higher
     // param can get a lot lumped into the first bucket.
     //
@@ -2269,14 +2269,14 @@ Workload::Workload(Context *context, const ThreadListWrapper &tlw)
     : options(), stats(), _context(context), _threads(tlw._threads)
 {
     if (context == NULL)
-        THROW("Workload contructor requires a Context");
+        THROW("Workload constructor requires a Context");
 }
 
 Workload::Workload(Context *context, const Thread &thread)
     : options(), stats(), _context(context), _threads()
 {
     if (context == NULL)
-        THROW("Workload contructor requires a Context");
+        THROW("Workload constructor requires a Context");
     _threads.push_back(thread);
 }
 

--- a/dist/s_string
+++ b/dist/s_string
@@ -46,7 +46,7 @@ check() {
 # List of files to spellchk.
 l=`(cd .. &&
     find bench examples ext src test -name '*.[chsy]' &&
-    find src -name '*.in' && find bench test -name '*.cxx')`
+    find src -name '*.in' && find test -name '*.cxx')`
 
 usage()
 {
@@ -59,7 +59,7 @@ while :
 		for f in $l; do
 			replace $f
 		done | sort -u > $t
-		cp $t s_string.ok
+		cp $t s_string.okgi
 		shift;;
 	*)
 		test "$#" -eq 0 || usage

--- a/dist/s_string
+++ b/dist/s_string
@@ -59,7 +59,7 @@ while :
 		for f in $l; do
 			replace $f
 		done | sort -u > $t
-		cp $t s_string.okgi
+		cp $t s_string.ok
 		shift;;
 	*)
 		test "$#" -eq 0 || usage

--- a/dist/s_string
+++ b/dist/s_string
@@ -46,7 +46,7 @@ check() {
 # List of files to spellchk.
 l=`(cd .. &&
     find bench examples ext src test -name '*.[chsy]' &&
-    find src -name '*.in')`
+    find src -name '*.in' && find bench test -name '*.cxx')`
 
 usage()
 {

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -89,6 +89,7 @@ Cmvxz
 Cmvz
 Collet
 Comparator
+Compressibility
 Config
 Coverity
 CreateFileMapping
@@ -143,6 +144,7 @@ Encryptor
 Encryptors
 Enqueue
 Eron
+Exponentiate
 FALLOC
 FALLTHROUGH
 FH
@@ -225,6 +227,7 @@ JPEG
 JSON
 Jyrki
 KEYFIRST
+KEYGEN
 KV
 KVS
 Kanowski's
@@ -328,6 +331,7 @@ PPC
 PREDEFINE
 PRId
 PRIu
+PRIuXX
 PRNG
 PTHREAD
 PTR
@@ -385,6 +389,7 @@ SSHH
 SSq
 STAILQ
 STEC
+STL
 STR
 STRUCT
 Scalability
@@ -443,6 +448,7 @@ UTF
 UltraSparc
 Unbuffered
 Unencrypted
+Unhandled
 UnixLib
 UnlockFile
 Unmap
@@ -478,6 +484,7 @@ Wduplicated
 WeakHashLen
 Werror
 Wformat
+Whitespaces
 WideCharToMultiByte
 WinNT
 WiredTiger
@@ -549,6 +556,8 @@ backport
 bal
 basecfg
 basho
+bb
+bba
 bbb
 bcr
 beginthreadex
@@ -610,6 +619,7 @@ cd
 ce
 celsius
 centric
+cerr
 cfg
 cfko
 chacha
@@ -651,11 +661,13 @@ comparator
 comparep
 compat
 compressStream
+compressibility
 concat
 cond
 conf
 confchk
 config
+configs
 conn
 connectionp
 const
@@ -704,6 +716,7 @@ cv
 cval
 cx
 cxa
+cxx
 dT
 data's
 database's
@@ -833,6 +846,7 @@ fgetln
 fgets
 fh
 fhandle
+fileX
 filefrag
 filehandle
 fileid
@@ -999,6 +1013,7 @@ keycmp
 keyid
 keyids
 keylen
+keyrange
 keyv
 kmsid
 kv
@@ -1103,6 +1118,7 @@ mkdir
 mmap
 mmrand
 mnt
+mongod
 movemask
 mrs
 msecs
@@ -1200,6 +1216,7 @@ packv
 pagedump
 pageref
 pagesize
+param
 parens
 pareto
 parserp
@@ -1404,6 +1421,7 @@ syscrypto
 sysinfo
 sz
 t's
+tIf
 tK
 tM
 tV
@@ -1439,6 +1457,7 @@ transactionally
 trecno
 trk
 trk's
+trun
 trunc
 trylock
 tsc
@@ -1580,4 +1599,5 @@ zstd
 zstd's
 zu
 zyxwvutsrqponmlkjihgfedcba
+zz
 zzz

--- a/test/cppsuite/test_harness/workload/workload_tracking.cxx
+++ b/test/cppsuite/test_harness/workload/workload_tracking.cxx
@@ -99,7 +99,7 @@ workload_tracking::do_work()
     /* Take a copy of the oldest so that we sweep with a consistent timestamp. */
     oldest_ts = _tsm.get_oldest_ts();
 
-    /* We need to check if the component is still running to avoid unecessary iterations. */
+    /* We need to check if the component is still running to avoid unnecessary iterations. */
     while (_running && (ret = _sweep_cursor->prev(_sweep_cursor.get())) == 0) {
         testutil_check(_sweep_cursor->get_key(_sweep_cursor.get(), &collection_id, &key, &ts));
         testutil_check(_sweep_cursor->get_value(_sweep_cursor.get(), &op_type, &value));

--- a/test/cppsuite/tests/example_test.cxx
+++ b/test/cppsuite/tests/example_test.cxx
@@ -30,7 +30,7 @@
 
 /*
  * Class that defines operations that do nothing as an example. This shows how database operations
- * can be overriden and customized.
+ * can be overridden and customized.
  */
 class example_test : public test_harness::test {
     public:

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -37,7 +37,7 @@ using namespace test_harness;
  * In this test, we want to verify that search_near with prefix enabled only traverses the portion
  * of the tree that follows the prefix portion of the search key. The test is composed of a populate
  * phase followed by a read phase. The populate phase will insert a set of random generated keys
- * with a prefix of aaa -> zzz. During the read phase, we have one read thread that peforms:
+ * with a prefix of aaa -> zzz. During the read phase, we have one read thread that performs:
  *  - Spawning multiple threads to perform one prefix search near.
  *  - Waiting on all threads to finish.
  *  - Using WiredTiger statistics to validate that the number of entries traversed is within

--- a/test/cppsuite/tests/search_near_02.cxx
+++ b/test/cppsuite/tests/search_near_02.cxx
@@ -145,7 +145,7 @@ class search_near_02 : public test_harness::test {
     {
         /*
          * Each read operation performs search_near calls with and without prefix enabled on random
-         * collections. Each prefix is randomly generated. The result of the seach_near call with
+         * collections. Each prefix is randomly generated. The result of the search_near call with
          * prefix enabled is then validated using the search_near call without prefix enabled.
          */
         logger::log_msg(


### PR DESCRIPTION
Extend s_string utility to check .cxx files. The utility has then been run and the appropriate spelling mistakes were fixed. 