### PR TITLE
WT-8963 Implement a stress test for insert operation

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -357,3 +357,11 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8659_reconstruct_database_from_logs>/WT_HOME>
     DEPENDS "WT_POSIX"
 )
+
+define_c_test(
+    TARGET test_wt8963_insert_stress
+    SOURCES wt8963_insert_stress/main.c
+    DIR_NAME wt8963_insert_stress
+    ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
+    DEPENDS "WT_POSIX"
+)

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -1,0 +1,171 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+/*
+ * The motivation for this test is to try and reproduce BF-24385 by stressing insert functionality.
+ * The test creates a lot of threads that concurrently insert a lot of records with random keys.
+ * Having a large memory page ensures that we have big insert lists. Big cache size allows having
+ * more dirty content in the memory before eviction kicks in.
+ */
+
+#define THREAD_NUM_ITERATIONS 200000
+#define NUM_THREADS 110
+#define KEY_MAX UINT32_MAX
+
+void *thread_insert_race(void *);
+
+static uint64_t ready_counter;
+static WT_RAND_STATE rnd;
+
+/*
+ * set_key --
+ *     Wrapper providing the correct typing for the WT_CURSOR::set_key variadic argument.
+ */
+static void
+set_key(WT_CURSOR *c, uint64_t value)
+{
+    c->set_key(c, value);
+}
+
+/*
+ * set_value --
+ *     Wrapper providing the correct typing for the WT_CURSOR::set_value variadic argument.
+ */
+static void
+set_value(TEST_OPTS *opts, WT_CURSOR *c, uint64_t value)
+{
+    if (opts->table_type == TABLE_FIX)
+        c->set_value(c, (uint8_t)value);
+    else
+        c->set_value(c, value);
+}
+
+/*
+ * main --
+ *     Test's entry point.
+ */
+int
+main(int argc, char *argv[])
+{
+    TEST_OPTS *opts, _opts;
+    WT_CURSOR *cursor;
+    WT_SESSION *session;
+    clock_t ce, cs;
+    pthread_t id[NUM_THREADS];
+    int i, ret;
+    char tableconf[128];
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    opts->nthreads = NUM_THREADS;
+    opts->table_type = TABLE_ROW;
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+    testutil_make_work_dir(opts->home);
+
+    testutil_check(
+      wiredtiger_open(opts->home, NULL, "create,cache_size=3G,statistics=(fast)", &opts->conn));
+    testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
+    testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
+      "key_format=%s,value_format=%s,leaf_page_max=32k,memory_page_image_max=50MB",
+      opts->table_type == TABLE_ROW ? "Q" : "r", opts->table_type == TABLE_FIX ? "8t" : "Q"));
+    testutil_check(session->create(session, opts->uri, tableconf));
+
+    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+
+    cs = clock();
+
+    /* Multithreaded insert */
+    for (i = 0; i < (int)opts->nthreads; ++i)
+        testutil_check(pthread_create(&id[i], NULL, thread_insert_race, opts));
+
+    while (--i >= 0)
+        testutil_check(pthread_join(id[i], NULL));
+
+    /* Reopen connection for WT_SESSION::verify. It requires exclusive access to the file. */
+    testutil_check(opts->conn->close(opts->conn, NULL));
+    opts->conn = NULL;
+    testutil_check(wiredtiger_open(opts->home, NULL,
+      "create,cache_size=4G,eviction=(threads_max=1),statistics=(fast)", &opts->conn));
+
+    /* Validate */
+    testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
+    testutil_check(session->verify(session, opts->uri, NULL));
+
+    testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
+    i = 0;
+    while ((ret = cursor->next(cursor)) == 0)
+        i++;
+    testutil_assert(ret == WT_NOTFOUND);
+
+    ce = clock();
+    printf(" Number of records: %" PRIu64 "\n Duration: %.2lf\n", (uint64_t)i,
+      (ce - cs) / (double)CLOCKS_PER_SEC);
+
+    testutil_cleanup(opts);
+
+    return (EXIT_SUCCESS);
+}
+
+/*
+ * thread_insert_race --
+ *     Insert items with random keys.
+ */
+WT_THREAD_RET
+thread_insert_race(void *arg)
+{
+    TEST_OPTS *opts;
+    WT_CONNECTION *conn;
+    WT_CURSOR *cursor;
+    WT_SESSION *session;
+    uint64_t i, ready_counter_local, key;
+
+    opts = (TEST_OPTS *)arg;
+    conn = opts->conn;
+
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
+
+    /* Wait until all the threads are ready to go. */
+    (void)__wt_atomic_add64(&ready_counter, 1);
+    for (;; __wt_yield()) {
+        WT_ORDERED_READ(ready_counter_local, ready_counter);
+        if (ready_counter_local >= opts->nthreads)
+            break;
+    }
+
+    for (i = 0; i < THREAD_NUM_ITERATIONS; ++i) {
+        /* Generate random values from [1, KEY_MAX] */
+        key = ((uint64_t)__wt_random(&rnd) % KEY_MAX) + 1;
+        set_key(cursor, key);
+        set_value(opts, cursor, key);
+        testutil_check(cursor->insert(cursor));
+    }
+
+    return (NULL);
+}

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -41,7 +41,6 @@
 void *thread_insert_race(void *);
 
 static uint64_t ready_counter;
