### PR TITLE
WT-8586 Data validation stress tests fail when logging is enabled

### DIFF
--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -50,7 +50,7 @@ create_table(WT_SESSION *session, COOKIE *cookie)
     vf = cookie->type == FIX ? "8t" : "S";
 
     /*
-     * Turn off logging for the table. This shouldn't be necessary, see FIXME-WT-8586
+     * If we're using timestamps, turn off logging for the table.
      */
     if (g.use_timestamps)
         testutil_check(__wt_snprintf(config, sizeof(config),
@@ -59,8 +59,8 @@ create_table(WT_SESSION *session, COOKIE *cookie)
           "memory_page_max=64KB,log=(enabled=false),%s",
           kf, vf, lsm));
     else
-        testutil_check(__wt_snprintf(config, sizeof(config),
-          "key_format=%s,value_format=%s,log=(enabled=false),%s", kf, vf, lsm));
+        testutil_check(
+          __wt_snprintf(config, sizeof(config), "key_format=%s,value_format=%s,%s", kf, vf, lsm));
 
     if ((ret = session->create(session, cookie->uri, config)) != 0)
         if (ret != EEXIST)


### PR DESCRIPTION
I have not been able to reproduce this failure since WT-8570 was committed, but it's always been difficult to reproduce. Turn testing back on and wait for fallout.