### PR TITLE
WT-9341 Implement proper visible_all for reading checkpoints

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -332,16 +332,10 @@ restart_read:
          * Note: it's important that we're checking the on-disk value for global visibility, and not
          * whatever __wt_txn_read returned, which might be something else. (If it's something else,
          * we can't cache it; but in that case the on-disk value cannot be globally visible.)
-         *
-         * If we're reading from a checkpoint, it's sufficient to check visibility against the
-         * checkpoint's snapshot. Don't check global visibility, because that checks the current
-         * state of the world rather than the checkpoint state.
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&
-          (WT_READING_CHECKPOINT(session) ?
-              __wt_txn_visible(session, unpack.tw.start_txn, unpack.tw.durable_start_ts) :
-              __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts))) {
+          __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts)) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -490,16 +490,10 @@ restart_read:
          * Note: it's important that we're checking the on-disk value for global visibility, and not
          * whatever __wt_txn_read returned, which might be something else. (If it's something else,
          * we can't cache it; but in that case the on-disk value cannot be globally visible.)
-         *
-         * If we're reading from a checkpoint, it's sufficient to check visibility against the
-         * checkpoint's snapshot. Don't check global visibility, because that checks the current
-         * state of the world rather than the checkpoint state.
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&
-          (WT_READING_CHECKPOINT(session) ?
-              __wt_txn_visible(session, unpack.tw.start_txn, unpack.tw.durable_start_ts) :
-              __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts))) {
+          __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts)) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -242,16 +242,11 @@ __wt_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
      * The fast-truncate structure can be freed as soon as the delete is stable: it is only read
      * when the ref state is locked. It is worth checking every time we come through because once
      * this is freed, we no longer need synchronization to check the ref.
-     *
-     * If we are reading from a checkpoint, we can't do the visible_all check (it checks the current
-     * state of the world and not the checkpoint) but also, because the checkpoint is immutable the
-     * delete can't ever become fully stable so we should never discard the fast-truncate structure.
      */
     if (skip && ref->ft_info.del != NULL &&
       (visible_all ||
-        (!WT_READING_CHECKPOINT(session) &&
-          __wt_txn_visible_all(
-            session, ref->ft_info.del->txnid, ref->ft_info.del->durable_timestamp))))
+        __wt_txn_visible_all(
+          session, ref->ft_info.del->txnid, ref->ft_info.del->durable_timestamp)))
         __wt_overwrite_and_free(session, ref->ft_info.del);
 
     WT_REF_SET_STATE(ref, WT_REF_DELETED);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -995,12 +995,8 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp)
              *
              * The visibility information is not referenced on the page so we need to ensure that
              * the value is globally visible at the point in time where we read the page into cache.
-             *
-             * Skip if reading from a checkpoint because visible_all uses the current oldest txnid,
-             * which is not in general the checkpoint's oldest txnid, and may make things visible
-             * that shouldn't be.
              */
