### PR TITLE
WT-9082 fd leak in libsodium extension

### DIFF
--- a/ext/encryptors/sodium/sodium_encrypt.c
+++ b/ext/encryptors/sodium/sodium_encrypt.c
@@ -339,7 +339,7 @@ sodium_terminate(WT_ENCRYPTOR *encryptor, WT_SESSION *session)
 
     (void)session; /* Unused parameters */
 
-    /* Close libsodium's internal reference to /dev/random so it doesn't leak. */
+    /* Close the internal reference in libsodium to /dev/random so it doesn't leak. */
     randombytes_close();
 
     /* Free the allocated memory. */

--- a/ext/encryptors/sodium/sodium_encrypt.c
+++ b/ext/encryptors/sodium/sodium_encrypt.c
@@ -339,6 +339,9 @@ sodium_terminate(WT_ENCRYPTOR *encryptor, WT_SESSION *session)
 
     (void)session; /* Unused parameters */
 
+    /* Close libsodium's internal reference to /dev/random so it doesn't leak. */
+    randombytes_close();
+
     /* Free the allocated memory. */
     sodium_free(sodium_encryptor->secretkey);
     free(sodium_encryptor);


### PR DESCRIPTION
Close libsodium's internal reference to the random device.

Avoids an fd leak that manifests when the extension is loaded and unloaded repeatedly (as happens during testing).