### PR TITLE
WT-8908 Expand s_all to check return values are in parentheses

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -46,9 +46,14 @@ else
 		if egrep -r -n '\b[a-z]+[A-Z]' $f | egrep -v ':[     ]+\*|"|UNCHECKED_STRING'; then
 			echo "$f: Styling requires variables that use underscores to separate parts of a name instead of camel casing.";
 		fi
-		if egrep -r -n '^[^*/"]*[[:space:]]*return [^(]' $f; then
-			echo "Adding parentheses to return values.";
-		fi
+		egrep -r -n '^[^*/"]*[[:space:]]*return [^(]' $f > $t;
+		test -s $t && {
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+			echo 'Add parentheses to return values indicated below in file '"$f"
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+			cat $t
+			exit 1
+		}
 	fi
 
 	# Remove non-ascii characters and substitute some expressions with accepted version.

--- a/dist/s_style
+++ b/dist/s_style
@@ -52,7 +52,6 @@ else
 			echo 'Add parentheses to return values indicated below in file '"$f"
 			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 			cat $t
-			exit 1
 		}
 	fi
 

--- a/dist/s_style
+++ b/dist/s_style
@@ -46,9 +46,9 @@ else
 		# Camel case style is not allowed.
 		if egrep -r -n '\b[a-z]+[A-Z]' $f | egrep -v ':[     ]+\*|"|UNCHECKED_STRING'; then
 			echo "$f: Styling requires variables that use underscores to separate parts of a name instead of camel casing.";
+		fi
 		
 		# Return values should be wrapped in parentheses.
