### PR TITLE
WT-8835 Allow relative directory to be passed into -b option in tiered_abort test

### DIFF
--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -145,7 +145,8 @@ testutil_clean_work_dir(const char *dir)
 void
 testutil_build_dir(TEST_OPTS *opts, char *buf, int size)
 {
-    /* To keep it simple, in order to get the build directory we require the user to set the build
+    /* 
+     * To keep it simple, in order to get the build directory we require the user to set the build
      * directory from the command line options.
      * We unfortunately can't depend on a known/constant build directory (the user could have
      * multiple out-of-source build directories). There's also not really any OS-agnostic mechanisms

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -145,12 +145,12 @@ testutil_clean_work_dir(const char *dir)
 void
 testutil_build_dir(TEST_OPTS *opts, char *buf, int size)
 {
-    /* 
+    /*
      * To keep it simple, in order to get the build directory we require the user to set the build
-     * directory from the command line options.
-     * We unfortunately can't depend on a known/constant build directory (the user could have
-     * multiple out-of-source build directories). There's also not really any OS-agnostic mechanisms
-     * we can here use to discover the build directory the calling test binary exists in.
+     * directory from the command line options. We unfortunately can't depend on a known/constant
+     * build directory (the user could have multiple out-of-source build directories). There's also
+     * not really any OS-agnostic mechanisms we can here use to discover the build directory the
+     * calling test binary exists in.
      */
     if (opts->build_dir == NULL)
         testutil_die(ENOENT, "No build directory given");


### PR DESCRIPTION
I have changed the test, such that it doesn't do a chdir() within `run_workload`. This is brcause the extensions for WT_LIB needs to have the proper build directory. WT-7598 also now enforces test to run with a -b option as well. To run the test currently requires the absolute directory e.g.
```./test/csuite/tiered_abort/test_tiered_abort -b /data/wiredtiger/build```
This ticket aims to be able to give support to also add in relative directory as well e.g. 
```./test/csuite/tiered_abort/test_tiered_abort -b .```