### PR TITLE
WT-9063 Handle occasional WT_ROLLBACK errors in Python test suite

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -409,6 +409,7 @@ typedef struct {
 } PY_CALLBACK;
 
 static PyObject *wtError;
+static PyObject *wtRollbackError;
 
 static int sessionFreeHandler(WT_SESSION *session_arg);
 static int cursorFreeHandler(WT_CURSOR *cursor_arg);
@@ -424,19 +425,22 @@ static int unpackBytesOrString(PyObject *obj, void **data, size_t *size);
 
 %init %{
 	/*
-	 * Create an exception type and put it into the _wiredtiger module.
-	 * First increment the reference count because PyModule_AddObject
-	 * decrements it.  Then note that "m" is the local variable for the
-	 * module in the SWIG generated code.  If there is a SWIG variable for
-	 * this, I haven't found it.
+	 * Create exception types and put them into the _wiredtiger module.
+	 * For each, first increment the reference count because PyModule_AddObject
+	 * decrements it, and we don't want to look it up later.
 	 */
 	wtError = PyErr_NewException("_wiredtiger.WiredTigerError", NULL, NULL);
 	Py_INCREF(wtError);
 	PyModule_AddObject(m, "WiredTigerError", wtError);
+
+	wtRollbackError = PyErr_NewException("_wiredtiger.WiredTigerRollbackError", wtError, NULL);
+	Py_INCREF(wtRollbackError);
+	PyModule_AddObject(m, "WiredTigerRollbackError", wtRollbackError);
 %}
 
 %pythoncode %{
 WiredTigerError = _wiredtiger.WiredTigerError
+WiredTigerRollbackError = _wiredtiger.WiredTigerRollbackError
 
 # Python3 has no explicit long type, recnos work as ints
 import sys
@@ -532,7 +536,10 @@ SELFHELPER(struct __wt_storage_source, storage_source)
 do {
 	if (PyErr_Occurred() == NULL) {
 		/* We could use PyErr_SetObject for more complex reporting. */
-		SWIG_SetErrorMsg(wtError, wiredtiger_strerror(result));
+                if (PyErr_Occurred() == NULL && (intptr_t)result == WT_ROLLBACK)
+			SWIG_SetErrorMsg(wtRollbackError, wiredtiger_strerror(result));
+                else
+			SWIG_SetErrorMsg(wtError, wiredtiger_strerror(result));
 	}
 	SWIG_fail;
 } while(0)

--- a/test/suite/hook_rollback.py
+++ b/test/suite/hook_rollback.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# ignored_file
+# [END_TAGS]
+
+# hook_rollback.py
+#   Intentionally have random failures of rollback some fraction of the time:
+#     python run.py --hook rollback=FAILRATE base01
+#
+# FAILRATE should be a floating number less than one, for example, 0.25 to fail a quarter of the time.
+#
+# This hook is used to test a feature of the test suite, where tests with rollback errors are automatically
+# restarted.
+
+from __future__ import print_function
+
+import os, sys, wthooks, random, wiredtiger
+from wttest import WiredTigerTestCase
+
+# Print to /dev/tty for debugging, since anything extraneous to stdout/stderr will
+# cause a test error.
+def tty(s):
+    WiredTigerTestCase.tty(s)
+
+# These are the hook functions that are run when particular APIs are called.
+
+def session_begin_transaction_notify(ret, session, *args):
+    session.in_transaction = True
+    #tty('==> in txn, session={}'.format(session))
+
+def session_end_transaction_notify(ret, session, *args):
+    session.in_transaction = False
+    #tty('==> out txn, session={}'.format(session))
+
+# Here we patch a deficiency of our SWIG setup.  When a cursor is created via
+# a session.open_cursor() call, a unique Cursor python object is created.
+# However, that particular 'cursor' object doesn't know what 'session' object created it,
+# only that there is a property 'session' that maps to the WT_CURSOR->session pointer.
+# The upshot is that cursor.session will not give us the same Python object that
+# created the cursor, though it will be a wrapper around the same C WT_SESSION.
+#
+# To fix this, we change the Cursor.session property, it was originally managed by SWIG,
+# now it just returns a session field, that we set immediately after the open_cursor.
+# In an ideal world, we'd change our SWIG configuration to do the right thing for
+# Cursor.session and Session.connection, but I don't think any of the regular tests care about it.
+
+wiredtiger.Cursor.session = property(lambda x: x._session_value)
+def session_open_cursor_notify(cursor, session, *args):
+    cursor._session_value = session
+
+def cursor_notify_for_rollback(cursor, creator):
+    s = cursor.session
+    #tty('   cursor_notify_for_rollback, session={}'.format(s))
+
+    # We only want to trigger a rollback error when we are in a transaction,
+    # to mimic when these errors occur in actual WiredTiger calls.  To do this
+    # we have a field on the session object that tells us if we are in a
+    # transaction.
+    if (hasattr(s, 'in_transaction') and s.in_transaction):
+        if creator.do_retry():
+            # Add something to stdout, we want to make sure it is cleaned up on a test retry.
+            print('retry transaction rollback error')
+            raise wiredtiger.WiredTigerRollbackError('retryable rollback error')
+
+# Every hook file must have one or more classes descended from WiredTigerHook
+# This is where the hook functions are 'hooked' to API methods.
+class RollbackHookCreator(wthooks.WiredTigerHookCreator):
+    def __init__(self, arg=0):
+        # The argument is the fail rate.  From it, we compute an integral "mod"
+        if arg == None:
+            failrate = 0.10
+        else:
+            failrate = float(arg)
+        if failrate < 0.0 or failrate > 1.0:
+            raise Exception('Illegal arg {} to rollback hook creator, expect 0.0 < N <= 1.0'.
+              format(failrate))
+        self.mod = int(1 / failrate)
+        self.rand = random.Random()
+
+    def do_retry(self):
+        return self.rand.randint(1, 1000000) % self.mod == 0
+
+    # No filtering needed
+    def filter_tests(self, tests):
+        #print('Filtering: ' + str(tests))
+        return tests
+
+    def setup_hooks(self):
+        self.Session['begin_transaction'] = (wthooks.HOOK_NOTIFY, session_begin_transaction_notify)
+        self.Session['commit_transaction'] = (wthooks.HOOK_NOTIFY, session_end_transaction_notify)
+        self.Session['rollback_transaction'] = (wthooks.HOOK_NOTIFY, session_end_transaction_notify)
+        self.Session['open_cursor'] = (wthooks.HOOK_NOTIFY, session_open_cursor_notify)
+
+        self.Cursor['insert'] = (wthooks.HOOK_NOTIFY,
+            lambda ret, c, *args, **kw: cursor_notify_for_rollback(c, self))
+        self.Cursor['modify'] = (wthooks.HOOK_NOTIFY,
+            lambda ret, c, *args, **kw: cursor_notify_for_rollback(c, self))
+        self.Cursor['search'] = (wthooks.HOOK_NOTIFY,
+            lambda ret, c, *args, **kw: cursor_notify_for_rollback(c, self))
+        self.Cursor['search_near'] = (wthooks.HOOK_NOTIFY,
+            lambda ret, c, *args, **kw: cursor_notify_for_rollback(c, self))
+        self.Cursor['update'] = (wthooks.HOOK_NOTIFY,
+            lambda ret, c, *args, **kw: cursor_notify_for_rollback(c, self))
+
+# Every hook file must have a top level initialize function,
+# returning a list of WiredTigerHook objects.
+def initialize(arg):
+    return [RollbackHookCreator(arg)]

--- a/test/suite/test_checkpoint_snapshot03.py
+++ b/test/suite/test_checkpoint_snapshot03.py
@@ -41,7 +41,6 @@ from wiredtiger import stat
 #   checkpoint snapshot.
 class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
 
-    # FIXME-WT-9063 revisit the use of self.retry() throughout this file.
     # Create a table.
     uri = "table:test_checkpoint_snapshot03"
     nrows = 500000
@@ -63,9 +62,7 @@ class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
         session = self.session
         cursor = session.open_cursor(uri)
         for i in range(1, nrows + 1):
-            for retry in self.retry():
-                with retry.transaction():
-                    cursor[ds.key(i)] = value
+            cursor[ds.key(i)] = value
         cursor.close()
 
     def check(self, check_value, uri, nrows):

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -70,16 +70,13 @@ class test_hs11(wttest.WiredTigerTestCase):
             value1 = 'a' * 500
             value2 = 'b' * 500
 
-        # FIXME-WT-9063 revisit the use of self.retry() throughout this file.
-
         # Apply a series of updates from timestamps 1-4.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
         for ts in range(1, 5):
             for i in range(1, self.nrows):
-                for retry in self.retry():
-                    with retry.transaction(commit_timestamp = ts):
-                        cursor[self.create_key(i)] = value1
+                with self.transaction(commit_timestamp = ts):
+                    cursor[self.create_key(i)] = value1
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
@@ -98,27 +95,25 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Now apply an update at timestamp 10.
         for i in range(1, self.nrows):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 10):