-static WT_RAND_STATE rnd;
 
 /*
  * set_key --
@@ -96,8 +95,6 @@ main(int argc, char *argv[])
       opts->table_type == TABLE_ROW ? "Q" : "r", opts->table_type == TABLE_FIX ? "8t" : "Q"));
     testutil_check(session->create(session, opts->uri, tableconf));
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
-
     cs = clock();
 
     /* Multithreaded insert */
@@ -145,12 +142,15 @@ thread_insert_race(void *arg)
     WT_CURSOR *cursor;
     WT_SESSION *session;
     uint64_t i, ready_counter_local, key;
+    WT_RAND_STATE rnd;
 
     opts = (TEST_OPTS *)arg;
     conn = opts->conn;
 
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
+
+    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
 
     /* Wait until all the threads are ready to go. */
     (void)__wt_atomic_add64(&ready_counter, 1);

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
       wiredtiger_open(opts->home, NULL, "create,cache_size=3G,statistics=(fast)", &opts->conn));
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
     testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
-      "key_format=%s,value_format=%s,leaf_page_max=32k,memory_page_image_max=50MB",
+      "key_format=%s,value_format=%s,memory_page_image_max=50MB",
       opts->table_type == TABLE_ROW ? "Q" : "r", opts->table_type == TABLE_FIX ? "8t" : "Q"));
     testutil_check(session->create(session, opts->uri, tableconf));
 

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -107,15 +107,15 @@ main(int argc, char *argv[])
     /* Reopen connection for WT_SESSION::verify. It requires exclusive access to the file. */
     testutil_check(opts->conn->close(opts->conn, NULL));
     opts->conn = NULL;
-    testutil_check(wiredtiger_open(opts->home, NULL,
-      "create,cache_size=4G,statistics=(fast)", &opts->conn));
+    testutil_check(
+      wiredtiger_open(opts->home, NULL, "create,cache_size=4G,statistics=(fast)", &opts->conn));
 
     /* Validate */
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
     testutil_check(session->verify(session, opts->uri, NULL));
 
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
-    
+
     for (i = 0; (ret = cursor->next(cursor)) == 0; i++)
         ;
 
@@ -140,9 +140,9 @@ thread_insert_race(void *arg)
     TEST_OPTS *opts;
     WT_CONNECTION *conn;
     WT_CURSOR *cursor;
+    WT_RAND_STATE rnd;
     WT_SESSION *session;
     uint64_t i, ready_counter_local, key;
-    WT_RAND_STATE rnd;
 
     opts = (TEST_OPTS *)arg;
     conn = opts->conn;

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -32,6 +32,7 @@
  * The test creates a lot of threads that concurrently insert a lot of records with random keys.
  * Having a large memory page ensures that we have big insert lists. Big cache size allows having
  * more dirty content in the memory before eviction kicks in.
