### PR TITLE
WT-8720 Introduce S3 extension testing to all the WiredTiger platforms

### DIFF
--- a/ext/storage_sources/s3_store/CMakeLists.txt
+++ b/ext/storage_sources/s3_store/CMakeLists.txt
@@ -3,6 +3,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(s3_store CXX)
 
+# This library needs to be linked in order for the std::filesystem to work. 
+set(filesystem_lib)
+if (WT_DARWIN)
+    set(filesystem_lib c++fs)
+elseif (WT_LINUX)
+    set(filesystem_lib stdc++fs)
+endif()
+
 # Create an intermediate library to build the helper library.
 add_library(aws_bucket_util STATIC s3_connection.cpp)
 set_property(TARGET aws_bucket_util PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -37,7 +45,7 @@ target_link_libraries(
         aws_bucket_util
         aws-sdk::s3-crt
         aws-sdk::core
-        stdc++fs
+        ${filesystem_lib}
 )
 
 # Add the unit tests.

--- a/ext/storage_sources/s3_store/CMakeLists.txt
+++ b/ext/storage_sources/s3_store/CMakeLists.txt
@@ -3,13 +3,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(s3_store CXX)
 
-# This library needs to be linked in order for the std::filesystem to work. 
+# On certain platforms with older compiler versions, an additional library needs to be linked in order for the std::filesystem include to work.
+# See the notes section of the documentation below for details.
+# https://en.cppreference.com/w/cpp/filesystem
+# This ultimately will need to be modified to be compiler dependent instead of platform dependent.set(filesystem_lib)
 set(filesystem_lib)
-if (WT_DARWIN)
-    set(filesystem_lib c++fs)
-elseif (WT_LINUX)
+if (WT_LINUX)
     set(filesystem_lib stdc++fs)
 endif()
+# No extra linking is required for compilation on OSX.
 
 # Create an intermediate library to build the helper library.
 add_library(aws_bucket_util STATIC s3_connection.cpp)

--- a/ext/storage_sources/s3_store/CMakeLists.txt
+++ b/ext/storage_sources/s3_store/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project(s3_store CXX)
 
 # Create an intermediate library to build the helper library.
@@ -34,6 +37,7 @@ target_link_libraries(
         aws_bucket_util
         aws-sdk::s3-crt
         aws-sdk::core
+        stdc++fs
 )
 
 # Add the unit tests.

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -717,7 +717,7 @@ S3Flush(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, WT_FILE_SYSTEM *f
 
     int ret;
     FS2S3(fileSystem)->statistics.putObjectCount++;
-    if (ret = (fs->connection->PutObject(object, source)) != 0)
+    if ((ret = (fs->connection->PutObject(object, source))) != 0)
         std::cerr << "S3Flush: PutObject request to S3 failed." << std::endl;
     return (ret);
 }

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -29,6 +29,7 @@
 #include <wiredtiger_ext.h>
 #include <sys/stat.h>
 #include <fstream>
+#include <experimental/filesystem>
 #include <list>
 #include <errno.h>
 #include <unistd.h>
@@ -197,8 +198,7 @@ S3CacheExists(WT_FILE_SYSTEM *fileSystem, const std::string &name)
 static bool
 LocalFileExists(const std::string &path)
 {
-    std::ifstream f(path);
-    return (f.good());
+    return (std::experimental::filesystem::exists(path));
 }
 
 /*

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -210,29 +210,22 @@ S3GetDirectory(const std::string &home, const std::string &name, bool create, st
 {
     copy = "";
 
-    struct stat sb;
-    int ret;
-    std::string dirName;
-
     /* For relative pathnames, the path is considered to be relative to the home directory. */
+    std::string dirName;
     if (name[0] == '/')
         dirName = name;
     else
         dirName = home + "/" + name;
+        
+    std::experimental::filesystem::path directory(dirName);
 
-    ret = stat(dirName.c_str(), &sb);
-    if (ret != 0 && errno == ENOENT && create) {
-        mkdir(dirName.c_str(), 0777);
-        ret = stat(dirName.c_str(), &sb);
+    if (!std::experimental::filesystem::is_directory(directory) && create) {
+        bool createSuccess = std::experimental::filesystem::create_directory(directory);
+        if (!createSuccess)
+            return (EINVAL);
     }
-
-    if (ret != 0)
-        ret = errno;
-    else if ((sb.st_mode & S_IFMT) != S_IFDIR)
-        ret = EINVAL;
-
     copy = dirName;
-    return (ret);
+    return (0);
 }
 
 /*


### PR DESCRIPTION
- Refactored to use std::filesystem instead of POSIX system calls.
- Added some CMake logic in order to get the std::filesystem import working with older compiler versions
- Compiling works on OSX

Note:
- Does not yet build on windows.
- Will need to add more logic to dynamically determine how to #include the filesystem. The file system exists in the experimental namespace in older complier and C++ STDL versions.