### PR TITLE
WT-8482 Use toolchain clang binary for PPC ASAN tests

### DIFF
--- a/cmake/toolchains/mongodbtoolchain_v4_clang.cmake
+++ b/cmake/toolchains/mongodbtoolchain_v4_clang.cmake
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+if(NOT TOOLCHAIN_ROOT)
+    set(TOOLCHAIN_ROOT "/opt/mongodbtoolchain/v4")
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_ROOT}/bin/clang")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_ROOT}/bin/clang++")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_ROOT}/bin/clang")

--- a/cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
+++ b/cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+if(NOT TOOLCHAIN_ROOT)
+    set(TOOLCHAIN_ROOT "/opt/mongodbtoolchain/v4")
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_ROOT}/bin/gcc")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_ROOT}/bin/g++")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_ROOT}/bin/gcc")

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -158,7 +158,7 @@ functions:
             if [ -d cmake_build ]; then rm -r cmake_build; fi
             mkdir -p cmake_build
             cd cmake_build
-            $CMAKE -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_clang.cmake -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1 \
+            $CMAKE -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1 \
               -DHAVE_DIAGNOSTIC=1 -DCMAKE_BUILD_TYPE=ASan \
               -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1 ${configure_python_setting|} \
               -G "${cmake_generator|Ninja}" ../.
@@ -2264,28 +2264,6 @@ tasks:
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           format_test_script_args: -S
 
-  # FIXME-WT-8482: Replace this test with format-asan-smoke-test.
-  - name: format-asan-smoke-ppc-test
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          # FIXME-WT-8482: CC is set to the system default "clang" binary here as a workaround.
-          # Change it back to mongodbtoolchain "clang" binary.
-          posix_configure_flags:
-            -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
-            -DHAVE_DIAGNOSTIC=1
-            -DWITH_PIC=1
-            -DCMAKE_BUILD_TYPE=ASan
-            -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1
-      - func: "format test script"
-        # Run smoke tests, don't stop at failed tests, use default config
-        vars:
-          test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
-            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          format_test_script_args: -S
-
   - name: format-wtperf-test
     commands:
       - func: "get project"
@@ -2544,34 +2522,6 @@ tasks:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
 
-  # FIXME-WT-8482: Replace this test with format-stress-sanitizer-test.
-  - name: format-stress-sanitizer-ppc-test
-    tags: ["stress-test-ppc-1"]
-    # Set 2.5 hours timeout (60 * 60 * 2.5)
-    exec_timeout_secs: 9000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          # FIXME-WT-8482: CC is set to the system default "clang" binary here as a workaround.
-          # Change it back to mongodbtoolchain "clang" binary.
-          posix_configure_flags:
-            -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
-            -DHAVE_DIAGNOSTIC=1
-            -DWITH_PIC=1
-            -DHAVE_BUILTIN_EXTENSION_LZ4=1
-            -DHAVE_BUILTIN_EXTENSION_SNAPPY=1
-            -DHAVE_BUILTIN_EXTENSION_ZLIB=1
-            -DCMAKE_BUILD_TYPE=ASan
-      - func: "format test script"
-        vars:
-          test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
-            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          # Run for 2 hours (2 * 60 = 120 minutes), don't stop at failed tests, use default config
-          format_test_script_args: -t 120
-
-
   - <<: *format-stress-test
     name: format-stress-test-1
     tags: ["stress-test-1"]
@@ -2586,16 +2536,16 @@ tasks:
     tags: ["stress-test-4"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-1
-    tags: ["stress-test-1"]
+    tags: ["stress-test-1", "stress-test-ppc-1"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-2
-    tags: ["stress-test-2"]
+    tags: ["stress-test-2", "stress-test-ppc-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-3
-    tags: ["stress-test-3"]
+    tags: ["stress-test-3", "stress-test-ppc-3"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-4
-    tags: ["stress-test-4"]
+    tags: ["stress-test-4", "stress-test-ppc-4"]
   - <<: *race-condition-stress-sanitizer-test
     name: race-condition-stress-sanitizer-test-1
     tags: ["stress-test-1"]
@@ -4065,7 +4015,7 @@ buildvariants:
       WT_BUILDDIR=$(git rev-parse --show-toplevel)/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR
     posix_configure_flags:
-      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
       -DCMAKE_C_FLAGS="-ggdb"
       -DHAVE_DIAGNOSTIC=1
       -DENABLE_PYTHON=1
@@ -4073,7 +4023,7 @@ buildvariants:
       -DENABLE_SNAPPY=1
       -DENABLE_STRICT=1
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
-    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    python_binary: '/opt/mongodbtoolchain/v4/bin/python3'
     # Use half number of vCPU to avoid OOM kill failure
     smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
     cmake_generator: Ninja
@@ -4082,9 +4032,12 @@ buildvariants:
     - name: compile
     - name: unit-test
     - name: format-smoke-test
-    - name: format-asan-smoke-ppc-test
+    - name: format-asan-smoke-test
     - name: format-wtperf-test
     - name: ".stress-test-ppc-1"
+    - name: ".stress-test-ppc-2"
+    - name: ".stress-test-ppc-3"
+    - name: ".stress-test-ppc-4"
 
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2542,10 +2542,10 @@ tasks:
     tags: ["stress-test-2", "stress-test-ppc-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-3
-    tags: ["stress-test-3", "stress-test-ppc-3"]
+    tags: ["stress-test-3"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-4
-    tags: ["stress-test-4", "stress-test-ppc-4"]
+    tags: ["stress-test-4"]
   - <<: *race-condition-stress-sanitizer-test
     name: race-condition-stress-sanitizer-test-1
     tags: ["stress-test-1"]
@@ -4036,8 +4036,6 @@ buildvariants:
     - name: format-wtperf-test
     - name: ".stress-test-ppc-1"
     - name: ".stress-test-ppc-2"
-    - name: ".stress-test-ppc-3"
-    - name: ".stress-test-ppc-4"
 
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"


### PR DESCRIPTION
Update the following PPC ASAN tests to use the base tests and adopt the V4 toolchain in the base tests:
* Replace `format-stress-sanitizer-ppc-test` with `format-stress-sanitizer-test`.
* Replace `format-asan-smoke-ppc-test` with `format-asan-smoke-test`.

Evergreen patch build: https://spruce.mongodb.com/version/620a203632f4171a210cf4a1/tasks
