### PR TITLE
WT-8726 Coverity analysis defect 121385: Missing varargs init or cleanup

### DIFF
--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -88,12 +88,12 @@ __curversion_get_value(WT_CURSOR *cursor, ...)
 
     version_cursor = (WT_CURSOR_VERSION *)cursor;
     file_cursor = version_cursor->file_cursor;
+    va_start(ap, cursor);
 
     CURSOR_API_CALL(cursor, session, get_value, NULL);
     WT_ERR(__cursor_checkvalue(cursor));
     WT_ERR(__cursor_checkvalue(file_cursor));
 
-    va_start(ap, cursor);
     if (F_ISSET(cursor, WT_CURSTD_RAW)) {
         /* Extract metadata and value separately as raw data. */
         metadata = va_arg(ap, WT_ITEM *);

--- a/src/include/packing_inline.h
+++ b/src/include/packing_inline.h
@@ -573,55 +573,55 @@ __unpack_read(WT_SESSION_IMPL *session, WT_PACK_VALUE *pv, const uint8_t **pp, s
     return (0);
 }
 
-#define WT_UNPACK_PUT(session, pv, ap)                             \
-    do {                                                           \
-        WT_ITEM *__item;                                           \
-        switch ((pv).type) {                                       \
-        case 'x':                                                  \
-            break;                                                 \
-        case 's':                                                  \
-        case 'S':                                                  \
-            *va_arg(ap, const char **) = (pv).u.s;                 \
-            break;                                                 \
-        case 'U':                                                  \
-        case 'u':                                                  \
-            __item = va_arg(ap, WT_ITEM *);                        \
-            __item->data = (pv).u.item.data;                       \
-            __item->size = (pv).u.item.size;                       \
-            break;                                                 \
-        case 'b':                                                  \
-            *va_arg(ap, int8_t *) = (int8_t)(pv).u.i;              \
-            break;                                                 \
-        case 'h':                                                  \
-            *va_arg(ap, int16_t *) = (short)(pv).u.i;              \
-            break;                                                 \
-        case 'i':                                                  \
-        case 'l':                                                  \
-            *va_arg(ap, int32_t *) = (int32_t)(pv).u.i;            \
-            break;                                                 \
-        case 'q':                                                  \
-            *va_arg(ap, int64_t *) = (pv).u.i;                     \
-            break;                                                 \
-        case 'B':                                                  \
-        case 't':                                                  \
-            *va_arg(ap, uint8_t *) = (uint8_t)(pv).u.u;            \
-            break;                                                 \
-        case 'H':                                                  \
-            *va_arg(ap, uint16_t *) = (uint16_t)(pv).u.u;          \
-            break;                                                 \
-        case 'I':                                                  \
-        case 'L':                                                  \
-            *va_arg(ap, uint32_t *) = (uint32_t)(pv).u.u;          \
-            break;                                                 \
-        case 'Q':                                                  \
-        case 'r':                                                  \
-        case 'R':                                                  \
-            *va_arg(ap, uint64_t *) = (pv).u.u;                    \
-            break;                                                 \
-        default:                                                   \
-            /* User format strings have already been validated. */ \
-            return (__wt_illegal_value(session, (pv).type));       \
-        }                                                          \
+#define WT_UNPACK_PUT(session, pv, ap)                                              \
+    do {                                                                            \
+        WT_ITEM *__item;                                                            \
+        switch ((pv).type) {                                                        \
+        case 'x':                                                                   \
+            break;                                                                  \
+        case 's':                                                                   \
+        case 'S':                                                                   \
+            *va_arg(ap, const char **) = (pv).u.s;                                  \
+            break;                                                                  \
+        case 'U':                                                                   \
+        case 'u':                                                                   \
+            __item = va_arg(ap, WT_ITEM *);                                         \
+            __item->data = (pv).u.item.data;                                        \
+            __item->size = (pv).u.item.size;                                        \
+            break;                                                                  \
+        case 'b':                                                                   \
+            *va_arg(ap, int8_t *) = (int8_t)(pv).u.i;                               \
+            break;                                                                  \
+        case 'h':                                                                   \
+            *va_arg(ap, int16_t *) = (short)(pv).u.i;                               \
+            break;                                                                  \
+        case 'i':                                                                   \
+        case 'l':                                                                   \
+            *va_arg(ap, int32_t *) = (int32_t)(pv).u.i;                             \
+            break;                                                                  \
+        case 'q':                                                                   \
+            *va_arg(ap, int64_t *) = (pv).u.i;                                      \
+            break;                                                                  \
+        case 'B':                                                                   \
+        case 't':                                                                   \
+            *va_arg(ap, uint8_t *) = (uint8_t)(pv).u.u;                             \
+            break;                                                                  \
+        case 'H':                                                                   \
+            *va_arg(ap, uint16_t *) = (uint16_t)(pv).u.u;                           \
+            break;                                                                  \
+        case 'I':                                                                   \
+        case 'L':                                                                   \
+            *va_arg(ap, uint32_t *) = (uint32_t)(pv).u.u;                           \
+            break;                                                                  \
+        case 'Q':                                                                   \
+        case 'r':                                                                   \
+        case 'R':                                                                   \
+            *va_arg(ap, uint64_t *) = (pv).u.u;                                     \
+            break;                                                                  \
+        default:                                                                    \
+            __wt_err(session, EINVAL, "unknown unpack-put type: %c", (int)pv.type); \
+            break;                                                                  \
+        }                                                                           \
     } while (0)
 
 /*


### PR DESCRIPTION
WT_UNPACK_PUT has a return out of the middle of the macro, __curversion_get_value() can't handle that. The return isn't necessary and should never be exercised, log an error and continue;

Call va_start before any possible jump to the err: label.