### PR TITLE
WT-8799 Disable Documentation Update on mongodb-5.0 (v4.4 backport) (#7599)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3405,6 +3405,9 @@ buildvariants:
     - name: package
 
 - name: documentation-update
+  # Documentation update is NOT expected to be triggered on Evergreen projects
+  # other than "WiredTiger (develop)"
+  activate: false
   display_name: "~ Documentation update"
   batchtime: 10080 # 7 days
   run_on:


### PR DESCRIPTION
* Disabling documentation-update for mongodb-5.0
* Fixed typo

(cherry picked from commit f297c94aec8141221ee7d11379f5941fc76662c2)