### PR TITLE
WT-4416 buffer_alignment setting does not work

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1143,7 +1143,10 @@ wiredtiger_open_common =\
         in-memory alignment (in bytes) for buffers used for I/O.  The
         default value of -1 indicates a platform-specific alignment value
         should be used (4KB on Linux systems when direct I/O is configured,
-        zero elsewhere)''',
+        zero elsewhere). If the configured alignment is larger than default
+        or configured object page sizes, file allocation and page sizes are
+        silently increased to the buffer alignment size. Requires the \c
+        posix_memalign API. See @ref tuning_system_buffer_cache_direct_io''',
         min='-1', max='1MB'),
     Config('builtin_extension_config', '', r'''
         A structure where the keys are the names of builtin extensions and the
@@ -1164,10 +1167,11 @@ wiredtiger_open_common =\
         Windows to access files.  Options are given as a list, such as
         <code>"direct_io=[data]"</code>.  Configuring \c direct_io requires
         care, see @ref tuning_system_buffer_cache_direct_io for important
-        warnings.  Including \c "data" will cause WiredTiger data files to use
-        direct I/O, including \c "log" will cause WiredTiger log files to use
-        direct I/O, and including \c "checkpoint" will cause WiredTiger data
-        files opened at a checkpoint (i.e: read-only) to use direct I/O.
+        warnings.  Including \c "data" will cause WiredTiger data files,
+        including WiredTiger internal data files, to use direct I/O;
+        including \c "log" will cause WiredTiger log files to use direct
+        I/O; including \c "checkpoint" will cause WiredTiger data files
+        opened using a (read-only) checkpoint cursor to use direct I/O.
         \c direct_io should be combined with \c write_through to get the
         equivalent of \c O_DIRECT on Windows''',
         type='list', choices=['checkpoint', 'data', 'log']),

--- a/src/docs/tune-system-buffer-cache.dox
+++ b/src/docs/tune-system-buffer-cache.dox
@@ -11,57 +11,59 @@ operating system buffer cache, and
 - avoid stalling underlying solid-state drives by writing a large number
 of dirty blocks.
 
-Direct I/O is configured using the "direct_io" configuration string to
-the ::wiredtiger_open function.  An example of configuring direct I/O
-for WiredTiger's data files:
+\warning
+Using Direct I/O is almost never a good idea. Direct I/O implies a writing
+thread waits for the write to complete (which is a slower operation than
+writing into the system buffer cache), and configuring direct I/O is likely
+to decrease overall application performance.
+\warning
+Direct I/O may not be available on all platforms.
+
+Direct I/O can be separately configured for log files, data files, and blocks
+read using a (read-only) checkpoint cursor. Configuring direct I/O for data
+files will also configure direct I/O for all internal data files created by
+WiredTiger itself as well as application owned data files.
+
+Direct I/O is configured using the \c direct_io configuration string to
+the ::wiredtiger_open function.  An example of configuring direct I/O for
+data files:
 
 @snippet ex_all.c Configure direct_io for data files
 
-On Windows, the "direct_io" configuration string controls whether the operating
-system cache is used to buffer reads, and writes to disk, i.e.,
-FILE_FLAG_NO_BUFFERING. When "direct_io" is off, Windows will use free RAM to
-cache access to files. This may had adverse effects because Windows may page out
-the WiredTiger buffer cache instead of its file cache. An additional
-configuration string "write_through" controls whether the disk is allowed to
-cache the writes. Enabling this flag increases write latency as the drive must
-ensure all writes are persisted to disk, but it ensures write durability. To get
-the equivalent of \c O_DIRECT on Windows, "direct_io", and "write_through" must
-be both set.
+Systems require alignment for I/O buffers when direct I/O is configured, and
+using the wrong alignment can cause data loss or corruption.  If direct I/O is
+configured, WiredTiger aligns I/O buffers to a default of 4KB; if different
+alignment is required by your system, the \c buffer_alignment configuration
+to the ::wiredtiger_open call should be set to the correct value. If buffer
+alignment is configured explicitly or as a result of configuring direct
+I/O, WiredTiger will silently increase file allocation and page sizes to
+be at least as large as the \c buffer_alignment value. In all cases, file
+allocation and page sizes must be a multiple of the \c buffer_alignment value.
 
-Direct I/O implies a writing thread waits for the write to complete
-(which is a slower operation than writing into the system buffer cache),
-and configuring direct I/O is likely to decrease overall application
-performance.
+On Windows, the \c direct_io configuration string controls whether the
+operating system cache is used to buffer reads, and writes to disk, i.e.,
+FILE_FLAG_NO_BUFFERING. When direct I/O is off, Windows will use free RAM
+to cache access to files. This may had adverse effects because Windows
+may page out the WiredTiger buffer cache instead of its file cache. An
+additional configuration string, \c write_through, controls whether the
+disk is allowed to cache the writes. Enabling this flag increases write
+latency as the drive must ensure all writes are persisted to disk, but it
+ensures write durability. To get the equivalent of \c O_DIRECT on Windows,
+both \c direct_io and \c write_through must be set.
 
