### PR TITLE
WT-8743 Configure hs_cleanup configuration to stress the cache less

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_default.txt
+++ b/test/cppsuite/configs/hs_cleanup_default.txt
@@ -29,9 +29,8 @@ runtime_monitor=
     ),
     stat_cache_size=
     (
-        # FIXME-WT-8743: Re-enable cache usage check once cache exceed problem is fixed.
         max=100,
-        runtime=false,
+        runtime=true,
     ),
     stat_db_size=
     (
@@ -61,7 +60,9 @@ workload_generator=
     update_config=
     (
         op_rate=10ms,
-        ops_per_transaction=(max=100,min=20),
+        # Be careful to not aim too high with this config, if we fill the dirty cache and
+        # all threads are trying to update, they'll get pulled into eviction and will get stuck.
+        ops_per_transaction=(max=20,min=0),
         thread_count=10,
         value_size=10000
     )

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -1,4 +1,4 @@
-# Run the test for half an hour.
+# Run for half an hour.
 duration_seconds=1800,
 # The configuration can produce a large number of updates at once, therefore use 500MB cache size 
 # to hold these values.

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -1,5 +1,7 @@
-# Run for half an hour.
+# Run the test for half an hour.  
 duration_seconds=1800,
+# The configuration can produce a large number of updates at once, therefore use 500MB cache size 
+# to hold these values.
 cache_size_mb=500,
 compression_enabled=true,
 statistics_config=

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -1,4 +1,4 @@
-# Run the test for half an hour.  
+# Run the test for half an hour.
 duration_seconds=1800,
 # The configuration can produce a large number of updates at once, therefore use 500MB cache size 
 # to hold these values.

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -1,6 +1,6 @@
 # Run for half an hour.
 duration_seconds=1800,
-cache_size_mb=2000,
+cache_size_mb=500,
 compression_enabled=true,
 statistics_config=
 (

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -1,6 +1,6 @@
 # Run for half an hour.
 duration_seconds=1800,
-cache_size_mb=200,
+cache_size_mb=2000,
 compression_enabled=true,
 statistics_config=
 (


### PR DESCRIPTION
This pull request aims to increase the stress test for hs_cleanup because it is generating lots of uncommitted updates for the cache, ideally we want to just test the history store. I have chosen 2 GB instead of 200MB because there are 10 updates threads with 100K value updates, and we have possibly 20 uncommited transactions. This means there is possibly 20 MB circling around inside the cache. That would constantly generate around 10% of uncommitted updates. 1% sounds like a more realistic expectation as it is not the goal of stressing the cache but the history store. 

I have also lowered the operations per transactions for the default test.