### PR TITLE
WT-9295 Add missing ENABLE_MEMKIND to wiredtiger_config generator file

### DIFF
--- a/cmake/configs/wiredtiger_config.h.in
+++ b/cmake/configs/wiredtiger_config.h.in
@@ -66,6 +66,9 @@
 /* Define to 1 if you have the `memkind' library (-lmemkind). */
 #cmakedefine HAVE_LIBMEMKIND 1
 
+/* Define to 1 if the user has explicitly enable memkind builds. */
+#cmakedefine ENABLE_MEMKIND 1
+
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #cmakedefine HAVE_LIBPTHREAD 1
 


### PR DESCRIPTION
Sorry about leaving this out, I've verified it's working now with the following four combinations:
* Machine without libmemkind, and `HAVE_MEMKIND=0` (builds fine, but without memkind of course)
* Machine without libmemkind, and `HAVE_MEMKIND=1` (fails to build, as expected)
* Machine with libmemkind, and `HAVE_MEMKIND=0` (verified it takes the non-memkind preprocessor option)
* Machien with libmemkind, and `HAVE_MEMKIND=1` (verified it's now seeing the right include directive).

Note that the default memkind version on an Ubuntu 18.04 workstation is too old, the version in 20.04 works fine though.