### PR TITLE
WT-9205 Correct transaction warning text in documentation

### DIFF
--- a/src/docs/transactions_api.dox
+++ b/src/docs/transactions_api.dox
@@ -70,7 +70,7 @@ allocated to hold the data required to satisfy transactional readers, operations
 may fail and return ::WT_ROLLBACK.
 
 \warning
-A thread with active transactions should avoid pausing or blocking. This may delay
+A thread with an active transaction should avoid pausing or blocking. This may delay
 other transactions that require the same resources, leading to performance problems that
 are hard to diagnose.
 


### PR DESCRIPTION
Sorry to hit you with another PR, @sueloverso.  I somehow missed your comment on the last one.  This change addresses that.