+ * The test is in CSuite because CPPSuite doesn't allow averriding validation a the moment.
  */
 
 #define THREAD_NUM_ITERATIONS 200000

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -118,9 +118,10 @@ main(int argc, char *argv[])
     testutil_check(session->verify(session, opts->uri, NULL));
 
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
-    i = 0;
-    while ((ret = cursor->next(cursor)) == 0)
-        i++;
+    
+    for (i = 0; (ret = cursor->next(cursor)) == 0; i++)
+        ;
+
     testutil_assert(ret == WT_NOTFOUND);
 
     ce = clock();

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -38,9 +38,11 @@
 #define NUM_THREADS 110
 #define KEY_MAX UINT32_MAX
 
-void *thread_insert_race(void *);
+static const char *const conn_config_string = "create,cache_size=4G,statistics=(fast)";
 
 static uint64_t ready_counter;
+
+void *thread_insert_race(void *);
 
 /*
  * set_key --
@@ -87,8 +89,7 @@ main(int argc, char *argv[])
     testutil_check(testutil_parse_opts(argc, argv, opts));
     testutil_make_work_dir(opts->home);
 
-    testutil_check(
-      wiredtiger_open(opts->home, NULL, "create,cache_size=3G,statistics=(fast)", &opts->conn));
+    testutil_check(wiredtiger_open(opts->home, NULL, conn_config_string, &opts->conn));
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
     testutil_check(__wt_snprintf(tableconf, sizeof(tableconf),
       "key_format=%s,value_format=%s,memory_page_image_max=50MB",
@@ -107,8 +108,7 @@ main(int argc, char *argv[])
     /* Reopen connection for WT_SESSION::verify. It requires exclusive access to the file. */
     testutil_check(opts->conn->close(opts->conn, NULL));
     opts->conn = NULL;
-    testutil_check(
-      wiredtiger_open(opts->home, NULL, "create,cache_size=4G,statistics=(fast)", &opts->conn));
+    testutil_check(wiredtiger_open(opts->home, NULL, conn_config_string, &opts->conn));
 
     /* Validate */
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
     testutil_check(opts->conn->close(opts->conn, NULL));
     opts->conn = NULL;
     testutil_check(wiredtiger_open(opts->home, NULL,
-      "create,cache_size=4G,eviction=(threads_max=1),statistics=(fast)", &opts->conn));
+      "create,cache_size=4G,statistics=(fast)", &opts->conn));
 
     /* Validate */
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1534,7 +1534,7 @@ tasks:
           test_name: wt8659_reconstruct_database_from_logs
 
   - name: csuite-wt8963-insert-stress-test
-    tags: ["pull_request"]
+    tags: ["stress-test-1"]
     depends_on:
       - name: compile
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1534,10 +1534,10 @@ tasks:
           test_name: wt8659_reconstruct_database_from_logs
 
   - name: csuite-wt8963-insert-stress-test
-    depends_on:
-      - name: compile
+    tags: ["stress-test-1"]
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
+      - func: "compile wiredtiger"
       - func: "csuite test"
         vars:
           test_name: wt8963_insert_stress

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1534,7 +1534,6 @@ tasks:
           test_name: wt8659_reconstruct_database_from_logs
 
   - name: csuite-wt8963-insert-stress-test
-    tags: ["stress-test-1"]
     depends_on:
       - name: compile
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1533,6 +1533,16 @@ tasks:
         vars:
           test_name: wt8659_reconstruct_database_from_logs
 
+  - name: csuite-wt8963-insert-stress-test
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "csuite test"
+        vars:
+          test_name: wt8963_insert_stress
+
   # End of csuite test tasks
 
   # Start of Python unit test tasks


### PR DESCRIPTION
The motivation for this test is to try and reproduce BF-24385 by stressing insert functionality. The test creates a lot of threads that concurrently insert a lot of records with random keys. Having a large memory page ensures that we have big insert lists. Big cache size allows having more dirty content in the memory before eviction kicks in.