### PR TITLE
WT-8747 Reading between commit_timestamp and durable_timestamp can produce inconsistency

### DIFF
--- a/src/docs/arch-timestamp.dox
+++ b/src/docs/arch-timestamp.dox
@@ -289,6 +289,17 @@ Reads between the prepare timestamp and commit timestamp of a
 transaction that has been prepared but not committed fail with
 ::WT_PREPARE_CONFLICT.
 
+Reads between the commit timestamp and durable timestamp of a
+transaction that has been committed but is not yet stable (that is,
+the stable timestamp is at or past the commit timestamp but has not
+yet advanced to the durable timestamp) are potentially unsafe.
+If a second transaction performs such a read and then commits with an
+<i>earlier</i> durable timestamp, and a checkpoint includes the second
+transaction's stable timestamp but not the first, that checkpoint then
+contains inconsistent data.
+Avoiding this inconsistency is, for the time being at least, the
+application's responsibility.
+
 See @ref arch-transaction-prepare for further discussion of prepared
 transactions.
 

--- a/src/docs/timestamp-prepare.dox
+++ b/src/docs/timestamp-prepare.dox
@@ -47,6 +47,25 @@ transactions are higher-level MongoDB operations, requiring cluster-level
 consensus on durability. Applications without similar requirements for prepared
 transactions should set the durable and commit timestamps to the same time.
 
+When a transaction has a durable timestamp later than its commit timestamp,
+reading its writes in a second transaction and then committing other writes such
+that the second transaction becomes durable before the first can produce data
+inconsistency.
+In this scenario the second transaction depends on the first; thus it must be
+rolled back if the first transaction is rolled back; thus it must not become
+durable before the first transaction.
+Applications that create gaps between their commit timestamps and durable
+timestamps are responsible for either not reading in those gaps, or establishing
+an ordering for the durable timestamps of their commits to make sure that
+this scenario cannot occur.
+(Note that for the purposes of this issue the commit timestamp of a non-prepared
+transaction is also its durable timestamp, and committing with no timestamp is
+roughly comparable to committing at the current stable timestamp.)
+
+\warning This scenario is not currently detected by WiredTiger; applications are
+responsible for avoiding it.
+In future versions such transactions might fail.
+
 Prepared transactions have their own configuration keyword for rounding
 timestamps; see @ref timestamp_roundup for more information.
 

--- a/test/suite/test_durable_rollback_to_stable.py
+++ b/test/suite/test_durable_rollback_to_stable.py
@@ -99,7 +99,7 @@ class test_durable_rollback_to_stable(wttest.WiredTigerTestCase, suite_subproces
 
         # Read the first update value with timestamp.
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + self.timestamp_str(200))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(220))
         self.assertEquals(cursor.next(), 0)
         for i in range(1, 50):
             self.assertEquals(cursor.get_value(), ds.value(111))

--- a/test/suite/test_durable_ts01.py
+++ b/test/suite/test_durable_ts01.py
@@ -98,7 +98,7 @@ class test_durable_ts01(wttest.WiredTigerTestCase):
 
         # Read the first update value with timestamp.
         self.assertEquals(cursor.reset(), 0)
-        session.begin_transaction('read_timestamp=' + self.timestamp_str(200))
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(220))
         self.assertEquals(cursor.next(), 0)
         for i in range(1, 50):
             self.assertEquals(cursor.get_value(), ds.value(111))

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
+import wiredtiger
 from wtscenario import make_scenarios
 
 # test_durable_ts03.py
@@ -96,9 +97,16 @@ class test_durable_ts03(wttest.WiredTigerTestCase):
             self.assertEqual(value, valueA)
         session.commit_transaction()
 
-        # Read the updated data to confirm that it is visible.
+        # Check that the updated data can still be read even while it is not yet durable.
         self.assertEquals(cursor.reset(), 0)
         session.begin_transaction('read_timestamp=' + self.timestamp_str(210))
+        for key, value in cursor:
+            self.assertEqual(value, valueB)
+        session.rollback_transaction()
+
+        # Read the updated data to confirm that it is visible.
+        self.assertEquals(cursor.reset(), 0)
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(220))
         for key, value in cursor:
             self.assertEqual(value, valueB)
         session.commit_transaction()

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -27,7 +27,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-import wiredtiger
 from wtscenario import make_scenarios
 
 # test_durable_ts03.py

--- a/test/suite/test_hs06.py
+++ b/test/suite/test_hs06.py
@@ -266,7 +266,13 @@ class test_hs06(wttest.WiredTigerTestCase):
         prepare_session.commit_transaction(
             'commit_timestamp=' + self.timestamp_str(5) + ',durable_timestamp=' + self.timestamp_str(6))
 
