### PR TITLE
WT-9336 WiredTiger's RNG seed function is limited to 10^9 initial states.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -292,6 +292,7 @@ MULTIBLOCK
 MUTEX
 Manos
 MapViewOfFile
+Marsaglia
 Marsaglia's
 Mellor
 Memrata
@@ -381,6 +382,7 @@ RLE
 RLEs
 RMW
 RNG
+RNGs
 RPC
 RTS
 RUNDIR
@@ -532,6 +534,7 @@ Wunused
 XP
 Xcode
 Xcode/
+Xorshift
 YCSB
 Yann
 ZSTD

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2085,6 +2085,12 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     session_ret->name = NULL;
     session_ret->id = i;
 
+    /*
+     * Initialize the pseudo random number generator. We're not seeding it, so all of the sessions
+     * initialize to the same value and proceed in lock step for the session's life. That's not a
+     * problem because sessions are long-lived and will diverge into different parts of the value
+     * space, and what we care about are small values, that is, the low-order bits.
+     */
     if (WT_SESSION_FIRST_USE(session_ret))
         __wt_random_init(&session_ret->rnd);
 

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -59,9 +59,7 @@ __wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visib
 
 /*
  * __wt_random_init_seed --
- *     Initialize the state of a 32-bit pseudo-random number. Use this, instead of __wt_random_init
- *     if we are running with multiple threads and we want each thread to initialize its own random
- *     state based on a different random seed.
+ *     Initialize the state of a 32-bit pseudo-random number.
  */
 void
 __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state)
@@ -72,9 +70,13 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
     uint32_t v;
 
     /*
+     * Use this, instead of __wt_random_init if we need to vary the initial state of the RNG. This
+     * is (currently) only used by test programs, where, for example, an initial set of test data is
+     * created by a single thread, and we want more variability in the initial state of the RNG.
+     *
      * A nanosecond seed only gives us 10^9 bits (assuming it's perfect), so sample it twice and
-     * generate an initial random number, using algorithm "xor" from p. 4 of Marsaglia, "Xorshift
-     * RNGs".
+     * generate an initial random number to use as our seed, using algorithm "xor" from Marsaglia,
+     * "Xorshift RNGs".
      */
     __wt_epoch(session, &ts);
     v = (uint32_t)ts.tv_nsec;


### PR DESCRIPTION
WiredTiger's RNG seed function uses the system's clock time nanoseconds component, which isn't a great source as a seed value, it's limited to 10^9 assuming it's uniform. Instead, sample the time twice (once for the top 4B, once for the bottom 4B), and use algorithm "xor" from Marsaglia, "Xorshift RNGs" to generate an initial random value to use as a seed.