### PR TITLE
WT-8849 in-memory RTS incorrectly rolls back "logged" files

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -382,22 +382,39 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
         F_CLR(btree, WT_BTREE_IGNORE_CACHE);
 
     /*
-     * The metadata isn't blocked by in-memory cache limits because metadata "unroll" is performed
-     * by updates that are potentially blocked by the cache-full checks.
+     * Turn on logging when it's enabled in the database and not disabled for the tree. Timestamp
+     * behavior is described by the logging configurations for historical reasons; logged objects
+     * imply commit-level durability and ignored timestamps, not-logged objects imply checkpoint-
+     * level durability and supported timestamps. In-memory configurations default to ignoring all
+     * timestamps, and the application uses the logging configuration flag to turn on timestamps.
      */
-    if (WT_IS_METADATA(btree->dhandle))
-        F_SET(btree, WT_BTREE_IGNORE_CACHE);
-
-    /*
-     * Turn on logging when it's enabled in the database and not disabled for the tree. (Other code
-     * only checks the tree flag, so it's important the tree flag match the overall configuration.)
-     */
-    F_SET(btree, WT_BTREE_NO_LOGGING);
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED)) {
-        WT_ASSERT(session, !F_ISSET(conn, WT_CONN_IN_MEMORY));
         WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
         if (cval.val)
-            F_CLR(btree, WT_BTREE_NO_LOGGING);
+            F_SET(btree, WT_BTREE_LOGGED);
+    }
+    if (F_ISSET(conn, WT_CONN_IN_MEMORY)) {
+        F_SET(btree, WT_BTREE_LOGGED);
+        WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
+        if (!cval.val)
+            F_CLR(btree, WT_BTREE_LOGGED);
+    }
+
+    /*
+     * The metadata isn't blocked by in-memory cache limits because metadata "unroll" is performed
+     * by updates that are potentially blocked by the cache-full checks.
+     *
+     * The metadata file ignores timestamps and is logged if at all possible.
+     */
+    if (WT_IS_METADATA(btree->dhandle)) {
+        F_SET(btree, WT_BTREE_IGNORE_CACHE);
+        F_SET(btree, WT_BTREE_LOGGED);
+    }
+
+    /* The history store file is never logged and supports timestamps. */
+    if (strcmp(session->dhandle->name, WT_HS_URI) == 0) {
+        F_SET(btree->dhandle, WT_DHANDLE_HS);
+        F_CLR(btree, WT_BTREE_LOGGED);
     }
 
     WT_RET(__wt_config_gets(session, cfg, "tiered_object", &cval));
@@ -484,12 +501,6 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
         }
     }
 
-    /* Set special flags for the history store table. */
-    if (strcmp(session->dhandle->name, WT_HS_URI) == 0) {
-        F_SET(btree->dhandle, WT_DHANDLE_HS);
-        F_SET(btree, WT_BTREE_NO_LOGGING);
-    }
-
     /* Configure encryption. */
     WT_RET(__wt_btree_config_encryptor(session, cfg, &btree->kencryptor));
 
@@ -544,8 +555,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
      * connection last checkpoint base write generation number is when rollback to stable doesn't
      * happen during the recovery due to the unavailability of history store file.
      */
-    if (!F_ISSET(conn, WT_CONN_RECOVERING) || WT_IS_METADATA(btree->dhandle) ||
-      !F_ISSET(btree, WT_BTREE_NO_LOGGING) || ckpt->run_write_gen < conn->last_ckpt_base_write_gen)
+    if (!F_ISSET(conn, WT_CONN_RECOVERING) || F_ISSET(btree, WT_BTREE_LOGGED) ||
+      ckpt->run_write_gen < conn->last_ckpt_base_write_gen)
         btree->base_write_gen = btree->run_write_gen;
     else
         btree->base_write_gen = ckpt->run_write_gen;

