### PR TITLE
WT-8708 Fix timestamp usage error in test/checkpoint

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -44,10 +44,10 @@ set_stable(void)
     char buf[128];
 
     if (g.race_timetamps)
-        testutil_check(__wt_snprintf(
-          buf, sizeof(buf), "stable_timestamp=%x,oldest_timestamp=%x", g.ts_stable, g.ts_stable));
+        testutil_check(__wt_snprintf(buf, sizeof(buf),
+          "stable_timestamp=%" PRIx64 ",oldest_timestamp=%" PRIx64, g.ts_stable, g.ts_stable));
     else
-        testutil_check(__wt_snprintf(buf, sizeof(buf), "stable_timestamp=%x", g.ts_stable));
+        testutil_check(__wt_snprintf(buf, sizeof(buf), "stable_timestamp=%" PRIx64, g.ts_stable));
     testutil_check(g.conn->set_timestamp(g.conn, buf));
 }
 
@@ -225,7 +225,7 @@ real_checkpointer(void)
         /* Advance the oldest timestamp to the most recently set stable timestamp. */
         if (g.use_timestamps && g.ts_oldest != 0) {
             testutil_check(__wt_snprintf(
-              timestamp_buf, sizeof(timestamp_buf), "oldest_timestamp=%x", g.ts_oldest));
+              timestamp_buf, sizeof(timestamp_buf), "oldest_timestamp=%" PRIx64, g.ts_oldest));
             testutil_check(g.conn->set_timestamp(g.conn, timestamp_buf));
         }
         /* Random value between 4 and 8 seconds. */

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -202,7 +202,9 @@ real_checkpointer(void)
                 verify_ts = stable_ts;
             else
                 verify_ts = __wt_random(&rnd) % (stable_ts - oldest_ts + 1) + oldest_ts;
-            WT_ORDERED_READ(g.ts_oldest, g.ts_stable);
+            __wt_writelock((WT_SESSION_IMPL *)session, &g.clock_lock);
+            g.ts_oldest = g.ts_stable;
+            __wt_writeunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
         }
 
         /* Execute a checkpoint */

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -74,8 +74,8 @@ typedef struct {
     bool hs_checkpoint_timing_stress;     /* History store checkpoint timing stress */
     bool reserved_txnid_timing_stress;    /* Reserved transaction id timing stress */
     bool checkpoint_slow_timing_stress;   /* Checkpoint slow timing stress */
-    u_int ts_oldest;                      /* Current oldest timestamp */
-    u_int ts_stable;                      /* Current stable timestamp */
+    uint64_t ts_oldest;                   /* Current oldest timestamp */
+    uint64_t ts_stable;                   /* Current stable timestamp */
     bool mixed_mode_deletes;              /* Run with mixed mode deletes */
     bool use_timestamps;                  /* Use txn timestamps */
     bool race_timetamps;                  /* Async update to oldest timestamp */

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -424,18 +424,18 @@ real_worker(void)
                         next_rnd = __wt_random(&rnd);
                         if (g.prepare && next_rnd % 2 == 0) {
                             testutil_check(__wt_snprintf(
-                              buf, sizeof(buf), "prepare_timestamp=%x", g.ts_stable + 1));
+                              buf, sizeof(buf), "prepare_timestamp=%" PRIx64, g.ts_stable + 1));
                             if ((ret = session->prepare_transaction(session, buf)) != 0) {
                                 __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);
                                 (void)log_print_err("real_worker:prepare_transaction", ret, 1);
                                 goto err;
                             }
                             testutil_check(__wt_snprintf(buf, sizeof(buf),
-                              "durable_timestamp=%x,commit_timestamp=%x", g.ts_stable + 3,
-                              g.ts_stable + 1));
+                              "durable_timestamp=%" PRIx64 ",commit_timestamp=%" PRIx64,
+                              g.ts_stable + 3, g.ts_stable + 1));
                         } else
                             testutil_check(__wt_snprintf(
-                              buf, sizeof(buf), "commit_timestamp=%x", g.ts_stable + 1));
+                              buf, sizeof(buf), "commit_timestamp=%" PRIx64, g.ts_stable + 1));
 
                         // Commit majority of times
                         if (next_rnd % 49 != 0) {


### PR DESCRIPTION
There's a race in test/checkpoint, we update `g.ts_stable` and then set the stable timestamp, while holding `g.clock_lock`, but read `g.ts_stable` without holding a lock, and if we read it between the update and the set, we can try and set the oldest timestamp after the stable timestamp.

The obvious change is to acquire the lock before reading `g.ts_stable`, and that's what I did. I don't think this will adversely affect how `test/checkpoint` works, but I'm not really familiar with it. The change was part of "WT-5605 Updating test checkpoint to no longer use checkpoint cursors and improve usage of timestamps": @luke-pearson authored that test, but he's not around at the moment, @sueloverso, it looks like you were involved at the time.