### PR TITLE
WT-9062 Enable logging for the tracking table in cpp testing

### DIFF
--- a/test/cppsuite/test_harness/workload/workload_tracking.h
+++ b/test/cppsuite/test_harness/workload/workload_tracking.h
@@ -39,8 +39,9 @@
  */
 #define OPERATION_TRACKING_KEY_FORMAT WT_UNCHECKED_STRING(QSQ)
 #define OPERATION_TRACKING_VALUE_FORMAT WT_UNCHECKED_STRING(iS)
-#define OPERATION_TRACKING_TABLE_CONFIG \
-    "key_format=" OPERATION_TRACKING_KEY_FORMAT ",value_format=" OPERATION_TRACKING_VALUE_FORMAT
+#define OPERATION_TRACKING_TABLE_CONFIG                                                          \
+    "key_format=" OPERATION_TRACKING_KEY_FORMAT ",value_format=" OPERATION_TRACKING_VALUE_FORMAT \
+    ",log=(enabled=true)"
 
 /*
  * Default schema for tracking schema operations on collections (key_format: Collection id /
@@ -48,8 +49,9 @@
  */
 #define SCHEMA_TRACKING_KEY_FORMAT WT_UNCHECKED_STRING(QQ)
 #define SCHEMA_TRACKING_VALUE_FORMAT WT_UNCHECKED_STRING(i)
-#define SCHEMA_TRACKING_TABLE_CONFIG \
-    "key_format=" SCHEMA_TRACKING_KEY_FORMAT ",value_format=" SCHEMA_TRACKING_VALUE_FORMAT
+#define SCHEMA_TRACKING_TABLE_CONFIG                                                       \
+    "key_format=" SCHEMA_TRACKING_KEY_FORMAT ",value_format=" SCHEMA_TRACKING_VALUE_FORMAT \
+    ",log=(enabled=true)"
 
 namespace test_harness {
 /* Tracking operations. */


### PR DESCRIPTION
The tracking table is our source of truth, we need to make sure it is persistent at all times by enabling logging.
No perf impacts have been found after this change.