### PR TITLE
WT-8704 Tidy up CMake warnings on Windows builds

### DIFF
--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -95,11 +95,16 @@ function(define_build_mode mode)
         "${linker_flags}" CACHE STRING
         "Linker lags to be used to create shared libraries for ${mode} build type." FORCE)
 
+    set(CMAKE_MODULE_LINKER_FLAGS_${build_mode}
+        "${linker_flags}" CACHE STRING
+        "Linker lags to be used to create shared modules for ${mode} build type." FORCE)
+
     mark_as_advanced(
         CMAKE_CXX_FLAGS_${build_mode}
         CMAKE_C_FLAGS_${build_mode}
         CMAKE_EXE_LINKER_FLAGS_${build_mode}
         CMAKE_SHARED_LINKER_FLAGS_${build_mode}
+        CMAKE_MODULE_LINKER_FLAGS_${build_mode}
     )
     set(BUILD_MODES "${BUILD_MODES};${mode}" CACHE INTERNAL "")
 endfunction()

--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -185,6 +185,8 @@ define_build_mode(Coverage
     DEPENDS "NOT MSVC"
 )
 
+define_build_mode(None)
+
 if(NOT CMAKE_BUILD_TYPE)
     string(REPLACE ";" " " build_modes_doc "${BUILD_MODES}")
     set(CMAKE_BUILD_TYPE "None" CACHE STRING "Choose the type of build, options are: ${build_modes_doc}." FORCE)

--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -93,11 +93,11 @@ function(define_build_mode mode)
 
     set(CMAKE_SHARED_LINKER_FLAGS_${build_mode}
         "${linker_flags}" CACHE STRING
-        "Linker lags to be used to create shared libraries for ${mode} build type." FORCE)
+        "Linker flags to be used to create shared libraries for ${mode} build type." FORCE)
 
     set(CMAKE_MODULE_LINKER_FLAGS_${build_mode}
         "${linker_flags}" CACHE STRING
-        "Linker lags to be used to create shared modules for ${mode} build type." FORCE)
+        "Linker flags to be used to create shared modules for ${mode} build type." FORCE)
 
     mark_as_advanced(
         CMAKE_CXX_FLAGS_${build_mode}

--- a/cmake/configs/x86/windows/config.cmake
+++ b/cmake/configs/x86/windows/config.cmake
@@ -22,6 +22,10 @@ add_compile_options(/Gy)
 add_compile_options(/Zc:wchar_t)
 # Use the __cdecl calling convention for all functions.
 add_compile_options(/Gd)
+# Ignore deprecated functions.
+add_compile_options(/wd4996)
+# Ignore warning about mismatched const qualifiers.
+add_compile_options(/wd4090)
 
 # Disable incremental linking.
 string(APPEND win_link_flags " /INCREMENTAL:NO")

--- a/cmake/strict/strict_flags_helpers.cmake
+++ b/cmake/strict/strict_flags_helpers.cmake
@@ -206,10 +206,6 @@ function(get_cl_base_flags flags)
 
     # Warning level 3.
     list(APPEND cl_flags "/WX")
-    # Ignore warning about mismatched const qualifiers.
-    list(APPEND cl_flags "/wd4090")
-    # Ignore deprecated functions.
-    list(APPEND cl_flags "/wd4996")
     # Complain about unreferenced format parameter.
     list(APPEND cl_flags "/we4100")
     # Enable security check.


### PR DESCRIPTION
When using newer versions of CMake & VS MSBuild, we get a significant number of warnings at both the CMake configuration stages and during an `MSBuild` compilation. The PR intends to tidy these warnings up, the key changes being:
- Added `CMAKE_MODULE_LINKER_FLAGS` to build modes: This being a missing flag variable that is appended to a given CMake build mode. Newer versions of CMake will flag a warning about the missing variable, this change addresses the warning.
- Defined `None` build mode: The `None` build mode is the default CMake build mode, where no additional compiler flags are appended. We want to explicitly define it as newer versions of CMake will display warning messages about the None build mode not existing in the CMake cache. This change shouldn't have an effect on the build, we still get the same functionality with or without the line. This change is just intended to suppress spurious warning messages.
- Moved select Windows warning diagnostics to main config file: The MSVC warnings `C4090` & `C4996` are quite prominent irrespective of a strict or non-strict build. As we don't intend to fix these issues, moved these diagnostic warnings to the main Windows config file to reduce noise.