### PR TITLE
WT-9251 Perform log flush before the metadata checkpoint (v5.0 backport) (#7910)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -845,9 +845,10 @@ connection_runtime_config = [
         type='list', undoc=True,
         choices=[
         'aggressive_sweep', 'backup_rename', 'checkpoint_reserved_txnid_delay', 'checkpoint_slow',
-        'checkpoint_stop', 'failpoint_history_store_delete_key_from_ts', 'history_store_checkpoint_delay',
-        'history_store_search', 'history_store_sweep_race', 'prepare_checkpoint_delay', 'split_1',
-        'split_2', 'split_3', 'split_4', 'split_5', 'split_6', 'split_7']),
+        'checkpoint_stop', 'failpoint_history_store_delete_key_from_ts',
+        'history_store_checkpoint_delay', 'history_store_search', 'history_store_sweep_race',
+        'prepare_checkpoint_delay', 'split_1', 'split_2', 'split_3', 'split_4', 'split_5',
+        'split_6', 'split_7']),
     Config('verbose', '[]', r'''
         enable messages for various subsystems and operations. Options are given as a list,
         where each message type can optionally define an associated verbosity level, such as

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -845,7 +845,7 @@ connection_runtime_config = [
         type='list', undoc=True,
         choices=[
         'aggressive_sweep', 'backup_rename', 'checkpoint_reserved_txnid_delay', 'checkpoint_slow',
-        'failpoint_history_store_delete_key_from_ts', 'history_store_checkpoint_delay',
+        'checkpoint_stop', 'failpoint_history_store_delete_key_from_ts', 'history_store_checkpoint_delay',
         'history_store_search', 'history_store_sweep_race', 'prepare_checkpoint_delay', 'split_1',
         'split_2', 'split_3', 'split_4', 'split_5', 'split_6', 'split_7']),
     Config('verbose', '[]', r'''
@@ -973,6 +973,11 @@ wiredtiger_open_log_configuration = [
             the maximum size of log files''',
             min='100KB',    # !!! Must match WT_LOG_FILE_MIN
             max='2GB'),    # !!! Must match WT_LOG_FILE_MAX
+        Config('force_write_wait', '0', r'''
+            enable code that interrupts the usual timing of flushing the log from
+            the internal log server thread with a goal of uncovering race conditions.
+            This option is intended for use with internal stress testing of WiredTiger.''',
+            min='1', max='60', undoc=True),
         Config('path', '"."', r'''
             the name of a directory into which log files are written. The
             directory must already exist. If the value is not an absolute path,

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -568,6 +568,7 @@ conn_stats = [
     TxnStat('txn_checkpoint_time_min', 'transaction checkpoint min time (msecs)', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_time_recent', 'transaction checkpoint most recent time (msecs)', 'no_clear,no_scale'),
     TxnStat('txn_checkpoint_time_total', 'transaction checkpoint total time (msecs)', 'no_clear,no_scale'),
+    TxnStat('txn_checkpoint_stop_stress_active', 'transaction checkpoint stop timing stress active', 'no_clear,no_scale'),
     TxnStat('txn_commit', 'transactions committed'),
     TxnStat('txn_fail_cache', 'transaction failures due to history store'),
     TxnStat('txn_pinned_checkpoint_range', 'transaction range of IDs currently pinned by a checkpoint', 'no_clear,no_scale'),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -154,6 +154,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
   {"timing_stress_for_test", "list", NULL,
     "choices=[\"aggressive_sweep\",\"backup_rename\","
     "\"checkpoint_reserved_txnid_delay\",\"checkpoint_slow\","
+    "\"checkpoint_stop\","
     "\"failpoint_history_store_delete_key_from_ts\","
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
@@ -804,6 +805,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_log_subconfigs[] = {
   {"archive", "boolean", NULL, NULL, NULL, 0}, {"compressor", "string", NULL, NULL, NULL, 0},
   {"enabled", "boolean", NULL, NULL, NULL, 0},
   {"file_max", "int", NULL, "min=100KB,max=2GB", NULL, 0},
+  {"force_write_wait", "int", NULL, "min=1,max=60", NULL, 0},
   {"os_cache_dirty_pct", "int", NULL, "min=0,max=100", NULL, 0},
   {"path", "string", NULL, NULL, NULL, 0}, {"prealloc", "boolean", NULL, NULL, NULL, 0},
   {"recover", "string", NULL, "choices=[\"error\",\"on\"]", NULL, 0},
@@ -862,7 +864,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"in_memory", "boolean", NULL, NULL, NULL, 0},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
-  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 9},
+  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2},
   {"mmap", "boolean", NULL, NULL, NULL, 0}, {"mmap_all", "boolean", NULL, NULL, NULL, 0},
   {"multiprocess", "boolean", NULL, NULL, NULL, 0},
@@ -884,6 +886,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
   {"timing_stress_for_test", "list", NULL,
     "choices=[\"aggressive_sweep\",\"backup_rename\","
     "\"checkpoint_reserved_txnid_delay\",\"checkpoint_slow\","
+    "\"checkpoint_stop\","
     "\"failpoint_history_store_delete_key_from_ts\","
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
@@ -943,7 +946,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"in_memory", "boolean", NULL, NULL, NULL, 0},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
-  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 9},
+  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2},
   {"mmap", "boolean", NULL, NULL, NULL, 0}, {"mmap_all", "boolean", NULL, NULL, NULL, 0},
   {"multiprocess", "boolean", NULL, NULL, NULL, 0},
@@ -965,6 +968,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
   {"timing_stress_for_test", "list", NULL,
     "choices=[\"aggressive_sweep\",\"backup_rename\","
     "\"checkpoint_reserved_txnid_delay\",\"checkpoint_slow\","
+    "\"checkpoint_stop\","
     "\"failpoint_history_store_delete_key_from_ts\","
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
@@ -1021,7 +1025,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
-  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 9},
+  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2},
   {"mmap", "boolean", NULL, NULL, NULL, 0}, {"mmap_all", "boolean", NULL, NULL, NULL, 0},
   {"multiprocess", "boolean", NULL, NULL, NULL, 0},
