### PR TITLE
WT-8768 Distinguish between hard & soft CMake dependencies

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -6,13 +6,16 @@ To build with CMake we **require** the following dependencies:
 
 * `cmake` : Official CMake install instructions found here: https://cmake.org/install/
   * *WiredTiger supports CMake 3.10+*
+
+We also suggest the following dependencies are also installed (for improved build times):
+
 * `ninja` : Official ninja install instructions found here: https://ninja-build.org/
+* `ccache` : Official ccache download instructions found here: https://ccache.dev/download.html
+
+If wanting to compile the Python API, we also require the following dependencies:
+
 * `python3-dev` : Consult your package management application for installation instructions. This is needed for building with Python support.
 * `swig`: Consult your package management application for installation instructions. This is needed for building with Python support.
-
-We also strongly suggest the following dependencies are also installed (for improved build times):
-
-* `ccache` : Official ccache download instructions found here: https://ccache.dev/download.html
 
 ##### Package Manager Instructions
 
@@ -21,7 +24,9 @@ Alternatively you can use your system's package manager to install the dependenc
 ###### Install commands for Ubuntu & Debian (tested on Ubuntu 18.04)
 
 ```bash
-sudo apt-get install cmake cmake-curses-gui
+sudo apt-get install cmake
+# Optional ...
+sudo apt-get install cmake-curses-gui
 sudo apt-get install ccache
 sudo apt-get install ninja-build
 sudo apt-get install python3-dev swig
@@ -30,9 +35,10 @@ sudo apt-get install python3-dev swig
 ###### Install commands for Mac (using HomeBrew)
 
 ```bash
+brew install cmake
+# Optional ...
 brew install ninja
 brew install ccache
-brew install cmake
 brew install python
 brew install swig
 ```
@@ -41,6 +47,7 @@ brew install swig
 
 ```bash
 choco install cmake
+# Optional ...
 choco install ninja
 choco install ccache --version=3.7.9
 choco install swig
@@ -49,8 +56,6 @@ choco install python --pre
 
 ### Building the WiredTiger Library
 
-> *The below commands are written for Linux and Darwin hosts. Windows instructions coming soon!*
-
 Building the WiredTiger library is relatively straightforward. Navigate to the top level of the WiredTiger repository and run the following commands:
 
 ###### Configure your build
@@ -58,8 +63,8 @@ Building the WiredTiger library is relatively straightforward. Navigate to the t
 ```bash
 # Create a new directory to run your build from
 $ mkdir build && cd build
-# Run the cmake configure step. Note: '-G Ninja' tells CMake to generate a ninja build
-$ cmake -G Ninja ../.
+# Run the cmake configure step. Note: Can optionally pass '-G Ninja' to generate a ninja build.
+$ cmake ../.
 ...
 -- Configuring done
 -- Generating done
@@ -70,15 +75,13 @@ $ cmake -G Ninja ../.
 
 ###### Run your build
 
-In the same directory you configured your build, run the `ninja` command to start the build:
+In the same directory you configured your build, run the `make` command to start the build:
 
 ```bash
-$ ninja
+$ make
 ...
 [211/211 (100%) 2.464s] Creating library symlink libwiredtiger.so
 ```
-
-*Note: Ninja doesn't need a `-j` option; it knows how many cores are available.*
 
 ###### Configuration Options
 
@@ -123,14 +126,14 @@ By default CMake will use your default system compiler (`cc`). If you want to us
 
 ```bash
 $ cd build
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/gcc.cmake -G Ninja ../.
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/gcc.cmake ../.
 ```
 
 *Using the Clang Toolchain*
 
 ```bash
 $ cd build
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -G Ninja ../.
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake ../.
 ```
 
 ### Running WiredTiger C Tests


### PR DESCRIPTION
The CMake `README` (under `cmake/README`), currently defines `ninja`, `python` and `swig` as hard dependencies. This isn't necessarily true. Python is only required when building the Python API and `ninja` is an optional generator. Updated the `README` to better distinguish between 'hard' and 'soft' dependencies.

The intention here is to make the cmake build more approachable to external users & contributors. Keeping the build to a minimal number of steps to make sure random community building remains easy (without requiring the end user to install multiple packages). 
_**Note** this README is mostly intended for external users_, and won't necessarily match the requirements of a WT developer, where we generally advocate using `ninja`, `python` etc. in the team (our internal wiki/docs remain unchanged).