### PR TITLE
WT-8679 Add support for arm64 Evergreen testing

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4107,6 +4107,46 @@ buildvariants:
     - name: ".stress-test-zseries-2"
     - name: ".stress-test-zseries-3"
 
+- name: ubuntu2004-arm64
+  display_name: "~ Ubuntu 20.04 ARM64"
+  run_on:
+  - ubuntu2004-arm64
+  expansions:
+    test_env_vars:
+      WT_TOPDIR=$(git rev-parse --show-toplevel)
+      WT_BUILDDIR=$WT_TOPDIR/cmake_build
+      LD_LIBRARY_PATH=$WT_BUILDDIR
+    posix_configure_flags:
+      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+      -DCMAKE_C_FLAGS="-ggdb"
+      -DHAVE_DIAGNOSTIC=1
+      -DENABLE_PYTHON=1
+      -DENABLE_ZLIB=1
+      -DENABLE_SNAPPY=1
+      -DENABLE_STRICT=1
+      -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
+    cmake_generator: Ninja
+    make_command: ninja
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: unit-test
+    - name: fops
+    - name: linux-directio
+    - name: checkpoint-filetypes-test
+    - name: unit-test-zstd
+    - name: unit-test-long
+    - name: spinlock-gcc-test
+    - name: spinlock-pthread-adaptive-test
+    - name: compile-wtperf
+    - name: wtperf-test
+    - name: ftruncate-test
+    - name: long-test
+    - name: configure-combinations
+    - name: format-smoke-test
+
 - name: ubuntu2004-tmp-s3-cmake
   display_name: "* (Temporary) Ubuntu 20.04 S3 Extension CMake"
   run_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4111,6 +4111,7 @@ buildvariants:
   display_name: "~ Ubuntu 20.04 ARM64"
   run_on:
   - ubuntu2004-arm64-small
+  batchtime: 1440 # 24 hours
   expansions:
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4110,7 +4110,7 @@ buildvariants:
 - name: ubuntu2004-arm64
   display_name: "~ Ubuntu 20.04 ARM64"
   run_on:
-  - ubuntu2004-arm64
+  - ubuntu2004-arm64-small
   expansions:
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Our current standalone evergreen CI setup doesn't include testing on arm64. The MongoDB server supports arm64 hosts and testing for arm64 builds of WT are done indirectly via MongoDB. There may be parts of WT that are not currently exercised by the server regression testing, and it would be better to catch any arm specific issues in WT itself. Since arm64 is becoming increasingly important in the cloud, we should perform testing on arm64 at a scope that is equivalent to our other target architectures.

Patch Build: https://spruce.mongodb.com/version/61fb57660ae60650cae29538/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Let me know if there's any test I should add or remove. Again I mostly tried to define a suite of tests equivalent to our x86_64 testing. Just some notes on the build variant:
* I disabled tcmalloc for arm64 builds. We end up running into a slight issue with respect to how gperftools manages its thread local storage (TLS) on arm64 targets, specifically when running python tests (`cannot allocate memory in static TLS block` when performing a `dlopen` , as described [here](https://bugzilla.redhat.com/show_bug.cgi?id=1483558)). We can get around this by specifically performing a `LD_PRELOAD` , but I wanted to keep this simple for now, to avoid propagating another `LD` environment variable (better left to another ticket, if required).
* Omitted the `time-shift-sensitivity-test` & `syscall-linux` due to incompatibility issues on arm64 hosts.