### PR TITLE
WT-8560 Clear the obsolete on-disk cell start time window if it exists

### DIFF
--- a/src/include/reconcile_inline.h
+++ b/src/include/reconcile_inline.h
@@ -490,8 +490,8 @@ __wt_rec_time_window_clear_obsolete(
       session, (upd_select != NULL && vpack == NULL) || (upd_select == NULL && vpack != NULL));
     tw = upd_select != NULL ? &upd_select->tw : &vpack->tw;
 
-    /* Return if the time window is empty. */
-    if (WT_TIME_WINDOW_IS_EMPTY(tw))
+    /* Return if the start time window is empty. */
+    if (!WT_TIME_WINDOW_HAS_START(tw))
         return;
 
     /*

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -27,6 +27,10 @@
       (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE && \
       (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0)
 
+/* Check if the start time window is set. */
+#define WT_TIME_WINDOW_HAS_START(tw) \
+    ((tw)->start_txn != WT_TXN_NONE || (tw)->start_ts != WT_TS_NONE)
+
 /* Check if the stop time window is set. */
 #define WT_TIME_WINDOW_HAS_STOP(tw) ((tw)->stop_txn != WT_TXN_MAX || (tw)->stop_ts != WT_TS_MAX)
 


### PR DESCRIPTION
Earlier logic clears the on-disk cell start time window even if
it is empty if that cell contains a stop time window which is
unnecessary extra work for no benefit. Clear the on-disk cell
start time window only if it exists.