### PR TITLE
WT-8619 Replace nullptr with empty string when key lacks prefix

### DIFF
--- a/test/cppsuite/tests/search_near_03.cxx
+++ b/test/cppsuite/tests/search_near_03.cxx
@@ -133,7 +133,7 @@ class search_near_03 : public test_harness::test {
     get_prefix_from_key(const std::string &s)
     {
         const std::string::size_type pos = s.find(',');
-        return pos != std::string::npos ? s.substr(0, pos) : nullptr;
+        return pos != std::string::npos ? s.substr(0, pos) : "";
     }
 
     void


### PR DESCRIPTION
Verified this locally and with a patch build.