### PR TITLE
WT-8915 Change log verbosity level mapping between AWS SDK and WiredTiger

### DIFF
--- a/ext/storage_sources/s3_store/s3_log_system.h
+++ b/ext/storage_sources/s3_store/s3_log_system.h
@@ -39,7 +39,9 @@
 // Mapping the desired WiredTiger extension verbosity level to a rough equivalent AWS
 // SDK verbosity level.
 static const std::map<int32_t, Aws::Utils::Logging::LogLevel> verbosityMapping = {
-  {WT_VERBOSE_ERROR, Aws::Utils::Logging::LogLevel::Fatal}, {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Error}, {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Warn},
+  {WT_VERBOSE_ERROR, Aws::Utils::Logging::LogLevel::Fatal},
+  {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Error},
+  {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Warn},
   {WT_VERBOSE_INFO, Aws::Utils::Logging::LogLevel::Info},
   {WT_VERBOSE_DEBUG, Aws::Utils::Logging::LogLevel::Debug}};
 

--- a/ext/storage_sources/s3_store/s3_log_system.h
+++ b/ext/storage_sources/s3_store/s3_log_system.h
@@ -39,9 +39,9 @@
 // Mapping the desired WiredTiger extension verbosity level to a rough equivalent AWS
 // SDK verbosity level.
 static const std::map<int32_t, Aws::Utils::Logging::LogLevel> verbosityMapping = {
-  {-3, Aws::Utils::Logging::LogLevel::Error}, {-2, Aws::Utils::Logging::LogLevel::Warn},
-  {-1, Aws::Utils::Logging::LogLevel::Info}, {0, Aws::Utils::Logging::LogLevel::Info},
-  {1, Aws::Utils::Logging::LogLevel::Debug}};
+  {WT_VERBOSE_ERROR, Aws::Utils::Logging::LogLevel::Fatal}, {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Error}, {WT_VERBOSE_WARNING, Aws::Utils::Logging::LogLevel::Warn},
+  {WT_VERBOSE_INFO, Aws::Utils::Logging::LogLevel::Info},
+  {WT_VERBOSE_DEBUG, Aws::Utils::Logging::LogLevel::Debug}};
 
 // Provides the S3 Store with a logger implementation that redirects the generated logs to
 // WiredTiger's logging streams. This class implements AWS's LogSystemInterface class, an interface

--- a/test/suite/test_tiered06.py
+++ b/test/suite/test_tiered06.py
@@ -58,8 +58,7 @@ class test_tiered06(wttest.WiredTigerTestCase):
         config = ''
         # S3 store is built as an optional loadable extension, not all test environments build S3.
         if self.ss_name == 's3_store':
-            #config = '=(config=\"(verbose=1)\")'
-            # config = '=(config=\"(verbose=[api:1,version,tiered:-3])\")'
+            #config = '=(config=\"(verbose=[api:1,version,tiered:1])\")'
             extlist.skip_if_missing = True
         #if self.ss_name == 'dir_store':
             #config = '=(config=\"(verbose=1,delay_ms=200,force_delay=3)\")'
@@ -105,20 +104,14 @@ class test_tiered06(wttest.WiredTigerTestCase):
             self.get_fs_config(prefix))
 
         # The object doesn't exist yet.
-        if self.ss_name == 's3_store':
-            self.assertFalse(fs.fs_exist(session, 'foobar'))
-        else:
-            self.assertFalse(fs.fs_exist(session, 'foobar'))
+        self.assertFalse(fs.fs_exist(session, 'foobar'))
 
         # We cannot use the file system to create files, it is readonly.
         # So use python I/O to build up the file.
         f = open('foobar', 'wb')
 
         # The object still doesn't exist yet.
-        if self.ss_name == 's3_store':
-            self.assertFalse(fs.fs_exist(session, 'foobar'))
-        else:
-            self.assertFalse(fs.fs_exist(session, 'foobar'))
+        self.assertFalse(fs.fs_exist(session, 'foobar'))
 
         outbytes = ('MORE THAN ENOUGH DATA\n'*100000).encode()
         f.write(outbytes)

