### PR TITLE
WT-7722 Clean up TESTUTIL_BYPASS_VALGRIND and TESTUTIL_SLOW_MACHINE flags

### DIFF
--- a/test/checkpoint/smoke.sh
+++ b/test/checkpoint/smoke.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Bypass this test for valgrind
-test "$TESTUTIL_BYPASS_VALGRIND" = "1" && exit 0
-
 # Smoke-test checkpoints as part of running "make check".
 
 # 1. Mixed tables cases. Use four (or eight) tables because there are four table types.

--- a/test/csuite/wt2246_col_append/main.c
+++ b/test/csuite/wt2246_col_append/main.c
@@ -106,10 +106,6 @@ main(int argc, char *argv[])
     uint64_t i, id;
     char buf[100];
 
-    /* Bypass this test for valgrind */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
-        return (EXIT_SUCCESS);
-
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
     opts->table_type = TABLE_ROW;

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -96,10 +96,6 @@ main(int argc, char *argv[])
     TEST_OPTS *opts, _opts;
     const char *tablename;
 
-    /* Bypass this test for valgrind */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
-        return (EXIT_SUCCESS);
-
     opts = &_opts;
     sharedopts = &_sharedopts;
     memset(opts, 0, sizeof(*opts));

--- a/test/csuite/wt2535_insert_race/main.c
+++ b/test/csuite/wt2535_insert_race/main.c
@@ -96,10 +96,6 @@ main(int argc, char *argv[])
     int i;
     char tableconf[128];
 
-    /* Bypass this test for valgrind */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
-        return (EXIT_SUCCESS);
-
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
     opts->nthreads = 20;

--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -92,13 +92,6 @@ main(int argc, char *argv[])
     char tableconf[128];
     const char *tablename;
 
-    /*
-     * Bypass this test for valgrind or slow test machines. This test is timing sensitive.
-     */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND") ||
-      testutil_is_flag_set("TESTUTIL_SLOW_MACHINE"))
-        return (EXIT_SUCCESS);
-
     opts = &_opts;
     sharedopts = &_sharedopts;
     memset(opts, 0, sizeof(*opts));

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -414,12 +414,6 @@ main(int argc, char *argv[])
 
     skip = false;
 
-    /*
-     * Bypass this test for valgrind. It has a fairly low thread limit.
-     */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_VALGRIND"))
-        skip = true;
-
 /*
  * Bypass this test for OS X. We periodically see it hang without error, leaving a zombie process
  * that never exits (WT-4613, BUILD-7616).

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3660,7 +3660,6 @@ buildvariants:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR
-      TESTUTIL_SLOW_MACHINE=1
     # We don't run C++ memory sanitized testing as it creates false positives.
     check_args: -LE cppsuite
   tasks:


### PR DESCRIPTION
Remove TESTUTIL_BYPASS_VALGRIND and TESTUTIL_SLOW_MACHINE flags, they're no longer useful.