### PR TITLE
WT-9249 Compare and fix the start durable timestamp if it is greater than OOO timestamp (v6.0 backport)

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -923,6 +923,10 @@ __curhs_insert(WT_CURSOR *cursor)
         hs_tombstone->durable_ts = hs_cursor->time_window.durable_stop_ts;
         hs_tombstone->txnid = hs_cursor->time_window.stop_txn;
 
+        WT_ASSERT(session,
+          hs_tombstone->start_ts >= hs_upd->start_ts &&
+            hs_tombstone->durable_ts >= hs_upd->durable_ts);
+
         hs_tombstone->next = hs_upd;
         hs_upd = hs_tombstone;
     }
@@ -1053,6 +1057,9 @@ __curhs_update(WT_CURSOR *cursor)
     hs_upd->start_ts = hs_cursor->time_window.start_ts;
     hs_upd->durable_ts = hs_cursor->time_window.durable_start_ts;
     hs_upd->txnid = hs_cursor->time_window.start_txn;
+
+    WT_ASSERT(session,
+      hs_tombstone->start_ts >= hs_upd->start_ts && hs_tombstone->durable_ts >= hs_upd->durable_ts);
 
     /* Connect the tombstone to the update. */
     hs_tombstone->next = hs_upd;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -1013,7 +1013,8 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
              * Use the original start time window's timestamps if it isn't out of order with respect
              * to the new update.
              */
-            if (hs_cbt->upd_value->tw.start_ts >= ts)
+            if (hs_cbt->upd_value->tw.start_ts >= ts ||
+              hs_cbt->upd_value->tw.durable_start_ts >= ts)
                 hs_insert_tw.start_ts = hs_insert_tw.durable_start_ts = ooo_tombstone ? ts : ts - 1;
             else {
                 hs_insert_tw.start_ts = hs_cbt->upd_value->tw.start_ts;


### PR DESCRIPTION
Performing a prepared insert rollback can lead to a situation where
the datastore and history store may have the same update and inserting it
back again to the history store triggers the OOO timestamp handling.

Compare and fix the existing history store entry start durable timestamp
also to avoid generating the condition where the start durable timestamp
is greater than the stop timestamp.

(cherry picked from commit 462db2dbb2ed77b516dd35addf5dce4f4978f3c1)