### PR TITLE
WT-8968 Fix races with local retention setting in python tests

### DIFF
--- a/test/suite/test_tiered03.py
+++ b/test/suite/test_tiered03.py
@@ -54,7 +54,7 @@ class test_tiered03(wttest.WiredTigerTestCase):
         #    bucket_prefix = generate_s3_prefix(),
         #    ss_name = 's3_store')),
     ]
-    # Occasionally add a lot of records, so that merges (and bloom) happen.
+    # Occasionally add a lot of records to vary the amount of work flush does.
     record_count_scenarios = wtscenario.quick_scenarios(
         'nrecs', [10, 10000], [0.9, 0.1])
     scenarios = wtscenario.make_scenarios(storage_sources, record_count_scenarios, prune=100, prunelong=500)

--- a/test/suite/test_tiered09.py
+++ b/test/suite/test_tiered09.py
@@ -118,9 +118,8 @@ class test_tiered09(wttest.WiredTigerTestCase):
         self.session.flush_tier(None)
         self.close_conn()
 
-        # For directory store, check if the path exists.
+        # For directory store, check that the expected files exist.
         if self.ss_name == 'dir_store':
-            self.assertTrue(os.path.exists(self.obj1file))
             self.assertTrue(os.path.exists(self.obj2file))
             bucket_obj = os.path.join(self.bucket, self.prefix1 + self.obj1file)
             self.assertTrue(os.path.exists(bucket_obj))

--- a/test/suite/test_tiered12.py
+++ b/test/suite/test_tiered12.py
@@ -113,9 +113,6 @@ class test_tiered12(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         self.session.flush_tier(None)
-        # Immediately after flush_tier finishes the cached object should not yet exist
-        cache_obj = os.path.join(cache, self.bucket_prefix + self.obj1file)
-        self.assertFalse(os.path.exists(cache_obj))
 
         # On directory store, the bucket object should exist.
         if self.ss_name == 'dir_store':
@@ -125,6 +122,7 @@ class test_tiered12(wttest.WiredTigerTestCase):
         # Sleep more than the one second stress timing amount and give the thread time to run.
         time.sleep(2)
         # After sleeping, the internal thread should have created the cached object.
+        cache_obj = os.path.join(cache, self.bucket_prefix + self.obj1file)
         self.assertTrue(os.path.exists(cache_obj))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also updated a stale comment in `test_tiered03` that was apparently copied out of an LSM test.