### PR TITLE
WT-9165 proxy cells must copy fast-truncate information before releasing the WT_REF lock

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1225,7 +1225,7 @@ extern int __wt_realloc_noclear(WT_SESSION_IMPL *session, size_t *bytes_allocate
 extern int __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv,
   uint8_t type, WT_TIME_WINDOW *tw, uint64_t rle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_child_modify(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *ref,
-  bool *hazardp, WT_CHILD_STATE *statep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_CHILD_MODIFY_STATE *cmsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
   WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -315,8 +315,8 @@ typedef struct {
 
 /*
  * WT_CHILD_RELEASE, WT_CHILD_RELEASE_ERR --
- *	Macros to clean up during internal-page reconciliation, releasing the
- *	hazard pointer we're holding on child pages.
+ *	Macros to clean up during internal-page reconciliation, releasing the hazard pointer we're
+ * holding on a child page.
  */
 #define WT_CHILD_RELEASE(session, hazard, ref)                          \
     do {                                                                \
@@ -331,12 +331,23 @@ typedef struct {
         WT_ERR(ret);                               \
     } while (0)
 
-typedef enum {
-    WT_CHILD_IGNORE,   /* Ignored child */
-    WT_CHILD_MODIFIED, /* Modified child */
-    WT_CHILD_ORIGINAL, /* Original child */
-    WT_CHILD_PROXY     /* Deleted child: proxy */
-} WT_CHILD_STATE;
+/*
+ * WT_CHILD_MODIFY_STATE --
+ *	We review child pages (while holding the child page's WT_REF lock), during internal-page
+ * reconciliation. This structure encapsulates the child page's returned information/state.
+ */
+typedef struct {
+    enum {
+        WT_CHILD_IGNORE,   /* Ignored child */
+        WT_CHILD_MODIFIED, /* Modified child */
+        WT_CHILD_ORIGINAL, /* Original child */
+        WT_CHILD_PROXY     /* Deleted child: proxy */
+    } state;               /* Returned child state */
+
+    WT_PAGE_DELETED del; /* WT_CHILD_PROXY state fast-truncate information */
+
+    bool hazard; /* If currently holding a child hazard pointer */
+} WT_CHILD_MODIFY_STATE;
 
 /*
  * Macros from fixed-length entries to/from bytes.


### PR DESCRIPTION
Proxy cells must copy fast-truncate information before releasing the WT_REF lock, it's possible for a checkpoint to need that information, and once the WT_REF lock is released, the page can be instantiated, discarding the fast-truncate information.

There are now three pieces of information returned from the underlying __wt_rec_child_modify() function (fast-truncate information, child state and hazard pointer), encapsulate it all into a return structure for simplicity.