### PR TITLE
WT-9096 Fix search near returning wrong key/value sometimes when key doesn't exist (v5.0 backport)

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -491,10 +491,13 @@ restart_read_page:
             return (WT_NOTFOUND);
         }
 
+<<<<<<< HEAD
         /*
          * Read the on-disk value and/or history. Pass an update list: the update list may contain
          * the base update for a modify chain after rollback-to-stable, required for correctness.
          */
+=======
+>>>>>>> 1e26b59bc... WT-9096 Fix search near returning wrong key/value sometimes when key doesn't exist (#7777)
         WT_RET(
           __wt_txn_read(session, cbt, &cbt->iface.key, WT_RECNO_OOB, WT_ROW_UPDATE(page, rip)));
         if (cbt->upd_value->type == WT_UPDATE_INVALID) {


### PR DESCRIPTION
Avoid using the cursor temporary key as the history store key when the
cursor search compare is not found an exact match. When cursor search
didn't find an exact match, the cursor tmp key and the cursor slot can diverge.
Generate the key from the cursor slot in those scenarios to avoid checking
the wrong key in the history store for visibility.

(cherry picked from commit 1e26b59bc55bc111d7b623685731e0784a52d281)