### PR TITLE
WT-8876 Make timestamp usage checking at commit the default

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -46,7 +46,7 @@ common_runtime_config = [
     Config('app_metadata', '', r'''
         application-owned metadata for this object'''),
     Config('assert', '', r'''
-        enable enhanced timestamp checking with error messages and optional core dump''',
+        declare timestamp usage''',
         type='category', subconfig= [
         Config('commit_timestamp', 'none', r'''
             this option is no longer supported, retained for backward compatibility''',
@@ -65,7 +65,7 @@ common_runtime_config = [
             \c write_timestamp_usage option for this table, writing
             an error message if policy is violated. If the library was
             built in diagnostic mode, drop core at the failing check''',
-            choices=['off', 'on']),
+            choices=['off', 'on'], undoc=True),
         ]),
     Config('verbose', '[]', r'''
         this option is no longer supported, retained for backward compatibility''',

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -532,7 +532,7 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_search);
 
-    __wt_txn_search_check(session);
+    WT_RET(__wt_txn_search_check(session));
     __cursor_state_save(cursor, &state);
 
     /*
@@ -645,7 +645,7 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_search_near);
 
-    __wt_txn_search_check(session);
+    WT_RET(__wt_txn_search_check(session));
     __cursor_state_save(cursor, &state);
 
     /*

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -477,9 +477,6 @@ __conn_dhandle_config_parse_ts(WT_SESSION_IMPL *session)
         LF_SET(WT_DHANDLE_TS_ASSERT_READ_ALWAYS);
     else if (WT_STRING_MATCH("never", cval.str, cval.len))
         LF_SET(WT_DHANDLE_TS_ASSERT_READ_NEVER);
-    WT_RET(__wt_config_gets(session, cfg, "assert.write_timestamp", &cval));
-    if (WT_STRING_MATCH("on", cval.str, cval.len))
-        LF_SET(WT_DHANDLE_TS_ASSERT_WRITE);
 
     /*
      * Timestamp usage configuration: Ignore the "always", "key_consistent" and "ordered" keywords:

--- a/src/docs/timestamp-misc.dox
+++ b/src/docs/timestamp-misc.dox
@@ -31,42 +31,6 @@ The database must be quiescent during this process, and applications must close
 or reset all open cursors before calling the WT_CONNECTION::rollback_to_stable
 method.
 
-@section timestamp_misc_diagnostic Using diagnostic configurations to enforce timestamp usage
-
-The WT_SESSION::create method supports additional checking of timestamp
-usage on a per-table basis. While these usage checks can decrease
-application performance, and applications may not choose to configure them
-in production settings, they are strongly recommended during development.
-
-By default, WiredTiger requires timestamps be used in "ordered" mode:
-updates to a table can be made either with and without a commit timestamp,
-but once a commit timestamp is used to update a key, all future updates to
-the key will require a commit timestamp. Further, each update to a key must
-have a commit timestamp at or after any previous update.
-
-Setting the \c write_timestamp_usage configuration changes how timestamps
-are expected to be used in the table:
-
-| Configuration | Description |
-|---------------|-------------|
-| never | Require no updates to the table have a commit timestamp. |
-| mixed_mode | Allow updates both with and without a commit timestamp. Each update must have a commit timestamp at or after the previous update, or no timestamp at all. |
-
-The \c write_timestamp_usage configuration is expected to be used with the
-WT_SESSION::create method's \c assert configuration. The \c
-"assert(read_timestamp)" configuration requires timestamps always or never
-be used on reads in the table.
-
-The \c "assert(write_timestamp)" configuration requires update
-timestamps conform to the \c write_timestamp_usage setting. If WiredTiger
-detects a violation of the configured policy, an error message will be
-logged. Additionally, in diagnostic builds, the library will fail and drop
-core at the failing check.
-
-\warning
-These are best-effort checks by WiredTiger, and there are cases where
-application misbehavior will not be detected.
-
 @section timestamps_misc_in_memory In-memory configurations and timestamps
 
 Timestamps are supported for in-memory databases, but must be configured as in

--- a/src/docs/timestamp-txn.dox
+++ b/src/docs/timestamp-txn.dox
@@ -33,22 +33,42 @@ values based on their timestamps. Readers acquiring a snapshot after the
 commit of the update without a timestamp will not see prior historical values
 regardless of their read timestamps.
 
-@section timestamp_txn_api_configure Enforcing application timestamp behavior
+@section timestamp_txn_api_configure Application timestamp configuration
 
 By default, WiredTiger requires timestamps be used in "ordered" mode:
-updates to a table can be made either with and without a commit timestamp,
+updates to a table can be made both with and without a commit timestamp,
 but once a commit timestamp is used to update a key, all future updates to
 the key will require a commit timestamp. Further, each update to a key must
 have a commit timestamp at or after any previous update.
 
-These requirements can be changed on a per-table basis to require no updates
+These requirements can be changed on a per-table basis to specify no updates
 to a table have timestamps, or that updates without timestamps be permitted
-even when a key has already been updated using a timestamp. Using timestamps
-that are before previously applied timestamps is never permitted.
+even when a key has already been updated using a timestamp. Commit timestamps
+before previously applied timestamps is never permitted.
 
-Enforcing application timestamp behavior can be challenging for application
-writers. WiredTiger includes diagnostic support for many common restrictions;
-see @ref timestamp_misc_diagnostic.
+Setting the WT_SESSION::create \c write_timestamp_usage configuration changes
+how timestamps are expected to be used in the table:
+
+| Configuration | Description |
+|---------------|-------------|
+| never | Require no updates to the table have a commit timestamp. |
+| mixed_mode | Allow updates both with and without a commit timestamp. Each update must have a commit timestamp at or after the previous update, or no timestamp at all. |
+
+The WT_SESSION::create \c "assert(read_timestamp)" configuration specifies
+that timestamps always or never be used on reads in the table.
+
+There are additional timestamp usage checks in diagnostic builds. While
+building in diagnostic mode to enable these usage checks will decrease
+application performance, and applications should not configure diagnostic
+builds for production use, they are strongly recommended during development.
+
+If WiredTiger detects a violation of timestamp policy, an error message
+will be logged and the transaction commit will fail. In diagnostic builds,
+the library will log an error message and drop core at the failing check.
+
+\warning
+These are best-effort checks by WiredTiger, and there are cases where
+application misbehavior will not be detected.
 
 @section timestamp_txn_api_query Querying transaction timestamp information
 
@@ -137,16 +157,6 @@ multiple commit timestamps, the first commit timestamp set is also required to
 be the earliest: the second and subsequent commit timestamps may not be
 earlier than the first commit timestamp.  This feature is not compatible with
 prepared transactions, which must use only a single commit timestamp.
-
-\warning
-It is \b strongly recommended that updates to a single data item always be presented
-in timestamp order, although this is not enforced by WiredTiger. Updating a
-single data item in other than timestamp order is allowed, and if applications
-do this, data consistency can be violated. This is not expected to be supported
-in future WiredTiger releases, and applications updating keys in other then
-timestamp order are expected to explicitly fail in future releases.
-Some diagnostic tools are available to help enforce this constraint;
-see @ref timestamp_misc_diagnostic.
 
 For prepared transactions, the commit timestamp must not be before the prepare
 timestamp. Otherwise, the commit timestamp must be after the stable timestamp.

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -131,10 +131,9 @@ struct __wt_data_handle {
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_DHANDLE_TS_ASSERT_READ_ALWAYS 0x01u /* Assert read always checking. */
 #define WT_DHANDLE_TS_ASSERT_READ_NEVER 0x02u  /* Assert read never checking. */
