### PR TITLE
WT-8362 Truncate HS when ooo or mm tombstone is written to datastore (mongodb-5.0)

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -178,12 +178,14 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, bool *vali
     WT_COL *cip;
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
+    WT_UPDATE *upd;
 
     *valid = false;
 
     btree = CUR2BT(cbt);
     page = cbt->ref->page;
     session = CUR2S(cbt);
+    upd = NULL;
 
     /*
      * We may be pointing to an insert object, and we may have a page with
@@ -263,8 +265,13 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, bool *vali
 
         *valid = true;
         /*
-         * An update would have appeared as an "insert" object; no further checks to do.
+         * Check for an update. For column store, modifications are handled with insert lists, so an
+         * insert can have the same key as an on-page or history store object.
+         *
+         * Note: we do not want to replace tombstones with zero here; it skips cases in other code
+         * below that expect to handle it themselves, and then doesn't work.
          */
+        upd = cbt->ins ? cbt->ins->upd : NULL;
         break;
     case BTREE_COL_VAR:
         /* The search function doesn't check for empty pages. */
@@ -294,15 +301,10 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, bool *vali
             return (0);
 
         /*
-         * Check for an update ondisk or in the history store. For column store, an insert object
-         * can have the same key as an on-page or history store object.
+         * Check for an update. For column store, modifications are handled with insert lists, so an
+         * insert can have the same key as an on-page or history store object.
          */
-        WT_RET(__wt_txn_read(session, cbt, key, recno, cbt->ins ? cbt->ins->upd : NULL));
-        if (cbt->upd_value->type != WT_UPDATE_INVALID) {
-            if (cbt->upd_value->type == WT_UPDATE_TOMBSTONE)
-                return (0);
-            *valid = true;
-        }
+        upd = cbt->ins ? cbt->ins->upd : NULL;
         break;
     case BTREE_ROW:
         /* The search function doesn't check for empty pages. */
@@ -321,17 +323,22 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, bool *vali
         if (cbt->ins != NULL)
             return (0);
 
+        /* Paranoia. */
+        WT_ASSERT(session, recno == WT_RECNO_OOB);
+
         /* Check for an update. */
-        WT_RET(__wt_txn_read(session, cbt, key, WT_RECNO_OOB,
-          (page->modify != NULL && page->modify->mod_row_update != NULL) ?
-            page->modify->mod_row_update[cbt->slot] :
-            NULL));
-        if (cbt->upd_value->type != WT_UPDATE_INVALID) {
-            if (cbt->upd_value->type == WT_UPDATE_TOMBSTONE)
-                return (0);
-            *valid = true;
-        }
+        upd = (page->modify != NULL && page->modify->mod_row_update != NULL) ?
+          page->modify->mod_row_update[cbt->slot] :
+          NULL;
         break;
