### PR TITLE
WT-8606 Set project-level exec_timeout_secs in evergreen.yml

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -19,6 +19,7 @@ post:
   - func: "cleanup"
 timeout:
   - func: "run wt hang analyzer"
+exec_timeout_secs: 21600 # 6 hrs
 
 #######################################
 #            Functions                #


### PR DESCRIPTION
Set project-level `exec_timeout_secs` in evergreen.yml to address the below warning captured by the "evergreen validate" command. 
```
WARNING: project '' does not have an exec_timeout_secs defined on one or more tasks; these tasks will default to a timeout of 6 hours
test/evergreen.yml is valid with warnings
```