### PR TITLE
WT-7848 Re-enable cache usage check in hs_cleanup_stress and disable hs_cleanup_default

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_default.txt
+++ b/test/cppsuite/configs/hs_cleanup_default.txt
@@ -29,8 +29,9 @@ runtime_monitor=
     ),
     stat_cache_size=
     (
+        # FIXME-WT-8743: Re-enable cache usage check once cache exceed problem is fixed.
         max=100,
-        runtime=true,
+        runtime=false,
     ),
     stat_db_size=
     (

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -32,9 +32,8 @@ runtime_monitor=
     ),
     stat_cache_size=
     (
-        # FIXME-WT-7848: Enable cache usage check once cache exceed failure is fixed.
         max=110,
-        runtime=false,
+        runtime=true,
     ),
     # The data files compress to around 25MB per table at the end of a run so 250MB total.
     # +1.4GB for the history store. With an additional 150MB margin.


### PR DESCRIPTION
Since WT-6707 has fixed the problem in WT-7848, but has a new error in WT-8743. I am using this ticket to re-enable WT-7848 and disabling the cache usage check in hs_cleanup_default for now.