### PR TITLE
WT-8821 Add a get object size method in S3Connection and implement file handle and file system size

### DIFF
--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -137,7 +137,7 @@ S3Connection::GetObject(const std::string &objectKey, const std::string &path) c
  *     Checks whether an object with the given key exists in the S3 bucket.
  */
 int
-S3Connection::ObjectExists(const std::string &objectKey, bool &exists) const
+S3Connection::ObjectExists(const std::string &objectKey, bool &exists, size_t &objectSize) const
 {
     exists = false;
 
@@ -152,6 +152,8 @@ S3Connection::ObjectExists(const std::string &objectKey, bool &exists) const
      */
     if (outcome.IsSuccess()) {
         exists = true;
+        objectSize = outcome.GetResult().GetContentLength();
+
         return (0);
     } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND)
         return (0);
@@ -162,27 +164,4 @@ S3Connection::ObjectExists(const std::string &objectKey, bool &exists) const
      */
     std::cerr << "Error in ObjectExists." << std::endl;
     return (1);
-}
-
-/*
- * ObjectExists --
- *     Checks whether an object with the given key exists in the S3 bucket.
- */
-int
-S3Connection::ObjectLength(const std::string &objectKey) const
-{
-
-    Aws::S3Crt::Model::HeadObjectRequest request;
-    request.SetBucket(_bucketName);
-    request.SetKey(_objectPrefix + objectKey);
-    Aws::S3Crt::Model::HeadObjectOutcome outcome = _s3CrtClient.HeadObject(request);
-
-    /*
-     * If an object with the given key does not exist the HEAD request will return a 404.
-     * https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html Do not fail in this case.
-     */
-    if (outcome.IsSuccess()) {
-        return outcome.GetResult().GetContentLength();
-    } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND)
-        return (1);
 }

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -163,3 +163,26 @@ S3Connection::ObjectExists(const std::string &objectKey, bool &exists) const
     std::cerr << "Error in ObjectExists." << std::endl;
     return (1);
 }