--- a/src/docs/timestamp-misc.dox
+++ b/src/docs/timestamp-misc.dox
@@ -57,6 +57,12 @@ WT_SESSION::reset_snapshot, but it will have no effect.
 
 @section timestamps_misc_in_memory In-memory configurations and timestamps
 
-Timestamps are supported for in-memory databases.
+Timestamps are supported for in-memory databases, but must be configured as in
+ordinary databases, and the same APIs are used in both cases for historical
+reasons. By default, in-memory database objects behave like commit-level
+objects in ordinary databases, that is, timestamps are ignored. If logging
+is disabled for the object, using the \c log=(enabled=false) configuration,
+then the timestamps will not be ignored and will behave as with objects in
+ordinary databases where logging has been disabled.
 
 */

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -108,18 +108,6 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
         conn->cache->hs_fileid = btree->id;
 
     /*
-     * Set special flags for the history store table: the history store flag (used, for example, to
-     * avoid writing records during reconciliation), also turn off checkpoints and logging.
-     *
-     * Test flags before setting them so updates can't race in subsequent opens (the first update is
-     * safe because it's single-threaded from wiredtiger_open).
-     */
-    if (!F_ISSET(btree->dhandle, WT_DHANDLE_HS))
-        F_SET(btree->dhandle, WT_DHANDLE_HS);
-    if (!F_ISSET(btree, WT_BTREE_NO_LOGGING))
-        F_SET(btree, WT_BTREE_NO_LOGGING);
-
-    /*
      * We need to set file_max on the btree associated with one of the history store sessions.
      */
     btree->file_max = (uint64_t)cval.val;

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -256,8 +256,8 @@ struct __wt_btree {
 #define WT_BTREE_CLOSED 0x0004000u         /* Handle closed */
 #define WT_BTREE_IGNORE_CACHE 0x0008000u   /* Cache-resident object */
 #define WT_BTREE_IN_MEMORY 0x0010000u      /* Cache-resident object */
-#define WT_BTREE_NO_CHECKPOINT 0x0020000u  /* Disable checkpoints */
-#define WT_BTREE_NO_LOGGING 0x0040000u     /* Disable logging */
+#define WT_BTREE_LOGGED 0x0020000u         /* Commit-level durability without timestamps */
+#define WT_BTREE_NO_CHECKPOINT 0x0040000u  /* Disable checkpoints */
 #define WT_BTREE_OBSOLETE_PAGES 0x0080000u /* Handle has obsolete pages */
 #define WT_BTREE_READONLY 0x0100000u       /* Handle is readonly */
 #define WT_BTREE_SALVAGE 0x0200000u        /* Handle is for salvage */

--- a/src/include/log_inline.h
+++ b/src/include/log_inline.h
@@ -40,13 +40,18 @@ __wt_log_op(WT_SESSION_IMPL *session)
      * Objects with checkpoint durability don't need logging unless we're in debug mode. That rules
      * out almost all log records, check it first.
      */
-    if (F_ISSET(S2BT(session), WT_BTREE_NO_LOGGING) &&
+    if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
       !FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE))
         return (false);
 
-    /* Logging must be enabled, and outside of recovery. */
+    /*
+     * Correct the above check for logging being configured. Files are configured for logging to
+     * turn off timestamps, so stop here if there aren't actually any log files.
+     */
     if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
         return (false);
