### PR TITLE
WT-8877 Always dump transaction state of active sessions on RTS failure

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1393,15 +1393,12 @@ static int
 __rollback_to_stable_check(WT_SESSION_IMPL *session)
 {
     WT_DECL_RET;
-    bool txn_active;
 
     /*
      * Help the user comply with the requirement that there are no concurrent user operations. It is
      * okay to have a transaction in prepared state.
      */
-    txn_active = __txn_user_active(session);
-
-    if (txn_active) {
+    if (__txn_user_active(session)) {
         WT_TRET(__wt_verbose_dump_txn(session));
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active transactions");
     }

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1401,7 +1401,7 @@ __rollback_to_stable_check(WT_SESSION_IMPL *session)
      */
     txn_active = __txn_user_active(session);
 
-    if (txn_active){
+    if (txn_active) {
         WT_TRET(__wt_verbose_dump_txn(session));
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active transactions");
     }

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1400,13 +1400,11 @@ __rollback_to_stable_check(WT_SESSION_IMPL *session)
      * okay to have a transaction in prepared state.
      */
     txn_active = __txn_user_active(session);
-#ifdef HAVE_DIAGNOSTIC
-    if (txn_active)
-        WT_TRET(__wt_verbose_dump_txn(session));
-#endif
 
-    if (txn_active)
+    if (txn_active){
+        WT_TRET(__wt_verbose_dump_txn(session));
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active transactions");
+    }
 
     return (ret);
 }

--- a/test/suite/test_rollback_to_stable30.py
+++ b/test/suite/test_rollback_to_stable30.py
@@ -62,11 +62,7 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
 
         # Roll back to stable should fail because there's an active transaction.
         msg = '/rollback_to_stable.*active/'
-        if wiredtiger.diagnostic_build():
-            with self.expectedStdoutPattern('transaction state dump'):
-                self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                    lambda:self.conn.rollback_to_stable(), msg)
-        else:
+        with self.expectedStdoutPattern('transaction state dump'):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda:self.conn.rollback_to_stable(), msg)
 


### PR DESCRIPTION
Removed the have diagnostic check to always dump active transaction information when rollback to stable fails due to active transactions. Also changed test_rollback_to_stable30 to reflect this change and to always check for the transaction state dump on failure.