### PR TITLE
WT-7195 Remove non-ascii input and paired typos in any source files

### DIFF
--- a/bench/workgen/workgen/__init__.py
+++ b/bench/workgen/workgen/__init__.py
@@ -31,7 +31,7 @@
 #
 import os, sys
 
-# After importing the SWIG-generated file, copy all symbols from from it
+# After importing the SWIG-generated file, copy all symbols from it
 # to this module so they will appear in the workgen namespace.
 me = sys.modules[__name__]
 sys.path.append(os.path.dirname(__file__))  # needed for Python3

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -90,20 +90,6 @@ structurechk()
 	}
 }
 
-asciichk()
-{
-    # Make sure there are only ASCII characters in the input files.
-    # Odd characters can cause our Python filter to fail.
-    (cd ../src/docs && LC_ALL=C grep -n '[^[:print:]	]' *.dox | cat -v) > $t
-    test -s $t && {
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-	echo 'Non-ASCII content in src/docs/*.dox files is not allowed.'
-	sed -e 's/^/	/' < $t
-	echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-	e=1
-    }
-}
-
 spellchk()
 {
 	# If aspell has been installed, run a spell check.
@@ -238,7 +224,6 @@ changelog
 wtperf_config
 
 # Spell and structure check the documentation.
-asciichk
 spellchk
 structurechk
 glossarychk

--- a/dist/s_style
+++ b/dist/s_style
@@ -19,7 +19,7 @@ if [ $# -ne 1 ]; then
 	find bench examples ext src test \
 	    -name '*.[chsy]' -o -name '*.in' -o -name '*.dox' -o -name '*.cxx' -o -name '*.py' -o -name '*.cmake' -o -name '*.i' |
 	sed -e '/Makefile.in/d' \
-		-e '/test\/3rdparty/d' \
+	    -e '/test\/3rdparty/d' \
 	    -e '/build_win\/wiredtiger_config.h/d' \
 	    -e '/checksum\/power8/d' \
 	    -e '/checksum\/zseries/d' |
@@ -49,6 +49,7 @@ else
 		fi
 	fi
 
+	# Remove non-ascii characters and substitute some expressions with accepted version.
 	tr -cd '[:alnum:][:space:][:punct:]' < $f |
 	sed -e '/for /!s/;;$/;/' \
 	    -e 's/(EOPNOTSUPP)/(ENOTSUP)/' \

--- a/dist/s_style
+++ b/dist/s_style
@@ -17,7 +17,7 @@ if [ $# -ne 1 ]; then
 	cd ..
 
 	find bench examples ext src test \
-	    -name '*.[chsy]' -o -name '*.in' -o -name '*.dox' |
+	    -name '*.[chsy]' -o -name '*.in' -o -name '*.dox' -o -name '*.cxx' -o -name '*.py' -o -name '*.cmake' -o -name '*.i' |
 	sed -e '/Makefile.in/d' \
 	    -e '/build_win\/wiredtiger_config.h/d' \
 	    -e '/checksum\/power8/d' \
@@ -46,6 +46,19 @@ else
 		if egrep -r -n '\b[a-z]+[A-Z]' $f | egrep -v ':[     ]+\*|"|UNCHECKED_STRING'; then
 			echo "$f: Styling requires variables that use underscores to separate parts of a name instead of camel casing.";
 		fi
+	fi
+
+	tr -cd '[:alnum:][:space:][:punct:]' < $f |
+	sed -e '/for /!s/;;$/;/' \
+	    -e 's/(EOPNOTSUPP)/(ENOTSUP)/' \
+	    -e 's/(unsigned)/(u_int)/' \
+	    -e 's/hazard reference/hazard pointer/' >$t
+
+	cmp $t $f > /dev/null 2>&1 || (echo "modifying $f" && cp $t $f)
+
+	extension="${fname##*.}"
+	if [ "x$extension" = "xcxx" ] || [ "x$extension" = "xpy" ] || [ "x$extension" = "xcmake" ] || [ "x$extension" = "xi" ]; then
+		exit 0;
 	fi
 
 	egrep -w 'a a|an an|and and|are are|be be|by by|for for|from from|if if|in in[^-]|is is|it it|of of|the the|this this|to to|was was|were were|when when|with with|a an|an a|a the|the a' $f > $t
@@ -198,14 +211,6 @@ else
 			}
 		fi
 	fi
-
-	tr -cd '[:alnum:][:space:][:punct:]' < $f |
-	sed -e '/for /!s/;;$/;/' \
-	    -e 's/(EOPNOTSUPP)/(ENOTSUP)/' \
-	    -e 's/(unsigned)/(u_int)/' \
-	    -e 's/hazard reference/hazard pointer/' >$t
-
-	cmp $t $f > /dev/null 2>&1 || (echo "modifying $f" && cp $t $f)
 fi
 
 exit 0

--- a/dist/s_style
+++ b/dist/s_style
@@ -19,6 +19,7 @@ if [ $# -ne 1 ]; then
 	find bench examples ext src test \
 	    -name '*.[chsy]' -o -name '*.in' -o -name '*.dox' -o -name '*.cxx' -o -name '*.py' -o -name '*.cmake' -o -name '*.i' |
 	sed -e '/Makefile.in/d' \
+		-e '/test\/3rdparty/d' \
 	    -e '/build_win\/wiredtiger_config.h/d' \
 	    -e '/checksum\/power8/d' \
 	    -e '/checksum\/zseries/d' |
@@ -56,12 +57,7 @@ else
 
 	cmp $t $f > /dev/null 2>&1 || (echo "modifying $f" && cp $t $f)
 
-	extension="${fname##*.}"
-	if [ "x$extension" = "xcxx" ] || [ "x$extension" = "xpy" ] || [ "x$extension" = "xcmake" ] || [ "x$extension" = "xi" ]; then
-		exit 0;
-	fi
-
-	egrep -w 'a a|an an|and and|are are|be be|by by|for for|from from|if if|in in[^-]|is is|it it|of of|the the|this this|to to|was was|were were|when when|with with|a an|an a|a the|the a' $f > $t
+	egrep -w 'a a|an an|and and|are are|be be|by by|for for|from from|if if|in in[[:space:]]|is is|it it|of of|the the|this this|to to|was was|were were|when when|with with|a an|an a|a the|the a' $f > $t
 	test -s $t && {
 		echo "paired typo"
 		echo "============================"
@@ -140,6 +136,7 @@ else
 	fi
 
 	if ! expr "$f" : 'examples/c/*' > /dev/null &&
+	   ! expr "$f" : '.*cxx' > /dev/null &&
 	   ! expr "$f" : 'ext/*' > /dev/null &&
 	   ! expr "$f" : 'src/os_posix/os_snprintf.c' > /dev/null &&
 	    egrep '[^a-z_]snprintf\(|[^a-z_]vsnprintf\(' $f > $t; then
@@ -203,6 +200,7 @@ else
 	   ! expr "$f" : 'test/csuite/.*' > /dev/null &&
 	   ! expr "$f" : 'examples/.*' > /dev/null &&
 	   ! expr "$f" : 'ext/.*' > /dev/null &&
+	   ! expr "$f" : '.*py' > /dev/null &&
 	   ! expr "$f" : 'src/include/ctype.i' > /dev/null; then
 		if egrep '(#include.*["</]ctype.h[">]|\b(is(alnum|alpha|cntrl|digit|graph|lower|print|punct|space|upper|xdigit)|to(lower|toupper))\()' $f > $t; then
 			test -s $t && {

--- a/lang/python/wiredtiger/init.py
+++ b/lang/python/wiredtiger/init.py
@@ -42,7 +42,7 @@ if sys.version_info[0] <= 2:
     print('WiredTiger requires Python version 3.0 or above')
     sys.exit(1)
 
-# After importing the SWIG-generated file, copy all symbols from from it
+# After importing the SWIG-generated file, copy all symbols from it
 # to this module so they will appear in the wiredtiger namespace.
 me = sys.modules[__name__]
 sys.path.append(os.path.dirname(__file__))

--- a/test/suite/suite_subprocess.py
+++ b/test/suite/suite_subprocess.py
@@ -182,8 +182,8 @@ class suite_subprocess:
                     WiredTigerTestCase.prout(out)
 
     # Run a method as a subprocess using the run.py machinery.
-    # Return the process exit status and the the WiredTiger
-    # home directory used by the subprocess.
+    # Return the process exit status and the WiredTiger home
+    # directory used by the subprocess.
     def run_subprocess_function(self, directory, funcname):
         testparts = funcname.split('.')
         if len(testparts) != 3:

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -284,8 +284,8 @@ class test_cursor13_reopens(test_cursor13_base):
                 # reopen the second cached cursor, see the data handle now
                 # open and will succeed the reopen.
                 #
-                # This test checks that reopens of cursor using a an
-                # already reopened data handle will work.
+                # This test checks that reopens of cursor using an already
+                # reopened data handle will work.
                 c = self.session.open_cursor(self.uri)
                 ds.check()
                 c.close()

--- a/test/suite/test_prepare08.py
+++ b/test/suite/test_prepare08.py
@@ -286,7 +286,7 @@ class test_prepare08(wttest.WiredTigerTestCase):
         # Checkpoint
         self.session.checkpoint()
 
-        # Remove the updates from a prepare session and and keep it open.
+        # Remove the updates from a prepare session and keep it open.
         session_p = self.conn.open_session()
         cursor_p = session_p.open_cursor(uri_1)
         session_p.begin_transaction()

--- a/test/suite/test_search_near04.py
+++ b/test/suite/test_search_near04.py
@@ -53,7 +53,7 @@ class test_search_near04(wttest.WiredTigerTestCase):
         self.session.create(uri, 'key_format={},value_format=S'.format(self.key_format))
 
         # Make the keys big enough to span over multiple pages.
-        # key_size can be set to to a lower value so only one page is used and search_near works.
+        # key_size can be set to a lower value so only one page is used and search_near works.
         key_size = 200
 
         cursor = self.session.open_cursor(uri)

--- a/test/suite/test_stat01.py
+++ b/test/suite/test_stat01.py
@@ -62,7 +62,7 @@ class test_stat01(wttest.WiredTigerTestCase):
         parts = str.rpartition('(')
         return int(parts[2].rstrip(')'))
 
-    # Do a quick check of the entries in the the stats cursor, the "lookfor"
+    # Do a quick check of the entries in the stats cursor, the "lookfor"
     # string should appear with a minimum value of least "min".
     def check_stats(self, statcursor, min, lookfor):
         stringclass = ''.__class__

--- a/test/suite/test_timestamp14.py
+++ b/test/suite/test_timestamp14.py
@@ -361,7 +361,7 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
 
         # Create a read session.
         session1.begin_transaction('read_timestamp=2')
-        # Confirm oldest reader is 2 and the the value we read is 1.
+        # Confirm oldest reader is 2 and the value we read is 1.
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=oldest_reader'), "2")
 

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -526,7 +526,7 @@ class Runner:
             return False
         return True
 
-    # func(args);  is shorthand for for ASSERT_EQ(func(args), xxx);
+    # func(args);  is shorthand for ASSERT_EQ(func(args), xxx);
     # where xxx may be 0 or may be derived from one of the args.
     def call_compare(self, callname, result, eargs, errline):
         if callname in calls_returning_zero:


### PR DESCRIPTION
* Add non-ascii character removal on `.dox`, `.cxx`, `.py`, `.cmake`,  `.i` source files in `s_style`.
* Remove similar check in `s_docs` which prints error at non-ascii characters in `.dox` files.
* Add check for paired typos to `.cxx`, `.py`, `.cmake`,  `.i` source files.
* Fix paired typos in source files.