-		fi
 		egrep -r -n '^[^*/"]*[[:space:]]*return [^(]' $f > $t;
 		test -s $t && {
 			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="

--- a/dist/s_style
+++ b/dist/s_style
@@ -34,7 +34,7 @@ else
 		exit 1;
 	fi
 
-	# Ignore styling errors of external libraries. 
+	# Ignore styling errors of external libraries.
 	if expr "$f" : 'src/' > /dev/null &&
 	  ! expr "$f" : 'src/os_win/' > /dev/null &&
 	  ! expr "$f" : 'src/docs/' > /dev/null &&

--- a/dist/s_style
+++ b/dist/s_style
@@ -34,8 +34,7 @@ else
 		exit 1;
 	fi
 
-	# For files in the src directory, camel case style is not allowed.
-	# Ignore styling errors of external libraries.
+	# Ignore styling errors of external libraries. 
 	if expr "$f" : 'src/' > /dev/null &&
 	  ! expr "$f" : 'src/os_win/' > /dev/null &&
 	  ! expr "$f" : 'src/docs/' > /dev/null &&
@@ -43,8 +42,12 @@ else
 	  ! expr "$f" : 'src/.*/hash_city.*' > /dev/null &&
 	  ! expr "$f" : 'src/.*/huffman.*' > /dev/null &&
 	  ! expr "$f" : 'src/checksum.*' > /dev/null; then
+
+		# Camel case style is not allowed.
 		if egrep -r -n '\b[a-z]+[A-Z]' $f | egrep -v ':[     ]+\*|"|UNCHECKED_STRING'; then
 			echo "$f: Styling requires variables that use underscores to separate parts of a name instead of camel casing.";
+		
+		# Return values should be wrapped in parentheses.
 		fi
 		egrep -r -n '^[^*/"]*[[:space:]]*return [^(]' $f > $t;
 		test -s $t && {

--- a/dist/s_style
+++ b/dist/s_style
@@ -46,6 +46,9 @@ else
 		if egrep -r -n '\b[a-z]+[A-Z]' $f | egrep -v ':[     ]+\*|"|UNCHECKED_STRING'; then
 			echo "$f: Styling requires variables that use underscores to separate parts of a name instead of camel casing.";
 		fi
+		if egrep -r -n '^[^*/"]*[[:space:]]*return [^(]' $f; then
+			echo "Adding parentheses to return values.";
+		fi
 	fi
 
 	# Remove non-ascii characters and substitute some expressions with accepted version.

--- a/src/conn/api_calc_modify.c
+++ b/src/conn/api_calc_modify.c
@@ -199,5 +199,6 @@ int
 wiredtiger_calc_modify(WT_SESSION *wt_session, const WT_ITEM *oldv, const WT_ITEM *newv,
   size_t maxdiff, WT_MODIFY *entries, int *nentriesp)
 {
-    return __wt_calc_modify((WT_SESSION_IMPL *)wt_session, oldv, newv, maxdiff, entries, nentriesp);
+    return (
+      __wt_calc_modify((WT_SESSION_IMPL *)wt_session, oldv, newv, maxdiff, entries, nentriesp));
 }

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -93,18 +93,18 @@ static uint16_t
 __logmgr_get_log_version(WT_VERSION version)
 {
     if (!__wt_version_defined(version))
-        return WT_NO_VALUE;
+        return (WT_NO_VALUE);
 
     if (__wt_version_lt(version, WT_LOG_V2_VERSION))
-        return 1;
+        return (1);
     else if (__wt_version_lt(version, WT_LOG_V3_VERSION))
-        return 2;
+        return (2);
     else if (__wt_version_lt(version, WT_LOG_V4_VERSION))
-        return 3;
+        return (3);
     else if (__wt_version_lt(version, WT_LOG_V5_VERSION))
-        return 4;
+        return (4);
     else
-        return WT_LOG_VERSION;
+        return (WT_LOG_VERSION);
 }
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -950,7 +950,7 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
 static inline int
 __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd)
 {
-    return __wt_txn_read_upd_list_internal(session, cbt, upd, NULL, NULL);
+    return (__wt_txn_read_upd_list_internal(session, cbt, upd, NULL, NULL));
 }
 
 /*

--- a/src/include/version.h
+++ b/src/include/version.h
@@ -45,16 +45,16 @@ __wt_version_cmp(WT_VERSION v, WT_VERSION other)
         v.patch = other.patch = 0;
 
     if (v.major == other.major && v.minor == other.minor && v.patch == other.patch)
-        return 0;
+        return (0);
 
     if (v.major > other.major)
-        return 1;
+        return (1);
     if (v.major == other.major && v.minor > other.minor)
-        return 1;
+        return (1);
     if (v.major == other.major && v.minor == other.minor && v.patch > other.patch)
-        return 1;
+        return (1);
 
-    return -1;
+    return (-1);
 }
 
 /*
@@ -65,7 +65,7 @@ __wt_version_cmp(WT_VERSION v, WT_VERSION other)
 static inline bool
 __wt_version_defined(WT_VERSION v)
 {
-    return v.major != WT_NO_VALUE && v.minor != WT_NO_VALUE;
+    return (v.major != WT_NO_VALUE && v.minor != WT_NO_VALUE);
 }
 
 /*
@@ -75,7 +75,7 @@ __wt_version_defined(WT_VERSION v)
 static inline bool
 __wt_version_eq(WT_VERSION v, WT_VERSION other)
 {
-    return __wt_version_cmp(v, other) == 0;
+    return (__wt_version_cmp(v, other) == 0);
 }
 
 /*
@@ -85,7 +85,7 @@ __wt_version_eq(WT_VERSION v, WT_VERSION other)
 static inline bool
 __wt_version_gt(WT_VERSION v, WT_VERSION other)
 {
-    return __wt_version_cmp(v, other) == 1;
+    return (__wt_version_cmp(v, other) == 1);
 }
 
 /*
@@ -95,7 +95,7 @@ __wt_version_gt(WT_VERSION v, WT_VERSION other)
 static inline bool
 __wt_version_gte(WT_VERSION v, WT_VERSION other)
 {
-    return __wt_version_cmp(v, other) != -1;
+    return (__wt_version_cmp(v, other) != -1);
 }
 
 /*
@@ -105,7 +105,7 @@ __wt_version_gte(WT_VERSION v, WT_VERSION other)
 static inline bool
 __wt_version_lt(WT_VERSION v, WT_VERSION other)
 {
-    return __wt_version_cmp(v, other) == -1;
+    return (__wt_version_cmp(v, other) == -1);
 }
 
 /*
@@ -115,5 +115,5 @@ __wt_version_lt(WT_VERSION v, WT_VERSION other)
 static inline bool
 __wt_version_lte(WT_VERSION v, WT_VERSION other)
 {
-    return __wt_version_cmp(v, other) != 1;
+    return (__wt_version_cmp(v, other) != 1);
 }

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -147,7 +147,7 @@ __alter_get_object_id_range(WT_SESSION_IMPL *session, WT_TIERED *tiered, const c
 err:
     __wt_free(session, value);
 
-    return ret;
+    return (ret);
 }
 
 /*

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -375,7 +375,7 @@ __create_import_cmp_uri(const void *a, const void *b)
     ae = (WT_IMPORT_ENTRY *)a;
     be = (WT_IMPORT_ENTRY *)b;
 
-    return strcmp(ae->uri, be->uri);
+    return (strcmp(ae->uri, be->uri));
 }
 
 /*
@@ -394,11 +394,11 @@ __create_import_cmp_id(const void *a, const void *b)
 
     res = ae->file_id - be->file_id;
     if (res < 0)
-        return -1;
+        return (-1);
     else if (res > 0)
-        return 1;
+        return (1);
     else
-        return 0;
+        return (0);
 }
 
 /*


### PR DESCRIPTION
* Added a check to `s_all` in `s_style` to check that return values are in brackets.
  * Modified the regex to ensure that comments and strings with 'return' will not be picked up. 
  * Output with filename, line number and expression. 
  * Tested with edge cases. 
  
* Modified code in files that have missed parentheses.  