### PR TITLE
WT-8431 Increase test_hs14 cache size to reduce eviction activity

### DIFF
--- a/test/suite/test_hs14.py
+++ b/test/suite/test_hs14.py
@@ -33,7 +33,7 @@ from wtscenario import make_scenarios
 # Ensure that point in time reads with few visible history store records don't
 # damage performance.
 class test_hs14(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB'
+    conn_config = 'cache_size=500MB'
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('column-fix', dict(key_format='r', value_format='8t')),


### PR DESCRIPTION
Increase the cache size to reduce eviction activity. Eviction hinders the latency and gets inaccurate results.