### PR TITLE
WT-8328 Dump and upload backtraces when python and test format fails in evergreen testing

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -11,7 +11,7 @@ stepback: true
 pre:
   - func: "cleanup"
 post:
-  - func: "print python stacktrace"
+  - func: "dump stacktraces"
   - func: "dump stderr/stdout"
   - func: "upload artifact"
     vars:
@@ -504,16 +504,28 @@ functions:
         display_name: WT Hang Analyzer Output - Execution ${execution}
         remote_file: wiredtiger/${build_variant}/${revision}/wt_hang_analyzer/wt-hang-analyzer_${task_name}_${build_id}${postfix|}.tgz
 
-  "print python stacktrace":
-    command: shell.exec
-    params:
-      working_dir: "wiredtiger/cmake_build"
-      script: |
-        set -o errexit
-        set -o verbose
-        if [ -d "WT_TEST" ]; then
-          ${python_binary|python3} ../test/evergreen/print_python_stack_trace.py -e ${python_binary|python3} -c WT_TEST -l .
-        fi
+  "dump stacktraces":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build"
+        script: |
+          set -o errexit
+          set -o verbose
+          if [ -d "WT_TEST" ]; then
+            ${python_binary|python3} ../test/evergreen/print_stack_trace.py -e ${python_binary|python3} -c WT_TEST -l .
+          fi
+          ${python_binary|python3} ../test/evergreen/print_stack_trace.py -e ./test/format/t -c test/format -l .
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        local_files_include_filter:
+          - wiredtiger/cmake_build/*stacktrace.txt
+          - wiredtiger/cmake_build/test/format/*stacktrace.txt
+        bucket: build_external
+        permissions: public-read
+        content_type: text/plain
+        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/
 
   "dump stderr/stdout":
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -511,10 +511,12 @@ functions:
         script: |
           set -o errexit
           set -o verbose
-          if [ -d "WT_TEST" ]; then
-            ${python_binary|python3} ../test/evergreen/print_stack_trace.py -e ${python_binary|python3} -c WT_TEST -l .
-          fi
-          ${python_binary|python3} ../test/evergreen/print_stack_trace.py -e ./test/format/t -c test/format -l .
+          # Parse through any failures inside the WT_TEST directory.
+          ${python_binary|python3} ../test/evergreen/print_stack_trace.py --unit_test -e ${python_binary|python3} -c WT_TEST -l .
+          
+          # Look through the stress format directory for any coredumps.
+          cd test/format
+          ${python_binary|python3} ../../../test/evergreen/print_stack_trace.py --format -e ./t -c . -l .
     - command: s3.put
       params:
         aws_secret: ${aws_secret}

--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -115,18 +115,24 @@ def main():
                         help='directory path to the core dumps',
                         required=True)
     parser.add_argument('-l', '--lib_path', help='library path')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--unit_test', action='store_true', help='Format core dumps from python unit tests')
+    group.add_argument('--format', action='store_true', help='Format core dumps from format tests')
     args = parser.parse_args()
 
     # Store the path of the core files as a list.
     core_files = []
-    format_regex = re.compile(r'dump_t', re.IGNORECASE)
-    python_regex = re.compile(r'dump.*python', re.IGNORECASE)
+
+    regex = None
+    if (args.format):
+        regex = re.compile(r'dump_t.*core', re.IGNORECASE)
+    elif (args.unit_test):
+        regex = re.compile(r'dump.*python.*core', re.IGNORECASE)
+
     for root, _, files in os.walk(args.core_path):
         for file in files:
-            if format_regex.match(file):
-                core_files.append((os.path.join(root, file), False))
-            elif python_regex.match(file):
-                core_files.append((os.path.join(root, file), True))
+            if regex.match(file):
+                core_files.append((os.path.join(root, file), args.format))
 
     for core_file_path, dump_all in core_files:
         print(border_msg(core_file_path), flush=True)

--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -143,7 +143,7 @@ def main():
 
             # Extract the filename from the core file path, to create a stacktrace output file.
             file_name, _ = os.path.splitext(os.path.basename(core_file_path))
-            dbg.dump(args.executable_path, core_file_path, args.lib_path, True, file_name + "-stacktrace.txt")
+            dbg.dump(args.executable_path, core_file_path, args.lib_path, True, file_name + ".stacktrace.txt")
         elif sys.platform.startswith('darwin'):
             # FIXME - macOS to be supported in WT-8976
             # dbg = LLDBDumper()
@@ -151,7 +151,7 @@ def main():
 
             # Extract the filename from the core file path, to create a stacktrace output file.
             # file_name, _ = os.path.splitext(os.path.basename(core_file_path))
-            # dbg.dump(args.executable_path, core_file_path, args.lib_path, dump_all, file_name + "-stacktrace.txt")
+            # dbg.dump(args.executable_path, core_file_path, args.lib_path, dump_all, file_name + ".stacktrace.txt")
             pass
         elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
             # FIXME - Windows to be supported in WT-8937

--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -122,6 +122,7 @@ def main():
 
     # Store the path of the core files as a list.
     core_files = []
+    dump_all = args.unit_test
 
     regex = None
     if (args.format):
@@ -132,9 +133,9 @@ def main():
     for root, _, files in os.walk(args.core_path):
         for file in files:
             if regex.match(file):
-                core_files.append((os.path.join(root, file), args.format))
+                core_files.append(os.path.join(root, file))
 
-    for core_file_path, dump_all in core_files:
+    for core_file_path in core_files:
         print(border_msg(core_file_path), flush=True)
         if sys.platform.startswith('linux'):
             dbg = GDBDumper()

--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -51,7 +51,7 @@ class LLDBDumper:
         """Find the installed debugger."""
         return which(debugger)
 
-    def dump(self, exe_path: str, core_path: str, dump_all: bool):
+    def dump(self, exe_path: str, core_path: str, dump_all: bool, output_file: str):
         """Dump stack trace."""
         if self.dbg is None:
             sys.exit("Debugger lldb not found,"
@@ -63,9 +63,12 @@ class LLDBDumper:
             cmds.append("backtrace -c 30")
         cmds.append("quit")
 
+        output = None
+        if (output_file):
+            output = open(output_file, "w")
         subprocess.run([self.dbg, "--batch"] + [exe_path, "-c", core_path] +
                        list(itertools.chain.from_iterable([['-o', b] for b in cmds])),
-                       check=True)
+                       check=True, stdout=output)
 
 
 class GDBDumper:
@@ -77,7 +80,7 @@ class GDBDumper:
     def _find_debugger(debugger: str):
         """Find the installed debugger."""
         return which(debugger)
-    
+
     def dump(self, exe_path: str, core_path: str, lib_path: str, dump_all: bool, output_file: str):
         """Dump stack trace."""
         if self.dbg is None:


### PR DESCRIPTION
This ticket delves into adding support to dump all the threads when a test/format failure occurs. Furthermore I have added functionality to also upload all the stacktraces into the evergreen UI as well. **Note: For printing our the test format, we only print the aborting thread, and dump all the threads in the backtrace txt file instead.**