### PR TITLE
WT-8748 turn off key-consistent checking for MongoDB builds

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1388,16 +1388,16 @@ err:
     return (ret);
 }
 
+#ifdef WT_STANDALONE_BUILD
 /*
- * __txn_commit_timestamps_assert --
+ * __txn_commit_timestamps_assert_standalone --
  *     Validate that timestamps provided to commit are legal.
  */
 static inline int
-__txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
+__txn_commit_timestamps_assert_standalone(WT_SESSION_IMPL *session, WT_TXN *txn)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
-    WT_TXN *txn;
     WT_TXN_OP *op;
     WT_UPDATE *upd;
 #ifdef HAVE_DIAGNOSTIC
@@ -1405,33 +1405,9 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
 #endif
     wt_timestamp_t prev_op_durable_ts, prev_op_ts;
     u_int i;
-    bool op_zero_ts, upd_zero_ts, used_ts;
+    bool op_zero_ts, upd_zero_ts;
 
-    txn = session->txn;
     cursor = NULL;
-
-    used_ts = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) || F_ISSET(txn, WT_TXN_HAS_TS_DURABLE);
-    /*
-     * Debugging checks on timestamps, if user requested them. We additionally don't expect recovery
-     * to be using timestamps when applying commits. If recovery is running, skip this assert to
-     * avoid failing the recovery process.
-     */
-    if (F_ISSET(txn, WT_TXN_TS_WRITE_ALWAYS) && !used_ts && txn->mod_count != 0 &&
-      !F_ISSET(S2C(session), WT_CONN_RECOVERING))
-        WT_RET_MSG(session, EINVAL, "commit_timestamp required and none set on this transaction");
-    if (F_ISSET(txn, WT_TXN_TS_WRITE_NEVER) && used_ts && txn->mod_count != 0)
-        WT_RET_MSG(
-          session, EINVAL, "no commit_timestamp expected and timestamp set on this transaction");
-
-    if (txn->commit_timestamp > txn->durable_timestamp)
-        WT_RET_MSG(
-          session, EINVAL, "transaction with commit timestamp greater than durable timestamp");
-
-    /*
-     * If we're not doing any key consistency checking, we're done.
-     */
-    if (!F_ISSET(txn, WT_TXN_TS_WRITE_ORDERED))
-        return (0);
 
     /*
      * Error on any valid update structures for the same key that are at a later timestamp or use
@@ -1523,18 +1499,52 @@ __txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
          * comparing commit timestamps would be.
          */
         WT_ASSERT(session, txn->durable_timestamp >= op_ts && prev_op_durable_ts >= prev_op_ts);
-        if (F_ISSET(txn, WT_TXN_TS_WRITE_ORDERED) && txn->durable_timestamp < prev_op_durable_ts)
+        if (txn->durable_timestamp < prev_op_durable_ts)
             WT_ERR_MSG(session, EINVAL, "out of order commit timestamps");
     }
-
-#ifndef HAVE_DIAGNOSTIC
-    WT_UNUSED(prev_op_ts);
-#endif
 
 err:
     if (cursor != NULL)
         WT_TRET(cursor->close(cursor));
     return (ret);
+}
+#endif
+
+/*
+ * __txn_commit_timestamps_assert --
+ *     Validate that timestamps provided to commit are legal.
+ */
+static inline int
+__txn_commit_timestamps_assert(WT_SESSION_IMPL *session)
+{
+    WT_TXN *txn;
+    bool used_ts;
+
+    txn = session->txn;
+    used_ts = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT) || F_ISSET(txn, WT_TXN_HAS_TS_DURABLE);
+
+    /*
+     * Debugging checks on timestamps, if user requested them. We additionally don't expect recovery
+     * to be using timestamps when applying commits. If recovery is running, skip this assert to
+     * avoid failing the recovery process.
+     */
+    if (F_ISSET(txn, WT_TXN_TS_WRITE_ALWAYS) && !used_ts && txn->mod_count != 0 &&
+      !F_ISSET(S2C(session), WT_CONN_RECOVERING))
+        WT_RET_MSG(session, EINVAL, "commit_timestamp required and none set on this transaction");
+    if (F_ISSET(txn, WT_TXN_TS_WRITE_NEVER) && used_ts && txn->mod_count != 0)
+        WT_RET_MSG(
+          session, EINVAL, "no commit_timestamp expected and timestamp set on this transaction");
+
+    if (txn->commit_timestamp > txn->durable_timestamp)
+        WT_RET_MSG(
+          session, EINVAL, "transaction with commit timestamp greater than durable timestamp");
+
+#ifdef WT_STANDALONE_BUILD
+    /* If we're not doing any key consistency checking, we're done. */
+    if (F_ISSET(txn, WT_TXN_TS_WRITE_ORDERED))
+        WT_RET(__txn_commit_timestamps_assert_standalone(session, txn));
+#endif
+    return (0);
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1503,6 +1503,10 @@ __txn_commit_timestamps_assert_standalone(WT_SESSION_IMPL *session, WT_TXN *txn)
             WT_ERR_MSG(session, EINVAL, "out of order commit timestamps");
     }
 
+#ifndef HAVE_DIAGNOSTIC
+    WT_UNUSED(prev_op_ts);
+#endif
+
 err:
     if (cursor != NULL)
         WT_TRET(cursor->close(cursor));


### PR DESCRIPTION
Limit the key consistency checks run on MongoDB server builds.

@kommiharibabu, the changes in WT-8691 to add in all of the `key_consistent` checks when the `ordered` keyword was set breaks the MDB server build.

This change only runs those tests in standalone mode.