### PR TITLE
WT-8930 Make s_string hex number search compatible with MacOS

### DIFF
--- a/dist/s_string
+++ b/dist/s_string
@@ -34,7 +34,7 @@ check() {
 	# Strip out double quote char literals ('"'), they confuse aspell.
 	# Strip out calls to __wt_getopt so the option lists don't have to be spelling words.
 	# Strip out C-style hex constants.
-	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' ../$2 -e 's/0x[[:xdigit:]]\+//' |
+	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' -e 's/0x[[:xdigit:]]\{0,\}/ /g' ../$2 |
 	aspell --lang=en_US $1 list |
 	sort -u |
 	comm -23 /dev/stdin s_string.ok > $t

--- a/dist/s_string
+++ b/dist/s_string
@@ -34,7 +34,7 @@ check() {
 	# Strip out double quote char literals ('"'), they confuse aspell.
 	# Strip out calls to __wt_getopt so the option lists don't have to be spelling words.
 	# Strip out C-style hex constants.
-	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' -e 's/0x[[:xdigit:]]\{0,\}/ /g' ../$2 |
+	sed -e 's/ [0-9a-f]\{7\} / /g' -e "s/'\"'//g" -e 's/__wt_getopt([^()]*)//' -e 's/0x[[:xdigit:]]\{1,\}/ /g' ../$2 |
 	aspell --lang=en_US $1 list |
 	sort -u |
 	comm -23 /dev/stdin s_string.ok > $t


### PR DESCRIPTION
There's a few things going on with GNU vs. BSD sed. The order of the arguments matters a bit more (need to have the filename last), the `+` operator is only supported with extended regexes (`-E`) but that breaks other stuff so just use a `{0,}` range operator. I also added the `global` flag to catch cases where there are multiple constants on the one line.