### PR TITLE
WT-8666 Fix syntax error opening 'coredump_filter' in wt_hang_analyzer.py

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3965,7 +3965,7 @@ buildvariants:
   run_on:
   - windows-64-vs2017-test
   expansions:
-    python_binary: 'python'
+    python_binary: '/cygdrive/c/Python39/python'
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build

--- a/test/wt_hang_analyzer/wt_hang_analyzer.py
+++ b/test/wt_hang_analyzer/wt_hang_analyzer.py
@@ -643,7 +643,7 @@ def main():
 # of writing there aren't any, and in any case a partial core dump is better
 # than none because of an ENOSPC.
 def avoid_asan_dump(pid):
-    with open(f"/proc/{pid}/coredump_filter", "w+") as f:
+    with open("/proc/%d/coredump_filter" % pid, "w+") as f:
         mask = int(f.read(), 16)
         mask &= 0xfffffffe
         f.write(str(hex(mask)))


### PR DESCRIPTION
Fixes a syntax error when opening the `coredump_filter` in the `wt_hang_analyzer.py` script on Windows platforms. This was occurring since Windows was defaulting to Python2.7 when running the hang analyzer, whilst Python f-String's are only available in Python 3.6+. This PR adds the following small changes to address the issue:
* Explicitly configure the Windows Evergreen variant to use the Python3.9 executable
* Updated the `coredump_filter` access to use the old-school Python string formatting method. 

Though the Windows Evergreen change should strictly fix this issue, the later change in the `wt_hang_analyzer.py` was intended to make the script compatible across all Python3 versions (it also seems to work in Python2, not that its a requirement).