### PR TITLE
WT-8622 Read in last_ckpt_base_write_gen at start of recovery

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -835,6 +835,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     metafile = &r.files[WT_METAFILE_ID];
     metafile->c = metac;
 
+    WT_ERR(__recovery_set_ckpt_base_write_gen(&r));
+
     /*
      * If no log was found (including if logging is disabled), or if the last checkpoint was done
      * with logging disabled, recovery should not run. Scan the metadata to figure out the largest
@@ -1010,7 +1012,6 @@ done:
     WT_ERR(__recovery_set_checkpoint_timestamp(&r));
     WT_ERR(__recovery_set_oldest_timestamp(&r));
     WT_ERR(__recovery_set_checkpoint_snapshot(session));
-    WT_ERR(__recovery_set_ckpt_base_write_gen(&r));
 
     /*
      * Set the history store file size as it may already exist after a restart.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1864,6 +1864,8 @@ tasks:
     - name: compile
     - name: generate-datafile-little-endian
       variant: little-endian
+    - name: verify-datafile-little-endian
+      variant: little-endian
     commands:
       - func: "fetch artifacts"
       - func: "fetch endian format artifacts"
@@ -1913,6 +1915,8 @@ tasks:
     depends_on:
     - name: compile
     - name: generate-datafile-big-endian
+      variant: big-endian
+    - name: verify-datafile-big-endian
       variant: big-endian
     commands:
       - func: "fetch artifacts"


### PR DESCRIPTION
Summary: In special cases during recovery WiredTiger will use the wrong Write Generation Number for some btrees and retains the `start_txn` and `stop_txn` of updates made before a restart. These outdated txn ids then cause visible updates to be incorrectly treated as invisible by WiredTiger.

In current WT behaviour `last_ckpt_base_write_gen` is not set at the start of recovery, but [this check](https://github.com/wiredtiger/wiredtiger/blob/f74c4db3a8018c7d6af9b55bb90f4b4050746a8d/src/btree/bt_handle.c#L558) uses it to determine the WGN for btrees when opening them. As `last_ckpt_base_write_gen` has a default value of zero the check evaluates to false and the btree will use the largest WGN from the start of recovery instead of the largest WGN at the end of recovery. As a result any changes made during recovery are considered to be newer than the `btree->base_write_gen` and their start/stop_txn values from before the WT restart are retained.

In the triggering scenario from WT-8622 updates on a key `(U2 -> U1)` were spread across two pages in the history store and WT was restarted with logging disabled on the `wt` table, which previously had logging enabled. `U2`s page was touched during recovery and so U2 retained its `start_txn` and `stop_txn` values.
WT then treated `U2` as invisible when comparing `U2`s `start_txn` from prior to restart (> `322000`) with `snap_max` from after the restart (`8`). This then triggered [the following assertion](https://github.com/wiredtiger/wiredtiger/blob/f74c4db3a8018c7d6af9b55bb90f4b4050746a8d/src/txn/txn_rollback_to_stable.c#L563) as `U2->start_ts` and `U1->stop_ts` were identical, but `U1->stop_ts` was visible while `U2->start_ts` was invisible.

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>