### PR TITLE
WT-8900 incr_backup fails due to EBUSY from rename

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -2113,8 +2113,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * can lead to files that are inconsistent on disk after a crash.
      */
     if (btree->modified && !bulk && !metadata)
-        WT_RET_MSG(session, EBUSY, "%s: checkpoint close blocked by modified data in the cache",
-          session->dhandle->name);
+        return (__wt_set_return(session, EBUSY));
 
     /*
      * Make sure there isn't a potential race between backup copying the metadata and a checkpoint

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -2113,7 +2113,8 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * can lead to files that are inconsistent on disk after a crash.
      */
     if (btree->modified && !bulk && !metadata)
-        return (__wt_set_return(session, EBUSY));
+        WT_RET_MSG(session, EBUSY, "%s: checkpoint close blocked by modified data in the cache",
+          session->dhandle->name);
 
     /*
      * Make sure there isn't a potential race between backup copying the metadata and a checkpoint

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -473,8 +473,7 @@ rename_table(WT_SESSION *session, TABLE_INFO *tinfo, uint32_t slot)
 
     olduri = tinfo->table[slot].name;
     VERBOSE(3, "rename %s %s\n", olduri, uri);
-    testutil_check(session->checkpoint(session, NULL));
-    testutil_check(session->rename(session, olduri, uri, NULL));
+    WT_OP_CHECKPOINT_WAIT(session, session->rename(session, olduri, uri, NULL));
     free(olduri);
     tinfo->table[slot].name = uri;
 }
@@ -492,7 +491,7 @@ drop_table(WT_SESSION *session, TABLE_INFO *tinfo, uint32_t slot)
     uri = tinfo->table[slot].name;
 
     VERBOSE(3, "drop %s\n", uri);
-    testutil_drop(session, uri, NULL);
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, uri, NULL));
     free(uri);
     tinfo->table[slot].name = NULL;
     tinfo->table[slot].change_count = 0;

--- a/test/csuite/wt2323_join_visibility/main.c
+++ b/test/csuite/wt2323_join_visibility/main.c
@@ -210,10 +210,10 @@ test_join(TEST_OPTS *opts, SHARED_OPTS *sharedopts, bool bloom, bool sometimes_r
           insert_args[i].inserts, insert_args[i].removes, insert_args[i].notfounds,
           insert_args[i].rollbacks);
 
-    testutil_drop(session, sharedopts->posturi, NULL);
-    testutil_drop(session, sharedopts->baluri, NULL);
-    testutil_drop(session, sharedopts->flaguri, NULL);
-    testutil_drop(session, opts->uri, NULL);
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, sharedopts->posturi, NULL));
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, sharedopts->baluri, NULL));
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, sharedopts->flaguri, NULL));
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, opts->uri, NULL));
     testutil_check(session->close(session, NULL));
 }
 

--- a/test/csuite/wt3135_search_near_collator/main.c
+++ b/test/csuite/wt3135_search_near_collator/main.c
@@ -327,8 +327,8 @@ test_one_set(WT_SESSION *session, TEST_SET set)
         search_using_item(cursor, set, i);
     testutil_check(cursor->close(cursor));
 
-    testutil_drop(session, "table:main", NULL);
-    testutil_drop(session, "table:main2", NULL);
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, "table:main", NULL));
+    WT_OP_CHECKPOINT_WAIT(session, session->drop(session, "table:main2", NULL));
 }
 
 /*

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -163,6 +163,18 @@ typedef struct {
     } while (0)
 
 /*
+ * WT_OP_CHECKPOINT_WAIT --
+ *	If an operation returns EBUSY checkpoint and retry.
+ */
+#define WT_OP_CHECKPOINT_WAIT(session, op)                      \
+    do {                                                        \
+        int __ret;                                              \
+        while ((__ret = (op)) == EBUSY)                         \
+            testutil_check(session->checkpoint(session, NULL)); \
+        testutil_check(__ret);                                  \
+    } while (0)
+
+/*
  * testutil_drop --
  *     Drop a table
  */


### PR DESCRIPTION
Wrap rename in a checkpoint loop if it returns EBUSY.
Add a message when checkpoint-close is blocked by modified data.
Generalize test suite support for checkpoint/op loops.