### PR TITLE
WT-9137 Implement the CppSuite range bounded cursor stress test

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -240,6 +240,7 @@ methods = {
     'burst_inserts' : Method(test_config + [
                         Config("burst_duration", 90, r'''
                             How long the insertions will occur for.''')]),
+    'cursor_bound_01' : Method(test_config),
     'hs_cleanup' : Method(test_config),
     'operations_test' : Method(test_config),
     'search_near_01' : Method(test_config + [
@@ -248,5 +249,4 @@ methods = {
     'search_near_02' : Method(test_config),
     'search_near_03' : Method(test_config),
     'test_template' : Method(test_config),
-    'cursor_bound_01' : Method(test_config),
 }

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -240,9 +240,7 @@ methods = {
     'burst_inserts' : Method(test_config + [
                         Config("burst_duration", 90, r'''
                             How long the insertions will occur for.''')]),
-    'cursor_bound_01' : Method(test_config + [
-                        Config("count_reverse_tables", 0, r'''
-                            Number of tables that configure with the reverse collator.''')]),
+    'cursor_bound_01' : Method(test_config),
     'hs_cleanup' : Method(test_config),
     'operations_test' : Method(test_config),
     'search_near_01' : Method(test_config + [

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -248,4 +248,5 @@ methods = {
     'search_near_02' : Method(test_config),
     'search_near_03' : Method(test_config),
     'test_template' : Method(test_config),
+    'cursor_bound_01' : Method(test_config),
 }

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -240,7 +240,9 @@ methods = {
     'burst_inserts' : Method(test_config + [
                         Config("burst_duration", 90, r'''
                             How long the insertions will occur for.''')]),
-    'cursor_bound_01' : Method(test_config),
+    'cursor_bound_01' : Method(test_config + [
+                        Config("count_reverse_tables", 0, r'''
+                            Number of tables that configure with the reverse collator.''')]),
     'hs_cleanup' : Method(test_config),
     'operations_test' : Method(test_config),
     'search_near_01' : Method(test_config + [

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -119,7 +119,6 @@ static const WT_CONFIG_CHECK confchk_cursor_bound_01[] = {
   {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
   {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
-  {"count_reverse_tables", "string", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
   {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
@@ -245,8 +244,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     confchk_burst_inserts, 12},
   {"cursor_bound_01",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
-    "compression_enabled=false,count_reverse_tables=,"
-    "duration_seconds=0,enable_logging=false,reverse_collator=false,"
+    "compression_enabled=false,duration_seconds=0,"
+    "enable_logging=false,reverse_collator=false,"
     "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -268,7 +267,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_cursor_bound_01, 12},
+    confchk_cursor_bound_01, 11},
   {"hs_cleanup",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -119,6 +119,7 @@ static const WT_CONFIG_CHECK confchk_cursor_bound_01[] = {
   {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
   {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
+  {"count_reverse_tables", "string", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
   {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
@@ -244,8 +245,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     confchk_burst_inserts, 12},
   {"cursor_bound_01",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
-    "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,reverse_collator=false,"
+    "compression_enabled=false,count_reverse_tables=,"
+    "duration_seconds=0,enable_logging=false,reverse_collator=false,"
     "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -267,7 +268,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_cursor_bound_01, 11},
+    confchk_cursor_bound_01, 12},
   {"hs_cleanup",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -115,6 +115,20 @@ static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
   {"workload_tracking", "category", NULL, NULL, confchk_workload_tracking_subconfigs, 4},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
+static const WT_CONFIG_CHECK confchk_cursor_bound_01[] = {
+  {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
+  {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
+  {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
+  {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
+  {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
+  {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
+  {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
+  {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
+  {"workload_generator", "category", NULL, NULL, confchk_workload_generator_subconfigs, 8},
+  {"workload_tracking", "category", NULL, NULL, confchk_workload_tracking_subconfigs, 4},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
+
 static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"cache_size_mb", "int", NULL, "min=0,max=100000000000", NULL, 0},
   {"checkpoint_manager", "category", NULL, NULL, confchk_checkpoint_manager_subconfigs, 2},
@@ -228,6 +242,32 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
     confchk_burst_inserts, 12},
+  {"cursor_bound_01",
+    "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
+    "compression_enabled=false,duration_seconds=0,"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
+    "statistics_config=(enable_logging=true,type=all),"
+    "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
+    "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
+    "op_rate=1s,ops_per_transaction=(max=1,min=0),thread_count=0,"
+    "value_size=5),enabled=true,insert_config=(key_size=5,op_rate=1s,"
+    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
+    "op_rate=1s,populate_config=(collection_count=1,"
+    "key_count_per_collection=0,key_size=5,thread_count=1,"
+    "value_size=5),read_config=(key_size=5,op_rate=1s,"
+    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
+    "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
+    "thread_count=0),update_config=(key_size=5,op_rate=1s,"
+    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
+    "workload_tracking=(enabled=true,op_rate=1s,"
+    "tracking_key_format=QSQ,tracking_value_format=iS)",
+    confchk_cursor_bound_01, 11},
   {"hs_cleanup",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"

--- a/test/cppsuite/configs/cursor_bound_01_default.txt
+++ b/test/cppsuite/configs/cursor_bound_01_default.txt
@@ -1,4 +1,47 @@
-# Configuration for cursor_bound_01.
-# need to be defined.
-duration_seconds=5,
-cache_size_mb=250
+# Configuration for cursor_bound_01 default test.
+# The configuration creates:
+# - threads that continuously insert random keys and values.
+# - threads that continuously perform prefix search_near calls on random keys.
+duration_seconds=60,
+cache_size_mb=500,
+timestamp_manager=
+(
+    # This will let us randomly pick a read timestamp in a bigger range to trigger visibility
+    # checks.
+    oldest_lag=50,
+),
+workload_generator=
+(
+    populate_config=
+    (
+        collection_count=10,
+        thread_count=10,
+    ),
+    insert_config=
+    (
+        key_size=10,
+        op_rate=10ms,
+        thread_count=5,
+        value_size=20
+    ),
+    read_config=
+    (
+        op_rate=3ms,
+        thread_count=10
+    ),
+    remove_config=
+    (
+        op_rate=500ms,
+        thread_count=1
+    ),
+    update_config=
+    (
+        op_rate=15ms,
+        thread_count=10,
+        value_size=20
+    ),
+    custom_config=
+    (
+        thread_count=1
+    )
+),

--- a/test/cppsuite/configs/cursor_bound_01_default.txt
+++ b/test/cppsuite/configs/cursor_bound_01_default.txt
@@ -2,8 +2,9 @@
 # The configuration creates:
 # - threads that continuously insert random keys and values.
 # - threads that continuously perform prefix search_near calls on random keys.
-duration_seconds=60,
+duration_seconds=600,
 cache_size_mb=500,
+count_reverse_tables=5,
 timestamp_manager=
 (
     # This will let us randomly pick a read timestamp in a bigger range to trigger visibility
@@ -43,6 +44,6 @@ workload_generator=
     ),
     custom_config=
     (
-        thread_count=1
+        thread_count=5
     )
 ),

--- a/test/cppsuite/configs/cursor_bound_01_default.txt
+++ b/test/cppsuite/configs/cursor_bound_01_default.txt
@@ -4,7 +4,7 @@
 # - threads that continuously perform prefix search_near calls on random keys.
 duration_seconds=600,
 cache_size_mb=500,
-count_reverse_tables=5,
+reverse_collator=true,
 timestamp_manager=
 (
     # This will let us randomly pick a read timestamp in a bigger range to trigger visibility

--- a/test/cppsuite/configs/cursor_bound_01_default.txt
+++ b/test/cppsuite/configs/cursor_bound_01_default.txt
@@ -15,7 +15,8 @@ workload_generator=
     populate_config=
     (
         collection_count=10,
-        thread_count=10,
+        key_count_per_collection=0,
+        thread_count=0,
     ),
     insert_config=
     (

--- a/test/cppsuite/configs/cursor_bound_01_default.txt
+++ b/test/cppsuite/configs/cursor_bound_01_default.txt
@@ -1,0 +1,4 @@
+# Configuration for cursor_bound_01.
+# need to be defined.
+duration_seconds=5,
+cache_size_mb=250

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -33,6 +33,7 @@
 #include "connection_manager.h"
 #include "core/configuration.h"
 #include "timestamp_manager.h"
+#include "workload/random_generator.h"
 #include "util/api_const.h"
 #include "workload/random_generator.h"
 
@@ -125,6 +126,16 @@ timestamp_manager::get_next_ts()
     uint64_t increment = _increment_ts.fetch_add(1);
     current_time |= (increment & 0x00000000FFFFFFFF);
     return (current_time);
+}
+
+wt_timestamp_t
+timestamp_manager::get_random_ts()
+{
+    wt_timestamp_t ts = random_generator::instance().generate_integer(
+      (_oldest_ts >> 32), (this->get_next_ts() >> 32));
+    /* Put back the timestamp in the correct format. */
+    ts <<= 32;
+    return (ts);
 }
 
 wt_timestamp_t

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -131,11 +131,7 @@ timestamp_manager::get_next_ts()
 wt_timestamp_t
 timestamp_manager::get_random_ts()
 {
-    wt_timestamp_t ts = random_generator::instance().generate_integer(
-      (_oldest_ts >> 32), (this->get_next_ts() >> 32));
-    /* Put back the timestamp in the correct format. */
-    ts <<= 32;
-    return (ts);
+    return random_generator::instance().generate_integer(static_cast<uint64_t>(_oldest_ts), get_time_now_s());
 }
 
 wt_timestamp_t

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -131,7 +131,8 @@ timestamp_manager::get_next_ts()
 wt_timestamp_t
 timestamp_manager::get_random_ts()
 {
-    return random_generator::instance().generate_integer(static_cast<uint64_t>(_oldest_ts), get_time_now_s());
+    return random_generator::instance().generate_integer(
+      static_cast<uint64_t>(_oldest_ts), get_time_now_s());
 }
 
 wt_timestamp_t

--- a/test/cppsuite/test_harness/timestamp_manager.h
+++ b/test/cppsuite/test_harness/timestamp_manager.h
@@ -59,6 +59,12 @@ class timestamp_manager : public component {
     /* Get a unique timestamp. */
     wt_timestamp_t get_next_ts();
 
+    /*
+     * Get a random timestamp between the oldest and now. Get rid of the last 32 bits as they
+     * represent an increment for uniqueness.
+     */
+    wt_timestamp_t get_random_ts();
+
     /* Get oldest timestamp. */
     wt_timestamp_t get_oldest_ts() const;
 

--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -83,7 +83,7 @@ database_operation::populate(
     key_count = config->get_int(KEY_COUNT_PER_COLLECTION);
     value_size = config->get_int(VALUE_SIZE);
     thread_count = config->get_int(THREAD_COUNT);
-    testutil_assert(collection_count % thread_count == 0);
+    testutil_assert(thread_count == 0 || collection_count % thread_count == 0);
     testutil_assert(value_size > 0);
     key_size = config->get_int(KEY_SIZE);
     testutil_assert(key_size > 0);

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -1,0 +1,274 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test_harness/test.h"
+#include "test_harness/util/api_const.h"
+#include "test_harness/workload/random_generator.h"
+
+using namespace test_harness;
+
+/*
+ * In this test, we want to verify the usage of the cursor bound API and check that the cursor
+ * returns the correct key when bounds are set.
+ * During the test duration:
+ *  - M threads will keep inserting new random keys
+ *  - N threads will execute search_near calls with random bounds set. Each search_near
+ * call with bounds set is verified against the default search_near.
+ *  - O threads will continously remove random keys
+ *  - P threads will continously update random keys
+ *  - Q threads will utilise the custom operation and will execute next() or prev() calls with bounds set using random bounds. Each next() 
+ * or prev() with bounds set is verified against the default cursor next() and prev() calls. 
+ */
+
+namespace test_harness {
+
+class cursor_bound_01 : public test_harness::test {
+    const uint64_t MAX_ROLLBACKS = 100;
+    /* Helper struct which stores a pointer to a collection and a cursor associated with it. */
+    struct collection_cursor {
+        collection &coll;
+        scoped_cursor cursor;
+
+        collection_cursor(collection &coll, scoped_cursor &&cursor)
+            : coll(coll), cursor(std::move(cursor))
+        {
+        }
+    };
+
+    public:
+    cursor_bound_01(const test_harness::test_args &args) : test(args) {}
+    
+
+    void
+    populate(test_harness::database &database, test_harness::timestamp_manager *,
+      test_harness::configuration *config, test_harness::workload_tracking *) override final
+    {
+        /*
+         * The populate phase only creates empty collections. The number of collections is defined
+         * in the configuration.
+         */
+        int64_t collection_count = config->get_int(COLLECTION_COUNT);
+
+        logger::log_msg(
+          LOG_INFO, "Populate: " + std::to_string(collection_count) + " creating collections.");
+
+        for (uint64_t i = 0; i < collection_count; ++i)
+            database.add_collection();
+
+        logger::log_msg(LOG_INFO, "Populate: finished.");
+    }
+
+    void
+    insert_operation(test_harness::thread_context *tc) override final
+    {
+        /* Each insert operation will insert new keys in the collections. */
+        logger::log_msg(
+          LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
+
+        /* Collection cursor vector. */
+        std::vector<collection_cursor> ccv;
+        int64_t collection_count = tc->db.get_collection_count();
+        int64_t collections_per_thread = collection_count / tc->thread_count;
+
+        /* Must have unique collections for each thread. */
+        testutil_assert(collection_count % tc->thread_count == 0);
+        const uint64_t thread_offset = tc->id * collections_per_thread;
+        for (uint64_t i = thread_offset;
+             i < thread_offset + collections_per_thread && tc->running(); ++i) {
+            collection &coll = tc->db.get_collection(i);
+            scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
+            ccv.push_back({coll, std::move(cursor)});
+        }
+
+        std::string key;
+        uint64_t counter = 0;
+        uint32_t rollback_retries = 0;
+        while (tc->running()) {
+
+            auto &cc = ccv[counter];
+            tc->transaction.begin();
+
+            while (tc->transaction.active() && tc->running()) {
+
+                /* Generate a random key. */
+                key = random_generator::instance().generate_random_string(tc->key_size);
+
+                /* Insert a key value pair. */
+                if (tc->insert(cc.cursor, cc.coll.id, key)) {
+                    if (tc->transaction.can_commit()) {
+                        /* We are not checking the result of commit as it is not necessary. */
+                        if (tc->transaction.commit())
+                            rollback_retries = 0;
+                        else
+                            ++rollback_retries;
+                    }
+                } else {
+                    tc->transaction.rollback();
+                    ++rollback_retries;
+                }
+                testutil_assert(rollback_retries < MAX_ROLLBACKS);
+
+                /* Sleep the duration defined by the configuration. */
+                tc->sleep();
+            }
+
+            /* Rollback any transaction that could not commit before the end of the test. */
+            if (tc->transaction.active())
+                tc->transaction.rollback();
+
+            /* Reset our cursor to avoid pinning content. */
+            testutil_check(cc.cursor->reset(cc.cursor.get()));
+            if (++counter == ccv.size())
+                counter = 0;
+            testutil_assert(counter < collections_per_thread);
+        }
+    }
+
+    void run_operation(test_harness::thread_context *tc, std::vector<collection_cursor> &ccv,  
+        int64_t collections_per_thread, bool (test_harness::thread_context::*op_func)(scoped_cursor &,uint64_t, const std::string &)) {
+        std::string random_key;
+        uint64_t counter = 0;
+        uint32_t rollback_retries = 0;
+        while (tc->running()) {
+
+            auto &cc = ccv[counter];
+            tc->transaction.begin();
+
+            while (tc->transaction.active() && tc->running()) {
+
+                /* Generate a random key. */
+                random_key = random_generator::instance().generate_random_string(tc->key_size);
+
+                /* Call search near to position cursor. */
+                int exact;
+                cc.cursor->set_key(cc.cursor.get(), random_key);
+                int ret = cc.cursor->search_near(cc.cursor.get(), &exact);
+                if (ret == WT_NOTFOUND)
+                    continue;
+
+                /* Retrieve the key the cursor is pointing at. */
+                const char *key;
+                testutil_check(cc.cursor->get_key(cc.cursor.get(), &key));
+
+                /* Perform remove on the key */
+                if ((tc->*op_func)(cc.cursor, cc.coll.id, key)) {
+                    if (tc->transaction.can_commit()) {
+                        /* We are not checking the result of commit as it is not necessary. */
+                        if (tc->transaction.commit())
+                            rollback_retries = 0;
+                        else
+                            ++rollback_retries;
+                    }
+                } else {
+                    tc->transaction.rollback();
+                    ++rollback_retries;
+                }
+                testutil_assert(rollback_retries < MAX_ROLLBACKS);
+
+                /* Sleep the duration defined by the configuration. */
+                tc->sleep();
+            }
+
+            /* Rollback any transaction that could not commit before the end of the test. */
+            if (tc->transaction.active())
+                tc->transaction.rollback();
+
+            /* Reset our cursor to avoid pinning content. */
+            testutil_check(cc.cursor->reset(cc.cursor.get()));
+            if (++counter == ccv.size())
+                counter = 0;
+            testutil_assert(counter < collections_per_thread);
+        }
+    }
+
+    void
+    remove_operation(test_harness::thread_context *tc) override final
+    {
+        /* Each remove operation will remove existing keys in the collections. */
+        logger::log_msg(
+          LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
+
+        /* Collection cursor vector. */
+        std::vector<collection_cursor> ccv;
+        int64_t collection_count = tc->db.get_collection_count();
+        int64_t collections_per_thread = collection_count / tc->thread_count;
+
+        /* Must have unique collections for each thread. */
+        testutil_assert(collection_count % tc->thread_count == 0);
+        const uint64_t thread_offset = tc->id * collections_per_thread;
+        for (uint64_t i = thread_offset;
+             i < thread_offset + collections_per_thread && tc->running(); ++i) {
+            collection &coll = tc->db.get_collection(i);
+            scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
+            ccv.push_back({coll, std::move(cursor)});
+        }
+
+        run_operation(tc, ccv, collections_per_thread, &test_harness::thread_context::remove);
+     }
+
+    void
+    update_operation(test_harness::thread_context *tc) override final
+    {
+        /* Each update operation will update existing keys in the collections. */
+        logger::log_msg(
+          LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
+
+        /* Collection cursor vector. */
+        std::vector<collection_cursor> ccv;
+        int64_t collection_count = tc->db.get_collection_count();
+        int64_t collections_per_thread = collection_count / tc->thread_count;
+
+        /* Must have unique collections for each thread. */
+        testutil_assert(collection_count % tc->thread_count == 0);
+        const uint64_t thread_offset = tc->id * collections_per_thread;
+        for (uint64_t i = thread_offset;
+             i < thread_offset + collections_per_thread && tc->running(); ++i) {
+            collection &coll = tc->db.get_collection(i);
+            scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
+            ccv.push_back({coll, std::move(cursor)});
+        }
+
+        run_operation(tc, ccv, collections_per_thread, &test_harness::thread_context::update);
+    }
+
+
+    void
+    read_operation(test_harness::thread_context *) override final
+    {
+        std::cout << "read_operation: nothing done." << std::endl;
+    }
+
+    void
+    custom_operation(test_harness::thread_context *) override final
+    {
+        std::cout << "custom_operation: nothing done." << std::endl;
+    }
+
+};
+
+} // namespace test_harness

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -36,14 +36,16 @@ using namespace test_harness;
  * In this test, we want to verify the usage of the cursor bound API and check that the cursor
  * returns the correct key when bounds are set.
  * During the test duration:
- *  - M threads will keep inserting new random keys
+ *  - M threads will keep inserting new random keys.
  *  - N threads will execute search_near calls with random bounds set. Each search_near
  * call with bounds set is verified against the default search_near.
- *  - O threads will continously remove random keys
- *  - P threads will continously update random keys
+ *  - O threads will continously remove random keys.
+ *  - P threads will continously update random keys.
  *  - Q threads will utilise the custom operation and will execute next() or prev() calls with
  * bounds set using random bounds. Each next() or prev() with bounds set is verified against the
  * default cursor next() and prev() calls.
+ * 
+ * TODO: add support for reverse collator. 
  */
 namespace test_harness {
 
@@ -118,6 +120,11 @@ class cursor_bound_01 : public test_harness::test {
         }
     }
 
+    /* 
+     * Use the random generator either set no bounds, only lower bounds, only upper bounds or both
+     * bounds on the range cursor. The lower and upper bounds are randomly generated strings as well.
+     * The inclusive configuration is also randomly set as well.
+     */
     std::pair<std::string, std::string> set_random_bounds(test_harness::thread_context *tc, scoped_cursor &range_cursor) {
         int set_random_bounds;
         int64_t key_size;
@@ -125,55 +132,187 @@ class cursor_bound_01 : public test_harness::test {
 
 
         set_random_bounds = random_generator::instance().generate_integer(0, 3);
-        /*
-         * Generate a random prefix. For this, we start by generating a random size and then
-         * its value.
-         */
         if (set_random_bounds == LOWER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
             key_size = random_generator::instance().generate_integer(
                 static_cast<int64_t>(1), tc->key_size);
-            lower_key = random_generator::instance().generate_random_string(
-                key_size, characters_type::ALPHABET);
+            (void) key_size;
+            // lower_key = random_generator::instance().generate_random_string(
+            //     key_size, characters_type::ALPHABET);
+            lower_key = std::string("0");
         }
 
         if (set_random_bounds == UPPER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
             key_size = random_generator::instance().generate_integer(
                 static_cast<int64_t>(1), tc->key_size);
-            upper_key = random_generator::instance().generate_random_string(
-                key_size, characters_type::ALPHABET);
+            (void) key_size;
+            // upper_key = random_generator::instance().generate_random_string(
+            //     key_size, characters_type::ALPHABET);
+            upper_key = std::string(tc->key_size, 'z');
         }
-        /* Perform validation here. */
+
+        /* TODO: Check that upper bound should be greater than lower key bound. */
         //range_cursor->bound(range_cursor.get(), key.c_str());
         return std::make_pair(lower_key, upper_key);
     }
 
-    /* Validate prefix search_near call outputs using a cursor without prefix key enabled. */
+    /* Validate bound search_near call outputs using a cursor without bounds set. */
     void
-    validate_bound_search_near(int ret_prefix, scoped_cursor &range_cursor, scoped_cursor &normal_cursor, const std::string &search_key, const std::string &lower_key, const std::string &upper_key)
+    validate_bound_search_near(int range_ret, int range_exact, scoped_cursor &range_cursor,
+        scoped_cursor &normal_cursor, const std::string &search_key, const std::string &lower_key, const std::string &upper_key)
     {
         /* Call search near with the default cursor using the given prefix. */
-        int exact_default;
-
-        
+        int normal_exact;
         normal_cursor->set_key(normal_cursor.get(), search_key.c_str());
-        int ret_default = normal_cursor->search_near(normal_cursor.get(), &exact_default);
+        int normal_ret = normal_cursor->search_near(normal_cursor.get(), &normal_exact);
 
         /*
          * It is not possible to have a prefix search near call successful and the default search
          * near call unsuccessful.
          */
         testutil_assert(
-          ret_default == ret_prefix || (ret_default == 0 && ret_prefix == WT_NOTFOUND));
+          normal_ret == range_ret || (normal_ret == 0 && range_ret == WT_NOTFOUND));
 
         /* We only have to perform validation when the default search near call is successful. */
-        if (ret_default == 0) {
-            /* Both calls are successful. */
-            // if (ret_prefix == 0)
-            //     validate_successful_calls(
-            //       ret_prefix, exact_prefix, key_prefix, normal_cursor, exact_default, prefix);
-            // /* The prefix search near call failed. */
-            // else
-            //     validate_unsuccessful_prefix_call(normal_cursor, prefix, exact_default);
+        if (normal_ret == WT_NOTFOUND)
+            return;
+
+        /* If there are no bounds set, the return value of the range cursor needs to match the normal cursor. */
+        if ((lower_key.length() == 0 && upper_key.length() == 0))
+            testutil_assert(range_ret == normal_ret);
+
+        /* Both calls are successful. */
+        if (range_ret == 0)
+            validate_successful_search_near_calls(
+                normal_cursor, range_cursor, normal_exact, range_exact, search_key, lower_key, upper_key);
+        /* The prefix search near call failed. */
+        else
+            validate_unsuccessful_search_near_call(normal_cursor, lower_key, upper_key);
+    }
+
+    /*
+     * If both cursor has returned a valid key, there are two scenarios that need to be validated
+     * differently:
+     *  Scenario 1: normal cursor is positioned outside of the bounded range, then the range cursor
+     * must be at the either at the first or last key of the bounded key range. Therefore we validate
+     * this behaviour through using the normal cursor to traverse until the first or last key, and
+     * then check that the keys are the same.
+     *  Scenario 2: normal cursor is positioned inside the bounded range. In this case we check the
+     * exact values of both the cursors. If the exact values are equal or zero, then check if the
+     * keys match. Align the normal cursor to the match the same as the range cursor, and further
+     * check if the keys match.
+     */
+    void
+    validate_successful_search_near_calls(scoped_cursor &normal_cursor, scoped_cursor &range_cursor, int normal_exact, int range_exact ,const std::string &search_key, const std::string &lower_key, const std::string &upper_key)
+    {
+        int ret = 0;
+        bool above_lower_key, below_upper_key, start_upper;
+
+        /* Retrieve the key the default cursor is pointing at. */
+        const char *key_default, *key_range;
+        testutil_check(normal_cursor->get_key(normal_cursor.get(), &key_default));
+        std::string key_default_str = key_default;
+
+        testutil_check(range_cursor->get_key(range_cursor.get(), &key_range));
+        std::string key_range_str = key_range;
+
+        logger::log_msg(LOG_TRACE,
+          "search_near (normal) exact " + std::to_string(normal_exact) + " key " + key_default);
+        logger::log_msg(LOG_TRACE,
+          "search_near (bound) exact " + std::to_string(range_exact) + " key " + key_range);
+
+        /* Assert that the range cursor has returned a key inside the bounded range. */
+        above_lower_key = lower_key.length() == 0 || std::lexicographical_compare(lower_key.begin(), lower_key.end(), key_range_str.begin(), key_range_str.end());
+        below_upper_key = upper_key.length() == 0 || std::lexicographical_compare(key_range_str.begin(), key_range_str.end(), upper_key.begin(), upper_key.end());
+        testutil_assert(above_lower_key && below_upper_key);
+
+        /* Check whether the normal cursor has returned a key inside or outside the range. */
+        above_lower_key = lower_key.length() == 0 || std::lexicographical_compare(lower_key.begin(), lower_key.end(), key_default_str.begin(), key_default_str.end());
+        below_upper_key = upper_key.length() == 0 || std::lexicographical_compare(key_default_str.begin(), key_default_str.end(), upper_key.begin(), upper_key.end());
+        /* 
+         * Scenario: Normal cursor positioned outside bounded key range. Traverse until we find the
+         * first or last key of the bounded range.
+         */
+        if (!(above_lower_key && below_upper_key)) {
+            start_upper = above_lower_key;
+            /* Traverse backwards or forwards depending on where the normal cursor was positioned. */
+            while (true) {
+                ret = start_upper ? ret = normal_cursor->prev(normal_cursor.get()) : normal_cursor->next(normal_cursor.get());
+                if (ret == WT_NOTFOUND)
+                    break;
+                testutil_assert(ret == 0);
+
+                testutil_check(normal_cursor->get_key(normal_cursor.get(), &key_default));
+                key_default_str = key_default;
+                
+                above_lower_key = lower_key.length() == 0 || std::lexicographical_compare(lower_key.begin(), lower_key.end(), key_default_str.begin(), key_default_str.end());
+                below_upper_key = upper_key.length() == 0 || std::lexicographical_compare(key_default_str.begin(), key_default_str.end(), upper_key.begin(), upper_key.end());
+                /* Assert that the keys should match the first time we find a key within the bounded range. */
+                if ((!start_upper && above_lower_key) || (start_upper && below_upper_key)) {
+                    testutil_assert(strcmp(key_default, key_range) == 0);
+                    break;
+                }
+            }
+        /* 
+         * Scenario: Normal cursor positioned inside the bounded key range. Check exact values and
+         * align the default cursor with the range cursor if needed.
+         */
+        } else if (above_lower_key && below_upper_key) {
+            if (normal_exact == 0 && range_exact == 0)
+                /* Check that the keys match. */
+                testutil_assert(strcmp(key_default, key_range) == 0);           
+            else { 
+                testutil_assert(range_exact != 0 && normal_exact != 0);
+                /* Perform cursor position alignment. */
+                if (normal_exact > 0 && range_exact < 0)
+                    ret = normal_cursor->prev(normal_cursor.get());
+                if (normal_exact < 0 && range_exact > 0)
+                    ret = normal_cursor->next(normal_cursor.get());
+                testutil_assert(ret == 0);
+
+                /* Check that the keys match. */
+                testutil_check(normal_cursor->get_key(normal_cursor.get(), &key_default));
+                key_default_str = key_default;
+                testutil_assert(strcmp(key_default, key_range) == 0);  
+            }
+        }
+    }
+
+    /*
+     * Validate that the normal cursor is positioned at a key that is outside of the bounded range,
+     * and that no visible keys exist in the bounded range. 
+     */
+    void
+    validate_unsuccessful_search_near_call(scoped_cursor &normal_cursor, const std::string &lower_key, const std::string &upper_key)
+    {
+        int ret;
+        bool above_lower_key, below_upper_key;
+
+        /* Retrieve the key at the default cursor. */
+        const char *key_default;
+        testutil_check(normal_cursor->get_key(normal_cursor.get(), &key_default));
+        std::string key_default_str = key_default;
+
+        /* Check if the normal cursor's key is below the range or above the range bound. */
+        bool start_upper = lower_key.length() == 0 || std::lexicographical_compare(lower_key.begin(), lower_key.end(), key_default_str.begin(), key_default_str.end());
+
+        /* Here we validate that there are no keys in the bounded range that the range cursor could have returned. */
+        while (true) {
+            /* Traverse backwards or forwards depending on where the normal cursor is positioned. */
+            ret = start_upper ? normal_cursor->prev(normal_cursor.get()) : normal_cursor->next(normal_cursor.get());
+            if (ret == WT_NOTFOUND)
+                break;
+            testutil_assert(ret == 0);
+
+            testutil_check(normal_cursor->get_key(normal_cursor.get(), &key_default));
+            key_default_str = key_default;
+            /* Asserted that the traveresed key is not within the range bound. */
+            above_lower_key = lower_key.length() == 0 || std::lexicographical_compare(lower_key.begin(), lower_key.end(), key_default_str.begin(), key_default_str.end());
+            below_upper_key = upper_key.length() == 0 || std::lexicographical_compare(key_default_str.begin(), key_default_str.end(), upper_key.begin(), upper_key.end());
+            testutil_assert(!(above_lower_key && below_upper_key));
+            
+            /* Optimisation to early exit, if we have traversed past all possible records in the range bound. */
+            if ((!start_upper && !below_upper_key) || (start_upper && !above_lower_key))
+                break;
         }
     }
 
@@ -217,7 +356,7 @@ class cursor_bound_01 : public test_harness::test {
                 /* Generate a random key. */
                 key = random_generator::instance().generate_random_string(tc->key_size);
 
-                /* Insert a key value pair. */
+                /* Insert a key/value pair. */
                 if (tc->insert(cursor, coll.id, key)) {
                     if (tc->transaction.can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
@@ -268,7 +407,11 @@ class cursor_bound_01 : public test_harness::test {
     void
     read_operation(test_harness::thread_context *tc) override final
     {
-        /* Each read operation will read and validate existing keys in the collections. */
+        /*
+         * Each read operation will perform search nears with a range bounded cursor and a normal
+         * cursor without any bounds set. The normal cursor will be used to validate the results
+         * from the range cursor. validate existing keys in the collections.
+         */
         logger::log_msg(
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
@@ -284,6 +427,7 @@ class cursor_bound_01 : public test_harness::test {
             if (cursors.find(coll.id) == cursors.end())
                 cursors.emplace(coll.id, std::move(tc->session.open_scoped_cursor(coll.name)));
 
+            /* Set random bounds on cached range cursor. */
             auto &range_cursor = cursors[coll.id];
             //range_cursor->bounds("action=clear");
             auto bound_pair = set_random_bounds(tc, range_cursor);
@@ -291,7 +435,6 @@ class cursor_bound_01 : public test_harness::test {
             upper_key = bound_pair.second;
 
             scoped_cursor normal_cursor = tc->session.open_scoped_cursor(coll.name);
-
             /*
              * Pick a random timestamp between the oldest and now. Get rid of the last 32 bits as
              * they represent an increment for uniqueness.
@@ -309,6 +452,7 @@ class cursor_bound_01 : public test_harness::test {
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
 
             while (tc->transaction.active() && tc->running()) {
+                /* Generate a random string. */
                 key_size = random_generator::instance().generate_integer(
                   static_cast<int64_t>(1), tc->key_size);
                 srch_key = random_generator::instance().generate_random_string(
@@ -319,16 +463,13 @@ class cursor_bound_01 : public test_harness::test {
                 ret = range_cursor->search_near(range_cursor.get(), &exact);
                 testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
-                /* Verify the prefix search_near output using the default cursor. */
-                validate_bound_search_near(ret, range_cursor, normal_cursor, srch_key, lower_key, upper_key);
+                /* Verify the bound search_near result using the normal cursor. */
+                validate_bound_search_near(ret, exact, range_cursor, normal_cursor, srch_key, lower_key, upper_key);
 
                 tc->transaction.add_op();
                 tc->transaction.try_rollback();
                 tc->sleep();
             }
-            /* Each read operation will update existing keys in the collections. */
-            logger::log_msg(
-                LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} succeeded one op.");
             testutil_check(range_cursor->reset(range_cursor.get()));
         }
         /* Roll back the last transaction if still active now the work is finished. */
@@ -339,14 +480,17 @@ class cursor_bound_01 : public test_harness::test {
     void
     custom_operation(test_harness::thread_context *tc) override final
     {
-        /* Each read operation will update existing keys in the collections. */
+        /* 
+         * Each custom operation will use the range bounded cursor to traverse through existing keys
+         * in the collection. The records will be validated against with the normal cursor to check
+         * for any potential missing records.
+         */
         logger::log_msg(
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
         int normal_ret, range_ret;
         std::map<uint64_t, scoped_cursor> cursors;
         std::string lower_key, upper_key;
-
         while (tc->running()) {
             /* Get a random collection to work on. */
             collection &coll = tc->db.get_random_collection();
@@ -355,6 +499,7 @@ class cursor_bound_01 : public test_harness::test {
             if (cursors.find(coll.id) == cursors.end())
                 cursors.emplace(coll.id, std::move(tc->session.open_scoped_cursor(coll.name)));
 
+            /* Set random bounds on cached range cursor. */
             auto &range_cursor = cursors[coll.id];
             //range_cursor->bounds("action=clear");
             auto bound_pair = set_random_bounds(tc, range_cursor);
@@ -362,6 +507,7 @@ class cursor_bound_01 : public test_harness::test {
             upper_key = bound_pair.second;
 
             scoped_cursor normal_cursor = tc->session.open_scoped_cursor(coll.name);
+
             /*
              * Pick a random timestamp between the oldest and now. Get rid of the last 32 bits as
              * they represent an increment for uniqueness.
@@ -377,9 +523,8 @@ class cursor_bound_01 : public test_harness::test {
              */
             tc->transaction.begin(
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
-
             while (tc->transaction.active() && tc->running()) {
-                /* Call search near to position cursor. */  
+                /* Call search near to position the normal cursor. */  
                 int exact;
                 normal_cursor->set_key(normal_cursor.get(), "0");
                 normal_ret = normal_cursor->search_near(normal_cursor.get(), &exact);
@@ -388,10 +533,12 @@ class cursor_bound_01 : public test_harness::test {
                     break;
                 }
 
+                /* Search near can position before the lower key bound, perform a next call here */
                 if (exact < 0) {
-                    testutil_assert(normal_cursor->next(normal_cursor.get()) == 0);
+                    normal_ret = normal_cursor->next(normal_cursor.get());
                 }
-                range_cursor->next(range_cursor.get());
+                range_ret = range_cursor->next(range_cursor.get());
+                testutil_assert(normal_ret == range_ret && (normal_ret == 0 || normal_ret == WT_NOTFOUND));
 
                 /* Retrieve the key the cursor is pointing at. */
                 const char *normal_key, *range_key;
@@ -403,14 +550,22 @@ class cursor_bound_01 : public test_harness::test {
                     range_ret = range_cursor->next(range_cursor.get());
                     testutil_assert(normal_ret == 0 || normal_ret == WT_NOTFOUND);
                     testutil_assert(range_ret == 0 || range_ret == WT_NOTFOUND);
+
+                    /* Early exit if we have reached the end of the table. */
                     if (range_ret == WT_NOTFOUND && normal_ret == WT_NOTFOUND)
                         break;
+                    /* 
+                     * It is possible that we have reached the end of the bounded range, make sure
+                     * that normal cursor returns a key that is greater than the upper bound.
+                     */
                     else if (range_ret == WT_NOTFOUND && normal_ret == 0) {
                         testutil_assert(upper_key.length() != 0);
                         testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
                         testutil_assert(strcmp(normal_key, upper_key.c_str()) > 0);
+                        break;
                     }
 
+                    /* Make sure that records match between both cursors. */
                     testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
                     testutil_check(range_cursor->get_key(range_cursor.get(), &range_key));
                     testutil_assert(strcmp(range_key, normal_key) == 0);
@@ -420,9 +575,6 @@ class cursor_bound_01 : public test_harness::test {
                 tc->transaction.try_rollback();
                 tc->sleep();
             }
-            /* Each read operation will update existing keys in the collections. */
-            logger::log_msg(
-                LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} succeeded one op.");
             testutil_check(range_cursor->reset(range_cursor.get()));
         }
         /* Roll back the last transaction if still active now the work is finished. */

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -55,17 +55,19 @@ class cursor_bound_01 : public test_harness::test {
     public:
     cursor_bound_01(const test_harness::test_args &args) : test(args) {}
 
-    bool custom_lexicographical_compare(const std::string &first_key, const std::string &second_key, bool reverse_collator, bool inclusive) {
+    bool
+    custom_lexicographical_compare(const std::string &first_key, const std::string &second_key,
+      bool reverse_collator, bool inclusive)
+    {
         if (reverse_collator)
             if (!inclusive)
                 return first_key.compare(second_key) > 0;
             else
                 return first_key.compare(second_key) >= 0;
+        else if (!inclusive)
+            return first_key.compare(second_key) < 0;
         else
-            if (!inclusive)
-                return first_key.compare(second_key) < 0;
-            else
-                return first_key.compare(second_key) <= 0;
+            return first_key.compare(second_key) <= 0;
     }
     /*
      * This function acts as a helper function for both the remove and update operation. The
@@ -132,12 +134,17 @@ class cursor_bound_01 : public test_harness::test {
         }
     }
 
-    void cursor_traversal(scoped_cursor &range_cursor, scoped_cursor &normal_cursor, const std::pair<std::string, bool> &lower_bound_pair, const std::pair<std::string, bool> &upper_bound_pair, bool next) {
+    void
+    cursor_traversal(scoped_cursor &range_cursor, scoped_cursor &normal_cursor,
+      const std::pair<std::string, bool> &lower_bound_pair,
+      const std::pair<std::string, bool> &upper_bound_pair, bool next)
+    {
         int exact, normal_ret, range_ret;
         exact = normal_ret = range_ret = 0;
         if (next) {
             range_ret = range_cursor->next(range_cursor.get());
-            /* If the key exists, position the cursor to the lower key using search near otherwise use prev(). */
+            /* If the key exists, position the cursor to the lower key using search near otherwise
+             * use prev(). */
             if (lower_bound_pair.first.length() != 0) {
                 normal_cursor->set_key(normal_cursor.get(), "0");
                 normal_ret = normal_cursor->search_near(normal_cursor.get(), &exact);
@@ -149,7 +156,8 @@ class cursor_bound_01 : public test_harness::test {
                 normal_ret = normal_cursor->next(normal_cursor.get());
         } else {
             range_ret = range_cursor->prev(range_cursor.get());
-            /* If the key exists, position the cursor to the upper key using search near otherwise use next(). */
+            /* If the key exists, position the cursor to the upper key using search near otherwise
+             * use next(). */
             if (upper_bound_pair.first.length() != 0) {
                 normal_cursor->set_key(normal_cursor.get(), "zzzzzzzzzzz");
                 normal_ret = normal_cursor->search_near(normal_cursor.get(), &exact);
@@ -164,9 +172,8 @@ class cursor_bound_01 : public test_harness::test {
         if (normal_ret == WT_NOTFOUND)
             return;
 
-        testutil_assert(
-            normal_ret == range_ret && (normal_ret == 0 || normal_ret == WT_NOTFOUND));
-            
+        testutil_assert(normal_ret == range_ret && (normal_ret == 0 || normal_ret == WT_NOTFOUND));
+
         /* Retrieve the key the cursor is pointing at. */
         const char *normal_key, *range_key;
         testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
@@ -178,7 +185,7 @@ class cursor_bound_01 : public test_harness::test {
                 range_ret = range_cursor->next(range_cursor.get());
             } else {
                 normal_ret = normal_cursor->prev(normal_cursor.get());
-                range_ret = range_cursor->prev(range_cursor.get()); 
+                range_ret = range_cursor->prev(range_cursor.get());
             }
             testutil_assert(normal_ret == 0 || normal_ret == WT_NOTFOUND);
             testutil_assert(range_ret == 0 || range_ret == WT_NOTFOUND);
@@ -194,19 +201,23 @@ class cursor_bound_01 : public test_harness::test {
                 /*  Make sure that normal cursor returns a key that is outside of the range. */
                 if (next) {
                     testutil_assert(upper_bound_pair.first.length() != 0);
-                    testutil_assert(custom_lexicographical_compare(normal_key_str, upper_bound_pair.first, false, true) == false);
+                    testutil_assert(custom_lexicographical_compare(normal_key_str,
+                                      upper_bound_pair.first, false, true) == false);
                 } else {
                     testutil_assert(lower_bound_pair.first.length() != 0);
-                    testutil_assert(custom_lexicographical_compare(normal_key_str, lower_bound_pair.first, false, false) == true);
+                    testutil_assert(custom_lexicographical_compare(normal_key_str,
+                                      lower_bound_pair.first, false, false) == true);
                 }
                 break;
             }
 
             std::string range_key_str = range_key;
             if (next && upper_bound_pair.first.length() != 0)
-                testutil_assert(custom_lexicographical_compare(range_key_str, upper_bound_pair.first , false, upper_bound_pair.second) == true);
+                testutil_assert(custom_lexicographical_compare(range_key_str,
+                                  upper_bound_pair.first, false, upper_bound_pair.second) == true);
             else if (!next && lower_bound_pair.first.length() != 0)
-                testutil_assert(custom_lexicographical_compare(lower_bound_pair.first, range_key_str, false, lower_bound_pair.second) == true);
+                testutil_assert(custom_lexicographical_compare(lower_bound_pair.first,
+                                  range_key_str, false, lower_bound_pair.second) == true);
             /* Make sure that records match between both cursors. */
             testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
             testutil_check(range_cursor->get_key(range_cursor.get(), &range_key));
@@ -230,7 +241,7 @@ class cursor_bound_01 : public test_harness::test {
         set_random_bounds = random_generator::instance().generate_integer(0, 3);
         if (set_random_bounds == LOWER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
             set_lower_inclusive = random_generator::instance().generate_integer(0, 1);
-            (void) set_lower_inclusive;
+            (void)set_lower_inclusive;
             key_size =
               random_generator::instance().generate_integer(static_cast<int64_t>(1), tc->key_size);
             (void)key_size;
@@ -243,7 +254,7 @@ class cursor_bound_01 : public test_harness::test {
 
         if (set_random_bounds == UPPER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
             set_upper_inclusive = random_generator::instance().generate_integer(0, 1);
-            (void) set_upper_inclusive;
+            (void)set_upper_inclusive;
             key_size =
               random_generator::instance().generate_integer(static_cast<int64_t>(1), tc->key_size);
             (void)key_size;
@@ -252,10 +263,10 @@ class cursor_bound_01 : public test_harness::test {
             upper_key = std::string(tc->key_size, 'z');
             range_cursor->bound(range_cursor.get(), "bound=upper");
             range_cursor->set_key(range_cursor.get(), upper_key);
-
         }
 
-        return std::make_pair(std::make_pair(lower_key, set_lower_inclusive), std::make_pair(upper_key, set_upper_inclusive));
+        return std::make_pair(std::make_pair(lower_key, set_lower_inclusive),
+          std::make_pair(upper_key, set_upper_inclusive));
     }
 
     /*
@@ -272,7 +283,8 @@ class cursor_bound_01 : public test_harness::test {
      */
     void
     validate_bound_search_near(int range_ret, int range_exact, scoped_cursor &range_cursor,
-      scoped_cursor &normal_cursor, const std::string &search_key, const std::pair<std::string, bool> &lower_bound_pair,
+      scoped_cursor &normal_cursor, const std::string &search_key,
+      const std::pair<std::string, bool> &lower_bound_pair,
       const std::pair<std::string, bool> &upper_bound_pair)
     {
         bool above_lower_key, below_upper_key, search_key_inside_range;
@@ -285,16 +297,20 @@ class cursor_bound_01 : public test_harness::test {
 
             /* Assert that the range cursor has returned a key inside the bounded range. */
             above_lower_key = lower_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(lower_bound_pair.first, key_str, false, lower_bound_pair.second);
+              custom_lexicographical_compare(
+                lower_bound_pair.first, key_str, false, lower_bound_pair.second);
             below_upper_key = upper_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(key_str, upper_bound_pair.first, false, upper_bound_pair.second);
+              custom_lexicographical_compare(
+                key_str, upper_bound_pair.first, false, upper_bound_pair.second);
             testutil_assert(above_lower_key && below_upper_key);
 
             /* Decide whether the search key is inside or outside the bounded range. */
             above_lower_key = lower_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(lower_bound_pair.first, search_key, false, lower_bound_pair.second);
+              custom_lexicographical_compare(
+                lower_bound_pair.first, search_key, false, lower_bound_pair.second);
             below_upper_key = upper_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(search_key, upper_bound_pair.first, false, upper_bound_pair.second);
+              custom_lexicographical_compare(
+                search_key, upper_bound_pair.first, false, upper_bound_pair.second);
             search_key_inside_range = above_lower_key && below_upper_key;
 
             normal_cursor->set_key(normal_cursor.get(), key);
@@ -338,7 +354,8 @@ class cursor_bound_01 : public test_harness::test {
              * a prev() should be less than the search key. */
         }
         if (range_exact > 0) {
-            testutil_assert(custom_lexicographical_compare(key_str, search_key, false, true) == false);
+            testutil_assert(
+              custom_lexicographical_compare(key_str, search_key, false, true) == false);
 
             /* Check that the previous key is less than the search key. */
             ret = normal_cursor->prev(normal_cursor.get());
@@ -347,11 +364,13 @@ class cursor_bound_01 : public test_harness::test {
                 return;
             testutil_check(normal_cursor->get_key(normal_cursor.get(), &key));
             key_str = key;
-            testutil_assert(custom_lexicographical_compare(key_str, search_key, false, false) == true);
+            testutil_assert(
+              custom_lexicographical_compare(key_str, search_key, false, false) == true);
             /* When exact < 0, the returned key should be less than the search key and performing a
              * next() should be greater than the search key. */
         } else if (range_exact < 0) {
-            testutil_assert(custom_lexicographical_compare(key_str, search_key, false, false) == true);
+            testutil_assert(
+              custom_lexicographical_compare(key_str, search_key, false, false) == true);
 
             /* Check that the next key is greater than the search key. */
             ret = normal_cursor->next(normal_cursor.get());
@@ -360,7 +379,8 @@ class cursor_bound_01 : public test_harness::test {
                 return;
             testutil_check(normal_cursor->get_key(normal_cursor.get(), &key));
             key_str = key;
-            testutil_assert(custom_lexicographical_compare(key_str, search_key, false, true) == false);
+            testutil_assert(
+              custom_lexicographical_compare(key_str, search_key, false, true) == false);
         }
     }
 
@@ -373,7 +393,8 @@ class cursor_bound_01 : public test_harness::test {
      */
     void
     validate_successful_search_near_outside_range(scoped_cursor &normal_cursor,
-      const std::pair<std::string, bool> &lower_bound_pair, const std::pair<std::string, bool> &upper_bound_pair, bool larger_search_key)
+      const std::pair<std::string, bool> &lower_bound_pair,
+      const std::pair<std::string, bool> &upper_bound_pair, bool larger_search_key)
     {
 
         int ret;
@@ -391,9 +412,11 @@ class cursor_bound_01 : public test_harness::test {
         /* Assert that the next() or prev() call has placed the normal cursor outside of the bounded
          * range. */
         above_lower_key = lower_bound_pair.first.length() == 0 ||
-          custom_lexicographical_compare(lower_bound_pair.first, key_str, false, lower_bound_pair.second);
+          custom_lexicographical_compare(
+            lower_bound_pair.first, key_str, false, lower_bound_pair.second);
         below_upper_key = upper_bound_pair.first.length() == 0 ||
-          custom_lexicographical_compare(key_str, upper_bound_pair.first, false, upper_bound_pair.second);
+          custom_lexicographical_compare(
+            key_str, upper_bound_pair.first, false, upper_bound_pair.second);
         testutil_assert(!(above_lower_key && below_upper_key));
     }
 
@@ -402,8 +425,9 @@ class cursor_bound_01 : public test_harness::test {
      * and that no visible keys exist in the bounded range.
      */
     void
-    validate_search_near_not_found(
-      scoped_cursor &normal_cursor, const std::pair<std::string, bool> &lower_bound_pair, const std::pair<std::string, bool> &upper_bound_pair)
+    validate_search_near_not_found(scoped_cursor &normal_cursor,
+      const std::pair<std::string, bool> &lower_bound_pair,
+      const std::pair<std::string, bool> &upper_bound_pair)
     {
         int ret, exact;
         bool above_lower_key, below_upper_key;
@@ -411,12 +435,13 @@ class cursor_bound_01 : public test_harness::test {
         std::string key_str;
 
         logger::log_msg(LOG_TRACE,
-          "bounded search_near found WT_NOTFOUND on lower bound: " + lower_bound_pair.first + " upper bound: " +
-            upper_bound_pair.first + " traversing range to validate that there are no keys within range.");
+          "bounded search_near found WT_NOTFOUND on lower bound: " + lower_bound_pair.first +
+            " upper bound: " + upper_bound_pair.first +
+            " traversing range to validate that there are no keys within range.");
         if (lower_bound_pair.first.length() != 0) {
             normal_cursor->set_key(normal_cursor.get(), lower_bound_pair.first.c_str());
             ret = normal_cursor->search_near(normal_cursor.get(), &exact);
-        } else 
+        } else
             ret = normal_cursor->next(normal_cursor.get());
 
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
@@ -435,9 +460,11 @@ class cursor_bound_01 : public test_harness::test {
             key_str = key;
             /* Asserted that the traversed key is not within the range bound. */
             above_lower_key = lower_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(lower_bound_pair.first, key_str, false, lower_bound_pair.second);
+              custom_lexicographical_compare(
+                lower_bound_pair.first, key_str, false, lower_bound_pair.second);
             below_upper_key = upper_bound_pair.first.length() == 0 ||
-                custom_lexicographical_compare(key_str, upper_bound_pair.first, false, upper_bound_pair.second);
+              custom_lexicographical_compare(
+                key_str, upper_bound_pair.first, false, upper_bound_pair.second);
             testutil_assert(!(above_lower_key && below_upper_key));
 
             /*
@@ -449,6 +476,43 @@ class cursor_bound_01 : public test_harness::test {
 
             ret = normal_cursor->next(normal_cursor.get());
         }
+    }
+
+    void
+    populate(database &database, timestamp_manager *tsm, configuration *config,
+      workload_tracking *tracking)
+    {
+        int64_t collection_count, key_count, key_size, thread_count, value_size;
+        std::vector<thread_context *> workers;
+        std::string collection_name;
+        thread_manager tm;
+
+        /* Validate our config. */
+        collection_count = config->get_int(COLLECTION_COUNT);
+        key_count = config->get_int(KEY_COUNT_PER_COLLECTION);
+        value_size = config->get_int(VALUE_SIZE);
+        thread_count = config->get_int(THREAD_COUNT);
+        testutil_assert(thread_count == 0 || collection_count % thread_count == 0);
+        testutil_assert(value_size > 0);
+        key_size = config->get_int(KEY_SIZE);
+        testutil_assert(key_size > 0);
+        /* Keys must be unique. */
+        testutil_assert(key_count <= pow(10, key_size));
+
+        logger::log_msg(
+          LOG_INFO, "Populate: creating " + std::to_string(collection_count) + " collections.");
+
+        /* Create n collections as per the configuration. */
+        for (int64_t i = 0; i < collection_count; ++i)
+            /*
+             * The database model will call into the API and create the collection, with its own
+             * session.
+             */
+            database.add_collection(key_count);
+        logger::log_msg(
+          LOG_INFO, "Populate: " + std::to_string(collection_count) + " collections created.");
+
+        logger::log_msg(LOG_INFO, "Populate: finished.");
     }
 
     void
@@ -573,8 +637,8 @@ class cursor_bound_01 : public test_harness::test {
                 testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
                 /* Verify the bound search_near result using the normal cursor. */
-                validate_bound_search_near(
-                  ret, exact, range_cursor, normal_cursor, srch_key, lower_bound_pair, upper_bound_pair);
+                validate_bound_search_near(ret, exact, range_cursor, normal_cursor, srch_key,
+                  lower_bound_pair, upper_bound_pair);
 
                 tc->transaction.add_op();
                 tc->transaction.try_rollback();

--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -34,13 +34,13 @@
 #include "test_harness/test.h"
 
 #include "burst_inserts.cpp"
+#include "cursor_bound_01.cpp"
 #include "hs_cleanup.cpp"
 #include "operations_test.cpp"
 #include "search_near_01.cpp"
 #include "search_near_02.cpp"
 #include "search_near_03.cpp"
 #include "test_template.cpp"
-#include "cursor_bound_01.cpp"
 
 /* Declarations to avoid the error raised by -Werror=missing-prototypes. */
 const std::string parse_configuration_from_file(const std::string &filename);
@@ -123,6 +123,8 @@ run_test(const std::string &test_name, const std::string &config, const std::str
         hs_cleanup(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "burst_inserts")
         burst_inserts(test_harness::test_args{config, test_name, wt_open_config}).run();
+    else if (test_name == "cursor_bound_01")
+        cursor_bound_01(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "operations_test")
         operations_test(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "search_near_01")
@@ -133,8 +135,6 @@ run_test(const std::string &test_name, const std::string &config, const std::str
         search_near_03(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "test_template")
         test_template(test_harness::test_args{config, test_name, wt_open_config}).run();
-    else if (test_name == "cursor_bound_01")
-        cursor_bound_01(test_harness::test_args{config, test_name, wt_open_config}).run();
     else {
         test_harness::logger::log_msg(LOG_ERROR, "Test not found: " + test_name);
         error_code = -1;
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
 {
     std::string cfg, config_filename, current_cfg, current_test_name, test_name, wt_open_config;
     int64_t error_code = 0;
-    const std::vector<std::string> all_tests = {"cursor_bound_01", "burst_inserts", "hs_cleanup",
+    const std::vector<std::string> all_tests = {"burst_inserts", "cursor_bound_01", "hs_cleanup",
       "operations_test", "search_near_01", "search_near_02", "search_near_03", "test_template"};
 
     /* Set the program name for error messages. */

--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -40,6 +40,7 @@
 #include "search_near_02.cpp"
 #include "search_near_03.cpp"
 #include "test_template.cpp"
+#include "cursor_bound_01.cpp"
 
 /* Declarations to avoid the error raised by -Werror=missing-prototypes. */
 const std::string parse_configuration_from_file(const std::string &filename);
@@ -132,6 +133,8 @@ run_test(const std::string &test_name, const std::string &config, const std::str
         search_near_03(test_harness::test_args{config, test_name, wt_open_config}).run();
     else if (test_name == "test_template")
         test_template(test_harness::test_args{config, test_name, wt_open_config}).run();
+    else if (test_name == "cursor_bound_01")
+        cursor_bound_01(test_harness::test_args{config, test_name, wt_open_config}).run();
     else {
         test_harness::logger::log_msg(LOG_ERROR, "Test not found: " + test_name);
         error_code = -1;
@@ -154,8 +157,8 @@ main(int argc, char *argv[])
 {
     std::string cfg, config_filename, current_cfg, current_test_name, test_name, wt_open_config;
     int64_t error_code = 0;
-    const std::vector<std::string> all_tests = {"burst_inserts", "hs_cleanup", "operations_test",
-      "search_near_01", "search_near_02", "search_near_03", "test_template"};
+    const std::vector<std::string> all_tests = {"cursor_bound_01", "burst_inserts", "hs_cleanup",
+      "operations_test", "search_near_01", "search_near_02", "search_near_03", "test_template"};
 
     /* Set the program name for error messages. */
     (void)testutil_set_progname(argv);


### PR DESCRIPTION
This pull request adds a cppsuite test for the new bound API. Once the skeleton API WT-9135 gets merged in, i will rebase and start using the bound API. This is currently a draft PR because there are still some todos left until we are ready, but It is ready for a small review. 
TODOS:
- Add random inclusive configuration support
- Make sure that random generated upper key is greater than lower key
- Add reverse collator support

Done:
- The core mechanics of populate, update, read, and insert mechanics operations are completed.
- Validation of the bound API is done through custom and read operation are completed.

I have also removed unused variables in the framework.