### PR TITLE
WT-9438 Skip cppsuite files for spell check

### DIFF
--- a/dist/s_string
+++ b/dist/s_string
@@ -49,7 +49,6 @@ check() {
 l=`(cd .. &&
     find bench examples ext src test -not -path "test/cppsuite/*" -name '*.[chsy]' &&
     find src -name '*.in' &&
-    find test -name '*.cxx' &&
     find test -not -path "test/cppsuite/*" -name '*.cpp')`
 
 usage()

--- a/dist/s_string
+++ b/dist/s_string
@@ -45,9 +45,12 @@ check() {
 }
 
 # List of files to spellchk.
+# FIXME-WT-9433 Skip files in the test/cppsuite folder.
 l=`(cd .. &&
-    find bench examples ext src test -name '*.[chsy]' &&
-    find src -name '*.in' && find test -name '*.cxx' && find test -name '*.cpp')`
+    find bench examples ext src test -not -path "test/cppsuite/*" -name '*.[chsy]' &&
+    find src -name '*.in' &&
+    find test -name '*.cxx' &&
+    find test -not -path "test/cppsuite/*" -name '*.cpp')`
 
 usage()
 {


### PR DESCRIPTION
Make `s_script` skip all the files in the `test/cppsuite` folder. This will unblock WT-9385 and is a temporary change that will be fixed by WT-9433.