### PR TITLE
WT-9100 Restart work units to drop locally retained tiered objects.

### DIFF
--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -178,6 +178,8 @@ class test_tiered04(wttest.WiredTigerTestCase):
         self.pr(self.obj1file)
         self.assertTrue(os.path.exists(self.obj1file))
         self.assertTrue(os.path.exists(self.obj2file))
+
+        remove1 = self.get_stat(stat.conn.local_objects_removed, None)
         time.sleep(self.retention + 1)
         # We call flush_tier here because otherwise the internal thread that
         # processes the work units won't run for a while. This call will signal
@@ -190,6 +192,8 @@ class test_tiered04(wttest.WiredTigerTestCase):
         self.pr("Check removal of ")
         self.pr(self.obj1file)
         self.assertFalse(os.path.exists(self.obj1file))
+        remove2 = self.get_stat(stat.conn.local_objects_removed, None)
+        self.assertTrue(remove2 > remove1)
 
         c = self.session.open_cursor(self.uri)
         c["1"] = "1"
@@ -308,11 +312,24 @@ class test_tiered04(wttest.WiredTigerTestCase):
         # Manually reopen the connection because the default function above tries to
         # make the bucket directories.
         self.reopen_conn(config = self.saved_conn)
+        remove1 = self.get_stat(stat.conn.local_objects_removed, None)
         skip1 = self.get_stat(stat.conn.flush_tier_skipped, None)
         switch1 = self.get_stat(stat.conn.flush_tier_switched, None)
         self.session.flush_tier(None)
         skip2 = self.get_stat(stat.conn.flush_tier_skipped, None)
         switch2 = self.get_stat(stat.conn.flush_tier_switched, None)
+
+        # The first flush_tier after restart should have queued removal work units
+        # for other objects. Sleep and then force a flush tier to signal the internal
+        # thread and make sure that some objects were removed.
+        time.sleep(self.retention + 1)
+        self.session.flush_tier('force=true')
+
+        # Sleep to give the internal thread time to run and process.
+        time.sleep(1)
+        self.assertFalse(os.path.exists(self.obj1file))
+        remove2 = self.get_stat(stat.conn.local_objects_removed, None)
+        self.assertTrue(remove2 > remove1)
         #
         # Due to the above modification, we should skip the 'other' table while
         # switching the main tiered table. Therefore, both the skip and switch


### PR DESCRIPTION
@keitharnoldsmith this ticket is pretty small as the earlier ticket put in all the infrastructure needed. And testing is far easier because it will generally hit anytime we have a restart.