-#define WT_DHANDLE_TS_ASSERT_WRITE 0x04u       /* Assert write checking. */
-#define WT_DHANDLE_TS_MIXED_MODE 0x08u         /* Handle using mixed mode timestamps checking. */
-#define WT_DHANDLE_TS_NEVER 0x10u              /* Handle never using timestamps checking. */
-#define WT_DHANDLE_TS_ORDERED 0x20u            /* Handle using ordered timestamps checking. */
+#define WT_DHANDLE_TS_MIXED_MODE 0x04u         /* Handle using mixed mode timestamps checking. */
+#define WT_DHANDLE_TS_NEVER 0x08u              /* Handle never using timestamps checking. */
+#define WT_DHANDLE_TS_ORDERED 0x10u            /* Handle using ordered timestamps checking. */
                                                /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t ts_flags;
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2170,6 +2170,8 @@ static inline int __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_CURSOR_BTR
 static inline int __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline int __wt_txn_search_check(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, u_int modify_type,
   WT_UPDATE **updp, size_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_upd_alloc_tombstone(WT_SESSION_IMPL *session, WT_UPDATE **updp,
@@ -2353,7 +2355,6 @@ static inline void __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recn
 static inline void __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 static inline void __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp);
 static inline void __wt_txn_read_last(WT_SESSION_IMPL *session);
-static inline void __wt_txn_search_check(WT_SESSION_IMPL *session);
 static inline void __wt_txn_unmodify(WT_SESSION_IMPL *session);
 static inline void __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd);
 static inline void __wt_upd_value_clear(WT_UPDATE_VALUE *upd_value);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1035,18 +1035,13 @@ struct __wt_session {
 	 * "sequential"; default \c none.}
 	 * @config{app_metadata, application-owned metadata for this object., a string; default
 	 * empty.}