@@ -1043,6 +1047,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
   {"timing_stress_for_test", "list", NULL,
     "choices=[\"aggressive_sweep\",\"backup_rename\","
     "\"checkpoint_reserved_txnid_delay\",\"checkpoint_slow\","
+    "\"checkpoint_stop\","
     "\"failpoint_history_store_delete_key_from_ts\","
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
@@ -1097,7 +1102,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
-  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 9},
+  {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2},
   {"mmap", "boolean", NULL, NULL, NULL, 0}, {"mmap_all", "boolean", NULL, NULL, NULL, 0},
   {"multiprocess", "boolean", NULL, NULL, NULL, 0},
@@ -1119,6 +1124,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
   {"timing_stress_for_test", "list", NULL,
     "choices=[\"aggressive_sweep\",\"backup_rename\","
     "\"checkpoint_reserved_txnid_delay\",\"checkpoint_slow\","
+    "\"checkpoint_stop\","
     "\"failpoint_history_store_delete_key_from_ts\","
     "\"history_store_checkpoint_delay\",\"history_store_search\","
     "\"history_store_sweep_race\",\"prepare_checkpoint_delay\","
@@ -1453,16 +1459,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
     "hazard_max=1000,history_store=(file_max=0),in_memory=false,"
     "io_capacity=(total=0),log=(archive=true,compressor=,"
-    "enabled=false,file_max=100MB,os_cache_dirty_pct=0,path=\".\","
-    "prealloc=true,recover=on,zero_fill=false),"
-    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
-    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
-    "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
-    "salvage=false,session_max=100,session_scratch_max=2MB,"
-    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
-    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-    ",wait=0),tiered_manager=(threads_max=8,threads_min=1,wait=0),"
+    "enabled=false,file_max=100MB,force_write_wait=0,"
+    "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
+    "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+    "mmap=true,mmap_all=false,multiprocess=false,"
+    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
+    "path=\".\"),readonly=false,salvage=false,session_max=100,"
+    "session_scratch_max=2MB,session_table_cache=true,"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "statistics=none,statistics_log=(json=false,on_close=false,"
+    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "tiered_manager=(threads_max=8,threads_min=1,wait=0),"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,local_retention=300,name=,"
     "object_target_size=10M),timing_stress_for_test=,"
@@ -1493,16 +1500,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
     "hazard_max=1000,history_store=(file_max=0),in_memory=false,"
     "io_capacity=(total=0),log=(archive=true,compressor=,"
-    "enabled=false,file_max=100MB,os_cache_dirty_pct=0,path=\".\","
-    "prealloc=true,recover=on,zero_fill=false),"
-    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
-    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
-    "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
-    "salvage=false,session_max=100,session_scratch_max=2MB,"
-    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
-    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
-    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
-    ",wait=0),tiered_manager=(threads_max=8,threads_min=1,wait=0),"
+    "enabled=false,file_max=100MB,force_write_wait=0,"
+    "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
+    "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+    "mmap=true,mmap_all=false,multiprocess=false,"
+    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
+    "path=\".\"),readonly=false,salvage=false,session_max=100,"
+    "session_scratch_max=2MB,session_table_cache=true,"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "statistics=none,statistics_log=(json=false,on_close=false,"
+    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "tiered_manager=(threads_max=8,threads_min=1,wait=0),"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,local_retention=300,name=,"
     "object_target_size=10M),timing_stress_for_test=,"
@@ -1533,10 +1541,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
     "hazard_max=1000,history_store=(file_max=0),io_capacity=(total=0)"
     ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-    "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
-    "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
-    "mmap=true,mmap_all=false,multiprocess=false,"
-    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
+    "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
+    ",recover=on,zero_fill=false),lsm_manager=(merge=true,"
+    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
+    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
     "path=\".\"),readonly=false,salvage=false,session_max=100,"
     "session_scratch_max=2MB,session_table_cache=true,"
     "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
@@ -1572,10 +1580,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
     "hazard_max=1000,history_store=(file_max=0),io_capacity=(total=0)"
     ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
-    "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
-    "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
-    "mmap=true,mmap_all=false,multiprocess=false,"
-    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
+    "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
+    ",recover=on,zero_fill=false),lsm_manager=(merge=true,"
+    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
+    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
     "path=\".\"),readonly=false,salvage=false,session_max=100,"
     "session_scratch_max=2MB,session_table_cache=true,"
     "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2189,6 +2189,7 @@ __wt_timing_stress_config(WT_SESSION_IMPL *session, const char *cfg[])
       {"backup_rename", WT_TIMING_STRESS_BACKUP_RENAME},
       {"checkpoint_reserved_txnid_delay", WT_TIMING_STRESS_CHECKPOINT_RESERVED_TXNID_DELAY},
       {"checkpoint_slow", WT_TIMING_STRESS_CHECKPOINT_SLOW},
+      {"checkpoint_stop", WT_TIMING_STRESS_CHECKPOINT_STOP},
       {"failpoint_history_delete_key_from_ts",
         WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS},
       {"history_store_checkpoint_delay", WT_TIMING_STRESS_HS_CHECKPOINT_DELAY},

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -477,6 +477,7 @@ struct __wt_connection_impl {
     uint32_t log_cursors;                  /* Log cursor count */
     wt_off_t log_dirty_max;                /* Log dirty system cache max size */
     wt_off_t log_file_max;                 /* Log file max size */
+    uint32_t log_force_write_wait;         /* Log force write wait configuration */
     const char *log_path;                  /* Logging path format */
     uint32_t log_prealloc;                 /* Log file pre-allocation */
     uint16_t log_req_max;                  /* Max required log version */
@@ -566,22 +567,23 @@ struct __wt_connection_impl {
  * Variable with flags for which subsystems the diagnostic stress timing delays have been requested.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_TIMING_STRESS_AGGRESSIVE_SWEEP 0x0001u
-#define WT_TIMING_STRESS_BACKUP_RENAME 0x0002u
-#define WT_TIMING_STRESS_CHECKPOINT_RESERVED_TXNID_DELAY 0x0004u
-#define WT_TIMING_STRESS_CHECKPOINT_SLOW 0x0008u
-#define WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS 0x0010u
-#define WT_TIMING_STRESS_HS_CHECKPOINT_DELAY 0x0020u
-#define WT_TIMING_STRESS_HS_SEARCH 0x0040u
-#define WT_TIMING_STRESS_HS_SWEEP 0x0080u
-#define WT_TIMING_STRESS_PREPARE_CHECKPOINT_DELAY 0x0100u
-#define WT_TIMING_STRESS_SPLIT_1 0x0200u
-#define WT_TIMING_STRESS_SPLIT_2 0x0400u
-#define WT_TIMING_STRESS_SPLIT_3 0x0800u
-#define WT_TIMING_STRESS_SPLIT_4 0x1000u
-#define WT_TIMING_STRESS_SPLIT_5 0x2000u
-#define WT_TIMING_STRESS_SPLIT_6 0x4000u
-#define WT_TIMING_STRESS_SPLIT_7 0x8000u
+#define WT_TIMING_STRESS_AGGRESSIVE_SWEEP 0x00001u
+#define WT_TIMING_STRESS_BACKUP_RENAME 0x00002u
+#define WT_TIMING_STRESS_CHECKPOINT_RESERVED_TXNID_DELAY 0x00004u
+#define WT_TIMING_STRESS_CHECKPOINT_SLOW 0x00008u
+#define WT_TIMING_STRESS_CHECKPOINT_STOP 0x00010u
+#define WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS 0x00020u
+#define WT_TIMING_STRESS_HS_CHECKPOINT_DELAY 0x00040u
+#define WT_TIMING_STRESS_HS_SEARCH 0x00080u
+#define WT_TIMING_STRESS_HS_SWEEP 0x00100u
+#define WT_TIMING_STRESS_PREPARE_CHECKPOINT_DELAY 0x00200u
+#define WT_TIMING_STRESS_SPLIT_1 0x00400u
+#define WT_TIMING_STRESS_SPLIT_2 0x00800u
+#define WT_TIMING_STRESS_SPLIT_3 0x01000u
+#define WT_TIMING_STRESS_SPLIT_4 0x02000u
+#define WT_TIMING_STRESS_SPLIT_5 0x04000u
+#define WT_TIMING_STRESS_SPLIT_6 0x08000u
+#define WT_TIMING_STRESS_SPLIT_7 0x10000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 64 */
     uint64_t timing_stress_flags;
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -828,6 +828,7 @@ struct __wt_connection_stats {
     int64_t txn_checkpoint_prep_total;
     int64_t txn_checkpoint_scrub_target;
     int64_t txn_checkpoint_scrub_time;
+    int64_t txn_checkpoint_stop_stress_active;
     int64_t txn_checkpoint_time_total;
     int64_t txn_checkpoint;
     int64_t txn_checkpoint_obsolete_applied;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3009,20 +3009,26 @@ struct __wt_connection {
  * subsystem., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;file_max, the
  * maximum size of log files., an integer between 100KB and 2GB; default \c 100MB.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\, as
- * a percentage of the log's \c file_max.  If non-zero\, schedule writes for dirty blocks belonging
- * to the log in the system buffer cache after that percentage of the log has been written into the
- * buffer cache without an intervening file sync., an integer between 0 and 100; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the name of a directory into which log files are written.
- * The directory must already exist.  If the value is not an absolute path\, the path is relative to
- * the database home (see @ref absolute_path for more information)., a string; default \c ".".}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean flag; default \c
- * true.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if recovery needs to run
- * after an unclean shutdown., a string\, chosen from the following options: \c "error"\, \c "on";
- * default \c on.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write zeroes into log files.,
- * a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;force_write_wait, enable code that interrupts the usual timing of
+ * flushing the log from the internal log server thread with a goal of uncovering race conditions.
+ * This option is intended for use with internal stress testing of WiredTiger., an integer between 1
+ * and 60; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system
+ * buffer cache usage\, as a percentage of the log's \c file_max.  If non-zero\, schedule writes for
+ * dirty blocks belonging to the log in the system buffer cache after that percentage of the log has
+ * been written into the buffer cache without an intervening file sync., an integer between 0 and
+ * 100; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the name of a directory into which log
+ * files are written.  The directory must already exist.  If the value is not an absolute path\, the
+ * path is relative to the database home (see @ref absolute_path for more information)., a string;
+ * default \c ".".}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;prealloc, pre-allocate log files., a boolean
+ * flag; default \c true.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;recover, run recovery or error if
+ * recovery needs to run after an unclean shutdown., a string\, chosen from the following options:
+ * \c "error"\, \c "on"; default \c on.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;zero_fill, manually write
+ * zeroes into log files., a boolean flag; default \c false.}
  * @config{ ),,}
  * @config{lsm_manager = (, configure database wide options for LSM tree management.  The LSM
  * manager is started automatically the first time an LSM tree is opened.  The LSM manager uses a
@@ -6310,59 +6316,61 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1494
 /*! transaction: transaction checkpoint scrub time (msecs) */
 #define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1495
+/*! transaction: transaction checkpoint stop timing stress active */
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1496
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1496
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1497
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1497
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1498
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1499
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1500
 /*! transaction: transaction failures due to history store */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1500
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1501
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1501
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1502
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1502
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1503
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1503
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1504
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1504
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1505
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1505
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1506
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1506
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1507
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1507
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1508
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1508
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1509
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1509
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1510
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1510
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1511
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1511
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1512
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1512
+#define	WT_STAT_CONN_TXN_COMMIT				1513
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1513
+#define	WT_STAT_CONN_TXN_ROLLBACK			1514
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1514
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1515
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1552,6 +1552,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: transaction checkpoint prepare total time (msecs)",
   "transaction: transaction checkpoint scrub dirty target",
   "transaction: transaction checkpoint scrub time (msecs)",
+  "transaction: transaction checkpoint stop timing stress active",
   "transaction: transaction checkpoint total time (msecs)",
   "transaction: transaction checkpoints",
   "transaction: transaction checkpoints due to obsolete pages",
@@ -2108,6 +2109,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing txn_checkpoint_prep_total */
     /* not clearing txn_checkpoint_scrub_target */
     /* not clearing txn_checkpoint_scrub_time */
+    /* not clearing txn_checkpoint_stop_stress_active */
     /* not clearing txn_checkpoint_time_total */
     stats->txn_checkpoint = 0;
     stats->txn_checkpoint_obsolete_applied = 0;
@@ -2684,6 +2686,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_checkpoint_prep_total += WT_STAT_READ(from, txn_checkpoint_prep_total);
     to->txn_checkpoint_scrub_target += WT_STAT_READ(from, txn_checkpoint_scrub_target);
     to->txn_checkpoint_scrub_time += WT_STAT_READ(from, txn_checkpoint_scrub_time);
+    to->txn_checkpoint_stop_stress_active += WT_STAT_READ(from, txn_checkpoint_stop_stress_active);
     to->txn_checkpoint_time_total += WT_STAT_READ(from, txn_checkpoint_time_total);
     to->txn_checkpoint += WT_STAT_READ(from, txn_checkpoint);
     to->txn_checkpoint_obsolete_applied += WT_STAT_READ(from, txn_checkpoint_obsolete_applied);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1021,6 +1021,15 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_ERR(__wt_txn_commit(session, NULL));
 
     /*
+     * Flush all the logs that are generated during the checkpoint. It is possible that checkpoint
+     * may include the changes that are written in parallel by an eviction. To have a consistent
+     * view of the data, make sure that all the logs are flushed to disk before the checkpoint is
+     * complete.
+     */
+    if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
+        WT_ERR(__wt_log_flush(session, WT_LOG_FSYNC));
+
+    /*
      * Ensure that the metadata changes are durable before the checkpoint is resolved. Do this by
      * either checkpointing the metadata or syncing the log file. Recovery relies on the checkpoint
      * LSN in the metadata only being updated by full checkpoints so only checkpoint the metadata
@@ -1046,6 +1055,11 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     } else
         WT_WITH_DHANDLE(session, WT_SESSION_META_DHANDLE(session),
           ret = __wt_txn_checkpoint_log(session, false, WT_TXN_LOG_CKPT_SYNC, NULL));
+
+    WT_STAT_CONN_SET(session, txn_checkpoint_stop_stress_active, 1);
+    /* Wait prior to flush the checkpoint stop log record. */
+    __checkpoint_timing_stress(session, WT_TIMING_STRESS_CHECKPOINT_STOP, &tsp);
+    WT_STAT_CONN_SET(session, txn_checkpoint_stop_stress_active, 0);
 
     /*
      * Now that the metadata is stable, re-open the metadata file for regular eviction by clearing

--- a/test/suite/test_rollback_to_stable35.py
+++ b/test/suite/test_rollback_to_stable35.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest, threading, time
+from wtdataset import SimpleDataSet
+from wtthread import checkpoint_thread
+from helper import simulate_crash_restart
+from wiredtiger import stat
+from helper import copy_wiredtiger_home
+from wtscenario import make_scenarios
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+# test_rollback_to_stable35.py
+# Test that log is flushed for all writes that occurred in the checkpoint.
+class test_rollback_to_stable35(test_rollback_to_stable_base):
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('column_fix', dict(key_format='r', value_format='8t')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def large_updates(self, uri_1, uri_2, value, ds_1, ds_2, nrows):
+        # Update a large number of records.
+        session = self.session
+        cursor_1 = session.open_cursor(uri_1)
+        cursor_2 = session.open_cursor(uri_2)
+        for i in range(1, nrows + 1):
+            session.begin_transaction()
+            cursor_1[ds_1.key(i)] = value
+            cursor_2[ds_2.key(i)] = value
+            session.commit_transaction()
+        cursor_1.close()
+        cursor_2.close()
+
+    def check(self, check_value, uri_1, uri_2, nrows):
+        session = self.session
+        session.begin_transaction()
+        cursor_1 = session.open_cursor(uri_1)
+        cursor_2 = session.open_cursor(uri_2)
+        count = 0
+        for k, v in cursor_1:
+            self.assertEqual(v, check_value)
+            count += 1
+        self.assertEqual(count, nrows)
+        count = 0
+        for k, v in cursor_2:
+            self.assertEqual(v, check_value)
+            count += 1
+        self.assertEqual(count, nrows)
+        session.commit_transaction()
+        cursor_1.close()
+        cursor_2.close()
+
+    def conn_config(self):
+        config = 'cache_size=50MB,statistics=(all),log=(enabled,force_write_wait=60),timing_stress_for_test=[checkpoint_slow, checkpoint_stop]'
+        return config
+
+    def test_rollback_to_stable(self):
+        nrows = 10
+
+        # Create two tables.
+        uri_1 = "table:rollback_to_stable35_1"
+        ds_1 = SimpleDataSet(
+            self, uri_1, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_1.populate()
+
+        uri_2 = "table:rollback_to_stable35_2"
+        ds_2 = SimpleDataSet(
+            self, uri_2, 0, key_format=self.key_format, value_format=self.value_format)
+        ds_2.populate()
+
+        if self.value_format == '8t':
+            valuea = 97
+            valueb = 98
+            valuec = 99
+        else:
+            valuea = "aaaaa" * 100
+            valueb = "bbbbb" * 100
+            valuec = "ccccc" * 100
+
+        self.large_updates(uri_1, uri_2, valuea, ds_1, ds_2, nrows)
+        self.check(valuea, uri_1, uri_2, nrows)
+
+        # Start a long running transaction and keep it open.
+        session_2 = self.conn.open_session()
+        session_2.begin_transaction()
+
+        self.large_updates(uri_1, uri_2, valueb, ds_1, ds_2, nrows)
+        self.check(valueb, uri_1, uri_2, nrows)
+
+        # Create a checkpoint thread
+        done = threading.Event()
+        ckpt = checkpoint_thread(self.conn, done)
+        try:
+            ckpt.start()
+            # Wait for checkpoint to start before committing.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
+                stat_cursor.close()
+                time.sleep(1)
+            
+            self.large_updates(uri_1, uri_2, valuec, ds_1, ds_2, nrows)
+            self.check(valuec, uri_1, uri_2, nrows)
+
+            # Evict the data.
+            self.evict_cursor(uri_1, nrows, valuec)
+
+            # Wait for checkpoint stop timing stress to copy the database.
+            ckpt_stop_timing_stress = 0
+            while not ckpt_stop_timing_stress:
+                time.sleep(1)
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_stop_timing_stress = stat_cursor[stat.conn.txn_checkpoint_stop_stress_active][2]
+                stat_cursor.close()
+
+            copy_wiredtiger_home(self, '.', "RESTART")
+
+        finally:
+            done.set()
+            ckpt.join()
+        self.session.checkpoint()
+
+        # Clear all running transactions before rollback to stable.
+        session_2.commit_transaction()
+        session_2.close()
+
+        # Open the new directory
+        self.close_conn()
+        self.conn_config = 'cache_size=50MB,statistics=(all),log=(enabled)'
+        conn = self.setUpConnectionOpen("RESTART")
+        self.session = self.setUpSessionOpen(conn)
+
+        self.check(valuec, uri_1, uri_2, nrows)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        calls = stat_cursor[stat.conn.txn_rts][2]
+        upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
+        hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
+        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
+        keys_restored = stat_cursor[stat.conn.txn_rts_keys_restored][2]
+        pages_visited = stat_cursor[stat.conn.txn_rts_pages_visited][2]
+        stat_cursor.close()
+
+        self.assertEqual(calls, 0)
+        self.assertEqual(keys_removed, 0)
+        self.assertEqual(keys_restored, 0)
+        self.assertEqual(pages_visited, 0)
+        self.assertEqual(upd_aborted, 0)
+        self.assertGreaterEqual(hs_removed, 0)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The checkpoint may include the updates from a recent transactions
due to some parallel eviction activity. Ensure that all the log
writes that are performed in parallel are flushed to disk before the
metadata gets checkpointed to ensure that all the log records are
written to the disk before the checkpoint becomes stable.

(cherry picked from commit e41ecd207030991a3c79a27ba39e35025f2e8379)