### PR TITLE
WT-7187 Re-enable compact tests for macOS

### DIFF
--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -73,12 +73,6 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
 
     # Test compaction.
     def test_compact(self):
-        # FIXME-WT-7187
-        # This test is temporarily disabled for OS/X, it fails often, but not consistently.
-        import platform
-        if platform.system() == 'Darwin':
-            self.skipTest('Compaction tests skipped, as they fail on OS/X')
-
         # Populate an object
         uri = self.type + self.name
         ds = self.dataset(self, uri, self.nentries - 1, config=self.config)

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -38,7 +38,7 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
     name = 'test_compact'
 
     # Use a small page size because we want to create lots of pages.
-    config = 'allocation_size=8KB,leaf_page_max=8KB,key_format=S'
+    config = 'leaf_page_max=8KB,key_format=S'
     nentries = 50000
 
     # The table is a complex object, give it roughly 5 pages per underlying

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -38,8 +38,7 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
     name = 'test_compact'
 
     # Use a small page size because we want to create lots of pages.
-    config = 'allocation_size=512,' +\
-        'leaf_page_max=512,key_format=S'
+    config = 'allocation_size=8KB,leaf_page_max=8KB,key_format=S'
     nentries = 50000
 
     # The table is a complex object, give it roughly 5 pages per underlying

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -37,7 +37,9 @@ from wtscenario import make_scenarios
 class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
     name = 'test_compact'
 
-    # Use a small page size because we want to create lots of pages.
+    # We don't want to set the page size too small as compaction doesn't work on tables with many
+    # overflow items, furthermore eviction can get very slow with overflow items. We don't want the
+    # page size to be too big either as there won't be enough pages to rewrite.
     config = 'leaf_page_max=8KB,key_format=S'
     nentries = 50000
 

--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -123,12 +123,6 @@ class test_compact02(wttest.WiredTigerTestCase):
     def test_compact02(self):
         mb = 1024 * 1024
 
-        # FIXME-WT-7187
-        # This test is temporarily disabled for OS/X, it fails, but not consistently.
-        import platform
-        if platform.system() == 'Darwin':
-            self.skipTest('Compaction tests skipped, as they fail on OS/X')
-
         self.ConnectionOpen(self.cacheSize)
 
         # Set the leaf_value_max to ensure we never create overflow items.


### PR DESCRIPTION
Since overflow reads are synchronous, it might be slow to process all of them and eviction can take too long. To avoid this situation, we decided to increase the page size so we have fewer chances to deal with overflow items. The intent of the test has never been to work with overflow items.
With the new changes, I checked and no overflow items are created.

**Note: I have enabled the tests on macOS in the PR testing.**