### PR TITLE
WT-8926 Turn off SDK's integration tests when building the SDK

### DIFF
--- a/cmake/third_party/aws_sdk.cmake
+++ b/cmake/third_party/aws_sdk.cmake
@@ -40,6 +40,10 @@ elseif(IMPORT_S3_SDK_EXTERNAL)
             -DBUILD_ONLY=s3-crt
             -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            # This chooses whether or not to build AWS CPP SDK with the service integration tests
+            # Alternatively you can set -DAUTORUN_UNIT_TESTS to decide whether or not to run the tests if you build with them.
+            # Note: if testing is not enabled, this AUTORUN_UNIT_TESTS gets ignored. 
+            -DENABLE_TESTING=OFF
         BUILD_ALWAYS FALSE
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install
         BUILD_BYPRODUCTS

--- a/cmake/third_party/aws_sdk.cmake
+++ b/cmake/third_party/aws_sdk.cmake
@@ -40,9 +40,9 @@ elseif(IMPORT_S3_SDK_EXTERNAL)
             -DBUILD_ONLY=s3-crt
             -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            # This chooses whether or not to build AWS CPP SDK with the service integration tests
-            # Alternatively you can set -DAUTORUN_UNIT_TESTS to decide whether or not to run the tests if you build with them.
-            # Note: if testing is not enabled, this AUTORUN_UNIT_TESTS gets ignored. 
+            # ENABLE TESTING decides whether or not to build the AWS CPP SDK with the services integration tests.
+            # Alternatively you can build with testing enabled but set AUTORUN_UNIT_TESTS flag to ON/OFF to decide 
+            # whether or not to run the tests. If testing is not enabled, the AUTORUN_UNIT_TESTS flag gets ignored. 
             -DENABLE_TESTING=OFF
         BUILD_ALWAYS FALSE
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install


### PR DESCRIPTION
There are two solutions to stop the AWS SDK integration tests from running when building the SDK.

- Turn off the services integration tests by setting the CMake flag `ENABLE_TESTING` to off. 
  - This means it will not build the SDK with the testing. 
- Build with the integration testing enabled, but skip running them by setting the `AUTORUN_UNIT_TESTS` flag. 
  - This flag will get ignored when `ENABLE_TESTING` is turned off. 

I have implemented the first option; with a comment on the CMake file outlining the alternative option should we need it in the future. 