-                    cursor[self.create_key(i)] = value2
+            with self.transaction(commit_timestamp = 10):
+                cursor[self.create_key(i)] = value2
 
         # Ensure that we blew away history store content.
         for ts in range(1, 5):
-            for retry in self.retry():
-                with retry.transaction(read_timestamp = ts, rollback = True):
-                    for i in range(1, self.nrows):
-                        if i % 2 == 0:
-                            if self.update_type == 'deletion':
-                                cursor.set_key(self.create_key(i))
-                                if self.value_format == '8t':
-                                    self.assertEqual(cursor.search(), 0)
-                                    self.assertEqual(cursor.get_value(), 0)
-                                else:
-                                    self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+            with self.transaction(read_timestamp = ts, rollback = True):
+                for i in range(1, self.nrows):
+                    if i % 2 == 0:
+                        if self.update_type == 'deletion':
+                            cursor.set_key(self.create_key(i))
+                            if self.value_format == '8t':
+                                self.assertEqual(cursor.search(), 0)
+                                self.assertEqual(cursor.get_value(), 0)
                             else:
-                                self.assertEqual(cursor[self.create_key(i)], value2)
+                                self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
                         else:
-                            self.assertEqual(cursor[self.create_key(i)], value1)
+                            self.assertEqual(cursor[self.create_key(i)], value2)
+                    else:
+                        self.assertEqual(cursor[self.create_key(i)], value1)
 
         if self.update_type == 'deletion':
             hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
