### PR TITLE
WT-6356 Change WiredTiger MDB timestamp default to "ordered", remove "always".

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -71,21 +71,15 @@ common_runtime_config = [
         this option is no longer supported, retained for backward compatibility''',
         type='list', choices=['write_timestamp'], undoc=True),
     Config('write_timestamp_usage', 'none', r'''
-        describe how timestamps are expected to be used on modifications
-        to the table. This option should be used in conjunction with the
-        corresponding \c write_timestamp configuration under the \c assert
-        option to provide logging and assertions for incorrect timestamp
-        usage. The choices are \c always which ensures a timestamp is used
-        for every operation on a table, \c ordered which ensures that once
-        timestamps are used for a key, they are always used, and also that
-        subsequent updates to each key must use increasing timestamps,
-        \c mixed_mode is like \c ordered except that updates with no timestamp
-        are allowed at any time, \c never enforces that timestamps are never
-        used for a table and \c none does not enforce any expectation on
-        timestamp usage meaning that no log message or assertions will be
-        produced regardless of the corresponding \c assert setting. (The
-        \c key_consistent choice is no longer supported, retained for
-        backward compatibility.)''',
+        describe how timestamps are expected to be used on table modifications. This option should
+        be used in conjunction with the corresponding \c write_timestamp configuration under the
+        \c assert option to provide errors and assertions for incorrect timestamp usage. The
+        choices are the default, which ensures that once timestamps are used for a key, they are
+        always used, and also that multiple updates to a key never use decreasing timestamps,
+        \c mixed_mode, which additionally allows updates with no timestamp even after timestamps
+        are first used, and \c never which enforces that timestamps are never used for a table.
+        (The \c always, \c key_consistent and \c ordered choices should not be used, and are
+        retained for backward compatibility.)''',
         choices=['always', 'key_consistent', 'mixed_mode', 'never', 'none', 'ordered']),
 ]
 

--- a/src/docs/timestamp-misc.dox
+++ b/src/docs/timestamp-misc.dox
@@ -34,28 +34,34 @@ method.
 @section timestamp_misc_diagnostic Using diagnostic configurations to enforce timestamp usage
 
 The WT_SESSION::create method supports additional checking of timestamp
-usage on a per-key or per-table basis. While these usage checks can decrease
+usage on a per-table basis. While these usage checks can decrease
 application performance, and applications may not choose to configure them
 in production settings, they are strongly recommended during development.
 
-Setting the \c write_timestamp_usage configuration specifies how timestamps
-are expected to be used by the table:
+By default, WiredTiger requires timestamps be used in "ordered" mode:
+updates to a table can be made either with and without a commit timestamp,
+but once a commit timestamp is used to update a key, all future updates to
+the key will require a commit timestamp. Further, each update to a key must
+have a commit timestamp at or after any previous update.
+
+Setting the \c write_timestamp_usage configuration changes how timestamps
+are expected to be used in the table:
 
 | Configuration | Description |
 |---------------|-------------|
-| always | Require all updates to the table have a commit timestamp. |
 | never | Require no updates to the table have a commit timestamp. |
-| ordered | Allow updates both with and without a commit timestamp, but once a commit timestamp is used when updating a key in the table, all future updates to the key require a commit timestamp as well; each update must have a commit timestamp after the previous update. |
-| mixed_mode | Allow updates both with and without a commit timestamp; each update must have a commit timestamp after the previous update, or no timestamp at all. |
+| mixed_mode | Allow updates both with and without a commit timestamp. Each update must have a commit timestamp at or after the previous update, or no timestamp at all. |
 
-The \c write_timestamp_usage configuration is expected to be used
-with the WT_SESSION::create method's \c assert configuration. The
-\c "assert(read_timestamp)" configuration requires timestamps always or never
-be used on reads in the table. The \c "assert(write_timestamp)" configuration
-requires update timestamps conform to the \c write_timestamp_usage setting. If
-WiredTiger detects a violation of the configured policy, an error message
-will be logged. Additionally, in diagnostic builds, the library
-will fail and drop core at the failing check.
+The \c write_timestamp_usage configuration is expected to be used with the
+WT_SESSION::create method's \c assert configuration. The \c
+"assert(read_timestamp)" configuration requires timestamps always or never
+be used on reads in the table.
+
+The \c "assert(write_timestamp)" configuration requires update
+timestamps conform to the \c write_timestamp_usage setting. If WiredTiger
+detects a violation of the configured policy, an error message will be
+logged. Additionally, in diagnostic builds, the library will fail and drop
+core at the failing check.
 
 \warning
 These are best-effort checks by WiredTiger, and there are cases where