+        # Specifically check that we can read between commit and durable.
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(5))
+        for i in range(1, 11):
+            self.assertEquals(value2, cursor[self.create_key(i)])
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(6))
         for i in range(1, 11):
             self.assertEquals(value2, cursor[self.create_key(i)])
         self.session.rollback_transaction()

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -229,12 +229,12 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
 
         # Remove all keys with newer timestamp.
         self.large_removes(uri, ds, nrows, self.prepare, 20)
         # Check that the no keys should be visible.
-        self.check(valuea, uri, 0, nrows, 20)
+        self.check(valuea, uri, 0, nrows, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 20 if prepare otherwise 10.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -98,19 +98,19 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
 
         self.large_updates(uri, valueb, ds, nrows, self.prepare, 20)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valueb, uri, nrows, None, 20)
+        self.check(valueb, uri, nrows, None, 21 if self.prepare else 20)
 
         self.large_updates(uri, valuec, ds, nrows, self.prepare, 30)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valuec, uri, nrows, None, 30)
+        self.check(valuec, uri, nrows, None, 31 if self.prepare else 30)
 
         self.large_updates(uri, valued, ds, nrows, self.prepare, 40)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valued, uri, nrows, None, 40)
+        self.check(valued, uri, nrows, None, 41 if self.prepare else 40)
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -85,15 +85,15 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
 
         self.large_updates(uri, valueb, ds, nrows, self.prepare, 20)
         # Check that all updates are seen.
-        self.check(valueb, uri, nrows, None, 20)
+        self.check(valueb, uri, nrows, None, 21 if self.prepare else 20)
 
         self.large_updates(uri, valuec, ds, nrows, self.prepare, 30)
         # Check that all updates are seen.
-        self.check(valuec, uri, nrows, None, 30)
+        self.check(valuec, uri, nrows, None, 31 if self.prepare else 30)
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -123,19 +123,19 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.large_modifies(uri, 'Z', ds, 7, 1, nrows, self.prepare, 140)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modR, uri, nrows, None, 40)
-        self.check(value_modS, uri, nrows, None, 50)
-        self.check(value_b, uri, nrows, None, 60)
-        self.check(value_c, uri, nrows, None, 70)
-        self.check(value_modT, uri, nrows, None, 80)
-        self.check(value_d, uri, nrows, None, 90)
-        self.check(value_modW, uri, nrows, None, 100)
-        self.check(value_a, uri, nrows, None, 110)
-        self.check(value_modX, uri, nrows, None, 120)
-        self.check(value_modY, uri, nrows, None, 130)
-        self.check(value_modZ, uri, nrows, None, 140)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_c, uri, nrows, None, 71 if self.prepare else 70)
+        self.check(value_modT, uri, nrows, None, 81 if self.prepare else 80)
+        self.check(value_d, uri, nrows, None, 91 if self.prepare else 90)
+        self.check(value_modW, uri, nrows, None, 101 if self.prepare else 100)
+        self.check(value_a, uri, nrows, None, 111 if self.prepare else 110)
+        self.check(value_modX, uri, nrows, None, 121 if self.prepare else 120)
+        self.check(value_modY, uri, nrows, None, 131 if self.prepare else 130)
+        self.check(value_modZ, uri, nrows, None, 141 if self.prepare else 140)
 
         # Pin stable to timestamp 40 if prepare otherwise 30.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -92,10 +92,10 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_c, uri, nrows, None, 40)
-        self.check(value_d, uri, nrows, None, 50)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_c, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_d, uri, nrows, None, 51 if self.prepare else 50)
 
         # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
         if not self.in_memory:

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -86,10 +86,10 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.large_updates(uri, value_a, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri, nrows, None, 20)
-        self.check(value_c, uri, nrows, None, 30)
-        self.check(value_b, uri, nrows, None, 40)
-        self.check(value_a, uri, nrows, None, 50)
+        self.check(value_d, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_c, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_a, uri, nrows, None, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -106,9 +106,9 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Verify additional update data is visible and correct.
-        self.check(value_b, uri, nrows, None, 60)
-        self.check(value_c, uri, nrows, None, 70)
-        self.check(value_d, uri, nrows, None, 80)
+        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_c, uri, nrows, None, 71 if self.prepare else 70)
+        self.check(value_d, uri, nrows, None, 81 if self.prepare else 80)
 
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -92,10 +92,10 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_c, uri, nrows, None, 40)
-        self.check(value_d, uri, nrows, None, 50)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_c, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_d, uri, nrows, None, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -104,15 +104,15 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.large_updates(uri_2, value_a, ds_2, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri_1, nrows, None, 20)
-        self.check(value_c, uri_1, nrows, None, 30)
-        self.check(value_b, uri_1, nrows, None, 40)
-        self.check(value_a, uri_1, nrows, None, 50)
+        self.check(value_d, uri_1, nrows, None, 21 if self.prepare else 20)
+        self.check(value_c, uri_1, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri_1, nrows, None, 41 if self.prepare else 40)
+        self.check(value_a, uri_1, nrows, None, 51 if self.prepare else 50)
 
