### PR TITLE
WT-9439 Don't attempt to evict using a checkpoint-cursor snapshot

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -692,6 +692,9 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
 
     WT_ASSERT(session, LF_ISSET(WT_REC_VISIBLE_ALL) || F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
+    /* We should not be trying to evict using a checkpoint-cursor transaction. */
+    WT_ASSERT(session, !F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+
     /*
      * Reconcile the page. Force read-committed isolation level if we are using snapshots for
      * eviction workers or application threads.

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -452,6 +452,15 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
         return (0);
 
     /*
+     * If the transaction is a checkpoint cursor transaction, don't try to evict. Because eviction
+     * keeps the current transaction snapshot, and the snapshot in a checkpoint cursor transaction
+     * can be (and likely is) very old, we won't be able to see anything current to evict and won't
+     * be able to accomplish anything useful.
+     */
+    if (F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT))
+        return (0);
+
+    /*
      * If the current transaction is keeping the oldest ID pinned, it is in the middle of an
      * operation. This may prevent the oldest ID from moving forward, leading to deadlock, so only
      * evict what we can. Otherwise, we are at a transaction boundary and we can work harder to make

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -519,6 +519,10 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
 
     txn = session->txn;
 
+    /* Make sure that checkpoint cursor transactions only read checkpoints. */
+    WT_ASSERT(
+      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+
     /*
      * When reading from a checkpoint, all readers use the same snapshot, so a transaction is
      * globally visible if it is visible in that snapshot. Note that this can cause things that were
@@ -567,6 +571,10 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
     /* Timestamp check. */
     if (timestamp == WT_TS_NONE)
         return (true);
+
+    /* Make sure that checkpoint cursor transactions only read checkpoints. */
+    WT_ASSERT(
+      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
 
     /* When reading a checkpoint, use the checkpoint state instead of the current state. */
     if (WT_READING_CHECKPOINT(session))


### PR DESCRIPTION
Don't use checkpoint-cursor transactions for eviction.

Also assert that we don't try to do visibility checks using a checkpoint-cursor transaction when not reading from a checkpoint, or vice versa.
