### PR TITLE
WT-8481 Split cppsuite search near tests and update their logging levels (backport 5.0)

### DIFF
--- a/test/cppsuite/test_harness/timestamp_manager.cxx
+++ b/test/cppsuite/test_harness/timestamp_manager.cxx
@@ -105,7 +105,7 @@ timestamp_manager::do_work()
     }
 
     if (!log_msg.empty())
-        logger::log_msg(LOG_INFO, log_msg);
+        logger::log_msg(LOG_TRACE, log_msg);
 
     /*
      * Save the new timestamps. Any timestamps that we're viewing from another thread should be set

--- a/test/cppsuite/tests/search_near_01.cxx
+++ b/test/cppsuite/tests/search_near_01.cxx
@@ -183,7 +183,7 @@ class search_near_01 : public test_harness::test {
         /* Generate search prefix key of random length between a -> zzz. */
         srch_key = random_generator::instance().generate_random_string(
           srchkey_len, characters_type::ALPHABET);
-        logger::log_msg(LOG_INFO,
+        logger::log_msg(LOG_TRACE,
           "Search near thread {" + std::to_string(tc->id) +
             "} performing prefix search near with key: " + srch_key);
 
@@ -276,7 +276,7 @@ class search_near_01 : public test_harness::test {
               tc->stat_cursor, WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100, &entries_stat);
             runtime_monitor::get_stat(
               tc->stat_cursor, WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS, &prefix_stat);
-            logger::log_msg(LOG_INFO,
+            logger::log_msg(LOG_TRACE,
               "Read thread skipped entries: " + std::to_string(entries_stat - prev_entries_stat) +
                 " prefix early exit: " +
                 std::to_string(prefix_stat - prev_prefix_stat - z_key_searches));

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1042,7 +1042,7 @@ tasks:
 
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t hs_cleanup -C 'debug_mode=(cursor_copy=true)' -f test/cppsuite/configs/hs_cleanup_default.txt -l 2
 
-  - name: cppsuite-search-near-default
+  - name: cppsuite-search-near-01-default
     tags: ["pull_request"]
     depends_on:
       - name: compile
@@ -1056,6 +1056,20 @@ tasks:
             set -o verbose
 
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_01 -f test/cppsuite/configs/search_near_01_default.txt -l 2
+
+  - name: cppsuite-search-near-02-default
+    tags: ["pull_request"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix/"
+          script: |
+            set -o errexit
+            set -o verbose
+
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_02 -f test/cppsuite/configs/search_near_02_default.txt -l 2
 
   - name: cppsuite-base-test-stress
@@ -1086,7 +1100,7 @@ tasks:
 
             ${test_env_vars|} $(pwd)/run -t hs_cleanup -f configs/hs_cleanup_stress.txt -l 2
   
-  - name: cppsuite-search-near-stress
+  - name: cppsuite-search-near-01-stress
     depends_on:
       - name: compile
     commands:
@@ -1099,6 +1113,19 @@ tasks:
             set -o verbose
 
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_01 -f test/cppsuite/configs/search_near_01_stress.txt -l 2
+
+  - name: cppsuite-search-near-02-stress
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/build_posix/"
+          script: |
+            set -o errexit
+            set -o verbose
+
             ${test_env_vars|} $(pwd)/test/cppsuite/run -t search_near_02 -f test/cppsuite/configs/search_near_02_stress.txt -l 2
 
   # End of cppsuite test tasks.
@@ -3784,7 +3811,8 @@ buildvariants:
     - name: make-check-test
     - name: cppsuite-base-test-default
     - name: cppsuite-hs-cleanup-default
-    - name: cppsuite-search-near-default
+    - name: cppsuite-search-near-01-default
+    - name: cppsuite-search-near-02-default
 
 - name: ubuntu2004-compilers
   display_name: "! Ubuntu 20.04 Compilers"
@@ -3943,7 +3971,8 @@ buildvariants:
     - name: compile
     - name: cppsuite-base-test-stress
     - name: cppsuite-hs-cleanup-stress
-    - name: cppsuite-search-near-stress
+    - name: cppsuite-search-near-01-stress
+    - name: cppsuite-search-near-02-stress
 
 - name: package
   display_name: "~ Package"


### PR DESCRIPTION
* Split cppsuite search near tests into 4 separate tasks on evergreen.
* Update some log message levels from LOG_INFO to LOG_TRACE.

(cherry picked from commit efd9d9adf2af4d68383868c4bd5e156b19bca99b)