### PR TITLE
[RFC] WT-8682: Remove session from some function calls

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -300,7 +300,7 @@ __wt_block_compact_page_rewrite(
     *addr_sizep = WT_PTRDIFF(endp, addr);
 
     WT_STAT_CONN_INCR(session, block_write);
-    WT_STAT_CONN_INCRV(session, block_byte_write, size);
+    WT_STAT_CONN_INCRV(session->metadata, block_byte_write, size);
 
     discard_block = false;
 

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -299,8 +299,8 @@ __wt_block_compact_page_rewrite(
     WT_ERR(__wt_block_addr_pack(block, &endp, objectid, new_offset, size, checksum));
     *addr_sizep = WT_PTRDIFF(endp, addr);
 
-    WT_STAT_CONN_INCR(session, block_write);
-    WT_STAT_CONN_INCRV(session->metadata, block_byte_write, size);
+    WT_STAT_CONN_INCR(&session->metadata, block_write);
+    WT_STAT_CONN_INCRV(&session->metadata, block_byte_write, size);
 
     discard_block = false;
 

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -166,7 +166,7 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, uin
       (uintmax_t)offset, size, checksum);
 
     WT_STAT_CONN_INCR(session, block_read);
-    WT_STAT_CONN_INCRV(session, block_byte_read, size);
+    WT_STAT_CONN_INCRV(session->metadata, block_byte_read, size);
 
     /*
      * Grow the buffer as necessary and read the block. Buffers should be aligned for reading, but

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -165,8 +165,8 @@ __wt_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, uin
     __wt_verbose(session, WT_VERB_READ, "off %" PRIuMAX ", size %" PRIu32 ", checksum %#" PRIx32,
       (uintmax_t)offset, size, checksum);
 
-    WT_STAT_CONN_INCR(session, block_read);
-    WT_STAT_CONN_INCRV(session->metadata, block_byte_read, size);
+    WT_STAT_CONN_INCR(&session->metadata, block_read);
+    WT_STAT_CONN_INCRV(&session->metadata, block_byte_read, size);
 
     /*
      * Grow the buffer as necessary and read the block. Buffers should be aligned for reading, but

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -354,9 +354,9 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, uint3
     WT_RET(__wt_block_discard(session, block, align_size));
 
     WT_STAT_CONN_INCR(session, block_write);
-    WT_STAT_CONN_INCRV(session, block_byte_write, align_size);
+    WT_STAT_CONN_INCRV(session->metadata, block_byte_write, align_size);
     if (checkpoint_io)
-        WT_STAT_CONN_INCRV(session, block_byte_write_checkpoint, align_size);
+        WT_STAT_CONN_INCRV(session->metadata, block_byte_write_checkpoint, align_size);
 
     __wt_verbose(session, WT_VERB_WRITE, "off %" PRIuMAX ", size %" PRIuMAX ", checksum %#" PRIx32,
       (uintmax_t)offset, (uintmax_t)align_size, checksum);

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -353,10 +353,10 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, uint3
     /* Optionally discard blocks from the buffer cache. */
     WT_RET(__wt_block_discard(session, block, align_size));
 
-    WT_STAT_CONN_INCR(session, block_write);
-    WT_STAT_CONN_INCRV(session->metadata, block_byte_write, align_size);
+    WT_STAT_CONN_INCR(&session->metadata, block_write);
+    WT_STAT_CONN_INCRV(&session->metadata, block_byte_write, align_size);
     if (checkpoint_io)
-        WT_STAT_CONN_INCRV(session->metadata, block_byte_write_checkpoint, align_size);
+        WT_STAT_CONN_INCRV(&session->metadata, block_byte_write_checkpoint, align_size);
 
     __wt_verbose(session, WT_VERB_WRITE, "off %" PRIuMAX ", size %" PRIuMAX ", checksum %#" PRIx32,
       (uintmax_t)offset, (uintmax_t)align_size, checksum);

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -458,7 +458,7 @@ __wt_blkcache_put(
                 __wt_spin_unlock(session, &blkcache->hash_locks[bucket]);
                 WT_ASSERT(session, !write);
 
-                WT_STAT_CONN_INCRV(session, block_cache_bytes_update, data->size);
+                WT_STAT_CONN_INCRV(session->metadata, block_cache_bytes_update, data->size);
                 WT_STAT_CONN_INCR(session, block_cache_blocks_update);
                 __blkcache_verbose(session, "block already in cache", hash, addr, addr_size);
                 goto err;
@@ -477,13 +477,13 @@ __wt_blkcache_put(
 
     __wt_spin_unlock(session, &blkcache->hash_locks[bucket]);
 
-    WT_STAT_CONN_INCRV(session, block_cache_bytes, data->size);
+    WT_STAT_CONN_INCRV(session->metadata, block_cache_bytes, data->size);
     WT_STAT_CONN_INCR(session, block_cache_blocks);
     if (write) {
-        WT_STAT_CONN_INCRV(session, block_cache_bytes_insert_write, data->size);
+        WT_STAT_CONN_INCRV(session->metadata, block_cache_bytes_insert_write, data->size);
         WT_STAT_CONN_INCR(session, block_cache_blocks_insert_write);
     } else {
-        WT_STAT_CONN_INCRV(session, block_cache_bytes_insert_read, data->size);
+        WT_STAT_CONN_INCRV(session->metadata, block_cache_bytes_insert_read, data->size);
         WT_STAT_CONN_INCR(session, block_cache_blocks_insert_read);
     }
 

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -106,14 +106,14 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
 
     /* Read the block. */
     if (!found) {
-        timer = WT_STAT_ENABLED(session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
+        timer = WT_STAT_ENABLED(&session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
         time_start = timer ? __wt_clock(session) : 0;
         WT_ERR(bm->read(bm, session, ip, addr, addr_size));
         if (timer) {
             time_stop = __wt_clock(session);
             time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
-            WT_STAT_CONN_INCR(session, cache_read_app_count);
-            WT_STAT_CONN_INCRV(session->metadata, cache_read_app_time, time_diff);
+            WT_STAT_CONN_INCR(&session->metadata, cache_read_app_count);
+            WT_STAT_CONN_INCRV(&session->metadata, cache_read_app_time, time_diff);
             WT_STAT_SESSION_INCRV(session, read_time, time_diff);
         }
 
@@ -366,15 +366,15 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
     }
 
     /* Call the block manager to write the block. */
-    timer = WT_STAT_ENABLED(session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
+    timer = WT_STAT_ENABLED(&session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
     time_start = timer ? __wt_clock(session) : 0;
     WT_ERR(checkpoint ? bm->checkpoint(bm, session, ip, btree->ckpt, data_checksum) :
                         bm->write(bm, session, ip, addr, addr_sizep, data_checksum, checkpoint_io));
     if (timer) {
         time_stop = __wt_clock(session);
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
-        WT_STAT_CONN_INCR(session, cache_write_app_count);
-        WT_STAT_CONN_INCRV(session->metadata, cache_write_app_time, time_diff);
+        WT_STAT_CONN_INCR(&session->metadata, cache_write_app_count);
+        WT_STAT_CONN_INCRV(&session->metadata, cache_write_app_time, time_diff);
         WT_STAT_SESSION_INCRV(session, write_time, time_diff);
     }
 
@@ -407,9 +407,9 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
     if (blkcache->type == BLKCACHE_UNCONFIGURED)
         ;
     else if (!blkcache->cache_on_checkpoint && checkpoint_io)
-        WT_STAT_CONN_INCR(session, block_cache_bypass_chkpt);
+        WT_STAT_CONN_INCR(&session->metadata, block_cache_bypass_chkpt);
     else if (!blkcache->cache_on_writes)
-        WT_STAT_CONN_INCR(session, block_cache_bypass_writealloc);
+        WT_STAT_CONN_INCR(&session->metadata, block_cache_bypass_writealloc);
     else if (!checkpoint)
         WT_ERR(__wt_blkcache_put(session, compressed ? ctmp : buf, addr, *addr_sizep, true));
 

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -106,7 +106,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
 
     /* Read the block. */
     if (!found) {
-        timer = WT_STAT_ENABLED(session) && !F_ISSET(session, WT_SESSION_INTERNAL);
+        timer = WT_STAT_ENABLED(session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
         time_start = timer ? __wt_clock(session) : 0;
         WT_ERR(bm->read(bm, session, ip, addr, addr_size));
         if (timer) {
@@ -366,7 +366,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
     }
 
     /* Call the block manager to write the block. */
-    timer = WT_STAT_ENABLED(session) && !F_ISSET(session, WT_SESSION_INTERNAL);
+    timer = WT_STAT_ENABLED(session->metadata) && !F_ISSET(session, WT_SESSION_INTERNAL);
     time_start = timer ? __wt_clock(session) : 0;
     WT_ERR(checkpoint ? bm->checkpoint(bm, session, ip, btree->ckpt, data_checksum) :
                         bm->write(bm, session, ip, addr, addr_sizep, data_checksum, checkpoint_io));

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -113,7 +113,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
             time_stop = __wt_clock(session);
             time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
             WT_STAT_CONN_INCR(session, cache_read_app_count);
-            WT_STAT_CONN_INCRV(session, cache_read_app_time, time_diff);
+            WT_STAT_CONN_INCRV(session->metadata, cache_read_app_time, time_diff);
             WT_STAT_SESSION_INCRV(session, read_time, time_diff);
         }
 
@@ -374,7 +374,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
         time_stop = __wt_clock(session);
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
         WT_STAT_CONN_INCR(session, cache_write_app_count);
-        WT_STAT_CONN_INCRV(session, cache_write_app_time, time_diff);
+        WT_STAT_CONN_INCRV(session->metadata, cache_write_app_time, time_diff);
         WT_STAT_SESSION_INCRV(session, write_time, time_diff);
     }
 

--- a/src/block_cache/block_map.c
+++ b/src/block_cache/block_map.c
@@ -122,8 +122,8 @@ __wt_blkcache_map_read(
         }
 
         *foundp = true;
-        WT_STAT_CONN_INCR(session, block_map_read);
-        WT_STAT_CONN_INCRV(session->metadata, block_byte_map_read, size);
+        WT_STAT_CONN_INCR(&session->metadata, block_map_read);
+        WT_STAT_CONN_INCRV(&session->metadata, block_byte_map_read, size);
     }
 
     return (0);

--- a/src/block_cache/block_map.c
+++ b/src/block_cache/block_map.c
@@ -123,7 +123,7 @@ __wt_blkcache_map_read(
 
         *foundp = true;
         WT_STAT_CONN_INCR(session, block_map_read);
-        WT_STAT_CONN_INCRV(session, block_byte_map_read, size);
+        WT_STAT_CONN_INCRV(session->metadata, block_byte_map_read, size);
     }
 
     return (0);

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -314,7 +314,7 @@ __wt_compact(WT_SESSION_IMPL *session)
      */
     WT_RET(bm->compact_skip(bm, session, &skip));
     if (skip) {
-        WT_STAT_CONN_INCR(session, session_table_compact_skipped);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_compact_skipped);
         WT_STAT_DATA_INCR(session, btree_compact_skipped);
         return (0);
     }

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -819,7 +819,7 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
           (cbt->page_deleted_count > WT_BTREE_DELETE_THRESHOLD ||
             (newpage && cbt->page_deleted_count > 0))) {
             WT_ERR(__wt_page_dirty_and_evict_soon(session, cbt->ref));
-            WT_STAT_CONN_INCR(session, cache_eviction_force_delete);
+            WT_STAT_CONN_INCR(&session->metadata, cache_eviction_force_delete);
         }
         cbt->page_deleted_count = 0;
 

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -759,7 +759,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
           (cbt->page_deleted_count > WT_BTREE_DELETE_THRESHOLD ||
             (newpage && cbt->page_deleted_count > 0))) {
             WT_ERR(__wt_page_dirty_and_evict_soon(session, cbt->ref));
-            WT_STAT_CONN_INCR(session, cache_eviction_force_delete);
+            WT_STAT_CONN_INCR(&session->metadata, cache_eviction_force_delete);
         }
         cbt->page_deleted_count = 0;
 

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -181,7 +181,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
          * times, start sleeping so we don't burn CPU to no purpose.
          */
         __wt_spin_backoff(&yield_count, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session, page_del_rollback_blocked, sleep_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, page_del_rollback_blocked, sleep_usecs);
     }
 
     /*

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -181,7 +181,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
          * times, start sleeping so we don't burn CPU to no purpose.
          */
         __wt_spin_backoff(&yield_count, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session->metadata, page_del_rollback_blocked, sleep_usecs);
+        WT_STAT_CONN_INCRV(&session->metadata, page_del_rollback_blocked, sleep_usecs);
     }
 
     /*

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -817,7 +817,7 @@ __btree_preload(WT_SESSION_IMPL *session)
 err:
     __wt_scr_free(session, &tmp);
 
-    WT_STAT_CONN_INCRV(session, block_preload, block_preload);
+    WT_STAT_CONN_INCRV(session->metadata, block_preload, block_preload);
     return (ret);
 }
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -817,7 +817,7 @@ __btree_preload(WT_SESSION_IMPL *session)
 err:
     __wt_scr_free(session, &tmp);
 
-    WT_STAT_CONN_INCRV(session->metadata, block_preload, block_preload);
+    WT_STAT_CONN_INCRV(&session->metadata, block_preload, block_preload);
     return (ret);
 }
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -399,6 +399,6 @@ skip_evict:
                 continue;
         }
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session, page_sleep, sleep_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, page_sleep, sleep_usecs);
     }
 }

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -261,10 +261,10 @@ read:
                     return (WT_NOTFOUND);
 
                 /* Waiting on another thread's read, stall. */
-                WT_STAT_CONN_INCR(session, page_read_blocked);
+                WT_STAT_CONN_INCR(&session->metadata, page_read_blocked);
             } else
                 /* Waiting on eviction, stall. */
-                WT_STAT_CONN_INCR(session, page_locked_blocked);
+                WT_STAT_CONN_INCR(&session->metadata, page_locked_blocked);
 
             stalled = true;
             break;
@@ -290,7 +290,7 @@ read:
             WT_RET(__wt_hazard_set_func(session, ref, &busy));
 #endif
             if (busy) {
-                WT_STAT_CONN_INCR(session, page_busy_blocked);
+                WT_STAT_CONN_INCR(&session->metadata, page_busy_blocked);
                 break;
             }
 
@@ -325,7 +325,7 @@ read:
                     evict_skip = true;
                 else if (ret == EBUSY) {
                     WT_NOT_READ(ret, 0);
-                    WT_STAT_CONN_INCR(session, page_forcible_evict_blocked);
+                    WT_STAT_CONN_INCR(&session->metadata, page_forcible_evict_blocked);
                     stalled = true;
                     break;
                 }
@@ -399,6 +399,6 @@ skip_evict:
                 continue;
         }
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session->metadata, page_sleep, sleep_usecs);
+        WT_STAT_CONN_INCRV(&session->metadata, page_sleep, sleep_usecs);
     }
 }

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -161,8 +161,8 @@ __stat_page_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
     WT_SKIP_FOREACH (ins, WT_COL_APPEND(page))
         stat_entries++;
 
