### PR TITLE
WT-7236 wiredtiger_crc32c_func() should cache result

### DIFF
--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -106,14 +106,25 @@ extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
 {
+    static uint32_t (*crc32c_func)(const void *, size_t);
 #if defined(__linux__) && !defined(HAVE_NO_CRC32_HARDWARE)
-    unsigned long caps = getauxval(AT_HWCAP);
+    unsigned long caps;
+#endif
 
+    /*
+     * This function calls slow hardware functions; if the application doesn't realize that, they
+     * may call it on every request.
+     */
+    if (crc32c_func != NULL)
+        return (crc32c_func);
+
+#if defined(__linux__) && !defined(HAVE_NO_CRC32_HARDWARE)
+    caps = getauxval(AT_HWCAP);
     if (caps & HWCAP_S390_VX)
-        return (__wt_checksum_hw);
+        return (crc32c_func = __wt_checksum_hw);
     else
-        return (__wt_checksum_sw);
+        return (crc32c_func = __wt_checksum_sw);
 #else
-    return (__wt_checksum_sw);
+    return (crc32c_func = __wt_checksum_sw);
 #endif
 }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3663,13 +3663,13 @@ struct __wt_config_parser {
 /*!
  * Return a pointer to a function that calculates a CRC32C checksum.
  *
- * The WiredTiger library CRC32C checksum function uses hardware support where
- * available, else it falls back to a software implementation.
+ * The WiredTiger library CRC32C checksum function uses hardware support where available, else it
+ * falls back to a software implementation. Selecting a CRC32C checksum function can be slow, the
+ * return value should be cached by the caller for repeated use.
  *
  * @snippet ex_all.c Checksum a buffer
  *
- * @returns a pointer to a function that takes a buffer and length and returns
- * the CRC32C checksum
+ * @returns a pointer to a function that takes a buffer and length and returns the CRC32C checksum
  */
 uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
     WT_ATTRIBUTE_LIBRARY_VISIBLE;


### PR DESCRIPTION
Cache the result of the wiredtiger_crc32c_func() return value, the server is calling it on every CRC32 operation.