### PR TITLE
WT-7509 Document dangers around checkpointing a targeted list of objects

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1883,7 +1883,10 @@ methods = {
         if set, specify a name for the checkpoint (note that checkpoints
         including LSM trees may not be named)'''),
     Config('target', '', r'''
-        if non-empty, checkpoint the list of objects''', type='list'),
+        if non-empty, checkpoint the list of objects.  Checkpointing a list of objects separately
+        from a database-wide checkpoint can lead to data inconsistencies, see @ref checkpoint_target
+        for more information''',
+        type='list'),
     Config('use_timestamp', 'true', r'''
         if true (the default), create the checkpoint as of the last stable timestamp if timestamps
         are in use, or all current updates if there is no stable timestamp set. If false, this

--- a/src/docs/checkpoint.dox
+++ b/src/docs/checkpoint.dox
@@ -46,6 +46,26 @@ checkpoint will not appear in the data source at checkpoint-level durability.
 If no checkpoint is found when the data source is opened, the data source will
 appear empty.
 
+@subsection checkpoint_target Checkpointing specific objects
+
+The WT_SESSION::checkpoint method supports checkpoint of a set of target objects
+(as opposed to a database-wide checkpoint), using the \c target configuration.
+
+\warning
+If objects are separately checkpointed from a database-wide checkpoint, it is
+obviously possible to introduce data consistency problems if the objects have
+related data. Additionally, because WiredTiger has a single database-wide file
+used to store data history and other transactional information related to the
+database objects, checkpointing a set of target objects without also
+checkpointing that database-wide store can also lead to data inconsistencies.
+In other words, it is difficult to use a targetted checkpoint in the current
+WiredTiger release safely. Future development directions for the WiredTiger
+library include splitting the database-wide history file into per-object files,
+which will then be automatically checkpointed any time a database object is
+checkpointed. For that reason, we anticipate checkpointing a set of objects will
+become useful again in the future, but until those changes are made, extreme
+caution is warranted.
+
 @section checkpoint_cursors Checkpoint cursors
 
 Cursors are normally opened in the most recent version of a data source.

--- a/src/docs/checkpoint.dox
+++ b/src/docs/checkpoint.dox
@@ -52,19 +52,19 @@ The WT_SESSION::checkpoint method supports checkpoint of a set of target objects
 (as opposed to a database-wide checkpoint), using the \c target configuration.
 
 \warning
-If objects are separately checkpointed from a database-wide checkpoint, it is
-obviously possible to introduce data consistency problems if the objects have
-related data. Additionally, because WiredTiger has a single database-wide file
-used to store data history and other transactional information related to the
-database objects, checkpointing a set of target objects without also
+If objects are separately checkpointed from a database-wide checkpoint, it
+is obviously possible to introduce data consistency problems if the objects
+have related data. Additionally, because WiredTiger has a single database-wide
+file used to store data history and other transactional information related
+to the database objects, checkpointing a set of target objects without also
 checkpointing that database-wide store can also lead to data inconsistencies.
-In other words, it is difficult to use a targetted checkpoint in the current
-WiredTiger release safely. Future development directions for the WiredTiger
+In other words, it is difficult to safely use a targeted checkpoint in the
+current WiredTiger release. Future development directions for the WiredTiger
 library include splitting the database-wide history file into per-object files,
 which will then be automatically checkpointed any time a database object is
-checkpointed. For that reason, we anticipate checkpointing a set of objects will
-become useful again in the future, but until those changes are made, extreme
-caution is warranted.
+checkpointed. For that reason, we anticipate checkpointing a set of objects
+will become useful again in the future, but extreme caution is warranted
+until those changes are made.
 
 @section checkpoint_cursors Checkpoint cursors
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1809,27 +1809,6 @@ struct __wt_session {
 	int __F(prepare_transaction)(WT_SESSION *session, const char *config);
 
 	/*!
-	 * Reset the snapshot.
-	 *
-	 * This method resets snapshots for snapshot isolation transactions to update their existing
-	 * snapshot. It raises an error when this API is used in an isolation other than snapshot,
-	 * or when the transaction has performed any write operations.
-	 *
-	 * This API internally releases the current snapshot and gets the new running transactions
-	 * snapshot to avoid pinning the content in the database that is no longer needed.
-	 * Applications not using read timestamps for search may see different results after the
-	 * snapshot is updated.
-	 *
-	 * @requires_transaction
-	 *
-	 * @snippet ex_all.c reset snapshot
-	 *
-	 * @param session the session handle
-	 * @errors
-	 */
-	int __F(reset_snapshot)(WT_SESSION *session);
-
-	/*!
 	 * Roll back the current transaction.
 	 *
 	 * A transaction must be in progress when this method is called.
@@ -1852,6 +1831,35 @@ struct __wt_session {
 	 * @errors
 	 */
 	int __F(rollback_transaction)(WT_SESSION *session, const char *config);
+	/*! @} */
+
+	/*!
+	 * @name Transaction timestamps
+	 * @{
+	 */
+	/*!
+	 * Query the session's transaction timestamp state.
+	 *
+	 * The WT_SESSION.query_timestamp method can only be used at snapshot isolation.
+	 *
+	 * @param session the session handle
+	 * @param[out] hex_timestamp a buffer that will be set to the
+	 * hexadecimal encoding of the timestamp being queried.  Must be large
+	 * enough to hold a NUL terminated, hex-encoded 8B timestamp (17 bytes).
+	 * @configstart{WT_SESSION.query_timestamp, see dist/api_data.py}
+	 * @config{get, specify which timestamp to query: \c commit returns the most recently set
+	 * commit_timestamp; \c first_commit returns the first set commit_timestamp; \c prepare
+	 * returns the timestamp used in preparing a transaction; \c read returns the timestamp at
+	 * which the transaction is reading at.  See @ref timestamp_txn_api., a string\, chosen from
+	 * the following options: \c "commit"\, \c "first_commit"\, \c "prepare"\, \c "read";
+	 * default \c read.}
+	 * @configend
+	 * @errors
+	 * ::WT_NOTFOUND is returned if the session is not in a transaction or there is no matching
+	 * timestamp.
+	 */
+	int __F(query_timestamp)(
+	    WT_SESSION *session, char *hex_timestamp, const char *config);
 
 	/*!
 	 * Set a timestamp on a transaction.
@@ -1890,47 +1898,25 @@ struct __wt_session {
 	 * @errors
 	 */
 	int __F(timestamp_transaction)(WT_SESSION *session, const char *config);
+	/*! @} */
 
 	/*!
-	 * Query the session's transaction timestamp state.
-	 *
-	 * The WT_SESSION.query_timestamp method can only be used at snapshot isolation.
-	 *
-	 * @param session the session handle
-	 * @param[out] hex_timestamp a buffer that will be set to the
-	 * hexadecimal encoding of the timestamp being queried.  Must be large
-	 * enough to hold a NUL terminated, hex-encoded 8B timestamp (17 bytes).
-	 * @configstart{WT_SESSION.query_timestamp, see dist/api_data.py}
-	 * @config{get, specify which timestamp to query: \c commit returns the most recently set
-	 * commit_timestamp; \c first_commit returns the first set commit_timestamp; \c prepare
-	 * returns the timestamp used in preparing a transaction; \c read returns the timestamp at
-	 * which the transaction is reading at.  See @ref timestamp_txn_api., a string\, chosen from
-	 * the following options: \c "commit"\, \c "first_commit"\, \c "prepare"\, \c "read";
-	 * default \c read.}
-	 * @configend
-	 * @errors
-	 * ::WT_NOTFOUND is returned if the session is not in a transaction or there is no matching
-	 * timestamp.
+	 * @name Transaction support
+	 * @{
 	 */
-	int __F(query_timestamp)(
-	    WT_SESSION *session, char *hex_timestamp, const char *config);
-
 	/*!
-	 * Write a transactionally consistent snapshot of a database or set of
-	 * objects.  In the absence of transaction timestamps, the checkpoint
-	 * includes all transactions committed before the checkpoint starts.
+	 * Write a transactionally consistent snapshot of a database or set of objects.  In the
+	 * absence of transaction timestamps, the checkpoint includes all transactions committed
+	 * before the checkpoint starts.
 	 *
-	 * When timestamps are in use and a \c stable_timestamp has been set
-	 * via WT_CONNECTION::set_timestamp and the checkpoint runs with
-	 * \c use_timestamp=true (the default), updates committed with a
-	 * timestamp larger than the \c stable_timestamp will not be included
-	 * in the checkpoint for tables configured with \c log=(enabled=false).
-	 * For tables with logging enabled, all committed changes will be
-	 * included in the checkpoint (since recovery would roll them forward
-	 * anyway).
+	 * When timestamps are in use and the checkpoint runs with \c use_timestamp=true (the
+	 * default), updates committed with a timestamp after the \c stable_timestamp, in tables
+	 * configured for checkpoint-level durability, are not included in the checkpoint. See
+	 * @ref checkpoint for more information. Committed updates in tables configured for
+	 * commit-level durability are always included in the checkpoint. See @ref durability for
+	 * more information.
 	 *
-	 * Additionally, existing named checkpoints may optionally be
-	 * discarded.
+	 * Additionally, existing named checkpoints may optionally be discarded.
 	 *
 	 * @requires_notransaction
 	 *
@@ -1950,8 +1936,9 @@ struct __wt_session {
 	 * flag; default \c false.}
 	 * @config{name, if set\, specify a name for the checkpoint (note that checkpoints including
 	 * LSM trees may not be named)., a string; default empty.}
-	 * @config{target, if non-empty\, checkpoint the list of objects., a list of strings;
-	 * default empty.}
+	 * @config{target, if non-empty\, checkpoint the list of objects.  Checkpointing a list of
+	 * objects separately from a database-wide checkpoint can lead to data inconsistencies\, see
+	 * @ref checkpoint_target for more information., a list of strings; default empty.}
 	 * @config{use_timestamp, if true (the default)\, create the checkpoint as of the last
 	 * stable timestamp if timestamps are in use\, or all current updates if there is no stable
 	 * timestamp set.  If false\, this option generates a checkpoint with all updates including
@@ -1960,6 +1947,27 @@ struct __wt_session {
 	 * @errors
 	 */
 	int __F(checkpoint)(WT_SESSION *session, const char *config);
+
+	/*!
+	 * Reset the snapshot.
+	 *
+	 * This method resets snapshots for snapshot isolation transactions to update their existing
+	 * snapshot. It raises an error when this API is used in an isolation other than snapshot,
+	 * or when the transaction has performed any write operations.
+	 *
+	 * This API internally releases the current snapshot and gets the new running transactions
+	 * snapshot to avoid pinning the content in the database that is no longer needed.
+	 * Applications not using read timestamps for search may see different results after the
+	 * snapshot is updated.
+	 *
+	 * @requires_transaction
+	 *
+	 * @snippet ex_all.c reset snapshot
+	 *
+	 * @param session the session handle
+	 * @errors
+	 */
+	int __F(reset_snapshot)(WT_SESSION *session);
 
 	/*!
 	 * Return the transaction ID range pinned by the session handle.
@@ -1976,6 +1984,7 @@ struct __wt_session {
 	 * @errors
 	 */
 	int __F(transaction_pinned_range)(WT_SESSION* session, uint64_t *range);
+	/*! @} */
 
 #ifndef DOXYGEN
 	/*!

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2015,9 +2015,9 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __wt_session_compact, __session_drop, __session_join, __session_log_flush,
         __session_log_printf, __session_rename, __session_reset, __session_salvage,
         __session_truncate, __session_upgrade, __session_verify, __session_begin_transaction,
-        __session_commit_transaction, __session_prepare_transaction, __session_reset_snapshot,
-        __session_rollback_transaction, __session_timestamp_transaction, __session_query_timestamp,
-        __session_checkpoint, __session_transaction_pinned_range, __session_get_rollback_reason,
+        __session_commit_transaction, __session_prepare_transaction, __session_rollback_transaction,
+        __session_query_timestamp, __session_timestamp_transaction, __session_checkpoint,
+        __session_reset_snapshot, __session_transaction_pinned_range, __session_get_rollback_reason,
         __wt_session_breakpoint},
       stds_readonly = {NULL, NULL, __session_close, __session_reconfigure, __session_flush_tier,
         __wt_session_strerror, __session_open_cursor, __session_alter_readonly,
@@ -2026,10 +2026,10 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_rename_readonly, __session_reset, __session_salvage_readonly,
         __session_truncate_readonly, __session_upgrade_readonly, __session_verify,
         __session_begin_transaction, __session_commit_transaction,
-        __session_prepare_transaction_readonly, __session_reset_snapshot,
-        __session_rollback_transaction, __session_timestamp_transaction, __session_query_timestamp,
-        __session_checkpoint_readonly, __session_transaction_pinned_range,
-        __session_get_rollback_reason, __wt_session_breakpoint};
+        __session_prepare_transaction_readonly, __session_rollback_transaction,
+        __session_query_timestamp, __session_timestamp_transaction, __session_checkpoint_readonly,
+        __session_reset_snapshot, __session_transaction_pinned_range, __session_get_rollback_reason,
+        __wt_session_breakpoint};
     WT_DECL_RET;
     WT_SESSION_IMPL *session, *session_ret;
     uint32_t i;


### PR DESCRIPTION
Add a warning about checkpointing a target set of objects.
Reorder the WT_SESSION transaction methods, right now the list is completely unordered.

@quchenhao, @kommiharibabu, let me know if you disagree with this decision.

There's a prebuilt version of the docs for your review. The important changes are:

[WT_SESSION transaction method restructuring](https://keithbostic.github.io/docs.build/struct_w_t___s_e_s_s_i_o_n.html)
[The Ref Guide warning for the 'target' configuration](https://keithbostic.github.io/docs.build/struct_w_t___s_e_s_s_i_o_n.html#a6550c9079198955c5071583941c85bbf)
[The User Guide warning](https://keithbostic.github.io/docs.build/checkpoint.html#checkpoint_target)

I had to restructure session initialization in `session_api.c`, but that was a mechanical change.
