### PR TITLE
WT-8787 Update C++ compiler standard in builds from C++11 to C++17

### DIFF
--- a/bench/workgen/CMakeLists.txt
+++ b/bench/workgen/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
     set(swig_cxx_flags
         -Wno-sign-conversion
         -w
-        -std=c++11
+        -std=c++17
     )
 endif()
 list(APPEND swig_cxx_flags -I${CMAKE_SOURCE_DIR})

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(cppsuite_test_harness STATIC
 target_include_directories(cppsuite_test_harness PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(
     cppsuite_test_harness
-    PUBLIC -std=c++11
+    PUBLIC -std=c++17
     PRIVATE ${COMPILER_DIAGNOSTIC_CXX_FLAGS}
 )
 target_link_libraries(cppsuite_test_harness PRIVATE test_util)

--- a/test/cppsuite/test_harness/core/configuration.cxx
+++ b/test/cppsuite/test_harness/core/configuration.cxx
@@ -198,7 +198,7 @@ configuration::merge_default_config(
     auto user_it = split_user_config.begin();
     for (auto default_it = split_default_config.begin(); default_it != split_default_config.end();
          ++default_it) {
-        if (user_it->first != default_it->first)
+        if (user_it == split_user_config.end() || user_it->first != default_it->first)
             /* The default does not exist in the user configuration, add it. */
             merged_config += default_it->first + "=" + default_it->second;
         else {
@@ -214,6 +214,11 @@ configuration::merge_default_config(
         /* Add a comma after every item we add except the last one. */
         if (split_default_config.end() - default_it != 1)
             merged_config += ",";
+    }
+    /* Add any remaining user config items. */
+    while (user_it != split_user_config.end()) {
+        merged_config += "," + user_it->first + "=" + user_it->second;
+        ++user_it;
     }
     return (merged_config);
 }

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3546,6 +3546,7 @@ buildvariants:
     posix_configure_flags:
       -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
       -DCMAKE_C_FLAGS="-ggdb"
+      -DCMAKE_CXX_FLAGS="-ggdb"
       -DHAVE_DIAGNOSTIC=1
       -DENABLE_PYTHON=1
       -DENABLE_ZLIB=1
@@ -3609,6 +3610,7 @@ buildvariants:
       -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
       -DCMAKE_C_FLAGS="-ggdb"
+      -DCMAKE_CXX_FLAGS="-ggdb"
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: ninja
     test_env_vars:
@@ -3678,6 +3680,7 @@ buildvariants:
       -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
       -DCMAKE_C_FLAGS="-ggdb"
+      -DCMAKE_CXX_FLAGS="-ggdb"
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: ninja
     test_env_vars:
@@ -3899,6 +3902,7 @@ buildvariants:
       -DENABLE_STATIC=1
       -DENABLE_TCMALLOC=1
       -DENABLE_ZLIB=1
+      -DCMAKE_CXX_FLAGS="-ggdb"
       -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
   tasks:
     - name: compile


### PR DESCRIPTION
This PR fixes a bug in the `cppsuite` code that was picked up by the C++17 address sanitizer build. I also updated the `evergreen.yml` to add `CXX_FLAGS=-ggdb` to the `cmake` flags for all build variants running the `cppsuite` tests, so that we can have line number information in the evergreen logs on test failure.