-            if (!btree->huffman_value && !WT_READING_CHECKPOINT(session) &&
+            if (!btree->huffman_value &&
               (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
                 (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&
                   __wt_txn_tw_start_visible_all(session, &unpack.tw))))

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -449,13 +449,11 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
             break;
 
         /*
-         * If the stop time pair on the tombstone in the history store is already globally visible
-         * we can skip it. But only if we aren't reading from a checkpoint. If we're reading from a
-         * checkpoint, we need to see the world as of the checkpoint, and visible-all checks refer
-         * to the current world.
+         * If the stop time pair on the tombstone in the history store is already globally visible,
+         * it is outdated and we must skip it rather than returning NOTFOUND. Subsequent entries
+         * might have later stop times and we might need to return one of them.
          */
-        if (!WT_READING_CHECKPOINT(session) &&
-          __wt_txn_tw_stop_visible_all(session, &cbt->upd_value->tw)) {
+        if (__wt_txn_tw_stop_visible_all(session, &cbt->upd_value->tw)) {
             WT_STAT_CONN_DATA_INCR(session, cursor_prev_hs_tombstone);
             continue;
         }
@@ -548,13 +546,11 @@ __curhs_next_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
             break;
 
         /*
-         * If the stop time pair on the tombstone in the history store is already globally visible
-         * we can skip it. But only if we aren't reading from a checkpoint. If we're reading from a
-         * checkpoint, we need to see the world as of the checkpoint, and visible-all checks refer
-         * to the current world.
+         * If the stop time pair on the tombstone in the history store is already globally visible,
+         * it is outdated and we must skip it rather than returning NOTFOUND. Subsequent entries
+         * might have later stop times and we might need to return one of them.
          */
-        if (!WT_READING_CHECKPOINT(session) &&
-          __wt_txn_tw_stop_visible_all(session, &cbt->upd_value->tw)) {
+        if (__wt_txn_tw_stop_visible_all(session, &cbt->upd_value->tw)) {
             WT_STAT_CONN_DATA_INCR(session, cursor_next_hs_tombstone);
             continue;
         }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1539,14 +1539,6 @@ __wt_page_del_active(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
         return (false);
     if (page_del->txnid == WT_TXN_ABORTED)
         return (false);
-    /*
-     * If we are reading from a checkpoint, visible_all checks don't work (they check the current
-     * state of the world and not the checkpoint) so operate under the assumption that if the
-     * truncate operation appears in the checkpoint, it must have been visible to somebody, and
-     * because the checkpoint is immutable, that won't ever change.
-     */
-    if (WT_READING_CHECKPOINT(session) && visible_all)
-        return (true);
     WT_ORDERED_READ(prepare_state, page_del->prepare_state);
     if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
         return (true);

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -293,9 +293,11 @@ struct __wt_txn {
     wt_timestamp_t prepare_timestamp;
 
     /*
-     * Timestamp used for reading via a checkpoint cursor instead of txn_shared->read_timestamp.
+     * Timestamps used for reading via a checkpoint cursor instead of txn_shared->read_timestamp and
+     * the current oldest/pinned timestamp, respectively.
      */
     wt_timestamp_t checkpoint_read_timestamp;
+    wt_timestamp_t checkpoint_oldest_timestamp;
 
     /* Array of modifications by this transaction. */
     WT_TXN_OP *mod;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -514,8 +514,24 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
 static inline bool
 __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
 {
+    WT_TXN *txn;
     uint64_t oldest_id;
 
+    txn = session->txn;
+
+    /*
+     * When reading from a checkpoint, all readers use the same snapshot, so a transaction is
+     *     globally visible if it is visible in that snapshot. Note that this can cause things that
+     *     were not globally visible yet when the checkpoint is taken to become globally visible in
+     *     the checkpoint. This is expected (it is like all the old running transactions exited) --
+     *     but note that it's important that the inverse change (something globally visible when the
+     *     checkpoint was taken becomes not globally visible in the checkpoint) never happen as this
+     *     violates basic assumptions about visibility. (And, concretely, it can cause stale history
+     *     store entries to come back to life and produce wrong answers.)
+     */
+    if (WT_READING_CHECKPOINT(session))
+        return (__wt_txn_visible_id_snapshot(
+          id, txn->snap_min, txn->snap_max, txn->snapshot, txn->snapshot_count));
     oldest_id = __wt_txn_oldest_id(session);
 
     return (WT_TXNID_LT(id, oldest_id));
@@ -551,6 +567,11 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
     /* Timestamp check. */
     if (timestamp == WT_TS_NONE)
         return (true);
+
+    /* When reading a checkpoint, use the checkpoint state instead of the current state. */
+    if (WT_READING_CHECKPOINT(session))
+        return (session->txn->checkpoint_oldest_timestamp != WT_TS_NONE &&
+          timestamp <= session->txn->checkpoint_oldest_timestamp);
 
     /* If no oldest timestamp has been supplied, updates have to stay in cache. */
     __wt_txn_pinned_timestamp(session, &pinned_ts);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -521,13 +521,13 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
 
     /*
      * When reading from a checkpoint, all readers use the same snapshot, so a transaction is
-     *     globally visible if it is visible in that snapshot. Note that this can cause things that
-     *     were not globally visible yet when the checkpoint is taken to become globally visible in
-     *     the checkpoint. This is expected (it is like all the old running transactions exited) --
-     *     but note that it's important that the inverse change (something globally visible when the
-     *     checkpoint was taken becomes not globally visible in the checkpoint) never happen as this
-     *     violates basic assumptions about visibility. (And, concretely, it can cause stale history
-     *     store entries to come back to life and produce wrong answers.)
+     * globally visible if it is visible in that snapshot. Note that this can cause things that were
+     * not globally visible yet when the checkpoint is taken to become globally visible in the
+     * checkpoint. This is expected (it is like all the old running transactions exited) -- but note
+     * that it's important that the inverse change (something globally visible when the checkpoint
+     * was taken becomes not globally visible in the checkpoint) never happen as this violates basic
+     * assumptions about visibility. (And, concretely, it can cause stale history store entries to
+     * come back to life and produce wrong answers.)
      */
     if (WT_READING_CHECKPOINT(session))
         return (__wt_txn_visible_id_snapshot(

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2108,8 +2108,9 @@ __wt_txn_init_checkpoint_cursor(
      */
     snapinfo->snapshot_txns = NULL;
 
-    /* Set the read timestamp.  */
+    /* Set the read and oldest timestamps.  */
     txn->checkpoint_read_timestamp = snapinfo->stable_ts;
+    txn->checkpoint_oldest_timestamp = snapinfo->oldest_ts;
 
     /* Set the flag that indicates if we have a timestamp. */
     if (txn->checkpoint_read_timestamp != WT_TS_NONE)


### PR DESCRIPTION
It turns out that reading from a history store checkpoint correctly requires doing accurate visible_all checks relative to the checkpoint context; bypassing them doesn't work. This is because it's possible for outdated history store entries with globally visible stop times and nonzero start times to hang around; they are necessarily sorted (and thus seen during reads) before more recently added entries with zero start times and later stop times. They're supposed to be skipped over via a global visibility check; that check can't be shortcut. (Assuming all stop times are globally visible causes items to disappear; assuming none are causes obsolete stop times to be honored and thus also causes items to disappear.) Therefore, visible_all needs to be able to test against the checkpoint's oldest timestamp and the checkpoint's transaction state. Fortunately all the needed information is reasonably readily available...