### PR TITLE
WT-7712 commit and durable timestamps should be disallowed at stable timestamp

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -542,8 +542,7 @@ connection_runtime_config = [
         Config('max_percent_overhead', '10', r'''
             maximum tolerated overhead expressed as the number of blocks added
             and removed as percent of blocks looked up; cache population
-            and eviction will be suppressed if the overhead exceeds the
-            supplied threshold''',
+            and eviction will be suppressed if the overhead exceeds the threshold''',
             min='1', max='500'),
         Config('nvram_path', '', r'''
             the absolute path to the file system mounted on the NVRAM device'''),
@@ -1658,7 +1657,7 @@ methods = {
 'WT_SESSION.flush_tier' : Method([
     Config('flush_timestamp', '', r'''
         flush objects to all storage sources using the specified timestamp.
-        The supplied value must not be older than the current oldest timestamp and it must
+        The value must not be older than the current oldest timestamp and it must
         not be newer than the stable timestamp'''),
     Config('force', 'false', r'''
         force sharing of all data''',
@@ -1746,7 +1745,7 @@ methods = {
         Transactions with higher values are less likely to abort''',
         min='-100', max='100'),
     Config('read_timestamp', '', r'''
-        read using the specified timestamp.  The supplied value must not be
+        read using the specified timestamp.  The value must not be
         older than the current oldest timestamp.  See
         @ref timestamp_txn_api'''),
     Config('roundup_timestamps', '', r'''
@@ -1776,7 +1775,7 @@ methods = {
 
 'WT_SESSION.commit_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The supplied
+        set the commit timestamp for the current transaction. The
         value must not be older than the first commit timestamp already set
         for the current transaction, if any. The value must not be older than
         the current oldest timestamp and must be after the current stable
@@ -1788,7 +1787,7 @@ methods = {
         set the durable timestamp for the current transaction. Required for
         the commit of a prepared transaction, and otherwise not permitted. Can
         only be set after the transaction has been prepared and a commit
-        timestamp has been set. The supplied value must not be older than
+        timestamp has been set. The value must not be older than
         the commit timestamp. See @ref timestamp_prepare'''),
     Config('operation_timeout_ms', '0', r'''
         when non-zero, a requested limit on the time taken to complete operations in this
@@ -1808,13 +1807,13 @@ methods = {
 'WT_SESSION.prepare_transaction' : Method([
     Config('prepare_timestamp', '', r'''
         set the prepare timestamp for the updates of the current transaction.
-        The supplied value must not be older than any active read timestamps, and must
+        The value must not be older than any active read timestamps, and must
         be newer than the current stable timestamp. See @ref timestamp_prepare'''),
 ]),
 
 'WT_SESSION.timestamp_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The supplied
+        set the commit timestamp for the current transaction. The
         value must not be older than the first commit timestamp already set
         for the current transaction, if any. The value must not be older than
         the current oldest timestamp and must be after the current stable
@@ -1826,17 +1825,17 @@ methods = {
         set the durable timestamp for the current transaction. Required for
         the commit of a prepared transaction, and otherwise not permitted. Can
         only be set after the transaction has been prepared and a commit
-        timestamp has been set. The supplied value must not be older than
+        timestamp has been set. The value must not be older than
         the commit timestamp. See @ref timestamp_prepare'''),
     Config('prepare_timestamp', '', r'''
         set the prepare timestamp for the updates of the current transaction.
-        The supplied value must not be older than any active read timestamps,
+        The value must not be older than any active read timestamps,
         and must be newer than the current stable timestamp. Can be set only
         once per transaction. Setting the prepare timestamp does not by itself
         prepare the transaction, but does oblige the application to eventually
         prepare the transaction before committing it. See @ref timestamp_prepare'''),
     Config('read_timestamp', '', r'''
-        read using the specified timestamp.  The supplied value must not be
+        read using the specified timestamp.  The value must not be
         older than the current oldest timestamp.  This can only be set once
         for a transaction. See @ref timestamp_txn_api'''),
 ]),
@@ -1968,7 +1967,7 @@ methods = {
         timestamps greater than the specified value until the next durable
         timestamp moves the tracked durable timestamp forwards.  This is only
         intended for use where the application is rolling back locally committed
-        transactions. The supplied value must not be older than the current
+        transactions. The value must not be older than the current
         oldest and stable timestamps.  See @ref timestamp_global_api'''),
     Config('force', 'false', r'''
         set timestamps even if they violate normal ordering requirements.
@@ -1976,15 +1975,15 @@ methods = {
         type='boolean'),
     Config('oldest_timestamp', '', r'''
         future commits and queries will be no earlier than the specified
-        timestamp.  Supplied values must be monotonically increasing, any
+        timestamp. Values must be monotonically increasing, any
         attempt to set the value to older than the current is silently ignored.
-        The supplied value must not be newer than the current
+        The value must not be newer than the current
         stable timestamp.  See @ref timestamp_global_api'''),
     Config('stable_timestamp', '', r'''
         checkpoints will not include commits that are newer than the specified
-        timestamp in tables configured with \c log=(enabled=false).  Supplied
-        values must be monotonically increasing, any attempt to set the value to
-        older than the current is silently ignored.  The supplied value must
+        timestamp in tables configured with \c log=(enabled=false).
+        Values must be monotonically increasing, any attempt to set the value to
+        older than the current is silently ignored.  The value must
         not be older than the current oldest timestamp.  See
         @ref timestamp_global_api'''),
 ]),

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1776,18 +1776,20 @@ methods = {
 
 'WT_SESSION.commit_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The supplied value
-        must not be older than the first commit timestamp already set for the
-        current transaction, if any. The value must also not be older than the
-        current oldest and stable timestamps. For prepared transactions, exactly one
-        commit timestamp is required; it must not be older than the prepare timestamp.
-        See @ref timestamp_txn_api'''),
+        set the commit timestamp for the current transaction. The supplied
+        value must not be older than the first commit timestamp already set
+        for the current transaction, if any. The value must not be older than
+        the current oldest timestamp and must be after the current stable
+        timestamp. For prepared transactions, a commit timestamp is required,
+        must not be older than the prepare timestamp, can be set only once,
+        and must not be set until after the transaction has successfully
+        prepared. See @ref timestamp_txn_api and @ref timestamp_prepare'''),
     Config('durable_timestamp', '', r'''
-        set the durable timestamp for the current transaction. Required for the
-        commit of a prepared transaction, and otherwise not permitted. The
-        supplied value must not be older than the commit timestamp set for the
-        current transaction. The value must also be newer than the current
-        oldest and stable timestamps. See @ref timestamp_prepare'''),
+        set the durable timestamp for the current transaction. Required for
+        the commit of a prepared transaction, and otherwise not permitted. Can
+        only be set after the transaction has been prepared and a commit
+        timestamp has been set. The supplied value must not be older than
+        the commit timestamp. See @ref timestamp_prepare'''),
     Config('operation_timeout_ms', '0', r'''
         when non-zero, a requested limit on the time taken to complete operations in this
         transaction. Time is measured in real time milliseconds from the start of each WiredTiger
