### PR TITLE
WT-8701 Fix test_backup07.py to test the creation of new tables when backup cursor is open

### DIFF
--- a/test/suite/test_backup07.py
+++ b/test/suite/test_backup07.py
@@ -79,7 +79,12 @@ class test_backup07(backup_base):
 
         # Now copy the files using full backup. This should not include the newly
         # created table.
-        self.take_full_backup(self.dir, bkup_c)
+        all_files = self.take_full_backup(self.dir, bkup_c)
+        orig_logs = [file for file in all_files if "WiredTigerLog" in file]
+        self.assertFalse(self.newuri in all_files)
+
+        # Now open a duplicate backup cursor and copy all the logs into the backup directory.
+        dup_logs = self.take_log_backup(bkup_c, self.dir, orig_logs)
         bkup_c.close()
 
         # After the full backup, open and recover the backup database.

--- a/test/suite/test_backup07.py
+++ b/test/suite/test_backup07.py
@@ -65,9 +65,11 @@ class test_backup07(backup_base):
         # We allow creates during backup because the file doesn't exist
         # when the backup metadata is created on cursor open and the newly
         # created file is not in the cursor list.
-
-        # Create and add data to a new table and then copy the files with a full backup.
         os.mkdir(self.dir)
+
+        # Open up the backup cursor, create and add data to a new table
+        # and then copy the files.
+        bkup_c = self.session.open_cursor('backup:', None, None)
 
         # Now create and populate the new table. Make sure the log records
         # are on disk and will be copied to the backup.
@@ -77,7 +79,8 @@ class test_backup07(backup_base):
 
         # Now copy the files using full backup. This should not include the newly
         # created table.
-        self.take_full_backup(self.dir)
+        self.take_full_backup(self.dir, bkup_c)
+        bkup_c.close()
 
         # After the full backup, open and recover the backup database.
         # Make sure we properly recover even though the log file will have

--- a/test/suite/test_backup10.py
+++ b/test/suite/test_backup10.py
@@ -79,8 +79,6 @@ class test_backup10(backup_base):
         orig_logs = [file for file in all_files if "WiredTigerLog" in file]
 
         # Now open a duplicate backup cursor.
-        config = 'target=("log:")'
-        dupc = self.session.open_cursor(None, bkup_c, config)
         dup_logs = self.take_log_backup(bkup_c, self.dir, orig_logs, dupc)
 
         # We expect that the duplicate logs are a superset of the

--- a/test/suite/test_backup10.py
+++ b/test/suite/test_backup10.py
@@ -79,6 +79,8 @@ class test_backup10(backup_base):
         orig_logs = [file for file in all_files if "WiredTigerLog" in file]
 
         # Now open a duplicate backup cursor.
+        config = 'target=("log:")'
+        dupc = self.session.open_cursor(None, bkup_c, config)
         dup_logs = self.take_log_backup(bkup_c, self.dir, orig_logs, dupc)
 
         # We expect that the duplicate logs are a superset of the


### PR DESCRIPTION
From #6291, The ticket involved refactoring all the backup tests to use a class in the means to simplify all the backup tests. This however caused backup07 to lose the flavour for the original of its testing. I have fixed this and still used the refactored portions.