### PR TITLE
WT-7922 Handle missing or empty WiredTiger version file

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1702,6 +1702,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_RET(__wt_config_gets(session, cfg, "create", &cval));
     is_create = cval.val != 0;
+
     if (F_ISSET(conn, WT_CONN_READONLY))
         is_create = false;
 
@@ -1830,7 +1831,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
      * If the turtle file exists, the WiredTiger file should exist as well, unless we are salvaging.
      */
     WT_ERR(__wt_config_gets(session, cfg, "salvage", &cval));
-    is_salvage = cval.val;
+    is_salvage = cval.val != 0;
     if (!is_salvage && !conn->is_new) {
         WT_ERR(__wt_fs_exist(session, WT_WIREDTIGER, &exist));
         if (!exist) {

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1831,7 +1831,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
      */
     WT_ERR(__wt_config_gets(session, cfg, "salvage", &cval));
     is_salvage = cval.val;
-    if (is_create && !is_salvage && !conn->is_new) {
+    if (!is_salvage && !conn->is_new) {
         WT_ERR(__wt_fs_exist(session, WT_WIREDTIGER, &exist));
         if (!exist) {
             F_SET(conn, WT_CONN_DATA_CORRUPTION);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1880,7 +1880,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
         WT_ERR(__wt_filesize(session, fh, &size));
         empty = size == 0;
         if (!is_salvage && !conn->is_new && empty)
-            WT_IGNORE_RET(__wt_msg(session, "WiredTiger version file is empty"));
+            WT_ERR(__wt_msg(session, "WiredTiger version file is empty"));
     }
 
     /*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1843,10 +1843,8 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     /* We own the lock file, optionally create the WiredTiger file. */
     ret = __wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR,
       is_create || is_salvage ? WT_FS_OPEN_CREATE : 0, &fh);
-
     empty = false;
-    WT_TRET(__wt_fs_exist(session, WT_WIREDTIGER, &exist));
-    if (exist) {
+    if (fh) {
         WT_TRET(__wt_filesize(session, fh, &size));
         if ((size_t)size == 0) {
             empty = true;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1843,6 +1843,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     /* We own the lock file, optionally create the WiredTiger file. */
     ret = __wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR,
       is_create || is_salvage ? WT_FS_OPEN_CREATE : 0, &fh);
+
     empty = false;
     if (fh) {
         WT_TRET(__wt_filesize(session, fh, &size));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1877,7 +1877,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     empty = false;
     if (fh != NULL) {
         WT_ERR(__wt_filesize(session, fh, &size));
-        empty = (size_t)size == 0;
+        empty = size == 0;
         if (!is_salvage && !conn->is_new && empty)
             WT_IGNORE_RET(__wt_msg(session, "WiredTiger version file is empty"));
     }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1844,8 +1844,8 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     ret = __wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR,
       is_create || is_salvage ? WT_FS_OPEN_CREATE : 0, &fh);
 
+    WT_ERR(__wt_filesize(session, fh, &size));
     if (!is_salvage && !conn->is_new) {
-        WT_ERR(__wt_filesize(session, fh, &size));
         if ((size_t)size == 0)
             /*
              * If WiredTiger file exists but is size zero, write a message but don't fail.
@@ -1881,7 +1881,6 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     /*
      * Populate WiredTiger file if new connection or WiredTiger file is empty and we are salvaging.
      */
-    WT_ERR(__wt_filesize(session, fh, &size));
     if (conn->is_new || (is_salvage && (size_t)size == 0)) {
         if (F_ISSET(conn, WT_CONN_READONLY))
             WT_ERR_MSG(session, EINVAL,

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1828,7 +1828,8 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     conn->is_new = exist ? 0 : 1;
 
     /*
-     * If the turtle file exists, the WiredTiger file should exist as well, unless we are salvaging.
+     * Unless we are salvaging, if the turtle file exists then the WiredTiger file should exist as
+     * well.
      */
     WT_ERR(__wt_config_gets(session, cfg, "salvage", &cval));
     is_salvage = cval.val != 0;
@@ -1883,7 +1884,8 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     }
 
     /*
-     * Populate WiredTiger file if new connection or WiredTiger file is empty and we are salvaging.
+     * Populate the WiredTiger file if this is a new connection or if the WiredTiger file is empty
+     * and we are salvaging.
      */
     if (conn->is_new || (is_salvage && empty)) {
         if (F_ISSET(conn, WT_CONN_READONLY))

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1851,7 +1851,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* We own the lock file, optionally create the WiredTiger file. */
     ret = __wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR,
-      is_create || cval.val ? WT_FS_OPEN_CREATE : 0, &fh);
+      is_create || is_salvage ? WT_FS_OPEN_CREATE : 0, &fh);
 
     /*
      * If we're read-only, check for handled errors. Even if able to open the WiredTiger file

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1695,7 +1695,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     wt_off_t size;
     size_t len;
     char buf[256];
-    bool bytelock, exist, empty, is_create, is_salvage, match;
+    bool bytelock, empty, exist, is_create, is_salvage, match;
 
     conn = S2C(session);
     fh = NULL;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1836,13 +1836,13 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
             F_SET(conn, WT_CONN_DATA_CORRUPTION);
             WT_ERR_MSG(session, WT_TRY_SALVAGE, "WiredTiger version file cannot be found");
         } else {
-            WT_RET(__wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR, 0, &fh));
+            WT_ERR(__wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR, 0, &fh));
             WT_ERR(__wt_filesize(session, fh, &size));
             if ((size_t)size == 0)
                 /*
                  * If WiredTiger file exists but is size zero, write a message but don't fail.
                  */
-                WT_RET(__wt_msg(session, "WiredTiger version file is empty"));
+                WT_ERR(__wt_msg(session, "WiredTiger version file is empty"));
             WT_TRET(__wt_close(session, &fh));
         }
     }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1837,21 +1837,21 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
         if (!exist) {
             F_SET(conn, WT_CONN_DATA_CORRUPTION);
             WT_ERR_MSG(session, WT_TRY_SALVAGE, "WiredTiger version file cannot be found");
-        } else {
-            WT_ERR(__wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR, 0, &fh));
-            WT_ERR(__wt_filesize(session, fh, &size));
-            if ((size_t)size == 0)
-                /*
-                 * If WiredTiger file exists but is size zero, write a message but don't fail.
-                 */
-                WT_ERR(__wt_msg(session, "WiredTiger version file is empty"));
-            WT_TRET(__wt_close(session, &fh));
         }
     }
 
     /* We own the lock file, optionally create the WiredTiger file. */
     ret = __wt_open(session, WT_WIREDTIGER, WT_FS_OPEN_FILE_TYPE_REGULAR,
       is_create || is_salvage ? WT_FS_OPEN_CREATE : 0, &fh);
+
+    if (!is_salvage && !conn->is_new) {
+        WT_ERR(__wt_filesize(session, fh, &size));
+        if ((size_t)size == 0)
+            /*
+             * If WiredTiger file exists but is size zero, write a message but don't fail.
+             */
+            WT_ERR(__wt_msg(session, "WiredTiger version file is empty"));
+    }
 
     /*
      * If we're read-only, check for handled errors. Even if able to open the WiredTiger file

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1875,7 +1875,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
      * exists and we are not salvaging), write a message but don't fail.
      */
     empty = false;
-    if (fh) {
+    if (fh != NULL) {
         WT_ERR(__wt_filesize(session, fh, &size));
         empty = (size_t)size == 0;
         if (!is_salvage && !conn->is_new && empty)

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1847,9 +1847,7 @@ __conn_single(WT_SESSION_IMPL *session, const char *cfg[])
     empty = false;
     if (fh) {
         WT_TRET(__wt_filesize(session, fh, &size));
-        if ((size_t)size == 0) {
-            empty = true;
-        }
+        empty = (size_t)size == 0;
         if (!is_salvage && !conn->is_new && empty)
             /*
              * If WiredTiger file exists but is size zero when it is not supposed to be (the turtle

--- a/test/suite/test_config10.py
+++ b/test/suite/test_config10.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_config10.py
+#   Test valid behaviour when starting WiredTiger with the with missing
+#   or empty WiredTiger version file.
+
+import wiredtiger, wttest
+from wiredtiger import stat
+import os
+
+class test_config10(wttest.WiredTigerTestCase):
+    uri = 'table:config10.'
+    
+    def test_missing_version_file(self):
+        self.conn.close()
+        os.remove('WiredTiger')
+        # Ensure error occurs when WiredTiger file is missing.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.setUpConnectionOpen('.'), '/WT_TRY_SALVAGE: database corruption detected/')
+    
+    def test_empty_version_file(self):
+        self.conn.close()
+        # Ensure returns message when WiredTiger file is empty.
+        open('WiredTiger','w').close()
+        expectMessage = 'WiredTiger version file is empty'
+        with self.expectedStdoutPattern(expectMessage):
+            self.setUpConnectionOpen('.')
+
+    def test_missing_version_file_with_salvage(self):
+        self.conn.close()
+        os.remove('WiredTiger')
+        salvage_config = 'salvage=true'
+        self.conn = self.wiredtiger_open('.', salvage_config)
+        # Check salvage creates and populates file.
+        self.assertNotEqual(os.stat('WiredTiger').st_size, 0)
+
+    def test_empty_version_file_with_salvage(self):
+        self.conn.close()
+        open('WiredTiger','w').close()
+        salvage_config = 'salvage=true'
+        self.conn = self.wiredtiger_open('.', salvage_config)
+        # Check salvage populates file.
+        self.assertNotEqual(os.stat('WiredTiger').st_size, 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_config10.py
+++ b/test/suite/test_config10.py
@@ -27,8 +27,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # test_config10.py
-#   Test valid behaviour when starting WiredTiger with the with missing
-#   or empty WiredTiger version file.
+#   Test valid behaviour when starting WiredTiger with missing or empty
+#   WiredTiger version file.
 
 import wiredtiger, wttest
 from wiredtiger import stat

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -401,7 +401,6 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
     openable = [
         "removal:WiredTiger.basecfg",
         "removal:WiredTiger.turtle",
-        "removal:WiredTiger",
         "truncate:WiredTiger",
         "truncate:WiredTiger.basecfg",
         "truncate-middle:WiredTiger",
@@ -509,6 +508,9 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
                     self.reopen_conn(dir, self.conn_config)
                     self.captureout.checkAdditionalPattern(self,
                         'unexpected file WiredTiger.wt found, renamed to WiredTiger.wt.1')
+            elif self.filename == 'WiredTiger' and self.kind == 'truncate':
+                with self.expectedStdoutPattern("WiredTiger version file is empty"):
+                    self.reopen_conn(dir, self.conn_config)
             else:
                 self.reopen_conn(dir, self.conn_config)
             self.close_conn()


### PR DESCRIPTION
- If the `WiredTiger` file is missing during a normal startup, WiredTiger will write an error message and fail.
- If the `WiredTiger` file is empty during a normal startup, WiredTiger will write an error message.
- If the `WiredTiger` file is missing or empty, but "salvage" is on, it will create and populate the file with the current version string.