### PR TITLE
WT-9007 test_compact02 has unexpected stdout: oldest pinned transaction

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2408,9 +2408,6 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
                   session, WT_VERB_TRANSACTION, "Rollback reason: %s", "Cache full");
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
-                if (app_thread)
-                    __wt_verbose_notice(
-                      session, WT_VERB_TRANSACTION, "%s", session->txn->rollback_reason);
             }
             WT_ERR(ret);
         }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2032,7 +2032,6 @@ int
 __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
 {
     session->txn->rollback_reason = reason;
-    __wt_verbose_debug(session, WT_VERB_TRANSACTION, "Rollback reason: %s", reason);
     return (WT_ROLLBACK);
 }
 

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -369,8 +369,5 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         # should not depend on it.
         self.assertGreater(hs_removed + hs_sweep, 0)
 
-        # The test may output the following message in eviction under cache pressure. Ignore that.
-        self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
-
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -170,9 +170,6 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.check(value_modR, uri, nrows, None, 40)
         self.check(value_modS, uri, nrows, None, 50)
 
-        # The test may output the following message in eviction under cache pressure. Ignore that.
-        self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
-
     def test_rollback_to_stable_same_ts(self):
         nrows = 100
 
@@ -278,9 +275,6 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.check(value_a, uri, nrows, None, 20)
         self.check(value_modQ, uri, nrows, None, 30)
 
-        # The test may output the following message in eviction under cache pressure. Ignore that.
-        self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
-
     def test_rollback_to_stable_same_ts_append(self):
         nrows = 100
 
@@ -383,9 +377,6 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         # Check that the correct data is seen at and after the stable timestamp.
         self.check(value_a, uri, nrows, None, 20)
         self.check(value_modQ, uri, nrows, None, 30)
-
-        # The test may output the following message in eviction under cache pressure. Ignore that.
-        self.ignoreStdoutPatternIfExists("oldest pinned transaction ID rolled back for eviction")
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn27.py
+++ b/test/suite/test_txn27.py
@@ -78,10 +78,8 @@ class test_txn27(wttest.WiredTigerTestCase):
         # This is the message that we expect to be raised when a thread is rolled back due to
         # cache pressure.
         msg2 = 'oldest pinned transaction ID rolled back for eviction'
-        # Expect stdout to give us the true reason for the rollback.
-        with self.expectedStdoutPattern(msg2):
-            # This reason is the default reason for WT_ROLLBACK errors so we need to catch it.
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor1.update(), msg1)
+        # This reason is the default reason for WT_ROLLBACK errors so we need to catch it.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor1.update(), msg1)
         # Expect the rollback reason to give us the true reason for the rollback.
         self.assertEquals(session1.get_rollback_reason(), msg2)
 


### PR DESCRIPTION
Don't output verbose messages when rolling back transactions.