### PR TITLE
WT-9029 Remove tiered storage object_target_size. It is unused. (v4.4 backport)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -226,10 +226,6 @@ tiered_config = [
             time in seconds to retain data on tiered storage on the local tier
             for faster read access''',
             min='0', max='10000'),
-        Config('object_target_size', '10M', r'''
-            the approximate size of objects before creating them on the
-            tiered storage tier''',
-            min='100K', max='10TB'),
         ]),
 ]
 

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -883,7 +883,6 @@ conn_dsrc_stats = [
     ##########################################
     # Tiered storage statistics
     ##########################################
-    StorageStat('tiered_object_size', 'tiered storage object size', 'no_clear,no_scale,size'),
     StorageStat('tiered_retention', 'tiered storage local retention time (secs)', 'no_clear,no_scale,size'),
     StorageStat('tiered_work_units_created', 'tiered operations scheduled'),
     StorageStat('tiered_work_units_dequeued', 'tiered operations dequeued and processed'),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -265,9 +265,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create_tiered_storage_subconfigs
   {"bucket_prefix", "string", NULL, NULL, NULL, 0},
   {"cache_directory", "string", NULL, NULL, NULL, 0},
   {"local_retention", "int", NULL, "min=0,max=10000", NULL, 0},
-  {"name", "string", NULL, NULL, NULL, 0},
-  {"object_target_size", "int", NULL, "min=100K,max=10TB", NULL, 0},
-  {NULL, NULL, NULL, NULL, NULL, 0}};
+  {"name", "string", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
   {"access_pattern_hint", "string", NULL, "choices=[\"none\",\"random\",\"sequential\"]", NULL, 0},
@@ -313,7 +311,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"type", "string", NULL, NULL, NULL, 0},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
@@ -468,7 +466,7 @@ static const WT_CONFIG_CHECK confchk_file_config[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
@@ -520,7 +518,7 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
@@ -588,7 +586,7 @@ static const WT_CONFIG_CHECK confchk_lsm_meta[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"write_timestamp_usage", "string", NULL,
@@ -641,7 +639,7 @@ static const WT_CONFIG_CHECK confchk_object_meta[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
@@ -710,7 +708,7 @@ static const WT_CONFIG_CHECK confchk_tier_meta[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
   {"version", "string", NULL, NULL, NULL, 0},
@@ -763,7 +761,7 @@ static const WT_CONFIG_CHECK confchk_tiered_meta[] = {
   {"split_pct", "int", NULL, "min=50,max=100", NULL, 0},
   {"tiered_object", "boolean", NULL, NULL, NULL, 0},
   {"tiered_storage", "category", NULL, NULL, confchk_WT_SESSION_create_tiered_storage_subconfigs,
-    7},
+    6},
   {"tiers", "list", NULL, NULL, NULL, 0},
   {"value_format", "format", __wt_struct_confchk, NULL, NULL, 0},
   {"verbose", "list", NULL, "choices=[\"write_timestamp\"]", NULL, 0},
@@ -1216,8 +1214,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     ",source=,split_deepen_min_child=0,split_deepen_per_child=0,"
     "split_pct=90,tiered_object=false,tiered_storage=(auth_token=,"
     "bucket=,bucket_prefix=,cache_directory=,local_retention=300,"
-    "name=,object_target_size=10M),type=file,value_format=u,"
-    "verbose=[],write_timestamp_usage=none",
+    "name=),type=file,value_format=u,verbose=[],"
+    "write_timestamp_usage=none",
     confchk_WT_SESSION_create, 50},
   {"WT_SESSION.drop",
     "checkpoint_wait=true,force=false,lock_wait=true,"
@@ -1282,9 +1280,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "prefix_compression=false,prefix_compression_min=4,readonly=false"
     ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
     "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
-    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),value_format=u,verbose=[],"
-    "write_timestamp_usage=none",
+    "bucket_prefix=,cache_directory=,local_retention=300,name=),"
+    "value_format=u,verbose=[],write_timestamp_usage=none",
     confchk_file_config, 42},
   {"file.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
@@ -1303,9 +1300,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "prefix_compression_min=4,readonly=false,split_deepen_min_child=0"
     ",split_deepen_per_child=0,split_pct=90,tiered_object=false,"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
-    "cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),value_format=u,verbose=[],"
-    "version=(major=0,minor=0),write_timestamp_usage=none",
+    "cache_directory=,local_retention=300,name=),value_format=u,"
+    "verbose=[],version=(major=0,minor=0),write_timestamp_usage=none",
     confchk_file_meta, 47},
   {"index.meta",
     "app_metadata=,assert=(commit_timestamp=none,"
@@ -1335,9 +1331,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     ",readonly=false,split_deepen_min_child=0,"
     "split_deepen_per_child=0,split_pct=90,tiered_object=false,"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
-    "cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),value_format=u,verbose=[],"
-    "write_timestamp_usage=none",
+    "cache_directory=,local_retention=300,name=),value_format=u,"
+    "verbose=[],write_timestamp_usage=none",
     confchk_lsm_meta, 46},
   {"object.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
@@ -1356,9 +1351,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "prefix_compression_min=4,readonly=false,split_deepen_min_child=0"
     ",split_deepen_per_child=0,split_pct=90,tiered_object=false,"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
-    "cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),value_format=u,verbose=[],"
-    "version=(major=0,minor=0),write_timestamp_usage=none",
+    "cache_directory=,local_retention=300,name=),value_format=u,"
+    "verbose=[],version=(major=0,minor=0),write_timestamp_usage=none",
     confchk_object_meta, 48},
   {"table.meta",
     "app_metadata=,assert=(commit_timestamp=none,"
@@ -1383,9 +1377,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "prefix_compression=false,prefix_compression_min=4,readonly=false"
     ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
     "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
-    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),value_format=u,verbose=[],"
-    "version=(major=0,minor=0),write_timestamp_usage=none",
+    "bucket_prefix=,cache_directory=,local_retention=300,name=),"
+    "value_format=u,verbose=[],version=(major=0,minor=0),"
+    "write_timestamp_usage=none",
     confchk_tier_meta, 50},
   {"tiered.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
@@ -1404,9 +1398,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "prefix_compression=false,prefix_compression_min=4,readonly=false"
     ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
     "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
-    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
-    "object_target_size=10M),tiers=,value_format=u,verbose=[],"
-    "version=(major=0,minor=0),write_timestamp_usage=none",
+    "bucket_prefix=,cache_directory=,local_retention=300,name=),"
+    "tiers=,value_format=u,verbose=[],version=(major=0,minor=0),"
+    "write_timestamp_usage=none",
     confchk_tiered_meta, 49},
   {"wiredtiger_open",
     "buffer_alignment=-1,builtin_extension_config=,cache_cursors=true"

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -40,7 +40,6 @@ struct __wt_bucket_storage {
     const char *bucket_prefix;         /* Bucket prefix */
     const char *cache_directory;       /* Locally cached file location */
     int owned;                         /* Storage needs to be terminated */
-    uint64_t object_size;              /* Tiered object size */
     uint64_t retain_secs;              /* Tiered period */
     const char *auth_token;            /* Tiered authentication cookie */
     WT_FILE_SYSTEM *file_system;       /* File system for bucket */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -718,7 +718,6 @@ struct __wt_connection_stats {
     int64_t tiered_work_units_dequeued;
     int64_t tiered_work_units_created;
     int64_t tiered_retention;
-    int64_t tiered_object_size;
     int64_t thread_fsync_active;
     int64_t thread_read_active;
     int64_t thread_write_active;
@@ -1029,7 +1028,6 @@ struct __wt_dsrc_stats {
     int64_t tiered_work_units_dequeued;
     int64_t tiered_work_units_created;
     int64_t tiered_retention;
-    int64_t tiered_object_size;
     int64_t txn_read_race_prepare_update;
     int64_t txn_rts_hs_stop_older_than_newer_start;
     int64_t txn_rts_inconsistent_ckpt;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1313,9 +1313,6 @@ struct __wt_session {
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;name, permitted values are \c "none" or custom storage
 	 * source name created with WT_CONNECTION::add_storage_source.  See @ref
 	 * custom_storage_sources for more information., a string; default \c none.}
-	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;object_target_size, the approximate size of objects
-	 * before creating them on the tiered storage tier., an integer between 100K and 10TB;
-	 * default \c 10M.}
 	 * @config{ ),,}
 	 * @config{type, set the type of data source used to store a column group\, index or simple
 	 * table.  By default\, a \c "file:" URI is derived from the object name.  The \c type
@@ -6004,238 +6001,236 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1403
 /*! session: tiered storage local retention time (secs) */
 #define	WT_STAT_CONN_TIERED_RETENTION			1404
-/*! session: tiered storage object size */
-#define	WT_STAT_CONN_TIERED_OBJECT_SIZE			1405
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1406
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1405
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1407
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1406
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1408
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1407
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1409
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1408
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1410
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1409
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1411
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1410
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1412
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1411
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1413
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1412
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1414
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1413
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1415
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1414
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1416
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1415
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1417
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1416
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1418
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1417
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1419
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1418
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1420
+#define	WT_STAT_CONN_PAGE_SLEEP				1419
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1421
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1420
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1422
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1421
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1423
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1422
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1424
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1423
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1425
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1424
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1426
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1425
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1427
+#define	WT_STAT_CONN_TXN_PREPARE			1426
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1428
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1427
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1429
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1428
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1430
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1429
 /*!
  * transaction: prepared transactions rolled back and do not remove the
  * history store entry
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1431
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1430
 /*!
  * transaction: prepared transactions rolled back and fix the history
  * store entry with checkpoint reserved transaction id
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1432
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1431
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1433
+#define	WT_STAT_CONN_TXN_QUERY_TS			1432
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1434
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1433
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1435
+#define	WT_STAT_CONN_TXN_RTS				1434
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1436
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1435
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1437
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1436
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1438
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1437
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1439
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1438
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1440
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1439
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1441
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1440
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1442
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1441
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1443
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1442
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1444
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1443
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1445
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1444
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1446
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1445
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1447
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1446
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1448
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1447
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1449
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1448
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1450
+#define	WT_STAT_CONN_TXN_SET_TS				1449
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1451
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1450
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1452
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1451
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1453
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1452
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1454
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1453
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1455
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1454
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1456
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1455
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1457
+#define	WT_STAT_CONN_TXN_BEGIN				1456
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1458
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1457
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1459
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1458
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1460
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1459
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1461
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1460
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1462
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1461
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1463
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1462
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1464
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1463
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1465
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1464
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1466
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1465
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1467
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1466
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1468
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1467
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1469
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1468
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1470
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1469
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1471
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1470
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1472
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1471
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1473
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1472
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1474
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1473
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1475
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1474
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1476
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1475
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1477
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1476
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1478
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1477
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1479
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1478
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1480
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1479
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1481
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1480
 /*! transaction: transaction failures due to history store */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1482
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1481
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1483
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1482
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1483
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1485
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1484
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1486
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1485
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1487
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1486
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1488
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1487
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1489
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1488
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1490
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1489
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1491
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1490
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1492
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1491
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1493
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1492
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1494
+#define	WT_STAT_CONN_TXN_COMMIT				1493
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1495
+#define	WT_STAT_CONN_TXN_ROLLBACK			1494
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1496
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1495
 
 /*!
  * @}
@@ -6869,37 +6864,35 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2210
 /*! session: tiered storage local retention time (secs) */
 #define	WT_STAT_DSRC_TIERED_RETENTION			2211
-/*! session: tiered storage object size */
-#define	WT_STAT_DSRC_TIERED_OBJECT_SIZE			2212
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2213
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2212
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2214
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2213
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2215
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2214
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2216
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2215
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2217
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2216
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2218
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2217
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2219
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2218
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2220
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2219
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2221
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2220
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2222
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2221
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2223
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2222
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2224
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2223
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2225
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2224
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -224,7 +224,6 @@ static const char *const __stats_dsrc_desc[] = {
   "session: tiered operations dequeued and processed",
   "session: tiered operations scheduled",
   "session: tiered storage local retention time (secs)",
-  "session: tiered storage object size",
   "transaction: race to read prepared update retry",
   "transaction: rollback to stable history store records with stop timestamps older than newer "
   "records",
@@ -491,7 +490,6 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->tiered_work_units_dequeued = 0;
     stats->tiered_work_units_created = 0;
     /* not clearing tiered_retention */
-    /* not clearing tiered_object_size */
     stats->txn_read_race_prepare_update = 0;
     stats->txn_rts_hs_stop_older_than_newer_start = 0;
     stats->txn_rts_inconsistent_ckpt = 0;
@@ -748,7 +746,6 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->tiered_work_units_dequeued += from->tiered_work_units_dequeued;
     to->tiered_work_units_created += from->tiered_work_units_created;
     to->tiered_retention += from->tiered_retention;
-    to->tiered_object_size += from->tiered_object_size;
     to->txn_read_race_prepare_update += from->txn_read_race_prepare_update;
     to->txn_rts_hs_stop_older_than_newer_start += from->txn_rts_hs_stop_older_than_newer_start;
     to->txn_rts_inconsistent_ckpt += from->txn_rts_inconsistent_ckpt;
@@ -1013,7 +1010,6 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->tiered_work_units_dequeued += WT_STAT_READ(from, tiered_work_units_dequeued);
     to->tiered_work_units_created += WT_STAT_READ(from, tiered_work_units_created);
     to->tiered_retention += WT_STAT_READ(from, tiered_retention);
-    to->tiered_object_size += WT_STAT_READ(from, tiered_object_size);
     to->txn_read_race_prepare_update += WT_STAT_READ(from, txn_read_race_prepare_update);
     to->txn_rts_hs_stop_older_than_newer_start +=
       WT_STAT_READ(from, txn_rts_hs_stop_older_than_newer_start);
@@ -1450,7 +1446,6 @@ static const char *const __stats_connection_desc[] = {
   "session: tiered operations dequeued and processed",
   "session: tiered operations scheduled",
   "session: tiered storage local retention time (secs)",
-  "session: tiered storage object size",
   "thread-state: active filesystem fsync calls",
   "thread-state: active filesystem read calls",
   "thread-state: active filesystem write calls",
@@ -1990,7 +1985,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->tiered_work_units_dequeued = 0;
     stats->tiered_work_units_created = 0;
     /* not clearing tiered_retention */
-    /* not clearing tiered_object_size */
     /* not clearing thread_fsync_active */
     /* not clearing thread_read_active */
     /* not clearing thread_write_active */
@@ -2544,7 +2538,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->tiered_work_units_dequeued += WT_STAT_READ(from, tiered_work_units_dequeued);
     to->tiered_work_units_created += WT_STAT_READ(from, tiered_work_units_created);
     to->tiered_retention += WT_STAT_READ(from, tiered_retention);
-    to->tiered_object_size += WT_STAT_READ(from, tiered_object_size);
     to->thread_fsync_active += WT_STAT_READ(from, thread_fsync_active);
     to->thread_read_active += WT_STAT_READ(from, thread_read_active);
     to->thread_write_active += WT_STAT_READ(from, thread_write_active);

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -47,9 +47,6 @@ __tiered_common_config(WT_SESSION_IMPL *session, const char **cfg, WT_BUCKET_STO
     WT_RET(__wt_config_gets(session, cfg, "tiered_storage.local_retention", &cval));
     bstorage->retain_secs = (uint64_t)cval.val;
 
-    WT_RET(__wt_config_gets(session, cfg, "tiered_storage.object_target_size", &cval));
-    bstorage->object_size = (uint64_t)cval.val;
-
     return (0);
 }
 
@@ -173,7 +170,6 @@ __wt_tiered_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfi
       session, WT_VERB_TIERED, "TIERED_CONFIG: prefix %s", conn->bstorage->bucket_prefix);
 
     WT_ASSERT(session, conn->bstorage != NULL);
-    WT_STAT_CONN_SET(session, tiered_object_size, conn->bstorage->object_size);
     WT_STAT_CONN_SET(session, tiered_retention, conn->bstorage->retain_secs);
 
     /*

--- a/test/suite/test_tiered04.py
+++ b/test/suite/test_tiered04.py
@@ -52,10 +52,6 @@ class test_tiered04(wttest.WiredTigerTestCase):
     extension_name = "local_store"
     prefix = "this_pfx"
     prefix1 = "other_pfx"
-    object_sys = "9M"
-    object_sys_val = 9 * 1024 * 1024
-    object_uri = "15M"
-    object_uri_val = 15 * 1024 * 1024
     retention = 3
     retention1 = 600
     def conn_config(self):
@@ -67,8 +63,8 @@ class test_tiered04(wttest.WiredTigerTestCase):
           'bucket=%s,' % self.bucket + \
           'bucket_prefix=%s,' % self.prefix + \
           'local_retention=%d,' % self.retention + \
-          'name=%s,' % self.extension_name + \
-          'object_target_size=%s)' % self.object_sys
+          'name=%s)' % self.extension_name 
+        return self.saved_conn
 
     # Load the local store extension.
     def conn_extensions(self, extlist):
@@ -113,8 +109,7 @@ class test_tiered04(wttest.WiredTigerTestCase):
           'bucket=%s,' % self.bucket1 + \
           'bucket_prefix=%s,' % self.prefix1 + \
           'local_retention=%d,' % self.retention1 + \
-          'name=%s,' % self.extension_name + \
-          'object_target_size=%s)' % self.object_uri
+          'name=%s)' % self.extension_name
         self.pr("create non-sys tiered")
         self.session.create(self.uri1, base_create + conf)
         conf = ',tiered_storage=(name=none)'
@@ -178,8 +173,6 @@ class test_tiered04(wttest.WiredTigerTestCase):
         calls = self.get_stat(stat.conn.flush_tier, None)
         flush = 3
         self.assertEqual(calls, flush)
-        obj = self.get_stat(stat.conn.tiered_object_size, None)
-        self.assertEqual(obj, self.object_sys_val)
 
         # As we flush each object, we are currently removing the file: object. So N + 1 exists.
         fileuri = self.fileuri_base + str(flush + 1) + '.wtobj'

--- a/test/suite/test_tiered07.py
+++ b/test/suite/test_tiered07.py
@@ -52,8 +52,7 @@ class test_tiered07(wttest.WiredTigerTestCase):
           'tiered_storage=(auth_token=%s,' % self.auth_token + \
           'bucket=%s,' % self.bucket + \
           'bucket_prefix=%s,' % self.bucket_prefix + \
-          'name=%s,' % self.extension_name + \
-          'object_target_size=20M)'
+          'name=%s)' % self.extension_name 
 
     # Test calling schema APIs with a tiered table.
     def test_tiered(self):


### PR DESCRIPTION
* WT-9029 Remove tiered storage object_target_size. It is unused.


Co-authored-by: sueloverso <sue@mongodb.com>
