### PR TITLE
WT-7967 Document that block incremental backup IDs should be unique.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1585,7 +1585,8 @@ methods = {
         Config('this_id', '', r'''
             a string that identifies the current system state  as a future backup source
             for an incremental backup via 'src_id'. This identifier is required when opening
-            an incremental backup cursor and an error will be returned if one is not provided'''),
+            an incremental backup cursor and an error will be returned if one is not provided.
+            The identifiers can be any text string, but should be unique'''),
         ]),
     Config('next_random', 'false', r'''
         configure the cursor to return a pseudo-random record from the

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -127,7 +127,7 @@ using block modifications:
 additional configuration \c incremental=(enabled=true,this_id="ID1").
 The identifier specified in \c this_id starts block tracking and that
 identifier can be used in the future as the source of an incremental
-backup.
+backup. Identifiers can be any text string, but should be unique.
 
 2. Begin the incremental backup by opening a backup cursor with the
 \c backup: URI and config string of \c incremental=(src_id="ID1",this_id="ID2").

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -968,7 +968,8 @@ struct __wt_session {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;this_id, a string that identifies the
 	 * current system state as a future backup source for an incremental backup via 'src_id'.
 	 * This identifier is required when opening an incremental backup cursor and an error will
-	 * be returned if one is not provided., a string; default empty.}
+	 * be returned if one is not provided.  The identifiers can be any text string\, but should
+	 * be unique., a string; default empty.}
 	 * @config{ ),,}
 	 * @config{next_random, configure the cursor to return a pseudo-random record from the
 	 * object when the WT_CURSOR::next method is called; valid only for row-store cursors.  See


### PR DESCRIPTION
Document that block incremental backup IDs should be unique.