### PR TITLE
WT-8890 Add bucket prefix to S3 extension cache directory creation

### DIFF
--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -142,6 +142,7 @@ static int S3ObjectSize(WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *
 static std::string
 S3Path(const std::string &dir, const std::string &name)
 {
+    std::cout << "S3Path: Name: " + name + "   ::dir:" + dir << std::endl; 
     // Skip over "./" and variations (".//", ".///./././//") at the beginning of the name.
     int i = 0;
     while (name[i] == '.') {
@@ -152,6 +153,7 @@ S3Path(const std::string &dir, const std::string &name)
             i++;
     }
     std::string strippedName = name.substr(i, name.length() - i);
+    std::cout << "S3Path: Stripped: " + strippedName << std::endl; 
     return (dir + "/" + strippedName);
 }
 
@@ -803,6 +805,9 @@ S3FlushFinish(WT_STORAGE_SOURCE *storage, WT_SESSION *session, WT_FILE_SYSTEM *f
     // Constructing the pathname for source and cache from file system and local.
     std::string srcPath = S3Path(fs->homeDir, source);
     std::string destPath = S3Path(fs->cacheDir, object);
+
+    // Converting S3 object name to cache directory strcture to link the cache file with local file. 
+    std::filesystem::create_directories(std::filesystem::path(destPath).parent_path());
 
     // Linking file with the local file.
     std::error_code ec;

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -142,7 +142,6 @@ static int S3ObjectSize(WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *
 static std::string
 S3Path(const std::string &dir, const std::string &name)
 {
-    std::cout << "S3Path: Name: " + name + "   ::dir:" + dir << std::endl; 
     // Skip over "./" and variations (".//", ".///./././//") at the beginning of the name.
     int i = 0;
     while (name[i] == '.') {
@@ -153,7 +152,6 @@ S3Path(const std::string &dir, const std::string &name)
             i++;
     }
     std::string strippedName = name.substr(i, name.length() - i);
-    std::cout << "S3Path: Stripped: " + strippedName << std::endl; 
     return (dir + "/" + strippedName);
 }
 
@@ -806,7 +804,7 @@ S3FlushFinish(WT_STORAGE_SOURCE *storage, WT_SESSION *session, WT_FILE_SYSTEM *f
     std::string srcPath = S3Path(fs->homeDir, source);
     std::string destPath = S3Path(fs->cacheDir, object);
 
-    // Converting S3 object name to cache directory strcture to link the cache file with local file. 
+    // Converting S3 object name to cache directory strcture to link the cache file with local file.
     std::filesystem::create_directories(std::filesystem::path(destPath).parent_path());
 
     // Linking file with the local file.

--- a/test/suite/helper_tiered.py
+++ b/test/suite/helper_tiered.py
@@ -74,11 +74,11 @@ def get_bucket2_name(storage_source):
 # Generate a unique object prefix for the S3 store. 
 def generate_s3_prefix(test_name = ''):
     # Generates a unique prefix to be used with the object keys, eg:
-    # "s3test_artefacts/python_2022-31-01-16-34-10_623843294/"
-    prefix = 's3test_artefacts--python_'
+    # "s3test/2022-31-01-16-34-10_623843294/"
+    prefix = 's3test/'
     prefix += datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
     # Range upto int32_max, matches that of C++'s std::default_random_engine
-    prefix += '_' + str(random.randrange(1, 2147483646)) + '--'
+    prefix += '/' + str(random.randrange(1, 2147483646)) + '--'
 
     # If the calling function has not provided a name, extract it from the stack.
     # It is important to generate unique prefixes for different tests in the same class,

--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -47,7 +47,8 @@ class test_tiered04(wttest.WiredTigerTestCase):
             bucket = get_bucket1_name('s3_store'),
             bucket1 = get_bucket2_name('s3_store'),
             prefix = generate_s3_prefix(),
-            prefix1 = generate_s3_prefix(),
+            # Test that object name with "/" are processed. 
+            prefix1 = generate_s3_prefix() + "/s3/source/",
             ss_name = 's3_store')),
     ]
     # Make scenarios for different cloud service providers


### PR DESCRIPTION
- Prefixes that can simulate a directory structure using "/" are now reflected in the cache directory structure itself and directories are made from the prefixes. 
- The linking to the cache directory now succeeds because intermediate directory structures are created. 
- Changes were made to testing structures to include prefixes with "/". 