### PR TITLE
WT-8802 Removed duplicate -j argument in linux-directio evergreen task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1905,10 +1905,12 @@ tasks:
       - func: "make wiredtiger"
       - func: "make check all"
 
-  # Use format.sh to run tests in parallel (x4) for just under two hours (the
+  # Use format.sh to run tests in parallel for just under two hours (the
   # default Evergreen timeout) on the higher spec build distros. This allows
   # us to perform multiple test runs while ensuring a long-running config does
-  # not result in an Evergreen test timeout failure.
+  # not result in an Evergreen test timeout failure. This test is run on a 
+  # higher spec distro due to historical issues with timeout failures. Consider 
+  # reducing the parallelism if frequent timeouts occur.
   - name: linux-directio
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1915,7 +1915,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          format_test_script_args: -t 110 -j 4 direct_io=1
+          format_test_script_args: -t 110 direct_io=1
 
   - name: format-linux-no-ftruncate
     commands:


### PR DESCRIPTION
A second -j 4 argument was added to the linux-directio evergreen task as part of [WT-5458](https://jira.mongodb.org/browse/WT-5458) to increase the number of resources for the test however a patch build shows the default -j (number of processors) to be sufficient.

Evergreen patch build: https://spruce.mongodb.com/version/622028719ccd4e75c3b4b5ee/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC