### PR TITLE
WT-8605 Disable the perf tests for mongodb-4.4 branch in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3315,6 +3315,9 @@ buildvariants:
 
 - name: ubuntu2004-perf-tests
   display_name: Ubuntu 20.04 Performance tests
+  # Perf tests are NOT expected to be triggered on Evergreen projects
+  # other than "WiredTiger (develop)".
+  activate: false
   run_on:
     - ubuntu2004-test
   expansions:


### PR DESCRIPTION
Use the Evergreen build variant field activate (refer to [this](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants)[](https://github.com/lukech) wiki page) to disable perf tests for the mongodb-4.4 branch, as we only expect perf tests to be executed on the Evergreen project "WiredTiger (develop)".