-    WT_STAT_INCRV(session->metadata, stats, btree_column_tws, stat_tws);
-    WT_STAT_INCRV(session->metadata, stats, btree_entries, stat_entries);
+    WT_STAT_INCRV(&session->metadata, stats, btree_column_tws, stat_tws);
+    WT_STAT_INCRV(&session->metadata, stats, btree_entries, stat_entries);
 }
 
 /*
@@ -244,10 +244,10 @@ __stat_page_col_var(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
             break;
         }
 
-    WT_STAT_INCRV(session->metadata, stats, btree_column_deleted, deleted_cnt);
-    WT_STAT_INCRV(session->metadata, stats, btree_column_rle, rle_cnt);
-    WT_STAT_INCRV(session->metadata, stats, btree_entries, entry_cnt);
-    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_column_deleted, deleted_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_column_rle, rle_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_entries, entry_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_overflow, ovfl_cnt);
 }
 
 /*
@@ -276,7 +276,7 @@ __stat_page_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
         WT_CELL_FOREACH_END;
     }
 
-    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_overflow, ovfl_cnt);
 }
 
 /*
@@ -353,7 +353,7 @@ __stat_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **st
             ++empty_values;
     }
 
-    WT_STAT_INCRV(session->metadata, stats, btree_row_empty_values, empty_values);
-    WT_STAT_INCRV(session->metadata, stats, btree_entries, entry_cnt);
-    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_row_empty_values, empty_values);
+    WT_STAT_INCRV(&session->metadata, stats, btree_entries, entry_cnt);
+    WT_STAT_INCRV(&session->metadata, stats, btree_overflow, ovfl_cnt);
 }

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -161,8 +161,8 @@ __stat_page_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
     WT_SKIP_FOREACH (ins, WT_COL_APPEND(page))
         stat_entries++;
 
-    WT_STAT_INCRV(session, stats, btree_column_tws, stat_tws);
-    WT_STAT_INCRV(session, stats, btree_entries, stat_entries);
+    WT_STAT_INCRV(session->metadata, stats, btree_column_tws, stat_tws);
+    WT_STAT_INCRV(session->metadata, stats, btree_entries, stat_entries);
 }
 
 /*
@@ -244,10 +244,10 @@ __stat_page_col_var(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
             break;
         }
 
-    WT_STAT_INCRV(session, stats, btree_column_deleted, deleted_cnt);
-    WT_STAT_INCRV(session, stats, btree_column_rle, rle_cnt);
-    WT_STAT_INCRV(session, stats, btree_entries, entry_cnt);
-    WT_STAT_INCRV(session, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_column_deleted, deleted_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_column_rle, rle_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_entries, entry_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
 }
 
 /*
@@ -276,7 +276,7 @@ __stat_page_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
         WT_CELL_FOREACH_END;
     }
 
-    WT_STAT_INCRV(session, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
 }
 
 /*
@@ -353,7 +353,7 @@ __stat_page_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **st
             ++empty_values;
     }
 
-    WT_STAT_INCRV(session, stats, btree_row_empty_values, empty_values);
-    WT_STAT_INCRV(session, stats, btree_entries, entry_cnt);
-    WT_STAT_INCRV(session, stats, btree_overflow, ovfl_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_row_empty_values, empty_values);
+    WT_STAT_INCRV(session->metadata, stats, btree_entries, entry_cnt);
+    WT_STAT_INCRV(session->metadata, stats, btree_overflow, ovfl_cnt);
 }

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -63,7 +63,7 @@ __ref_index_slot(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp,
          * yielded enough times, start sleeping so we don't burn CPU to no purpose.
          */
         __wt_spin_backoff(&yield_count, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session->metadata, page_index_slot_ref_blocked, sleep_usecs);
+        WT_STAT_CONN_INCRV(&session->metadata, page_index_slot_ref_blocked, sleep_usecs);
     }
 
 found:
@@ -483,7 +483,7 @@ descend:
              * An expected error, so "couple" is unchanged.
              */
             if (ret == WT_NOTFOUND) {
-                WT_STAT_CONN_INCR(session, cache_eviction_walk_leaf_notfound);
+                WT_STAT_CONN_INCR(&session->metadata, cache_eviction_walk_leaf_notfound);
                 WT_NOT_READ(ret, 0);
                 break;
             }

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -63,7 +63,7 @@ __ref_index_slot(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_INDEX **pindexp,
          * yielded enough times, start sleeping so we don't burn CPU to no purpose.
          */
         __wt_spin_backoff(&yield_count, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session, page_index_slot_ref_blocked, sleep_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, page_index_slot_ref_blocked, sleep_usecs);
     }
 
 found:

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -393,7 +393,7 @@ __wt_update_obsolete_check(
      * This is why we use WT_THOUSAND here.
      */
     if (count > WT_THOUSAND) {
-        WT_STAT_CONN_INCR(session, cache_eviction_force_long_update_list);
+        WT_STAT_CONN_INCR(&session->metadata, cache_eviction_force_long_update_list);
         __wt_page_evict_soon(session, cbt->ref);
     }
 

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -116,6 +116,7 @@ __config_validate(WT_SESSION *wt_session, WT_EVENT_HANDLER *event_handler, const
         conn = &dummy_conn;
         session = conn->default_session = &conn->dummy_session;
         session->iface.connection = &conn->iface;
+        session->metadata.connection = &conn->iface;
         session->name = "wiredtiger_config_validate";
         __wt_event_handler_set(session, event_handler);
     }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2498,6 +2498,7 @@ wiredtiger_dummy_session_init(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_
      * we need to do better).
      */
     session->iface.connection = &conn->iface;
+    session->metadata.connection = &conn->iface;
     session->name = "wiredtiger_open";
 
     /* Standard I/O and error handling first. */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1333,7 +1333,7 @@ __conn_rollback_to_stable(WT_CONNECTION *wt_conn, const char *config)
     conn = (WT_CONNECTION_IMPL *)wt_conn;
 
     CONNECTION_API_CALL(conn, session, rollback_to_stable, config, cfg);
-    WT_STAT_CONN_INCR(session, txn_rts);
+    WT_STAT_CONN_INCR(&session->metadata, txn_rts);
     ret = __wt_rollback_to_stable(session, cfg, false);
 err:
     API_END_RET(session, ret);

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -292,25 +292,25 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
     case WT_THROTTLE_CKPT:
         capacity = cap->ckpt;
         reservation = &cap->reservation_ckpt;
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_ckpt, bytes);
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_ckpt, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_EVICT:
         capacity = cap->evict;
         reservation = &cap->reservation_evict;
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_evict, bytes);
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_evict, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_LOG:
         capacity = cap->log;
         reservation = &cap->reservation_log;
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_log, bytes);
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_log, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_READ:
         capacity = cap->read;
         reservation = &cap->reservation_read;
-        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_read, bytes);
+        WT_STAT_CONN_INCRV(&session->metadata, capacity_bytes_read, bytes);
         break;
     }
     total_capacity = cap->total;
@@ -407,20 +407,20 @@ again:
     if (res_value > now_ns) {
         sleep_us = (res_value - now_ns) / WT_THOUSAND;
         if (res_value == res_total_value)
-            WT_STAT_CONN_INCRV(session->metadata, capacity_time_total, sleep_us);
+            WT_STAT_CONN_INCRV(&session->metadata, capacity_time_total, sleep_us);
         else
             switch (type) {
             case WT_THROTTLE_CKPT:
-                WT_STAT_CONN_INCRV(session->metadata, capacity_time_ckpt, sleep_us);
+                WT_STAT_CONN_INCRV(&session->metadata, capacity_time_ckpt, sleep_us);
                 break;
             case WT_THROTTLE_EVICT:
-                WT_STAT_CONN_INCRV(session->metadata, capacity_time_evict, sleep_us);
+                WT_STAT_CONN_INCRV(&session->metadata, capacity_time_evict, sleep_us);
                 break;
             case WT_THROTTLE_LOG:
-                WT_STAT_CONN_INCRV(session->metadata, capacity_time_log, sleep_us);
+                WT_STAT_CONN_INCRV(&session->metadata, capacity_time_log, sleep_us);
                 break;
             case WT_THROTTLE_READ:
-                WT_STAT_CONN_INCRV(session->metadata, capacity_time_read, sleep_us);
+                WT_STAT_CONN_INCRV(&session->metadata, capacity_time_read, sleep_us);
                 break;
             }
         if (sleep_us > WT_CAPACITY_SLEEP_CUTOFF_US)

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -292,25 +292,25 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
     case WT_THROTTLE_CKPT:
         capacity = cap->ckpt;
         reservation = &cap->reservation_ckpt;
-        WT_STAT_CONN_INCRV(session, capacity_bytes_ckpt, bytes);
-        WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_ckpt, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_EVICT:
         capacity = cap->evict;
         reservation = &cap->reservation_evict;
-        WT_STAT_CONN_INCRV(session, capacity_bytes_evict, bytes);
-        WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_evict, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_LOG:
         capacity = cap->log;
         reservation = &cap->reservation_log;
-        WT_STAT_CONN_INCRV(session, capacity_bytes_log, bytes);
-        WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_log, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_READ:
         capacity = cap->read;
         reservation = &cap->reservation_read;
-        WT_STAT_CONN_INCRV(session, capacity_bytes_read, bytes);
+        WT_STAT_CONN_INCRV(session->metadata, capacity_bytes_read, bytes);
         break;
     }
     total_capacity = cap->total;
@@ -407,20 +407,20 @@ again:
     if (res_value > now_ns) {
         sleep_us = (res_value - now_ns) / WT_THOUSAND;
         if (res_value == res_total_value)
-            WT_STAT_CONN_INCRV(session, capacity_time_total, sleep_us);
+            WT_STAT_CONN_INCRV(session->metadata, capacity_time_total, sleep_us);
         else
             switch (type) {
             case WT_THROTTLE_CKPT:
-                WT_STAT_CONN_INCRV(session, capacity_time_ckpt, sleep_us);
+                WT_STAT_CONN_INCRV(session->metadata, capacity_time_ckpt, sleep_us);
                 break;
             case WT_THROTTLE_EVICT:
-                WT_STAT_CONN_INCRV(session, capacity_time_evict, sleep_us);
+                WT_STAT_CONN_INCRV(session->metadata, capacity_time_evict, sleep_us);
                 break;
             case WT_THROTTLE_LOG:
-                WT_STAT_CONN_INCRV(session, capacity_time_log, sleep_us);
+                WT_STAT_CONN_INCRV(session->metadata, capacity_time_log, sleep_us);
                 break;
             case WT_THROTTLE_READ:
-                WT_STAT_CONN_INCRV(session, capacity_time_read, sleep_us);
+                WT_STAT_CONN_INCRV(session->metadata, capacity_time_read, sleep_us);
                 break;
             }
         if (sleep_us > WT_CAPACITY_SLEEP_CUTOFF_US)

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -69,7 +69,7 @@ __logmgr_force_archive(WT_SESSION_IMPL *session, uint32_t lognum)
          * gradual.
          */
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session, log_force_archive_sleep, sleep_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, log_force_archive_sleep, sleep_usecs);
 
         WT_RET(WT_SESSION_CHECK_PANIC(tmp_session));
         WT_RET(__wt_log_truncate_files(tmp_session, NULL, true));

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -69,7 +69,7 @@ __logmgr_force_archive(WT_SESSION_IMPL *session, uint32_t lognum)
          * gradual.
          */
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
-        WT_STAT_CONN_INCRV(session->metadata, log_force_archive_sleep, sleep_usecs);
+        WT_STAT_CONN_INCRV(&session->metadata, log_force_archive_sleep, sleep_usecs);
 
         WT_RET(WT_SESSION_CHECK_PANIC(tmp_session));
         WT_RET(__wt_log_truncate_files(tmp_session, NULL, true));
@@ -491,7 +491,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      */
     for (i = reccount; i < (u_int)conn->log_prealloc; i++) {
         WT_ERR(__wt_log_allocfile(session, ++log->prep_fileid, WT_LOG_PREPNAME));
-        WT_STAT_CONN_INCR(session, log_prealloc_files);
+        WT_STAT_CONN_INCR(&session->metadata, log_prealloc_files);
     }
     /*
      * Reset the missed count now. If we missed during pre-allocating the log files, it means the
@@ -722,7 +722,7 @@ restart:
                  */
                 coalescing->slot_last_offset = slot->slot_last_offset;
                 WT_ASSIGN_LSN(&coalescing->slot_end_lsn, &slot->slot_end_lsn);
-                WT_STAT_CONN_INCR(session, log_slot_coalesced);
+                WT_STAT_CONN_INCR(&session->metadata, log_slot_coalesced);
                 /*
                  * Copy the flag for later closing.
                  */
@@ -753,7 +753,7 @@ restart:
                 WT_ASSIGN_LSN(&log->write_start_lsn, &slot->slot_start_lsn);
                 WT_ASSIGN_LSN(&log->write_lsn, &slot->slot_end_lsn);
                 __wt_cond_signal(session, log->log_write_cond);
-                WT_STAT_CONN_INCR(session, log_write_lsn);
+                WT_STAT_CONN_INCR(&session->metadata, log_write_lsn);
                 /*
                  * Signal the close thread if needed.
                  */
@@ -796,7 +796,7 @@ __log_wrlsn_server(void *arg)
           __wt_log_cmp(&log->write_lsn, &log->alloc_lsn) != 0)
             __wt_log_wrlsn(session, &yield);
         else
-            WT_STAT_CONN_INCR(session, log_write_lsn_skip);
+            WT_STAT_CONN_INCR(&session->metadata, log_write_lsn_skip);
         prev = log->alloc_lsn;
         did_work = yield == 0;
 

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -20,6 +20,7 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
     /* Default session. */
     session = conn->default_session;
     WT_ASSERT(session, session->iface.connection == &conn->iface);
+    WT_ASSERT(session, session->metadata.connection == &conn->iface);
 
     /* WT_SESSION_IMPL array. */
     WT_RET(__wt_calloc(session, conn->session_size, sizeof(WT_SESSION_IMPL), &conn->sessions));

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -126,7 +126,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
      * enable statistics gathering.
      */
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.json", &cval));
-    if (cval.val != 0 && WT_STAT_ENABLED(session))
+    if (cval.val != 0 && WT_STAT_ENABLED(session->metadata))
         FLD_SET(conn->stat_flags, WT_STAT_JSON);
 
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.on_close", &cval));
@@ -588,7 +588,7 @@ __statlog_server(void *arg)
         if (!__statlog_server_run_chk(session))
             break;
 
-        if (WT_STAT_ENABLED(session))
+        if (WT_STAT_ENABLED(session->metadata))
             WT_ERR(__statlog_log_one(session, &path, &tmp));
     }
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -126,7 +126,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
      * enable statistics gathering.
      */
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.json", &cval));
-    if (cval.val != 0 && WT_STAT_ENABLED(session->metadata))
+    if (cval.val != 0 && WT_STAT_ENABLED(&session->metadata))
         FLD_SET(conn->stat_flags, WT_STAT_JSON);
 
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.on_close", &cval));
@@ -588,7 +588,7 @@ __statlog_server(void *arg)
         if (!__statlog_server_run_chk(session))
             break;
 
-        if (WT_STAT_ENABLED(session->metadata))
+        if (WT_STAT_ENABLED(&session->metadata))
             WT_ERR(__statlog_log_one(session, &path, &tmp));
     }
 

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -45,7 +45,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
             continue;
 
         dhandle->timeofdeath = now;
-        WT_STAT_CONN_INCR(session, dh_sweep_tod);
+        WT_STAT_CONN_INCR(&session->metadata, dh_sweep_tod);
     }
 }
 
