### PR TITLE
WT-8820 Investigate why checkpoint sometimes return ebusy

### DIFF
--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -548,8 +548,7 @@ wts_verify(TABLE *table, void *arg)
      * Do a full checkpoint to reduce the possibility of returning EBUSY from the following verify
      * call.
      */
-    ret = session->checkpoint(session, NULL);
-    testutil_assert(ret == 0 || ret == EBUSY);
+    testutil_check(session->checkpoint(session, NULL));
     session->app_private = table->track_prefix;
     ret = session->verify(session, table->uri, "strict");
     testutil_assert(ret == 0 || ret == EBUSY);


### PR DESCRIPTION
@quchenhao, I haven't seen this failure in quite some time -- let's go looking.

Fail if checkpoint returns EBUSY.