### PR TITLE
WT-8362 Truncate HS when ooo or mm tombstone is written to datastore (v4.4 backport)

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -9,8 +9,8 @@
 #include "wt_internal.h"
 
 static int __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
-  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts,
-  uint64_t *hs_counter);
+  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone,
+  bool error_on_ooo_ts, uint64_t *hs_counter);
 
 /*
  * __hs_verbose_cache_stats --
@@ -208,8 +208,8 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
     }
 
     if (ret == 0)
-        WT_ERR(__hs_delete_reinsert_from_pos(
-          session, cursor, btree->id, key, tw->start_ts + 1, true, error_on_ooo_ts, &counter));
+        WT_ERR(__hs_delete_reinsert_from_pos(session, cursor, btree->id, key, tw->start_ts + 1,
+          true, false, error_on_ooo_ts, &counter));
 
 #ifdef HAVE_DIAGNOSTIC
     /*
@@ -533,7 +533,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
             if (!F_ISSET(fix_ts_upd, WT_UPDATE_FIXED_HS)) {
                 /* Delete and reinsert any update of the key with a higher timestamp. */
                 WT_ERR(__wt_hs_delete_key_from_ts(session, hs_cursor, btree->id, key,
-                  fix_ts_upd->start_ts + 1, true, error_on_ooo_ts));
+                  fix_ts_upd->start_ts + 1, true, false, error_on_ooo_ts));
                 F_SET(fix_ts_upd, WT_UPDATE_FIXED_HS);
             }
         }
@@ -782,7 +782,7 @@ err:
  */
 int
 __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
-  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts)
+  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone, bool error_on_ooo_ts)
 {
     WT_DECL_RET;
     WT_ITEM hs_key;
@@ -792,10 +792,10 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
     bool hs_read_all_flag;
 
     /*
-     * If we will delete all the updates of the key from the history store, we should not reinsert
-     * any update.
+     * If we delete all the updates of the key from the history store, we should not reinsert any
+     * update except when an out-of-order tombstone is not globally visible yet.
      */
-    WT_ASSERT(session, ts > WT_TS_NONE || !reinsert);
+    WT_ASSERT(session, ooo_tombstone || ts > WT_TS_NONE || !reinsert);
 
     hs_read_all_flag = F_ISSET(hs_cursor, WT_CURSTD_HS_READ_ALL);
 
@@ -815,8 +815,8 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
         ++hs_counter;
     }
 
-    WT_ERR(__hs_delete_reinsert_from_pos(
-      session, hs_cursor, btree_id, key, ts, reinsert, error_on_ooo_ts, &hs_counter));
+    WT_ERR(__hs_delete_reinsert_from_pos(session, hs_cursor, btree_id, key, ts, reinsert,
+      ooo_tombstone, error_on_ooo_ts, &hs_counter));
 
 done:
 err:
@@ -834,7 +834,8 @@ err:
  */
 static int
 __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
-  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts, uint64_t *counter)
+  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone, bool error_on_ooo_ts,
+  uint64_t *counter)
 {
     WT_CURSOR *hs_insert_cursor;
     WT_CURSOR_BTREE *hs_cbt;
@@ -858,9 +859,11 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     WT_UNUSED(key);
 #endif
 
-    /* If we will delete all the updates of the key from the history store, we should not reinsert
-     * any update. */
-    WT_ASSERT(session, ts > WT_TS_NONE || !reinsert);
+    /*
+     * If we delete all the updates of the key from the history store, we should not reinsert any
+     * update except when an out-of-order tombstone is not globally visible yet.
+     */
+    WT_ASSERT(session, ooo_tombstone || ts > WT_TS_NONE || !reinsert);
 
     for (; ret == 0; ret = hs_cursor->next(hs_cursor)) {
         /* Ignore records that are obsolete. */
@@ -971,7 +974,16 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
               __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_stop_ts, ts_string[3]),
               __wt_timestamp_to_string(ts, ts_string[4]));
 
