### PR TITLE
WT-7205 Fix backup documentation to be more accurate with respect to named checkpoints

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1158,10 +1158,6 @@ backup(WT_SESSION *session)
       session, "backup:", NULL, "incremental=(enabled,src_id=ID0,this_id=ID1)", &cursor));
     /*! [incremental block backup]*/
     error_check(cursor->close(cursor));
-
-    /*! [backup of a checkpoint]*/
-    error_check(session->checkpoint(session, "drop=(from=June01),name=June01"));
-    /*! [backup of a checkpoint]*/
 }
 
 int

--- a/src/docs/backup.dox
+++ b/src/docs/backup.dox
@@ -91,13 +91,6 @@ to closing the parent backup cursor.
 
 @snippet ex_all.c backup log duplicate
 
-In cases where the backup is desired for a checkpoint other than the
-most recent, applications can discard all checkpoints subsequent to the
-checkpoint they want using the WT_SESSION::checkpoint method.  For
-example:
-
-@snippet ex_all.c backup of a checkpoint
-
 @section backup_util Backup from the command line
 
 The @ref_single util_backup command may also be used to create backups:


### PR DESCRIPTION
Remove paragraph and example about backing up from a prior (named) checkpoint.

In addition to being possibly incorrect on its own terms, it doesn't work; backup works from the latest checkpoint, and dropping
checkpoints always creates a new one. The example is particularly hazardous as it replaces the old checkpoint with a new one of the same name.