@@ -1812,20 +1814,20 @@ methods = {
 
 'WT_SESSION.timestamp_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The supplied value
-        must not be older than the first commit timestamp already set for the
-        current transaction, if any. The value must also not be older than the
-        current oldest and stable timestamps. For prepared transactions, a commit
-        timestamp is required for commit, must not be older than the prepare
-        timestamp, can be set only once, and must not be set until after the
-        transaction has successfully prepared. See @ref timestamp_txn_api'''),
+        set the commit timestamp for the current transaction. The supplied
+        value must not be older than the first commit timestamp already set
+        for the current transaction, if any. The value must not be older than
+        the current oldest timestamp and must be after the current stable
+        timestamp. For prepared transactions, a commit timestamp is required,
+        must not be older than the prepare timestamp, can be set only once,
+        and must not be set until after the transaction has successfully
+        prepared. See @ref timestamp_txn_api and @ref timestamp_prepare'''),
     Config('durable_timestamp', '', r'''
-        set the durable timestamp for the current transaction. Required for the
-        commit of a prepared transaction, and otherwise not permitted. Can only
-        be set once the current transaction has been prepared, and a commit
-        timestamp has been set. The supplied value must not be older than the
-        commit timestamp. The value must also be newer than the current
-        oldest and stable timestamps. See @ref timestamp_prepare'''),
+        set the durable timestamp for the current transaction. Required for
+        the commit of a prepared transaction, and otherwise not permitted. Can
+        only be set after the transaction has been prepared and a commit
+        timestamp has been set. The supplied value must not be older than
+        the commit timestamp. See @ref timestamp_prepare'''),
     Config('prepare_timestamp', '', r'''
         set the prepare timestamp for the updates of the current transaction.
         The supplied value must not be older than any active read timestamps,

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1775,20 +1775,17 @@ methods = {
 
 'WT_SESSION.commit_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The
-        value must not be older than the first commit timestamp already set
-        for the current transaction, if any. The value must not be older than
-        the current oldest timestamp and must be after the current stable
-        timestamp. For prepared transactions, a commit timestamp is required,
-        must not be older than the prepare timestamp, can be set only once,
-        and must not be set until after the transaction has successfully
-        prepared. See @ref timestamp_txn_api and @ref timestamp_prepare'''),
+        set the commit timestamp for the current transaction. For non-prepared transactions,
+        value must not be older than the first commit timestamp already set for the current
+        transaction, if any, must not be older than the current oldest timestamp and must
+        be after the current stable timestamp. For prepared transactions, a commit timestamp
+        is required, must not be older than the prepare timestamp and can be set only once.
+        See @ref timestamp_txn_api and @ref timestamp_prepare'''),
     Config('durable_timestamp', '', r'''
-        set the durable timestamp for the current transaction. Required for
-        the commit of a prepared transaction, and otherwise not permitted. Can
-        only be set after the transaction has been prepared and a commit
-        timestamp has been set. The value must not be older than
-        the commit timestamp. See @ref timestamp_prepare'''),
+        set the durable timestamp for the current transaction. Required for the commit of a
+        prepared transaction, and otherwise not permitted. The value must also be after the
+        current oldest and stable timestamps and must not be older than the commit timestamp.
+        See @ref timestamp_prepare'''),
     Config('operation_timeout_ms', '0', r'''
         when non-zero, a requested limit on the time taken to complete operations in this
         transaction. Time is measured in real time milliseconds from the start of each WiredTiger
