### PR TITLE
WT-9004 Free the onpage tombstone after update restore eviction

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1571,7 +1571,12 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
         } else
             supd->ins->upd = NULL;
 
-        /* Free the updates written to the data store and the history store. */
+        /*
+         * Free the updates written to the data store and the history store when there exists an
+         * onpage value. It is possible that there can be an onpage tombstone without an onpage
+         * value when the tombstone is globally visible. Do not free them here as it is possible
+         * that the globally visible tombstone is already freed as part of update obsolete check.
+         */
         if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
             tmp = supd->onpage_tombstone != NULL ? &supd->onpage_tombstone : &supd->onpage_upd;
             __wt_free_update_list(session, tmp);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1572,8 +1572,8 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
             supd->ins->upd = NULL;
 
         /* Free the updates written to the data store and the history store. */
-        tmp = supd->onpage_tombstone != NULL ? &supd->onpage_tombstone : &supd->onpage_upd;
-        if (tmp != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+        if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+            tmp = supd->onpage_tombstone != NULL ? &supd->onpage_tombstone : &supd->onpage_upd;
             __wt_free_update_list(session, tmp);
             supd->onpage_tombstone = supd->onpage_upd = NULL;
         }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1547,7 +1547,7 @@ static void
 __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE *tmp;
+    WT_UPDATE **tmp;
     uint32_t i, slot;
 
     /* If we have saved updates, we must have decided to restore them to the new page. */
@@ -1572,10 +1572,11 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
             supd->ins->upd = NULL;
 
         /* Free the updates written to the data store and the history store. */
-        tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
-        if (tmp != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-            __wt_free_update_list(session, &tmp);
-        supd->onpage_tombstone = supd->onpage_upd = NULL;
+        tmp = supd->onpage_tombstone != NULL ? &supd->onpage_tombstone : &supd->onpage_upd;
+        if (tmp != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+            __wt_free_update_list(session, tmp);
+            supd->onpage_tombstone = supd->onpage_upd = NULL;
+        }
     }
 }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1547,6 +1547,7 @@ static void
 __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
+    WT_UPDATE *tmp;
     uint32_t i, slot;
 
     /* If we have saved updates, we must have decided to restore them to the new page. */
@@ -1571,8 +1572,10 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
             supd->ins->upd = NULL;
 
         /* Free the updates written to the data store and the history store. */
-        if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-            __wt_free_update_list(session, &supd->onpage_upd);
+        tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
+        if (tmp != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
+            __wt_free_update_list(session, &tmp);
+        supd->onpage_tombstone = supd->onpage_upd = NULL;
     }
 }
 
@@ -1585,7 +1588,7 @@ static void
 __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT_REF *ref)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE *upd;
+    WT_UPDATE *upd, *tmp;
     uint32_t i, slot;
 
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
@@ -1606,11 +1609,11 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
                 upd = supd->ins->upd;
 
             WT_ASSERT(session, upd != NULL);
-
-            for (; upd->next != NULL && upd->next != supd->onpage_upd; upd = upd->next)
+            tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
+            for (; upd->next != NULL && upd->next != tmp; upd = upd->next)
                 ;
             if (upd->next == NULL)
-                upd->next = supd->onpage_upd;
+                upd->next = tmp;
         }
 
     /*


### PR DESCRIPTION
Once the update restore eviction is finished with restoring
the updates, free all the update written to the data store
and history store including the on-page tombstone.