### PR TITLE
WT-8896 Add class to s3_storage_source to handle AWS SDK initialization and termination

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -29,6 +29,7 @@ AsyncOp
 Athanassoulis
 Athlon
 Aws
+AwsManager
 Axxx
 BBBBB
 BBBBBB

--- a/ext/storage_sources/s3_store/s3_aws_manager.h
+++ b/ext/storage_sources/s3_store/s3_aws_manager.h
@@ -1,0 +1,98 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef S3AWSMANAGER
+#define S3AWSMANAGER
+
+#include <mutex>
+#include <aws/core/Aws.h>
+
+// The AWS SDK must only be intialized once and must call initialization and shutdown in the correct
+// order. The AwsManager handles multiple calls from the S3 extension initialization and uses a
+// reference counter to check how many instances of the S3 extension are using the SDK.  The first
+// call to the extension will initiate the SDK while subsequent calls will increment the reference
+// counter. Then each call to terminate will decrement the reference counter until it reaches 0 at
+// which point SDK shutdown will be called.
+class AwsManager {
+    public:
+    static AwsManager &
+    Get()
+    {
+        return aws_instance;
+    }
+
+    // Public facing function to call the SDK initialization and abstract the reference to the
+    // class.
+    static void
+    Init()
+    {
+        return Get().InitInternal();
+    }
+
+    // Public facing function to call the SDK shutdown and abstract the reference to the class.
+    static void
+    Terminate()
+    {
+        return Get().TerminateInternal();
+    }
+
+    private:
+    AwsManager()
+    {
+        refCount = 0;
+    }
+
+    // Check the number of references to the class and initialize the AWS SDK if it's the first
+    // reference.
+    void
+    InitInternal()
+    {
+        std::lock_guard<std::mutex> lock(InitGuard);
+        if (refCount == 0) {
+            Aws::InitAPI(options);
+        }
+        refCount++;
+    }
+
+    // Check the number of references to the class and shutdown the AWS SDK if there are no more
+    // references.
+    void
+    TerminateInternal()
+    {
+        std::lock_guard<std::mutex> lock(InitGuard);
+        refCount--;
+        if (refCount == 0) {
+            Aws::ShutdownAPI(options);
+        }
+    }
+
+    static AwsManager aws_instance;
+    Aws::SDKOptions options;
+    int refCount;
+    static std::mutex InitGuard;
+};
+#endif

--- a/ext/storage_sources/s3_store/s3_aws_manager.h
+++ b/ext/storage_sources/s3_store/s3_aws_manager.h
@@ -31,12 +31,12 @@
 #include <mutex>
 #include <aws/core/Aws.h>
 
