### PR TITLE
WT-8672 Restore missing evergreen.yml settings

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4206,7 +4206,7 @@ buildvariants:
     - name: fops
 
 - name: macos-1014
-  display_name: "OS X 10.14 CMake"
+  display_name: "OS X 10.14"
   run_on:
   - macos-1014
   batchtime: 120 # 2 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4281,6 +4281,7 @@ buildvariants:
   - ubuntu1804-power8-test
   batchtime: 120 # 2 hours
   expansions:
+    format_test_setting: ulimit -c unlimited
     test_env_vars:
       WT_BUILDDIR=$(git rev-parse --show-toplevel)/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4279,7 +4279,7 @@ buildvariants:
   display_name: "~ Ubuntu 18.04 PPC"
   run_on:
   - ubuntu1804-power8-test
-  batchtime: 10080 # 7 days
+  batchtime: 120 # 2 hours
   expansions:
     test_env_vars:
       WT_BUILDDIR=$(git rev-parse --show-toplevel)/cmake_build
@@ -4309,7 +4309,7 @@ buildvariants:
   display_name: "~ Ubuntu 18.04 zSeries"
   run_on:
   - ubuntu1804-zseries-test
-  batchtime: 10080 # 7 days
+  batchtime: 120 # 2 hours
   expansions:
     test_env_vars:
       WT_BUILDDIR=$(git rev-parse --show-toplevel)/cmake_build


### PR DESCRIPTION
Minor patch forward fixing some small settings missed after the WT-8020 refactor.
- Renamed 'OS X 10.14 CMake' to 'OS X 10.14'
- Restore exotic variants batch time
- Restore PPC variant 'format_test_setting' setting