### PR TITLE
WT-7954 Use longer flush_tier timeout in test_tiered04 (#7607)

### DIFF
--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -229,7 +229,7 @@ class test_tiered04(wttest.WiredTigerTestCase):
         # Call flush_tier with its various configuration arguments. It is difficult
         # to force a timeout or lock contention with a unit test. So just test the
         # call for now.
-        self.session.flush_tier('timeout=10')
+        self.session.flush_tier('timeout=100')
         self.session.flush_tier('lock_wait=false')
         self.session.flush_tier('sync=off')
         flush += 3


### PR DESCRIPTION
When testing the "timeout=" config option for flush_tier() us a large enough timeout that a slow system doesn't take so long that it hits the timeout generating an unexpected EBUSY error.

(cherry picked from commit 8f6a0a2e0de9e89041479af9e899df4dd93da5d7)