### PR TITLE
WT-8515 Remove unused code in evergreen.yml

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1480,13 +1480,6 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
 
-  - name: unit-test-with-compile
-    tags: ["python"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "unit test"
-
   - name: unit-test-zstd
     tags: ["python"]
     depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1863,18 +1863,6 @@ tasks:
         vars:
           format_test_script_args: -t 110 -j 4 direct_io=1
 
-  # - name: linux-directio
-  #   depends_on:
-  #   - name: compile
-  #   commands:
-  #     - func: "fetch artifacts"
-  #     - func: "compile wiredtiger"
-  #     - func: "format test"
-  #       vars:
-  #         times: 3
-  #         config: ../../../test/format/CONFIG.stress
-  #         extra_args: -C "direct_io=[data]"
-
   - name: format-linux-no-ftruncate
     commands:
       - func: "get project"


### PR DESCRIPTION
This ticket is part of WT-8498, the initial PR is #7285, this PR aims at merging the same changes to the develop branch. The task is no longer used at all since #7317, see the diff [here](https://github.com/wiredtiger/wiredtiger/pull/7317/files#diff-42f20e21217bd7d4b14489056e1ea24ea2b87599c85413d49182a3b0b721c132L4327).
The second commit is from #7296.