### PR TITLE
WT-8686 WT_SESSION.truncate doesn't map WT_PREPARE_CONFLICT to WT_ROLLBACK

### DIFF
--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -420,6 +420,11 @@ err:
     else
         WT_STAT_CONN_INCR(session, session_table_compact_success);
     WT_STAT_CONN_SET(session, session_table_compact_running, 0);
+
+    /* Map prepare-conflict to rollback. */
+    if (ret == WT_PREPARE_CONFLICT)
+        ret = WT_ROLLBACK;
+
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 

--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -150,7 +150,8 @@ wts_load(TABLE *table, void *arg)
          * row counter and continue.
          */
         if ((ret = cursor->insert(cursor)) != 0) {
-            testutil_assert(ret == WT_CACHE_FULL || ret == WT_ROLLBACK);
+            testutil_assertfmt(
+              ret == WT_CACHE_FULL || ret == WT_ROLLBACK, "WT_CURSOR.insert failed: %d", ret);
 
             if (g.transaction_timestamps_config) {
                 bulk_rollback_transaction(session);

--- a/test/format/compact.c
+++ b/test/format/compact.c
@@ -69,9 +69,9 @@ compact(void *arg)
          */
         table = table_select(NULL);
         ret = session->compact(session, table->uri, NULL);
-        if (ret != 0 && ret != EBUSY && ret != ETIMEDOUT && ret != WT_ROLLBACK &&
-          ret != WT_CACHE_FULL)
-            testutil_die(ret, "session.compact");
+        testutil_assertfmt(ret == 0 || ret == EBUSY || ret == ETIMEDOUT || ret == WT_CACHE_FULL ||
+            ret == WT_ROLLBACK,
+          "WT_SESSION.compact failed: %s: %d", table->uri, ret);
     }
 
     testutil_check(session->close(session, NULL));

--- a/test/format/hs.c
+++ b/test/format/hs.c
@@ -78,10 +78,10 @@ hs_cursor(void *arg)
          */
         next = mmrand(NULL, 0, 1) == 1;
         for (i = mmrand(NULL, 1000, 100000); i > 0; --i) {
-            if ((ret = (next ? cursor->next(cursor) : cursor->prev(cursor))) != 0) {
-                testutil_assert(ret == WT_NOTFOUND || ret == WT_ROLLBACK || ret == WT_CACHE_FULL);
-                break;
-            }
+            if ((ret = (next ? cursor->next(cursor) : cursor->prev(cursor))) != 0)
+                testutil_assertfmt(ret == WT_NOTFOUND || ret == WT_CACHE_FULL || ret == WT_ROLLBACK,
+                  "WT_CURSOR.%s failed: %d", next ? "next" : "prev", ret);
+
             testutil_check(
               cursor->get_key(cursor, &hs_btree_id, &hs_key, &hs_start_ts, &hs_counter));
             testutil_check(cursor->get_value(

--- a/test/format/hs.c
+++ b/test/format/hs.c
@@ -78,10 +78,11 @@ hs_cursor(void *arg)
          */
         next = mmrand(NULL, 0, 1) == 1;
         for (i = mmrand(NULL, 1000, 100000); i > 0; --i) {
-            if ((ret = (next ? cursor->next(cursor) : cursor->prev(cursor))) != 0)
+            if ((ret = (next ? cursor->next(cursor) : cursor->prev(cursor))) != 0) {
                 testutil_assertfmt(ret == WT_NOTFOUND || ret == WT_CACHE_FULL || ret == WT_ROLLBACK,
                   "WT_CURSOR.%s failed: %d", next ? "next" : "prev", ret);
-
+                break;
+            }
             testutil_check(
               cursor->get_key(cursor, &hs_btree_id, &hs_key, &hs_start_ts, &hs_counter));
             testutil_check(cursor->get_value(

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -593,7 +593,7 @@ prepare_transaction(TINFO *tinfo)
             goto rollback;                                                                   \
         testutil_assertfmt(                                                                  \
           (notfound_ok && ret == WT_NOTFOUND) || ret == WT_CACHE_FULL || ret == WT_ROLLBACK, \
-          "operation failed with %d", ret);                                                  \
+          "operation failed: %d", ret);                                                      \
     } while (0)
 
 /*
@@ -1032,7 +1032,8 @@ update_instead_of_chosen_op:
             __wt_yield(); /* Encourage races */
 
             ret = snap_repeat_txn(tinfo);
-            testutil_assert(ret == 0 || ret == WT_ROLLBACK || ret == WT_CACHE_FULL);
+            testutil_assertfmt(
+              ret == 0 || ret == WT_ROLLBACK || ret == WT_CACHE_FULL, "operation failed: %d", ret);
             if (ret == WT_ROLLBACK || ret == WT_CACHE_FULL)
                 goto rollback;
         }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -586,13 +586,14 @@ prepare_transaction(TINFO *tinfo)
  * OP_FAILED --
  *	Error handling.
  */
-#define OP_FAILED(notfound_ok)                                                                \
-    do {                                                                                      \
-        positioned = false;                                                                   \
-        if (intxn && (ret == WT_CACHE_FULL || ret == WT_ROLLBACK))                            \
-            goto rollback;                                                                    \
-        testutil_assert(                                                                      \
-          (notfound_ok && ret == WT_NOTFOUND) || ret == WT_CACHE_FULL || ret == WT_ROLLBACK); \
+#define OP_FAILED(notfound_ok)                                                               \
+    do {                                                                                     \
+        positioned = false;                                                                  \
+        if (intxn && (ret == WT_CACHE_FULL || ret == WT_ROLLBACK))                           \
+            goto rollback;                                                                   \
+        testutil_assertfmt(                                                                  \
+          (notfound_ok && ret == WT_NOTFOUND) || ret == WT_CACHE_FULL || ret == WT_ROLLBACK, \
+          "operation failed with %d", ret);                                                  \
     } while (0)
 
 /*

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -586,7 +586,7 @@ snap_repeat(TINFO *tinfo, SNAP_OPS *snap)
          */
         if ((ret = snap_verify(tinfo, snap)) == 0)
             break;
-        testutil_assert(ret == WT_ROLLBACK);
+        testutil_assertfmt(ret == WT_ROLLBACK, "operation failed: %d", ret);
 
         testutil_check(session->rollback_transaction(session, NULL));
     }

--- a/test/suite/test_prepare13.py
+++ b/test/suite/test_prepare13.py
@@ -91,13 +91,14 @@ class test_prepare13(wttest.WiredTigerTestCase):
             cursor.close()
 
             # Truncate the middle chunk and expect a conflict.
-            preparemsg = '/conflict with a prepared update/'
+            msg = preparemsg = '/conflict between concurrent operations/'
             s.begin_transaction()
             c1 = s.open_cursor(uri, None)
             c1.set_key(simple_key(c1, 100))
             c2 = s.open_cursor(uri, None)
             c2.set_key(simple_key(c1, nrows))
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:s.truncate(None, c1, c2, None), preparemsg)
+            self.assertRaisesException(
+                wiredtiger.WiredTigerError, lambda:s.truncate(None, c1, c2, None), msg)
             c1.close()
             c2.close()
             s.rollback_transaction()

--- a/test/suite/test_truncate07.py
+++ b/test/suite/test_truncate07.py
@@ -186,7 +186,7 @@ class test_truncate07(wttest.WiredTigerTestCase):
         # Truncate the data, including what we prepared.
         self.session.begin_transaction()
         err = self.truncate(ds.uri, ds.key, nrows // 4, nrows - nrows // 4)
-        self.assertEqual(err, WT_PREPARE_CONFLICT)
+        self.assertEqual(err, WT_ROLLBACK)
         self.session.rollback_transaction()
 
         # Move the stable timestamp forward before exiting so we don't waste time rolling


### PR DESCRIPTION
WT_SESSION.truncate and WT_SESSION.compact should map WT_PREPARE_CONFLICT to WT_ROLLBACK.