### PR TITLE
WT-9195 disable torn transaction tests

### DIFF
--- a/test/suite/test_checkpoint10.py
+++ b/test/suite/test_checkpoint10.py
@@ -180,14 +180,21 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         # If we haven't died yet, pretend to crash and run RTS to see if the
         # checkpoint was inconsistent.
         # (This only works if we didn't reopen the connection, so don't bother if we did.)
-        if not self.do_reopen:
-            simulate_crash_restart(self, ".", "RESTART")
-
-            # Make sure we did get an inconsistent checkpoint.
-            stat_cursor = self.session.open_cursor('statistics:', None, None)
-            inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
-            stat_cursor.close()
-            self.assertGreater(inconsistent_ckpt, 0)
+        #
+        # Disable this crosscheck until we have a more reliable way to generate inconsistent
+        # checkpoints (checkpoints with a torn transaction) on demand. The current method
+        # waits until the checkpoint has started to begin committing, but there's still a
+        # race where the checkpoint thread starts another checkpoint after the commit is
+        # finished. Consequently, occasional failures occur in the testbed, which are a waste
+        # of everyone's time.
+        #if not self.do_reopen:
+        #    simulate_crash_restart(self, ".", "RESTART")
+        #
+        #    # Make sure we did get an inconsistent checkpoint.
+        #    stat_cursor = self.session.open_cursor('statistics:', None, None)
+        #    inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
+        #    stat_cursor.close()
+        #    self.assertGreater(inconsistent_ckpt, 0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint11.py
+++ b/test/suite/test_checkpoint11.py
@@ -239,14 +239,21 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         # If we haven't died yet, pretend to crash and run RTS to see if the
         # checkpoint was inconsistent.
         # (This only works if we didn't reopen the connection, so don't bother if we did.)
-        if not self.do_reopen:
-            simulate_crash_restart(self, ".", "RESTART")
-
-            # Make sure we did get an inconsistent checkpoint.
-            stat_cursor = self.session.open_cursor('statistics:', None, None)
-            inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
-            stat_cursor.close()
-            self.assertGreater(inconsistent_ckpt, 0)
+        #
+        # Disable this crosscheck until we have a more reliable way to generate inconsistent
+        # checkpoints (checkpoints with a torn transaction) on demand. The current method
+        # waits until the checkpoint has started to begin committing, but there's still a
+        # race where the checkpoint thread starts another checkpoint after the commit is
+        # finished. Consequently, occasional failures occur in the testbed, which are a waste
+        # of everyone's time.
+        #if not self.do_reopen:
+        #    simulate_crash_restart(self, ".", "RESTART")
+        #
+        #    # Make sure we did get an inconsistent checkpoint.
+        #    stat_cursor = self.session.open_cursor('statistics:', None, None)
+        #    inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
+        #    stat_cursor.close()
+        #    self.assertGreater(inconsistent_ckpt, 0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint14.py
+++ b/test/suite/test_checkpoint14.py
@@ -181,10 +181,17 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Make sure we did get an inconsistent checkpoint.
-        stat_cursor = self.session.open_cursor('statistics:', None, None)
-        inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
-        stat_cursor.close()
-        self.assertGreater(inconsistent_ckpt, 0)
+        #
+        # Disable this crosscheck until we have a more reliable way to generate inconsistent
+        # checkpoints (checkpoints with a torn transaction) on demand. The current method
+        # waits until the checkpoint has started to begin committing, but there's still a
+        # race where the checkpoint thread starts another checkpoint after the commit is
+        # finished. Consequently, occasional failures occur in the testbed, which are a waste
+        # of everyone's time.
+        #stat_cursor = self.session.open_cursor('statistics:', None, None)
+        #inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
+        #stat_cursor.close()
+        #self.assertGreater(inconsistent_ckpt, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Disable crosschecks in tests.

These tests use timing_stress_for_test=[checkpoint_slow] and a
background checkpoint Python-thread to create a torn transaction in a
checkpoint. This is important for testing that the torn transaction
isn't visible. Actually getting one relies on racing with the
background thread, and (especially under load) sometimes one loses the
race and the checkpoint isn't inconsistent. When I wrote the tests I
added code to crosscheck that this doesn't happen, because when it
does the test succeeds but doesn't actually test anything interesting.
However, it seems that we do get occasional failures on the test
machines, which are at best a nuisance and at worst can get mistaken
for real problems.

Consequently, I'm going to disable the crosschecks until we have a
reliable way to generate inconsistent checkpoints. The current method
waits for the checkpoint to start before starting to commit, but
there's still a race where the checkpoint thread can start another
checkpoint after the commit finishes.