### PR TITLE
WT-8299 All object metadata should consistently indicate it is a tiered object.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -273,10 +273,6 @@ file_runtime_config = common_runtime_config + [
         the file is read-only. All methods that may modify a file are
         disabled. See @ref readonly for more information''',
         type='boolean'),
-    Config('tiered_object', 'false', r'''
-        this file is a tiered object. When opened on its own, it is marked as
-        readonly and may be restricted in other ways''',
-        type='boolean', undoc=True),
 ]
 
 # Per-file configuration
@@ -440,6 +436,10 @@ file_meta = file_config + [
         LSN of the last checkpoint'''),
     Config('id', '', r'''
         the file's ID number'''),
+    Config('tiered_object', 'false', r'''
+        this file is a tiered object. When opened on its own, it is marked as
+        readonly and may be restricted in other ways''',
+        type='boolean', undoc=True),
     Config('version', '(major=0,minor=0)', r'''
         the file version'''),
 ]
@@ -467,6 +467,7 @@ tiered_meta = file_meta + tiered_config + [
 ]
 
 tier_meta = file_meta + tiered_tree_config
+
 # Objects need to have the readonly setting set and bucket_prefix.
 # The file_meta already contains those pieces.
 object_meta = file_meta + [

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -216,7 +216,6 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_alter[] = {
   {"log", "category", NULL, NULL, confchk_WT_SESSION_create_log_subconfigs, 1},
   {"os_cache_dirty_max", "int", NULL, "min=0", NULL, 0},
   {"os_cache_max", "int", NULL, "min=0", NULL, 0}, {"readonly", "boolean", NULL, NULL, NULL, 0},
-  {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
     "choices=[\"always\",\"key_consistent\",\"mixed_mode\","
@@ -337,7 +336,6 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
   {"split_deepen_min_child", "int", NULL, NULL, NULL, 0},
   {"split_deepen_per_child", "int", NULL, NULL, NULL, 0},
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
-  {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
     7},
   {"type", "string", NULL, NULL, NULL, 0},
@@ -495,7 +493,6 @@ static const WT_CONFIG_CHECK confchk_file_config[] = {
   {"split_deepen_min_child", "int", NULL, NULL, NULL, 0},
   {"split_deepen_per_child", "int", NULL, NULL, NULL, 0},
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
-  {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
     7},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
@@ -615,7 +612,6 @@ static const WT_CONFIG_CHECK confchk_lsm_meta[] = {
   {"split_deepen_min_child", "int", NULL, NULL, NULL, 0},
   {"split_deepen_per_child", "int", NULL, NULL, NULL, 0},
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
-  {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
     7},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
@@ -1231,9 +1227,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "assert=(commit_timestamp=none,durable_timestamp=none,"
     "read_timestamp=none,write_timestamp=off),cache_resident=false,"
     "checkpoint=,exclusive_refreshed=true,log=(enabled=true),"
-    "os_cache_dirty_max=0,os_cache_max=0,readonly=false,"
-    "tiered_object=false,verbose=[],write_timestamp_usage=none",
-    confchk_WT_SESSION_alter, 13},
+    "os_cache_dirty_max=0,os_cache_max=0,readonly=false,verbose=[],"
+    "write_timestamp_usage=none",
+    confchk_WT_SESSION_alter, 12},
   {"WT_SESSION.begin_transaction",
     "ignore_prepare=false,isolation=,name=,operation_timeout_ms=0,"
     "priority=0,read_timestamp=,roundup_timestamps=(prepared=false,"
@@ -1268,11 +1264,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "memory_page_max=5MB,os_cache_dirty_max=0,os_cache_max=0,"
     "prefix_compression=false,prefix_compression_min=4,readonly=false"
     ",source=,split_deepen_min_child=0,split_deepen_per_child=0,"
-    "split_pct=90,tiered_object=false,tiered_storage=(auth_token=,"
-    "bucket=,bucket_prefix=,cache_directory=,local_retention=300,"
-    "name=,object_target_size=10M),type=file,value_format=u,"
-    "verbose=[],write_timestamp_usage=none",
-    confchk_WT_SESSION_create, 50},
+    "split_pct=90,tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "cache_directory=,local_retention=300,name=,"
+    "object_target_size=10M),type=file,value_format=u,verbose=[],"
+    "write_timestamp_usage=none",
+    confchk_WT_SESSION_create, 49},
   {"WT_SESSION.drop",
     "checkpoint_wait=true,force=false,lock_wait=true,"
     "remove_files=true",
@@ -1340,11 +1336,11 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "memory_page_max=5MB,os_cache_dirty_max=0,os_cache_max=0,"
     "prefix_compression=false,prefix_compression_min=4,readonly=false"
     ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
-    "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
-    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
+    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "cache_directory=,local_retention=300,name=,"
     "object_target_size=10M),value_format=u,verbose=[],"
     "write_timestamp_usage=none",
-    confchk_file_config, 42},
+    confchk_file_config, 41},
   {"file.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"
@@ -1392,12 +1388,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "memory_page_max=5MB,old_chunks=,os_cache_dirty_max=0,"
     "os_cache_max=0,prefix_compression=false,prefix_compression_min=4"
     ",readonly=false,split_deepen_min_child=0,"
-    "split_deepen_per_child=0,split_pct=90,tiered_object=false,"
+    "split_deepen_per_child=0,split_pct=90,"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,local_retention=300,name=,"
     "object_target_size=10M),value_format=u,verbose=[],"
     "write_timestamp_usage=none",
-    confchk_lsm_meta, 46},
+    confchk_lsm_meta, 45},
   {"object.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"

--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -61,10 +61,12 @@ class test_tiered04(wttest.WiredTigerTestCase):
     obj2file = base + '2.wtobj'
     objuri = 'object:' + base + '1.wtobj'
     tiereduri = "tiered:test_tiered04"
+    tieruri = "tier:test_tiered04"
     uri = "table:test_tiered04"
 
     uri1 = "table:test_other_tiered04"
     uri_none = "table:test_local04"
+    file_none = "file:test_local04.wt"
 
     object_sys = "9M"
     object_sys_val = 9 * 1024 * 1024
@@ -235,7 +237,17 @@ class test_tiered04(wttest.WiredTigerTestCase):
         self.check_metadata(self.tiereduri, last)
         self.check_metadata(self.tiereduri, oldest)
         self.check_metadata(fileuri, intl_page)
+        self.check_metadata(fileuri, intl_page)
         self.check_metadata(self.objuri, intl_page)
+
+        # Check for the correct tiered_object setting for both tiered and not tiered tables.
+        tiered_false = 'tiered_object=false'
+        tiered_true = 'tiered_object=true'
+        self.check_metadata(fileuri, tiered_true)
+        self.check_metadata(self.objuri, tiered_true)
+        self.check_metadata(self.tieruri, tiered_true)
+
+        self.check_metadata(self.file_none, tiered_false)
 
         # Now test some connection statistics with operations.
         retain = self.get_stat(stat.conn.tiered_retention, None)

--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -237,7 +237,6 @@ class test_tiered04(wttest.WiredTigerTestCase):
         self.check_metadata(self.tiereduri, last)
         self.check_metadata(self.tiereduri, oldest)
         self.check_metadata(fileuri, intl_page)
-        self.check_metadata(fileuri, intl_page)
         self.check_metadata(self.objuri, intl_page)
 
         # Check for the correct tiered_object setting for both tiered and not tiered tables.


### PR DESCRIPTION
We have a place in `tiered->obj_config` to store the base object configuration. I fixed that to contain the consistent information and removed the places where it was hard coded on particular paths.