-Many Linux systems do not support mixing \c O_DIRECT and memory
-mapping or normal I/O to the same file, and attempting to do so can
-result in data loss or corruption.   For this reason:
+Some Linux systems do not support mixing \c O_DIRECT and memory mapping or
+normal I/O to the same file, and attempting to do so can result in data loss
+or corruption. For this reason:
 
-- WiredTiger silently ignores the setting of the \c mmap configuration
-to the wiredtiger_open function in those cases, and will never memory
-map a file which is configured for direct I/O.
+- WiredTiger silently ignores the setting of the \c mmap configuration to
+the ::wiredtiger_open function in those cases, and will never memory map a
+file which is configured for direct I/O.
 
-- If \c O_DIRECT is configured for data files on Linux systems, any
-system utilities used to copy data files for the purposes of backup
-should also specify \c O_DIRECT when configuring their file access.  A
-standard Linux system utility that supports \c O_DIRECT is the \c dd
-utility, when using the \c iflag=direct command-line option.
-
-Additionally, Windows, and many Linux systems require specific alignment for
-buffers used for I/O when direct I/O is configured, and using the wrong
-alignment can cause data loss or corruption.  When direct I/O is
-configured on Windows, and Linux systems, WiredTiger aligns I/O buffers to 4KB;
-if different alignment is required by your system, the \c buffer_alignment
-configuration to the wiredtiger_open call should be configured to the
-correct value.
-
-Finally, if direct I/O is configured on any system, WiredTiger will
-silently change the file unit allocation size and the maximum leaf and
-internal page sizes to be at least as large as the \c buffer_alignment
-value as well as a multiple of that value.
-
-Direct I/O is based on the non-standard \c O_DIRECT flag to the POSIX
-1003.1 open system call and may not be available on all platforms.
+- If \c O_DIRECT is configured for data files on Linux systems, any system
+utilities used to copy data files for the purposes of backup should also
+specify \c O_DIRECT when configuring their file access.  A standard Linux
+system utility that supports \c O_DIRECT is the \c dd utility, when using
+the \c iflag=direct command-line option.
 
 @section tuning_system_buffer_cache_os_cache_dirty_max os_cache_dirty_max
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2775,7 +2775,10 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{buffer_alignment, in-memory alignment (in bytes) for buffers used for I/O. The default
  * value of -1 indicates a platform-specific alignment value should be used (4KB on Linux systems
- * when direct I/O is configured\, zero elsewhere)., an integer between -1 and 1MB; default \c -1.}
+ * when direct I/O is configured\, zero elsewhere). If the configured alignment is larger than
+ * default or configured object page sizes\, file allocation and page sizes are silently increased
+ * to the buffer alignment size.  Requires the \c posix_memalign API. See @ref
+ * tuning_system_buffer_cache_direct_io., an integer between -1 and 1MB; default \c -1.}
  * @config{builtin_extension_config, A structure where the keys are the names of builtin extensions
  * and the values are passed to WT_CONNECTION::load_extension as the \c config parameter (for
  * example\, <code>builtin_extension_config={zlib={compression_level=3}}</code>)., a string; default
@@ -2872,12 +2875,12 @@ struct __wt_connection {
  * @config{direct_io, Use \c O_DIRECT on POSIX systems\, and \c FILE_FLAG_NO_BUFFERING on Windows to
  * access files.  Options are given as a list\, such as <code>"direct_io=[data]"</code>. Configuring
  * \c direct_io requires care\, see @ref tuning_system_buffer_cache_direct_io for important
- * warnings.  Including \c "data" will cause WiredTiger data files to use direct I/O\, including \c
- * "log" will cause WiredTiger log files to use direct I/O\, and including \c "checkpoint" will
- * cause WiredTiger data files opened at a checkpoint (i.e: read-only) to use direct I/O. \c
- * direct_io should be combined with \c write_through to get the equivalent of \c O_DIRECT on
- * Windows., a list\, with values chosen from the following options: \c "checkpoint"\, \c "data"\,
- * \c "log"; default empty.}
+ * warnings.  Including \c "data" will cause WiredTiger data files\, including WiredTiger internal
+ * data files\, to use direct I/O; including \c "log" will cause WiredTiger log files to use direct
+ * I/O; including \c "checkpoint" will cause WiredTiger data files opened using a (read-only)
+ * checkpoint cursor to use direct I/O. \c direct_io should be combined with \c write_through to get
+ * the equivalent of \c O_DIRECT on Windows., a list\, with values chosen from the following
+ * options: \c "checkpoint"\, \c "data"\, \c "log"; default empty.}
  * @config{encryption = (, configure an encryptor for system wide metadata and logs.  If a system
  * wide encryptor is set\, it is also used for encrypting data files and tables\, unless encryption
  * configuration is explicitly set for them when they are created with WT_SESSION::create., a set of

--- a/test/suite/test_bug028.py
+++ b/test/suite/test_bug028.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_bug028.py
+#   Test buffer alignment and direct I/O settings.
+
+import os
+import wiredtiger, wttest
+from suite_subprocess import suite_subprocess
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+class test_bug028(wttest.WiredTigerTestCase, suite_subprocess):
+    format_values = [
+        ('fix', dict(key_format = 'r', value_format='8t')),
+        ('row', dict(key_format = 'S', value_format='S')),
+        ('var', dict(key_format = 'r', value_format='S')),
+    ]
+    ckpt_directio = [
+        ('ckpt-directio', dict(ckpt_directio=True)),
+        ('no-ckpt-directio', dict(ckpt_directio=False)),
+    ]
+    data_directio = [
+        ('data-directio', dict(data_directio=True)),
+        ('no-data-directio', dict(data_directio=False)),
+    ]
+    log_directio = [
+        ('log-directio', dict(log_directio=True)),
+        ('no-log-directio', dict(log_directio=False)),
+    ]
+    reopen = [
+        ('in-memory', dict(reopen=False)),
+        ('on-disk', dict(reopen=True)),
+    ]
+    scenarios = make_scenarios(format_values, ckpt_directio, data_directio, log_directio, reopen)
+
+    # Test is opening its own home.
+    def setUpConnectionOpen(self, dir):
+        return None
+    def setUpSessionOpen(self, conn):
+        return None
+
+    # Open a connection with direct I/O and a non-standard buffer alignment.
+    def open_conn(self, run, align, fail):
+        # This is a smoke test of buffer alignment and direct I/O. We don't want to debug any
+        # of this under any systems that aren't vanilla POSIX. Do not try and fix this test on
+        # those systems, just stop the test from running there.
+        if os.name != 'posix':
+            self.skipTest('skipping buffer alignment and direct I/O test on non-POSIX system')
+
+        config = 'create'
+        config += ",buffer_alignment=" + align
+        config += ',direct_io=('
+        if self.ckpt_directio:
+            config += ',checkpoint'
+        if self.data_directio:
+            config += ',data'
+        if self.log_directio:
+            config += ',log'
+            self.skipTest('FIXME WT-8684 skipping test of logging with direct I/O')
+        config += ')'
+        if self.log_directio:
+            config += ',log=(enabled=true)'
+
+        homedir = 'test_bug028.' + str(run)
+        os.mkdir(homedir)
+        self.pr(homedir)
+        if fail:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: wiredtiger.wiredtiger_open(homedir, config),
+                '/memory allocation .* failed/')
+            return
+        else:
+            self.conn = wiredtiger.wiredtiger_open(homedir, config)
+        self.session = self.conn.open_session(self.session_config)
+
+        uri = 'table:buf_align'
+        nitems = 50000 # Enough items to create multiple pages.
+
+        # Configuring direct I/O with checkpoint or data files forces allocation and page sizes to
+        # match the buffer alignment size. Else, we have to do it explicitly.
+        size = align
+        if align == '-1':
+            size = '4K'
+        dsconfig = 'allocation_size={}'.format(size)
+        if not self.ckpt_directio and not self.data_directio:
+            dsconfig += ',internal_page_max={},leaf_page_max={}'.format(size, size)
+        ds = SimpleDataSet(self, uri, nitems,
+            key_format=self.key_format, value_format=self.value_format, config=dsconfig)
+        ds.populate()
+
+        # Optionally flush the file to disk and re-open it.
+        if self.reopen:
+            self.conn.close()
+            self.conn = wiredtiger.wiredtiger_open(homedir, config)
+            self.session = self.conn.open_session(self.session_config)
+
+        c = self.session.open_cursor(uri, None, None)
+        i = 0
+        while True:
+            ret = c.next()
+            if ret != 0:
+                break
+            c.get_key()
+            c.get_value()
+            i += 1
+        self.assertEqual(i, nitems)
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+
+        self.conn.close()
+
+    # Open a connection with a non-standard buffer alignment.
+    def test_bug028(self):
+        self.open_conn(1, '-1', False)
+        self.open_conn(2, '1K', False)
+        self.open_conn(3, '2K', False)
+        self.open_conn(4, '4K', False)
+        self.open_conn(5, '32K', False)
+        self.open_conn(6, '64K', False)
+        self.open_conn(7, '8000', True)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Silently increase allocation and page sizes to be at least as large as any configured buffer alignment.
Add a smoke test for direct I/O and buffer alignment.
Refresh  the documentation for direct I/O.