### PR TITLE
WT-9314 Let users provide values for the inserts/updates operations in the cpp suite

### DIFF
--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -335,6 +335,7 @@ database_operation::update_operation(thread_context *tc)
       LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
     /* Cursor map. */
     std::map<uint64_t, scoped_cursor> cursors;
+    std::string value;
 
     /*
      * Loop while the test is running.
@@ -369,7 +370,8 @@ database_operation::update_operation(thread_context *tc)
         testutil_assert(coll.get_key_count() != 0);
         uint64_t key_id =
           random_generator::instance().generate_integer<uint64_t>(0, coll.get_key_count() - 1);
-        if (!tc->update(cursor, coll.id, tc->key_to_string(key_id))) {
+        value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+        if (!tc->update(cursor, coll.id, tc->key_to_string(key_id), value)) {
             tc->transaction.rollback();
         }
 

--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -43,7 +43,6 @@ static void
 populate_worker(thread_context *tc)
 {
     uint64_t collections_per_thread = tc->collection_count / tc->thread_count;
-    std::string value;
 
     for (int64_t i = 0; i < collections_per_thread; ++i) {
         collection &coll = tc->db.get_collection((tc->id * collections_per_thread) + i);
@@ -55,7 +54,8 @@ populate_worker(thread_context *tc)
         uint64_t j = 0;
         while (j < tc->key_count) {
             tc->transaction.begin();
-            value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+            std::string value =
+              random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (tc->insert(cursor, coll.id, tc->key_to_string(j), value)) {
                 if (tc->transaction.commit()) {
                     ++j;
@@ -165,7 +165,6 @@ database_operation::insert_operation(thread_context *tc)
     }
 
     uint64_t counter = 0;
-    std::string value;
     while (tc->running()) {
         uint64_t start_key = ccv[counter].coll.get_key_count();
         uint64_t added_count = 0;
@@ -175,7 +174,8 @@ database_operation::insert_operation(thread_context *tc)
         auto &cc = ccv[counter];
         while (tc->transaction.active() && tc->running()) {
             /* Insert a key value pair, rolling back the transaction if required. */