+
+    /* No logging during recovery. */
     if (F_ISSET(conn, WT_CONN_RECOVERING))
         return (false);
 

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -73,18 +73,15 @@ __wt_metadata_cursor_open(WT_SESSION_IMPL *session, const char *config, WT_CURSO
      */
     btree = CUR2BT(*cursorp);
 
-/*
- * Special settings for metadata: skew eviction so metadata almost always stays in cache and make
- * sure metadata is logged if possible.
- *
- * Test before setting so updates can't race in subsequent opens (the first update is safe because
- * it's single-threaded from wiredtiger_open).
- */
 #define WT_EVICT_META_SKEW 10000
+    /*
+     * Skew eviction so metadata almost always stays in cache.
+     *
+     * Test before setting so updates can't race in subsequent opens (the first update is safe
+     * because it's single-threaded from wiredtiger_open).
+     */
     if (btree->evict_priority == 0)
         WT_WITH_BTREE(session, btree, __wt_evict_priority_set(session, WT_EVICT_META_SKEW));
-    if (F_ISSET(btree, WT_BTREE_NO_LOGGING))
-        F_CLR(btree, WT_BTREE_NO_LOGGING);
 
     return (0);
 }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -856,7 +856,7 @@ __txn_timestamp_usage_check(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_UPDATE *
         return;
 
     /* Timestamps are ignored on logged files. */
-    if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_NO_LOGGING))
+    if (F_ISSET(btree, WT_BTREE_LOGGED))
         return;
 
     /*
@@ -1802,8 +1802,11 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
          * Logged table updates should never be prepared. As these updates are immediately durable,
          * it is not possible to roll them back if the prepared transaction is rolled back.
          */
-        if (!F_ISSET(op->btree, WT_BTREE_NO_LOGGING))
-            WT_RET_MSG(session, EINVAL, "transaction prepare is not supported with logged tables");
+        if (F_ISSET(op->btree, WT_BTREE_LOGGED))
+            WT_RET_MSG(session, ENOTSUP,
+              "%s: transaction prepare is not supported on logged tables or tables without "
+              "timestamps",
+              op->btree->dhandle->name);
         switch (op->type) {
         case WT_TXN_OP_NONE:
             break;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1985,7 +1985,7 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
     with_timestamp = F_ISSET(txn, WT_TXN_SHARED_TS_READ);
 
     /* Logged tables ignore any read timestamp configured for the checkpoint. */
-    if (!F_ISSET(btree, WT_BTREE_NO_LOGGING))
+    if (F_ISSET(btree, WT_BTREE_LOGGED))
         F_CLR(txn, WT_TXN_SHARED_TS_READ);
 
     ret = __checkpoint_tree(session, true, cfg);
@@ -2102,7 +2102,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * is a stable timestamp set or the connection is configured to disallow such operation.
      * Flushing trees can lead to files that are inconsistent on disk after a crash.
      */
-    if (btree->modified && !bulk && F_ISSET(btree, WT_BTREE_NO_LOGGING) &&
+    if (btree->modified && !bulk && !F_ISSET(btree, WT_BTREE_LOGGED) &&
       (S2C(session)->txn_global.has_stable_timestamp ||
         (!F_ISSET(S2C(session), WT_CONN_FILE_CLOSE_SYNC) && !metadata)))
         return (__wt_set_return(session, EBUSY));

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -267,7 +267,7 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
      * If this operation is diagnostic only, set the ignore bit on the fileid so that recovery can
      * skip it.
      */
-    if (F_ISSET(S2BT(session), WT_BTREE_NO_LOGGING) &&
+    if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
       FLD_ISSET(conn->log_flags, WT_CONN_LOG_DEBUG_MODE))
         FLD_SET(fileid, WT_LOGOP_IGNORE);
 

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1322,13 +1322,10 @@ __rollback_to_stable_btree(WT_SESSION_IMPL *session, wt_timestamp_t rollback_tim
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       "rollback to stable connection logging enabled: %s and btree logging enabled: %s",
       FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ? "true" : "false",
-      !F_ISSET(btree, WT_BTREE_NO_LOGGING) ? "true" : "false");
+      F_ISSET(btree, WT_BTREE_LOGGED) ? "true" : "false");
 
-    /*
-     * Files with commit-level durability don't get their commits wiped. Check in-memory first,
-     * in-memory files won't have logging turned on.
-     */
-    if (!F_ISSET(conn, WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_NO_LOGGING))
+    /* Files with commit-level durability (and without timestamps),don't get their commits wiped. */
+    if (F_ISSET(btree, WT_BTREE_LOGGED))
         return (0);
 
     /* There is never anything to do for checkpoint handles. */

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1324,7 +1324,7 @@ __rollback_to_stable_btree(WT_SESSION_IMPL *session, wt_timestamp_t rollback_tim
       FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED) ? "true" : "false",
       F_ISSET(btree, WT_BTREE_LOGGED) ? "true" : "false");
 
