### PR TITLE
WT-8889 Remove unused failpoint definition in test checkpoint

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -43,7 +43,7 @@ set_stable(void)
 {
     char buf[128];
 
-    if (g.race_timetamps)
+    if (g.race_timestamps)
         testutil_check(__wt_snprintf(buf, sizeof(buf),
           "stable_timestamp=%" PRIx64 ",oldest_timestamp=%" PRIx64, g.ts_stable, g.ts_stable));
     else

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
             g.use_timestamps = true;
             break;
         case 'X':
-            g.use_timestamps = g.race_timetamps = true;
+            g.use_timestamps = g.race_timestamps = true;
             break;
         default:
             return (usage());
@@ -267,9 +267,8 @@ wt_connect(const char *config_open)
     bool timing_stress;
 
     timing_stress = false;
-    if (g.sweep_stress || g.failpoint_hs_delete_key_from_ts || g.failpoint_hs_insert_1 ||
-      g.failpoint_hs_insert_2 || g.hs_checkpoint_timing_stress || g.reserved_txnid_timing_stress ||
-      g.checkpoint_slow_timing_stress) {
+    if (g.sweep_stress || g.failpoint_hs_delete_key_from_ts || g.hs_checkpoint_timing_stress ||
+      g.reserved_txnid_timing_stress || g.checkpoint_slow_timing_stress) {
         timing_stress = true;
         testutil_check(__wt_snprintf(timing_stress_config, sizeof(timing_stress_config),
           ",timing_stress_for_test=[%s%s%s%s%s]", g.sweep_stress ? "aggressive_sweep" : "",

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -69,8 +69,6 @@ typedef struct {
     int status;                           /* Exit status */
     bool sweep_stress;                    /* Sweep stress test */
     bool failpoint_hs_delete_key_from_ts; /* Failpoint for hs key deletion. */
-    bool failpoint_hs_insert_1;           /* Failpoint for hs insertion. */
-    bool failpoint_hs_insert_2;           /* Failpoint for hs insertion. */
     bool hs_checkpoint_timing_stress;     /* History store checkpoint timing stress */
     bool reserved_txnid_timing_stress;    /* Reserved transaction id timing stress */
     bool checkpoint_slow_timing_stress;   /* Checkpoint slow timing stress */
@@ -78,7 +76,7 @@ typedef struct {
     uint64_t ts_stable;                   /* Current stable timestamp */
     bool mixed_mode_deletes;              /* Run with mixed mode deletes */
     bool use_timestamps;                  /* Use txn timestamps */
-    bool race_timetamps;                  /* Async update to oldest timestamp */
+    bool race_timestamps;                 /* Async update to oldest timestamp */
     bool prepare;                         /* Use prepare transactions */
     COOKIE *cookies;                      /* Per-thread info */
     WT_RWLOCK clock_lock;                 /* Clock synchronization */


### PR DESCRIPTION
Remove two unused failpoint definitions in test checkpoint.
Fix an obvious typo.