### PR TITLE
WT-9367 Fix remaining race in checkpoint cursor open

### DIFF
--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1680,7 +1680,7 @@ err:
 
 /*
  * __meta_retrieve_timestamp --
- *     Retrieve a timestamp from the metadata. Not present explicitly means WT_TXN_NONE.
+ *     Retrieve a timestamp from the metadata. Not present explicitly means WT_TS_NONE.
  */
 static int
 __meta_retrieve_timestamp(WT_SESSION_IMPL *session, const char *system_uri,


### PR DESCRIPTION
Fix metadata race in checkpoint cursor open.

Read the timestamps after the snapshot; the timestamps are written
before the snapshot, so we know that if we get a timestamp it must be
either from the same checkpoint or newer than the snapshot. It isn't
valid to have or use a timestamp from an earlier checkpoint (unlike a
btree) -- if the timestamp isn't present it's cleared. However,
because the system can't go from having a stable (or oldest) timestamp
to not having one, if we get none we're ok even if it's actually from
the next checkpoint.

(The trouble is that if the timestamp isn't written, we don't get a
wall clock time for it, so we have to allow for this.)