--- a/test/suite/test_tiered06.py
+++ b/test/suite/test_tiered06.py
@@ -59,6 +59,7 @@ class test_tiered06(wttest.WiredTigerTestCase):
         # S3 store is built as an optional loadable extension, not all test environments build S3.
         if self.ss_name == 's3_store':
             #config = '=(config=\"(verbose=1)\")'
+            # config = '=(config=\"(verbose=[api:1,version,tiered:-3])\")'
             extlist.skip_if_missing = True
         #if self.ss_name == 'dir_store':
             #config = '=(config=\"(verbose=1,delay_ms=200,force_delay=3)\")'
@@ -105,8 +106,7 @@ class test_tiered06(wttest.WiredTigerTestCase):
 
         # The object doesn't exist yet.
         if self.ss_name == 's3_store':
-            with self.expectedStderrPattern('.*HTTP response code: 404.*'):
-                self.assertFalse(fs.fs_exist(session, 'foobar'))
+            self.assertFalse(fs.fs_exist(session, 'foobar'))
         else:
             self.assertFalse(fs.fs_exist(session, 'foobar'))
 
@@ -116,8 +116,7 @@ class test_tiered06(wttest.WiredTigerTestCase):
 
         # The object still doesn't exist yet.
         if self.ss_name == 's3_store':
-            with self.expectedStderrPattern('.*HTTP response code: 404.*'):
-                self.assertFalse(fs.fs_exist(session, 'foobar'))
+            self.assertFalse(fs.fs_exist(session, 'foobar'))
         else:
             self.assertFalse(fs.fs_exist(session, 'foobar'))
 

--- a/test/suite/test_tiered14.py
+++ b/test/suite/test_tiered14.py
@@ -86,7 +86,7 @@ class test_tiered14(wttest.WiredTigerTestCase):
         config = ''
         # S3 store is built as an optional loadable extension, not all test environments build S3.
         if self.ss_name == 's3_store':
-            # config = '=(config=\"(verbose=[api:1,version,tiered:-3])\")'
+            #config = '=(config=\"(verbose=[api:1,version,tiered:-3])\")'
             extlist.skip_if_missing = True
         #if self.ss_name == 'dir_store':
             #config = '=(config=\"(verbose=1,delay_ms=200,force_delay=3)\")'

--- a/test/suite/test_tiered14.py
+++ b/test/suite/test_tiered14.py
@@ -28,7 +28,7 @@
 
 from helper_tiered import generate_s3_prefix, get_auth_token, get_bucket1_name
 from wtscenario import make_scenarios
-import os, random, wtscenario, wttest
+import os, random, wttest
 from wtdataset import TrackedSimpleDataSet, TrackedComplexDataSet
 
 # test_tiered14.py
@@ -69,7 +69,7 @@ class test_tiered14(wttest.WiredTigerTestCase):
             num_ops = 20,
             ss_name = 's3_store')),
     ]
-    scenarios = wtscenario.make_scenarios(multiplier, keyfmt, dataset, storage_sources)
+    scenarios = make_scenarios(multiplier, keyfmt, dataset, storage_sources)
 
     def conn_config(self):
         if self.ss_name == 'dir_store' and not os.path.exists(self.bucket):
@@ -86,7 +86,7 @@ class test_tiered14(wttest.WiredTigerTestCase):
         config = ''
         # S3 store is built as an optional loadable extension, not all test environments build S3.
         if self.ss_name == 's3_store':
-            #config = '=(config=\"(verbose=1)\")'
+            # config = '=(config=\"(verbose=[api:1,version,tiered:-3])\")'
             extlist.skip_if_missing = True
         #if self.ss_name == 'dir_store':
             #config = '=(config=\"(verbose=1,delay_ms=200,force_delay=3)\")'


### PR DESCRIPTION
This change fixes the python test failures due to aws calls intermittently timing out by changing the aws SDK log levels, such that only fatal errors are output to stderr by default. The aws log levels are now mapped to the WiredTiger verbosity levels as follows:
AWS::Fatal -> WT_VERBOSE_ERROR
AWS::Error -> WT_VERBOSE_WARNING
AWS::Warn -> WT_VERBOSE_WARNING
AWS::Info -> WT_VERBOSE_INFO
AWS::Debug -> WT_VERBOSE_DEBUG
