### PR TITLE
WT-8616 Btree walk functions can ignore the caller's "skip function"

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -438,7 +438,10 @@ descend:
                 if (skip)
                     break;
                 empty_internal = false;
-            } else if (skip_func != NULL) {
+            }
+
+            /* See if our caller wants to skip this page. */
+            if (skip_func != NULL) {
                 WT_ERR(skip_func(session, ref, func_cookie, &skip));
                 if (skip)
                     break;


### PR DESCRIPTION
Check if the caller wants to skip the page regardless of the outcome of previous "skip this page tests". If the caller wants to skip a class of pages (for example, compaction wants to skip all leaf pages), we have to check in the caller's skip function regardless of other tests.

@kommiharibabu, @sulabhM, I'm asking you for review because I think the danger in this one is that some other user of the custom tree-walk skip functionality isn't prepared for the skip function to be called after an earlier test in the tree-walk code has already tested some page information. I don't see a problem, but I think there's danger there. The interesting cases are cursor.next/prev, sync and RTS, and I believe you two are likely to be the best reviewers of changes in those areas. -- Thank you!