### PR TITLE
WT-6035 Reenable lower isolation level tests in test_random_abort

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -190,8 +190,7 @@ thread_run(void *arg)
         if (i == 0)
             i++;
 
-        /* FIXME-WT-6035: temporarily turn off tests for lower isolation levels. */
-        testutil_check(session->begin_transaction(session, "isolation=snapshot"));
+        testutil_check(session->begin_transaction(session, NULL));
 
         /*
          * The value is the insert- with key appended.
@@ -218,7 +217,6 @@ thread_run(void *arg)
         cursor->set_value(cursor, &data);
         testutil_check(cursor->insert(cursor));
 
-        /* FIXME-WT-6035: temporarily turn off tests for lower isolation levels. */
         testutil_check(session->commit_transaction(session, NULL));
 
         /*
@@ -242,8 +240,7 @@ thread_run(void *arg)
          * Decide what kind of operation can be performed on the already inserted data.
          */
         if (i % MAX_NUM_OPS == OP_TYPE_DELETE) {
-            /* FIXME-WT-6035: temporarily turn off tests for lower isolation levels. */
-            testutil_check(session->begin_transaction(session, "isolation=snapshot"));
+            testutil_check(session->begin_transaction(session, NULL));
 
             if (columnar_table)
                 cursor->set_key(cursor, i);
@@ -252,7 +249,6 @@ thread_run(void *arg)
 
             testutil_check(cursor->remove(cursor));
 
-            /* FIXME-WT-6035: temporarily turn off tests for lower isolation levels. */
             testutil_check(session->commit_transaction(session, NULL));
 
             /* Save the key separately for checking later.*/
@@ -270,7 +266,7 @@ thread_run(void *arg)
              * Make sure the modify operation is carried out in an snapshot isolation level with
              * explicit transaction.
              */
-            testutil_check(session->begin_transaction(session, "isolation=snapshot"));
+            testutil_check(session->begin_transaction(session, NULL));
 
             ret = wiredtiger_calc_modify(session, &data, &newv, maxdiff, entries, &nentries);
 


### PR DESCRIPTION
We're unlikely to ever allow updates at anything other than snapshot isolation, remove the FIXME reference for WT-6035 and close that ticket.

Snapshot-isolation is the default, there's no need to set it explicitly.