### PR TITLE
WT-8260 Truncate the logs in verbose tests (v5.0 backport)

### DIFF
--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -64,6 +64,11 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         else:
             self.assertEqual(len(verbose_messages), 0)
 
+        if len(output) >= self.nlines:
+            # If we've read the maximum number of characters, its likely that the last line is truncated ('...'). In this
+            # case, trim the last message as we can't parse it.
+            verbose_messages = verbose_messages[:-1]
+
         # Test the contents of each verbose message, ensuring it satisfies the expected pattern.
         verb_pattern = re.compile('|'.join(patterns))
         for line in verbose_messages:


### PR DESCRIPTION
Note: This cherry-pick only adds the changes required to fix a bug when
parsing the logs. We need to truncate them when too many are received.

(cherry picked from commit 4f9feab8ca9ead857ef7e0493a92617e889ae0b9)