### PR TITLE
WT-8717 Flush files to S3 store and cache them locally to a local directory

### DIFF
--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -84,16 +84,15 @@ int
 S3Connection::PutObject(
   const std::string &bucketName, const std::string &objectKey, const std::string &fileName) const
 {
-    Aws::S3Crt::Model::PutObjectRequest request;
-    request.SetBucket(bucketName);
-    request.SetKey(objectKey);
     std::shared_ptr<Aws::IOStream> inputData = Aws::MakeShared<Aws::FStream>(
       "s3-source", fileName.c_str(), std::ios_base::in | std::ios_base::binary);
 
+    Aws::S3Crt::Model::PutObjectRequest request;
+    request.SetBucket(bucketName);
+    request.SetKey(objectKey);
     request.SetBody(inputData);
 
     Aws::S3Crt::Model::PutObjectOutcome outcome = s3CrtClient.PutObject(request);
-
     if (outcome.IsSuccess()) {
         return (0);
     } else {

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -87,7 +87,6 @@ S3Connection::PutObject(
     Aws::S3Crt::Model::PutObjectRequest request;
     request.SetBucket(bucketName);
     request.SetKey(objectKey);
-
     std::shared_ptr<Aws::IOStream> inputData = Aws::MakeShared<Aws::FStream>(
       "s3-source", fileName.c_str(), std::ios_base::in | std::ios_base::binary);
 

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -88,7 +88,7 @@ static int S3ObjectListSingle(
 static int S3ObjectListFree(WT_FILE_SYSTEM *, WT_SESSION *, char **, uint32_t);
 
 /*
- *   --
+ *   S3Exist--
  *     Return if the file exists. First checks the cache, and then the S3 Bucket.
  */
 static int
@@ -410,7 +410,7 @@ S3Terminate(WT_STORAGE_SOURCE *storage, WT_SESSION *session)
 
 /*
  * S3Flush --
- *     Flush file to S3 Store using AWS PutObject.
+ *     Flush file to S3 Store using AWS SDK C++ PutObject.
  */
 static int
 S3Flush(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, WT_FILE_SYSTEM *fileSystem,
@@ -429,13 +429,15 @@ static int
 S3FlushFinish(WT_STORAGE_SOURCE *storage, WT_SESSION *session, WT_FILE_SYSTEM *fileSystem,
   const char *source, const char *object, const char *config)
 {
-    S3_STORAGE *s3 = (S3_STORAGE *)storage;
     std::string srcPath = S3HomePath(fileSystem, source);
     std::string destPath = S3CachePath(fileSystem, source);
-    std::cout << srcPath << destPath << std::endl;
     int ret;
+
+    /* Linking file with the local file. */
     if ((ret = link(srcPath.c_str(), destPath.c_str())) != 0)
         return ret;
+    
+    /* Set the file to readonly in the cache. */
     if ((ret = chmod(destPath.c_str(), 0444)) != 0)
         return ret;
     return ret;

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -51,7 +51,7 @@ class test_s3_store01(wttest.WiredTigerTestCase):
        
         # Test flush functionality and flushing to cache and checking if file exists.
         f = open('foobar', 'wb')
-        outbytes = ('MORE THAN ENOUGH DATA\n'*100000).encode()
+        outbytes = ('Ruby\n'*100).encode()
         f.write(outbytes)
         f.close()
         s3_store.ss_flush(session, fs, "foobar", "foobar")

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -45,22 +45,28 @@ class test_s3_store01(wttest.WiredTigerTestCase):
     def test_local_basic(self):
         # Test some basic functionality of the storage source API, calling
         # each supported method in the API at least once.
+        bucket_name = "rubysfirstbucket"
+        cache_prefix = "cache-"
+        filename = "foobar"
+        object_name = "foobar"
+    
         session = self.session
         s3_store = self.get_s3_storage_source()
-        fs = s3_store.ss_customize_file_system(session, "rubysfirstbucket", "Secret", None)
+        fs = s3_store.ss_customize_file_system(session, bucket_name, "Secret", None)
        
         # Test flush functionality and flushing to cache and checking if file exists.
-        f = open('foobar', 'wb')
+        f = open(filename, 'wb')
         outbytes = ('Ruby\n'*100).encode()
         f.write(outbytes)
         f.close()
-        s3_store.ss_flush(session, fs, "foobar", "foobar")
-        s3_store.ss_flush_finish(session, fs, "foobar", "foobar" )
-        self.assertTrue(fs.fs_exist(session, "foobar"))
+
+        s3_store.ss_flush(session, fs, filename, object_name)
+        s3_store.ss_flush_finish(session, fs, filename, object_name)
+        self.assertTrue(fs.fs_exist(session, filename))
 
         # Checking that the file still exists in S3 after removing it from the cache.
-        os.remove("cache-rubysfirstbucket/foobar")
-        self.assertTrue(fs.fs_exist(session, "foobar"))
+        os.remove(cache_prefix + bucket_name + '/' + filename)
+        self.assertTrue(fs.fs_exist(session, filename))
 
         fs2 = s3_store.ss_customize_file_system(session, "wt-bucket", "Secret", None)
         _ = fs2.fs_directory_list(session, self.bucket_name, '')

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import os, wttest
 
 # test_s3_store01.py
 #   Test minimal S3 extension with basic interactions with AWS S3CrtClient.
@@ -47,11 +47,26 @@ class test_s3_store01(wttest.WiredTigerTestCase):
         # each supported method in the API at least once.
         session = self.session
         s3_store = self.get_s3_storage_source()
+        fs = s3_store.ss_customize_file_system(session, "rubysfirstbucket", "Secret", None)
+       
+        # Test flush functionality and flushing to cache and checking if file exists.
+        f = open('foobar', 'wb')
+        outbytes = ('MORE THAN ENOUGH DATA\n'*100000).encode()
+        f.write(outbytes)
+        f.close()
+        s3_store.ss_flush(session, fs, "foobar", "foobar")
+        s3_store.ss_flush_finish(session, fs, "foobar", "foobar" )
+        self.assertTrue(fs.fs_exist(session, "foobar"))
 
-        fs = s3_store.ss_customize_file_system(session, "wt-bucket", "Secret", None)
-        _ = fs.fs_directory_list(session, self.bucket_name, '')
+        # Checking that the file still exists in S3 after removing it from the cache.
+        os.remove("cache-rubysfirstbucket/foobar")
+        self.assertTrue(fs.fs_exist(session, "foobar"))
+
+        fs2 = s3_store.ss_customize_file_system(session, "wt-bucket", "Secret", None)
+        _ = fs2.fs_directory_list(session, self.bucket_name, '')
 
         fs.terminate(session)
+        fs2.terminate(session)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
- Implemented `WT_STORAGE_SOURCE.ss_flush` for tiered storage as `S3Flush`  using AWS SDK C++ PutObject to flush file to the S3. 
- Implemented `WT_STORAGE_SOURCE.ss_flush` as `S3FlushFinish` to flush the local file to cache.
- Added python testing in to validate the file exists in S3 and the cache, as well as expiring the cached file.  
  - Additionally also tested if the file remains in S3 after deleting it from the cache.  