### PR TITLE
WT-9189 Compile CMake with RelWithDebInfo build type

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -249,7 +249,7 @@ config_string(
 )
 
 # Diagnostic mode requires diagnostic flags. These are set by default in debug mode, otherwise set
-# set them manually.
+# them manually.
 if(HAVE_DIAGNOSTIC AND NOT "${CMAKE_BUILD_TYPE}" MATCHES "^(Debug|RelWithDebInfo)$")
     if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
         # Produce full symbolic debugging information.

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -276,7 +276,7 @@ if(WT_WIN)
     endif()
 endif()
 
-if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     # Don't use the optimization level if we have specified a release config.
     # CMakes Release config sets compilation to the highest optimization level
     # by default.

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -248,9 +248,9 @@ config_string(
     DEFAULT "\"${WT_VERSION_STRING}\""
 )
 
+# Diagnostic mode requires diagnostic flags. These are set by default in debug mode, otherwise set
+# set them manually.
 if(HAVE_DIAGNOSTIC AND NOT "${CMAKE_BUILD_TYPE}" MATCHES "^(Debug|RelWithDebInfo)$")
-    # Avoid setting diagnostic flags if we are building with Debug mode.
-    # CMakes Debug config sets compilation with debug symbols by default.
     if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
         # Produce full symbolic debugging information.
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Z7")

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -276,9 +276,21 @@ if(WT_WIN)
     endif()
 endif()
 
-if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     # Don't use the optimization level if we have specified a release config.
     # CMakes Release config sets compilation to the highest optimization level
     # by default.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CC_OPTIMIZE_LEVEL}")
+endif()
+
+# For the RelWithDebInfo build, the optimisation level is set to 02 by default, we want to remove it
+# as we want to use CC_OPTIMIZE_LEVEL instead.
+if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+    if("${WT_OS}" STREQUAL "windows")
+        string(REPLACE "/O2" "" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
+        string(REPLACE "/O2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+    else()
+        string(REPLACE "-O2" "" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
+        string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+    endif()
 endif()

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -248,7 +248,7 @@ config_string(
     DEFAULT "\"${WT_VERSION_STRING}\""
 )
 
-if(HAVE_DIAGNOSTIC AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+if(HAVE_DIAGNOSTIC AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
     # Avoid setting diagnostic flags if we are building with Debug mode.
     # CMakes Debug config sets compilation with debug symbols by default.
     if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -248,7 +248,7 @@ config_string(
     DEFAULT "\"${WT_VERSION_STRING}\""
 )
 
-if(HAVE_DIAGNOSTIC AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"))
+if(HAVE_DIAGNOSTIC AND NOT "${CMAKE_BUILD_TYPE}" MATCHES "^(Debug|RelWithDebInfo)$")
     # Avoid setting diagnostic flags if we are building with Debug mode.
     # CMakes Debug config sets compilation with debug symbols by default.
     if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -276,13 +276,6 @@ if(WT_WIN)
     endif()
 endif()
 
-if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-    # Don't use the optimization level if we have specified a release config.
-    # CMakes Release config sets compilation to the highest optimization level
-    # by default.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CC_OPTIMIZE_LEVEL}")
-endif()
-
 # For the RelWithDebInfo build, the optimisation level is set to 02 by default, we want to remove it
 # as we want to use CC_OPTIMIZE_LEVEL instead.
 if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
@@ -293,4 +286,11 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
         string(REPLACE "-O2" "" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
         string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
     endif()
+endif()
+
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    # Don't use the optimization level if we have specified a release config.
+    # CMakes Release config sets compilation to the highest optimization level
+    # by default.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CC_OPTIMIZE_LEVEL}")
 endif()

--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -5,7 +5,7 @@ include(CheckCXXCompilerFlag)
 include(${CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 
 # Establish an internal cache variable to track our custom build modes.
-set(BUILD_MODES None Debug Release CACHE INTERNAL "")
+set(BUILD_MODES None Debug Release RelWithDebInfo CACHE INTERNAL "")
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set(MSVC_C_COMPILER 1)


### PR DESCRIPTION
We can now build CMake using the build type RelWithDebInfo:

```
-DCMAKE_BUILD_TYPE=RelWithDebInfo
```
Additional changes were made to remove the default optimization level set by the RelWithDebInfo build type to use our own `CC_OPTIMIZE_LEVEL` instead. By default, `CMAKE_C_FLAGS_RELWITHDEBINFO` is evaluated to `-O2 -g -DNDEBUG`.

Note: This is incompatible with the `ENABLE_STRICT` flag, see WT-9209.