-            value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+            std::string value =
+              random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (!tc->insert(
                   cc.cursor, cc.coll.id, tc->key_to_string(start_key + added_count), value)) {
                 added_count = 0;
@@ -335,7 +335,6 @@ database_operation::update_operation(thread_context *tc)
       LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
     /* Cursor map. */
     std::map<uint64_t, scoped_cursor> cursors;
-    std::string value;
 
     /*
      * Loop while the test is running.
@@ -370,7 +369,8 @@ database_operation::update_operation(thread_context *tc)
         testutil_assert(coll.get_key_count() != 0);
         uint64_t key_id =
           random_generator::instance().generate_integer<uint64_t>(0, coll.get_key_count() - 1);
-        value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+        std::string value =
+          random_generator::instance().generate_pseudo_random_string(tc->value_size);
         if (!tc->update(cursor, coll.id, tc->key_to_string(key_id), value)) {
             tc->transaction.rollback();
         }

--- a/test/cppsuite/test_harness/workload/database_operation.cpp
+++ b/test/cppsuite/test_harness/workload/database_operation.cpp
@@ -53,7 +53,7 @@ populate_worker(thread_context *tc)
         uint64_t j = 0;
         while (j < tc->key_count) {
             tc->transaction.begin();
-            if (tc->insert(cursor, coll.id, j)) {
+            if (tc->insert(cursor, coll.id, tc->key_to_string(j))) {
                 if (tc->transaction.commit()) {
                     ++j;
                 }
@@ -171,7 +171,7 @@ database_operation::insert_operation(thread_context *tc)
         auto &cc = ccv[counter];
         while (tc->transaction.active() && tc->running()) {
             /* Insert a key value pair, rolling back the transaction if required. */
-            if (!tc->insert(cc.cursor, cc.coll.id, start_key + added_count)) {
+            if (!tc->insert(cc.cursor, cc.coll.id, tc->key_to_string(start_key + added_count))) {
                 added_count = 0;
                 tc->transaction.rollback();
             } else {

--- a/test/cppsuite/test_harness/workload/thread_context.cpp
+++ b/test/cppsuite/test_harness/workload/thread_context.cpp
@@ -249,7 +249,8 @@ thread_context::update(scoped_cursor &cursor, uint64_t collection_id, const std:
 }
 
 bool
-thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, const std::string &key)
+thread_context::insert(
+  scoped_cursor &cursor, uint64_t collection_id, const std::string &key, const std::string &value)
 {
     WT_DECL_RET;
 
@@ -259,11 +260,10 @@ thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, const std:
     wt_timestamp_t ts = tsm->get_next_ts();
     transaction.set_commit_timestamp(ts);
 
-    std::string value = random_generator::instance().generate_pseudo_random_string(value_size);
-
     cursor->set_key(cursor.get(), key.c_str());
     cursor->set_value(cursor.get(), value.c_str());
     ret = cursor->insert(cursor.get());
+
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
             transaction.set_needs_rollback(true);

--- a/test/cppsuite/test_harness/workload/thread_context.cpp
+++ b/test/cppsuite/test_harness/workload/thread_context.cpp
@@ -286,19 +286,13 @@ thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, const std:
 }
 
 bool
-thread_context::remove(
-  scoped_cursor &cursor, uint64_t collection_id, const std::string &key, wt_timestamp_t ts)
+thread_context::remove(scoped_cursor &cursor, uint64_t collection_id, const std::string &key)
 {
     WT_DECL_RET;
     testutil_assert(tracking != nullptr);
     testutil_assert(cursor.get() != nullptr);
 
-    /*
-     * When no timestamp is specified, get one to apply for the deletion. We still do this even if
-     * the timestamp manager is not enabled as it will return a value for the tracking table.
-     */
-    if (ts == 0)
-        ts = tsm->get_next_ts();
+    wt_timestamp_t ts = tsm->get_next_ts();
     transaction.set_commit_timestamp(ts);
 
     cursor->set_key(cursor.get(), key.c_str());

--- a/test/cppsuite/test_harness/workload/thread_context.cpp
+++ b/test/cppsuite/test_harness/workload/thread_context.cpp
@@ -214,7 +214,8 @@ thread_context::key_to_string(uint64_t key_id)
 }
 
 bool
-thread_context::update(scoped_cursor &cursor, uint64_t collection_id, const std::string &key)
+thread_context::update(
+  scoped_cursor &cursor, uint64_t collection_id, const std::string &key, const std::string &value)
 {
     WT_DECL_RET;
 
@@ -223,10 +224,11 @@ thread_context::update(scoped_cursor &cursor, uint64_t collection_id, const std:
 
     wt_timestamp_t ts = tsm->get_next_ts();
     transaction.set_commit_timestamp(ts);
-    std::string value = random_generator::instance().generate_pseudo_random_string(value_size);
+
     cursor->set_key(cursor.get(), key.c_str());
     cursor->set_value(cursor.get(), value.c_str());
     ret = cursor->update(cursor.get());
+
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
             transaction.set_needs_rollback(true);

--- a/test/cppsuite/test_harness/workload/thread_context.cpp
+++ b/test/cppsuite/test_harness/workload/thread_context.cpp
@@ -249,12 +249,6 @@ thread_context::update(scoped_cursor &cursor, uint64_t collection_id, const std:
 }
 
 bool
-thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id)
-{
-    return insert(cursor, collection_id, key_to_string(key_id));
-}
-
-bool
 thread_context::insert(scoped_cursor &cursor, uint64_t collection_id, const std::string &key)
 {
     WT_DECL_RET;

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -121,12 +121,13 @@ class thread_context {
     std::string key_to_string(uint64_t key_id);
 
     /*
-     * Generic update function, takes a collection_id and key, will generate the value.
+     * Generic update function, takes a collection_id, key and value.
      *
      * Return true if the operation was successful, a return value of false implies the transaction
      * needs to be rolled back.
      */
-    bool update(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
+    bool update(scoped_cursor &cursor, uint64_t collection_id, const std::string &key,
+      const std::string &value);
 
     /*
      * Generic insert function, takes a collection_id, key and value.

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -134,7 +134,6 @@ class thread_context {
      * Return true if the operation was successful, a return value of false implies the transaction
      * needs to be rolled back.
      */
-    bool insert(scoped_cursor &cursor, uint64_t collection_id, uint64_t key_id);
     bool insert(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
 
     /*

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -142,8 +142,7 @@ class thread_context {
      * Return true if the operation was successful, a return value of false implies the transaction
      * needs to be rolled back.
      */
-    bool remove(
-      scoped_cursor &cursor, uint64_t collection_id, const std::string &key, wt_timestamp_t ts = 0);
+    bool remove(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
     void sleep();
     bool running() const;
 

--- a/test/cppsuite/test_harness/workload/thread_context.h
+++ b/test/cppsuite/test_harness/workload/thread_context.h
@@ -129,12 +129,13 @@ class thread_context {
     bool update(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
 
     /*
-     * Generic insert function, takes a collection_id and key_id, will generate the value.
+     * Generic insert function, takes a collection_id, key and value.
      *
      * Return true if the operation was successful, a return value of false implies the transaction
      * needs to be rolled back.
      */
-    bool insert(scoped_cursor &cursor, uint64_t collection_id, const std::string &key);
+    bool insert(scoped_cursor &cursor, uint64_t collection_id, const std::string &key,
+      const std::string &value);
 
     /*
      * Generic remove function, takes a collection_id and key and will delete the key if it exists.

--- a/test/cppsuite/tests/burst_inserts.cpp
+++ b/test/cppsuite/tests/burst_inserts.cpp
@@ -100,7 +100,8 @@ class burst_inserts : public test {
                 cc.write_cursor->search(cc.write_cursor.get());
 
                 /* A return value of true implies the insert was successful. */
-                if (!tc->insert(cc.write_cursor, cc.coll.id, start_key + added_count)) {
+                if (!tc->insert(
+                      cc.write_cursor, cc.coll.id, tc->key_to_string(start_key + added_count))) {
                     tc->transaction.rollback();
                     added_count = 0;
                     continue;

--- a/test/cppsuite/tests/burst_inserts.cpp
+++ b/test/cppsuite/tests/burst_inserts.cpp
@@ -86,7 +86,6 @@ class burst_inserts : public test {
         }
 
         uint64_t counter = 0;
-        std::string value;
         while (tc->running()) {
             uint64_t start_key = ccv[counter].coll.get_key_count();
             uint64_t added_count = 0;
@@ -101,7 +100,8 @@ class burst_inserts : public test {
                 cc.write_cursor->search(cc.write_cursor.get());
 
                 /* A return value of true implies the insert was successful. */
-                value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+                std::string value =
+                  random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 if (!tc->insert(cc.write_cursor, cc.coll.id,
                       tc->key_to_string(start_key + added_count), value)) {
                     tc->transaction.rollback();

--- a/test/cppsuite/tests/burst_inserts.cpp
+++ b/test/cppsuite/tests/burst_inserts.cpp
@@ -86,6 +86,7 @@ class burst_inserts : public test {
         }
 
         uint64_t counter = 0;
+        std::string value;
         while (tc->running()) {
             uint64_t start_key = ccv[counter].coll.get_key_count();
             uint64_t added_count = 0;
@@ -100,8 +101,9 @@ class burst_inserts : public test {
                 cc.write_cursor->search(cc.write_cursor.get());
 
                 /* A return value of true implies the insert was successful. */
-                if (!tc->insert(
-                      cc.write_cursor, cc.coll.id, tc->key_to_string(start_key + added_count))) {
+                value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+                if (!tc->insert(cc.write_cursor, cc.coll.id,
+                      tc->key_to_string(start_key + added_count), value)) {
                     tc->transaction.rollback();
                     added_count = 0;
                     continue;

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -51,6 +51,7 @@ class hs_cleanup : public test {
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
         const char *key_tmp;
+        std::string value;
         const uint64_t MAX_ROLLBACKS = 100;
         uint32_t rollback_retries = 0;
 
@@ -93,7 +94,7 @@ class hs_cleanup : public test {
              * API doesn't guarantee our buffer will still be valid once it is called, as such we
              * copy the buffer and then pass it into the API.
              */
-            if (tc->update(cursor, coll.id, key_value_t(key_tmp))) {
+            if (tc->update(cursor, coll.id, key_tmp, value)) {
                 if (tc->transaction.can_commit()) {
                     if (tc->transaction.commit())
                         rollback_retries = 0;

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -51,7 +51,6 @@ class hs_cleanup : public test {
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
         const char *key_tmp;
-        std::string value;
         const uint64_t MAX_ROLLBACKS = 100;
         uint32_t rollback_retries = 0;
 
@@ -94,6 +93,8 @@ class hs_cleanup : public test {
              * API doesn't guarantee our buffer will still be valid once it is called, as such we
              * copy the buffer and then pass it into the API.
              */
+            std::string value =
+              random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (tc->update(cursor, coll.id, key_tmp, value)) {
                 if (tc->transaction.can_commit()) {
                     if (tc->transaction.commit())

--- a/test/cppsuite/tests/search_near_01.cpp
+++ b/test/cppsuite/tests/search_near_01.cpp
@@ -55,7 +55,6 @@ class search_near_01 : public test_harness::test {
     {
         logger::log_msg(LOG_INFO, "Populate with thread id: " + std::to_string(tc->id));
 
-        std::string prefix_key, value;
         uint64_t collections_per_thread = tc->collection_count;
         const uint64_t MAX_ROLLBACKS = 100;
         uint32_t rollback_retries = 0;
@@ -76,11 +75,13 @@ class search_near_01 : public test_harness::test {
                          * Generate the prefix key, and append a random generated key string based
                          * on the key size configuration.
                          */
-                        prefix_key = {ALPHABET.at(tc->id), ALPHABET.at(j), ALPHABET.at(k)};
+                        std::string prefix_key = {
+                          ALPHABET.at(tc->id), ALPHABET.at(j), ALPHABET.at(k)};
                         prefix_key += random_generator::instance().generate_random_string(
                           tc->key_size - PREFIX_KEY_LEN);
-                        value = random_generator::instance().generate_pseudo_random_string(
-                          tc->value_size);
+                        std::string value =
+                          random_generator::instance().generate_pseudo_random_string(
+                            tc->value_size);
                         if (!tc->insert(cursor, coll.id, prefix_key, value)) {
                             testutil_assert(rollback_retries < MAX_ROLLBACKS);
                             /* We failed to insert, rollback our transaction and retry. */

--- a/test/cppsuite/tests/search_near_01.cpp
+++ b/test/cppsuite/tests/search_near_01.cpp
@@ -55,7 +55,7 @@ class search_near_01 : public test_harness::test {
     {
         logger::log_msg(LOG_INFO, "Populate with thread id: " + std::to_string(tc->id));
 
-        std::string prefix_key;
+        std::string prefix_key, value;
         uint64_t collections_per_thread = tc->collection_count;
         const uint64_t MAX_ROLLBACKS = 100;
         uint32_t rollback_retries = 0;
@@ -79,7 +79,9 @@ class search_near_01 : public test_harness::test {
                         prefix_key = {ALPHABET.at(tc->id), ALPHABET.at(j), ALPHABET.at(k)};
                         prefix_key += random_generator::instance().generate_random_string(
                           tc->key_size - PREFIX_KEY_LEN);
-                        if (!tc->insert(cursor, coll.id, prefix_key)) {
+                        value = random_generator::instance().generate_pseudo_random_string(
+                          tc->value_size);
+                        if (!tc->insert(cursor, coll.id, prefix_key, value)) {
                             testutil_assert(rollback_retries < MAX_ROLLBACKS);
                             /* We failed to insert, rollback our transaction and retry. */
                             tc->transaction.rollback();

--- a/test/cppsuite/tests/search_near_02.cpp
+++ b/test/cppsuite/tests/search_near_02.cpp
@@ -94,7 +94,6 @@ class search_near_02 : public test_harness::test {
             ccv.push_back({coll, std::move(cursor)});
         }
 
-        std::string key, value;
         const uint64_t MAX_ROLLBACKS = 100;
         uint64_t counter = 0;
         uint32_t rollback_retries = 0;
@@ -107,8 +106,9 @@ class search_near_02 : public test_harness::test {
             while (tc->transaction.active() && tc->running()) {
 
                 /* Generate a random key/value pair. */
-                key = random_generator::instance().generate_random_string(tc->key_size);
-                value = random_generator::instance().generate_random_string(tc->value_size);
+                std::string key = random_generator::instance().generate_random_string(tc->key_size);
+                std::string value =
+                  random_generator::instance().generate_random_string(tc->value_size);
 
                 /* Insert a key value pair. */
                 if (tc->insert(cc.cursor, cc.coll.id, key, value)) {

--- a/test/cppsuite/tests/search_near_02.cpp
+++ b/test/cppsuite/tests/search_near_02.cpp
@@ -94,7 +94,7 @@ class search_near_02 : public test_harness::test {
             ccv.push_back({coll, std::move(cursor)});
         }
 
-        std::string key;
+        std::string key, value;
         const uint64_t MAX_ROLLBACKS = 100;
         uint64_t counter = 0;
         uint32_t rollback_retries = 0;
@@ -106,11 +106,12 @@ class search_near_02 : public test_harness::test {
 
             while (tc->transaction.active() && tc->running()) {
 
-                /* Generate a random key. */
+                /* Generate a random key/value pair. */
                 key = random_generator::instance().generate_random_string(tc->key_size);
+                value = random_generator::instance().generate_random_string(tc->value_size);
 
                 /* Insert a key value pair. */
-                if (tc->insert(cc.cursor, cc.coll.id, key)) {
+                if (tc->insert(cc.cursor, cc.coll.id, key, value)) {
                     if (tc->transaction.can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
                         if (tc->transaction.commit())

--- a/test/cppsuite/tests/search_near_03.cpp
+++ b/test/cppsuite/tests/search_near_03.cpp
@@ -62,12 +62,13 @@ class search_near_03 : public test_harness::test {
     perform_unique_index_insertions(
       thread_context *tc, scoped_cursor &cursor, collection &coll, std::string &prefix_key)
     {
-        std::string ret_key;
+        std::string ret_key, value;
         const char *key_tmp;
         int exact_prefix, ret;
 
         /* Insert the prefix. */
-        if (!tc->insert(cursor, coll.id, prefix_key))
+        value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+        if (!tc->insert(cursor, coll.id, prefix_key, value))
             return false;
 
         /* Remove the prefix. */
@@ -91,7 +92,8 @@ class search_near_03 : public test_harness::test {
         }
 
         /* Now insert the key with prefix and id. Use thread id to guarantee uniqueness. */
-        return tc->insert(cursor, coll.id, prefix_key + "," + std::to_string(tc->id));
+        value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+        return tc->insert(cursor, coll.id, prefix_key + "," + std::to_string(tc->id), value);
     }
 
     static void

--- a/test/cppsuite/tests/search_near_03.cpp
+++ b/test/cppsuite/tests/search_near_03.cpp
@@ -62,12 +62,13 @@ class search_near_03 : public test_harness::test {
     perform_unique_index_insertions(
       thread_context *tc, scoped_cursor &cursor, collection &coll, std::string &prefix_key)
     {
-        std::string ret_key, value;
+        std::string ret_key;
         const char *key_tmp;
         int exact_prefix, ret;
 
         /* Insert the prefix. */
-        value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+        std::string value =
+          random_generator::instance().generate_pseudo_random_string(tc->value_size);
         if (!tc->insert(cursor, coll.id, prefix_key, value))
             return false;
 


### PR DESCRIPTION
This ticket includes changes to improve the framework flexibility:

- The `insert` function from the `thread_class` was overloaded but it was not necessary
- The `timestamp` argument from the `remove` function appears to be unused, it has been removed
- Users can now provide the `value` they want to insert/update when calling the `insert` and `update` functions from the `thread_class`

Those changes will benefit WT-9094 and won't appear in https://github.com/wiredtiger/wiredtiger/pull/7916 as they deal with internal stuff.