### PR TITLE
WT-8874 Disable compatibility tests on mongodb-5.0 (v4.4 backport) (#7593)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3488,15 +3488,21 @@ buildvariants:
     - name: cyclomatic-complexity
 
 - name: compatibility-tests-less-frequent
+  # Compatibility tests are NOT expected to be triggered on Evergreen projects
+  # other than "WiredTiger (develop)".
+  activate: false
   display_name: Compatibility tests (less frequent)
   batchtime: 10080 # 7 days
   run_on:
-  - ubuntu1804-test
+    - ubuntu1804-test
   tasks:
     - name: compatibility-test-for-older-releases
     - name: compatibility-test-for-wt-standalone-releases
 
 - name: compatibility-tests
+  # Compatibility tests are NOT expected to be triggered on Evergreen projects
+  # other than "WiredTiger (develop)".
+  activate: false
   display_name: Compatibility tests
   run_on:
   - ubuntu2004-test


### PR DESCRIPTION
(cherry picked from commit 72c1b33f3b54d4c07091f8ede1513f0d66b49f08)