### PR TITLE
WT-8995 Create S3 extension documentation

### DIFF
--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -1,31 +1,31 @@
 # WiredTiger's S3 Extension
 
-## Building and running 
+## Building and running
 
 This is a guide to build WiredTiger with the S3 extension enabled.
 
 There are two different ways to build WiredTiger with S3 extension:
-1. Using a system installation of the S3.
-2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
+1. Using a system installation of the AWS SDK dependency.
+2. Letting CMake manage the AWS SDK dependency as an external project, letting it download and compile each time.
 
 There are two CMake flags associated with the S3 extension: `ENABLE_S3` and `IMPORT_S3_SDK`.
 * `ENABLE_S3=1` is required to build the S3 extension.
 * `IMPORT_S3_SDK={external,package}` is used to set the build method.
-    *   `external` tells the compiler to search for an existing system installation of the S3 SDK.
-    *   `package` tells the compiler to download and install the S3 SDK as part of the build.
-    *    This flag should be set alongside the `ENABLE_S3` flag. 
+    *   `external` tells the compiler to search for an existing system installation of the SDK.
+    *   `package` tells the compiler to download and install the SDK as part of the build.
+    *    This flag should be set alongside the `ENABLE_S3` flag.
     *    If the `IMPORT_S3_SDK` flag is not specified, the compiler will assume a system installation of the SDK.
 
-#### Instructions on installing AWS SDK S3 C++ locally
+#### Instructions on installing AWS SDK for C++ locally
 
-Follow the [guide to install SDK locally](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html): 
-* Note: Set BUILD_ONLY flag to "s3-crt" to install only the necessary dependencies for this extension. 
-    *   CMake searches locally for the 's3-crt' package and will not find the 's3' package.
+Follow the [guide to install SDK locally](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html):
+* Note: The S3 extension uses the S3-CRT client provided by the SDK. This is different from the S3 client, so it is important to install the right dependency.
+Set `BUILD_ONLY` flag to "s3-crt" to install only the necessary dependencies for this extension.
 
 
-##### **First** build method - meeting AWS dependency through system installed library
+##### **First** build method - meeting AWS SDK dependency through system installed library
 
-This method will find an existing system installation of the AWS S3 and will not require a download stage during build.
+This method will find an existing system installation of the SDK and will not require a download stage during build.
 
 ```bash
 # Create a new directory to run your build from
@@ -36,15 +36,15 @@ cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G N
 ninja
 ```
 
-* Setting the `IMPORT_S3_SDK` flag is optional for this build method. 
-* `ENABLE_S3` will default to looking for a local installation of the S3. 
+* Setting the `IMPORT_S3_SDK` flag is optional for this build method.
+* `ENABLE_S3` will default to looking for a local installation of the SDK.
 * `ENABLE_STRICT` should be set to 0.
-    This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependenceis.
+    This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependencies.
 
 
-##### **Second** build method - externally installing AWS S3 during build step
+##### **Second** build method - letting CMake manage the SDK dependency as an external project
 
-This method configures CMake to download, compile, and install the AWS S3 every build.
+This method configures CMake to download, compile, and install the AWS SDK while building the S3 extension.
 
 ```bash
 # Create a new directory to run your build from
@@ -59,7 +59,7 @@ ninja
 * `ENABLE_S3` defaults to looking for a local version, the `IMPORT_S3_SDK` setting will override that default.
 
 
-## Testing 
+## Testing
 
 #### To run the tiered python tests for S3:
 
@@ -73,8 +73,8 @@ python3 ../test/suite/run.py -v 4 tiered
 
 ```bash
 # Once WiredTiger has been built with the S3 Extension, run the tests from the build directory
-cd build 
+cd build
 ctest --verbose -R ${TEST NAME}
 ```
 
-To add any additional unit testing, adding the file into the `ext/storage_sources/s3_store/test` directory will allow the test to be picked up by the `CMakeLists.txt` and be incorporated and run with the above instructions. 
+To add any additional unit testing, adding the file into the `ext/storage_sources/s3_store/test` directory will allow the test to be picked up by the `CMakeLists.txt` and be incorporated and run with the above instructions.

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -1,74 +1,81 @@
-# WiredTiger's S3 Store Extension
+# WiredTiger's S3 Extension
 
 ## Building and running 
 
 This is a guide to build WiredTiger with the S3 extension enabled.
 
+There are two different ways to build WiredTiger with S3 extension:
+*    1. Using a system installation of the S3.
+*    2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
+
+There are two CMake flags associated with the S3 extension: `ENABLE_S3` and `IMPORT_S3_SDK`.
+* `ENABLE_S3=1` is required to build the S3 extension.
+* `IMPORT_S3_SDK={external,package}` is used to set the build method.
+    *   `external` tells the compiler to search for an existing system installation of the S3 SDK.
+    *   `package` tells the compiler to download and install the S3 SDK as part of the build.
+    *    This flag should be set alongside the `ENABLE_S3` flag. 
+    *    If the `IMPORT_S3_SDK` flag is not specified, the compiler will assume a system installation of the SDK.
+
+#### Instructions on installing AWS SDK S3 C++ locally
+
+Follow the [guide to install SDK locally](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html): 
+* Note: Set BUILD_ONLY flag to "s3-crt" to install only the necessary dependencies for this extension. 
+    *   CMake searches locally for the 's3-crt' package and will not find the 's3' package.
+
+
 ##### **First** Build method - meeting AWS dependency through system installed library
 
-This method will find a locally installed version of the AWS S3 and will not require a download stage during build.
+This method will find an existing system installation of the AWS S3 and will not require a download stage during build.
 
 ```bash
 # Create a new directory to run your build from
 $ mkdir build && cd build
 