@@ -141,9 +136,8 @@ class test_hs11(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri)
         for ts in range(1, 5):
             for i in range(1, self.nrows):
-                for retry in self.retry():
-                    with retry.transaction(commit_timestamp = ts):
-                        cursor[self.create_key(i)] = value1
+                with self.transaction(commit_timestamp = ts):
+                    cursor[self.create_key(i)] = value1
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
@@ -151,10 +145,9 @@ class test_hs11(wttest.WiredTigerTestCase):
         # Remove the key with timestamp 10.
         for i in range(1, self.nrows):
             if i % 2 == 0:
-                for retry in self.retry():
-                    with retry.transaction(commit_timestamp = 10):
-                        cursor.set_key(self.create_key(i))
-                        cursor.remove()
+                with self.transaction(commit_timestamp = 10):
+                    cursor.set_key(self.create_key(i))
+                    cursor.remove()
 
         # Reconcile and remove the obsolete entries.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
@@ -162,23 +155,21 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Now apply an update at timestamp 20.
         for i in range(1, self.nrows):
-                for retry in self.retry():
-                    with retry.transaction(commit_timestamp = 20):
-                        cursor[self.create_key(i)] = value2
+                with self.transaction(commit_timestamp = 20):
+                    cursor[self.create_key(i)] = value2
 
         # Ensure that we didn't select old history store content even if it is not blew away.
-        for retry in self.retry():
-            with retry.transaction(read_timestamp = 10, rollback = True):
-                for i in range(1, self.nrows):
-                    if i % 2 == 0:
-                        cursor.set_key(self.create_key(i))
-                        if self.value_format == '8t':
-                            self.assertEqual(cursor.search(), 0)
-                            self.assertEqual(cursor.get_value(), 0)
-                        else:
-                            self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        with self.transaction(read_timestamp = 10, rollback = True):
+            for i in range(1, self.nrows):
+                if i % 2 == 0:
+                    cursor.set_key(self.create_key(i))
+                    if self.value_format == '8t':
+                        self.assertEqual(cursor.search(), 0)
+                        self.assertEqual(cursor.get_value(), 0)
                     else:
-                        self.assertEqual(cursor[self.create_key(i)], value1)
+                        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+                else:
+                    self.assertEqual(cursor[self.create_key(i)], value1)
 
         hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
         self.assertEqual(hs_truncate, 0)

--- a/test/suite/test_hs14.py
+++ b/test/suite/test_hs14.py
@@ -68,57 +68,47 @@ class test_hs14(wttest.WiredTigerTestCase):
             value4 = 'd' * 500
             value5 = 'e' * 500
 
-        # FIXME-WT-9063 revisit the use of self.retry() throughout this file.
-
         for i in range(1, nrows):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 2):
-                    cursor[self.create_key(i)] = value1
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 2):
-                    cursor[self.create_key(i)] = value2
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 3):
-                    cursor[self.create_key(i)] = value3
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 4):
-                    cursor[self.create_key(i)] = value4
+            with self.transaction(commit_timestamp = 2):
+                cursor[self.create_key(i)] = value1
+            with self.transaction(commit_timestamp = 2):
+                cursor[self.create_key(i)] = value2
+            with self.transaction(commit_timestamp = 3):
+                cursor[self.create_key(i)] = value3
+            with self.transaction(commit_timestamp = 4):
+                cursor[self.create_key(i)] = value4
 
         # A checkpoint will ensure that older values are written to the history store.
         self.session.checkpoint()
 
         start = time.time()