-	 * @config{assert = (, enable enhanced timestamp checking with error messages and optional
-	 * core dump., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read_timestamp, check timestamps are \c always or \c
-	 * never used on reads with this table\, writing an error message if policy is violated.  If
-	 * the library was built in diagnostic mode\, drop core at the failing check.  Should be set
-	 * to \c none if mixed read use is allowed., a string\, chosen from the following options:
-	 * \c "always"\, \c "never"\, \c "none"; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * write_timestamp, check timestamps are used consistently with the configured \c
-	 * write_timestamp_usage option for this table\, writing an error message if policy is
-	 * violated.  If the library was built in diagnostic mode\, drop core at the failing check.,
-	 * a string\, chosen from the following options: \c "off"\, \c "on"; default \c off.}
+	 * @config{assert = (, declare timestamp usage., a set of related configuration options
+	 * defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read_timestamp, check timestamps are \c
+	 * always or \c never used on reads with this table\, writing an error message if policy is
+	 * violated.  If the library was built in diagnostic mode\, drop core at the failing check.
+	 * Should be set to \c none if mixed read use is allowed., a string\, chosen from the
+	 * following options: \c "always"\, \c "never"\, \c "none"; default \c none.}
 	 * @config{ ),,}
 	 * @config{cache_resident, do not ever evict the object's pages from cache.  Not compatible
 	 * with LSM tables; see @ref tuning_cache_resident for more information., a boolean flag;
@@ -1107,18 +1102,13 @@ struct __wt_session {
 	 * an integer between 512B and 128MB; default \c 4KB.}
 	 * @config{app_metadata, application-owned metadata for this object., a string; default
 	 * empty.}
-	 * @config{assert = (, enable enhanced timestamp checking with error messages and optional
-	 * core dump., a set of related configuration options defined below.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read_timestamp, check timestamps are \c always or \c
-	 * never used on reads with this table\, writing an error message if policy is violated.  If
-	 * the library was built in diagnostic mode\, drop core at the failing check.  Should be set
-	 * to \c none if mixed read use is allowed., a string\, chosen from the following options:
-	 * \c "always"\, \c "never"\, \c "none"; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-	 * write_timestamp, check timestamps are used consistently with the configured \c
-	 * write_timestamp_usage option for this table\, writing an error message if policy is
-	 * violated.  If the library was built in diagnostic mode\, drop core at the failing check.,
-	 * a string\, chosen from the following options: \c "off"\, \c "on"; default \c off.}
+	 * @config{assert = (, declare timestamp usage., a set of related configuration options
+	 * defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;read_timestamp, check timestamps are \c
+	 * always or \c never used on reads with this table\, writing an error message if policy is
+	 * violated.  If the library was built in diagnostic mode\, drop core at the failing check.
+	 * Should be set to \c none if mixed read use is allowed., a string\, chosen from the
+	 * following options: \c "always"\, \c "never"\, \c "none"; default \c none.}
 	 * @config{ ),,}
 	 * @config{block_allocation, configure block allocation.  Permitted values are \c "best" or
 	 * \c "first"; the \c "best" configuration uses a best-fit algorithm\, the \c "first"

--- a/test/suite/test_assert06.py
+++ b/test/suite/test_assert06.py
@@ -43,15 +43,17 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
     ]
     scenarios = make_scenarios(key_format_values)
 
-    msg_usage='use timestamps once they are first used'
+    msg_usage='/use timestamps once they are first used/'
 
-    def apply_timestamps(self, timestamp):
-        self.session.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(timestamp))
+    def apply_timestamps(self, timestamp, prepare):
+        if prepare:
+            self.session.prepare_transaction(
+                'prepare_timestamp=' + self.timestamp_str(timestamp))
         self.session.timestamp_transaction(
             'commit_timestamp=' + self.timestamp_str(timestamp))
-        self.session.timestamp_transaction(
-            'durable_timestamp=' + self.timestamp_str(timestamp))
+        if prepare:
+            self.session.timestamp_transaction(
+                'durable_timestamp=' + self.timestamp_str(timestamp))
 
     def test_timestamp_alter(self):
         if wiredtiger.diagnostic_build():
@@ -61,8 +63,8 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         ds = SimpleDataSet(
             self, 'file:notused', 10, key_format=self.key_format, value_format=self.value_format)
 
-        cfg_on = 'write_timestamp_usage=ordered,assert=(write_timestamp=on)'
-        cfg_off = 'write_timestamp_usage=never,assert=(write_timestamp=off)'
+        cfg_on = 'write_timestamp_usage=ordered'
+        cfg_off = 'write_timestamp_usage=none'
 
         # Create the table without the key consistency checking turned on.
         # Create a few items breaking the rules.
@@ -76,13 +78,13 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         key = ds.key(1)
         self.session.begin_transaction()
         c[key] = ds.value(1)
-        self.apply_timestamps(2)
+        self.apply_timestamps(2, True)
         self.session.commit_transaction()
 
         # Modify the data item at timestamp 1, illegally moving the timestamp backward.
         self.session.begin_transaction()
         c[key] = ds.value(2)
-        self.apply_timestamps(1)
+        self.apply_timestamps(1, True)
         self.session.commit_transaction()
 
         # Insert a non-timestamped item.
@@ -94,7 +96,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[key] = ds.value(4)
-        self.apply_timestamps(2)
+        self.apply_timestamps(2, True)
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[key] = ds.value(5)
@@ -112,12 +114,12 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         key = ds.key(3)
         self.session.begin_transaction()
         c[key] = ds.value(6)
-        self.apply_timestamps(5)
+        self.apply_timestamps(5, True)
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[key] = ds.value(6)
-        with self.expectedStderrPattern(self.msg_usage):
-            self.session.commit_transaction()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), self.msg_usage)
 
         # Detect using a timestamp on a non-timestamp key. We must first use a non-timestamped
         # operation on the key in order to violate the key consistency condition in the following
