### PR TITLE
WT-9046 Don't call error handler when logging an error with __stdio_printf

### DIFF
--- a/src/os_common/os_fstream_stdio.c
+++ b/src/os_common/os_fstream_stdio.c
@@ -48,6 +48,8 @@ __stdio_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fs, WT_ITEM *buf)
 static int
 __stdio_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fs, const char *fmt, va_list ap)
 {
+    WT_UNUSED(session);
+
     if (vfprintf(fs->fp, fmt, ap) >= 0)
         return (0);
     return(EIO);

--- a/src/os_common/os_fstream_stdio.c
+++ b/src/os_common/os_fstream_stdio.c
@@ -50,7 +50,7 @@ __stdio_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fs, const char *fmt, va_lis
 {
     if (vfprintf(fs->fp, fmt, ap) >= 0)
         return (0);
-    WT_RET_MSG(session, EIO, "%s: printf", fs->name);
+    return(EIO);
 }
 
 /*

--- a/src/os_common/os_fstream_stdio.c
+++ b/src/os_common/os_fstream_stdio.c
@@ -52,7 +52,7 @@ __stdio_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fs, const char *fmt, va_lis
 
     if (vfprintf(fs->fp, fmt, ap) >= 0)
         return (0);
-    return(EIO);
+    return (EIO);
 }
 
 /*


### PR DESCRIPTION
Returning EIO from __stdio_printf if `vfprintf` fails (instead of `WT_ERR_MSG`), prevents the stack from overflowing with printf errors with printf is unable to print.