+    }
+
+    /* Check for a value on disk or in the history store. Pass in any update. */
+    WT_RET(__wt_txn_read(session, cbt, key, recno, upd));
+    if (cbt->upd_value->type != WT_UPDATE_INVALID) {
+        if (cbt->upd_value->type == WT_UPDATE_TOMBSTONE)
+            return (0);
+        *valid = true;
     }
     return (0);
 }

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -163,7 +163,8 @@ __wt_value_return_buf(WT_CURSOR_BTREE *cbt, WT_REF *ref, WT_ITEM *buf, WT_TIME_W
     page = ref->page;
     cursor = &cbt->iface;
 
-    if (page->type == WT_PAGE_ROW_LEAF) {
+    switch (page->type) {
+    case WT_PAGE_ROW_LEAF:
         rip = &page->pg_row[cbt->slot];
 
         /*
@@ -181,26 +182,29 @@ __wt_value_return_buf(WT_CURSOR_BTREE *cbt, WT_REF *ref, WT_ITEM *buf, WT_TIME_W
         if (tw != NULL)
             WT_TIME_WINDOW_COPY(tw, &unpack.tw);
         return (__wt_page_cell_data_ref(session, page, &unpack, buf));
-    }
 
-    if (page->type == WT_PAGE_COL_VAR) {
+    case WT_PAGE_COL_VAR:
         /* Take the value from the original page cell. */
         cell = WT_COL_PTR(page, &page->pg_var[cbt->slot]);
         __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
         if (tw != NULL)
             WT_TIME_WINDOW_COPY(tw, &unpack.tw);
         return (__wt_page_cell_data_ref(session, page, &unpack, buf));
+
+    case WT_PAGE_COL_FIX:
+        /*
+         * WT_PAGE_COL_FIX: Take the value from the original page.
+         *
+         * FIXME-WT-6126: Should also check visibility here
+         */
+        if (tw != NULL)
+            WT_TIME_WINDOW_INIT(tw);
+        v = __bit_getv_recno(ref, cursor->recno, btree->bitcnt);
+        return (__wt_buf_set(session, buf, &v, 1));
     }
 
-    /*
-     * WT_PAGE_COL_FIX: Take the value from the original page.
-     *
-     * FIXME-WT-6126: Should also check visibility here
-     */
-    if (tw != NULL)
-        WT_TIME_WINDOW_INIT(tw);
-    v = __bit_getv_recno(ref, cursor->recno, btree->bitcnt);
-    return (__wt_buf_set(session, buf, &v, 1));
+    /* Compilers can't in general tell that other values of page->type aren't valid here. */
+    return (__wt_illegal_value(session, page->type));
 }
 
 /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -848,14 +848,8 @@ __verify_page_content_int(
     uint32_t cell_num;
 
     page = ref->page;
+    dsk = page->dsk;
     ta = &unpack.ta;
-
-    /*
-     * If a tree is empty (just created), it won't have a disk image; if there is no disk image,
-     * we're done.
-     */
-    if ((dsk = page->dsk) == NULL)
-        return (0);
 
     /* Walk the page, verifying overflow pages and validating timestamps. */
     cell_num = 0;
@@ -921,17 +915,11 @@ __verify_page_content_leaf(
     bool found_ovfl;
 
     page = ref->page;
+    dsk = page->dsk;
     rip = page->pg_row;
     tw = &unpack.tw;
     recno = ref->ref_recno;
     found_ovfl = false;
-
-    /*
-     * If a tree is empty (just created), it won't have a disk image; if there is no disk image,
-     * we're done.
-     */
-    if ((dsk = page->dsk) == NULL)
-        return (0);
 
     /* Walk the page, tracking timestamps and verifying overflow pages. */
     cell_num = 0;

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -89,7 +89,7 @@
          * We should not leave any history store cursor open when return from an api call. \
          * However, we cannot do a stricter check before WT-7247 is resolved.              \
          */                                                                                \
-        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 2);            \
+        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 3);            \
         /*                                                                                 \
          * No code after this line, otherwise error handling                               \
          * won't be correct.                                                               \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -785,8 +785,8 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
-  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone,
+  bool error_on_ooo_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
   const char *value_format, uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1237,8 +1237,9 @@ extern int __wt_rec_dictionary_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, u
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_dictionary_lookup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *val,
   WT_REC_DICTIONARY **dpp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint64_t recno,
-  WT_ITEM *rowkey) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r,
+  wt_timestamp_t ts, uint64_t recno, WT_ITEM *rowkey, bool reinsert)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1237,6 +1237,8 @@ extern int __wt_rec_dictionary_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, u
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_dictionary_lookup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *val,
   WT_REC_DICTIONARY **dpp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint64_t recno,
+  WT_ITEM *rowkey) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -299,7 +299,8 @@ typedef struct {
 
     WT_TIME_WINDOW tw;
 
-    bool upd_saved; /* An element on the row's update chain was saved */
+    bool upd_saved;     /* An element on the row's update chain was saved */
+    bool ooo_tombstone; /* Out-of-order tombstone */
 } WT_UPDATE_SELECT;
 
 /*

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -284,6 +284,14 @@ struct __wt_reconcile {
     bool rec_page_cell_with_ts;
     bool rec_page_cell_with_txn_id;
     bool rec_page_cell_with_prepared_txn;
+
+    /*
+     * When removing a key due to a tombstone with a durable timestamp of "none", we also remove the
+     * history store contents associated with that key. Keep the pertinent state here: a flag to say
+     * whether this is appropriate, and a cached history store cursor for doing it.
+     */
+    bool hs_clear_on_tombstone;
+    WT_CURSOR *hs_cursor;
 };
 
 typedef struct {

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -159,7 +159,7 @@ struct __wt_session_impl {
     size_t op_handle_allocated; /* Bytes allocated */
 
     void *reconcile; /* Reconciliation support */
-    void (*reconcile_cleanup)(WT_SESSION_IMPL *);
+    int (*reconcile_cleanup)(WT_SESSION_IMPL *);
 
     /* Salvage support. */
     void *salvage_track;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -580,20 +580,17 @@ __wt_rec_col_var(
     WT_CELL *cell;
     WT_CELL_UNPACK_KV *vpack, _vpack;
     WT_COL *cip;
-    WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_ITEM(orig);
     WT_DECL_RET;
     WT_INSERT *ins;
-    WT_ITEM hs_recno_key;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw, *twp;
     WT_UPDATE *upd;
     WT_UPDATE_SELECT upd_select;
     uint64_t n, nrepeat, repeat_count, rle, skip, src_recno;
     uint32_t i, size;
-    uint8_t *p, hs_recno_key_buf[WT_INTPACK64_MAXSIZE];
-    bool deleted, hs_clear, orig_deleted, update_no_copy;
+    bool deleted, orig_deleted, update_no_copy;
     const void *data;
 
     btree = S2BT(session);
@@ -612,23 +609,6 @@ __wt_rec_col_var(
     last.value = r->last;
     WT_TIME_WINDOW_INIT(&last.tw);
     last.deleted = false;
-
-    /*
-     * When removing a key due to a tombstone with a durable timestamp of "none", also remove the
-     * history store contents associated with that key. It's safe to do even if we fail
-     * reconciliation after the removal, the history store content must be obsolete in order for us
-     * to consider removing the key.
-     *
-     * Ignore if this is metadata, as metadata doesn't have any history.
-     *
-     * Some code paths, such as schema removal, involve deleting keys in metadata and assert that
-     * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
-     * store content, so we can skip this.
-     */
-    hs_cursor = NULL;
-    hs_clear = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
-      !WT_IS_METADATA(btree->dhandle);
 
     WT_RET(__wt_rec_split_init(session, r, page, pageref->ref_recno, btree->maxleafpage_precomp));
 
@@ -822,35 +802,8 @@ record_loop:
                      * When removing a key due to a tombstone with a durable timestamp of "none",
                      * also remove the history store contents associated with that key.
                      */
-                    if (twp->durable_stop_ts == WT_TS_NONE && hs_clear) {
-                        p = hs_recno_key_buf;
-                        WT_ERR(__wt_vpack_uint(&p, 0, src_recno));
-                        hs_recno_key.data = hs_recno_key_buf;
-                        hs_recno_key.size = WT_PTRDIFF(p, hs_recno_key_buf);
-
-                        /* Open a history store cursor if we don't yet have one. */
-                        if (hs_cursor == NULL)
-                            WT_ERR(__wt_curhs_open(session, NULL, &hs_cursor));
-
-                        /*
-                         * From WT_TS_NONE delete all the history store content of the key. This
-                         * path will never be taken for a mixed-mode deletion being evicted and with
-                         * a checkpoint that started prior to the eviction starting its
-                         * reconciliation as previous checks done while selecting an update will
-                         * detect that.
-                         */
-                        WT_ERR(__wt_hs_delete_key_from_ts(
-                          session, hs_cursor, btree->id, &hs_recno_key, WT_TS_NONE, false, false));
-
-                        /* Fail 0.01% of the time. */
-                        if (F_ISSET(r, WT_REC_EVICT) &&
-                          __wt_failpoint(session,
-                            WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 0.01))
-                            WT_ERR(EBUSY);
-
-                        WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
-                        WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
-                    }
+                    if (twp->durable_stop_ts == WT_TS_NONE && r->hs_clear_on_tombstone)
+                        WT_ERR(__wt_rec_hs_clear_on_tombstone(session, r, src_recno, NULL));
 
                     deleted = true;
                     twp = &clear_tw;
@@ -1077,8 +1030,6 @@ next:
     ret = __wt_rec_split_finish(session, r);
 
 err:
-    if (hs_cursor != NULL)
-        WT_TRET(hs_cursor->close(hs_cursor));
     __wt_scr_free(session, &orig);
     return (ret);
 }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -639,7 +639,6 @@ __wt_rec_row_leaf(
     WT_BTREE *btree;
     WT_CELL *cell;
     WT_CELL_UNPACK_KV *kpack, _kpack, *vpack, _vpack;
-    WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_ITEM(tmpkey);
     WT_DECL_RET;
@@ -655,7 +654,7 @@ __wt_rec_row_leaf(
     uint64_t slvg_skip;
     uint32_t i;
     uint8_t key_prefix;
-    bool dictionary, hs_clear, key_onpage_ovfl, ovfl_key;
+    bool dictionary, key_onpage_ovfl, ovfl_key;
     void *copy;
     const void *key_data;
 
@@ -671,23 +670,6 @@ __wt_rec_row_leaf(
 
     cbt = &r->update_modify_cbt;
     cbt->iface.session = (WT_SESSION *)session;
-
-    /*
-     * When removing a key due to a tombstone with a durable timestamp of "none", also remove the
-     * history store contents associated with that key. It's safe to do even if we fail
-     * reconciliation after the removal, the history store content must be obsolete in order for us
-     * to consider removing the key.
-     *
-     * Ignore if this is metadata, as metadata doesn't have any history.
-     *
-     * Some code paths, such as schema removal, involve deleting keys in metadata and assert that
-     * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
-     * store content, so we can skip this.
-     */
-    hs_cursor = NULL;
-    hs_clear = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
-      !WT_IS_METADATA(btree->dhandle);
 
     WT_RET(__wt_rec_split_init(session, r, page, 0, btree->maxleafpage_precomp));
 
@@ -852,29 +834,9 @@ __wt_rec_row_leaf(
                  * When removing a key due to a tombstone with a durable timestamp of "none", also
                  * remove the history store contents associated with that key.
                  */
-                if (twp->durable_stop_ts == WT_TS_NONE && hs_clear) {
+                if (twp->durable_stop_ts == WT_TS_NONE && r->hs_clear_on_tombstone) {
                     WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
-
-                    /* Open a history store cursor if we don't yet have one. */
-                    if (hs_cursor == NULL)
-                        WT_ERR(__wt_curhs_open(session, NULL, &hs_cursor));
-
-                    /*
-                     * From WT_TS_NONE delete all the history store content of the key. This path
-                     * will never be taken for a mixed-mode deletion being evicted and with a
-                     * checkpoint that started prior to the eviction starting its reconciliation as
-                     * previous checks done while selecting an update will detect that.
-                     */
-                    WT_ERR(__wt_hs_delete_key_from_ts(
-                      session, hs_cursor, btree->id, tmpkey, WT_TS_NONE, false, false));
-
-                    /* Fail 0.01% of the time. */
-                    if (F_ISSET(r, WT_REC_EVICT) &&
-                      __wt_failpoint(
-                        session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 0.01))
-                        WT_ERR(EBUSY);
-                    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
-                    WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
+                    WT_ERR(__wt_rec_hs_clear_on_tombstone(session, r, WT_RECNO_OOB, tmpkey));
                 }
 
                 /*
@@ -1006,8 +968,6 @@ leaf_insert:
     ret = __wt_rec_split_finish(session, r);
 
 err:
-    if (hs_cursor != NULL)
-        WT_TRET(hs_cursor->close(hs_cursor));
     __wt_scr_free(session, &tmpkey);
     return (ret);
 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -8,9 +8,9 @@
 
 #include "wt_internal.h"
 
-static void __rec_cleanup(WT_SESSION_IMPL *, WT_RECONCILE *);
-static void __rec_destroy(WT_SESSION_IMPL *, void *);
-static void __rec_destroy_session(WT_SESSION_IMPL *);
+static int __rec_cleanup(WT_SESSION_IMPL *, WT_RECONCILE *);
+static int __rec_destroy(WT_SESSION_IMPL *, void *);
+static int __rec_destroy_session(WT_SESSION_IMPL *);
 static int __rec_init(WT_SESSION_IMPL *, WT_REF *, uint32_t, WT_SALVAGE_COOKIE *, void *);
 static int __rec_hs_wrapup(WT_SESSION_IMPL *, WT_RECONCILE *);
 static int __rec_root_write(WT_SESSION_IMPL *, WT_PAGE *, uint32_t);
@@ -149,6 +149,68 @@ __reconcile_save_evict_state(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
 }
 
 /*
+ * __reconcile_post_wrapup --
+ *     Do the last things necessary after wrapping up the reconciliation. Called whether or not the
+ *     reconciliation fails, with different error-path behavior in the parent.
+ */
+static int
+__reconcile_post_wrapup(
+  WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page, uint32_t flags, bool *page_lockedp)
+{
+    WT_BTREE *btree;
+
+    btree = S2BT(session);
+
+    /* Release the reconciliation lock. */
+    *page_lockedp = false;
+    WT_PAGE_UNLOCK(session, page);
+
+    /* Update statistics. */
+    WT_STAT_CONN_INCR(session, rec_pages);
+    WT_STAT_DATA_INCR(session, rec_pages);
+    if (LF_ISSET(WT_REC_EVICT))
+        WT_STAT_CONN_DATA_INCR(session, rec_pages_eviction);
+    if (r->cache_write_hs)
+        WT_STAT_CONN_DATA_INCR(session, cache_write_hs);
+    if (r->cache_write_restore)
+        WT_STAT_CONN_DATA_INCR(session, cache_write_restore);
+    if (!WT_IS_HS(btree->dhandle)) {
+        if (r->rec_page_cell_with_txn_id)
+            WT_STAT_CONN_INCR(session, rec_pages_with_txn);
+        if (r->rec_page_cell_with_ts)
+            WT_STAT_CONN_INCR(session, rec_pages_with_ts);
+        if (r->rec_page_cell_with_prepared_txn)
+            WT_STAT_CONN_INCR(session, rec_pages_with_prepare);
+    }
+    if (r->multi_next > btree->rec_multiblock_max)
+        btree->rec_multiblock_max = r->multi_next;
+
+    /* Clean up the reconciliation structure. */
+    WT_RET(__rec_cleanup(session, r));
+
+    /*
+     * When threads perform eviction, don't cache block manager structures (even across calls), we
+     * can have a significant number of threads doing eviction at the same time with large items.
+     * Ignore checkpoints, once the checkpoint completes, all unnecessary session resources will be
+     * discarded.
+     */
+    if (!WT_SESSION_IS_CHECKPOINT(session)) {
+        /*
+         * Clean up the underlying block manager memory too: it's not reconciliation, but threads
+         * discarding reconciliation structures want to clean up the block manager's structures as
+         * well, and there's no obvious place to do that.
+         */
+        if (session->block_manager_cleanup != NULL) {
+            WT_RET(session->block_manager_cleanup(session));
+        }
+
+        WT_RET(__rec_destroy_session(session));
+    }
+
+    return (0);
+}
+
+/*
  * __reconcile --
  *     Reconcile an in-memory page into its on-disk format, and write it.
  */
@@ -200,6 +262,10 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     }
 
     /*
+     * If we failed, don't bail out yet; we still need to update stats and tidy up.
+     */
+
+    /*
      * Update the global history store score. Only use observations during eviction, not checkpoints
      * and don't count eviction of the history store table itself.
      */
@@ -233,67 +299,19 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     if (ret != 0) {
         /* Make sure that reconciliation doesn't free the page that has been written to disk. */
         WT_ASSERT(session, addr == NULL || ref->addr != NULL);
-        WT_TRET(__rec_write_err(session, r, page));
-    } else {
-        /* Wrap up the page reconciliation. Panic on failure. */
-        if ((ret = __rec_write_wrapup(session, r, page)) != 0)
-            goto panic;
-        __rec_write_page_status(session, r);
-    }
-
-    /* Release the reconciliation lock. */
-    *page_lockedp = false;
-    WT_PAGE_UNLOCK(session, page);
-
-    /* Update statistics. */
-    WT_STAT_CONN_INCR(session, rec_pages);
-    WT_STAT_DATA_INCR(session, rec_pages);
-    if (LF_ISSET(WT_REC_EVICT))
-        WT_STAT_CONN_DATA_INCR(session, rec_pages_eviction);
-    if (r->cache_write_hs)
-        WT_STAT_CONN_DATA_INCR(session, cache_write_hs);
-    if (r->cache_write_restore)
-        WT_STAT_CONN_DATA_INCR(session, cache_write_restore);
-    if (!WT_IS_HS(btree->dhandle)) {
-        if (r->rec_page_cell_with_txn_id)
-            WT_STAT_CONN_INCR(session, rec_pages_with_txn);
-        if (r->rec_page_cell_with_ts)
-            WT_STAT_CONN_INCR(session, rec_pages_with_ts);
-        if (r->rec_page_cell_with_prepared_txn)
-            WT_STAT_CONN_INCR(session, rec_pages_with_prepare);
-    }
-    if (r->multi_next > btree->rec_multiblock_max)
-        btree->rec_multiblock_max = r->multi_next;
-
-    /* Clean up the reconciliation structure. */
-    __rec_cleanup(session, r);
-
-    /*
-     * When threads perform eviction, don't cache block manager structures (even across calls), we
-     * can have a significant number of threads doing eviction at the same time with large items.
-     * Ignore checkpoints, once the checkpoint completes, all unnecessary session resources will be
-     * discarded.
-     */
-    if (!WT_SESSION_IS_CHECKPOINT(session)) {
+        WT_IGNORE_RET(__rec_write_err(session, r, page));
+        WT_IGNORE_RET(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
         /*
-         * Clean up the underlying block manager memory too: it's not reconciliation, but threads
-         * discarding reconciliation structures want to clean up the block manager's structures as
-         * well, and there's no obvious place to do that.
+         * This return statement covers non-panic error scenarios; any failure beyond this point is
+         * a panic. Conversely, no return prior to this point should use the "err" label.
          */
-        if (session->block_manager_cleanup != NULL) {
-            if (ret == 0 && (ret = session->block_manager_cleanup(session)) != 0) {
-                goto panic;
-            } else
-                WT_TRET(session->block_manager_cleanup(session));
-        }
-
-        __rec_destroy_session(session);
+        return (ret);
     }
-    /*
-     * This return statement covers non-panic error scenarios, any failure beyond this point is a
-     * panic.
-     */
-    WT_RET(ret);
+
+    /* Wrap up the page reconciliation. Panic on failure. */
+    WT_ERR(__rec_write_wrapup(session, r, page));
+    __rec_write_page_status(session, r);
+    WT_ERR(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
     /*
      * Root pages are special, splits have to be done, we can't put it off as the parent's problem
@@ -302,7 +320,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     if (__wt_ref_is_root(ref)) {
         WT_WITH_PAGE_INDEX(session, ret = __rec_root_write(session, page, flags));
         if (ret != 0)
-            goto panic;
+            goto err;
         return (0);
     }
 
@@ -311,11 +329,12 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * in service of a checkpoint, it's cleared the tree's dirty flag, and we don't want to set it
      * again as part of that walk.
      */
-    if ((ret = __wt_page_parent_modify_set(session, ref, true)) == 0)
-        return (0);
+    WT_ERR(__wt_page_parent_modify_set(session, ref, true));
 
-panic:
-    WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");
+err:
+    if (ret != 0)
+        WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");
+    return (ret);
 }
 
 /*
@@ -680,6 +699,22 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->rec_page_cell_with_txn_id = false;
     r->rec_page_cell_with_prepared_txn = false;
 
+    /*
+     * When removing a key due to a tombstone with a durable timestamp of "none", also remove the
+     * history store contents associated with that key. It's safe to do even if we fail
+     * reconciliation after the removal, the history store content must be obsolete in order for us
+     * to consider removing the key.
+     *
+     * Ignore if this is metadata, as metadata doesn't have any history.
+     *
+     * Some code paths, such as schema removal, involve deleting keys in metadata and assert that
+     * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
+     * store content, so we can skip this.
+     */
+    r->hs_clear_on_tombstone = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
+      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
+      !WT_IS_METADATA(btree->dhandle);
+
 /*
  * If we allocated the reconciliation structure and there was an error, clean up. If our caller
  * passed in a structure, they own it.
@@ -689,8 +724,8 @@ err:
         if (ret == 0)
             *(WT_RECONCILE **)reconcilep = r;
         else {
-            __rec_cleanup(session, r);
-            __rec_destroy(session, &r);
+            WT_TRET(__rec_cleanup(session, r));
+            WT_TRET(__rec_destroy(session, &r));
         }
     }
 
@@ -701,7 +736,7 @@ err:
  * __rec_cleanup --
  *     Clean up after a reconciliation run, except for structures cached across runs.
  */
-static void
+static int
 __rec_cleanup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 {
     WT_BTREE *btree;
@@ -709,6 +744,9 @@ __rec_cleanup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     uint32_t i;
 
     btree = S2BT(session);
+
+    if (r->hs_cursor != NULL)
+        WT_RET(r->hs_cursor->reset(r->hs_cursor));
 
     if (btree->type == BTREE_ROW)
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
@@ -722,19 +760,25 @@ __rec_cleanup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     /* Reconciliation is not re-entrant, make sure that doesn't happen. */
     r->ref = NULL;
+
+    return (0);
 }
 
 /*
  * __rec_destroy --
  *     Clean up the reconciliation structure.
  */
-static void
+static int
 __rec_destroy(WT_SESSION_IMPL *session, void *reconcilep)
 {
     WT_RECONCILE *r;
 
     if ((r = *(WT_RECONCILE **)reconcilep) == NULL)
-        return;
+        return (0);
+
+    if (r->hs_cursor != NULL)
+        WT_RET(r->hs_cursor->close(r->hs_cursor));
+
     *(WT_RECONCILE **)reconcilep = NULL;
 
     __wt_buf_free(session, &r->chunk_A.key);
@@ -757,16 +801,18 @@ __rec_destroy(WT_SESSION_IMPL *session, void *reconcilep)
     __wt_buf_free(session, &r->update_modify_cbt._upd_value.buf);
 
     __wt_free(session, r);
+
+    return (0);
 }
 
 /*
  * __rec_destroy_session --
  *     Clean up the reconciliation structure, session version.
  */
-static void
+static int
 __rec_destroy_session(WT_SESSION_IMPL *session)
 {
-    __rec_destroy(session, &session->reconcile);
+    return (__rec_destroy(session, &session->reconcile));
 }
 
 /*
@@ -2019,8 +2065,8 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     __wt_page_modify_set(session, parent);
 
 err:
-    __rec_cleanup(session, r);
-    __rec_destroy(session, &cbulk->reconcile);
+    WT_TRET(__rec_cleanup(session, r));
+    WT_TRET(__rec_destroy(session, &cbulk->reconcile));
 
     return (ret);
 }
@@ -2441,4 +2487,56 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
 err:
     __wt_scr_free(session, &tmp);
     return (ret);
+}
+
+/*
+ * __wt_rec_hs_clear_on_tombstone --
+ *     When removing a key due to a tombstone with a durable timestamp of "none", also remove the
+ *     history store contents associated with that key.
+ */
+int
+__wt_rec_hs_clear_on_tombstone(
+  WT_SESSION_IMPL *session, WT_RECONCILE *r, uint64_t recno, WT_ITEM *rowkey)
+{
+    WT_BTREE *btree;
+    WT_ITEM hs_recno_key, *key;
+    uint8_t hs_recno_key_buf[WT_INTPACK64_MAXSIZE], *p;
+
+    btree = S2BT(session);
+
+    /* We should be passed a recno or a row-store key, but not both. */
+    WT_ASSERT(session, (recno == WT_RECNO_OOB) != (rowkey == NULL));
+
+    if (rowkey != NULL)
+        key = rowkey;
+    else {
+        p = hs_recno_key_buf;
+        WT_RET(__wt_vpack_uint(&p, 0, recno));
+        hs_recno_key.data = hs_recno_key_buf;
+        hs_recno_key.size = WT_PTRDIFF(p, hs_recno_key_buf);
+        key = &hs_recno_key;
+    }
+
+    /* Open a history store cursor if we don't yet have one. */
+    if (r->hs_cursor == NULL)
+        WT_RET(__wt_curhs_open(session, NULL, &r->hs_cursor));
+
+    /*
+     * From WT_TS_NONE delete all the history store content of the key. This path will never be
+     * taken for a mixed-mode deletion being evicted and with a checkpoint that started prior to the
+     * eviction starting its reconciliation as previous checks done while selecting an update will
+     * detect that.
+     */
+    WT_RET(
+      __wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key, WT_TS_NONE, false, false));
+
+    /* Fail 0.01% of the time. */
+    if (F_ISSET(r, WT_REC_EVICT) &&
+      __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 1))
+        return (EBUSY);
+
+    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
+    WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
+
+    return (0);
 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2495,8 +2495,8 @@ err:
  *     history store contents associated with that key.
  */
 int
-__wt_rec_hs_clear_on_tombstone(
-  WT_SESSION_IMPL *session, WT_RECONCILE *r, uint64_t recno, WT_ITEM *rowkey)
+__wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r, wt_timestamp_t ts,
+  uint64_t recno, WT_ITEM *rowkey, bool reinsert)
 {
     WT_BTREE *btree;
     WT_ITEM hs_recno_key, *key;
@@ -2527,8 +2527,8 @@ __wt_rec_hs_clear_on_tombstone(
      * eviction starting its reconciliation as previous checks done while selecting an update will
      * detect that.
      */
-    WT_RET(
-      __wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key, WT_TS_NONE, false, false));
+    WT_RET(__wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key, ts, reinsert, true,
+      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)));
 
     /* Fail 0.01% of the time. */
     if (F_ISSET(r, WT_REC_EVICT) &&

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -169,7 +169,7 @@ __wt_session_release_resources(WT_SESSION_IMPL *session)
 
     /* Reconciliation cleanup */
     if (session->reconcile_cleanup != NULL)
-        session->reconcile_cleanup(session);
+        WT_TRET(session->reconcile_cleanup(session));
 
     /* Stashed memory. */
     __wt_stash_discard(session);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -891,9 +891,6 @@ stop:
     if ((inshead = WT_COL_APPEND(page)) != NULL)
         WT_RET(__rollback_abort_insert_list(session, page, inshead, rollback_timestamp, NULL));
 
-    /* Mark the page as dirty to reconcile the page. */
-    if (page->modify)
-        __wt_page_modify_set(session, page);
     return (0);
 }
 
@@ -914,10 +911,6 @@ __rollback_abort_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, wt_timestamp_t
     /* Review the append list */
     if ((ins = WT_COL_APPEND(page)) != NULL)
         WT_RET(__rollback_abort_insert_list(session, page, ins, rollback_timestamp, NULL));
-
-    /* Mark the page as dirty to reconcile the page. */
-    if (page->modify)
-        __wt_page_modify_set(session, page);
 
     return (0);
 }
@@ -976,10 +969,6 @@ __rollback_abort_row_leaf(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t 
               session, ref, rip, 0, have_key ? key : NULL, vpack, rollback_timestamp, NULL));
         }
     }
-
-    /* Mark the page as dirty to reconcile the page. */
-    if (page->modify)
-        __wt_page_modify_set(session, page);
 
 err:
     __wt_scr_free(session, &key);
@@ -1113,21 +1102,21 @@ __rollback_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
     case WT_PAGE_COL_VAR:
         WT_RET(__rollback_abort_col_var(session, ref, rollback_timestamp));
         break;
-    case WT_PAGE_COL_INT:
-    case WT_PAGE_ROW_INT:
-        /*
-         * There is nothing to do for internal pages, since we aren't rolling back far enough to
-         * potentially include reconciled changes - and thus won't need to roll back structure
-         * changes on internal pages.
-         */
-        break;
     case WT_PAGE_ROW_LEAF:
         WT_RET(__rollback_abort_row_leaf(session, ref, rollback_timestamp));
         break;
+    case WT_PAGE_COL_INT:
+    case WT_PAGE_ROW_INT:
+        /* This function is not called for internal pages. */
+        WT_ASSERT(session, false);
+        /* Fall through. */
     default:
         WT_RET(__wt_illegal_value(session, page->type));
     }
 
