### PR TITLE
WT-8437 Fix "No space left on device" issue

### DIFF
--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -169,10 +169,6 @@ run_test(bool column_store, const char *uri, bool preserve)
     testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 
     printf("Compact process interrupted and killed...\n");
-
-    /* Copy the data to a separate folder for debugging purpose. */
-    testutil_copy_data(home);
-
     printf("Open database and run recovery\n");
 
     /* Open the connection which forces recovery to be run. */

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -243,7 +243,8 @@ testutil_cleanup(TEST_OPTS *opts)
 
 /*
  * testutil_copy_data --
- *     Copy the data to a backup folder.
+ *     Copy the data to a backup folder. Usually, the data copy is cleaned up by a call to
+ *     testutil_clean_test_artifacts.
  */
 void
 testutil_copy_data(const char *dir)


### PR DESCRIPTION
Do not make a copy of the working database in wt8246_compact_rts_data_correctness because it's not used anywhere and not deleted after the test is finished.