-            hs_insert_tw.start_ts = hs_insert_tw.durable_start_ts = ts - 1;
+            /*
+             * Use the original start time window's timestamps if it isn't out of order with respect
+             * to the new update.
+             */
+            if (hs_cbt->upd_value->tw.start_ts >= ts)
+                hs_insert_tw.start_ts = hs_insert_tw.durable_start_ts = ooo_tombstone ? ts : ts - 1;
+            else {
+                hs_insert_tw.start_ts = hs_cbt->upd_value->tw.start_ts;
+                hs_insert_tw.durable_start_ts = hs_cbt->upd_value->tw.durable_start_ts;
+            }
             hs_insert_tw.start_txn = hs_cbt->upd_value->tw.start_txn;
 
             /*
@@ -979,12 +991,16 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
              * another moved update OR the update itself triggered the correction. In either case,
              * we should preserve the stop transaction id.
              */
-            hs_insert_tw.stop_ts = hs_insert_tw.durable_stop_ts = ts - 1;
+            hs_insert_tw.stop_ts = hs_insert_tw.durable_stop_ts = ooo_tombstone ? ts : ts - 1;
             hs_insert_tw.stop_txn = hs_cbt->upd_value->tw.stop_txn;
 
             /* Extract the underlying value for reinsertion. */
             WT_ERR(hs_cursor->get_value(
               hs_cursor, &tw.durable_stop_ts, &tw.durable_start_ts, &hs_upd_type, &hs_value));
