### PR TITLE
WT-8906 Restore the change to set the btree handle logging flags

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -388,11 +388,12 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt)
     if (WT_IS_METADATA(btree->dhandle))
         F_SET(btree, WT_BTREE_IGNORE_CACHE);
 
-    WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
-    if (cval.val)
-        F_CLR(btree, WT_BTREE_NO_LOGGING);
-    else
-        F_SET(btree, WT_BTREE_NO_LOGGING);
+    F_SET(btree, WT_BTREE_NO_LOGGING);
+    if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED)) {
+        WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
+        if (cval.val)
+            F_CLR(btree, WT_BTREE_NO_LOGGING);
+    }
 
     WT_RET(__wt_config_gets(session, cfg, "tiered_object", &cval));
     if (cval.val)


### PR DESCRIPTION
Reverting WT-8601 breaks some configurations; restore a small part of that change to set the btree handle logging flags.