### PR TITLE
WT-9208 add cursor method to allow applications to detect checkpoint cursor mismatch

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -272,6 +272,7 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curbackup_close);                             /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_BACKUP *cb, *othercb;

--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -54,6 +54,7 @@ __wt_curconfig_open(
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curconfig_close);
     WT_CURSOR_CONFIG *cconfig;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -428,6 +428,7 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curds_close);                                 /* close */
     WT_CONFIG_ITEM cval, metadata;
     WT_CURSOR *cursor, *source;

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -399,6 +399,7 @@ __wt_curdump_create(WT_CURSOR *child, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_notsup,                           /* largest_key */
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
+      __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curdump_close);                             /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_DUMP *cdump;

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1135,6 +1135,7 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curhs_close);                                 /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_HS *hs_cursor;

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -456,6 +456,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curindex_close);                              /* close */
     WT_CURSOR_INDEX *cindex;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -579,6 +579,7 @@ __curjoin_entry_member(
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup);                            /* close */
     WT_DECL_RET;
     WT_INDEX *idx;
@@ -1226,6 +1227,7 @@ __wt_curjoin_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
       __wt_cursor_notsup,                           /* largest_key */
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
+      __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curjoin_close);                             /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_JOIN *cjoin;

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -343,6 +343,7 @@ __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], W
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curlog_close);                                /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_LOG *cl;

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -578,6 +578,7 @@ __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owne
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curmetadata_close);                           /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_METADATA *mdc;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -611,6 +611,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
       __wt_cursor_notsup,                           /* largest_key */
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
+      __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curstat_close);                             /* close */
     WT_CONFIG_ITEM cval, sval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -105,6 +105,7 @@ __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup);                            /* close */
     WT_CURSOR_EXTRACTOR extract_cursor;
     WT_DECL_RET;
@@ -992,6 +993,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __curtable_largest_key,                           /* largest_key */
       __wt_cursor_notsup,                               /* cache */
       __wt_cursor_reopen_notsup,                        /* reopen */
+      __wt_cursor_checkpoint_id,                        /* checkpoint ID */
       __curtable_close);                                /* close */
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -606,6 +606,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
       __wt_cursor_notsup,                              /* largest_key */
       __wt_cursor_notsup,                              /* cache */
       __wt_cursor_reopen_notsup,                       /* reopen */
+      __wt_cursor_checkpoint_id,                       /* checkpoint ID */
       __curversion_close);                             /* close */
 
     WT_CURSOR *cursor;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1673,6 +1673,8 @@ extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint64_t __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_gen(WT_SESSION_IMPL *session, int which)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_hash_city64(const void *s, size_t len)

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -176,6 +176,7 @@ struct __wt_ckpt {
  *     Snapshot and timestamp information associated with a checkpoint.
  */
 struct __wt_ckpt_snapshot {
+    uint64_t ckpt_id;
     uint64_t oldest_ts;
     uint64_t stable_ts;
     uint64_t snapshot_write_gen;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -617,6 +617,20 @@ struct __wt_cursor {
 	int __F(reserve)(WT_CURSOR *cursor);
 	/*! @} */
 
+#ifndef DOXYGEN
+	/*!
+	 * If the cursor is opened on a checkpoint, return a unique identifier for the checkpoint;
+	 * otherwise return 0.
+	 *
+	 * This allows applications to confirm that checkpoint cursors opened on default checkpoints
+	 * in different objects reference the same database checkpoint.
+	 *
+	 * @param cursor the cursor handle
+	 * @errors
+	 */
+	uint64_t __F(checkpoint_id)(WT_CURSOR *cursor);
+#endif
+
 	/*!
 	 * Close the cursor.
 	 *

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1693,6 +1693,7 @@ __wt_clsm_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, cons
       __wt_cursor_notsup,                             /* largest_key */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
+      __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_clsm_close);                               /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_LSM *clsm;


### PR DESCRIPTION
Add undocumented cursor method to allow applications to detect checkpoint cursor mismatch.