-// The AWS SDK must only be initialized once and must call initialization and shutdown in the correct
-// order. The AwsManager handles multiple calls from the S3 extension initialization and uses a
-// reference counter to check how many instances of the S3 extension are using the SDK.  The first
-// call to the extension will initiate the SDK while subsequent calls will increment the reference
-// counter. Then each call to terminate will decrement the reference counter until it reaches 0 at
-// which point SDK shutdown will be called.
+// The AWS SDK must only be initialized once and must call initialization and shutdown in the
+// correct order. The AwsManager handles multiple calls from the S3 extension initialization and
+// uses a reference counter to check how many instances of the S3 extension are using the SDK.  The
+// first call to the extension will initiate the SDK while subsequent calls will increment the
+// reference counter. Then each call to terminate will decrement the reference counter until it
+// reaches 0 at which point SDK shutdown will be called.
 class AwsManager {
     public:
     static AwsManager &

--- a/ext/storage_sources/s3_store/s3_aws_manager.h
+++ b/ext/storage_sources/s3_store/s3_aws_manager.h
@@ -31,7 +31,7 @@
 #include <mutex>
 #include <aws/core/Aws.h>
 
-// The AWS SDK must only be intialized once and must call initialization and shutdown in the correct
+// The AWS SDK must only be initialized once and must call initialization and shutdown in the correct
 // order. The AwsManager handles multiple calls from the S3 extension initialization and uses a
 // reference counter to check how many instances of the S3 extension are using the SDK.  The first
 // call to the extension will initiate the SDK while subsequent calls will increment the reference

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -735,8 +735,6 @@ S3Terminate(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session)
 {
     S3Storage *s3 = (S3Storage *)storageSource;
 
-    s3->log->LogDebugMessage("S3Terminate: terminating s3.");
-
     if (--s3->referenceCount != 0)
         return (0);
 
@@ -898,8 +896,6 @@ wiredtiger_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
     // The first reference is implied by the call to add_storage_source.
     s3->referenceCount = 1;
 
-    s3->log->LogDebugMessage("wiredtiger_extension_init: Allocated s3 storage structure.");
-
     // Load the storage
     if ((ret = connection->add_storage_source(
            connection, "s3_store", &s3->storageSource, nullptr)) != 0) {
@@ -909,8 +905,6 @@ wiredtiger_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
         AwsManager::Terminate();
         delete (s3);
     }
-
-    s3->log->LogDebugMessage("wiredtiger_extension_init: Storage loaded.");
 
     return (ret);
 }

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -136,7 +136,6 @@ class AWSInitializer {
     void
     InitInternal()
     {
-        std::cout << "SingletonInit: refCount = " << refCount << std::endl;
         if (refCount == 0) {
             Aws::InitAPI(options);
         }
@@ -147,7 +146,6 @@ class AWSInitializer {
     TerminateInternal()
     {
         refCount--;
-        std::cout << "SingletonTerminate: refCount = " << refCount << std::endl;
         if (refCount == 0) {
             Aws::ShutdownAPI(options);
         }
@@ -831,13 +829,9 @@ S3Flush(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, WT_FILE_SYSTEM *f
     s3->log->LogDebugMessage("S3Flush: Flush to S3 Store using AWS SDK C++ PutObject");
 
     // Confirm that the file exists on the native filesystem.
-    std::string homeDir = session->connection->get_home(session->connection);
-    std::string path = source;
+    std::string srcPath = S3Path(fs->homeDir, source);
 
-    if (homeDir != ".")
-        path = homeDir + "/" + source;
-
-    if ((ret = wtFileSystem->fs_exist(wtFileSystem, session, path.c_str(), &nativeExist)) != 0) {
+    if ((ret = wtFileSystem->fs_exist(wtFileSystem, session, srcPath.c_str(), &nativeExist)) != 0) {
         s3->log->LogErrorMessage("S3Flush: Failed to check for the existence of " +
           std::string(source) + " on the native filesystem.");
         return (ret);
@@ -850,7 +844,7 @@ S3Flush(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, WT_FILE_SYSTEM *f
     s3->log->LogDebugMessage(
       "S3Flush: Uploading object: " + std::string(object) + "into bucket using PutObject");
     // Upload the object into the bucket.
-    if (ret = (fs->connection->PutObject(object, path)) != 0)
+    if (ret = (fs->connection->PutObject(object, srcPath)) != 0)
         s3->log->LogErrorMessage("S3Flush: PutObject request to S3 failed.");
     else
         s3->log->LogDebugMessage("S3Flush: Uploaded object to S3.");

--- a/ext/storage_sources/s3_store/s3_storage_source.cpp
+++ b/ext/storage_sources/s3_store/s3_storage_source.cpp
@@ -32,6 +32,7 @@
 #include <list>
 #include <errno.h>
 #include <filesystem>
+#include <mutex>
 
 #include "s3_connection.h"
 #include "s3_log_system.h"
@@ -39,8 +40,6 @@
 #include <aws/auth/credentials.h>
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/AWSLogging.h>
-
-#include <mutex>
 
 #define UNUSED(x) (void)(x)
 #define FS2S3(fs) (((S3FileSystem *)(fs))->storage)
@@ -833,7 +832,6 @@ S3Flush(WT_STORAGE_SOURCE *storageSource, WT_SESSION *session, WT_FILE_SYSTEM *f
     bool nativeExist;
     FS2S3(fileSystem)->statistics.putObjectCount++;
 
-    s3->log->LogDebugMessage("S3Flush: Flush to S3 Store using AWS SDK C++ PutObject");
 
     // Confirm that the file exists on the native filesystem.
     std::string srcPath = S3Path(fs->homeDir, source);

--- a/test/suite/test_tiered03.py
+++ b/test/suite/test_tiered03.py
@@ -47,12 +47,11 @@ class test_tiered03(wttest.WiredTigerTestCase):
             bucket = get_bucket1_name('dir_store'),
             bucket_prefix = "pfx_",
             ss_name = 'dir_store')),
-        # FIXME-WT-8896 The S3 extension gets stuck during initialization if more than one
         # simultaneous WT connection is created. Enable once we have fixed this issue.
-        #('s3', dict(auth_token = get_auth_token('s3_store'),
-        #    bucket = get_bucket1_name('s3_store'),
-        #    bucket_prefix = generate_s3_prefix(),
-        #    ss_name = 's3_store')),
+        ('s3', dict(auth_token = get_auth_token('s3_store'),
+           bucket = get_bucket1_name('s3_store'),
+           bucket_prefix = generate_s3_prefix(),
+           ss_name = 's3_store')),
     ]
     # Occasionally add a lot of records to vary the amount of work flush does.
     record_count_scenarios = wtscenario.quick_scenarios(

--- a/test/suite/test_tiered03.py
+++ b/test/suite/test_tiered03.py
@@ -47,7 +47,6 @@ class test_tiered03(wttest.WiredTigerTestCase):
             bucket = get_bucket1_name('dir_store'),
             bucket_prefix = "pfx_",
             ss_name = 'dir_store')),
-        # simultaneous WT connection is created. Enable once we have fixed this issue.
         ('s3', dict(auth_token = get_auth_token('s3_store'),
            bucket = get_bucket1_name('s3_store'),
            bucket_prefix = generate_s3_prefix(),

--- a/test/suite/test_tiered10.py
+++ b/test/suite/test_tiered10.py
@@ -29,7 +29,6 @@
 from helper_tiered import generate_s3_prefix, get_auth_token, get_bucket1_name
 from wtscenario import make_scenarios
 import os, wiredtiger, wttest
-import time
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
 # test_tiered10.py

--- a/test/suite/test_tiered10.py
+++ b/test/suite/test_tiered10.py
@@ -29,6 +29,7 @@
 from helper_tiered import generate_s3_prefix, get_auth_token, get_bucket1_name
 from wtscenario import make_scenarios
 import os, wiredtiger, wttest
+import time
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
 # test_tiered10.py
@@ -41,13 +42,12 @@ class test_tiered10(wttest.WiredTigerTestCase):
             prefix1 = '1_',
             prefix2 = '2_',
             ss_name = 'dir_store')),
-        # FIXME-WT-8896 The S3 extension gets stuck during initialization if more than one
         # simultaneous WT connection is created. Enable once we have fixed this issue.
-        #('s3', dict(auth_token = get_auth_token('s3_store'),
-        #    bucket = get_bucket1_name('s3_store'),
-        #    prefix1 = generate_s3_prefix(),
-        #    prefix2 = generate_s3_prefix(),
-        #    ss_name = 's3_store')),
+        ('s3', dict(auth_token = get_auth_token('s3_store'),
+           bucket = get_bucket1_name('s3_store'),
+           prefix1 = generate_s3_prefix(),
+           prefix2 = generate_s3_prefix(),
+           ss_name = 's3_store')),
     ]
     # Make scenarios for different cloud service providers
     scenarios = make_scenarios(storage_sources)
@@ -89,9 +89,9 @@ class test_tiered10(wttest.WiredTigerTestCase):
         config = ''
         # S3 store is built as an optional loadable extension, not all test environments build S3.
         if self.ss_name == 's3_store':
-            #config = '=(config=\"(verbose=1)\")'
+            # config = '=(config=\"(verbose=[api:1,version,tiered:1])\")'
             extlist.skip_if_missing = True
-        #if self.ss_name == 'dir_store':
+        # if self.ss_name == 'dir_store':
             #config = '=(config=\"(verbose=1,delay_ms=200,force_delay=3)\")'
         # Windows doesn't support dynamically loaded extension libraries.
         if os.name == 'nt':
@@ -142,8 +142,11 @@ class test_tiered10(wttest.WiredTigerTestCase):
         session2.flush_tier(None)
         conn1_obj1 = os.path.join(self.bucket, self.prefix1 + self.obj1file)
         conn2_obj1 = os.path.join(self.bucket, self.prefix2 + self.obj1file)
-        self.assertTrue(os.path.exists(conn1_obj1))
-        self.assertTrue(os.path.exists(conn2_obj1))
+
+        if self.ss_name == 'dir_store':
+            self.assertTrue(os.path.exists(conn1_obj1))
+            self.assertTrue(os.path.exists(conn2_obj1))
+
         conn1.close()
         conn2.close()
 

--- a/test/suite/test_tiered10.py
+++ b/test/suite/test_tiered10.py
@@ -42,7 +42,6 @@ class test_tiered10(wttest.WiredTigerTestCase):
             prefix1 = '1_',
             prefix2 = '2_',
             ss_name = 'dir_store')),
-        # simultaneous WT connection is created. Enable once we have fixed this issue.
         ('s3', dict(auth_token = get_auth_token('s3_store'),
            bucket = get_bucket1_name('s3_store'),
            prefix1 = generate_s3_prefix(),


### PR DESCRIPTION
This PR adds a singleton class to s3_storage_source to ensure the AWS SDK is initialized and terminated in the correct order when multiple connections are active. The class is globally visible across connections and uses a reference counter to know when to initialize the SDK and when to terminate without causing other connections to hang. The first call to the extension will initiate the SDK while subsequent calls will increment the reference counter. Then each call to terminate will decrement the reference counter until it reaches 0 at which point SDK shutdown will be called. The fix also includes changes to S3Flush to properly handle multiple WT home directories. 