### PR TITLE
WT-9177 Checkpoint waiting for transactions to complete can deadlock

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -572,7 +572,6 @@ conn_stats = [
     TxnStat('txn_checkpoint_prep_recent', 'transaction checkpoint prepare most recent time (msecs)', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_prep_running', 'transaction checkpoint prepare currently running', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_prep_total', 'transaction checkpoint prepare total time (msecs)', 'no_clear,no_scale'),
-    TxnStat('txn_checkpoint_prep_wait', 'transaction checkpoint prepare wait time (msecs)', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_running', 'transaction checkpoint currently running', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_running_hs', 'transaction checkpoint currently running for history store file', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_scrub_target', 'transaction checkpoint scrub dirty target', 'no_clear,no_scale'),

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -37,8 +37,6 @@ extern bool __wt_rwlock_islocked(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_txn_active(WT_SESSION_IMPL *session, uint64_t txnid)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wt_txn_checkpoint_cannot_start(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern char *__wt_time_aggregate_to_string(WT_TIME_AGGREGATE *ta, char *ta_string)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern char *__wt_time_point_to_string(wt_timestamp_t ts, wt_timestamp_t durable_ts,

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -827,7 +827,6 @@ struct __wt_connection_stats {
     int64_t txn_checkpoint_prep_min;
     int64_t txn_checkpoint_prep_recent;
     int64_t txn_checkpoint_prep_total;
-    int64_t txn_checkpoint_prep_wait;
     int64_t txn_checkpoint_scrub_target;
     int64_t txn_checkpoint_scrub_time;
     int64_t txn_checkpoint_time_total;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6348,65 +6348,63 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1493
 /*! transaction: transaction checkpoint prepare total time (msecs) */
 #define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1494
-/*! transaction: transaction checkpoint prepare wait time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_WAIT		1495
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1496
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1495
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1497
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1496
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1497
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1498
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1500
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1499
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1501
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1500
 /*! transaction: transaction failures due to history store */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1502
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1501
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1503
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1502
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1504
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1503
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1505
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1504
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1506
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1505
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1507
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1506
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1508
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1507
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1509
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1508
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1510
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1509
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1511
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1510
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1512
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1511
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1513
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1512
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1514
+#define	WT_STAT_CONN_TXN_COMMIT				1513
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1515
+#define	WT_STAT_CONN_TXN_ROLLBACK			1514
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1516
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1515
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1543,7 +1543,6 @@ static const char *const __stats_connection_desc[] = {
   "transaction: transaction checkpoint prepare min time (msecs)",
   "transaction: transaction checkpoint prepare most recent time (msecs)",
   "transaction: transaction checkpoint prepare total time (msecs)",
-  "transaction: transaction checkpoint prepare wait time (msecs)",
   "transaction: transaction checkpoint scrub dirty target",
   "transaction: transaction checkpoint scrub time (msecs)",
   "transaction: transaction checkpoint total time (msecs)",
@@ -2101,7 +2100,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing txn_checkpoint_prep_min */
     /* not clearing txn_checkpoint_prep_recent */
     /* not clearing txn_checkpoint_prep_total */
-    /* not clearing txn_checkpoint_prep_wait */
     /* not clearing txn_checkpoint_scrub_target */
     /* not clearing txn_checkpoint_scrub_time */
     /* not clearing txn_checkpoint_time_total */
@@ -2679,7 +2677,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_checkpoint_prep_min += WT_STAT_READ(from, txn_checkpoint_prep_min);
     to->txn_checkpoint_prep_recent += WT_STAT_READ(from, txn_checkpoint_prep_recent);
     to->txn_checkpoint_prep_total += WT_STAT_READ(from, txn_checkpoint_prep_total);
-    to->txn_checkpoint_prep_wait += WT_STAT_READ(from, txn_checkpoint_prep_wait);
     to->txn_checkpoint_scrub_target += WT_STAT_READ(from, txn_checkpoint_scrub_target);
     to->txn_checkpoint_scrub_time += WT_STAT_READ(from, txn_checkpoint_scrub_time);
     to->txn_checkpoint_time_total += WT_STAT_READ(from, txn_checkpoint_time_total);

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -215,18 +215,8 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-
-            # Wait for checkpoint to start before committing last transaction.
-            # Note: because we assigned the transaction a commit timestamp before the
-            # checkpoint timestamp, the checkpoint will wait for us to finish committing.
-            # But that happens after it starts running according to the stat.
-            ckpt_started = 0
-            while not ckpt_started:
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
-                stat_cursor.close()
-                time.sleep(1)
-
+            # Sleep for sometime so that checkpoint starts before committing last transaction.
+            time.sleep(2)
             session1.commit_transaction()
 
         finally:
@@ -272,8 +262,6 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             cursor2.set_key(ds.key(i))
             cursor2.set_value(self.valuea)
             self.assertEqual(cursor2.insert(), 0)
-
-        # Give the first transaction (which has no contents) a timestamp.
         session1.timestamp_transaction('commit_timestamp=' + self.timestamp_str(30))
 
         # Set stable timestamp to 40
@@ -284,15 +272,8 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-
-            # Wait for checkpoint to start before committing last transaction.
-            ckpt_started = 0
-            while not ckpt_started:
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
-                stat_cursor.close()
-                time.sleep(1)
-
+            # Sleep for sometime so that checkpoint starts before committing last transaction.
+            time.sleep(2)
             session2.commit_transaction()
 
         finally:


### PR DESCRIPTION
Revert "WT-9041 checkpoint can miss transactions with commit times before stable (#7774)"

This reverts commit 07cee370d83fd1c90f4ecf6781331db020960323.