### PR TITLE
WT-8970 Turn on exclusive access to dhandles during RTS

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1681,7 +1681,8 @@ __rollback_to_stable_btree_apply(
 
     if (perform_rts || max_durable_ts > rollback_timestamp || prepared_updates ||
       !durable_ts_found || has_txn_updates_gt_than_ckpt_snap) {
-        ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
+        ret = __wt_session_get_dhandle(
+          session, uri, NULL, NULL, WT_DHANDLE_DISCARD | WT_DHANDLE_EXCLUSIVE);
         if (ret != 0)
             WT_ERR_MSG(session, ret, "%s: unable to open handle%s", uri,
               ret == EBUSY ? ", error indicates handle is unavailable due to concurrent use" : "");

--- a/test/suite/test_log04.py
+++ b/test/suite/test_log04.py
@@ -141,11 +141,20 @@ class test_log04(wttest.WiredTigerTestCase):
         self.check(c_ts, 30, key, value60)
         self.check(c_nots, 30, key, value60)
 
+        # Close cursors before calling RTS.
+        c_log.close()
+        c_ts.close()
+        c_nots.close()
+
         # Move the stable timestamp to 25. Checkpoint and rollback to a timestamp.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
         if self.ckpt:
             self.session.checkpoint()
         self.conn.rollback_to_stable()
+
+        c_log = self.session.open_cursor(uri_log)
+        c_ts = self.session.open_cursor(uri_ts)
+        c_nots = self.session.open_cursor(uri_nots)
 
         # Confirm data at time 20 and 30.
         self.check(c_log, 20, key, value60)


### PR DESCRIPTION
Turn on exclusive access to dhandles during RTS.

This should wait on [SERVER-63989](https://jira.mongodb.org/browse/SERVER-63989) to merge, assuming it passes local testing.