-# Configure and run cmake
+# Configure and run cmake with Ninja
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
+
+ninja
 ```
 
-* Running with the flag `ENABLE_S3=1` will default to looking for a local installation of S3.
-
-* Optionally the compiler flag `IMPORT_S3_SDK` can also be set to:
-    *   `package` for the compiler to search for a local installation of the S3 to use.
-    *    This flag should be set alongside the `ENABLE_S3` flag.   
-
+* Setting the `IMPORT_S3_SDK` flag is optional for this build method. 
+* `ENABLE_S3` will default to looking for a local installation of the S3. 
 * `ENABLE_STRICT` should be set to 0.
     This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependenceis.
-
-* Also optionally: `- G Ninja` here to generate a ninja build. 
-
-#### Instructions on installing AWS SDK S3 C++ locally
-
-Follow the guide below to install SDK locally: 
-* Note: Set BUILD_ONLY flag to "s3-crt" to install only the necessary dependencies for this extension. 
-    *   CMake searches locally for the 's3-crt' package and will not find the 's3' package.
-
-https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html
 
 
 ##### **Second** Build method - externally installing AWS S3 during build step
 
-This method will download and compile the AWS S3 every time. 
+This method configures CMake to download, compile, and install the AWS S3 every build.
 
 ```bash
 # Create a new directory to run your build from
 $ mkdir build && cd build
 
-# Configure and run cmake
+# Configure and run cmake with Ninja
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DIMPORT_S3_SDK=external -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
+
+ninja
 ```
 
-* The compiler flag `IMPORT_S3_SDK` should be set to:
-    *   `external` to prompt the S3 to be externally installed during the build step.
-    *    This should be set alongside the `ENABLE_S3` flag also. 
-    *   `ENABLE_S3` defaults to looking for a local version, the `IMPORT_S3_SDK` setting will override the default.
-
-* There are no changes in the other flags mentioned in the first build method. 
+* The compiler flag `IMPORT_S3_SDK` must be set to `external` for this build method.
+* `ENABLE_S3` defaults to looking for a local version, the `IMPORT_S3_SDK` setting will override that default.
 
 
 ## Testing 
 
-#### To run the Tiered python tests for S3:
+#### To run the tiered python tests for S3:
 
 ```bash
-# This will run all tiered tests on S3 
-env LD_LIBRARY_PATH=.libs python3 ../test/suite/run.py -v 4 tiered
+# This will run all tiered tests on storage sources including S3, run the tests from the build directory
+cd build
+
+python3 ../test/suite/run.py -v 4 tiered
 ```
 
 #### To run the C unit tests for S3
 
 ```bash
-# Once WiredTiger has been built with the S3 Extension, run the tests from the build directory 
+# Once WiredTiger has been built with the S3 Extension, run the tests from the build directory
 cd build 
 
 ctest --verbose -R ${TEST NAME}

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -5,8 +5,8 @@
 This is a guide to build WiredTiger with the S3 extension enabled.
 
 There are two different ways to build WiredTiger with S3 extension:
-    1. Using a system installation of the S3.
-    2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
+1. Using a system installation of the S3.
+2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
 
 There are two CMake flags associated with the S3 extension: `ENABLE_S3` and `IMPORT_S3_SDK`.
 * `ENABLE_S3=1` is required to build the S3 extension.

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -10,10 +10,8 @@ $ mkdir build && cd build
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
 ```
 
-* Running with the tag '-DENABLE_S3=1' will default to looking for a local installation of S3 because of the compiler flag in cmake.
-   
-    - Otherwise if a local S3 installation is not found, an external installation will be prompted to install S3 during the build step.
-    
+* Running with the tag '-DENABLE_S3=1' will default to looking for a local installation of S3.
+       
 * Optionally the compiler flag 'IMPORT_S3_SDK' can be set to either:
     -  'external' prompts the S3 to be externally installed during the build step.
     -  'package' for the compiler to search for a local installation of the S3 to use.  

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -5,8 +5,8 @@
 This is a guide to build WiredTiger with the S3 extension enabled.
 
 There are two different ways to build WiredTiger with S3 extension:
-*    1. Using a system installation of the S3.
-*    2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
+    1. Using a system installation of the S3.
+    2. Letting CMake manage the S3 dependency as an external project, letting it download and compile each time.
 
 There are two CMake flags associated with the S3 extension: `ENABLE_S3` and `IMPORT_S3_SDK`.
 * `ENABLE_S3=1` is required to build the S3 extension.
@@ -23,7 +23,7 @@ Follow the [guide to install SDK locally](https://docs.aws.amazon.com/sdk-for-cp
     *   CMake searches locally for the 's3-crt' package and will not find the 's3' package.
 
 
-##### **First** Build method - meeting AWS dependency through system installed library
+##### **First** build method - meeting AWS dependency through system installed library
 
 This method will find an existing system installation of the AWS S3 and will not require a download stage during build.
 
@@ -33,7 +33,6 @@ $ mkdir build && cd build
 
 # Configure and run cmake with Ninja
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
-
 ninja
 ```
 
@@ -43,7 +42,7 @@ ninja
     This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependenceis.
 
 
-##### **Second** Build method - externally installing AWS S3 during build step
+##### **Second** build method - externally installing AWS S3 during build step
 
 This method configures CMake to download, compile, and install the AWS S3 every build.
 
@@ -53,7 +52,6 @@ $ mkdir build && cd build
 
 # Configure and run cmake with Ninja
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DIMPORT_S3_SDK=external -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
-
 ninja
 ```
 
@@ -68,7 +66,6 @@ ninja
 ```bash
 # This will run all tiered tests on storage sources including S3, run the tests from the build directory
 cd build
-
 python3 ../test/suite/run.py -v 4 tiered
 ```
 
@@ -77,7 +74,6 @@ python3 ../test/suite/run.py -v 4 tiered
 ```bash
 # Once WiredTiger has been built with the S3 Extension, run the tests from the build directory
 cd build 
-
 ctest --verbose -R ${TEST NAME}
 ```
 

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -2,8 +2,7 @@
 
 ## Building and running 
 
-This is a guide to build WiredTiger with the S3 extension enabled. 
-
+This is a guide to build WiredTiger with the S3 extension enabled.
 
 ##### **First** Build method - meeting AWS dependency through system installed library
 
@@ -17,13 +16,13 @@ $ mkdir build && cd build
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
 ```
 
-* Running with the tag `-DENABLE_S3=1` will default to looking for a local installation of S3.
+* Running with the flag `ENABLE_S3=1` will default to looking for a local installation of S3.
 
 * Optionally the compiler flag `IMPORT_S3_SDK` can also be set to:
     *   `package` for the compiler to search for a local installation of the S3 to use.
     *    This flag should be set alongside the `ENABLE_S3` flag.   
 
-* `DENABLE_STRICT` should be set to 0.
+* `ENABLE_STRICT` should be set to 0.
     This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependenceis.
 
 * Also optionally: `- G Ninja` here to generate a ninja build. 

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -25,6 +25,9 @@ cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G N
 ### Installing AWS SDK S3 C++ locally
 
 Follow the guide below to install SDK locally: 
+* Note: Set BUILD_ONLY flag to "s3-crt" to only install necessary dependencies for this extension. 
+    -  CMake searches locally for the s3-crt package and not s3 only package.
+
 https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html
 
 

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -1,6 +1,13 @@
-# S3 Store Extension
+# WiredTiger's S3 Store Extension
 
-## Building and running
+## Building and running 
+
+This is a guide to build WiredTiger with the S3 extension enabled. 
+
+
+##### **First** Build method - meeting AWS dependency through system installed library
+
+This method will find a locally installed version of the AWS S3 and will not require a download stage during build.
 
 ```bash
 # Create a new directory to run your build from
@@ -10,35 +17,51 @@ $ mkdir build && cd build
 cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
 ```
 
-* Running with the tag '-DENABLE_S3=1' will default to looking for a local installation of S3.
-       
-* Optionally the compiler flag 'IMPORT_S3_SDK' can be set to either:
-    -  'external' prompts the S3 to be externally installed during the build step.
-    -  'package' for the compiler to search for a local installation of the S3 to use.  
+* Running with the tag `-DENABLE_S3=1` will default to looking for a local installation of S3.
 
