### PR TITLE
WT-9112: Fix build on systems not using libmemkind, but with it installed

### DIFF
--- a/cmake/third_party/memkind.cmake
+++ b/cmake/third_party/memkind.cmake
@@ -1,6 +1,11 @@
 if(NOT HAVE_LIBMEMKIND)
-    # We don't need to construct a memkind library target.
+    # We can't construct a memkind library target.
     return()
+endif()
+
+if (NOT ENABLE_MEMKIND)
+  # We don't want to construct a memkind library target.
+  return()
 endif()
 
 if(TARGET wt::memkind)

--- a/src/include/block_cache.h
+++ b/src/include/block_cache.h
@@ -11,7 +11,7 @@
  * faster storage medium, such as NVRAM.
  */
 
-#ifdef HAVE_LIBMEMKIND
+#ifdef ENABLE_MEMKIND
 #include <memkind.h>
 #endif
 
@@ -80,7 +80,7 @@ struct __wt_blkcache {
     bool cache_on_checkpoint; /* Don't cache blocks written by checkpoints */
     bool cache_on_writes;     /* Cache blocks on writes */
 
-#ifdef HAVE_LIBMEMKIND
+#ifdef ENABLE_MEMKIND
     struct memkind *pmem_kind; /* NVRAM connection */
 #endif
     char *nvram_device_path; /* The absolute path of the file system on NVRAM device */


### PR DESCRIPTION
See the ticket for a full description. This also fixes `memkind.cmake` to respect either flag.