@@ -1813,20 +1810,19 @@ methods = {
 
 'WT_SESSION.timestamp_transaction' : Method([
     Config('commit_timestamp', '', r'''
-        set the commit timestamp for the current transaction. The
-        value must not be older than the first commit timestamp already set
-        for the current transaction, if any. The value must not be older than
-        the current oldest timestamp and must be after the current stable
-        timestamp. For prepared transactions, a commit timestamp is required,
-        must not be older than the prepare timestamp, can be set only once,
-        and must not be set until after the transaction has successfully
-        prepared. See @ref timestamp_txn_api and @ref timestamp_prepare'''),
+        set the commit timestamp for the current transaction. For non-prepared transactions,
+        the value must not be older than the first commit timestamp already set for the current
+        transaction, if any, must not be older than the current oldest timestamp and must be after
+        the current stable timestamp. For prepared transactions, a commit timestamp is required,
+        must not be older than the prepare timestamp, can be set only once, and must not be
+        set until after the transaction has successfully prepared. See @ref timestamp_txn_api
+        and @ref timestamp_prepare'''),
     Config('durable_timestamp', '', r'''
-        set the durable timestamp for the current transaction. Required for
-        the commit of a prepared transaction, and otherwise not permitted. Can
-        only be set after the transaction has been prepared and a commit
-        timestamp has been set. The value must not be older than
-        the commit timestamp. See @ref timestamp_prepare'''),
+        set the durable timestamp for the current transaction. Required for the commit of a
+        prepared transaction, and otherwise not permitted. Can only be set after the transaction
+        has been prepared and a commit timestamp has been set. The value must be after the
+        current oldest and stable timestamps and must not be older than the commit timestamp. See
+        @ref timestamp_prepare'''),
     Config('prepare_timestamp', '', r'''
         set the prepare timestamp for the updates of the current transaction.
         The value must not be older than any active read timestamps,

--- a/src/docs/timestamp-txn.dox
+++ b/src/docs/timestamp-txn.dox
@@ -65,8 +65,8 @@ transaction commits, using WT_SESSION::commit_transaction:
 
 | Timestamp | Constraint | Description |
 |-----------|------------|-------------|
-| commit_timestamp | >= stable and >= prepare and >= any system read timestamp | the transaction's commit timestamp, see @ref timestamp_txn_api_commit_timestamp for details |
-| durable_timestamp | >= commit and > stable | the transaction's durable timestamp, only applicable to prepared transactions, see @ref timestamp_prepare for details |
+| commit_timestamp | > stable and >= prepare and >= any system read timestamp | the transaction's commit timestamp, see @ref timestamp_txn_api_commit_timestamp for details |
+| durable_timestamp | >= commit | the transaction's durable timestamp, only applicable to prepared transactions, see @ref timestamp_prepare for details |
 
 @section timestamp_txn_api_prepare Configuring transaction timestamp information with WT_SESSION::prepare_transaction
 
@@ -84,8 +84,8 @@ points in the transaction's lifetime, using WT_SESSION::timestamp_transaction:
 
 | Timestamp | Constraint | Description |
 |-----------|------------|-------------|
-| commit_timestamp | >= stable and >= prepare and >= any system read timestamp | the transaction's commit timestamp, see @ref timestamp_txn_api_commit_timestamp for details |
-| durable_timestamp | >= commit and > stable | the transaction's durable timestamp, only applicable to prepared transactions, see @ref timestamp_prepare for details |
+| commit_timestamp | > stable and >= prepare and >= any system read timestamp | the transaction's commit timestamp, see @ref timestamp_txn_api_commit_timestamp for details |
+| durable_timestamp | >= commit | the transaction's durable timestamp, only applicable to prepared transactions, see @ref timestamp_prepare for details |
 | prepare_timestamp | > stable and >= any system read timestamp | the transaction's prepare timestamp, see @ref timestamp_prepare for details |
 | read_timestamp | >= oldest or >= pinned | the transaction's read timestamp, see @ref timestamp_txn_api_read_timestamp for details |
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1919,7 +1919,7 @@ struct __wt_session {
 	 * calls wait for running checkpoint calls to complete.
 	 *
 	 * Existing named checkpoints may optionally be discarded.
-	 * 
+	 *
 	 * @requires_notransaction
 	 *
 	 * @snippet ex_all.c Checkpoint examples

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1755,18 +1755,17 @@ struct __wt_session {
 	 *
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.commit_transaction, see dist/api_data.py}
-	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
-	 * value must not be older than the first commit timestamp already set for the current
-	 * transaction\, if any.  The value must not be older than the current oldest timestamp and
-	 * must be after the current stable timestamp.  For prepared transactions\, a commit
-	 * timestamp is required\, must not be older than the prepare timestamp\, can be set only
-	 * once\, and must not be set until after the transaction has successfully prepared.  See
-	 * @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
+	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  For
+	 * non-prepared transactions\, value must not be older than the first commit timestamp
+	 * already set for the current transaction\, if any\, must not be older than the current
+	 * oldest timestamp and must be after the current stable timestamp.  For prepared
+	 * transactions\, a commit timestamp is required\, must not be older than the prepare
+	 * timestamp and can be set only once.  See @ref timestamp_txn_api and @ref
+	 * timestamp_prepare., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
-	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
-	 * only be set after the transaction has been prepared and a commit timestamp has been set.
-	 * The value must not be older than the commit timestamp.  See @ref timestamp_prepare., a
-	 * string; default empty.}
+	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  The
+	 * value must also be after the current oldest and stable timestamps and must not be older
+	 * than the commit timestamp.  See @ref timestamp_prepare., a string; default empty.}
 	 * @config{operation_timeout_ms, when non-zero\, a requested limit on the time taken to
 	 * complete operations in this transaction.  Time is measured in real time milliseconds from
 	 * the start of each WiredTiger API call.  There is no guarantee any operation will not take
@@ -1873,18 +1872,19 @@ struct __wt_session {
 	 *
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.timestamp_transaction, see dist/api_data.py}
-	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
-	 * value must not be older than the first commit timestamp already set for the current
-	 * transaction\, if any.  The value must not be older than the current oldest timestamp and
-	 * must be after the current stable timestamp.  For prepared transactions\, a commit
-	 * timestamp is required\, must not be older than the prepare timestamp\, can be set only
-	 * once\, and must not be set until after the transaction has successfully prepared.  See
-	 * @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
+	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  For
+	 * non-prepared transactions\, the value must not be older than the first commit timestamp
+	 * already set for the current transaction\, if any\, must not be older than the current
+	 * oldest timestamp and must be after the current stable timestamp.  For prepared
+	 * transactions\, a commit timestamp is required\, must not be older than the prepare
+	 * timestamp\, can be set only once\, and must not be set until after the transaction has
+	 * successfully prepared.  See @ref timestamp_txn_api and @ref timestamp_prepare., a string;
+	 * default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
 	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
 	 * only be set after the transaction has been prepared and a commit timestamp has been set.
-	 * The value must not be older than the commit timestamp.  See @ref timestamp_prepare., a
-	 * string; default empty.}
+	 * The value must be after the current oldest and stable timestamps and must not be older
+	 * than the commit timestamp.  See @ref timestamp_prepare., a string; default empty.}
 	 * @config{prepare_timestamp, set the prepare timestamp for the updates of the current
 	 * transaction.  The value must not be older than any active read timestamps\, and must be
 	 * newer than the current stable timestamp.  Can be set only once per transaction.  Setting
@@ -1905,19 +1905,21 @@ struct __wt_session {
 	 * @{
 	 */
 	/*!
-	 * Write a transactionally consistent snapshot of a database or set of objects.  In the
-	 * absence of transaction timestamps, the checkpoint includes all transactions committed
-	 * before the checkpoint starts.
+	 * Write a transactionally consistent snapshot of a database or set of individual objects.
 	 *
-	 * When timestamps are in use and the checkpoint runs with \c use_timestamp=true (the
-	 * default), updates committed with a timestamp after the \c stable_timestamp, in tables
-	 * configured for checkpoint-level durability, are not included in the checkpoint. See
-	 * @ref checkpoint for more information. Committed updates in tables configured for
-	 * commit-level durability are always included in the checkpoint. See @ref durability for
-	 * more information.
+	 * When timestamps are not in use, the checkpoint includes all transactions committed
+	 * before the checkpoint starts. When timestamps are in use and the checkpoint runs with
+	 * \c use_timestamp=true (the default), updates committed with a timestamp after the
+	 * \c stable timestamp, in tables configured for checkpoint-level durability, are not
+	 * included in the checkpoint. Updates committed in tables configured for commit-level
+	 * durability are always included in the checkpoint. See @ref checkpoint and @ref durability
+	 * for more information.
 	 *
-	 * Additionally, existing named checkpoints may optionally be discarded.
+	 * Calling the checkpoint method multiple times serializes the checkpoints, new checkpoint
+	 * calls wait for running checkpoint calls to complete.
 	 *
+	 * Existing named checkpoints may optionally be discarded.
+	 * 
 	 * @requires_notransaction
 	 *
 	 * @snippet ex_all.c Checkpoint examples

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -830,8 +830,8 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.flush_tier, see dist/api_data.py}
 	 * @config{flush_timestamp, flush objects to all storage sources using the specified
-	 * timestamp.  The supplied value must not be older than the current oldest timestamp and it
-	 * must not be newer than the stable timestamp., a string; default empty.}
+	 * timestamp.  The value must not be older than the current oldest timestamp and it must not
+	 * be newer than the stable timestamp., a string; default empty.}
 	 * @config{force, force sharing of all data., a boolean flag; default \c false.}
 	 * @config{lock_wait, wait for locks\, if \c lock_wait=false\, fail if any required locks
 	 * are not available immediately., a boolean flag; default \c true.}
@@ -1713,9 +1713,9 @@ struct __wt_session {
 	 * greater than or equal to 1; default \c 0.}
 	 * @config{priority, priority of the transaction for resolving conflicts.  Transactions with
 	 * higher values are less likely to abort., an integer between -100 and 100; default \c 0.}
-	 * @config{read_timestamp, read using the specified timestamp.  The supplied value must not
-	 * be older than the current oldest timestamp.  See @ref timestamp_txn_api., a string;
-	 * default empty.}
+	 * @config{read_timestamp, read using the specified timestamp.  The value must not be older
+	 * than the current oldest timestamp.  See @ref timestamp_txn_api., a string; default
+	 * empty.}
 	 * @config{roundup_timestamps = (, round up timestamps of the transaction., a set of related
 	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;prepared,
@@ -1756,17 +1756,17 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.commit_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
-	 * supplied value must not be older than the first commit timestamp already set for the
-	 * current transaction\, if any.  The value must not be older than the current oldest
-	 * timestamp and must be after the current stable timestamp.  For prepared transactions\, a
-	 * commit timestamp is required\, must not be older than the prepare timestamp\, can be set
-	 * only once\, and must not be set until after the transaction has successfully prepared.
-	 * See @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
+	 * value must not be older than the first commit timestamp already set for the current
+	 * transaction\, if any.  The value must not be older than the current oldest timestamp and
+	 * must be after the current stable timestamp.  For prepared transactions\, a commit
+	 * timestamp is required\, must not be older than the prepare timestamp\, can be set only
+	 * once\, and must not be set until after the transaction has successfully prepared.  See
+	 * @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
 	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
 	 * only be set after the transaction has been prepared and a commit timestamp has been set.
-	 * The supplied value must not be older than the commit timestamp.  See @ref
-	 * timestamp_prepare., a string; default empty.}
+	 * The value must not be older than the commit timestamp.  See @ref timestamp_prepare., a
+	 * string; default empty.}
 	 * @config{operation_timeout_ms, when non-zero\, a requested limit on the time taken to
 	 * complete operations in this transaction.  Time is measured in real time milliseconds from
 	 * the start of each WiredTiger API call.  There is no guarantee any operation will not take
@@ -1801,9 +1801,9 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.prepare_transaction, see dist/api_data.py}
 	 * @config{prepare_timestamp, set the prepare timestamp for the updates of the current
-	 * transaction.  The supplied value must not be older than any active read timestamps\, and
-	 * must be newer than the current stable timestamp.  See @ref timestamp_prepare., a string;
-	 * default empty.}
+	 * transaction.  The value must not be older than any active read timestamps\, and must be
+	 * newer than the current stable timestamp.  See @ref timestamp_prepare., a string; default
+	 * empty.}
 	 * @configend
 	 * @errors
 	 */
@@ -1874,26 +1874,26 @@ struct __wt_session {
 	 * @param session the session handle
 	 * @configstart{WT_SESSION.timestamp_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
-	 * supplied value must not be older than the first commit timestamp already set for the
-	 * current transaction\, if any.  The value must not be older than the current oldest
-	 * timestamp and must be after the current stable timestamp.  For prepared transactions\, a
-	 * commit timestamp is required\, must not be older than the prepare timestamp\, can be set
-	 * only once\, and must not be set until after the transaction has successfully prepared.
-	 * See @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
+	 * value must not be older than the first commit timestamp already set for the current
+	 * transaction\, if any.  The value must not be older than the current oldest timestamp and
+	 * must be after the current stable timestamp.  For prepared transactions\, a commit
+	 * timestamp is required\, must not be older than the prepare timestamp\, can be set only
+	 * once\, and must not be set until after the transaction has successfully prepared.  See
+	 * @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
 	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
 	 * only be set after the transaction has been prepared and a commit timestamp has been set.
-	 * The supplied value must not be older than the commit timestamp.  See @ref
-	 * timestamp_prepare., a string; default empty.}
+	 * The value must not be older than the commit timestamp.  See @ref timestamp_prepare., a
+	 * string; default empty.}
 	 * @config{prepare_timestamp, set the prepare timestamp for the updates of the current
-	 * transaction.  The supplied value must not be older than any active read timestamps\, and
-	 * must be newer than the current stable timestamp.  Can be set only once per transaction.
-	 * Setting the prepare timestamp does not by itself prepare the transaction\, but does
-	 * oblige the application to eventually prepare the transaction before committing it.  See
-	 * @ref timestamp_prepare., a string; default empty.}
-	 * @config{read_timestamp, read using the specified timestamp.  The supplied value must not
-	 * be older than the current oldest timestamp.  This can only be set once for a transaction.
-	 * See @ref timestamp_txn_api., a string; default empty.}
+	 * transaction.  The value must not be older than any active read timestamps\, and must be
+	 * newer than the current stable timestamp.  Can be set only once per transaction.  Setting
+	 * the prepare timestamp does not by itself prepare the transaction\, but does oblige the
+	 * application to eventually prepare the transaction before committing it.  See @ref
+	 * timestamp_prepare., a string; default empty.}
+	 * @config{read_timestamp, read using the specified timestamp.  The value must not be older
+	 * than the current oldest timestamp.  This can only be set once for a transaction.  See
+	 * @ref timestamp_txn_api., a string; default empty.}
 	 * @configend
 	 * @errors
 	 */
@@ -2097,15 +2097,16 @@ struct __wt_connection {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
 	 * max_percent_overhead, maximum tolerated overhead expressed as the number of blocks added
 	 * and removed as percent of blocks looked up; cache population and eviction will be
-	 * suppressed if the overhead exceeds the supplied threshold., an integer between 1 and 500;
-	 * default \c 10.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;nvram_path, the absolute path to the file
-	 * system mounted on the NVRAM device., a string; default empty.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;percent_file_in_dram, bypass cache for a file if the set
-	 * percentage of the file fits in system DRAM (as specified by block_cache.system_ram)., an
-	 * integer between 0 and 100; default \c 50.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum
-	 * memory to allocate for the block cache., an integer between 0 and 10TB; default \c 0.}
+	 * suppressed if the overhead exceeds the threshold., an integer between 1 and 500; default
+	 * \c 10.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;nvram_path, the absolute path to the file system
+	 * mounted on the NVRAM device., a string; default empty.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * percent_file_in_dram, bypass cache for a file if the set percentage of the file fits in
+	 * system DRAM (as specified by block_cache.system_ram)., an integer between 0 and 100;
+	 * default \c 50.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;size, maximum memory to allocate for the
+	 * block cache., an integer between 0 and 10TB; default \c 0.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;system_ram, the bytes of system DRAM available for
 	 * caching filesystem blocks., an integer between 0 and 1024GB; default \c 0.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;type, cache location: DRAM or NVRAM., a string; default
@@ -2523,22 +2524,21 @@ struct __wt_connection {
 	 * This will cause future calls to WT_CONNECTION::query_timestamp to ignore durable
 	 * timestamps greater than the specified value until the next durable timestamp moves the
 	 * tracked durable timestamp forwards.  This is only intended for use where the application
-	 * is rolling back locally committed transactions.  The supplied value must not be older
-	 * than the current oldest and stable timestamps.  See @ref timestamp_global_api., a string;
-	 * default empty.}
+	 * is rolling back locally committed transactions.  The value must not be older than the
+	 * current oldest and stable timestamps.  See @ref timestamp_global_api., a string; default
+	 * empty.}
 	 * @config{force, set timestamps even if they violate normal ordering requirements.  For
 	 * example allow the \c oldest_timestamp to move backwards., a boolean flag; default \c
 	 * false.}
 	 * @config{oldest_timestamp, future commits and queries will be no earlier than the
-	 * specified timestamp.  Supplied values must be monotonically increasing\, any attempt to
-	 * set the value to older than the current is silently ignored.  The supplied value must not
-	 * be newer than the current stable timestamp.  See @ref timestamp_global_api., a string;
-	 * default empty.}
+	 * specified timestamp.  Values must be monotonically increasing\, any attempt to set the
+	 * value to older than the current is silently ignored.  The value must not be newer than
+	 * the current stable timestamp.  See @ref timestamp_global_api., a string; default empty.}
 	 * @config{stable_timestamp, checkpoints will not include commits that are newer than the
-	 * specified timestamp in tables configured with \c log=(enabled=false). Supplied values
-	 * must be monotonically increasing\, any attempt to set the value to older than the current
-	 * is silently ignored.  The supplied value must not be older than the current oldest
-	 * timestamp.  See @ref timestamp_global_api., a string; default empty.}
+	 * specified timestamp in tables configured with \c log=(enabled=false). Values must be
+	 * monotonically increasing\, any attempt to set the value to older than the current is
+	 * silently ignored.  The value must not be older than the current oldest timestamp.  See
+	 * @ref timestamp_global_api., a string; default empty.}
 	 * @configend
 	 * @errors
 	 */
@@ -2791,7 +2791,7 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
  * max_percent_overhead, maximum tolerated overhead expressed as the number of blocks added and
  * removed as percent of blocks looked up; cache population and eviction will be suppressed if the
- * overhead exceeds the supplied threshold., an integer between 1 and 500; default \c 10.}
+ * overhead exceeds the threshold., an integer between 1 and 500; default \c 10.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;nvram_path, the absolute path to the file system mounted on the
  * NVRAM device., a string; default empty.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;percent_file_in_dram,

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1757,15 +1757,16 @@ struct __wt_session {
 	 * @configstart{WT_SESSION.commit_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
 	 * supplied value must not be older than the first commit timestamp already set for the
-	 * current transaction\, if any.  The value must also not be older than the current oldest
-	 * and stable timestamps.  For prepared transactions\, exactly one commit timestamp is
-	 * required; it must not be older than the prepare timestamp.  See @ref timestamp_txn_api.,
-	 * a string; default empty.}
+	 * current transaction\, if any.  The value must not be older than the current oldest
+	 * timestamp and must be after the current stable timestamp.  For prepared transactions\, a
+	 * commit timestamp is required\, must not be older than the prepare timestamp\, can be set
+	 * only once\, and must not be set until after the transaction has successfully prepared.
+	 * See @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
-	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  The
-	 * supplied value must not be older than the commit timestamp set for the current
-	 * transaction.  The value must also be newer than the current oldest and stable timestamps.
-	 * See @ref timestamp_prepare., a string; default empty.}
+	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
+	 * only be set after the transaction has been prepared and a commit timestamp has been set.
+	 * The supplied value must not be older than the commit timestamp.  See @ref
+	 * timestamp_prepare., a string; default empty.}
 	 * @config{operation_timeout_ms, when non-zero\, a requested limit on the time taken to
 	 * complete operations in this transaction.  Time is measured in real time milliseconds from
 	 * the start of each WiredTiger API call.  There is no guarantee any operation will not take
@@ -1874,16 +1875,15 @@ struct __wt_session {
 	 * @configstart{WT_SESSION.timestamp_transaction, see dist/api_data.py}
 	 * @config{commit_timestamp, set the commit timestamp for the current transaction.  The
 	 * supplied value must not be older than the first commit timestamp already set for the
-	 * current transaction\, if any.  The value must also not be older than the current oldest
-	 * and stable timestamps.  For prepared transactions\, a commit timestamp is required for
-	 * commit\, must not be older than the prepare timestamp\, can be set only once\, and must
-	 * not be set until after the transaction has successfully prepared.  See @ref
-	 * timestamp_txn_api., a string; default empty.}
+	 * current transaction\, if any.  The value must not be older than the current oldest
+	 * timestamp and must be after the current stable timestamp.  For prepared transactions\, a
+	 * commit timestamp is required\, must not be older than the prepare timestamp\, can be set
+	 * only once\, and must not be set until after the transaction has successfully prepared.
+	 * See @ref timestamp_txn_api and @ref timestamp_prepare., a string; default empty.}
 	 * @config{durable_timestamp, set the durable timestamp for the current transaction.
 	 * Required for the commit of a prepared transaction\, and otherwise not permitted.  Can
-	 * only be set once the current transaction has been prepared\, and a commit timestamp has
-	 * been set.  The supplied value must not be older than the commit timestamp.  The value
-	 * must also be newer than the current oldest and stable timestamps.  See @ref
+	 * only be set after the transaction has been prepared and a commit timestamp has been set.
+	 * The supplied value must not be older than the commit timestamp.  See @ref
 	 * timestamp_prepare., a string; default empty.}
 	 * @config{prepare_timestamp, set the prepare timestamp for the updates of the current
 	 * transaction.  The supplied value must not be older than any active read timestamps\, and

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -521,10 +521,7 @@ __txn_assert_after_reads(WT_SESSION_IMPL *session, const char *op, wt_timestamp_
 
 /*
  * __wt_txn_set_commit_timestamp --
- *     Validate the commit timestamp of a transaction. If the commit timestamp is less than the
- *     oldest timestamp and transaction is configured to roundup timestamps of a prepared
- *     transaction, then we will roundup the commit timestamp to the prepare timestamp of the
- *     transaction.
+ *     Validate the commit timestamp of a transaction.
  */
 int
 __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts)
@@ -566,8 +563,13 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts
               __wt_timestamp_to_string(commit_ts, ts_string[0]),
               __wt_timestamp_to_string(oldest_ts, ts_string[1]));
 
+#ifdef WT_STANDALONE_BUILD
+        if (has_stable_ts && commit_ts <= stable_ts)
+            WT_RET_MSG(session, EINVAL, "commit timestamp %s must be after the stable timestamp %s",
+#else
         if (has_stable_ts && commit_ts < stable_ts)
-            WT_RET_MSG(session, EINVAL, "commit timestamp %s is less than the stable timestamp %s",
+            WT_RET_MSG(session, EINVAL, "commit timestamp %s is before the stable timestamp %s",
+#endif
               __wt_timestamp_to_string(commit_ts, ts_string[0]),
               __wt_timestamp_to_string(stable_ts, ts_string[1]));
 
@@ -587,6 +589,10 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts
          * For a prepared transaction, the commit timestamp should not be less than the prepare
          * timestamp. Also, the commit timestamp cannot be set before the transaction has actually
          * been prepared.
+         *
+         * If the commit timestamp is less than the oldest timestamp and transaction is configured
+         * to roundup timestamps of a prepared transaction, then we will roundup the commit
+         * timestamp to the prepare timestamp of the transaction.
          */
         if (txn->prepare_timestamp > commit_ts) {
             if (!F_ISSET(txn, WT_TXN_TS_ROUND_PREPARED))
@@ -659,17 +665,18 @@ __wt_txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_
     if (has_stable_ts)
         stable_ts = txn_global->stable_timestamp;
 
-    /*
-     * For a non-prepared transactions the commit timestamp should not be less than the stable
-     * timestamp.
-     */
     if (has_oldest_ts && durable_ts < oldest_ts)
         WT_RET_MSG(session, EINVAL, "durable timestamp %s is less than the oldest timestamp %s",
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(oldest_ts, ts_string[1]));
 
+#ifdef WT_STANDALONE_BUILD
+    if (has_stable_ts && durable_ts <= stable_ts)
+        WT_RET_MSG(session, EINVAL, "durable timestamp %s must be after the stable timestamp %s",
+#else
     if (has_stable_ts && durable_ts < stable_ts)
         WT_RET_MSG(session, EINVAL, "durable timestamp %s is less than the stable timestamp %s",
+#endif
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(stable_ts, ts_string[1]));
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -566,12 +566,14 @@ __wt_txn_set_commit_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t commit_ts
 #ifdef WT_STANDALONE_BUILD
         if (has_stable_ts && commit_ts <= stable_ts)
             WT_RET_MSG(session, EINVAL, "commit timestamp %s must be after the stable timestamp %s",
+              __wt_timestamp_to_string(commit_ts, ts_string[0]),
+              __wt_timestamp_to_string(stable_ts, ts_string[1]));
 #else
         if (has_stable_ts && commit_ts < stable_ts)
             WT_RET_MSG(session, EINVAL, "commit timestamp %s is before the stable timestamp %s",
-#endif
               __wt_timestamp_to_string(commit_ts, ts_string[0]),
               __wt_timestamp_to_string(stable_ts, ts_string[1]));
+#endif
 
         /*
          * Compare against the commit timestamp of the current transaction. Return an error if the
@@ -673,12 +675,14 @@ __wt_txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_
 #ifdef WT_STANDALONE_BUILD
     if (has_stable_ts && durable_ts <= stable_ts)
         WT_RET_MSG(session, EINVAL, "durable timestamp %s must be after the stable timestamp %s",
+          __wt_timestamp_to_string(durable_ts, ts_string[0]),
+          __wt_timestamp_to_string(stable_ts, ts_string[1]));
 #else
     if (has_stable_ts && durable_ts < stable_ts)
         WT_RET_MSG(session, EINVAL, "durable timestamp %s is less than the stable timestamp %s",
-#endif
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(stable_ts, ts_string[1]));
+#endif
 
     /* Check if the durable timestamp is less than the commit timestamp. */
     if (durable_ts < txn->commit_timestamp)

--- a/test/suite/test_hs02.py
+++ b/test/suite/test_hs02.py
@@ -93,11 +93,12 @@ class test_hs02(wttest.WiredTigerTestCase):
             bigvalue = "aaaaa" * 100
             bigvalue2 = "ddddd" * 100
 
+        # Commit at timestamp 1.
+        self.large_updates(uri, bigvalue, ds, nrows // 3, 1)
+
         # Pin oldest and stable to timestamp 1.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
-
-        self.large_updates(uri, bigvalue, ds, nrows // 3, 1)
 
         # Check that all updates are seen
         self.check(uri, [(bigvalue, nrows // 3)], 1)

--- a/test/suite/test_hs07.py
+++ b/test/suite/test_hs07.py
@@ -85,11 +85,12 @@ class test_hs07(wttest.WiredTigerTestCase):
             bigvalue = "aaaaa" * 100
             bigvalue2 = "ddddd" * 100
 
+        # Commit at timestamp 1.
+        self.large_updates(uri, bigvalue, ds, nrows, 1)
+
         # Pin oldest and stable to timestamp 1.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
-
-        self.large_updates(uri, bigvalue, ds, nrows, 1)
 
         # Check that all updates are seen
         self.check(bigvalue, uri, nrows, 100)

--- a/test/suite/test_hs22.py
+++ b/test/suite/test_hs22.py
@@ -53,7 +53,8 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         key1 = self.key1
         key2 = self.key2
@@ -116,7 +117,8 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         key1 = self.key1
         key2 = self.key2
@@ -184,7 +186,8 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         key1 = self.key1
 
@@ -200,7 +203,7 @@ class test_hs22(wttest.WiredTigerTestCase):
             value4 = 'd'
 
         self.session.begin_transaction()
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(1))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(2))
         cursor[key1] = value1
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(3))
         cursor[key1] = value2
@@ -233,7 +236,8 @@ class test_hs22(wttest.WiredTigerTestCase):
         self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
         self.conn.set_timestamp(
-            'oldest_timestamp=' + self.timestamp_str(1) + ',stable_timestamp=' + self.timestamp_str(1))
+            'oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         key1 = self.key1
 

--- a/test/suite/test_hs24.py
+++ b/test/suite/test_hs24.py
@@ -185,11 +185,11 @@ class test_hs24(wttest.WiredTigerTestCase):
         for i in range(1, self.numrows + 1):
             self.session.begin_transaction()
             cursor[i] = self.value1
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
             self.session.begin_transaction()
             cursor[i] = self.value2
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
         for i in range(1, self.numrows + 1):
             self.session.begin_transaction()
             cursor[i] = self.value3
@@ -201,10 +201,9 @@ class test_hs24(wttest.WiredTigerTestCase):
         thread.join()
         simulate_crash_restart(self, '.', "RESTART")
         cursor = self.session.open_cursor(self.uri)
-        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(4))
-        # Check we can only see the version at timestamp 4, it's either
-        # committed by the out of order timestamp commit thread before the
-        # checkpoint starts or value1.
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(2))
+        # Check we can only see the version at timestamp 2, it's either committed by the out of
+        # order timestamp commit thread before the checkpoint starts or value1.
         newer_data_visible = False
         for i in range(1, self.numrows + 1):
             value = cursor[i]

--- a/test/suite/test_hs27.py
+++ b/test/suite/test_hs27.py
@@ -265,13 +265,13 @@ class test_hs27(wttest.WiredTigerTestCase):
         ds.populate()
         self.session.checkpoint()
 
-        # Pin oldest and stable to timestamp 1.
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
-            ',stable_timestamp=' + self.timestamp_str(1))
-
         # Write the initial values, if requested.
         if self.doinit:
             self.initialize(ds.uri, ds)
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
 
         # Create a long running read transaction in a separate session.
         session_read = self.conn.open_session()

--- a/test/suite/test_hs_evict_race01.py
+++ b/test/suite/test_hs_evict_race01.py
@@ -69,10 +69,10 @@ class test_hs_evict_race01(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
         # Move the stable timestamp.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4))
-        # Insert a value at timetamp 5
+        # Insert a value at timetamp 6
         self.session.begin_transaction()
         cursor[1] = self.value2
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(6))
 
         cursor.close()
 
@@ -97,7 +97,7 @@ class test_hs_evict_race01(wttest.WiredTigerTestCase):
         cursor = session.open_cursor(self.uri)
         session.begin_transaction()
         cursor[1] = self.value4
-        session.commit_transaction('commit_timestamp=' + self.timestamp_str(4))
+        session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
         cursor.close()
         sleep(1.5)
         evict_cursor = session.open_cursor(self.uri, None, "debug=(release_evict)")

--- a/test/suite/test_prepare_hs01.py
+++ b/test/suite/test_prepare_hs01.py
@@ -88,7 +88,7 @@ class test_prepare_hs01(wttest.WiredTigerTestCase):
             cursor.set_key(ds.key(nrows + i))
             cursor.set_value(bigvalue1)
             self.assertEquals(cursor.insert(), 0)
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         # Have prepared updates in multiple sessions. This should ensure writing
         # prepared updates to the history store
@@ -105,11 +105,11 @@ class test_prepare_hs01(wttest.WiredTigerTestCase):
                 cursors[j].set_key(ds.key(nrows + i))
                 cursors[j].set_value(bigvalue2)
                 self.assertEquals(cursors[j].insert(), 0)
-            sessions[j].prepare_transaction('prepare_timestamp=' + self.timestamp_str(2))
+            sessions[j].prepare_transaction('prepare_timestamp=' + self.timestamp_str(3))
 
         # Re-read the original versions of all the data. This ensures reading
         # original versions from the history store
-        self.check(uri, ds, nrows, nsessions, nkeys, 1, bigvalue1, bigvalue2)
+        self.check(uri, ds, nrows, nsessions, nkeys, 2, bigvalue1, bigvalue2)
 
         # Close all cursors and sessions, this will cause prepared updates to be
         # rollback-ed
@@ -120,7 +120,7 @@ class test_prepare_hs01(wttest.WiredTigerTestCase):
         # Re-read the original versions of all the data. This ensures reading
         # original versions from the data store as the prepared updates are
         # aborted
-        self.check(uri, ds, nrows, nsessions, nkeys, 2, bigvalue1, bigvalue2)
+        self.check(uri, ds, nrows, nsessions, nkeys, 3, bigvalue1, bigvalue2)
 
     def test_prepare_hs(self):
         # Create a small table.

--- a/test/suite/test_prepare_hs04.py
+++ b/test/suite/test_prepare_hs04.py
@@ -113,7 +113,7 @@ class test_prepare_hs04(wttest.WiredTigerTestCase):
             cursor.set_key(key)
             cursor.set_value(commit_value)
             self.assertEquals(cursor.insert(), 0)
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
         cursor.close()
 
         # Call checkpoint.

--- a/test/suite/test_rollback_to_stable24.py
+++ b/test/suite/test_rollback_to_stable24.py
@@ -74,11 +74,11 @@ class test_rollback_to_stable24(wttest.WiredTigerTestCase):
         uri = "table:rollback_to_stable24"
         self.session.create(uri, 'key_format={},value_format=S'.format(self.key_format))
 
-        # Pin oldest timestamp to 10.
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        # Pin oldest timestamp to 5.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
 
-        # Start stable timestamp at 10.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        # Start stable timestamp at 5.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
 
         value_a = "aaaaa" * 100
         value_b = "bbbbb" * 100

--- a/test/suite/test_rollback_to_stable25.py
+++ b/test/suite/test_rollback_to_stable25.py
@@ -229,11 +229,11 @@ class test_rollback_to_stable25(wttest.WiredTigerTestCase):
         uri = "table:rollback_to_stable25"
         self.session.create(uri, 'key_format=r,value_format=S')
 
-        # Pin oldest timestamp to 5.
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
+        # Pin oldest timestamp to 2.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(2))
 
-        # Start stable timestamp at 5.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
+        # Start stable timestamp at 2.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
 
         value_a = "aaaaa" * 10
         value_b = "bbbbb" * 10

--- a/test/suite/test_tiered11.py
+++ b/test/suite/test_tiered11.py
@@ -81,8 +81,8 @@ class test_tiered11(wttest.WiredTigerTestCase):
         for i in range(start, end):
             self.session.begin_transaction()
             c[i] = i
-            self.session.commit_transaction(
-              'commit_timestamp=' + self.timestamp_str(i))
+            # Jump the commit TS to leave rooom for the stable TS separate from any commit TS.
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(i * 2))
         # Set the oldest and stable timestamp to the end.
         end_ts = self.timestamp_str(end-1)
         self.conn.set_timestamp('oldest_timestamp=' + end_ts + ',stable_timestamp=' + end_ts)

--- a/test/suite/test_timestamp09.py
+++ b/test/suite/test_timestamp09.py
@@ -124,15 +124,14 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
                 self.timestamp_str(6)),
                 '/oldest timestamp \(0, 6\) must not be later than stable timestamp \(0, 5\)/')
 
-        # Commit timestamp >= Stable timestamp.
+        # Commit timestamp > Stable timestamp.
         # Check both timestamp_transaction and commit_transaction APIs.
         # Oldest and stable timestamp are set to 5 at the moment.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(6))
         self.session.begin_transaction()
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.timestamp_transaction(
                 'commit_timestamp=' + self.timestamp_str(5)),
-                '/less than the stable timestamp/')
+                '/must be after the stable timestamp/')
         self.session.rollback_transaction()
 
         self.session.begin_transaction()
@@ -140,7 +139,7 @@ class test_timestamp09(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.commit_transaction(
                 'commit_timestamp=' + self.timestamp_str(5)),
-                '/less than the stable timestamp/')
+                '/must be after the stable timestamp/')
 
         # When explicitly set, commit timestamp for a transaction can be earlier
         # than the commit timestamp of an earlier transaction.

--- a/test/suite/test_timestamp22.py
+++ b/test/suite/test_timestamp22.py
@@ -157,7 +157,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
             if this_commit_ts >= 0:
                 if this_commit_ts < running_commit_ts:
                     ok = False
-                if this_commit_ts < self.stable_ts:
+                if this_commit_ts <= self.stable_ts:
                     ok = False
                 if this_commit_ts < self.oldest_ts:
                     ok = False
@@ -229,7 +229,7 @@ class test_timestamp22(wttest.WiredTigerTestCase):
                 ok_prepare = False
 
         # If the final commit is too old, we'll fail.
-        if commit_ts < self.oldest_ts or commit_ts < self.stable_ts:
+        if commit_ts < self.oldest_ts or commit_ts <= self.stable_ts:
             ok_commit = False
 
         # ODDITY: We don't have to move the commit_ts ahead, but it has to be
@@ -293,7 +293,8 @@ class test_timestamp22(wttest.WiredTigerTestCase):
                     needs_rollback = False
                     session.rollback_transaction()
         except Exception as e:
-            # We don't expect any exceptions, they should be caught as part of self.expect statements.
+            # We don't expect any exceptions, they should be caught as part of self.expect
+            # statements.
             self.pr(msg + 'UNEXPECTED EXCEPTION!')
             self.pr(msg + 'fail: ' + str(e))
             raise e


### PR DESCRIPTION
@kommiharibabu, @sauclovian-wt, would you please do the review? I tried to be careful in the test suite to be sure my changes didn't alter the intent of the test, but obviously that's the most interesting question for the test suite.

