### PR TITLE
WT-9338 Fix wttest to not download S3 objects when test is skipped

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -580,7 +580,7 @@ class WiredTigerTestCase(unittest.TestCase):
 
         # Download the files from the S3 bucket for tiered tests if the test fails or preserve is
         # turned on.
-        if hasattr(self, 'ss_name') and self.ss_name == 's3_store' and not self.skipped \
+        if hasattr(self, 'ss_name') and self.ss_name == 's3_store' and not self.skipped and \
             (not passed or WiredTigerTestCase._preserveFiles):
                 self.download_objects(self.bucket, self.bucket_prefix)
                 self.pr('downloading s3 files')

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -580,8 +580,8 @@ class WiredTigerTestCase(unittest.TestCase):
 
         # Download the files from the S3 bucket for tiered tests if the test fails or preserve is
         # turned on.
-        if hasattr(self, 'ss_name') and self.ss_name == 's3_store' and \
-            ((not passed and not self.skipped) or (WiredTigerTestCase._preserveFiles)):
+        if hasattr(self, 'ss_name') and self.ss_name == 's3_store' and not self.skipped \
+            (not passed or WiredTigerTestCase._preserveFiles):
                 self.download_objects(self.bucket, self.bucket_prefix)
                 self.pr('downloading s3 files')
 


### PR DESCRIPTION
This change fixes the bug where `wttest` would try and download objects from the S3 bucket even when the S3 test is skipped.