--- a/src/docs/timestamp-txn.dox
+++ b/src/docs/timestamp-txn.dox
@@ -35,8 +35,18 @@ regardless of their read timestamps.
 
 @section timestamp_txn_api_configure Enforcing application timestamp behavior
 
-Enforcing application timestamp behavior (for example, requiring updates to a
-single data item appear in timestamp order), can be challenging for application
+By default, WiredTiger requires timestamps be used in "ordered" mode:
+updates to a table can be made either with and without a commit timestamp,
+but once a commit timestamp is used to update a key, all future updates to
+the key will require a commit timestamp. Further, each update to a key must
+have a commit timestamp at or after any previous update.
+
+These requirements can be changed on a per-table basis to require no updates
+to a table have timestamps, or that updates without timestamps be permitted
+even when a key has already been updated using a timestamp. Using timestamps
+that are before previously applied timestamps is never permitted.
+
+Enforcing application timestamp behavior can be challenging for application
 writers. WiredTiger includes diagnostic support for many common restrictions;
 see @ref timestamp_misc_diagnostic.
 

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -129,13 +129,12 @@ struct __wt_data_handle {
     uint32_t flags;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_DHANDLE_TS_ALWAYS 0x01u             /* Handle using always checking. */
-#define WT_DHANDLE_TS_ASSERT_READ_ALWAYS 0x02u /* Assert read always checking. */
-#define WT_DHANDLE_TS_ASSERT_READ_NEVER 0x04u  /* Assert read never checking. */
-#define WT_DHANDLE_TS_ASSERT_WRITE 0x08u       /* Assert write checking. */
-#define WT_DHANDLE_TS_MIXED_MODE 0x10u         /* Handle using mixed mode timestamps checking. */
-#define WT_DHANDLE_TS_NEVER 0x20u              /* Handle never using timestamps checking. */
-#define WT_DHANDLE_TS_ORDERED 0x40u            /* Handle using ordered timestamps checking. */
+#define WT_DHANDLE_TS_ASSERT_READ_ALWAYS 0x01u /* Assert read always checking. */
+#define WT_DHANDLE_TS_ASSERT_READ_NEVER 0x02u  /* Assert read never checking. */
+#define WT_DHANDLE_TS_ASSERT_WRITE 0x04u       /* Assert write checking. */
+#define WT_DHANDLE_TS_MIXED_MODE 0x08u         /* Handle using mixed mode timestamps checking. */
+#define WT_DHANDLE_TS_NEVER 0x10u              /* Handle never using timestamps checking. */
+#define WT_DHANDLE_TS_ORDERED 0x20u            /* Handle using ordered timestamps checking. */
                                                /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t ts_flags;
 };

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1066,20 +1066,17 @@ struct __wt_session {
 	 * 0.}
 	 * @config{readonly, the file is read-only.  All methods that may modify a file are
 	 * disabled.  See @ref readonly for more information., a boolean flag; default \c false.}