@@ -143,7 +145,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[key] = ds.value(1)
-        self.apply_timestamps(6)
+        self.apply_timestamps(6, True)
         self.session.commit_transaction()
 
     def test_timestamp_usage(self):
@@ -166,13 +168,13 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         # Insert a data item at timestamp 2.
         self.session.begin_transaction()
         c[ds.key(1)] = ds.value(1)
-        self.apply_timestamps(2)
+        self.apply_timestamps(2, True)
         self.session.commit_transaction()
 
         # Make sure we can successfully add a different key at timestamp 1.
         self.session.begin_transaction()
         c[ds.key(2)] = ds.value(2)
-        self.apply_timestamps(1)
+        self.apply_timestamps(1, True)
         self.session.commit_transaction()
 
         # Insert key_ts3 at timestamp 10 and key_ts4 at 15, then modify both keys in one transaction
@@ -180,33 +182,32 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         c[ds.key(3)] = ds.value(3)
-        self.apply_timestamps(10)
+        self.apply_timestamps(10, True)
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[ds.key(4)] = ds.value(4)
-        self.apply_timestamps(15)
+        self.apply_timestamps(15, True)
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[ds.key(3)] = ds.value(5)
         c[ds.key(4)] = ds.value(6)
-        self.apply_timestamps(13)
-        with self.expectedStderrPattern('unexpected timestamp usage'):
-            self.session.commit_transaction()
-        self.assertEquals(c[ds.key(3)], ds.value(5))
-        self.assertEquals(c[ds.key(4)], ds.value(6))
+        self.apply_timestamps(13, False)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), '/unexpected timestamp usage/')
+        self.assertEquals(c[ds.key(3)], ds.value(3))
+        self.assertEquals(c[ds.key(4)], ds.value(4))
 
         # Modify a key previously used with timestamps without one. We should get the inconsistent
         # usage message.
         key = ds.key(5)
         self.session.begin_transaction()
         c[key] = ds.value(7)
