### PR TITLE
WT-8943 Fix metadata configuration string resource leak in meta_turtle.c

### DIFF
--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -135,7 +135,7 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session, WT_BACKUPHASH *backuphash)
              * The target uri will be the deciding factor if a specific metadata table entry needs
              * to be dropped. If the metadata table entry does not exist in the target uri hash
              * table, append the metadata key to the backup remove list.
-             */ 
+             */
             if (__metadata_backup_target_uri_search(session, backuphash, metadata_key) == false) {
                 if (key->size > max_len)
                     max_len = key->size;

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -100,6 +100,7 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session, WT_BACKUPHASH *backuphash)
     allocated_name = file_len = max_len = slot = 0;
     conn = S2C(session);
     filename = NULL;
+    metadata_conf = NULL;
     partial_backup_names = NULL;
 
     /* Look for a hot backup file: if we find it, load it. */
@@ -180,10 +181,14 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session, WT_BACKUPHASH *backuphash)
               WT_WITH_TABLE_WRITE_LOCK(
                 session, ret = __wt_schema_drop(session, partial_backup_names[slot], drop_cfg)));
             WT_ERR(ret);
+            __wt_free(session, metadata_conf);
         }
     }
 
 err:
+    if (metadata_conf != NULL)
+        __wt_free(session, metadata_conf);
+
     if (filename != NULL)
         __wt_free(session, filename);
 

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -99,8 +99,7 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session, WT_BACKUPHASH *backuphash)
 
     allocated_name = file_len = max_len = slot = 0;
     conn = S2C(session);
-    filename = NULL;
-    metadata_conf = NULL;
+    filename = metadata_conf = NULL;
     partial_backup_names = NULL;
 
     /* Look for a hot backup file: if we find it, load it. */
@@ -136,7 +135,7 @@ __metadata_load_hot_backup(WT_SESSION_IMPL *session, WT_BACKUPHASH *backuphash)
              * The target uri will be the deciding factor if a specific metadata table entry needs
              * to be dropped. If the metadata table entry does not exist in the target uri hash
              * table, append the metadata key to the backup remove list.
-             */
+             */ 
             if (__metadata_backup_target_uri_search(session, backuphash, metadata_key) == false) {
                 if (key->size > max_len)
                     max_len = key->size;


### PR DESCRIPTION
This ticket frees up the metadata configuration after we have done a metadata search to fix a resource leak.