-	 * @config{write_timestamp_usage, describe how timestamps are expected to be used on
-	 * modifications to the table.  This option should be used in conjunction with the
-	 * corresponding \c write_timestamp configuration under the \c assert option to provide
-	 * logging and assertions for incorrect timestamp usage.  The choices are \c always which
-	 * ensures a timestamp is used for every operation on a table\, \c ordered which ensures
-	 * that once timestamps are used for a key\, they are always used\, and also that subsequent
-	 * updates to each key must use increasing timestamps\, \c mixed_mode is like \c ordered
-	 * except that updates with no timestamp are allowed at any time\, \c never enforces that
-	 * timestamps are never used for a table and \c none does not enforce any expectation on
-	 * timestamp usage meaning that no log message or assertions will be produced regardless of
-	 * the corresponding \c assert setting.  (The \c key_consistent choice is no longer
-	 * supported\, retained for backward compatibility.)., a string\, chosen from the following
-	 * options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\, \c "never"\, \c "none"\,
-	 * \c "ordered"; default \c none.}
+	 * @config{write_timestamp_usage, describe how timestamps are expected to be used on table
+	 * modifications.  This option should be used in conjunction with the corresponding \c
+	 * write_timestamp configuration under the \c assert option to provide errors and assertions
+	 * for incorrect timestamp usage.  The choices are the default\, which ensures that once
+	 * timestamps are used for a key\, they are always used\, and also that multiple updates to
+	 * a key never use decreasing timestamps\, \c mixed_mode\, which additionally allows updates
+	 * with no timestamp even after timestamps are first used\, and \c never which enforces that
+	 * timestamps are never used for a table.  (The \c always\, \c key_consistent and \c ordered
+	 * choices should not be used\, and are retained for backward compatibility.)., a string\,
+	 * chosen from the following options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\,
+	 * \c "never"\, \c "none"\, \c "ordered"; default \c none.}
 	 * @configend
 	 * @ebusy_errors
 	 */
@@ -1350,20 +1347,17 @@ struct __wt_session {
 	 * applications use a WT_ITEM structure to manipulate raw byte arrays.  Value items of type
 	 * 't' are bitfields\, and when configured with record number type keys\, will be stored
 	 * using a fixed-length store., a format string; default \c u.}