-        self.apply_timestamps(14)
+        self.apply_timestamps(14, True)
         self.session.commit_transaction()
         self.session.begin_transaction()
         c[key] = ds.value(8)
-        with self.expectedStderrPattern(self.msg_usage):
-            self.session.commit_transaction()
-        self.assertEquals(c[key], ds.value(8))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), self.msg_usage)
 
         # Set the timestamp in the beginning, middle or end of the transaction.
         key = ds.key(6)
@@ -229,7 +230,7 @@ class test_assert06(wttest.WiredTigerTestCase, suite_subprocess):
         key = ds.key(8)
         self.session.begin_transaction()
         c[key] = ds.value(14)
-        self.apply_timestamps(18)
+        self.apply_timestamps(18, True)
         self.session.commit_transaction()
         self.assertEquals(c[key], ds.value(14))
 

--- a/test/suite/test_timestamp26.py
+++ b/test/suite/test_timestamp26.py
@@ -34,13 +34,8 @@ import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-# Test assert never setting when associated with write_timestamp_usage.
-class test_timestamp26_never(wttest.WiredTigerTestCase):
-    conn_config = 'debug_mode=(corruption_abort=false)'
-    assert_ts = [
-        ('on', dict(assert_ts='on')),
-        ('off', dict(assert_ts='off')),
-    ]
+# Test write_timestamp_usage never setting.
+class test_timestamp26_wtu_never(wttest.WiredTigerTestCase):
     commit_ts = [
         ('yes', dict(commit_ts=True)),
         ('no', dict(commit_ts=False)),
@@ -54,9 +49,9 @@ class test_timestamp26_never(wttest.WiredTigerTestCase):
         ('row', dict(key_format='S', value_format='S')),
         ('var', dict(key_format='r', value_format='S')),
     ]
-    scenarios = make_scenarios(types, assert_ts, commit_ts, with_ts)
+    scenarios = make_scenarios(types, commit_ts, with_ts)
 
-    def test_never(self):
+    def test_wtu_never(self):
         if wiredtiger.diagnostic_build():
             self.skipTest('requires a non-diagnostic build')
 
@@ -68,7 +63,7 @@ class test_timestamp26_never(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=never' + ',assert=(write_timestamp=' + self.assert_ts + ')')
+            ',write_timestamp_usage=never')
 
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
@@ -82,11 +77,9 @@ class test_timestamp26_never(wttest.WiredTigerTestCase):
                 self.session.timestamp_transaction(commit_ts)
                 commit_ts = ''
 
-            if self.assert_ts == 'off':
-                self.session.commit_transaction(commit_ts)
-            else:
-                with self.expectedStderrPattern('set when disallowed'):
-                    self.session.commit_transaction(commit_ts)
+            msg = '/set when disallowed/'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.commit_transaction(commit_ts), msg)
 
         # Commit without a timestamp.
         else:
@@ -114,7 +107,7 @@ class test_timestamp26_read_timestamp(wttest.WiredTigerTestCase):
         ds = SimpleDataSet(
             self, 'file:notused', 10, key_format=self.key_format, value_format=self.value_format)
 
-        # Open the object, configuring timestamp usage.
+        # Open the object, configuring read timestamp usage.
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
@@ -134,26 +127,25 @@ class test_timestamp26_read_timestamp(wttest.WiredTigerTestCase):
         # Try reading without a timestamp.
         self.session.begin_transaction()
         c.set_key(key)
-        msg = 'read timestamps required and none set'
         if self.read_ts != 'always':
             self.assertEquals(c.search(), 0)
             self.assertEqual(c.get_value(), value)
         else:
-            with self.expectedStderrPattern(msg):
-                self.assertEquals(c.search(), 0)
+            msg = '/read timestamps required and none set/'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c.search(), msg)
+
         self.session.rollback_transaction()
 
         # Try reading with a timestamp.
         self.session.begin_transaction()
         self.session.timestamp_transaction('read_timestamp=20')
         c.set_key(key)
