### PR TITLE
WT-8642 Update test code with failed system calls to report errno

### DIFF
--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -665,7 +665,7 @@ incr_backup(WT_CONNECTION *conn, const char *home, const char *backup_home, TABL
             testutil_check(session->open_cursor(session, NULL, cursor, buf, &file_cursor));
             VERBOSE(3, "open_cursor(session, NULL, cursor, \"%s\", &file_cursor)\n", buf);
             while ((ret = file_cursor->next(file_cursor)) == 0) {
-                error_check(file_cursor->get_key(file_cursor, &offset, &size, &type));
+                testutil_check(file_cursor->get_key(file_cursor, &offset, &size, &type));
                 testutil_assert(type == WT_BACKUP_FILE || type == WT_BACKUP_RANGE);
                 if (type == WT_BACKUP_RANGE) {
                     nrange++;

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -191,10 +191,10 @@ again:
 #if 0
             fprintf(stderr, "Removing file from backup: %s\n", filename);
 #endif
-            error_sys_check(unlink(filename));
+            testutil_assert_errno(unlink(filename) == 0);
             testutil_check(__wt_snprintf(
               filename, sizeof(filename), "%s/BACKUP.copy/%s", g.home, prev->names[prevpos]));
-            error_sys_check(unlink(filename));
+            testutil_assert_errno(unlink(filename) == 0);
         } else {
             /*
              * There is something in the current list not in the prev list. Walk past it in the
@@ -258,21 +258,21 @@ copy_blocks(WT_SESSION *session, WT_CURSOR *bkup_c, const char *name)
                 len = strlen(g.home) + strlen(name) + 10;
                 tmp = dmalloc(len);
                 testutil_check(__wt_snprintf(tmp, len, "%s/%s", g.home, name));
-                error_sys_check(rfd = open(tmp, O_RDONLY, 0644));
+                testutil_assert_errno((rfd = open(tmp, O_RDONLY, 0644)) != -1);
                 free(tmp);
                 tmp = NULL;
 
                 len = strlen(g.home) + strlen("BACKUP") + strlen(name) + 10;
                 tmp = dmalloc(len);
                 testutil_check(__wt_snprintf(tmp, len, "%s/BACKUP/%s", g.home, name));
-                error_sys_check(wfd1 = open(tmp, O_WRONLY | O_CREAT, 0644));
+                testutil_assert_errno((wfd1 = open(tmp, O_WRONLY | O_CREAT, 0644)) != -1);
                 free(tmp);
                 tmp = NULL;
 
                 len = strlen(g.home) + strlen("BACKUP.copy") + strlen(name) + 10;
                 tmp = dmalloc(len);
                 testutil_check(__wt_snprintf(tmp, len, "%s/BACKUP.copy/%s", g.home, name));
-                error_sys_check(wfd2 = open(tmp, O_WRONLY | O_CREAT, 0644));
+                testutil_assert_errno((wfd2 = open(tmp, O_WRONLY | O_CREAT, 0644)) != -1);
                 free(tmp);
                 tmp = NULL;
 
@@ -297,12 +297,12 @@ copy_blocks(WT_SESSION *session, WT_CURSOR *bkup_c, const char *name)
             total = 0;
             while (total < size) {
                 /* Use the read size since we may have read less than the granularity. */
-                error_sys_check(rdsize = read(rfd, tmp, this_size));
+                testutil_assert_errno((rdsize = read(rfd, tmp, this_size)) != -1);
                 /* If we get EOF, we're done. */
                 if (rdsize == 0)
                     break;
-                error_sys_check(write(wfd1, tmp, (size_t)rdsize));
-                error_sys_check(write(wfd2, tmp, (size_t)rdsize));
+                testutil_assert_errno((write(wfd1, tmp, (size_t)rdsize)) != -1);
+                testutil_assert_errno((write(wfd2, tmp, (size_t)rdsize)) != -1);
                 total += (uint64_t)rdsize;
                 offset += (uint64_t)rdsize;
                 this_size = WT_MIN(this_size, size - total);
@@ -334,9 +334,9 @@ copy_blocks(WT_SESSION *session, WT_CURSOR *bkup_c, const char *name)
     testutil_assert(ret == WT_NOTFOUND);
     testutil_check(incr_cur->close(incr_cur));
     if (rfd != -1) {
-        error_sys_check(close(rfd));
-        error_sys_check(close(wfd1));
-        error_sys_check(close(wfd2));
+        testutil_assert_errno(close(rfd) == 0);
+        testutil_assert_errno(close(wfd1) == 0);
+        testutil_assert_errno(close(wfd2) == 0);
     }
     free(tmp);
 }
@@ -449,7 +449,7 @@ save_backup_info(ACTIVE_FILES *active, uint64_t id)
     len = strlen(g.home) + strlen(BACKUP_INFO_FILE) + 2;
     to_path = dmalloc(len);
     testutil_check(__wt_snprintf(to_path, len, "%s/%s", g.home, BACKUP_INFO_FILE));
-    error_sys_check(rename(from_path, to_path));
+    testutil_assert_errno(rename(from_path, to_path) == 0);
     free(from_path);
     free(to_path);
 }

--- a/test/format/import.c
+++ b/test/format/import.c
@@ -150,9 +150,9 @@ verify_import(WT_SESSION *session)
     testutil_check(session->open_cursor(session, IMPORT_URI, NULL, NULL, &cursor));
 
     while ((ret = cursor->next(cursor)) == 0) {
-        error_check(cursor->get_key(cursor, &key));
+        testutil_check(cursor->get_key(cursor, &key));
         testutil_assert(key == iteration);
-        error_check(cursor->get_value(cursor, &value));
+        testutil_check(cursor->get_value(cursor, &value));
         testutil_assert(value == iteration);
         iteration++;
     }

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -155,6 +155,8 @@ typedef struct {
  * error_sys_check --
  *     Complain and quit if a function call fails. A special name because it appears in the
  *     documentation. Allow any non-negative values.
+ *
+ *     DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
  */
 #define error_sys_check(call)                                                     \
     do {                                                                          \
@@ -168,6 +170,8 @@ typedef struct {
  *     Complain and quit if a function call fails. A special name because it appears in the
  *     documentation. Ignore ENOTSUP to allow library calls which might not be included in any
  *     particular build.
+ *
+ *     DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
  */
 #define error_check(call)                                                         \
     do {                                                                          \

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -156,7 +156,7 @@ typedef struct {
  *     Complain and quit if a function call fails. A special name because it appears in the
  *     documentation. Allow any non-negative values.
  *
- *     DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
+ * DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
  */
 #define error_sys_check(call)                                                     \
     do {                                                                          \
@@ -171,7 +171,7 @@ typedef struct {
  *     documentation. Ignore ENOTSUP to allow library calls which might not be included in any
  *     particular build.
  *
- *     DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
+ * DO NOT USE THIS MACRO IN TEST CODE, IT IS ONLY FOR DOCUMENTATION.
  */
 #define error_check(call)                                                         \
     do {                                                                          \


### PR DESCRIPTION
Don't use documentation macros in test code, specifically update test code with failed system calls to report errno.