-* 'DENABLE_STRICT' is set to 0 to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party
-    dependenceis.
+* Optionally the compiler flag `IMPORT_S3_SDK` can also be set to:
+    *   `package` for the compiler to search for a local installation of the S3 to use.
+    *    This flag should be set alongside the `ENABLE_S3` flag.   
 
-* Also optionally: '- G Ninja' here to generate a ninja build. _
+* `DENABLE_STRICT` should be set to 0.
+    This is to to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party dependenceis.
 
+* Also optionally: `- G Ninja` here to generate a ninja build. 
 
-### Installing AWS SDK S3 C++ locally
+#### Instructions on installing AWS SDK S3 C++ locally
 
 Follow the guide below to install SDK locally: 
-* Note: Set BUILD_ONLY flag to "s3-crt" to only install necessary dependencies for this extension. 
-    -  CMake searches locally for the s3-crt package and not s3 only package.
+* Note: Set BUILD_ONLY flag to "s3-crt" to install only the necessary dependencies for this extension. 
+    *   CMake searches locally for the 's3-crt' package and will not find the 's3' package.
 
 https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html
 
 
-## Testing 
+##### **Second** Build method - externally installing AWS S3 during build step
 
-Testing should be done after building WiredTiger with the S3 Extension 
+This method will download and compile the AWS S3 every time. 
+
+```bash
+# Create a new directory to run your build from
+$ mkdir build && cd build
+
+# Configure and run cmake
+cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DIMPORT_S3_SDK=external -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
+```
+
+* The compiler flag `IMPORT_S3_SDK` should be set to:
+    *   `external` to prompt the S3 to be externally installed during the build step.
+    *    This should be set alongside the `ENABLE_S3` flag also. 
+    *   `ENABLE_S3` defaults to looking for a local version, the `IMPORT_S3_SDK` setting will override the default.
+
+* There are no changes in the other flags mentioned in the first build method. 
+
+
+## Testing 
 
 #### To run the Tiered python tests for S3:
 
 ```bash
-
 # This will run all tiered tests on S3 
 env LD_LIBRARY_PATH=.libs python3 ../test/suite/run.py -v 4 tiered
 ```
@@ -52,4 +75,4 @@ cd build
 ctest --verbose -R ${TEST NAME}
 ```
 
-To add any additional unit testing, adding the file into the ext/storage_sources/s3_store/test directory will allow the test to be picked up by the CMakeLists.txt and be incorporated and run with the above instructions. 
+To add any additional unit testing, adding the file into the `ext/storage_sources/s3_store/test` directory will allow the test to be picked up by the `CMakeLists.txt` and be incorporated and run with the above instructions. 

--- a/ext/storage_sources/s3_store/README.md
+++ b/ext/storage_sources/s3_store/README.md
@@ -1,0 +1,54 @@
+# S3 Store Extension
+
+## Building and running
+
+```bash
+# Create a new directory to run your build from
+$ mkdir build && cd build
+
+# Configure and run cmake
+cmake -DENABLE_PYTHON=1 -DHAVE_DIAGNOSTIC=1 -DENABLE_S3=1 -DENABLE_STRICT=0 -G Ninja ../.
+```
+
+* Running with the tag '-DENABLE_S3=1' will default to looking for a local installation of S3 because of the compiler flag in cmake.
+   
+    - Otherwise if a local S3 installation is not found, an external installation will be prompted to install S3 during the build step.
+    
+* Optionally the compiler flag 'IMPORT_S3_SDK' can be set to either:
+    -  'external' prompts the S3 to be externally installed during the build step.
+    -  'package' for the compiler to search for a local installation of the S3 to use.  
+
+* 'DENABLE_STRICT' is set to 0 to turn off strict compiler warnings so it does not pick up different formatting errors of the 3rd party
+    dependenceis.
+
+* Also optionally: '- G Ninja' here to generate a ninja build. _
+
+
+### Installing AWS SDK S3 C++ locally
+
+Follow the guide below to install SDK locally: 
+https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/setup-linux.html
+
+
+## Testing 
+
+Testing should be done after building WiredTiger with the S3 Extension 
+
+#### To run the Tiered python tests for S3:
+
+```bash
+
+# This will run all tiered tests on S3 
+env LD_LIBRARY_PATH=.libs python3 ../test/suite/run.py -v 4 tiered
+```
+
+#### To run the C unit tests for S3
+
+```bash
+# Once WiredTiger has been built with the S3 Extension, run the tests from the build directory 
+cd build 
+
+ctest --verbose -R ${TEST NAME}
+```
+
+To add any additional unit testing, adding the file into the ext/storage_sources/s3_store/test directory will allow the test to be picked up by the CMakeLists.txt and be incorporated and run with the above instructions. 


### PR DESCRIPTION
Created `README.md` file to document building, running and testing S3. 
Stored in `/ext/storage_sources/s3_store`.