### PR TITLE
WT-8621 Enable diagnostics for spinlock-gcc and spinlock-pthread-adaptive tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2391,7 +2391,7 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          posix_configure_flags: --enable-python --with-spinlock=gcc --enable-strict
+          posix_configure_flags: --enable-python --with-spinlock=gcc --enable-strict --enable-diagnostic
       - func: "make check all"
       - func: "format test"
         vars:
@@ -2403,7 +2403,7 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          posix_configure_flags: --enable-python --with-spinlock=pthread_adaptive --enable-strict
+          posix_configure_flags: --enable-python --with-spinlock=pthread_adaptive --enable-strict --enable-diagnostic
       - func: "make check all"
       - func: "format test"
         vars:


### PR DESCRIPTION
The new tests in `test_rollback_to_stable30.py` expect a verbose transaction
dump, but this only happens if diagnostics are enabled. Turn these on during
the configure stage.

The alternative would've been to change the log message that the test
expects to see, but there doesn't seem to be any harm in enabling
diagnostics.