### PR TITLE
Run performance tests once per day in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3729,6 +3729,7 @@ buildvariants:
 
 - name: ubuntu2004-perf-tests
   display_name: Ubuntu 20.04 Performance tests
+  batchtime: 1440 # 1 day
   run_on:
     - ubuntu2004-medium
   expansions:


### PR DESCRIPTION
Reduce the running frequency of perf Evergreen tasks to once per day (They used to run for every commit) to save build resources. 