### PR TITLE
WT-8584 Replace wait signal with global thread counter in wt7989-compact-checkpoint-test

### DIFF
--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -102,13 +102,13 @@ main(int argc, char *argv[])
     /*
      * Next, run test with WT_TIMING_STRESS_CHECKPOINT_SLOW. Column store case.
      */
-    // run_test_clean(true, true, opts->preserve, opts->home, "SC", opts->uri);
+    run_test_clean(true, true, opts->preserve, opts->home, "SC", opts->uri);
 
     /*
      * Finally, run test where compact and checkpoint threads are synchronized using global thread
      * counter. Column store case.
      */
-    // run_test_clean(false, true, opts->preserve, opts->home, "NC", opts->uri);
+    run_test_clean(false, true, opts->preserve, opts->home, "NC", opts->uri);
 
     testutil_cleanup(opts);
 
@@ -294,8 +294,9 @@ thread_func_checkpoint(void *arg)
  * thread_wait --
  *     Loop to constantly yield the calling thread until all threads are ready.
  */
-static void 
-thread_wait(void){
+static void
+thread_wait(void)
+{
     uint64_t ready_counter_local;
 
     (void)__wt_atomic_add64(&ready_counter, 1);

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -222,7 +222,6 @@ thread_func_compact(void *arg)
 {
     struct thread_data *td;
     WT_SESSION *session;
-    // uint64_t ready_counter_local;
 
     td = (struct thread_data *)arg;
 


### PR DESCRIPTION
The wt7989-compact-checkpoint-test failed as a result of synchronizing the checkpoint and compaction threads using the conditional variable to signal when the threads are ready. The log showed the compaction thread sending a ready signal before the checkpoint thread waits for it, resulting in the checkpoint thread waiting forever. This PR replaces the signal with a global thread-ready counter as an alternative approach to force the threads to wait until all threads are ready before starting their operations.