### PR TITLE
WT-8752 Coverity analysis defect 121408: Missing unlock

### DIFF
--- a/src/include/block.h
+++ b/src/include/block.h
@@ -230,6 +230,7 @@ struct __wt_block {
 
     TAILQ_ENTRY(__wt_block) q;     /* Linked list of handles */
     TAILQ_ENTRY(__wt_block) hashq; /* Hashed list of handles */
+    bool linked;
 
     WT_BLOCK **related;       /* Related objects */
     size_t related_allocated; /* Size of related object array */


### PR DESCRIPTION
Fix an error return path that could return without releasing the connection's block-manager lock.  Add an explicit boolean value if the WT_BLOCK structure has been linked into the block list, so we do the right thing during close after an allocation error.