### PR TITLE
WT-9322 Clean up random timestamp and create reverse configuration option CPPSuite framework

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -218,6 +218,8 @@ test_config = [
         The cache size that wiredtiger will be configured to run with''', min=0, max=100000000000),
     Config('compression_enabled', 'false', r'''
         Whether the database files will use snappy compression or not.''', type='boolean'),
+    Config('reverse_collator', 'false', r'''
+        Configure the database files to use the reverse collator.''', type='boolean'),
     Config('duration_seconds', 0, r'''
         The duration that the test run will last''', min=0, max=1000000),
     Config('enable_logging', 'false', r'''

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -107,6 +107,7 @@ static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -120,6 +121,7 @@ static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -133,6 +135,7 @@ static const WT_CONFIG_CHECK confchk_operations_test[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -146,6 +149,7 @@ static const WT_CONFIG_CHECK confchk_search_near_01[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"search_near_threads", "string", NULL, NULL, NULL, 0},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
@@ -160,6 +164,7 @@ static const WT_CONFIG_CHECK confchk_search_near_02[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -173,6 +178,7 @@ static const WT_CONFIG_CHECK confchk_search_near_03[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -186,6 +192,7 @@ static const WT_CONFIG_CHECK confchk_test_template[] = {
   {"compression_enabled", "boolean", NULL, NULL, NULL, 0},
   {"duration_seconds", "int", NULL, "min=0,max=1000000", NULL, 0},
   {"enable_logging", "boolean", NULL, NULL, NULL, 0},
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0},
   {"runtime_monitor", "category", NULL, NULL, confchk_runtime_monitor_subconfigs, 6},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4},
@@ -198,12 +205,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "burst_duration=90,cache_size_mb=0,"
     "checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -219,16 +227,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_burst_inserts, 11},
+    confchk_burst_inserts, 12},
   {"hs_cleanup",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -244,16 +253,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_hs_cleanup, 10},
+    confchk_hs_cleanup, 11},
   {"operations_test",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -269,22 +279,22 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_operations_test, 10},
+    confchk_operations_test, 11},
   {"search_near_01",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
-    "search_near_threads=10,statistics_config=(enable_logging=true,"
-    "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
-    "op_rate=1s,stable_lag=1),"
-    "workload_generator=(custom_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "enabled=true,insert_config=(key_size=5,op_rate=1s,"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),search_near_threads=10,"
+    "statistics_config=(enable_logging=true,type=all),"
+    "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
+    "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
+    "op_rate=1s,ops_per_transaction=(max=1,min=0),thread_count=0,"
+    "value_size=5),enabled=true,insert_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
     "op_rate=1s,populate_config=(collection_count=1,"
     "key_count_per_collection=0,key_size=5,thread_count=1,"
@@ -295,16 +305,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_search_near_01, 11},
+    confchk_search_near_01, 12},
   {"search_near_02",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -320,16 +331,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_search_near_02, 10},
+    confchk_search_near_02, 11},
   {"search_near_03",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -345,16 +357,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_search_near_03, 10},
+    confchk_search_near_03, 11},
   {"test_template",
     "cache_size_mb=0,checkpoint_manager=(enabled=false,op_rate=1s),"
     "compression_enabled=false,duration_seconds=0,"
-    "enable_logging=false,runtime_monitor=(cache_hs_insert=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false),"
-    "cc_pages_removed=(max=1,min=0,postrun=false,runtime=false,"
-    "save=false),enabled=true,op_rate=1s,stat_cache_size=(max=1,min=0"
-    ",postrun=false,runtime=false,save=false),stat_db_size=(max=1,"
-    "min=0,postrun=false,runtime=false,save=false)),"
+    "enable_logging=false,reverse_collator=false,"
+    "runtime_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
+    "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
+    "stat_cache_size=(max=1,min=0,postrun=false,runtime=false,"
+    "save=false),stat_db_size=(max=1,min=0,postrun=false,"
+    "runtime=false,save=false)),"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
     "stable_lag=1),workload_generator=(custom_config=(key_size=5,"
@@ -370,7 +383,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5)),"
     "workload_tracking=(enabled=true,op_rate=1s,"
     "tracking_key_format=QSQ,tracking_value_format=iS)",
-    confchk_test_template, 10},
+    confchk_test_template, 11},
   {NULL, NULL, NULL, 0}};
 
 /*

--- a/test/cppsuite/test_harness/test.cpp
+++ b/test/cppsuite/test_harness/test.cpp
@@ -55,7 +55,8 @@ test::test(const test_args &args) : _args(args)
 
     _database.set_timestamp_manager(_timestamp_manager);
     _database.set_workload_tracking(_workload_tracking);
-    _database.set_create_config(_config->get_bool(COMPRESSION_ENABLED));
+    _database.set_create_config(
+      _config->get_bool(COMPRESSION_ENABLED), _config->get_bool(REVERSE_COLLATOR));
 
     /*
      * Ordering is not important here, any dependencies between components should be resolved
@@ -95,9 +96,15 @@ test::run()
     /* Build the database creation config string. */
     std::string db_create_config = CONNECTION_CREATE;
 
