### PR TITLE
WT-8935 Failed transaction commit doesn't reset cursors.

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1678,26 +1678,21 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
           F_ISSET(txn, WT_TXN_PREPARE) ? "prepared " : "", txn->rollback_reason == NULL ? "" : ": ",
           txn->rollback_reason == NULL ? "" : txn->rollback_reason);
 
-    F_SET(session, WT_SESSION_RESOLVING_TXN);
-    ret = __wt_txn_commit(session, cfg);
-    F_CLR(session, WT_SESSION_RESOLVING_TXN);
-
 err:
     /*
-     * We can fail because of an illegal configuration, or there wasn't a transaction running, or
-     * because commit itself failed. Deal with it here: if there's an error and a transaction is
-     * still running, roll it back.
-     *
-     * Check for a prepared transaction, and quit: we can't ignore the error and we can't roll back
-     * a prepared transaction the application wanted to commit.
+     * We might have failed because an illegal configuration was specified or because there wasn't a
+     * transaction running, and we check the former as part of the api macros before we check the
+     * latter. Deal with it here: if there's an error and a transaction is running, roll it back.
      */
-    if (ret != 0 && F_ISSET(txn, WT_TXN_RUNNING)) {
+    if (ret == 0) {
+        F_SET(session, WT_SESSION_RESOLVING_TXN);
+        ret = __wt_txn_commit(session, cfg);
+        F_CLR(session, WT_SESSION_RESOLVING_TXN);
+    } else if (F_ISSET(txn, WT_TXN_RUNNING)) {
         if (F_ISSET(txn, WT_TXN_PREPARE))
-            WT_TRET(__wt_panic(
-              session, ret, "failed to commit prepared transaction, failing the system"));
+            WT_RET_PANIC(session, ret, "failed to commit prepared transaction, failing the system");
 
         WT_TRET(__wt_session_reset_cursors(session, false));
-
         F_SET(session, WT_SESSION_RESOLVING_TXN);
         WT_TRET(__wt_txn_rollback(session, cfg));
         F_CLR(session, WT_SESSION_RESOLVING_TXN);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1720,12 +1720,6 @@ err:
     if (cursor != NULL)
         WT_TRET(cursor->close(cursor));
 
-    /*
-     * If anything went wrong, roll back.
-     *
-     * !!!
-     * Nothing can fail after this point.
-     */
     if (locked)
         __wt_readunlock(session, &txn_global->visibility_rwlock);
 
@@ -1733,15 +1727,6 @@ err:
     if (cannot_fail)
         WT_RET_PANIC(session, ret,
           "failed to commit a transaction after data corruption point, failing the system");
-
-    /*
-     * Check for a prepared transaction, and quit: we can't ignore the error and we can't roll back
-     * a prepared transaction.
-     */
-    if (prepare)
-        WT_RET_PANIC(session, ret, "failed to commit prepared transaction, failing the system");
-
-    WT_TRET(__wt_txn_rollback(session, cfg));
     return (ret);
 }
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1708,8 +1708,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     }
 
     /*
-     * We're between transactions, if we need to block for eviction, it's a good time to do so. Note
-     * that we must ignore any error return because the user's data is committed.
+     * We're between transactions, if we need to block for eviction, it's a good time to do so.
+     * Ignore error returns, the return must reflect the fate of the transaction.
      */
     if (!readonly)
         WT_IGNORE_RET(__wt_cache_eviction_check(session, false, false, NULL));
@@ -1727,6 +1727,16 @@ err:
     if (cannot_fail)
         WT_RET_PANIC(session, ret,
           "failed to commit a transaction after data corruption point, failing the system");
+
+    /*
+     * Check for a prepared transaction, and quit: we can't ignore the error and we can't roll back
+     * a prepared transaction.
+     */
+    if (prepare)
+        WT_RET_PANIC(session, ret, "failed to commit prepared transaction, failing the system");
+
+    WT_TRET(__wt_session_reset_cursors(session, false));
+    WT_TRET(__wt_txn_rollback(session, cfg));
     return (ret);
 }
 
@@ -1903,7 +1913,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
     WT_ASSERT(session, F_ISSET(txn, WT_TXN_RUNNING));
 
     /* Configure the timeout for this rollback operation. */
-    WT_RET(__txn_config_operation_timeout(session, cfg, true));
+    WT_TRET(__txn_config_operation_timeout(session, cfg, true));
 
     /*
      * Resolving prepared updates is expensive. Sort prepared modifications so all updates for each
@@ -1979,9 +1989,10 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
     }
 
     __wt_txn_release(session);
+
     /*
-     * We're between transactions, if we need to block for eviction, it's a good time to do so. Note
-     * that we must ignore any error return because the user's data is committed.
+     * We're between transactions, if we need to block for eviction, it's a good time to do so.
+     * Ignore error returns, the return must reflect the fate of the transaction.
      */
     if (!readonly)
         WT_IGNORE_RET(__wt_cache_eviction_check(session, false, false, NULL));


### PR DESCRIPTION
@luke-pearson, I messed this up the first time around -- `__wt_txn_commit()` gets called from a set of different places, and so the simplest fix is to put the cursor reset in that function.