### PR TITLE
WT-8382 Halve the number of concurrent jobs when running PPC & zSeries tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4068,7 +4068,8 @@ buildvariants:
       -DENABLE_STRICT=1
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
-    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    # Use half number of vCPU to avoid OOM kill failure
+    smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
     cmake_generator: Ninja
     make_command: ninja
   tasks:
@@ -4098,7 +4099,8 @@ buildvariants:
       -DENABLE_STRICT=1
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
-    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    # Use half number of vCPU to avoid OOM kill failure
+    smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
     cmake_generator: Ninja
     make_command: ninja
   tasks:


### PR DESCRIPTION
PPC & zSeries test hosts are not performant as their x86 equivalents, which could cause OOM-kill failures for some format tests if setting the number of concurrent jobs to the number of vCPU. The solution is to halve the number of concurrent jobs for PPC & zSeries builders in Evergreen.