### PR TITLE
WT-8637 Fix Mem Leak error for csuite build directory option

### DIFF
--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -239,6 +239,7 @@ testutil_cleanup(TEST_OPTS *opts)
     free(opts->uri);
     free(opts->progress_file_name);
     free(opts->home);
+    free(opts->build_dir);
 }
 
 /*


### PR DESCRIPTION
When using ASAN, we generate LeakSanitizer errors if passing a build directory option (-b) to the csuite test framework library.
This particular option allocates memory to hold the build directory path string but doesn't free the memory on exit/cleanup. To avoid a memory leak, we want to free the memory backing the build directory argument on `testutil_cleanup`.