-        self.check(value_d, uri_2, nrows, None, 20)
-        self.check(value_c, uri_2, nrows, None, 30)
-        self.check(value_b, uri_2, nrows, None, 40)
-        self.check(value_a, uri_2, nrows, None, 50)
+        self.check(value_d, uri_2, nrows, None, 21 if self.prepare else 20)
+        self.check(value_c, uri_2, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri_2, nrows, None, 41 if self.prepare else 40)
+        self.check(value_a, uri_2, nrows, None, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -234,15 +234,15 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.large_updates(uri_2, value_a, ds_2, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri_1, nrows, None, 20)
-        self.check(value_c, uri_1, nrows, None, 30)
-        self.check(value_b, uri_1, nrows, None, 40)
-        self.check(value_a, uri_1, nrows, None, 50)
+        self.check(value_d, uri_1, nrows, None, 21 if self.prepare else 20)
+        self.check(value_c, uri_1, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri_1, nrows, None, 41 if self.prepare else 40)
+        self.check(value_a, uri_1, nrows, None, 51 if self.prepare else 50)
 
-        self.check(value_d, uri_2, nrows, None, 20)
-        self.check(value_c, uri_2, nrows, None, 30)
-        self.check(value_b, uri_2, nrows, None, 40)
-        self.check(value_a, uri_2, nrows, None, 50)
+        self.check(value_d, uri_2, nrows, None, 21 if self.prepare else 20)
+        self.check(value_c, uri_2, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri_2, nrows, None, 41 if self.prepare else 40)
+        self.check(value_a, uri_2, nrows, None, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable11.py
+++ b/test/suite/test_rollback_to_stable11.py
@@ -83,7 +83,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         self.large_updates(uri, value_b, ds, nrows, self.prepare, 20)
 
         # Verify data is visible and correct.
-        self.check(value_b, uri, nrows, None, 20)
+        self.check(value_b, uri, nrows, None, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 28 if prepare otherwise 20.
         # large_updates() prepares at 1 before the timestamp passed (so 29)
@@ -109,7 +109,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 30)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri, nrows, None, 30)
+        self.check(value_d, uri, nrows, None, 31 if self.prepare else 30)
 
         # Checkpoint to ensure that all the updates are flushed to disk.
         self.session.checkpoint()

--- a/test/suite/test_rollback_to_stable12.py
+++ b/test/suite/test_rollback_to_stable12.py
@@ -83,7 +83,7 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         self.large_updates(uri, value_a, ds, nrows, self.prepare, 20)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 28 if prepare otherwise 20.
         # We prepare at commit_ts - 1 (so 29) and this is required to be strictly

--- a/test/suite/test_rollback_to_stable13.py
+++ b/test/suite/test_rollback_to_stable13.py
@@ -84,9 +84,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Verify data is visible and correct.
         # (In FLCS, the removed rows should read back as zero.)
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(None, uri, 0, nrows, 30)
-        self.check(value_b, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -159,9 +159,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Verify data is visible and correct.
         # (In FLCS, the removed rows should read back as zero.)
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(None, uri, 0, nrows, 30)
-        self.check(value_d, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
+        self.check(value_d, uri, nrows, None, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -235,9 +235,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Verify data is visible and correct.
         # (In FLCS, the removed rows should read back as zero.)
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(None, uri, 0, nrows, 40)
-        self.check(value_c, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(None, uri, 0, nrows, 41 if self.prepare else 40)
+        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
 
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")
@@ -290,9 +290,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
 
         # Verify data is visible and correct.
         # (In FLCS, the removed rows should read back as zero.)
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(None, uri, 0, nrows, 40)
-        self.check(value_c, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(None, uri, 0, nrows, 41 if self.prepare else 40)
+        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
 
         self.conn.rollback_to_stable()
         # Perform several updates and checkpoint.

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -96,11 +96,11 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modR, uri, nrows, None, 40)
-        self.check(value_modS, uri, nrows, None, 50)
-        self.check(value_modT, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -212,9 +212,9 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
             self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modT, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
@@ -320,9 +320,9 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
             self.large_modifies(uri, 'T', ds, len(value_modS), 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modT, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 

--- a/test/suite/test_rollback_to_stable18.py
+++ b/test/suite/test_rollback_to_stable18.py
@@ -84,8 +84,8 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
         self.large_removes(uri, ds, nrows, self.prepare, 30)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(None, uri, 0, nrows, 30)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")

--- a/test/suite/test_rollback_to_stable23.py
+++ b/test/suite/test_rollback_to_stable23.py
@@ -96,11 +96,11 @@ class test_rollback_to_stable23(test_rollback_to_stable_base):
         self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modR, uri, nrows, None, 40)
-        self.check(value_modS, uri, nrows, None, 50)
-        self.check(value_modT, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:


### PR DESCRIPTION
Document the problem and, for now at least, don't attempt to enforce a solution.

Also adjust a bunch of tests to not read in that window unless they really meant to.