### PR TITLE
WT-9183 Fast-truncate in readonly trees can result in truncated items reappearing

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1509,6 +1509,14 @@ __wt_page_del_active(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
         return (false);
     if (page_del->txnid == WT_TXN_ABORTED)
         return (false);
+    /*
+     * If we are reading from a checkpoint, visible_all checks don't work (they check the current
+     * state of the world and not the checkpoint) so operate under the assumption that if the
+     * truncate operation appears in the checkpoint, it must have been visible to somebody, and
+     * because the checkpoint is immutable, that won't ever change.
+     */
+    if (WT_READING_CHECKPOINT(session) && visible_all)
+        return (true);
     WT_ORDERED_READ(prepare_state, page_del->prepare_state);
     if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
         return (true);

--- a/test/suite/test_checkpoint24.py
+++ b/test/suite/test_checkpoint24.py
@@ -52,8 +52,11 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         #('column', dict(key_format='r', value_format='S', extraconfig='')),
     ]
     name_values = [
-        ('named', dict(first_checkpoint='first_checkpoint')),
-        ('unnamed', dict(first_checkpoint=None)),
+        # Reopening and unnamed checkpoints will not work as intended because the reopen makes
+        # a new checkpoint.
+        ('named', dict(first_checkpoint='first_checkpoint', do_reopen=False)),
+        ('named_reopen', dict(first_checkpoint='first_checkpoint', do_reopen=True)),
+        ('unnamed', dict(first_checkpoint=None, do_reopen=False)),
     ]
     scenarios = make_scenarios(format_values, name_values)
         
@@ -138,6 +141,9 @@ class test_checkpoint(wttest.WiredTigerTestCase):
 
         # Take a checkpoint.
         self.do_checkpoint(self.first_checkpoint)
+
+        if self.do_reopen:
+            self.reopen_conn()
 
         # Read the checkpoint.
         nonzeros = nrows // 2

