### PR TITLE
WT-7662 Format timed out with prepare-conflict

### DIFF
--- a/test/format/format.i
+++ b/test/format/format.i
@@ -26,6 +26,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#define FORMAT_PREPARE_TIMEOUT 120
+
 /*
  * read_op --
  *     Perform a read operation, waiting out prepare conflicts.
@@ -48,7 +50,7 @@ read_op(WT_CURSOR *cursor, read_operation op, int *exactp)
 
             /* Ignore clock reset. */
             __wt_seconds(NULL, &now);
-            testutil_assertfmt(now < start || now - start < 60,
+            testutil_assertfmt(now < start || now - start < FORMAT_PREPARE_TIMEOUT,
               "%s: timed out with prepare-conflict", "WT_CURSOR.next");
         }
         break;
@@ -58,7 +60,7 @@ read_op(WT_CURSOR *cursor, read_operation op, int *exactp)
 
             /* Ignore clock reset. */
             __wt_seconds(NULL, &now);
-            testutil_assertfmt(now < start || now - start < 60,
+            testutil_assertfmt(now < start || now - start < FORMAT_PREPARE_TIMEOUT,
               "%s: timed out with prepare-conflict", "WT_CURSOR.prev");
         }
         break;
@@ -68,7 +70,7 @@ read_op(WT_CURSOR *cursor, read_operation op, int *exactp)
 
             /* Ignore clock reset. */
             __wt_seconds(NULL, &now);
-            testutil_assertfmt(now < start || now - start < 60,
+            testutil_assertfmt(now < start || now - start < FORMAT_PREPARE_TIMEOUT,
               "%s: timed out with prepare-conflict", "WT_CURSOR.search");
         }
         break;
@@ -78,7 +80,7 @@ read_op(WT_CURSOR *cursor, read_operation op, int *exactp)
 
             /* Ignore clock reset. */
             __wt_seconds(NULL, &now);
-            testutil_assertfmt(now < start || now - start < 60,
+            testutil_assertfmt(now < start || now - start < FORMAT_PREPARE_TIMEOUT,
               "%s: timed out with prepare-conflict", "WT_CURSOR.search_near");
         }
         break;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -553,7 +553,6 @@ prepare_transaction(TINFO *tinfo)
     WT_DECL_RET;
     WT_SESSION *session;
     uint64_t ts;
-    uint32_t longwait, pause_ms;
     char buf[64];
 
     session = tinfo->session;
@@ -580,19 +579,6 @@ prepare_transaction(TINFO *tinfo)
 
     lock_writeunlock(session, &g.ts_lock);
 
-    /*
-     * Sometimes add a delay after prepare to induce extra memory stress. For 80% of the threads,
-     * there is never a delay, so there is always a dedicated set of threads trying to do work. For
-     * the other 20%, we'll sometimes delay. For these threads, 99% of the time, proceed without
-     * delay. The rest of the time, pause up to 5 seconds, weighted toward the smaller delays.
-     */
-    if (tinfo->id % 5 == 0) {
-        longwait = mmrand(&tinfo->rnd, 0, 999);
-        if (longwait < 10) {
-            pause_ms = mmrand(&tinfo->rnd, 1, 10) << longwait;
-            __wt_sleep(0, (uint64_t)pause_ms * WT_THOUSAND);
-        }
-    }
     return (ret);
 }
 


### PR DESCRIPTION
Periodically we're flagging a failure in a prepared transaction, and as far as we can tell, it's not real, it's just that prepared transactions are staying around without resolution for too long (the last one was a measured 70 seconds). Stop sleeping after prepared transactions and increase the amount of time we'll wait for prepare-conflict resolution from 1 to 2 minutes.

@ddanderson, would you please do the review? You put this code in originally, and I want to make sure there's no history here where it's a bad idea for correctness testing to let prepared transactions proceed at a faster rate. If you feel strongly that is the case, I can revisit this change: the alternative I was considering was to sleep in tiny increments instead of for seconds at a time, that way we could ensure that the overall sleep doesn't become too long. -- Thanks!