### PR TITLE
WT-8422 Clear the on-disk cell time window if it is obsolete (#7214) …

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2315,8 +2315,8 @@ static inline void __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCI
 static inline void __wt_rec_image_copy(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv);
 static inline void __wt_rec_incr(
   WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, size_t size);
-static inline void __wt_rec_time_window_clear_obsolete(
-  WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, WT_RECONCILE *r);
+static inline void __wt_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session,
+  WT_UPDATE_SELECT *upd_select, WT_CELL_UNPACK_KV *vpack, WT_RECONCILE *r);
 static inline void __wt_ref_key(WT_PAGE *page, WT_REF *ref, void *keyp, size_t *sizep);
 static inline void __wt_ref_key_clear(WT_REF *ref);
 static inline void __wt_ref_key_onpage_set(WT_PAGE *page, WT_REF *ref, WT_CELL_UNPACK_ADDR *unpack);

--- a/src/include/reconcile_inline.h
+++ b/src/include/reconcile_inline.h
@@ -447,8 +447,19 @@ __wt_rec_dict_replace(
  *     Where possible modify time window values to avoid writing obsolete values to the cell later.
  */
 static inline void
-__wt_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, WT_RECONCILE *r)
+__wt_rec_time_window_clear_obsolete(
+  WT_SESSION_IMPL *session, WT_UPDATE_SELECT *upd_select, WT_CELL_UNPACK_KV *vpack, WT_RECONCILE *r)
 {
+    WT_TIME_WINDOW *tw;
+
+    WT_ASSERT(
+      session, (upd_select != NULL && vpack == NULL) || (upd_select == NULL && vpack != NULL));
+    tw = upd_select != NULL ? &upd_select->tw : &vpack->tw;
+
+    /* Return if the time window is empty. */
+    if (WT_TIME_WINDOW_IS_EMPTY(tw))
+        return;
+
     /*
      * In memory database don't need to avoid writing values to the cell. If we remove this check we
      * create an extra update on the end of the chain later in reconciliation as we'll re-append the
@@ -465,6 +476,10 @@ __wt_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw
 
             tw->start_ts = tw->durable_start_ts = WT_TS_NONE;
             tw->start_txn = WT_TXN_NONE;
+
+            /* Mark the cell with time window cleared flag to let the cell to be rebuild again. */
+            if (vpack)
+                F_SET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED);
         }
     }
 }

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -751,6 +751,9 @@ record_loop:
                 }
                 twp = &vpack->tw;
 
+                /* Clear the on-disk cell time window if it is obsolete. */
+                __wt_rec_time_window_clear_obsolete(session, NULL, vpack, r);
+
                 /*
                  * If we are handling overflow items, use the overflow item itself exactly once,
                  * after which we have to copy it into a buffer and from then on use a complete copy

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -822,6 +822,9 @@ __wt_rec_row_leaf(
 
         /* Build value cell. */
         if (upd == NULL) {
+            /* Clear the on-disk cell time window if it is obsolete. */
+            __wt_rec_time_window_clear_obsolete(session, NULL, vpack, r);
+
             /*
              * When the page was read into memory, there may not have been a value item.
              *

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -778,7 +778,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
       !vpack->tw.prepare && (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
         WT_ERR(__rec_append_orig_value(session, page, upd_select->upd, vpack));
 
-    __wt_rec_time_window_clear_obsolete(session, &upd_select->tw, r);
+    __wt_rec_time_window_clear_obsolete(session, upd_select, NULL, r);
 err:
     __wt_scr_free(session, &tmp);
     return (ret);

--- a/test/suite/test_checkpoint09.py
+++ b/test/suite/test_checkpoint09.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_checkpoint09.py
+# Test that reconcile clears the time window of on-disk cell if it is obsolete.
+
+import wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+class test_checkpoint09(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB,log=(enabled),statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='u')),
+        ('string_row', dict(key_format='S', value_format='u')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def large_updates(self, uri, value, ds, nrows, skip_count, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            if (i % skip_count) == 0:
+                session.begin_transaction()
+                cursor[ds.key(i)] = value
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, nrows):
+        session = self.session
+        session.begin_transaction()
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, check_value)
+            count += 1
+        session.commit_transaction()
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def evict_cursor(self, uri, ds, nrows):
+        s = self.conn.open_session()
+        s.begin_transaction()
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(ds.key(i))
+            self.assertEquals(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        s.rollback_transaction()
+        evict_cursor.close()
+
+    def test_checkpoint09(self):
+        uri = 'table:ckpt09'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(self, uri, nrows, key_format=self.key_format, value_format=self.value_format)
+        ds.populate()
+
+        # Pin oldest and stable timestamp to 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        if self.value_format == '8t':
+            value1 = 86
+            value2 = 87
+            value3 = 88
+        else:
+            value1 = b"aaaaa" * 100
+            value2 = b"bbbbb" * 100
+            value3 = b"ccccc" * 100
+
+        self.large_updates(uri, value1, ds, nrows, 1, 10)
+        self.check(value1, uri, nrows)
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        val = self.get_stat(stat.conn.rec_time_window_start_ts)
+        self.assertEqual(val, nrows)
+
+        self.evict_cursor(uri, ds, nrows)
+        self.large_updates(uri, value2, ds, nrows, 10, 20)
+
+        # Pin oldest timestamp to 10 and stable timestamp to 20.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(20))
+        self.session.checkpoint(None)
+
+        val = self.get_stat(stat.conn.rec_time_window_start_ts)
+        self.assertEqual(val, nrows + nrows/10)
+
+        self.evict_cursor(uri, ds, nrows)
+        self.large_updates(uri, value3, ds, nrows, 100, 30)
+
+        # Pin oldest timestamp to 20 and stable timestamp to 30.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
+            ',stable_timestamp=' + self.timestamp_str(30))
+        self.session.checkpoint()
+
+        val = self.get_stat(stat.conn.rec_time_window_start_ts)
+        self.assertEqual(val, nrows + nrows/10 + nrows/100)
+
+        self.session.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
…(#7476)

Whenever we are rewriting an existing page image with the latest update of keys
on reconciliation, clear out any of the existing time windows from other keys
on the page, if they are obsolete.

Clearing the time window will decrease the size required to store the
same cell and also improves the performance.

(cherry picked from commit b757e1c61d3b2d54300d7b3be5b68f7316140fed)

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
(cherry picked from commit 727e30305bf64c36ec24d028ab57f2f436b1e07d)