### PR TITLE
WT-8994 Increase gap error in wt2853_perf

### DIFF
--- a/test/csuite/wt2853_perf/main.c
+++ b/test/csuite/wt2853_perf/main.c
@@ -45,7 +45,7 @@ static void *thread_get(void *);
 
 #define BLOOM false
 #define GAP_DISPLAY 3 /* Threshold for seconds of gap to be displayed */
-#define GAP_ERROR 7   /* Threshold for seconds of gap to be treated as error */
+#define GAP_ERROR 20  /* Threshold for seconds of gap to be treated as error */
 #define N_RECORDS 10000
 #define N_INSERT 1000000
 #define N_INSERT_THREAD 1


### PR DESCRIPTION
The root cause of `wt2853_perf` failures is still under investigation in WT-8373. This change is to suppress noisy evergreen failures while investigation is underway.