### PR TITLE
WT-9096 Fix search near returning wrong key/value sometimes when key doesn't exist (v5.0 backport)

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -442,7 +442,12 @@ restart_read_insert:
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
 restart_read_page:
         rip = &page->pg_row[cbt->slot];
+        /*
+         * The saved cursor key from the slot is used later to match the prefix match or get the
+         * value from the history store if the on-disk data is not visible.
+         */
         WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack));
+
         /*
          * If the cursor has prefix search configured we can early exit here if the key that we are
          * visiting is after our prefix.
@@ -452,6 +457,7 @@ restart_read_page:
             WT_STAT_CONN_DATA_INCR(session, cursor_search_near_prefix_fast_paths);
             return (WT_NOTFOUND);
         }
+
         WT_RET(
           __wt_txn_read(session, cbt, &cbt->iface.key, WT_RECNO_OOB, WT_ROW_UPDATE(page, rip)));
         if (cbt->upd_value->type == WT_UPDATE_INVALID) {

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -599,6 +599,10 @@ restart_read_insert:
         cbt->slot = cbt->row_iteration_slot / 2 - 1;
 restart_read_page:
         rip = &page->pg_row[cbt->slot];
+        /*
+         * The saved cursor key from the slot is used later to get the value from the history store
+         * if the on-disk data is not visible.
+         */
         WT_RET(__cursor_row_slot_key_return(cbt, rip, &kpack));
 
         if (F_ISSET(&cbt->iface, WT_CURSTD_KEY_ONLY))

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -321,6 +321,19 @@ __wt_cursor_valid(WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, bool *vali
         if (cbt->ins != NULL)
             return (0);
 
+        /* Paranoia. */
+        WT_ASSERT(session, recno == WT_RECNO_OOB);
+
+        /*
+         * The key can be NULL only when we didn't find an exact match, copy the search found key
+         * into the temporary buffer for further use.
+         */
+        if (key == NULL) {
+            WT_RET(__wt_row_leaf_key(
+              session, cbt->ref->page, &cbt->ref->page->pg_row[cbt->slot], cbt->tmp, true));
+            key = cbt->tmp;
+        }
+
         /* Check for an update. */
         WT_RET(__wt_txn_read(session, cbt, key, WT_RECNO_OOB,
           (page->modify != NULL && page->modify->mod_row_update != NULL) ?
@@ -662,10 +675,14 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
          * better match. This test is simplistic as we're ignoring append lists (there may be no
          * page slots or we might be legitimately positioned after the last page slot). Ignore those
          * cases, it makes things too complicated.
+         *
+         * If there's an exact match, the row-store search function built the key in the cursor's
+         * temporary buffer.
          */
         if (leaf_found &&
           (cbt->compare == 0 || (cbt->slot != 0 && cbt->slot != cbt->ref->page->entries - 1)))
-            WT_ERR(__wt_cursor_valid(cbt, cbt->tmp, WT_RECNO_OOB, &valid));
+            WT_ERR(
+              __wt_cursor_valid(cbt, (cbt->compare == 0 ? cbt->tmp : NULL), WT_RECNO_OOB, &valid));
     }
     if (!valid) {
         WT_ERR(__wt_cursor_func_init(cbt, true));
@@ -676,7 +693,12 @@ __wt_btcur_search_near(WT_CURSOR_BTREE *cbt, int *exactp)
          */
         if (btree->type == BTREE_ROW) {
             WT_ERR(__cursor_row_search(cbt, true, NULL, NULL));
-            WT_ERR(__wt_cursor_valid(cbt, cbt->tmp, WT_RECNO_OOB, &valid));
+            /*
+             * If there's an exact match, the row-store search function built the key in the
+             * cursor's temporary buffer.
+             */
+            WT_ERR(
+              __wt_cursor_valid(cbt, (cbt->compare == 0 ? cbt->tmp : NULL), WT_RECNO_OOB, &valid));
         } else {
             WT_ERR(__cursor_col_search(cbt, NULL, NULL));
             WT_ERR(__wt_cursor_valid(cbt, NULL, cbt->recno, &valid));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -39,6 +39,13 @@ __key_return(WT_CURSOR_BTREE *cbt)
             return (0);
         }
 
+        /*
+         * If there's an exact match, the row-store search function built the key we want to return
+         * in the cursor's temporary buffer. Swap the cursor's search-key and temporary buffers so
+         * we can return it (it's unsafe to return the temporary buffer itself because our caller
+         * might do another search in this table using the key we return, and we'd corrupt the
+         * search key during any subsequent search that used the temporary buffer).
+         */
         if (cbt->compare == 0) {
             /*
              * If not in an insert list and there's an exact match, the row-store search function

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -988,7 +988,7 @@ retry:
     WT_ASSERT(session, cbt->upd_value->type == WT_UPDATE_INVALID);
 
     /* If there is no ondisk value, there can't be anything in the history store either. */
-    if (cbt->ref->page->dsk == NULL || cbt->slot == UINT32_MAX) {
+    if (cbt->ref->page->dsk == NULL) {
         cbt->upd_value->type = WT_UPDATE_TOMBSTONE;
         return (0);
     }

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -195,6 +195,16 @@ worker_op(WT_CURSOR *cursor, uint64_t keyno, u_int new_val)
                 return (WT_ROLLBACK);
             return (log_print_err("cursor.search_near", ret, 1));
         }
+
+        /* Retry the result of search_near again to confirm the result. */
+        if (new_val % 2 == 0) {
+            if ((ret = cursor->search(cursor)) != 0) {
+                if (ret == WT_ROLLBACK)
+                    return (WT_ROLLBACK);
+                return (log_print_err("cursor.search", ret, 1));
+            }
+        }
+
         if (cmp < 0) {
             if ((ret = cursor->next(cursor)) != 0) {
                 if (ret == WT_NOTFOUND)


### PR DESCRIPTION
Avoid using the cursor temporary key as the history store key when the
cursor search compare is not found an exact match. When cursor search
didn't find an exact match, the cursor tmp key and the cursor slot can diverge.
Generate the key from the cursor slot in those scenarios to avoid checking
the wrong key in the history store for visibility.

(cherry picked from commit 1e26b59bc55bc111d7b623685731e0784a52d281)

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
(cherry picked from commit 5003f657b04bde3df73de6f655cbfbbc081cd252)