### PR TITLE
 WT-7984 Fix a bug that could cause a checkpoint to omit a page of data (v4.0 backport) (#7051)

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -157,6 +157,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
     WT_RECONCILE *r;
+#ifdef HAVE_DIAGNOSTIC
+    void *addr;
+#endif
 
     btree = S2BT(session);
     page = ref->page;
@@ -204,11 +207,17 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     /* Check for a successful reconciliation. */
     WT_TRET(__rec_write_check_complete(session, r, ret, lookaside_retryp));
 
+#ifdef HAVE_DIAGNOSTIC
+    addr = ref->addr;
+#endif
     /* Wrap up the page reconciliation. */
     if (ret == 0 && (ret = __rec_write_wrapup(session, r, page)) == 0)
         __rec_write_page_status(session, r);
-    else
+    else {
+        /* Make sure that reconciliation doesn't free the page that has been written to disk. */
+        WT_ASSERT(session, addr == NULL || ref->addr != NULL);
         WT_TRET(__rec_write_wrapup_err(session, r, page));
+    }
 
     /*
      * If reconciliation completes successfully, save the stable timestamp.
@@ -2165,6 +2174,21 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     ref = r->ref;
 
     /*
+     * If using the lookaside table eviction path and we found updates that weren't globally visible
+     * when reconciling this page, copy them into the database's lookaside store.
+     */
+    if (F_ISSET(r, WT_REC_LOOKASIDE))
+        WT_RET(__rec_las_wrapup(session, r));
+
+    /*
+     * Wrap up overflow tracking. If we are about to create a checkpoint, the system must be
+     * entirely consistent at that point (the underlying block manager is presumably going to do
+     * some action to resolve the list of allocated/free/whatever blocks that are associated with
+     * the checkpoint).
+     */
+    WT_RET(__wt_ovfl_track_wrapup(session, page));
+
+    /*
      * This page may have previously been reconciled, and that information is now about to be
      * replaced. Make sure it's discarded at some point, and clear the underlying modification
      * information, we're creating a new reality.
@@ -2212,21 +2236,6 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
     /* Reset the reconciliation state. */
     mod->rec_result = 0;
-
-    /*
-     * If using the lookaside table eviction path and we found updates that weren't globally visible
-     * when reconciling this page, copy them into the database's lookaside store.
-     */
-    if (F_ISSET(r, WT_REC_LOOKASIDE))
-        WT_RET(__rec_las_wrapup(session, r));
-
-    /*
-     * Wrap up overflow tracking. If we are about to create a checkpoint, the system must be
-     * entirely consistent at that point (the underlying block manager is presumably going to do
-     * some action to resolve the list of allocated/free/whatever blocks that are associated with
-     * the checkpoint).
-     */
-    WT_RET(__wt_ovfl_track_wrapup(session, page));
 
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages", (void *)ref,
       r->multi_next);


### PR DESCRIPTION
Cherry-picked from c457fb3, which is the 4.2 backport of 405b72f. 
v4.2 backport PR: #7051 
Initial PR: #6926

This cherry-pick applied cleanly after the modifications made in the 4.2 backport.

Co-authored-by: Michael Cahill <michael.cahill@mongodb.com>
Co-authored-by: Monica Ng <mailto:monica.ng@mongodb.com>
(cherry picked from commit c457fb3eee12986e206a09bbc04e8daf4fa892b3)