### PR TITLE
WT-8846 Fix S3 directory listing - strip prefix from the output files

### DIFF
--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -43,7 +43,7 @@ S3Connection::ListObjects(const std::string &prefix, std::vector<std::string> &o
         return (1);
     auto result = outcomes.GetResult();
     for (const auto &object : result.GetContents())
-        objects.push_back(object.GetKey());
+        objects.push_back(object.GetKey().substr(_objectPrefix.length()));
 
     if (listSingle)
         return (0);

--- a/ext/storage_sources/s3_store/s3_connection.cpp
+++ b/ext/storage_sources/s3_store/s3_connection.cpp
@@ -42,6 +42,8 @@ S3Connection::ListObjects(const std::string &prefix, std::vector<std::string> &o
     if (!outcomes.IsSuccess())
         return (1);
     auto result = outcomes.GetResult();
+
+    /* Returning the object name with the prefix stripped. */
     for (const auto &object : result.GetContents())
         objects.push_back(object.GetKey().substr(_objectPrefix.length()));
 

--- a/test/suite/test_s3_store01.py
+++ b/test/suite/test_s3_store01.py
@@ -89,7 +89,7 @@ class test_s3_store01(wttest.WiredTigerTestCase):
         # Checking that the file still exists in S3 after removing it from the cache.
         os.remove(cache_prefix + self.bucket_name + '/' + filename)
         self.assertTrue(fs.fs_exist(session, filename))
-        file_list = [self.prefix + object_name]
+        file_list = [object_name]
         self.assertEquals(fs.fs_directory_list(session, None, None), file_list)
 
         fs2 = s3_store.ss_customize_file_system(session, self.bucket_name, "Secret", self.fs_config)


### PR DESCRIPTION
Directory listing was changed in `S3Connection.cpp` so when returning the output files, the filenames do not include the prefix. 
* Testing was adjusted for this change. 