### PR TITLE
WT-8777 Fix compatibility test issue about invalid key_consistent argument

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -50,10 +50,10 @@ common_runtime_config = [
         type='category', subconfig= [
         Config('commit_timestamp', 'none', r'''
             this option is no longer supported, retained for backward compatibility''',
-            choices=['always', 'never', 'none'], undoc=True),
+            choices=['always', 'key_consistent', 'never', 'none'], undoc=True),
         Config('durable_timestamp', 'none', r'''
             this option is no longer supported, retained for backward compatibility''',
-            choices=['always', 'never', 'none'], undoc=True),
+            choices=['always', 'key_consistent', 'never', 'none'], undoc=True),
         Config('read_timestamp', 'none', r'''
             check timestamps are \c always or \c never used on reads with
             this table, writing an error message if policy is violated.
@@ -83,8 +83,10 @@ common_runtime_config = [
         are allowed at any time, \c never enforces that timestamps are never
         used for a table and \c none does not enforce any expectation on
         timestamp usage meaning that no log message or assertions will be
-        produced regardless of the corresponding \c assert setting''',
-        choices=['always', 'mixed_mode', 'never', 'none', 'ordered']),
+        produced regardless of the corresponding \c assert setting. (The
+        \c key_consistent choice is no longer supported, retained for
+        backward compatibility.)''',
+        choices=['always', 'key_consistent', 'mixed_mode', 'never', 'none', 'ordered']),
 ]
 
 # Metadata shared by all schema objects

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -191,8 +191,14 @@ static const WT_CONFIG_CHECK confchk_WT_CURSOR_reconfigure[] = {
   {"prefix_search", "boolean", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_create_assert_subconfigs[] = {
-  {"commit_timestamp", "string", NULL, "choices=[\"always\",\"never\",\"none\"]", NULL, 0},
-  {"durable_timestamp", "string", NULL, "choices=[\"always\",\"never\",\"none\"]", NULL, 0},
+  {"commit_timestamp", "string", NULL,
+    "choices=[\"always\",\"key_consistent\",\"never\","
+    "\"none\"]",
+    NULL, 0},
+  {"durable_timestamp", "string", NULL,
+    "choices=[\"always\",\"key_consistent\",\"never\","
+    "\"none\"]",
+    NULL, 0},
   {"read_timestamp", "string", NULL, "choices=[\"always\",\"never\",\"none\"]", NULL, 0},
   {"write_timestamp", "string", NULL, "choices=[\"off\",\"on\"]", NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
@@ -212,8 +218,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_alter[] = {
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -336,8 +342,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -444,8 +450,8 @@ static const WT_CONFIG_CHECK confchk_colgroup_meta[] = {
   {"source", "string", NULL, NULL, NULL, 0}, {"type", "string", NULL, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -493,8 +499,8 @@ static const WT_CONFIG_CHECK confchk_file_config[] = {
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -546,8 +552,8 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -562,8 +568,8 @@ static const WT_CONFIG_CHECK confchk_index_meta[] = {
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -613,8 +619,8 @@ static const WT_CONFIG_CHECK confchk_lsm_meta[] = {
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -667,8 +673,8 @@ static const WT_CONFIG_CHECK confchk_object_meta[] = {
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -681,8 +687,8 @@ static const WT_CONFIG_CHECK confchk_table_meta[] = {
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -736,8 +742,8 @@ static const WT_CONFIG_CHECK confchk_tier_meta[] = {
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -791,8 +797,8 @@ static const WT_CONFIG_CHECK confchk_tiered_meta[] = {
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
   {"write_timestamp_usage", "string", NULL,
-    "choices=[\"always\",\"mixed_mode\",\"never\",\"none\","
-    "\"ordered\"]",
+    "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
+    "\"never\",\"none\",\"ordered\"]",
     NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1083,8 +1083,10 @@ struct __wt_session {
 	 * except that updates with no timestamp are allowed at any time\, \c never enforces that
 	 * timestamps are never used for a table and \c none does not enforce any expectation on
 	 * timestamp usage meaning that no log message or assertions will be produced regardless of
-	 * the corresponding \c assert setting., a string\, chosen from the following options: \c
-	 * "always"\, \c "mixed_mode"\, \c "never"\, \c "none"\, \c "ordered"; default \c none.}
+	 * the corresponding \c assert setting.  (The \c key_consistent choice is no longer
+	 * supported\, retained for backward compatibility.)., a string\, chosen from the following
+	 * options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\, \c "never"\, \c "none"\,
+	 * \c "ordered"; default \c none.}
 	 * @configend
 	 * @errors
 	 */
@@ -1365,8 +1367,10 @@ struct __wt_session {
 	 * except that updates with no timestamp are allowed at any time\, \c never enforces that
 	 * timestamps are never used for a table and \c none does not enforce any expectation on
 	 * timestamp usage meaning that no log message or assertions will be produced regardless of
-	 * the corresponding \c assert setting., a string\, chosen from the following options: \c
-	 * "always"\, \c "mixed_mode"\, \c "never"\, \c "none"\, \c "ordered"; default \c none.}
+	 * the corresponding \c assert setting.  (The \c key_consistent choice is no longer
+	 * supported\, retained for backward compatibility.)., a string\, chosen from the following
+	 * options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\, \c "never"\, \c "none"\,
+	 * \c "ordered"; default \c none.}
 	 * @configend
 	 * @errors
 	 */


### PR DESCRIPTION
Put key_consistent back into the write_timestamp_usage choice table for backward compatibility.