### PR TITLE
WT-9250 Make __wt_debug_cursor_page print the history store for checkpoints

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -985,11 +985,27 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
     WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
+    bool did_hs_checkpoint;
 
     cbt = cursor_arg;
     session = CUR2S(cursor_arg);
+    did_hs_checkpoint = false;
+
+    /*
+     * If the cursor is a checkpoint cursor and we don't already have a history store checkpoint
+     * name in the session, substitute the one from this cursor. This allows the dump to print from
+     * the history store, which otherwise will get skipped.
+     */
+    if (cbt->checkpoint_hs_dhandle != NULL && session->hs_checkpoint == NULL) {
+        session->hs_checkpoint = cbt->checkpoint_hs_dhandle->checkpoint;
+        did_hs_checkpoint = true;
+    }
 
     WT_WITH_BTREE(session, CUR2BT(cbt), ret = __wt_debug_page(session, NULL, cbt->ref, ofile));
+
+    if (did_hs_checkpoint)
+        session->hs_checkpoint = NULL;
+
     return (ret);
 }
 


### PR DESCRIPTION
Make __wt_debug_cursor_page print history for checkpoint cursors.

We can temporarily substitute the right history checkpoint name into the session when called on a checkpoint cursor and there's none already set.