### PR TITLE
WT-8664 Rework the monitoring component and statistics in the cpp suite

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -88,21 +88,21 @@ enabled_config_false = [
         type='boolean'),
 ]
 
-stat_config = enabled_config_false
-
-limit_stat = stat_config + [
-    Config('limit', 0, r'''
-    The limit value a statistic is allowed to reach''', min=0)
-]
-
 range_config = [
     Config('min', 0, r'''
-        The minimum a value can be in a range''', min=0),
+        Lower limit''', min=0),
     Config('max', 1, r'''
-        The maximum a value can be in a range''')
+        Upper limit''')
 ]
 
-component_config =  throttle_config
+stat_config = range_config + [
+    Config('postrun', 'false', r'''
+        Whether the stat needs to be checked post run.''', type='boolean'),
+    Config('runtime', 'false', r'''
+        Whether the stat needs to be checked at runtime.''', type='boolean'),
+]
+
+component_config = throttle_config
 
 transaction_config = [
     Config('ops_per_transaction', '', r'''
@@ -129,16 +129,18 @@ checkpoint_manager = enabled_config_false + component_config
 # that need to be checked by the component.
 #
 runtime_monitor = enabled_config_true + component_config + [
-    Config('stat_cache_size', '', '''
-        The maximum cache percentage that can be hit while running.''',
-        type='category', subconfig=limit_stat),
-    Config('stat_db_size', '', '''
-        The maximum on-disk database size in bytes that can be hit while running.''',
-        type='category', subconfig=limit_stat),
-    Config('postrun_statistics', '[]', '''
-        A list of statistics to be checked after the workload has completed. Each element of the
-        list should be formatted as "stat_name:min_limit:max_limit".''',
-        type='list')
+    Config('cache_hs_insert', '', r'''
+        Number of history store table insert calls.''',
+        type='category', subconfig=stat_config),
+    Config('cc_pages_removed', '', r'''
+        Number of pages removed.''',
+        type='category', subconfig=stat_config),
+    Config('stat_cache_size', '', r'''
+        Cache size statistics.''',
+        type='category', subconfig=stat_config),
+    Config('stat_db_size', '', r'''
+        Size of the database.''',
+        type='category', subconfig=stat_config),
 ]
 
 #

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -6,19 +6,32 @@ static const WT_CONFIG_CHECK confchk_checkpoint_manager_subconfigs[] = {
   {"enabled", "boolean", NULL, NULL, NULL, 0}, {"op_rate", "string", NULL, NULL, NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
+static const WT_CONFIG_CHECK confchk_cache_hs_insert_subconfigs[] = {
+  {"max", "string", NULL, NULL, NULL, 0}, {"min", "int", NULL, "min=0", NULL, 0},
+  {"postrun", "boolean", NULL, NULL, NULL, 0}, {"runtime", "boolean", NULL, NULL, NULL, 0},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
+
+static const WT_CONFIG_CHECK confchk_cc_pages_removed_subconfigs[] = {
+  {"max", "string", NULL, NULL, NULL, 0}, {"min", "int", NULL, "min=0", NULL, 0},
+  {"postrun", "boolean", NULL, NULL, NULL, 0}, {"runtime", "boolean", NULL, NULL, NULL, 0},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
+
 static const WT_CONFIG_CHECK confchk_stat_cache_size_subconfigs[] = {
-  {"enabled", "boolean", NULL, NULL, NULL, 0}, {"limit", "int", NULL, "min=0", NULL, 0},
+  {"max", "string", NULL, NULL, NULL, 0}, {"min", "int", NULL, "min=0", NULL, 0},
+  {"postrun", "boolean", NULL, NULL, NULL, 0}, {"runtime", "boolean", NULL, NULL, NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_stat_db_size_subconfigs[] = {
-  {"enabled", "boolean", NULL, NULL, NULL, 0}, {"limit", "int", NULL, "min=0", NULL, 0},
+  {"max", "string", NULL, NULL, NULL, 0}, {"min", "int", NULL, "min=0", NULL, 0},
+  {"postrun", "boolean", NULL, NULL, NULL, 0}, {"runtime", "boolean", NULL, NULL, NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_runtime_monitor_subconfigs[] = {
+  {"cache_hs_insert", "category", NULL, NULL, confchk_cache_hs_insert_subconfigs, 4},
+  {"cc_pages_removed", "category", NULL, NULL, confchk_cc_pages_removed_subconfigs, 4},
   {"enabled", "boolean", NULL, NULL, NULL, 0}, {"op_rate", "string", NULL, NULL, NULL, 0},
-  {"postrun_statistics", "list", NULL, NULL, NULL, 0},
-  {"stat_cache_size", "category", NULL, NULL, confchk_stat_cache_size_subconfigs, 2},
-  {"stat_db_size", "category", NULL, NULL, confchk_stat_db_size_subconfigs, 2},
+  {"stat_cache_size", "category", NULL, NULL, confchk_stat_cache_size_subconfigs, 4},
+  {"stat_db_size", "category", NULL, NULL, confchk_stat_db_size_subconfigs, 4},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_statistics_config_subconfigs[] = {
@@ -79,7 +92,7 @@ static const WT_CONFIG_CHECK confchk_base_test[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -93,7 +106,7 @@ static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -106,7 +119,7 @@ static const WT_CONFIG_CHECK confchk_example_test[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -119,7 +132,7 @@ static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -132,7 +145,7 @@ static const WT_CONFIG_CHECK confchk_search_near_01[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"search_near_threads", "string", NULL, NULL, NULL, 0},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -146,7 +159,7 @@ static const WT_CONFIG_CHECK confchk_search_near_02[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -159,7 +172,7 @@ static const WT_CONFIG_CHECK confchk_search_near_03[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
   {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
@@ -170,9 +183,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"base_test",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"
@@ -189,9 +204,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "burst_duration=90,cache_size_mb=0,"
     "checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"
@@ -207,9 +224,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"example_test",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"
@@ -225,9 +244,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"hs_cleanup",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"
@@ -243,12 +264,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"search_near_01",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),search_near_threads=10,"
-    "statistics_config=(enable_logging=true,type=all),"
-    "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
-    "stable_lag=1),workload_generator=(enabled=true,"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
+    "search_near_threads=10,statistics_config=(enable_logging=true,"
+    "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
+    "op_rate=1s,stable_lag=1),workload_generator=(enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -261,9 +284,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"search_near_02",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"
@@ -279,9 +304,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"search_near_03",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
+    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
+    "min=0,postrun=false,runtime=false),cc_pages_removed=(max=1,min=0"
+    ",postrun=false,runtime=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false),"
+    "stat_db_size=(max=1,min=0,postrun=false,runtime=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(enabled=true,"

--- a/test/cppsuite/configs/base_test_default.txt
+++ b/test/cppsuite/configs/base_test_default.txt
@@ -1,5 +1,5 @@
 # Used as a base test for the framework.
-duration_seconds=5,
+duration_seconds=60,
 cache_size_mb=200,
 enable_logging=true,
 checkpoint_manager=

--- a/test/cppsuite/configs/base_test_default.txt
+++ b/test/cppsuite/configs/base_test_default.txt
@@ -1,5 +1,5 @@
 # Used as a base test for the framework.
-duration_seconds=60,
+duration_seconds=5,
 cache_size_mb=200,
 enable_logging=true,
 checkpoint_manager=
@@ -9,18 +9,27 @@ checkpoint_manager=
 ),
 runtime_monitor=
 (
+    cache_hs_insert=
+    (
+        max=100000000,
+        postrun=true,
+    ),
+    cc_pages_removed=
+    (
+        max=10000000,
+        postrun=true,
+    ),
     stat_cache_size=
     (
-        enabled=true,
-        limit=1000
+        max=1000,
+        runtime=true,
     ),
     stat_db_size=
     (
-        enabled=true,
         #10GB
-        limit=10000000000
+        max=10000000000,
+        runtime=true,
     ),
-    postrun_statistics=[cache_hs_insert:0:100000000, cc_pages_removed:0:10000000],
 ),
 timestamp_manager=
 (

--- a/test/cppsuite/configs/base_test_insert_heavy.txt
+++ b/test/cppsuite/configs/base_test_insert_heavy.txt
@@ -6,14 +6,6 @@ checkpoint_manager=
     enabled=true,
     op_rate=20s
 ),
-runtime_monitor=
-(
-    stat_cache_size=
-    (
-        enabled=false,
-        limit=100
-    )
-),
 timestamp_manager=
 (
     enabled=true,

--- a/test/cppsuite/configs/base_test_stress.txt
+++ b/test/cppsuite/configs/base_test_stress.txt
@@ -9,17 +9,12 @@ checkpoint_manager=
 ),
 runtime_monitor=
 (
-    stat_cache_size=
-    (
-        enabled=false,
-        limit=100
-    ),
     stat_db_size=
     (
-        enabled=true,
         #At the end of the run the data files are approximately 2.3MB each. Which is a total of:
         #1.15GB, the history store isn't significant. Give the workload an extra 200MB of margin.
-        limit=1350000000,
+        max=1350000000,
+        runtime=true,
     )
 ),
 timestamp_manager=

--- a/test/cppsuite/configs/burst_inserts_stress.txt
+++ b/test/cppsuite/configs/burst_inserts_stress.txt
@@ -6,10 +6,6 @@ checkpoint_manager=
     enabled=true,
     op_rate=60s
 ),
-runtime_monitor=
-(
-    enabled=false
-),
 timestamp_manager=
 (
     enabled=true,

--- a/test/cppsuite/configs/hs_cleanup_default.txt
+++ b/test/cppsuite/configs/hs_cleanup_default.txt
@@ -14,18 +14,28 @@ checkpoint_manager=
 ),
 runtime_monitor=
 (
+    cache_hs_insert=
+    (
+        max=10,
+        max=100000000,
+        postrun=true,
+    ),
+    cc_pages_removed=
+    (
+        max=10000000,
+        postrun=true,
+    ),
     stat_cache_size=
     (
-        enabled=true,
-        limit=1000
+        max=1000,
+        runtime=true,
     ),
     stat_db_size=
     (
-        enabled=true,
         #10GB
-        limit=10000000000
+        max=10000000000,
+        runtime=true,
     ),
-    postrun_statistics=[cache_hs_insert:10:100000000, cc_pages_removed:0:10000000],
 ),
 timestamp_manager=
 (

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -14,21 +14,32 @@ checkpoint_manager=
 ),
 runtime_monitor=
 (
+    # Seems to insert around 477K records. Give it +-20K margin.
+    cache_hs_insert=
+    (
+        max=497000,
+        min=457000,
+        postrun=true,
+    ),
+    # Seems to remove 160K records. Give it a similar margin.
+    cc_pages_removed=
+    (
+        max=170000,
+        min=150000,
+        postrun=true,
+    ),
     stat_cache_size=
     (
-        enabled=true,
-        limit=110
+        max=110,
+        runtime=true,
     ),
     # The data files compress to around 25MB per table at the end of a run so 250MB total.
     # +1.4GB for the history store. With an additional 150MB margin.
     stat_db_size=
     (
-        enabled=true,
-        limit=1900000000,
+        max=1900000000,
+        runtime=true,
     ),
-    # Seems to insert around 477K records. Give it +-20K margin.
-    # Seems to remove 160K records. Give it a similar margin.
-    postrun_statistics=[cache_hs_insert:457000:497000, cc_pages_removed:150000:170000]
 ),
 timestamp_manager=
 (

--- a/test/cppsuite/test_harness/core/configuration.cxx
+++ b/test/cppsuite/test_harness/core/configuration.cxx
@@ -164,14 +164,14 @@ configuration::get(
 {
     WT_DECL_RET;
     WT_CONFIG_ITEM value = {"", 0, 1, WT_CONFIG_ITEM::WT_CONFIG_ITEM_BOOL};
-    const char *error_msg = "Configuration value doesn't match requested type";
 
     ret = _config_parser->get(_config_parser, key.c_str(), &value);
     if (ret == WT_NOTFOUND && optional)
         return (def);
     else if (ret != 0)
-        testutil_die(ret, "Error while finding config");
+        testutil_die(ret, ("Error while finding config with key \"" + key + "\"").c_str());
 
+    const char *error_msg = "Configuration value doesn't match requested type";
     if (type == types::STRING &&
       (value.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRING &&
         value.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_ID))

--- a/test/cppsuite/test_harness/core/configuration.h
+++ b/test/cppsuite/test_harness/core/configuration.h
@@ -65,8 +65,6 @@ class configuration {
 
     ~configuration();
 
-    const std::string &get_config() const;
-
     /*
      * Wrapper functions for retrieving basic configuration values. Ideally tests can avoid using
      * the config item struct provided by wiredtiger.

--- a/test/cppsuite/test_harness/runtime_monitor.cxx
+++ b/test/cppsuite/test_harness/runtime_monitor.cxx
@@ -35,6 +35,7 @@
 #include "util/logger.h"
 
 namespace test_harness {
+
 /* Static methods implementation. */
 static std::string
 collection_name_to_file_name(const std::string &collection_name)
@@ -49,6 +50,7 @@ collection_name_to_file_name(const std::string &collection_name)
 }
 
 /* Inline methods implementation. */
+
 /*
  * The WiredTiger configuration API doesn't accept string statistic names when retrieving statistic
  * values. This function provides the required mapping to statistic id. We should consider
@@ -58,35 +60,106 @@ collection_name_to_file_name(const std::string &collection_name)
 inline int
 get_stat_field(const std::string &name)
 {
-    if (name == "cache_hs_insert")
+    if (name == CACHE_HS_INSERT)
         return (WT_STAT_CONN_CACHE_HS_INSERT);
-    else if (name == "cc_pages_removed")
+    else if (name == CC_PAGES_REMOVED)
         return (WT_STAT_CONN_CC_PAGES_REMOVED);
     testutil_die(EINVAL, "get_stat_field: Stat \"%s\" is unrecognized", name.c_str());
 }
 
-/* runtime_statistic class implementation */
-runtime_statistic::runtime_statistic(configuration *config)
+/* statistics class implementation */
+statistics::statistics(configuration *config, const std::string &stat_name, int stat_field)
+    : field(stat_field), max(config->get_int(MAX)), min(config->get_int(MIN)), name(stat_name),
+      postrun(config->get_bool(POSTRUN_STATISTICS)), runtime(config->get_bool(RUNTIME_STATISTICS))
 {
-    _enabled = config->get_bool(ENABLED);
+}
+
+void
+statistics::check(scoped_cursor &cursor)
+{
+    int64_t stat_value;
+    runtime_monitor::get_stat(cursor, field, &stat_value);
+    if (stat_value < min || stat_value > max) {
+        const std::string error_string = "runtime_monitor: Postrun stat \"" + name +
+          "\" was outside of the specified limits. Min=" + std::to_string(min) +
+          " Max=" + std::to_string(max) + " Actual=" + std::to_string(stat_value);
+        testutil_die(-1, error_string.c_str());
+    } else
+        logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(stat_value));
+}
+
+std::string
+statistics::get_value_str(scoped_cursor &cursor)
+{
+    int64_t stat_value;
+    runtime_monitor::get_stat(cursor, field, &stat_value);
+    return std::to_string(stat_value);
+}
+
+int
+statistics::get_field() const
+{
+    return field;
+}
+
+int64_t
+statistics::get_max() const
+{
+    return max;
+}
+
+int64_t
+statistics::get_min() const
+{
+    return min;
+}
+
+const std::string &
+statistics::get_name() const
+{
+    return name;
 }
 
 bool
-runtime_statistic::enabled() const
+statistics::get_postrun()
 {
-    return (_enabled);
+    return postrun;
+}
+
+bool
+statistics::get_runtime()
+{
+    return runtime;
 }
 
 /* cache_limit_statistic class implementation */
-cache_limit_statistic::cache_limit_statistic(configuration *config) : runtime_statistic(config)
+cache_limit_statistic::cache_limit_statistic(configuration *config, const std::string &name)
+    : statistics(config, name, -1)
 {
-    _limit = config->get_int(LIMIT);
 }
 
 void
 cache_limit_statistic::check(scoped_cursor &cursor)
 {
-    testutil_assert(cursor.get() != nullptr);
+    double use_percent = get_cache_value(cursor);
+    if (use_percent > max) {
+        const std::string error_string =
+          "runtime_monitor: Cache usage exceeded during test! Limit: " + std::to_string(max) +
+          " usage: " + std::to_string(use_percent);
+        testutil_die(-1, error_string.c_str());
+    } else
+        logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(use_percent));
+}
+
+std::string
+cache_limit_statistic::get_value_str(scoped_cursor &cursor)
+{
+    return std::to_string(get_cache_value(cursor));
+}
+
+double
+cache_limit_statistic::get_cache_value(scoped_cursor &cursor)
+{
     int64_t cache_bytes_image, cache_bytes_other, cache_bytes_max;
     double use_percent;
     /* Three statistics are required to compute cache use percentage. */
@@ -98,20 +171,14 @@ cache_limit_statistic::check(scoped_cursor &cursor)
      * point conversion errors.
      */
     use_percent = ((cache_bytes_image + cache_bytes_other + 0.0) / cache_bytes_max) * 100;
-    if (use_percent > _limit) {
-        const std::string error_string =
-          "runtime_monitor: Cache usage exceeded during test! Limit: " + std::to_string(_limit) +
-          " usage: " + std::to_string(use_percent);
-        testutil_die(-1, error_string.c_str());
-    } else
-        logger::log_msg(LOG_TRACE, "Cache usage: " + std::to_string(use_percent));
+    return use_percent;
 }
 
 /* db_size_statistic class implementation */
-db_size_statistic::db_size_statistic(configuration *config, database &database)
-    : runtime_statistic(config), _database(database)
+db_size_statistic::db_size_statistic(
+  configuration *config, const std::string &name, database &database)
+    : statistics(config, name, -1), _database(database)
 {
-    _limit = config->get_int(LIMIT);
 #ifdef _WIN32
     Logger::log_msg("Database size checking is not implemented on Windows", LOG_ERROR);
 #endif
@@ -120,9 +187,32 @@ db_size_statistic::db_size_statistic(configuration *config, database &database)
 void
 db_size_statistic::check(scoped_cursor &)
 {
-    const auto file_names = get_file_names();
 #ifndef _WIN32
+    const auto file_names = get_file_names();
+    size_t db_size = get_db_size();
+    logger::log_msg(LOG_TRACE, "Current database size is " + std::to_string(db_size) + " bytes");
+
+    if (db_size > max) {
+        const std::string error_string =
+          "runtime_monitor: Database size limit exceeded during test! Limit: " +
+          std::to_string(max) + " db size: " + std::to_string(db_size);
+        testutil_die(-1, error_string.c_str());
+    }
+#endif
+}
+
+std::string
+db_size_statistic::get_value_str(scoped_cursor &)
+{
+    return std::to_string(get_db_size());
+}
+
+size_t
+db_size_statistic::get_db_size() const
+{
+    const auto file_names = get_file_names();
     size_t db_size = 0;
+
     for (const auto &name : file_names) {
         struct stat sb;
         if (stat(name.c_str(), &sb) == 0) {
@@ -132,22 +222,12 @@ db_size_statistic::check(scoped_cursor &)
             /* The only good reason for this to fail is if the file hasn't been created yet. */
             testutil_assert(errno == ENOENT);
     }
-    logger::log_msg(LOG_TRACE, "Current database size is " + std::to_string(db_size) + " bytes");
-    if (db_size > _limit) {
-        const std::string error_string =
-          "runtime_monitor: Database size limit exceeded during test! Limit: " +
-          std::to_string(_limit) + " db size: " + std::to_string(db_size);
-        testutil_die(-1, error_string.c_str());
-    }
-#else
-    static_cast<void>(file_names);
-    static_cast<void>(_database);
-    static_cast<void>(_limit);
-#endif
+
+    return db_size;
 }
 
-std::vector<std::string>
-db_size_statistic::get_file_names()
+const std::vector<std::string>
+db_size_statistic::get_file_names() const
 {
     std::vector<std::string> file_names;
     for (const auto &name : _database.get_collection_names())
@@ -158,71 +238,6 @@ db_size_statistic::get_file_names()
     file_names.push_back(std::string(DEFAULT_DIR) + "/" + WT_METAFILE);
 
     return (file_names);
-}
-
-/* postrun_statistic_check class implementation */
-postrun_statistic_check::postrun_statistic::postrun_statistic(
-  std::string &&name, const int64_t min_limit, const int64_t max_limit)
-    : name(std::move(name)), field(get_stat_field(this->name)), min_limit(min_limit),
-      max_limit(max_limit)
-{
-}
-
-postrun_statistic_check::postrun_statistic_check(configuration *config)
-{
-    const auto config_stats = config->get_list(POSTRUN_STATISTICS);
-    /*
-     * Each stat in the configuration is a colon separated list in the following format:
-     * <stat_name>:<min_limit>:<max_limit>
-     */
-    for (const auto &c : config_stats) {
-        auto stat = split_string(c, ':');
-        if (stat.size() != 3)
-            testutil_die(EINVAL,
-              "runtime_monitor: Each postrun statistic must follow the format of "
-              "\"stat_name:min_limit:max_limit\". Invalid format \"%s\" provided.",
-              c.c_str());
-        const int min_limit = std::stoi(stat.at(1)), max_limit = std::stoi(stat.at(2));
-        if (min_limit > max_limit)
-            testutil_die(EINVAL,
-              "runtime_monitor: The min limit of each postrun statistic must be less than or "
-              "equal to its max limit. Config=\"%s\" Min=%ld Max=%ld",
-              c.c_str(), min_limit, max_limit);
-        _stats.emplace_back(std::move(stat.at(0)), min_limit, max_limit);
-    }
-}
-
-void
-postrun_statistic_check::check(scoped_cursor &cursor) const
-{
-    bool success = true;
-    for (const auto &stat : _stats) {
-        if (!check_stat(cursor, stat))
-            success = false;
-    }
-    if (!success)
-        testutil_die(-1,
-          "runtime_monitor: One or more postrun statistics were outside of their specified "
-          "limits.");
-}
-
-bool
-postrun_statistic_check::check_stat(scoped_cursor &cursor, const postrun_statistic &stat) const
-{
-    int64_t stat_value;
-
-    testutil_assert(cursor.get() != nullptr);
-    runtime_monitor::get_stat(cursor, stat.field, &stat_value);
-    if (stat_value < stat.min_limit || stat_value > stat.max_limit) {
-        const std::string error_string = "runtime_monitor: Postrun stat \"" + stat.name +
-          "\" was outside of the specified limits. Min=" + std::to_string(stat.min_limit) +
-          " Max=" + std::to_string(stat.max_limit) + " Actual=" + std::to_string(stat_value);
-        logger::log_msg(LOG_ERROR, error_string);
-        return (false);
-    }
-    logger::log_msg(LOG_INFO,
-      "runtime_monitor: Final value of stat " + stat.name + " is: " + std::to_string(stat_value));
-    return (true);
 }
 
 /* runtime_monitor class implementation */
@@ -237,56 +252,98 @@ runtime_monitor::get_stat(scoped_cursor &cursor, int stat_field, int64_t *valuep
 }
 
 runtime_monitor::runtime_monitor(configuration *config, database &database)
-    : component("runtime_monitor", config), _postrun_stats(config), _database(database)
+    : component("runtime_monitor", config), _database(database)
 {
 }
 
 runtime_monitor::~runtime_monitor()
 {
-    for (auto &it : _stats)
-        delete it;
+    for (auto &stat : _stats)
+        delete stat;
     _stats.clear();
 }
 
 void
 runtime_monitor::load()
 {
-    configuration *sub_config;
-    std::string statistic_list;
-
     /* Load the general component things. */
     component::load();
 
+    /* If the component is enabled, load all the known statistics. */
     if (_enabled) {
-        _session = connection_manager::instance().create_session();
+
+        configuration *stat_config = _config->get_subconfig(STAT_CACHE_SIZE);
+        _stats.push_back(new cache_limit_statistic(stat_config, STAT_CACHE_SIZE));
+        delete stat_config;
+
+        stat_config = _config->get_subconfig(STAT_DB_SIZE);
+        _stats.push_back(new db_size_statistic(stat_config, STAT_DB_SIZE, _database));
+        delete stat_config;
+
+        stat_config = _config->get_subconfig(CACHE_HS_INSERT);
+        _stats.push_back(
+          new statistics(stat_config, CACHE_HS_INSERT, get_stat_field(CACHE_HS_INSERT)));
+        delete stat_config;
+
+        stat_config = _config->get_subconfig(CC_PAGES_REMOVED);
+        _stats.push_back(
+          new statistics(stat_config, CC_PAGES_REMOVED, get_stat_field(CC_PAGES_REMOVED)));
+        delete stat_config;
 
         /* Open our statistic cursor. */
+        _session = connection_manager::instance().create_session();
         _cursor = _session.open_scoped_cursor(STATISTICS_URI);
-
-        /* Load known runtime statistics. */
-        sub_config = _config->get_subconfig(STAT_CACHE_SIZE);
-        _stats.push_back(new cache_limit_statistic(sub_config));
-        delete sub_config;
-
-        sub_config = _config->get_subconfig(STAT_DB_SIZE);
-        _stats.push_back(new db_size_statistic(sub_config, _database));
-        delete sub_config;
     }
 }
 
 void
 runtime_monitor::do_work()
 {
-    for (const auto &it : _stats) {
-        if (it->enabled())
-            it->check(_cursor);
+    /* Check runtime statistics. */
+    for (const auto &stat : _stats) {
+        if (stat->get_runtime())
+            stat->check(_cursor);
     }
 }
 
 void
 runtime_monitor::finish()
 {
-    _postrun_stats.check(_cursor);
     component::finish();
+
+    /* Check the post run statistics now. */
+    bool success = true;
+    int64_t stat_max, stat_min, stat_value;
+    std::string stat_name;
+
+    for (const auto &stat : _stats) {
+
+        if (!stat->get_postrun())
+            continue;
+
+        stat_max = stat->get_max();
+        stat_min = stat->get_min();
+        stat_name = stat->get_name();
+
+        stat_value = std::stoi(stat->get_value_str(_cursor));
+
+        if (stat_value < stat_min || stat_value > stat_max) {
+            const std::string error_string = "runtime_monitor: Postrun stat \"" + stat_name +
+              "\" was outside of the specified limits. Min=" + std::to_string(stat_min) +
+              " Max=" + std::to_string(stat_max) + " Actual=" + std::to_string(stat_value);
+            logger::log_msg(LOG_ERROR, error_string);
+            success = false;
+        }
+
+        logger::log_msg(LOG_INFO,
+          "runtime_monitor: Final value of stat " + stat_name +
+            " is: " + std::to_string(stat_value));
+    }
+
+    if (!success)
+        testutil_die(-1,
+          "runtime_monitor: One or more postrun statistics were outside of their specified "
+          "limits.");
 }
+
 } // namespace test_harness

--- a/test/cppsuite/test_harness/runtime_monitor.cxx
+++ b/test/cppsuite/test_harness/runtime_monitor.cxx
@@ -257,11 +257,6 @@ runtime_monitor::runtime_monitor(configuration *config, database &database)
 {
 }
 
-runtime_monitor::~runtime_monitor()
-{
-    _stats.clear();
-}
-
 void
 runtime_monitor::load()
 {

--- a/test/cppsuite/test_harness/runtime_monitor.cxx
+++ b/test/cppsuite/test_harness/runtime_monitor.cxx
@@ -170,6 +170,7 @@ cache_limit_statistic::get_cache_value(scoped_cursor &cursor)
      * Assert that we never exceed our configured limit for cache usage. Add 0.0 to avoid floating
      * point conversion errors.
      */
+    testutil_assert(cache_bytes_max > 0);
     use_percent = ((cache_bytes_image + cache_bytes_other + 0.0) / cache_bytes_max) * 100;
     return use_percent;
 }

--- a/test/cppsuite/test_harness/runtime_monitor.h
+++ b/test/cppsuite/test_harness/runtime_monitor.h
@@ -113,7 +113,7 @@ class runtime_monitor : public component {
 
     public:
     explicit runtime_monitor(configuration *config, database &database);
-    ~runtime_monitor();
+    virtual ~runtime_monitor() = default;
 
     /* Delete the copy constructor and the assignment operator. */
     runtime_monitor(const runtime_monitor &) = delete;

--- a/test/cppsuite/test_harness/runtime_monitor.h
+++ b/test/cppsuite/test_harness/runtime_monitor.h
@@ -48,7 +48,7 @@ namespace test_harness {
 class statistics {
     public:
     statistics() = default;
-    explicit statistics(configuration *config, const std::string &stat_name, int stat_field);
+    explicit statistics(configuration &config, const std::string &stat_name, int stat_field);
     virtual ~statistics() = default;
 
     /* Check that the statistics are within bounds. */
@@ -76,7 +76,7 @@ class statistics {
 
 class cache_limit_statistic : public statistics {
     public:
-    explicit cache_limit_statistic(configuration *config, const std::string &name);
+    explicit cache_limit_statistic(configuration &config, const std::string &name);
     virtual ~cache_limit_statistic() = default;
 
     void check(scoped_cursor &cursor) override final;
@@ -88,7 +88,7 @@ class cache_limit_statistic : public statistics {
 
 class db_size_statistic : public statistics {
     public:
-    explicit db_size_statistic(configuration *config, const std::string &name, database &database);
+    explicit db_size_statistic(configuration &config, const std::string &name, database &database);
     virtual ~db_size_statistic() = default;
 
     /* Don't need the stat cursor for these. */
@@ -126,7 +126,7 @@ class runtime_monitor : public component {
     private:
     scoped_session _session;
     scoped_cursor _cursor;
-    std::vector<statistics *> _stats;
+    std::vector<std::unique_ptr<statistics>> _stats;
     database &_database;
 };
 } // namespace test_harness

--- a/test/cppsuite/test_harness/runtime_monitor.h
+++ b/test/cppsuite/test_harness/runtime_monitor.h
@@ -45,67 +45,62 @@ class configuration;
 
 namespace test_harness {
 
-class runtime_statistic {
+class statistics {
     public:
-    explicit runtime_statistic(configuration *config);
-    virtual ~runtime_statistic() = default;
+    statistics() = default;
+    explicit statistics(configuration *config, const std::string &stat_name, int stat_field);
+    virtual ~statistics() = default;
 
-    /* Check that the given statistic is within bounds. */
-    virtual void check(scoped_cursor &cursor) = 0;
+    /* Check that the statistics are within bounds. */
+    virtual void check(scoped_cursor &cursor);
 
-    bool enabled() const;
+    /* Retrieve the value associated to the stat in a string format. */
+    virtual std::string get_value_str(scoped_cursor &cursor);
+
+    /* Getters. */
+    int get_field() const;
+    int64_t get_max() const;
+    int64_t get_min() const;
+    const std::string &get_name() const;
+    bool get_runtime();
+    bool get_postrun();
 
     protected:
-    bool _enabled = false;
+    int field;
+    int64_t max;
+    int64_t min;
+    std::string name;
+    bool postrun;
+    bool runtime;
 };
 
-class cache_limit_statistic : public runtime_statistic {
+class cache_limit_statistic : public statistics {
     public:
-    explicit cache_limit_statistic(configuration *config);
+    explicit cache_limit_statistic(configuration *config, const std::string &name);
     virtual ~cache_limit_statistic() = default;
 
     void check(scoped_cursor &cursor) override final;
+    std::string get_value_str(scoped_cursor &cursor) override final;
 
     private:
-    int64_t _limit;
+    double get_cache_value(scoped_cursor &cursor);
 };
 
-class db_size_statistic : public runtime_statistic {
+class db_size_statistic : public statistics {
     public:
-    explicit db_size_statistic(configuration *config, database &database);
+    explicit db_size_statistic(configuration *config, const std::string &name, database &database);
     virtual ~db_size_statistic() = default;
 
-    /* Don't need the stat cursor for this. */
+    /* Don't need the stat cursor for these. */
     void check(scoped_cursor &) override final;
+    std::string get_value_str(scoped_cursor &) override final;
 
     private:
-    std::vector<std::string> get_file_names();
+    size_t get_db_size() const;
+    const std::vector<std::string> get_file_names() const;
 
     private:
     database &_database;
-    int64_t _limit;
-};
-
-class postrun_statistic_check {
-    public:
-    explicit postrun_statistic_check(configuration *config);
-
-    void check(scoped_cursor &cursor) const;
-
-    private:
-    struct postrun_statistic {
-        postrun_statistic(std::string &&name, const int64_t min_limit, const int64_t max_limit);
-
-        const std::string name;
-        const int field;
-        const int64_t min_limit, max_limit;
-    };
-
-    private:
-    bool check_stat(scoped_cursor &cursor, const postrun_statistic &stat) const;
-
-    private:
-    std::vector<postrun_statistic> _stats;
 };
 
 /*
@@ -131,8 +126,7 @@ class runtime_monitor : public component {
     private:
     scoped_session _session;
     scoped_cursor _cursor;
-    std::vector<runtime_statistic *> _stats;
-    postrun_statistic_check _postrun_stats;
+    std::vector<statistics *> _stats;
     database &_database;
 };
 } // namespace test_harness

--- a/test/cppsuite/test_harness/util/api_const.cxx
+++ b/test/cppsuite/test_harness/util/api_const.cxx
@@ -39,7 +39,9 @@ const std::string WORKLOAD_GENERATOR = "workload_generator";
 const std::string WORKLOAD_TRACKING = "workload_tracking";
 
 /* Configuration API consts. */
+const std::string CACHE_HS_INSERT = "cache_hs_insert";
 const std::string CACHE_SIZE_MB = "cache_size_mb";
+const std::string CC_PAGES_REMOVED = "cc_pages_removed";
 const std::string COLLECTION_COUNT = "collection_count";
 const std::string COMPRESSION_ENABLED = "compression_enabled";
 const std::string DURATION_SECONDS = "duration_seconds";
@@ -55,8 +57,9 @@ const std::string OLDEST_LAG = "oldest_lag";
 const std::string OP_RATE = "op_rate";
 const std::string OPS_PER_TRANSACTION = "ops_per_transaction";
 const std::string POPULATE_CONFIG = "populate_config";
-const std::string POSTRUN_STATISTICS = "postrun_statistics";
+const std::string POSTRUN_STATISTICS = "postrun";
 const std::string READ_CONFIG = "read_config";
+const std::string RUNTIME_STATISTICS = "runtime";
 const std::string STABLE_LAG = "stable_lag";
 const std::string STAT_CACHE_SIZE = "stat_cache_size";
 const std::string STAT_DB_SIZE = "stat_db_size";

--- a/test/cppsuite/test_harness/util/api_const.h
+++ b/test/cppsuite/test_harness/util/api_const.h
@@ -42,7 +42,9 @@ extern const std::string WORKLOAD_GENERATOR;
 extern const std::string WORKLOAD_TRACKING;
 
 /* Configuration API consts. */
+extern const std::string CACHE_HS_INSERT;
 extern const std::string CACHE_SIZE_MB;
+extern const std::string CC_PAGES_REMOVED;
 extern const std::string COLLECTION_COUNT;
 extern const std::string COMPRESSION_ENABLED;
 extern const std::string DURATION_SECONDS;
@@ -60,6 +62,7 @@ extern const std::string OPS_PER_TRANSACTION;
 extern const std::string POPULATE_CONFIG;
 extern const std::string POSTRUN_STATISTICS;
 extern const std::string READ_CONFIG;
+extern const std::string RUNTIME_STATISTICS;
 extern const std::string STABLE_LAG;
 extern const std::string STAT_CACHE_SIZE;
 extern const std::string STAT_DB_SIZE;

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1096,7 +1096,7 @@ tasks:
         vars:
           test_config_filename: configs/hs_cleanup_stress.txt
           test_name: hs_cleanup
-  
+
   - name: cppsuite-search-near-01-stress
     depends_on:
       - name: compile


### PR DESCRIPTION
This commits reworks the way the statistics are defined in a configuration file from the cpp suite. It also reworks how statistics are defined and handled within the runtime component.

Sorry, this PR is quite big, to review it, I suggest the following:

- Review the runtime_monitor.h file and get familiar with the different classes:
  - The base class is `statistics` and there are two derived classes, `cache_limit_statistic` and `db_size_statistic`. The previous class `postrun_statistic_check` has been removed as it is no longer used.
  - A statistic is now made of a field, min/max values, a name, and two fields that indicate whether it should be checked at runtime or post-run.
- Then move on to the runtime_monitor.cxx file to check the definitions of the different methods:
  - The base class provides a default implementation of the `check` and `get_value_str` functions while the derived classes implement their own.
- The two points above represent most of the PR, the rest is mostly related to the way statistics are defined in a configuration file.