### PR TITLE
WT-8550 Bump the maximum number of opened hs cursors to 3

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -780,7 +780,6 @@ err:
     __wt_scr_free(session, &prev_full_value);
 
     WT_TRET(hs_cursor->close(hs_cursor));
-
     return (ret);
 }
 

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -317,7 +317,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
     uint32_t i;
     uint8_t *p;
     int nentries;
-    bool cur_hs_read_committed, enable_reverse_modify, error_on_ooo_ts, hs_inserted, squashed;
+    bool enable_reverse_modify, error_on_ooo_ts, hs_inserted, squashed;
 
     error_on_ooo_ts = F_ISSET(r, WT_REC_CHECKPOINT_RUNNING);
     r->cache_write_hs = false;
@@ -328,11 +328,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 
     if (r->hs_cursor == NULL)
         WT_RET(__wt_curhs_open(session, NULL, &r->hs_cursor));
-
-    cur_hs_read_committed = F_ISSET(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
-    if (!cur_hs_read_committed)
-        F_SET(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+    F_SET(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     __wt_update_vector_init(session, &updates);
     /*
@@ -783,10 +779,7 @@ err:
     __wt_scr_free(session, &full_value);
     __wt_scr_free(session, &prev_full_value);
 
-    /* Unset the flag if it was not set prior to this function. */
-    if (!cur_hs_read_committed)
-        F_CLR(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
+    F_CLR(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     return (ret);
 }
 

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -295,7 +295,6 @@ int
 __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *multi)
 {
     WT_BTREE *btree, *hs_btree;
-    WT_CURSOR *hs_cursor;
     WT_DECL_ITEM(full_value);
     WT_DECL_ITEM(key);
     WT_DECL_ITEM(modify_value);
@@ -327,8 +326,9 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
     insert_cnt = 0;
     WT_TIME_WINDOW_INIT(&tw);
 
-    WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+    if (r->hs_cursor == NULL)
+        WT_RET(__wt_curhs_open(session, NULL, &r->hs_cursor));
+    F_SET(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     __wt_update_vector_init(session, &updates);
     /*
@@ -540,7 +540,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 
             if (!F_ISSET(fix_ts_upd, WT_UPDATE_FIXED_HS)) {
                 /* Delete and reinsert any update of the key with a higher timestamp. */
-                WT_ERR(__wt_hs_delete_key_from_ts(session, hs_cursor, btree->id, key,
+                WT_ERR(__wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key,
                   fix_ts_upd->start_ts + 1, true, error_on_ooo_ts));
                 F_SET(fix_ts_upd, WT_UPDATE_FIXED_HS);
             }
@@ -681,7 +681,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 #endif
 
             /* Clear out the insert success flag prior to our insert attempt. */
-            __wt_curhs_clear_insert_success(hs_cursor);
+            __wt_curhs_clear_insert_success(r->hs_cursor);
 
             /*
              * Calculate reverse modify and clear the history store records with timestamps when
@@ -701,15 +701,15 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
               modify_cnt < WT_MAX_CONSECUTIVE_REVERSE_MODIFY &&
               __wt_calc_modify(session, prev_full_value, full_value, prev_full_value->size / 10,
                 entries, &nentries) == 0) {
-                WT_ERR(__wt_modify_pack(hs_cursor, entries, nentries, &modify_value));
-                ret = __hs_insert_record(session, hs_cursor, btree, key, WT_UPDATE_MODIFY,
+                WT_ERR(__wt_modify_pack(r->hs_cursor, entries, nentries, &modify_value));
+                ret = __hs_insert_record(session, r->hs_cursor, btree, key, WT_UPDATE_MODIFY,
                   modify_value, &tw, error_on_ooo_ts);
                 WT_STAT_CONN_DATA_INCR(session, cache_hs_insert_reverse_modify);
                 __wt_scr_free(session, &modify_value);
                 ++modify_cnt;
             } else {
                 modify_cnt = 0;
-                ret = __hs_insert_record(session, hs_cursor, btree, key, WT_UPDATE_STANDARD,
+                ret = __hs_insert_record(session, r->hs_cursor, btree, key, WT_UPDATE_STANDARD,
                   full_value, &tw, error_on_ooo_ts);
                 WT_STAT_CONN_DATA_INCR(session, cache_hs_insert_full_update);
             }
@@ -722,7 +722,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
              * to write the flag to mark the update as having been written to the history store
              * before jumping to the error handling.
              */
-            if (__wt_curhs_check_insert_success(hs_cursor)) {
+            if (__wt_curhs_check_insert_success(r->hs_cursor)) {
                 F_SET(upd, WT_UPDATE_HS);
                 if (tombstone != NULL)
                     F_SET(tombstone, WT_UPDATE_HS);
@@ -755,7 +755,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
     }
 
     WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
-    hs_btree = __wt_curhs_get_btree(hs_cursor);
+    hs_btree = __wt_curhs_get_btree(r->hs_cursor);
     max_hs_size = hs_btree->file_max;
     if (max_hs_size != 0 && (uint64_t)hs_size > max_hs_size)
         WT_ERR_PANIC(session, WT_PANIC,
@@ -779,7 +779,7 @@ err:
     __wt_scr_free(session, &full_value);
     __wt_scr_free(session, &prev_full_value);
 
-    WT_TRET(hs_cursor->close(hs_cursor));
+    F_CLR(r->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     return (ret);
 }
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -89,7 +89,7 @@
          * We should not leave any history store cursor open when return from an api call. \
          * However, we cannot do a stricter check before WT-7247 is resolved.              \
          */                                                                                \
-        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 2);            \
+        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 3);            \
         /*                                                                                 \
          * No code after this line, otherwise error handling                               \
          * won't be correct.                                                               \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -89,7 +89,7 @@
          * We should not leave any history store cursor open when return from an api call. \
          * However, we cannot do a stricter check before WT-7247 is resolved.              \
          */                                                                                \
-        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 3);            \
+        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 2);            \
         /*                                                                                 \
          * No code after this line, otherwise error handling                               \
          * won't be correct.                                                               \

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -29,9 +29,8 @@
 import wttest
 
 # test_hs29.py
-# Before the history store was reusing the cursor from the reconciliation structure, it was possible
-# to end up with 3 opened history store cursors at the same time while the hard limit is 2. The
-# following scenario would trigger the issue:
+# It is possible to end up with 3 opened history store cursors at the same time when the following
+# occurs:
 # - The reconciliation process opens one history store cursor.
 # - The function hs_delete_reinsert_from_pos creates a history store cursor too. This means we need
 # an update with an OOO timestamp to trigger that function.

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+
+# test_hs29.py
+# Test that we can open three hs cursors.
+class test_hs29(wttest.WiredTigerTestCase):
+
+    def test_3_hs_cursors(self):
+
+        # Create a table.
+        uri = "table:test_hs_cursor"
+        self.session.create(uri, 'key_format=S,value_format=S')
+        
+        # Open one cursor to operate on the table and another one to perform eviction.
+        cursor = self.session.open_cursor(uri)
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+
+        # Create two keys and perform an update on each.
+        self.session.begin_transaction()
+        cursor['1'] = '1'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+
+        self.session.begin_transaction()
+        cursor['1'] = '11'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+
+        self.session.begin_transaction()
+        cursor['2'] = '2'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        self.session.begin_transaction()
+        cursor['2'] = '22'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Perform eviction.
+        cursor2.set_key('1')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.reset(), 0)
+
+        cursor2.set_key('2')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.reset(), 0)
+
+        # Remove the first key without giving a ts.
+        self.session.begin_transaction()
+        cursor.set_key('1')
+        cursor.remove()
+        self.session.commit_transaction()
+
+        # Update the second key with out of order timestamp.
+        self.session.begin_transaction()
+        cursor['2'] = '222'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+
+        # Close the connection to trigger a final checkpoint and reconciliation.
+        self.conn.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -69,10 +69,12 @@ class test_hs29(wttest.WiredTigerTestCase):
         # Perform eviction.
         cursor2.set_key('1')
         self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '11')
         self.assertEqual(cursor2.reset(), 0)
 
         cursor2.set_key('2')
         self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '22')
         self.assertEqual(cursor2.reset(), 0)
 
         # Remove the first key without giving a ts.

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -29,7 +29,14 @@
 import wttest
 
 # test_hs29.py
-# Test that we can open three hs cursors.
+# Before the history store was reusing the cursor from the reconciliation structure, it was possible
+# to end up with 3 opened history store cursors at the same time while the hard limit is 2. The
+# following scenario would trigger the issue:
+# - The reconciliation process opens one history store cursor.
+# - The function hs_delete_reinsert_from_pos creates a history store cursor too. This means we need
+# an update with an OOO timestamp to trigger that function.
+# - The function wt_rec_hs_clear_on_tombstone creates a history store cursor as well. This means we
+# need a tombstone to trigger the function, i.e a deleted key.
 class test_hs29(wttest.WiredTigerTestCase):
 
     def test_3_hs_cursors(self):


### PR DESCRIPTION
In some scenarios, it is possible to open up to three hs cursors, see WT-8550 for more details and the new [Python script](https://github.com/wiredtiger/wiredtiger/pull/7362/files#diff-90038e6aefdcbf60dc857d7eb67c1cc0052e66ff763211868e4b4dfa8acfe87f) included in this PR.