### PR TITLE
WT-8776 Setting a read timestamp after prepare panics

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -758,7 +758,15 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
-    WT_RET(__wt_txn_context_prepare_check(session));
+    /*
+     * Silently ignore attempts to set the read timestamp after a transaction is prepared (if we
+     * error, the system will panic because an operation on a prepared transaction cannot fail).
+     */
+    if (F_ISSET(session->txn, WT_TXN_PREPARE)) {
+        __wt_errx(session,
+          "attempt to set the read timestamp after the transaction is prepared silently ignored");
+        return (0);
+    }
 
     /* Read timestamps imply / require snapshot isolation. */
     if (!F_ISSET(txn, WT_TXN_RUNNING))
@@ -883,30 +891,30 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
             WT_RET(__wt_txn_parse_timestamp(session, "prepare", &prepare_ts, &cval));
             set_ts = true;
         } else if (WT_STRING_MATCH("read_timestamp", ckey.str, ckey.len)) {
-            WT_RET(__wt_txn_parse_timestamp(session, "durable", &read_ts, &cval));
+            WT_RET(__wt_txn_parse_timestamp(session, "read", &read_ts, &cval));
             set_ts = true;
         }
     }
     WT_RET_NOTFOUND_OK(ret);
 
     /* Look for a commit timestamp. */
-    if (commit_ts != 0)
+    if (commit_ts != WT_TS_NONE)
         WT_RET(__wt_txn_set_commit_timestamp(session, commit_ts));
 
     /*
      * Look for a durable timestamp. Durable timestamp should be set only after setting the commit
      * timestamp.
      */
-    if (durable_ts != 0)
+    if (durable_ts != WT_TS_NONE)
         WT_RET(__wt_txn_set_durable_timestamp(session, durable_ts));
     __wt_txn_publish_durable_timestamp(session);
 
     /* Look for a read timestamp. */
-    if (read_ts != 0)
+    if (read_ts != WT_TS_NONE)
         WT_RET(__wt_txn_set_read_timestamp(session, read_ts));
 
     /* Look for a prepare timestamp. */
-    if (prepare_ts != 0)
+    if (prepare_ts != WT_TS_NONE)
         WT_RET(__wt_txn_set_prepare_timestamp(session, prepare_ts));
 
     if (set_ts)

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -862,7 +862,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
     bool set_ts;
 
     set_ts = false;
-    commit_ts = durable_ts = prepare_ts = read_ts = 0;
+    commit_ts = durable_ts = prepare_ts = read_ts = WT_TS_NONE;
 
     WT_TRET(__wt_txn_context_check(session, true));
 

--- a/test/suite/test_prepare01.py
+++ b/test/suite/test_prepare01.py
@@ -142,5 +142,17 @@ class test_prepare01(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
         self.check(cursor, self.nentries, self.nentries)
 
+# Attempts to set the read timestamp after preparing the transaction should be ignored.
+class test_prepare01_read_ts(wttest.WiredTigerTestCase):
+    def test_prepare01_read_ts(self):
+        uri = 'table:prepare01_read_ts'
+        self.session.create(uri, 'key_format=S,value_format=S')
+        c = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        c['aaa'] = 'value'
+        self.session.prepare_transaction('prepare_timestamp=a')
+        with self.expectedStderrPattern('.*silently ignored.*'):
+            self.session.timestamp_transaction('read_timestamp=a')
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
@bvpvamsikrishna, @kommiharibabu: I'm torn about this one. Trying to set the read timestamp after a transaction is prepared is technically an error on the transaction after it's prepared -- but the error also seems like an easy one for an application to make and not discover until after deployment.

There is a typo in `__wt_txn_set_timestamp()` that this PR also fixes, so if you decide to not allow a read timestamp after prepare, that's fine, with me and I'll remove that part of the change and keep the rest.