+    /* Mark the page as dirty to reconcile the page. */
+    if (page->modify)
+        __wt_page_modify_set(session, page);
     return (0);
 }
 

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+
+# test_hs29.py
+# It is possible to end up with 3 opened history store cursors at the same time when the following
+# occurs:
+# - The reconciliation process opens one history store cursor.
+# - The function hs_delete_reinsert_from_pos creates a history store cursor too. This means we need
+# an update with an OOO timestamp to trigger that function.
+# - The function wt_rec_hs_clear_on_tombstone creates a history store cursor as well. This means we
+# need a tombstone to trigger the function, i.e a deleted key.
+class test_hs29(wttest.WiredTigerTestCase):
+
+    def test_3_hs_cursors(self):
+
+        # Create a table.
+        uri = "table:test_hs_cursor"
+        self.session.create(uri, 'key_format=S,value_format=S')
+        
+        # Open one cursor to operate on the table and another one to perform eviction.
+        cursor = self.session.open_cursor(uri)
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+
+        # Create two keys and perform an update on each.
+        self.session.begin_transaction()
+        cursor['1'] = '1'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+
+        self.session.begin_transaction()
+        cursor['1'] = '11'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+
+        self.session.begin_transaction()
+        cursor['2'] = '2'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        self.session.begin_transaction()
+        cursor['2'] = '22'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Perform eviction.
+        cursor2.set_key('1')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '11')
+        self.assertEqual(cursor2.reset(), 0)
+
+        cursor2.set_key('2')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '22')
+        self.assertEqual(cursor2.reset(), 0)
+
+        # Remove the first key without giving a ts.
+        self.session.begin_transaction()
+        cursor.set_key('1')
+        cursor.remove()
+        self.session.commit_transaction()
+
+        # Update the second key with out of order timestamp.
+        self.session.begin_transaction()
+        cursor['2'] = '222'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+
+        # Close the connection to trigger a final checkpoint and reconciliation.
+        self.conn.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_hs31.py
+++ b/test/suite/test_hs31.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_hs31.py
+# Ensure that tombstone with out of order timestamp clear the history store records.
+class test_hs31(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=5MB,statistics=(all)'
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        # FIXME-WT-8287, FIXME-WT-8362, FIXME-WT-8476, : Changes related to FLCS were not fully
+        # backported from those tickets. In the meantime, disable the FLCS scenario.
+        # ('column-fix', dict(key_format='r', value_format='8t')),
+        ('integer-row', dict(key_format='i', value_format='S')),
+        ('string-row', dict(key_format='S', value_format='S')),
+    ]
+
+    ooo_values = [
+        ('out-of-order', dict(ooo_value=True)),
+        ('mixed-mode', dict(ooo_value=False)),
+    ]
+
+    globally_visible_before_ckpt_values = [
+        ('globally_visible_before_ckpt', dict(globally_visible_before_ckpt=True)),
+        ('no_globally_visible_before_ckpt', dict(globally_visible_before_ckpt=False)),
+    ]
+
+    scenarios = make_scenarios(format_values, ooo_values, globally_visible_before_ckpt_values)
+    nrows = 1000
+
+    def create_key(self, i):
+        if self.key_format == 'S':
+            return str(i)
+        return i
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def test_ooo_tombstone_clear_hs(self):
+        uri = 'file:test_hs31'
+        create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(uri, create_params)
+
+        if self.value_format == '8t':
+            value1 = 97
+            value2 = 98
+        else:
+            value1 = 'a' * 500
+            value2 = 'b' * 500
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Apply a series of updates from timestamps 10-14.
+        cursor = self.session.open_cursor(uri)
+        for ts in range(10, 15):
+            for i in range(1, self.nrows):
+                self.session.begin_transaction()
+                cursor[self.create_key(i)] = value1
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+
+        # Reconcile and flush versions 10-13 to the history store.
+        self.session.checkpoint()
+
+        # Evict the data from the cache.
+        self.session.begin_transaction()
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+        for i in range(1, self.nrows):
+            cursor2.set_key(self.create_key(i))
+            cursor2.search()
+            cursor2.reset()
+        self.session.rollback_transaction()
+
+        if not self.ooo_value:
+            self.session.breakpoint()
+            # Start a long running transaction to stop the oldest id being advanced.
+            session2 = self.conn.open_session()
+            session2.begin_transaction()
+            long_cursor = session2.open_cursor(uri, None)
+            long_cursor[self.create_key(self.nrows + 10)] = value1
+            long_cursor.reset()
+            long_cursor.close()
+
+        # Remove the key with an ooo or mm timestamp.
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor.set_key(self.create_key(i))
+            cursor.remove()
+            if self.ooo_value:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+            else:
+                self.session.commit_transaction()
+
+        if not self.globally_visible_before_ckpt:
+            # Reconcile to write the stop time window.
+            self.session.checkpoint()
+
+        if not self.ooo_value:
+            self.session.breakpoint()
+            # Ensure that old reader can read the history content.
+            long_cursor = session2.open_cursor(uri, None)
+            for i in range(1, self.nrows):
+                long_cursor.set_key(self.create_key(i))
+                self.assertEqual(long_cursor.search(), 0)
+                self.assertEqual(long_cursor.get_value(), value1)
+            long_cursor.reset()
+            long_cursor.close()
+
+            # Rollback the long running transaction.
+            session2.rollback_transaction()
+            session2.close()
+
+        # Pin oldest and stable to timestamp 5 so that the ooo tombstone is globally visible.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
+
+        # Reconcile and remove the obsolete entries.
+        self.session.checkpoint()
+
+        # Evict the data from the cache.
+        self.session.begin_transaction()
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+        for i in range(1, self.nrows):
+            cursor2.set_key(self.create_key(i))
+            if self.value_format == '8t':
+                self.assertEqual(cursor2.search(), 0)
+            else:
+                self.assertEqual(cursor2.search(), wiredtiger.WT_NOTFOUND)
+            cursor2.reset()
+        self.session.rollback_transaction()
+
+        # Now apply an insert at timestamp 20.
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor[self.create_key(i)] = value2
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Ensure that we blew away history store content.
+        for ts in range(10, 15):
+            self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+            for i in range(1, self.nrows):
+                cursor.set_key(self.create_key(i))
+                if self.value_format == '8t':
+                    self.assertEqual(cursor.search(), 0)
+                    self.assertEqual(cursor.get_value(), 0)
+                else:
+                    self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+            self.session.rollback_transaction()
+
+        hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
+        self.assertGreater(hs_truncate, 0)
+


### PR DESCRIPTION
This PR contains changes from:
- [WT-8476](https://jira.mongodb.org/browse/WT-8476) (https://github.com/wiredtiger/wiredtiger/pull/7252)
- [WT-8550](https://jira.mongodb.org/browse/WT-8476) (https://github.com/wiredtiger/wiredtiger/pull/7362)
- [WT-8362](https://jira.mongodb.org/browse/WT-8476) (https://github.com/wiredtiger/wiredtiger/pull/7520)

WT-8476 and WT-8550 were necessary to import the code changes from WT-8362. Only the columns store changes required for the code to compile were imported as 5.0 does not support column store.
The important bit in this backport was to have test_hs31.py pass since it can reproduce an error prior to the changes done on WT-8362.