### PR TITLE
WT-8700 Define a dedicated session for sweeping data in the cpp suite

### DIFF
--- a/test/cppsuite/test_harness/workload/workload_tracking.cxx
+++ b/test/cppsuite/test_harness/workload/workload_tracking.cxx
@@ -75,10 +75,11 @@ workload_tracking::load()
     logger::log_msg(LOG_TRACE, "Operations tracking created");
 
     /*
-     * Open sweep cursor. This cursor will be used to clear out obsolete data from the tracking
-     * table.
+     * Open sweep cursor in a dedicated sweep session. This cursor will be used to clear out
+     * obsolete data from the tracking table.
      */
-    _sweep_cursor = _session.open_scoped_cursor(_operation_table_name);
+    _sweep_session = connection_manager::instance().create_session();
+    _sweep_cursor = _sweep_session.open_scoped_cursor(_operation_table_name);
     logger::log_msg(LOG_TRACE, "Tracking table sweep initialized");
 }
 

--- a/test/cppsuite/test_harness/workload/workload_tracking.h
+++ b/test/cppsuite/test_harness/workload/workload_tracking.h
@@ -105,6 +105,7 @@ class workload_tracking : public component {
 
     private:
     scoped_session _session;
+    scoped_session _sweep_session;
     scoped_cursor _schema_track_cursor;
     scoped_cursor _sweep_cursor;
     const std::string _operation_table_config;


### PR DESCRIPTION
The tracking table is in charge of saving all the operations that occur in a test. The same session is used to track schema operations and when we try to sweep obsolete data from the tracking table periodically. If a thread creates a collection and another thread tries to sweep data from the tracking table, the same session ends up being used by two different threads which is not allowed in WT.
In this PR, we define a dedicated session for the sweeping process.