### PR TITLE
WT-5316 Investigate the feasibility to remove __rec_update_stable check in __wt_rec_upd_select

### DIFF
--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -97,9 +97,6 @@ struct __wt_reconcile {
     wt_timestamp_t max_ts;
     wt_timestamp_t min_skipped_ts;
 
-    u_int updates_seen;     /* Count of updates seen. */
-    u_int updates_unstable; /* Count of updates not visible_all. */
-
     /*
      * When we do not find any update to be written for the whole page, we would like to mark
      * eviction failed in the case of update-restore. There is no progress made by eviction in such

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -9,18 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __rec_update_stable --
- *     Return whether an update is stable or not.
- */
-static inline bool
-__rec_update_stable(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *upd)
-{
-    return (F_ISSET(r, WT_REC_VISIBLE_ALL) ? __wt_txn_upd_visible_all(session, upd) :
-                                             __wt_txn_upd_visible(session, upd) &&
-          __wt_txn_visible(session, upd->txnid, upd->durable_ts));
-}
-
-/*
  * __rec_update_save --
  *     Save a WT_UPDATE list for later restoration.
  */
@@ -442,7 +430,6 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
         if ((txnid = upd->txnid) == WT_TXN_ABORTED)
             continue;
 
-        ++r->updates_seen;
         upd_memsize += WT_UPDATE_MEMSIZE(upd);
 
         /*
@@ -535,9 +522,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
         if (upd_select->upd == NULL)
             upd_select->upd = upd;
 
-        if (F_ISSET(r, WT_REC_EVICT) && !__rec_update_stable(session, r, upd))
-            ++r->updates_unstable;
-        else if (!F_ISSET(r, WT_REC_EVICT))
+        if (!F_ISSET(r, WT_REC_EVICT))
             break;
     }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -599,7 +599,6 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->min_skipped_ts = WT_TS_MAX;
 
     /* Track if updates were used and/or uncommitted. */
-    r->updates_seen = r->updates_unstable = 0;
     r->update_used = false;
 
     /* Track if the page can be marked clean. */


### PR DESCRIPTION
Remove __rec_update_stable(), it's no longer used.