-        msg = 'read timestamps disallowed'
         if self.read_ts != 'never':
             self.assertEquals(c.search(), 0)
             self.assertEqual(c.get_value(), value)
         else:
-            with self.expectedStderrPattern(msg):
-                self.assertEquals(c.search(), 0)
+            msg = '/read timestamps disallowed/'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c.search(), msg)
         self.session.rollback_transaction()
 
 # Test alter of timestamp settings.
@@ -180,14 +172,15 @@ class test_timestamp26_alter(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=never,assert=(write_timestamp=on)')
+            ',write_timestamp_usage=never')
 
         c = self.session.open_cursor(uri)
         self.session.begin_transaction()
         c[ds.key(10)] = ds.value(10)
-        msg = 'set when disallowed by table configuration'
-        with self.expectedStderrPattern(msg):
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        msg = '/set when disallowed by table configuration/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10)),
+            msg)
         c.close()
 
         self.session.alter(uri, 'write_timestamp_usage=ordered')
@@ -198,12 +191,12 @@ class test_timestamp26_alter(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(11))
         self.session.begin_transaction()
         c[ds.key(10)] = ds.value(10)
-        msg = 'always use timestamps'
-        with self.expectedStderrPattern(msg):
-            self.session.commit_transaction()
+        msg = '/always use timestamps/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
-# Test timestamp settings with inconsistent updates.
-class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
+# Test timestamp settings with alter and inconsistent updates.
+class test_timestamp26_alter_inconsistent_update(wttest.WiredTigerTestCase):
     types = [
         ('fix', dict(key_format='r', value_format='8t')),
         ('row', dict(key_format='S', value_format='S')),
@@ -211,7 +204,7 @@ class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(types)
 
-    def test_ordered(self):
+    def test_alter_inconsistent_update(self):
         if wiredtiger.diagnostic_build():
             self.skipTest('requires a non-diagnostic build')
 
@@ -249,9 +242,8 @@ class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
 
         self.session.begin_transaction()
-        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(2))
         c[key] = ds.value(13)
-        self.session.commit_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
         self.session.begin_transaction()
         c[key] = ds.value(14)
@@ -261,8 +253,7 @@ class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
         # timestamp forward in order to alter, otherwise alter will fail with EBUSY.
         c.close()
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
-        config = 'assert=(write_timestamp=on)'
-        self.session.alter(uri, 'write_timestamp_usage=ordered,' + config)
+        self.session.alter(uri, 'write_timestamp_usage=ordered')
 
         c = self.session.open_cursor(uri)
         key = ds.key(15)
@@ -272,39 +263,22 @@ class test_timestamp26_inconsistent(wttest.WiredTigerTestCase):
         c[key] = ds.value(15)
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
 
-        msg = 'with an older timestamp'
+        msg = '/with an older timestamp/'
         self.session.begin_transaction()
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(14))
         c[key] = ds.value(16)
-        with self.expectedStderrPattern(msg):
-            self.session.commit_transaction()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
         # Detect not using a timestamp.
-        msg = 'use timestamps once they are first used'
+        msg = '/use timestamps once they are first used/'
         self.session.begin_transaction()
         c[key] = ds.value(17)
-        with self.expectedStderrPattern(msg):
-            self.session.commit_transaction()
-
-        # Now alter the setting again and detection is off.
-        c.close()
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20))
-        self.session.alter(uri, 'assert=(write_timestamp=off)')
-        c = self.session.open_cursor(uri)
-        key = ds.key(18)
-
-        # Detection is off we can successfully change the same key with then without a timestamp.
-        self.session.begin_transaction()
-        c[key] = ds.value(18)
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(21))
-
-        self.session.begin_transaction()
-        c[key] = ds.value(19)
-        self.session.commit_transaction()
-        c.close()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
 # Test timestamp settings with inconsistent updates.
-class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
+class test_timestamp26_inconsistent_update(wttest.WiredTigerTestCase):
     types = [
         ('fix', dict(key_format='r', value_format='8t')),
         ('row', dict(key_format='S', value_format='S')),
@@ -312,7 +286,7 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(types)
 
-    def test_timestamp_inconsistent(self):
+    def test_timestamp_inconsistent_update(self):
         if wiredtiger.diagnostic_build():
             self.skipTest('requires a non-diagnostic build')
 
@@ -326,7 +300,7 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=ordered,assert=(write_timestamp=on)')
+            ',write_timestamp_usage=ordered')
 
         c = self.session.open_cursor(uri)
         key = ds.key(1)
