### PR TITLE
WT-9439 Don't attempt to evict using a checkpoint-cursor snapshot

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -692,6 +692,9 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
 
     WT_ASSERT(session, LF_ISSET(WT_REC_VISIBLE_ALL) || F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
+    /* We should not be trying to evict using a checkpoint-cursor transaction. */
+    WT_ASSERT(session, !F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+
     /*
      * Reconcile the page. Force read-committed isolation level if we are using snapshots for
      * eviction workers or application threads.

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -452,6 +452,15 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
         return (0);
 
     /*
+     * If the transaction is a checkpoint cursor transaction, don't try to evict. Because eviction
+     * keeps the current transaction snapshot, and the snapshot in a checkpoint cursor transaction
+     * can be (and likely is) very old, we won't be able to see anything current to evict and won't
+     * be able to accomplish anything useful.
+     */
+    if (F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT))
+        return (0);
+
+    /*
      * If the current transaction is keeping the oldest ID pinned, it is in the middle of an
      * operation. This may prevent the oldest ID from moving forward, leading to deadlock, so only
      * evict what we can. Otherwise, we are at a transaction boundary and we can work harder to make

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -519,9 +519,10 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
 
     txn = session->txn;
 
-    /* Make sure that checkpoint cursor transactions only read checkpoints. */
-    WT_ASSERT(
-      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+    /* Make sure that checkpoint cursor transactions only read checkpoints, except for metadata. */
+    WT_ASSERT(session,
+      (session->dhandle != NULL && WT_IS_METADATA(session->dhandle)) ||
+        WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
 
     /*
      * When reading from a checkpoint, all readers use the same snapshot, so a transaction is
@@ -532,8 +533,17 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
      * was taken becomes not globally visible in the checkpoint) never happen as this violates basic
      * assumptions about visibility. (And, concretely, it can cause stale history store entries to
      * come back to life and produce wrong answers.)
+     *
+     * Note: we use the transaction to check this rather than testing WT_READING_CHECKPOINT because
+     * reading the metadata while working with a checkpoint cursor will borrow the transaction; it
+     * then ends up using it to read a non-checkpoint tree. This is believed to be ok because the
+     * metadata is always read-uncommitted, but we want to still use the checkpoint-cursor
+     * visibility logic. Using the regular visibility logic with a checkpoint cursor transaction can
+     * be logically invalid (it is possible that way for something to be globally visible but
+     * specifically invisible) and also can end up comparing transaction ids from different database
+     * opens.
      */
-    if (WT_READING_CHECKPOINT(session))
+    if (F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT))
         return (__wt_txn_visible_id_snapshot(
           id, txn->snap_min, txn->snap_max, txn->snapshot, txn->snapshot_count));
     oldest_id = __wt_txn_oldest_id(session);
@@ -572,12 +582,13 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
     if (timestamp == WT_TS_NONE)
         return (true);
 
-    /* Make sure that checkpoint cursor transactions only read checkpoints. */
-    WT_ASSERT(
-      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+    /* Make sure that checkpoint cursor transactions only read checkpoints, except for metadata. */
+    WT_ASSERT(session,
+      (session->dhandle != NULL && WT_IS_METADATA(session->dhandle)) ||
+        WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
 
     /* When reading a checkpoint, use the checkpoint state instead of the current state. */
-    if (WT_READING_CHECKPOINT(session))
+    if (F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT))
         return (session->txn->checkpoint_oldest_timestamp != WT_TS_NONE &&
           timestamp <= session->txn->checkpoint_oldest_timestamp);
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -519,6 +519,10 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
 
     txn = session->txn;
 
+    /* Make sure that checkpoint cursor transactions only read checkpoints. */
+    WT_ASSERT(
+      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
+
     /*
      * When reading from a checkpoint, all readers use the same snapshot, so a transaction is
      * globally visible if it is visible in that snapshot. Note that this can cause things that were
@@ -567,6 +571,10 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
     /* Timestamp check. */
     if (timestamp == WT_TS_NONE)
         return (true);
+
+    /* Make sure that checkpoint cursor transactions only read checkpoints. */
+    WT_ASSERT(
+      session, WT_READING_CHECKPOINT(session) == F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT));
 
     /* When reading a checkpoint, use the checkpoint state instead of the current state. */
     if (WT_READING_CHECKPOINT(session))


### PR DESCRIPTION
Don't use checkpoint-cursor transactions for eviction.

Allow using the checkpoint-cursor txn to read the metadata. See the commit message (and the ticket) for further info.