### PR TITLE
WT-9259 Unquoted shell metacharacters in s_typedef

### DIFF
--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -27,7 +27,7 @@ build() {
 	        -e 's/WT_COMPILER_TYPE_ALIGN(.*)[ ]*//' \
 	        -e 's/^[ ]*//' -e 's/[ ]*{.*//' | sort -u | \
 	while read t n; do
-		upper=`echo $n | sed -e 's/^__//' | tr [a-z] [A-Z]`
+		upper=`echo $n | sed -e 's/^__//' | tr '[a-z]' '[A-Z]'`
 		echo "$t $n;"
 		echo "    typedef $t $n $upper;"
 	done


### PR DESCRIPTION
Quote [] characters used in tr(1) invocation.

(The use of [] characters here is incorrect, but harmless, and might cause the script to work on some very old legacy systems, so is best left alone.)