### PR TITLE
WT-8882 Fix bug showing as no space left on device for wtperf test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2136,11 +2136,29 @@ tasks:
             for file in `ls $dir`
             do
               echo "===="
+              echo "Disk usage and free space for the current drive (pre-test):"
+              df -h .
+              echo "===="
               echo "==== Initiating wtperf test using $dir/$file ===="
               echo "===="
               ${test_env_vars|} ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
+              echo "===="
+              echo "Disk usage and free space for the current drive (pre-copy):"
+              df -h .
+              echo "===="
+              echo "Total size of WT_TEST dirwectory:"
+              du -hs WT_TEST
+              echo "===="
               cp -rf WT_TEST WT_TEST_$file
+              echo "===="
+              echo "Disk usage and free space for the current drive (post-copy):"
+              df -h .
+              echo "===="
             done
+            echo "===="
+            echo "Disk usage and free space for the current drive (at the end):"
+            df -h .
+            echo "===="
 
   - name: ftruncate-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2142,16 +2142,12 @@ tasks:
               echo "===="
               ${test_env_vars|} ./bench/wtperf/wtperf -O $dir/$file -o verbose=2
               echo "===="
-              echo "Disk usage and free space for the current drive (pre-copy):"
+              echo "Disk usage and free space for the current drive (post-test):"
               df -h .
-              echo "Total size of WT_TEST directory prior to copy:"
+              echo "Total size of WT_TEST directory prior to move:"
               du -hs WT_TEST
-              cp -rf WT_TEST WT_TEST_$file
-              echo "Disk usage and free space for the current drive (post-copy):"
-              df -h .
+              mv WT_TEST WT_TEST_$file
             done
-            echo "Disk usage and free space for the current drive (at the end):"
-            df -h .
 
   - name: ftruncate-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2135,7 +2135,6 @@ tasks:
             dir=../bench/wtperf/stress
             for file in `ls $dir`
             do
-              echo "===="
               echo "Disk usage and free space for the current drive (pre-test):"
               df -h .
               echo "===="
@@ -2145,20 +2144,14 @@ tasks:
               echo "===="
               echo "Disk usage and free space for the current drive (pre-copy):"
               df -h .
-              echo "===="
               echo "Total size of WT_TEST directory prior to copy:"
               du -hs WT_TEST
-              echo "===="
               cp -rf WT_TEST WT_TEST_$file
-              echo "===="
               echo "Disk usage and free space for the current drive (post-copy):"
               df -h .
-              echo "===="
             done
-            echo "===="
             echo "Disk usage and free space for the current drive (at the end):"
             df -h .
-            echo "===="
 
   - name: ftruncate-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2146,7 +2146,7 @@ tasks:
               echo "Disk usage and free space for the current drive (pre-copy):"
               df -h .
               echo "===="
-              echo "Total size of WT_TEST dirwectory:"
+              echo "Total size of WT_TEST directory prior to copy:"
               du -hs WT_TEST
               echo "===="
               cp -rf WT_TEST WT_TEST_$file


### PR DESCRIPTION
The problem was caused by the test creating and then attempting to copy a large (26Gb) database file on a machine with only 50Gb of disk. Renaming the file (using mv) solves the issue, while also keeping the database available.

I have deliberately left the disk space diagnostics I added in place to make it easier/faster to debug issues in the future.