+
+            /* Reinsert the update with corrected timestamps. */
+            if (ooo_tombstone && hs_ts == ts)
+                *counter = hs_counter;
 
             /* Insert the value back with different timestamps. */
             hs_insert_cursor->set_key(

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -89,7 +89,7 @@
          * We should not leave any history store cursor open when return from an api call. \
          * However, we cannot do a stricter check before WT-7247 is resolved.              \
          */                                                                                \
-        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 2);            \
+        WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 3);            \
         /*                                                                                 \
          * No code after this line, otherwise error handling                               \
          * won't be correct.                                                               \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -780,8 +780,8 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
-  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone,
+  bool error_on_ooo_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
   const char *value_format, uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1232,6 +1232,9 @@ extern int __wt_rec_dictionary_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, u
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_dictionary_lookup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *val,
   WT_REC_DICTIONARY **dpp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r,
+  wt_timestamp_t ts, uint64_t recno, WT_ITEM *rowkey, bool reinsert)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -284,6 +284,14 @@ struct __wt_reconcile {
     bool rec_page_cell_with_ts;
     bool rec_page_cell_with_txn_id;
     bool rec_page_cell_with_prepared_txn;
+
+    /*
+     * When removing a key due to a tombstone with a durable timestamp of "none", we also remove the
+     * history store contents associated with that key. Keep the pertinent state here: a flag to say
+     * whether this is appropriate, and a cached history store cursor for doing it.
+     */
+    bool hs_clear_on_tombstone;
+    WT_CURSOR *hs_cursor;
 };
 
 typedef struct {
@@ -291,7 +299,8 @@ typedef struct {
 
     WT_TIME_WINDOW tw;
 
-    bool upd_saved; /* An element on the row's update chain was saved */
+    bool upd_saved;     /* An element on the row's update chain was saved */
+    bool ooo_tombstone; /* Out-of-order tombstone */
 } WT_UPDATE_SELECT;
 
 /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -159,7 +159,7 @@ struct __wt_session_impl {
     size_t op_handle_allocated; /* Bytes allocated */
 
     void *reconcile; /* Reconciliation support */
-    void (*reconcile_cleanup)(WT_SESSION_IMPL *);
+    int (*reconcile_cleanup)(WT_SESSION_IMPL *);
 
     /* Salvage support. */
     void *salvage_track;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -580,20 +580,17 @@ __wt_rec_col_var(
     WT_CELL *cell;
     WT_CELL_UNPACK_KV *vpack, _vpack;
     WT_COL *cip;
-    WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_ITEM(orig);
     WT_DECL_RET;
     WT_INSERT *ins;
-    WT_ITEM hs_recno_key;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw, *twp;
     WT_UPDATE *upd;
     WT_UPDATE_SELECT upd_select;
     uint64_t n, nrepeat, repeat_count, rle, skip, src_recno;
     uint32_t i, size;
-    uint8_t *p, hs_recno_key_buf[WT_INTPACK64_MAXSIZE];
-    bool deleted, hs_clear, orig_deleted, update_no_copy;
+    bool deleted, orig_deleted, update_no_copy;
     const void *data;
 
     btree = S2BT(session);
@@ -625,11 +622,6 @@ __wt_rec_col_var(
      * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
      * store content, so we can skip this.
      */
-    hs_cursor = NULL;
-    hs_clear = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
-      !WT_IS_METADATA(btree->dhandle);
-
     WT_RET(__wt_rec_split_init(session, r, page, pageref->ref_recno, btree->maxleafpage_precomp));
 
     WT_RET(__wt_scr_alloc(session, 0, &orig));
@@ -816,41 +808,25 @@ record_loop:
                 case WT_UPDATE_STANDARD:
                     data = upd->data;
                     size = upd->size;
+                    /*
+                     * When an out-of-order or mixed-mode tombstone is getting written to disk,
+                     * remove any historical versions that are greater in the history store for this
+                     * key.
+                     */
+                    if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone)
+                        WT_ERR(__wt_rec_hs_clear_on_tombstone(
+                          session, r, twp->durable_stop_ts, src_recno, NULL, true));
+
                     break;
                 case WT_UPDATE_TOMBSTONE:
                     /*
-                     * When removing a key due to a tombstone with a durable timestamp of "none",
-                     * also remove the history store contents associated with that key.
+                     * When an out-of-order or mixed-mode tombstone is getting written to disk,
+                     * remove any historical versions that are greater in the history store for this
+                     * key.
                      */
-                    if (twp->durable_stop_ts == WT_TS_NONE && hs_clear) {
-                        p = hs_recno_key_buf;
-                        WT_ERR(__wt_vpack_uint(&p, 0, src_recno));
-                        hs_recno_key.data = hs_recno_key_buf;
-                        hs_recno_key.size = WT_PTRDIFF(p, hs_recno_key_buf);
-
-                        /* Open a history store cursor if we don't yet have one. */
-                        if (hs_cursor == NULL)
-                            WT_ERR(__wt_curhs_open(session, NULL, &hs_cursor));
-
-                        /*
-                         * From WT_TS_NONE delete all the history store content of the key. This
-                         * path will never be taken for a mixed-mode deletion being evicted and with
-                         * a checkpoint that started prior to the eviction starting its
-                         * reconciliation as previous checks done while selecting an update will
-                         * detect that.
-                         */
-                        WT_ERR(__wt_hs_delete_key_from_ts(
-                          session, hs_cursor, btree->id, &hs_recno_key, WT_TS_NONE, false, false));
-
-                        /* Fail 0.01% of the time. */
-                        if (F_ISSET(r, WT_REC_EVICT) &&
-                          __wt_failpoint(session,
-                            WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 0.01))
-                            WT_ERR(EBUSY);
-
-                        WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
-                        WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
-                    }
+                    if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone)
+                        WT_ERR(__wt_rec_hs_clear_on_tombstone(
+                          session, r, twp->durable_stop_ts, src_recno, NULL, false));
 
                     deleted = true;
                     twp = &clear_tw;
@@ -1077,8 +1053,6 @@ next:
     ret = __wt_rec_split_finish(session, r);
 
 err:
-    if (hs_cursor != NULL)
-        WT_TRET(hs_cursor->close(hs_cursor));
     __wt_scr_free(session, &orig);
     return (ret);
 }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -710,7 +710,6 @@ __wt_rec_row_leaf(
     WT_BTREE *btree;
     WT_CELL *cell;
     WT_CELL_UNPACK_KV *kpack, _kpack, *vpack, _vpack;
-    WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_DECL_ITEM(tmpkey);
     WT_DECL_RET;
@@ -726,7 +725,7 @@ __wt_rec_row_leaf(
     uint64_t slvg_skip;
     uint32_t i;
     uint8_t key_prefix;
-    bool dictionary, hs_clear, key_onpage_ovfl, ovfl_key;
+    bool dictionary, key_onpage_ovfl, ovfl_key;
     void *copy;
     const void *key_data;
 
@@ -755,11 +754,6 @@ __wt_rec_row_leaf(
      * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
      * store content, so we can skip this.
      */
-    hs_cursor = NULL;
-    hs_clear = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
-      !WT_IS_METADATA(btree->dhandle);
-
     WT_RET(__wt_rec_split_init(session, r, page, 0, btree->maxleafpage_precomp));
 
     /*
@@ -896,6 +890,15 @@ __wt_rec_row_leaf(
             case WT_UPDATE_STANDARD:
                 /* Take the value from the update. */
                 WT_ERR(__wt_rec_cell_build_val(session, r, upd->data, upd->size, twp, 0));
+                /*
+                 * When an out-of-order or mixed-mode tombstone is getting written to disk, remove
+                 * any historical versions that are greater in the history store for that key.
+                 */
+                if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
+                    WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
+                    WT_ERR(__wt_rec_hs_clear_on_tombstone(
+                      session, r, twp->durable_stop_ts, WT_RECNO_OOB, tmpkey, true));
+                }
                 dictionary = true;
                 break;
             case WT_UPDATE_TOMBSTONE:
@@ -920,32 +923,13 @@ __wt_rec_row_leaf(
                 }
 
                 /*
-                 * When removing a key due to a tombstone with a durable timestamp of "none", also
-                 * remove the history store contents associated with that key.
+                 * When an out-of-order or mixed-mode tombstone is getting written to disk, remove
+                 * any historical versions that are greater in the history store for this key.
                  */
-                if (twp->durable_stop_ts == WT_TS_NONE && hs_clear) {
+                if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
                     WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
-
-                    /* Open a history store cursor if we don't yet have one. */
-                    if (hs_cursor == NULL)
-                        WT_ERR(__wt_curhs_open(session, NULL, &hs_cursor));
-
-                    /*
-                     * From WT_TS_NONE delete all the history store content of the key. This path
-                     * will never be taken for a mixed-mode deletion being evicted and with a
-                     * checkpoint that started prior to the eviction starting its reconciliation as
-                     * previous checks done while selecting an update will detect that.
-                     */
-                    WT_ERR(__wt_hs_delete_key_from_ts(
-                      session, hs_cursor, btree->id, tmpkey, WT_TS_NONE, false, false));
-
-                    /* Fail 0.01% of the time. */
-                    if (F_ISSET(r, WT_REC_EVICT) &&
-                      __wt_failpoint(
-                        session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 0.01))
-                        WT_ERR(EBUSY);
-                    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
-                    WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
+                    WT_ERR(__wt_rec_hs_clear_on_tombstone(
+                      session, r, twp->durable_stop_ts, WT_RECNO_OOB, tmpkey, false));
                 }
 
                 /*
@@ -1077,8 +1061,6 @@ leaf_insert:
     ret = __wt_rec_split_finish(session, r);
 
 err:
-    if (hs_cursor != NULL)
-        WT_TRET(hs_cursor->close(hs_cursor));
     __wt_scr_free(session, &tmpkey);
     return (ret);
 }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -402,6 +402,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
      */
     upd_select->upd = NULL;
     upd_select->upd_saved = false;
+    upd_select->ooo_tombstone = false;
     select_tw = &upd_select->tw;
     WT_TIME_WINDOW_INIT(select_tw);
 
@@ -697,6 +698,23 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
 
     /* Check the update chain for conditions that could prevent it's eviction. */
     WT_ERR(__rec_validate_upd_chain(session, r, onpage_upd, select_tw, vpack));
+
+    /*
+     * Set the flag if the selected tombstone is an out-of-order or mixed mode to an update. Based
+     * on this flag, the caller functions perform the history store truncation for this key.
+     */
+    if (tombstone != NULL &&
+      !F_ISSET(tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS)) {
+        upd = upd_select->upd;
+        while (upd != NULL && upd->txnid == WT_TXN_ABORTED)
+            upd = upd->next;
+
+        if (upd != NULL && upd->start_ts > tombstone->start_ts)
+            upd_select->ooo_tombstone = true;
+
+        if (vpack != NULL && vpack->tw.start_ts > upd->start_ts)
+            upd_select->ooo_tombstone = true;
+    }
 
     /*
      * Fixup any out of order timestamps, assert that checkpoint wasn't running when this round of

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -675,6 +675,22 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->rec_page_cell_with_txn_id = false;
     r->rec_page_cell_with_prepared_txn = false;
 
+    /*
+     * When removing a key due to a tombstone with a durable timestamp of "none", also remove the
+     * history store contents associated with that key. It's safe to do even if we fail
+     * reconciliation after the removal, the history store content must be obsolete in order for us
+     * to consider removing the key.
+     *
+     * Ignore if this is metadata, as metadata doesn't have any history.
+     *
+     * Some code paths, such as schema removal, involve deleting keys in metadata and assert that
+     * they shouldn't open new dhandles. In those cases we won't ever need to blow away history
+     * store content, so we can skip this.
+     */
+    r->hs_clear_on_tombstone = F_ISSET(S2C(session), WT_CONN_HS_OPEN) &&
+      !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES) && !WT_IS_HS(btree->dhandle) &&
+      !WT_IS_METADATA(btree->dhandle);
+
 /*
  * If we allocated the reconciliation structure and there was an error, clean up. If our caller
  * passed in a structure, they own it.
@@ -2427,4 +2443,56 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
 err:
     __wt_scr_free(session, &tmp);
     return (ret);
+}
+
+/*
+ * __wt_rec_hs_clear_on_tombstone --
+ *     When removing a key due to a tombstone with a durable timestamp of "none", also remove the
+ *     history store contents associated with that key.
+ */
+int
+__wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r, wt_timestamp_t ts,
+  uint64_t recno, WT_ITEM *rowkey, bool reinsert)
+{
+    WT_BTREE *btree;
+    WT_ITEM hs_recno_key, *key;
+    uint8_t hs_recno_key_buf[WT_INTPACK64_MAXSIZE], *p;
+
+    btree = S2BT(session);
+
+    /* We should be passed a recno or a row-store key, but not both. */
+    WT_ASSERT(session, (recno == WT_RECNO_OOB) != (rowkey == NULL));
+
+    if (rowkey != NULL)
+        key = rowkey;
+    else {
+        p = hs_recno_key_buf;
+        WT_RET(__wt_vpack_uint(&p, 0, recno));
+        hs_recno_key.data = hs_recno_key_buf;
+        hs_recno_key.size = WT_PTRDIFF(p, hs_recno_key_buf);
+        key = &hs_recno_key;
+    }
+
+    /* Open a history store cursor if we don't yet have one. */
+    if (r->hs_cursor == NULL)
+        WT_RET(__wt_curhs_open(session, NULL, &r->hs_cursor));
+
+    /*
+     * From WT_TS_NONE delete all the history store content of the key. This path will never be
+     * taken for a mixed-mode deletion being evicted and with a checkpoint that started prior to the
+     * eviction starting its reconciliation as previous checks done while selecting an update will
+     * detect that.
+     */
+    WT_RET(__wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key, ts, reinsert, true,
+      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)));
+
+    /* Fail 0.01% of the time. */
+    if (F_ISSET(r, WT_REC_EVICT) &&
+      __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 1))
+        return (EBUSY);
+
+    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
+    WT_STAT_DATA_INCR(session, cache_hs_key_truncate_onpage_removal);
+
+    return (0);
 }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -178,7 +178,7 @@ __wt_session_release_resources(WT_SESSION_IMPL *session)
 
     /* Reconciliation cleanup */
     if (session->reconcile_cleanup != NULL)