-    /* Enable snappy compression if required. */
-    if (_config->get_bool(COMPRESSION_ENABLED))
-        db_create_config += SNAPPY_EXT;
+    /* Enable snappy compression or reverse collator if required. */
+    if (_config->get_bool(COMPRESSION_ENABLED) || _config->get_bool(REVERSE_COLLATOR)) {
+        db_create_config += EXTENSIONS_START;
+        db_create_config +=
+          _config->get_bool(COMPRESSION_ENABLED) ? std::string(SNAPPY_PATH) + "," : "";
+        db_create_config += _config->get_bool(REVERSE_COLLATOR) ? std::string(REVERSE_PATH) : "";
+        db_create_config += EXTENSIONS_STOP;
+        std::cout << db_create_config << std::endl;
+    }
 
     /* Get the cache size. */
     cache_size_mb = _config->get_int(CACHE_SIZE_MB);

--- a/test/cppsuite/test_harness/test.cpp
+++ b/test/cppsuite/test_harness/test.cpp
@@ -98,11 +98,12 @@ test::run()
 
     /* Enable snappy compression or reverse collator if required. */
     if (_config->get_bool(COMPRESSION_ENABLED) || _config->get_bool(REVERSE_COLLATOR)) {
-        db_create_config += EXTENSIONS_START;
+        db_create_config += ",extensions=[";
         db_create_config +=
           _config->get_bool(COMPRESSION_ENABLED) ? std::string(SNAPPY_PATH) + "," : "";
-        db_create_config += _config->get_bool(REVERSE_COLLATOR) ? std::string(REVERSE_PATH) : "";
-        db_create_config += EXTENSIONS_STOP;
+        db_create_config +=
+          _config->get_bool(REVERSE_COLLATOR) ? std::string(REVERSE_COLLATOR_PATH) : "";
+        db_create_config += "]";
     }
 
     /* Get the cache size. */

--- a/test/cppsuite/test_harness/test.cpp
+++ b/test/cppsuite/test_harness/test.cpp
@@ -103,7 +103,6 @@ test::run()
           _config->get_bool(COMPRESSION_ENABLED) ? std::string(SNAPPY_PATH) + "," : "";
         db_create_config += _config->get_bool(REVERSE_COLLATOR) ? std::string(REVERSE_PATH) : "";
         db_create_config += EXTENSIONS_STOP;
-        std::cout << db_create_config << std::endl;
     }
 
     /* Get the cache size. */

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -33,8 +33,8 @@
 #include "connection_manager.h"
 #include "core/configuration.h"
 #include "timestamp_manager.h"
-#include "workload/random_generator.h"
 #include "util/api_const.h"
+#include "workload/random_generator.h"
 
 namespace test_harness {
 const std::string
@@ -128,10 +128,10 @@ timestamp_manager::get_next_ts()
 }
 
 wt_timestamp_t
-timestamp_manager::get_random_ts()
+timestamp_manager::get_random_ts() const
 {
-    return random_generator::instance().generate_integer(
-      static_cast<uint64_t>(_oldest_ts), get_time_now_s());
+    return random_generator::instance().generate_integer<wt_timestamp_t>(
+      _oldest_ts, static_cast<wt_timestamp_t>(get_time_now_s()));
 }
 
 wt_timestamp_t

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -133,7 +133,6 @@ timestamp_manager::get_oldest_ts() const
     return (_oldest_ts);
 }
 
-
 wt_timestamp_t
 timestamp_manager::get_random_ts() const
 {

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -33,6 +33,7 @@
 #include "connection_manager.h"
 #include "core/configuration.h"
 #include "timestamp_manager.h"
+#include "workload/random_generator.h"
 #include "util/api_const.h"
 
 namespace test_harness {
@@ -124,6 +125,13 @@ timestamp_manager::get_next_ts()
     uint64_t increment = _increment_ts.fetch_add(1);
     current_time |= (increment & 0x00000000FFFFFFFF);
     return (current_time);
+}
+
+wt_timestamp_t
+timestamp_manager::get_random_ts()
+{
+    return random_generator::instance().generate_integer(
+      static_cast<uint64_t>(_oldest_ts), get_time_now_s());
 }
 
 wt_timestamp_t

--- a/test/cppsuite/test_harness/timestamp_manager.cpp
+++ b/test/cppsuite/test_harness/timestamp_manager.cpp
@@ -128,16 +128,17 @@ timestamp_manager::get_next_ts()
 }
 
 wt_timestamp_t
