### PR TITLE
WT-9093 Allow the user to override the validation algorithm in the cpp suite

### DIFF
--- a/test/cppsuite/test_harness/test.cpp
+++ b/test/cppsuite/test_harness/test.cpp
@@ -37,7 +37,6 @@
 #include "test.h"
 #include "thread_manager.h"
 #include "timestamp_manager.h"
-#include "workload/workload_validation.h"
 #include "util/api_const.h"
 
 namespace test_harness {
@@ -162,12 +161,10 @@ test::run()
         it->finish();
 
     /* Validation stage. */
-    if (_workload_tracking->enabled()) {
-        workload_validation wv;
-        wv.validate(_workload_tracking->get_operation_table_name(),
+    if (_workload_tracking->enabled())
+        this->validate(_workload_tracking->get_operation_table_name(),
           _workload_tracking->get_schema_table_name(),
           _workload_generator->get_database().get_collection_ids());
-    }
 
     logger::log_msg(LOG_INFO, "SUCCESS");
 }

--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -35,6 +35,7 @@
 #include "database_operation.h"
 #include "random_generator.h"
 #include "workload_tracking.h"
+#include "workload_validation.h"
 
 namespace test_harness {
 /* Static methods. */
@@ -378,4 +379,11 @@ database_operation::update_operation(thread_context *tc)
         tc->transaction.rollback();
 }
 
+void
+database_operation::validate(const std::string &operation_table_name,
+  const std::string &schema_table_name, const std::vector<uint64_t> &known_collection_ids)
+{
+    workload_validation wv;
+    wv.validate(operation_table_name, schema_table_name, known_collection_ids);
+}
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/database_operation.h
+++ b/test/cppsuite/test_harness/workload/database_operation.h
@@ -62,6 +62,9 @@ class database_operation {
     /* Basic update operation that chooses a random key and updates it. */
     virtual void update_operation(thread_context *tc);
 
+    virtual void validate(const std::string &operation_table_name,
+      const std::string &schema_table_name, const std::vector<uint64_t> &known_collection_ids);
+
     virtual ~database_operation() = default;
 };
 } // namespace test_harness

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -79,4 +79,10 @@ class test_template : public test_harness::test {
     {
         std::cout << "update_operation: nothing done." << std::endl;
     }
+
+    void
+    validate(const std::string &, const std::string &, const std::vector<uint64_t> &) override final
+    {
+        std::cout << "validate: nothing done." << std::endl;
+    }
 };


### PR DESCRIPTION
Those changes let the user be able to override the validation algorithm that is triggered at the end of a test when the tracking component is enabled.

**Note: The testing of this new feature will be done as part of WT-9094.**