### PR TITLE
WT-8635 Extend VLCS RLE caching test to another set of cases

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -321,6 +321,10 @@ restart_read:
          * It is only safe to cache the value for other keys in the same RLE cell if it is globally
          * visible. Otherwise, there might be some older timestamp where the value isn't uniform
          * across the cell. Always set cip_saved so it's easy to tell when we change cells.
+         *
+         * Note: it's important that we're checking the on-disk value for global visibility, and not
+         * whatever __wt_txn_read returned, which might be something else. (If it's something else,
+         * we can't cache it; but in that case the on-disk value cannot be globally visible.)
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -479,6 +479,10 @@ restart_read:
          * It is only safe to cache the value for other keys in the same RLE cell if it is globally
          * visible. Otherwise, there might be some older timestamp where the value isn't uniform
          * across the cell. Always set cip_saved so it's easy to tell when we change cells.
+         *
+         * Note: it's important that we're checking the on-disk value for global visibility, and not
+         * whatever __wt_txn_read returned, which might be something else. (If it's something else,
+         * we can't cache it; but in that case the on-disk value cannot be globally visible.)
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&

--- a/test/suite/test_hs27.py
+++ b/test/suite/test_hs27.py
@@ -275,7 +275,6 @@ class test_hs27(wttest.WiredTigerTestCase):
             self.initialize(ds.uri, ds)
 
         # Create a long running read transaction in a separate session.
-        # (Is it necessary for it to be separate? Not sure.)
         session_read = self.conn.open_session()
         session_read.begin_transaction('read_timestamp=' + self.timestamp_str(2))
 
@@ -287,8 +286,6 @@ class test_hs27(wttest.WiredTigerTestCase):
 
         # Check that the new updates are appropriately visible.
         self.checkall(self.session, ds.uri, ds)
-
-        self.session.breakpoint()
 
         # Now forcibly evict, so that all the pages are RLE-encoded and then read back in.
         # There doesn't seem to be any way to just forcibly evict an entire table, so what


### PR DESCRIPTION
Extend hs26 to the case when its initial values are globally stable.

Add comments in cursor next/prev to note a critical point about why this works.

While here, tidy up a couple leftovers in the test code.