+timestamp_manager::get_oldest_ts() const
+{
+    return (_oldest_ts);
+}
+
+
+wt_timestamp_t
 timestamp_manager::get_random_ts() const
 {
     return random_generator::instance().generate_integer<wt_timestamp_t>(
       _oldest_ts, static_cast<wt_timestamp_t>(get_time_now_s()));
-}
-
-wt_timestamp_t
-timestamp_manager::get_oldest_ts() const
-{
-    return (_oldest_ts);
 }
 
 uint64_t

--- a/test/cppsuite/test_harness/timestamp_manager.h
+++ b/test/cppsuite/test_harness/timestamp_manager.h
@@ -59,6 +59,9 @@ class timestamp_manager : public component {
     /* Get a unique timestamp. */
     wt_timestamp_t get_next_ts();
 
+    /* Generate a random timestamp between the oldest timestamp and now. */
+    wt_timestamp_t get_random_ts();
+
     /* Get oldest timestamp. */
     wt_timestamp_t get_oldest_ts() const;
 

--- a/test/cppsuite/test_harness/timestamp_manager.h
+++ b/test/cppsuite/test_harness/timestamp_manager.h
@@ -59,11 +59,11 @@ class timestamp_manager : public component {
     /* Get a unique timestamp. */
     wt_timestamp_t get_next_ts();
 
-    /* Generate a random timestamp between the oldest timestamp and now. */
-    wt_timestamp_t get_random_ts() const;
-
     /* Get oldest timestamp. */
     wt_timestamp_t get_oldest_ts() const;
+
+    /* Generate a random timestamp between the oldest timestamp and now. */
+    wt_timestamp_t get_random_ts() const;
 
     private:
     /* Get the current time in seconds, bit shifted to the expected location. */

--- a/test/cppsuite/test_harness/timestamp_manager.h
+++ b/test/cppsuite/test_harness/timestamp_manager.h
@@ -60,7 +60,7 @@ class timestamp_manager : public component {
     wt_timestamp_t get_next_ts();
 
     /* Generate a random timestamp between the oldest timestamp and now. */
-    wt_timestamp_t get_random_ts();
+    wt_timestamp_t get_random_ts() const;
 
     /* Get oldest timestamp. */
     wt_timestamp_t get_oldest_ts() const;

--- a/test/cppsuite/test_harness/util/api_const.cpp
+++ b/test/cppsuite/test_harness/util/api_const.cpp
@@ -61,6 +61,7 @@ const std::string POPULATE_CONFIG = "populate_config";
 const std::string POSTRUN_STATISTICS = "postrun";
 const std::string READ_OP_CONFIG = "read_config";
 const std::string REMOVE_OP_CONFIG = "remove_config";
+const std::string REVERSE_COLLATOR = "reverse_collator";
 const std::string RUNTIME_STATISTICS = "runtime";
 const std::string SAVE = "save";
 const std::string STABLE_LAG = "stable_lag";

--- a/test/cppsuite/test_harness/util/api_const.h
+++ b/test/cppsuite/test_harness/util/api_const.h
@@ -98,12 +98,11 @@ extern const std::string STATISTICS_LOG;
 #endif
 
 /* Use reverse collator to test changes that deal different table sorting orders. */
-#define REVERSE_COL "collator=reverse"
+#define REVERSE_COL_CFG "collator=reverse"
 
-#define EXTENSIONS_START ",extensions=["
-#define EXTENSIONS_STOP "]"
 #define SNAPPY_PATH EXTPATH "compressors/snappy/" EXTSUBPATH "libwiredtiger_snappy.so"
-#define REVERSE_PATH EXTPATH "collators/reverse/" EXTSUBPATH "libwiredtiger_reverse_collator.so"
+#define REVERSE_COLLATOR_PATH \
+    EXTPATH "collators/reverse/" EXTSUBPATH "libwiredtiger_reverse_collator.so"
 
 /* Test harness consts. */
 extern const std::string DEFAULT_FRAMEWORK_SCHEMA;

--- a/test/cppsuite/test_harness/util/api_const.h
+++ b/test/cppsuite/test_harness/util/api_const.h
@@ -64,6 +64,7 @@ extern const std::string POPULATE_CONFIG;
 extern const std::string POSTRUN_STATISTICS;
 extern const std::string READ_OP_CONFIG;
 extern const std::string REMOVE_OP_CONFIG;
+extern const std::string REVERSE_COLLATOR;
 extern const std::string RUNTIME_STATISTICS;
 extern const std::string SAVE;
 extern const std::string STABLE_LAG;
@@ -95,8 +96,14 @@ extern const std::string STATISTICS_LOG;
 #ifndef EXTSUBPATH
 #define EXTSUBPATH ".libs/"
 #endif
+
+/* Use reverse collator to test changes that deal different table sorting orders. */
+#define REVERSE_COL "collator=reverse"
+
+#define EXTENSIONS_START ",extensions=["
+#define EXTENSIONS_STOP "]"
 #define SNAPPY_PATH EXTPATH "compressors/snappy/" EXTSUBPATH "libwiredtiger_snappy.so"
-#define SNAPPY_EXT ",extensions=(" SNAPPY_PATH ")"
+#define REVERSE_PATH EXTPATH "collators/reverse/" EXTSUBPATH "libwiredtiger_reverse_collator.so"
 
 /* Test harness consts. */
 extern const std::string DEFAULT_FRAMEWORK_SCHEMA;

--- a/test/cppsuite/test_harness/workload/database_model.cpp
+++ b/test/cppsuite/test_harness/workload/database_model.cpp
@@ -147,10 +147,10 @@ database::set_workload_tracking(workload_tracking *tracking)
 }
 
 void
-database::set_create_config(bool use_compression)
+database::set_create_config(bool use_compression, bool use_reverse_collator)
 {
-    _collection_create_config = use_compression ?
-      DEFAULT_FRAMEWORK_SCHEMA + std::string(SNAPPY_BLK) :
-      DEFAULT_FRAMEWORK_SCHEMA;
+    _collection_create_config = DEFAULT_FRAMEWORK_SCHEMA;
+    _collection_create_config += use_compression ? std::string(SNAPPY_BLK) + "," : "";
+    _collection_create_config += use_reverse_collator ? std::string(REVERSE_COL) + "," : "";
 }
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/database_model.cpp
+++ b/test/cppsuite/test_harness/workload/database_model.cpp
@@ -151,6 +151,6 @@ database::set_create_config(bool use_compression, bool use_reverse_collator)
 {
     _collection_create_config = DEFAULT_FRAMEWORK_SCHEMA;
     _collection_create_config += use_compression ? std::string(SNAPPY_BLK) + "," : "";
-    _collection_create_config += use_reverse_collator ? std::string(REVERSE_COL) + "," : "";
+    _collection_create_config += use_reverse_collator ? std::string(REVERSE_COL_CFG) + "," : "";
 }
 } // namespace test_harness

--- a/test/cppsuite/test_harness/workload/database_model.h
+++ b/test/cppsuite/test_harness/workload/database_model.h
@@ -105,7 +105,7 @@ class database {
     std::vector<uint64_t> get_collection_ids();
     void set_timestamp_manager(timestamp_manager *tsm);
     void set_workload_tracking(workload_tracking *tracking);
-    void set_create_config(bool use_compression);
+    void set_create_config(bool use_compression, bool use_reverse_collator);
 
     private:
     std::string _collection_create_config = "";

--- a/test/cppsuite/tests/search_near_02.cpp
+++ b/test/cppsuite/tests/search_near_02.cpp
@@ -173,15 +173,7 @@ class search_near_02 : public test_harness::test {
 
             auto &cursor_prefix = cursors[coll.id];
 
-            /*
-             * Pick a random timestamp between the oldest and now. Get rid of the last 32 bits as
-             * they represent an increment for uniqueness.
-             */
-            wt_timestamp_t ts = random_generator::instance().generate_integer(
-              (tc->tsm->get_oldest_ts() >> 32), (tc->tsm->get_next_ts() >> 32));
-            /* Put back the timestamp in the correct format. */
-            ts <<= 32;
-
+            wt_timestamp_t ts = tc->tsm->get_random_ts();
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
@@ -251,7 +243,7 @@ class search_near_02 : public test_harness::test {
             /* Both calls are successful. */
             if (ret_prefix == 0)
                 validate_successful_calls(
-                  ret_prefix, exact_prefix, key_prefix, cursor_default, exact_default, prefix);
+                  exact_prefix, key_prefix, cursor_default, exact_default, prefix);
             /* The prefix search near call failed. */
             else
                 validate_unsuccessful_prefix_call(cursor_default, prefix, exact_default);
@@ -271,7 +263,7 @@ class search_near_02 : public test_harness::test {
      * key that is lexicographically greater than the prefix but still contains the prefix.
      */
     void
-    validate_successful_calls(int ret_prefix, int exact_prefix, const std::string &key_prefix,
+    validate_successful_calls(int exact_prefix, const std::string &key_prefix,
       scoped_cursor &cursor_default, int exact_default, const std::string &prefix)
     {
         const char *k;


### PR DESCRIPTION
This ticket involves creating a reverse collator configuration in the CPPSuite framework. Furthermore the random timestamp functionality has been moved to the timestamp manager.