-    /* Files with commit-level durability (and without timestamps),don't get their commits wiped. */
+    /* Files with commit-level durability (without timestamps), don't get their commits wiped. */
     if (F_ISSET(btree, WT_BTREE_LOGGED))
         return (0);
 

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -373,6 +373,10 @@ create_object(TABLE *table, void *arg)
       p, ",internal_key_truncate=%s", TV(BTREE_INTERNAL_KEY_TRUNCATION) ? "true" : "false");
     CONFIG_APPEND(p, ",split_pct=%" PRIu32, TV(BTREE_SPLIT_PCT));
 
+    /* Timestamps */
+    if (g.transaction_timestamps_config)
+        CONFIG_APPEND(p, ",log=(enabled=false)");
+
     /* Assertions: assertions slow down the code for additional diagnostic checking.  */
     if (GV(ASSERT_READ_TIMESTAMP))
         CONFIG_APPEND(

--- a/test/suite/test_flcs02.py
+++ b/test/suite/test_flcs02.py
@@ -40,8 +40,6 @@ from wtscenario import make_scenarios
 # in-memory update records. (Testing on an in-memory database does not have that
 # effect.)
 class test_flcs01(wttest.WiredTigerTestCase):
-    conn_config = 'in_memory=false'
-
     prepare_values = [
         ('no_prepare', dict(do_prepare=False)),
         ('prepare', dict(do_prepare=True))

--- a/test/suite/test_flcs03.py
+++ b/test/suite/test_flcs03.py
@@ -118,8 +118,8 @@ class test_flcs03(wttest.WiredTigerTestCase):
     def test_flcs(self):
         uri = "table:test_flcs03"
         nrows = 10
-        ds = SimpleDataSet(
-            self, uri, 0, key_format='r', value_format='6t', config='leaf_page_max=4096')
+        ds = SimpleDataSet(self, uri,
+            0, key_format='r', value_format='6t', config='leaf_page_max=4096,log=(enabled=false)')
         ds.populate()
 
         # Pin oldest and stable to timestamp 1.

--- a/test/suite/test_prepare14.py
+++ b/test/suite/test_prepare14.py
@@ -32,9 +32,8 @@ from wtdataset import simple_key
 from wtscenario import make_scenarios
 
 # test_prepare14.py
-# Test that the transaction visibility of an on-disk update
-# that has both the start and the stop time points from the
-# same uncommitted prepared transaction.
+# Test that the transaction visibility of an on-disk update that has both the start and the stop
+# time points from the same uncommitted prepared transaction.
 class test_prepare14(wttest.WiredTigerTestCase):
 
     in_memory_values = [
@@ -59,10 +58,12 @@ class test_prepare14(wttest.WiredTigerTestCase):
         return config
 
     def test_prepare14(self):
-        # Create a table without logging.
+        # Create a table that supports timestamps.
         uri = "table:prepare14"
         create_config = 'allocation_size=512,key_format={},value_format={}'.format(
             self.key_format, self.value_format)
+        if self.in_memory:
+            create_config += ',log=(enabled=false)'
         self.session.create(uri, create_config)
 
         if self.value_format == '8t':
@@ -85,7 +86,8 @@ class test_prepare14(wttest.WiredTigerTestCase):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.

--- a/test/suite/test_prepare15.py
+++ b/test/suite/test_prepare15.py
@@ -31,9 +31,9 @@ from wiredtiger import WT_NOTFOUND
 from wtscenario import make_scenarios
 
 # test_prepare15.py
-# Test that the prepare transaction rollback removes the on-disk key
-# or replace it with history store and commit retains the changes when
-# both insert and remove operations are from the same prepared transaction.
+# Test that the prepare transaction rollback removes the on-disk key or replace it with history
+# store and commit retains the changes when both insert and remove operations are from the same
+# prepared transaction.
 class test_prepare15(wttest.WiredTigerTestCase):
     in_memory_values = [
         ('no_inmem', dict(in_memory=False)),
@@ -63,6 +63,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         # Create a table.
         uri = "table:prepare15"
         create_config = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        if self.in_memory:
+            create_config += ',log=(enabled=false)'
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
@@ -98,7 +100,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -121,7 +124,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         else:
             s.rollback_transaction()
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -148,6 +152,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         # Create a table.
         uri = "table:prepare15"
         create_config = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        if self.in_memory:
+            create_config += ',log=(enabled=false)'
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
@@ -180,7 +186,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -218,7 +225,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.close()
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(80))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -251,6 +259,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         # Create a table.
         uri = "table:prepare15"
         create_config = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        if self.in_memory:
+            create_config += ',log=(enabled=false)'
         self.session.create(uri, create_config)
 
         # Pin oldest and stable timestamps to 10.
@@ -272,7 +282,8 @@ class test_prepare15(wttest.WiredTigerTestCase):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.

--- a/test/suite/test_prepare16.py
+++ b/test/suite/test_prepare16.py
@@ -31,8 +31,8 @@ from wiredtiger import WT_NOTFOUND
 from wtscenario import make_scenarios
 
 # test_prepare16.py
-# Test that the prepare transaction rollback/commit multiple keys
-# and each key can occupy a leaf page.
+# Test that the prepare transaction rollback/commit multiple keys and each key can occupy a leaf
+# page.
 class test_prepare16(wttest.WiredTigerTestCase):
     in_memory_values = [
         ('no_inmem', dict(in_memory=False)),
@@ -68,10 +68,12 @@ class test_prepare16(wttest.WiredTigerTestCase):
     def test_prepare(self):
         nrows = 1000
 
-        # Create a table without logging.
+        # Create a table that supports timestamps.
         uri = "table:prepare16"
         format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
         create_config = 'allocation_size=512,leaf_page_max=512,leaf_value_max=64MB,' + format
+        if self.in_memory:
+            create_config += ',log=(enabled=false)'
         self.session.create(uri, create_config)
 
         if self.value_format == '8t':
@@ -94,7 +96,8 @@ class test_prepare16(wttest.WiredTigerTestCase):
 
         s = self.conn.open_session()
         s.begin_transaction('ignore_prepare = true')
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
 
         for i in range(1, nrows + 1):

--- a/test/suite/test_prepare19.py
+++ b/test/suite/test_prepare19.py
@@ -35,14 +35,12 @@ import wiredtiger
 # update results in an empty update chain then a tombstone is appended to the chain
 class test_prepare19(wttest.WiredTigerTestCase):
 
-
     def conn_config(self):
         return 'in_memory=true'
-    
 
     def test_server_example(self):
         uri = 'table:test_prepare19'
-        config = 'key_format=i,value_format=S'
+        config = 'key_format=i,value_format=S,log=(enabled=false)'
 
         self.session.create(uri, config)
 
@@ -56,7 +54,8 @@ class test_prepare19(wttest.WiredTigerTestCase):
         # Make a prepared update on key 1, force eviction, and rollback.
         self.prepare_evict_rollback(uri, config, 1101)
 
-        # If no tombstone is written the update will be aborted in the update chain but not in the btree.
+        # If no tombstone is written the update will be aborted in the update chain but not in the
+        # btree.
         # The transaction will see an active transaction on key 1 and raise a write conflict.
         # Expect no error is raised.
         self.session.begin_transaction()

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -213,7 +213,9 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable01"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = 'log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -75,8 +75,10 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable02"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format,
-            config=self.extraconfig)
+        ds_config = self.extraconfig
+        ds_config += ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -65,7 +65,9 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable03"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -68,7 +68,9 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable04"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -65,7 +65,9 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable06"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -65,7 +65,9 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable08"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable15.py
+++ b/test/suite/test_rollback_to_stable15.py
@@ -78,6 +78,7 @@ class test_rollback_to_stable15(wttest.WiredTigerTestCase):
 
         # Create a table.
         create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        create_params += ',log=(enabled=false)' if self.in_memory else ''
         self.session.create(uri, create_params)
         cursor = self.session.open_cursor(uri)
 

--- a/test/suite/test_rollback_to_stable16.py
+++ b/test/suite/test_rollback_to_stable16.py
@@ -127,6 +127,7 @@ class test_rollback_to_stable16(wttest.WiredTigerTestCase):
 
         # Create a table.
         create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        create_params += ',log=(enabled=false)' if self.in_memory else ''
         self.session.create(uri, create_params)
 
         # Pin oldest and stable to timestamp 1.

--- a/test/suite/test_rollback_to_stable17.py
+++ b/test/suite/test_rollback_to_stable17.py
@@ -89,6 +89,7 @@ class test_rollback_to_stable17(wttest.WiredTigerTestCase):
 
         # Create a table.
         config = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        config += ',log=(enabled=false)' if self.in_memory else ''
         self.session.create(uri, config)
 
         # Pin oldest and stable to timestamp 1.

--- a/test/suite/test_rollback_to_stable18.py
+++ b/test/suite/test_rollback_to_stable18.py
@@ -63,7 +63,9 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable18"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)'
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':

--- a/test/suite/test_rollback_to_stable19.py
+++ b/test/suite/test_rollback_to_stable19.py
@@ -66,7 +66,9 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable19"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':
@@ -89,7 +91,8 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -156,7 +159,9 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable19"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format=self.value_format, config=ds_config)
         ds.populate()
 
         if self.value_format == '8t':
@@ -187,7 +192,8 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         cursor.close()
         s.prepare_transaction('prepare_timestamp=' + self.timestamp_str(40))
 
-        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API
+        # is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
 
         # Search for the key so we position our cursor on the page that we want to evict.
@@ -238,9 +244,9 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
         upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
         hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
 
-        # After restart (not crash) the stats for the aborted updates and history store removed will be 0,
-        # as the updates aborted and history store removed will occur during shutdown, and on startup there
-        # will be no updates to be removed.
+        # After restart (not crash) the stats for the aborted updates and history store removed
+        # will be 0, as the updates aborted and history store removed will occur during shutdown,
+        # and on startup there will be no updates to be removed.
         if self.in_memory or not self.crash:
             self.assertEqual(hs_removed, 0)
             self.assertEqual(upd_aborted, 0)

--- a/test/suite/test_rollback_to_stable27.py
+++ b/test/suite/test_rollback_to_stable27.py
@@ -69,7 +69,9 @@ class test_rollback_to_stable27(test_rollback_to_stable_base):
 
         # Create a table.
         uri = "table:rollback_to_stable27"
-        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format="S")
+        ds_config = ',log=(enabled=false)' if self.in_memory else ''
+        ds = SimpleDataSet(self, uri, 0,
+            key_format=self.key_format, value_format="S", config=ds_config)
         ds.populate()
 
         value_a = "aaaaa" * 10


### PR DESCRIPTION
@kommiharibabu, @agorrod: This is the fix to revert the change in WT-8601 that changed in-memory databases so that timestamps applied to all objects created in an in-memory database, which broke the MDB build.

Here's the patch build: https://spruce.mongodb.com/version/6211a7bc3627e010721bec31/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.

It looks clean to me but someone should please double-check that conclusion.

@lukech, this ticket is for [BF-24333](https://jira.mongodb.org/browse/BF-24333), so if we can get it into the merge soon, that would be terrific.