### PR TITLE
WT-8696 Clean up thread start/stop calls

### DIFF
--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -676,8 +676,7 @@ __wt_statlog_destroy(WT_SESSION_IMPL *session, bool is_close)
 
     /* Stop the server thread. */
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_STATISTICS);
-
-    WT_TRET(__wt_thread_stop_and_cleanup(session, &conn->stat_thread));
+    WT_TRET(__wt_thread_stop(session, &conn->stat_thread));
 
     /* Log a set of statistics on shutdown if configured. */
     if (is_close)
@@ -686,5 +685,6 @@ __wt_statlog_destroy(WT_SESSION_IMPL *session, bool is_close)
     /* Discard all configuration information. */
     WT_TRET(__stat_config_discard(session));
 
+    WT_TRET(__wt_thread_cleanup(session, &conn->stat_thread));
     return (ret);
 }

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -742,9 +742,9 @@ __wt_tiered_storage_create(WT_SESSION_IMPL *session, const char *cfg[])
     /* Start the internal thread. */
     WT_ERR(__wt_cond_alloc(session, "flush tier", &conn->flush_cond));
 
+    FLD_SET(conn->server_flags, WT_CONN_SERVER_TIERED);
     WT_ERR(__wt_thread_start(conn, "storage-server", true, 0, "storage server", 0, 0,
       __tiered_server, &conn->tiered_thread));
