### PR TITLE
WT-8762 Fix S3 extension not compiling on evergreen.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4125,6 +4125,7 @@ buildvariants:
       -DENABLE_STRICT=0
       -DENABLE_TCMALLOC=1
       -DENABLE_S3=1
+      -DIMPORT_S3_SDK=external
       -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'


### PR DESCRIPTION
Updating the build command used to compile WT with the S3 extension on evergreen to use the new CMake flag and specify the AWS SDK to be downloaded as an external project.