### PR TITLE
WT-9024 Don't allow "all" as a checkpoint name

### DIFF
--- a/src/docs/durability-checkpoint.dox
+++ b/src/docs/durability-checkpoint.dox
@@ -94,6 +94,8 @@ string are reserved.) Applications can open the most recent of these checkpoints
 by specifying \c WiredTigerCheckpoint as the checkpoint name to
 WT_SESSION::open_cursor.
 
+The name "all" is also reserved as it is used when dropping checkpoints.
+
 \warning
 Applications wanting a consistent view of the data in two separate tables must
 either use named checkpoints or explicitly control when checkpoints are taken,


### PR DESCRIPTION
Don't allow "all" to be a checkpoint name. It means something special when dropping checkpoints.