-    FLD_SET(conn->server_flags, WT_CONN_SERVER_TIERED);
 
     /* After starting non-configurable threads, start the tiered manager if needed. */
     if (start)

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -470,13 +470,10 @@ struct __wt_connection_impl {
      */
     bool modified;
 
-    WT_SESSION_IMPL *sweep_session; /* Handle sweep session */
-    wt_thread_t sweep_tid;          /* Handle sweep thread */
-    int sweep_tid_set;              /* Handle sweep thread set */
-    WT_CONDVAR *sweep_cond;         /* Handle sweep wait mutex */
-    uint64_t sweep_idle_time;       /* Handle sweep idle time */
-    uint64_t sweep_interval;        /* Handle sweep interval */
-    uint64_t sweep_handles_min;     /* Handle sweep minimum open */
+    WT_THREAD sweep_thread;     /* Handle sweep thread */
+    uint64_t sweep_idle_time;   /* Handle sweep idle time */
+    uint64_t sweep_interval;    /* Handle sweep interval */
+    uint64_t sweep_handles_min; /* Handle sweep minimum open */
 
     /* Locked: collator list */
     TAILQ_HEAD(__wt_coll_qh, __wt_named_collator) collqh;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -424,11 +424,8 @@ struct __wt_connection_impl {
     uint32_t flush_state;            /* State of last flush tier */
     wt_timestamp_t flush_ts;         /* Timestamp of most recent flush_tier */
 
-    WT_TIERED_MANAGER tiered_mgr;        /* Tiered manager thread information */
-    WT_SESSION_IMPL *tiered_mgr_session; /* Tiered manager thread session */
-    wt_thread_t tiered_mgr_tid;          /* Tiered manager thread */
-    bool tiered_mgr_tid_set;             /* Tiered manager thread set */
-    WT_CONDVAR *tiered_mgr_cond;         /* Tiered manager wait mutex */
+    WT_TIERED_MANAGER tiered_mgr; /* Tiered manager thread information */
+    WT_THREAD tiered_mgr_thread;  /* Tiered manager thread */
 
     uint32_t tiered_threads_max; /* Max tiered threads */
     uint32_t tiered_threads_min; /* Min tiered threads */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -450,10 +450,7 @@ struct __wt_connection_impl {
     uint32_t log_flags;                    /* Global logging configuration */
     WT_THREAD log_server_thread;           /* Log server thread */
     WT_THREAD log_file_thread;             /* Log file thread */
-    WT_CONDVAR *log_wrlsn_cond;            /* Log write lsn thread wait mutex */
-    WT_SESSION_IMPL *log_wrlsn_session;    /* Log write lsn thread session */
-    wt_thread_t log_wrlsn_tid;             /* Log write lsn thread */
-    bool log_wrlsn_tid_set;                /* Log write lsn thread set */
+    WT_THREAD log_wrlsn_thread;            /* Log write lsn thread */
     WT_LOG *log;                           /* Logging structure */
     WT_COMPRESSOR *log_compressor;         /* Logging compressor */
     uint32_t log_cursors;                  /* Log cursor count */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -338,11 +338,8 @@ struct __wt_connection_impl {
     uint64_t hot_backup_start; /* Clock value of most recent checkpoint needed by hot backup */
     char **hot_backup_list;    /* Hot backup file list */
 
-    WT_SESSION_IMPL *ckpt_session; /* Checkpoint thread session */
-    wt_thread_t ckpt_tid;          /* Checkpoint thread */
-    bool ckpt_tid_set;             /* Checkpoint thread set */
-    WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
-    uint64_t ckpt_most_recent;     /* Clock value of most recent checkpoint */
+    WT_THREAD ckpt_thread;     /* Checkpoint thread */
+    uint64_t ckpt_most_recent; /* Clock value of most recent checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -413,16 +413,13 @@ struct __wt_connection_impl {
     const char *stat_stamp; /* Statistics log entry timestamp */
     uint64_t stat_usecs;    /* Statistics log period */
 
-    uint64_t tiered_retention;       /* Earliest time to check to remove local overlap copies */
-    WT_SESSION_IMPL *tiered_session; /* Tiered thread session */
-    wt_thread_t tiered_tid;          /* Tiered thread */
-    bool tiered_tid_set;             /* Tiered thread set */
-    WT_CONDVAR *flush_cond;          /* Flush wait mutex */
-    WT_CONDVAR *tiered_cond;         /* Tiered wait mutex */
-    bool tiered_server_running;      /* Internal tiered server operating */
-    uint64_t flush_most_recent;      /* Clock value of most recent flush_tier */
-    uint32_t flush_state;            /* State of last flush tier */
-    wt_timestamp_t flush_ts;         /* Timestamp of most recent flush_tier */
+    uint64_t tiered_retention;  /* Earliest time to check to remove local overlap copies */
+    WT_THREAD tiered_thread;    /* Tiered thread */
+    WT_CONDVAR *flush_cond;     /* Flush wait mutex */
+    bool tiered_server_running; /* Internal tiered server operating */
+    uint64_t flush_most_recent; /* Clock value of most recent flush_tier */
+    uint32_t flush_state;       /* State of last flush tier */
+    wt_timestamp_t flush_ts;    /* Timestamp of most recent flush_tier */
 
     WT_TIERED_MANAGER tiered_mgr; /* Tiered manager thread information */
     WT_THREAD tiered_mgr_thread;  /* Tiered manager thread */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -449,10 +449,7 @@ struct __wt_connection_impl {
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t log_flags;                    /* Global logging configuration */
     WT_THREAD log_server_thread;           /* Log server thread */
-    WT_CONDVAR *log_file_cond;             /* Log file thread wait mutex */
-    WT_SESSION_IMPL *log_file_session;     /* Log file thread session */
-    wt_thread_t log_file_tid;              /* Log file thread */
-    bool log_file_tid_set;                 /* Log file thread set */
+    WT_THREAD log_file_thread;             /* Log file thread */
     WT_CONDVAR *log_wrlsn_cond;            /* Log write lsn thread wait mutex */
     WT_SESSION_IMPL *log_wrlsn_session;    /* Log write lsn thread session */
     wt_thread_t log_wrlsn_tid;             /* Log write lsn thread */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -403,12 +403,9 @@ struct __wt_connection_impl {
     uint32_t evict_threads_min; /* Min eviction threads */
 
 #define WT_STATLOG_FILENAME "WiredTigerStat.%d.%H"
-    WT_SESSION_IMPL *stat_session; /* Statistics log session */
-    wt_thread_t stat_tid;          /* Statistics log thread */
-    bool stat_tid_set;             /* Statistics log thread set */
-    WT_CONDVAR *stat_cond;         /* Statistics log wait mutex */
-    const char *stat_format;       /* Statistics log timestamp format */
-    WT_FSTREAM *stat_fs;           /* Statistics log stream */
+    WT_THREAD stat_thread;   /* Statistics log thread */
+    const char *stat_format; /* Statistics log timestamp format */
+    WT_FSTREAM *stat_fs;     /* Statistics log stream */
     /* Statistics log json table printing state flag */
     bool stat_json_tables;
     char *stat_path;        /* Statistics log path format */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -386,11 +386,8 @@ struct __wt_connection_impl {
     WT_CONNECTION_STATS *stats[WT_COUNTER_SLOTS];
     WT_CONNECTION_STATS *stat_array;
 
-    WT_CAPACITY capacity;              /* Capacity structure */
-    WT_SESSION_IMPL *capacity_session; /* Capacity thread session */
-    wt_thread_t capacity_tid;          /* Capacity thread */
-    bool capacity_tid_set;             /* Capacity thread set */
-    WT_CONDVAR *capacity_cond;         /* Capacity wait mutex */
+    WT_CAPACITY capacity;      /* Capacity structure */
+    WT_THREAD capacity_thread; /* Capacity thread */
 
     WT_LSM_MANAGER lsm_manager; /* LSM worker thread information */
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -448,10 +448,7 @@ struct __wt_connection_impl {
 #define WT_CONN_LOG_ZERO_FILL 0x800u       /* Manually zero files */
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t log_flags;                    /* Global logging configuration */
-    WT_CONDVAR *log_cond;                  /* Log server wait mutex */
-    WT_SESSION_IMPL *log_session;          /* Log server session */
-    wt_thread_t log_tid;                   /* Log server thread */
-    bool log_tid_set;                      /* Log server thread set */
+    WT_THREAD log_server_thread;           /* Log server thread */
     WT_CONDVAR *log_file_cond;             /* Log file thread wait mutex */
     WT_SESSION_IMPL *log_file_session;     /* Log file thread session */
     wt_thread_t log_file_tid;              /* Log file thread */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1962,6 +1962,8 @@ static inline bool __wt_session_can_wait(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref,
   WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_thread_running(WT_THREAD *thread)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
@@ -2137,6 +2139,16 @@ static inline int __wt_struct_unpackv(WT_SESSION_IMPL *session, const void *buff
   const char *fmt, va_list ap) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_sync_and_rename(WT_SESSION_IMPL *session, WT_FSTREAM **fstrp,
   const char *from, const char *to) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_thread_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_thread_start(WT_CONNECTION_IMPL *conn, const char *session_name,
+  bool open_metadata, uint32_t session_flags, const char *cond_name, uint32_t min, uint32_t max,
+  WT_THREAD_RET (*thread_runner)(void *arg), WT_THREAD *threadp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_thread_stop_and_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_txn_autocommit_check(WT_SESSION_IMPL *session)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2143,7 +2143,7 @@ static inline int __wt_thread_cleanup(WT_SESSION_IMPL *session, WT_THREAD *threa
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_thread_start(WT_CONNECTION_IMPL *conn, const char *session_name,
   bool open_metadata, uint32_t session_flags, const char *cond_name, uint32_t min, uint32_t max,
-  WT_THREAD_RET (*thread_runner)(void *arg), WT_THREAD *threadp)
+  WT_THREAD_CALLBACK (*thread_runner)(void *), WT_THREAD *threadp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/thread_group.h
+++ b/src/include/thread_group.h
@@ -32,7 +32,7 @@ struct __wt_thread {
     /*
      * Condition signalled when a thread becomes active. Paused threads wait on this condition.
      */
-    WT_CONDVAR *pause_cond;
+    WT_CONDVAR *cond;
 
     /* The check function used by all threads. */
     bool (*chk_func)(WT_SESSION_IMPL *session);

--- a/src/include/thread_inline.h
+++ b/src/include/thread_inline.h
@@ -87,13 +87,14 @@ __wt_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
 /*
  * __wt_thread_stop_and_cleanup --
- *     Stop and cleanup up a thread.
+ *     Stop and cleanup up a thread. This frees up resources in reverse order to their creation in
+ *     __wt_thread_start.
  */
 static inline int
 __wt_thread_stop_and_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
 {
     WT_DECL_RET;
-    WT_TRET(__wt_thread_stop(session, thread));
-    WT_TRET(__wt_thread_cleanup(session, thread));
+    WT_RET(__wt_thread_stop(session, thread));
+    WT_RET(__wt_thread_cleanup(session, thread));
     return ret;
 }

--- a/src/include/thread_inline.h
+++ b/src/include/thread_inline.h
@@ -1,0 +1,99 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * __wt_thread_cleanup --
+ *     Cleanup up a stopped thread. Free its condition mutex and close its attached session.
+ */
+static inline int
+__wt_thread_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
+{
+    /* The system thread must have joined at this point */
+    WT_ASSERT(session, !thread->tid.created);
+
+    __wt_cond_destroy(session, &thread->pause_cond);
+    thread->pause_cond = NULL;
+
+    if (thread->session != NULL) {
+        WT_RET(__wt_session_close_internal(thread->session));
+        thread->session = NULL;
+    }
+
+    return (0);
+}
+
+/*
+ * __wt_thread_running --
+ *     Return true if the thread is running.
+ */
+static inline bool
+__wt_thread_running(WT_THREAD *thread)
+{
+    return thread->session != NULL;
+}
+
+/*
+ * __wt_thread_start --
+ *     Initialize and start up a thread.
+ */
+static inline int
+__wt_thread_start(WT_CONNECTION_IMPL *conn, const char *session_name, bool open_metadata,
+  uint32_t session_flags, const char *cond_name, uint32_t min, uint32_t max,
+  WT_THREAD_RET (*thread_runner)(void *arg), WT_THREAD *threadp)
+{
+    if (__wt_thread_running(threadp))
+        return (0);
+
+    // FIXME WT-8696 - This usage of WT_THREAD is a bit leaky, we're not using any of the below
+    // fields
+    threadp->id = 0;
+    threadp->flags = 0;
+    threadp->chk_func = NULL;
+    threadp->run_func = NULL;
+    threadp->stop_func = NULL;
+
+    WT_RET(__wt_open_internal_session(
+      conn, session_name, open_metadata, session_flags, 0, &threadp->session));
+
+    if (min != 0 && max != 0)
+        WT_RET(__wt_cond_auto_alloc(threadp->session, cond_name, min, max, &threadp->pause_cond));
+    else
+        WT_RET(__wt_cond_alloc(threadp->session, cond_name, &threadp->pause_cond));
+
+    WT_RET(__wt_thread_create(threadp->session, &threadp->tid, thread_runner, threadp->session));
+
+    return (0);
+}
+
+/*
+ * __wt_thread_stop --
+ *     Stop a running thread.
+ */
+static inline int
+__wt_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
+{
+    if (__wt_thread_running(thread))
+        if (thread->tid.created) {
+            __wt_cond_signal(session, thread->pause_cond);
+            WT_RET(__wt_thread_join(session, &thread->tid));
+        }
+    return (0);
+}
+
+/*
+ * __wt_thread_stop_and_cleanup --
+ *     Stop and cleanup up a thread.
+ */
+static inline int
+__wt_thread_stop_and_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
+{
+    WT_DECL_RET;
+    WT_TRET(__wt_thread_stop(session, thread));
+    WT_TRET(__wt_thread_cleanup(session, thread));
+    return ret;
+}

--- a/src/include/thread_inline.h
+++ b/src/include/thread_inline.h
@@ -44,7 +44,7 @@ __wt_thread_running(WT_THREAD *thread)
 static inline int
 __wt_thread_start(WT_CONNECTION_IMPL *conn, const char *session_name, bool open_metadata,
   uint32_t session_flags, const char *cond_name, uint32_t min, uint32_t max,
-  WT_THREAD_RET (*thread_runner)(void *arg), WT_THREAD *threadp)
+  WT_THREAD_CALLBACK (*thread_runner)(void *), WT_THREAD *threadp)
 {
     if (__wt_thread_running(threadp))
         return (0);
@@ -93,8 +93,7 @@ __wt_thread_stop(WT_SESSION_IMPL *session, WT_THREAD *thread)
 static inline int
 __wt_thread_stop_and_cleanup(WT_SESSION_IMPL *session, WT_THREAD *thread)
 {
-    WT_DECL_RET;
     WT_RET(__wt_thread_stop(session, thread));
     WT_RET(__wt_thread_cleanup(session, thread));
-    return ret;
+    return (0);
 }

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -475,6 +475,7 @@ typedef uint64_t wt_timestamp_t;
 #include "packing_inline.h"
 #include "reconcile_inline.h"
 #include "serial_inline.h"
+#include "thread_inline.h"
 #include "time_inline.h"
 
 #if defined(__cplusplus)

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -163,8 +163,8 @@ __log_wait_for_earlier_slot(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
          * This may not be initialized if we are starting at an older log file version. So only
          * signal if valid.
          */
-        if (conn->log_wrlsn_cond != NULL)
-            __wt_cond_signal(session, conn->log_wrlsn_cond);
+        if (conn->log_wrlsn_thread.cond != NULL)
+            __wt_cond_signal(session, conn->log_wrlsn_thread.cond);
         if (++yield_count < WT_THOUSAND)
             __wt_yield();
         else

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -281,7 +281,7 @@ __log_slot_new(WT_SESSION_IMPL *session)
          * threads waiting for it can acquire and possibly move things forward.
          */
         WT_STAT_CONN_INCR(session, log_slot_no_free_slots);
-        __wt_cond_signal(session, conn->log_wrlsn_cond);
+        __wt_cond_signal(session, conn->log_wrlsn_thread.cond);
         __wt_spin_unlock(session, &log->log_slot_lock);
         __wt_yield();
         __wt_spin_lock(session, &log->log_slot_lock);

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -327,8 +327,8 @@ err:
      * Wake up the sweep thread: particularly for the in-memory storage engine, we want to reclaim
      * space immediately.
      */
-    if (did_drop && S2C(session)->sweep_cond != NULL)
-        __wt_cond_signal(session, S2C(session)->sweep_cond);
+    if (did_drop && S2C(session)->sweep_thread.cond != NULL)
+        __wt_cond_signal(session, S2C(session)->sweep_thread.cond);
 
     if (ret != 0)
         WT_RET_PANIC(session, ret, "failed to apply or unroll all tracked operations");

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -58,7 +58,7 @@ __wt_tiered_push_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry)
     WT_STAT_CONN_INCR(session, tiered_work_units_created);
     __wt_spin_unlock(session, &conn->tiered_lock);
     __tiered_flush_state(session, entry->type, true);
-    __wt_cond_signal(session, conn->tiered_cond);
+    __wt_cond_signal(session, conn->tiered_thread.cond);
     return;
 }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -2163,7 +2163,7 @@ __checkpoint_timing_stress(WT_SESSION_IMPL *session, uint64_t flag, struct times
      * We only want to sleep if the flag is set and the checkpoint comes from the API, so check if
      * the session used is either of the two sessions set aside for internal checkpoints.
      */
-    if (conn->ckpt_session != session && conn->meta_ckpt_session != session &&
+    if (conn->ckpt_thread.session != session && conn->meta_ckpt_session != session &&
       FLD_ISSET(conn->timing_stress_flags, flag))
         __wt_sleep((uint64_t)tsp->tv_sec, (uint64_t)tsp->tv_nsec / WT_THOUSAND);
 }


### PR DESCRIPTION
This PR is in draft mode as I'd like to get some early feedback before making the final required changes.

As part of WT-8663 we were trying to reduce the number of fields in WT_CONNECTION, and I identified a repeated pattern where we use four variables `*_cond`, `*_session`, `*_tid`, `*_tid_set` for handling threads in a connection (such as the sweep thread, logging thread) that could be replaced by a single `WT_THREAD` instead.

This PR makes the above change, as well as:
- Identifying locations where we create an internal session, allocate a condition, and spin up a thread. Replacing this with a `__wt_thread_create` call.
- Identifying locations where we join a thread, delete the condition, and close the internal session. Replacing this with a `__wt_thread_stop_and_cleanup` call.

As this is a refactor there's a lot of touched code, but the changes are rather mechanical. I'd recommend reading `thread_inline.h` first to understand the changes.

Specifically I'd like to get feedback on whether using `WT_THREAD` here is a good idea. `WT_THREAD` is defined in `thread_group.h` and I'm not sure if the threads in `WT_CONNECTION` and the threads in `thread_group.h` are meant to server different purposes.