### PR TITLE
WT-8392 Add debugging to catch missing log record.

### DIFF
--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -612,6 +612,10 @@ __posix_file_write(
               "%s: handle-write: pwrite: failed to write %" WT_SIZET_FMT
               " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
+        if (wt_session->app_private != NULL &&
+          WT_PREFIX_MATCH((char *)wt_session->app_private, "TID"))
+            WT_RET(__wt_msg(session, "pwrite: %s: %s offset %" PRIu64 " len %" PRIu64,
+              file_handle->name, (char *)wt_session->app_private, (uint64_t)offset, (uint64_t)len));
     }
     WT_STAT_CONN_INCRV(session, block_byte_write_syscall, len);
     return (0);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -284,6 +284,7 @@ thread_run(void *arg)
     uint64_t i, active_ts;
     char cbuf[MAX_VAL], lbuf[MAX_VAL], obuf[MAX_VAL];
     char kname[64], tscfg[64], uri[128];
+    char private[128];
     bool durable_ahead_commit, use_prep;
 
     __wt_random_init(&rnd);
@@ -353,6 +354,8 @@ thread_run(void *arg)
      */
     printf("Thread %" PRIu32 " starts at %" PRIu64 "\n", td->info, td->start);
     active_ts = 0;
+    if (stress)
+        session->app_private = private;
     for (i = td->start;; ++i) {
         testutil_check(session->begin_transaction(session, NULL));
         if (use_prep)
@@ -379,6 +382,9 @@ thread_run(void *arg)
             cur_shadow->set_key(cur_shadow, i + 1);
         } else {
             testutil_check(__wt_snprintf(kname, sizeof(kname), KEY_STRINGFORMAT, i));
+            if (stress)
+                testutil_check(
+                  __wt_snprintf(private, sizeof(private), "TID %" PRIu32 ":%s", td->info, kname));
             cur_coll->set_key(cur_coll, kname);
             cur_local->set_key(cur_local, kname);
             cur_oplog->set_key(cur_oplog, kname);


### PR DESCRIPTION
This has not been able to be reproduced so I've added debugging to catch it for whenever it might hit. @keithbostic test/format also uses the `app_private` field (and is the only other user). I don't see MongoDB using it. I wanted to make sure this use didn't result in output from test/format runs.

@lukech this change will generate a lot of output on `test_timestamp_abort -s` stress runs. I don't know if that matters but wanted to call that out to you.