### PR TITLE
WT-9176 Set operation rate to 10ms for update threads (v6.0 backport) 

### DIFF
--- a/test/cppsuite/configs/operations_test_stress.txt
+++ b/test/cppsuite/configs/operations_test_stress.txt
@@ -52,7 +52,7 @@ workload_generator=
     ),
     update_config=
     (
-        op_rate=10s,
+        op_rate=10ms,
         ops_per_transaction=(max=10,min=5),
         thread_count=25,
         value_size=10000


### PR DESCRIPTION
…est (#7828)

(cherry picked from commit 484656b0971c16e5fb45c46589c6bd94ebeb9eb4)