### PR TITLE
WT-4907 WT_PREPARE_CONFLICT error description is wrong

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -61,10 +61,9 @@ errors = [
         should be rolled back and the operation retried in a new transaction.'''),
     Error('WT_PREPARE_CONFLICT', -31808,
         'conflict with a prepared update', '''
-        This error is generated when the application attempts to update
-        an already updated record which is in prepared state. An updated
-        record will be in prepared state, when the transaction that performed
-        the update is in prepared state.'''),
+        This error is generated when the application attempts to read an
+        updated record which is part of a transaction that has been prepared
+        but not yet resolved.'''),
     Error('WT_TRY_SALVAGE', -31809,
         'database corruption detected', '''
         This error is generated when corruption is detected in an on-disk file.

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -56,9 +56,8 @@ thread fails to do eviction within cache_max_wait_ms. The operation may be retri
 is in progress, it should be rolled back and the operation retried in a new transaction.
 
 @par <code>WT_PREPARE_CONFLICT</code>
-This error is generated when the application attempts to update an already updated record which is
-in prepared state. An updated record will be in prepared state, when the transaction that performed
-the update is in prepared state.
+This error is generated when the application attempts to read an updated record which is part of a
+transaction that has been prepared but not yet resolved.
 
 @par <code>WT_TRY_SALVAGE</code>
 This error is generated when corruption is detected in an on-disk file. During normal operations,

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3803,10 +3803,9 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
 #define	WT_CACHE_FULL	(-31807)
 /*!
  * Conflict with a prepared update.
- * This error is generated when the application attempts to update an already
- * updated record which is in prepared state. An updated record will be in
- * prepared state, when the transaction that performed the update is in prepared
- * state.
+ * This error is generated when the application attempts to read an updated
+ * record which is part of a transaction that has been prepared but not yet
+ * resolved.
  */
 #define	WT_PREPARE_CONFLICT	(-31808)
 /*!

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -26,26 +26,26 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_prepare_conflict.py
-#   Evict a page while in the fast-truncate state.
+# test_truncate08.py
+#   Check for prepare-conflict return after fast-truncate committed.
 #
 
 import wiredtiger, wttest
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 
-class test_prepare_conflict(wttest.WiredTigerTestCase):
+class test_truncate08(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column_fix', dict(key_format='r', value_format='8t')),
+        ('fix', dict(key_format='r', value_format='8t')),
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 
     scenarios = make_scenarios(format_values)
 
-    def test_prepare(self):
+    def test_truncate08(self):
         # Create a large table with lots of pages.
-        uri = "table:test_prepare_conflict"
+        uri = "table:test_truncate08"
         format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
         self.session.create(uri, 'allocation_size=512,leaf_page_max=512,' + format)
 


### PR DESCRIPTION
@kommiharibabu, I made the change you suggested, but I also updated `format`, it anticipated `WT_PREPARE_CONFLICT` being returned from write operations. It will now assert in that case, which should give us better test coverage of error handling in the library.