-	 * @config{write_timestamp_usage, describe how timestamps are expected to be used on
-	 * modifications to the table.  This option should be used in conjunction with the
-	 * corresponding \c write_timestamp configuration under the \c assert option to provide
-	 * logging and assertions for incorrect timestamp usage.  The choices are \c always which
-	 * ensures a timestamp is used for every operation on a table\, \c ordered which ensures
-	 * that once timestamps are used for a key\, they are always used\, and also that subsequent
-	 * updates to each key must use increasing timestamps\, \c mixed_mode is like \c ordered
-	 * except that updates with no timestamp are allowed at any time\, \c never enforces that
-	 * timestamps are never used for a table and \c none does not enforce any expectation on
-	 * timestamp usage meaning that no log message or assertions will be produced regardless of
-	 * the corresponding \c assert setting.  (The \c key_consistent choice is no longer
-	 * supported\, retained for backward compatibility.)., a string\, chosen from the following
-	 * options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\, \c "never"\, \c "none"\,
-	 * \c "ordered"; default \c none.}
+	 * @config{write_timestamp_usage, describe how timestamps are expected to be used on table
+	 * modifications.  This option should be used in conjunction with the corresponding \c
+	 * write_timestamp configuration under the \c assert option to provide errors and assertions
+	 * for incorrect timestamp usage.  The choices are the default\, which ensures that once
+	 * timestamps are used for a key\, they are always used\, and also that multiple updates to
+	 * a key never use decreasing timestamps\, \c mixed_mode\, which additionally allows updates
+	 * with no timestamp even after timestamps are first used\, and \c never which enforces that
+	 * timestamps are never used for a table.  (The \c always\, \c key_consistent and \c ordered
+	 * choices should not be used\, and are retained for backward compatibility.)., a string\,
+	 * chosen from the following options: \c "always"\, \c "key_consistent"\, \c "mixed_mode"\,
+	 * \c "never"\, \c "none"\, \c "ordered"; default \c none.}
 	 * @configend
 	 * @errors
 	 */

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -851,8 +851,7 @@ __txn_timestamp_usage_check(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_UPDATE *
     /* Skip timestamp usage checks unless both assert and usage configurations are set. */
     if (!LF_ISSET(WT_DHANDLE_TS_ASSERT_WRITE))
         return;
-    if (!LF_ISSET(WT_DHANDLE_TS_ALWAYS | WT_DHANDLE_TS_MIXED_MODE | WT_DHANDLE_TS_NEVER |
-          WT_DHANDLE_TS_ORDERED))
+    if (!LF_ISSET(WT_DHANDLE_TS_MIXED_MODE | WT_DHANDLE_TS_NEVER | WT_DHANDLE_TS_ORDERED))
         return;
 
     /* Timestamps are ignored on logged files. */
@@ -865,16 +864,6 @@ __txn_timestamp_usage_check(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_UPDATE *
      */
     if (F_ISSET(S2C(session), WT_CONN_RECOVERING))
         return;
-
-    /* Check for required timestamps. */
-    if (LF_ISSET(WT_DHANDLE_TS_ALWAYS) && !txn_has_ts && txn->mod_count != 0) {
-        __wt_err(session, EINVAL,
-          "%s: " WT_TS_VERBOSE_PREFIX "timestamp required by table configuration and none set",
-          name);
-#ifdef HAVE_DIAGNOSTIC
-        __wt_abort(session);
-#endif
-    }
 
     op_ts = upd->start_ts != WT_TS_NONE ? upd->start_ts : txn->commit_timestamp;
 

--- a/test/suite/test_timestamp26.py
+++ b/test/suite/test_timestamp26.py
@@ -35,7 +35,7 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
 # Test assert always/never settings when associated with write_timestamp_usage.
-class test_timestamp26_always_never(wttest.WiredTigerTestCase):
+class test_timestamp26_never(wttest.WiredTigerTestCase):
     conn_config = 'debug_mode=(corruption_abort=false)'
     assert_ts = [
         ('on', dict(assert_ts='on')),
@@ -49,16 +49,12 @@ class test_timestamp26_always_never(wttest.WiredTigerTestCase):
         ('yes', dict(with_ts=True)),
         ('no', dict(with_ts=False)),
     ]
-    write_timestamp = [
-        ('always', dict(write_timestamp='always')),
-        ('never', dict(write_timestamp='never')),
-    ]
     types = [
         ('fix', dict(key_format='r', value_format='8t')),
         ('row', dict(key_format='S', value_format='S')),
         ('var', dict(key_format='r', value_format='S')),
     ]
-    scenarios = make_scenarios(types, assert_ts, commit_ts, with_ts, write_timestamp)
+    scenarios = make_scenarios(types, assert_ts, commit_ts, with_ts)
 
     def test_always_never(self):
         if wiredtiger.diagnostic_build():
@@ -72,8 +68,7 @@ class test_timestamp26_always_never(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=' + self.write_timestamp + ',' +
-            ',assert=(write_timestamp=' + self.assert_ts + ')')
+            ',write_timestamp_usage=never' + ',assert=(write_timestamp=' + self.assert_ts + ')')
 
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
@@ -87,7 +82,7 @@ class test_timestamp26_always_never(wttest.WiredTigerTestCase):
                 self.session.timestamp_transaction(commit_ts)
                 commit_ts = ''
 
-            if self.assert_ts == 'off' or self.write_timestamp == 'always':
+            if self.assert_ts == 'off':
                 self.session.commit_transaction(commit_ts)
             else:
                 with self.expectedStderrPattern('set when disallowed'):
@@ -95,11 +90,7 @@ class test_timestamp26_always_never(wttest.WiredTigerTestCase):
 
         # Commit without a timestamp.
         else:
-            if self.assert_ts == 'off' or self.write_timestamp == 'never':
-                self.session.commit_transaction()
-            else:
-                with self.expectedStderrPattern('timestamp required by table'):
-                        self.session.commit_transaction()
+            self.session.commit_transaction()
 
 # Test assert read timestamp settings.
 class test_timestamp26_read_timestamp(wttest.WiredTigerTestCase):
@@ -167,29 +158,12 @@ class test_timestamp26_read_timestamp(wttest.WiredTigerTestCase):
 
 # Test alter of timestamp settings.
 class test_timestamp26_alter(wttest.WiredTigerTestCase):
-    start = [
-        ('always', dict(init_always=True)),
-        ('never', dict(init_always=False)),
-    ]
     types = [
         ('fix', dict(key_format='r', value_format='8t')),
         ('row', dict(key_format='S', value_format='S')),
         ('var', dict(key_format='r', value_format='S')),
     ]
-    scenarios = make_scenarios(types, start)
-
-    # Perform and operation and check the result for failure.
-    def check(self, ds, uri, willfail):
-        c = self.session.open_cursor(uri)
-        self.session.begin_transaction()
-        c[ds.key(10)] = ds.value(10)
-        if willfail:
-            msg = 'timestamp required by table configuration'
-            with self.expectedStderrPattern(msg):
-                self.session.commit_transaction()
-        else:
-            self.session.commit_transaction()
-        c.close()
+    scenarios = make_scenarios(types)
 
     def test_alter(self):
         if wiredtiger.diagnostic_build():
@@ -199,24 +173,34 @@ class test_timestamp26_alter(wttest.WiredTigerTestCase):
         ds = SimpleDataSet(
             self, 'file:notused', 10, key_format=self.key_format, value_format=self.value_format)
 
-        if self.init_always:
-            start = 'always'
-            switch = 'never'
-        else:
-            start = 'never'
-            switch = 'always'
-
-        # Open the object, configuring the initial timestamp usage.
+        # Open the object, configuring "never" timestamp usage.
         # Check it.
-        # Switch the object to the opposite usage.
+        # Switch the object to "ordered" usage.
         # Check it.
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',' + 'write_timestamp_usage={}'.format(start) + ',assert=(write_timestamp=on)')
-        self.check(ds, uri, self.init_always)
-        self.session.alter(uri, 'write_timestamp_usage={}'.format(switch))
-        self.check(ds, uri, not self.init_always)
+            ',write_timestamp_usage=never,assert=(write_timestamp=on)')
+
+        c = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        c[ds.key(10)] = ds.value(10)
+        msg = 'set when disallowed by table configuration'
+        with self.expectedStderrPattern(msg):
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        c.close()
+
+        self.session.alter(uri, 'write_timestamp_usage=ordered')
+
+        c = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        c[ds.key(10)] = ds.value(10)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(11))
+        self.session.begin_transaction()
+        c[ds.key(10)] = ds.value(10)
+        msg = 'always use timestamps'
+        with self.expectedStderrPattern(msg):
+            self.session.commit_transaction()
 
 # Test timestamp settings with inconsistent updates.
 class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
