### PR TITLE
WT-9185 Add checks for random generator for uint64 in cppsuite

### DIFF
--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -360,6 +360,7 @@ database_operation::update_operation(thread_context *tc)
         scoped_cursor &cursor = cursors[coll.id];
 
         /* Choose a random key to update. */
+        testutil_assert(coll.get_key_count() != 0);
         uint64_t key_id =
           random_generator::instance().generate_integer<uint64_t>(0, coll.get_key_count() - 1);
         if (!tc->update(cursor, coll.id, tc->key_to_string(key_id))) {

--- a/test/cppsuite/tests/search_near_03.cpp
+++ b/test/cppsuite/tests/search_near_03.cpp
@@ -240,6 +240,7 @@ class search_near_03 : public test_harness::test {
              * Grab a random existing prefix and perform unique index insertion. We expect it to
              * fail to insert, because it should already exist.
              */
+            testutil_assert(prefixes_map.at(coll.id).size() != 0);
             random_index = random_generator::instance().generate_integer(
               static_cast<size_t>(0), prefixes_map.at(coll.id).size() - 1);
             prefix_key = get_prefix_from_key(prefixes_map.at(coll.id).at(random_index));


### PR DESCRIPTION
- Check all usage of `random_generator` where generating a `uint64` value and make sure that invalid inputs (inputs of less than 0) will not be allowed.
- Added checks in `search_near_03.cpp` and `database_operation.cpp`