### PR TITLE
WT-9377 Reduce the time between each insert in the cache_resize cpp test

### DIFF
--- a/test/cppsuite/configs/cache_resize_default.txt
+++ b/test/cppsuite/configs/cache_resize_default.txt
@@ -22,7 +22,7 @@ workload_manager=
     insert_config=
     (
         key_size=1000000,
-        op_rate=4s,
+        op_rate=3s,
         ops_per_transaction=(min=2,max=2),
         thread_count=5,
     ),


### PR DESCRIPTION
The time has been reduced between each insert so it is less likely that we will change the cache size while we try to insert data.