--- a/test/suite/test_checkpoint24.py
+++ b/test/suite/test_checkpoint24.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_checkpoint24.py
+#
+# Test reading a checkpoint that contains fast-delete pages.
+# This version does not use timestamps.
+
+class test_checkpoint(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+
+    format_values = [
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+        # For now, because column-store doesn't support fast-delete, run just the
+        # FLCS case (which is smaller and faster) as a crosscheck on the behavior,
+        # and turn off VLCS. This should be turned on when/if fast-delete for
+        # columns gets implemented.
+        ('column-fix', dict(key_format='r', value_format='8t',
+            extraconfig=',allocation_size=512,leaf_page_max=512')),
+        #('column', dict(key_format='r', value_format='S', extraconfig='')),
+    ]
+    name_values = [
+        ('named', dict(first_checkpoint='first_checkpoint')),
+        ('unnamed', dict(first_checkpoint=None)),
+    ]
+    scenarios = make_scenarios(format_values, name_values)
+        
+
+    def large_updates(self, uri, ds, nrows, value):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value
+            if i % 101 == 0:
+                self.session.commit_transaction()
+                self.session.begin_transaction()
+        self.session.commit_transaction()
+        cursor.close()
+
+    def do_truncate(self, ds, lo, hi):
+        self.session.begin_transaction()
+        locursor = self.session.open_cursor(ds.uri)
+        hicursor = self.session.open_cursor(ds.uri)
+        locursor.set_key(ds.key(lo))
+        hicursor.set_key(ds.key(hi))
+        self.session.truncate(None, locursor, hicursor, None)
+        self.session.commit_transaction()
+
+    def do_checkpoint(self, ckpt_name):
+        if ckpt_name is None:
+            self.session.checkpoint()
+        else:
+            self.session.checkpoint('name=' + ckpt_name)
+
+    def check(self, ds, ckpt, nrows, zeros, value):
+        if ckpt is None:
+            ckpt = 'WiredTigerCheckpoint'
+        cfg = 'checkpoint=' + ckpt
+        cursor = self.session.open_cursor(ds.uri, None, cfg)
+        #self.session.begin_transaction()
+        count = 0
+        zcount = 0
+        for k, v in cursor:
+            if self.value_format == '8t' and v == 0:
+                zcount += 1
+            else:
+                self.assertEqual(v, value)
+                count += 1
+        #self.session.rollback_transaction()
+        self.assertEqual(count, nrows)
+        self.assertEqual(zcount, zeros if self.value_format == '8t' else 0)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint24'
+        nrows = 10000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        if self.value_format == '8t':
+            value_a = 97
+        else:
+            value_a = "aaaaa" * 100
+
+        # Write some data at time 10.
+        self.large_updates(uri, ds, nrows, value_a)
+
+        # Reopen the connection (which checkpoints it) so it's all on disk and not in memory.
+        self.reopen_conn()
+
+        # Truncate half of it.
+        self.do_truncate(ds, nrows // 4 + 1, nrows // 4 + nrows // 2)
+
+        # Check stats to make sure we fast-deleted at least one page.
+        # Since VLCS and FLCS do not (yet) support fast-delete, instead assert we didn't.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        if self.key_format == 'r':
+            self.assertEqual(fastdelete_pages, 0)
+        else:
+            self.assertGreater(fastdelete_pages, 0)
+
+        # Take a checkpoint.
+        self.do_checkpoint(self.first_checkpoint)
+
+        # Read the checkpoint.
+        nonzeros = nrows // 2
+        zeros = nrows - nonzeros
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_checkpoint25.py
+++ b/test/suite/test_checkpoint25.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_checkpoint25.py
+#
+# Test reading a checkpoint that contains fast-delete pages.
+# This version uses timestamps.
+
+class test_checkpoint(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+
+    format_values = [
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+        # For now, because column-store doesn't support fast-delete, run just the
+        # FLCS case (which is smaller and faster) as a crosscheck on the behavior,
+        # and turn off VLCS. This should be turned on when/if fast-delete for
+        # columns gets implemented.
+        ('column-fix', dict(key_format='r', value_format='8t',
+            extraconfig=',allocation_size=512,leaf_page_max=512')),
+        #('column', dict(key_format='r', value_format='S', extraconfig='')),
+    ]
+    name_values = [
+        ('named', dict(first_checkpoint='first_checkpoint')),
+        ('unnamed', dict(first_checkpoint=None)),
+    ]
+    scenarios = make_scenarios(format_values, name_values)
+        
+
+    def large_updates(self, uri, ds, nrows, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value
+            if i % 101 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def do_truncate(self, ds, lo, hi, read_ts, commit_ts):
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        locursor = self.session.open_cursor(ds.uri)
+        hicursor = self.session.open_cursor(ds.uri)
+        locursor.set_key(ds.key(lo))
+        hicursor.set_key(ds.key(hi))
+        self.session.truncate(None, locursor, hicursor, None)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+
+    def do_checkpoint(self, ckpt_name):
+        if ckpt_name is None:
+            self.session.checkpoint()
+        else:
+            self.session.checkpoint('name=' + ckpt_name)
+
+    def check(self, ds, ckpt, nrows, zeros, value, ts):
+        if ckpt is None:
+            ckpt = 'WiredTigerCheckpoint'
+        cfg = 'checkpoint=' + ckpt
+        if ts is not None:
+            cfg += ',debug=(checkpoint_read_timestamp=' + self.timestamp_str(ts) + ')'
+        cursor = self.session.open_cursor(ds.uri, None, cfg)
+        #self.session.begin_transaction()
+        count = 0
+        zcount = 0
+        for k, v in cursor:
+            if self.value_format == '8t' and v == 0:
+                zcount += 1
+            else:
+                self.assertEqual(v, value)
+                count += 1
+        #self.session.rollback_transaction()
+        self.assertEqual(count, nrows)
+        self.assertEqual(zcount, zeros if self.value_format == '8t' else 0)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint25'
+        nrows = 10000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        if self.value_format == '8t':
+            value_a = 97
+        else:
+            value_a = "aaaaa" * 100
+
+        # Pin oldest and stable timestamps to 5.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5) +
+            ',stable_timestamp=' + self.timestamp_str(5))
+
+        # Write some data at time 10.
+        self.large_updates(uri, ds, nrows, value_a, 10)
+
+        # Mark it stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        # Reopen the connection (which checkpoints it) so it's all on disk and not in memory.
+        self.reopen_conn()
+
+        # Truncate half of it at time 20.
+        self.do_truncate(ds, nrows // 4 + 1, nrows // 4 + nrows // 2, 10, 20)
+
+        # Mark that stable so it appears in the checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+
+        # Check stats to make sure we fast-deleted at least one page.
+        # Since VLCS and FLCS do not (yet) support fast-delete, instead assert we didn't.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        if self.key_format == 'r':
+            self.assertEqual(fastdelete_pages, 0)
+        else:
+            self.assertGreater(fastdelete_pages, 0)
+
+        # Take a checkpoint.
+        self.do_checkpoint(self.first_checkpoint)
+
+        # Read the checkpoint.
+        nonzeros = nrows // 2
+        zeros = nrows - nonzeros
+        self.check(ds, self.first_checkpoint, nrows, 0, value_a, 15)
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, 25)
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, None) # default read ts
+        self.check(ds, self.first_checkpoint, nonzeros, zeros, value_a, 0) # no read ts
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Add tests for fast-truncate and checkpoint cursors.