-        session->reconcile_cleanup(session);
+        WT_TRET(session->reconcile_cleanup(session));
 
     /* Stashed memory. */
     __wt_stash_discard(session);

--- a/test/suite/test_hs29.py
+++ b/test/suite/test_hs29.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+
+# test_hs29.py
+# It is possible to end up with 3 opened history store cursors at the same time when the following
+# occurs:
+# - The reconciliation process opens one history store cursor.
+# - The function hs_delete_reinsert_from_pos creates a history store cursor too. This means we need
+# an update with an OOO timestamp to trigger that function.
+# - The function wt_rec_hs_clear_on_tombstone creates a history store cursor as well. This means we
+# need a tombstone to trigger the function, i.e a deleted key.
+class test_hs29(wttest.WiredTigerTestCase):
+
+    def test_3_hs_cursors(self):
+
+        # Create a table.
+        uri = "table:test_hs_cursor"
+        self.session.create(uri, 'key_format=S,value_format=S')
+        
+        # Open one cursor to operate on the table and another one to perform eviction.
+        cursor = self.session.open_cursor(uri)
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+
+        # Create two keys and perform an update on each.
+        self.session.begin_transaction()
+        cursor['1'] = '1'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+
+        self.session.begin_transaction()
+        cursor['1'] = '11'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+
+        self.session.begin_transaction()
+        cursor['2'] = '2'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        self.session.begin_transaction()
+        cursor['2'] = '22'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Perform eviction.
+        cursor2.set_key('1')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '11')
+        self.assertEqual(cursor2.reset(), 0)
+
+        cursor2.set_key('2')
+        self.assertEqual(cursor2.search(), 0)
+        self.assertEqual(cursor2.get_value(), '22')
+        self.assertEqual(cursor2.reset(), 0)
+
+        # Remove the first key without giving a ts.
+        self.session.begin_transaction()
+        cursor.set_key('1')
+        cursor.remove()
+        self.session.commit_transaction()
+
+        # Update the second key with out of order timestamp.
+        self.session.begin_transaction()
+        cursor['2'] = '222'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+
+        # Close the connection to trigger a final checkpoint and reconciliation.
+        self.conn.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_hs31.py
+++ b/test/suite/test_hs31.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_hs31.py
+# Ensure that tombstone with out of order timestamp clear the history store records.
+class test_hs31(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=5MB,statistics=(all)'
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('column-fix', dict(key_format='r', value_format='8t')),
+        ('integer-row', dict(key_format='i', value_format='S')),
+        ('string-row', dict(key_format='S', value_format='S')),
+    ]
+
+    ooo_values = [
+        ('out-of-order', dict(ooo_value=True)),
+        ('mixed-mode', dict(ooo_value=False)),
+    ]
+
+    globally_visible_before_ckpt_values = [
+        ('globally_visible_before_ckpt', dict(globally_visible_before_ckpt=True)),
+        ('no_globally_visible_before_ckpt', dict(globally_visible_before_ckpt=False)),
+    ]
+
+    scenarios = make_scenarios(format_values, ooo_values, globally_visible_before_ckpt_values)
+    nrows = 1000
+
+    def create_key(self, i):
+        if self.key_format == 'S':
+            return str(i)
+        return i
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def test_ooo_tombstone_clear_hs(self):
+        uri = 'file:test_hs31'
+        create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(uri, create_params)
+
+        if self.value_format == '8t':
+            value1 = 97
+            value2 = 98
+        else:
+            value1 = 'a' * 500
+            value2 = 'b' * 500
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Apply a series of updates from timestamps 10-14.
+        cursor = self.session.open_cursor(uri)
+        for ts in range(10, 15):
+            for i in range(1, self.nrows):
+                self.session.begin_transaction()
+                cursor[self.create_key(i)] = value1
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+
+        # Reconcile and flush versions 10-13 to the history store.
+        self.session.checkpoint()
+
+        # Evict the data from the cache.
+        self.session.begin_transaction()
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+        for i in range(1, self.nrows):
+            cursor2.set_key(self.create_key(i))
+            cursor2.search()
+            cursor2.reset()
+        self.session.rollback_transaction()
+
+        if not self.ooo_value:
+            self.session.breakpoint()
+            # Start a long running transaction to stop the oldest id being advanced.
+            session2 = self.conn.open_session()
+            session2.begin_transaction()
+            long_cursor = session2.open_cursor(uri, None)
+            long_cursor[self.create_key(self.nrows + 10)] = value1
+            long_cursor.reset()
+            long_cursor.close()
+
+        # Remove the key with an ooo or mm timestamp.
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor.set_key(self.create_key(i))
+            cursor.remove()
+            if self.ooo_value:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+            else:
+                self.session.commit_transaction()
+
+        if not self.globally_visible_before_ckpt:
+            # Reconcile to write the stop time window.
+            self.session.checkpoint()
+
+        if not self.ooo_value:
+            self.session.breakpoint()
+            # Ensure that old reader can read the history content.
+            long_cursor = session2.open_cursor(uri, None)
+            for i in range(1, self.nrows):
+                long_cursor.set_key(self.create_key(i))
+                self.assertEqual(long_cursor.search(), 0)
+                self.assertEqual(long_cursor.get_value(), value1)
+            long_cursor.reset()
+            long_cursor.close()
+
+            # Rollback the long running transaction.
+            session2.rollback_transaction()
+            session2.close()
+
+        # Pin oldest and stable to timestamp 5 so that the ooo tombstone is globally visible.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
+
+        # Reconcile and remove the obsolete entries.
+        self.session.checkpoint()
+
+        # Evict the data from the cache.
+        self.session.begin_transaction()
+        cursor2 = self.session.open_cursor(uri, None, "debug=(release_evict=true)")
+        for i in range(1, self.nrows):
+            cursor2.set_key(self.create_key(i))
+            if self.value_format == '8t':
+                self.assertEqual(cursor2.search(), 0)
+            else:
+                self.assertEqual(cursor2.search(), wiredtiger.WT_NOTFOUND)
+            cursor2.reset()
+        self.session.rollback_transaction()
+
+        # Now apply an insert at timestamp 20.
+        for i in range(1, self.nrows):
+            self.session.begin_transaction()
+            cursor[self.create_key(i)] = value2
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Ensure that we blew away history store content.
+        for ts in range(10, 15):
+            self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+            for i in range(1, self.nrows):
+                cursor.set_key(self.create_key(i))
+                if self.value_format == '8t':
+                    self.assertEqual(cursor.search(), 0)
+                    self.assertEqual(cursor.get_value(), 0)
+                else:
+                    self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+            self.session.rollback_transaction()
+
+        hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
+        self.assertGreater(hs_truncate, 0)
+

--- a/test/suite/test_hs31.py
+++ b/test/suite/test_hs31.py
@@ -36,7 +36,7 @@ class test_hs31(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=5MB,statistics=(all)'
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column-fix', dict(key_format='r', value_format='8t')),
+        # ('column-fix', dict(key_format='r', value_format='8t')),
         ('integer-row', dict(key_format='i', value_format='S')),
         ('string-row', dict(key_format='S', value_format='S')),
     ]


### PR DESCRIPTION
These changes include [WT-8362](https://jira.mongodb.org/browse/WT-8362) and additional changes in order to have the function __wt_rec_hs_clear_on_tombstone available as well as [WT-8550](https://jira.mongodb.org/browse/WT-8550) since more hs cursors can be opened at once now.

Note: the FLCS scenario has been disabled as it is not supported in 4.4