### PR TITLE
WT-9161 format: __err_cell_corrupt, 1005: item 2 on page at [write-check] is a corrupted cell

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -206,28 +206,15 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
     __cell_pack_addr_validity(session, &p, ta);
 
     /*
-     * If passed fast-delete information, override the cell type and append the fast-delete
-     * information after the aggregated timestamp information.
+     * If passed fast-delete information, append the fast-delete information after the aggregated
+     * timestamp information.
      */
-    if (page_del != NULL) {
-        /*
-         * We only fast-truncate leaf pages without overflow items, however, we can write a proxy
-         * cell for a page, evict and then read the internal page, and then checkpoint is writing it
-         * again.
-         */
-        WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
-        cell_type = WT_CELL_ADDR_DEL;
+    if (page_del != NULL && __wt_process.fast_truncate_2022) {
+        WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);
 
-        /* We should never be in an in-progress prepared state. */
-        WT_ASSERT(session,
-          page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED);
-
-        if (__wt_process.fast_truncate_2022) {
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->timestamp));
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->durable_timestamp));
-        }
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->timestamp));
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->durable_timestamp));
     }
 
     if (recno == WT_RECNO_OOB)


### PR DESCRIPTION
If we write the original page's fast-truncate cell, we have to extract the original fast-truncate timestamp information as well, otherwise we'll write a corrupted page.

Refactor the code in __wt_cell_pack_addr(), moving the parts that set the cell type to proxy (WT_CELL_ADDR_DEL) and assert the state of the fast-truncate code to __wt_rec_cell_build_addr().  Additionally, assert we never see a proxy cell without fast-truncate information.