@@ -340,8 +314,9 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(1))
         c[key] = ds.value(2)
-        with self.expectedStderrPattern('updates a value with an older timestamp'):
-                self.session.commit_transaction()
+        msg = '/updates a value with an older timestamp/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
         # Make sure we can successfully add a different key at timestamp 1.
         self.session.begin_transaction()
@@ -364,10 +339,9 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(13))
         c[key1] = ds.value(5)
         c[key2] = ds.value(6)
-        with self.expectedStderrPattern('updates a value with an older timestamp'):
-            self.session.commit_transaction()
-        self.assertEquals(c[key1], ds.value(5))
-        self.assertEquals(c[key2], ds.value(6))
+        msg = '/updates a value with an older timestamp/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
     # Try to update a key previously used with timestamps without one. We should get the
     # inconsistent usage error/message.
@@ -385,7 +359,7 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=ordered,assert=(write_timestamp=on)')
+            ',write_timestamp_usage=ordered')
 
         c = self.session.open_cursor(uri)
         key = ds.key(5)
@@ -396,10 +370,9 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
 
         self.session.begin_transaction()
         c[key] = ds.value(12)
-        msg_usage ='configured to always use timestamps once they are first used'
-        with self.expectedStderrPattern(msg_usage):
-            self.session.commit_transaction()
-        self.assertEquals(c[key], ds.value(12))
+        msg ='/configured to always use timestamps once they are first used/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.commit_transaction(), msg)
 
     # Smoke test setting the timestamp at various points in the transaction.
     def test_timestamp_ts_order(self):
@@ -416,7 +389,7 @@ class test_timestamp26_ts_inconsistent(wttest.WiredTigerTestCase):
         uri = 'table:ts'
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            ',write_timestamp_usage=ordered,assert=(write_timestamp=on)')
+            ',write_timestamp_usage=ordered')
 
         c = self.session.open_cursor(uri)
         key1 = ds.key(6)
@@ -483,8 +456,7 @@ class test_timestamp26_log_ts(wttest.WiredTigerTestCase):
         config = ',write_timestamp_usage='
         config += 'always' if self.always else 'never'
         self.session.create(uri,
-            'key_format={},value_format={}'.format(self.key_format, self.value_format) +
-            config + ',assert=(write_timestamp=on)')
+            'key_format={},value_format={}'.format(self.key_format, self.value_format) + config)
 
         c = self.session.open_cursor(uri)
 
@@ -542,7 +514,6 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
         config = ',' + self.obj_config
         config += ',write_timestamp_usage='
         config += 'ordered' if self.always else 'never'
-        config += ',assert=(write_timestamp=on)'
         self.session.breakpoint()
         self.session.create(uri,
             'key_format={},value_format={}'.format(self.key_format, self.value_format) + config)
@@ -555,8 +526,10 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
         if self.always == True or self.obj_ignore == True:
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
         else:
-            with self.expectedStderrPattern('unexpected timestamp usage'):
-                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+            msg = '/unexpected timestamp usage/'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1)),
+                msg)
 
         # Commit without a timestamp (but first with a timestamp if in ordered mode so we get
         # a failure).
@@ -569,8 +542,9 @@ class test_timestamp26_in_memory_ts(wttest.WiredTigerTestCase):
         if self.always == False or self.obj_ignore == True:
             self.session.commit_transaction()
         else:
-            with self.expectedStderrPattern('unexpected timestamp usage'):
-                self.session.commit_transaction()
+            msg = '/no timestamp provided/'
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.commit_transaction(), msg)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Change WiredTiger to do commit timestamp checking by default, that is, timestamp usage will always be called at commit.

If timestamp usage is violated, an error message will always be logged.

In DIAGNOSTIC builds, timestamp usage violations will result in an immediate core dump after the error message

In STANDALONE builds, timestamp usage violations will result in transaction rollback (the commit will fail after the error message)

In MDB builds the transaction commit will succeed after the error message

Remove the assert=(write_timestamp) configuration from the documentation and update the User Guide.