### PR TITLE
WT-8909 Disable cpp test search_near_01 on 4.4

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -220,6 +220,7 @@ methods = {
                             How long the insertions will occur for.''')]),
     'example_test' : Method(test_config),
     'hs_cleanup' : Method(test_config),
-    'search_near_01' : Method(test_config),
+    # Disabled as part of WT-8909.
+    # 'search_near_01' : Method(test_config),
     'search_near_02' : Method(test_config),
 }

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -220,7 +220,5 @@ methods = {
                             How long the insertions will occur for.''')]),
     'example_test' : Method(test_config),
     'hs_cleanup' : Method(test_config),
-    # Disabled as part of WT-8909.
-    # 'search_near_01' : Method(test_config),
     'search_near_02' : Method(test_config),
 }

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -126,19 +126,6 @@ static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"workload_tracking", "category", NULL, NULL, confchk_workload_tracking_subconfigs, 2},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
-static const WT_CONFIG_CHECK confchk_search_near_01[] = {
-  {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
-  {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
-  {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
-  {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
-  {"enable_logging", "boolean", NULL, NULL, NULL, 0},
-  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 5},
-  {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
-  {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
-  {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 6},
-  {"workload_tracking", "category", NULL, NULL, confchk_workload_tracking_subconfigs, 2},
-  {NULL, NULL, NULL, NULL, NULL, 0}};
-
 static const WT_CONFIG_CHECK confchk_search_near_02[] = {
   {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
   {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
@@ -226,24 +213,6 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s)",
     confchk_hs_cleanup, 10},
-  {"search_near_01",
-    "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
-    "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(enabled=true,op_rate=1s,"
-    "postrun_statistics=[],stat_cache_size=(enabled=false,limit=0),"
-    "stat_db_size=(enabled=false,limit=0)),"
-    "statistics_config=(enable_logging=true,type=all),"
-    "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
-    "stable_lag=1),workload_generator=(enabled=true,"
-    "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
-    "min=0),thread_count=0,value_size=5),op_rate=1s,"
-    "populate_config=(collection_count=1,key_count_per_collection=0,"
-    "key_size=5,thread_count=1,value_size=5),read_config=(key_size=5,"
-    "op_rate=1s,ops_per_transaction=(max=1,min=0),thread_count=0,"
-    "value_size=5),update_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
-    "workload_tracking=(enabled=true,op_rate=1s)",
-    confchk_search_near_01, 10},
   {"search_near_02",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -37,10 +37,6 @@
 #include "burst_inserts.cxx"
 #include "example_test.cxx"
 #include "hs_cleanup.cxx"
-/*
- * Disabled as part of WT-8909.
- * #include "search_near_01.cxx"
- */
 #include "search_near_02.cxx"
 
 std::string
@@ -124,11 +120,6 @@ run_test(const std::string &test_name, const std::string &config, const std::str
         hs_cleanup(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "burst_inserts")
         burst_inserts(test_harness::test_args{config, test_name, wt_open_config}).run();
-    /*
-     * Disabled as part of WT-8909.
-     * else if (test_name == "search_near_01")
-     *   search_near_01(test_harness::test_args{config, test_name, wt_open_config}).run();
-     */
     else {
         test_harness::logger::log_msg(LOG_ERROR, "Test not found: " + test_name);
         error_code = -1;
@@ -151,8 +142,8 @@ main(int argc, char *argv[])
 {
     std::string cfg, config_filename, current_cfg, current_test_name, test_name, wt_open_config;
     int64_t error_code = 0;
-    const std::vector<std::string> all_tests = {"base_test", "burst_inserts", "example_test",
-      "hs_cleanup", /* "search_near_01",*/ "search_near_02"};
+    const std::vector<std::string> all_tests = {
+      "base_test", "burst_inserts", "example_test", "hs_cleanup", "search_near_02"};
 
     /* Set the program name for error messages. */
     (void)testutil_set_progname(argv);

--- a/test/cppsuite/tests/run.cxx
+++ b/test/cppsuite/tests/run.cxx
@@ -37,7 +37,10 @@
 #include "burst_inserts.cxx"
 #include "example_test.cxx"
 #include "hs_cleanup.cxx"
-#include "search_near_01.cxx"
+/*
+ * Disabled as part of WT-8909.
+ * #include "search_near_01.cxx"
+ */
 #include "search_near_02.cxx"
 
 std::string
@@ -121,8 +124,11 @@ run_test(const std::string &test_name, const std::string &config, const std::str
         hs_cleanup(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "burst_inserts")
         burst_inserts(test_harness::test_args{config, test_name, wt_open_config}).run();
-    else if (test_name == "search_near_01")
-        search_near_01(test_harness::test_args{config, test_name, wt_open_config}).run();
+    /*
+     * Disabled as part of WT-8909.
+     * else if (test_name == "search_near_01")
+     *   search_near_01(test_harness::test_args{config, test_name, wt_open_config}).run();
+     */
     else {
         test_harness::logger::log_msg(LOG_ERROR, "Test not found: " + test_name);
         error_code = -1;
@@ -146,7 +152,7 @@ main(int argc, char *argv[])
     std::string cfg, config_filename, current_cfg, current_test_name, test_name, wt_open_config;
     int64_t error_code = 0;
     const std::vector<std::string> all_tests = {"base_test", "burst_inserts", "example_test",
-      "hs_cleanup", "search_near_01", "search_near_02"};
+      "hs_cleanup", /* "search_near_01",*/ "search_near_02"};
 
     /* Set the program name for error messages. */
     (void)testutil_set_progname(argv);

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -34,6 +34,8 @@
 
 using namespace test_harness;
 /*
+ * Disabled as part of WT-8909.
+ *
  * In this test, we want to verify that search_near with prefix enabled only traverses the portion
  * of the tree that follows the prefix portion of the search key. The test is composed of a populate
  * phase followed by a read phase. The populate phase will insert a set of random generated keys

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1050,7 +1050,8 @@ tasks:
             set -o errexit
             set -o verbose
 
-            ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_01 -f test/cppsuite/configs/search_near_01_default.txt -l 2
+            # Disabled as part of WT-8909.
+            # ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_01 -f test/cppsuite/configs/search_near_01_default.txt -l 2
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_02 -f test/cppsuite/configs/search_near_02_default.txt -l 2
 
   - name: cppsuite-base-test-stress

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1050,8 +1050,6 @@ tasks:
             set -o errexit
             set -o verbose
 
-            # Disabled as part of WT-8909.
-            # ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_01 -f test/cppsuite/configs/search_near_01_default.txt -l 2
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_02 -f test/cppsuite/configs/search_near_02_default.txt -l 2
 
   - name: cppsuite-base-test-stress


### PR DESCRIPTION
This test focuses on the prefix_search feature that is not available on
4.4. It has been decided to disable the test.