### PR TITLE
WT-9154 Have test_checkpoint flush all its prints

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -142,6 +142,7 @@ checkpointer(void *arg)
 
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
     printf("checkpointer thread starting: tid: %s\n", tid);
+    fflush(stdout);
 
     (void)real_checkpointer();
     return (WT_THREAD_RET_VALUE);
@@ -357,6 +358,7 @@ verify_consistency(WT_SESSION *session, wt_timestamp_t verify_ts)
     /* There's no way to verify LSM-only runs. */
     if (cursors[reference_table] == NULL) {
         printf("LSM-only, skipping checkpoint verification\n");
+        fflush(stdout);
         goto err;
     }
 
@@ -494,6 +496,7 @@ mismatch:
     printf("Key/value mismatch: %" PRIu64 "/%s (%" PRIu8 ") from a %s table is not %" PRIu64
            "/%s (%" PRIu8 ") from a %s table\n",
       key1, strval1, fixval1, type_to_string(type1), key2, strval2, fixval2, type_to_string(type2));
+    fflush(stdout);
 
     return (ret);
 

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -309,6 +309,7 @@ wt_connect(const char *config_open)
           config_open == NULL ? "" : config_open, timing_stress ? timing_stress_config : ""));
 
     printf("WT open config: %s\n", config);
+    fflush(stdout);
     if ((ret = wiredtiger_open(g.home, &event_handler, config, &g.conn)) != 0)
         return (log_print_err("wiredtiger_open", ret, 1));
     return (0);
@@ -327,6 +328,7 @@ wt_shutdown(void)
         return (0);
 
     printf("Closing connection\n");
+    fflush(stdout);
     ret = g.conn->close(g.conn, NULL);
     g.conn = NULL;
     if (ret != 0)
@@ -356,11 +358,15 @@ cleanup(bool remove_dir)
 static int
 handle_error(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const char *errmsg)
 {
+    int ret;
+
     WT_UNUSED(handler);
     WT_UNUSED(session);
     WT_UNUSED(error);
 
-    return (fprintf(stderr, "%s\n", errmsg) < 0 ? -1 : 0);
+    ret = fprintf(stderr, "%s\n", errmsg) < 0 ? -1 : 0;
+    fflush(stderr);
+    return (ret);
 }
 
 /*
@@ -370,13 +376,17 @@ handle_error(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const ch
 static int
 handle_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, const char *message)
 {
+    int ret;
+
     WT_UNUSED(handler);
     WT_UNUSED(session);
 
     if (g.logfp != NULL)
         return (fprintf(g.logfp, "%s\n", message) < 0 ? -1 : 0);
 
-    return (printf("%s\n", message) < 0 ? -1 : 0);
+    ret = printf("%s\n", message) < 0 ? -1 : 0;
+    fflush(stdout);
+    return (ret);
 }
 
 /*
@@ -406,6 +416,7 @@ log_print_err_worker(const char *func, int line, const char *m, int e, int fatal
         g.status = e;
     }
     fprintf(stderr, "%s: %s,%d: %s: %s\n", progname, func, line, m, wiredtiger_strerror(e));
+    fflush(stderr);
     if (g.logfp != NULL)
         fprintf(g.logfp, "%s: %s,%d: %s: %s\n", progname, func, line, m, wiredtiger_strerror(e));
     return (e);

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -131,6 +131,7 @@ start_workers(void)
     (void)gettimeofday(&stop, NULL);
     seconds = (stop.tv_sec - start.tv_sec) + (stop.tv_usec - start.tv_usec) * 1e-6;
     printf("Ran workers for: %f seconds\n", seconds);
+    fflush(stdout);
 
 err:
     free(tids);
@@ -339,6 +340,7 @@ worker(void *arg)
 
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
     printf("worker thread starting: tid: %s\n", tid);
+    fflush(stdout);
 
     (void)real_worker();
     return (WT_THREAD_RET_VALUE);


### PR DESCRIPTION
Flush all prints in test_checkpoint instead of just some.

(actually doesn't flush everything during startup; flushes the last of those before things get going)

This prevents messages to stdout and stderr from getting reordered, which can be quite misleading if one isn't expecting it.