### PR TITLE
WT-8636: add check for zero snprintf buffer size when buffer is NULL

### DIFF
--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -134,8 +134,12 @@ __fstream_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, const char *fmt, va
         va_copy(ap_copy, ap);
         if ((p = buf->mem) != NULL)
             p += buf->size;
-        WT_ASSERT(session, buf->memsize >= buf->size);
         space = buf->memsize - buf->size;
+
+        WT_ASSERT(session, buf->memsize >= buf->size);
+        if (buf->mem == NULL)
+            WT_ASSERT(session, space == 0);
+
         WT_RET(__wt_vsnprintf_len_set(p, space, &len, fmt, ap_copy));
         va_end(ap_copy);
 


### PR DESCRIPTION
This is to fix the immediate issue identified by Coverity. None of the other uses of this function were identified as problematic. It would be possible to add this check to all of them, but not all callers have a `session` available for `WT_ASSERT`, and it would be a lot of noise to fix this in lots of places that my have other guarantees the arguments are valid.

It would also be possible to add this check to `__wt_vsnprintf_len_set`, but again it doesn't have a `session` pointer, and there really shouldn't be a need to change the signature to provide one.