### PR TITLE
WT-8248 Check for valid configuration key when using the WT_CURSOR.reconfigure API

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1051,9 +1051,8 @@ __wt_cursor_reconfigure(WT_CURSOR *cursor, const char *config)
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    const char *cfg[] = {config, NULL};
 
-    CURSOR_API_CALL(cursor, session, reconfigure, NULL);
+    CURSOR_API_CALL_CONF(cursor, session, reconfigure, config, cfg, NULL);
 
     /* Reconfiguration resets the cursor. */
     WT_ERR(cursor->reset(cursor));

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -220,6 +220,13 @@
     if (F_ISSET(cur, WT_CURSTD_CACHED))                                                    \
     WT_ERR(__wt_cursor_cached(cur))
 
+#define CURSOR_API_CALL_CONF(cur, s, n, config, cfg, bt)                                         \
+    (s) = CUR2S(cur);                                                                            \
+    SESSION_API_PREPARE_CHECK(s, WT_CURSOR, n);                                                  \
+    API_CALL(s, WT_CURSOR, n, ((bt) == NULL) ? NULL : ((WT_BTREE *)(bt))->dhandle, config, cfg); \
+    if (F_ISSET(cur, WT_CURSTD_CACHED))                                                          \
+    WT_ERR(__wt_cursor_cached(cur))
+
 #define CURSOR_API_CALL_PREPARE_ALLOWED(cur, s, n, bt)                                     \
     (s) = CUR2S(cur);                                                                      \
     API_CALL_NOCONF(s, WT_CURSOR, n, ((bt) == NULL) ? NULL : ((WT_BTREE *)(bt))->dhandle); \

--- a/test/suite/test_cursor06.py
+++ b/test/suite/test_cursor06.py
@@ -97,5 +97,14 @@ class test_cursor06(wttest.WiredTigerTestCase):
                 cursor.update()
             cursor.close()
 
+    def test_reconfigure_invalid(self):
+        uri = self.type + self.name
+        self.populate(uri)
+        c = self.session.open_cursor(uri, None, None)
+        c.reconfigure("overwrite=1")
+        msg = '/Invalid argument/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: c.reconfigure("xxx=true"), msg)
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Do validation checking on WT_CURSOR.reconfigure arguments.