### PR TITLE
WT-8072 Check if all_durable is moving backwards with internal testing

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -159,7 +159,7 @@ thread_ts_run(void *arg)
     int dbg;
     char tscfg[64], ts_string[WT_TS_HEX_STRING_SIZE];
     bool first;
-    
+
     prev_all_dur_ts = WT_TS_NONE;
 
     td = (THREAD_DATA *)arg;

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -179,7 +179,7 @@ thread_ts_run(void *arg)
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
         /*
          * All durable can intermittently move backwards, we do not want to set stable and the
-         * oldest timestamps backwards - refer WT-8001.
+         * oldest timestamps backwards.
          */
         all_dur_ts = strtoul(ts_string, NULL, 16);
         if (!first && all_dur_ts < prev_all_dur_ts) {

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -154,10 +154,13 @@ thread_ts_run(void *arg)
     WT_RAND_STATE rnd;
     WT_SESSION *session;
     THREAD_DATA *td;
+    wt_timestamp_t all_dur_ts, prev_all_dur_ts;
     uint32_t rand_op;
     int dbg;
     char tscfg[64], ts_string[WT_TS_HEX_STRING_SIZE];
     bool first;
+    
+    prev_all_dur_ts = WT_TS_NONE;
 
     td = (THREAD_DATA *)arg;
     __wt_random_init(&rnd);
@@ -174,6 +177,15 @@ thread_ts_run(void *arg)
         ret = td->conn->query_timestamp(td->conn, ts_string, "get=all_durable");
         testutil_check(pthread_rwlock_unlock(&ts_lock));
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+        /*
+         * All durable can intermittently move backwards, we do not want to set stable and the
+         * oldest timestamps backwards - refer WT-8001.
+         */
+        all_dur_ts = strtoul(ts_string, NULL, 16);
+        if (!first && all_dur_ts < prev_all_dur_ts) {
+            __wt_sleep(0, 1000);
+            continue;
+        }
         if (ret == 0) {
             rand_op = __wt_random(&rnd) % 4;
             /*
@@ -196,6 +208,7 @@ thread_ts_run(void *arg)
                       "oldest_timestamp=%s,stable_timestamp=%s", ts_string, ts_string));
                 testutil_check(td->conn->set_timestamp(td->conn, tscfg));
             }
+            prev_all_dur_ts = all_dur_ts;
             first = false;
             /*
              * Set and reset the checkpoint retention setting on a regular basis. We want to test


### PR DESCRIPTION
The check for all_durable moving backwards in txn_commit can fail when multiple transactions commit at the same time since it's possible for the durable timestamp to move backward. timestamp_abort is the only test to use the all_durable timestamp so I've added back the check from WT-7968 to prevent the stable timestamp from moving backward as a result of all_durable. 