@@ -162,10 +162,10 @@ __sweep_discard_trees(WT_SESSION_IMPL *session, u_int *dead_handlesp)
 
         /* We closed the btree handle. */
         if (ret == 0) {
-            WT_STAT_CONN_INCR(session, dh_sweep_close);
+            WT_STAT_CONN_INCR(&session->metadata, dh_sweep_close);
             ++*dead_handlesp;
         } else
-            WT_STAT_CONN_INCR(session, dh_sweep_ref);
+            WT_STAT_CONN_INCR(&session->metadata, dh_sweep_ref);
 
         WT_RET_BUSY_OK(ret);
     }
@@ -231,9 +231,9 @@ __sweep_remove_handles(WT_SESSION_IMPL *session)
         else
             WT_WITH_HANDLE_LIST_WRITE_LOCK(session, ret = __sweep_remove_one(session, dhandle));
         if (ret == 0)
-            WT_STAT_CONN_INCR(session, dh_sweep_remove);
+            WT_STAT_CONN_INCR(&session->metadata, dh_sweep_remove);
         else
-            WT_STAT_CONN_INCR(session, dh_sweep_ref);
+            WT_STAT_CONN_INCR(&session->metadata, dh_sweep_ref);
         WT_RET_BUSY_OK(ret);
     }
 
@@ -302,10 +302,10 @@ __sweep_server(void *arg)
         if (!cv_signalled && (now - last < sweep_interval))
             continue;
         if (F_ISSET(conn, WT_CONN_CKPT_GATHER)) {
-            WT_STAT_CONN_INCR(session, dh_sweep_skip_ckpt);
+            WT_STAT_CONN_INCR(&session->metadata, dh_sweep_skip_ckpt);
             continue;
         }
-        WT_STAT_CONN_INCR(session, dh_sweeps);
+        WT_STAT_CONN_INCR(&session->metadata, dh_sweeps);
         /*
          * Mark handles with a time of death, and report whether any handles are marked dead. If
          * sweep_idle_time is 0, handles never become idle.

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -143,7 +143,7 @@ __flush_tier_once(WT_SESSION_IMPL *session, uint32_t flags)
 
                 /* If nothing has changed, there's nothing to do. */
                 if (ckpt_time == 0 || (uint64_t)cval.val > ckpt_time) {
-                    WT_STAT_CONN_INCR(session, flush_tier_skipped);
+                    WT_STAT_CONN_INCR(&session->metadata, flush_tier_skipped);
                     continue;
                 }
             }
@@ -154,7 +154,7 @@ __flush_tier_once(WT_SESSION_IMPL *session, uint32_t flags)
              * the arg is the config string that is currently in the metadata.
              */
             WT_ERR(__wt_tiered_switch(session, value));
-            WT_STAT_CONN_INCR(session, flush_tier_switched);
+            WT_STAT_CONN_INCR(&session->metadata, flush_tier_switched);
             WT_ERR(__wt_session_release_dhandle(session));
         }
     }
@@ -200,7 +200,7 @@ __tier_storage_remove_local(WT_SESSION_IMPL *session)
          */
         if (__wt_handle_is_open(session, object)) {
             __wt_verbose(session, WT_VERB_TIERED, "REMOVE_LOCAL: %s in USE, queue again", object);
-            WT_STAT_CONN_INCR(session, local_objects_inuse);
+            WT_STAT_CONN_INCR(&session->metadata, local_objects_inuse);
             /*
              * FIXME-WT-7470: If the object we want to remove is in use this is the place to call
              * object sweep to clean up block->ofh file handles. Another alternative would be to try
@@ -215,7 +215,7 @@ __tier_storage_remove_local(WT_SESSION_IMPL *session)
             __wt_tiered_push_work(session, entry);
         } else {
             __wt_verbose(session, WT_VERB_TIERED, "REMOVE_LOCAL: actually remove %s", object);
-            WT_STAT_CONN_INCR(session, local_objects_removed);
+            WT_STAT_CONN_INCR(&session->metadata, local_objects_removed);
             WT_ERR(__wt_fs_remove(session, object, false));
             /*
              * We are responsible for freeing the work unit when we're done with it.
@@ -493,7 +493,7 @@ __wt_flush_tier(WT_SESSION_IMPL *session, const char *config)
     bool locked, wait;
 
     conn = S2C(session);
-    WT_STAT_CONN_INCR(session, flush_tier);
+    WT_STAT_CONN_INCR(&session->metadata, flush_tier);
     if (FLD_ISSET(conn->server_flags, WT_CONN_SERVER_TIERED_MGR))
         WT_RET_MSG(
           session, EINVAL, "Cannot call flush_tier when storage manager thread is configured");

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -601,7 +601,7 @@ __curhs_search_near_helper(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool bef
          */
         if (cmp > 0) {
             while ((ret = cursor->prev(cursor)) == 0) {
-                WT_STAT_CONN_INCR(session, cursor_skip_hs_cur_position);
+                WT_STAT_CONN_INCR(&session->metadata, cursor_skip_hs_cur_position);
                 WT_STAT_DATA_INCR(session, cursor_skip_hs_cur_position);
                 WT_ERR(__wt_compare(session, NULL, &cursor->key, srch_key, &cmp));
                 /*
@@ -618,7 +618,7 @@ __curhs_search_near_helper(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool bef
          */
         if (cmp < 0) {
             while ((ret = cursor->next(cursor)) == 0) {
-                WT_STAT_CONN_INCR(session, cursor_skip_hs_cur_position);
+                WT_STAT_CONN_INCR(&session->metadata, cursor_skip_hs_cur_position);
                 WT_STAT_DATA_INCR(session, cursor_skip_hs_cur_position);
                 WT_ERR(__wt_compare(session, NULL, &cursor->key, srch_key, &cmp));
                 /* Exit if we have found a key that is larger than or equal to the specified key. */

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -630,7 +630,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
     /*
      * Statistics cursor configuration: must match (and defaults to), the database configuration.
      */
-    if (!WT_STAT_ENABLED(session))
+    if (!WT_STAT_ENABLED(session->metadata))
         goto config_err;
     ret = __wt_config_gets(session, cfg, "statistics", &cval);
     WT_ERR_NOTFOUND_OK(ret, true);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -630,7 +630,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
     /*
      * Statistics cursor configuration: must match (and defaults to), the database configuration.
      */
-    if (!WT_STAT_ENABLED(session->metadata))
+    if (!WT_STAT_ENABLED(&session->metadata))
         goto config_err;
     ret = __wt_config_gets(session, cfg, "statistics", &cval);
     WT_ERR_NOTFOUND_OK(ret, true);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1287,7 +1287,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
         }
     }
 
-    WT_STAT_CONN_INCRV(session, cache_eviction_pages_queued_post_lru, queue->evict_candidates);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_pages_queued_post_lru, queue->evict_candidates);
     queue->evict_current = queue->evict_queue;
     __wt_spin_unlock(session, &queue->evict_lock);
 
@@ -2037,7 +2037,7 @@ fast:
     WT_RET_NOTFOUND_OK(ret);
 
     *slotp += (u_int)(evict - start);
-    WT_STAT_CONN_INCRV(session, cache_eviction_pages_queued, (u_int)(evict - start));
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_pages_queued, (u_int)(evict - start));
 
     __wt_verbose(session, WT_VERB_EVICTSERVER, "%s walk: seen %" PRIu64 ", queued %" PRIu64,
       session->dhandle->name, pages_seen, pages_queued);
@@ -2084,13 +2084,13 @@ fast:
         btree->evict_ref = ref;
     }
 
-    WT_STAT_CONN_INCRV(session, cache_eviction_walk, refs_walked);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_walk, refs_walked);
     WT_STAT_CONN_DATA_INCRV(session, cache_eviction_pages_seen, pages_seen);
-    WT_STAT_CONN_INCRV(session, cache_eviction_pages_already_queued, pages_already_queued);
-    WT_STAT_CONN_INCRV(session, cache_eviction_internal_pages_seen, internal_pages_seen);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_pages_already_queued, pages_already_queued);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_seen, internal_pages_seen);
     WT_STAT_CONN_INCRV(
-      session, cache_eviction_internal_pages_already_queued, internal_pages_already_queued);
-    WT_STAT_CONN_INCRV(session, cache_eviction_internal_pages_queued, internal_pages_queued);
+      session->metadata, cache_eviction_internal_pages_already_queued, internal_pages_already_queued);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_queued, internal_pages_queued);
     WT_STAT_CONN_DATA_INCR(session, cache_eviction_walk_passes);
     return (0);
 }
@@ -2315,7 +2315,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 
     if (time_start != 0) {
         time_stop = __wt_clock(session);
-        WT_STAT_CONN_INCRV(session, application_evict_time, WT_CLOCKDIFF_US(time_stop, time_start));
+        WT_STAT_CONN_INCRV(session->metadata, application_evict_time, WT_CLOCKDIFF_US(time_stop, time_start));
     }
     WT_TRACK_OP_END(session);
     return (ret);
@@ -2449,7 +2449,7 @@ err:
     if (time_start != 0) {
         time_stop = __wt_clock(session);
         elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
-        WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+        WT_STAT_CONN_INCRV(session->metadata, application_cache_time, elapsed);
         WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
         session->cache_wait_us += elapsed;
         if (cache_max_wait_us != 0 && session->cache_wait_us > cache_max_wait_us) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1287,7 +1287,8 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
         }
     }
 
-    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_pages_queued_post_lru, queue->evict_candidates);
+    WT_STAT_CONN_INCRV(
+      session->metadata, cache_eviction_pages_queued_post_lru, queue->evict_candidates);
     queue->evict_current = queue->evict_queue;
     __wt_spin_unlock(session, &queue->evict_lock);
 
@@ -2086,11 +2087,13 @@ fast:
 
     WT_STAT_CONN_INCRV(session->metadata, cache_eviction_walk, refs_walked);
     WT_STAT_CONN_DATA_INCRV(session, cache_eviction_pages_seen, pages_seen);
-    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_pages_already_queued, pages_already_queued);
-    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_seen, internal_pages_seen);
     WT_STAT_CONN_INCRV(
-      session->metadata, cache_eviction_internal_pages_already_queued, internal_pages_already_queued);
-    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_queued, internal_pages_queued);
+      session->metadata, cache_eviction_pages_already_queued, pages_already_queued);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_seen, internal_pages_seen);
+    WT_STAT_CONN_INCRV(session->metadata, cache_eviction_internal_pages_already_queued,
+      internal_pages_already_queued);
+    WT_STAT_CONN_INCRV(
+      session->metadata, cache_eviction_internal_pages_queued, internal_pages_queued);
     WT_STAT_CONN_DATA_INCR(session, cache_eviction_walk_passes);
     return (0);
 }
@@ -2315,7 +2318,8 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 
     if (time_start != 0) {
         time_stop = __wt_clock(session);
-        WT_STAT_CONN_INCRV(session->metadata, application_evict_time, WT_CLOCKDIFF_US(time_stop, time_start));
+        WT_STAT_CONN_INCRV(
+          session->metadata, application_evict_time, WT_CLOCKDIFF_US(time_stop, time_start));
     }
     WT_TRACK_OP_END(session);
     return (ret);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2297,7 +2297,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
             WT_STAT_CONN_INCR(session, cache_eviction_app_dirty);
         WT_STAT_CONN_INCR(session, cache_eviction_app);
         cache->app_evicts++;
-        time_start = WT_STAT_ENABLED(session) ? __wt_clock(session) : 0;
+        time_start = WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
     }
 
     /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -204,11 +204,11 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         if (clean_page) {
             WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
             WT_STAT_CONN_INCRV(
-              session, cache_eviction_force_clean_time, WT_CLOCKDIFF_US(time_stop, time_start));
+              session->metadata, cache_eviction_force_clean_time, WT_CLOCKDIFF_US(time_stop, time_start));
         } else {
             WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
             WT_STAT_CONN_INCRV(
-              session, cache_eviction_force_dirty_time, WT_CLOCKDIFF_US(time_stop, time_start));
+              session->metadata, cache_eviction_force_dirty_time, WT_CLOCKDIFF_US(time_stop, time_start));
         }
     }
     if (clean_page)
@@ -231,7 +231,7 @@ err:
                 WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
             WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
             WT_STAT_CONN_INCRV(
-              session, cache_eviction_force_fail_time, WT_CLOCKDIFF_US(time_stop, time_start));
+              session->metadata, cache_eviction_force_fail_time, WT_CLOCKDIFF_US(time_stop, time_start));
         }
 
         WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -203,12 +203,12 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
         if (clean_page) {
             WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
-            WT_STAT_CONN_INCRV(
-              session->metadata, cache_eviction_force_clean_time, WT_CLOCKDIFF_US(time_stop, time_start));
+            WT_STAT_CONN_INCRV(session->metadata, cache_eviction_force_clean_time,
+              WT_CLOCKDIFF_US(time_stop, time_start));
         } else {
             WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
-            WT_STAT_CONN_INCRV(
-              session->metadata, cache_eviction_force_dirty_time, WT_CLOCKDIFF_US(time_stop, time_start));
+            WT_STAT_CONN_INCRV(session->metadata, cache_eviction_force_dirty_time,
+              WT_CLOCKDIFF_US(time_stop, time_start));
         }
     }
     if (clean_page)
@@ -230,8 +230,8 @@ err:
             if (force_evict_hs)
                 WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
             WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
-            WT_STAT_CONN_INCRV(
-              session->metadata, cache_eviction_force_fail_time, WT_CLOCKDIFF_US(time_stop, time_start));
+            WT_STAT_CONN_INCRV(session->metadata, cache_eviction_force_fail_time,
+              WT_CLOCKDIFF_US(time_stop, time_start));
         }
 
         WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -451,7 +451,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
                  */
                 if (error_on_ooo_ts) {
                     ret = EBUSY;
-                    WT_STAT_CONN_INCR(session, cache_eviction_fail_checkpoint_out_of_order_ts);
+                    WT_STAT_CONN_INCR(
+                      &session->metadata, cache_eviction_fail_checkpoint_out_of_order_ts);
                     goto err;
                 }
 
@@ -903,7 +904,7 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
      */
     if (error_on_ooo_ts) {
         ret = EBUSY;
-        WT_STAT_CONN_INCR(session, cache_eviction_fail_checkpoint_out_of_order_ts);
+        WT_STAT_CONN_INCR(&session->metadata, cache_eviction_fail_checkpoint_out_of_order_ts);
         goto err;
     }
 
@@ -1036,13 +1037,13 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
               &hs_value);
             WT_ERR(hs_insert_cursor->insert(hs_insert_cursor));
             ++(*counter);
-            WT_STAT_CONN_INCR(session, cache_hs_order_reinsert);
+            WT_STAT_CONN_INCR(&session->metadata, cache_hs_order_reinsert);
             WT_STAT_DATA_INCR(session, cache_hs_order_reinsert);
         }
 
         /* Delete the out-of-order entry. */
         WT_ERR(hs_cursor->remove(hs_cursor));
