### PR TITLE
WT-9054 format.sh incorrectly configures split stress options

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -547,8 +547,8 @@ format()
 		args+=" format.abort=1"
 	fi
 	if [[ $stress_split_test -ne 0 ]]; then
-		for k in {1..8}; do
-			args+=" stress_split_$k=$(($RANDOM%2))"
+		for k in {1..7}; do
+			args+=" stress.split_$k=$(($RANDOM%2))"
 		done
 	fi
 	args+=" $format_args"


### PR DESCRIPTION
Fix split  stress argument specification ("stress.", not "stress_"), there are currently only 7 stress.split tests.

@lukech, I messed up a change in WT-7936, merged in August 2021, so this has been broken for awhile, and could potentially affect our testing when it's turned back on.