-        for retry in self.retry():
-            with retry.transaction(read_timestamp = 3, rollback = True):
-                for i in range(1, nrows):
-                    self.assertEqual(cursor[self.create_key(i)], value3)
+        with self.transaction(read_timestamp = 3, rollback = True):
+            for i in range(1, nrows):
+                self.assertEqual(cursor[self.create_key(i)], value3)
         end = time.time()
 
         # The time spent when all history store keys are visible to us.
         visible_hs_latency = (end - start)
 
         for i in range(1, nrows):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 5):
-                    cursor.set_key(self.create_key(i))
-                    cursor.remove()
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 10):
-                    cursor[self.create_key(i)] = value5
+            with self.transaction(commit_timestamp = 5):
+                cursor.set_key(self.create_key(i))
+                cursor.remove()
+            with self.transaction(commit_timestamp = 10):
+                cursor[self.create_key(i)] = value5
 
         # A checkpoint will ensure that older values are written to the history store.
         self.session.checkpoint()
 
         start = time.time()
-        for retry in self.retry():
-            with retry.transaction(read_timestamp = 9, rollback = True):
-                for i in range(1, nrows):
-                    cursor.set_key(self.create_key(i))
-                    if self.value_format == '8t':
-                        self.assertEqual(cursor.search(), 0)
-                        self.assertEqual(cursor.get_value(), 0)
-                    else:
-                        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        with self.transaction(read_timestamp = 9, rollback = True):
+            for i in range(1, nrows):
+                cursor.set_key(self.create_key(i))
+                if self.value_format == '8t':
+                    self.assertEqual(cursor.search(), 0)
+                    self.assertEqual(cursor.get_value(), 0)
+                else:
+                    self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
         end = time.time()
 
         # The time spent when all history store keys are invisible to us.

--- a/test/suite/test_hs20.py
+++ b/test/suite/test_hs20.py
@@ -60,46 +60,38 @@ class test_hs20(wttest.WiredTigerTestCase):
         value1 = 'a' * 500
         value2 = 'b' * 50
 
-        # FIXME-WT-9063 revisit the use of self.retry() throughout this file.
-
         # Insert a value that is larger than the maximum leaf value.
         for i in range(0, 10):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 2):
-                    cursor[self.make_key(i)] = value1
+            with self.transaction(commit_timestamp = 2):
+                cursor[self.make_key(i)] = value1
 
         # Do 2 modifies.
         for i in range(0, 10):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 3):
-                    cursor.set_key(self.make_key(i))
-                    mods = [wiredtiger.Modify('B', 500, 1)]
-                    self.assertEqual(cursor.modify(mods), 0)
+            with self.transaction(commit_timestamp = 3):
+                cursor.set_key(self.make_key(i))
+                mods = [wiredtiger.Modify('B', 500, 1)]
+                self.assertEqual(cursor.modify(mods), 0)
 
         for i in range(0, 10):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 4):
-                    cursor.set_key(self.make_key(i))
-                    mods = [wiredtiger.Modify('C', 501, 1)]
-                    self.assertEqual(cursor.modify(mods), 0)
+            with self.transaction(commit_timestamp = 4):
+                cursor.set_key(self.make_key(i))
+                mods = [wiredtiger.Modify('C', 501, 1)]
+                self.assertEqual(cursor.modify(mods), 0)
 
         # Insert more data to trigger eviction.
         for i in range(10, 100000):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 5):
-                    cursor[self.make_key(i)] = value2
+            with self.transaction(commit_timestamp = 5):
+                cursor[self.make_key(i)] = value2
 
         # Update the overflow values.
         for i in range(0, 10):
-            for retry in self.retry():
-                with retry.transaction(commit_timestamp = 5):
-                    cursor[self.make_key(i)] = value2
+            with self.transaction(commit_timestamp = 5):
+                cursor[self.make_key(i)] = value2
 
         # Do a checkpoint to move the overflow values to the history store but keep the current in memory disk image.
         self.session.checkpoint()
 
         # Search the first modifies.
         for i in range(0, 10):
-            for retry in self.retry():
-                with retry.transaction(read_timestamp = 3, rollback = True):
-                    self.assertEqual(cursor[self.make_key(i)], value1 + "B")
+            with self.transaction(read_timestamp = 3, rollback = True):
+                self.assertEqual(cursor[self.make_key(i)], value1 + "B")


### PR DESCRIPTION
* When a rollback error occurs, retry the entire test case.  If too
  may retries on a particular test case, or in the entire suite happens,
  raise an error.
* Add a test hook to inject rollback errors to verify the retry logic.
* Removed WiredTigerTestCase.retry() function, it is no longer needed.
  Adjust callers accordingly.
A similar change was tried before, and was reverted due to errors when
running tests in parallel.  This change overrides Python test case
execution in a cleaner way that avoids pitfalls of the previous approach.