### PR TITLE
WT-9134 Document WiredTiger expectations for transaction progress

### DIFF
--- a/src/docs/transactions_api.dox
+++ b/src/docs/transactions_api.dox
@@ -63,10 +63,16 @@ other writes, although concurrent transactions updating the same value will fail
 synchronization to avoid repeated attempts to update and then roll back the same
 value.
 
+Transactions hold resources, such as cache space, that may be in high demand.
 Both read and write transactions may fail with the ::WT_ROLLBACK error if a
 resource cannot be allocated. For example, if cache resources cannot be
 allocated to hold the data required to satisfy transactional readers, operations
 may fail and return ::WT_ROLLBACK.
+
+\warning
+A thread with active transactions should avoid pausing or blocking. This may delay
+other transactions that require the same resources, leading to performance problems that
+are hard to diagnose.
 
 \warning
 As read transactions rarely fail, application developers may neglect to correctly


### PR DESCRIPTION
@sueloverso and @keithbostic: This is a very small doc change to capture the point Keith B. made in slack last week that applications should not pause during a transaction.   

I'm open to suggestions if you think this point should be stated more forcefully, or if there is other information from that conversation (copied onto the WT-9134 ticket) should be added to the doc.