-        WT_STAT_CONN_INCR(session, cache_hs_order_remove);
+        WT_STAT_CONN_INCR(&session->metadata, cache_hs_order_remove);
         WT_STAT_DATA_INCR(session, cache_hs_order_remove);
     }
     if (ret == WT_NOTFOUND)

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -252,7 +252,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      */
     if (cbt->page_deleted_count > WT_BTREE_DELETE_THRESHOLD) {
         WT_RET(__wt_page_dirty_and_evict_soon(session, cbt->ref));
-        WT_STAT_CONN_INCR(session, cache_eviction_force_delete);
+        WT_STAT_CONN_INCR(&session->metadata, cache_eviction_force_delete);
     }
     cbt->page_deleted_count = 0;
 

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -277,12 +277,12 @@ struct __wt_lsm_tree {
  */
 #define WT_LSM_TREE_STAT_INCR(session, fld) \
     do {                                    \
-        if (WT_STAT_ENABLED(session))       \
+        if (WT_STAT_ENABLED(session->metadata)) \
             ++(fld);                        \
     } while (0)
 #define WT_LSM_TREE_STAT_INCRV(session, fld, v) \
     do {                                        \
-        if (WT_STAT_ENABLED(session))           \
+        if (WT_STAT_ENABLED(session->metadata)) \
             (fld) += (int64_t)(v);              \
     } while (0)
     int64_t bloom_false_positive;

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -275,10 +275,10 @@ struct __wt_lsm_tree {
  * We maintain a set of statistics outside of the normal statistics area, copying them into place
  * when a statistics cursor is created.
  */
-#define WT_LSM_TREE_STAT_INCR(session, fld) \
-    do {                                    \
+#define WT_LSM_TREE_STAT_INCR(session, fld)     \
+    do {                                        \
         if (WT_STAT_ENABLED(session->metadata)) \
-            ++(fld);                        \
+            ++(fld);                            \
     } while (0)
 #define WT_LSM_TREE_STAT_INCRV(session, fld, v) \
     do {                                        \

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -275,15 +275,15 @@ struct __wt_lsm_tree {
  * We maintain a set of statistics outside of the normal statistics area, copying them into place
  * when a statistics cursor is created.
  */
-#define WT_LSM_TREE_STAT_INCR(session, fld)     \
-    do {                                        \
-        if (WT_STAT_ENABLED(session->metadata)) \
-            ++(fld);                            \
+#define WT_LSM_TREE_STAT_INCR(session, fld)      \
+    do {                                         \
+        if (WT_STAT_ENABLED(&session->metadata)) \
+            ++(fld);                             \
     } while (0)
-#define WT_LSM_TREE_STAT_INCRV(session, fld, v) \
-    do {                                        \
-        if (WT_STAT_ENABLED(session->metadata)) \
-            (fld) += (int64_t)(v);              \
+#define WT_LSM_TREE_STAT_INCRV(session, fld, v)  \
+    do {                                         \
+        if (WT_STAT_ENABLED(&session->metadata)) \
+            (fld) += (int64_t)(v);               \
     } while (0)
     int64_t bloom_false_positive;
     int64_t bloom_hit;

--- a/src/include/mutex_inline.h
+++ b/src/include/mutex_inline.h
@@ -300,7 +300,7 @@ __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
     uint64_t time_diff, time_start, time_stop;
     int64_t *session_stats, **stats;
 
-    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session)) {
+    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
         time_start = __wt_clock(session);
         __wt_spin_lock(session, t);
         time_stop = __wt_clock(session);
@@ -327,7 +327,7 @@ __wt_spin_trylock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
     int64_t **stats;
 
-    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session)) {
+    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
         WT_RET(__wt_spin_trylock(session, t));
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][t->stat_count_off]++;

--- a/src/include/mutex_inline.h
+++ b/src/include/mutex_inline.h
@@ -300,7 +300,7 @@ __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
     uint64_t time_diff, time_start, time_stop;
     int64_t *session_stats, **stats;
 
-    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
+    if (t->stat_count_off != -1 && WT_STAT_ENABLED(&session->metadata)) {
         time_start = __wt_clock(session);
         __wt_spin_lock(session, t);
         time_stop = __wt_clock(session);
@@ -327,7 +327,7 @@ __wt_spin_trylock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 {
     int64_t **stats;
 
-    if (t->stat_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
+    if (t->stat_count_off != -1 && WT_STAT_ENABLED(&session->metadata)) {
         WT_RET(__wt_spin_trylock(session, t));
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][t->stat_count_off]++;

--- a/src/include/os_fhandle_inline.h
+++ b/src/include/os_fhandle_inline.h
@@ -32,7 +32,7 @@ __wt_fsync(WT_SESSION_IMPL *session, WT_FH *fh, bool block)
      * time taken in the call for completeness.
      */
     WT_STAT_CONN_INCR_ATOMIC(session, thread_fsync_active);
-    WT_STAT_CONN_INCR(session, fsync_io);
+    WT_STAT_CONN_INCR(&session->metadata, fsync_io);
     if (block)
         ret = (handle->fh_sync == NULL ? 0 : handle->fh_sync(handle, (WT_SESSION *)session));
     else
@@ -100,7 +100,7 @@ __wt_read(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void
       fh->handle->name, len, (uintmax_t)offset);
 
     WT_STAT_CONN_INCR_ATOMIC(session, thread_read_active);
-    WT_STAT_CONN_INCR(session, read_io);
+    WT_STAT_CONN_INCR(&session->metadata, read_io);
     time_start = __wt_clock(session);
 
     ret = fh->handle->fh_read(fh->handle, (WT_SESSION *)session, offset, len, buf);
@@ -175,7 +175,7 @@ __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, con
      */
     WT_RET(WT_SESSION_CHECK_PANIC(session));
 
-    WT_STAT_CONN_INCR(session, write_io);
+    WT_STAT_CONN_INCR(&session->metadata, write_io);
     WT_STAT_CONN_INCR_ATOMIC(session, thread_write_active);
     time_start = __wt_clock(session);
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -11,7 +11,6 @@
  *	Per-session cache of handles to avoid synchronization when opening
  *	cursors.
  */
-#include "wiredtiger.h"
 struct __wt_data_handle_cache {
     WT_DATA_HANDLE *dhandle;
 
@@ -59,9 +58,9 @@ typedef TAILQ_HEAD(__wt_cursor_list, __wt_cursor) WT_CURSOR_LIST;
 struct __wt_session_metadata {
     WT_EVENT_HANDLER *event_handler; /* Application's event handlers */
 
-    const char *name;   /* Name */
+    const char *name; /* Name */
 
-    WT_DATA_HANDLE *dhandle;           /* Current data handle */
+    WT_DATA_HANDLE *dhandle; /* Current data handle */
 
     struct timespec last_epoch; /* Last epoch time returned */
 
@@ -74,7 +73,7 @@ struct __wt_session_metadata {
     WT_SESSION_STATS stats;
 
     /* Sessions have an associated statistics bucket based on its ID. */
-    u_int stat_bucket;     /* Statistics bucket offset */
+    u_int stat_bucket; /* Statistics bucket offset */
 
     WT_CONNECTION *connection;
 };
@@ -91,7 +90,7 @@ struct __wt_session_impl {
 
             WT_EVENT_HANDLER *event_handler; /* Application's event handlers */
 
-            const char *name;      /* Name */
+            const char *name; /* Name */
 
             WT_DATA_HANDLE *dhandle; /* Current data handle */
 
@@ -101,12 +100,12 @@ struct __wt_session_impl {
             u_int scratch_alloc;   /* Currently allocated */
             size_t scratch_cached; /* Scratch bytes cached */
 
-            WT_ITEM err;           /* Error buffer */
+            WT_ITEM err; /* Error buffer */
 
             WT_SESSION_STATS stats;
 
             /* Sessions have an associated statistics bucket based on its ID. */
-            u_int stat_bucket;      /* Statistics bucket offset */
+            u_int stat_bucket; /* Statistics bucket offset */
         };
 
         struct __wt_session_metadata metadata;
@@ -134,7 +133,7 @@ struct __wt_session_impl {
      */
     /* Session handle reference list */
     TAILQ_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
-    uint64_t last_sweep;        /* Last sweep for dead handles */
+    uint64_t last_sweep; /* Last sweep for dead handles */
 
     WT_CURSOR_LIST cursors;          /* Cursors closed with the session */
     u_int ncursors;                  /* Count of active file cursors. */

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -32,7 +32,7 @@ struct __wt_hazard {
 
 /* Get the connection implementation for a session or metadata */
 #define S2C(session) ((WT_CONNECTION_IMPL *)(session)->metadata.connection)
-#define M2C(meta) ((WT_CONNECTION_IMPL *)(meta).connection)
+#define M2C(meta) ((WT_CONNECTION_IMPL *)(meta)->connection)
 
 /* Get the btree for a session */
 #define S2BT(session) ((WT_BTREE *)(session)->dhandle->handle)

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -52,19 +52,62 @@ typedef TAILQ_HEAD(__wt_cursor_list, __wt_cursor) WT_CURSOR_LIST;
 
 /* Maximum number of buckets to visit during cursor sweep. */
 #define WT_SESSION_CURSOR_SWEEP_MAX 32
+
+/* TODO this name sucks */
+struct __wt_session_metadata {
+    WT_SESSION iface; /* TODO move this out, or get the connection pointer out */
+
+    WT_EVENT_HANDLER *event_handler; /* Application's event handlers */
+
+    const char *name;   /* Name */
+
+    WT_DATA_HANDLE *dhandle;           /* Current data handle */
+
+    struct timespec last_epoch; /* Last epoch time returned */
+
+    WT_ITEM **scratch;     /* Temporary memory for any function */
+    u_int scratch_alloc;   /* Currently allocated */
+    size_t scratch_cached; /* Scratch bytes cached */
+
+    WT_ITEM err; /* Error buffer */
+
+    WT_SESSION_STATS stats;
+};
+
 /*
  * WT_SESSION_IMPL --
  *	Implementation of WT_SESSION.
  */
 struct __wt_session_impl {
-    WT_SESSION iface;
-    WT_EVENT_HANDLER *event_handler; /* Application's event handlers */
+
+    union {
+        struct {
+            WT_SESSION iface; /* TODO move this out, or get the connection pointer out */
+
+            WT_EVENT_HANDLER *event_handler; /* Application's event handlers */
+
+            const char *name;   /* Name */
+
+            WT_DATA_HANDLE *dhandle;           /* Current data handle */
+
+            struct timespec last_epoch; /* Last epoch time returned */
+
+            WT_ITEM **scratch;     /* Temporary memory for any function */
+            u_int scratch_alloc;   /* Currently allocated */
+            size_t scratch_cached; /* Scratch bytes cached */
+
+            WT_ITEM err; /* Error buffer */
+
+            WT_SESSION_STATS stats;
+        };
+
+        struct __wt_session_metadata metadata;
+    };
 
     void *lang_private; /* Language specific private storage */
 
     u_int active; /* Non-zero if the session is in-use */
 
-    const char *name;   /* Name */
     const char *lastop; /* Last operation */
     uint32_t id;        /* UID, offset in session array */
 
@@ -73,7 +116,6 @@ struct __wt_session_impl {
     uint64_t operation_timeout_us; /* Maximum operation period before rollback */
     u_int api_call_counter;        /* Depth of api calls */
 
-    WT_DATA_HANDLE *dhandle;           /* Current data handle */
     WT_BUCKET_STORAGE *bucket_storage; /* Current bucket storage and file system */
 
     /*
@@ -85,7 +127,6 @@ struct __wt_session_impl {
     /* Session handle reference list */
     TAILQ_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
     uint64_t last_sweep;        /* Last sweep for dead handles */
-    struct timespec last_epoch; /* Last epoch time returned */
 
     WT_CURSOR_LIST cursors;          /* Cursors closed with the session */
     u_int ncursors;                  /* Count of active file cursors. */
@@ -112,9 +153,6 @@ struct __wt_session_impl {
     WT_RWLOCK *current_rwlock;
     uint8_t current_rwticket;
 
-    WT_ITEM **scratch;     /* Temporary memory for any function */
-    u_int scratch_alloc;   /* Currently allocated */
-    size_t scratch_cached; /* Scratch bytes cached */
 #ifdef HAVE_DIAGNOSTIC
     /*
      * Variables used to look for violations of the contract that a session is only used by a single
@@ -132,8 +170,6 @@ struct __wt_session_impl {
         int line;
     } * scratch_track;
 #endif
-
-    WT_ITEM err; /* Error buffer */
 
     WT_TXN_ISOLATION isolation;
     WT_TXN *txn; /* Transaction state */
@@ -286,6 +322,4 @@ struct __wt_session_impl {
     u_int optrackbuf_ptr;
     uint64_t optrack_offset;
     WT_FH *optrack_fh;
-
-    WT_SESSION_STATS stats;
 };

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -141,10 +141,10 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define WT_STAT_ENABLED(meta) (M2C(meta)->stat_flags != 0)
 
 #define WT_STAT_READ(stats, fld) __wt_stats_aggregate(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld))
-#define WT_STAT_WRITE(session, stats, fld, v) \
-    do {                                      \
+#define WT_STAT_WRITE(session, stats, fld, v)   \
+    do {                                        \
         if (WT_STAT_ENABLED(session->metadata)) \
-            (stats)->fld = (int64_t)(v);      \
+            (stats)->fld = (int64_t)(v);        \
     } while (0)
 
 #define WT_STAT_DECRV_BASE(session, stat, fld, value) \
@@ -158,9 +158,9 @@ __wt_stats_clear(void *stats_arg, int slot)
             (void)__wt_atomic_subi64(&(stat)->fld, (int64_t)(value)); \
     } while (0)
 #define WT_STAT_INCRV_BASE(metadata, stat, fld, value) \
-    do {                                              \
-        if (WT_STAT_ENABLED(metadata))       \
-            (stat)->fld += (int64_t)(value);          \
+    do {                                               \
+        if (WT_STAT_ENABLED(metadata))                 \
+            (stat)->fld += (int64_t)(value);           \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC_BASE(session, stat, fld, value)          \
     do {                                                              \
@@ -179,7 +179,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define WT_STAT_DECR(session, stats, fld) WT_STAT_DECRV(session, stats, fld, 1)
 
 #define WT_STAT_INCRV(metadata, stats, fld, value)                                 \
-    do {                                                                          \
+    do {                                                                           \
         WT_STAT_INCRV_BASE(metadata, (stats)[(metadata).stat_bucket], fld, value); \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC(session, stats, fld, value)                                 \
@@ -225,10 +225,10 @@ __wt_stats_clear(void *stats_arg, int slot)
             WT_STAT_DECRV(session, (session)->dhandle->stats, fld, value);        \
     } while (0)
 #define WT_STAT_DATA_DECR(session, fld) WT_STAT_DATA_DECRV(session, fld, 1)
-#define WT_STAT_DATA_INCRV(session, fld, value)                                   \
-    do {                                                                          \
-        if ((session)->dhandle != NULL && (session)->dhandle->stat_array != NULL) \
-            WT_STAT_INCRV(session->metadata, (session)->dhandle->stats, fld, value);        \
+#define WT_STAT_DATA_INCRV(session, fld, value)                                      \
+    do {                                                                             \
+        if ((session)->dhandle != NULL && (session)->dhandle->stat_array != NULL)    \
+            WT_STAT_INCRV(session->metadata, (session)->dhandle->stats, fld, value); \
     } while (0)
 #define WT_STAT_DATA_INCR(session, fld) WT_STAT_DATA_INCRV(session, fld, 1)
 #define WT_STAT_DATA_SET(session, fld, value)                                     \
@@ -249,10 +249,10 @@ __wt_stats_clear(void *stats_arg, int slot)
     } while (0)
 #define WT_STAT_CONN_DATA_DECR(session, fld) WT_STAT_CONN_DATA_DECRV(session, fld, 1)
 
-#define WT_STAT_CONN_DATA_INCRV(session, fld, value) \
-    do {                                             \
+#define WT_STAT_CONN_DATA_INCRV(session, fld, value)       \
+    do {                                                   \
         WT_STAT_CONN_INCRV(session->metadata, fld, value); \
-        WT_STAT_DATA_INCRV(session, fld, value);     \
+        WT_STAT_DATA_INCRV(session, fld, value);           \
     } while (0)
 #define WT_STAT_CONN_DATA_INCR(session, fld) WT_STAT_CONN_DATA_INCRV(session, fld, 1)
 /*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -178,15 +178,15 @@ __wt_stats_clear(void *stats_arg, int slot)
     } while (0)
 #define WT_STAT_DECR(session, stats, fld) WT_STAT_DECRV(session, stats, fld, 1)
 
-#define WT_STAT_INCRV(session, stats, fld, value)                                 \
+#define WT_STAT_INCRV(metadata, stats, fld, value)                                 \
     do {                                                                          \
-        WT_STAT_INCRV_BASE(session->metadata, (stats)[(session)->stat_bucket], fld, value); \
+        WT_STAT_INCRV_BASE(metadata, (stats)[(metadata).stat_bucket], fld, value); \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC(session, stats, fld, value)                                 \
     do {                                                                                 \
         WT_STAT_INCRV_ATOMIC_BASE(session, (stats)[(session)->stat_bucket], fld, value); \
     } while (0)
-#define WT_STAT_INCR(session, stats, fld) WT_STAT_INCRV(session, stats, fld, 1)
+#define WT_STAT_INCR(session, stats, fld) WT_STAT_INCRV(session->metadata, stats, fld, 1)
 #define WT_STAT_SET(session, stats, fld, value)                            \
     do {                                                                   \
         if (WT_STAT_ENABLED(session->metadata)) {                          \
@@ -204,11 +204,11 @@ __wt_stats_clear(void *stats_arg, int slot)
     WT_STAT_DECRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_bucket], fld, 1)
 #define WT_STAT_CONN_DECR(session, fld) WT_STAT_CONN_DECRV(session, fld, 1)
 
-#define WT_STAT_CONN_INCRV(session, fld, value) \
-    WT_STAT_INCRV_BASE(session->metadata, S2C(session)->stats[(session)->stat_bucket], fld, value)
+#define WT_STAT_CONN_INCRV(metadata, fld, value) \
+    WT_STAT_INCRV_BASE(metadata, M2C(metadata)->stats[(metadata).stat_bucket], fld, value)
 #define WT_STAT_CONN_INCR_ATOMIC(session, fld) \
     WT_STAT_INCRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_bucket], fld, 1)
-#define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session, fld, 1)
+#define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session->metadata, fld, 1)
 
 #define WT_STAT_CONN_SET(session, fld, value) WT_STAT_SET(session, S2C(session)->stats, fld, value)
 
@@ -228,7 +228,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define WT_STAT_DATA_INCRV(session, fld, value)                                   \
     do {                                                                          \
         if ((session)->dhandle != NULL && (session)->dhandle->stat_array != NULL) \
-            WT_STAT_INCRV(session, (session)->dhandle->stats, fld, value);        \
+            WT_STAT_INCRV(session->metadata, (session)->dhandle->stats, fld, value);        \
     } while (0)
 #define WT_STAT_DATA_INCR(session, fld) WT_STAT_DATA_INCRV(session, fld, 1)
 #define WT_STAT_DATA_SET(session, fld, value)                                     \
@@ -251,7 +251,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 
 #define WT_STAT_CONN_DATA_INCRV(session, fld, value) \
     do {                                             \
-        WT_STAT_CONN_INCRV(session, fld, value);     \
+        WT_STAT_CONN_INCRV(session->metadata, fld, value); \
         WT_STAT_DATA_INCRV(session, fld, value);     \
     } while (0)
 #define WT_STAT_CONN_DATA_INCR(session, fld) WT_STAT_CONN_DATA_INCRV(session, fld, 1)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -138,33 +138,33 @@ __wt_stats_clear(void *stats_arg, int slot)
  * different actions: reading sums the values across the array of structures, writing updates a
  * single structure's value.
  */
-#define WT_STAT_ENABLED(session) (S2C(session)->stat_flags != 0)
+#define WT_STAT_ENABLED(meta) (M2C(meta)->stat_flags != 0)
 
 #define WT_STAT_READ(stats, fld) __wt_stats_aggregate(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld))
 #define WT_STAT_WRITE(session, stats, fld, v) \
     do {                                      \
-        if (WT_STAT_ENABLED(session))         \
+        if (WT_STAT_ENABLED(session->metadata)) \
             (stats)->fld = (int64_t)(v);      \
     } while (0)
 
 #define WT_STAT_DECRV_BASE(session, stat, fld, value) \
     do {                                              \
-        if (WT_STAT_ENABLED(session))                 \
+        if (WT_STAT_ENABLED(session->metadata))       \
             (stat)->fld -= (int64_t)(value);          \
     } while (0)
 #define WT_STAT_DECRV_ATOMIC_BASE(session, stat, fld, value)          \
     do {                                                              \
-        if (WT_STAT_ENABLED(session))                                 \
+        if (WT_STAT_ENABLED(session->metadata))                       \
             (void)__wt_atomic_subi64(&(stat)->fld, (int64_t)(value)); \
     } while (0)
 #define WT_STAT_INCRV_BASE(session, stat, fld, value) \
     do {                                              \
-        if (WT_STAT_ENABLED(session))                 \
+        if (WT_STAT_ENABLED(session->metadata))       \
             (stat)->fld += (int64_t)(value);          \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC_BASE(session, stat, fld, value)          \
     do {                                                              \
-        if (WT_STAT_ENABLED(session))                                 \
+        if (WT_STAT_ENABLED(session->metadata))                       \
             (void)__wt_atomic_addi64(&(stat)->fld, (int64_t)(value)); \
     } while (0)
 
@@ -189,7 +189,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define WT_STAT_INCR(session, stats, fld) WT_STAT_INCRV(session, stats, fld, 1)
 #define WT_STAT_SET(session, stats, fld, value)                            \
     do {                                                                   \
-        if (WT_STAT_ENABLED(session)) {                                    \
+        if (WT_STAT_ENABLED(session->metadata)) {                          \
             __wt_stats_clear(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld)); \
             (stats)[0]->fld = (int64_t)(value);                            \
         }                                                                  \

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -157,9 +157,9 @@ __wt_stats_clear(void *stats_arg, int slot)
         if (WT_STAT_ENABLED(session->metadata))                       \
             (void)__wt_atomic_subi64(&(stat)->fld, (int64_t)(value)); \
     } while (0)
-#define WT_STAT_INCRV_BASE(session, stat, fld, value) \
+#define WT_STAT_INCRV_BASE(metadata, stat, fld, value) \
     do {                                              \
-        if (WT_STAT_ENABLED(session->metadata))       \
+        if (WT_STAT_ENABLED(metadata))       \
             (stat)->fld += (int64_t)(value);          \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC_BASE(session, stat, fld, value)          \
@@ -180,7 +180,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 
 #define WT_STAT_INCRV(session, stats, fld, value)                                 \
     do {                                                                          \
-        WT_STAT_INCRV_BASE(session, (stats)[(session)->stat_bucket], fld, value); \
+        WT_STAT_INCRV_BASE(session->metadata, (stats)[(session)->stat_bucket], fld, value); \
     } while (0)
 #define WT_STAT_INCRV_ATOMIC(session, stats, fld, value)                                 \
     do {                                                                                 \
@@ -205,7 +205,7 @@ __wt_stats_clear(void *stats_arg, int slot)
 #define WT_STAT_CONN_DECR(session, fld) WT_STAT_CONN_DECRV(session, fld, 1)
 
 #define WT_STAT_CONN_INCRV(session, fld, value) \
-    WT_STAT_INCRV_BASE(session, S2C(session)->stats[(session)->stat_bucket], fld, value)
+    WT_STAT_INCRV_BASE(session->metadata, S2C(session)->stats[(session)->stat_bucket], fld, value)
 #define WT_STAT_CONN_INCR_ATOMIC(session, fld) \
     WT_STAT_INCRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_bucket], fld, 1)
 #define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session, fld, 1)
@@ -259,7 +259,7 @@ __wt_stats_clear(void *stats_arg, int slot)
  * Update per session statistics.
  */
 #define WT_STAT_SESSION_INCRV(session, fld, value) \
-    WT_STAT_INCRV_BASE(session, &(session)->stats, fld, value)
+    WT_STAT_INCRV_BASE(session->metadata, &(session)->stats, fld, value)
 
 /*
  * Construct histogram increment functions to put the passed value into the right bucket. Bucket

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -48,20 +48,20 @@ __wt_rdtsc(void)
  *     highest value seen so far.
  */
 static inline void
-__time_check_monotonic(WT_SESSION_IMPL *session, struct timespec *tsp)
+__time_check_monotonic(WT_SESSION_METADATA *meta, struct timespec *tsp)
 {
     /*
      * Detect time going backward. If so, use the last saved timestamp.
      */
-    if (session == NULL)
+    if (meta == NULL)
         return;
 
-    if (tsp->tv_sec < session->last_epoch.tv_sec ||
-      (tsp->tv_sec == session->last_epoch.tv_sec && tsp->tv_nsec < session->last_epoch.tv_nsec)) {
-        WT_STAT_CONN_INCR(session, time_travel);
-        *tsp = session->last_epoch;
+    if (tsp->tv_sec < meta->last_epoch.tv_sec ||
+      (tsp->tv_sec == meta->last_epoch.tv_sec && tsp->tv_nsec < meta->last_epoch.tv_nsec)) {
+        WT_STAT_CONN_INCR(meta, time_travel);
+        *tsp = meta->last_epoch;
     } else
-        session->last_epoch = *tsp;
+        meta->last_epoch = *tsp;
 }
 
 /*
@@ -82,7 +82,10 @@ __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp)
      * the time structure to the returned memory location implies multicycle writes to memory).
      */
     __wt_epoch_raw(session, &tmp);
-    __time_check_monotonic(session, &tmp);
+
+    if (session != NULL)
+        __time_check_monotonic(&session->metadata, &tmp);
+
     *tsp = tmp;
 }
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -783,7 +783,7 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
         if (previous_state == prepare_state)
             break;
 
-        WT_STAT_CONN_INCR(session, prepared_transition_blocked_page);
+        WT_STAT_CONN_INCR(&session->metadata, prepared_transition_blocked_page);
     }
 
     if (!upd_visible)

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -311,6 +311,8 @@ struct __wt_scratch_track;
 typedef struct __wt_scratch_track WT_SCRATCH_TRACK;
 struct __wt_session_impl;
 typedef struct __wt_session_impl WT_SESSION_IMPL;
+struct __wt_session_metadata;
+typedef struct __wt_session_metadata WT_SESSION_METADATA;
 struct __wt_session_stash;
 typedef struct __wt_session_stash WT_SESSION_STASH;
 struct __wt_session_stats;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -307,7 +307,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
         fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
         WT_ASSIGN_LSN(&log->sync_dir_lsn, min_lsn);
         WT_STAT_CONN_INCR(session, log_sync_dir);
-        WT_STAT_CONN_INCRV(session, log_sync_dir_duration, fsync_duration_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, log_sync_dir_duration, fsync_duration_usecs);
     }
     /*
      * Sync the log file if needed.
@@ -327,7 +327,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
         fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
         WT_ASSIGN_LSN(&log->sync_lsn, min_lsn);
         WT_STAT_CONN_INCR(session, log_sync);
-        WT_STAT_CONN_INCRV(session, log_sync_duration, fsync_duration_usecs);
+        WT_STAT_CONN_INCRV(session->metadata, log_sync_duration, fsync_duration_usecs);
         __wt_cond_signal(session, log->log_sync_cond);
     }
 err:
@@ -702,7 +702,7 @@ __wt_log_fill(
         WT_ERR(__log_fs_write(session, myslot->slot,
           myslot->offset + myslot->slot->slot_start_offset, record->size, record->mem));
 
-    WT_STAT_CONN_INCRV(session, log_bytes_written, record->size);
+    WT_STAT_CONN_INCRV(session->metadata, log_bytes_written, record->size);
     if (lsnp != NULL) {
         *lsnp = myslot->slot->slot_start_lsn;
         lsnp->l.offset += (uint32_t)myslot->offset;
@@ -1961,7 +1961,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
             fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
             WT_ASSIGN_LSN(&log->sync_dir_lsn, &sync_lsn);
             WT_STAT_CONN_INCR(session, log_sync_dir);
-            WT_STAT_CONN_INCRV(session, log_sync_dir_duration, fsync_duration_usecs);
+            WT_STAT_CONN_INCRV(session->metadata, log_sync_dir_duration, fsync_duration_usecs);
         }
 
         /*
@@ -1976,7 +1976,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
             WT_ERR(__wt_fsync(session, log->log_fh, true));
             time_stop = __wt_clock(session);
             fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop, time_start);
-            WT_STAT_CONN_INCRV(session, log_sync_duration, fsync_duration_usecs);
+            WT_STAT_CONN_INCRV(session->metadata, log_sync_duration, fsync_duration_usecs);
             WT_ASSIGN_LSN(&log->sync_lsn, &sync_lsn);
             __wt_cond_signal(session, log->log_sync_cond);
         }
@@ -2514,8 +2514,8 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t
             WT_STAT_CONN_INCR(session, log_compress_write_fails);
         else {
             WT_STAT_CONN_INCR(session, log_compress_writes);
-            WT_STAT_CONN_INCRV(session, log_compress_mem, record->size);
-            WT_STAT_CONN_INCRV(session, log_compress_len, result_len);
+            WT_STAT_CONN_INCRV(session->metadata, log_compress_mem, record->size);
+            WT_STAT_CONN_INCRV(session->metadata, log_compress_len, result_len);
 
             /*
              * Copy in the skipped header bytes, set the final data size.
@@ -2589,7 +2589,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, ui
      * is big enough and zero-filled so that we can write the full amount. Do this whether or not
      * direct_io is in use because it makes the reading code cleaner.
      */
-    WT_STAT_CONN_INCRV(session, log_bytes_payload, record->size);
+    WT_STAT_CONN_INCRV(session->metadata, log_bytes_payload, record->size);
     rdup_len = __wt_rduppo2((uint32_t)record->size, log->allocsize);
     WT_ERR(__wt_buf_grow(session, record, rdup_len));
     WT_ASSERT(session, record->data == record->mem);

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -179,7 +179,7 @@ retry:
 
     end_offset = WT_LOG_SLOT_JOINED_BUFFERED(old_state) + slot->slot_unbuffered;
     slot->slot_end_lsn.l.offset += (uint32_t)end_offset;
-    WT_STAT_CONN_INCRV(session, log_slot_consolidated, end_offset);
+    WT_STAT_CONN_INCRV(session->metadata, log_slot_consolidated, end_offset);
     /*
      * XXX Would like to change so one piece of code advances the LSN.
      */
@@ -604,7 +604,7 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
         WT_STAT_CONN_INCR(session, log_slot_yield);
         time_stop = __wt_clock(session);
         usecs = WT_CLOCKDIFF_US(time_stop, time_start);
-        WT_STAT_CONN_INCRV(session, log_slot_yield_duration, usecs);
+        WT_STAT_CONN_INCRV(session->metadata, log_slot_yield_duration, usecs);
         if (closed)
             WT_STAT_CONN_INCR(session, log_slot_yield_close);
         if (raced)

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1430,9 +1430,9 @@ __clsm_put(WT_SESSION_IMPL *session, WT_CURSOR_LSM *clsm, const WT_ITEM *key, co
       lsm_tree->merge_throttle + lsm_tree->ckpt_throttle > 0) {
         clsm->update_count = 0;
         WT_LSM_TREE_STAT_INCRV(session, lsm_tree->lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
-        WT_STAT_CONN_INCRV(session->metadata, lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
+        WT_STAT_CONN_INCRV(&session->metadata, lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
         WT_LSM_TREE_STAT_INCRV(session, lsm_tree->lsm_merge_throttle, lsm_tree->merge_throttle);
-        WT_STAT_CONN_INCRV(session->metadata, lsm_merge_throttle, lsm_tree->merge_throttle);
+        WT_STAT_CONN_INCRV(&session->metadata, lsm_merge_throttle, lsm_tree->merge_throttle);
         __wt_sleep(0, lsm_tree->ckpt_throttle + lsm_tree->merge_throttle);
     }
 

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1430,9 +1430,9 @@ __clsm_put(WT_SESSION_IMPL *session, WT_CURSOR_LSM *clsm, const WT_ITEM *key, co
       lsm_tree->merge_throttle + lsm_tree->ckpt_throttle > 0) {
         clsm->update_count = 0;
         WT_LSM_TREE_STAT_INCRV(session, lsm_tree->lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
-        WT_STAT_CONN_INCRV(session, lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
+        WT_STAT_CONN_INCRV(session->metadata, lsm_checkpoint_throttle, lsm_tree->ckpt_throttle);
         WT_LSM_TREE_STAT_INCRV(session, lsm_tree->lsm_merge_throttle, lsm_tree->merge_throttle);
-        WT_STAT_CONN_INCRV(session, lsm_merge_throttle, lsm_tree->merge_throttle);
+        WT_STAT_CONN_INCRV(session->metadata, lsm_merge_throttle, lsm_tree->merge_throttle);
         __wt_sleep(0, lsm_tree->ckpt_throttle + lsm_tree->merge_throttle);
     }
 

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -305,7 +305,7 @@ __wt_lsm_manager_destroy(WT_SESSION_IMPL *session)
         for (i = 0; i < WT_LSM_MAX_WORKERS; i++)
             WT_TRET(__wt_session_close_internal(manager->lsm_worker_cookies[i].session));
     }
-    WT_STAT_CONN_INCRV(session, lsm_work_units_discarded, removed);
+    WT_STAT_CONN_INCRV(session->metadata, lsm_work_units_discarded, removed);
 
     return (ret);
 }
@@ -495,7 +495,7 @@ __wt_lsm_manager_clear_tree(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
         __wt_lsm_manager_free_work_unit(session, current);
     }
     __wt_spin_unlock(session, &manager->manager_lock);
-    WT_STAT_CONN_INCRV(session, lsm_work_units_discarded, removed);
+    WT_STAT_CONN_INCRV(session->metadata, lsm_work_units_discarded, removed);
 }
 
 /*

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -437,7 +437,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
             if (!lsm_tree->active)
                 WT_ERR(EINTR);
 
-            WT_STAT_CONN_INCRV(session, lsm_rows_merged, LSM_MERGE_CHECK_INTERVAL);
+            WT_STAT_CONN_INCRV(session->metadata, lsm_rows_merged, LSM_MERGE_CHECK_INTERVAL);
             ++lsm_tree->merge_progressing;
         }
 
@@ -451,7 +451,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 
-    WT_STAT_CONN_INCRV(session, lsm_rows_merged, insert_count % LSM_MERGE_CHECK_INTERVAL);
+    WT_STAT_CONN_INCRV(session->metadata, lsm_rows_merged, insert_count % LSM_MERGE_CHECK_INTERVAL);
     ++lsm_tree->merge_progressing;
     __wt_verbose(session, WT_VERB_LSM, "Bloom size for %" PRIu64 " has %" PRIu64 " items inserted",
       record_count, insert_count);

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -437,7 +437,7 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
             if (!lsm_tree->active)
                 WT_ERR(EINTR);
 
-            WT_STAT_CONN_INCRV(session->metadata, lsm_rows_merged, LSM_MERGE_CHECK_INTERVAL);
+            WT_STAT_CONN_INCRV(&session->metadata, lsm_rows_merged, LSM_MERGE_CHECK_INTERVAL);
             ++lsm_tree->merge_progressing;
         }
 
@@ -451,7 +451,8 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 
-    WT_STAT_CONN_INCRV(session->metadata, lsm_rows_merged, insert_count % LSM_MERGE_CHECK_INTERVAL);
+    WT_STAT_CONN_INCRV(
+      &session->metadata, lsm_rows_merged, insert_count % LSM_MERGE_CHECK_INTERVAL);
     ++lsm_tree->merge_progressing;
     __wt_verbose(session, WT_VERB_LSM, "Bloom size for %" PRIu64 " has %" PRIu64 " items inserted",
       record_count, insert_count);

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -55,7 +55,7 @@ __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)
     WT_ASSERT(session, number != 0 && size != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR(session, memory_allocation);
+        WT_STAT_CONN_INCR(&session->metadata, memory_allocation);
 
     if ((p = calloc(number, size)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
@@ -86,7 +86,7 @@ __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp)
     WT_ASSERT(session, bytes_to_allocate != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR(session, memory_allocation);
+        WT_STAT_CONN_INCR(&session->metadata, memory_allocation);
 
     if ((p = malloc(bytes_to_allocate)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
@@ -124,9 +124,9 @@ __realloc_func(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t byt
 
     if (session != NULL) {
         if (p == NULL)
-            WT_STAT_CONN_INCR(session, memory_allocation);
+            WT_STAT_CONN_INCR(&session->metadata, memory_allocation);
         else
-            WT_STAT_CONN_INCR(session, memory_grow);
+            WT_STAT_CONN_INCR(&session->metadata, memory_grow);
     }
 
     if ((p = realloc(p, bytes_to_allocate)) == NULL)
@@ -209,7 +209,7 @@ __wt_realloc_aligned(
          */
         bytes_to_allocate = WT_ALIGN(bytes_to_allocate, S2C(session)->buffer_alignment);
 
-        WT_STAT_CONN_INCR(session, memory_allocation);
+        WT_STAT_CONN_INCR(&session->metadata, memory_allocation);
 
         if ((ret = posix_memalign(&newp, S2C(session)->buffer_alignment, bytes_to_allocate)) != 0)
             WT_RET_MSG(session, ret, "memory allocation of %" WT_SIZET_FMT " bytes failed",
@@ -308,7 +308,7 @@ __wt_free_int(WT_SESSION_IMPL *session, const void *p_arg)
      * This function MUST handle a NULL WT_SESSION_IMPL handle.
      */
     if (session != NULL)
-        WT_STAT_CONN_INCR(session, memory_free);
+        WT_STAT_CONN_INCR(&session->metadata, memory_free);
 
     free(p);
 }

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -388,7 +388,7 @@ __fsync_background(WT_SESSION_IMPL *session, WT_FH *fh)
     uint64_t now;
 
     conn = S2C(session);
-    WT_STAT_CONN_INCR(session, fsync_all_fh_total);
+    WT_STAT_CONN_INCR(&session->metadata, fsync_all_fh_total);
 
     handle = fh->handle;
     if (handle->fh_sync_nowait == NULL || fh->written < WT_CAPACITY_FILE_THRESHOLD)
@@ -409,7 +409,7 @@ __fsync_background(WT_SESSION_IMPL *session, WT_FH *fh)
          */
         ret = __wt_fsync(session, fh, false);
         if (ret == 0) {
-            WT_STAT_CONN_INCR(session, fsync_all_fh);
+            WT_STAT_CONN_INCR(&session->metadata, fsync_all_fh);
             fh->last_sync = now;
             fh->written = 0;
         }
@@ -501,7 +501,7 @@ __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t
      * to use this function.
      */
     type = WT_THROTTLE_LOG;
-    WT_STAT_CONN_INCR(session, log_zero_fills);
+    WT_STAT_CONN_INCR(&session->metadata, log_zero_fills);
     WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
     memset(zerobuf->mem, 0, zerobuf->memsize);
     off = (uint64_t)start_off;

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -427,7 +427,7 @@ __posix_file_read(
               "%s: handle-read: pread: failed to read %" WT_SIZET_FMT " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
     }
-    WT_STAT_CONN_INCRV(session->metadata, block_byte_read_syscall, len);
+    WT_STAT_CONN_INCRV(&session->metadata, block_byte_read_syscall, len);
     return (0);
 }
 
@@ -465,7 +465,7 @@ __posix_file_read_mmap(
     if (pfh->mmap_buf != NULL && pfh->mmap_size >= offset + (wt_off_t)len && !pfh->mmap_resizing) {
         memcpy(buf, (void *)(pfh->mmap_buf + offset), len);
         mmap_success = true;
-        WT_STAT_CONN_INCRV(session->metadata, block_byte_read_mmap, len);
+        WT_STAT_CONN_INCRV(&session->metadata, block_byte_read_mmap, len);
     }
 
     /* Signal that we are done using the mapped buffer. */
@@ -613,7 +613,7 @@ __posix_file_write(
               " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
     }
-    WT_STAT_CONN_INCRV(session->metadata, block_byte_write_syscall, len);
+    WT_STAT_CONN_INCRV(&session->metadata, block_byte_write_syscall, len);
     return (0);
 }
 
@@ -652,7 +652,7 @@ __posix_file_write_mmap(
     if (pfh->mmap_buf != NULL && pfh->mmap_size >= offset + (wt_off_t)len && !pfh->mmap_resizing) {
         memcpy((void *)(pfh->mmap_buf + offset), buf, len);
         mmap_success = true;
-        WT_STAT_CONN_INCRV(session->metadata, block_byte_write_mmap, len);
+        WT_STAT_CONN_INCRV(&session->metadata, block_byte_write_mmap, len);
     }
 
     /* Signal that we are done using the mapped buffer. */
@@ -675,7 +675,7 @@ __posix_file_write_mmap(
         if ((remap_opportunities++) % WT_REMAP_SKIP == 0) {
             __wt_prepare_remap_resize_file(file_handle, wt_session);
             __wt_remap_resize_file(file_handle, wt_session);
-            WT_STAT_CONN_INCRV(session->metadata, block_remap_file_write, 1);
+            WT_STAT_CONN_INCRV(&session->metadata, block_remap_file_write, 1);
         }
     return (0);
 }
@@ -1122,7 +1122,7 @@ __wt_remap_resize_file(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
         __wt_unmap_file(file_handle, wt_session);
 
     __wt_map_file(file_handle, wt_session);
-    WT_STAT_CONN_INCRV(session->metadata, block_remap_file_resize, 1);
+    WT_STAT_CONN_INCRV(&session->metadata, block_remap_file_resize, 1);
 
     /* Signal that we are done resizing the buffer */
     (void)__wt_atomic_subv32(&pfh->mmap_resizing, 1);

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -427,7 +427,7 @@ __posix_file_read(
               "%s: handle-read: pread: failed to read %" WT_SIZET_FMT " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
     }
-    WT_STAT_CONN_INCRV(session, block_byte_read_syscall, len);
+    WT_STAT_CONN_INCRV(session->metadata, block_byte_read_syscall, len);
     return (0);
 }
 
@@ -465,7 +465,7 @@ __posix_file_read_mmap(
     if (pfh->mmap_buf != NULL && pfh->mmap_size >= offset + (wt_off_t)len && !pfh->mmap_resizing) {
         memcpy(buf, (void *)(pfh->mmap_buf + offset), len);
         mmap_success = true;
-        WT_STAT_CONN_INCRV(session, block_byte_read_mmap, len);
+        WT_STAT_CONN_INCRV(session->metadata, block_byte_read_mmap, len);
     }
 
     /* Signal that we are done using the mapped buffer. */
@@ -613,7 +613,7 @@ __posix_file_write(
               " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
     }
-    WT_STAT_CONN_INCRV(session, block_byte_write_syscall, len);
+    WT_STAT_CONN_INCRV(session->metadata, block_byte_write_syscall, len);
     return (0);
 }
 
@@ -652,7 +652,7 @@ __posix_file_write_mmap(
     if (pfh->mmap_buf != NULL && pfh->mmap_size >= offset + (wt_off_t)len && !pfh->mmap_resizing) {
         memcpy((void *)(pfh->mmap_buf + offset), buf, len);
         mmap_success = true;
-        WT_STAT_CONN_INCRV(session, block_byte_write_mmap, len);
+        WT_STAT_CONN_INCRV(session->metadata, block_byte_write_mmap, len);
     }
 
     /* Signal that we are done using the mapped buffer. */
@@ -675,7 +675,7 @@ __posix_file_write_mmap(
         if ((remap_opportunities++) % WT_REMAP_SKIP == 0) {
             __wt_prepare_remap_resize_file(file_handle, wt_session);
             __wt_remap_resize_file(file_handle, wt_session);
-            WT_STAT_CONN_INCRV(session, block_remap_file_write, 1);
+            WT_STAT_CONN_INCRV(session->metadata, block_remap_file_write, 1);
         }
     return (0);
 }
@@ -1122,7 +1122,7 @@ __wt_remap_resize_file(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session)
         __wt_unmap_file(file_handle, wt_session);
 
     __wt_map_file(file_handle, wt_session);
-    WT_STAT_CONN_INCRV(session, block_remap_file_resize, 1);
+    WT_STAT_CONN_INCRV(session->metadata, block_remap_file_resize, 1);
 
     /* Signal that we are done resizing the buffer */
     (void)__wt_atomic_subv32(&pfh->mmap_resizing, 1);

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -73,7 +73,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
     }
 
     __wt_verbose(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR(session, cond_wait);
+    WT_STAT_CONN_INCR(&session->metadata, cond_wait);
 
     WT_ERR(pthread_mutex_lock(&cond->mtx));
     locked = true;

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -53,7 +53,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
         return;
 
     __wt_verbose(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR(session, cond_wait);
+    WT_STAT_CONN_INCR(&session->metadata, cond_wait);
 
     EnterCriticalSection(&cond->mtx);
     locked = true;

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -221,7 +221,7 @@ __wt_rec_child_modify(
         default:
             return (__wt_illegal_value(session, r->tested_ref_state));
         }
-        WT_STAT_CONN_INCR(session, child_modify_blocked_page);
+        WT_STAT_CONN_INCR(&session->metadata, child_modify_blocked_page);
     }
 
 in_memory:

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -166,7 +166,7 @@ __reconcile_post_wrapup(
     WT_PAGE_UNLOCK(session, page);
 
     /* Update statistics. */
-    WT_STAT_CONN_INCR(session, rec_pages);
+    WT_STAT_CONN_INCR(&session->metadata, rec_pages);
     WT_STAT_DATA_INCR(session, rec_pages);
     if (LF_ISSET(WT_REC_EVICT))
         WT_STAT_CONN_DATA_INCR(session, rec_pages_eviction);
@@ -176,11 +176,11 @@ __reconcile_post_wrapup(
         WT_STAT_CONN_DATA_INCR(session, cache_write_restore);
     if (!WT_IS_HS(btree->dhandle)) {
         if (r->rec_page_cell_with_txn_id)
-            WT_STAT_CONN_INCR(session, rec_pages_with_txn);
+            WT_STAT_CONN_INCR(&session->metadata, rec_pages_with_txn);
         if (r->rec_page_cell_with_ts)
-            WT_STAT_CONN_INCR(session, rec_pages_with_ts);
+            WT_STAT_CONN_INCR(&session->metadata, rec_pages_with_ts);
         if (r->rec_page_cell_with_prepared_txn)
-            WT_STAT_CONN_INCR(session, rec_pages_with_prepare);
+            WT_STAT_CONN_INCR(&session->metadata, rec_pages_with_prepare);
     }
     if (r->multi_next > btree->rec_multiblock_max)
         btree->rec_multiblock_max = r->multi_next;
@@ -2752,7 +2752,7 @@ __wt_rec_hs_clear_on_tombstone(
       __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 1))
         return (EBUSY);
 
-    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
+    WT_STAT_CONN_INCR(&session->metadata, cache_hs_key_truncate_onpage_removal);
     WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
 
     return (0);

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -43,7 +43,7 @@ __alter_apply(
     if (strcmp(config, newconfig) != 0)
         WT_ERR(__wt_metadata_update(session, uri, newconfig));
     else
-        WT_STAT_CONN_INCR(session, session_table_alter_skip);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_alter_skip);
 
 err:
     __wt_free(session, config);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -114,10 +114,10 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
     session->cursor_sweep_position = position;
     F_SET(session, WT_SESSION_CACHE_CURSORS);
 
-    WT_STAT_CONN_INCR(session, cursor_sweep);
-    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_buckets, nbuckets);
-    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_examined, nexamined);
-    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_closed, nclosed);
+    WT_STAT_CONN_INCR(&session->metadata, cursor_sweep);
+    WT_STAT_CONN_INCRV(&session->metadata, cursor_sweep_buckets, nbuckets);
+    WT_STAT_CONN_INCRV(&session->metadata, cursor_sweep_examined, nexamined);
+    WT_STAT_CONN_INCRV(&session->metadata, cursor_sweep_closed, nclosed);
 
     WT_ASSERT(session, session->dhandle == saved_dhandle);
     return (ret);
@@ -694,9 +694,9 @@ __session_alter_internal(WT_SESSION_IMPL *session, const char *uri, const char *
 
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_alter_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_alter_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_alter_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_alter_success);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 
@@ -754,7 +754,7 @@ __session_alter(WT_SESSION *wt_session, const char *uri, const char *config)
     ret = __session_alter_internal(session, uri, config);
     if (ret == EBUSY) {
         WT_RET(__session_blocking_checkpoint(session));
-        WT_STAT_CONN_INCR(session, session_table_alter_trigger_checkpoint);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_alter_trigger_checkpoint);
         ret = __session_alter_internal(session, uri, config);
     }
 
@@ -777,7 +777,7 @@ __session_alter_readonly(WT_SESSION *wt_session, const char *uri, const char *co
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, alter);
 
-    WT_STAT_CONN_INCR(session, session_table_alter_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_alter_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -839,9 +839,9 @@ __session_create(WT_SESSION *wt_session, const char *uri, const char *config)
 
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_create_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_create_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_create_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_create_success);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 
@@ -861,7 +861,7 @@ __session_create_readonly(WT_SESSION *wt_session, const char *uri, const char *c
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, create);
 
-    WT_STAT_CONN_INCR(session, session_table_create_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_create_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -882,7 +882,7 @@ __session_log_flush(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL(session, log_flush, config, cfg);
-    WT_STAT_CONN_INCR(session, log_flush);
+    WT_STAT_CONN_INCR(&session->metadata, log_flush);
 
     conn = S2C(session);
     flags = 0;
@@ -989,9 +989,9 @@ __session_rename(WT_SESSION *wt_session, const char *uri, const char *newuri, co
         WT_WITH_TABLE_WRITE_LOCK(session, ret = __wt_schema_rename(session, uri, newuri, cfg))));
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_rename_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_rename_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_rename_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_rename_success);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 
@@ -1013,7 +1013,7 @@ __session_rename_readonly(
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, rename);
 
-    WT_STAT_CONN_INCR(session, session_table_rename_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_rename_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -1045,7 +1045,7 @@ __session_reset(WT_SESSION *wt_session)
     WT_TRET(__wt_session_release_resources(session));
 
     /* Reset the session statistics. */
-    if (WT_STAT_ENABLED(session->metadata))
+    if (WT_STAT_ENABLED(&session->metadata))
         __wt_stat_session_clear_single(&session->stats);
 
 err:
@@ -1101,9 +1101,9 @@ __session_drop(WT_SESSION *wt_session, const char *uri, const char *config)
 
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_drop_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_drop_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_drop_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_drop_success);
 
     /* Note: drop operations cannot be unrolled (yet?). */
     API_END_RET_NOTFOUND_MAP(session, ret);
@@ -1125,7 +1125,7 @@ __session_drop_readonly(WT_SESSION *wt_session, const char *uri, const char *con
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, drop);
 
-    WT_STAT_CONN_INCR(session, session_table_drop_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_drop_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -1299,9 +1299,9 @@ __session_salvage(WT_SESSION *wt_session, const char *uri, const char *config)
 
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_salvage_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_salvage_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_salvage_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_salvage_success);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 
@@ -1321,7 +1321,7 @@ __session_salvage_readonly(WT_SESSION *wt_session, const char *uri, const char *
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, salvage);
 
-    WT_STAT_CONN_INCR(session, session_table_salvage_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_salvage_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -1460,7 +1460,7 @@ __session_truncate(
 
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_TXN_API_CALL(session, truncate, config, cfg);
-    WT_STAT_CONN_INCR(session, cursor_truncate);
+    WT_STAT_CONN_INCR(&session->metadata, cursor_truncate);
 
     /*
      * If the URI is specified, we don't need a start/stop, if start/stop is specified, we don't
@@ -1502,9 +1502,9 @@ err:
     TXN_API_END(session, ret, false);
 
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_truncate_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_truncate_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_truncate_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_truncate_success);
     /*
      * Only map WT_NOTFOUND to ENOENT if a URI was specified.
      */
@@ -1530,7 +1530,7 @@ __session_truncate_readonly(
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, truncate);
 
-    WT_STAT_CONN_INCR(session, session_table_truncate_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_truncate_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);
@@ -1605,9 +1605,9 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
     WT_ERR(ret);
 err:
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_verify_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_verify_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_verify_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_verify_success);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 
@@ -1623,7 +1623,7 @@ __session_begin_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, begin_transaction, config, cfg);
-    WT_STAT_CONN_INCR(session, txn_begin);
+    WT_STAT_CONN_INCR(&session->metadata, txn_begin);
 
     WT_ERR(__wt_txn_context_check(session, false));
 
@@ -1647,10 +1647,10 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
     session = (WT_SESSION_IMPL *)wt_session;
     txn = session->txn;
     SESSION_API_CALL_PREPARE_ALLOWED(session, commit_transaction, config, cfg);
-    WT_STAT_CONN_INCR(session, txn_commit);
+    WT_STAT_CONN_INCR(&session->metadata, txn_commit);
 
     if (F_ISSET(txn, WT_TXN_PREPARE)) {
-        WT_STAT_CONN_INCR(session, txn_prepare_commit);
+        WT_STAT_CONN_INCR(&session->metadata, txn_prepare_commit);
         WT_STAT_CONN_DECR(session, txn_prepare_active);
     }
 
@@ -1701,8 +1701,8 @@ __session_prepare_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL(session, prepare_transaction, config, cfg);
-    WT_STAT_CONN_INCR(session, txn_prepare);
-    WT_STAT_CONN_INCR(session, txn_prepare_active);
+    WT_STAT_CONN_INCR(&session->metadata, txn_prepare);
+    WT_STAT_CONN_INCR(&session->metadata, txn_prepare_active);
 
     WT_ERR(__wt_txn_context_check(session, true));
 
@@ -1747,11 +1747,11 @@ __session_rollback_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_PREPARE_ALLOWED(session, rollback_transaction, config, cfg);
-    WT_STAT_CONN_INCR(session, txn_rollback);
+    WT_STAT_CONN_INCR(&session->metadata, txn_rollback);
 
     txn = session->txn;
     if (F_ISSET(txn, WT_TXN_PREPARE)) {
-        WT_STAT_CONN_INCR(session, txn_prepare_rollback);
+        WT_STAT_CONN_INCR(&session->metadata, txn_prepare_rollback);
         WT_STAT_CONN_DECR(session, txn_prepare_active);
     }
 
@@ -1890,7 +1890,7 @@ __session_checkpoint(WT_SESSION *wt_session, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    WT_STAT_CONN_INCR(session, txn_checkpoint);
+    WT_STAT_CONN_INCR(&session->metadata, txn_checkpoint);
     SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, checkpoint, config, cfg);
 
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
@@ -2132,7 +2132,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     WT_STATIC_ASSERT(offsetof(WT_SESSION_IMPL, iface) == 0);
     *sessionp = session_ret;
 
-    WT_STAT_CONN_INCR(session, session_open);
+    WT_STAT_CONN_INCR(&session->metadata, session_open);
 
 err:
     __wt_spin_unlock(session, &conn->api_lock);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1045,7 +1045,7 @@ __session_reset(WT_SESSION *wt_session)
     WT_TRET(__wt_session_release_resources(session));
 
     /* Reset the session statistics. */
-    if (WT_STAT_ENABLED(session))
+    if (WT_STAT_ENABLED(session->metadata))
         __wt_stat_session_clear_single(&session->stats);
 
 err:
@@ -2047,6 +2047,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
 
     session_ret->iface = F_ISSET(conn, WT_CONN_READONLY) ? stds_readonly : stds;
     session_ret->iface.connection = &conn->iface;
+    session_ret->metadata.connection = &conn->iface;
 
     session_ret->name = NULL;
     session_ret->id = i;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -115,9 +115,9 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
     F_SET(session, WT_SESSION_CACHE_CURSORS);
 
     WT_STAT_CONN_INCR(session, cursor_sweep);
-    WT_STAT_CONN_INCRV(session, cursor_sweep_buckets, nbuckets);
-    WT_STAT_CONN_INCRV(session, cursor_sweep_examined, nexamined);
-    WT_STAT_CONN_INCRV(session, cursor_sweep_closed, nclosed);
+    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_buckets, nbuckets);
+    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_examined, nexamined);
+    WT_STAT_CONN_INCRV(session->metadata, cursor_sweep_closed, nclosed);
 
     WT_ASSERT(session, session->dhandle == saved_dhandle);
     return (ret);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -193,7 +193,7 @@ __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
     ret =
       session->compact->max_time > WT_TIMEDIFF_SEC(end, session->compact->begin) ? 0 : ETIMEDOUT;
     if (ret != 0) {
-        WT_STAT_CONN_INCR(session, session_table_compact_timeout);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_compact_timeout);
 
         __wt_verbose_info(session, WT_VERB_COMPACT,
           "Compact has timed out! The operation has been running for %" PRIu64
@@ -283,7 +283,8 @@ __compact_worker(WT_SESSION_IMPL *session)
              */
             if (ret == EBUSY) {
                 if (__wt_cache_stuck(session)) {
-                    WT_STAT_CONN_INCR(session, session_table_compact_fail_cache_pressure);
+                    WT_STAT_CONN_INCR(
+                      &session->metadata, session_table_compact_fail_cache_pressure);
                     WT_ERR_MSG(session, EBUSY, "compaction halted by eviction pressure");
                 }
                 ret = 0;
@@ -416,9 +417,9 @@ err:
         F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
 
     if (ret != 0)
-        WT_STAT_CONN_INCR(session, session_table_compact_fail);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_compact_fail);
     else
-        WT_STAT_CONN_INCR(session, session_table_compact_success);
+        WT_STAT_CONN_INCR(&session->metadata, session_table_compact_success);
     WT_STAT_CONN_SET(session, session_table_compact_running, 0);
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
@@ -439,7 +440,7 @@ __wt_session_compact_readonly(WT_SESSION *wt_session, const char *uri, const cha
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL_NOCONF(session, compact);
 
-    WT_STAT_CONN_INCR(session, session_table_compact_fail);
+    WT_STAT_CONN_INCR(&session->metadata, session_table_compact_fail);
     ret = __wt_session_notsup(session);
 err:
     API_END_RET(session, ret);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -209,7 +209,7 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
         lock_busy = true;
 
         /* Give other threads a chance to make progress. */
-        WT_STAT_CONN_INCR(session, dhandle_lock_blocked);
+        WT_STAT_CONN_INCR(&session->metadata, dhandle_lock_blocked);
         __wt_yield();
     }
 }
@@ -373,7 +373,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
         return;
     session->last_sweep = now;
 
-    WT_STAT_CONN_INCR(session, dh_session_sweeps);
+    WT_STAT_CONN_INCR(&session->metadata, dh_session_sweeps);
 
     TAILQ_FOREACH_SAFE(dhandle_cache, &session->dhandles, q, dhandle_cache_tmp)
     {
@@ -388,7 +388,7 @@ __session_dhandle_sweep(WT_SESSION_IMPL *session)
           (WT_DHANDLE_INACTIVE(dhandle) ||
             (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time)) &&
           (!WT_DHANDLE_BTREE(dhandle) || F_ISSET(dhandle, WT_DHANDLE_EVICTED))) {
-            WT_STAT_CONN_INCR(session, dh_session_handles);
+            WT_STAT_CONN_INCR(&session->metadata, dh_session_handles);
             WT_ASSERT(session, !WT_IS_METADATA(dhandle));
             __session_discard_dhandle(session, dhandle_cache);
         }

--- a/src/support/cond_auto.c
+++ b/src/support/cond_auto.c
@@ -50,7 +50,7 @@ __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool prog
      */
     WT_ASSERT(session, cond->min_wait != 0);
 
-    WT_STAT_CONN_INCR(session, cond_auto_wait);
+    WT_STAT_CONN_INCR(&session->metadata, cond_auto_wait);
     if (progress)
         cond->prev_wait = cond->min_wait;
     else {
@@ -64,13 +64,13 @@ __wt_cond_auto_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, bool prog
         WT_ORDERED_READ(saved_prev_wait, cond->prev_wait);
         if (!__wt_atomic_cas64(
               &cond->prev_wait, saved_prev_wait, WT_MIN(cond->max_wait, saved_prev_wait + delta)))
-            WT_STAT_CONN_INCR(session, cond_auto_wait_skipped);
+            WT_STAT_CONN_INCR(&session->metadata, cond_auto_wait_skipped);
     }
 
     __wt_cond_wait_signal(session, cond, cond->prev_wait, run_func, signalled);
 
     if (progress || *signalled)
-        WT_STAT_CONN_INCR(session, cond_auto_wait_reset);
+        WT_STAT_CONN_INCR(&session->metadata, cond_auto_wait_reset);
     if (*signalled)
         cond->prev_wait = cond->min_wait;
 }

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -333,14 +333,14 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
         for (j = 0; j < hazard_inuse; ++hp, ++j) {
             ++walk_cnt;
             if (hp->ref == ref) {
-                WT_STAT_CONN_INCRV(session, cache_hazard_walks, walk_cnt);
+                WT_STAT_CONN_INCRV(session->metadata, cache_hazard_walks, walk_cnt);
                 if (sessionp != NULL)
                     *sessionp = s;
                 goto done;
             }
         }
     }
-    WT_STAT_CONN_INCRV(session, cache_hazard_walks, walk_cnt);
+    WT_STAT_CONN_INCRV(session->metadata, cache_hazard_walks, walk_cnt);
     hp = NULL;
 
 done:

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -303,7 +303,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
 
     conn = S2C(session);
 
-    WT_STAT_CONN_INCR(session, cache_hazard_checks);
+    WT_STAT_CONN_INCR(&session->metadata, cache_hazard_checks);
 
     /*
      * Hazard pointer arrays might grow and be freed underneath us; enter the current hazard
@@ -333,14 +333,14 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
         for (j = 0; j < hazard_inuse; ++hp, ++j) {
             ++walk_cnt;
             if (hp->ref == ref) {
-                WT_STAT_CONN_INCRV(session->metadata, cache_hazard_walks, walk_cnt);
+                WT_STAT_CONN_INCRV(&session->metadata, cache_hazard_walks, walk_cnt);
                 if (sessionp != NULL)
                     *sessionp = s;
                 goto done;
             }
         }
     }
-    WT_STAT_CONN_INCRV(session->metadata, cache_hazard_walks, walk_cnt);
+    WT_STAT_CONN_INCRV(&session->metadata, cache_hazard_walks, walk_cnt);
     hp = NULL;
 
 done:

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -128,7 +128,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     int64_t **stats;
 
     WT_STAT_CONN_INCR(session, rwlock_read);
-    if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session)) {
+    if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][l->stat_read_count_off]++;
     }
@@ -229,7 +229,7 @@ stall:
     }
 
     /* Wait for our group to start. */
-    time_start = l->stat_read_count_off != -1 && WT_STAT_ENABLED(session) ? __wt_clock(session) : 0;
+    time_start = l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
     for (pause_cnt = 0; ticket != l->u.s.current; pause_cnt++) {
         if (pause_cnt < 1000)
             WT_PAUSE();
@@ -303,7 +303,7 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     int64_t **stats;
 
     WT_STAT_CONN_INCR(session, rwlock_write);
-    if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session)) {
+    if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][l->stat_write_count_off]++;
     }
@@ -388,7 +388,7 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      * decide that we have the lock.
      */
     time_start =
-      l->stat_write_count_off != -1 && WT_STAT_ENABLED(session) ? __wt_clock(session) : 0;
+      l->stat_write_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
     for (pause_cnt = 0, old.u.v = l->u.v; ticket != old.u.s.current || old.u.s.readers_active != 0;
          pause_cnt++, old.u.v = l->u.v) {
         if (pause_cnt < 1000)

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -127,8 +127,8 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR(session, rwlock_read);
-    if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
+    WT_STAT_CONN_INCR(&session->metadata, rwlock_read);
+    if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(&session->metadata)) {
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][l->stat_read_count_off]++;
     }
@@ -175,7 +175,7 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     uint8_t ticket;
     int pause_cnt;
 
-    WT_STAT_CONN_INCR(session, rwlock_read);
+    WT_STAT_CONN_INCR(&session->metadata, rwlock_read);
 
     WT_DIAGNOSTIC_YIELD;
 
@@ -230,7 +230,7 @@ stall:
 
     /* Wait for our group to start. */
     time_start =
-      l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
+      l->stat_read_count_off != -1 && WT_STAT_ENABLED(&session->metadata) ? __wt_clock(session) : 0;
     for (pause_cnt = 0; ticket != l->u.s.current; pause_cnt++) {
         if (pause_cnt < 1000)
             WT_PAUSE();
@@ -303,8 +303,8 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR(session, rwlock_write);
-    if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session->metadata)) {
+    WT_STAT_CONN_INCR(&session->metadata, rwlock_write);
+    if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(&session->metadata)) {
         stats = (int64_t **)S2C(session)->stats;
         stats[session->stat_bucket][l->stat_write_count_off]++;
     }
@@ -360,7 +360,7 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     uint8_t ticket;
     int pause_cnt;
 
-    WT_STAT_CONN_INCR(session, rwlock_write);
+    WT_STAT_CONN_INCR(&session->metadata, rwlock_write);
 
     for (;;) {
         old.u.v = l->u.v;
@@ -388,8 +388,9 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      * not guaranteed to be ordered and we could see no readers active from a different batch and
      * decide that we have the lock.
      */
-    time_start =
-      l->stat_write_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
+    time_start = l->stat_write_count_off != -1 && WT_STAT_ENABLED(&session->metadata) ?
+      __wt_clock(session) :
+      0;
     for (pause_cnt = 0, old.u.v = l->u.v; ticket != old.u.s.current || old.u.s.readers_active != 0;
          pause_cnt++, old.u.v = l->u.v) {
         if (pause_cnt < 1000)

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -229,7 +229,8 @@ stall:
     }
 
     /* Wait for our group to start. */
-    time_start = l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
+    time_start =
+      l->stat_read_count_off != -1 && WT_STAT_ENABLED(session->metadata) ? __wt_clock(session) : 0;
     for (pause_cnt = 0; ticket != l->u.s.current; pause_cnt++) {
         if (pause_cnt < 1000)
             WT_PAUSE();

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -55,7 +55,7 @@ __wt_tiered_push_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry)
     conn = S2C(session);
     __wt_spin_lock(session, &conn->tiered_lock);
     TAILQ_INSERT_TAIL(&conn->tieredqh, entry, q);
-    WT_STAT_CONN_INCR(session, tiered_work_units_created);
+    WT_STAT_CONN_INCR(&session->metadata, tiered_work_units_created);
     __wt_spin_unlock(session, &conn->tiered_lock);
     __tiered_flush_state(session, entry->type, true);
     __wt_cond_signal(session, conn->tiered_cond);
@@ -85,7 +85,7 @@ __wt_tiered_pop_work(
     TAILQ_FOREACH (entry, &conn->tieredqh, q) {
         if (FLD_ISSET(type, entry->type) && (maxval == 0 || entry->op_val < maxval)) {
             TAILQ_REMOVE(&conn->tieredqh, entry, q);
-            WT_STAT_CONN_INCR(session, tiered_work_units_dequeued);
+            WT_STAT_CONN_INCR(&session->metadata, tiered_work_units_dequeued);
             *entryp = entry;
             break;
         }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2013,8 +2013,8 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
             break;
         }
     }
-    WT_STAT_CONN_INCRV(session, txn_prepared_updates, prepared_updates);
-    WT_STAT_CONN_INCRV(session, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
+    WT_STAT_CONN_INCRV(session->metadata, txn_prepared_updates, prepared_updates);
+    WT_STAT_CONN_INCRV(session->metadata, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
 #ifdef HAVE_DIAGNOSTIC
     txn->prepare_count = prepared_updates;
 #endif

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2014,7 +2014,8 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
         }
     }
     WT_STAT_CONN_INCRV(session->metadata, txn_prepared_updates, prepared_updates);
-    WT_STAT_CONN_INCRV(session->metadata, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
+    WT_STAT_CONN_INCRV(
+      session->metadata, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
 #ifdef HAVE_DIAGNOSTIC
     txn->prepare_count = prepared_updates;
 #endif

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -169,9 +169,9 @@ __wt_txn_active(WT_SESSION_IMPL *session, uint64_t txnid)
 
     /* Walk the array of concurrent transactions. */
     WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(&session->metadata, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
-        WT_STAT_CONN_INCR(session, txn_sessions_walked);
+        WT_STAT_CONN_INCR(&session->metadata, txn_sessions_walked);
         /* If the transaction is in the list, it is uncommitted. */
         if (s->id == txnid)
             goto done;
@@ -242,9 +242,9 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool publish)
 
     /* Walk the array of concurrent transactions. */
     WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(&session->metadata, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
-        WT_STAT_CONN_INCR(session, txn_sessions_walked);
+        WT_STAT_CONN_INCR(&session->metadata, txn_sessions_walked);
         /*
          * Build our snapshot of any concurrent transaction IDs.
          *
@@ -344,9 +344,9 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
 
     /* Walk the array of concurrent transactions. */
     WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(&session->metadata, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
-        WT_STAT_CONN_INCR(session, txn_sessions_walked);
+        WT_STAT_CONN_INCR(&session->metadata, txn_sessions_walked);
         /* Update the last running transaction ID. */
         while ((id = s->id) != WT_TXN_NONE && WT_TXNID_LE(prev_oldest_id, id) &&
           WT_TXNID_LT(id, last_running)) {
@@ -1046,11 +1046,11 @@ __txn_fixup_prepared_update(
                     hs_cursor->set_value(hs_cursor, &tw, tw.durable_stop_ts, tw.durable_start_ts,
                       (uint64_t)WT_UPDATE_STANDARD, &hs_value);
                     WT_ERR(hs_cursor->update(hs_cursor));
-                    WT_STAT_CONN_INCR(
-                      session, txn_prepare_rollback_fix_hs_update_with_ckpt_reserved_txnid);
+                    WT_STAT_CONN_INCR(&session->metadata,
+                      txn_prepare_rollback_fix_hs_update_with_ckpt_reserved_txnid);
                 }
             } else
-                WT_STAT_CONN_INCR(session, txn_prepare_rollback_do_not_remove_hs_update);
+                WT_STAT_CONN_INCR(&session->metadata, txn_prepare_rollback_do_not_remove_hs_update);
         } else
             WT_ERR(hs_cursor->remove(hs_cursor));
     }
@@ -1297,7 +1297,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
 
         if (!commit) {
             upd->txnid = WT_TXN_ABORTED;
-            WT_STAT_CONN_INCR(session, txn_prepared_updates_rolledback);
+            WT_STAT_CONN_INCR(&session->metadata, txn_prepared_updates_rolledback);
             continue;
         }
 
@@ -1336,7 +1336,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * Resolve the prepared update to be committed update.
          */
         __txn_resolve_prepared_update(session, upd);
-        WT_STAT_CONN_INCR(session, txn_prepared_updates_committed);
+        WT_STAT_CONN_INCR(&session->metadata, txn_prepared_updates_committed);
     }
 
     /* Mark the page dirty once the prepared updates are resolved. */
@@ -2013,9 +2013,9 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
             break;
         }
     }
-    WT_STAT_CONN_INCRV(session->metadata, txn_prepared_updates, prepared_updates);
+    WT_STAT_CONN_INCRV(&session->metadata, txn_prepared_updates, prepared_updates);
     WT_STAT_CONN_INCRV(
-      session->metadata, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
+      &session->metadata, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
 #ifdef HAVE_DIAGNOSTIC
     txn->prepare_count = prepared_updates;
 #endif
@@ -2350,7 +2350,7 @@ __wt_txn_activity_drain(WT_SESSION_IMPL *session)
         if (!txn_active)
             break;
 
-        WT_STAT_CONN_INCR(session, txn_release_blocked);
+        WT_STAT_CONN_INCR(&session->metadata, txn_release_blocked);
         __wt_yield();
     }
 
@@ -2587,9 +2587,9 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
      * handles is not thread safe, so some information may change while traversing if other threads
      * are active at the same time, which is OK since this is diagnostic code.
      */
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(&session->metadata, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
-        WT_STAT_CONN_INCR(session, txn_sessions_walked);
+        WT_STAT_CONN_INCR(&session->metadata, txn_sessions_walked);
         /* Skip sessions with no active transaction */
         if ((id = s->id) == WT_TXN_NONE && s->pinned_id == WT_TXN_NONE)
             continue;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -816,7 +816,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     /* Avoid doing work if possible. */
     WT_RET(__txn_checkpoint_can_skip(session, cfg, &full, &use_timestamp, &can_skip));
     if (can_skip) {
-        WT_STAT_CONN_INCR(session, txn_checkpoint_skipped);
+        WT_STAT_CONN_INCR(&session->metadata, txn_checkpoint_skipped);
         return (0);
     }
 
@@ -1000,7 +1000,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     time_stop_fsync = __wt_clock(session);
     fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop_fsync, time_start_fsync);
-    WT_STAT_CONN_INCR(session, txn_checkpoint_fsync_post);
+    WT_STAT_CONN_INCR(&session->metadata, txn_checkpoint_fsync_post);
     WT_STAT_CONN_SET(session, txn_checkpoint_fsync_post_duration, fsync_duration_usecs);
 
     __checkpoint_verbose_track(session, "sync completed");

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -100,7 +100,7 @@ __rollback_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *first
               rollback_timestamp < upd->durable_ts ? "false" : "true");
 
             upd->txnid = WT_TXN_ABORTED;
-            WT_STAT_CONN_INCR(session, txn_rts_upd_aborted);
+            WT_STAT_CONN_INCR(&session->metadata, txn_rts_upd_aborted);
         } else {
             /* Valid update is found. */
             stable_upd = upd;
@@ -1170,7 +1170,7 @@ __rollback_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
         return (0);
     }
 
-    WT_STAT_CONN_INCR(session, txn_rts_pages_visited);
+    WT_STAT_CONN_INCR(&session->metadata, txn_rts_pages_visited);
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       "%p: page rolled back when page is modified: %s", (void *)ref,
       __wt_page_is_modified(page) ? "true" : "false");
@@ -1250,7 +1250,7 @@ __wt_rts_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool *s
         *skipp = true;
         __wt_verbose_multi(
           session, WT_VERB_RECOVERY_RTS(session), "%p: page walk skipped", (void *)ref);
-        WT_STAT_CONN_INCR(session, txn_rts_tree_walk_skip_pages);
+        WT_STAT_CONN_INCR(&session->metadata, txn_rts_tree_walk_skip_pages);
     }
 
     return (0);
@@ -1333,7 +1333,7 @@ __txn_user_active(WT_SESSION_IMPL *session)
     conn = S2C(session);
     txn_active = false;
 
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(&session->metadata, txn_walk_sessions);
 
     /*
      * WT_TXN structures are allocated and freed as sessions are activated and closed. Lock the


### PR DESCRIPTION
This is a draft pull request for one possible approach to removing the session pointer from a large number of function calls. The eventual goal of this work is to make unit testing feasible. Please feel free to remove yourself as a reviewer if you don't want to look at it; I just want some experienced eyes on this before I forge ahead.

A few points:

The key changes are in `session.h`. The main risks here are the "union of structs" thing, which would only have to last until the refactoring work is done, and the fact that there are now two identical `WT_CONNECTION` pointers in `__wt_session_impl`. One is added to the new "metadata" struct (name is a WIP, suggestions welcome) and the existing one in `iface`. I didn't want to include the entire `iface` in the `metadata` struct, but opinions on this are welcome.

Secondly, the overall thing I'm trying to show is what it would look like for this work to continue. It should be visible at this point how the metadata struct would get "hoisted up" along the call stack as this work progresses, eventually winding up at a hopefully small number of functions that genuinely need the entire session. This might include further breaking down the session, or removing parts of the metadata struct - I'll cross that bridge when I come to it.

Finally - thanks for any time you spend on this. There's no pressure to merge it, it's an experiment and I've got about 2.5 days into it. Saying the entire approach is wrong and I should do something else is an outcome I'm happy with.