### PR TITLE
WT-8522 Don't report error in Evergreen when there are no Hang Analyer artifacts to upload

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -480,6 +480,7 @@ functions:
         aws_key: ${aws_key}
         local_file: wt-hang-analyzer.tgz
         bucket: build_external
+        optional: true
         permissions: public-read
         content_type: application/tar
         display_name: WT Hang Analyzer Output - Execution ${execution}


### PR DESCRIPTION
This ticket is part of [WT-8498](https://jira.mongodb.org/browse/WT-8498) and initially reviewed in #7297. 
This new PR merges the same change into `develop`.
