### PR TITLE
WT-8611 Use system timing stress function for compact.

### DIFF
--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -176,24 +176,6 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
- * __compact_timing_stress --
- *     Optionally add a delay to the compact for debug purposes.
- */
-static void
-__compact_timing_stress(WT_SESSION_IMPL *session)
-{
-    struct timespec tsp;
-
-    /* We only want to sleep if the flag is set. */
-    if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_COMPACT_SLOW)) {
-        /* Add a 2 second wait to simulate compact slowness. */
-        tsp.tv_sec = 2;
-        tsp.tv_nsec = 0;
-        __wt_sleep((uint64_t)tsp.tv_sec, (uint64_t)tsp.tv_nsec / WT_THOUSAND);
-    }
-}
-
-/*
  * __wt_session_compact_check_timeout --
  *     Check if the timeout has been exceeded.
  */
@@ -275,7 +257,7 @@ __compact_worker(WT_SESSION_IMPL *session)
             if (session->op_handle[i]->compact_skip)
                 continue;
 
-            __compact_timing_stress(session);
+            __wt_timing_stress(session, WT_TIMING_STRESS_COMPACT_SLOW);
 
             session->compact_state = WT_COMPACT_RUNNING;
             WT_WITH_DHANDLE(session, session->op_handle[i], ret = __wt_compact(session));


### PR DESCRIPTION
@raviprakashgiri29 I noticed this when I was doing other timing stress related work. Is there any reason why the compact timing stress needs its own function instead of using the system function? At a minimum I think we want this change.

However, I also could not find any test code, anywhere, that uses this. Is there any use of this? If not, can it be removed instead? I do not see any follow-on tickets for tests to use it. I can see why it was thought at the beginning of the compact project that it might be useful, but if it turned out not to be, can we just remove it?