### PR TITLE
WT-8424 Use consistent toolchain in little-endian (#7216)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3596,6 +3596,7 @@ buildvariants:
       top_dir=$(git rev-parse --show-toplevel)
       top_builddir=$top_dir/build_posix
       LD_LIBRARY_PATH=$top_builddir/.libs
+    make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
   tasks:
   - name: compile
   - name: generate-datafile-little-endian


### PR DESCRIPTION
When compiling WiredTiger in the Evergreen little-endian variant,
the build is configured with the v3 mongodbtoolchain. We
subsequently need to ensure the PATH is set to point to the mongodb
toolchain when running make. Otherwise build scripts invoked
during the compiliation process i.e. workgen's 'setup.py', will
be called with a mis-matched toolchain.

(cherry picked from commit 8b101406dae486678313d3189f971dc4beaa68d4)