@@ -515,7 +499,6 @@ class test_timestamp26_log_ts(wttest.WiredTigerTestCase):
         c[ds.key(2)] = ds.value(2)
         self.session.commit_transaction()
 
-
 # Test that timestamps are ignored in in-memory configurations and that object configurations always
 # override.
 class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
@@ -558,7 +541,7 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         config = ',' + self.obj_config
         config += ',write_timestamp_usage='
-        config += 'always' if self.always else 'never'
+        config += 'ordered' if self.always else 'never'
         config += ',assert=(write_timestamp=on)'
         self.session.breakpoint()
         self.session.create(uri,
@@ -576,6 +559,10 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
                 self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
 
         # Commit without a timestamp.
+        if self.always:
+            self.session.begin_transaction()
+            c[ds.key(2)] = ds.value(2)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
         self.session.begin_transaction()
         c[ds.key(2)] = ds.value(2)
         if self.always == False or self.obj_ignore == True:

--- a/test/suite/test_timestamp26.py
+++ b/test/suite/test_timestamp26.py
@@ -34,7 +34,7 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-# Test assert always/never settings when associated with write_timestamp_usage.
+# Test assert never setting when associated with write_timestamp_usage.
 class test_timestamp26_never(wttest.WiredTigerTestCase):
     conn_config = 'debug_mode=(corruption_abort=false)'
     assert_ts = [
@@ -56,7 +56,7 @@ class test_timestamp26_never(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(types, assert_ts, commit_ts, with_ts)
 
-    def test_always_never(self):
+    def test_never(self):
         if wiredtiger.diagnostic_build():
             self.skipTest('requires a non-diagnostic build')
 
@@ -558,7 +558,8 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
             with self.expectedStderrPattern('unexpected timestamp usage'):
                 self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
 
-        # Commit without a timestamp.
+        # Commit without a timestamp (but first with a timestamp if in ordered mode so we get
+        # a failure).
         if self.always:
             self.session.begin_transaction()
             c[ds.key(2)] = ds.value(2)


### PR DESCRIPTION
Change the MDB timestamp default behavior to "ordered", leaving the WiredTiger standalone build default at "none".

Remove the "always" configuration, it's no longer useful.

The documentation has been updated to match the MDB timestamp behavior, and it is expected the WiredTiger standalone code will follow shortly.