+
+/*
+ * ObjectExists --
+ *     Checks whether an object with the given key exists in the S3 bucket.
+ */
+int
+S3Connection::ObjectLength(const std::string &objectKey) const
+{
+
+    Aws::S3Crt::Model::HeadObjectRequest request;
+    request.SetBucket(_bucketName);
+    request.SetKey(_objectPrefix + objectKey);
+    Aws::S3Crt::Model::HeadObjectOutcome outcome = _s3CrtClient.HeadObject(request);
+
+    /*
+     * If an object with the given key does not exist the HEAD request will return a 404.
+     * https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html Do not fail in this case.
+     */
+    if (outcome.IsSuccess()) {
+        return outcome.GetResult().GetContentLength();
+    } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND)
+        return (1);
+}

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -141,6 +141,7 @@ int
 S3Connection::ObjectExists(const std::string &objectKey, bool &exists, size_t &objectSize) const
 {
     exists = false;
+    objectSize = 0;
 
     Aws::S3Crt::Model::HeadObjectRequest request;
     request.SetBucket(_bucketName);
@@ -154,7 +155,6 @@ S3Connection::ObjectExists(const std::string &objectKey, bool &exists, size_t &o
     if (outcome.IsSuccess()) {
         exists = true;
         objectSize = outcome.GetResult().GetContentLength();
-
         return (0);
     } else if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND)
         return (0);

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -135,7 +135,7 @@ S3Connection::GetObject(const std::string &objectKey, const std::string &path) c
 /*
  * ObjectExists --
  *     Checks whether an object with the given key exists in the S3 bucket and also retrieves
- * objectSize.
+ *     size of the object.
  */
 int
 S3Connection::ObjectExists(const std::string &objectKey, bool &exists, size_t &objectSize) const

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -134,7 +134,8 @@ S3Connection::GetObject(const std::string &objectKey, const std::string &path) c
 
 /*
  * ObjectExists --
- *     Checks whether an object with the given key exists in the S3 bucket.
+ *     Checks whether an object with the given key exists in the S3 bucket and also retrieves
+ * objectSize.
  */
 int
 S3Connection::ObjectExists(const std::string &objectKey, bool &exists, size_t &objectSize) const

--- a/ext/storage_sources/s3_store/s3_connection.h
+++ b/ext/storage_sources/s3_store/s3_connection.h
@@ -21,6 +21,7 @@ class S3Connection {
     int PutObject(const std::string &objectKey, const std::string &fileName) const;
     int DeleteObject(const std::string &objectKey) const;
     int ObjectExists(const std::string &objectKey, bool &exists) const;
+    int ObjectLength(const std::string &objectKey) const;
     int GetObject(const std::string &objectKey, const std::string &path) const;
 
     ~S3Connection() = default;

--- a/ext/storage_sources/s3_store/s3_connection.h
+++ b/ext/storage_sources/s3_store/s3_connection.h
@@ -20,8 +20,7 @@ class S3Connection {
       uint32_t batchSize = 1000, bool listSingle = false) const;
     int PutObject(const std::string &objectKey, const std::string &fileName) const;
     int DeleteObject(const std::string &objectKey) const;
-    int ObjectExists(const std::string &objectKey, bool &exists) const;
-    int ObjectLength(const std::string &objectKey) const;
+    int ObjectExists(const std::string &objectKey, bool &exists, size_t &objectSize) const;
     int GetObject(const std::string &objectKey, const std::string &path) const;
 
     ~S3Connection() = default;

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -365,11 +365,14 @@ S3Size(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name, wt_off
 {
     S3_STORAGE *s3 = FS2S3(fileSystem);
     size_t objectSize;
-    bool exist = false;
+    bool exist;
+    *sizep = 0;
+    int ret;
 
     S3_FILE_SYSTEM *fs = (S3_FILE_SYSTEM *)fileSystem;
     s3->statistics.objectExistsCount++;
-    int ret = fs->connection->ObjectExists(name, exist, objectSize);
+    if ((ret = fs->connection->ObjectExists(name, exist, objectSize)) != 0)
+        return (ret);
     *sizep = objectSize;
     return (ret);
 }

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -399,13 +399,11 @@ S3FileRead(WT_FILE_HANDLE *fileHandle, WT_SESSION *session, wt_off_t offset, siz
 static int
 S3FileSize(WT_FILE_HANDLE *fileHandle, WT_SESSION *session, wt_off_t *sizep)
 {
-    S3_FILE_HANDLE *s3FileHandle;
+    S3_FILE_HANDLE *s3FileHandle = (S3_FILE_HANDLE *)fileHandle;
     S3_STORAGE *storage = s3FileHandle->storage;
-    WT_FILE_HANDLE *wt_fh;
-    s3FileHandle = (S3_FILE_HANDLE *)fileHandle;
-    wt_fh = s3FileHandle->wtFileHandle;
-    storage->statistics.fhSizeOps++;
-    return (wt_fh->fh_size(wt_fh, session, sizep));
+    WT_FILE_HANDLE *wtFh = s3FileHandle->wtFileHandle;
+    storage->statistics.fhOps++;
+    return (wtFh->fh_size(wtFh, session, sizep));
 }
 
 /*

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -119,7 +119,6 @@ static int S3FileClose(WT_FILE_HANDLE *, WT_SESSION *);
 static int S3FileSize(WT_FILE_HANDLE *, WT_SESSION *, wt_off_t *);
 static int S3Size(WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *);
 
-
 /*
  * S3Path --
  *     Construct a pathname from the directory and the object name.
@@ -154,9 +153,7 @@ S3Exist(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name, bool 
     /* It's not in the cache, try the S3 bucket. */
     *exist = S3CacheExists(fileSystem, name);
     if (!*exist)
-        std::cout << "Inside S3Exist->ObjectExist" << std::endl;
         return (fs->connection->ObjectExists(name, *exist));
-    std::cout << "Inside S3Exist" << std::endl;
     return (0);
 }
 
@@ -247,8 +244,6 @@ S3FileClose(WT_FILE_HANDLE *fileHandle, WT_SESSION *session)
 
     free(s3FileHandle->iface.name);
     free(s3FileHandle);
-    std::cout << "Inside S3FileClose" << std::endl;
-
     return (ret);
 }
 
@@ -266,7 +261,6 @@ S3Open(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name,
     WT_FILE_SYSTEM *wtFileSystem = s3Fs->wtFileSystem;
     WT_FILE_HANDLE *wtFileHandle;
     int ret;
-    std::cout << "Inside S3Open start" << std::endl;
 
     *fileHandlePtr = NULL;
 
@@ -341,8 +335,6 @@ S3Open(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name,
     }
 
     *fileHandlePtr = fileHandle;
-    std::cout << "Inside S3Open end" << std::endl;
-
     return (0);
 }
 
@@ -358,7 +350,6 @@ S3Size(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name, wt_off
     s3 = FS2S3(fileSystem);
     S3_FILE_SYSTEM *fs = (S3_FILE_SYSTEM *)fileSystem;
     *sizep = fs->connection->ObjectLength(name);
-    std::cout << "Inside S3Size " << *sizep << std::endl;
     return (0);
 }
 
@@ -369,7 +360,6 @@ S3Size(WT_FILE_SYSTEM *fileSystem, WT_SESSION *session, const char *name, wt_off
 static int
 S3FileRead(WT_FILE_HANDLE *file_handle, WT_SESSION *session, wt_off_t offset, size_t len, void *buf)
 {
-    std::cout << "Inside S3FileRead" << std::endl;
     WT_FILE_HANDLE *wtFileHandle = ((S3_FILE_HANDLE *)file_handle)->wtFileHandle;
     return (wtFileHandle->fh_read(wtFileHandle, session, offset, len, buf));
 }
@@ -381,13 +371,10 @@ S3FileRead(WT_FILE_HANDLE *file_handle, WT_SESSION *session, wt_off_t offset, si
 static int
 S3FileSize(WT_FILE_HANDLE *fileHandle, WT_SESSION *session, wt_off_t *sizep)
 {
-    std::cout << "Inside S3FileSize" << std::endl;
     S3_FILE_HANDLE *s3FileHandle;
     WT_FILE_HANDLE *wt_fh;
-
-    s3FileHandle= (S3_FILE_HANDLE *)fileHandle;
+    s3FileHandle = (S3_FILE_HANDLE *)fileHandle;
     wt_fh = s3FileHandle->wtFileHandle;
-    std::cout << "Inside S3FileSize" << std::endl;
     return (wt_fh->fh_size(wt_fh, session, sizep));
 }
 
@@ -477,7 +464,7 @@ S3CustomizeFileSystem(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, con
     fs->fileSystem.terminate = S3FileSystemTerminate;
     fs->fileSystem.fs_exist = S3Exist;
     fs->fileSystem.fs_open_file = S3Open;
-    fs->fileSystem.fs_size = S3Size; 
+    fs->fileSystem.fs_size = S3Size;
 
     /* Add to the list of the active file systems. Lock will be freed when the scope is exited. */
     {

--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -302,7 +302,7 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
     File.close();
 
     ret = conn.ObjectExists(objectName, exists, objectSize);
-    if (ret != 0 || exists)
+    if (ret != 0 || exists || objectSize != 0)
         return (TEST_FAILURE);
 
     if ((ret = conn.PutObject(objectName, fileName)) != 0)

--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -282,7 +282,7 @@ TestGetObject(const Aws::S3Crt::ClientConfiguration &config)
 }
 /*
  * TestObjectExists --
- *     Unit test to check if an object exists in an AWS bucket.
+ *     Unit test to check if an object exists in an AWS bucket and objectSize is correct.
  */
 int
 TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
@@ -297,7 +297,8 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
 
     /* Create a file to upload to the bucket.*/
     std::ofstream File(fileName);
-    File << "Test payload";
+    std::string payload = "Test payload";
+    File << payload;
     File.close();
 
     ret = conn.ObjectExists(objectName, exists, objectSize);
@@ -308,10 +309,13 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
         return (ret);
 
     ret = conn.ObjectExists(objectName, exists, objectSize);
-    std::cout << objectSize << std::endl;
     if (ret != 0 || !exists)
         return (TEST_FAILURE);
 
+    if (objectSize != payload.length()) {
+        std::cout << "TestObjectExist().objectSize failed." << std::endl;
+        return (TEST_FAILURE);
+    }
     if ((ret = conn.DeleteObject(objectName)) != 0)
         return (ret);
     std::cout << "TestObjectExists() succeeded." << std::endl;

--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -290,6 +290,7 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
     S3Connection conn(config, TestDefaults::bucketName, TestDefaults::objPrefix);
     bool exists = false;
     int ret = TEST_FAILURE;
+    size_t objectSize;
 
     const std::string objectName = "test_object";
     const std::string fileName = "test_object.txt";
@@ -299,14 +300,15 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
     File << "Test payload";
     File.close();
 
-    ret = conn.ObjectExists(objectName, exists);
+    ret = conn.ObjectExists(objectName, exists, objectSize);
     if (ret != 0 || exists)
         return (TEST_FAILURE);
 
     if ((ret = conn.PutObject(objectName, fileName)) != 0)
         return (ret);
 
-    ret = conn.ObjectExists(objectName, exists);
+    ret = conn.ObjectExists(objectName, exists, objectSize);
+    std::cout << objectSize << std::endl;
     if (ret != 0 || !exists)
         return (TEST_FAILURE);
 

--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -315,7 +315,7 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
         return (TEST_FAILURE);
 
     if (objectSize != payload.length()) {
-        std::cout << "TestObjectExist().objectSize failed." << std::endl;
+        std::cerr << "TestObjectExist().objectSize failed." << std::endl;
         return (TEST_FAILURE);
     }
 

--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -282,7 +282,7 @@ TestGetObject(const Aws::S3Crt::ClientConfiguration &config)
 }
 /*
  * TestObjectExists --
- *     Unit test to check if an object exists in an AWS bucket and objectSize is correct.
+ *     Unit test to check if an object exists in an AWS bucket and size of the object is correct.
  */
 int
 TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
@@ -301,21 +301,24 @@ TestObjectExists(const Aws::S3Crt::ClientConfiguration &config)
     File << payload;
     File.close();
 
-    ret = conn.ObjectExists(objectName, exists, objectSize);
-    if (ret != 0 || exists || objectSize != 0)
+    if ((ret = conn.ObjectExists(objectName, exists, objectSize)) != 0)
+        return (ret);
+    if (exists || objectSize != 0)
         return (TEST_FAILURE);
 
     if ((ret = conn.PutObject(objectName, fileName)) != 0)
         return (ret);
 
-    ret = conn.ObjectExists(objectName, exists, objectSize);
-    if (ret != 0 || !exists)
+    if ((ret = conn.ObjectExists(objectName, exists, objectSize)) != 0)
+        return (ret);
+    if (!exists)
         return (TEST_FAILURE);
 
     if (objectSize != payload.length()) {
         std::cout << "TestObjectExist().objectSize failed." << std::endl;
         return (TEST_FAILURE);
     }
+
     if ((ret = conn.DeleteObject(objectName)) != 0)
         return (ret);
     std::cout << "TestObjectExists() succeeded." << std::endl;

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -45,7 +45,7 @@ class test_s3_store01(wttest.WiredTigerTestCase):
     # Bucket name can be overridden by an environment variable.
     bucket_name = os.getenv('WT_S3_EXT_BUCKET')
     if bucket_name is None:
-        bucket_name = "rubysfirstbucket"
+        bucket_name = "s3testext"
 
     # Load the s3 store extension, skip the test if missing.
     def conn_extensions(self, extlist):

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -87,8 +87,6 @@ class test_s3_store01(wttest.WiredTigerTestCase):
         # Checking that the file still exists in S3 after removing it from the cache.
         os.remove(cache_prefix + self.bucket_name + '/' + filename)
         self.assertTrue(fs.fs_exist(session, filename))
- 
-
         file_list = [self.prefix + object_name]
         self.assertEquals(fs.fs_directory_list(session, None, None), file_list)
 

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -45,7 +45,7 @@ class test_s3_store01(wttest.WiredTigerTestCase):
     # Bucket name can be overridden by an environment variable.
     bucket_name = os.getenv('WT_S3_EXT_BUCKET')
     if bucket_name is None:
-        bucket_name = "s3testext"
+        bucket_name = "rubysfirstbucket"
 
     # Load the s3 store extension, skip the test if missing.
     def conn_extensions(self, extlist):

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -80,11 +80,14 @@ class test_s3_store01(wttest.WiredTigerTestCase):
         inbytes = bytes(1000000)         # An empty buffer with a million zero bytes.
         fh.fh_read(session, 0, inbytes)  # Read into the buffer.
         self.assertEquals(outbytes[0:1000000], inbytes)
+        self.assertTrue(fs.fs_size(session, filename), len(outbytes))
+        self.assertEquals(fh.fh_size(session), len(outbytes))
         fh.close(session)
 
         # Checking that the file still exists in S3 after removing it from the cache.
         os.remove(cache_prefix + self.bucket_name + '/' + filename)
         self.assertTrue(fs.fs_exist(session, filename))
+ 
 
         file_list = [self.prefix + object_name]
         self.assertEquals(fs.fs_directory_list(session, None, None), file_list)


### PR DESCRIPTION
- Created a function `ObjectSize` that gets the `ContentLength` of the object in bucket in `S3Connection.cpp`.
- Implemented `fh_size` that gets the file size from WiredTiger's native file handle.
- Implemented `fs_size` that uses the `ObjectSize` function `S3Connection.cpp` to get the object size. 
- Added testing for the functions that can be merged into `test_tiered06.py` and others. 